### PR TITLE
View files in ECK Afform

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -318,7 +318,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     foreach ($fileFields as $fieldName => $fieldDefn) {
       foreach ($result as &$item) {
         if (!empty($item[$fieldName])) {
-          $fileInfo = $this->getFileInfo($item[$fieldName]);
+          $fileInfo = $this->getFileInfo($item[$fieldName], $afEntityName);
           $item[$fieldName] = $fileInfo;
         }
       }
@@ -326,9 +326,9 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     return $result;
   }
 
-  protected function getFileInfo(int $fileId):? array {
+  protected function getFileInfo(int $fileId, string $afEntityName):? array {
     $select = ['id', 'file_name', 'icon'];
-    if ($this->canViewFileAttachments($this->modelName)) {
+    if ($this->canViewFileAttachments($afEntityName)) {
       $select[] = 'url';
     }
     return File::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
You currently get a 500 error when you attempt to view an ECK entity that has a file.

Replication:
* Install ECK.
* Create a custom entity with a file.
* Add an entity of this new type, uploading a file.
* Click "View" or "Edit" next to the new entity.

Before
----------------------------------------
```
TypeError: Civi\Api4\Action\Afform\AbstractProcessor::canViewFileAttachments(): Argument #1 ($afEntityName) must be of type string, null given, called in /home/jon/local/civicrm-buildkit/build/smaster/web/core/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php on line 331
```

After
----------------------------------------
No error.

Technical Details
----------------------------------------
`$this->modelName` is never set anywhere, so no surprise this fails.  Maybe a copy/past issue?

Comments
----------------------------------------
I'm sure there's a non-ECK way to trigger this but this seemed fastest - I'm not sure if any core entities can be viewed in FormBuilder like this yet.
