### PR TITLE
RiverLea: 1.4.5 – fixes FormBuilder DropDown delete colour clash + metadata

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,6 +1,12 @@
+1.4.5-6.3beta
+ - CHANGED 'text-danger' in FormBuilder drop-down to cover tabset dropdown 'delete tab'.
+
 1.4.4-6.3alpha
  - FIXED inline checkbox regression (https://lab.civicrm.org/extensions/riverlea/-/merge_requests/51) ht @yashodha
  - FIXED loading animation, re-using nav-bar spinning logo svg, set as a css variable. (ref https://lab.civicrm.org/dev/user-interface/-/issues/84)
+ - FIXED invisible select2 selected item when in a dropdown (ref https://lab.civicrm.org/dev/core/-/issues/5870)
+ - FIXED PrettyPrint code blocks: restored indents lost in 1.3.8-6.0alpha change.
+ - FIXED ol.linenums line-numbering restored.
 
 1.4.3-6.2alpha
 This release makes a series of changes to how emphasis colours (ie primary/success/info/etc) are handled across RiverLea. The main changes:

--- a/ext/riverlea/core/css/_core.css
+++ b/ext/riverlea/core/css/_core.css
@@ -4,5 +4,5 @@
    can be merged later. */
 
 @import url(components/_accordion.css); @import url(components/_alerts.css); @import url(components/_buttons.css); @import url(components/_form.css); @import url(components/_icons.css); @import url(components/_nav.css); @import url(components/_tabs.css); @import url(components/_dropdowns.css); @import url(components/_tables.css); @import url(components/_dialogs.css); @import url(components/_page.css); @import url(components/_components.css); @import url(components/_front.css); :root {
-  --crm-release: '1.4.3-6.2alpha';
+  --crm-release: '1.4.5-6.3beta';
 }

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -411,12 +411,12 @@
 
 /* Dropdown alert links */
 
-#afGuiEditor  .af-gui-bar .dropdown-menu a:has(.text-danger) {
+#afGuiEditor .dropdown-menu a:has(.text-danger) {
   display: flex;
   justify-content: center;
   background: var(--crm-dropdown-danger-bg);
 }
-#afGuiEditor  .af-gui-bar .dropdown-menu .text-danger {
+#afGuiEditor .dropdown-menu .text-danger {
   color: var(--crm-c-danger-text);
 }
 

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.4-[civicrm.version]</version>
+  <version>1.4.5-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
The dropdown delete button for tab elements is illegible because the FormBuilder 'text-danger' on a dropdown styling was too tightly scoped to target it. Release also adds metadata for 1.4.3 updates and updates version number.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/46dfb916-e8e4-4379-80bc-530f443df126)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/0161b9b3-ac38-47c4-b3e2-52007be1b71d)
