### PR TITLE
dev/core#5932 - Bump select2 to v3.5-civicrm-1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -269,7 +269,7 @@
         "ignore": [".*", "*.log", "*.md", "component.json", "package.json", "node_modules"]
       },
       "select2": {
-        "url": "https://github.com/colemanw/select2/archive/v3.5-civicrm-1.2.zip"
+        "url": "https://github.com/colemanw/select2/archive/v3.5-civicrm-1.3.zip"
       },
       "js-yaml": {
         "url": "https://github.com/nodeca/js-yaml/archive/3.13.1.zip",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c595415e6763bcb31e481675e9055e2b",
+    "content-hash": "eeca511da0a9751434265fcfb6a7b487",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
Applies https://github.com/colemanw/select2/pull/7

Fixes [dev/core#5932](https://lab.civicrm.org/dev/core/-/issues/5932).

Technical Details
-------
It was hard.