### PR TITLE
Simplify numeric check

### DIFF
--- a/api/v3/Contact.php
+++ b/api/v3/Contact.php
@@ -1040,9 +1040,12 @@ function civicrm_api3_contact_proximity($params) {
 
   // check and ensure that lat/long and distance are floats
   if (
-    !CRM_Utils_Rule::numeric($latitude) ||
-    !CRM_Utils_Rule::numeric($longitude) ||
-    !CRM_Utils_Rule::numeric($distance)
+    // We should just declare the data type correctly in the _spec function
+    // and leave this to the api layer, but reluctant to make changes to
+    // apiv3 now.
+    !is_numeric($latitude) ||
+    !is_numeric($longitude) ||
+    !is_numeric($distance)
   ) {
     throw new CRM_Core_Exception(ts('Latitude, Longitude and Distance should exist and be numeric'));
   }

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -235,7 +235,7 @@ function _civicrm_api3_custom_field_validate_field($fieldName, $value, $fieldDet
       break;
 
     case 'Float':
-      if (!CRM_Utils_Rule::numeric($value)) {
+      if (!is_numeric($value)) {
         $errors[$fieldName] = 'Invalid numeric value for ' . $fieldName;
       }
       break;


### PR DESCRIPTION
Based on discussion in https://github.com/civicrm/civicrm-core/pull/32791 I think we should update CRM_Utils_Rule::numeric to handle numbers with Euro style decimals - but just doing a bit of an audit of callers & in this case it seems overly complex to call the rule, in fact it seems a bit of overkill to do anything but...
