### PR TITLE
(REF) JobManager - Extract log code. Abide PSR-3.

### DIFF
--- a/CRM/Core/JobLogger.php
+++ b/CRM/Core/JobLogger.php
@@ -26,19 +26,7 @@ class CRM_Core_JobLogger extends \Psr\Log\AbstractLogger {
     $dao = new CRM_Core_DAO_JobLog();
     $dao->domain_id = CRM_Core_Config::domainID();
 
-    /*
-     * The description is a summary of the message.
-     * HTML tags are stripped from the message.
-     * The description is limited to 240 characters
-     * and has an ellipsis added if it is truncated.
-     */
-    $maxDescription = 240;
-    $ellipsis = " (...)";
-    $description = strip_tags($message);
-    if (strlen($description) > $maxDescription) {
-      $description = substr($description, 0, $maxDescription - strlen($ellipsis)) . $ellipsis;
-    }
-
+    $description = CRM_Utils_String::ellipsify(strip_tags($message), 255, ' (...)');
     $dao->description = $description;
 
     if (!empty($context['job'])) {

--- a/CRM/Core/JobLogger.php
+++ b/CRM/Core/JobLogger.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Write log messages to the civicrm_job_log table.
+ */
+class CRM_Core_JobLogger extends \Psr\Log\AbstractLogger {
+
+  /**
+   * Logs with an arbitrary level.
+   *
+   * @param string $level
+   * @param string $message
+   * @param array{job:\CRM_Core_ScheduledJob,source:?string,effective:?array,singleRun:?array} $context
+   */
+  public function log($level, $message, array $context = []): void {
+    $dao = new CRM_Core_DAO_JobLog();
+    $dao->domain_id = CRM_Core_Config::domainID();
+
+    /*
+     * The description is a summary of the message.
+     * HTML tags are stripped from the message.
+     * The description is limited to 240 characters
+     * and has an ellipsis added if it is truncated.
+     */
+    $maxDescription = 240;
+    $ellipsis = " (...)";
+    $description = strip_tags($message);
+    if (strlen($description) > $maxDescription) {
+      $description = substr($description, 0, $maxDescription - strlen($ellipsis)) . $ellipsis;
+    }
+
+    $dao->description = $description;
+
+    if (!empty($context['job'])) {
+      $job = $context['job'];
+      $dao->job_id = $job->id;
+      $dao->name = $job->name;
+
+      $dao->command = ts("Entity:") . " " . $job->api_entity . " " . ts("Action:") . " " . $job->api_action;
+      // This seems weird to me - the output is a little hard to read. More punctuation?
+
+      $data = '';
+      if (!empty($job->parameters)) {
+        $data .= "\n\nParameters raw (from db settings): \n" . $job->parameters;
+      }
+      if (!empty($context['source']) && !empty($context['singleRun']['parameters'])) {
+        $data .= "\n\nParameters raw (" . $context['source'] . "): \n" . serialize($context['singleRun']['parameters']);
+      }
+      if (!empty($context['effective']['parameters'])) {
+        $data .= "\n\nParameters parsed (and passed to API method): \n" . serialize($context['effective']['parameters']);
+      }
+      if ($description !== $message) {
+        $data .= "\n\nFull message: \n" . $message;
+        // This seems weird to me. Shouldn't you do it regardless of `job` availability?
+      }
+      $dao->data = $data;
+    }
+
+    $dao->save();
+  }
+
+}

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -665,14 +665,16 @@ class CRM_Utils_String {
    *
    * @param string $string
    * @param int $maxLen
-   *
+   * @param string $ellipsis
+   *  The literal form of the ellipsis.
    * @return string
    */
-  public static function ellipsify($string, $maxLen) {
+  public static function ellipsify($string, $maxLen, $ellipsis = '...') {
     if (mb_strlen($string, 'UTF-8') <= $maxLen) {
       return $string;
     }
-    return mb_substr($string, 0, $maxLen - 3, 'UTF-8') . '...';
+    $ellipsisLen = mb_strlen($ellipsis, 'UTF-8');
+    return mb_substr($string, 0, $maxLen - $ellipsisLen, 'UTF-8') . $ellipsis;
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -112,6 +112,10 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     $input = 'Registro de eventos on-line: Taller: "Onboarding - Cómo integrar exitosamente a los nuevos talentos dentro de su organización - Formación práctica."';
     $maxLen = 128;
     $this->assertEquals(TRUE, mb_check_encoding(CRM_Utils_String::ellipsify($input, $maxLen), 'UTF-8'));
+
+    $input = 'Hello world is the greatest greeting in the world';
+    $actual = CRM_Utils_String::ellipsify($input, 11, ' (...)');
+    $this->assertEquals('Hello (...)', $actual);
   }
 
   public function testRandom(): void {


### PR DESCRIPTION
Overview
----------------------------------------

This is an internal reorganization of the `JobManager`. It updates the log-handling to follow PSR-3, which will (later) allow log data to be used in more ways.

Before
----------------------------------------

The `JobManager` has an internal helper, `logEntry()`, which creates a record in `civicrm_job_log`. All logs are written here with this helper.

After
----------------------------------------

The `JobManager` has an internal helper, `$logger`. All logs are written with this helper. 

The standard implementation of `$logger` is an instance of `JobLogger`, which creates records in `civicrm_job_log`.

The data format of `civicrm_job_log` should be the same as before.

(*The old `logEntry()` is still available -- there are handful of references to it in contrib.*)

Comments
----------------------------------------

There's a separate configuration-management question of when/how one might decorate or replace this logger instance. That is left for a separate issue. (Regardless of one's opinion on that, you want 95%+ of this patch to be the same.)