### PR TITLE
Don't show activity description when deleting

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -11,7 +11,7 @@
   {if $action eq 4}
     <div class="crm-block crm-content-block crm-activity-view-block">
   {else}
-    {if $activityTypeDescription}
+    {if $activityTypeDescription && $action neq 8}
       <div class="help">{$activityTypeDescription|purify}</div>
     {/if}
     <div class="crm-block crm-form-block crm-activity-form-block">


### PR DESCRIPTION
Overview
----------------------------------------
The activity description is shown when deleting an activity, which is potentially confusing and unnecessary. This removes the description.

Before
----------------------------------------
For example:
<img width="403" alt="Screenshot 2025-06-06 at 2 10 45 PM" src="https://github.com/user-attachments/assets/acb6f0a3-fdfd-44ab-9df4-91383af5a0d9" />
Wait.. did I just send an email?

<img width="403" alt="Screenshot 2025-06-06 at 2 17 35 PM" src="https://github.com/user-attachments/assets/1bddba3e-2e23-4e87-b56e-d2522a0de762" />

After
----------------------------------------
<img width="402" alt="image" src="https://github.com/user-attachments/assets/af4929af-dfec-447e-9ab8-1c5f66b3c492" />
<img width="404" alt="image" src="https://github.com/user-attachments/assets/9d0fe4b7-1ff2-4bf0-a27f-2770cafbd577" />