### PR TITLE
Show cancelled participants in Also registered by

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1006,23 +1006,33 @@ WHERE cpf.price_set_id = %1 AND cpfv.label LIKE %2";
    *   Id of primary participant record.
    *
    * @return array
-   *   $displayName => $viewUrl
+   *   $displayName => ['url' => $viewUrl, 'status' => $status]
+   *   status is NULL if positive, status label otherwise.
    */
   public static function getAdditionalParticipants($primaryParticipantID) {
     $additionalParticipants = [];
-    $additionalParticipantIDs = self::getAdditionalParticipantIds($primaryParticipantID);
+    $additionalParticipantIDs = self::getAdditionalParticipantIds($primaryParticipantID, FALSE);
     if (!empty($additionalParticipantIDs)) {
+      $positiveStatuses = CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Positive'");
       foreach ($additionalParticipantIDs as $additionalParticipantID) {
         $additionalContactID = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant',
           $additionalParticipantID,
           'contact_id', 'id'
         );
         $additionalContactName = CRM_Contact_BAO_Contact::displayName($additionalContactID);
+        $participantCancelled = \Civi\Api4\Participant::get(TRUE)
+          ->addSelect('status_id:label')
+          ->addWhere('id', '=', $additionalParticipantID)
+          ->addWhere('status_id:name', 'NOT IN', $positiveStatuses)
+          ->execute()->first();
         $pViewURL = CRM_Utils_System::url('civicrm/contact/view/participant',
           "action=view&reset=1&id={$additionalParticipantID}&cid={$additionalContactID}"
         );
 
-        $additionalParticipants[$additionalContactName] = $pViewURL;
+        $additionalParticipants[$additionalContactName] = [
+          'url' => $pViewURL,
+          'status' => $participantCancelled['status_id:label'] ?? NULL,
+        ];
       }
     }
     return $additionalParticipants;

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -46,8 +46,8 @@
               <tr class="crm-participant-form-block-additionalParticipants">
                 <td class="label"><label>{ts}Also Registered by this Participant{/ts}</label></td>
                 <td>
-                  {foreach from=$additionalParticipants key=apName item=apURL}
-                    <a href="{$apURL}" title="{ts escape='htmlattribute'}view additional participant{/ts}">{$apName}</a><br />
+                  {foreach from=$additionalParticipants key=apName item=ap}
+                    <a href="{$ap.url}" title="{ts escape='htmlattribute'}view additional participant{/ts}">{$apName}</a>{if $ap.status} ({$ap.status}){/if}<br />
                   {/foreach}
                 </td>
               </tr>

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -45,8 +45,8 @@
         <tr class="crm-event-participantview-form-block-additionalParticipants">
             <td class="label">{ts}Also Registered by this Participant{/ts}</td>
             <td>
-                {foreach from=$additionalParticipants key=participantName item=participantURL}
-                    <a href="{$participantURL}" title="{ts escape='htmlattribute'}view additional participant{/ts}">{$participantName|escape}</a><br />
+                {foreach from=$additionalParticipants key=participantName item=participant}
+                  <a href="{$participant.url}" title="{ts escape='htmlattribute'}view additional participant{/ts}">{$participantName|escape}</a>{if $participant.status} ({$participant.status}){/if}<br />
                 {/foreach}
             </td>
         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Cancelled additional participants are not shown under Also registered by for the primary participant when the additional participant is cancelled, making things confusing for users who are managing events, especially refunds.

Before
----------------------------------------
<img width="839" alt="image" src="https://github.com/user-attachments/assets/b6d44861-4aba-40c9-9887-398e3ae37dbd" />
Cancelled additional participants are not show on primary participant under Also Registered by this Participant.

After
----------------------------------------
<img width="834" alt="image" src="https://github.com/user-attachments/assets/3db34ca9-6fa7-4206-bbbd-e230ab3946f3" />
All additional participants are shown on primary participant, with status in brackets if their participant status is not positive (i.e. not Registered, Attended, Partially paid or Pending refund).
