### PR TITLE
Notice fix on apiv4

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -299,7 +299,7 @@ abstract class AbstractAction implements \ArrayAccess {
         $name = $property->getName();
         if ($name != 'version' && $name[0] != '_') {
           $docs = ReflectionUtils::getCodeDocs($property, 'Property', $vars);
-          $docs['default'] = $defaults[$name];
+          $docs['default'] = $defaults[$name] ?? NULL;
           // Exclude `null` which is not a value type
           if (!empty($docs['type']) && is_array($docs['type'])) {
             $docs['type'] = array_diff($docs['type'], ['null']);


### PR DESCRIPTION
Overview
----------------------------------------
Notice fix on apiv4

Before
----------------------------------------
If I define a custom api with a property that is typed, and required but has no default then I consistently get a notice on this line - because the `   $defaults = $this->getParamDefaults();` for some reason does not include the field in it's return when it is typed as int - I guess that makes sense as it can't determine the default - but we don't want a notice

```
  /**
   * My number.
   *
   * @required
   *
   * @var int
   */
  protected int $number;
```

After
----------------------------------------
No notice

Technical Details
----------------------------------------

Comments
----------------------------------------

@colemanw 