### PR TITLE
RiverLea Regressions: Contact Summary inline edit issues, with some tidying

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -329,7 +329,7 @@
   --crm-dash-panel-bg: #fff;
   --crm-dash-panel-border: 0;
   --crm-dash-panel-radius: 0 0 var(--crm-dash-roundness) var(--crm-dash-roundness);
-  --crm-dash-edit-border: 2px dashed var(--crm-c-gray-300);
+  --crm-dash-edit-border: 1px dashed var(--crm-c-gray-300);
   --crm-dash-block-padding: 0;
   --crm-dash-block-bg: unset;
   --crm-dash-block-radius: var(--crm-roundness);

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -60,16 +60,15 @@
   border: 1px solid var(--crm-c-focus);
   border-radius: var(--crm-roundness);
   background: var(--crm-inline-edit-bg);
-  padding: var(--crm-r);
-  width: fit-content;
+  padding: var(--crm-padding-reg);
   z-index: 99;
-  position: absolute;
-  left: calc(var(--crm-dash-panel-padding) + var(--crm-side-tabs-width));
-}
-.crm-contact-summary-layout-col-2 .crm-inline-edit.form, /* CLE */
-.contactCardRight .crm-inline-edit.form {
-  right: var(--crm-dash-panel-padding);
-  left: initial;
+  width: fit-content;
+  float: left;
+  box-shadow: rgba(255, 255, 255, 0.3) 0 0 0 99999px;
+/}
+.contactCardRight .crm-inline-edit.form,
+.contactCardRight {
+  float: right;
 }
 .crm-container .crm-inline-edit.add-new {
   min-height: 2.5em;
@@ -123,6 +122,9 @@
   white-space: nowrap;
   text-align: left !important /* vs _tables.css:95 */;
 }
+.crm-container .crm-inline-edit-form tr {
+  border-bottom: 0;
+}
 .crm-container table.crm-inline-edit-form td.crm-label,
 .crm-container div.crm-inline-edit-form .crm-label,
 .crm-container div.crm-inline-edit-form .messages {
@@ -132,10 +134,13 @@
   display: inline-block;
   padding: 4px 5px;
 }
