### PR TITLE
Finish deprecating smarty location variable in event templates

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2378,13 +2378,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
       CRM_Event_BAO_Event::retrieve($eventParams, $values['event']);
 
-      //get location details
-      $locationParams = [
-        'entity_id' => $eventID,
-        'entity_table' => 'civicrm_event',
-      ];
-      $values['location'] = CRM_Core_BAO_Location::getValues($locationParams);
-
       //for tasks 'Change Participant Status' and 'Update multiple Contributions' case
       //and cases involving status updation through ipn
       // whatever that means!
@@ -2734,7 +2727,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $template->assign('title', $values['event']['title']);
       $template->assign('event', $values['event']);
       $template->assign('participant', $values['participant']);
-      $template->assign('location', $values['location']);
       $template->assign('customPre', $values['custom_pre_id']);
       $template->assign('customPost', $values['custom_post_id']);
 
@@ -4551,13 +4543,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
     $values['participant']['customGroup'] = $participantCustomGroup;
-
-    //get location details
-    $locationParams = [
-      'entity_id' => $eventID,
-      'entity_table' => 'civicrm_event',
-    ];
-    $values['location'] = CRM_Core_BAO_Location::getValues($locationParams);
 
     $ufJoinParams = [
       'entity_table' => 'civicrm_event',

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1202,10 +1202,6 @@ UPDATE  civicrm_participant
 
         //get default participant role.
         $eventDetails[$eventId]['participant_role'] = $participantRoles[$eventDetails[$eventId]['default_role_id']] ?? NULL;
-
-        //get the location info
-        $locParams = ['entity_id' => $eventId, 'entity_table' => 'civicrm_event'];
-        $eventDetails[$eventId]['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);
       }
     }
 

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -625,16 +625,6 @@ SELECT  id, html_type
 
     $this->assign('event', $event);
 
-    $this->assign('isShowLocation', $event['is_show_location']);
-    if (($event['is_show_location'] ?? NULL) == 1) {
-      $locationParams = [
-        'entity_id' => $params['event_id'],
-        'entity_table' => 'civicrm_event',
-      ];
-      $location = CRM_Core_BAO_Location::getValues($locationParams, TRUE);
-      $this->assign('location', $location);
-    }
-
     if ($this->_isPaidEvent) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
       if (!$this->_mode) {

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -418,9 +418,6 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails[$this->_event_id]);
     //get default participant role.
     $eventDetails[$this->_event_id]['participant_role'] = $participantRoles[$eventDetails[$this->_event_id]['default_role_id']] ?? NULL;
-    //get the location info
-    $locParams = ['entity_id' => $this->_event_id, 'entity_table' => 'civicrm_event'];
-    $eventDetails[$this->_event_id]['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);
     //send a 'cancelled' email to user, and cc the event's cc_confirm email
     CRM_Event_BAO_Participant::sendTransitionParticipantMail($this->_from_participant_id,
       $participantDetails[$this->_from_participant_id],

--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -354,12 +354,7 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
 
     //get default participant role.
     $eventDetails['participant_role'] = $participantRoles[$eventDetails['default_role_id']] ?? NULL;
-    //get the location info
-    $locParams = [
-      'entity_id' => $participant->event_id,
-      'entity_table' => 'civicrm_event',
-    ];
-    $eventDetails['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);
+
     $toEmail = $contactDetails['email'] ?? NULL;
     if ($toEmail) {
       //take a receipt from as event else domain.

--- a/CRM/Event/Form/SelfSvcUpdate.php
+++ b/CRM/Event/Form/SelfSvcUpdate.php
@@ -295,9 +295,6 @@ class CRM_Event_Form_SelfSvcUpdate extends CRM_Core_Form {
     CRM_Event_BAO_Event::retrieve($eventParams, $eventDetails[$this->_event_id]);
     //get default participant role.
     $eventDetails[$this->_event_id]['participant_role'] = $participantRoles[$eventDetails[$this->_event_id]['default_role_id']] ?? NULL;
-    //get the location info
-    $locParams = ['entity_id' => $this->_event_id, 'entity_table' => 'civicrm_event'];
-    $eventDetails[$this->_event_id]['location'] = CRM_Core_BAO_Location::getValues($locParams, TRUE);
 
     //send a 'cancelled' email to user, and cc the event's cc_confirm email
     $statusMsg = ts('Event registration for %1 has been cancelled.', [1 => $this->_contact_name]);

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -351,13 +351,6 @@ class CRM_Financial_BAO_Payment {
     if (!empty($participantRecords)) {
       $entities['participant'] = $participantRecords[0]['api.Participant.get']['values'][0];
       $entities['event'] = civicrm_api3('Event', 'getsingle', ['id' => $entities['participant']['event_id']]);
-      if (!empty($entities['event']['is_show_location'])) {
-        $locationParams = [
-          'entity_id' => $entities['event']['id'],
-          'entity_table' => 'civicrm_event',
-        ];
-        $entities['location'] = CRM_Core_BAO_Location::getValues($locationParams, TRUE);
-      }
     }
 
     return $entities;
@@ -403,7 +396,6 @@ class CRM_Financial_BAO_Payment {
       'receive_date' => $entities['payment']['trxn_date'],
       'paidBy' => CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_FinancialTrxn', 'payment_instrument_id', $entities['payment']['payment_instrument_id']),
       'isShowLocation' => (!empty($entities['event']) ? $entities['event']['is_show_location'] : FALSE),
-      'location' => $entities['location'] ?? NULL,
       'event' => $entities['event'] ?? NULL,
       'component' => (!empty($entities['event']) ? 'event' : 'contribution'),
       'isRefund' => $entities['payment']['total_amount'] < 0,
@@ -439,7 +431,6 @@ class CRM_Financial_BAO_Payment {
       'receive_date',
       'paidBy',
       'isShowLocation',
-      'location',
       'isRefund',
       'refundAmount',
       'totalPaid',

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -86,16 +86,6 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
 
     $event_values = [];
     CRM_Core_DAO::storeValues($event, $event_values);
-
-    $location = [];
-    if (($event_values['is_show_location'] ?? NULL) == 1) {
-      $location['address'] = CRM_Core_BAO_Address::getValues([
-        'entity_id' => $participant->event_id,
-        'entity_table' => 'civicrm_event',
-      ], TRUE);
-      CRM_Core_BAO_Address::fixAddress($location['address'][1]);
-    }
-
     [$pre_id, $post_id] = CRM_Event_Cart_Form_MerParticipant::get_profile_groups($participant->event_id);
     $payer_values = [
       'email' => '',
@@ -111,7 +101,6 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
     $values = [
       'params' => [$participant->id => $participantParams],
       'event' => $event_values,
-      'location' => $location,
       'custom_pre_id' => $pre_id,
       'custom_post_id' => $post_id,
       'payer' => $payer_values,


### PR DESCRIPTION
Overview
----------------------------------------
Finish deprecating smarty location variable in event templates

Before
----------------------------------------
In 2023 we took the `{$location}` variable out of the online & offline event templates. However, some sites might still have the variable in their templates and we never took any more aggressive steps to address

After
----------------------------------------
In 6.3 we attempt to do replace for any templates that still have this variable.  If they still have it after that they will get a system notice (probably unlikely for this variable). In addition the variable is no longer assigned & will not be rendered if present

Technical Details
----------------------------------------
The calls to render this token call `CRM_Core_BAO_Location::getValues($locationParams, TRUE);` - this is a function that @MegaphoneJon is working on adding permissions to - which might make it unreliable so completing the deprecation feels like the best path here


Comments
----------------------------------------
