### PR TITLE
CiviImport - Fix undefined indices

### DIFF
--- a/CRM/Contact/Import/Form/Summary.php
+++ b/CRM/Contact/Import/Form/Summary.php
@@ -31,7 +31,7 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
     $userJobID = CRM_Utils_Request::retrieve('user_job_id', 'String', $this, TRUE);
     $userJob = UserJob::get(TRUE)->addWhere('id', '=', $userJobID)->addSelect('metadata', 'job_type:label')->execute()->first();
     $this->setTitle($userJob['job_type:label']);
-    $onDuplicate = $userJob['metadata']['submitted_values']['onDuplicate'];
+    $onDuplicate = (int) ($userJob['metadata']['submitted_values']['onDuplicate'] ?? 0);
     $this->assign('dupeError', FALSE);
     $importBaseURL = $this->getUserJobInfo()['url'] ?? NULL;
     $this->assign('templateURL', ($importBaseURL && $this->getTemplateID()) ? CRM_Utils_System::url($importBaseURL, ['template_id' => $this->getTemplateID(), 'reset' => 1]) : '');
@@ -103,7 +103,7 @@ class CRM_Contact_Import_Form_Summary extends CRM_Import_Forms {
           ->setFragment("display/{$userJob['search_display_id.saved_search_id.name']}/{$userJob['search_display_id.name']}?batch={$userJobID}");
       }
       $this->assign('searchDisplayLink', (string) $searchDisplayLink);
-      $onDuplicate = (int) $userJob['metadata']['submitted_values']['onDuplicate'];
+      $onDuplicate = (int) ($userJob['metadata']['submitted_values']['onDuplicate'] ?? 0);
       $this->assign('dupeError', FALSE);
       if ($onDuplicate === CRM_Import_Parser::DUPLICATE_UPDATE) {
         $dupeActionString = ts('These records have been updated with the imported data.');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes minor annoyance in the new SearchKit batch import screen:

![image](https://github.com/user-attachments/assets/114d68a0-b145-4ef7-875e-d449e384ba30)


Technical Details
----------------------------------------
The `submitted_values` key does not exist for non-quickform imports such as the new SearchKit batch import display.