### PR TITLE
SearchKit - Allow row count to be set when starting a batch

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
@@ -12,6 +12,8 @@ use Civi\Api4\UserJob;
  * @method $this setSavedSearch(string $savedSearchName)
  * @method $this setDisplay(string $displayName)
  * @method string getDisplay()
+ * @method $this setRowCount(int $rowCount)
+ * @method int getRowCount()
  *
  * @since 6.3
  */
@@ -33,6 +35,13 @@ class CreateBatch extends AbstractAction {
    * @required
    */
   protected $display;
+
+  /**
+   * Number of rows to insert
+   *
+   * @var int
+   */
+  protected $rowCount = 1;
 
   /**
    * @inheritDoc
@@ -90,9 +99,12 @@ class CreateBatch extends AbstractAction {
       ->setValues($userJob)
       ->execute()->single();
 
-    // Add an empty row to get the user started
-    $sql = "INSERT INTO `$tableName` () VALUES ()";
-    \CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);
+    // Add empty rows per $this->rowCount
+    if ($this->rowCount > 0) {
+      $values = rtrim(str_repeat("(),", $this->rowCount), ",");
+      $sql = "INSERT INTO `$tableName` () VALUES $values";
+      \CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);
+    }
   }
 
   private function getSqlType(array $fieldSpec) {

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -40,6 +40,7 @@
           }, 10000);
         }
         else {
+          this.newBatchRowCount = 1;
           this.reportLinks = [
             {
               title: ts('View My Import Batches'),
@@ -100,6 +101,7 @@
         crmApi4('SearchDisplay', 'createBatch', {
           savedSearch: this.search,
           display: this.display,
+          rowCount: this.newBatchRowCount,
         }, 0).then(function(userJob) {
           $location.search('batch', userJob.id);
         });

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
@@ -1,6 +1,13 @@
 <div ng-if="!$ctrl.userJobId && !$ctrl.isPreviewMode" class="crm-search-display crm-search-display-batch">
   <ul class="list-group">
-    <li class="list-group-item">
+    <li class="list-group-item form-inline">
+      <div class="form-group">
+        <label class="sr-only" for="crm-create-new-batch-row-count">{{:: ts('Initial row count for new batch') }}</label>
+        <div class="input-group">
+          <input type="number" min="1" step="1" class="form-control" id="crm-create-new-batch-row-count" ng-model="$ctrl.newBatchRowCount" title="{{:: ts('Initial row count for new batch') }}">
+          <div class="input-group-addon">{{:: ts('Rows') }}</div>
+        </div>
+      </div>
       <button type="button" class="btn btn-primary" ng-click="$ctrl.createNewBatch()" ng-disabled="$ctrl.creatingBatch">
         <i ng-if="$ctrl.creatingBatch" class="crm-i fa-spin fa-spinner"></i>
         <i ng-if="!$ctrl.creatingBatch" class="crm-i fa-plus"></i>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchBatch/SearchBatchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchBatch/SearchBatchTest.php
@@ -284,8 +284,12 @@ class SearchBatchTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     $userJob = SearchDisplay::createBatch(FALSE)
       ->setSavedSearch($name)
       ->setDisplay($name)
+      ->setRowCount(3)
       ->execute()->single();
     $apiName = 'Import_' . $userJob['id'];
+
+    $rows = civicrm_api4($apiName, 'get');
+    $this->assertEquals([1, 2, 3], $rows->column('_id'));
 
     $fields = civicrm_api4($apiName, 'getFields', ['loadOptions' => TRUE])->indexBy('label');
 


### PR DESCRIPTION
Overview
----------------------------------------
For the new batch entry display, allows user to set the initial row count.

Item 1 on https://lab.civicrm.org/dev/core/-/issues/5889

![image](https://github.com/user-attachments/assets/19d5f943-0564-4de0-9c69-2f1a1382c2c8)
