### PR TITLE
SearchKit - Handle REGEXP operator as string in data type checks

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -119,7 +119,11 @@
         }
 
         function convertDataType(val) {
-          if (dataType === 'Integer' || dataType === 'Float') {
+          // A regex is always a string
+          if (ctrl.op && ctrl.op.includes('REGEXP')) {
+            dataType = 'String';
+          }
+          else if (dataType === 'Integer' || dataType === 'Float') {
             let newVal = Number(val);
             // FK Entities can use a mix of numeric & string values (see `"static": options` above)
             if (ctrl.field.fk_entity && ('' + newVal) !== val) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -42,6 +42,10 @@
           if (ctrl.optionKey && ctrl.optionKey !== 'id') {
             return val;
           }
+          // A regex is always a string
+          if (ctrl.op && ctrl.op.includes('REGEXP')) {
+            return val;
+          }
           if (Array.isArray(val)) {
             const formatted = angular.copy(val);
             formatted.forEach((v, i) => formatted[i] = formatDataType(v));


### PR DESCRIPTION
Overview
----------------------------------------
Prevents bug where the entered regex is lost due to reformatting.

See https://chat.civicrm.org/civicrm/pl/achutrd3bf8s9qtoizm9iwcnwc

Before
----------------------------------------
Enter a regex string in the WHERE clause. Switch to a different vertical tab in the SK UI and then back to the Filter Conditions tab, and the regex will be gone.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
This regressed when stricter value formatting was introduced.

Updated formatter to treat REGEXP operators as strings in both `afGuiFieldValue.directive.js` and `crmSearchInput.component.js`.