### PR TITLE
Afform.submit - use instance property rather than local var for entityValues

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -33,7 +33,7 @@ class Submit extends AbstractProcessor {
 
   protected function processForm() {
     // preprocess submitted values
-    $entityValues = $this->preprocessSubmittedValues($this->values);
+    $this->_entityValues = $this->preprocessSubmittedValues($this->values);
 
     // get the submission information if we have submission id.
     // currently we don't support processing of already processed forms
@@ -51,7 +51,7 @@ class Submit extends AbstractProcessor {
     }
 
     // Call validation handlers
-    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this, $entityValues);
+    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this, $this->_entityValues);
     \Civi::dispatcher()->dispatch('civi.afform.validate', $event);
     $errors = $event->getErrors();
     if ($errors) {
@@ -100,7 +100,7 @@ class Submit extends AbstractProcessor {
     }
 
     // process and save various enities
-    $this->processFormData($entityValues);
+    $this->processFormData($this->_entityValues);
 
     $submissionData = $this->combineValuesAndIds($this->getValues(), $this->_entityIds);
     // Update submission record with entity IDs.


### PR DESCRIPTION
Before
----------------------------------------
- AbstractProcessor has a property called `$_entityValues`
- the handling in Afform.submit ignores it, and uses a local var `$entityValues` instead
- no way to check the full `$_entityValues` when handling validate/submit

After
----------------------------------------
- use the instance property
- unlocks server-side token processing

Comments
----------------------------------------
Any reason not to do this @colemanw ?
