### PR TITLE
Fix `AbstractGetAction::_whereContains()`

### DIFF
--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -154,13 +154,13 @@ abstract class AbstractGetAction extends AbstractQueryAction {
     $fieldName = (array) $fieldName;
     foreach ($clauses as $clause) {
       if (is_array($clause) && is_string($clause[0])) {
-        if (in_array($clause[0], $fieldName)) {
-          return TRUE;
-        }
-        elseif (is_array($clause[1])) {
+        if (is_array($clause[1])) {
           if ($this->_whereContains($fieldName, $clause[1])) {
             return TRUE;
           }
+        }
+        elseif (in_array($clause[0], $fieldName)) {
+          return TRUE;
         }
       }
     }

--- a/Civi/Api4/Generic/AbstractGetAction.php
+++ b/Civi/Api4/Generic/AbstractGetAction.php
@@ -158,7 +158,9 @@ abstract class AbstractGetAction extends AbstractQueryAction {
           return TRUE;
         }
         elseif (is_array($clause[1])) {
-          return $this->_whereContains($fieldName, $clause[1]);
+          if ($this->_whereContains($fieldName, $clause[1])) {
+            return TRUE;
+          }
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Handle all clauses in `_whereContains()` even if a clause contains sub-clauses.

Before
----------------------------------------
If a clause with sub-clauses exists, later clauses aren't handled. E.g. with the following clauses the clause `['x', '=', 'y']` wasn't checked:
```php
[
  ['OR', [['foo', '=', 'bar'], ['bar', '=', 'baz']]], 
  ['x', '=', 'y'],
]
```

Comments
----------------------------------------
I'm wondering if the `if-elseif` should be swapped, e.g. test `if (is_array($clause[1]))` first. Currently the field name is checked against operators like `AND` or `OR`.