### PR TITLE
Move tax term

### DIFF
--- a/CRM/Admin/Form/Preferences/Contribute.php
+++ b/CRM/Admin/Form/Preferences/Contribute.php
@@ -27,7 +27,7 @@ class CRM_Admin_Form_Preferences_Contribute extends CRM_Admin_Form_Preferences {
    */
   public function buildQuickForm(): void {
     parent::buildQuickForm();
-    $invoiceSettings = SettingsMetadata::getMetadata(['name' => ['invoice_prefix', 'tax_term', 'invoice_notes', 'invoice_due_date', 'invoice_is_email_pdf', 'invoice_due_date_period', 'tax_display_settings']], NULL, TRUE);
+    $invoiceSettings = SettingsMetadata::getMetadata(['name' => ['invoice_prefix', 'invoice_notes', 'invoice_due_date', 'invoice_is_email_pdf', 'invoice_due_date_period', 'tax_display_settings']], NULL, TRUE);
     // Let the main template file deal with the main setting & then Contribute.tpl
     // can stick the invoice settings in a div that can show-hide-toggle if invoicing is enabled.
     $this->assign('fields', $this->filterMetadataByWeight(array_diff_key($this->getSettingsMetaData(), $invoiceSettings)));

--- a/settings/Contribute.setting.php
+++ b/settings/Contribute.setting.php
@@ -140,7 +140,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => '',
-    'settings_pages' => ['contribute' => ['weight' => 150]],
+    'settings_pages' => ['contribute' => ['weight' => 80]],
   ],
   'tax_display_settings' => [
     'default' => 'Inclusive',


### PR DESCRIPTION
Overview
----------------------------------------
The `tax term` admin setting in CiviContribute Component Settings is only shown if you tick `Enable Tax and Invoicing`. But the setting is used during contribution checkout even if you _haven't_ enabled invoicing, so the setting should always be available.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/b3fb396d-9f0a-4fe3-b0ae-33c38ebc84da)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/8bcaa138-cc60-457d-b23c-8b2e29ead2af)
