### PR TITLE
Add 'add' metadata to civicrm_user_job.search_display_id

### DIFF
--- a/schema/Core/UserJob.entityType.php
+++ b/schema/Core/UserJob.entityType.php
@@ -155,6 +155,7 @@ return [
       'input_attrs' => [
         'label' => ts('Search Display'),
       ],
+      'add' => '6.3',
       'entity_reference' => [
         'entity' => 'SearchDisplay',
         'key' => 'id',


### PR DESCRIPTION
Overview
----------------------------------------
Adds missing field metadata.