-.crm-inline-edit.form td {
+.crm-container .crm-inline-edit.form td {
   background: transparent;
   padding: var(--crm-m);
   border-bottom: 0 solid transparent;
+}
+.crm-container .add-more-inline::after {
+  content: '+ ';
 }
 .CRM_Contact_Form_Inline_ContactName div.crm-inline-edit-form {
   white-space: nowrap;
@@ -196,13 +201,8 @@ div.crm-inline-edit-form div.crm-clear {
 }
 .crm-container div.contact_panel {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, calc(50% - calc(var(--crm-dash-panel-padding) * 0.5)));
   column-gap: var(--crm-dash-panel-padding);
-}
-.crm-container div.contactCardLeft,
-.crm-container div.contactCardRight {
-  width: 100%;
-  overflow: auto;
 }
 .crm-container div.contact_panel table {
   margin-bottom: 0;
@@ -234,12 +234,12 @@ div.crm-inline-edit-form div.crm-clear {
   height: 0;
   visibility: hidden;
 }
-.crm-container div.crm-summary-row {
+.crm-container .crm-summary-row {
   background-color: var(--crm-dash-summary-row-bg);
   border-top: 1px solid var(--crm-dash-summary-row-bg);
   display: flex;
 }
-.crm-container div.crm-summary-row div.crm-label {
+.crm-container .crm-summary-row .crm-label {
   background-color: var(--crm-dash-label-bg);
   color: var(--crm-input-label-color);
   font-weight: var(--crm-input-label-weight);
@@ -249,15 +249,15 @@ div.crm-inline-edit-form div.crm-clear {
   min-width: var(--crm-input-label-width);
   text-align: left;
 }
-/* Prevent wide content over-spilling page */
-.crm-container div.crm-summary-row div.crm-label {
-  max-width: calc(100% - var(--crm-input-label-width));
-  overflow: auto;
+/* Stops width from expanding in edit view */
+.crm-container .crm-inline-edit.form .crm-label {
+  width: var(--crm-input-label-width);
 }
-.crm-container div.crm-summary-row div.crm-content {
+.crm-container .crm-summary-row .crm-content {
   padding: var(--crm-m);
+  overflow: auto; /* adds scroll for values wider than container */
 }
-.crm-container #customFields div.contact_panel td {
+.crm-container #customFields .contact_panel td {
   border-bottom: 1px solid #ffffff;
   padding: 4px;
   vertical-align: top;
@@ -353,6 +353,7 @@ div.crm-inline-edit-form div.crm-clear {
   box-shadow: var(--crm-block-shadow);
 }
 .crm-contact-page .crm-summary-block {
+  display: flow-root; /* to keep block position during edit */
   background: var(--crm-dash-block-bg);
   border-radius: var(--crm-roundness);
   box-shadow: var(--crm-block-shadow);
@@ -398,15 +399,13 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
 
 @media (max-width: 991px) {
   .crm-container div.contact_panel {
-    display: block;
+    grid-template-columns: 100%;
   }
   .crm-container .contact_panel.crm-contact-summary-layout-row {
     flex-direction: column;
   }
-  .crm-contact-summary-layout-col-2 .crm-inline-edit.form,
-  .contactCardRight .crm-inline-edit.form {
-    right: inherit;
-    left: calc(var(--crm-dash-panel-padding) + var(--crm-side-tabs-width));
+  .contactCardRight .crm-inline-edit.form, .contactCardRight {
+    float: none;
   }
 }
 @media (max-width: 767px) {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -65,7 +65,7 @@
   width: fit-content;
   float: left;
   box-shadow: rgba(255, 255, 255, 0.3) 0 0 0 99999px;
-/}
+}
 .contactCardRight .crm-inline-edit.form,
 .contactCardRight {
   float: right;
@@ -404,7 +404,8 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
   .crm-container .contact_panel.crm-contact-summary-layout-row {
     flex-direction: column;
   }
-  .contactCardRight .crm-inline-edit.form, .contactCardRight {
+  .contactCardRight .crm-inline-edit.form,
+  .contactCardRight {
     float: none;
   }
 }

--- a/ext/riverlea/streams/empty/css/_variables.css
+++ b/ext/riverlea/streams/empty/css/_variables.css
@@ -313,7 +313,7 @@
 --crm-dash-panel-bg: #fff;
 --crm-dash-panel-border: 0;
 --crm-dash-panel-radius: 0 0 var(--crm-dash-roundness) var(--crm-dash-roundness);
---crm-dash-edit-border: 2px dashed var(--crm-c-gray-300);
+--crm-dash-edit-border: 1px dashed var(--crm-c-gray-300);
 --crm-dash-block-padding: 0;
 --crm-dash-block-bg: ;
 --crm-dash-block-radius: var(--crm-roundness);


### PR DESCRIPTION
Overview
----------------------------------------
There's a number of issues with the Contact Summary inline edit, as described here - https://lab.civicrm.org/extensions/riverlea/-/issues/129 - with screencasts. Some of the problem is RiverLea making things bigger, and Walbrook having less screen estate than Greenwich; some is dealt with in PR #32933, but some is down to the way those edit regions load.

This PR removes position absolute from inline edit, which was added to handle some quirks with Flexbox and Grid (which are both being used here), helped by `display: flow-root`, and returns to the original behaviour of edit regions expanding inline - stretch the height, and over-flowing left/right. This fixes that regression, which is most visible at the bottom of the page, and seems to sometimes clip content.

A few other things were tweaked with this, while comparing the CSS of old/new versions:
- Restore box-shadow effect to fade the background during edit which had been lost.
- Reduced dashed hover border in Minetta to 1px to avoid the border width hover dance.
- Changed widths of labels so they are more consistent when there's varying contents
- Add scroll to input values for too long values like email addresses.
- Removed table row border for the areas here where forms are being laid out with table (it's a mixture)
- Added a '+' to the 'add' link for more addresses/emails/phones/etc.

Before
----------------------------------------
Misaligned label regions:
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/309ac8d5-f04d-4d41-a81c-80e5852f63d4" />

Bottom float:
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/f50a0b0c-4657-4ad5-b781-1845ad167dbf" />

Lots of borders:
<img width="744" alt="image" src="https://github.com/user-attachments/assets/923da226-749e-4773-b43d-e8c46cd81735" />

After
----------------------------------------
**Minetta** - 3 viewports
![image](https://github.com/user-attachments/assets/84f290aa-93e8-473b-8b75-17f636eaebcf)

![image](https://github.com/user-attachments/assets/dcf273be-a528-4d91-90f4-dc0001671f3e)

![image](https://github.com/user-attachments/assets/2c5ae8fb-94a0-4463-a8e4-f27f076d57d3)

**Walbrook** - 2 viewports
![image](https://github.com/user-attachments/assets/dbf8b588-96ee-4259-93d6-456a0f60d811)

![image](https://github.com/user-attachments/assets/6dcb8be8-f4a9-4c46-ae2d-9c77b2fcec89)
NB - this doesn't fix the side scroll overflow - but #32933 will help with that, and more can be done separately.

**Hackney** - 2 viewports
![image](https://github.com/user-attachments/assets/c49412f3-9108-4199-9503-da6ec855e1ea)

![image](https://github.com/user-attachments/assets/1a60b544-f2b8-4ebc-b9ed-f11e29fd800f)
NB - same as above with overflow

**Thames** - 2 viewports
![image](https://github.com/user-attachments/assets/55a10f3f-ee7a-4538-ab8e-068e1023c9b8)

![image](https://github.com/user-attachments/assets/c55c1560-277d-47c8-bfb2-4db3b82e7958)
NB - same as above with overflow

Comments
----------------------------------------
Putting against 6.4 as most of this is regression-fixing, but this gives a month to test. #32933 will change these screengrabs, and reduce the overflow issue, further work could be done to reduce padding / wrapping on the edit screens, this at least improves things.