### PR TITLE
Remove non-functional Profile Update from SK contact actions

### DIFF
--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -128,8 +128,6 @@ class CRM_Contact_Task extends CRM_Core_Task {
             'CRM_Contact_Form_Task_Batch',
           ],
           'result' => TRUE,
-          'url' => 'civicrm/task/pick-profile',
-          'icon' => 'fa-pencil',
         ],
         self::PDF_LETTER => [
           'title' => ts('Print/merge document'),

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -170,9 +170,6 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
           !empty($task['url']) &&
           !in_array($id, $redundant)
         ) {
-          if ($task['url'] === 'civicrm/task/pick-profile') {
-            $task['title'] = E::ts('Profile Update');
-          }
           $key = \CRM_Core_Key::get(\CRM_Utils_Array::first((array) $task['class']), TRUE);
 
           // Print Labels action does not support popups, open full-screen


### PR DESCRIPTION
Overview
----------------------------------------
See [dev/core#5898](https://lab.civicrm.org/dev/core/-/issues/5898). This has never worked in SK, as far as I'm aware, and is going to be replaced with something else according to @totten, so it makes sense to remove it from the actions menu.