### PR TITLE
Catch Firebase/JWT/ExpiredException

### DIFF
--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -355,7 +355,8 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
       ];
     }
     catch (ExpiredException $e) {
-      // Not sure what we should do here?
+      // See https://github.com/civicrm/civicrm-core/pull/32986
+      \Civi::log()->error($e->getMessage() . ': This usually means you had debug mode enabled in the last 48 hours');
       return [];
     }
   }

--- a/Civi/Core/AssetBuilder.php
+++ b/Civi/Core/AssetBuilder.php
@@ -3,6 +3,7 @@
 namespace Civi\Core;
 
 use Civi\Core\Exception\UnknownAssetException;
+use Firebase\JWT\ExpiredException;
 
 /**
  * Class AssetBuilder
@@ -352,6 +353,10 @@ class AssetBuilder extends \Civi\Core\Service\AutoService {
         'mimeType' => 'text/plain',
         'content' => $e->getMessage(),
       ];
+    }
+    catch (ExpiredException $e) {
+      // Not sure what we should do here?
+      return [];
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Related https://github.com/civicrm/civicrm-core/pull/25305

Every so often get:
```
[error] 
$Fatal Error Details = array:3 [
  "message" => "Firebase\JWT\ExpiredException: Expired token"
  "code" => null
  "exception" => Civi\Crypto\Exception\CryptoException {#15625
    #message: "Firebase\JWT\ExpiredException: Expired token"
    #code: 0
    #file: "/var/www/vhosts/mysite/httpdocs/wp-content/plugins/civicrm/civicrm/Civi/Crypto/CryptoJwt.php"
    #line: 101
    #cause: null
    -_trace: null
    -errorData: array:1 [
      "error_code" => 0
    ]
    trace: {
      /var/www/vhosts/mysite/httpdocs/wp-content/plugins/civicrm/civicrm/Civi/Crypto/CryptoJwt.php:101 {
        Civi\Crypto\CryptoJwt->decode($token, $keyTag = 'SIGN')
        ›   // Keep our signature independent of the implementation.
        ›   throw new CryptoException(get_class($e) . ': ' . $e->getMessage());
        › }
      }
      /var/www/vhosts/mysite/httpdocs/wp-content/plugins/civicrm/civicrm/Civi/Core/AssetBuilder.php:345 { …}
```

This is because the JWT token for parameter validation has expired. But I don't think we really care. For example it might get triggered when running a scheduled job, a random API function etc.
So we should catch that error and send a more sensible response.

@totten I'm not really sure *what* that response should be? But I don't think we should be spamming the logs with unhelpful "crashes" like this.

Before
----------------------------------------
Every now and again get "Firebase\JWT\ExpiredException: Expired token" error in CiviCRM logs.

After
----------------------------------------
Error is caught.

Technical Details
----------------------------------------


Comments
----------------------------------------

