### PR TITLE
RiverLea regression: restores UL/OL list rendering markers

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -54,9 +54,12 @@ body {
 }
 /* Remove list styles (bullets/numbers) */
 .crm-container ol,
-.crm-container ul,
-.crm-container menu {
+.crm-container ul {
   list-style: none;
+}
+/* Restores list styles for text-editor regions */
+.crm-container :is(tr,td).html-adjust :is(ol,ul) {
+  list-style: initial;
 }
 /* For images to not be able to exceed their container */
 .crm-container img {


### PR DESCRIPTION
Overview
----------------------------------------
As raised here: https://lab.civicrm.org/extensions/riverlea/-/issues/130 by @mattwire. 

Restores correct list rendering to .html-adjust regions (mostly free/rich text-areas). 

Before
----------------------------------------
Ordered and unordered lists show no list style in rich text regions, such as Notes.

After
----------------------------------------
They do.

Technical Details
----------------------------------------
Also removes an unnecessary selector (.crm-container menu) that was added[ in a bulk set of resets](https://lab.civicrm.org/extensions/riverlea/-/commit/b54d7a70a1a7c0a2d3feae685ca3183ecd8a350e) 11 months ago but isn't used.

Comments
----------------------------------------
Wasn't sure if I should apply to 6.3 as it's a regression - we're just quite close to the release for that.