### PR TITLE
Remove unnecessary code

### DIFF
--- a/CRM/Contact/Page/View/Print.php
+++ b/CRM/Contact/Page/View/Print.php
@@ -35,20 +35,4 @@ class CRM_Contact_Page_View_Print extends CRM_Contact_Page_View_Summary {
     return parent::run();
   }
 
-  /**
-   * View summary details of a contact.
-   */
-  public function view() {
-    $params = [];
-    $defaults = [];
-    $ids = [];
-
-    $params['id'] = $params['contact_id'] = $this->_contactId;
-    $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults, $ids);
-
-    $this->assign('pageTitle', $contact->sort_name);
-
-    return parent::view();
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove unnecessary code

The print screen calls `$contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults, $ids);` but only uses the results to assign the sort name - which is assigned by the parent without this code

Before
----------------------------------------
Unchanged from
![image](https://github.com/user-attachments/assets/8e623314-2ef1-4496-be55-abd9b36df68c)


After
----------------------------------------
Unchanged

![image](https://github.com/user-attachments/assets/2f063496-eb40-46d5-96be-35725fd8d051)

Technical Details
----------------------------------------
I'm trying to get to the bottom of / rationalise the callers referring to `microformat` & this is passing `$ids` (albeit emptily) so I wanted to investigate it & found I could remove it

Comments
----------------------------------------
