### PR TITLE
load settings defaults before Standalone session start

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -88,9 +88,9 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       \Civi\Core\Container::boot($loadFromDB);
 
       if ($loadFromDB && self::$_singleton->dsn) {
-        self::$_singleton->userSystem->postContainerBoot();
-
         Civi::service('settings_manager')->bootComplete();
+
+        self::$_singleton->userSystem->postContainerBoot();
 
         $domain = \CRM_Core_BAO_Domain::getDomain();
         \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);


### PR DESCRIPTION
Overview
----------------------------------------
Swap the boot finalisation order so that the Standaloneusers session timeout setting default is respected when the Standalone session boots.

Before
----------------------------------------
- setting defaults aren't loaded when initialising the Standalone session. the default session timeout is ignored

After
----------------------------------------
- setting defaults are loaded when initialising the Standalone session. the default session timeout is respected

Comments
----------------------------------------
cc @eileenmcnaughton 
