### PR TITLE
Slight simplification of legacy code

### DIFF
--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -120,7 +120,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('General', $msg['html']);
 
-    $this->ids['contact'] = $this->_contactId = $this->individualCreate(['prefix_id' => 'Dr.', 'first_name' => 'Donald', 'last_name' => 'Duck', 'email' => 'the-don@duckville.com']);
+    $this->ids['contact'] = $this->_contactId = $this->_contributionParams['contact_id'] = $this->individualCreate(['prefix_id' => 'Dr.', 'first_name' => 'Donald', 'last_name' => 'Duck', 'email' => 'the-don@duckville.com']);
     $contribution = $this->callAPISuccess('contribution', 'create', array_merge($this->_contributionParams, ['invoice_id' => 'abc']));
     $this->_contributionId = $contribution['id'];
 


### PR DESCRIPTION
Overview
----------------------------------------
Slight simplification of legacy code

Before
----------------------------------------
`payment_processor_id` loaded from `relatedObjects` in a confusing way

After
----------------------------------------
Retrieve it in-function by the api

Technical Details
----------------------------------------
possibly one more get here - but then again we are no longer loading the recurring contribution object

Comments
----------------------------------------

@mattwire I looked at this code again - arg - I really want to see the back of `_relatedObjects()` but most of what they are doing relate to assigning smarty values to the template that are no longer used due to the tokens being in use now - sigh - https://github.com/civicrm/civicrm-core/pull/32745