### PR TITLE
Update location form test to use wrapper

### DIFF
--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -60,7 +60,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
     $this->setSelectedChild('location');
 
     $this->_values = $this->get('values');
-    if ($this->_id && empty($this->_values)) {
+    if ($this->getEventID() && empty($this->_values)) {
       //get location values.
       $params = [
         'entity_id' => $this->_id,
@@ -212,7 +212,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
        * affects the selected LocBlock and not the previous one - whether or not
        * there is a previous LocBlock.
        */
-      CRM_Core_DAO::setFieldValue('CRM_Event_DAO_Event', $this->_id,
+      CRM_Core_DAO::setFieldValue('CRM_Event_DAO_Event', $this->getEventID(),
         'loc_block_id', $params['loc_event_id']
       );
 
@@ -353,7 +353,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
     $params['loc_block_id'] = LocBlock::save(FALSE)->setRecords([$record])->execute()->first()['id'];
 
     // Finally update Event params.
-    $params['id'] = $this->_id;
+    $params['id'] = $this->getEventID();
     Event::save(FALSE)->addRecord($params)->execute();
 
     // Update tab "disabled" CSS class.

--- a/Civi/Test/FormWrapper.php
+++ b/Civi/Test/FormWrapper.php
@@ -240,6 +240,7 @@ class FormWrapper {
     $this->form = new $class();
     $_SERVER['REQUEST_METHOD'] = 'GET';
     $_REQUEST = array_merge($_REQUEST, $urlParameters);
+    $_GET = array_merge($_GET, $urlParameters);
     switch ($class) {
       case 'CRM_Event_Cart_Form_Checkout_Payment':
       case 'CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices':

--- a/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
+++ b/tests/phpunit/CRM/Event/Form/ManageEvent/LocationTest.php
@@ -274,11 +274,8 @@ class CRM_Event_Form_ManageEvent_LocationTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   protected function submitForm(array $formValues, int $eventID): void {
-    $form = $this->getFormObject('CRM_Event_Form_ManageEvent_Location', array_merge($this->getFormValues(), $formValues));
-    $form->set('id', $eventID);
-    $form->preProcess();
-    $form->buildQuickForm();
-    $form->postProcess();
+    $form = $this->getTestForm('CRM_Event_Form_ManageEvent_Location', array_merge($this->getFormValues(), $formValues), ['id' => $eventID]);
+    $form->processForm();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update location form test to use wrapper

Before
----------------------------------------
Doesn't use latest method

After
----------------------------------------
now it does

Technical Details
----------------------------------------
This form specifically looks in `$_GET` for the id - unlike the others which use `$_REQUEST` so I added to the test wrapper

Comments
----------------------------------------
