### PR TITLE
Assign tax term (eg. VAT) to Smarty on participant.view form

### DIFF
--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -182,6 +182,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
     $this->assign('totalTaxAmount', $totalTaxAmount ?? NULL);
     $this->assign('totalAmount', $totalAmount);
     $this->assign('pricesetFieldsCount', $participantCount);
+    $this->assign('taxTerm', Civi::settings()->get('tax_term'));
     $this->assign('displayName', $displayName);
     // omitting contactImage from title for now since the summary overlay css doesn't work outside of our crm-container
     $this->setTitle(ts('View Event Registration for') . ' ' . $displayName);


### PR DESCRIPTION
Overview
----------------------------------------
From https://github.com/civicrm/civicrm-core/pull/31532 replaces  https://github.com/civicrm/civicrm-core/pull/31539

Before
----------------------------------------
Tax term (e.g. VAT) not visible on participant view form

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
@mattwire 

Comments
----------------------------------------
