### PR TITLE
Deal with possibility of import_mappings not being configured

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixOne.php
+++ b/CRM/Upgrade/Incremental/php/SixOne.php
@@ -140,14 +140,15 @@ class CRM_Upgrade_Incremental_php_SixOne extends CRM_Upgrade_Incremental_Base {
       $userJob->find();
       while ($userJob->fetch()) {
         $metadata = json_decode($userJob->metadata, TRUE);
-        foreach ($metadata['import_mappings'] as &$mapping) {
-          if (isset($fieldsToConvert[$mapping['name']])) {
-            $mapping['name'] = $fieldsToConvert[$mapping['name']];
+        if (!empty($metadata['import_mappings'])) {
+          foreach ($metadata['import_mappings'] as &$mapping) {
+            if (isset($fieldsToConvert[$mapping['name']])) {
+              $mapping['name'] = $fieldsToConvert[$mapping['name']];
+            }
+            $userJob->metadata = json_encode($metadata);
+            $userJob->save();
           }
-          $userJob->metadata = json_encode($metadata);
-          $userJob->save();
         }
-
       }
     }
     return TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
Deal with possibility of import_mappings not being configured

Before
----------------------------------------
In some cases UI errors

.............[PHP Parse Error] foreach() argument must be of type array|object, null given at /var/www/html/vendor/civicrm/civicrm-core/CRM/Upgrade/Incremental/php/SixOne.php:143
[PHP Parse Error] foreach() argument must be of type array|object, null given at /var/www/html/vendor/civicrm/civicrm-core/CRM/Upgrade/Incremental/php/SixOne.php:143
[PHP Parse Error] foreach() argument must be of type array|object, null given at /var/www/html/vendor/civicrm/civicrm-core/CRM/Upgrade/Incremental/php/SixOne.php:143
[PHP Parse Error] foreach() argument must be of type array|object, null given at /var/www/html/vendor/civicrm/civicrm-core/CRM/Upgrade/Incremental/php/SixOne.php:143
.......
Finishing upgrade...
Upgrade to 6.1.2 completed.


After
----------------------------------------
Handle null

Technical Details
----------------------------------------
This might be NULL if civiimport had been disabled

Comments
----------------------------------------
