### PR TITLE
RiverLea Responsive Tables bug - fixes /dev/core/5948 & tidies related css

### DIFF
--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -360,12 +360,6 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   border-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
   margin-bottom: 0;
 }
-.crm-container .crm-search-nav-tabs { /* Fix for SK tabs border */
-  border-bottom-left-radius: 0;
-  border-bottom-right-radius: 0;
-  margin-bottom: 0;
-  border-bottom: 0;
-}
 .crm-container .panel-heading:has(.nav-tabs) {
   padding: 0;
   border-bottom: 0;
@@ -380,14 +374,6 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   box-shadow: none;
   border-radius: 0 0 var(--crm-roundness) var(--crm-roundness);
   background: var(--crm-tab-bg-active);
-  overflow-x: auto;
-}
-.crm-search:has(.crm-search-nav-tabs) .crm-search-display.crm-search-display-table table {
-  border-width: 1px 0 0 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  box-shadow: none;
-  margin-bottom: 0;
 }
 .crm-container .afadmin-list >  .form-inline,
 .crm-search > .ng-scope > .form-inline {

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -1,7 +1,6 @@
 /* JQuery UI tabs */
 
 .crm-container .ui-tabs,
-.crm-container .crm-search-nav-tabs,
 .crm-container .afadmin-list .nav.nav-tabs { /* entire tab region */
   border: var(--crm-tabs-border);
   border-radius: var(--crm-tabs-radius);

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -4,8 +4,19 @@
 
 /* Searchkit listing */
 
-.crm-search-nav-tabs {
+.crm-search:has(.crm-search-nav-tabs) {
+  min-width: fit-content;
+}
+.crm-search:has(.crm-search-nav-tabs) .crm-search-display-table table {
+  border-width: 1px 0 0 0;
+  box-shadow: none;
+  margin-bottom: 0;
+}
+.crm-container .crm-search-nav-tabs {
   position: relative;
+  border-radius: var(--crm-tabs-radius) var(--crm-tabs-radius) 0 0;
+  border: var(--crm-tabs-border);
+  border-bottom: 0;
 }
 #bootstrap-theme .crm-search-nav-tabs > div.btn-group {
   position: absolute;


### PR DESCRIPTION
Overview
----------------------------------------
An [old bug](https://lab.civicrm.org/extensions/riverlea/-/issues/90) introduced by RiverLea around responsive tables clipping dropdown menus hadn't been removed from SearchKit tables, as identified by @larssandergreen in https://lab.civicrm.org/dev/core/-/issues/5948.

Before
----------------------------------------
SearchKit tables with a nav clip dropdowns:
![image](https://github.com/user-attachments/assets/c8e0c17e-3551-4821-bbc7-54f66b524fd3)

After
----------------------------------------
They don't:
![image](https://github.com/user-attachments/assets/321b1ba6-77b6-46d0-be27-5fc20ccbef94)

Technical Details
----------------------------------------
While fixing this, took the time to move some SearchKit admin css into the same place, merging matching selectors, removing un-necessary descriptors, remove 4 lines overall with no change.

Comments
----------------------------------------
When a table is larger than a viewport the full browser horizontal scrolls now appear: previously it was only on the SK table. This might have a consequence for places where wide SearchKit tables are nested inside smaller layouts.