### PR TITLE
fix phpoffice requiring dev stability for drupal 8 installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
     "zetacomponents/base": "1.9.*",
     "zetacomponents/mail": "~1.9.4",
     "marcj/topsort": "~1.1",
-    "phpoffice/phpword": "dev-master#44e6c268e3c03b0ce5e5ca2665c400a211d34d8b",
+    "phpoffice/phpword": "^1.4",
     "phpseclib/phpseclib": "~2.0",
     "pear/validate_finance_creditcard": "0.7.0",
     "pear/auth_sasl": "1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c5c5e7e63e9e3c5dd8099738c013057",
+    "content-hash": "c595415e6763bcb31e481675e9055e2b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2810,16 +2810,16 @@
         },
         {
             "name": "phpoffice/phpword",
-            "version": "dev-master",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PHPWord.git",
-                "reference": "44e6c268e3c03b0ce5e5ca2665c400a211d34d8b"
+                "reference": "6d75328229bc93790b37e93741adf70646cea958"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PHPWord/zipball/44e6c268e3c03b0ce5e5ca2665c400a211d34d8b",
-                "reference": "44e6c268e3c03b0ce5e5ca2665c400a211d34d8b",
+                "url": "https://api.github.com/repos/PHPOffice/PHPWord/zipball/6d75328229bc93790b37e93741adf70646cea958",
+                "reference": "6d75328229bc93790b37e93741adf70646cea958",
                 "shasum": ""
             },
             "require": {
@@ -2848,7 +2848,6 @@
                 "ext-xmlwriter": "Allows writing OOXML and ODF",
                 "ext-xsl": "Allows applying XSL style sheet to headers, to main document part, and to footers of an OOXML template"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -2913,9 +2912,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PHPWord/issues",
-                "source": "https://github.com/PHPOffice/PHPWord/tree/master"
+                "source": "https://github.com/PHPOffice/PHPWord/tree/1.4.0"
             },
-            "time": "2025-06-03T05:06:38+00:00"
+            "time": "2025-06-05T10:32:36+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -5960,9 +5959,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "phpoffice/phpword": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Overview
----------------------------------------
Can't install/upgrade a real drupal 8 site because dev version of phpword requires minimum-stability: dev, but they just released 1.4