### PR TITLE
Fix fatal error

### DIFF
--- a/CRM/Upgrade/Incremental/php/FiveSeventySix.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventySix.php
@@ -72,7 +72,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventySix extends CRM_Upgrade_Incremental
        " . $domain['id'] . ",
        'message_header',
        '" . ts('Message Header') . "',
-     '<!-- " . ts('This is the %1 token HTML content.', [1 => '{site.message_header}']) . " -->',
+     '<!-- " . CRM_Core_DAO::escapeString(ts('This is the %1 token HTML content.', [1 => '{site.message_header}'])) . " -->',
       '', 1, 1)"
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a fatal error on upgrade when the translation contains an apostrophe character as in (French):
> Il s'agit du contenu HTML du jeton

Before
----------------------------------------
The CiviCRM upgrader fails with a fatal SQL error when CiviCRM is installed in French

After
----------------------------------------
The upgrade happens without issues

Technical Details
----------------------------------------
We are only calling the DAO function to sanitize the passed string.

Comments
----------------------------------------
