### PR TITLE
Enable custom data for IM & Open IDs

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -27,6 +27,15 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
   use CRM_Contact_Form_ContactFormTrait;
   use CRM_Custom_Form_CustomDataTrait;
+  use CRM_Contact_Form_Edit_OpenIDBlockTrait;
+
+  /**
+   * Is this the contact summary edit screen.
+   *
+   * @var bool
+   */
+  protected bool $isContactSummaryEdit = TRUE;
+
 
   /**
    * The contact type of the form.
@@ -244,7 +253,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           CRM_Contact_BAO_Contact::getValues(['id' => $this->_contactId, 'contact_id' => $this->_contactId], $this->_values);
           $this->_values['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $this->_contactId]);
           $this->_values['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $this->_contactId]);
-          $this->_values['openid'] = CRM_Core_BAO_OpenID::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['openid'] = $this->getExistingOpenIDsReIndexed();
           $this->_values['phone'] = CRM_Core_BAO_Phone::getValues(['contact_id' => $this->_contactId]);
           $this->_values['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $this->_contactId], TRUE);
           CRM_Core_BAO_Website::getValues(['contact_id' => $this->_contactId], $this->_values);
@@ -1476,7 +1485,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       return;
     }
     if ($name === 'OpenID') {
-      CRM_Contact_Form_Edit_OpenID::buildQuickForm($this, $instance);
+      $this->addOpenIDBlockFields($instance);
       return;
     }
     if ($name === 'Email') {

--- a/CRM/Contact/Form/Edit/IM.php
+++ b/CRM/Contact/Form/Edit/IM.php
@@ -32,6 +32,7 @@ class CRM_Contact_Form_Edit_IM {
    */
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
     if (!$blockCount) {
+      CRM_Core_Error::deprecatedWarning('pass in blockCount');
       $blockId = ($form->get('IM_Block_Count')) ? $form->get('IM_Block_Count') : 1;
     }
     else {

--- a/CRM/Contact/Form/Edit/IMBlockTrait.php
+++ b/CRM/Contact/Form/Edit/IMBlockTrait.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Api4\IM;
+use Civi\Api4\Generic\Result;
+
+/**
+ * Form helper trait for including IMs in forms.
+ *
+ * @internal not supported for use outside core - if you do use it ensure your
+ *  code has adequate unit test cover.
+ */
+trait CRM_Contact_Form_Edit_IMBlockTrait {
+  use CRM_Contact_Form_Edit_BlockCustomDataTrait;
+
+  /**
+   * @var \Civi\Api4\Generic\Result
+   */
+  private Result $existingIMs;
+
+  protected bool $isContactSummaryEdit = FALSE;
+
+  /**
+   * @return \Civi\Api4\Generic\Result
+   * @throws CRM_Core_Exception
+   */
+  public function getExistingIMs() : Result {
+    if (!isset($this->existingIMs)) {
+      $this->existingIMs = IM::get()
+        ->addSelect('*', 'custom.*')
+        ->addOrderBy('is_primary', 'DESC')
+        ->addWhere('contact_id', '=', $this->getContactID())
+        ->execute();
+    }
+    return $this->existingIMs;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function addIMBlockFields(int $blockNumber): void {
+
+    $this->applyFilter('__ALL__', 'trim');
+    //IM provider select
+    $this->addField("im[$blockNumber][provider_id]", ['entity' => 'im', 'class' => 'eight', 'placeholder' => NULL, 'title' => ts('IM Type %1', [1 => $blockNumber])]);
+    //Block type select
+    $this->addField("im[$blockNumber][location_type_id]", ['entity' => 'im', 'class' => 'eight', 'placeholder' => NULL, 'option_url' => NULL, 'title' => ts('IM Location %1', [1 => $blockNumber])]);
+
+    //IM box
+    $this->addField("im[$blockNumber][name]", ['entity' => 'im', 'aria-label' => ts('Instant Messenger %1', [1 => $blockNumber])]);
+    //is_Primary radio
+    $js = ['id' => 'IM_' . $blockNumber . '_IsPrimary', 'aria-label' => ts('Instant Messenger %1 is primary?', [1 => $blockNumber])];
+    if ($this->isContactSummaryEdit) {
+      $js['onClick'] = 'singleSelect( this.id );';
+    }
+
+    $this->addElement('radio', "im[$blockNumber][is_primary]", '', '', '1', $js);
+    $this->addCustomDataFieldBlock('IM', $blockNumber);
+  }
+
+  /**
+   * @throws CRM_Core_Exception
+   */
+  public function saveIMs(array $ims): void {
+    $existingIMs = (array) $this->getExistingIMs()->indexBy('id');
+    foreach ($ims as $index => $im) {
+      $id = $im['id'] ?? NULL;
+      $dataExists = !CRM_Utils_System::isNull($im['name']);
+      if (!$dataExists) {
+        unset($ims[$index]);
+        continue;
+      }
+      if (!array_key_exists('contact_id', $im)) {
+        $ims[$index]['contact_id'] = $this->getContactID();
+      }
+      if ($id) {
+        if (array_key_exists($id, $existingIMs)) {
+          // We unset this here because we are going to delete any existing
+          // emails that were not in the incoming array.
+          unset($existingIMs[$id]);
+        }
+        else {
+          // The id is not valid, this becomes a create.
+          unset($im['id']);
+        }
+      }
+    }
+    if ($ims) {
+      IM::save()
+        ->setRecords($ims)
+        ->execute();
+    }
+
+    if (!empty($ims)) {
+      IM::delete()->addWhere('id', 'IN', array_keys($existingIMs))
+        ->execute();
+    }
+
+  }
+
+}

--- a/CRM/Contact/Form/Edit/OpenID.php
+++ b/CRM/Contact/Form/Edit/OpenID.php
@@ -29,8 +29,10 @@ class CRM_Contact_Form_Edit_OpenID {
    *   Block number to build.
    * @param bool $blockEdit
    *   Is it block edit.
+   * @deprecated since 6.3 will be removed around 6.10
    */
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if (!$blockCount) {
       CRM_Core_Error::deprecatedWarning('pass in blockCount');
       $blockId = ($form->get('OpenID_Block_Count')) ? $form->get('OpenID_Block_Count') : 1;

--- a/CRM/Contact/Form/Edit/OpenID.php
+++ b/CRM/Contact/Form/Edit/OpenID.php
@@ -32,6 +32,7 @@ class CRM_Contact_Form_Edit_OpenID {
    */
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
     if (!$blockCount) {
+      CRM_Core_Error::deprecatedWarning('pass in blockCount');
       $blockId = ($form->get('OpenID_Block_Count')) ? $form->get('OpenID_Block_Count') : 1;
     }
     else {

--- a/CRM/Contact/Form/Edit/OpenIDBlockTrait.php
+++ b/CRM/Contact/Form/Edit/OpenIDBlockTrait.php
@@ -1,0 +1,116 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+use Civi\Api4\OpenID;
+use Civi\Api4\Generic\Result;
+
+/**
+ * Form helper trait for including open IDs in forms.
+ *
+ * @internal not supported for use outside core - if you do use it ensure your
+ *  code has adequate unit test cover.
+ */
+trait CRM_Contact_Form_Edit_OpenIDBlockTrait {
+  use CRM_Contact_Form_Edit_BlockCustomDataTrait;
+
+  protected bool $isContactSummaryEdit = FALSE;
+
+  /**
+   * @var \Civi\Api4\Generic\Result
+   */
+  private Result $existingOpenIDs;
+
+  /**
+   * @return \Civi\Api4\Generic\Result
+   * @throws CRM_Core_Exception
+   */
+  public function getExistingOpenIDs() : Result {
+    if (!isset($this->existingOpenIDs)) {
+      $this->existingOpenIDs = OpenID::get()
+        ->addSelect('*', 'custom.*', 'location_type_id:label')
+        ->addOrderBy('is_primary', 'DESC')
+        ->addWhere('contact_id', '=', $this->getContactID())
+        ->execute();
+    }
+    return $this->existingOpenIDs;
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function addOpenIDBlockFields(int $blockNumber): void {
+
+    $this->applyFilter('__ALL__', 'trim');
+
+    $this->addElement('text', "openid[$blockNumber][openid]", ts('OpenID'),
+      CRM_Core_DAO::getAttribute('CRM_Core_DAO_OpenID', 'openid')
+    );
+
+    //Block type
+    $this->addElement('select', "openid[$blockNumber][location_type_id]", '', CRM_Core_DAO_Address::buildOptions('location_type_id'));
+
+    //is_Primary radio
+    $js = ['id' => "OpenID_" . $blockNumber . "_IsPrimary"];
+    if ($this->isContactSummaryEdit) {
+      $js['onClick'] = 'singleSelect( this.id );';
+    }
+
+    $this->addElement('radio', "openid[$blockNumber][is_primary]", '', '', '1', $js);
+    $this->addCustomDataFieldBlock('OpenID', $blockNumber);
+  }
+
+  /**
+   * @throws CRM_Core_Exception
+   */
+  public function saveOpenIDss(array $openIDs): void {
+    $existingOpenIDs = (array) $this->getExistingOpenIDs()->indexBy('id');
+    foreach ($openIDs as $index => $openID) {
+      $id = $openID['id'] ?? NULL;
+      $dataExists = !CRM_Utils_System::isNull($openID['openid']);
+      if (!$dataExists) {
+        unset($openIDs[$index]);
+        continue;
+      }
+      if (!array_key_exists('contact_id', $openID)) {
+        $openIDs[$index]['contact_id'] = $this->getContactID();
+      }
+      if ($id) {
+        if (array_key_exists($id, $existingOpenIDs)) {
+          // We unset this here because we are going to delete any existing
+          // emails that were not in the incoming array.
+          unset($existingOpenIDs[$id]);
+        }
+        else {
+          // The id is not valid, this becomes a create.
+          unset($openID['id']);
+        }
+      }
+    }
+    if ($openIDs) {
+      OpenID::save()
+        ->setRecords($openIDs)
+        ->execute();
+    }
+
+    if (!empty($existingOpenIDs)) {
+      OpenID::delete()->addWhere('id', 'IN', array_keys($existingOpenIDs))
+        ->execute();
+    }
+
+  }
+
+}

--- a/CRM/Contact/Form/Edit/OpenIDBlockTrait.php
+++ b/CRM/Contact/Form/Edit/OpenIDBlockTrait.php
@@ -27,16 +27,16 @@ use Civi\Api4\Generic\Result;
 trait CRM_Contact_Form_Edit_OpenIDBlockTrait {
   use CRM_Contact_Form_Edit_BlockCustomDataTrait;
 
-  protected bool $isContactSummaryEdit = FALSE;
-
   /**
    * @var \Civi\Api4\Generic\Result
    */
   private Result $existingOpenIDs;
 
   /**
+   *
    * @return \Civi\Api4\Generic\Result
-   * @throws CRM_Core_Exception
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function getExistingOpenIDs() : Result {
     if (!isset($this->existingOpenIDs)) {
@@ -47,6 +47,21 @@ trait CRM_Contact_Form_Edit_OpenIDBlockTrait {
         ->execute();
     }
     return $this->existingOpenIDs;
+  }
+
+  /**
+   * Get the open ids indexed numerically from 1.
+   *
+   * This reflects historical form requirements.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function getExistingOpenIDsReIndexed() : array {
+    $result = array_merge([0 => 1], (array) $this->getExistingOpenIDs());
+    unset($result[0]);
+    return $result;
   }
 
   /**

--- a/CRM/Contact/Form/Inline/IM.php
+++ b/CRM/Contact/Form/Inline/IM.php
@@ -19,36 +19,38 @@
  * Form helper class for an IM object.
  */
 class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
+  use CRM_Contact_Form_Edit_IMBlockTrait;
+  use CRM_Contact_Form_ContactFormTrait;
 
   /**
    * Ims of the contact that is been viewed.
    * @var array
    */
-  private $_ims = [];
+  private array $_ims = [];
 
   /**
    * No of im blocks for inline edit.
    * @var int
    */
-  private $_blockCount = 6;
+  private int $_blockCount = 6;
 
   /**
    * Call preprocess.
    */
-  public function preProcess() {
+  public function preProcess(): void {
     parent::preProcess();
-
-    //get all the existing ims
-    $im = new CRM_Core_BAO_IM();
-    $im->contact_id = $this->_contactId;
-
-    $this->_ims = CRM_Core_BAO_Block::retrieveBlock($im);
+    // Get all the existing ims , The array historically starts
+    // with 1 not 0 so we do something nasty to continue that.
+    $this->_ims = array_merge([0 => 1], (array) $this->getExistingIMs());
+    unset($this->_ims[0]);
   }
 
   /**
    * Build the form object elements for im object.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     parent::buildQuickForm();
 
     $totalBlocks = $this->_blockCount;
@@ -68,10 +70,8 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
     $this->assign('actualBlockCount', $actualBlockCount);
     $this->assign('totalBlocks', $totalBlocks);
 
-    $this->applyFilter('__ALL__', 'trim');
-
     for ($blockId = 1; $blockId < $totalBlocks; $blockId++) {
-      CRM_Contact_Form_Edit_IM::buildQuickForm($this, $blockId, TRUE);
+      $this->addIMBlockFields($blockId);
     }
 
     $this->addFormRule(['CRM_Contact_Form_Inline_IM', 'formRule']);
@@ -120,7 +120,7 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
    *
    * @return array
    */
-  public function setDefaultValues() {
+  public function setDefaultValues(): array {
     $defaults = [];
     if (!empty($this->_ims)) {
       foreach ($this->_ims as $id => $value) {
@@ -137,20 +137,17 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
 
   /**
    * Process the form.
+   *
+   * @throws \CRM_Core_Exception
    */
-  public function postProcess() {
-    $params = $this->exportValues();
-
-    // Process / save IMs
-    $params['contact_id'] = $this->_contactId;
-    $params['updateBlankLocInfo'] = TRUE;
-    $params['im']['isIdSet'] = TRUE;
+  public function postProcess(): void {
+    $params = $this->getSubmittedValues();
     foreach ($this->_ims as $count => $value) {
       if (!empty($value['id']) && isset($params['im'][$count])) {
         $params['im'][$count]['id'] = $value['id'];
       }
     }
-    CRM_Core_BAO_Block::create('im', $params);
+    $this->saveIMs($params['im']);
 
     $this->log();
     $this->response();

--- a/CRM/Contact/Form/Inline/OpenID.php
+++ b/CRM/Contact/Form/Inline/OpenID.php
@@ -23,6 +23,13 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
   use CRM_Contact_Form_ContactFormTrait;
 
   /**
+   * Is this the contact summary edit screen.
+   *
+   * @var bool
+   */
+  protected bool $isContactSummaryEdit = FALSE;
+
+  /**
    * Ims of the contact that is been viewed.
    * @var array
    */
@@ -40,9 +47,8 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
   public function preProcess() {
     parent::preProcess();
     // Get all the existing ims , The array historically starts
-    // with 1 not 0 so we do something nasty to continue that.
-    $this->_openids = array_merge([0 => 1], (array) $this->getExistingOpenIDs());
-    unset($this->_openids[0]);
+    // with 1 not 0.
+    $this->_openids = $this->getExistingOpenIDsReIndexed();
   }
 
   /**

--- a/CRM/Contact/Form/Inline/OpenID.php
+++ b/CRM/Contact/Form/Inline/OpenID.php
@@ -19,6 +19,8 @@
  * Form helper class for an OpenID object.
  */
 class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
+  use CRM_Contact_Form_Edit_OpenIDBlockTrait;
+  use CRM_Contact_Form_ContactFormTrait;
 
   /**
    * Ims of the contact that is been viewed.
@@ -37,12 +39,10 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
    */
   public function preProcess() {
     parent::preProcess();
-
-    //get all the existing openids
-    $openid = new CRM_Core_BAO_OpenID();
-    $openid->contact_id = $this->_contactId;
-
-    $this->_openids = CRM_Core_BAO_Block::retrieveBlock($openid);
+    // Get all the existing ims , The array historically starts
+    // with 1 not 0 so we do something nasty to continue that.
+    $this->_openids = array_merge([0 => 1], (array) $this->getExistingOpenIDs());
+    unset($this->_openids[0]);
   }
 
   /**
@@ -71,7 +71,7 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
     $this->applyFilter('__ALL__', 'trim');
 
     for ($blockId = 1; $blockId < $totalBlocks; $blockId++) {
-      CRM_Contact_Form_Edit_OpenID::buildQuickForm($this, $blockId, TRUE);
+      $this->addOpenIDBlockFields($blockId);;
     }
 
     $this->addFormRule(['CRM_Contact_Form_Inline_OpenID', 'formRule']);
@@ -138,19 +138,16 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
   /**
    * Process the form.
    */
-  public function postProcess() {
-    $params = $this->exportValues();
+  public function postProcess(): void {
+    $params = $this->getSubmittedValues();
 
     // Process / save openID
-    $params['contact_id'] = $this->_contactId;
-    $params['updateBlankLocInfo'] = TRUE;
-    $params['openid']['isIdSet'] = TRUE;
     foreach ($this->_openids as $count => $value) {
       if (!empty($value['id']) && isset($params['openid'][$count])) {
         $params['openid'][$count]['id'] = $value['id'];
       }
     }
-    CRM_Core_BAO_Block::create('openid', $params);
+    $this->saveOpenIDss($params['openid']);
 
     $this->log();
     $this->response();

--- a/CRM/Contact/Page/Inline/IM.php
+++ b/CRM/Contact/Page/Inline/IM.php
@@ -19,13 +19,14 @@
  * Dummy page for details for IM.
  */
 class CRM_Contact_Page_Inline_IM extends CRM_Core_Page {
+  use CRM_Custom_Page_CustomDataTrait;
 
   /**
    * Run the page.
    *
    * This method is called after the page is created.
    */
-  public function run() {
+  public function run(): void {
     // get the emails for this contact
     $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
 
@@ -38,6 +39,7 @@ class CRM_Contact_Page_Inline_IM extends CRM_Core_Page {
       foreach ($ims as $key => & $value) {
         $value['location_type'] = $locationTypes[$value['location_type_id']];
         $value['provider'] = $IMProviders[$value['provider_id']];
+        $value['custom'] = $this->getCustomDataFieldsForEntityDisplay('IM', $value['id']);
       }
     }
 

--- a/CRM/Contact/Page/Inline/OpenID.php
+++ b/CRM/Contact/Page/Inline/OpenID.php
@@ -19,6 +19,9 @@
  * Dummy page for details for OpenID.
  */
 class CRM_Contact_Page_Inline_OpenID extends CRM_Core_Page {
+  use CRM_Custom_Page_CustomDataTrait;
+  use CRM_Contact_Form_Edit_OpenIDBlockTrait;
+  use CRM_Contact_Form_ContactFormTrait;
 
   /**
    * Run the page.
@@ -27,25 +30,20 @@ class CRM_Contact_Page_Inline_OpenID extends CRM_Core_Page {
    *
    * @throws \CRM_Core_Exception
    */
-  public function run() {
-    // get the emails for this contact
-    $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', CRM_Core_DAO::$_nullObject, TRUE);
-
-    $locationTypes = CRM_Core_BAO_Address::buildOptions('location_type_id');
-
-    $entityBlock = ['contact_id' => $contactId];
-    $openids = CRM_Core_BAO_OpenID::getValues($entityBlock);
+  public function run(): void {
+    $openids = (array) $this->getExistingOpenIDs();
     if (!empty($openids)) {
-      foreach ($openids as $key => & $value) {
-        $value['location_type'] = $locationTypes[$value['location_type_id']];
+      foreach ($openids as &$value) {
+        $value['location_type'] = $value['location_type_id:label'];
+        $value['custom'] = $this->getCustomDataFieldsForEntityDisplay('Openid', $value['id']);
       }
     }
 
-    $this->assign('contactId', $contactId);
+    $this->assign('contactId', $this->getContactID());
     $this->assign('openid', $openids);
 
     // check logged in user permission
-    CRM_Contact_Page_View::checkUserPermission($this, $contactId);
+    CRM_Contact_Page_View::checkUserPermission($this, $this->getContactID());
 
     // finally call parent
     parent::run();

--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -185,19 +185,12 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
     ];
 
     CRM_Contact_BAO_Contact::getValues(['id' => $this->_contactId], $defaults);
-    $defaults['im'] = $this->getLocationValues($this->_contactId, 'IM');
-    $emails = $this->getLocationValues($this->_contactId, 'Email');
-    foreach ($emails as $blockId => $email) {
-      $emails[$blockId]['custom'] = $this->addBlockCustomData('Email', $email['id']);
-    }
-    $this->assign('email', $emails);
-    $defaults['openid'] = $this->getLocationValues($this->_contactId, 'OpenID');
-    $phones = $this->getLocationValues($this->_contactId, 'Phone');
-    foreach ($phones as $blockId => $phone) {
-      $phones[$blockId]['custom'] = $this->addBlockCustomData('Phone', $phone['id']);
-    }
-    $this->assign('phone', $phones);
-    $defaults['website'] = $this->getLocationValues($this->_contactId, 'Website');
+    $this->assign('im', $this->getLocationValues($this->_contactId, 'IM'));
+    $this->assign('email', $this->getLocationValues($this->_contactId, 'Email'));
+    $this->assign('openid', $this->getLocationValues($this->_contactId, 'OpenID'));
+    $this->assign('phone', $this->getLocationValues($this->_contactId, 'Phone'));
+    $this->assign('website', $this->getLocationValues($this->_contactId, 'Website'));
+
     // Copy employer fields to the current_employer keys.
     if (($defaults['contact_type'] === 'Individual') && !empty($defaults['employer_id']) && !empty($defaults['organization_name'])) {
       $defaults['current_employer'] = $defaults['organization_name'];
@@ -538,6 +531,7 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
       foreach ($optionFields as $optionField) {
         $locationEntities[$index][$fieldMap[$optionField]] = $locationEntity[$optionField . ':label'];
       }
+      $locationEntities[$index]['custom'] = $this->addBlockCustomData($entity, $locationEntity['id']);
     }
     return $locationEntities;
   }

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2142,6 +2142,20 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
         'table_name' => 'civicrm_email',
         'allow_is_multiple' => FALSE,
       ],
+      [
+        'id' => 'IM',
+        'label' => ts('Ims'),
+        'grouping' => NULL,
+        'table_name' => 'civicrm_im',
+        'allow_is_multiple' => FALSE,
+      ],
+      [
+        'id' => 'OpenID',
+        'label' => ts('Open IDs'),
+        'grouping' => NULL,
+        'table_name' => 'civicrm_openid',
+        'allow_is_multiple' => FALSE,
+      ],
       // TODO: Move to civi_campaign extension (example: OptionValue_cg_extends_objects_grant.mgd.php)
       [
         'id' => 'Campaign',

--- a/templates/CRM/Contact/Form/Inline/IM.tpl
+++ b/templates/CRM/Contact/Form/Inline/IM.tpl
@@ -29,7 +29,7 @@
     </tr>
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
-    <tr id="IM_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
+    <tr data-entity='im' data-block-number={$blockId} id="IM_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
         <td>{$form.im.$blockId.name.html}&nbsp;</td>
         <td>{$form.im.$blockId.location_type_id.html}</td>
         <td>{$form.im.$blockId.provider_id.html}</td>
@@ -39,6 +39,7 @@
             <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete IM{/ts}"><span class="icon delete-icon"></span></a>
           {/if}
         </td>
+      {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=im customFields=$custom_fields_im blockId=$blockId actualBlockCount=$actualBlockCount}
     </tr>
     {/section}
 </table>

--- a/templates/CRM/Contact/Form/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Inline/OpenID.tpl
@@ -30,7 +30,7 @@
 
   {section name='i' start=1 loop=$totalBlocks}
   {assign var='blockId' value=$smarty.section.i.index}
-  <tr id="OpenID_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
+  <tr data-entity='openid' data-block-number={$blockId} id="OpenID_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
     <td>{$form.openid.$blockId.openid.html|crmAddClass:twenty}&nbsp;</td>
     <td>{$form.openid.$blockId.location_type_id.html}</td>
     <td align="center" id="OpenID-Primary-html" class="crm-openid-is_primary">{$form.openid.$blockId.is_primary.1.html}</td>
@@ -39,6 +39,7 @@
         <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete OpenID{/ts}"><span class="icon delete-icon"></span></a>
       {/if}
     </td>
+    {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=openid customFields=$custom_fields_openid blockId=$blockId actualBlockCount=$actualBlockCount}
   </tr>
   {/section}
 </table>

--- a/templates/CRM/Contact/Page/Inline/IM.tpl
+++ b/templates/CRM/Contact/Page/Inline/IM.tpl
@@ -29,6 +29,7 @@
           <div class="crm-content crm-contact_im">{$item.name}</div>
         </div>
         {/if}
+        {include file="CRM/Contact/Page/Inline/BlockCustomData.tpl" entity='im' customGroups=$item.custom identifier=$blockId}
       {/if}
     {/foreach}
    </div>

--- a/templates/CRM/Contact/Page/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Page/Inline/OpenID.tpl
@@ -29,6 +29,7 @@
           <a href="{$item.openid}">{$item.openid|mb_truncate:40}</a>
         </div>
       </div>
+        {include file="CRM/Contact/Page/Inline/BlockCustomData.tpl" entity='openid' customGroups=$item.custom identifier=$blockId}
       {/if}
     {/foreach}
    </div>


### PR DESCRIPTION
Overview
----------------------------------------
Enable custom data for IM & Open IDs

Before
----------------------------------------
Custom data can't be used

After
----------------------------------------
now it can

Technical Details
----------------------------------------
This is primarily about consistency - making the changes to these previously made to phone & email

Comments
----------------------------------------
