### PR TITLE
Riverlea: Improve contast of tag checkboxes

### DIFF
--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -250,7 +250,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .jstree-default.jstree-checkbox-selection .jstree-clicked > .jstree-checkbox::before,
 .crm-container .jstree-default .jstree-checked > .jstree-checkbox::before {
   content: '\f046';
-  color: var(--crm-c-success);
+  color: var(--crm-c-success-on-page-bg);
 }
 .jstree-default > .jstree-no-dots .jstree-closed > .jstree-ocl::before,
 .jstree .jstree-closed > .jstree-ocl::before {


### PR DESCRIPTION
Overview
----------------------------------------
Riverlea: Improve contast of tag checkboxes (Walbrook stream)

Before
----------------------------------------
The contast of the checkboxes is light:

<img width="267" alt="Screenshot 2025-05-17 at 16 26 15" src="https://github.com/user-attachments/assets/d1016189-951c-4b29-b298-a92257491a05" />

After
----------------------------------------
We use `--crm-c-success-on-page-bg` which is better suited to use against the page background.

<img width="263" alt="Screenshot 2025-05-17 at 16 27 27" src="https://github.com/user-attachments/assets/0b572d7a-4029-4d17-97de-799b69b06783" />

Non-Walbrook streams use the same value for `--crm-c-success` and `--crm-c-success-on-page-bg`, and so are not impacted by this change.

I've checked, and this also improves Walbrook in dark mode.

