### PR TITLE
Add some smarty variables to deprecated list

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1742,12 +1742,40 @@ class CRM_Utils_Token {
           '$contributionTypeName' => 'contribution.financial_type_id:label',
           '$trxn_id' => 'contribution.trxn_id',
           '$participant_status_id' => 'participant.status_id',
-
+          '$participant.role' => 'participant.role_id:label',
         ],
         'event_online_receipt' => [
           '`$participant.id`' => 'participant.id',
           '$dataArray' => ts('see default template for how to show this'),
           '$individual' => ts('see default template for how to show this'),
+          '$location' => 'event.location',
+          '$participant.role' => 'participant.role_id:label',
+          '$event.participant_role' => 'participant.role_id:label',
+        ],
+        'participant_transferred' => [
+          '$location' => 'event.location',
+          '$participant.role' => 'participant.role_id:label',
+          '$event.participant_role' => 'participant.role_id:label',
+        ],
+        'participant_cancelled' => [
+          '$location' => 'event.location',
+          '$participant.role' => 'participant.role_id:label',
+          '$event.participant_role' => 'participant.role_id:label',
+        ],
+        'participant_expired' => [
+          '$location' => 'event.location',
+          '$participant.role' => 'participant.role_id:label',
+          '$event.participant_role' => 'participant.role_id:label',
+        ],
+        'participant_confirm' => [
+          '$location' => 'event.location',
+          '$participant.role' => 'participant.role_id:label',
+          '$event.participant_role' => 'participant.role_id:label',
+        ],
+        'payment_or_refund_notification' => [
+          '$location' => 'event.location',
+          '$participant.role' => 'participant.role_id:label',
+          '$event.participant_role' => 'participant.role_id:label',
         ],
         'pledge_acknowledgement' => [
           '$domain' => ts('no longer available / relevant'),


### PR DESCRIPTION
Overview
----------------------------------------
Add some smarty variables to deprecated list

Before
----------------------------------------
We have not had any noise about the following smarty variables  which we will stop assigning soon

`{$event.location}`  - affected by proposed permission changes to underlying templates, fully removed from core templates in 2023 https://github.com/civicrm/civicrm-core/pull/32742

`{participant.role} - removed from core templates in Jan 2024 & subsequently the replacement was removed https://github.com/civicrm/civicrm-core/pull/30322 due to it being seen to be of low value & poor translation

After
----------------------------------------
We have created some noise - if anyone has data disappear from their templates, that they notice, they will have a pointer as to why

Technical Details
----------------------------------------


Comments
----------------------------------------

