### PR TITLE
River Lea - Display a warning if using D7 Bartik

### DIFF
--- a/ext/riverlea/Civi/Riverlea/Checks.php
+++ b/ext/riverlea/Civi/Riverlea/Checks.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Civi\Riverlea;
+
+use CRM_Riverlea_ExtensionUtil as E;
+use Civi\Core\Service\AutoService;
+use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service riverlea.checks
+ */
+class Checks extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      '&hook_civicrm_check' => ['checkRiverleaDrupalTheme', 0],
+    ];
+  }
+
+  /**
+   * @see \CRM_Utils_Hook::check()
+   */
+  public function checkRiverleaDrupalTheme(&$messages, $statusNames = [], $includeDisabled = FALSE) {
+    if ($statusNames && !in_array(__FUNCTION__, $statusNames)) {
+      return;
+    }
+    if (CIVICRM_UF !== 'Drupal') {
+      return;
+    }
+
+    global $theme_key;
+
+    $bad = ['bartik' => 'Drupal Bartik'];
+    // $neutral = ['garland' => 'Garland'];
+    $good = ['seven' => 'Drupal Seven'];
+
+    if (isset($bad[$theme_key])) {
+      $body = ts('The current theme (%1) integrates poorly with CiviCRM. For a better experience, evaluate alternative themes (such as %2).', [
+        1 => $bad[$theme_key],
+        2 => implode('", "', $good),
+      ]);
+
+      $body .= '<br/><br/>';
+
+      if (function_exists('civicrmtheme_custom_theme')) {
+        $body .= ts('TIP: You may set the Drupal theme for CiviCRM without changing the entire site. See: "<a %1>Administration: Appearance</a>"', [
+          1 => 'href="' . htmlentities(url('admin/appearance')) . '"',
+        ]);
+      }
+      else {
+        $body .= ts('TIP: For more theming options, enable the module "CiviCRM Theme". See: "<a %1>Administration: Modules</a>"', [
+          1 => 'href="' . htmlentities(url('admin/modules')) . '"',
+        ]);
+      }
+
+      $messages[] = new \CRM_Utils_Check_Message(__FUNCTION__, $body, ts('Theme Compatibility'), LogLevel::WARNING, 'fa-diamond');
+    }
+
+  }
+
+}

--- a/ext/riverlea/Civi/Riverlea/DynamicCss.php
+++ b/ext/riverlea/Civi/Riverlea/DynamicCss.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Civi\riverlea;
+namespace Civi\Riverlea;
 
 use CRM_riverlea_ExtensionUtil as E;
 

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -22,7 +22,7 @@
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>
   <civix>
-    <namespace>CRM/riverlea</namespace>
+    <namespace>CRM/Riverlea</namespace>
     <format>25.01.1</format>
   </civix>
   <mixins>

--- a/ext/riverlea/riverlea.php
+++ b/ext/riverlea/riverlea.php
@@ -76,8 +76,8 @@ function riverlea_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
   if ($bundle->name === 'coreResources') {
     // get DynamicCss asset
     $bundle->addStyleUrl(\Civi::service('asset_builder')->getUrl(
-      \Civi\riverlea\DynamicCss::CSS_FILE,
-      \Civi\riverlea\DynamicCss::getCssParams()
+      \Civi\Riverlea\DynamicCss::CSS_FILE,
+      \Civi\Riverlea\DynamicCss::getCssParams()
     ));
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------

Add a status-check to warn that D7's default `bartik` theme may look poor.

(It's not worth doing any on-going maintenance just for Riverlea-Bartik - since D7 is EOL, and since most people wind up changing away from Bartik anyway. A warning is much easier.)

Before
----------------------------------------

Out-of-the-box, you see some weird artifacts like:

![image](https://github.com/user-attachments/assets/c449ba2b-c953-4167-8a50-0bab5733d865)


After
----------------------------------------

Well, that's not changing. But at least you get a warning advising how to fix:

<img width="626" alt="Screenshot 2025-06-05 at 11 51 48 AM" src="https://github.com/user-attachments/assets/5348a92f-e842-473a-b0dd-6c726f7da859" />


Comments
----------------------------------------

Incidentally, class-naming in this folder got a little weird (with `Civi\riverlea` instead of `Civi\Riverlea`). This includes a cleanup.