### PR TITLE
Upgrader - Ensure that doRebuild() runs in the expected way (via assertion)

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -778,6 +778,8 @@ SET    version = '$version'
   }
 
   public static function doRebuild(CRM_Queue_TaskContext $ctx): bool {
+    CRM_Upgrade_DispatchPolicy::assertActive('upgrade.finish');
+
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
     $config->userSystem->flush();
 


### PR DESCRIPTION
Overview
----------

This adds an extra guard to the upgrade logic.

Background
----------

This is a follow-up to 6dba02846124d6bf4886310f6488b10c0a9034b6. In the code-comments for that commit ("(1)...(2)..."), it explains the intended conditions - switch to `upgrade.finish` and then run `rebuildMenuAndCaches()`.

Said another way: General system-flush (`rebuildMenuAndCaches()`) should only run if we have access to all our regular hooks. The rebuild process fires a dozen hooks (for menus and navigation and mgds and permissions etc). If the hooks aren't runnable, then the system-flush will misbehave.

Before
------

The expected precondition is noted by the code-comments, but it is not specifically enforced.

If the precondition is not met, then... _something_ will fail, but it's a bit circumstantial. (It's hard to predict which thing will fail. Right now, it seems involve cleanupPermissions() / assembleBasicPermissions().)

After
-----

The precondition is enforced.

If the precondition is not met, then we raise an upfront error.

Comments
----------------------------------------

This is inspired by a bug-report from Mattermost. The circumstances to reproduce the bug haven't been found yet. But hopefully a more immediate will make it easier to spot/report.