### PR TITLE
[NFC] dev/core#5854 - unit test for overlay popup clarifying what groups should appear in it

### DIFF
--- a/tests/phpunit/CRM/Profile/Page/ViewTest.php
+++ b/tests/phpunit/CRM/Profile/Page/ViewTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Profile_Page_ViewTest extends CiviUnitTestCase {
+
+  use CRMTraits_Page_PageTestTrait;
+
+  /**
+   * @var int
+   */
+  protected $contactID;
+
+  /**
+   * @var int
+   */
+  protected $groupID1;
+
+  /**
+   * @var int
+   */
+  protected $groupID2;
+
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->contactID = $this->individualCreate();
+    $this->groupID1 = $this->groupCreate(['name' => 'g1name', 'title' => 'g1', 'frontend_title' => 'g1front', 'visibility' => 'User and User Admin Only']);
+    $this->groupID2 = $this->groupCreate(['name' => 'g2name', 'title' => 'g2', 'frontend_title' => 'g2front', 'visibility' => 'Public Pages']);
+    $this->callAPISuccess('GroupContact', 'create', ['group_id' => $this->groupID1, 'contact_id' => $this->contactID, 'status' => 'Added']);
+    $this->callAPISuccess('GroupContact', 'create', ['group_id' => $this->groupID2, 'contact_id' => $this->contactID, 'status' => 'Added']);
+
+    $this->listenForPageContent();
+  }
+
+  public function tearDown(): void {
+    $_GET = $_REQUEST = [];
+    $this->callAPISuccess('Contact', 'delete', ['id' => $this->contactID]);
+    $this->callAPISuccess('Group', 'delete', ['id' => $this->groupID1]);
+    $this->callAPISuccess('Group', 'delete', ['id' => $this->groupID2]);
+    parent::tearDown();
+  }
+
+  /**
+   * The contact overlay is only seen by backend users, and generally they
+   * have permission to see both public and admin groups, so we expect the
+   * overlay to include both.
+   */
+  public function testContactOverlayContainsAllGroups(): void {
+    $gid = $this->callAPISuccessGetSingle('UFGroup', ['name' => 'summary_overlay', 'return' => ['id']])['id'];
+    $_GET = $_REQUEST = ['reset' => 1, 'id' => $this->contactID, 'gid' => $gid, 'is_show_email_task' => 1, 'snippet' => 4];
+    $page = new CRM_Profile_Page_View();
+
+    $expectedExit = FALSE;
+    try {
+      $page->run();
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $expectedExit = TRUE;
+      $this->assertStringContainsString("Groups\n        </div>\n        <div class=\"content\">\n          g1, g2\n        </div>\n", $this->pageContent);
+    }
+    if (!$expectedExit) {
+      $this->fail('We were expecting an early exit since snippets bypass the theme');
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5854

Unit test to clarify what groups should appear in overlay popup

Before
----------------------------------------
No test

After
----------------------------------------
test

Technical Details
----------------------------------------

Comments
----------------------------------------
According to the [code comments and the referenced jira](https://github.com/civicrm/civicrm-core/blob/a38976b50110885e14f5f1fa703810fd55a234cc/CRM/Core/BAO/UFGroup.php#L1003-L1004) in the code area related to https://lab.civicrm.org/dev/core/-/issues/5854 and https://github.com/civicrm/civicrm-core/pull/32667, and consistent with some manual testing, the overlay popup (the thing that appears when you hover over the contact icon on the contact summary page) should include non-public groups if the user has permission.

I have an alternate to https://github.com/civicrm/civicrm-core/pull/32667 in the works but I'm not crazy about my solution, but in the meantime here's a test.