### PR TITLE
Api4 - Order by serialized fields

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -250,6 +250,28 @@ class Api4SelectQuery extends Api4Query {
           if ($options) {
             asort($options);
             $keys = \CRM_Core_DAO::escapeStrings(array_keys($options));
+
+            // If the field is serialized, sort by the first option
+            if (!empty($field['serialize'])) {
+              $sep = \CRM_Core_DAO::VALUE_SEPARATOR;
+              switch ($field['serialize']) {
+                case \CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND:
+                  $column = "SUBSTRING_INDEX(SUBSTRING($column, 2), '$sep', 1)";
+                  break;
+
+                case \CRM_Core_DAO::SERIALIZE_SEPARATOR_TRIMMED:
+                  $column = "SUBSTRING_INDEX($column, '$sep', 1)";
+                  break;
+
+                case \CRM_Core_DAO::SERIALIZE_COMMA:
+                  $column = "SUBSTRING_INDEX($column, ',', 1)";
+                  break;
+
+                default:
+                  // Other serialization methods cannot be sorted
+                  continue 2;
+              }
+            }
             $column = "FIELD($column, $keys)";
           }
         }

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -140,9 +140,9 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
       ['first_name' => 'Yan', 'contact_sub_type:label' => []],
       ['first_name' => 'Eli', 'contact_sub_type:label' => ['0.Décédé', '1.Actif']],
       ['first_name' => 'Bob', 'contact_sub_type:label' => ['1.Actif']],
-      ['first_name' => 'Joe', 'contact_sub_type:label' => ['1.Actif', '5.Employé']],
-      ['first_name' => 'Jan', 'contact_sub_type:label' => ['2.Proche',]],
-      ['first_name' => 'Dan', 'contact_sub_type:label' => ['3.Soutien']]
+      ['first_name' => 'Jan', 'contact_sub_type:label' => ['2.Proche']],
+      ['first_name' => 'Dan', 'contact_sub_type:label' => ['3.Soutien']],
+      ['first_name' => 'Joe', 'contact_sub_type:label' => ['5.Employé', '1.Actif']],
     ];
 
     // Assert contact query results equals sorted dataset #2.

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -131,4 +131,31 @@ class TagTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotContains('tagset', $options);
   }
 
+  /**
+   * Test ordering tags by used_for:label (SERIALIZE_COMMA field)
+   */
+  public function testOrderByUsedForLabel(): void {
+    $tagData = [
+      ['name' => 'tag_savedSearch', 'label' => 'Tag SavedSearch', 'used_for:label' => ['Saved Searches', 'Attachments']],
+      ['name' => 'tag_contact', 'label' => 'Tag Contact', 'used_for:label' => ['Contacts']],
+      ['name' => 'tag_activity', 'label' => 'Tag Activity', 'used_for:label' => ['Activities', 'Contacts']],
+      ['name' => 'tag_file', 'label' => 'Tag File', 'used_for:label' => ['Attachments']],
+    ];
+
+    $this->saveTestRecords('Tag', ['records' => $tagData]);
+
+    $result = Tag::get(TRUE)
+      ->addSelect('id', 'name', 'label', 'used_for', 'used_for:label')
+      ->addWhere('name', 'LIKE', 'tag_%')
+      ->addOrderBy('used_for:label', 'ASC')
+      ->execute();
+
+    $expectedNames = ['tag_activity', 'tag_file', 'tag_contact', 'tag_savedSearch'];;
+
+    $this->assertCount(4, $result);
+    foreach ($result as $index => $record) {
+      $this->assertEquals($expectedNames[$index], $record['name']);
+    }
+  }
+
 }

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -131,6 +131,33 @@ class TagTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotContains('tagset', $options);
   }
 
+  /**
+   * Test ordering tags by used_for:label (SERIALIZE_COMMA field)
+   */
+  public function testOrderByUsedForLabel(): void {
+    $tagData = [
+      ['name' => 'tag_savedSearch', 'label' => 'Tag SavedSearch', 'used_for:label' => ['Saved Searches', 'Attachments']],
+      ['name' => 'tag_contact', 'label' => 'Tag Contact', 'used_for:label' => ['Contacts']],
+      ['name' => 'tag_activity', 'label' => 'Tag Activity', 'used_for:label' => ['Activities', 'Contacts']],
+      ['name' => 'tag_file', 'label' => 'Tag File', 'used_for:label' => ['Attachments']],
+    ];
+
+    $this->saveTestRecords('Tag', ['records' => $tagData]);
+
+    $result = Tag::get(TRUE)
+      ->addSelect('id', 'name', 'label', 'used_for', 'used_for:label')
+      ->addWhere('name', 'LIKE', 'tag_%')
+      ->addOrderBy('used_for:label', 'ASC')
+      ->execute();
+
+    $expectedNames = ['tag_activity', 'tag_file', 'tag_contact', 'tag_savedSearch'];;
+
+    $this->assertCount(4, $result);
+    foreach ($result as $index => $record) {
+      $this->assertEquals($expectedNames[$index], $record['name']);
+    }
+  }
+
   public function testTagLongNameAndLabel(): void {
     $longName = \CRM_Utils_String::createRandom(128, \CRM_Utils_String::ALPHANUMERIC);
 


### PR DESCRIPTION
Overview
----------------------------------------
Add a test to verify contact query with results order by contact_subtype:label.

This resurects 2 PRs by @syxys1 written to demonstrate a bug

https://github.com/civicrm/civicrm-core/pull/28038
https://github.com/civicrm/civicrm-core/pull/27653

These PRs did not quite leave draft stage - I've cleaned them up into this PR

Before
----------------------------------------
No test for reported issue

After
----------------------------------------
Failing test captures reported issue

Technical Details
----------------------------------------

@colemanw the crux of the reported bug is [here](https://github.com/civicrm/civicrm-core/pull/32856/files#diff-5fd2ae029c0bcf515f974ead560fdfb84f049b6666f6c4734e5b7ae2d6cd62d8R129-R152)
 - you can see in the test the expected sort order for the contacts  (sorted by contact subtype label) is 
 
```
      ['first_name' => 'Yan', 'contact_sub_type:label' => []],
      ['first_name' => 'Eli', 'contact_sub_type:label' => ['0.Décédé', '1.Actif']],
      ['first_name' => 'Bob', 'contact_sub_type:label' => ['1.Actif']],
      ['first_name' => 'Joe', 'contact_sub_type:label' => ['1.Actif', '5.Employé']],
      ['first_name' => 'Jan', 'contact_sub_type:label' => ['2.Proche',]],
      ['first_name' => 'Dan', 'contact_sub_type:label' => ['3.Soutien']]
```
 


 - but the actual  is 
 

```
      ['first_name' => 'Joe', 'contact_sub_type:label' => ['1.Actif', '5.Employé']],
      ['first_name' => 'Eli', 'contact_sub_type:label' => ['0.Décédé', '1.Actif']],
      ['first_name' => 'Yan', 'contact_sub_type:label' => []],
      ['first_name' => 'Bob', 'contact_sub_type:label' => ['1.Actif']],
      ['first_name' => 'Jan', 'contact_sub_type:label' => ['2.Proche',]],
      ['first_name' => 'Dan', 'contact_sub_type:label' => ['3.Soutien']]
```

I presume the issue is sorting data in `CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND` as a string and also possibly the types not being in the DB in alpha order....

Comments
----------------------------------------
