### PR TITLE
Use api to get phone & email, narrow getLocations call

### DIFF
--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -121,8 +121,11 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * Get the location values of a domain.
    *
    * @return CRM_Core_BAO_Location[]|NULL
+   *
+   * @deprecated since 6.3 will be removed around 6.13.
    */
   public function getLocationValues() {
+    CRM_Core_Error::deprecatedFunctionWarning('use the api');
     if ($this->_location == NULL) {
       $params = [
         'contact_id' => $this->contact_id,

--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -63,6 +63,7 @@ class CRM_Utils_Address {
       $fullPostalCode .= '-' . $fields['postal_code_suffix'];
     }
     self::addLabelFields($fields, str_contains($formatted, '{country_id.world_region'));
+
     $replacements = [
       'contact.display_name' => $fields['display_name'] ?? NULL,
       'contact.formal_title' => $fields['formal_title'] ?? NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Use api to get phone & email, narrow getLocations call

Before
----------------------------------------
generic call to hated `getLocations()`

After
----------------------------------------
More specific calls

Technical Details
----------------------------------------
This is a step towards separating this call out from the other callers of `getValues()` - we know that many of those calls SHOULD respect permissions but this one should NOT - this should help to land https://github.com/civicrm/civicrm-core/pull/32665

Comments
----------------------------------------
The first 2 commits have been put up as separate PRs https://github.com/civicrm/civicrm-core/pull/32744