### PR TITLE
dev/core#5930 Fix incorrect processing of line items on Contribution update

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -890,9 +890,11 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
    * @param string $thousandSeparator
    *
    * @dataProvider getThousandSeparators
+   * @throws \Civi\Core\Exception\DBQueryException
    */
   public function testSubmitUpdate(string $thousandSeparator): void {
     $contactID = $this->individualCreate();
+    CRM_Core_DAO::executeQuery('ALTER TABLE civicrm_line_item AUTO_INCREMENT=58');
     $this->setCurrencySeparators($thousandSeparator);
     $this->submitContributionForm([
       'total_amount' => $this->formatMoneyInput(6100.10),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes fatal on editing amount on contributions

When trying to edit a contribution amount of a manually entered contribution, a fatal error occurs. This appears to the user as an endlessly spinning triangle.

Reproduction steps
----------------------------------------
1. Go to the **Contributions** tab of a contact
1. Click **Record Contribution (Check, Cash, EFT...)**
1. Enter a transaction (I chose Donation, $10)
2. Click **Save**
3. Go back to the **Contributions** tab of the same contact
4. Click **Edit** against the contribution just entered
5. Change the value of the contribution from $10 to $20
6. Click **Save**
7. The user experiences an endlessly spinning triangle. The logs are shown below.
8. When going back to the original contribution, it can be seen that even though the contribution amount and payments have been updated correctly, the line item remains incorrectly set to the original value.

Before
----------------------------------------
The following error shows in the logs:

```
The website encountered an unexpected error. Try again later.

TypeError: CRM_Contribute_BAO_FinancialProcessor::getFinancialAccountForStatusChangeTrxn(): Return value must be of type int, null returned in CRM_Contribute_BAO_FinancialProcessor::getFinancialAccountForStatusChangeTrxn() (line 51 of /srv/buildkit/build/d10-master/vendor/civicrm/civicrm-core/CRM/Contribute/BAO/FinancialProcessor.php).

CRM_Contribute_BAO_FinancialProcessor::createFinancialItemsForLine() (Line: 225)
CRM_Contribute_BAO_FinancialProcessor::updateFinancialAccounts() (Line: 3107)
CRM_Contribute_BAO_Contribution::recordFinancialAccounts() (Line: 226)
CRM_Contribute_BAO_Contribution::add() (Line: 495)
CRM_Contribute_BAO_Contribution::create() (Line: 2183)
CRM_Contribute_Form_Contribution->submit() (Line: 1148)
CRM_Contribute_Form_Contribution->postProcess() (Line: 649)
CRM_Core_Form->mainProcess() (Line: 153)
CRM_Core_QuickForm_Action_Upload->realPerform() (Line: 120)
CRM_Core_QuickForm_Action_Upload->perform() (Line: 203)
HTML_QuickForm_Controller->handle() (Line: 103)
HTML_QuickForm_Page->handle() (Line: 356)
CRM_Core_Controller->run() (Line: 417)
CRM_Contribute_Page_Tab->edit() (Line: 471)
CRM_Contribute_Page_Tab->run() (Line: 276)
CRM_Core_Invoke::runItem() (Line: 73)
CRM_Core_Invoke::_invoke() (Line: 38)
CRM_Core_Invoke::invoke() (Line: 87)
Drupal\civicrm\Civicrm->invoke() (Line: 83)
Drupal\civicrm\Controller\CivicrmController->main()
call_user_func_array() (Line: 123)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 638)
Drupal\Core\Render\Renderer->executeInRenderContext() (Line: 121)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext() (Line: 97)
Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 181)
Symfony\Component\HttpKernel\HttpKernel->handleRaw() (Line: 76)
Symfony\Component\HttpKernel\HttpKernel->handle() (Line: 53)
Drupal\Core\StackMiddleware\Session->handle() (Line: 48)
Drupal\Core\StackMiddleware\KernelPreHandle->handle() (Line: 28)
Drupal\Core\StackMiddleware\ContentLength->handle() (Line: 32)
Drupal\big_pipe\StackMiddleware\ContentLength->handle() (Line: 116)
Drupal\page_cache\StackMiddleware\PageCache->pass() (Line: 90)
Drupal\page_cache\StackMiddleware\PageCache->handle() (Line: 48)
Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle() (Line: 51)
Drupal\Core\StackMiddleware\NegotiationMiddleware->handle() (Line: 36)
Drupal\Core\StackMiddleware\AjaxPageState->handle() (Line: 51)
Drupal\Core\StackMiddleware\StackedHttpKernel->handle() (Line: 741)
Drupal\Core\DrupalKernel->handle() (Line: 19)
```

After
----------------------------------------
Fixed

Technical details 
----------------------------------------

Regression seems new to 6.2 - exact commit not pinned down but there were a handle of relevant fixes towards fixing the participant update

Test did not pick it up due to @aydun's favourite test issue - matching IDs in relevant tables