### PR TITLE
JobManager - Fix reporting/classification of APIv3 errors

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -170,12 +170,13 @@ class CRM_Core_JobManager {
     try {
       $result = civicrm_api($job->api_entity, $job->api_action, $params);
     }
-    catch (Exception $e) {
+    catch (\Throwable $e) {
       $this->logger->error('Error while executing ' . $job->name . ': ' . $e->getMessage(), $this->createLogContext());
       $result = $e;
     }
     CRM_Utils_Hook::postJob($job, $params, $result);
-    $this->logger->info('Finished execution of ' . $job->name . ' with result: ' . $this->apiResultToMessage($result), $this->createLogContext());
+    $logLevel = ($result instanceof \Throwable || !empty($result['is_error'])) ? \Psr\Log\LogLevel::ERROR : \Psr\Log\LogLevel::INFO;
+    $this->logger->log($logLevel, 'Finished execution of ' . $job->name . ' with result: ' . $this->apiResultToMessage($result), $this->createLogContext());
     $this->currentJob = FALSE;
 
     // Save the job last run end date (if this doesn't get written we know the job crashed and was not caught (eg. OOM).


### PR DESCRIPTION
Overview
--------

When a Scheduled Job fails, we should report the error as an error (consistently).

Before
------

If `civicrm_api()` encounters an error, then `JobManager` -might- report the result to the `$logger` as an error. Or it might not.

* It will report `Exception`s raised by `civicrm_api()`
* It will not report other `Throwable`s.
* It will not report APIv3-style error-arrays (`$result['error_message']`).

After
-----

If `civicrm_api()` encounters an error of any kind (`Exception` or `RuntimeException` or `$result['error_message']`), then `JobManager` will report a log-entry with severity `error`.

Comments
-----------

The distinction is hard to see in the normal `civicrm_job_log` data. (That table does not currently record severity levels.) However, I'm working on an update for `cv cron` to allow verbose output (`-vv`). And in that context, the difference appears like so:

<img width="1021" alt="Screenshot 2025-06-11 at 5 12 21 PM" src="https://github.com/user-attachments/assets/5b0b100b-cbe3-440c-a3fa-8f1aaaf3e3ad" />

If the error message is categorized as an error message, then it prints red. Red is good. (Well, red is bad -- but it's also good.)