### PR TITLE
RiverLea: fixes variable name typo for padding on new/edit contact

### DIFF
--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -421,8 +421,8 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .CRM_Contact_Form_Contact > .crm-form-block > details,
 .CRM_Contact_Form_Contact > .crm-form-block > div > details {
   margin-inline: calc(-1 * var(--crm-form-block-padding));
-  padding-inline: var(--crm-expand-2-body-padding);
-  margin-bottom: var(--crm-expand-2-body-padding);
+  padding-inline: var(--crm-expand2-body-padding);
+  margin-bottom: var(--crm-expand2-body-padding);
 }
 .crm-container .crm-add-address-wrapper {
   height: auto;


### PR DESCRIPTION
Overview
----------------------------------------
Two variables used for padding between multiple accordions wasn't loading as their name wasn't updated. This is an old bug. 

I've screengrabbed the impacts on the different changes, but to a reviewer in a rush: this was not a big problem before and the change after is hard to notice. But it fixes a typo, and make a subtle improvement in two streams in the process.

Before
----------------------------------------
Minetta:
<img width="1743" alt="image" src="https://github.com/user-attachments/assets/360c62f3-6efa-400d-bc41-eac2eb1d5931" />
<img width="1752" alt="image" src="https://github.com/user-attachments/assets/69a2e6be-65f8-47f0-9aef-1a6f0b234984" />

Hackney Brook:
<img width="698" alt="image" src="https://github.com/user-attachments/assets/10dab9dd-cf24-4aec-93f4-84ff139e41fa" />

Thames:
<img width="1756" alt="image" src="https://github.com/user-attachments/assets/b95ff5a8-f06c-4f4d-be3a-a118be267f7e" />

After
----------------------------------------
<img width="1734" alt="image" src="https://github.com/user-attachments/assets/337c28b3-dbba-4da0-93b9-49e8cb22427a" />
<img width="1747" alt="image" src="https://github.com/user-attachments/assets/71b13008-8ae4-43dc-9a1f-77bdd0fd1a0f" />

Hackney Brook:
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/fe13bea1-5df0-4bf0-ae48-a7483c7996dd" />

Thames:
Notable change is to the hover padding - as it now loads the values for `--crm-expand2-body-padding` which Thames sets as `0.25rem 2.8rem;`
<img width="1742" alt="image" src="https://github.com/user-attachments/assets/75753b44-b126-458e-918e-4133241b2c55" />

Walbrook is unchanged.

Technical Details
----------------------------------------
This CSS only impacts the contact edit and new contact layouts - nothing else is impacted. cc @artfulrobot as this makes something in Thames work that wasn't working before.