### PR TITLE
dev/core#5955 - fix error in help bubble

### DIFF
--- a/templates/CRM/Admin/Form/Setting/Miscellaneous.hlp
+++ b/templates/CRM/Admin/Form/Setting/Miscellaneous.hlp
@@ -1,0 +1,6 @@
+{htxt id="import-batch-size-id"}
+<p>{ts}If your imports time out, reduce this number. You can increase it for better import performance on servers with longer timeouts.{/ts}</p>
+{/htxt}
+{htxt id="dedupe-default-limit-id"}
+<p>{ts}Deduping larger databases can crash the server. By configuring a limit other than 0 here the dedupe query will only search for matches against a limited number of contacts.{/ts}</p>
+{/htxt}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5955

Before
----------------------------------------
Error when clicking help bubbles at Administer - System Settings - Misc

After
----------------------------------------
Words

Technical Details
----------------------------------------
I don't think the "metadata-only" help system has ever worked. It just wasn't an error before until this form was converted to a generic form because there was no help icon displayed. You can see this in 5.82. But now the generic form adds a non-functional icon, without the associated .hlp file.

Comments
----------------------------------------
Copied the text from settings/core.settings.php
