### PR TITLE
Stop assigning legacy smarty variable event.participant_role

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2761,12 +2761,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
     if ($this->_component === 'event') {
       $template->assign('title', $values['event']['title']);
-      $participantRoles = CRM_Event_PseudoConstant::participantRole();
-      $viewRoles = [];
-      foreach (explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_relatedObjects['participant']->role_id) as $k => $v) {
-        $viewRoles[] = $participantRoles[$v];
-      }
-      $values['event']['participant_role'] = implode(', ', $viewRoles);
       $template->assign('event', $values['event']);
       $template->assign('participant', $values['participant']);
       $template->assign('location', $values['location']);


### PR DESCRIPTION


Overview
----------------------------------------
Stop assigning legacy smarty variable event.participant_role



Before
----------------------------------------
Code ensures legacy `$event.participant_role` is assigned

After
----------------------------------------
it no longer does

Technical Details
----------------------------------------
We migrated the templates to use tokens at the start of 2024 - but then they got removed too https://github.com/civicrm/civicrm-core/pull/30322 by @mlutfy  I added a status warning in 6.3 https://github.com/civicrm/civicrm-core/pull/32745 that the smarty variable is deprecated

We don't plan on assigning the legacy tokens forever as we can make our code much more maintainable & predictable by removing them over time

This feels low hanging as it is generally considered to be of low value in the receipt and it also removes a reference to the dreaded 'relatedObjects'


Comments
----------------------------------------
