### PR TITLE
RiverLea: fixes two code block regressions

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -365,11 +365,20 @@ dl dl {
 }
 .crm-container pre.prettyprint {
   background: var(--crm-c-text-light); /* method to force light bg on prettyprint code as inverting is too complex */
-  white-space: normal;
+  white-space: pre;
+  text-wrap: auto;
 }
 .crm-container pre.linenums {
   background: var(--crm-c-text-light);
   color: var(--crm-c-text-dark);
+}
+.crm-container ol.linenums {
+  list-style-type: decimal;
+  margin-inline: 0;
+  padding-inline-start: 5ch;
+}
+.crm-container ol.linenums li:nth-of-type(5n) {
+  list-style: inherit !important; /* vs WordPress list-style reset */
 }
 .crm-container td > code {
   display: block;


### PR DESCRIPTION
Three parts to this:
----------------------------------------
1. fix for regression 1 - indenting is vanished from `pre.prettyprint` code blocks, since a fix to make code block lines wrap inside their container 1.3.8-6.0alpha.
2. fix for regression 2 - line numbering has maybe been lost in prettyprint codet blocks perhaps forever.
3. fix for the cause of regression 1 - an alternative way for code block lines to wrap.

None of these problems exist in Greenwich.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/e81c970b-38af-4f6e-9618-aa9c70a72c94)
![image](https://github.com/user-attachments/assets/a931242b-b505-443d-9109-c0ffbcd0b7e5)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/1dafa036-61ec-40f3-a78c-f76597dd6148)
Line-wrapping still works:
![image](https://github.com/user-attachments/assets/18f78a3e-01a5-4a6c-aa68-cba2531d1296)

Technical Details
----------------------------------------
PrettyPrint was using a more complex method to hide the numbers 1-4 and 6-9, this method just uses `nth-of-type`.