### PR TITLE
RiverLea: Make FormBuilder edit buttons the same across streams, and subtler

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -88,29 +88,35 @@ details.af-container > *:last-of-type {
 }
 
 /* Admin edit links */
-.afform-directive .af-admin-edit-form-link {
-  position: absolute !important;
+#bootstrap-theme .afform-directive:has(> .af-admin-edit-form-link) .crm-search-display {
+  padding-top: 0.5rem;
+}
+#bootstrap-theme .afform-directive .af-admin-edit-form-link {
+  position: absolute;
   right: 0;
   top: 0;
-  opacity: .5;
-}
-.afform-directive .af-admin-edit-form-link.open,
-.afform-directive:hover .af-admin-edit-form-link {
-  opacity: 1;
 }
 #bootstrap-theme .af-admin-edit-form-link > button {
-  background: hsl(from var(--crm-c-page-background) h s calc(l - 10));
+  background: transparent;
   color: var(--crm-c-text);
   border-radius: 2rem;
   height: inherit;
-  padding: 0.4rem !important;
+  padding: 0 !important;
   border: 0;
+  opacity: 0.6;
+}
+#bootstrap-theme .af-admin-edit-form-link.open button,
+#bootstrap-theme .af-admin-edit-form-link button:hover,
+#bootstrap-theme .af-admin-edit-form-link button:focus  {
+  background: transparent;
+  color: var(--crm-c-text);
+  opacity: 1;
+  box-shadow: none !important; /* vs dropdown-toggle */
 }
 #bootstrap-theme .af-admin-edit-form-link > button .crm-i {
   padding: 0;
   border: 0;
 }
-
 /* Fieldset */
 
 fieldset.af-container.af-layout-inline {

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -107,7 +107,7 @@ details.af-container > *:last-of-type {
 }
 #bootstrap-theme .af-admin-edit-form-link.open button,
 #bootstrap-theme .af-admin-edit-form-link button:hover,
-#bootstrap-theme .af-admin-edit-form-link button:focus  {
+#bootstrap-theme .af-admin-edit-form-link button:focus {
   background: transparent;
   color: var(--crm-c-text);
   opacity: 1;

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -98,6 +98,18 @@ details.af-container > *:last-of-type {
 .afform-directive:hover .af-admin-edit-form-link {
   opacity: 1;
 }
+#bootstrap-theme .af-admin-edit-form-link > button {
+  background: hsl(from var(--crm-c-page-background) h s calc(l - 10));
+  color: var(--crm-c-text);
+  border-radius: 2rem;
+  height: inherit;
+  padding: 0.4rem !important;
+  border: 0;
+}
+#bootstrap-theme .af-admin-edit-form-link > button .crm-i {
+  padding: 0;
+  border: 0;
+}
 
 /* Fieldset */
 


### PR DESCRIPTION
Overview
----------------------------------------
FormBuilder Admin editor button/menus are quite dominant in RiverLea, they also inherit the button style of the parent Stream. This PR follows discussion [here](https://chat.civicrm.org/civicrm/pl/rapik4a15irk7pqfozkmuqbpmw), and aims to a) give a design to those buttons independent of the Stream, and make the look and feel subtler.

Before
----------------------------------------
Minetta
![image](https://github.com/user-attachments/assets/820f65ed-aa3e-4ea5-81e5-8693b51b5dfc)
![image](https://github.com/user-attachments/assets/4b8978b3-1d52-4d91-babb-2288d18b4a4a)

Walbrook
![image](https://github.com/user-attachments/assets/772dc933-0bc0-4505-a35c-fb200cdb1a9b)
![image](https://github.com/user-attachments/assets/e3343d14-3d38-4b05-bf2f-5336538a57f8)

Hackney
![image](https://github.com/user-attachments/assets/54da27bd-53c0-4323-bc74-b2a9d60883ff)
![image](https://github.com/user-attachments/assets/2b002f72-d1ec-45f7-a300-0414d036b03b)

Thames
![image](https://github.com/user-attachments/assets/5c91e3dd-4916-4e0e-a158-1fedb6df0984)
![image](https://github.com/user-attachments/assets/d6bf4604-0053-48ee-aa0a-7a20c697bf95)

After
----------------------------------------
Minetta + DM
![image](https://github.com/user-attachments/assets/2a058841-410f-4f76-aeb9-c6d55105ee17)
![image](https://github.com/user-attachments/assets/610898a5-12b7-46dd-9f06-13e24eaeae7d)
![image](https://github.com/user-attachments/assets/4fe3435a-6119-4aa4-97d4-eea3e591c142)

Walbrook
![image](https://github.com/user-attachments/assets/6e6cf379-289c-46fe-a4aa-41734fb659db)
![image](https://github.com/user-attachments/assets/15aef4fc-43a6-4345-b35c-7acb6cdb8a87)
![image](https://github.com/user-attachments/assets/096e8c77-4b27-4305-8571-6bb83979c59e)

Hackney
![image](https://github.com/user-attachments/assets/45f248d6-c7f1-4f0e-aa15-88df3c99697c)
![image](https://github.com/user-attachments/assets/025c45d1-f355-466a-9264-74123bca1862)

Thames
![image](https://github.com/user-attachments/assets/e726e5ea-324c-4d2d-a9f4-a1d0d4dc7708)
![image](https://github.com/user-attachments/assets/4b8f127a-a03e-4d8b-9fae-53747df9d1eb)
![image](https://github.com/user-attachments/assets/3a7edcab-a3ab-454c-8b65-529745c6d6d8)

Technical Details
----------------------------------------
The overlapping nature of this contextual button - and it's colour contrast ratio - make the current implementation of this button seem not very accessible, and these changes are maybe a small improvement, but are still not accessible imho - the overlap of other buttons and 50% opacity prevents that. But the opacity allows the button underneath to be somewhat seen - and the alternative of always giving this button its own space to never overlap may have it's own problems.

Comments
----------------------------------------
cc @artfulrobot & @ufundo.