### PR TITLE
Fix hard crash when adding PriceSetEntity entity_table to Afform as a filter

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -142,7 +142,7 @@ class AfformMetadataInjector {
     if ($inputType === 'Select' || $inputType === 'ChainSelect') {
       $fieldInfo['input_attrs']['placeholder'] = E::ts('Select');
     }
-    elseif ($inputType === 'EntityRef' && empty($field['input_attrs']['placeholder'])) {
+    elseif ($inputType === 'EntityRef' && !empty($fieldInfo['fk_entity']) && empty($field['input_attrs']['placeholder'])) {
       $info = civicrm_api4('Entity', 'get', [
         'where' => [['name', '=', $fieldInfo['fk_entity']]],
         'checkPermissions' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
Identified when working on shoppingcart

Before
----------------------------------------
Crash

After
----------------------------------------
No crash

Technical Details
----------------------------------------
When entity_table is empty and it's added as a filter to Afform (eg. with a PriceFieldValue->PriceField->PriceSet->PriceSetEntity searchkit) the form crashes because of undefined value. With this patch it does not (filter does not work, all values are displayed)

Comments
----------------------------------------
Filtering by entity_table/entity_id does not work because Afform does not yet understand that. To be fixed in follow up.