### PR TITLE
Tidy up SearchEvent.tpl

### DIFF
--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -7,47 +7,51 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-  <details class="crm-accordion-bold crm-block crm-form-block crm-event-searchevent-form-block" open>
-    <summary>
-      {ts}Find Events{/ts}
-    </summary>
-    <div class="crm-accordion-body">
-  <table class="form-layout">
-    <tr class="crm-event-searchevent-form-block-title">
-        <td>
-          <label>{$form.title.label}</label>
-          {$form.title.html|crmAddClass:twenty}
+<details class="crm-accordion-bold crm-block crm-form-block crm-event-searchevent-form-block" open>
+  <summary>
+    {ts}Find Events{/ts}
+  </summary>
+  <div class="crm-accordion-body">
+    <table class="form-layout">
+      <tr class="crm-event-searchevent-form-block-title">
+          <td>
+            {$form.title.label}
+            {$form.title.html|crmAddClass:twenty}
+          </td>
+          <td>
+            <label>{ts}Event Type{/ts}</label>
+            {$form.event_type_id.html}
+          </td>
+      </tr>
+      <tr>
+        <td colspan="2">
+          <div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div>
         </td>
-        <td><label>{ts}Event Type{/ts}</label>
-          {$form.event_type_id.html}
-        </td>
-    </tr>
-    <tr>
-    <td colspan="2"><div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div></td>
-    </tr>
-    <tr>
+      </tr>
+      <tr>
        <td colspan="2">
-       <table class="form-layout-compressed" id="id_fromToDates">
-        <tr class="">
-          <td class="crm-event-searchevent-form-block-start_date">
-            <label>{$form.start_date.label}</label>
-            {$form.start_date.html}
-          </td>
-          <td class="crm-event-searchevent-form-block-end_date">
-            <label>{$form.end_date.label}</label>
-            {$form.end_date.html}
-          </td>
-        </tr>
-      </table>
-    </td></tr>
+          <table class="form-layout-compressed" id="id_fromToDates">
+            <tr class="">
+              <td class="crm-event-searchevent-form-block-start_date">
+                {$form.start_date.label}
+                {$form.start_date.html}
+              </td>
+              <td class="crm-event-searchevent-form-block-end_date">
+                {$form.end_date.label}
+                {$form.end_date.html}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
 
-    {* campaign in event search *}
-    {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
-    campaignTrClass='crm-event-searchevent-form-block-campaign_id' campaignTdClass=''}
-    <td class="right">{include file="CRM/common/formButtons.tpl" location=''}</td>
-  </table>
-    </div>
-  </details>
+      {* campaign in event search *}
+      {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
+      campaignTrClass='crm-event-searchevent-form-block-campaign_id' campaignTdClass=''}
+      <td class="right">{include file="CRM/common/formButtons.tpl" location=''}</td>
+    </table>
+  </div>
+</details>
 
 {include file="CRM/common/showHide.tpl"}
 


### PR DESCRIPTION
Overview
----------------------------------------
Tidy up SearchEvent.tpl

My main motivation for this was to remove the nested `<label>` elements, which are invalid HTML and semantically bad:

<img width="637" alt="Screenshot 2025-05-10 at 09 14 53" src="https://github.com/user-attachments/assets/6706a22d-5ba0-47a1-be14-f6460ef733a4" />

I figured I might as well tidy up the whitespace and indentation at the same time.