### PR TITLE
Follow on code consolidations

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -29,6 +29,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   use CRM_Custom_Form_CustomDataTrait;
   use CRM_Contact_Form_Edit_OpenIDBlockTrait;
   use CRM_Contact_Form_Edit_PhoneBlockTrait;
+  use CRM_Contact_Form_Edit_IMBlockTrait;
 
   /**
    * Is this the contact summary edit screen.
@@ -252,7 +253,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         }
         else {
           CRM_Contact_BAO_Contact::getValues(['id' => $this->_contactId, 'contact_id' => $this->_contactId], $this->_values);
-          $this->_values['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['im'] = $this->getExistingIMsReIndexed();
           $this->_values['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $this->_contactId]);
           $this->_values['openid'] = $this->getExistingOpenIDsReIndexed();
           $this->_values['phone'] = $this->getExistingPhonessReIndexed();
@@ -1478,7 +1479,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       return;
     }
     if ($name === 'IM') {
-      CRM_Contact_Form_Edit_IM::buildQuickForm($this, $instance);
+      $this->addOpenIDBlockFields($instance);
       return;
     }
     if ($name === 'Website') {

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -28,6 +28,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   use CRM_Contact_Form_ContactFormTrait;
   use CRM_Custom_Form_CustomDataTrait;
   use CRM_Contact_Form_Edit_OpenIDBlockTrait;
+  use CRM_Contact_Form_Edit_PhoneBlockTrait;
 
   /**
    * Is this the contact summary edit screen.
@@ -254,7 +255,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           $this->_values['im'] = CRM_Core_BAO_IM::getValues(['contact_id' => $this->_contactId]);
           $this->_values['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $this->_contactId]);
           $this->_values['openid'] = $this->getExistingOpenIDsReIndexed();
-          $this->_values['phone'] = CRM_Core_BAO_Phone::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['phone'] = $this->getExistingPhonessReIndexed();
           $this->_values['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $this->_contactId], TRUE);
           CRM_Core_BAO_Website::getValues(['contact_id' => $this->_contactId], $this->_values);
           $this->set('values', $this->_values);
@@ -1473,7 +1474,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       return;
     }
     if ($name === 'Phone') {
-      CRM_Contact_Form_Edit_Phone::buildQuickForm($this, $instance);
+      $this->addPhoneBlockFields($instance);
       return;
     }
     if ($name === 'IM') {

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -30,6 +30,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
   use CRM_Contact_Form_Edit_OpenIDBlockTrait;
   use CRM_Contact_Form_Edit_PhoneBlockTrait;
   use CRM_Contact_Form_Edit_IMBlockTrait;
+  use CRM_Contact_Form_Edit_EmailBlockTrait;
 
   /**
    * Is this the contact summary edit screen.
@@ -254,7 +255,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         else {
           CRM_Contact_BAO_Contact::getValues(['id' => $this->_contactId, 'contact_id' => $this->_contactId], $this->_values);
           $this->_values['im'] = $this->getExistingIMsReIndexed();
-          $this->_values['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $this->_contactId]);
+          $this->_values['email'] = $this->getExistingEmailsReIndexed();
           $this->_values['openid'] = $this->getExistingOpenIDsReIndexed();
           $this->_values['phone'] = $this->getExistingPhonessReIndexed();
           $this->_values['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $this->_contactId], TRUE);
@@ -923,7 +924,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         }
         switch ($blockName) {
           case 'Email':
-            CRM_Contact_Form_Edit_Email::buildQuickForm($this, $instance);
+            $this->addEmailBlockFields($instance);
             // Only display the signature fields if this contact has a CMS account
             // because they can only send email if they have access to the CRM
             $ufID = $this->_contactId && CRM_Core_BAO_UFMatch::getUFId($this->_contactId);
@@ -1491,7 +1492,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       return;
     }
     if ($name === 'Email') {
-      CRM_Contact_Form_Edit_Email::buildQuickForm($this, $instance);
+      $this->addEmailBlockFields($instance);
       return;
     }
     CRM_Core_Error::deprecatedWarning('unused?');

--- a/CRM/Contact/Form/Edit/BlockCustomDataTrait.php
+++ b/CRM/Contact/Form/Edit/BlockCustomDataTrait.php
@@ -54,9 +54,9 @@ trait CRM_Contact_Form_Edit_BlockCustomDataTrait {
       if ($field['input_type'] === 'File') {
         $this->registerFileField([$elementName]);
       }
-      $this->customFieldBlocks[$blockNumber][$field['name']] = $field;
+      $this->customFieldBlocks[$entity][$blockNumber][$field['name']] = $field;
     }
-    $this->assign('custom_fields_' . strtolower($entity), $this->customFieldBlocks);
+    $this->assign('custom_fields_' . strtolower($entity), $this->customFieldBlocks[$entity]);
   }
 
 }

--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -29,6 +29,7 @@ class CRM_Contact_Form_Edit_Email {
    *   Block number to build.
    * @param bool $blockEdit
    *   Is it block edit.
+   * @deprecated moving core usages to EmailBlockTrait
    */
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
     // passing this via the session is AWFUL. we need to fix this

