### PR TITLE
FormBuilder support image URL upload

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -84,6 +84,16 @@ class SubmitFile extends AbstractProcessor {
     if ($this->isDraft()) {
       return $this->updateDraft($draft, $file['id']);
     }
+    // Handle special case for image URL
+    elseif (isset($entityId) && $this->getFieldName() === 'Image URL') {
+      civicrm_api4('Contact', 'update', [
+        'values' => [
+          'id' => $entityId,
+          'image_URL' => sprintf('/civicrm/contact/imagefile?photo=%s', $file['uri']),
+        ],
+      ]);
+      return [];
+    }
     else {
       return $this->updateEntity($entityId, $file['id']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
It's not currently possible to upload an "Image URL" field (aka contact record's headshot) via FormBuilder.

Before
----------------------------------------
Broken link, no image

After
----------------------------------------
Successful upload

Comments
----------------------------------------
This is a variation on #28840, adapted to handle merge conflicts and without style issues.
