### PR TITLE
Upgrader - Skip rebuild of permission-list. Switch to Civi::rebuild().

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -781,7 +781,22 @@ SET    version = '$version'
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
     $config->userSystem->flush();
 
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
+    Civi::rebuild([
+      'ext' => TRUE,
+      'files' => TRUE,
+      'tables' => TRUE,
+      'sessions' => FALSE,
+      'metadata' => TRUE,
+      'system' => TRUE,
+      'userjob' => TRUE,
+      'menu' => TRUE,
+      'perms' => FALSE,
+      'strings' => TRUE,
+      'settings' => TRUE,
+      'cases' => TRUE,
+      'triggers' => FALSE,
+      'entities' => TRUE,
+    ])->execute();
     // NOTE: triggerRebuild is FALSE becaues it will run again in a moment (via fixSchemaDifferences).
     // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the Page. We reset later in doFinish().
 


### PR DESCRIPTION
Switch to using the Civi::rebuild directly and do not rebuild permissions whilst still in upgrade dispatch to prevent error reported

Overview
----------------------------------------
This aims to fix an error that seems to occur when performing the upgrade using the Web UI on WordPress where it tries to rebuild the permissions before the dispatch policy will permit it

Before
----------------------------------------
Permissions tries to be rebuilt before dispatch policy will allow

After
----------------------------------------
No error

Technical Details
----------------------------------------
Relevant Backtrace from the error the user reported is 

```
[Error: Rebuild]

RuntimeException: "The dispatch policy prohibits event "hook_civicrm_permission"."

#0 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Utils/Hook.php(168): Civi\Core\CiviEventDispatcher->dispatch()
#1 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Utils/Hook.php(2348): CRM_Utils_Hook->invoke()
#2 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Core/Permission/Base.php(418): CRM_Utils_Hook::permission()
#3 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Core/Permission.php(610): CRM_Core_Permission_Base->getAllModulePermissions()
#4 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Core/Permission.php(594): CRM_Core_Permission::assembleBasicPermissions()
#5 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Core/Config.php(298): CRM_Core_Permission::basicPermissions()
#6 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/Civi/Core/Rebuilder.php(177): CRM_Core_Config->cleanupPermissions()
#7 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(370): Civi\Core\Rebuilder->execute()
#8 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Upgrade/Form.php(784): CRM_Core_Invoke::rebuildMenuAndCaches()
#9 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Queue/Task.php(101): CRM_Upgrade_Form::doRebuild()
#10 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Queue/Runner.php(279): CRM_Queue_Task->run()
#11 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Queue/Page/AJAX.php(36): CRM_Queue_Runner->runNext()
#12 /home/u734419955/domains/challengers.one/public_html/wp-content/plugins/civicrm/civicrm/CRM/Queue/ErrorPolicy.php(93): CRM_Queue_Page_AJAX::{closure}()
``` 

At this point in the upgrade the dispatch policy is still upgrade.main which fails the call to hook_civicrm_permission see https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/DispatchPolicy.php#L116

We only change the dispatch policy to permit hook_civicrm_permission later on https://github.com/civicrm/civicrm-core/blob/master/CRM/Upgrade/Form.php#L776 

@totten thoughts?