### PR TITLE
Resolve dev/5872 (Add note button does not work)

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -308,6 +308,10 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
             $url = 'civicrm/contact/view/activity';
             $qs = "atype=3&action=add&reset=1&cid=%%id%%{$extraParams}";
           }
+          elseif ($value['key'] === 'note') {
+            $url = 'civicrm/note';
+            $qs = "reset=1&action=add&entity_table=civicrm_contact&entity_id='%%id%%{$extraParams}";
+          }
 
           self::$_links[$counter++] = [
             'name' => $value['title'],


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5872

Before
----------------------------------------
See steps to reproduce on GitLab.

After
----------------------------------------
Add new note link works

Technical Details
----------------------------------------
I hoped to find a more generic solution, to stop this happening in future - but I couldn't see one. I thought we could read `href` from the `$value` array, but that doens't have the reference to the contact ID, so is no use. This matches what we do for activies and email on the lines directly before this, so in that regard this should be a safe fix.