### PR TITLE
Rename multisite is_enabled setting

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -295,7 +295,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
 
     $params['contact_id'] = $contact->id;
 
-    if (!$isEdit && Civi::settings()->get('is_enabled')) {
+    if (!$isEdit && Civi::settings()->get('multisite_is_enabled')) {
       // Enabling multisite causes the contact to be added to the domain group.
       $domainGroupID = CRM_Core_BAO_Domain::getGroupId();
       if (!empty($domainGroupID)) {

--- a/CRM/Contact/Page/View.php
+++ b/CRM/Contact/Page/View.php
@@ -361,7 +361,7 @@ class CRM_Contact_Page_View extends CRM_Core_Page {
   protected function getGroupOrganizationUrl(string $contactType): string {
     if ($contactType !== 'Organization' || !CRM_Core_Permission::check('administer Multiple Organizations')
       || !CRM_Contact_BAO_GroupOrganization::hasGroupAssociated($this->_contactId)
-      || !Civi::settings()->get('is_enabled')
+      || !Civi::settings()->get('multisite_is_enabled')
     ) {
       return '';
     }

--- a/CRM/Contact/Page/View/GroupContact.php
+++ b/CRM/Contact/Page/View/GroupContact.php
@@ -163,7 +163,7 @@ class CRM_Contact_Page_View_GroupContact extends CRM_Core_Page {
     }
 
     $groupNum = CRM_Contact_BAO_GroupContact::getContactGroup($contactID, 'Added', NULL, TRUE, TRUE);
-    if ($groupNum == 1 && $groupStatus == 'Removed' && Civi::settings()->get('is_enabled')) {
+    if ($groupNum == 1 && $groupStatus == 'Removed' && Civi::settings()->get('multisite_is_enabled')) {
       CRM_Core_Session::setStatus(ts('Please ensure at least one contact group association is maintained.'), ts('Could Not Remove'));
       return FALSE;
     }

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -258,7 +258,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
     }
 
     $domainGroupID = Civi::settings()->get('domain_group_id');
-    $multisite = Civi::settings()->get('is_enabled');
+    $multisite = Civi::settings()->get('multisite_is_enabled');
 
     if ($domainGroupID) {
       $groupID = $domainGroupID;

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1828,7 +1828,7 @@ class CRM_Core_Permission {
    * @return bool
    */
   public static function isMultisiteEnabled() {
-    return (bool) Civi::settings()->get('is_enabled');
+    return (bool) Civi::settings()->get('multisite_is_enabled');
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixThree.php
+++ b/CRM/Upgrade/Incremental/php/SixThree.php
@@ -36,10 +36,16 @@ class CRM_Upgrade_Incremental_php_SixThree extends CRM_Upgrade_Incremental_Base 
     for ($i = 1; $i <= $iterations; $i++) {
       $this->addTask('Delete non-attachment rows from civicrm_entity_file', 'deleteNonAttachmentFiles', $i);
     }
+    $this->addTask('Rename multisite_is_enabled setting', 'renameMultisiteSetting');
   }
 
   public static function deleteNonAttachmentFiles(): bool {
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_entity_file WHERE entity_table LIKE "civicrm_value_%" LIMIT ' . self::BATCH_SIZE);
+    return TRUE;
+  }
+
+  public static function renameMultisiteSetting(): bool {
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_setting SET name = "multisite_is_enabled" WHERE name = "is_enabled"');
     return TRUE;
   }
 

--- a/Civi/Managed/MultisiteManaged.php
+++ b/Civi/Managed/MultisiteManaged.php
@@ -30,7 +30,7 @@ class MultisiteManaged extends AutoService implements EventSubscriberInterface {
    */
   public function generateDomainEntities(array &$managedRecords): void {
     $multisiteEnabled = Setting::get(FALSE)
-      ->addSelect('is_enabled')
+      ->addSelect('multisite_is_enabled')
       ->execute()->first();
     if (empty($multisiteEnabled['value'])) {
       return;

--- a/settings/Multisite.setting.php
+++ b/settings/Multisite.setting.php
@@ -20,11 +20,10 @@
  */
 
 return [
-  // FIXME: This is arguably the worst name for a setting ever
-  'is_enabled' => [
+  'multisite_is_enabled' => [
     'group_name' => 'Multi Site Preferences',
     'group' => 'multisite',
-    'name' => 'is_enabled',
+    'name' => 'multisite_is_enabled',
     'title' => ts('Enable Multi Site Configuration'),
     'html_type' => 'checkbox',
     'type' => 'Boolean',

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -57,7 +57,7 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
   public function tearDown(): void {
     \Civi::settings()->revert('debug_enabled');
     // Disable multisite
-    \Civi::settings()->revert('is_enabled');
+    \Civi::settings()->revert('multisite_is_enabled');
     parent::tearDown();
   }
 
@@ -685,7 +685,7 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     $this->assertSame(['name'], $result[0]['params']['match']);
 
     // Enable multisite with multiple domains
-    \Civi::settings()->set('is_enabled', TRUE);
+    \Civi::settings()->set('multisite_is_enabled', TRUE);
     Domain::create(FALSE)
       ->addValue('name', 'Another domain')
       ->addValue('version', CRM_Utils_System::version())


### PR DESCRIPTION
Overview
----------------------------------------
Per the comment "  // FIXME: This is arguably the worst name for a setting ever" let's rename it to something sensible.

Before
----------------------------------------
Multisite enabled controlled by setting `is_enabled`

After
----------------------------------------
Multisite enabled controlled by setting `multisite_is_enabled`

Technical Details
----------------------------------------
Related PRs:
* https://github.com/christianwach/civicrm-admin-utilities/pull/41
* https://lab.civicrm.org/extensions/multisite/-/merge_requests/16

Comments
----------------------------------------

