### PR TITLE
SiteEmail - Remove redundant label from "Site Email Address" form

### DIFF
--- a/ang/afform/afformSiteEmailAddress.aff.html
+++ b/ang/afform/afformSiteEmailAddress.aff.html
@@ -1,6 +1,6 @@
 <af-form ctrl="afform">
   <af-entity actions="{create: true, update: true}" type="SiteEmailAddress" name="email" label="Site Email Address 1" security="RBAC" url-autofill="1" />
-  <fieldset af-fieldset="email" class="af-container" af-title="Site Email Address 1">
+  <fieldset af-fieldset="email" class="af-container">
     <div class="af-container af-layout-inline">
       <af-field name="display_name" />
       <af-field name="email" />


### PR DESCRIPTION
Overview
----------------------------------------
Unnecessary label "Site Email Address 1" removed from form.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/91f90464-c6e5-4451-a834-ea4697db2ef4)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/a2929d5a-a5b5-40e9-b517-4e3512d33899)
