### PR TITLE
add Civi::settings helpers to get resolved setting paths/urls

### DIFF
--- a/CRM/Core/Config/MagicMerge.php
+++ b/CRM/Core/Config/MagicMerge.php
@@ -235,7 +235,7 @@ class CRM_Core_Config_MagicMerge {
         // Array(0 => $type, 1 => $setting, 2 => $actions).
         $value = ($type === 'path')
           ? Civi::paths()->getVariable($name, 'path')
-          : Civi::paths()->getPath($this->getSettings()->get($name));
+          : Civi::settings()->getPath($name);
         if ($value) {
           $value = CRM_Utils_File::addTrailingSlash($value);
           if (isset($this->map[$k][2]) && in_array('mkdir', $this->map[$k][2])) {

--- a/CRM/Core/Config/Runtime.php
+++ b/CRM/Core/Config/Runtime.php
@@ -120,12 +120,11 @@ class CRM_Core_Config_Runtime {
    * Include custom PHP and template paths
    */
   public function includeCustomPath() {
-    $customProprtyName = ['customPHPPathDir', 'customTemplateDir'];
-    foreach ($customProprtyName as $property) {
-      $value = Civi::settings()->get($property);
-      if (!empty($value)) {
-        $customPath = Civi::paths()->getPath($value);
-        set_include_path($customPath . PATH_SEPARATOR . get_include_path());
+    $customPropertyName = ['customPHPPathDir', 'customTemplateDir'];
+    foreach ($customPropertyName as $property) {
+      $path = Civi::settings()->getPath($property);
+      if (!empty($path)) {
+        set_include_path($path . PATH_SEPARATOR . get_include_path());
       }
     }
   }

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -288,10 +288,11 @@ class CRM_Utils_PDF_Utils {
       'enable_remote' => \Civi::settings()->get('dompdf_enable_remote') ?? TRUE,
     ];
     // only set these ones if a setting exists for them
-    foreach (['font_dir', 'chroot', 'log_output_file'] as $setting) {
-      $value = \Civi::settings()->get("dompdf_$setting");
-      if (isset($value)) {
-        $settings[$setting] = Civi::paths()->getPath($value);
+    foreach (['dompdf_font_dir', 'dompdf_chroot', 'dompdf_log_output_file'] as $setting) {
+      $path = \Civi::settings()->getPath($setting);
+      if (!empty($path)) {
+        $withoutPrefix = substr($setting, 7);
+        $settings[$withoutPrefix] = $path;
       }
     }
 

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -636,4 +636,36 @@ class SettingsBag {
     return $computed;
   }
 
+  /**
+   * Sometimes settings correspond to paths - which then resolving
+   * to get the final usable value
+   *
+   * @param string $key the name of the setting e.g. extensionsDir
+   * @return ?string final path value with any variables resolved, or NULL if not set
+   */
+  public function getPath(string $key): ?string {
+    $rawValue = $this->get($key);
+    return \Civi::paths()->getPath($rawValue);
+  }
+
+  /**
+   * Sometimes settings correspond to URLs - which then need resolving
+   * to get the final usable value
+   *
+   * @param string $key the name of the setting e.g. extensionsURL
+   * @param string $preferFormat
+   *   The preferred format ('absolute', 'relative').
+   *   The result data may not meet the preference -- if the setting
+   *   refers to an external domain, then the result will be
+   *   absolute (regardless of preference).
+   * @param bool|null $ssl
+   *   NULL to autodetect. TRUE to force to SSL.
+   *
+   * @return ?string final value with any variables resolved
+   */
+  public function getUrl(string $key, string $preferFormat = 'relative', ?bool $ssl = NULL): ?string {
+    $rawValue = $this->get($key);
+    return \Civi::paths()->getUrl($rawValue, $preferFormat, $ssl);
+  }
+
 }

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -257,8 +257,7 @@ class CRM_Case_BAO_CaseTest extends CiviCaseTestCase {
     ]);
 
     // Create two files to attach to the new case
-    $customFilesSetting = Civi::settings()->get('customFileUploadDir');
-    $filepath = Civi::paths()->getPath($customFilesSetting);
+    $filepath = Civi::settings()->getPath('customFileUploadDir');
 
     CRM_Utils_File::createFakeFile($filepath, 'Bananas do not bend themselves without a little help.', 'i_bend_bananas.txt');
     $fileA = $this->callAPISuccess('File', 'create', ['uri' => "$filepath/i_bend_bananas.txt"]);


### PR DESCRIPTION
Overview
----------------------------------------
Adds helper functions to get resolved values of settings paths/urls. 

Initially just neatens https://github.com/civicrm/civicrm-core/pull/32796 but has potential to be used all over the place. (for example in MagicMerge)

What do you think @totten ?
