### PR TITLE
RiverLea Regression: fixes Bootstrap .btn-block width

### DIFF
--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -189,6 +189,7 @@
 #bootstrap-theme .btn-block {
   display: block;
   width: 100%;
+  max-width: 100%;
 }
 #bootstrap-theme .btn-block + .btn-block {
   margin-top: 5px;


### PR DESCRIPTION
Overview
----------------------------------------
RiverLea button css adds a `max-width: fit-content` - to limit oversized buttons (can't remember where that bug emerged, but that was the fix). However this stops Bootstrap's `btn-block` from having any impact, as spotted in @eileenmcnaughton's dupefinder extension. That class should make buttons full width, that's the behaviour on Greenwich, but RiverLea breaks it.

Before
----------------------------------------
Greenwich:
![image](https://github.com/user-attachments/assets/e3a7063b-864b-417f-a1d5-46c8336fca89)

Riverlea/Walbrook
![image](https://github.com/user-attachments/assets/d8a7cbee-b537-4347-aab9-7c4db8d716b7)

After
----------------------------------------
Riverlea/Walbrook
![image](https://github.com/user-attachments/assets/c414c70f-3439-4701-9aa9-ff184afe3e08)

Comments
----------------------------------------
As discussed [here](https://chat.civicrm.org/civicrm/pl/3a8e3xtrbbgofpci63am74mcfo).