### PR TITLE
Clarify that microformat is never passed to Contact::retrieve

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -772,11 +772,14 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    *   (reference ) an assoc array to hold the name / value pairs.
    *                        in a hierarchical manner
    * @param bool $microformat
-   *   For location in microformat.
+   *   Deprecated value
    *
    * @return CRM_Contact_BAO_Contact
    */
   public static function &retrieve(&$params, &$defaults = [], $microformat = FALSE) {
+    if ($microformat) {
+      CRM_Core_Error::deprecatedWarning('microformat is deprecated in CRM_Contact_BAO_Contact::retrieve');
+    }
     if (array_key_exists('contact_id', $params)) {
       $params['id'] = $params['contact_id'];
     }

--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -40,7 +40,7 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
 
     $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     $params['id'] = $params['contact_id'] = $this->_contactId;
-    $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults, $ids);
+    $contact = CRM_Contact_BAO_Contact::retrieve($params, $defaults);
     $this->_displayName = $contact->display_name;
     $this->_email = $contact->email;
     $this->setTitle(ts('Create User Record for %1', [1 => $this->_displayName]));

--- a/CRM/Contact/Page/View/Vcard.php
+++ b/CRM/Contact/Page/View/Vcard.php
@@ -33,10 +33,9 @@ class CRM_Contact_Page_View_Vcard extends CRM_Contact_Page_View {
 
     $params = [];
     $defaults = [];
-    $ids = [];
 
     $params['id'] = $params['contact_id'] = $this->_contactId;
-    CRM_Contact_BAO_Contact::retrieve($params, $defaults, $ids);
+    CRM_Contact_BAO_Contact::retrieve($params, $defaults);
 
     // now that we have the contact's data - let's build the vCard
     // TODO: non-US-ASCII support (requires changes to the Contact_Vcard_Build class)


### PR DESCRIPTION
The only calls pass an empty ids array which does NOT resolve to TRUE.
