### PR TITLE
fix undefined notice in CRM_Core_Controller

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -826,7 +826,7 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
   public function setDestination($url = NULL, $setToReferer = FALSE) {
     if (empty($url)) {
       if ($setToReferer) {
-        $url = $_SERVER['HTTP_REFERER'];
+        $url = $_SERVER['HTTP_REFERER'] ?? NULL;
       }
       else {
         $config = CRM_Core_Config::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
If you visit the page (such as /civicrm/mailing/subscribe) directly the referer may not be set, and this throws a notice on php8.3.