### PR TITLE
Replace getCRMDatabasePrefix() with simpler/more sensible functions getCMSDatabaseName()/getCRMDatabaseName()

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1145,7 +1145,11 @@ AND    u.status = 1
    * CMS's drupal views expectations, if any.
    */
   public function getCRMDatabasePrefix(): string {
-    return str_replace('`', '', parent::getCRMDatabasePrefix());
+    $crmDatabaseName = parent::getCRMDatabaseName();
+    if (!empty($crmDatabaseName)) {
+      return "$crmDatabaseName.";
+    }
+    return $crmDatabaseName;
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1114,6 +1114,8 @@ abstract class CRM_Utils_System_Base {
    *
    * However, this string should contain backticks, or not, in accordance with the
    * CMS's drupal views expectations, if any.
+   *
+   * @deprecated
    */
   public function getCRMDatabasePrefix(): string {
     $crmDatabase = DB::parseDSN(CRM_Core_Config::singleton()->dsn)['database'];
@@ -1122,6 +1124,40 @@ abstract class CRM_Utils_System_Base {
       return '';
     }
     return "`$crmDatabase`.";
+  }
+
+  /**
+   * Get the CMS database name.
+   *
+   * This returns an empty string if the CRM/CMS database is shared.
+   * Otherwise it returns the name of the CMS database.
+   *
+   * @return string
+   */
+  public function getCMSDatabaseName(): string {
+    $crmDatabase = DB::parseDSN(CRM_Core_Config::singleton()->dsn)['database'];
+    $cmsDatabase = DB::parseDSN(CRM_Core_Config::singleton()->userFrameworkDSN)['database'];
+    if ($crmDatabase === $cmsDatabase) {
+      return '';
+    }
+    return $cmsDatabase;
+  }
+
+  /**
+   * Get the CRM database name.
+   *
+   * This returns an empty string if the CRM/CMS database is shared.
+   * Otherwise it returns the name of the CRM database.
+   *
+   * @return string
+   */
+  public function getCRMDatabaseName(): string {
+    $crmDatabase = DB::parseDSN(CRM_Core_Config::singleton()->dsn)['database'];
+    $cmsDatabase = DB::parseDSN(CRM_Core_Config::singleton()->userFrameworkDSN)['database'];
+    if ($crmDatabase === $cmsDatabase) {
+      return '';
+    }
+    return $crmDatabase;
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -886,6 +886,14 @@ AND    u.status = 1
     return $text;
   }
 
+  public function getCRMDatabasePrefix(): string {
+    $crmDatabaseName = parent::getCRMDatabaseName();
+    if (!empty($crmDatabaseName)) {
+      return "`$crmDatabaseName`.";
+    }
+    return $crmDatabaseName;
+  }
+
   /**
    * @inheritdoc
    */


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/32968 based on feedback.

Before
----------------------------------------
`CRM_Utils_System_Base::getCRMDatabasePrefix()` returns a string with some extra formatted which drupal uses and backdrop removes a bit of. We don't have an equivalent function to get the CMS database prefix which is useful for things like the standalone migrate system.

After
----------------------------------------
We have two functions which return strings without formatting. Formatting is added in the relevant drupal/backdrop classes as required.

Technical Details
----------------------------------------


Comments
----------------------------------------

