### PR TITLE
Allow extra detail to be passed through to validate

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1956,7 +1956,7 @@ LIKE %1
     $tr = [];
     foreach ($params as $key => $item) {
       if (is_numeric($key)) {
-        if (CRM_Utils_Type::validate($item[0], $item[1]) !== NULL) {
+        if (CRM_Utils_Type::validate($item[0], $item[1], TRUE, $item[2] ?? 'One of the parameters ') !== NULL) {
           $item[0] = self::escapeString($item[0]);
           if ($item[1] == 'String' ||
             $item[1] == 'Memo' ||


### PR DESCRIPTION
Overview
----------------------------------------
Allow extra detail to be passed through to validate"

Before
----------------------------------------
How many times have we seen
```One of parameters (value: null) is not of the type Integer```

After
----------------------------------------
IF the calling function passes a 3rd parameter then that will show

Technical Details
----------------------------------------
Retro-adding this means there are no existing places it is set - but it does provide an option for those limping through trying to find out the cause of a bug that is hard-to-replicate or only occurs on production. I think I might lean towards using a named parameter though instead of '2' 

Comments
----------------------------------------
