### PR TITLE
Afform - Fix viewing files

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -322,7 +322,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     foreach ($fileFields as $fieldName => $fieldDefn) {
       foreach ($result as &$item) {
         if (!empty($item[$fieldName])) {
-          $fileInfo = $this->getFileInfo($item[$fieldName]);
+          $fileInfo = $this->getFileInfo($item[$fieldName], $afEntityName);
           $item[$fieldName] = $fileInfo;
         }
       }
@@ -330,9 +330,9 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     return $result;
   }
 
-  protected function getFileInfo(int $fileId):? array {
+  protected function getFileInfo(int $fileId, string $afEntityName):? array {
     $select = ['id', 'file_name', 'icon'];
-    if ($this->canViewFileAttachments($this->modelName)) {
+    if ($this->canViewFileAttachments($afEntityName)) {
       $select[] = 'url';
     }
     return File::get(FALSE)

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -164,7 +164,7 @@ class SubmitFile extends AbstractProcessor {
   }
 
   private function updateDraft(array $draft, int $fileId): array {
-    $fileInfo = $this->getFileInfo($fileId);
+    $fileInfo = $this->getFileInfo($fileId, $this->modelName);
 
     // Place fileInfo into correct entity
     $entityData =& $draft['data'][$this->modelName][$this->entityIndex];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal error in Afform when trying to view a file.

Reroll of https://github.com/civicrm/civicrm-core/pull/32887

Before
----------------------------------------
Before: 500 error when you attempt to view an Afform entity that has a file.

```
TypeError: Civi\Api4\Action\Afform\AbstractProcessor::canViewFileAttachments(): Argument #1 ($afEntityName) must be of type string, null given, called in /home/jon/local/civicrm-buildkit/build/smaster/web/core/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php on line 331
```

After
----------------------------------------
Works

Technical Details
----------------------------------------
`modelName` is set in one class but not the other, so must pass it in explicitly.


