### PR TITLE
NFC Fix comment to match type hint

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/SessionHandler.php
+++ b/ext/standaloneusers/Civi/Standalone/SessionHandler.php
@@ -107,7 +107,7 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface, Ses
    * Called right after the session starts or when session_start() is called
    *
    * @param string $id
-   * @return string|false
+   * @return string
    */
   public function read($id): string {
     return $this->data ?? '';


### PR DESCRIPTION
Overview
----------------------------------------
Fix comment to match type hint

Before
----------------------------------------
Comment says string|false but type hint is set to string

After
----------------------------------------
Comment also says string

Technical Details
----------------------------------------

Comments
----------------------------------------
