### PR TITLE
AfformAdmin - Fix missing Url field type

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/inputType/Url.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Url.html
@@ -1,0 +1,3 @@
+<div class="form-inline">
+  <input autocomplete="off" class="form-control" placeholder="{{:: ts('(no placeholder)') }}" ng-model="getSet('input_attrs.placeholder')" ng-model-options="$ctrl.editor.debounceWithGetterSetter" type="text" title="{{:: ts('Click to add placeholder text') }}"/>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5897](https://lab.civicrm.org/dev/core/-/issues/5897)

Technical Details
----------------------------------------
Was added to Afform in 8c28cee but missing from the AfformAdmin gui editor.