### PR TITLE
dev/core#5942 Permit logging in with email instead of user name

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -113,6 +113,14 @@ class Security {
       ->addSelect('hashed_password', 'id')
       ->execute()
       ->first();
+    if (!$user && str_contains($username, '@')) {
+      $user = \Civi\Api4\User::get(FALSE)
+        ->addWhere('uf_name', '=', $username)
+        ->addWhere('is_active', '=', TRUE)
+        ->addSelect('hashed_password', 'id')
+        ->execute()
+        ->first();
+    }
 
     if ($user && $this->checkHashedPassword($plaintextPassword, $user['hashed_password'])) {
       return $user['id'];


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5942 Permit logging in with email instead of user name

Before
----------------------------------------
Users can only login with their username


After
----------------------------------------
The can log in using their email too

Technical Details
----------------------------------------
Not sure if anyone has any concerns but this seems pretty common on that thing that the arpanet evolved into & feels like best practice

We did also find the assumption that primary email should be the uf_email problematic & I put notes on gitlab https://lab.civicrm.org/dev/core/-/issues/5942


Comments
----------------------------------------
