### PR TITLE
Add static cache on array_filter to improve performance

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -44,9 +44,13 @@ class CRM_Core_DAO_AllCoreTables {
    */
   public static function getEntities(): array {
     $allEntities = EntityRepository::getEntities();
-    // Filter out entities without a table or class
 
-    return array_filter($allEntities, fn($entity) => (!empty($entity['table']) && !empty($entity['class'])));
+    // Filter out entities without a table or class
+    static $filteredEntities;
+    if (!isset($filteredEntities)) {
+      $filteredEntities = array_filter($allEntities, fn($entity) => (!empty($entity['table']) && !empty($entity['class'])));
+    }
+    return $filteredEntities;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Doing some profiling on a site that has been running very slowly. Using API4 Managed.reconcile for tests.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/db199adf-f28c-4e64-ba96-5e5e71882d22)

array_filter function in `CRM_Core_DAO_AllCoreTables::getEntities()` using 16 seconds and a lot of memory.


After
----------------------------------------
![image](https://github.com/user-attachments/assets/65f8ab65-2e09-4bb5-9b40-eb5b6d4697eb)

array_filter function in `CRM_Core_DAO_AllCoreTables::getEntities()` using 0.34 seconds and much less memory.


Technical Details
----------------------------------------
$allEntities does not change because it also has a static cache. So we can use a static cache on array_filter result as well.

Comments
----------------------------------------
