### PR TITLE
SearchKit - Add 'search_fields' to Db Entities 

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -62,7 +62,11 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
         'searchable' => 'secondary',
         'class' => SKEntity::class,
         'icon' => 'fa-search-plus',
+        'search_fields' => [],
       ];
+      foreach ($display['settings']['columns'] as $column) {
+        $event->entities[$display['entityName']]['search_fields'][] = $column['spec']['name'];
+      }
     }
   }
 

--- a/ext/search_kit/Civi/Api4/SKEntity.php
+++ b/ext/search_kit/Civi/Api4/SKEntity.php
@@ -2,8 +2,6 @@
 
 namespace Civi\Api4;
 
-use CRM_Core_DAO;
-
 /**
  * Virtual API entities provided by SearchDisplays of type "entity"
  * @package Civi\Api4
@@ -99,7 +97,7 @@ class SKEntity {
     $query->select(['settings']);
     $query->where('type = "entity"');
     $query->where('name = @name', ['@name' => $displayName]);
-    $settings = CRM_Core_DAO::singleValueQuery($query->toSQL());
+    $settings = \CRM_Core_DAO::singleValueQuery($query->toSQL());
     if ($settings) {
       $settings = json_decode($settings, TRUE);
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../../../../../../../tests/phpunit/api/v4/Api4TestBase.
 
 use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\Entity;
 use Civi\Api4\SearchDisplay;
 use Civi\Search\Admin;
 use Civi\Test\CiviEnvBuilder;
@@ -24,8 +25,8 @@ class EntityDisplayTest extends Api4TestBase {
 
   public static function getDataModes(): array {
     return [
-      ['table'],
-      ['view'],
+      'table' => ['table'],
+      'view' => ['view'],
     ];
   }
 
@@ -58,7 +59,7 @@ class EntityDisplayTest extends Api4TestBase {
     $display = SearchDisplay::create(FALSE)
       ->addValue('saved_search_id', $savedSearch['id'])
       ->addValue('type', 'entity')
-      ->addValue('label', 'MyNewEntity')
+      ->addValue('label', 'My New Entity')
       ->addValue('name', 'MyNewEntity')
       ->addValue('settings', [
         'data_mode' => $dataMode,
@@ -123,6 +124,14 @@ class EntityDisplayTest extends Api4TestBase {
       $rows = \CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_sk_my_new_entity')->fetchAll();
       $this->assertCount(0, $rows);
     }
+
+    $info = Entity::get(FALSE)
+      ->addWhere('name', '=', 'SK_MyNewEntity')
+      ->execute()->single();
+    $this->assertSame('My New Entity', $info['title']);
+    $this->assertSame('civicrm_sk_my_new_entity', $info['table_name']);
+    $this->assertSame('secondary', $info['searchable']);
+    $this->assertSame(['id', 'first', 'last_name', 'prefix_id', 'created_date', 'modified_date'], $info['search_fields']);
 
     $getFields = civicrm_api4('SK_MyNewEntity', 'getFields', ['loadOptions' => TRUE])->indexBy('name');
     $this->assertNotEmpty($getFields['prefix_id']['options'][1]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5867](https://lab.civicrm.org/dev/core/-/issues/5867)

Before
----------------------------------------
SearchKit was crashing when attempting to create a new search with a db entity (because it has no default columns).

After
----------------------------------------

Giving the columns as search fields provides the defaults needed.