### PR TITLE
Add 'add' to field metadata

### DIFF
--- a/schema/Core/UserJob.entityType.php
+++ b/schema/Core/UserJob.entityType.php
@@ -152,6 +152,7 @@ return [
       'sql_type' => 'int unsigned',
       'input_type' => 'EntityRef',
       'description' => ts('Batch import search display'),
+      'add' => '6.3',
       'input_attrs' => [
         'label' => ts('Search Display'),
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Field added in https://github.com/civicrm/civicrm-core/pull/32799/files#diff-1135a3aa62db51336f388ef48299109f911f7958c939deffe6b52d36ca0a9303 does not have 'add' - @colemanw just an omission - or are they out of fashion?