### PR TITLE
Revert "Riverlea - Reset details css for consistency"

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -73,9 +73,6 @@ body {
 .crm-container table {
   border-collapse: collapse;
 }
-.crm-container details {
-  display: initial;
-}
 
 /* JQueryUI resets (!important vs JQuery UI css) */
 


### PR DESCRIPTION
Reverts civicrm/civicrm-core#32902

The upstream bug was already resolved, and this patch messes up some browsers. See https://github.com/civicrm/civicrm-core/pull/32936#issuecomment-2959518884