### PR TITLE
Escape HML characters in parameters for `{help}` smarty tag

### DIFF
--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -127,5 +127,6 @@ function smarty_function_help($params, $smarty) {
   foreach ($params as &$param) {
     $param = is_bool($param) || is_numeric($param) ? (int) $param : (string) $param;
   }
-  return '<a class="' . $class . '" title="' . $title . '" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $helpTextTitle . ', ' . json_encode($params) . '); return false;\'>&nbsp;</a>';
+  $helpTextParams = htmlspecialchars(json_encode($params), ENT_QUOTES);
+  return '<a class="' . $class . '" title="' . $title . '" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $helpTextTitle . ', ' . $helpTextParams . '); return false;\'>&nbsp;</a>';
 }


### PR DESCRIPTION
Overview
----------------------------------------
Parameters to the `{help}` Smarty function are not sufficiently escaped.

Before
----------------------------------------
Parameters containing e.g. double quotes inside a string cause help bubbles failing to open. 

After
----------------------------------------
Help bubbles with e.g. double quotes in parameters load correctly.

Technical Details
----------------------------------------
`$helpTextTitle` is being escaped already using `$helpTextTitle = htmlspecialchars(json_encode($helpTextTitle), ENT_QUOTES);`, so this does the same to the params with `$helpTextParams = htmlspecialchars(json_encode($params), ENT_QUOTES);`. This can't be done before passing parameters because `json_encode()` might return unescaped characters (like double quotes).
