### PR TITLE
Use checkPermissions = FALSE for retrieving weight

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -398,6 +398,7 @@ trait DAOActionTrait {
         $oldWeight = civicrm_api4($this->getEntityName(), 'get', [
           'select' => [$weightField],
           'where' => $where,
+          'checkPermissions' => $this->getCheckPermissions(),
         ])[0][$weightField] ?? NULL;
       }
       $record[$weightField] = \CRM_Utils_Weight::updateOtherWeights($daoName, $oldWeight, $newWeight, $filters, $weightField);


### PR DESCRIPTION

Overview
----------------------------------------
Use checkPermissions = FALSE for retrieving weight

I have an update api call where checkPermissions is set to FALSE.

It is failing on this line because checkPermissions is not reaching this line.

Given the line is just retrieving the weight I don't think it needs to have permissions applied regardless of the incoming permission so this seems appropriate

Before
----------------------------------------
API call with checkPermissions set to FALSE can fail on trying to retrieve the weight on this line

After
----------------------------------------
Permissions not checked when retrieving weight

Technical Details
----------------------------------------
Slightly more seriously this updates the weights on the other items - my feeling is that the code would not reach this point without appropriate permissions - but also that even if someone sneakily altered the weight & then could not commit their update due to a later permission check - the updated weights would all still be the same relative to each other - no harm no foul

Comments
----------------------------------------
Here is a fowl
![image](https://github.com/user-attachments/assets/c9852953-7885-4db8-97fb-aada92318ea8)
