### PR TITLE
Fix activity-selectors/filters too wide

### DIFF
--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -14,20 +14,19 @@
     </summary>
     <div class="crm-accordion-body">
       <form><!-- form element is here to fool the datepicker widget -->
-      <table class="no-border form-layout-compressed activity-search-options">
-        <tr>
-          <td class="crm-contact-form-block-activity_type_filter_id crm-inline-edit-field">
+
+      <div class="no-border form-layout-compressed activity-search-options crm-flex-box">
+          <div class="crm-contact-form-block-activity_type_filter_id crm-inline-edit-field">
             {$form.activity_type_filter_id.label}<br /> {$form.activity_type_filter_id.html|crmAddClass:medium}
-          </td>
-          <td class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
+          </div>
+          <div class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
             {$form.activity_type_exclude_filter_id.label}<br /> {$form.activity_type_exclude_filter_id.html|crmAddClass:medium}
-          </td>
-          {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="activity_date_time" hideRelativeLabel=false}
-          <td class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
+          </div>
+          <div>{include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="activity_date_time" hideRelativeLabel=false}</div>
+          <div class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
             <label for="status_id">{ts}Status{/ts}</label><br /> {$form.status_id.html|crmAddClass:medium}
-          </td>
-        </tr>
-      </table>
+          </div>
+      </div>
       </form>
     </div>
   </details>

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -22,7 +22,7 @@
           <div class="crm-contact-form-block-activity_type_exclude_filter_id crm-inline-edit-field">
             {$form.activity_type_exclude_filter_id.label}<br /> {$form.activity_type_exclude_filter_id.html|crmAddClass:medium}
           </div>
-          <div>{include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="activity_date_time" hideRelativeLabel=false}</div>
+          <div class="crm-contact-form-block-activity_date_time_filter_id crm-inline-edit-field">{include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="activity_date_time" hideRelativeLabel=false}</div>
           <div class="crm-contact-form-block-activity_status_filter_id crm-inline-edit-field">
             <label for="status_id">{ts}Status{/ts}</label><br /> {$form.status_id.html|crmAddClass:medium}
           </div>


### PR DESCRIPTION
Overview
----------------------------------------

Activity filters were placed in a table, like it was the 90s. They're now in a flexbox container with flex-wrap.


Before
----------------------------------------

![image](https://github.com/user-attachments/assets/79708187-5b27-4d86-a5f5-348c7a045d34)

Some filters are off screen.


After
----------------------------------------

Filters always fit.

![image](https://github.com/user-attachments/assets/32950336-602d-40c8-ab4f-81fad9b28602)

![image](https://github.com/user-attachments/assets/b11941af-f102-42b4-86dc-2dbdef310df5)


Note
------------

This assumes RiverLea. Is that ok?
