### PR TITLE
[SearchKit] Use native data types in spreadsheet export

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -197,11 +197,11 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @param array $column
    * @param array $data
    * @param array $settings
-   * @return array{val: mixed, links: array, edit: array, label: string, title: string, image: array, cssClass: string}
+   * @return array{dataType: ?string, val: mixed, links: array, edit: array, label: string, title: string, image: array, cssClass: string}
    */
   private function formatColumn(array $column, array $data, array $settings) {
     $column += ['rewrite' => NULL, 'label' => NULL, 'key' => '', 'type' => NULL];
-    $out = [];
+    $out = ['dataType' => NULL];
     switch ($column['type']) {
       case 'field':
       case 'html':
@@ -209,15 +209,18 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $key = str_replace('()', ':', $column['key']);
         $rawValue = $data[$key] ?? NULL;
         if (!$this->hasValue($rawValue) && isset($column['empty_value'])) {
+          $out['dataType'] = 'String';
           $out['val'] = $this->replaceTokens($column['empty_value'], $data, 'view');
         }
         elseif ($column['rewrite']) {
+          $out['dataType'] = 'String';
           $out['val'] = $this->rewrite($column['rewrite'], $data);
         }
         else {
-          $dataType = $this->getSelectExpression($key)['dataType'] ?? NULL;
+          $out['dataType'] = $dataType = $this->getSelectExpression($key)['dataType'] ?? NULL;
           $out['val'] = $this->formatViewValue($key, $rawValue, $data, $dataType, $column['format'] ?? NULL);
         }
+
         if ($this->hasValue($column['label']) && (!empty($column['forceLabel']) || $this->hasValue($out['val']))) {
           $out['label'] = $this->replaceTokens($column['label'], $data, 'view');
         }
@@ -1478,7 +1481,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @param string $select
    * @return string|null
    */
-  private function getCurrencyField(string $select): ?string {
+  protected function getCurrencyField(string $select): ?string {
     // This function is called one or more times per row so cache the results
     if (array_key_exists($select, $this->currencyFields)) {
       return $this->currencyFields[$select];

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -83,9 +83,22 @@ class Download extends AbstractRunAction {
     if (($dataType === 'Date' || $dataType === 'Timestamp') && in_array($this->format, ['csv', 'xlsx', 'ods'])) {
       return $rawValue;
     }
-    else {
+
+    if (in_array($this->format, ['array', 'csv'], TRUE)) {
       return parent::formatViewValue($key, $rawValue, $data, $dataType, $format);
     }
+
+    if ($dataType === 'Money') {
+      $currencyField = $this->getCurrencyField($key);
+      $currency = is_string($data[$currencyField] ?? NULL) ? $data[$currencyField] : \Civi::settings()->get('defaultCurrency');
+
+      return [
+        'currency' => $currency,
+        'value' => $rawValue,
+      ];
+    }
+
+    return $rawValue;
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -2,9 +2,12 @@
 
 namespace Civi\Api4\Action\SearchDisplay;
 
+use Civi\Util\PhpSpreadsheetUtil;
 use League\Csv\Writer;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat\Wizard\Currency;
 
 trait ResultDataTrait {
 
@@ -120,13 +123,31 @@ trait ResultDataTrait {
     // Header row
     foreach (array_values($columns) as $index => $col) {
       $sheet->setCellValue([$index + 1, 1], $col['label']);
-      $sheet->getColumnDimensionByColumn($index)->setAutoSize(TRUE);
+      $sheet->getColumnDimensionByColumn($index + 1)->setAutoSize(TRUE);
     }
 
+    global $civicrmLocale;
+    $moneyLocale = $civicrmLocale->moneyFormat ?? (\Civi::settings()->get('format_locale') ?? \CRM_Core_I18n::getLocale());
+
     foreach ($rows as $rowNum => $data) {
-      $colNum = 1;
-      foreach ($columns as $index => $col) {
-        $sheet->setCellValue([$colNum++, $rowNum + 2], $this->formatColumnValue($col, $data['columns'][$index]));
+      foreach ($columns as $colNum => $col) {
+        $value = $data['columns'][$colNum];
+        $cell = $sheet->getCell([$colNum + 1, $rowNum + 2]);
+        $cell->setValue($this->formatColumnValue($col, $value));
+
+        if ($value['dataType'] === 'Money') {
+          $numberFormatter = new \NumberFormatter($moneyLocale . '@currency=' . $value['val']['currency'], \NumberFormatter::CURRENCY);
+          $currencySymbol = $numberFormatter->getSymbol(\NumberFormatter::CURRENCY_SYMBOL);
+          $cell->getStyle()->getNumberFormat()->setFormatCode(new Currency($currencySymbol, locale: $numberFormatter->getLocale()));
+        }
+        elseif ($value['dataType'] === 'Date') {
+          $format = \Civi::settings()->get(($col['format'] ?? NULL) ?: 'dateformatFull');
+          $cell->getStyle()->getNumberFormat()->setFormatCode(PhpSpreadsheetUtil::crmDateFormatToFormatCode($format));
+        }
+        elseif ($value['dataType'] === 'Timestamp') {
+          $format = \Civi::settings()->get(($col['format'] ?? NULL) ?: 'dateformatDatetime');
+          $cell->getStyle()->getNumberFormat()->setFormatCode(PhpSpreadsheetUtil::crmDateFormatToFormatCode($format));
+        }
       }
     }
 
@@ -140,10 +161,21 @@ trait ResultDataTrait {
    *
    * @param array $col
    * @param array $value
-   * @return string
+   * @return scalar|null
    */
   protected function formatColumnValue(array $col, array $value) {
-    $val = $value['val'] ?? '';
+    $val = $value['val'];
+
+    if (!in_array($this->format, ['array', 'csv'], TRUE)) {
+      if ($value['dataType'] === 'Money') {
+        return $val['value'];
+      }
+
+      if (($value['dataType'] === 'Date' || $value['dataType'] === 'Timestamp') && ($val !== NULL)) {
+        return Date::stringToExcel($val);
+      }
+    }
+
     return is_array($val) ? implode(', ', $val) : $val;
   }
 

--- a/ext/search_kit/Civi/Util/PhpSpreadsheetUtil.php
+++ b/ext/search_kit/Civi/Util/PhpSpreadsheetUtil.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Util;
+
+final class PhpSpreadsheetUtil {
+
+  /**
+   * Converts a format string that is compatible with
+   * \CRM_Utils_Date::customFormat() to a format code for PhpSpreadsheet.
+   *
+   * @see \CRM_Utils_Date::customFormat()
+   * @see https://phpspreadsheet.readthedocs.io/en/latest/topics/The%20Dating%20Game/#formatting-options
+   */
+  public static function crmDateFormatToFormatCode(string $format): string {
+    // Drop strings like " Uhr" or " o'clock".
+    $format = preg_replace('/( (?!%)[^%\s]+)/', '', $format);
+    // Drop everything after a format character that is neither a punctuation character nor whitespace.
+    $format = preg_replace('/(%[a-zA-Z])[^\p{P}\s]+/', '$1', $format);
+    // Drop everything after a punctuation character ("%" excluded) that is not "%" or whitespace.
+    $format = preg_replace('/(?!%)([\p{P}])[^%\s]+/', '$1', $format);
+
+    return trim(strtr($format, [
+      '%A' => 'dddd',
+      '%a' => 'ddd',
+      '%b' => 'mmm',
+      '%B' => 'mmmm',
+      '%d' => 'dd',
+      '%e' => ' d',
+      '%E' => 'd',
+      // Number suffixes like "st" or "nd" are not possible.
+      '%f' => '',
+      '%H' => 'hh',
+      '%h' => 'hh',
+      '%I' => 'hh',
+      '%k' => ' h',
+      '%l' => ' h',
+      '%m' => 'mm',
+      '%M' => 'mm',
+      '%i' => 'mm',
+      '%p' => 'AM/PM',
+      '%P' => 'AM/PM',
+      '%Y' => 'yyyy',
+      '%y' => 'yy',
+      '%s' => 'ss',
+      '%S' => 'ss',
+      // Timezone is not possible.
+      '%Z' => '',
+    ]));
+  }
+
+}

--- a/ext/search_kit/tests/phpunit/Civi/Util/PhpSpreadsheetUtilTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Util/PhpSpreadsheetUtilTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Util;
+
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\Util\PhpSpreadsheetUtil
+ *
+ * @group headless
+ */
+final class PhpSpreadsheetUtilTest extends TestCase implements HeadlessInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testCrmDateFormatToFormatCode(): void {
+    static::assertSame('mmmm d, yyyy  h:mm AM/PM', PhpSpreadsheetUtil::crmDateFormatToFormatCode('%B %E%f, %Y %l:%M %P'));
+    static::assertSame('mm/dd/yyyy', PhpSpreadsheetUtil::crmDateFormatToFormatCode('%m/%d/%Y'));
+    static::assertSame('dd.mm.yyyy, hh:mm', PhpSpreadsheetUtil::crmDateFormatToFormatCode('%d.%m.%Y, %H:%M Uhr'));
+    static::assertSame('h', PhpSpreadsheetUtil::crmDateFormatToFormatCode("%l o'clock"));
+
+    // No real world formats, just for test.
+    static::assertSame('mm/dd/yyyy', PhpSpreadsheetUtil::crmDateFormatToFormatCode('%mTest/%d/%Y'));
+    static::assertSame('mm:dd/yyyy', PhpSpreadsheetUtil::crmDateFormatToFormatCode('%mTe:st/%d/%Y'));
+  }
+
+}

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -3,8 +3,12 @@ namespace api\v4\SearchDisplay;
 
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
+use Civi\Api4\Event;
+use Civi\Api4\OptionValue;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 
 /**
  * @group headless
@@ -167,6 +171,225 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     }
     catch (\CRM_Core_Exception_PrematureExitException $e) {
       // All good, we expected the api to exit
+    }
+  }
+
+  /**
+   * Test downloading xlsx format.
+   */
+  public function testDownloadXlsxContact(): void {
+    $cid = Contact::create(FALSE)
+      ->setValues([
+        'first_name' => 'Test',
+        'birth_date' => '2020-05-23',
+        'do_not_email' => FALSE,
+        'do_not_mail' => TRUE,
+      ])->execute()->single()['id'];
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'xlsx',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'where' => [['id', '=', $cid]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'test',
+        'settings' => [
+          'actions' => TRUE,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'id',
+              'label' => 'Contact ID',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'first_name',
+              'label' => 'First Name',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'birth_date',
+              'label' => 'Birth Date',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'do_not_email',
+              'label' => 'Do Not Email',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'do_not_mail',
+              'label' => 'Do Not Mail (rewrite)',
+              'rewrite' => 'rewrite: [do_not_mail]',
+            ],
+          ],
+        ],
+      ],
+      'afform' => NULL,
+    ];
+
+    ob_start();
+    try {
+      civicrm_api4('SearchDisplay', 'download', $params);
+      static::fail();
+    }
+    catch (\CRM_Core_Exception_PrematureExitException $e) {
+      // All good, we expected the api to exit
+    }
+
+    $xlsx = ob_get_clean();
+    $tmpFile = tempnam(sys_get_temp_dir(), 'SearchDownloadTestXslx');
+    try {
+      file_put_contents($tmpFile, $xlsx);
+      $reader = IOFactory::createReader('Xlsx');
+      $spreadsheet = $reader->load($tmpFile);
+      $sheet = $spreadsheet->getSheet(0);
+
+      static::assertSame(2, $sheet->getHighestRow());
+      static::assertSame('E', $sheet->getHighestColumn());
+
+      static::assertSame('Contact ID', $sheet->getCell('A1')->getValue());
+      static::assertSame($cid, $sheet->getCell('A2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('A2')->getDataType());
+      static::assertSame('General', $sheet->getCell('A2')->getStyle()->getNumberFormat()->getFormatCode());
+
+      static::assertSame('First Name', $sheet->getCell('B1')->getValue());
+      static::assertSame('Test', $sheet->getCell('B2')->getValue());
+      static::assertSame(DataType::TYPE_STRING, $sheet->getCell('B2')->getDataType());
+
+      static::assertSame('Birth Date', $sheet->getCell('C1')->getValue());
+      static::assertSame(43974.0, $sheet->getCell('C2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('C2')->getDataType());
+      static::assertSame('mmmm d, yyyy', $sheet->getCell('C2')->getStyle()->getNumberFormat()->getFormatCode());
+
+      static::assertSame('Do Not Email', $sheet->getCell('D1')->getValue());
+      static::assertFalse($sheet->getCell('D2')->getValue());
+      static::assertSame(DataType::TYPE_BOOL, $sheet->getCell('D2')->getDataType());
+
+      static::assertSame('Do Not Mail (rewrite)', $sheet->getCell('E1')->getValue());
+      static::assertSame('rewrite: 1', $sheet->getCell('E2')->getValue());
+      static::assertSame(DataType::TYPE_STRING, $sheet->getCell('E2')->getDataType());
+    }
+    finally {
+      unlink($tmpFile);
+    }
+  }
+
+  /**
+   * Test downloading xlsx format.
+   */
+  public function testDownloadXlsxEvent(): void {
+    $eventTypeId = OptionValue::create(FALSE)
+      ->setValues([
+        'option_group_id.name' => 'event_type',
+        'name' => 'test',
+        'label' => 'test',
+      ])
+      ->execute()->single()['value'];
+    $eventId = Event::create(FALSE)
+      ->setValues([
+        'title' => 'test',
+        'event_type_id' => $eventTypeId,
+        'start_date' => '2020-05-23',
+        'end_date' => '2020-05-24 01:02:03',
+        'min_initial_amount' => 1.23,
+      ])->execute()->single()['id'];
+    // API doesn't allow to set created_date.
+    \CRM_Core_DAO::executeQuery('UPDATE civicrm_contact SET created_date = "2025-05-23 01:02:03" WHERE id = ' . $eventId);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'xlsx',
+      'savedSearch' => [
+        'api_entity' => 'Event',
+        'api_params' => [
+          'version' => 4,
+          'where' => [['id', '=', $eventId]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'test',
+        'settings' => [
+          'actions' => TRUE,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'id',
+              'label' => 'Event ID',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'start_date',
+              'label' => 'Start Date',
+              // Use default format.
+              'format' => '',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'end_date',
+              'label' => 'End Date',
+              'format' => 'dateformatshortdate',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'min_initial_amount',
+              'label' => 'Minimum Initial Amount',
+            ],
+          ],
+        ],
+      ],
+      'afform' => NULL,
+    ];
+
+    ob_start();
+    try {
+      civicrm_api4('SearchDisplay', 'download', $params);
+      static::fail();
+    }
+    catch (\CRM_Core_Exception_PrematureExitException $e) {
+      // All good, we expected the api to exit
+    }
+
+    $xlsx = ob_get_clean();
+    $tmpFile = tempnam(sys_get_temp_dir(), 'SearchDownloadTestXslx');
+    try {
+      file_put_contents($tmpFile, $xlsx);
+      $reader = IOFactory::createReader('Xlsx');
+      $spreadsheet = $reader->load($tmpFile);
+      $sheet = $spreadsheet->getSheet(0);
+
+      static::assertSame(2, $sheet->getHighestRow());
+      static::assertSame('D', $sheet->getHighestColumn());
+
+      static::assertSame('Event ID', $sheet->getCell('A1')->getValue());
+      static::assertSame($eventId, $sheet->getCell('A2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('A2')->getDataType());
+      static::assertSame('General', $sheet->getCell('A2')->getStyle()->getNumberFormat()->getFormatCode());
+
+      static::assertSame('Start Date', $sheet->getCell('B1')->getValue());
+      static::assertSame(43974.0, $sheet->getCell('B2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('B2')->getDataType());
+      static::assertSame('mmmm d, yyyy  h:mm AM/PM', $sheet->getCell('B2')->getStyle()->getNumberFormat()->getFormatCode());
+
+      static::assertSame('End Date', $sheet->getCell('C1')->getValue());
+      static::assertSame(43975.043090278, $sheet->getCell('C2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('C2')->getDataType());
+      static::assertSame('mm/dd/yyyy', $sheet->getCell('C2')->getStyle()->getNumberFormat()->getFormatCode());
+
+      static::assertSame('Minimum Initial Amount', $sheet->getCell('D1')->getValue());
+      static::assertSame(1.23, $sheet->getCell('D2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('D2')->getDataType());
+      static::assertSame('[$$-en-US]#,##0.00', $sheet->getCell('D2')->getStyle()->getNumberFormat()->getFormatCode());
+    }
+    finally {
+      unlink($tmpFile);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
On SearchKit export to ODS or XLSX native types will be used for the various data types (bool, numeric, strings) . This allows for example numeric values (including date, timestamp, and money values) to be used in calculations when modifying the exported document. For date, timestamp, and money fields an appropriate number format is set.

Before
----------------------------------------
Every value is exported as string.

After
----------------------------------------
Native types are used on spreadsheet export, not only string.

Technical Details
----------------------------------------
For money fields the [Currency "Wizard"](https://phpspreadsheet.readthedocs.io/en/latest/topics/Behind%20the%20Mask/#currency) is used.

For dates and timestamps the CiviCRM format is converted to a [spreadsheet format](https://phpspreadsheet.readthedocs.io/en/latest/topics/The%20Dating%20Game/#formatting-options). (Not for everything exists an exact equivalent).