### PR TITLE
Deprecate a couple of token functions not used in core

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1262,8 +1262,11 @@ class CRM_Utils_Token {
    *
    * @return string
    *   The processed string
+   *
+   * @deprecated since 6.3 will be removed around 6.15
    */
-  public static function &replaceUserTokens($str, $knownTokens = NULL, $escapeSmarty = FALSE) {
+  public static function replaceUserTokens($str, $knownTokens = NULL, $escapeSmarty = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     $key = 'user';
     if (!$knownTokens ||
       !isset($knownTokens[$key])
@@ -1289,6 +1292,7 @@ class CRM_Utils_Token {
    */
   public static function getUserTokenReplacement($token, $escapeSmarty = FALSE) {
     $value = '';
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
 
     [$objectName, $objectValue] = explode('-', $token, 2);
 


### PR DESCRIPTION

Overview
----------------------------------------
Deprecate a couple of token functions not used in core

Before
----------------------------------------
Token functions in core - but unused in core

After
----------------------------------------
Deprecated (noisily)

Technical Details
----------------------------------------
These do appear to be used in Civi-rules & while the obvious answer might be to copy the code into CiviRules it feels like it might be worth creating a token processor class in core to do this - which would obviously need unit tests but if they were written I think we would merge a token processor alternative to core, if submitted


Comments
----------------------------------------
@mattwire FYI