### PR TITLE
generate `invoice_id` in Order.create if not provided

### DIFF
--- a/Civi/Api4/Action/Order/Create.php
+++ b/Civi/Api4/Action/Order/Create.php
@@ -62,6 +62,10 @@ class Create extends AbstractAction {
         throw new \CRM_Core_Exception(ts('Invalid financial type %1', [1 => $financialType]));
       }
     }
+    // generate invoice id if not set
+    if (empty($values['invoice_id'])) {
+      $values['invoice_id'] = bin2hex(random_bytes(16));
+    }
     return $values;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Currently autogenerated at various places in the form layer. Add similar behaviour to Order.create 

Before
----------------------------------------
- Order API creates contributions whilst calculating what some of Contribution record values _should_ be (e.g. `financial_type_id`)
- `invoice_id` really _should_ have a value on Contribution. Various places (such as payment processors) assume it will be populated
- it may be specified directly, but if not it currently get autogenerated at the form layer in various different places ( `CRM_Contribute_Form_AbstractEditPayment` `CRM_Contribute_Form_Contribution_Confirm` ... )

After
----------------------------------------
- autogenerated in one more place - if you are creating a Contribution with the Order api, and don't specify an invoice id

Technical Details
----------------------------------------
Ultimately I think this auto-generation probably "belongs" in the Contribution entity proper (e.g. `hook_civicrm_pre::Contribution`). But this is an easy step to achieve what we want for now.
