### PR TITLE
issues#5281 : Increase length of MailingEventBounce.bounce_reason field

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFour.php
+++ b/CRM/Upgrade/Incremental/php/SixFour.php
@@ -31,6 +31,12 @@ class CRM_Upgrade_Incremental_php_SixFour extends CRM_Upgrade_Incremental_Base {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Rename multisite_is_enabled setting', 'renameMultisiteSetting');
     $this->addTask('Remove Foreign Key References from cache tables', 'removeForeignKeyReferencesCacheTables');
+    $this->addTask('Increase length of MailingEventBounce.bounce_reason field', 'alterSchemaField', 'MailingEventBounce', 'bounce_reason', [
+      'title' => ts('Bounce Reason'),
+      'sql_type' => 'varchar(512)',
+      'input_type' => 'Text',
+      'description' => ts('The reason the email bounced.'),
+    ]);
   }
 
   public static function removeForeignKeyReferencesCacheTables(): bool {

--- a/schema/Mailing/MailingEventBounce.entityType.php
+++ b/schema/Mailing/MailingEventBounce.entityType.php
@@ -52,7 +52,7 @@ return [
     ],
     'bounce_reason' => [
       'title' => ts('Bounce Reason'),
-      'sql_type' => 'varchar(255)',
+      'sql_type' => 'varchar(512)',
       'input_type' => 'Text',
       'description' => ts('The reason the email bounced.'),
     ],


### PR DESCRIPTION
## Overview

CiviCRM stores the mail bounces in the database, which is nice. However, the bounce reason is truncated and often too short to be analyzed, as shown in this typical example.

## Example use-case

![grafik.png](/uploads/6ae1f4aca5859707c3f3b67230432d3b/grafik.png)

The bounce reason says:

> \-REPORT-0- This message was created automatically by mail delivery software. A message that you sent could not be delivered to one or more of its recipients. This is a permanent error. The following address(es) failed: lawyershubcommunications@gmail.com

`... which is obviously not helpful.`

## Current behaviour

The field bounce_reason is defined in the database as varchar(255 ), and probably also elsewhere in the code, the field is truncated to 254 charas.

## Proposed behaviour

The bounce reason should be able to store messages with e.g. 512 chars.

Ref - https://lab.civicrm.org/dev/core/-/issues/5281 

ping @eileenmcnaughton @colemanw 