### PR TITLE
i18n - Flush relevant caches after changing multilingual configuration

### DIFF
--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -107,7 +107,7 @@ class CRM_Core_I18n_Schema {
     $dbLocale = '';
 
     // now lets rebuild all triggers
-    CRM_Core_DAO::triggerRebuild();
+    self::clearCaches();
   }
 
   /**
@@ -189,9 +189,6 @@ class CRM_Core_I18n_Schema {
           CRM_Core_DAO::executeQuery("DROP TRIGGER IF EXISTS {$triggerName}");
         }
       }
-
-      // invoke the meta trigger creation call
-      CRM_Core_DAO::triggerRebuild($table);
     }
   }
 
@@ -250,8 +247,7 @@ class CRM_Core_I18n_Schema {
     $domain->locales = implode(CRM_Core_DAO::VALUE_SEPARATOR, $locales);
     $domain->save();
 
-    // invoke the meta trigger creation call
-    CRM_Core_DAO::triggerRebuild();
+    self::clearCaches();
   }
 
   /**
@@ -614,6 +610,23 @@ class CRM_Core_I18n_Schema {
       $dao->query($query, FALSE);
     }
     return TRUE;
+  }
+
+  /**
+   * Clear relevant caches after changing available languages
+   * @return void
+   */
+  private static function clearCaches() {
+    Civi::rebuild([
+      // Clear metadata in case it holds any language-specific info
+      'metadata' => TRUE,
+      // Flush translated string cache
+      'strings' => TRUE,
+      // Rebuild sql triggers because i18n schema is trigger-based
+      'triggers' => TRUE,
+      // Reconcile managed entities because some are language-specific
+      'entities' => TRUE,
+    ])->execute();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This unblocks an issue with #32859 - now the navigation menu and managed search displays auto-populate when modifying the site language settings.

Technical Details
------------
This clears more caches when enabling/disabling languages on a multilingual site.