### PR TITLE
NFC: Fix message when WordPress users/contacts are synced

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1280,10 +1280,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
         TRUE
       )
       ) {
-        $contactCreated++;
+        $contactMatching++;
       }
       else {
-        $contactMatching++;
+        $contactCreated++;
       }
       if (is_object($match)) {
         $match->free();


### PR DESCRIPTION
Overview
----------------------------------------
When using the option on WordPress `Administer->Users and Permissions->Synchronise users to contacts` a message is generated that says how many contacts were created and how many were found.

But it's backwards.

Before
----------------------------------------
Counts are added to the wrong variables. Message displays the wrong info.


After
----------------------------------------
Counts are added to the correct variables. Message displays the correct info.

Technical Details
----------------------------------------
In `CRM_Admin_Form_CMSUser::postProcess()` the message is generated based on counts generated in `CRM_Utils_System_WordPress::synchronizeUsers()`. But those counts are reversed.

Comments
----------------------------------------
Fixes a misleading message
