### PR TITLE
REF: ContributionPage: Replace direct access to _ccid with getter function

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -267,7 +267,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   public function preProcess() {
     parent::preProcess();
-    $this->_ccid = $this->get('ccid');
+    $this->_ccid = $this->getExistingContributionID();
 
     $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
@@ -471,7 +471,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $params = $this->_params;
     // make sure we have values for it
-    if (!empty($this->_values['honoree_profile_id']) && !empty($params['soft_credit_type_id']) && empty($this->_ccid)) {
+    if (!empty($this->_values['honoree_profile_id']) && !empty($params['soft_credit_type_id']) && empty($this->getExistingContributionID())) {
       $honorName = NULL;
       $softCreditTypes = CRM_Core_OptionGroup::values("soft_credit_type", FALSE);
 
@@ -520,7 +520,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
     }
     $this->assign('membershipBlock', FALSE);
-    if (CRM_Core_Component::isEnabled('CiviMember') && empty($this->_ccid)) {
+    if (CRM_Core_Component::isEnabled('CiviMember') && empty($this->getExistingContributionID())) {
       if (isset($params['selectMembership']) &&
         $params['selectMembership'] !== 'no_thanks'
       ) {
@@ -531,7 +531,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
     }
 
-    if (empty($this->_ccid)) {
+    if (empty($this->getExistingContributionID())) {
       $this->buildCustom($this->_values['custom_pre_id'], 'customPre', TRUE);
       $this->buildCustom($this->_values['custom_post_id'], 'customPost', TRUE);
     }
@@ -540,7 +540,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       !empty($params['onbehalf']) &&
       ($this->_values['is_for_organization'] == 2 ||
         !empty($params['is_for_organization'])
-      ) && empty($this->_ccid)
+      ) && empty($this->getExistingContributionID())
     ) {
       $fieldTypes = ['Contact', 'Organization'];
       $contactSubType = CRM_Contact_BAO_ContactType::subTypes('Organization');
@@ -563,20 +563,20 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $this->assign('priceSetID', $this->_priceSetId);
     $contributionButtonText = $this->getPaymentProcessorObject()->getText('contributionPageButtonText', [
-      'is_payment_to_existing' => !empty($this->_ccid),
+      'is_payment_to_existing' => !empty($this->getExistingContributionID()),
       'amount' => $this->_amount,
     ]);
     $this->assign('button', $contributionButtonText);
 
     $this->assign('continueText',
       $this->getPaymentProcessorObject()->getText('contributionPageContinueText', [
-        'is_payment_to_existing' => !empty($this->_ccid),
+        'is_payment_to_existing' => !empty($this->getExistingContributionID()),
         'amount' => $this->_amount,
       ])
     );
     $this->assign('confirmText',
       $this->getPaymentProcessorObject()->getText('contributionPageConfirmText', [
-        'is_payment_to_existing' => !empty($this->_ccid),
+        'is_payment_to_existing' => !empty($this->getExistingContributionID()),
         'amount' => $this->_amount,
       ])
     );
@@ -2035,7 +2035,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // organization params in a separate variable, to make sure
     // normal behavior is continued. And use that variable to
     // process on-behalf-of functionality.
-    if (!empty($this->_values['onbehalf_profile_id']) && empty($this->_ccid)) {
+    if (!empty($this->_values['onbehalf_profile_id']) && empty($this->getExistingContributionID())) {
       $behalfOrganization = [];
       $orgFields = ['organization_name', 'organization_id', 'org_option'];
       foreach ($orgFields as $organizationField) {

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -124,7 +124,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     // Make the contributionPageID available to the template
     $this->assign('contributionPageID', $this->_id);
-    $this->assign('ccid', $this->_ccid);
+    $this->assign('ccid', $this->getExistingContributionID());
     $this->assign('isShare', $this->_values['is_share'] ?? NULL);
     $this->assign('isConfirmEnabled', $this->_values['is_confirm_enabled'] ?? NULL);
 
@@ -318,7 +318,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   public function buildQuickForm() {
     // build profiles first so that we can determine address fields etc
     // and then show copy address checkbox
-    if (empty($this->_ccid)) {
+    if (empty($this->getExistingContributionID())) {
       $this->buildCustom($this->_values['custom_pre_id'], 'customPre');
       $this->buildCustom($this->_values['custom_post_id'], 'customPost');
 
@@ -340,8 +340,8 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     $this->applyFilter('__ALL__', 'trim');
-    $this->assign('showMainEmail', (empty($this->_ccid) && $this->_emailExists === FALSE));
-    if (empty($this->_ccid)) {
+    $this->assign('showMainEmail', (empty($this->getExistingContributionID()) && $this->_emailExists === FALSE));
+    if (empty($this->getExistingContributionID())) {
       if ($this->_emailExists == FALSE) {
         $this->add('text', "email-{$this->_bltID}",
           ts('Email Address'),
@@ -366,7 +366,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     //build pledge block.
     //don't build membership block when pledge_id is passed
-    if (empty($this->_values['pledge_id']) && empty($this->_ccid)) {
+    if (empty($this->_values['pledge_id']) && empty($this->getExistingContributionID())) {
       $this->_separateMembershipPayment = FALSE;
       if (CRM_Core_Component::isEnabled('CiviMember')) {
         $this->_separateMembershipPayment = $this->buildMembershipBlock();
@@ -382,7 +382,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->add('hidden', 'priceSetId', $this->_priceSetId);
       // build price set form.
       $this->set('priceSetId', $this->_priceSetId);
-      if (empty($this->_ccid)) {
+      if (empty($this->getExistingContributionID())) {
         $this->buildPriceSet();
       }
       if ($this->_values['is_monetary'] &&
@@ -393,19 +393,19 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     }
 
     //we allow premium for pledge during pledge creation only.
-    if (empty($this->_values['pledge_id']) && empty($this->_ccid)) {
+    if (empty($this->_values['pledge_id']) && empty($this->getExistingContributionID())) {
       $this->buildPremiumsBlock(TRUE);
     }
 
     //don't build pledge block when mid is passed
-    if (!$this->getRenewalMembershipID() && empty($this->_ccid)) {
+    if (!$this->getRenewalMembershipID() && empty($this->getExistingContributionID())) {
       if (CRM_Core_Component::isEnabled('CiviPledge') && !empty($this->_values['pledge_block_id'])) {
         $this->buildPledgeBlock();
       }
     }
 
     //to create an cms user
-    if (!$this->_contactID && empty($this->_ccid)) {
+    if (!$this->_contactID && empty($this->getExistingContributionID())) {
       $createCMSUser = FALSE;
 
       if ($this->_values['custom_pre_id']) {
@@ -435,7 +435,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         CRM_Core_BAO_CMSUser::buildForm($this, $profileID, TRUE);
       }
     }
-    if ($this->getPcpID() && empty($this->_ccid)) {
+    if ($this->getPcpID() && empty($this->getExistingContributionID())) {
       if (CRM_PCP_BAO_PCP::displayName($this->_pcpId)) {
         $pcp_supporter_text = CRM_PCP_BAO_PCP::getPcpSupporterText($this->_pcpId, $this->_id, 'contribute');
       }
@@ -454,7 +454,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       }
     }
     $this->assign('pcpSupporterText', $pcp_supporter_text ?? NULL);
-    if (empty($this->_values['fee']) && empty($this->_ccid)) {
+    if (empty($this->_values['fee']) && empty($this->getExistingContributionID())) {
       throw new CRM_Core_Exception(ts('This page does not have any price fields configured or you may not have permission for them. Please contact the site administrator for more details.'));
     }
 
@@ -493,7 +493,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $this->submitOnce = TRUE;
       }
       //change button name for updating contribution
-      if (!empty($this->_ccid)) {
+      if (!empty($this->getExistingContributionID())) {
         $submitButton['name'] = ts('Confirm Payment');
       }
       $this->addButtons([$submitButton]);
@@ -1217,7 +1217,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     $params['amount'] = $this->getMainContributionAmount();
     $this->set('amount_level', $this->order->getAmountLevel());
-    if (!empty($this->_ccid)) {
+    if (!empty($this->getExistingContributionID())) {
       // @todo - verify that this is the same as `$this->>getLineItems()` which it should be & consolidate
       $this->set('lineItem', [$this->getPriceSetID() => $this->getExistingContributionLineItems()]);
     }
@@ -1358,7 +1358,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       throw new CRM_Core_Exception(ts('Sorry, this contribution has been cancelled.'));
     }
 
-    $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->_ccid);
+    $paymentBalance = CRM_Contribute_BAO_Contribution::getContributionBalance($this->getExistingContributionID());
     //bounce if the contribution is not pending.
     if ((float) $paymentBalance <= 0) {
       CRM_Core_Error::statusBounce(ts('Returning since contribution has already been handled.'));

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -95,7 +95,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
   public function buildQuickForm() {
     // FIXME: Some of this code is identical to Confirm.php and should be broken out into a shared function
     $this->assignToTemplate();
-    $this->_ccid = $this->get('ccid');
+    $this->_ccid = $this->getExistingContributionID();
     $option = $this->get('option');
     $membershipTypeID = $this->get('membershipTypeID');
     $this->assign('receiptFromEmail', $this->_values['receipt_from_email'] ?? NULL);
@@ -180,7 +180,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     $this->_separateMembershipPayment = $this->get('separateMembershipPayment');
     $this->assign('is_separate_payment', $this->_separateMembershipPayment);
 
-    if (empty($this->_ccid)) {
+    if (empty($this->getExistingContributionID())) {
       $this->buildCustom($this->_values['custom_pre_id'], 'customPre', TRUE);
       $this->buildCustom($this->_values['custom_post_id'], 'customPost', TRUE);
     }
@@ -188,7 +188,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
       !empty($params['onbehalf']) &&
       ($this->_values['is_for_organization'] == 2 ||
         !empty($params['is_for_organization'])
-      ) && empty($this->_ccid)
+      ) && empty($this->getExistingContributionID())
     ) {
       $fieldTypes = ['Contact', 'Organization'];
       $contactSubType = CRM_Contact_BAO_ContactType::subTypes('Organization');

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -353,7 +353,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
     // current contribution page id
     $this->getContributionPageID();
-    $this->_ccid = CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
+    $this->_ccid = $this->getExistingContributionID();
     $this->_emailExists = $this->get('emailExists') ?? FALSE;
     $this->assign('isShowAdminVisibilityFields', CRM_Core_Permission::check('administer CiviCRM'));
 
@@ -415,7 +415,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
       $isPayLater = $this->_values['is_pay_later'] ?? NULL;
       if ($this->getExistingContributionID()) {
         $this->_values['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',
-          $this->_ccid,
+          $this->getExistingContributionID(),
           'financial_type_id'
         );
         if ($isPayLater) {


### PR DESCRIPTION
Overview
----------------------------------------
`$_ccid` is used on Contribution Pages when in "Invoice Mode". It contains the ContributionID of the existing contribution that is being paid for.
There was an existing "getter" function `getExistingContributionID()` added by @eileenmcnaughton which we can use instead of directly accessing the variable.

Before
----------------------------------------
Direct access.

After
----------------------------------------
Access via getter function.

Technical Details
----------------------------------------


Comments
----------------------------------------

