### PR TITLE
Standalone page template - move crm-public to crm-container element to match other UFs

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html >
-<html lang="{$config->lcMessages|substr:0:2}" class="crm-standalone {if !empty($urlIsPublic)}crm-public{/if}">
+<html lang="{$config->lcMessages|substr:0:2}" class="crm-standalone">
  <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -15,7 +15,7 @@
   {include file="CRM/common/debug.tpl"}
   {/if}
 
-  <div id="crm-container" class="crm-container standalone-page-padding" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
+  <div id="crm-container" class="crm-container standalone-page-padding {if !empty($urlIsPublic)}crm-public{/if}" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
     {if $breadcrumb}
       <nav aria-label="{ts escape='htmlattribute'}Breadcrumb{/ts}" class="breadcrumb"><ol>
         <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html >
-<html lang="{$config->lcMessages|substr:0:2}" class="crm-standalone">
+<html lang="{$config->lcMessages|substr:0:2}" class="crm-standalone {if !empty($urlIsPublic)}crm-standalone-frontend{/if}">
  <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Overview
----------------------------------------
Fix mismatch with other UF page templates.

Before
----------------------------------------
- In other every other UF, the `crm-public` class goes on the `crm-container` element
- `.crm-container.crm-public` is used as a selector for frontend styles [in Riverlea](https://github.com/civicrm/civicrm-core/blob/1f015344f8de1cc13aa57ea149f21b85cb1dd857/ext/riverlea/core/css/components/_front.css#L28) (and `#crm-container.crm-public` [in Greenwich](https://github.com/civicrm/civicrm-core/blob/1f015344f8de1cc13aa57ea149f21b85cb1dd857/css/civicrm.css#L3735) )
- Standalone puts `crm-public` on the `html` element, `.crm-container.crm-public` selectors never match and are ignored

After
----------------------------------------
- `crm-public` is put on the `crm-container` element in Standalone too
- `crm-standalone-frontend` is added to the `html` element, if for some reason you need to target the `html` or `body` elements (though I think/hope this is probably rare?)

Comments
----------------------------------------
This will require a little attention from anyone who has used/not used those selectors and/or has overridden `standalone.tpl` or `standalone-frontend.tpl` . But the sooner the correction is made, the fewer people this will be.

Cc @artfulrobot :grinning: 