### PR TITLE
Fix failure to load defaults on import

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -164,36 +164,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
   }
 
   /**
-   * Get default values for the mapping.
-   *
-   * This looks up any saved mapping or derives them from the headers if possible.
-   *
-   * @return array
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function getDefaults(): array {
-    $defaults = [];
-    $fieldMappings = $this->getFieldMappings();
-    foreach ($this->getColumnHeaders() as $i => $columnHeader) {
-      $defaults["mapper[$i]"] = [];
-      if ($this->getSubmittedValue('savedMapping')) {
-        $fieldMapping = $fieldMappings[$i] ?? [];
-        $this->addMappingToDefaults($defaults, $fieldMapping, $i);
-      }
-      elseif ($this->getSubmittedValue('skipColumnHeader')) {
-        $defaults["mapper[$i]"][0] = $this->guessMappingBasedOnColumns($columnHeader);
-      }
-    }
-    $userDefinedMappings = array_diff_key($this->getFieldMappings(), $this->getColumnHeaders());
-    foreach ($userDefinedMappings as $index => $mapping) {
-      $this->addMappingToDefaults($defaults, $mapping, $index);
-    }
-
-    return $defaults;
-  }
-
-  /**
    * Add the saved mapping to the defaults.
    *
    * @param array $defaults

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -239,7 +239,8 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       $userJobName = $userJob['name'];
       // Strip off import_ prefix from UserJob.name
       $mappingName = substr($userJobName, 7);
-      $mappingID = Mapping::get(FALSE)->addWhere('name', '=', $mappingName)->addSelect('id')->execute()->first()['id'];
+      // This mapping is deprecated but still used for Contact, Activity.
+      $mappingID = Mapping::get(FALSE)->addWhere('name', '=', $mappingName)->addSelect('id')->execute()->first()['id'] ?? NULL;
       // Unset fields that should not be copied over.
       unset($userJob['id'], $userJob['name'], $userJob['created_date'], $userJob['is_template'], $userJob['queue_id'], $userJob['start_date'], $userJob['end_date']);
       $userJob['metadata']['template_id'] = $templateID;

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -28,4 +28,39 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
     return 'CRM/Import/MapField.tpl';
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  protected function getFieldMappings(): array {
+    return $this->getUserJob()['metadata']['import_mappings'] ?? [];
+  }
+
+  /**
+   * Get default values for the mapping.
+   *
+   * This looks up any saved mapping or derives them from the headers if possible.
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getDefaults(): array {
+    $defaults = [];
+    $fieldMappings = $this->getFieldMappings();
+    foreach ($this->getColumnHeaders() as $i => $columnHeader) {
+      $defaults["mapper[$i]"] = [];
+      if ($fieldMappings) {
+        $fieldMapping = $fieldMappings[$i] ?? [];
+        $this->addMappingToDefaults($defaults, $fieldMapping, $i);
+      }
+    }
+    if (empty($defaults) && $this->getSubmittedValue('skipColumnHeader')) {
+      foreach ($this->getColumnHeaders() as $i => $columnHeader) {
+        $defaults["mapper[$i]"][0] = $this->guessMappingBasedOnColumns($columnHeader);
+      }
+    }
+
+    return $defaults;
+  }
+
 }

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -51,7 +51,9 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
       $defaults["mapper[$i]"] = [];
       if ($fieldMappings) {
         $fieldMapping = $fieldMappings[$i] ?? [];
-        $this->addMappingToDefaults($defaults, $fieldMapping, $i);
+        if (!empty($fieldMapping['name']) && $fieldMapping['name'] !== ts('do_not_import')) {
+          $this->addMappingToDefaults($defaults, $fieldMapping, $i);
+        }
       }
     }
     if (empty($defaults) && $this->getSubmittedValue('skipColumnHeader')) {
@@ -61,6 +63,20 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
     }
 
     return $defaults;
+  }
+
+  /**
+   * Add the saved mapping to the defaults.
+   *
+   * @param array $defaults
+   * @param array $fieldMapping
+   * @param int $rowNumber
+   *
+   * @return void
+   */
+  public function addMappingToDefaults(array &$defaults, array $fieldMapping, int $rowNumber): void {
+    $fieldName = $fieldMapping['name'];
+    $defaults["mapper[$rowNumber]"] = [$fieldName];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to load defaults on import, regression

Before
----------------------------------------
Fields saved into the user job (e.g in an mgd file) are not loaded as defaults

After
--------------------------------------
![image](https://github.com/user-attachments/assets/342b6643-6bf4-4495-9e24-cc1f2c08e082)



Technical Details
----------------------------------------
We unfortunately have a migrational mess for where mappings are stored - but from 6.2 CiviImport is required & enabled for most imports (not yet Activity or Contact) - for those where it IS enabled the authoritative source of mapping data is the import_mappings key in the user job

Comments
----------------------------------------

There is some confounding factor here - I can't always replicate it - I think this fix is right & appropriate to the rc but gonna hang off on further backports to stable