### PR TITLE
In the abstract method 'send' of the SMS provider, fix the typo

### DIFF
--- a/CRM/SMS/Provider.php
+++ b/CRM/SMS/Provider.php
@@ -79,9 +79,10 @@ abstract class CRM_SMS_Provider {
    * @param array $recipients
    * @param string $header
    * @param string $message
-   * @param int $dncID
+   * @param int|null $jobID
+   * @param int|null $userID
    */
-  abstract public function send($recipients, $header, $message, $dncID = NULL);
+  abstract public function send($recipients, $header, $message, $jobID = NULL, $userID = NULL);
 
   /**
    * @param int $apiMsgID

--- a/tests/phpunit/CiviTest/CiviTestSMSProvider.php
+++ b/tests/phpunit/CiviTest/CiviTestSMSProvider.php
@@ -44,10 +44,10 @@ class CiviTestSMSProvider extends CRM_SMS_Provider {
     return self::$_singleton[$cacheKey];
   }
 
-  public function send($recipients, $header, $message, $dncID = NULL) {
+  public function send($recipients, $header, $message, $jobID = NULL, $userID = NULL) {
     $this->sentMessage = $message;
     $sid = substr(str_shuffle('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'), 0, 16);
-    $this->createActivity($sid, $message, $header, $dncID);
+    $this->createActivity($sid, $message, $header, $jobID);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Adjust the Typo

Technical Details
----------------------------------------

Fixes a typo and updates the abstract send method signature to match its usage: `$providerObj->send($recipient, $smsProviderParams, $tokenText, NULL, $sourceContactID);`

Ref: https://github.com/civicrm/civicrm-core/blob/master/CRM/Activity/BAO/Activity.php#L1317