### PR TITLE
Add Group Type filter to Manage Groups

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchManageGroups.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageGroups.aff.html
@@ -1,6 +1,7 @@
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
     <af-field name="title" defn="{label: 'Title', input_attrs: {}}" />
+    <af-field name="group_type" defn="{input_attrs: {multiple: true}}" />
     <af-field name="visibility" defn="{label: 'Visibility', input_attrs: {multiple: true}}" />
     <af-field name="is_active" defn="{input_type: 'Radio', label: 'Enabled', afform_default: true}" />
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Group Type is quite a useful filter when groups are used for different things. By default we have "Access Control" and "Mailing List" groups but it is also possible to define other group types.

Before
----------------------------------------
No Group Type filter

After
----------------------------------------
![image](https://github.com/user-attachments/assets/55d9a40b-011b-4fc4-9efc-b31b95ace012)

Technical Details
----------------------------------------
Just adds filter to FormBuilder for Manage Groups

Comments
----------------------------------------

