### PR TITLE
If a field is already an array then don't pass through string unserialize functions

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3488,6 +3488,9 @@ SELECT contact_id
     if ($value === '') {
       return [];
     }
+    if (is_array($value)) {
+      return $value;
+    }
     switch ($serializationType) {
       case self::SERIALIZE_SEPARATOR_BOOKEND:
         return (array) CRM_Utils_Array::explodePadded($value);


### PR DESCRIPTION
Overview
----------------------------------------
If a field is already an array then don't pass through string unserialize functions

Before
----------------------------------------
If an array is passed in it crashes

After
----------------------------------------
It early returns


Technical Details
----------------------------------------
We've hit this with defaults on settings being declared as an array not working consistently - but at a higher level, this is a function for converting strings

Comments
----------------------------------------
