### PR TITLE
[REF] Update Composer.json PHP extension requirements to match the In…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,15 @@
   },
   "require": {
     "php": "~8.0",
+    "ext-bcmath": "*",
+    "ext-curl": "*",
+    "ext-fileinfo": "*",
+    "ext-intl": "*",
+    "ext-json": "*",
+    "ext-mbstring": "*",
+    "ext-mysqli": "*",
+    "ext-zip": "*",
+    "ext-xml": "*",
     "composer-runtime-api": "~2.0",
     "dompdf/dompdf": "~2.0.4|| ~3.0",
     "firebase/php-jwt": ">=3 <7",
@@ -90,13 +99,9 @@
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
     "brick/money": "~0.5",
-    "ext-intl": "*",
     "pear/mail_mime": "~1.10",
     "pear/db": "~1.12.1",
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",
-    "ext-json": "*",
-    "ext-mbstring": "*",
-    "ext-mysqli": "*",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18 || ^2",
     "symfony/polyfill-php80": "^1.0",
@@ -106,12 +111,10 @@
     "symfony/polyfill-php84": "^1.0",
     "soundasleep/html2text": "^2.1",
     "psr/container": "~1.0 || ~2.0",
-    "ext-fileinfo": "*",
     "behat/mink": "^1.10",
     "dmore/chrome-mink-driver": "^2.9",
     "pontedilana/php-weasyprint": "^0.13.0 || ^1",
-    "knplabs/knp-snappy": "^1.4",
-    "ext-bcmath": "*"
+    "knplabs/knp-snappy": "^1.4"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e864ea41c1f2ac4db2392f365125c52",
+    "content-hash": "e0e36ec95b16d41f83c27cc1478dca5f",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -5960,20 +5960,23 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.0",
-        "composer-runtime-api": "~2.0",
+        "ext-bcmath": "*",
+        "ext-curl": "*",
+        "ext-fileinfo": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-mysqli": "*",
-        "ext-fileinfo": "*",
-        "ext-bcmath": "*"
+        "ext-zip": "*",
+        "ext-xml": "*",
+        "composer-runtime-api": "~2.0"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.0.0"
     },


### PR DESCRIPTION
…stall Guide

Overview
----------------------------------------
This updates the composer.json in regards to the PHP extensions (Modules) that a site needs to run CiviCRM to match the [Install docs requirements](https://docs.civicrm.org/installation/en/latest/requirements/#php-extensions)

Before
----------------------------------------
Composer JSON doesn't enforce the requirement to have xml, zip, 

After
----------------------------------------
Docs and composer.json match up

ping @eileenmcnaughton @totten @wmortada et al