### PR TITLE
Standalone - more consistently prefer /civicrm/home to /civicrm/dashboard

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -916,28 +916,15 @@ ORDER BY weight";
             'weight' => 1,
           ],
         ];
-        if (CIVICRM_UF !== 'Standalone') {
-          $item['child'][] = [
-            'attributes' => [
-              'label' => ts('Hide Menu'),
-              'name' => 'Hide Menu',
-              'url' => '#hidemenu',
-              'icon' => 'crm-i fa-minus',
-              'weight' => 2,
-            ],
-          ];
-        }
-        else {
-          $item['child'][] = [
-            'attributes' => [
-              'label' => ts('Change Password'),
-              'name' => 'Change Password',
-              'url' => 'civicrm/admin/user/password',
-              'icon' => 'crm-i fa-keyboard',
-              'weight' => 2,
-            ],
-          ];
-        }
+        $item['child'][] = [
+          'attributes' => [
+            'label' => ts('Hide Menu'),
+            'name' => 'Hide Menu',
+            'url' => '#hidemenu',
+            'icon' => 'crm-i fa-minus',
+            'weight' => 2,
+          ],
+        ];
         $item['child'][] = [
           'attributes' => [
             'label' => ts('Log out'),

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -6,7 +6,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
   public function run() {
     if (CRM_Core_Config::singleton()->userSystem->isUserLoggedIn()) {
       // Already logged in.
-      CRM_Utils_System::redirect('/civicrm');
+      CRM_Utils_System::redirect('/civicrm/home?reset=1');
     }
     if (isset($_GET['justLoggedOut'])) {
       // When the user has just logged out their session is destroyed

--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -100,7 +100,7 @@ class Login extends AbstractAction {
    */
   protected function passwordCheck(Result $result) {
 
-    $successUrl = '/civicrm';
+    $successUrl = '/civicrm/home';
     if (!empty($this->originalUrl) && parse_url($this->originalUrl, PHP_URL_PATH) !== '/civicrm/login') {
       // We will return to this URL on success.
       $successUrl = $this->originalUrl;

--- a/ext/standaloneusers/Civi/Standalone/Utils.php
+++ b/ext/standaloneusers/Civi/Standalone/Utils.php
@@ -10,6 +10,13 @@ class Utils {
         continue;
       }
 
+      // use /civicrm/home rather than /civicrm/dashboard
+      foreach ($item['child'] as &$subitem) {
+        if ($subitem['attributes']['name'] === 'CiviCRM Home') {
+          $subitem['attributes']['url'] = 'civicrm/home?reset=1';
+        }
+      }
+
       // remove hide menu
       $item['child'] = array_filter($item['child'], fn ($subitem) => ($subitem['attributes']['name'] !== 'Hide Menu'));
 

--- a/ext/standaloneusers/Civi/Standalone/Utils.php
+++ b/ext/standaloneusers/Civi/Standalone/Utils.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi\Standalone;
+
+class Utils {
+
+  public static function alterHomeMenuItems(&$menu) {
+    foreach ($menu as &$item) {
+      if (($item['attributes']['name'] ?? NULL) !== 'Home') {
+        continue;
+      }
+
+      // remove hide menu
+      $item['child'] = array_filter($item['child'], fn ($subitem) => ($subitem['attributes']['name'] !== 'Hide Menu'));
+
+      // add change password
+      $item['child'][] = [
+        'attributes' => [
+          'label' => ts('Change Password'),
+          'name' => 'Change Password',
+          'url' => 'civicrm/admin/user/password?reset=1',
+          'icon' => 'crm-i fa-keyboard',
+          'weight' => 2,
+        ],
+      ];
+
+      return;
+
+    }
+  }
+
+}

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -88,6 +88,8 @@ function standaloneusers_civicrm_navigationMenu(&$menu) {
     'url' => 'civicrm/admin/setting/standaloneusers?reset=1',
     'permission' => 'cms:administer users',
   ]);
+
+  \Civi\Standalone\Utils::alterHomeMenuItems($menu);
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Standalone allows you to create a page at `/civicrm/home` to use as the home page, but it's not that consistent. Improve it.

Before
----------------------------------------
- `/civicrm/home` shows a custom page if you create one, or the normal dashboard if none exists
- `/civicrm/dashboard` always still shows you the normal dashboard
- heading to `https://my.standalone.site` takes you to `/civicrm/home`
- heading to `https://my.standalone.site/civicrm/login` takes you to `/civicrm` (which always shows the normal dashboard)
- the CiviCRM Home item in the Home menu takes you to `/civicrm/dashboard`

After
---------------------------------------
- `/civicrm/home` shows a custom page if you create one, or the normal dashboard if none exists
- `/civicrm/dashboard` always shows you the normal dashboard
- heading to `https://my.standalone.site` takes you to `/civicrm/home`
- heading to `https://my.standalone.site/civicrm/login` takes you to `/civicrm/home`
- the CiviCRM Home item in the Home menu takes you to `/civicrm/home`

Comments
----------------------------------------
It's quite a naive implementation of the home menu, so maybe it could be completely overhauled. But this is a simple consistency improvement on the current implementation

The Home menu uses `CIVICRM_UF` check, which we've been trying to avoid to be as OO as possible. This moves the mods to the regular hook. (I sort of think this menu should work like the others, and be moddable with `*.mgd.php` records. But currently any Navigation records under Home are overridden.)