### PR TITLE
[NFC] fix edge case in testFileHash

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/FileTest.php
+++ b/tests/phpunit/CRM/Core/BAO/FileTest.php
@@ -153,13 +153,11 @@ class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
    * @return array
    */
   public function fileHashProvider() {
-    $currentTimestamp = time();
-
     return [
       // Test case 1: Valid token with a specific fileId
       'valid_file_hash' => [
         'fileId' => 123,
-        'genTs' => $currentTimestamp,
+        'genTs' => 'now',
         'life' => 1,
         'expectedResult' => TRUE,
       ],
@@ -168,7 +166,7 @@ class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
       'expired_file_hash' => [
         'fileId' => 123,
         // Token generated 2 hours ago
-        'genTs' => $currentTimestamp - (2 * 60 * 60),
+        'genTs' => '2 hours ago',
         'life' => 1,
         'expectedResult' => FALSE,
       ],
@@ -176,7 +174,7 @@ class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
       // Test case 3: Invalid fileId
       'invalid_file_id' => [
         'fileId' => 123,
-        'genTs' => $currentTimestamp,
+        'genTs' => 'now',
         'life' => 1,
         'expectedResult' => FALSE,
         'invalidFileId' => 999,
@@ -190,6 +188,11 @@ class CRM_Core_BAO_FileTest extends CiviUnitTestCase {
    * @dataProvider fileHashProvider
    */
   public function testFileHash($fileId, $genTs, $life, $expectedResult, $invalidFileId = NULL) {
+    // We generate it now from its word description because dataproviders run
+    // at the start of the suite, so could have expired already in a
+    // long-running suite.
+    $genTs = strtotime($genTs);
+
     // Generate token
     $token = CRM_Core_BAO_File::generateFileHash(NULL, $fileId, $genTs, $life);
 


### PR DESCRIPTION
Overview
----------------------------------------
This test has been failing intermittently in another environment.

Before
----------------------------------------
token is effectively created relative to when the dataprovider is evaluated

After
----------------------------------------
token is effectively created relative to when the testFileHash test is run

Technical Details
----------------------------------------
Dataproviders are evaluated at the start of a phpunit run. In a long-running test suite, it could be over an hour before the actual test that uses it runs. Since the first testcase in this specific test is testing that the token is valid if it's less than an hour old, it can fail.

Comments
----------------------------------------
It doesn't come up in jenkins here because the tests were split up some time ago to improve performance and the suite this runs in never goes over 1 hour.
