### PR TITLE
SearchKitBatch - Switch to search_display_id column

### DIFF
--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -91,8 +91,19 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
       $userJobID = CRM_Utils_Request::retrieve('user_job_id', 'String', $this, TRUE);
       $userJob = UserJob::get(TRUE)
         ->addWhere('id', '=', $userJobID)
+        ->addSelect('*', 'status_id:name', 'status_id:label')
         ->execute()
         ->first();
+      $this->assign('statusName', $userJob['status_id:name']);
+      $this->assign('statusLabel', $userJob['status_id:label']);
+      $dataSource = $userJob['metadata']['DataSource'] ?? [];
+      $searchDisplayLink = '';
+      // If this is a SearchKit batch, add a link to get back to the search display.
+      if (isset($dataSource['search_display'])) {
+        $searchDisplayLink = \Civi::url('backend://civicrm/search')
+          ->setFragment("display/{$dataSource['saved_search']}/{$dataSource['search_display']}?batch={$userJobID}");
+      }
+      $this->assign('searchDisplayLink', (string) $searchDisplayLink);
       $onDuplicate = (int) $userJob['metadata']['submitted_values']['onDuplicate'];
       $this->assign('dupeError', FALSE);
       if ($onDuplicate === CRM_Import_Parser::DUPLICATE_UPDATE) {

--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -91,17 +91,16 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
       $userJobID = CRM_Utils_Request::retrieve('user_job_id', 'String', $this, TRUE);
       $userJob = UserJob::get(TRUE)
         ->addWhere('id', '=', $userJobID)
-        ->addSelect('*', 'status_id:name', 'status_id:label')
+        ->addSelect('*', 'status_id:name', 'status_id:label', 'search_display_id.name', 'search_display_id.saved_search_id.name')
         ->execute()
         ->first();
       $this->assign('statusName', $userJob['status_id:name']);
       $this->assign('statusLabel', $userJob['status_id:label']);
-      $dataSource = $userJob['metadata']['DataSource'] ?? [];
       $searchDisplayLink = '';
       // If this is a SearchKit batch, add a link to get back to the search display.
-      if (isset($dataSource['search_display'])) {
+      if (!empty($userJob['search_display_id.name'])) {
         $searchDisplayLink = \Civi::url('backend://civicrm/search')
-          ->setFragment("display/{$dataSource['saved_search']}/{$dataSource['search_display']}?batch={$userJobID}");
+          ->setFragment("display/{$userJob['search_display_id.saved_search_id.name']}/{$userJob['search_display_id.name']}?batch={$userJobID}");
       }
       $this->assign('searchDisplayLink', (string) $searchDisplayLink);
       $onDuplicate = (int) $userJob['metadata']['submitted_values']['onDuplicate'];

--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -379,11 +379,11 @@ class CRM_Core_DAO_AllCoreTables {
    * @param string $entityName
    *   e.g. 'Activity'
    *
-   * @return string
+   * @return string|null
    *   e.g. 'civicrm_activity'
    */
-  public static function getTableForEntityName($entityName): string {
-    return self::getEntities()[$entityName]['table'];
+  public static function getTableForEntityName($entityName): ?string {
+    return self::getEntities()[$entityName]['table'] ?? NULL;
   }
 
   /**

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -398,16 +398,20 @@ class CRM_Upgrade_Incremental_Base {
    * @param string $fieldName
    * @param array $fieldSpec
    *   As definied in the .entityType.php file for $entityName
+   * @param string|null $after
    * @return bool
    * @throws CRM_Core_Exception
    */
-  public static function alterSchemaField($ctx, string $entityName, string $fieldName, array $fieldSpec): bool {
+  public static function alterSchemaField($ctx, string $entityName, string $fieldName, array $fieldSpec, ?string $after = NULL): bool {
     $tableName = Civi::entity($entityName)->getMeta('table');
     $fieldSql = Civi::schemaHelper()->arrayToSql($fieldSpec);
     if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, $fieldName, FALSE)) {
       return self::alterColumn($ctx, $tableName, $fieldName, $fieldSql, !empty($fieldSpec['localizable']));
     }
     else {
+      if ($after) {
+        $fieldSql .= " AFTER `$after`";
+      }
       return self::addColumn($ctx, $tableName, $fieldName, $fieldSql, !empty($fieldSpec['localizable']));
     }
   }

--- a/CRM/Upgrade/Incremental/php/SixThree.php
+++ b/CRM/Upgrade/Incremental/php/SixThree.php
@@ -38,6 +38,23 @@ class CRM_Upgrade_Incremental_php_SixThree extends CRM_Upgrade_Incremental_Base 
     }
   }
 
+  public function upgrade_6_3_beta1($rev): void {
+    $this->addTask('Add column "UserJob.search_display_id"', 'alterSchemaField', 'UserJob', 'search_display_id', [
+      'title' => ts('SearchDisplay ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => ts('Batch import search display'),
+      'input_attrs' => [
+        'label' => ts('Search Display'),
+      ],
+      'entity_reference' => [
+        'entity' => 'SearchDisplay',
+        'key' => 'id',
+        'fk' => FALSE,
+      ],
+    ], 'queue_id');
+  }
+
   public static function deleteNonAttachmentFiles(): bool {
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_entity_file WHERE entity_table LIKE "civicrm_value_%" LIMIT ' . self::BATCH_SIZE);
     return TRUE;

--- a/Civi/UserJob/UserJobTrait.php
+++ b/Civi/UserJob/UserJobTrait.php
@@ -70,6 +70,7 @@ trait UserJobTrait {
   protected function getUserJob(): array {
     if (empty($this->userJob)) {
       $this->userJob = UserJob::get()
+        ->addSelect('*', 'search_display_id.name', 'search_display_id.saved_search_id.name')
         ->addWhere('id', '=', $this->getUserJobID())
         ->execute()
         ->single();

--- a/ext/search_kit/CRM/Search/Import/Parser.php
+++ b/ext/search_kit/CRM/Search/Import/Parser.php
@@ -277,6 +277,10 @@ class CRM_Search_Import_Parser extends CRM_Import_Parser {
 
   public function init() {
     $userJob = $this->getUserJob();
+    if (empty($userJob['search_display_id.name'])) {
+      // Exception is caught by ImportSpecProvider::modifySpec to prevent hard crash in Api4 getFields
+      throw new \CRM_Core_Exception('No search display found for this job.');
+    }
     $this->display = $userJob['search_display_id.name'];
     $this->savedSearch = $userJob['search_display_id.saved_search_id.name'];
     $this->loadSavedSearch();

--- a/ext/search_kit/CRM/Search/Import/Parser.php
+++ b/ext/search_kit/CRM/Search/Import/Parser.php
@@ -277,8 +277,8 @@ class CRM_Search_Import_Parser extends CRM_Import_Parser {
 
   public function init() {
     $userJob = $this->getUserJob();
-    $this->display = $userJob['metadata']['DataSource']['search_display'];
-    $this->savedSearch = $userJob['metadata']['DataSource']['saved_search'];
+    $this->display = $userJob['search_display_id.name'];
+    $this->savedSearch = $userJob['search_display_id.saved_search_id.name'];
     $this->loadSavedSearch();
     $this->loadSearchDisplay();
     $this->baseEntity = $this->savedSearch['api_entity'];

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
@@ -52,11 +52,10 @@ class CreateBatch extends AbstractAction {
       'status_id:name' => 'draft',
       'is_template' => FALSE,
       'expires_date' => $this->savedSearch['expires_date'],
+      'search_display_id' => $this->display['id'],
       'metadata' => [
         'DataSource' => [
           'table_name' => $tableName,
-          'saved_search' => $this->savedSearch['name'],
-          'search_display' => $this->display['name'],
           'column_headers' => [],
           'column_specs' => [],
         ],

--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
@@ -33,9 +33,8 @@ class SKBatchSpecProvider extends AutoService implements SpecProviderInterface {
 
     $select = \CRM_Utils_SQL_Select::from('civicrm_user_job')
       ->where('job_type = "search_batch_import"')
+      ->where('search_display_id IS NOT NULL')
       ->where('metadata LIKE \'%"table_name":"' . $tableName . '"%\'')
-      ->where('metadata LIKE \'%"saved_search":"%\'')
-      ->where('metadata LIKE \'%"search_display":"%\'')
       ->where('metadata LIKE \'%"column_specs":%\'')
       ->select('metadata');
 

--- a/ext/search_kit/ang/crmSearchDisplayBatch.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayBatch.ang.php
@@ -12,6 +12,7 @@ return [
   'basePages' => ['civicrm/search', 'civicrm/admin/search'],
   'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap', 'crmSearchTasks'],
   'bundles' => ['bootstrap3'],
+  'permissions' => ['administer queues'],
   'exports' => [
     'crm-search-display-batch' => 'E',
   ],

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -39,6 +39,22 @@
             ctrl.saveRows();
           }, 10000);
         }
+        else {
+          this.reportLinks = [
+            {
+              title: ts('View My Import Batches'),
+              href: CRM.url('civicrm/imports/my-listing'),
+              icon: 'fa-user-tag',
+            },
+          ];
+          if (CRM.checkPerm('administer queues')) {
+            this.reportLinks.push({
+              title: ts('View All Import Batches'),
+              href: CRM.url('civicrm/imports/all-imports'),
+              icon: 'fa-list-alt',
+            });
+          }
+        }
         if (this.isPreviewMode) {
           this.results = [{data: {}}];
           this.loading = false;

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
@@ -1,9 +1,19 @@
-<div ng-if="!$ctrl.userJobId && !$ctrl.isPreviewMode">
-  <button type="button" class="btn btn-primary" ng-click="$ctrl.createNewBatch()" ng-disabled="$ctrl.creatingBatch">
-    <i ng-if="$ctrl.creatingBatch" class="crm-i fa-spin fa-spinner"></i>
-    <i ng-if="!$ctrl.creatingBatch" class="crm-i fa-plus"></i>
-    {{:: ts('Start New Batch') }}
-  </button>
+<div ng-if="!$ctrl.userJobId && !$ctrl.isPreviewMode" class="crm-search-display crm-search-display-batch">
+  <ul class="list-group">
+    <li class="list-group-item">
+      <button type="button" class="btn btn-primary" ng-click="$ctrl.createNewBatch()" ng-disabled="$ctrl.creatingBatch">
+        <i ng-if="$ctrl.creatingBatch" class="crm-i fa-spin fa-spinner"></i>
+        <i ng-if="!$ctrl.creatingBatch" class="crm-i fa-plus"></i>
+        {{:: ts('Start New Batch') }}
+      </button>
+    </li>
+    <li class="list-group-item" ng-repeat="link in $ctrl.reportLinks">
+      <a href ng-href="{{:: link.href }}">
+        <i class="crm-i {{:: link.icon }}"></i>
+        {{:: link.title }}
+      </a>
+    </li>
+  </ul>
 </div>
 <div ng-if="$ctrl.userJobId || $ctrl.isPreviewMode" class="crm-search-display crm-search-display-batch">
   <div class="alert alert-info crm-search-display-description" ng-if="$ctrl.settings.description">{{:: $ctrl.settings.description }}</div>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchBatch/SearchBatchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchBatch/SearchBatchTest.php
@@ -84,6 +84,7 @@ class SearchBatchTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
       ->execute()->single();
 
     $tableName = $userJob['metadata']['DataSource']['table_name'];
+    $this->assertEquals($display['id'], $userJob['search_display_id']);
 
     $expectedFieldNames = ['_entity_id', '_status', '_status_message', '_id', 'first_name', 'contact_sub_type', 'gender_id', 'birth_date', 'is_deceased'];
 

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -144,7 +144,8 @@ return new class() {
   private function getTableConstraints(array $entity): array {
     $constraints = [];
     foreach ($entity['getFields']() as $fieldName => $field) {
-      if (!empty($field['entity_reference']['entity'])) {
+      // `entity_reference.fk` defaults to TRUE if not set. If FALSE, do not add constraint.
+      if (!empty($field['entity_reference']['entity']) && ($field['entity_reference']['fk'] ?? TRUE)) {
         $fkName = \CRM_Core_BAO_SchemaHandler::getIndexName($entity['table'], $fieldName);
         $constraint = "CONSTRAINT `FK_$fkName` FOREIGN KEY (`$fieldName`)" .
           " REFERENCES `" . $this->getTableForEntity($field['entity_reference']['entity']) . "`(`{$field['entity_reference']['key']}`)";

--- a/schema/Core/UserJob.entityType.php
+++ b/schema/Core/UserJob.entityType.php
@@ -147,6 +147,22 @@ return [
         'on_delete' => 'SET NULL',
       ],
     ],
+    'search_display_id' => [
+      'title' => ts('SearchDisplay ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => ts('Batch import search display'),
+      'input_attrs' => [
+        'label' => ts('Search Display'),
+      ],
+      'entity_reference' => [
+        'entity' => 'SearchDisplay',
+        'key' => 'id',
+        // Core tables get created before extension tables, so a FK constraint
+        // can't be added to this column.
+        'fk' => FALSE,
+      ],
+    ],
     'metadata' => [
       'title' => ts('Job metadata'),
       'sql_type' => 'text',

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -16,10 +16,9 @@
  {include file="CRM/common/WizardHeader.tpl"}
  <div class="help">
    <p>
-     {if $unprocessedRowCount}
-       <strong>{ts}The import is still processing.{/ts}</strong>
-     {else}
-       <strong>{ts}Import has completed successfully.{/ts}</strong>
+     <strong>{ts 1=$statusLabel}Import Status: %1{/ts}</strong>
+     {if $statusName === 'draft' && $searchDisplayLink}
+       <br><a href="{$searchDisplayLink}">{ts}Continue Entering Data{/ts}</a>
      {/if}
    </p>
    {if $templateURL}


### PR DESCRIPTION
Overview
----------------------------------------
Improves schema for batch search imports.

Technical Details
----------------------------------------
Instead of naming the savedSearch and searchDisplay in the metadata, use the new reference column to `search_display_id`.

This also adds the flexibility to the schema of allowing EntityReference fields to exist without a FK index.

Comments
----------
I put it against 6.3 to keep all the schema changes for this new feature in one version.
And to avoid the pain of needing to migrate live data from one schema to the other.