### PR TITLE
Add define to disable PHP IDS

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -150,8 +150,10 @@ class CRM_Core_Invoke {
    * @throws \CRM_Core_Exception
    */
   public static function runItem($item) {
-    $ids = new CRM_Core_IDS();
-    $ids->check($item);
+    if (!defined('CIVICRM_IDS_DISABLE') || !CIVICRM_IDS_DISABLE) {
+      $ids = new CRM_Core_IDS();
+      $ids->check($item);
+    }
 
     if (!PharLoader::isWrapperInstantiated()) {
       // Up to now, we're not guaranteed to have the wrapper. But we prefer to have it.


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5892

Add a define to allow the PHP IDS to be disabled.

Before
----------------------------------------
Cannot disable, only add exceptions through hook.

After
----------------------------------------
Can disable PHP IDS completely.

Technical Details
----------------------------------------


Comments
----------------------------------------
Needs adding to docs and maybe example to civicrm.settings template.
