### PR TITLE
[REF] Fix GetMergeTo return if no delete activity causing a type erro…

### DIFF
--- a/Civi/Api4/Action/Contact/GetMergedTo.php
+++ b/Civi/Api4/Action/Contact/GetMergedTo.php
@@ -63,7 +63,7 @@ class GetMergedTo extends \Civi\Api4\Generic\AbstractAction {
         ->execute()
         ->first()['contact_id'];
     }
-    $result[] = ['id' => $returnId];
+    $result[] = (empty($returnId) ? $returnId : ['id' => $returnId]);
   }
 
 }


### PR DESCRIPTION
…r in Import

Overview
----------------------------------------
This fixes a bug in the return of this API end point when no delete activity record can be found. It should return an Empty array instead it is returning `['id' => array()]`. This in a specific circumstance causes a type error in getContactID() here https://github.com/civicrm/civicrm-core/blob/master/CRM/Import/Parser.php#L1656 because $result will evaluate as true and $contactID will be set to an empty array rather than NULL or an Int

Before
----------------------------------------
getMergeTo returns a problematic return on no result

After
----------------------------------------
getMergeTo returns correctly a simple empty array

ping @eileenmcnaughton @johntwyman @Edzelopez 