### PR TITLE
dev/core#5936 - duplicate draft statuses appearing in mailing search form

### DIFF
--- a/CRM/Mailing/Form/Search.php
+++ b/CRM/Mailing/Form/Search.php
@@ -53,6 +53,8 @@ class CRM_Mailing_Form_Search extends CRM_Core_Form_Search {
 
     // CRM-15434 - Fix mailing search by status in non-English languages
     $statusVals = CRM_Core_SelectValues::getMailingJobStatus();
+    // This isn't a real status for search purposes, and the "status_unscheduled" below is how that's handled.
+    unset($statusVals['Draft']);
     foreach ($statusVals as $statusId => $statusName) {
       $this->addElement('checkbox', "mailing_status[$statusId]", NULL, $statusName);
     }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5936

Before
----------------------------------------
1. Go to the mailing search form.
2. There's two draft options. The first draft option does nothing.

After
----------------------------------------
One draft option like before.

Technical Details
----------------------------------------
There are probably some.

Comments
----------------------------------------
Since 5.76
