### PR TITLE
Add a more specific custom data selector

### DIFF
--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -52,7 +52,7 @@
                   {foreach from=$cd_edit.fields item=element key=field_id}
                     <tr>
                       <td class="label">{$element.field_title}</td>
-                      <td class="html-adjust">
+                      <td class="html-adjust crm-cf-datatype-{$element.field_data_type|lower} crm-cf-{$element.field_type|lower}">
                         {if $element.options_per_line != 0}
                           {* sort by fails for option per line. Added a variable to iterate through the element array*}
                           {foreach from=$element.field_value item=val}


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/extensions/riverlea/-/issues/130

This is a draft of a possible partial fix for that issue.

Before
----------------------------------------
All custom fields have the class "html-adjust" no matter what their type.

After
----------------------------------------
Custom fields have a more specific selector related to their type (when displayed via customdataview - eg. as tab, not inline).

Technical Details
----------------------------------------
> This PR currently just adds the html and field type directly in. We probably want to lowercase them and make them more crm-y. eg. crm-richtexteditor or something.

Update:
Added in prefixes and lowercased:
```
<td class="html-adjust html-adjust crm-cf-datatype-memo crm-cf-richtexteditor">
<td class="html-adjust crm-cf-datatype-memo crm-cf-textarea">
```

Comments
----------------------------------------
@vingle I think you need something like this to be able to resolve https://lab.civicrm.org/extensions/riverlea/-/issues/130 - please let me know your thoughts?
