### PR TITLE
Proof of concept: Save custom data before emiting postX events

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -143,6 +143,8 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   protected $_options = [];
 
+  protected $_custom = [];
+
   /**
    * Class constructor.
    *
@@ -806,6 +808,7 @@ class CRM_Core_DAO extends DB_DataObject {
   public function save($hook = TRUE) {
     $eventID = uniqid();
     $primaryField = $this->getFirstPrimaryKey();
+
     if (!empty($this->$primaryField)) {
       if ($hook) {
         $preEvent = new PreUpdate($this);
@@ -814,6 +817,11 @@ class CRM_Core_DAO extends DB_DataObject {
       }
 
       $result = $this->update();
+      if (!empty($this->_custom)) {
+        // @fixme: use a function with API4 syntax
+        // Add customFields back to $result
+        CRM_Core_BAO_CustomValueTable::store($this->_custom, $this->tableName(), $this->$primaryField, 'edit');
+      }
 
       if ($hook) {
         $event = new PostUpdate($this, $result);
@@ -830,6 +838,11 @@ class CRM_Core_DAO extends DB_DataObject {
       }
 
       $result = $this->insert();
+      if (!empty($this->_custom) && is_int($result)) {
+        // @fixme: use a function with API4 syntax
+        // Add customFields back to $result
+        CRM_Core_BAO_CustomValueTable::store($this->_custom, $this->tableName(), $result, 'create');
+      }
 
       if ($hook) {
         $event = new PostUpdate($this, $result);
@@ -1136,11 +1149,10 @@ class CRM_Core_DAO extends DB_DataObject {
     if (empty($values[$idField]) && array_key_exists('name', $fields) && empty($values['name'])) {
       $instance->makeNameFromLabel();
     }
-    $instance->save();
-
     if (!empty($record['custom']) && is_array($record['custom'])) {
-      CRM_Core_BAO_CustomValueTable::store($record['custom'], static::getTableName(), $instance->$idField, $op);
+      $instance->_custom = $record['custom'];
     }
+    $instance->save();
 
     \CRM_Utils_Hook::post($op, $entityName, $instance->$idField, $instance, $record);
 

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -143,6 +143,9 @@ class CRM_Core_DAO extends DB_DataObject {
    */
   protected $_options = [];
 
+  /**
+   * @var array
+   */
   protected $_custom = [];
 
   /**
@@ -998,7 +1001,47 @@ class CRM_Core_DAO extends DB_DataObject {
         }
       }
     }
+    // In order to return (and eventually save) using API4 style customFields
+    // Add API4 customfields to DAO object
+    foreach ($this->getAPI4Fields($params) as $fieldName => $fieldValue) {
+      $this->$fieldName = $fieldValue;
+    }
     return $allNull;
+  }
+
+  /**
+   * Retrieves all parameter values. Custom fields are in long name format (CustomGroup.CustomField).
+   *
+   * Note: unless all values are needed, getValue() is more performant.
+   *
+   * @since 6.15
+   * @fixme: This is a copy of \Civi\Core\Event\PreEvent::getValues() - need to refactor and share
+   */
+  public function getAPI4Fields($params): array {
+    $values = $params;
+    unset($values['custom']);
+
+    // Transform any custom values with shortNames (`custom_X`) to long name.
+    foreach ($values as $key => $value) {
+      if (str_starts_with($key, 'custom_')) {
+        $customField = \CRM_Core_BAO_CustomField::getFieldByName($key);
+        if ($customField) {
+          $values[$customField['custom_group']['name'] . '.' . $customField['name']] = $this->formatCustomValue($customField, $value);
+          unset($values[$key]);
+        }
+      }
+    }
+
+    // Collect custom values from $params['custom'] and add to params as their long names.
+    foreach ($params['custom'] ?? [] as $customFieldId => $customValues) {
+      $customField = \CRM_Core_BAO_CustomField::getField($customFieldId);
+      if ($customField && $customValues) {
+        $customValue = reset($customValues);
+        $values[$customField['custom_group']['name'] . '.' . $customField['name']] = $this->formatCustomValue($customField, $customValue['value'] ?? NULL);
+      }
+    }
+
+    return $values;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
`civi.dao.postInsert`/`civi.dao.postUpdate` are emitted when the entity is saved but before custom data is saved.

Custom data is still relying on the old record['custom'] style notation even though the API4 CustomGroup.CustomName style fields are there in the record data.

See eg. https://lab.civicrm.org/extensions/civirules/-/issues/244 for why this is a problem.

Before
----------------------------------------
Custom data saved after postInsert/postUpdate

After
----------------------------------------
Custom data saved before postInsert/postUpdate

Technical Details
----------------------------------------
For a proof of concept I've just moved `CRM_Core_BAO_CustomValueTable::store()` into the `save()` function and used a class var to bring across the custom data array. But ideally we should find a way for `$instance` to include the API4 custom fields and then for `save()` to read and save those at the same time as the main entity.

This is particularly an issue for eg. ECK where pretty much all fields are customfields.

Comments
----------------------------------------
@colemanw thoughts?
