### PR TITLE
Avoid deprecation warning for DateTime settings

### DIFF
--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -225,7 +225,7 @@ trait CRM_Admin_Form_SettingTrait {
         elseif ($add === 'addChainSelect') {
           $this->addChainSelect($setting, ['label' => $props['title']] + $props['chain_select_settings']);
         }
-        elseif ($add === 'addMonthDay') {
+        elseif (in_array($add, ['addMonthDay', 'addDateTime'])) {
           $this->add('date', $setting, $props['title'], CRM_Core_SelectValues::date(NULL, 'M d'));
         }
         elseif ($add === 'addEntityRef') {


### PR DESCRIPTION
Overview
----------------------------------------
When a setting has its quick_form_type set to 'DateTime', render a datepicker instead of a warning

Before
----------------------------------------
Deprecation warnings on a settings form with a DateTime setting

After
----------------------------------------
Datepicker for the DateTime setting

Technical Details
----------------------------------------
The rendered picker seems to have a time field, even though I piggy-backed on the MonthDay setting case
