### PR TITLE
Permit negative amounts to be treated as 'truthy' for the purposes of…

### DIFF
--- a/Civi/Token/TokenProcessor.php
+++ b/Civi/Token/TokenProcessor.php
@@ -497,7 +497,7 @@ class TokenProcessor {
 
         case 'boolean':
           // We resolve boolean to 0 or 1 or smarty chokes on FALSE.
-          return (int) $value->getAmount()->isGreaterThan(0);
+          return (int) ($value->getAmount()->isGreaterThan(0) || $value->getAmount()->isLessThan(0));
 
         case 'raw':
           return $value->getAmount();

--- a/tests/phpunit/Civi/Token/TokenProcessorTest.php
+++ b/tests/phpunit/Civi/Token/TokenProcessorTest.php
@@ -479,6 +479,11 @@ class TokenProcessorTest extends \CiviUnitTestCase {
         'currency' => 'EUR',
         'locale' => 'fr_FR',
       ],
+      'my_negative_currencies' => [
+        'amount' => Money::of(-123, 'USD', new DefaultContext()),
+        'currency' => 'EUR',
+        'locale' => 'fr_FR',
+      ],
     ];
 
     $testCases = [];
@@ -532,6 +537,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
         'Amount: {my_currencies.amount}' => 'Amount: $123.00',
         'Amount as money: {my_currencies.amount|crmMoney}' => 'Amount as money: $123.00',
         'Amount as money in France: {my_currencies.amount|crmMoney:"fr_FR"}' => 'Amount as money in France: 123,00 $US',
+        'Amount as boolean when negative: {my_negative_currencies.amount|boolean}' => 'Amount as boolean when negative: 1',
       ],
       $exampleTokens,
     ];
@@ -559,7 +565,7 @@ class TokenProcessorTest extends \CiviUnitTestCase {
         $p->addRow()
           ->format('text/plain')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_text']))
           ->format('text/html')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_rich_text']))
-          ->format('text/plain')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_currencies']));
+          ->format('text/plain')->tokens(\CRM_Utils_Array::subset($exampleTokens, ['my_currencies', 'my_negative_currencies']));
         foreach ($p->evaluate()->getRows() as $row) {
           $this->assertEquals($expectOutput, $row->render('example'));
           $actualExampleCount++;


### PR DESCRIPTION
… the boolean money filter

Overview
----------------------------------------
This modifies the boolean filter for Money amounts to treat negative numbers as "true" not false which I think matches the original handling prior to https://github.com/civicrm/civicrm-core/pull/26254 where the test was if the amount !== 0.00

Before
----------------------------------------
Negative Money amounts are treated as false

After
----------------------------------------
Negative Money amounts are treated as true

ping @eileenmcnaughton @andrew-cormick-dockery 