### PR TITLE
dev/core#5854 - [Alternate to 32667] - When sending a receipt as an admin, don't include the nonpublic groups

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -401,7 +401,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
         $id = $dao->civicrm_group_contact_id;
         $values[$id]['id'] = $id;
         $values[$id]['group_id'] = $dao->group_id;
-        $values[$id]['title'] = ($public && !empty($group->group_public_title) ? $group->group_public_title : $dao->group_title);
+        $values[$id]['title'] = ($public && !empty($dao->group_public_title)) ? $dao->group_public_title : $dao->group_title;
         $values[$id]['visibility'] = $dao->visibility;
         $values[$id]['is_hidden'] = $dao->is_hidden;
         $values[$id]['saved_search_id'] = $dao->saved_search_id;

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -494,7 +494,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
           }
         }
 
-        CRM_Core_BAO_UFGroup::getValues($cid, $fields, $values, FALSE, $params);
+        CRM_Core_BAO_UFGroup::getValues($cid, $fields, $values, FALSE, $params, FALSE, NULL, 'email');
       }
     }
     return [$groupTitle, $values];

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -908,13 +908,16 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
    * @param bool $absolute
    *   Return urls in absolute form (useful when sending an email).
    * @param null $additionalWhereClause
+   * @param string|null $context
+   *   If this is email then groups should be handled differently.
    *
    * @return null|array
    */
   public static function getValues(
     $cid, &$fields, &$values,
     $searchable = TRUE, $componentWhere = NULL,
-    $absolute = FALSE, $additionalWhereClause = NULL
+    $absolute = FALSE, $additionalWhereClause = NULL,
+    $context = NULL
   ) {
     if (empty($cid) && empty($componentWhere)) {
       return NULL;
@@ -996,20 +999,28 @@ class CRM_Core_BAO_UFGroup extends CRM_Core_DAO_UFGroup implements \Civi\Core\Ho
           $values[$index] = CRM_Core_PseudoConstant::getLabel('CRM_Contact_DAO_Contact', 'preferred_language', $details->$name);
         }
         elseif ($name == 'group') {
-          $groups = CRM_Contact_BAO_GroupContact::getContactGroup($cid, 'Added', NULL, FALSE, TRUE);
+          $groups = CRM_Contact_BAO_GroupContact::getContactGroup($cid, 'Added', NULL, FALSE, TRUE, FALSE, TRUE, NULL, FALSE, $context === 'email');
           $title = $ids = [];
 
           foreach ($groups as $g) {
             // CRM-8362: User and User Admin visibility groups should be included in display if user has
             // VIEW permission on that group
+            // dev/core#5854 - BUT if this is for an email being resent by an admin, then
+            // we only want public groups.
             $groupPerm = CRM_Contact_BAO_Group::checkPermission($g['group_id'], TRUE);
 
             if ($g['visibility'] != 'User and User Admin Only' ||
               CRM_Utils_Array::key(CRM_Core_Permission::VIEW, $groupPerm)
             ) {
-              $title[] = $g['title'];
+              if ($context != 'email') {
+                $title[] = $g['title'];
+              }
               if ($g['visibility'] == 'Public Pages') {
                 $ids[] = $g['group_id'];
+                if ($context == 'email') {
+                  // Note above when we called getContactGroup(), we passed in $public=true when context was email, which tells it to retrieve frontend_title, it just puts it in the field called title.
+                  $title[] = $g['title'];
+                }
               }
             }
           }

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -2338,7 +2338,7 @@ WHERE  ce.loc_block_id = $locBlockId";
           }
         }
 
-        CRM_Core_BAO_UFGroup::getValues($cid, $fields, $values, FALSE, $params);
+        CRM_Core_BAO_UFGroup::getValues($cid, $fields, $values, FALSE, $params, FALSE, NULL, 'email');
 
         //dev/event#10
         //If the event profile includes a note field and the submitted value of

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -477,6 +477,7 @@ trait ContributionPageTestTrait {
         'module' => 'CiviContribute',
         'uf_group_id:name' => $profileName,
         'entity_id' => $this->getContributionPageID($identifier),
+        'entity_table' => 'civicrm_contribution_page',
       ])->execute()->first(), $profileIdentifier);
     }
     catch (\CRM_Core_Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5854

Alternate to https://github.com/civicrm/civicrm-core/pull/32667

Before
----------------------------------------
If you have a contribution/event page with a profile that has a Groups field, then on the page it correctly only shows public groups. But if you go to resend the receipt later using the Send Receipt action on a contact's contribution tab or the Send Receipt contribution search results task, then you are likely someone with permission to nonpublic groups and the receipt then lists those groups in the email.

This can be bad. Further, it was showing the backend title.

After
----------------------------------------
Nonpublic groups not included.

Technical Details
----------------------------------------
The ContributionPage.php and Event.php functions seem limited to just sending the email, except for maybe the on behalf of block but you're unlikely to have a groups field in there.

There was a test merged earlier at https://github.com/civicrm/civicrm-core/pull/32783 to enforce that the contact popup overlay doesn't change, which was one problem with #32667.

Comments
----------------------------------------
Out of scope, but when you resend a receipt later, the groups are not necessarily the groups the person chose at the time on the form, it's the groups that the contact is currently in. But that's no change from before.