### PR TITLE
Update standaloneusers install to be non-destructive, possible on other UFs

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -589,6 +589,10 @@ MODIFY      {$columnName} varchar( $length )
    * @return bool TRUE if FK is found
    */
   public static function checkFKExists(string $table_name, string $constraint_name): bool {
+    if (!isset(\Civi::$statics['CRM_Core_DAO']['init'])) {
+      // This could get called early during installation.
+      return FALSE;
+    }
     $query = "
       SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
       WHERE TABLE_SCHEMA = DATABASE()

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -147,6 +147,8 @@ return new class() {
       // `entity_reference.fk` defaults to TRUE if not set. If FALSE, do not add constraint.
       if (!empty($field['entity_reference']['entity']) && ($field['entity_reference']['fk'] ?? TRUE)) {
         $fkName = \CRM_Core_BAO_SchemaHandler::getIndexName($entity['table'], $fieldName);
+        // Make sure the FK does not already exist...
+        CRM_Core_BAO_SchemaHandler::safeRemoveFK($entity['table'], 'FK_' . $fkName);
         $constraint = "CONSTRAINT `FK_$fkName` FOREIGN KEY (`$fieldName`)" .
           " REFERENCES `" . $this->getTableForEntity($field['entity_reference']['entity']) . "`(`{$field['entity_reference']['key']}`)";
         if (!empty($field['entity_reference']['on_delete'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Update standalone install to be non-destructive

This changes the pre-install such that it augments rather than drops & re-creates any pre-existing
civicrm_uf_match table.
    
   

Before
----------------------------------------
Installing standalone users drops the entire `civicrm_uf_match` table and recreates it

This is destructive as data is lost.  To mitigate this the install is blocked if the UF is not standalone - this has disadvantages for us when

1) testing & re-doing stuff
2) transitionally installing standaloneusers on a drupal 7 site for the purpose of allowing us to create and populate the relevant tables pre-switch over

After
----------------------------------------
If the table exists the columns are added (instead of drop + create). Installation is possible on a non-standalone site.

 I did think about putting some other check in there to enforce 'deliberateness'
    but I feel like the fact the extension is hidden covers that - and now
    that enabling is is non-destructive the consequences are not the same...

Technical Details
----------------------------------------

Comments
----------------------------------------
