### PR TITLE
Update Preview template to match changes made in #30681 to fix the ra…

### DIFF
--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -35,8 +35,8 @@
         {/if}
   {if !empty($element.options_per_line)}
         {assign var="element_name" value=$element.element_name}
-        <tr>
-         <td class="label">{$form.$element_name.label}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
+        <tr class="custom-field-row {$element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
+         <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
          <td>
             {assign var="count" value=1}
                 <table class="form-layout-compressed">
@@ -61,8 +61,8 @@
   {else}
         {capture assign="name"}{if !empty($element.name)}{$element.name}{/if}{/capture}
         {capture assign="element_name"}{if !empty($element.element_name)}{$element.element_name}{/if}{/capture}
-        <tr>
-          <td class="label">{$form.$element_name.label}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
+        <tr class="custom-field-row {$element_name}-row"  {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
+          <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
         <td>
           {$form.$element_name.html}&nbsp;
       {if $element.html_type eq 'Autocomplete-Select'}


### PR DESCRIPTION
…dio group role and the orphaned label in wave on custom field radio

Overview
----------------------------------------
This updates the template used when previewing custom fields to match that of the Custom FIeld edit template in #30681 and adds in the tr classes that are used in edit as well

Before
----------------------------------------
Wave error about orphaned form label and no radio group role defined

After
----------------------------------------
aria role set and no orphaned label

ping @vingle @eileenmcnaughton 