### PR TITLE
Use existing contribution currency when contributionPage is in invoice mode

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1985,7 +1985,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $this->_params['accountingCode'] = $this->_values['accountingCode'] ?? NULL;
 
     // fix currency ID
-    $this->_params['currencyID'] = CRM_Core_Config::singleton()->defaultCurrency;
+    $this->_params['currencyID'] = $this->getCurrency();
 
     CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($this->_params);
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -15,6 +15,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
+use Civi\Api4\Contribution;
 use Civi\Api4\PremiumsProduct;
 use Civi\Api4\PriceSet;
 
@@ -1544,11 +1545,22 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   public function getCurrency(): string {
-    $currency = $this->getContributionPageValue('currency');
-    if (empty($currency)) {
-      $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+    $existingContributionID = $this->getExistingContributionID();
+    if ($existingContributionID) {
+      $currency = Contribution::get(FALSE)
+        ->addSelect('currency')
+        ->addWhere('id', '=', $existingContributionID)
+        ->execute()
+        ->first()['currency'];
     }
-    return (string) ($currency ?? \Civi::settings()->get('currency'));
+    else {
+      $currency = $this->getContributionPageValue('currency');
+      if (empty($currency)) {
+        $currency = CRM_Utils_Request::retrieveValue('currency', 'String');
+      }
+      $currency = (string) ($currency ?? \Civi::settings()->get('currency'));
+    }
+    return $currency;
   }
 
 }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -1978,7 +1978,6 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'contact_id' => $this->individualID,
       'email-5' => 'anthony_anderson@civicrm.org',
       'payment_processor_id' => 0,
-      'currencyID' => 'USD',
       'is_pay_later' => 1,
       'invoiceID' => 'f28e1ddc86f8c4a0ff5bcf46393e4bc8',
       'description' => 'Online Contribution: Help Support CiviCRM!',
@@ -1991,7 +1990,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'pay_later_receipt:::This is a pay later receipt',
       'contributionPageId:::' . $contributionPageID,
       'title:::Test Contribution Page',
-      'amount:::$100.00',
+      'amount:::CA$100.00',
     ]);
     $mut->stop();
     $this->revertTemplateToReservedTemplate();


### PR DESCRIPTION
Overview
----------------------------------------
Use existing contribution currency when contributionPage is in invoice mode and add caching to the getCurrency() function.

Before
----------------------------------------
If you specify a contribution (ccid=X) then the contribution page will be used to pay for that contribution. But it loads the currency defined on the contributionpage and *changes* the currency on the contribution!

After
----------------------------------------
Currency is loaded from the contribution if it exists.
`getCurrency()` is called about 10 times and each time might do a database query, so added caching.


Technical Details
----------------------------------------
Extends getCurrency() function.

Comments
----------------------------------------

