### PR TITLE
RiverLea: restored internal scrolling in FormBuilder for left & right panels, new variable

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,5 +1,7 @@
 1.4.5-6.3beta
- - CHANGED 'text-danger' in FormBuilder drop-down to cover tabset dropdown 'delete tab'.
+ - RESOLVED 'text-danger' in FormBuilder drop-down to cover tabset dropdown 'delete tab'.
+ - CHANGED restored internal scrolling in FormBuilder for each panel to support longer forms (https://lab.civicrm.org/extensions/riverlea/-/issues/114)
+ - ADDED CSS VARIABLE '--crm-panel-head-height' to handle different stream panel head / tab-bar heights for the internal scrolling calculation.
 
 1.4.4-6.3alpha
  - FIXED inline checkbox regression (https://lab.civicrm.org/extensions/riverlea/-/merge_requests/51) ht @yashodha

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -192,6 +192,7 @@
   --crm-panel-background: var(--crm-c-page-background);
   --crm-panel-border: var(--crm-c-divider);
   --crm-panel-head-margin: 0px;
+  --crm-panel-head-height: 37px;
 /* Accordions */
   --crm-expand-icon: "\f0da"; /* unicode value for FontAwesome icon */
   --crm-expand-icon-color: var(--text);

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -20,7 +20,12 @@
 
 #afGuiEditor {
   gap: var(--crm-r);
-  height: 100% !important /* vs inline fixed height */;
+}
+#afGuiEditor-canvas,
+#afGuiEditor-palette,
+#afGuiEditor-canvas > .panel,
+#afGuiEditor-palette > .panel {
+  height: 100%; /* for scrolling panels */
 }
 #afGuiEditor .af-gui-columns {
   display: grid;
@@ -103,8 +108,9 @@
   padding: var(--crm-padding-reg);
   position: relative;
   border-top: none !important;
-  height: 100%;
+  height: calc(100% - var(--crm-panel-head-height));
   background: var(--crm-tab-bg-active);
+  overflow-y: scroll;
 }
 
 /* Edit palette (left side) */

--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -207,6 +207,7 @@
   --crm-panel-background: white;
   --crm-panel-border: var(--crm-c-divider);
   --crm-panel-head-margin: 0px;
+  --crm-panel-head-height: 42px;
 }
 :root {
 /* Accordions */

--- a/ext/riverlea/streams/walbrook/css/_variables.css
+++ b/ext/riverlea/streams/walbrook/css/_variables.css
@@ -97,6 +97,7 @@
   --crm-table-nested-border: 0 solid transparent;
 /* Panels */
   --crm-panel-head-margin: var(--crm-m2);
+  --crm-panel-head-height: 48px;
 /* Accordions */
   --crm-expand-icon: "\f105"; /* unicode value for FontAwesome icon */
   --crm-expand-icon-color: unset;


### PR DESCRIPTION
Resolves issue: https://lab.civicrm.org/extensions/riverlea/-/issues/114

Overview
----------------------------------------
FormBuilder Editor in RiverLea changed left and right panels to be max height with a single scroll for both sides. @Nadaillac pointed out the challenge this brought to building long forms - the elements to drag on the left aren't level with the bottom of the form.

Before
----------------------------------------
Scrolling to the bottom of a long form pushes everything up and the Palette is lost
![image](https://github.com/user-attachments/assets/316015d5-4b62-4fff-9f1d-a07e14b3fe84)

After
----------------------------------------
Scrolling to the bottom of a long form keeps the Palette in place
![image](https://github.com/user-attachments/assets/5916b9ae-b258-4e61-b02b-17e7d68f14aa)

Minetta:
![image](https://github.com/user-attachments/assets/3ec2b6e8-3271-4e20-8da3-693018b153a7)

Walbrook:
![image](https://github.com/user-attachments/assets/186885be-db73-441e-8502-0f61500be5c9)

Hackney:
![image](https://github.com/user-attachments/assets/28f48a8e-626c-4fbe-a5df-f58fa34580f4)

Thames:
![image](https://github.com/user-attachments/assets/f8004d3e-6113-48d6-a9d3-ac999b47ff03)

Technical Details
----------------------------------------
This PR is anticipated to be merged *after* https://github.com/civicrm/civicrm-core/pull/32811 – hence why the Changelog describes that change as well as this one… (both fixes were done at the same time but I'm trying to separate my RL PRs, and this one might want longer reviewing than the quick fix in the othre PR. I'm sure there must be a neater way to do this, but I don't know it yet!)

Comments
----------------------------------------
At the moment I've restored scroll to both left and right panels as that's the same pattern in core Civi/Greenwich/Island/etc. But it might be reasonable to only have a scroll on the canvas, not the palette - which could be easily achieved.

Since my first PR of this against Master I've refined the implementation a little by adding a custom variable for each stream to identify the height of the panel heading, which is subtracted from the 100% height which forces the scroll. This is a pixel-precise calculation because too high and it ends the scroll region too soon, and too low it overlaps the boundary - and this varies depending on tab padding/height. cc @artfulrobot as this adds & sets a variable to Thames. 