### PR TITLE
(dev/core#5902) Re-fix preferred communication method

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -129,15 +129,6 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
       }
     }
 
-    if (isset($params['preferred_communication_method']) && is_array($params['preferred_communication_method'])) {
-      if (!empty($params['preferred_communication_method']) && empty($params['preferred_communication_method'][0])) {
-        CRM_Core_Error::deprecatedWarning(' Form layer formatting should never get to the BAO');
-        CRM_Utils_Array::formatArrayKeys($params['preferred_communication_method']);
-        $contact->preferred_communication_method = CRM_Utils_Array::implodePadded($params['preferred_communication_method']);
-        unset($params['preferred_communication_method']);
-      }
-    }
-
     $defaults = ['source' => $params['contact_source'] ?? NULL];
     if ($params['contact_type'] === 'Organization' && isset($params['organization_name'])) {
       $defaults['display_name'] = $params['organization_name'];

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -962,11 +962,6 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
 
     //get the submitted values in an array
     $params = $this->getSubmittedValues();
-    if (!isset($params['preferred_communication_method'])) {
-      // If this field is empty QF will trim it so we have to add it in.
-      $params['preferred_communication_method'] = 'null';
-    }
-
     if (array_key_exists('group', $params)) {
       $group = is_array($params['group']) ? $params['group'] : explode(',', $params['group']);
       $params['group'] = array_fill_keys($group, 1);
@@ -1027,11 +1022,11 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       );
     }
 
-    if (array_key_exists('CommunicationPreferences', $this->_editOptions)) {
-      // this is a chekbox, so mark false if we dont get a POST value
-      $params['is_opt_out'] ??= FALSE;
+    $params['preferred_communication_method'] = $this->getSubmittedValue('preferred_communication_method') ? array_keys($params['preferred_communication_method']) : 'null';
 
-      CRM_Utils_Array::formatArrayKeys($params['preferred_communication_method']);
+    if (array_key_exists('CommunicationPreferences', $this->_editOptions)) {
+      // this is a checkbox, so mark false if we dont get a POST value
+      $params['is_opt_out'] ??= FALSE;
     }
 
     // process shared contact address.


### PR DESCRIPTION
Overview
----------------------------------------
This attempts to re-remove the reverted code touched in [dev/core#5902 
](https://lab.civicrm.org/dev/core/-/issues/5902#note_182254) - note to replicate the issue it turns out you need to be using the INLINE form AND test preferred communication methods other than phone 

This is not intended to change behaviour - only to use more recent code - a successful UI test would show editing communication preferences continues to work both via the Contact Edit form and the inline editing of communication preferences

Before
----------------------------------------
Deprecated code re-added

After
----------------------------------------
Removed again - form layer fix

Technical Details
----------------------------------------

Comments
----------------------------------------
