### PR TITLE
SearchKit - Selectable mailing type

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2490,6 +2490,8 @@ ORDER BY civicrm_mailing.id DESC";
       $types = [];
       $types[] = [
         'name' => 'traditional',
+        'label' => ts('Traditional'),
+        'description' => ts('Standard CiviMail interface with wysiwyg editor.'),
         'editorUrl' => CRM_Mailing_Info::workflowEnabled() ? '~/crmMailing/EditMailingCtrl/workflow.html' : '~/crmMailing/EditMailingCtrl/2step.html',
         'weight' => 0,
       ];
@@ -2514,17 +2516,21 @@ ORDER BY civicrm_mailing.id DESC";
   }
 
   /**
-   * Get a list of template types.
+   * Pseudoconstant callback for `template_type` field.
    *
    * @return array
-   *   Array(string $name => string $label).
    */
-  public static function getTemplateTypeNames() {
-    $r = [];
+  public static function getTemplateTypeNames(): array {
+    $types = [];
     foreach (self::getTemplateTypes() as $type) {
-      $r[$type['name']] = $type['name'];
+      $types[] = [
+        'id' => $type['name'],
+        'name' => $type['name'],
+        'label' => $type['label'] ?? ucfirst($type['name']),
+        'description' => $type['description'] ?? NULL,
+      ];
     }
-    return $r;
+    return $types;
   }
 
 }

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.html
@@ -4,8 +4,12 @@
       <p>{{:: ts('Compose and send a mass-mailing to the %1 selected contacts (you will be able to add or exclude additional groups of contacts in the next step).', {1: $ctrl.ids.length}) }}</p>
     </div>
     <label for="crm-search-task-mailing-name">{{:: ts('Mailing Name') }} <span class="crm-marker">*</span></label>
-    <input required class="form-control" id="crm-search-task-mailing-name" ng-model="$ctrl.name">
+    <input required class="form-control" id="crm-search-task-mailing-name" ng-model="$ctrl.mailing.name">
     <br>
+    <div class="form-inline" ng-if="$ctrl.templateTypes.length">
+      <label for="crm-search-task-mailing-template_type">{{:: ts('Mailing Type') }}</label>
+      <input id="crm-search-task-mailing-template_type" class="form-control" ng-model="$ctrl.mailing.template_type" crm-ui-select="{data: $ctrl.templateTypes, allowClear: false}">
+    </div>
     <div ng-if="!$ctrl.run" class="alert" ng-class="{'alert-success': $ctrl.recipientCount === $ctrl.ids.length, 'alert-danger': $ctrl.recipientCount === 0, 'alert-warning': $ctrl.recipientCount !== 0 && $ctrl.recipientCount &lt; $ctrl.ids.length}">
       <div ng-if="!$ctrl.recipientCount && $ctrl.recipientCount !== 0">
         <i class="crm-i fa-spinner fa-spin"></i>


### PR DESCRIPTION
Overview
----------------------------------------
With Mosaico installed, this gives the user a choice of which type of mailing they want (Mosaico or Traditional).

Before
----------------------------------------
Creating a mailing from SearchKit would not offer the user a choice and always create the default mailing type (Mosaico, if installed, otherwise Traditional).

After
----------------------------------------
If Mosaico is installed, a choice is offered:

![image](https://github.com/user-attachments/assets/e28f17f7-ec28-467e-8ffe-720cd43a5d42)

Technical Details
----------------------------------------
This adds user-facing label & description to the `template_type` options, for use on the form.
I also added it to Mosaico here: https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/pull/673 with a fallback so that PR is not strictly required for this to work (it just won't have the nice description in the dropdown).