### PR TITLE
[REF][PHP8.2] Declare properties CRM_Contact_Page_View_CustomData

### DIFF
--- a/CRM/Contact/Page/View/CustomData.php
+++ b/CRM/Contact/Page/View/CustomData.php
@@ -28,6 +28,32 @@ class CRM_Contact_Page_View_CustomData extends CRM_Core_Page {
   public $_groupId;
 
   /**
+   * The contact being viewed/edited
+   *
+   * @var int
+   */
+  public $_contactId;
+
+  /**
+   * The record ID for the custom data being viewed/edited
+   *
+   * @var mixed
+   */
+  public $_recId;
+
+  /**
+   * The mode in which the page is being run. ('single' or null)
+   *
+   * @var string|null
+   */
+  public $_multiRecordDisplay;
+
+  /**
+   * @var int
+   */
+  public $_cgcount;
+
+  /**
    * Run the page.
    *
    * This method is called after the page is created. It checks for the

--- a/CRM/Profile/Page/MultipleRecordFieldsListing.php
+++ b/CRM/Profile/Page/MultipleRecordFieldsListing.php
@@ -49,6 +49,13 @@ class CRM_Profile_Page_MultipleRecordFieldsListing extends CRM_Core_Page_Basic {
   public $_total = NULL;
 
   /**
+   * Render this listing as headers only?
+   *
+   * @var bool
+   */
+  public $_headersOnly;
+
+  /**
    * Get BAO Name.
    *
    * @return string


### PR DESCRIPTION
Overview
----------------------------------------
Declare properties `CRM_Contact_Page_View_CustomData` (plus a property on `CRM_Profile_Page_MultipleRecordFieldsListing` which is set by `CRM_Contact_Page_View_CustomData`.

Before
----------------------------------------
To test this, setup a custom fieldgroup, set to allow multiple records, displayed as tab. On visiting the tab, multiple deprecation warnings were shown:

<img width="1389" alt="Screenshot 2025-05-17 at 11 24 10" src="https://github.com/user-attachments/assets/5f26da34-0f08-4007-90c5-27a5c83588bd" />

After
----------------------------------------
Fixed.

This does not fix a similar set of issues when editing a multi-record field - I'll do a seperate PR for those.