### PR TITLE
RiverLea regression: fixes rendering of ul/ol in text regions

### DIFF
--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -86,6 +86,3 @@
 .status-debug-information {
   font-size: var(--crm-small-font-size);
 }
-.crm-status-message-body ul {
-  list-style: inherit;
-}

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -57,9 +57,10 @@ body {
 .crm-container ul {
   list-style: none;
 }
-/* Restores list styles for rich text output to UA stylesheet list def */
-.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages) :is(ol,ul) {
+/* Restores list styles for rich text output to UA stylesheet definition */
+.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body) :is(ol,ul) {
   list-style: revert;
+  padding: revert;
 }
 /* For images to not be able to exceed their container */
 .crm-container img {

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -54,9 +54,12 @@ body {
 }
 /* Remove list styles (bullets/numbers) */
 .crm-container ol,
-.crm-container ul,
-.crm-container menu {
+.crm-container ul {
   list-style: none;
+}
+/* Restores list styles for rich text output to UA stylesheet list def */
+.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages) :is(ol,ul) {
+  list-style: revert;
 }
 /* For images to not be able to exceed their container */
 .crm-container img {

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -158,7 +158,6 @@ body.wp-admin .crm-container input:not([type=checkbox]):not([type=radio]):not(.c
 body.wp-admin .crm-container p,
 body.wp-admin .crm-container li {
   margin-bottom: 0; /* resets WP li bottom margin */
-  list-style: none;
   white-space: inherit;
 }
 body.wp-admin .crm-container div.ui-notify-message .notify-content li {

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -29,7 +29,6 @@
 .crm-container .status li,
 .crm-container .messages li {
   color: var(--crm-alert-success-text);
-  list-style: initial;
 }
 .crm-container .status.alert,
 .crm-container .alert-warning,


### PR DESCRIPTION
Overview
----------------------------------------
Riverlea resets list-styles on ordered and unordered lists, this restores them to two regions: `.crm-content` (the rendered output of notes inline on contact dashboard), `.html-adjust` (rendered output in contact tabs) and `.note-editable` for inside wysiwyg editors, like Summernote, [where this is an issue](https://lab.civicrm.org/extensions/summernote/-/merge_requests/23). As initially raised here: https://lab.civicrm.org/extensions/riverlea/-/issues/130 by @mattwire.

Before
----------------------------------------
Inline:
![image](https://github.com/user-attachments/assets/5007c8a1-f822-46b6-8692-75fa081b022d)
Summernote:
<img width="372" alt="image" src="https://github.com/user-attachments/assets/b81fd1b4-692a-40c8-8a3e-dbe1be1e9bb5" />
Tabs & alerts:
<img width="552" alt="image" src="https://github.com/user-attachments/assets/da795331-97e6-4a32-8168-97bbfdd45f2e" />
WordPress extension status:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/237972e7-eb7a-43b0-ae02-6b495fa9588c" />

After
----------------------------------------
![image](https://github.com/user-attachments/assets/7112c82d-c702-4d4a-8e1e-91a743d21d16)
<img width="459" alt="image" src="https://github.com/user-attachments/assets/ff557725-0e5f-4488-8bd2-cecd4d196627" />
![image](https://github.com/user-attachments/assets/b1248189-e4d5-4f53-a3b0-f936ae3a1dba)
<img width="360" alt="image" src="https://github.com/user-attachments/assets/6c047709-5401-4603-abaf-754bdb92e76b" />

Technical Details
----------------------------------------
To unset the reset - rather than specify the `ul` should have `list-style: disc `and that `ol` should have `list-style-decimal` have used `revert` which is different to initial (which gives both ul and ol list-style: disc) but produces the right value and should reflect different number systems. FTR `revert` resets to the user-agent stylesheet, which is different to the browser's `initial` value (don't ask me why!).

Comments
----------------------------------------
This PR should remove the need for [this PR](https://lab.civicrm.org/extensions/summernote/-/merge_requests/23). It also replaces [this earlier attempt](https://github.com/civicrm/civicrm-core/pull/32881). The PR also removes an unnecessary selector `menu` that isn' relevant to Civi, came from a boilerplate reset.