### PR TITLE
Remove any existing ForeignKey before adding one

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -589,6 +589,10 @@ MODIFY      {$columnName} varchar( $length )
    * @return bool TRUE if FK is found
    */
   public static function checkFKExists(string $table_name, string $constraint_name): bool {
+    if (!isset(\Civi::$statics['CRM_Core_DAO']['init'])) {
+      // This could get called early during installation.
+      return FALSE;
+    }
     $query = "
       SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
       WHERE TABLE_SCHEMA = DATABASE()

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -147,6 +147,8 @@ return new class() {
       // `entity_reference.fk` defaults to TRUE if not set. If FALSE, do not add constraint.
       if (!empty($field['entity_reference']['entity']) && ($field['entity_reference']['fk'] ?? TRUE)) {
         $fkName = \CRM_Core_BAO_SchemaHandler::getIndexName($entity['table'], $fieldName);
+        // Make sure the FK does not already exist...
+        CRM_Core_BAO_SchemaHandler::safeRemoveFK($entity['table'], 'FK_' . $fkName);
         $constraint = "CONSTRAINT `FK_$fkName` FOREIGN KEY (`$fieldName`)" .
           " REFERENCES `" . $this->getTableForEntity($field['entity_reference']['entity']) . "`(`{$field['entity_reference']['key']}`)";
         if (!empty($field['entity_reference']['on_delete'])) {


### PR DESCRIPTION

Overview
----------------------------------------
Remove any existing ForeignKey before adding one

There is a hard-error if we try to add the same key twice - which this prevents by dropping any existing key

Before
----------------------------------------
If a table already exists in the database then it will not be added when an extension is being installed - however there will still be a failure when the Upgrader attempts to add Foreign Keys if they already exist.

After
----------------------------------------
As is the case in our main upgrade script - we can use this function to safely remove the foreign key constraint if it already exists

Technical Details
----------------------------------------


Comments
----------------------------------------
I'm going to do a more complete PR that alters the standalone install - but this patch can be reviewed in isolation