### PR TITLE
[NFC] [PHPUNIT10] - dev/core#5944 - typo in test envbuilder

### DIFF
--- a/Civi/Test/CiviEnvBuilder.php
+++ b/Civi/Test/CiviEnvBuilder.php
@@ -240,7 +240,7 @@ class CiviEnvBuilder {
       else {
         $test = $GLOBALS['CIVICRM_TEST_CASE'];
         $this->appliedBy = get_class($test) . '::';
-        $this->appliedBy .= (is_callable($test, 'name') ? $test->name() : $test->getName());
+        $this->appliedBy .= (is_callable([$test, 'name']) ? $test->name() : $test->getName());
       }
 
       $this->assertValid();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5944

Before
----------------------------------------
typo - it will always try to call getName()

After
----------------------------------------


Technical Details
----------------------------------------
phpunit 10 renames getName to name. The code was clearly intended to handle this, but is missing brackets.

Comments
----------------------------------------

