### PR TITLE
Consolidate a couple more places to use the traits to build location block forms

### DIFF
--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -95,7 +95,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
       unset($params['id']);
       $locParams = ['contact_id' => $domainDefaults['contact_id']];
       $this->_locationDefaults['address'] = $defaults['address'] = CRM_Core_BAO_Address::getValues($locParams);
-      $this->_locationDefaults['phone'] = $defaults['phone'] = $this->getExistingPhonessReIndexed();
+      $this->_locationDefaults['phone'] = $defaults['phone'] = $this->getExistingPhonesReIndexed();
       $this->_locationDefaults['email'] = $defaults['email'] = $this->getExistingEmailsReIndexed();
       $config = CRM_Core_Config::singleton();
       if (!isset($defaults['address'][1]['country_id'])) {

--- a/CRM/Contact/Form/Domain.php
+++ b/CRM/Contact/Form/Domain.php
@@ -19,6 +19,8 @@
  * This class is to build the form for adding Group.
  */
 class CRM_Contact_Form_Domain extends CRM_Core_Form {
+  use CRM_Contact_Form_Edit_PhoneBlockTrait;
+  use CRM_Contact_Form_Edit_EmailBlockTrait;
 
   /**
    * The group id, used when editing a group
@@ -92,8 +94,9 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
 
       unset($params['id']);
       $locParams = ['contact_id' => $domainDefaults['contact_id']];
-      $this->_locationDefaults = $defaults = CRM_Core_BAO_Location::getValues($locParams);
-
+      $this->_locationDefaults['address'] = $defaults['address'] = CRM_Core_BAO_Address::getValues($locParams);
+      $this->_locationDefaults['phone'] = $defaults['phone'] = $this->getExistingPhonessReIndexed();
+      $this->_locationDefaults['email'] = $defaults['email'] = $this->getExistingEmailsReIndexed();
       $config = CRM_Core_Config::singleton();
       if (!isset($defaults['address'][1]['country_id'])) {
         $defaults['address'][1]['country_id'] = $config->defaultContactCountry;
@@ -128,7 +131,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
       'label' => ts('Email 1'),
     ]);
     $this->addRule("email[1][email]", ts('Email is not valid.'), 'email');
-    CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);
+    $this->addPhoneBlockFields(1);
 
     $this->addButtons([
       [
@@ -167,7 +170,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
    */
   public static function formRule($fields) {
     // check for state/country mapping
-    $errors = CRM_Contact_Form_Edit_Address::formRule($fields, CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullObject);
+    $errors = CRM_Contact_Form_Edit_Address::formRule($fields);
     // $errors === TRUE means no errors from above formRule excution,
     // so declaring $errors to array for further processing
     if ($errors === TRUE) {
@@ -185,7 +188,7 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
    * Process the form when submitted.
    */
   public function postProcess() {
-    $params = $this->exportValues();
+    $params = $this->getSubmittedValues();
     $params['entity_id'] = $this->_id;
     $params['entity_table'] = CRM_Core_BAO_Domain::getTableName();
     $domain = CRM_Core_BAO_Domain::edit($params, $this->_id);
@@ -235,6 +238,10 @@ class CRM_Contact_Form_Domain extends CRM_Core_Form {
     CRM_Core_Session::setStatus(ts("Domain information for '%1' has been saved.", [1 => $domain->name]), ts('Saved'), 'success');
     $session = CRM_Core_Session::singleton();
     $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin', 'reset=1'));
+  }
+
+  public function getContactID() {
+    return CRM_Core_BAO_Domain::getDomain()->contact_id;
   }
 
 }

--- a/CRM/Contact/Form/Edit/Email.php
+++ b/CRM/Contact/Form/Edit/Email.php
@@ -29,9 +29,11 @@ class CRM_Contact_Form_Edit_Email {
    *   Block number to build.
    * @param bool $blockEdit
    *   Is it block edit.
-   * @deprecated moving core usages to EmailBlockTrait
+   *
+   * @deprecated since 6.3 will be removed around 6.10
    */
   public static function buildQuickForm(&$form, $blockCount = NULL, $blockEdit = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     // passing this via the session is AWFUL. we need to fix this
     if (!$blockCount) {
       CRM_Core_Error::deprecatedWarning('pass in blockCount');

--- a/CRM/Contact/Form/Edit/Phone.php
+++ b/CRM/Contact/Form/Edit/Phone.php
@@ -30,9 +30,10 @@ class CRM_Contact_Form_Edit_Phone {
    * @param bool $blockEdit
    *   deprecated variable.
    *
-   * @deprecated still used in core but PhoneBlockTrait is the apiv4 code that supports custom fields.
+   * @deprecated since 6.3 will be removed around 6.10
    */
   public static function buildQuickForm(&$form, $addressBlockCount = NULL, $blockEdit = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     // passing this via the session is AWFUL. we need to fix this
     if (!$addressBlockCount) {
       CRM_Core_Error::deprecatedWarning('pass in blockCount');

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -26,6 +26,8 @@ use Civi\Api4\Phone;
  * civicrm_event_page.
  */
 class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
+  use CRM_Contact_Form_Edit_PhoneBlockTrait;
+  use CRM_Contact_Form_Edit_EmailBlockTrait;
 
   /**
    * @var \Civi\Api4\Generic\Result
@@ -134,10 +136,10 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
    */
   public function buildQuickForm() {
     CRM_Contact_Form_Edit_Address::buildQuickForm($this, 1);
-    CRM_Contact_Form_Edit_Email::buildQuickForm($this, 1);
-    CRM_Contact_Form_Edit_Email::buildQuickForm($this, 2);
-    CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 1);
-    CRM_Contact_Form_Edit_Phone::buildQuickForm($this, 2);
+    $this->addEmailBlockNonContactFields(1);
+    $this->addEmailBlockNonContactFields(2);
+    $this->addPhoneBlockFields(1);
+    $this->addPhoneBlockFields(2);
 
     $this->applyFilter('__ALL__', 'trim');
 


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate a couple more places to use the traits to build location block forms

Before
----------------------------------------
Still using the old static function


After
----------------------------------------
Switched

Technical Details
----------------------------------------
Note that this will help us to expose the custom data fields but does not, of itself do that

Comments
----------------------------------------
This is the final PR in my clean up on this code - there is now contact summary support for custom fields for Phone, IM and Open ID on Contact summary in place edit, consistent with Email & Address & the code is broadly similar for all except Address which does not have a Trait (& which was converted much earlier).

The code would mostly support custom fields for those entities in other places but the TPL layer is not there for it
