### PR TITLE
[REF] Follow up to #32499 to followup to use standard frontend function

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -216,7 +216,7 @@ class CRM_Core_Invoke {
 
       $template = CRM_Core_Smarty::singleton();
 
-      $template->assign('urlIsPublic', CRM_Core_Config::singleton()->userFrameworkFrontend);
+      $template->assign('urlIsPublic', CRM_Core_Config::singleton()->userSystem->isFrontEndPage());
       if (empty($item['is_public'])) {
         self::statusCheck($template);
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow up to #32499 to switch to using what seems to be a standard function for determining if url is public see https://github.com/civicrm/civicrm-core/blob/master/Civi/Core/Themes.php#L73C42-L73C58 as example

Before
----------------------------------------
userFrameWorkFrontend config option used

After
----------------------------------------
Function on UserSystem class used which is also used in the theme subsystem

ping @mattwire @eileenmcnaughton @vingle 