### PR TITLE
(REF) Swap rebuildMenuAndCaches() with Civi::rebuild()

### DIFF
--- a/CRM/ACL/Form/WordPress/Permissions.php
+++ b/CRM/ACL/Form/WordPress/Permissions.php
@@ -181,7 +181,9 @@ class CRM_ACL_Form_WordPress_Permissions extends CRM_Core_Form {
     CRM_Core_Session::setStatus("", ts('Wordpress Access Control Updated'), "success");
 
     // rebuild the menus to comply with the new permissions/capabilites
-    CRM_Core_Invoke::rebuildMenuAndCaches();
+    Civi::rebuild(['*' => TRUE, 'triggers' => FALSE, 'sessions' => FALSE])->execute();
+    // ^^ The above is drop-in equivalent to tradition. But the below feels more consistent with commented intent:
+    // Civi::rebuild(['menu' => TRUE, 'perms' => TRUE])->execute();
 
     CRM_Utils_System::redirect('admin.php?page=CiviCRM&q=civicrm/admin/access&reset=1');
     CRM_Utils_System::civiExit();

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -85,7 +85,11 @@ class CRM_Core_Invoke {
     if (['civicrm', 'menu', 'rebuild'] == $args || ['civicrm', 'clearcache'] == $args) {
       // ensure that the user has a good privilege level
       if (CRM_Core_Permission::check('administer CiviCRM')) {
-        self::rebuildMenuAndCaches();
+        Civi::rebuild([
+          '*' => TRUE,
+          'triggers' => CRM_Utils_Request::retrieve('triggerRebuild', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'),
+          'sessions' => CRM_Utils_Request::retrieve('sessionReset', 'Boolean', CRM_Core_DAO::$_nullObject, FALSE, 0, 'GET'),
+        ])->execute();
         CRM_Core_Session::setStatus(ts('Cleared all CiviCRM caches (database, menu, templates)'), ts('Complete'), 'success');
         // exits
         return CRM_Utils_System::redirect();

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -236,7 +236,7 @@ class CRM_Extension_Manager {
       // It might be useful to reset the container, but (given dev/core#3686) that's not likely to do much.
       // \Civi::reset();
       // \CRM_Core_Config::singleton(TRUE, TRUE);
-      CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+      Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
     }
 
     return $tgtPath;
@@ -327,7 +327,7 @@ class CRM_Extension_Manager {
     if (!CRM_Core_Config::isUpgradeMode()) {
       \Civi::reset();
       \CRM_Core_Config::singleton(TRUE, TRUE);
-      CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+      Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
 
       $schema = new CRM_Logging_Schema();
       $schema->fixSchemaDifferences();
@@ -447,7 +447,7 @@ class CRM_Extension_Manager {
     $this->mapper->refresh();
     \Civi::reset();
     \CRM_Core_Config::singleton(TRUE, TRUE);
-    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+    Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
 
     $this->popProcess($keys);
   }
@@ -513,7 +513,7 @@ class CRM_Extension_Manager {
     $this->mapper->refresh();
     // At the analogous step of `install()` or `disable()`, it would reset the container.
     // But here, the extension goes from "disabled=>uninstall". All we really need is to reconcile mgd's.
-    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+    Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
     $this->popProcess($keys);
   }
 

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -112,7 +112,7 @@ class CRM_Extension_QueueTasks {
   }
 
   public static function rebuild(CRM_Queue_TaskContext $ctx): bool {
-    CRM_Core_Invoke::rebuildMenuAndCaches(TRUE, FALSE);
+    Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
     // FIXME: For 6.1+:, use: Civi::rebuild(['*' => TRUE, 'sessions' => FALSE]);
     return TRUE;
   }

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -781,7 +781,7 @@ SET    version = '$version'
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
     $config->userSystem->flush();
 
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
+    Civi::rebuild(['*' => TRUE, 'triggers' => FALSE, 'sessions' => FALSE])->execute();
     // NOTE: triggerRebuild is FALSE becaues it will run again in a moment (via fixSchemaDifferences).
     // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the Page. We reset later in doFinish().
 

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -333,7 +333,7 @@ class CRM_Upgrade_Incremental_Base {
       $schema->fixSchemaDifferences();
     }
 
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
+    Civi::rebuild(['*' => TRUE, 'triggers' => FALSE, 'sessions' => FALSE])->execute();
     // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the page. We reset later in doFinish().
 
     return TRUE;
@@ -353,7 +353,7 @@ class CRM_Upgrade_Incremental_Base {
     $manager->disable($extensionKeys);
     $manager->uninstall($extensionKeys);
 
-    CRM_Core_Invoke::rebuildMenuAndCaches(FALSE, FALSE);
+    Civi::rebuild(['*' => TRUE, 'triggers' => FALSE, 'sessions' => FALSE])->execute();
     // sessionReset is FALSE because upgrade status/postUpgradeMessages are needed by the page. We reset later in doFinish().
 
     return TRUE;

--- a/Civi/Api4/Action/System/Flush.php
+++ b/Civi/Api4/Action/System/Flush.php
@@ -37,7 +37,11 @@ class Flush extends \Civi\Api4\Generic\AbstractAction {
   protected $session = FALSE;
 
   public function _run(\Civi\Api4\Generic\Result $result) {
-    \CRM_Core_Invoke::rebuildMenuAndCaches($this->triggers, $this->session);
+    \Civi::rebuild([
+      '*' => TRUE,
+      'triggers' => $this->triggers,
+      'sessions' => $this->session,
+    ])->execute();
   }
 
 }

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -73,7 +73,7 @@ function _civicrm_api3_extension_install_spec(&$fields) {
  *   API result
  */
 function civicrm_api3_extension_upgrade() {
-  CRM_Core_Invoke::rebuildMenuAndCaches(TRUE);
+  Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
   $queue = CRM_Extension_Upgrades::createQueue();
   $runner = new CRM_Queue_Runner([
     'title' => 'Extension Upgrades',

--- a/api/v3/System.php
+++ b/api/v3/System.php
@@ -28,10 +28,11 @@
  * @return array
  */
 function civicrm_api3_system_flush($params) {
-  CRM_Core_Invoke::rebuildMenuAndCaches(
-    $params['triggers'] ?? FALSE,
-    $params['session'] ?? FALSE
-  );
+  Civi::rebuild([
+    '*' => TRUE,
+    'triggers' => $params['triggers'] ?? FALSE,
+    'sessions' => $params['session'] ?? FALSE,
+  ])->execute();
   return civicrm_api3_create_success();
 }
 


### PR DESCRIPTION
Overview
----------------------------------------

This replaces the deprecated method `CRM_Core_Invoke::rebuildMenuAndCaches()` with equivalent calls to `Civi::rebuild()`. Additionally, it means shorter backtraces. (It takes an idea from @seamuslee001 in #32970 and purifies/expands on it.)

Technical Details
----------------------------------------

Most of these are formulaic substitutions, along the lines of:

```diff
-CRM_Core_Invoke::rebuildMenuAndCaches($a, $b);
+Civi::rebuild(['*' => TRUE, 'triggers' => $a, 'sessions' => $b])->execute();
```

For this PR, I used slightly verbose formulation (where every call specifies `*` and `triggers` and `sessions`). This makes it is easier to skim and confirm equivalence.

Some of the calls can be cleaned up a bit further -- but I'll post that as another PR. (*If you do the substitution and the cleanup in a single step, then it's harder to skim and confirm equivalence.*)

This change has a small implication for the handling of the GET flags, as in:

```
civicrm/clearcache?sessionReset=1&triggerRebuild=0
```

The important thing is that these GET flags are still accepted on `civicrm/clearcache` and `civicrm/menu/rebuild`... where the flags are plausibly used. (And not anywhere else.)
