### PR TITLE
RiverLea: Fixes select2 inside dropdown breaking visual regression

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -275,7 +275,7 @@
   background-color: var(--crm-c-background3);
 }
 #bootstrap-theme .dropdown-menu li .form-inline,
-#bootstrap-theme .dropdown-menu li .form-inline a {
+#bootstrap-theme .dropdown-menu li .form-inline a:not(.select2-choice) {
   color: var(--crm-dropdown-col);
 }
 .crm-container .dropdown-menu > li {


### PR DESCRIPTION
The selected values on Select2 inside a dropdown are inheriting the dropdown text colour but not the background colour, causing a white-text on white-bg visual failure. Ref: https://lab.civicrm.org/dev/core/-/issues/5870. This fixes prevents that pattern from loading on Select2 selected items, as a limited scope fix.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/e4c99451-71a2-486b-b73c-ae9ce28064ec)

Also impacts Walbrook.

After
----------------------------------------
Minetta:
![image](https://github.com/user-attachments/assets/e93ca196-fbb9-42c0-ac86-ac249192f82f)

Walbrook:
![image](https://github.com/user-attachments/assets/19f218b5-cadf-491d-84d9-a4551301d97b)

(Hackney and Thames both have white BG dropdowns with dark text colour so this bug wasn't there).

Technical Details
----------------------------------------
This is quick, minimal impact fix - a more stable long-term solution involves moving the Select2 css to a high specificity so it's not impacted by dropdown (or any other) css.