### PR TITLE
Fix broken image thumbnails for uploaded files

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1372,7 +1372,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
         ) {
           [$path] = CRM_Core_BAO_File::path($fileID);
           $fileHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileID);
-          $url = CRM_Utils_System::url('civicrm/file', "reset=1&id=$fileID&fcs=$fileHash", $absolute);
+          $url = CRM_Utils_System::url('civicrm/file', "reset=1&id=$fileID&fcs=$fileHash", $absolute, NULL, TRUE, $absolute);
           $result['file_url'] = CRM_Utils_File::getFileURL($path, $fileType, $url);
         }
         // for non image files

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1382,7 +1382,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
             'uri'
           );
           $fileHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileID);
-          $url = CRM_Utils_System::url('civicrm/file', "reset=1&id=$fileID&eid=$contactID&fcs=$fileHash", $absolute);
+          $url = CRM_Utils_System::url('civicrm/file', "reset=1&id=$fileID&eid=$contactID&fcs=$fileHash", $absolute, NULL, TRUE, $absolute);
           $result['file_url'] = CRM_Utils_File::getFileURL($uri, $fileType, $url);
         }
       }

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1372,10 +1372,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
         ) {
           [$path] = CRM_Core_BAO_File::path($fileID);
           $fileHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileID);
-          $url = CRM_Utils_System::url('civicrm/file',
-            "reset=1&id=$fileID&fcs=$fileHash",
-            $absolute, NULL, TRUE, TRUE
-          );
+          $url = CRM_Utils_System::url('civicrm/file', "reset=1&id=$fileID&fcs=$fileHash", $absolute);
           $result['file_url'] = CRM_Utils_File::getFileURL($path, $fileType, $url);
         }
         // for non image files
@@ -1385,10 +1382,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
             'uri'
           );
           $fileHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileID);
-          $url = CRM_Utils_System::url('civicrm/file',
-            "reset=1&id=$fileID&eid=$contactID&fcs=$fileHash",
-            $absolute, NULL, TRUE, TRUE
-          );
+          $url = CRM_Utils_System::url('civicrm/file', "reset=1&id=$fileID&eid=$contactID&fcs=$fileHash", $absolute);
           $result['file_url'] = CRM_Utils_File::getFileURL($uri, $fileType, $url);
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
A proposed fix for [#5161](https://lab.civicrm.org/dev/core/-/issues/5161), where uploaded image thumbnails do not work in profile view mode without granting anonymous permissions to `CiviCRM: access uploaded files` (which is unsafe).

Before
----------------------------------------
Thumbnails to uploaded files are broken because they are forced to the CMS front-end which does not pick up the CiviCRM login:

![Screenshot 2025-06-03 124418](https://github.com/user-attachments/assets/b69bae04-427d-4cd4-92a8-3b22c530b4ff)

After
----------------------------------------
Thumbnails to uploaded files now work because they are directed to the current CMS context (back end):

![Screenshot 2025-06-03 124506](https://github.com/user-attachments/assets/1973c41f-c53a-47e3-bcda-2eb9764a17eb)

Thumbnails on the front end continue to work (URL unchanged) as long as registered users have access to uploaded files:

![Screenshot 2025-06-03 131002](https://github.com/user-attachments/assets/cccaafc3-433c-417f-8fef-1123048155ee)

Confirmation emails are unaffected because they do not include file upload fields anyway:

![Screenshot 2025-06-03 125306](https://github.com/user-attachments/assets/97d87990-6557-4fd9-a56b-d2610d2eaabd)

Technical Details
----------------------------------------
See linked issue for detailed discussion and code analysis to support this change.

Tested and confirmed working on CiviCRM 5.78.3 and 6.2.0 (using Joomla 4.4.13).

Comments
----------------------------------------
I think it would actually be OK to also remove the `$absolute` argument from these calls, as it is only used in one place (`CRM_Core_BAO_UFGroup::checkFieldsEmptyValues()`) where it makes no difference anyway. This would be a separate PR.