### PR TITLE
Store custom values for `CaseType`

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -412,6 +412,11 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
       $transaction->rollback();
       return $caseType;
     }
+
+    if (is_array($params['custom'] ?? NULL)) {
+      CRM_Core_BAO_CustomValueTable::store($params['custom'], static::getTableName(), $caseType->id, $action);
+    }
+
     $transaction->commit();
 
     CRM_Utils_Hook::post($action, 'CaseType', $caseType->id, $case);


### PR DESCRIPTION
Overview
----------------------------------------
For other entities it is possible to use custom fields when a corresponding option value in group `cg_extend_objects` exists. This is not the case for `CaseType`, though. The reason is the implementation of `CRM_Case_BAO_CaseType` which overrides the relevant code in `\CRM_Core_DAO` and doesn't handle custom values.

Before
----------------------------------------
Custom values in `CaseType` were not persisted.

After
----------------------------------------
Custom values in `CaseType` are persisted. (A corresponding option value in group `cg_extend_objects` is still necessary to create custom fields.)