### PR TITLE
Fix Civiimport dependence on Mapping Field 

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -217,14 +217,20 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   protected function getContactFields(string $contactType, ?string $prefix = ''): array {
     $contactFields = $this->getAllContactFields('');
-    $dedupeFields = $this->getDedupeFields($contactType);
     $matchText = ' ' . ts('(match to %1)', [1 => $prefix]);
-    foreach ($dedupeFields as $fieldName => $dedupeField) {
-      if (!isset($contactFields[$fieldName])) {
-        continue;
+    $contactTypes = [$contactType];
+    if (!$contactType) {
+      $contactTypes = ['Individual', 'Organization', 'Household'];
+    }
+    foreach ($contactTypes as $type) {
+      $dedupeFields = $this->getDedupeFields($type);
+      foreach ($dedupeFields as $fieldName => $dedupeField) {
+        if (!isset($contactFields[$fieldName])) {
+          continue;
+        }
+        $contactFields[$fieldName]['title'] .= $matchText;
+        $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($type);
       }
-      $contactFields[$fieldName]['title'] .= $matchText;
-      $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($contactType);
     }
 
     $contactFields['external_identifier']['title'] .= $matchText;


### PR DESCRIPTION
Overview
----------------------------------------
Fix Civiimport dependence on Mapping Field 

Before
----------------------------------------
The `UserJob` now holds the mappings - but the apron strings are not fully cut with the `Mapping` entity so if it does not exist there are problems saving Civiimport user job updates

Do a civiimport - eg. contribution, saving the template. Then in the DB delete the entry in `civicrm_mapping` - try to use the template, choosing to update it on the mapping screen  - the update button is not there

After
----------------------------------------
Saves successfully

Technical Details
----------------------------------------
I'll be looking at more follow ups to delete the Mapping entities - this would probably be better in 6.3 - but it's so late I think it has to go master - but before 6.4 is cut as it might get backported. It was experienced as a regression by our user but it is a bit obscure to reach it & probably not UI-doable.

Comments
----------------------------------------
