### PR TITLE
Allow custom separators to pass through numeric rule

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -456,6 +456,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       'autocomplete',
       'validContact',
       'email',
+      'numberInternational',
     ];
 
     foreach ($rules as $rule) {
@@ -3185,7 +3186,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     // Numeric fields are not in submittableMoneyFields (for now)
     $fieldRules = $this->_rules[$fieldName] ?? [];
     foreach ($fieldRules as $rule) {
-      if ('money' === $rule['type']) {
+      if ('money' === $rule['type'] || 'numberInternational' === $rule['type']) {
         return CRM_Utils_Rule::cleanMoney($value);
       }
     }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -349,7 +349,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $type = 'money';
         }
         else {
-          $type = 'numeric';
+          $type = 'numberInternational';
         }
         // integers will have numeric rule applied to them.
         $qf->addRule($elementName, ts('%1 must be a number.', [1 => $label]), $type);

--- a/CRM/Utils/Rule.php
+++ b/CRM/Utils/Rule.php
@@ -473,6 +473,34 @@ class CRM_Utils_Rule {
   }
 
   /**
+   * @param float|int|string|null $value
+   *
+   * @return bool
+   */
+  public static function numberInternational(float|int|string|null $value): bool {
+    $escapedThousand = preg_quote((string) \Civi::settings()->get('monetaryThousandSeparator'));
+    $escapedDecimal = preg_quote((string) \Civi::settings()->get('monetaryDecimalPoint'));
+    // This pattern supports:
+    // - Western format: 1,234,567.89
+    // - Or 1.234.234,89 (or any other configured separator)
+    // - Indian format: 12,34,567.89
+    // - Unformatted numbers: 1234567.89
+    // Optional negative sign and decimal part.
+    $pattern = "/^-?(?:" .
+      // Western grouping
+      "\d{1,3}(?:{$escapedThousand}\d{3})+" .
+      "|" .
+      // Indian grouping
+      "\d{1,2}(?:{$escapedThousand}\d{2}){1,}(?:{$escapedThousand}\d{3})" .
+      "|" .
+      // Plain number
+      "\d+" .
+      ")" .
+      "(?:{$escapedDecimal}\d+)?$/";
+    return preg_match($pattern, (string) $value) === 1;
+  }
+
+  /**
    * Test whether $value is alphanumeric.
    *
    * Underscores and dashes are also allowed!

--- a/tests/phpunit/CRM/Utils/RuleTest.php
+++ b/tests/phpunit/CRM/Utils/RuleTest.php
@@ -70,9 +70,21 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
   }
 
   /**
+   * @dataProvider numberInternationalDataProvider
+   *
+   * @param float|int|string $inputData
+   * @param $expectedResult
+   * @param string $thousandSeparator
+   */
+  public function testNumberInternational(float|int|string $inputData, $expectedResult, string $thousandSeparator = ','): void {
+    $this->setCurrencySeparators($thousandSeparator);
+    $this->assertEquals($expectedResult, CRM_Utils_Rule::numberInternational($inputData));
+  }
+
+  /**
    * @return array
    */
-  public function numericDataProvider() {
+  public function numericDataProvider(): array {
     return [
       [10, TRUE],
       ['145.0E+3', FALSE],
@@ -80,6 +92,32 @@ class CRM_Utils_RuleTest extends CiviUnitTestCase {
       [-10, TRUE],
       ['-10', TRUE],
       ['-10foo', FALSE],
+    ];
+  }
+
+  /**
+   * @return array
+   */
+  public function numberInternationalDataProvider(): array {
+    return [
+      'basic_integer' => [10, TRUE],
+      'no_separator_us' => ['1000.68', TRUE],
+      'no_separator_euro' => ['1000,68', TRUE, '.'],
+      'thousand_separated_us' => ['1,000.90', TRUE],
+      'thousand_separated_euro' => ['1.000,90', TRUE, '.'],
+      'million_separated_us' => ['1,000,000.90', TRUE],
+      'million_separated_euro' => ['1.000.000,90', TRUE, '.'],
+      'negative_million_separated_us' => ['-1,000,000.90', TRUE],
+      'negative_million_separated_euro' => ['-1.000.000,90', TRUE, '.'],
+      'rupee-like' => ['1,50,000', TRUE, ','],
+      'rupee-two' => ['3,00,00,000', TRUE, ','],
+      'thousand_separated_us_$' => ['$1,000.90', FALSE],
+      'thousand_separated_euro_$' => ['$1.000,90', FALSE, '.'],
+      'scientific' => ['145.0E+3', FALSE],
+      'string' => ['10', TRUE],
+      'negative' => [-10, TRUE],
+      'negative_string' => ['-10', TRUE],
+      'extra_word' => ['-10foo', FALSE],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Allow international amounts to be submitted for 'other amount'

https://github.com/civicrm/civicrm-core/pull/32778

Before
----------------------------------------


After
----------------------------------------
new rule - `numberInternational` for international numbers with possible separators

Technical Details
----------------------------------------

These paths call `CRM_Utils_Rule::numberic()`  - I thought we would want to switch them over - but the ones being used in `CRM_Utils_Type()` indicate it is called via that function for sql verification. So I sadly had to add another rule - a number of these would ideally be moved over- although I have not figured out exactly which 

api/v3/CustomField.php: if (!CRM_Utils_Rule::numeric($value)) {
Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php: if (\CRM_Utils_Rule::numeric($value)) {
CRM/Core/BAO/CustomValue.php: return CRM_Utils_Rule::numeric($value);
CRM/Core/Payment.php: if (!CRM_Utils_Rule::numeric($params['amount'])) { (remove https://github.com/civicrm/civicrm-core/pull/32834) 
CRM/Utils/Type.php: if (CRM_Utils_Rule::numeric($data)) {
CRM/Utils/Type.php: return CRM_Utils_Rule::numeric($value);
CRM/Custom/Form/Option.php: if (!CRM_Utils_Rule::numeric($fields["value"])) {
CRM/Custom/Form/Field.php: if (!CRM_Utils_Rule::numeric($default)) {
CRM/Custom/Form/Field.php: if (!CRM_Utils_Rule::numeric($fields['option_value'][$i])) {
CRM/Import/Parser.php: return CRM_Utils_Rule::numeric($importedValue) ? $importedValue : 'invalid_import_value';
CRM/Import/Parser.php: return CRM_Utils_Rule::numeric($importedValue) ? (int) $importedValue : 'invalid_import_value';
CRM/Financial/Form/PaymentEdit.php: !CRM_Utils_Rule::numeric($fields['pan_truncation']) (remove https://github.com/civicrm/civicrm-core/pull/32833 )
tests/phpunit/CRM/Utils/RuleTest.php: $this->assertEquals($expectedResult, CRM_Utils_Rule::numeric($inputData));


I need to grok but ChatGPT

Great idea! Using **variables** for thousand and decimal separators makes your PHP code much more flexible and locale-aware.

---

### ✅ PHP Function with Configurable Separators

Here’s a function that accepts **custom separators** for thousands and decimals:

```php
<?php

function isValidLocalizedNumber(string $number, string $thousandSep, string $decimalSep): bool {
    // Escape separators for regex
    $escapedThousand = preg_quote($thousandSep, '/');
    $escapedDecimal = preg_quote($decimalSep, '/');

    // Build regex dynamically based on separators
    $pattern = '/^-?(?:\d{1,3}(?:' . $escapedThousand . '\d{3})+|\d+)(?:' . $escapedDecimal . '\d+)?$/';

    return preg_match($pattern, $number);
}

// Example usage
$examples = [
    "1,000.68", // US style
    "1000.68",  // US without thousand
    "1.000,68", // EU style
    "1000,68",  // EU without thousand
    "-1.000,99",
    "1.000.000,01",
    "1,000,000.01"
];

echo "US format:\n";
foreach ($examples as $num) {
    echo "$num => " . (isValidLocalizedNumber($num, ',', '.') ? "✅ Valid" : "❌ Invalid") . "\n";
}

echo "\nEU format:\n";
foreach ($examples as $num) {
    echo "$num => " . (isValidLocalizedNumber($num, '.', ',') ? "✅ Valid" : "❌ Invalid") . "\n";
}
```

---

### 🔍 What This Does:

* Dynamically constructs a regex based on the separators passed.
* Allows:

  * Optional thousands grouping
  * Optional decimals
  * Negative numbers
* You can pass:

  * `','` and `'.'` for US-style
  * `'.'` and `','` for EU-style

---

### 🔄 Optional Normalization

If you also want to **convert** these to a standard (e.g., `float` with dot decimal), let me know — I can provide a function that does that too.


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
