### PR TITLE
Riverlea: Set color of icon in contactname block same as the text

### DIFF
--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -15,6 +15,9 @@
   padding: var(--crm-dash-header-padding);
   margin-left: var(--crm-dash-heading-inset);
 }
+.crm-summary-contactname-block .crm-summary-link {
+  color: inherit;
+}
 
 /* Image */
 


### PR DESCRIPTION
Overview
----------------------------------------
Riverlea: Set color of icon in contactname block same as the text (impacts all streams, but addresses issue in Walbrook)

Before
----------------------------------------
In Walbrook, the blue icon on the blue background is difficult to see and looks bad at the top of the contact summary:

<img width="997" alt="Screenshot 2025-05-17 at 11 28 49" src="https://github.com/user-attachments/assets/b39038b3-536f-4030-9a84-21daf9ae2af5" />

After
----------------------------------------
<img width="620" alt="Screenshot 2025-05-17 at 11 31 10" src="https://github.com/user-attachments/assets/cda463e2-d544-443d-a37b-7ef5303df266" />

Comments
----------------------------------------
I was in two minds whether to do this just for Walbrook or for all streams. None of the other streams specifically looked bad before, but the colour of the icon was always very similar to the colour of the text. Therefore, to avoid unnecesarially fragmenting the stream's CSS, and as the change to the other streams will be so subtle, I've gone for making this a global change. Of course, it'll be easy to move this css to the Walbrook stream only if prefered.