### PR TITLE
Type notice fix

### DIFF
--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -281,7 +281,7 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
    */
   public function mapConfigToSSL() {
     global $base_url;
-    $base_url = str_replace('http://', 'https://', $base_url);
+    $base_url = str_replace('http://', 'https://', (string) $base_url);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Affects drupal 7 + cli (I haven't checked other CMS - this is pretty low priority but I though I'd fix it while I'm seeing it)

docker@civicrm:/srv/civi-sites/dmaster/web$ cv api4 Managed.reconcile debug=1
[PHP Deprecation] str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated at /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/CRM/Utils/System/Drupal.php:284
