### PR TITLE
CRM_Utils_System - Add helper function `getCMSDatabasePrefix()`

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1125,6 +1125,23 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Get the CRM database as a 'prefix'.
+   *
+   * This returns a string that can be prepended to a query to include a CRM table.
+   *
+   * However, this string should contain backticks, or not, in accordance with the
+   * CMS's drupal views expectations, if any.
+   */
+  public function getCMSDatabasePrefix(): string {
+    $crmDatabase = DB::parseDSN(CRM_Core_Config::singleton()->dsn)['database'];
+    $cmsDatabase = DB::parseDSN(CRM_Core_Config::singleton()->userFrameworkDSN)['database'];
+    if ($crmDatabase === $cmsDatabase) {
+      return '';
+    }
+    return "`$cmsDatabase`.";
+  }
+
+  /**
    * Invalidates the cache of dynamic routes and forces a rebuild.
    */
   public function invalidateRouteCache() {


### PR DESCRIPTION
Overview
----------------------------------------
Since we already have a function `getCRMDatabasePrefix()` it makes sense to have the complementary `getCMSDatabasePrefix()`. Useful for eg. standalonemigrate extension.

Before
----------------------------------------
We have one function but not the other.

After
----------------------------------------
We have both functions

Technical Details
----------------------------------------


Comments
----------------------------------------
It might be nice to have a function that just returns the database name and leaves the formatting to the caller. But I didn't find an existing one like that.
