### PR TITLE
Properly replicate managed entities when not all domains are multisite enabled

### DIFF
--- a/Civi/Managed/MultisiteManaged.php
+++ b/Civi/Managed/MultisiteManaged.php
@@ -3,7 +3,6 @@
 namespace Civi\Managed;
 
 use Civi\Api4\Domain;
-use Civi\Api4\Setting;
 use Civi\Core\Service\AutoService;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -29,10 +28,17 @@ class MultisiteManaged extends AutoService implements EventSubscriberInterface {
    * @param array $managedRecords
    */
   public function generateDomainEntities(array &$managedRecords): void {
-    $multisiteEnabled = Setting::get(FALSE)
-      ->addSelect('multisite_is_enabled')
-      ->execute()->first();
-    if (empty($multisiteEnabled['value'])) {
+    // Clear the domains cache in case we added/removed domains (mostly happens in tests)
+    unset($this->domains);
+    // If *any* of the domains are multisite-enabled, then we need to replicate the records.
+    $multisiteEnabled = FALSE;
+    foreach ($this->getDomains() as $domainId) {
+      if (\Civi::settings($domainId)->get('multisite_is_enabled')) {
+        $multisiteEnabled = TRUE;
+        break;
+      }
+    }
+    if (!$multisiteEnabled) {
       return;
     }
 

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -709,6 +709,26 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
       $this->assertCount(1, $result);
       $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
     }
+
+    // Now we test Domain 1 NOT multisite enabled (ie. "global")
+    // all other domains multisite enabled
+    \Civi::settings($allDomains->first()['id'])->set('multisite_is_enabled', FALSE);
+
+    $managedRecords = [];
+    \CRM_Utils_Hook::managed($managedRecords, ['unit.test.fake.ext']);
+
+    // Base entity should not have been renamed
+    $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
+    $this->assertCount(1, $result);
+    $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
+
+    // New item should have been inserted for extra domains
+    foreach (array_slice($allDomains->column('id'), 1) as $domain) {
+      $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains_' . $domain]);
+      $this->assertCount(1, $result);
+      $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
+    }
+
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -673,7 +673,7 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
           'icon' => 'crm-i test',
           'permission' => ['access CiviCRM'],
           'weight' => 50,
-          'domain_id' => 'current_domain',
+          // 'domain_id' => 'current_domain', // This is implied if not set
         ],
         'match' => ['name'],
       ],
@@ -684,14 +684,16 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     $this->assertCount(1, $result);
     $this->assertSame(['name'], $result[0]['params']['match']);
 
-    // Enable multisite with multiple domains
-    \Civi::settings()->set('multisite_is_enabled', TRUE);
     Domain::create(FALSE)
       ->addValue('name', 'Another domain')
       ->addValue('version', CRM_Utils_System::version())
       ->execute()->single();
     $allDomains = Domain::get(FALSE)->addSelect('id')->addOrderBy('id')->execute();
     $this->assertGreaterThan(1, $allDomains->count());
+    foreach ($allDomains as $domain) {
+      // Enable multisite with multiple domains
+      \Civi::settings($domain['id'])->set('multisite_is_enabled', TRUE);
+    }
 
     $managedRecords = [];
     \CRM_Utils_Hook::managed($managedRecords, ['unit.test.fake.ext']);


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/32750 for the first part (rename multisite setting).

This fixes the issue described in https://lab.civicrm.org/dev/core/-/issues/5114 where one domain is not multisite enabled but the others are.

Before
----------------------------------------
Running Managed.reconcile (or clear caches) on domain which is not multisite enabled causes managed entities/jobs to be deleted for other domains.

After
----------------------------------------
Running Managed.reconcile (or clear caches) on domain which is not multisite enabled checks if any domain is multisite enabled and runs the "multisite copy entities to all domains" code so we always have per-domain managed entities copied to all domains and no random moving/deleting of them!


Technical Details
----------------------------------------
The multisite managed entity code checked the is_enabled setting only for it's own domain. But if any domain is multisite enabled we need to handle managed entities in multisite mode. So we now loop through domains until we find one that is multisite enabled.

Comments
----------------------------------------
@JKingsnorth @andyburnsco 
