### PR TITLE
Afform - compute redirects and confirmation messages server side

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -89,6 +89,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     }
     $this->_formDataModel = new FormDataModel($this->_afform['layout']);
     $this->loadEntities();
+    // TODO: use _response more consistently
     $result->exchangeArray($this->processForm());
   }
 
@@ -730,12 +731,16 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
-   * Stash things to return in the Api response
+   * Set a key in the api response
+   *
+   * Note: key should be recognised by the afForm controller
+   * expected keys are:
+   *   token, redirect, message
    *
    * @param string $key
    * @param mixed $value
    */
-  public function setResponseItem(string $key, mixed $value): void {
+  public function setResponseItem(string $key, $value): void {
     $this->_response[$key] = $value;
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -69,6 +69,8 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
 
   protected $_entityValues = [];
 
+  protected array $_response = [];
+
   /**
    * @param \Civi\Api4\Generic\Result $result
    * @throws \CRM_Core_Exception
@@ -725,6 +727,16 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   protected static function getNestedKey(array $values) {
     $firstValue = \CRM_Utils_Array::first(array_filter($values));
     return is_array($firstValue) && $firstValue ? array_keys($firstValue)[0] : NULL;
+  }
+
+  /**
+   * Stash things to return in the Api response
+   *
+   * @param string $key
+   * @param mixed $value
+   */
+  public function setResponseItem(string $key, mixed $value): void {
+    $this->_response[$key] = $value;
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -756,4 +756,32 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     return $actions;
   }
 
+  /**
+   * Function to replace tokens with entity values in e.g. redirect urls
+   *
+   * Tokens look like [Participant1.0.id]
+   *
+   * @param string $text
+   *
+   * @return string
+   */
+  public function replaceTokens(string $text): string {
+    $matches = [];
+    preg_match_all('/\[[a-zA-Z0-9]{1,}\.[0-9]{1,}\.[^.]{1,}\]/', $text, $matches);
+
+    foreach ($matches[0] as $match) {
+      // strip [ ] and split on .
+      [$entityName, $index, $field] = explode('.', substr($match, 1, -1));
+      if ($field === 'id') {
+        $value = $this->_entityIds[$entityName][$index]['id'];
+      }
+      else {
+        $value = $this->_entityValues[$entityName][$index]['fields'][$field];
+      }
+      $text = str_replace($match, $value, $text);
+    }
+
+    return $text;
+  }
+
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -125,6 +125,18 @@ class Submit extends AbstractProcessor {
     // todo - add only if needed?
     $this->setResponseItem('token', $this->generatePostSubmitToken());
 
+    if (!empty($this->_response['redirect']) || !empty($this->_reponse['message'] ?? NULL)) {
+      // redirect / message is already set, ignore defaults
+    }
+    elseif ($this->_afform['confirmation_type'] === 'show_confirmation_message') {
+      $message = $this->replaceTokens($this->_afform['confirmation_message']);
+      $this->setResponseItem('message', $message);
+    }
+    elseif ($this->_afform['redirect']) {
+      $redirect = $this->replaceTokens($this->_afform['redirect']);
+      $this->setResponseItem('redirect', $redirect);
+    }
+
     return [$this->_response];
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -117,10 +117,15 @@ class Submit extends AbstractProcessor {
         ->execute();
     }
 
-    // Return ids and a token for uploading files
-    return [
-      ['token' => $this->generatePostSubmitToken()] + $this->_entityIds,
-    ];
+    // Return ids plus token for uploading files
+    foreach ($this->_entityIds as $key => $value) {
+      $this->setResponseItem($key, $value);
+    }
+
+    // todo - add only if needed?
+    $this->setResponseItem('token', $this->generatePostSubmitToken());
+
+    return [$this->_response];
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -33,7 +33,7 @@ class Submit extends AbstractProcessor {
 
   protected function processForm() {
     // preprocess submitted values
-    $entityValues = $this->preprocessSubmittedValues($this->values);
+    $this->_entityValues = $this->preprocessSubmittedValues($this->values);
 
     // get the submission information if we have submission id.
     // currently we don't support processing of already processed forms
@@ -51,7 +51,7 @@ class Submit extends AbstractProcessor {
     }
 
     // Call validation handlers
-    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this, $entityValues);
+    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this, $this->_entityValues);
     \Civi::dispatcher()->dispatch('civi.afform.validate', $event);
     $errors = $event->getErrors();
     if ($errors) {
@@ -100,7 +100,7 @@ class Submit extends AbstractProcessor {
     }
 
     // process and save various enities
-    $this->processFormData($entityValues);
+    $this->processFormData($this->_entityValues);
 
     $submissionData = $this->combineValuesAndIds($this->getValues(), $this->_entityIds);
     // Update submission record with entity IDs.

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -328,22 +328,8 @@
           submissionResponse: submissionResponse,
         });
 
-        status.resolve();
-        $element.unblock();
-
-        if (dialog.length) {
-          dialog.dialog('close');
-        }
-
-        else if (metaData.confirmation_type && metaData.confirmation_type === 'show_confirmation_message') {
-          $element.hide();
-          const $confirmation = $('<div class="afform-confirmation" />');
-          $confirmation.text(metaData.confirmation_message);
-          $confirmation.insertAfter($element);
-        }
-
-        else if ((!metaData.confirmation_type && metaData.redirect ) || (metaData.confirmation_type && metaData.confirmation_type === 'redirect_to_url' && metaData.redirect)) {
-          var url = replaceTokens(metaData.redirect, submissionResponse[0]);
+        if (submissionResponse[0].redirect) {
+          let url = submissionResponse[0].redirect;
           if (url.indexOf('civicrm/') === 0) {
             url = CRM.url(url);
           } else if (url.indexOf('/') === 0) {
@@ -352,27 +338,28 @@
             url = `${$location.protocol()}://${$location.host()}${port}${url}`;
           }
           $window.location.href = url;
+          return;
         }
-      }
 
-      function replaceTokens(str, vars) {
-        function recurse(stack, values) {
-          _.each(values, function(value, key) {
-            if (_.isArray(value) || _.isPlainObject(value)) {
-              recurse(stack.concat([key]), value);
-            } else {
-              var token = (stack.length ? stack.join('.') + '.' : '') + key;
-              str = str.replace(new RegExp(_.escapeRegExp('[' + token + ']'), 'g'), value);
-            }
-          });
+        status.resolve();
+
+        if (submissionResponse[0].message) {
+          $element.hide();
+          const $confirmation = $('<div class="afform-confirmation" />');
+          $confirmation.text(submissionResponse[0].message);
+          $confirmation.insertAfter($element);
         }
-        recurse([], vars);
-        return str;
+        else if (dialog.length) {
+          dialog.dialog('close');
+        }
+        else {
+          $element.unblock();
+        }
       }
 
       function validateFileFields() {
         var valid = true;
-        $("af-form[ng-form=" + ctrl.getFormMeta().name +"] input[type='file']").each((index, fld) => {
+        $("af-form[ng-form=" + ctrl.getFormMeta().name + "] input[type='file']").each((index, fld) => {
           if ($(fld).attr('required') && $(fld).get(0).files.length == 0) {
             valid = false;
           }
@@ -387,7 +374,7 @@
         CRM.alert(errorMsg, ts('Sorry'), 'error');
       }
 
-      this.submit = function() {
+      this.submit = function () {
         // validate required fields on the form
         if (!ctrl.ngForm.$valid || !validateFileFields()) {
           CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
@@ -415,7 +402,8 @@
               });
             });
             ctrl.fileUploader.uploadAll();
-          } else {
+          }
+          else {
             postProcess();
           }
         })


### PR DESCRIPTION
Overview
----------------------------------------
Move post submit redirect/confirmation message content to the server so they can be more powerful.

Before
----------------------------------------
- Afforms can be configured to redirects or show a confirmation message on submit
- This is decided based on the fixed afform metadata, in the `afForm` js component
- Replacement of entity ID tokens is calculated based on the ids returned in the submission response.
- If form is in a dialog, these are ignored. The dialog closes before they are handled.

After
----------------------------------------
- The `afForm` js component will redirect or show a confirmation message based on what the server response says
- The redirect / message is calculated from the afform metadata server side
- Token replacement is done on the server, and is more powerful (can use e.g. a name field submitted through the form in the confirmation message "Thank you, Ben!")
- Afform validation / submit handlers can add more dynamic redirects/messages
- Redirects / confirmation messages will be shown for dialog forms (you can always close the dialog once you've read the message - or press back if you didnt like the redirect)

Comments
----------------------------------------
I dont know if the dialog behaviour is controversial. I can remove if preferred. I for one find it annoying that my carefully configured redirects/messages are ignored in those cases.

Also to note: this is very useful for payment processing.

Further point: I haven't tested the interaction with file uploads, though it shouldn't change the existing behaviour. It looks to me like the existing behaviour is to ignore redirect/confirmation if you have pending file uploads on your form, though I'm not totally sure of how the FileUploader service works. 
