### PR TITLE
Better event registration message for future events

### DIFF
--- a/CRM/Event/Page/EventInfo.php
+++ b/CRM/Event/Page/EventInfo.php
@@ -274,6 +274,11 @@ class CRM_Event_Page_EventInfo extends CRM_Core_Page {
     $this->assign('registerClosed', !empty($values['event']['is_online_registration']) && !$isEventOpenForRegistration && CRM_Core_Permission::check('register for events'));
     $this->assign('allowRegistration', $allowRegistration);
 
+    if (!empty($values['event']['registration_start_date'])
+        && strtotime($values['event']['registration_start_date']) > time()) {
+      $this->assign('registerStartDate', $values['event']['registration_start_date']);
+    }
+
     $isAlreadyRegistered = $this->isAlreadyRegistered();
     // noFullMsg was originally passed in to suppress the message about the event being full. The intent
     // was originally such that when you were sending the user back to the info page after registering

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -12,9 +12,13 @@
 {if $registerClosed}
 <div class="spacer"></div>
 <div class="messages status no-popup">
-  <i class="crm-i fa-info-circle" aria-hidden="true"></i>
-     &nbsp;{ts}Registration is closed for this event{/ts}
-  </div>
+  <i class="crm-i fa-info-circle" aria-hidden="true"></i>&nbsp;
+  {if $registerStartDate}
+    {ts 1=$registerStartDate|crmDate}Registration will open on %1{/ts}
+  {else}
+    {ts}Registration is closed for this event{/ts}
+  {/if}
+</div>
 {/if}
 {crmPermission has='access CiviEvent'}
 <div class="crm-actions-ribbon crm-event-manage-tab-actions-ribbon">


### PR DESCRIPTION
Overview
----------------------------------------
When event registration start date is set in the future, the user who wants to register see the message: `Registration is closed for this event` which is a bit misleading as it's not yet opened.

Before
----------------------------------------
The message `Registration is closed for this event` is displayed.

After
----------------------------------------
The message is instead `Registration will open on DATE`
