### PR TITLE
Simplify check on pan_truncation

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -162,7 +162,7 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
     // if Credit Card is chosen and pan_truncation is not NULL ensure that it's value is numeric else throw validation error
     if (CRM_Core_PseudoConstant::getName('CRM_Financial_DAO_FinancialTrxn', 'payment_instrument_id', $fields['payment_instrument_id']) === 'Credit Card' &&
       !empty($fields['pan_truncation']) &&
-      !CRM_Utils_Rule::numeric($fields['pan_truncation'])
+      !is_numeric($fields['pan_truncation'])
     ) {
       $errors['pan_truncation'] = ts('Please enter a valid Card Number');
     }


### PR DESCRIPTION
Overview
----------------------------------------
Simplify check on pan_truncation

Before
----------------------------------------
Since pan_truncation will never have separators the second part of the `CRM_Utils_Rule::numeric()` is not relevant - but since that function should handle currency it's cleaner not to call it here

After
----------------------------------------
Simple numeric check

Technical Details
----------------------------------------
ideally we would check something more like numbers only - but I guess no-one has hit issues here & the goal here is just to pave the way for https://github.com/civicrm/civicrm-core/pull/32832

Comments
----------------------------------------
