### PR TITLE
Make Smarty default to version 5

### DIFF
--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -41,6 +41,9 @@ function crm_smarty_compatibility_get_path() {
   if ($path) {
     $path = str_replace('smarty3', 'smarty4', $path);
   }
+  else {
+    $path = \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php');
+  }
   return $path;
 }
 

--- a/CRM/Upgrade/Incremental/php/SixFive.php
+++ b/CRM/Upgrade/Incremental/php/SixFive.php
@@ -22,6 +22,44 @@
 class CRM_Upgrade_Incremental_php_SixFive extends CRM_Upgrade_Incremental_Base {
 
   /**
+   * Compute any messages which should be displayed before upgrade.
+   *
+   * Downstream classes should implement this method to generate their messages.
+   *
+   * This method will be invoked multiple times. Implementations MUST consult the `$rev`
+   * before deciding what messages to add. See the examples linked below.
+   *
+   * @see \CRM_Upgrade_Incremental_php_FiveTwenty::setPreUpgradeMessage()
+   *
+   * @param string $preUpgradeMessage
+   *   Accumulated list of messages. Alterable.
+   * @param string $rev
+   *   The incremental version number. (Called repeatedly, once for each increment.)
+   *
+   *   Ex: Suppose the system upgrades from 5.7.3 to 5.10.0. The method FiveEight::setPreUpgradeMessage()
+   *   will be called for each increment of '5.8.*' ('5.8.alpha1' => '5.8.beta1' =>  '5.8.0').
+   * @param null $currentVer
+   *   This is the penultimate version targeted by the upgrader.
+   *   Equivalent to CRM_Utils_System::version().
+   */
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    $path = CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+    if ($rev == '6.5.alpha1' && !$path) {
+      $smarty2Path = \Civi::paths()->getPath('[civicrm.packages]/Smarty/Smarty.class.php');
+      $preUpgradeMessage .= '<br/>' . ts("WARNING: Your site is currently using the Smarty2 library which is being replaced by the Smarty5 library.")
+        . " " . ts("If you take no action your site will now switch to using Smarty5. Some sites use extensions which have not been upgraded to work with Smarty5")
+        . " " . ts("If your extensions or other custom code will not run on Smarty5, you should log an issue with the maintainer. If the maintainer does not respond you should consider uninstalling the extension.")
+        . " " . ts("In the short term you can make your site continue to use Smarty2 by editing your civicrm.settings.php file and adding the line %1",
+          [1 => sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smarty2Path, 1)))])
+        . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v6.4-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+          1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
+          2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
+        ])
+        );
+    }
+  }
+
+  /**
    * Upgrade step; adds tasks including 'runSql'.
    *
    * @param string $rev

--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -25,15 +25,18 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
    */
   public function checkSmartyVersion(): array {
     $messages = [];
-    if (!defined('CIVICRM_SMARTY_AUTOLOAD_PATH') && !defined('CIVICRM_SMARTY3_AUTOLOAD_PATH')) {
+    $smarty2Path = \Civi::paths()->getPath('[civicrm.packages]/Smarty/Smarty.class.php');
+    $path = CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
+    if ($path === $smarty2Path) {
       $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php');
+
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        '<p>' . (ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security and php 8.3 compatibility. The update is currently optional, but you should try it now.')) . '</p>'
+        '<p>' . (ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security and php 8.3 compatibility. The update is currently optional, but will be required soon.')) . '</p>'
         . '<p>' . (ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
         . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1))) . '</p>'
-        . '<p>' . ('Some extensions may not work yet with Smarty v5. If you encounter problems, then simply remove the statement.') . '</p>'
-        . '<p>' . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v5.81-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+        . '<p>' . ('Some extensions may not work yet with Smarty v5. If you encounter problems, then you can continue with the deprecated Smarty 2 for now but you should consider uninstalling any extensions that do not support Smarty5.') . '</p>'
+        . '<p>' . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v6.4-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
         ])),


### PR DESCRIPTION

Overview
----------------------------------------
Make Smarty default to version 5

This switches the assumption that smarty must be deliberately set to get version 5 but no setting gives version 2


Before
----------------------------------------
If a site has taken no action to specify the Smarty version they will get Smarty2

After
----------------------------------------
If a site has taken no action to specify the Smarty version they will get Smarty5

Technical Details
----------------------------------------
Before upgrading the following message will show

![image](https://github.com/user-attachments/assets/545c594d-9ab8-4912-94b8-1903cff201f5)

The status check now shows if Smarty2 is deliberately chosen

![image](https://github.com/user-attachments/assets/0d4187de-6aea-42fb-a9f6-5c107ff7a81e)


Comments
----------------------------------------
The link goes to this gitlab

https://lab.civicrm.org/dev/core/-/issues/4146

I note that people pointed out some extensions that still do not work with Smarty2
https://civicrm.org/extensions/content-tokens - this is a Pogstone one - I updated it to 'Unsupported' - @mlutfy we could move it to gitlab & update but I worry it is also an old CMS version...

Related Tokens and Summary Fields - these seem like they might have more recent releases?
