### PR TITLE
dev/core#5878 Extending SearchKit UI Permissions

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -8,6 +8,7 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
+use Civi\Api4\Event\AuthorizeRecordEvent;
 
 /**
  *
@@ -421,6 +422,92 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
       }
     }
     return $smartGroups;
+  }
+
+  /**
+   * Check related contact access.
+   * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
+   */
+  public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
+    $record = $e->getRecord();
+    $action = $e->getActionName();
+    if (!in_array($action, ['delete', 'update'], TRUE)) {
+      // We only care about these actions.
+      return;
+    }
+
+    $userID = $e->getUserID();
+    if (empty($userID)) {
+      $userID = CRM_Core_Session::getLoggedInContactID();
+    }
+
+    $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
+    if (!empty($created_id)) {
+      switch ($action) {
+        case 'delete':
+          if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && CRM_Core_Permission::check('delete own search_kit') && ($userID !== (int) $created_id)) {
+            $e->setAuthorized(FALSE);
+          }
+          break;
+
+        default:
+          if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && CRM_Core_Permission::check('edit own search_kit') && ($userID !== (int) $created_id)) {
+            $e->setAuthorized(FALSE);
+          }
+          break;
+
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function writeRecord(array $record): CRM_Contact_DAO_SavedSearch {
+    self::checkEditPermission($record);
+    return parent::writeRecord($record);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function deleteRecord(array $record): CRM_Contact_DAO_SavedSearch {
+    self::checkDeletePermission($record);
+    return parent::deleteRecord($record);
+  }
+
+  /**
+   * Ensure that the current user has permission to edit a SavedSearch record
+   *
+   * @param array $record
+   * @return void
+   * @throws CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function checkEditPermission(array $record): void {
+    if (!empty($record['id']) && CRM_Core_Permission::check('edit own search_kit')) {
+      $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
+      if ($created_id != CRM_Core_Session::getLoggedInContactID()) {
+        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to edit this SavedSearch.');
+      }
+    }
+  }
+
+  /**
+   * Ensure that the current user has permission to delete a SavedSearch record
+   *
+   * @param array $record
+   * @return void
+   * @throws CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function checkDeletePermission(array $record):void {
+    if (!empty($record['id']) && CRM_Core_Permission::check('delete own search_kit')) {
+      $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
+      if ($created_id != CRM_Core_Session::getLoggedInContactID()) {
+        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to delete this SavedSearch.');
+      }
+    }
   }
 
 }

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -443,19 +443,8 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
 
     $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
     if (!empty($created_id)) {
-      switch ($action) {
-        case 'delete':
-          if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && CRM_Core_Permission::check('delete own search_kit') && ($userID !== (int) $created_id)) {
-            $e->setAuthorized(FALSE);
-          }
-          break;
-
-        default:
-          if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && CRM_Core_Permission::check('edit own search_kit') && ($userID !== (int) $created_id)) {
-            $e->setAuthorized(FALSE);
-          }
-          break;
-
+      if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && CRM_Core_Permission::check('manage own search_kit') && ($userID !== (int) $created_id)) {
+        $e->setAuthorized(FALSE);
       }
     }
   }
@@ -464,7 +453,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    * @inheritDoc
    */
   public static function writeRecord(array $record): CRM_Contact_DAO_SavedSearch {
-    self::checkEditPermission($record);
+    if (!empty($record['check_permission'])) {
+      self::checkManageOwnPermission($record);
+    }
     return parent::writeRecord($record);
   }
 
@@ -472,40 +463,25 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    * @inheritDoc
    */
   public static function deleteRecord(array $record): CRM_Contact_DAO_SavedSearch {
-    self::checkDeletePermission($record);
+    if (!empty($record['check_permission'])) {
+      self::checkManageOwnPermission($record);
+    }
     return parent::deleteRecord($record);
   }
 
   /**
-   * Ensure that the current user has permission to edit a SavedSearch record
+   * Ensure that the current user has permission to manage their own SavedSearch records.
    *
    * @param array $record
    * @return void
    * @throws CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public static function checkEditPermission(array $record): void {
-    if (!empty($record['id']) && CRM_Core_Permission::check('edit own search_kit')) {
+  public static function checkManageOwnPermission(array $record): void {
+    if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && !empty($record['id']) && CRM_Core_Permission::check('manage own search_kit')) {
       $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
       if ($created_id != CRM_Core_Session::getLoggedInContactID()) {
-        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to edit this SavedSearch.');
-      }
-    }
-  }
-
-  /**
-   * Ensure that the current user has permission to delete a SavedSearch record
-   *
-   * @param array $record
-   * @return void
-   * @throws CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  public static function checkDeletePermission(array $record):void {
-    if (!empty($record['id']) && CRM_Core_Permission::check('delete own search_kit')) {
-      $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
-      if ($created_id != CRM_Core_Session::getLoggedInContactID()) {
-        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to delete this SavedSearch.');
+        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this SavedSearch.');
       }
     }
   }

--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -23,7 +23,6 @@ return [
     'administer afform',
     'view debug output',
     'schedule communications',
-    'edit own search_kit',
-    'delete own search_kit',
+    'manage own search_kit',
   ],
 ];

--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -23,5 +23,7 @@ return [
     'administer afform',
     'view debug output',
     'schedule communications',
+    'edit own search_kit',
+    'delete own search_kit',
   ],
 ];

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/buttons.html
@@ -40,7 +40,7 @@
         {{ row.data.is_template ? ts('Export Template') : ts('Export Search') }}
       </a>
     </li>
-    <li ng-if="!row.data['base_module:label']" title="{{:: ts('Delete search along with any displays and forms') }}">
+    <li ng-if="!row.data['base_module:label'] && row.permissionToDelete" title="{{:: ts('Delete search along with any displays and forms') }}">
       <a href ng-click="$ctrl.deleteOrRevert(row)">
         <i class="crm-i fa-trash"></i>
         {{:: ts('Delete') }}

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -38,6 +38,7 @@
             'api_params',
             'is_template',
             // These two need to be in the select clause so they are allowed as filters
+            'created_id',
             'created_id.display_name',
             'modified_id.display_name',
             'created_date',
@@ -105,6 +106,11 @@
       this.onPostRun.push(function(apiResults) {
         _.each(apiResults.run, function(row) {
           row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
+          // If someone has edit own permission, we need to override and only allow if they are the owner.
+          if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('edit own search_kit') && (CRM.config.cid !== row.data.created_id)) {
+            row.permissionToEdit = false;
+          }
+
           // If main entity doesn't exist, no can edit
           if (!row.data['api_entity:label']) {
             row.permissionToEdit = false;
@@ -116,6 +122,12 @@
           // Saves rendering cycles to not show an empty menu of search displays
           if (!row.data.display_name) {
             row.openDisplayMenu = false;
+          }
+
+          row.permissionToDelete = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
+          // If someone has 'delete own search_kit' permission, we need to override and only allow if they are the owner.
+          if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('delete own search_kit') && (CRM.config.cid !== row.data.created_id)) {
+            row.permissionToDelete = false;
           }
         });
         updateAfformCounts();

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -106,8 +106,8 @@
       this.onPostRun.push(function(apiResults) {
         _.each(apiResults.run, function(row) {
           row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
-          // If someone has edit own permission, we need to override and only allow if they are the owner.
-          if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('edit own search_kit') && (CRM.config.cid !== row.data.created_id)) {
+          // If someone has manage own permission, we need to override and only allow if they are the owner.
+          if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('manage own search_kit') && (CRM.config.cid !== row.data.created_id)) {
             row.permissionToEdit = false;
           }
 
@@ -124,11 +124,8 @@
             row.openDisplayMenu = false;
           }
 
-          row.permissionToDelete = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
-          // If someone has 'delete own search_kit' permission, we need to override and only allow if they are the owner.
-          if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('delete own search_kit') && (CRM.config.cid !== row.data.created_id)) {
-            row.permissionToDelete = false;
-          }
+          // Implied permission that if you can edit, you should be able to delete.
+          row.permissionToDelete = row.permissionToEdit;
         });
         updateAfformCounts();
       });

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -20,18 +20,13 @@ function search_kit_civicrm_config(&$config) {
  */
 function search_kit_civicrm_permission(&$permissions) {
   $permissions['administer search_kit'] = [
-    'label' => E::ts('SearchKit: edit and delete searches'),
+    'label' => E::ts('SearchKit: edit and delete all searches'),
     'description' => E::ts('Gives non-admin users access to the SearchKit UI to create, update and delete searches and displays'),
     'implied_by' => ['administer CiviCRM data'],
   ];
-  $permissions['edit own search_kit'] = [
-    'label' => E::ts('SearchKit: edit searches that the user created'),
-    'description' => E::ts('Gives non-admin users the permission to edit their own searches and displays'),
-    'implied_by' => ['administer search_kit'],
-  ];
-  $permissions['delete own search_kit'] = [
-    'label' => E::ts('SearchKit: delete searches that the user created'),
-    'description' => E::ts('Gives non-admin users the permission to delete their own searches and displays'),
+  $permissions['manage own search_kit'] = [
+    'label' => E::ts('SearchKit: edit and delete own searches'),
+    'description' => E::ts('Gives non-admin users the permission to manage their own searches and displays'),
     'implied_by' => ['administer search_kit'],
   ];
 }

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -24,6 +24,16 @@ function search_kit_civicrm_permission(&$permissions) {
     'description' => E::ts('Gives non-admin users access to the SearchKit UI to create, update and delete searches and displays'),
     'implied_by' => ['administer CiviCRM data'],
   ];
+  $permissions['edit own search_kit'] = [
+    'label' => E::ts('SearchKit: edit searches that the user created'),
+    'description' => E::ts('Gives non-admin users the permission to edit their own searches and displays'),
+    'implied_by' => ['administer search_kit'],
+  ];
+  $permissions['delete own search_kit'] = [
+    'label' => E::ts('SearchKit: delete searches that the user created'),
+    'description' => E::ts('Gives non-admin users the permission to delete their own searches and displays'),
+    'implied_by' => ['administer search_kit'],
+  ];
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
_By default, if you have permissions to `administer search_kit` you have full access to manage all saved searches. This is meant to add an additional set of permissions for general staff members who don't need full CiviCRM permissions. It will allow them to only edit/delete their own SK items, but not those created by others. The idea is to also limit access to the `Packaged Searches` as well since not everyone needs to manipulate core or extension SK items._

Before
----------------------------------------
_If you could administer SK, you had permissions to do anything._

After
----------------------------------------
_If you don't have the `all CiviCRM permissions and ACLs` permission, then this will help limit what actions can be made on SK items not owned by the current user._
