### PR TITLE
issue#5922: FormBuilder: Can't submit form with required date field with alternate format

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -101,6 +101,14 @@
                   if (settings.date === false) {
                     requiredLength = 8;
                   }
+                  else if (typeof settings.date === 'string') {
+                    var lowerFormat = settings.date.toLowerCase();
+                    // FIXME: parseDate doesn't work with incomplete date formats; skip validation if no month, day or year in format
+                    if (lowerFormat.indexOf('y') < 0 || lowerFormat.indexOf('m') < 0 || lowerFormat.indexOf('d') < 0) {
+                      // skipping the validation by setting the actual length of datepicker value
+                      requiredLength = element.val().length;
+                    }
+                  }
                   ngModel.$setValidity('incompleteDateTime', !(element.val().length && element.val().length !== requiredLength));
                 });
               });


### PR DESCRIPTION
## Overview

If you have a date field formatted as "M yy" (and presumably others), you can't submit a FormBuilder form that includes it as a required field.

## Reproduction steps

1. Change the "Marriage Date" custom field (in demo data) so its format is "M yy" (aka "May 2025").
2. Add it to a FormBuilder form, make it required.
3. Try to submit the form.

## Current behaviour

```
Form Error
Please fill all required fields.
```

## Expected behaviour

Form submits.

## Comments

Replicable on 6.1.2 and 6.4-master.


Technical Details
----------------------------------------
The logic is copied from [here](https://github.com/civicrm/civicrm-core/blob/master/js/crm.datepicker.js#L94) as we are bypassing the validation when date format doesn't include day. 


ping @colemanw @MegaphoneJon @seamuslee001 