### PR TITLE
Allow custom entityNames in ManagedEntityTrait (eg. for ECK)

### DIFF
--- a/Civi/Api4/Generic/Traits/ManagedEntity.php
+++ b/Civi/Api4/Generic/Traits/ManagedEntity.php
@@ -23,10 +23,14 @@ trait ManagedEntity {
 
   /**
    * @param bool $checkPermissions
+   * @param ?string $entityName
+   *   Usually the entityName matches the calling class, but for custom/dynamic entities
+   *   eg. ECK we need to specify a custom entityName.
+   *
    * @return \Civi\Api4\Generic\BasicBatchAction
    */
-  public static function revert($checkPermissions = TRUE) {
-    return (new BasicBatchAction(static::getEntityName(), __FUNCTION__, function($item, BasicBatchAction $action) {
+  public static function revert($checkPermissions = TRUE, ?string $entityName = NULL) {
+    return (new BasicBatchAction($entityName ?? static::getEntityName(), __FUNCTION__, function($item, BasicBatchAction $action) {
       if (\CRM_Core_ManagedEntities::singleton()->revert($action->getEntityName(), $item['id'])) {
         return $item;
       }
@@ -38,10 +42,14 @@ trait ManagedEntity {
 
   /**
    * @param bool $checkPermissions
+   * @param ?string $entityName
+   *   Usually the entityName matches the calling class, but for custom/dynamic entities
+   *   eg. ECK we need to specify a custom entityName.
+   *
    * @return \Civi\Api4\Generic\ExportAction
    */
-  public static function export($checkPermissions = TRUE) {
-    return (new ExportAction(static::getEntityName(), __FUNCTION__))
+  public static function export($checkPermissions = TRUE, ?string $entityName = NULL) {
+    return (new ExportAction($entityName ?? static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Most of the time the entityName matches what the calling class defines. But for things that define custom/dynamic entities (eg. ECK) we have to pass in a custom entityName.

Before
----------------------------------------
Cannot use ManagedEntityTrait with custom entities.

After
----------------------------------------
Can use ManagedEntityTrait with custom entities

Technical Details
----------------------------------------
Alters the signature of export/revert functions to allow a custom entityName to be passed in.

Comments
----------------------------------------
@colemanw for https://github.com/systopia/de.systopia.eck/pull/161
