### PR TITLE
Standalone login with email

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -106,6 +106,9 @@ class Login extends AbstractAction {
       $successUrl = $this->originalUrl;
     }
 
+    // clean whitespace
+    $this->identifier = trim($this->identifier);
+
     // Check user+password
     if (empty($this->identifier) || empty($this->password)) {
       $result['publicError'] = "Missing password/username";

--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -11,12 +11,12 @@ use Civi\Standalone\Security;
 class Login extends AbstractAction {
 
   /**
-   * Username to authenticate.
+   * Username or email to authenticate.
    *
    * @var string
    * @default NULL
    */
-  protected ?string $username = NULL;
+  protected ?string $identifier = NULL;
 
   /**
    * Password to authenticate.
@@ -107,30 +107,54 @@ class Login extends AbstractAction {
     }
 
     // Check user+password
-    if (empty($this->username) || empty($this->password)) {
+    if (empty($this->identifier) || empty($this->password)) {
       $result['publicError'] = "Missing password/username";
       return;
     }
-    $security = Security::singleton();
+
+    // Check for matching user
     $user = \Civi\Api4\User::get(FALSE)
-      ->addWhere('username', '=', $this->username)
+      ->addWhere('username', '=', $this->identifier)
       ->addWhere('is_active', '=', TRUE)
-      ->addSelect('hashed_password', 'id')
+      ->addSelect('username', 'id')
       ->execute()->first();
+
+    // TODO: should login by email be behind a setting?
+    // if (!$user && \Civi::settings()->get('standaloneusers_allow_login_by_email')) {
+    if (!$user) {
+      $user = \Civi\Api4\User::get(FALSE)
+        ->addWhere('uf_name', '=', $this->identifier)
+        ->addWhere('is_active', '=', TRUE)
+        ->addSelect('username', 'id')
+        ->execute()->first();
+    }
 
     // Allow flood control (etc.) by extensions.
     $event = new LoginEvent('pre_credentials_check', $user['id'] ?? NULL);
     Civi::dispatcher()->dispatch('civi.standalone.login', $event);
+
     if ($event->stopReason) {
       $result['url'] = '/civicrm/login?' . $event->stopReason;
+      $result['publicError'] = "Invalid request";
+      return;
     }
 
-    $userID = $security->checkPassword($this->username, $this->password);
-    if (!$userID) {
-      $result['publicError'] = "Invalid credentials";
+    if (!$user) {
       // Allow monitoring of failed attempts.
-      $event = new LoginEvent('post_credentials_check', $user['id'] ?? NULL, 'wrongUserPassword');
+      $event = new LoginEvent('post_credentials_check', NULL, 'noSuchUser');
       Civi::dispatcher()->dispatch('civi.standalone.login', $event);
+
+      $result['publicError'] = "Invalid credentials";
+      return;
+    }
+
+    $userID = Security::singleton()->checkPassword($user['username'], $this->password);
+    if (!$userID) {
+      // Allow monitoring of failed attempts.
+      $event = new LoginEvent('post_credentials_check', $user['id'], 'wrongUserPassword');
+      Civi::dispatcher()->dispatch('civi.standalone.login', $event);
+
+      $result['publicError'] = "Invalid credentials";
       return;
     }
     // Password is ok. Do we have mfa configured?
@@ -156,7 +180,7 @@ class Login extends AbstractAction {
         // @todo expose the 120s timeout to config?
         \CRM_Core_Session::singleton()->set('pendingLogin', [
           'userID' => $userID,
-          'username' => $this->username,
+          'username' => $user['username'],
           'expiry' => time() + 120,
           'successUrl' => $successUrl,
         ]);

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -39,7 +39,7 @@
         // Remove the current status popup messages.
         CRM.$('#crm-notification-container .ui-notify-message').remove();
         const response = await CRM.api4('User', 'login', {
-          username: username.value,
+          identifier: username.value,
           password: password.value,
           originalUrl
         });


### PR DESCRIPTION
Overview
----------------------------------------
Alternative place to implement https://github.com/civicrm/civicrm-core/pull/32972

Before
----------------------------------------
- User.login has a strict username param
- User.requestPasswordReset has an identifier param that can be username or user email

After
----------------------------------------
- both have an identifier param that can be username or user email

Comments
----------------------------------------
Technically changing an API because the parameter name changes, but very easily fixable downstream if anything exists, and seems unlikely.

Maintains MFA behaviour vs the alternative.
 
Couple of incidental things:
 - if the pre_auth event returns a stop reason, we should stop!
 - trim whitespace from the identifier in case you put a space at the end of your email
