### PR TITLE
[REF][PHP8.2] Declare properties for Petition Signature

### DIFF
--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -28,6 +28,11 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
   public $_surveyId;
 
   /**
+   * @var array
+   */
+  protected $_values;
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -66,9 +71,9 @@ class CRM_Campaign_Form_Petition extends CRM_Core_Form {
       CRM_Utils_System::permissionDenied();
     }
 
-    $this->_context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
-    $this->assign('context', $this->_context);
+    $this->assign('context', $context);
 
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this);
 

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -123,6 +123,18 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
    */
   public $submitOnce = TRUE;
 
+  protected array $forceEmailConfirmed = [];
+
+  /**
+   * @var CRM_Campaign_BAO_Petition
+   */
+  protected $bao;
+
+  /**
+   * @var array
+   */
+  protected $petition;
+
   /**
    */
   public function __construct() {
@@ -587,7 +599,6 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
           list($prefixName, $index) = CRM_Utils_System::explode('-', $key, 2);
 
           CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE, $contactID, TRUE);
-          $this->_fields[$key] = $field;
         }
       }
     }


### PR DESCRIPTION
And delete unused / undeclared $_fields.

Overview
----------------------------------------
Gets rid of some undeclared property warnings when signing a petition under PHP 8.2

https://dmaster.localhost:32353/civicrm/petition/sign?reset=1&sid=1