### PR TITLE
Updates to install into Wordpress with Composer

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -62,8 +62,9 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       Civi::paths()->register('cms', $cmsRoot);
       Civi::paths()->register('cms.root', $cmsRoot);
       Civi::paths()->register('civicrm.root', function () {
+        global $civicrm_root;
         return [
-          'path' => CIVICRM_PLUGIN_DIR . 'civicrm' . DIRECTORY_SEPARATOR,
+          'path' => $civicrm_root,
           'url' => CIVICRM_PLUGIN_URL . 'civicrm/',
         ];
       });


### PR DESCRIPTION
Overview
----------------------------------------
WIP Updates to allow CiviCRM to be installed with Composer https://lab.civicrm.org/dev/wordpress/-/issues/155
In tandem with https://github.com/civicrm/civicrm-wordpress/pull/348

If $civicrm_root is set to ./vendor/civicrm/civicrm-core/ instead of the "civicrm" directory inside the Wordpress plugin directory.

