### PR TITLE
Autocomplete - Fix more results after searching by ID 

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -196,12 +196,7 @@ class AutocompleteAction extends AbstractAction {
       $this->addFilter(implode(',', array_unique($searchFields)), $this->input);
     }
 
-    $apiResult = \Civi\Api4\SearchDisplay::run(FALSE)
-      ->setSavedSearch($this->savedSearch)
-      ->setDisplay($this->display)
-      ->setFilters($this->filters)
-      ->setReturn($return)
-      ->execute();
+    $apiResult = $this->getApiResult($return);
 
     foreach ($apiResult as $row) {
       $item = [
@@ -317,6 +312,20 @@ class AutocompleteAction extends AbstractAction {
   public function getPermissions() {
     // Permissions for this action are checked internally
     return [];
+  }
+
+  /**
+   * @param string|null $return
+   * @return \Civi\Api4\Result\SearchDisplayRunResult
+   */
+  private function getApiResult(?string $return): \Civi\Api4\Result\SearchDisplayRunResult {
+    $apiResult = \Civi\Api4\SearchDisplay::run(FALSE)
+      ->setSavedSearch($this->savedSearch)
+      ->setDisplay($this->display)
+      ->setFilters($this->filters)
+      ->setReturn($return)
+      ->execute();
+    return $apiResult;
   }
 
 }

--- a/js/Common.js
+++ b/js/Common.js
@@ -614,11 +614,19 @@ if (!CRM.vars) CRM.vars = {};
               page: pageNum || 1
             }, getApiParams()))};
           },
-          results: function(data) {
-            return {
-              results: data.values,
-              more: data.countMatched > data.countFetched
+          results: function(response, page, query) {
+            const data = {
+              results: response.values,
+              more: response.countMatched > response.countFetched,
             };
+            if (!data.results.length && data.more) {
+              data.results.push({
+                id: '',
+                label: ts('ID %1 not found.', {1: query.term}),
+                disabled: true,
+              });
+            }
+            return data;
           },
         },
         minimumInputLength: 1,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes "no results" when autocomplete with numeric input.

Before
----------------------------------------
When an autocomplete receives numeric input, it searches by ID and then does a followup search by other criteria.
But if no matching ID is found it was short-circuiting and failing to run the second search.

After
----------------------------------------
Fixed.

Comments
------------
This was partially fixed by https://github.com/civicrm/civicrm-core/pull/32752 which addressed the scenario when a matching ID *is* found. This fixes when an ID is *not* found.