### PR TITLE
make "DB Error Unknown Error" more knowable

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -982,10 +982,24 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @throws PEAR_Exception
    */
   public static function exceptionHandler($pearError) {
-    if ($pearError instanceof DB_Error) {
-      throw new DBQueryException($pearError->getMessage(), $pearError->getCode(), ['exception' => $pearError]);
+    $message = $pearError->getMessage();
+
+    // wrapped in case settings aren't available yet
+    try {
+      if (\Civi::settings()->get('debug_enabled')) {
+        $message .= ' ' . $pearError->getUserInfo();
+      }
     }
-    throw new CRM_Core_Exception($pearError->getMessage(), $pearError->getCode(), ['exception' => $pearError]);
+    catch (\Exception $e) {
+      // well we tried
+    }
+
+    $code = $pearError->getCode();
+
+    if ($pearError instanceof DB_Error) {
+      throw new DBQueryException($message, $code, ['exception' => $pearError]);
+    }
+    throw new CRM_Core_Exception($message, $code, ['exception' => $pearError]);
   }
 
   /**

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -988,7 +988,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     try {
       $messageWithDetails = $message . ' ' . $pearError->getUserInfo();
 
-      \Civi::log()->debug($messageWithDetails);
+      \Civi::log()->debug($messageWithDetails . "\n\n" . self::formatBacktrace($pearError->getBacktrace()));
 
       if (\Civi::settings()->get('debug_enabled')) {
         // if debug is enabled we print full error details to screen

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -984,10 +984,16 @@ class CRM_Core_Error extends PEAR_ErrorStack {
   public static function exceptionHandler($pearError) {
     $message = $pearError->getMessage();
 
-    // wrapped in case settings aren't available yet
+    // wrapped in case settings/log aren't available yet
     try {
+      $messageWithDetails = $message . ' ' . $pearError->getUserInfo();
+
+      \Civi::log()->debug($messageWithDetails);
+
       if (\Civi::settings()->get('debug_enabled')) {
-        $message .= ' ' . $pearError->getUserInfo();
+        // if debug is enabled we print full error details to screen
+        // as well as log
+        $message = $messageWithDetails;
       }
     }
     catch (\Exception $e) {

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -868,7 +868,7 @@ SET    version = '$version'
     foreach ($revisions as $rev) {
       if (version_compare($currentVer, $rev) < 0) {
         $versionObject = $this->incrementalPhpObject($rev);
-        CRM_Upgrade_Incremental_General::updateMessageTemplate($preUpgradeMessage, $rev);
+        CRM_Upgrade_Incremental_General::updateMessageTemplate($preUpgradeMessage, $rev, $currentVer);
         if (is_callable([$versionObject, 'setPreUpgradeMessage'])) {
           $versionObject->setPreUpgradeMessage($preUpgradeMessage, $rev, $currentVer);
         }

--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -152,14 +152,15 @@ class CRM_Upgrade_Incremental_General {
   /**
    * Perform any message template updates. 5.0+.
    * @param $message
-   * @param $version
+   * @param $version version we are upgrading to
+   * @param $fromVer version we are upgrading from
    */
-  public static function updateMessageTemplate(&$message, $version) {
+  public static function updateMessageTemplate(&$message, $version, $fromVer) {
     if (version_compare($version, 5.0, '<')) {
       return;
     }
     $messageObj = new CRM_Upgrade_Incremental_MessageTemplates($version);
-    $messages = $messageObj->getUpgradeMessages();
+    $messages = $messageObj->getUpgradeMessages($fromVer);
     if (empty($messages)) {
       return;
     }

--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -499,16 +499,16 @@ class CRM_Upgrade_Incremental_MessageTemplates {
 
   /**
    * Get the upgrade messages.
+   *
+   * @fromVer version we are upgrading from
    */
-  public function getUpgradeMessages() {
+  public function getUpgradeMessages($fromVer) {
     $updates = $this->getTemplatesToUpdate();
 
+    $uneditedTemplates = [];
     // workflow_name is not available pre-5.26, so we won't check if templates are changed or not pre-5.26
-    try {
+    if (version_compare($fromVer, 5.26, '>=')) {
       $uneditedTemplates = $this->getUneditedTemplates();
-    }
-    catch (Exception $e) {
-      $uneditedTemplates = [];
     }
 
     $messages = [];

--- a/CRM/Upgrade/Incremental/php/FiveSeventySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySix.php
@@ -147,6 +147,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventySix extends CRM_Upgrade_Incremental
 
       CRM_Core_DAO::executeQuery('INSERT INTO civicrm_event_cart_participant (participant_id, cart_id)
        SELECT id as participant_id, cart_id FROM civicrm_participant WHERE cart_id > 0');
+      \CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_participant', 'FK_civicrm_participant_cart_id');
       \CRM_Core_BAO_SchemaHandler::dropColumn('civicrm_participant', 'cart_id', FALSE, TRUE);
     }
     catch (CRM_Core_Exception $e) {

--- a/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/BaseTest.php
@@ -127,10 +127,10 @@ class CRM_Upgrade_Incremental_BaseTest extends CiviUnitTestCase {
       ->addWhere('workflow_name', '=', 'contribution_online_receipt')
       ->addWhere('is_default', '=', TRUE)
       ->execute();
-    $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.4.alpha1');
-    $messages = $messageTemplateObject->getUpgradeMessages();
+    $messageTemplateObject = new CRM_Upgrade_Incremental_MessageTemplates('5.43.alpha1');
+    $messages = $messageTemplateObject->getUpgradeMessages('5.40');
     $this->assertEquals([
-      'Contributions - Receipt (on-line)' => 'Use email greeting at top where available',
+      'Contributions - Receipt (on-line)' => 'Missed templates from earlier versions',
     ], $messages);
   }
 


### PR DESCRIPTION
Before
----------------------------------------
The error message for PEAR errors (including DBError) is very limited. Often limited to "DB Error: Unknown error" even though there is useful info in the PEAR error itself.

After
----------------------------------------
The error message for PEAR errors (including DBError) includes some more details when debug is enabled.

Comments
----------------------------------------
Related to https://github.com/civicrm/civicrm-core/pull/32922 ?
 