### PR TITLE
Upgrader - Ensure that doRebuild() runs in the expected way (by setting policy)

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -778,6 +778,10 @@ SET    version = '$version'
   }
 
   public static function doRebuild(CRM_Queue_TaskContext $ctx): bool {
+    // The dispatch policy should already be set to 'upgrade.finish'.
+    // But there's one report of getting here with 'upgrade.main' (not yet reproduced).
+    $restore = \CRM_Upgrade_DispatchPolicy::useTemporarily('upgrade.finish');
+
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
     $config->userSystem->flush();
 


### PR DESCRIPTION
Overview
----------------------------------------

This restores a bit from 6dba02846124d6bf4886310f6488b10c0a9034b6. This is a blind patch trying to fix a hard-to-reproduce upgrade-failure. It is an alternative to #32970 or #32985.

Before + After
----------------------------------------

* Up through 6.0, the `doCoreFinish()` step would [force the dispatcher into `upgrade.finish` mode and run a system-flush](https://github.com/civicrm/civicrm-core/blob/6.0/CRM/Upgrade/Form.php#L761-L774).
* In 6.1-6.3, the `doCoreFinish()` step would create the conditions for `upgrade.finish`... and then the `doRebuild()` step would run a system-flush.
* With this revision, we do both. `doCoreFinish()` creates the conditions for `upgrade.finish`, and `doRebuild()` also forces the conditions.

Comments
----------------------------------------

* In principle, this doesn't really change anything. `doRebuild()` is already running in `upgrade.finish` mode. This just makes doubly-sure.
* This patch and #32985 are tackling the same problem, but in different ways.
* The difference can be seen as  "urgency" vs "clarity".
    * If there are multiple upgrade failures (re: `doRebuild` and `hook_civicrm_permission`), then it's urgent to get a fix. This should fix it (or least reach parity with <=6.0). But it doesn't help us discover what the problem actually is.
    * If the problem is not urgent and we want clarity, then it's better to get some more reports. #32985 doesn't fix it, but it should make it clearer when it arises.