### PR TITLE
fix warning in Setting::getFields when passed non-existent name filter 

### DIFF
--- a/Civi/Api4/Action/Setting/GetFields.php
+++ b/Civi/Api4/Action/Setting/GetFields.php
@@ -31,6 +31,12 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
     $names = $this->_itemsToGet('name');
     $filter = $names ? ['name' => $names] : [];
     $settings = \Civi\Core\SettingsMetadata::getMetadata($filter, $this->domainId, $this->loadOptions);
+
+    // FIXME: This is a workaround for a workaround for settingsBag::setDb() which means [] is returned
+    // for non-existent settings if passed in name filter
+    // @see SettingsMetadata::_filterSettingsSpecification
+    $settings = array_filter($settings);
+
     $getReadonly = $this->_isFieldSelected('readonly');
     foreach ($settings as $index => $setting) {
       // Unserialize default value


### PR DESCRIPTION
Overview
----------------------------------------
Fix a warning notice. Updated the description to consolidate the stream of investigation in the comments...

Before
-----------------------------------------
- `cv api4 Setting.getFields +w name=this_setting_does_not_exist` returns empty array
     - this is the correct behaviour => there's no such setting, and settings = fields on the Setting Api4 entity
- `cv api4 Setting.getFields +w name=this_setting_does_not_exist` throws a warning on PHP8+
    - the warning is thrown in this line in GetFields because `$setting` is an empty array
    https://github.com/civicrm/civicrm-core/blob/807cb3887baba773181d0b8780816ce31c8f8b8a/Civi/Api4/Action/Setting/GetFields.php#L44
    - the empty array comes from this workaround in `\Civi\Core\SettingsMetadata::_filterSettingsSpecification` (which is commented with a FIXME)
    https://github.com/civicrm/civicrm-core/blob/8e4d1518959bb95ce0bef4a3e7fdc107981a9fdb/Civi/Core/SettingsMetadata.php#L167

- 

- the warning causes `setting-php` mixin test to fail on Standalone at this line https://github.com/civicrm/civicrm-core/blob/807cb3887baba773181d0b8780816ce31c8f8b8a/mixin/setting-php%401/example/tests/mixin/SettingsTest.php#L38
- for some reason the warning is ignored when running the same test suite on Drupal. It appears Drupal swallows warnings, at least in the mixin tests (nothing specific to this code path, see https://github.com/civicrm/civicrm-core/pull/32889 )


After
-----------------------------------------
- `cv api4 Setting.getFields +w name=this_setting_does_not_exist` still returns empty array, as well it should
- It *doesn't* throw the warning
- `mixin` suite passes on Standalone
- original FIXME in SettingsMetadata is not fixed - for that see https://github.com/civicrm/civicrm-core/pull/32802 


Comments
-----------------------------------------
The api result isn't changed.
I would also guess `getFields` is used fairly rarely directly, so apart from lots of under-the-hood uses with implicit test coverage everywhere else, it seems very unlikely to me this will have further ramifications