### PR TITLE
Automatically Sign In WP User After Creation

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -933,13 +933,17 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
         $creds['user_password'] = $user_data['user_pass'];
         $creds['remember'] = TRUE;
 
-        // Authenticate and log the user in.
-        $user = wp_signon($creds, FALSE);
-        if (is_wp_error($user)) {
-          Civi::log()->error("Could not log the user in. WordPress returned: " . $user->get_error_message());
-        }
-        else {
-          $logged_in = TRUE;
+        $should_login_user = boolval(get_option('civicrm_automatically_sign_in_user', TRUE));
+        if (TRUE === $should_login_user) {
+          // Authenticate and log the user in.
+          $user = wp_signon($creds, FALSE);
+          if (is_wp_error($user)) {
+            Civi::log()
+              ->error("Could not log the user in. WordPress returned: " . $user->get_error_message());
+          }
+          else {
+            $logged_in = TRUE;
+          }
         }
       }
 


### PR DESCRIPTION
## Automatically Sign In WP User After Creation
Overview
----------------------------------------

This PR leverages the [civicrm-wordpress #344](https://github.com/civicrm/civicrm-wordpress/pull/344) by checking for the existence of a new CiviCRM Setting in WP that would allow for preventing the automatic sign in after the WP user is created. This ideally only pertains to users being created via a membership signup/contribution form.

Before
----------------------------------------

When a WP user is created from purchasing a membership, it is also forcing an auto login of the user. 

After
----------------------------------------

In [PR #344](https://github.com/civicrm/civicrm-wordpress/pull/344), we are introducing a new CiviCRM Setting, 'Automatically Sign In User' which allows for you to set a yes/no value which then can allow/prevent the WP user from being automatically signed in.

Technical Details
----------------------------------------

This PR alone will not have any effect on current behavior. It also has no use without the [#344 PR](https://github.com/civicrm/civicrm-wordpress/pull/344) which actually allows for setting the new setting in the WP CiviCRM Settings page. Once both PR's have been committed, you will be able to control, per site, whether to automatically sign in users after they have been created.
