### PR TITLE
A/B Mailing Report: fix optouts and show separately from unsubscribes

### DIFF
--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -562,8 +562,8 @@
       {name: 'Unique Clicks', title: ts('Unique Clicks'),          searchFilter: '&mailing_click_status=Y',    eventsFilter: '&event=click&distinct=1', reportType: 'clicks', reportFilter: ''},
       // {name: 'Replies',    title: ts('Replies'),                 searchFilter: '&mailing_reply_status=Y',    eventsFilter: '&event=reply', reportType: 'detail', reportFilter: '&is_replied_value=1'},
       {name: 'Bounces',       title: ts('Bounces'),                 searchFilter: '&mailing_delivery_status=N', eventsFilter: '&event=bounce', reportType: 'bounce', reportFilter: ''},
-      {name: 'Unsubscribers', title: ts('Unsubscribes & Opt-outs'), searchFilter: '&mailing_unsubscribe=1',     eventsFilter: '&event=unsubscribe', reportType: 'detail', reportFilter: '&is_unsubscribed_value=1'},
-      // {name: 'OptOuts',    title: ts('Opt-Outs'),                searchFilter: '&mailing_optout=1',          eventsFilter: '&event=optout', reportType: 'detail', reportFilter: ''}
+      {name: 'Unsubscribers', title: ts('Unsubscribe Requests'), searchFilter: '&mailing_unsubscribe=1', eventsFilter: '&event=unsubscribe', reportType: 'detail', reportFilter: '&is_unsubscribed_value=1'},
+      {name: 'OptOuts', title: ts('Opt-out Requests'), searchFilter: '&mailing_optout=1', eventsFilter: '&event=optout', reportType: 'detail', reportFilter: ''}
     ];
 
     return {

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -809,6 +809,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
       'Opened' => 20,
       'Unique Clicks' => 0,
       'Unsubscribers' => 20,
+      'OptOuts' => 0,
       'delivered_rate' => '80%',
       'opened_rate' => '25%',
       'clickthrough_rate' => '0%',


### PR DESCRIPTION
Overview
----------------------------------------

In #20093, the "unsubscribes" and "opt-outs" were merged together, but this was a misunderstanding. The `getTotalCount` functions have obscure parameters and those two counts are always separate.

Furthermore, clicking on those links leads to pages where the URL really just searches for unsubscribes, not optouts.

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/37eb3c3f-6049-4568-9aee-5ba0b25cb970)

After
----------------------------------------

![image](https://github.com/user-attachments/assets/34c5bc35-2ca8-4288-88ce-e1d6471c58d6)

Technical Details
----------------------------------------

Cleanup in  `api/v3/Mailing.php` because it was simpler/clearer without the loop. 
