### PR TITLE
HttpTestTrait - Set a concrete timeout

### DIFF
--- a/Civi/Test/HttpTestTrait.php
+++ b/Civi/Test/HttpTestTrait.php
@@ -61,6 +61,7 @@ trait HttpTestTrait {
     $defaults = [
       'handler' => $handler,
       'base_uri' => 'auto:',
+      'timeout' => 15,
     ];
 
     $options = array_merge($defaults, $options);

--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -4,6 +4,7 @@ namespace E2E\Core;
 
 use Civi\Core\AssetBuilder;
 use Civi\Core\Event\GenericHookEvent;
+use Civi\Test\HttpTestTrait;
 
 /**
  * Class AssetBuilderTest
@@ -11,6 +12,8 @@ use Civi\Core\Event\GenericHookEvent;
  * @group e2e
  */
 class AssetBuilderTest extends \CiviEndToEndTestCase {
+
+  use HttpTestTrait;
 
   protected $fired;
 
@@ -134,11 +137,11 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     $url = \Civi::service('asset_builder')->getUrl($asset, $params);
     $this->assertEquals(1, $this->fired['hook_civicrm_buildAsset']);
     $this->assertMatchesRegularExpression(';^https?:.*dyn/square.[0-9a-f]+.(txt|js)$;', $url);
-    $this->assertEquals($expectedContent, file_get_contents($url));
+    $response = $this->createGuzzle()->get($url);
     // Note: This actually relies on httpd to determine MIME type.
     // That could be ambiguous for javascript.
-    $this->assertContains("Content-Type: $expectedMimeType", $http_response_header);
-    $this->assertNotEmpty(preg_grep(';HTTP/1.1 200;', $http_response_header));
+    $this->assertContentType($expectedMimeType, $response);
+    $this->assertStatusCode(200, $response);
   }
 
   /**

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -3,6 +3,7 @@
 namespace E2E\Core;
 
 use Civi\Core\Url;
+use Civi\Test\HttpTestTrait;
 
 /**
  * Class PathUrlTest
@@ -12,6 +13,8 @@ use Civi\Core\Url;
  * Check that various paths and URLs are generated correctly.
  */
 class PathUrlTest extends \CiviEndToEndTestCase {
+
+  use HttpTestTrait;
 
   /**
    * `CRM_Utils_System::url()` should generate working URLs.
@@ -162,10 +165,10 @@ class PathUrlTest extends \CiviEndToEndTestCase {
    * @param string $expectContentRegex
    * @param string $url
    */
-  private function assertUrlContentRegex($expectContentRegex, $url) {
+  private function assertUrlContentRegex($expectContentRegex, string $url) {
     $this->assertMatchesRegularExpression(';^https?:;', $url, "The URL ($url) should be absolute.");
-    $content = file_get_contents($url);
-    $this->assertMatchesRegularExpression($expectContentRegex, $content);
+    $response = $this->createGuzzle()->get($url);
+    $this->assertBodyRegexp($expectContentRegex, $response);
   }
 
   /**


### PR DESCRIPTION
Overview
--------

In the test-runs, we're sometimes seeing `phpunit-e2e` spend an inordinate amount of time waiting for HTTP response (e.g. in cases like `E2E\Core\ErrorTest::testErrorMessage`).

While this suggests an underlying problem, it is also just in how long it holds back the queue.

Before
------

E2E tests which send internal requests through Guzzle have no timeout.

After
------

E2E tests which send internal requests through Guzzle do have a timeout.

Comments
--------

After waiting this inordinate amount of time, we subsequently see errors like "MySQL server has gone away". This is probably not a coincidence. However, the causation is unclear. (Perhaps one problem cascades to the next; or perhaps some error precedes them both; etc) It'll be interesting to see.
