### PR TITLE
RiverLea: restored internal scrolling in FormBuilder for left & right panels

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,6 +1,13 @@
+1.4.5-6.4alpha
+ - CHANGED 'text-danger' in FormBuilder drop-down to cover tabset dropdown 'delete tab'.
+ - CHANGED restored internal scrolling in FormBuilder for left & right panels to support longer forms (https://lab.civicrm.org/extensions/riverlea/-/issues/114)
+
 1.4.4-6.3alpha
  - FIXED inline checkbox regression (https://lab.civicrm.org/extensions/riverlea/-/merge_requests/51) ht @yashodha
  - FIXED loading animation, re-using nav-bar spinning logo svg, set as a css variable. (ref https://lab.civicrm.org/dev/user-interface/-/issues/84)
+ - FIXED invisible select2 selected item when in a dropdown (ref https://lab.civicrm.org/dev/core/-/issues/5870)
+ - FIXED PrettyPrint code blocks: restored indents lost in 1.3.8-6.0alpha change.
+ - FIXED ol.linenums line-numbering restored.
 
 1.4.3-6.2alpha
 This release makes a series of changes to how emphasis colours (ie primary/success/info/etc) are handled across RiverLea. The main changes:

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -20,7 +20,12 @@
 
 #afGuiEditor {
   gap: var(--crm-r);
-  height: 100% !important /* vs inline fixed height */;
+}
+#afGuiEditor-canvas,
+#afGuiEditor-palette,
+#afGuiEditor-canvas > .panel,
+#afGuiEditor-palette > .panel {
+  height: 100%; /* for scrolling panels */
 }
 #afGuiEditor .af-gui-columns {
   display: grid;
@@ -104,7 +109,9 @@
   position: relative;
   border-top: none !important;
   height: 100%;
+  height: calc(100% - 40px);
   background: var(--crm-tab-bg-active);
+  overflow-y: scroll;
 }
 
 /* Edit palette (left side) */

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -109,7 +109,7 @@
   position: relative;
   border-top: none !important;
   height: 100%;
-  height: calc(100% - 40px);
+  height: calc(100% - 41px);
   background: var(--crm-tab-bg-active);
   overflow-y: scroll;
 }


### PR DESCRIPTION
Resolves issue: https://lab.civicrm.org/extensions/riverlea/-/issues/114

Overview
----------------------------------------
FormBuilder Editor in RiverLea changed left and right panels to be max height with a single scroll for both sides. @Nadaillac pointed out the challenge this brought to building long forms - the elements to drag on the left aren't level with the bottom of the form.

Before
----------------------------------------
Scrolling to the bottom of a long form pushes everything up and the Palette is lost
![image](https://github.com/user-attachments/assets/316015d5-4b62-4fff-9f1d-a07e14b3fe84)

After
----------------------------------------
Scrolling to the bottom of a long form keeps the Palette in place
![image](https://github.com/user-attachments/assets/5916b9ae-b258-4e61-b02b-17e7d68f14aa)

Technical Details
----------------------------------------
This PR is anticipated to be merged *after* https://github.com/civicrm/civicrm-core/pull/32804 – hence why the Changelog describes that change as well as this one… (both fixes were done at the same time but I'm trying to separate my RL PRs, and this one might want longer reviewing than the quick fix in the othre PR. I'm sure there must be a neater way to do this, but I don't know it yet!)

Comments
----------------------------------------
At the moment I've restored scroll to both left and right panels as that's the same pattern in core Civi/Greenwich/Island/etc. But it might be reasonable to only have a scroll on the canvas, not the palette - which could be easily achieved.