### PR TITLE
RiverLea regression: css input size modifiers often over-ridden

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -214,21 +214,29 @@ select.crm-error {
 .crm-container .two {
   width: 3rem; /* .two is used on number inputs that need 1rem for the controls */
 }
-.crm-container .four {
-  width: 4rem;
+.crm-container .four,
+.crm-container input.four,
+.crm-container .crm-form-select.four {
+  width: 4em;
 }
-.crm-container .six {
-  width: 6rem;
+.crm-container .six,
+.crm-container input.six,
+.crm-container .crm-form-select.six {
+  width: 6em;
 }
-.crm-container .eight {
-  width: 8rem;
+.crm-container .eight,
+.crm-container input.eight,
+.crm-container .crm-form-select.eight {
+  width: 8em;
 }
 .crm-container .twelve,
-.crm-container .medium {
-  width: 12rem;
+.crm-container .medium,
+.crm-container input.twelve,
+.crm-container input.medium  {
+  width: 12em;
 }
 .crm-container .twenty {
-  width: 20rem;
+  width: 20em;
 }
 .crm-container .big {
   width: var(--crm-big-input);
@@ -407,7 +415,7 @@ input.crm-form-checkbox) + label {
   width: auto;
   max-width: 100%;
 }
-.crm-container .select2-container {
+.crm-container .select2-container:not(.four,.six,.eight,.twelve,.medium) {
   width: var(--crm-big-input) !important /* vs inline fixed width */;
 }
 .crm-container .select2-container-multi {


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM uses utilitiy classes like `.six`, `.eight`, `.four` etc to change the width of input boxes. While investigating another issue I saw in multiple cases these are being over-ridden by the theme width for `.ui-widget input` and `select2container`.

This PR does three things:
 - increase the specificity on these utility size classes so that input and select lists pick them up
 - change size from REMs to EMs as in this context the size relates to the font-size of the input boxes / select / table cell*
 - stop the Select2 width from applying to selects where there is a size modifier added.

Before
----------------------------------------
Phone block on contact dashboard - 1148px wide on Minetta:
![image](https://github.com/user-attachments/assets/c37d9a82-f817-42d1-9712-ffbc76c38a58)

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/2df5b037-9082-4b6d-bcf3-98910945d40e" />

After
----------------------------------------
Phone block on contact dashboard - 728px wide on Minetta:
![image](https://github.com/user-attachments/assets/974c1dbb-39ff-4031-bd79-6875764f3490)

![image](https://github.com/user-attachments/assets/c3554aac-7c84-487f-9eaf-f582ae7bef86)

Technical Details
----------------------------------------
*An alternative to changing from REMS to EMs would be to use `calc(8 * var(--crm-input-font-size))` for `.eight` etc - but it seems an extra layer of processing work when EM is right there.

Comments
----------------------------------------
Posting this to 6.3 as this is a quite wide regression and the fix has limited consequences beyond making forms look more like they were designed.