### PR TITLE
Don't create duplicate membership when in invoice mode with a pending membership

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1492,16 +1492,22 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         // @fixme: Can we use eg. $this->getSubmittedValue('campaign_id') ?: $this->getContributionPageValue('campaign_id');
         $campaignID = $this->_params['campaign_id'] ?? ($this->_values['campaign_id'] ?? NULL);
 
-        [$membership, $renewalMode, $dates] = self::legacyProcessMembership(
-          $contactID, $membershipTypeID, $isTest,
-          date('YmdHis'), $membershipParams['cms_contactID'] ?? NULL,
-          $customFieldsFormatted,
-          $numTerms, $membershipID, $pending,
-          $contributionRecurID, $membershipSource, $isPayLater,
-          $campaignID,
-          $membershipContribution,
-          $membershipLineItems
-        );
+        if (!$this->getExistingContributionID()) {
+          // @todo get rid of this function!
+          // Need to check that it's not actually doing anything useful in other scenarios
+          // For getExistingContributionID()/invoice mode it does nothing helpful!
+          // Most (all?) of this functionality is handled in OrderCompleteSubscriber::updateMembershipBasedOnCompletionOfContribution
+          [$membership, $renewalMode, $dates] = self::legacyProcessMembership(
+            $contactID, $membershipTypeID, $isTest,
+            date('YmdHis'), $membershipParams['cms_contactID'] ?? NULL,
+            $customFieldsFormatted,
+            $numTerms, $membershipID, $pending,
+            $contributionRecurID, $membershipSource, $isPayLater,
+            $campaignID,
+            $membershipContribution,
+            $membershipLineItems
+          );
+        }
 
         $this->set('renewal_mode', $renewalMode);
 


### PR DESCRIPTION
Overview
----------------------------------------
When you use a contributionpage in invoice mode (ccid=X) to pay for a pending contribution linked to a pending membership and you use a checksum to access the contribution page you end up with a duplicate pending membership as well as the original membership which transitions from "Pending" to "New".

Before
----------------------------------------
Duplicate membership created sometimes.

After
----------------------------------------
Duplicate membership not created. Less use of `legacyProcessMembership()` function.

Technical Details
----------------------------------------
It's a bit tricky to reproduce. I managed to eventually by creating a fixed period annual membership, adding to a priceset and then using the "Add Membership" button on the contact record to create a pending membership with a pending contribution. Then I ran a contribution page with stripe payment processor using a checksum, ccid=(contribution id) and cid=(contact id)

Comments
----------------------------------------

