### PR TITLE
dev/core#4749 fix handling File Custom fields in Case Data Changed activities

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -169,36 +169,79 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
         [, $customFieldId] = explode('_', $fieldKey);
 
         if (!empty($customFieldId) && is_numeric($customFieldId)) {
-          // Got a custom field ID
-          $customField = CRM_Core_BAO_CustomField::getField($customFieldId);
-          $label = $customField['label'];
+          // valid custom field id
+          $customFieldId = (int) $customFieldId;
 
-          // Convert dropdown and other machine values to human labels.
-          // Money is special for non-US locales because at this point it's in human format so we don't
-          // want to try to convert it.
-          $oldValue = $this->_defaults[$fieldKey] ?? '';
-          $newValue = $newCustomValue;
-          if ('Money' !== $customField['data_type']) {
-            $oldValue = civicrm_api3('CustomValue', 'getdisplayvalue', [
-              'custom_field_id' => $customFieldId,
-              'entity_id' => $this->_entityID,
-              'custom_field_value' => $oldValue,
-            ]);
-            $oldValue = $oldValue['values'][$customFieldId]['display'];
-            $newValue = civicrm_api3('CustomValue', 'getdisplayvalue', [
-              'custom_field_id' => $customFieldId,
-              'entity_id' => $this->_entityID,
-              'custom_field_value' => $newCustomValue,
-            ]);
-            $newValue = $newValue['values'][$customFieldId]['display'];
+          // check field exists and get meta
+          $customField = CRM_Core_BAO_CustomField::getField($customFieldId);
+
+          if ($customField) {
+            // label from custom field
+            $label = $customField['label'];
+
+            // before/after values from form
+            $oldValue = $this->_defaults[$fieldKey] ?? '';
+            $newValue = $newCustomValue;
+
+            // Convert dropdown and other machine values to human labels.
+            $oldValue = $this->formatDisplayValue($oldValue, $customFieldId, $customField['data_type']);
+            $newValue = $this->formatDisplayValue($newValue, $customFieldId, $customField['data_type']);
+
+            $formattedDetails[] = $label . ': ' . $oldValue . ' => ' . $newValue;
           }
-          $formattedDetails[] = $label . ': ' . $oldValue . ' => ' . $newValue;
+
         }
 
       }
     }
 
     return implode('<br/>', $formattedDetails);
+  }
+
+  private function formatDisplayValue(mixed $value, int $customFieldId, string $customFieldDataType): string {
+    switch ($customFieldDataType) {
+      case 'Money':
+        // Money is special for non-US locales because at this point it's in human format so we don't try
+        // want to try to convert it.
+        return $value;
+
+      case 'File':
+        // File is tricky - updating the case file reuses the same File ID.
+        // This makes saving /civicrm/file? urls meaningless as
+        // every URL will just render the latest version of the file...
+        //
+        // It also doesn't make sense to permanently save a url containing a time-limited checksum
+        //
+        // So for now we just save the filename before and after
+        //
+        // @todo consider updating the handling so new files are saved with new IDs,
+        // and then stashing the file ids somewhere that live urls can be rendered
+        // dynamically? (or is the expectation that old versions of files are totally gone forever?)
+
+        // old values come through with the whole file path in the `name` key
+        if (!empty($value['name'])) {
+          $filename = basename($value['name']);
+        }
+
+        // old values come through with the filename in the `data` key
+        if (!empty($value['data'])) {
+          $filename = $value['data'];
+        }
+
+        if ($filename) {
+          // remove hash so we don't expose this
+          return CRM_Utils_File::cleanFileName($filename);
+        }
+
+        return ts('No file');
+
+      default:
+        return civicrm_api3('CustomValue', 'getdisplayvalue', [
+          'custom_field_id' => $customFieldId,
+          'entity_id' => $this->_entityID,
+          'custom_field_value' => $value,
+        ])['values'][$customFieldId]['display'];
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Possible fix for https://lab.civicrm.org/dev/core/-/issues/5926 . It seems broken as far back as 6.2 to me.

Before
----------------------------------------
Editing a File type custom field on a case hangs - it can't handle rendering new vs old value for the "Change Custom Data" activity.

After
----------------------------------------
File URIs are saved in the Case Data Changed activity.

Technical Details
----------------------------------------
Beware browser caching when testing URLs when the source image changes on the server...

Comments
----------------------------------------
There seem to be a few things going wrong here.

Immediate issue = array values are being passed to functions that expect strings/ints, and things being in different keys between quickform / api3 / bao layers.

Bigger picture issues
- it seems that case file change maintain the same file ID, which messes with trying to render before/after values, as generated URLs will all point to the latest file.
- file urls with checksums are time limited anyway, so saving them permanently in the body of these Activities isn't going to work anyway. I think we'd need some special handling to save the before/after file ID, then render checksum-ed links dynamically
- it's not clear to me what the expected behaviour is when changing files. Would you expect the old one to be deleted? Or a permanent record created?
