### PR TITLE
dev/core#4251 Provided temporary support for writing contact image to civicrm_contacts

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -85,17 +85,19 @@ class SubmitFile extends AbstractProcessor {
       return $this->updateDraft($draft, $file['id']);
     }
     else {
+      $apiEntity = $this->getEntityApiName();
+      $entityTable = CoreUtil::getTableName($apiEntity);
       $file = civicrm_api3('Attachment', 'create', $attachmentParams);
 
       /**
        * Updates contact record to use existing file table data for contact_image. Temporary fix for dev/core#4251
        */
-      if ($attachmentParams['entity_table'] == 'civicrm_contact' && isset($attachmentParams['entity_id'])) {
+      if ($entityTable == 'civicrm_contact' && isset($entityId)) {
         $fileId = $file['id'];
         $filepath = pathinfo($file['values'][$fileId]['path']);
         $result = civicrm_api4('Contact', 'update', [
           'values' => [
-            'id' => $attachmentParams['entity_id'], 
+            'id' => $entityId, 
             'image_URL' => sprintf('/civicrm/contact/imagefile?photo=%s', $filepath['basename']),
           ],
         ]);

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -89,8 +89,19 @@ class SubmitFile extends AbstractProcessor {
       $entityTable = CoreUtil::getTableName($apiEntity);
       $attachmentParams = [
         'entity_id' => $entityId,
-        'entity_table' => $entityTable
+        'mime_type' => $_FILES['file']['type'],
+        'name' => $_FILES['file']['name'],
+        'options' => [
+          'move-file' => $_FILES['file']['tmp_name'],
+        ],
       ];
+
+    if (strpos($this->fieldName, '.')) {
+      $attachmentParams['field_name'] = $this->convertFieldNameToApi3($apiEntity, $this->fieldName);
+    }
+    else {
+      $attachmentParams['entity_table'] = CoreUtil::getTableName($apiEntity);
+    }
       $file = civicrm_api3('Attachment', 'create', $attachmentParams);
 
       /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -87,6 +87,10 @@ class SubmitFile extends AbstractProcessor {
     else {
       $apiEntity = $this->getEntityApiName();
       $entityTable = CoreUtil::getTableName($apiEntity);
+      $attachmentParams = [
+        'entity_id' => $entityId,
+        'entity_table' => $entityTable
+      ];
       $file = civicrm_api3('Attachment', 'create', $attachmentParams);
 
       /**
@@ -97,14 +101,14 @@ class SubmitFile extends AbstractProcessor {
         $filepath = pathinfo($file['values'][$fileId]['path']);
         $result = civicrm_api4('Contact', 'update', [
           'values' => [
-            'id' => $entityId, 
+            'id' => $entityId,
             'image_URL' => sprintf('/civicrm/contact/imagefile?photo=%s', $filepath['basename']),
           ],
         ]);
-        
+
         return [];
       }
-  
+
       // Update multi-record custom field with value
       if (strpos($apiEntity, 'Custom_') === 0) {
         return $this->updateEntity($entityId, $file['id']);


### PR DESCRIPTION
Overview
----------------------------------------
Provided temporary support to writing contact image URL to the contact record with existing infrastructure. Funding provided by National Institute for the Psychotherapies Professional Association

See https://lab.civicrm.org/dev/core/-/issues/4251 for details on existing issue.

Before
----------------------------------------
Image is stored as a entity file record, which is not compatible with the current contact image functionality or available in FormBuilder. Result is that image displays as broken because it cannot be fetched.

After
----------------------------------------
File uploads for the contact image create the appropriate API call for setting the contact image URL in the civicrm_contacts table.
