### PR TITLE
Fix Saving Of Free Tags During Case Activity Creation

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -525,8 +525,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         CRM_Core_BAO_EntityTag::create($tagParams, 'civicrm_activity', $vval['actId']);
 
         //save free tags
-        if (isset($params['taglist']) && !empty($params['taglist'])) {
-          CRM_Core_Form_Tag::postProcess($params['taglist'], $vval['actId'], 'civicrm_activity', $this);
+        if (isset($params['activity_taglist']) && !empty($params['activity_taglist'])) {
+          CRM_Core_Form_Tag::postProcess($params['activity_taglist'], $vval['actId'], 'civicrm_activity', $this);
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the saving of free tags during activity creation in a case.

Before
----------------------------------------
If there is a free tag set for activities and user selects any value for this tag set during case activity creation the value for this free tag set was not saving correctly.
![screen_recording_before](https://github.com/user-attachments/assets/3be24d75-876c-42ac-ac96-3e59e69f813b)


After
----------------------------------------
The value for free tag set is saved correctly.
