### PR TITLE
Select active not draft translation in API4 wrapper

### DIFF
--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -246,6 +246,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookI
 
     $translations = Translation::get()
       ->addWhere('entity_table', '=', CRM_Core_DAO_AllCoreTables::getTableForEntityName($apiRequest['entity']))
+      ->addWhere('status_id:name', '=', 'active')
       ->setCheckPermissions(FALSE)
       ->setSelect(['entity_field', 'entity_id', 'string', 'language']);
     if ((substr($userLocale->nominal ?? '', '-3', '3') !== '_NO')) {


### PR DESCRIPTION
Overview
----------------------------------------
Updates the Transalation API4 wrapper to select only active translations.

Before
----------------------------------------
Creating a draft version of e.g. a workflow message immediately overrides the 'active' version, sending draft content out to contacts before it is approved.

After
----------------------------------------
Only published / approved translations are selected in the API wrapper.

Technical Details
----------------------------------------
All translations for the table are selected at once and loaded into the $languages array. In the 'for $fields as $field' loop, the draft version has a higher ID and is encountered later in the loop, overwriting the active version.