### PR TITLE
dev/core#2072 - Remove old transitional include-path for tcpdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     },
     "files": ["functions.php", "guzzle_php81_shim.php"]
   },
-  "include-path": ["vendor/tecnickcom"],
   "config": {
     "platform": {
       "php": "8.0.0"


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/2072

Before
----------------------------------------
Not used for anything anymore

After
----------------------------------------
Not exist

Technical Details
----------------------------------------
This was transitional because tcpdf used to be in packages, which is in the include_path, and there were extensions that did `require_once 'tcpdf/tcpdf.php'`. When it was moved to composer, those extensions would give a fatal error. So this entry was put in as a temporary thing to avoid that, but there are no extensions in universe that do that anymore. https://github.com/civicrm/civicrm-core/commit/87f0580ce2cedadd10f3e792050ae1d84cb30b4b

Comments
----------------------------------------
I tested on drupal 7 and 8.