### PR TITLE
Migrate drupal7 users when standaloneusers installed on D7

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -589,6 +589,10 @@ MODIFY      {$columnName} varchar( $length )
    * @return bool TRUE if FK is found
    */
   public static function checkFKExists(string $table_name, string $constraint_name): bool {
+    if (!isset(\Civi::$statics['CRM_Core_DAO']['init'])) {
+      // This could get called early during installation.
+      return FALSE;
+    }
     $query = "
       SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
       WHERE TABLE_SCHEMA = DATABASE()

--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -187,8 +187,16 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
   //   return TRUE;
   // }
 
+  /**
+   * Copy drupal 7 users and roles to the civicrm_uf_match and civicrm_role tables.
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
   private function copyDrupalUsersAndRoles(): void {
-    $roles = user_roles(); // Returns array: rid => role name
+    // Returns array: rid => role name
+    $roles = user_roles();
     $role_permissions = user_role_permissions(array_keys($roles));
     foreach ($roles as $rid => $role) {
       // create roles matching d7 roles
@@ -212,7 +220,7 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
         2 => [$name, 'String'],
         3 => [$label, 'String'],
         // implode, bookend serialize
-        4 => [$permissions, 'String']
+        4 => [$permissions, 'String'],
       ]);
 
     }
@@ -266,6 +274,7 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
       }
     }
   }
+
   /**
    * Create table civicrm_session
    *

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -24,7 +24,11 @@ function standaloneusers_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) 
  */
 function standaloneusers_civicrm_config(&$config) {
   _standaloneusers_civix_civicrm_config($config);
-
+  if (CIVICRM_UF === 'Drupal') {
+    // Standalone users can run on a drupal site for migration purposes
+    // but it should not run config in this scenario.
+    return;
+  }
   // set system timezone based on logged in user
   \CRM_Utils_System::setTimeZone();
 

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -147,6 +147,8 @@ return new class() {
       // `entity_reference.fk` defaults to TRUE if not set. If FALSE, do not add constraint.
       if (!empty($field['entity_reference']['entity']) && ($field['entity_reference']['fk'] ?? TRUE)) {
         $fkName = \CRM_Core_BAO_SchemaHandler::getIndexName($entity['table'], $fieldName);
+        // Make sure the FK does not already exist...
+        CRM_Core_BAO_SchemaHandler::safeRemoveFK($entity['table'], 'FK_' . $fkName);
         $constraint = "CONSTRAINT `FK_$fkName` FOREIGN KEY (`$fieldName`)" .
           " REFERENCES `" . $this->getTableForEntity($field['entity_reference']['entity']) . "`(`{$field['entity_reference']['key']}`)";
         if (!empty($field['entity_reference']['on_delete'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Follow on from https://github.com/civicrm/civicrm-core/pull/32956 - this is how we have transitioned our users - running both sites concurrently for a few days on the same DB & code base (different webroots within the codebase, symlinks)

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
