### PR TITLE
add a relativeDate hook

### DIFF
--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -808,8 +808,11 @@ class CRM_Utils_Date {
    */
   public static function getFromTo($relative, $from = NULL, $to = NULL, $fromTime = NULL, $toTime = '235959') {
     if ($relative) {
-      [$term, $unit] = explode('.', $relative, 2);
-      $dateRange = self::relativeToAbsolute($term, $unit);
+      $dateRange = CRM_Utils_Hook::relativeDate($relative);
+      if (!is_array($dateRange) || (empty($dateRange['from']) && empty($dateRange['to']))) {
+        [$term, $unit] = explode('.', $relative, 2);
+        $dateRange = self::relativeToAbsolute($term, $unit);
+      }
       $from = substr(($dateRange['from'] ?? ''), 0, 8);
       $to = substr(($dateRange['to'] ?? ''), 0, 8);
       // @todo fix relativeToAbsolute & add tests

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3282,4 +3282,14 @@ abstract class CRM_Utils_Hook {
     );
   }
 
+  /**
+   * Extensions can define new formats for relative date filter "tokens".
+   * @param string $filter - the filter token, stored in civicrm_option_value
+   * @return mixed $dates - Should return an array with two elements, $dates['from']
+   *   and $dates['to'].  Or FALSE if hook isn't in use.
+   */
+  public static function relativeDate($filter) {
+    return self::singleton()->invoke(array('filter'), $filter, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_relativeDate');
+  }
+
 }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3285,8 +3285,8 @@ abstract class CRM_Utils_Hook {
   /**
    * Extensions can define new formats for relative date filter "tokens".
    * @param string $filter - the filter token, stored in civicrm_option_value
-   * @return array|false An array with two elements: $dates['from'] and $dates['to'],
-   * or FALSE if the hook isn't in use.
+   * @return array|false
+   *   An array with two elements: $dates['from'] and $dates['to'], or FALSE if the hook isn't in use.
    */
   public static function relativeDate($filter) {
     return self::singleton()->invoke(array('filter'), $filter, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_relativeDate');

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3285,8 +3285,8 @@ abstract class CRM_Utils_Hook {
   /**
    * Extensions can define new formats for relative date filter "tokens".
    * @param string $filter - the filter token, stored in civicrm_option_value
-   * @return mixed $dates - Should return an array with two elements, $dates['from']
-   *   and $dates['to'].  Or FALSE if hook isn't in use.
+   * @return array|false An array with two elements: $dates['from'] and $dates['to'],
+   * or FALSE if the hook isn't in use.
    */
   public static function relativeDate($filter) {
     return self::singleton()->invoke(array('filter'), $filter, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_relativeDate');

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -73,6 +73,14 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       'from' => '',
       'to' => '',
     ];
+    // "first quarter" relative date filter
+    $cases['q1'] = [
+      'expectedFrom' => (new DateTime('first day of January'))->format('Ymd') . '000000',
+      'expectedTo' => (new DateTime('last day of March'))->format('Ymd') . '235959',
+      'relative' => 'q1',
+      'from' => '',
+      'to' => '',
+    ];
     return $cases;
   }
 
@@ -80,12 +88,23 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
    * Test that getFromTo returns the correct dates.
    */
   public function testGetFromTo(): void {
+    $this->hookClass->setHook('civicrm_relativeDate', [$this, 'hook_civicrm_relativeDate_q1']);
     $cases = $this->fromToData();
     foreach ($cases as $caseDescription => $case) {
       [$calculatedFrom, $calculatedTo] = CRM_Utils_Date::getFromTo($case['relative'], $case['from'], $case['to']);
       $this->assertEquals($case['expectedFrom'], $calculatedFrom, "Expected From failed for case $caseDescription");
       $this->assertEquals($case['expectedTo'], $calculatedTo, "Expected To failed for case $caseDescription");
     }
+  }
+
+  public function hook_civicrm_relativeDate_q1($filter) {
+    $dates = [];
+    if ($filter == 'q1') {
+      //First quarter of this year.
+      $dates['from'] = (new DateTime('January 1st'))->format('Ymd');
+      $dates['to'] = (new DateTime('March 31st'))->format('Ymd');
+    }
+    return $dates;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This PR introduces a new relativeDate hook, allowing custom extensions to define their own relative date options within CiviCRM.

Before
----------------------------------------
There was no hook or extension point to allow custom extensions to introduce or modify these relative date options.
This limited flexibility for implementers who need to define business-specific date ranges.

After
----------------------------------------
This PR introduces a new hook, hook_civicrm_relativeDate, which allows custom extensions to define and inject their own relative date options.
The core logic calls this hook when building the list of relative dates, enabling extensibility for project-specific needs.

Example (in an extension): https://github.com/MegaphoneJon/com.megaphonetech.relativedatetest. You will need to previously update the civix of this extension in order to use it.

Technical Details
----------------------------------------
- A new hook `civicrm_relativeDate` was added.
- This implementation is based on a similar hook introduced in this commit:
https://github.com/MegaphoneJon/civicrm-core/commit/bf1b376938da7c0a45b3e11f3c8ebeb8c80218e9

Comments
----------------------------------------
This change enables more flexible date handling for use cases such as fiscal calendars, project-specific periods, or localized date semantics.
Open to feedback on naming or structural adjustments for consistency with other CiviCRM hooks.
