### PR TITLE
Avoid deprecation warning

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -91,7 +91,7 @@ jobs:
           cd xml
           php GenCode.php
           cd ..
-          $GITHUB_WORKSPACE/civicrm-cv/bin/cv core:install --cms-base-url=http://civi.localhost
+          $GITHUB_WORKSPACE/civicrm-cv/bin/cv core:install --url=http://civi.localhost
           # In this environment in this particular repo, we are under a workspace folder that contains the literal "civicrm-core" in the path, which makes civicrm.config.php think we are a composer install, so it gets the paths wrong.
           echo '<?php define("CIVICRM_CONFDIR", "/home/runner/work/civicrm-core/civicrm-core/drupal/sites/default");' > settings_location.php
       - name: regen


### PR DESCRIPTION
Overview
----------------------------------------
Same as https://github.com/civicrm/civicrm-buildkit/pull/933

! [NOTE] Option --cms-base-url is a deprecated alias for --url (-l)

Before
----------------------------------------
apparently this is the old argument

After
----------------------------------------
The new one

Technical Details
----------------------------------------

Comments
----------------------------------------
