### PR TITLE
RiverLea Regressions: as found in deduper extension: .panel-body and .btn-block issues

### DIFF
--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -189,6 +189,7 @@
 #bootstrap-theme .btn-block {
   display: block;
   width: 100%;
+  max-width: 100%;
 }
 #bootstrap-theme .btn-block + .btn-block {
   margin-top: 5px;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -224,6 +224,13 @@ table.advmultiselect {
   box-shadow: none;
   border-radius: var(--crm-roundness);
 }
+.crm-container .panel-body:before, #bootstrap-theme .panel-body:after {
+	display: table;
+	content: " ";
+}
+.crm-container .panel-body:after {
+	clear: both;
+}
 .crm-container .panel-title {
   margin-top: 0;
   margin-bottom: 0;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -225,11 +225,11 @@ table.advmultiselect {
   border-radius: var(--crm-roundness);
 }
 .crm-container .panel-body:before, #bootstrap-theme .panel-body:after {
-	display: table;
-	content: " ";
+  display: table;
+  content: " ";
 }
 .crm-container .panel-body:after {
-	clear: both;
+  clear: both;
 }
 .crm-container .panel-title {
   margin-top: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Two RiverLea changes have broken parts of Bootstrap, doesn't seem to impact core, but very noticeable in the deduper extension:
1. `.btn-block`, a class to make buttons 100% width has been overwritten by a `max-width: fit-content` for RIverLea buttons
2. `.panel-body` has some css magic to let it behave like `.row` and contain grids without a `.row`

This PR adds a fix for the first, and restores the css for the second.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/12f4458e-f510-4fda-b807-d9a944debd99)
(this looks even worse with multiple rows)

After
----------------------------------------
![image](https://github.com/user-attachments/assets/b7c0ae33-9e22-480b-aeff-c77eb2cdeb5f)

Comments
----------------------------------------
As raised in [this chat](https://chat.civicrm.org/civicrm/pl/njikpeitfindzk86mb3tifigmo).