### PR TITLE
simplify non-validation of settings keys

### DIFF
--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -252,18 +252,6 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
       $getFieldsParams['name'] = $singleSettingName;
     }
     $fields = civicrm_api3('setting', 'getfields', $getFieldsParams);
-    if ($singleSettingName) {
-      // this preserves behaviour from a previous workaround in
-      // SettingsMetadata::_filterSettingsSpecification which always returned
-      // the empty array for unrecognised settings if called with `name` filter
-      // moving here to prevent that causing issues elsewhere
-      // TODO: stop calling this with unrecognised settings and then remove this
-      // workaround so we actually validate
-      if (empty($fields['values'][$singleSettingName])) {
-        $fields['values'][$singleSettingName] = [];
-        \Civi::log()->debug("Unrecognised setting key: {$singleSettingName} - please ensure to define meta for this setting or this may fail in future");
-      }
-    }
     $invalidParams = (array_diff_key($settingParams, $fields['values']));
     if (!empty($invalidParams)) {
       throw new CRM_Core_Exception(implode(',', array_keys($invalidParams)) . " not valid settings");

--- a/Civi/Api4/Action/Setting/GetFields.php
+++ b/Civi/Api4/Action/Setting/GetFields.php
@@ -31,12 +31,6 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
     $names = $this->_itemsToGet('name');
     $filter = $names ? ['name' => $names] : [];
     $settings = \Civi\Core\SettingsMetadata::getMetadata($filter, $this->domainId, $this->loadOptions, FALSE, TRUE);
-
-    // FIXME: This is a workaround for a workaround for settingsBag::setDb() which means [] is returned
-    // for non-existent settings if passed in name filter
-    // @see SettingsMetadata::_filterSettingsSpecification
-    $settings = array_filter($settings);
-
     $getReadonly = $this->_isFieldSelected('readonly');
     foreach ($settings as $index => $setting) {
       // Unserialize default value

--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -411,14 +411,12 @@ class SettingsBag {
    *   The new value of the setting.
    */
   protected function setDb($name, $value) {
-    $fields = [];
-    $fieldsToSet = \CRM_Core_BAO_Setting::validateSettingsInput([$name => $value], $fields);
-    //We haven't traditionally validated inputs to setItem, so this breaks things.
-    //foreach ($fieldsToSet as $settingField => &$settingValue) {
-    //  self::validateSetting($settingValue, $fields['values'][$settingField]);
-    //}
+    // NOTE: for better or worse, we haven't traditionally validated whether the setting actually exists here
+    $metadata = SettingsMetadata::getMetadata(['name' => $name])[$name] ?? [];
 
-    $metadata = $fields['values'][$name];
+    if (!$metadata) {
+      \Civi::log()->debug("undefined setting {$name} - please add metadata or encourage the extension author to do so :)");
+    }
 
     // this should probably be higher in the Setting api layer as well
     if ($metadata['is_constant'] ?? FALSE) {

--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -171,8 +171,6 @@ class SettingsMetadata {
   protected static function _filterSettingsSpecification($filters, &$settingSpec) {
     if (!empty($filters['name'])) {
       $settingSpec = array_intersect_key($settingSpec, array_flip((array) $filters['name']));
-      // FIXME: This is a workaround for settingsBag::setDb() called by unit tests with settings names that don't exist
-      $settingSpec += array_fill_keys((array) $filters['name'], []);
       unset($filters['name']);
     }
     if (!empty($filters)) {

--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -172,8 +172,6 @@ class SettingsMetadata {
   protected static function _filterSettingsSpecification($filters, &$settingSpec) {
     if (!empty($filters['name'])) {
       $settingSpec = array_intersect_key($settingSpec, array_flip((array) $filters['name']));
-      // FIXME: This is a workaround for settingsBag::setDb() called by unit tests with settings names that don't exist
-      $settingSpec += array_fill_keys((array) $filters['name'], []);
       unset($filters['name']);
     }
     if (!empty($filters)) {


### PR DESCRIPTION
Before
------------
- SettingsBag::setDb looks like its validating its parameters with `validateSettingsInput`
- it's not -- `validateSettingsInput` has a workaround so it always returns even if the passed setting does not exist
- it's just a roundabout way of getting the settings metadata -- and necessitates other workarounds

After
----------------------
- SettingsBag::setDb just gets the setting metadata directly
- add a deprecation warning when setting undefined settings
- remove workarounds on workarounds
