### PR TITLE
ChartKit - Fix display in standalone mode

### DIFF
--- a/ext/chart_kit/ang/crmChartKit.ang.php
+++ b/ext/chart_kit/ang/crmChartKit.ang.php
@@ -21,7 +21,7 @@ return [
     'ui.bootstrap',
     'crmSearchDisplay',
   ],
-  'basePages' => ['civicrm/admin/search'],
+  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
   'bundles' => ['bootstrap3', 'chart_kit'],
   'exports' => [
     'crm-search-display-chart-kit' => 'E',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes chartKit displays to work on the standalone `civicrm/search` page.

Before
----------------------------------------
Clicking 'View Results' and selecting the chart would go to a blank page.

After
----------------------------------------
It goes to a page that displays the chart.