### PR TITLE
Autocomplete - Fix broken scroll-loading

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -617,7 +617,7 @@ if (!CRM.vars) CRM.vars = {};
           results: function(data) {
             return {
               results: data.values,
-              more: data.count > data.countFetched
+              more: data.countMatched > data.countFetched
             };
           },
         },


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the "infinite scroll" feature in autocompletes.

Before
----------------------------------------
More than 15 results not shown in autocomplete.
If searching by id, only 1 result is shown.

After
----------------------------------------
All results shown.

Technical Details
--------------------------
I'm not sure why the js code was wrong, but the unit tests are clear that it should be `countMatched` instead of `count`:
https://github.com/civicrm/civicrm-core/blob/bebc0c953a76679bd5dbf57579c47ed428a1e5a1/tests/phpunit/api/v4/Action/AutocompleteTest.php#L303