### PR TITLE
Add more criteria when determining which relationships to merge

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -1697,7 +1697,7 @@ AND cc.sort_name LIKE '%$name%'";
    *
    * @see CRM_Dedupe_Merger::cpTables()
    */
-  public static function mergeRelationships($mainId, $otherId, &$sqls) {
+  public static function mergeRelationships(int $mainId, int $otherId, &$sqls) {
     // Delete circular relationships
     $sqls[] = "DELETE FROM civicrm_relationship
       WHERE (contact_id_a = $mainId AND contact_id_b = $otherId AND case_id IS NULL)
@@ -1709,6 +1709,9 @@ AND cc.sort_name LIKE '%$name%'";
       WHERE r1.relationship_type_id = r2.relationship_type_id
       AND r1.id <> r2.id
       AND r1.case_id IS NULL AND r2.case_id IS NULL
+      AND r1.is_active = r2.is_active
+      AND ((r1.start_date = r2.start_date) OR (r1.start_date IS NULL AND r2.start_date IS NULL))
+      AND ((r1.end_date = r2.end_date) OR (r1.end_date IS NULL AND r2.end_date IS NULL))
       AND (
         r1.contact_id_a = $mainId AND r2.contact_id_a = $otherId AND r1.contact_id_b = r2.contact_id_b
         OR r1.contact_id_b = $mainId AND r2.contact_id_b = $otherId AND r1.contact_id_a = r2.contact_id_a


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5426
Having the same relationship between two contacts multiple times is a valid use case - e.g. former and current employee.  However, on dedupe, additional relationships with the same type are always dropped.

To replicate:
* Create two contacts with the same email address.
* Create a relationship to a third contact from both original contacts with the same relationship type but different start/end dates.

Before
----------------------------------------
Relationships are considered identical when they have the same relationship type ID.

After
----------------------------------------
Relationships must also have a matching start/end date (or both must be blank). They must also both be active or both be inactive.

Comments
----------------------------------------
On [the Gitlab issue](https://lab.civicrm.org/dev/core/-/issues/5426) folks also raised concerns about mismatched custom fields, and this doesn't address differing notes/permissions/etc., but it seems like a solid incremental improvement.