### PR TITLE
Separate MembershipStatus URLs for add/update/delete from browse

### DIFF
--- a/CRM/Member/Form/MembershipStatus.php
+++ b/CRM/Member/Form/MembershipStatus.php
@@ -23,6 +23,13 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
   use CRM_Core_Form_EntityFormTrait;
 
   /**
+   * The name of the BAO object for this form.
+   *
+   * @var string
+   */
+  protected $_BAOName = 'CRM_Member_BAO_MembershipStatus';
+
+  /**
    * Explicitly declare the entity api name.
    */
   public function getDefaultEntity() {
@@ -64,7 +71,6 @@ class CRM_Member_Form_MembershipStatus extends CRM_Core_Form {
 
   public function preProcess() {
     $this->_id = $this->get('id');
-    $this->_BAOName = 'CRM_Member_BAO_MembershipStatus';
   }
 
   /**

--- a/CRM/Member/xml/Menu/Member.xml
+++ b/CRM/Member/xml/Menu/Member.xml
@@ -35,6 +35,11 @@
      <weight>380</weight>
   </item>
   <item>
+     <path>civicrm/admin/member/membershipStatus/add</path>
+     <title>Membership Status Rules</title>
+     <page_callback>CRM_Member_Page_MembershipStatus</page_callback>
+  </item>
+  <item>
      <path>civicrm/admin/setting/preferences/member</path>
      <title>CiviMember Component Settings</title>
      <page_callback>CRM_Admin_Form_Preferences_Member</page_callback>

--- a/schema/Member/MembershipStatus.entityType.php
+++ b/schema/Member/MembershipStatus.entityType.php
@@ -13,9 +13,10 @@ return [
     'label_field' => 'label',
   ],
   'getPaths' => fn() => [
-    'add' => 'civicrm/admin/member/membershipStatus?action=add&reset=1',
-    'update' => 'civicrm/admin/member/membershipStatus?action=update&id=[id]&reset=1',
-    'delete' => 'civicrm/admin/member/membershipStatus?action=delete&id=[id]&reset=1',
+    'browse' => 'civicrm/admin/member/membershipStatus?reset=1',
+    'add' => 'civicrm/admin/member/membershipStatus/add?action=add&reset=1',
+    'update' => 'civicrm/admin/member/membershipStatus/add?action=update&id=[id]&reset=1',
+    'delete' => 'civicrm/admin/member/membershipStatus/add?action=delete&id=[id]&reset=1',
   ],
   'getFields' => fn() => [
     'id' => [


### PR DESCRIPTION
Overview
----------------------------------------
In order to use SearchKit for the MembershipStatus page, we need to separate out the add/update/delete URL's from the browse one.  This has been done for many other entities.

Before
----------------------------------------
add/update/delete/browse all use `civicrm/admin/member/membershipstatus`

After
----------------------------------------
browse uses  `civicrm/admin/member/membershipstatus`
add/update/delete uses  `civicrm/admin/member/membershipstatus/add`

Comments
----------------------------------------
For reviewing, main thing is to check that the `Administer > CiviMember > Membership Status Rules` still works correctly along with the add, update, delete links.
AdminUI version of this will follow later.

