### PR TITLE
SearchKit - Fix backward-compat for single-condition links

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -73,7 +73,7 @@
 
       function setDefaults(item, newValue) {
         // Backward support for singular "condition" from older versions of SearchKit (pre 6.4)
-        if (newValue.condition && (!item.conditions|| !item.conditions.length)) {
+        if (newValue.condition && newValue.condition.length && (!item.conditions|| !item.conditions.length)) {
           item.conditions = [newValue.condition];
           delete item.condition;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in https://github.com/civicrm/civicrm-core/pull/32854
