### PR TITLE
Fix comment, type hints

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1823,16 +1823,17 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   /**
    * Handles a repeated bit supplying a placeholder for entity selection
    *
-   * @param string $props
+   * @param array $props
    *   The field properties, including the entity and context.
    * @param bool $required
    *   If the field is required.
-   * @param string $title
+   * @param string|null $title
    *   A field title, if applicable.
-   * @return string
+   *
+   * @return string|null
    *   The placeholder text.
    */
-  private static function selectOrAnyPlaceholder($props, $required, $title = NULL) {
+  private static function selectOrAnyPlaceholder(array $props, bool $required, ?string $title = NULL): ?string {
     if (empty($props['entity'])) {
       return NULL;
     }


### PR DESCRIPTION
Overview
----------------------------------------
`$props` is clearly an array not a string, the rest of seems safe to enforce with hints on reading