### PR TITLE
Remove/deprecate addHtmlHead cruft

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1202,7 +1202,11 @@ class CRM_Utils_System {
    * @return void
    */
   public static function setNoRobotsFlag(): void {
-    CRM_Utils_System::addHTMLHead('<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">');
+    $region = CRM_Core_Region::instance('html-header', TRUE);
+    $region->add([
+      'type' => 'markup',
+      'markup' => '<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">',
+    ]);
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -31,7 +31,7 @@ use GuzzleHttp\Psr7\Response;
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.
  * @method static void appendBreadCrumb(array $breadCrumbs) Append an additional breadcrumb link to the existing breadcrumbs.
  * @method static void resetBreadCrumb() Reset an additional breadcrumb tag to the existing breadcrumb.
- * @method static void addHTMLHead(string $head) Append a string to the head of the HTML file.
+ * @method static void addHTMLHead(string $head) Append a string to the head of the HTML file. Note: this is only used in Drupal/Backdrop/Joomla and is deprecated in Wordpress/Standalone
  * @method static string postURL(int $action) Determine the post URL for a form.
  * @method static string|null getUFLocale() Get the locale of the CMS.
  * @method static bool setUFLocale(string $civicrm_language) Set the locale of the CMS.

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1211,7 +1211,7 @@ AND    u.status = 1
         backdrop_set_breadcrumb('');
         backdrop_maintenance_theme();
         if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
-          CRM_Utils_System::addHTMLHead($region->render(''));
+          $this->addHTMLHead($region->render(''));
         }
         print theme('maintenance_page', ['content' => $content]);
         exit();

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -115,6 +115,7 @@ abstract class CRM_Utils_System_Base {
    *   The new string to be appended.
    */
   public function addHTMLHead($head) {
+    \CRM_Core_Error::deprecatedFunctionWarning("addHTMLHead is deprecated in " . self::class);
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -897,7 +897,7 @@ AND    u.status = 1
         drupal_set_breadcrumb('');
         drupal_maintenance_theme();
         if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
-          CRM_Utils_System::addHTMLHead($region->render(''));
+          $this->addHTMLHead($region->render(''));
         }
         print theme('maintenance_page', ['content' => $content]);
         exit();

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -160,34 +160,30 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * @inheritDoc
+   *
+   * Note: Standalone renders the html-header region directly in its smarty page template
+   * so this should never be called
    */
   public function addHTMLHead($header) {
-    $template = CRM_Core_Smarty::singleton();
-    // Smarty's append function does not check for the existence of the var before appending to it.
-    // So this prevents a stupid notice error:
-    $template->ensureVariablesAreAssigned(['pageHTMLHead']);
-    $template->append('pageHTMLHead', $header);
-    return;
+    throw new \CRM_Core_Exception('addHTMLHead should never be called in Standalone');
   }
 
   /**
-   * @inheritDoc
+   * @inheritdoc
+   *
+   * No such things as CMS-rendering in Standlaone => always return FALSE
    */
   public function addStyleUrl($url, $region) {
-    if ($region != 'html-header') {
-      return FALSE;
-    }
-    $this->addHTMLHead('<link rel="stylesheet" href="' . $url . '"></style>');
+    return FALSE;
   }
 
   /**
-   * @inheritDoc
+   * @inheritdoc
+   *
+   * No such things as CMS-rendering in Standlaone => always return FALSE
    */
   public function addStyle($code, $region) {
-    if ($region != 'html-header') {
-      return FALSE;
-    }
-    $this->addHTMLHead('<style>' . $code . '</style>');
+    return FALSE;
   }
 
   /**

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -274,6 +274,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function addHTMLHead($head) {
+    \CRM_Core_Error::deprecatedFunctionWarning("addHTMLHead is deprecated in WordPress and will be removed in a future version");
     static $registered = FALSE;
     if (!$registered) {
       // front-end view

--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -15,7 +15,6 @@ class WebEntrypoint {
    * @see self::checkCiviInstalled
    */
   public static function index(): void {
-    define('CIVICRM_UF_HEAD', TRUE);
     if (self::checkCiviInstalled()) {
       ErrorHandler::setHandler();
       self::invoke();

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -5,13 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" type="image/png" href="{$config->resourceBase}i/logo_lg.png" >
 
-  {* @todo crmRegion below should replace this, but not working? *}
-  {if isset($pageHTMLHead)}
-    {foreach from=$pageHTMLHead item=i}
-      {$i}
-    {/foreach}
-  {/if}
-
   {crmRegion name='html-header'}
   {/crmRegion}
 


### PR DESCRIPTION
Overview
----------------------------------------
Following https://github.com/civicrm/civicrm-core/pull/32254 this strips out `addHtmlHead` from Standalone and deprecates it in WordPress.

Currently the Drupal/Backdrop/Joomla integrations use `addHtmlHead` in their alternative to `addHtmlHead` so can't be deprecated there yet. But I think the addHtmlHead code from each probably belongs in a more protected place in the integrations themselves. As @totten points out on the above PR, this function isn't safe to be called at random points in the codebase.

In Standalone we can render the `html-header` directly in the smarty template, so we don't need anything that looks like `addHtmlHead` at all.