### PR TITLE
RiverLea UI Regression: Close icon on community message floats left not right

### DIFF
--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -80,7 +80,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 
 /* Close icon */
 #crm-notification-container .ui-notify-message a.ui-notify-cross,
-div.civicrm-community-messages a.civicrm-community-message-dismiss,
+.crm-container div.civicrm-community-messages a.civicrm-community-message-dismiss,
 .crm-container .ui-icon-circle-close {
   font-size: 0;
   float: right;


### PR DESCRIPTION
Overview
----------------------------------------
The close icon on the community message banner is floating left because of a specificity clash. This fixes that.

Before
----------------------------------------
Floats left:
![image](https://github.com/user-attachments/assets/74d9034c-44b2-4b52-90e8-26fb6651df35)

After
----------------------------------------
Floats right:
![image](https://github.com/user-attachments/assets/9ed3abd8-ba4a-47d1-8140-94b9e3ac1dba)

Comments
----------------------------------------
Issue impacts core RiverLea, so is the same in all Streams.