### PR TITLE
dev/core#5851 Further fix on inability to add processor

### DIFF
--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -131,7 +131,6 @@ function _financialacls_civicrm_get_accounts_clause(): string {
       $clause = '= 0';
       Civi::$statics['financial_acls'][__FUNCTION__][CRM_Core_Session::getLoggedInContactID()] = &$clause;
       $accounts = (array) EntityFinancialAccount::get()
-        ->addWhere('entity_table', '=', 'civicrm_financial_type')
         ->addSelect('entity_id', 'financial_account_id')
         ->addJoin('FinancialType AS financial_type', 'LEFT', [
           'entity_id',

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialAccountTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/FinancialAccountTest.php
@@ -21,12 +21,14 @@ class FinancialAccountTest extends BaseTestClass {
     $this->setupLoggedInUserWithLimitedFinancialTypeAccess();
     $financialAccounts = FinancialAccount::get(FALSE)->execute();
     $this->assertCount(14, $financialAccounts);
-    $restrictedAccounts = FinancialAccount::get()->addOrderBy('id')->execute();
-    $this->assertCount(4, $restrictedAccounts);
-    $this->assertEquals('Donation', $restrictedAccounts[0]['name']);
+    $restrictedAccounts = FinancialAccount::get()->addOrderBy('name')->execute();
+    $this->assertCount(6, $restrictedAccounts);
+    $this->assertEquals('Accounts Receivable', $restrictedAccounts[0]['name']);
     $this->assertEquals('Banking Fees', $restrictedAccounts[1]['name']);
-    $this->assertEquals('Accounts Receivable', $restrictedAccounts[2]['name']);
-    $this->assertEquals('Premiums', $restrictedAccounts[3]['name']);
+    $this->assertEquals('Deposit Bank Account', $restrictedAccounts[2]['name']);
+    $this->assertEquals('Donation', $restrictedAccounts[3]['name']);
+    $this->assertEquals('Payment Processor Account', $restrictedAccounts[4]['name']);
+    $this->assertEquals('Premiums', $restrictedAccounts[5]['name']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5851 Further fix on inability to add processor

Before
----------------------------------------
1) log in as demo user
2) enable financial acls
3) attempt to add a payment processor 

After
----------------------------------------
It is possible again
![image](https://github.com/user-attachments/assets/54adf755-df4d-49ea-9077-45c7a2bc9076)

Technical Details
----------------------------------------
This picks up the outstanding part of https://github.com/civicrm/civicrm-core/pull/30643 - re-reading it I am unsure whether this line is disputed or not given @JoeMurray saying 

> I don't have a strong view about the viewability of accounts that are not in an EntityFinancialAccount relationship with any financial type. I tend to think it is safer to not have them viewable, but I won't insist.

https://github.com/civicrm/civicrm-core/pull/30643#issuecomment-2223510466

However, the current state of the issue is that it is waiting for some combo of @JoeMurray @monishdeb or @Edzelopez to review this change or propose an alternative that allows the creating of payment processors....

Comments
----------------------------------------