--- a/CRM/Contact/Form/Edit/EmailBlockTrait.php
+++ b/CRM/Contact/Form/Edit/EmailBlockTrait.php
@@ -48,6 +48,21 @@ trait CRM_Contact_Form_Edit_EmailBlockTrait {
   }
 
   /**
+   * Get the open ids indexed numerically from 1.
+   *
+   * This reflects historical form requirements.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function getExistingEmailsReIndexed() : array {
+    $result = array_merge([0 => 1], (array) $this->getExistingEmails());
+    unset($result[0]);
+    return $result;
+  }
+
+  /**
    * @throws \CRM_Core_Exception
    */
   protected function addEmailBlockFields(int $blockNumber): void {

--- a/CRM/Contact/Form/Edit/IM.php
+++ b/CRM/Contact/Form/Edit/IM.php
@@ -29,8 +29,11 @@ class CRM_Contact_Form_Edit_IM {
    *   Block number to build.
    * @param bool $blockEdit
    *   Is it block edit.
+   *
+   * @deprecated since 6.3 will be removed around 6.10
    */
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if (!$blockCount) {
       CRM_Core_Error::deprecatedWarning('pass in blockCount');
       $blockId = ($form->get('IM_Block_Count')) ? $form->get('IM_Block_Count') : 1;

--- a/CRM/Contact/Form/Edit/IMBlockTrait.php
+++ b/CRM/Contact/Form/Edit/IMBlockTrait.php
@@ -32,8 +32,6 @@ trait CRM_Contact_Form_Edit_IMBlockTrait {
    */
   private Result $existingIMs;
 
-  protected bool $isContactSummaryEdit = FALSE;
-
   /**
    * @return \Civi\Api4\Generic\Result
    * @throws CRM_Core_Exception
@@ -47,6 +45,21 @@ trait CRM_Contact_Form_Edit_IMBlockTrait {
         ->execute();
     }
     return $this->existingIMs;
+  }
+
+  /**
+   * Get the open ids indexed numerically from 1.
+   *
+   * This reflects historical form requirements.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function getExistingIMsReIndexed() : array {
+    $result = array_merge([0 => 1], (array) $this->getExistingIMs());
+    unset($result[0]);
+    return $result;
   }
 
   /**

--- a/CRM/Contact/Form/Edit/Phone.php
+++ b/CRM/Contact/Form/Edit/Phone.php
@@ -29,6 +29,8 @@ class CRM_Contact_Form_Edit_Phone {
    *   Block number to build.
    * @param bool $blockEdit
    *   deprecated variable.
+   *
+   * @deprecated still used in core but PhoneBlockTrait is the apiv4 code that supports custom fields.
    */
   public static function buildQuickForm(&$form, $addressBlockCount = NULL, $blockEdit = FALSE) {
     // passing this via the session is AWFUL. we need to fix this

--- a/CRM/Contact/Form/Edit/PhoneBlockTrait.php
+++ b/CRM/Contact/Form/Edit/PhoneBlockTrait.php
@@ -48,6 +48,21 @@ trait CRM_Contact_Form_Edit_PhoneBlockTrait {
   }
 
   /**
+   * Get the open ids indexed numerically from 1.
+   *
+   * This reflects historical form requirements.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function getExistingPhonessReIndexed() : array {
+    $result = array_merge([0 => 1], (array) $this->getExistingPhones());
+    unset($result[0]);
+    return $result;
+  }
+
+  /**
    * @throws \CRM_Core_Exception
    */
   protected function addPhoneBlockFields(int $blockNumber): void {

--- a/CRM/Contact/Form/Inline/Email.php
+++ b/CRM/Contact/Form/Inline/Email.php
@@ -50,9 +50,8 @@ class CRM_Contact_Form_Inline_Email extends CRM_Contact_Form_Inline {
     $this->_contactId = $this->getContactID();
 
     // Get all the existing email addresses, The array historically starts
-    // with 1 not 0 so we do something nasty to continue that.
-    $this->_emails = array_merge([0 => 1], (array) $this->getExistingEmails());
-    unset($this->_emails[0]);
+    // with 1 not 0.
+    $this->_emails = $this->getExistingEmailsReIndexed();
 
     // Check if this contact has a first/last/organization/household name
     if ($this->getContactValue('contact_type') === 'Individual') {

--- a/CRM/Contact/Form/Inline/IM.php
+++ b/CRM/Contact/Form/Inline/IM.php
@@ -23,6 +23,13 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
   use CRM_Contact_Form_ContactFormTrait;
 
   /**
+   * Is this the contact summary edit screen.
+   *
+   * @var bool
+   */
+  protected bool $isContactSummaryEdit = FALSE;
+
+  /**
    * Ims of the contact that is been viewed.
    * @var array
    */
@@ -41,8 +48,7 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
     parent::preProcess();
     // Get all the existing ims , The array historically starts
     // with 1 not 0 so we do something nasty to continue that.
-    $this->_ims = array_merge([0 => 1], (array) $this->getExistingIMs());
-    unset($this->_ims[0]);
+    $this->_ims = $this->getExistingIMsReIndexed();
   }
 
   /**

--- a/CRM/Contact/Form/Inline/Phone.php
+++ b/CRM/Contact/Form/Inline/Phone.php
@@ -41,9 +41,8 @@ class CRM_Contact_Form_Inline_Phone extends CRM_Contact_Form_Inline {
   public function preProcess(): void {
     parent::preProcess();
     // Get all the existing phones , The array historically starts
-    // with 1 not 0 so we do something nasty to continue that.
-    $this->_phones = array_merge([0 => 1], (array) $this->getExistingPhones());
-    unset($this->_phones[0]);
+    // with 1 not 0.
+    $this->_phones = $this->getExistingPhonessReIndexed();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Follow on code consolidations

Before
----------------------------------------
legacy code still called from Contact edit

After
----------------------------------------
The newer traits are called

Technical Details
----------------------------------------
I can get the custom data to show & be editable in the Contact Edit form with a tpl tweak - but the html is broken when I do this so leaving out of scope

Screenshots are from the changes NOT included - showing the gap

![image](https://github.com/user-attachments/assets/ba6a9ce0-cca4-4364-93dc-d4b367bd26a8)

HTML - the custom fields are all at the bottom

![image](https://github.com/user-attachments/assets/05957639-ae17-47d1-98f7-6be0523dc280)



Comments
----------------------------------------