### PR TITLE
dev/core#5945 Add in count of Recipients for the mailing as apposed t…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1412,6 +1412,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     $report['event_totals'] = [];
     $path = 'civicrm/mailing/report/event';
     $elements = [
+      'recipients',
       'queue',
       'delivered',
       'url',
@@ -1494,9 +1495,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['jobs'][] = $row;
     }
 
-    if (empty($report['event_totals']['queue'])) {
-      $report['event_totals']['queue'] = CRM_Mailing_BAO_MailingRecipients::mailingSize($mailing_id);
-    }
+    $report['event_totals']['recipients'] = CRM_Mailing_BAO_MailingRecipients::mailingSize($mailing_id);
 
     if (!empty($report['event_totals']['queue'])) {
       $report['event_totals']['delivered_rate'] = (100.0 * $report['event_totals']['delivered']) / $report['event_totals']['queue'];

--- a/api/v3/Mailing.php
+++ b/api/v3/Mailing.php
@@ -618,9 +618,15 @@ function civicrm_api3_mailing_stats($params) {
   if (empty($params['job_id'])) {
     $params['job_id'] = NULL;
   }
-  foreach (['Recipients', 'Delivered', 'Bounces', 'Unsubscribers', 'Unique Clicks', 'Opened'] as $detail) {
+  foreach (['Recipients', 'Queued', 'Delivered', 'Bounces', 'Unsubscribers', 'Unique Clicks', 'Opened'] as $detail) {
     switch ($detail) {
       case 'Recipients':
+        $stats[$params['mailing_id']] += [
+          $detail => CRM_Mailing_BAO_MailingRecipients::mailingSize($params['mailing_id']),
+        ];
+        break;
+
+      case 'Queued':
         $stats[$params['mailing_id']] += [
           $detail => CRM_Mailing_Event_BAO_MailingEventQueue::getTotalCount($params['mailing_id'], $params['job_id']),
         ];

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -556,7 +556,8 @@
 
   angular.module('crmMailing').factory('crmMailingStats', function (crmApi, crmLegacy) {
     var statTypes = [
-      {name: 'Recipients',    title: ts('Intended Recipients'),     searchFilter: '',                           eventsFilter: '&event=queue', reportType: 'detail', reportFilter: ''},
+      {name: 'Recipients',    title: ts('Intended Recipients'),     searchFilter: '',                           eventsFilter: '', reportType: false, reportFilter: ''},
+      {name: 'Queued',        title: ts('Mailings Sent'),     searchFilter: '',                           eventsFilter: '&event=queue', reportType: 'detail', reportFilter: ''},
       {name: 'Delivered',     title: ts('Successful Deliveries'),   searchFilter: '&mailing_delivery_status=Y', eventsFilter: '&event=delivered', reportType: 'detail', reportFilter: '&delivery_status_value=successful'},
       {name: 'Opened',        title: ts('Unique Opens'),           searchFilter: '&mailing_open_status=Y',     eventsFilter: '&event=opened', reportType: 'opened', reportFilter: ''},
       {name: 'Unique Clicks', title: ts('Unique Clicks'),          searchFilter: '&mailing_click_status=Y',    eventsFilter: '&event=click&distinct=1', reportType: 'clicks', reportFilter: ''},

--- a/ext/civi_mail/ang/crmMailingAB/EditCtrl/report.html
+++ b/ext/civi_mail/ang/crmMailingAB/EditCtrl/report.html
@@ -67,24 +67,29 @@
     <tr ng-repeat="statType in statTypes">
       <td>{{statType.title}}</td>
       <td ng-repeat="am in getActiveMailings()">
-        <a
-          class="crm-hover-button action-item"
-          ng-href="{{statUrl(am.mailing, statType, 'search')}}"
-          ng-if="checkPerm('view all contacts') || checkPerm('edit all contacts')"
-          title="{{ts('Search for contacts using \'%1\'', {1: statType.title})}}"
-          crm-icon="fa-search"
-          ></a>
-        <a
-          class="crm-hover-button action-item"
-          ng-href="{{statUrl(am.mailing, statType, 'events')}}"
-          title="{{ts('Browse events of type \'%1\'', {1: statType.title})}}"
-          >{{stats[am.name][statType.name] || 0}} </a> {{stats[am.name][rateStats[statType.name]] || ' '}}
-        <a
-          class="crm-hover-button action-item"
-          ng-href="{{statUrl(am.mailing, statType, 'report')}}"
-          title="{{ts('Reports for \'%1\'', {1: statType.title})}}"
-          crm-icon="fa-clipboard"
-          ></a>
+        <span ng-if="statType.name != 'Recipients'">
+          <a
+            class="crm-hover-button action-item"
+            ng-href="{{statUrl(am.mailing, statType, 'search')}}"
+            ng-if="checkPerm('view all contacts') || checkPerm('edit all contacts')"
+            title="{{ts('Search for contacts using \'%1\'', {1: statType.title})}}"
+            crm-icon="fa-search"
+            ></a>
+          <a
+            class="crm-hover-button action-item"
+            ng-href="{{statUrl(am.mailing, statType, 'events')}}"
+            title="{{ts('Browse events of type \'%1\'', {1: statType.title})}}"
+            >{{stats[am.name][statType.name] || 0}} </a> {{stats[am.name][rateStats[statType.name]] || ' '}}
+          <a
+            class="crm-hover-button action-item"
+            ng-href="{{statUrl(am.mailing, statType, 'report')}}"
+            title="{{ts('Reports for \'%1\'', {1: statType.title})}}"
+            crm-icon="fa-clipboard"
+            ></a>
+         </span>
+         <span ng-if="statType.name == 'Recipients'">
+           {{stats[am.name][statType.name] || 0}} {{stats[am.name][rateStats[statType.name]] || ' '}}
+         </span>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -15,9 +15,14 @@
   </div>
 {/if}
 <table class="crm-info-panel">
-  <tr><td class="label"><a href="{$report.event_totals.links.queue}">{ts}Intended Recipients{/ts}</a></td>
-      <td>{$report.event_totals.queue}</td>
-      <td>{$report.event_totals.actionlinks.queue}</td></tr>
+  <tr><td class="label">{ts}Intended Recipients{/ts}</td>
+      <td>{$report.event_totals.recipients}</td>
+      <td></td></tr>
+  {if $report.event_totals.queue}
+    <tr><td class="label"><a href="{$report.event_totals.links.queue}">{ts}Mailings Sent{/ts}</a></td>
+        <td>{$report.event_totals.queue}</td>
+        <td>{$report.event_totals.actionlinks.queue}</td></tr>
+  {/if}
   <tr><td class="label"><a href="{$report.event_totals.links.delivered}">{ts}Successful Deliveries{/ts}</a></td>
       <td>{$report.event_totals.delivered} ({$report.event_totals.delivered_rate|string_format:"%0.2f"}%)</td>
       <td>{$report.event_totals.actionlinks.delivered}</td></tr>

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -782,6 +782,8 @@ class api_v3_MailingTest extends CiviUnitTestCase {
     $sql = "UPDATE civicrm_mailing_job SET is_test = 0 WHERE mailing_id = {$mail['id']}";
     CRM_Core_DAO::executeQuery($sql);
 
+    CRM_Core_DAO::executeQuery("INSERT INTO civicrm_mailing_recipients(mailing_id,contact_id,email_id,phone_id) SELECT mailing_id,contact_id,email_id,phone_id FROM civicrm_mailing_event_queue");
+
     foreach (['bounce', 'unsubscribe', 'opened'] as $type) {
       $temporaryTable = CRM_Utils_SQL_TempTable::build()->setCategory($type)->createWithQuery("SELECT event_queue_id, time_stamp, id as delivered_id
         FROM civicrm_mailing_event_delivered
@@ -804,6 +806,7 @@ SELECT event_queue_id, time_stamp FROM {$temporaryTableName}";
     $expectedResult = [
       //since among 100 mails 20 has been bounced
       'Recipients' => 100,
+      'Queued' => 100,
       'Delivered' => 80,
       'Bounces' => 20,
       'Opened' => 20,


### PR DESCRIPTION
…o mailings sent (queued)

Overview
----------------------------------------
This adds a count of the mailing recipients to the mailing report by separating it out from the Mailings sent (i.e. the ones in the queue). This can be useful for diagnosing a stuck mailing or where there might have been contacts removed when the mailing was queued from when it was submitted (submitted populates the mailing recipients table)

Before
----------------------------------------
No report on the mailing recipients once the mailing delivery has started

After
----------------------------------------
Can see the mailings being sent and the total recipients for the mailing 