### PR TITLE
SearchKit - Hide non-viewable display types 

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -41,7 +41,7 @@ class Admin {
       'operators' => \CRM_Utils_Array::makeNonAssociative(self::getOperators()),
       'permissions' => [],
       'functions' => self::getSqlFunctions(),
-      'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon']),
+      'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon', 'grouping']),
       'styles' => \CRM_Utils_Array::makeNonAssociative(self::getStyles()),
       'defaultPagerSize' => (int) \Civi::settings()->get('default_pager_size'),
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -161,6 +161,10 @@
       loadAfforms();
     };
 
+    this.displayIsViewable = function (display) {
+      return display.id && (ctrl.displayTypes[display.type] && ctrl.displayTypes[display.type].grouping !== 'non-viewable');
+    };
+
     this.canAddSmartGroup = function() {
       return !ctrl.savedSearch.groups.length && !ctrl.savedSearch.is_template;
     };

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -77,7 +77,7 @@
                   {{:: ts('Search results table') }}
                 </a>
               </li>
-              <li ng-repeat="display in $ctrl.savedSearch.displays" ng-if="display.id" ng-class="{disabled: display.acl_bypass}" title="{{:: display.acl_bypass ? ts('Display has permissions disabled') : ts('View display') }}">
+              <li ng-repeat="display in $ctrl.savedSearch.displays" ng-if="$ctrl.displayIsViewable(display)" ng-class="{disabled: display.acl_bypass}" title="{{:: display.acl_bypass ? ts('Display has permissions disabled') : ts('View display') }}">
                 <a ng-href="{{ display.acl_bypass ? '' : $ctrl.searchDisplayPath + '#/display/' + $ctrl.savedSearch.name + '/' + display.name }}" target="_blank">
                   <i class="crm-i {{ display.acl_bypass ? 'fa-unlock' : $ctrl.displayTypes[display.type].icon }}"></i>
                   {{ display.label }}

--- a/ext/search_kit/managed/SearchDisplayType.mgd.php
+++ b/ext/search_kit/managed/SearchDisplayType.mgd.php
@@ -20,6 +20,7 @@ return [
           'label',
           'icon',
           'description',
+          'grouping',
         ],
       ],
       'match' => ['name'],
@@ -121,6 +122,8 @@ return [
         'icon' => 'fa-keyboard-o',
         'is_reserved' => TRUE,
         'is_active' => TRUE,
+        // This display type is not viewable
+        'grouping' => 'non-viewable',
       ],
       'match' => ['option_group_id', 'name'],
     ],
@@ -141,6 +144,8 @@ return [
         'icon' => 'fa-database',
         'is_reserved' => TRUE,
         'is_active' => TRUE,
+        // This display type is not viewable
+        'grouping' => 'non-viewable',
       ],
       'match' => ['option_group_id', 'name'],
     ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -17,6 +17,17 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ->apply();
   }
 
+  public function testGetOptions(): void {
+    $displayTypeOptions = \Civi\Api4\SearchDisplay::getFields(FALSE)
+      ->setLoadOptions(['id', 'name', 'label', 'description', 'icon', 'grouping'])
+      ->addWhere('name', '=', 'type')
+      ->execute()
+      ->first()['options'];
+
+    $displayTypeOptions = array_column($displayTypeOptions, NULL, 'id');
+    $this->assertEquals('non-viewable', $displayTypeOptions['autocomplete']['grouping']);
+  }
+
   public function testGetDefault() {
     $params = [
       'api_entity' => 'Contact',


### PR DESCRIPTION
Overview
----------------------------------------
Autocomplete and Entity type displays are not meant to be viewed by themselves, so should not be available in the "View Results" menu.

See https://lab.civicrm.org/dev/core/-/issues/5867#note_181510

Before
----------------------------------------
Autocomplete and Entity type displays were given as options in the "View Results" menu in SearchKit, but clicking on them would just show a blank page.

After
----------------------------------------
Hidden.

Technical Details
----------------------------------------
Depends on #32712