### PR TITLE
Afform.submit - better check for whether redirect/message is already set

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -125,7 +125,7 @@ class Submit extends AbstractProcessor {
     // todo - add only if needed?
     $this->setResponseItem('token', $this->generatePostSubmitToken());
 
-    if (!empty($this->_response['redirect']) || !empty($this->_reponse['message'] ?? NULL)) {
+    if (isset($this->_response['redirect']) || isset($this->_reponse['message'])) {
       // redirect / message is already set, ignore defaults
     }
     elseif ($this->_afform['confirmation_type'] === 'show_confirmation_message') {


### PR DESCRIPTION
Overview
----------------------------------------
Small follow up to https://github.com/civicrm/civicrm-core/pull/32965

Before
----------------------------------------
- the core submit action checks for a truthy `redirect` / `message` before adding defaults from the afform config

After
----------------------------------------
- the core submit action checks for whether the `redirect` / `message` are set at all before adding defaults from the afform config
- if a listener wants to ensure no redirect happens, it can set `"redirect" => FALSE` to override any defaults

