### PR TITLE
applyLocale before finalising SettingsManager

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -88,12 +88,12 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       \Civi\Core\Container::boot($loadFromDB);
 
       if ($loadFromDB && self::$_singleton->dsn) {
-        Civi::service('settings_manager')->bootComplete();
-
         self::$_singleton->userSystem->postContainerBoot();
 
         $domain = \CRM_Core_BAO_Domain::getDomain();
         \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);
+
+        Civi::service('settings_manager')->bootComplete();
 
         unset($errorScope);
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -661,13 +661,17 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       $session_cookie_name = 'SESSCIVISO';
     }
 
-    // session lifetime in seconds (default = 24 minutes)
-    $session_max_lifetime = (Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 24) * 60;
+    // session lifetime in seconds
+    // default = 24 days - NOTE this called too early to be read from ext/standaloneusers/settings/standaloneusers.setting.php
+    // so these should be kept in sync manually
+    $defaultLifetimeInMinutes = 24 * 24 * 60;
+    $lifetimeInMinutes = (Civi::settings()->get('standaloneusers_session_max_lifetime') ?? $defaultLifetimeInMinutes);
 
     session_start([
       'cookie_httponly'  => 1,
       'cookie_secure'    => !empty($_SERVER['HTTPS']),
-      'gc_maxlifetime'   => $session_max_lifetime,
+      // unit is seconds
+      'gc_maxlifetime'   => $lifetimeInMinutes * 60,
       'name'             => $session_cookie_name,
       'use_cookies'      => 1,
       'use_only_cookies' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
Attempt reshuffle container boot again in response to https://chat.civicrm.org/civicrm/pl/n31zqn1hipfnxkus38p6zd3g9w

There is a cyclic dependency issue. We want:
A) settings manager finalisation after `applyLocale` (so settings can read options from localised database tables)
B) `applyLocale` after `postContainerBoot` in order to be able to get locale for the user from Standalone session
C) `postContainerBoot` after settings manager finalisation in order to load default for `standaloneusers_session_max_lifetime` - see https://github.com/civicrm/civicrm-core/pull/32982

This breaks the loop by using a manual workaround for C.


Comments
-------------------------------------
I'm not sure if this is the best idea. It feels like there are safer ways to achieve the "dynamic settings behaviour" that is failing.
