### PR TITLE
SearchKit - Fix undefined variable 'requestId'

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -113,7 +113,7 @@
               ctrl.toolbar = apiResults.run.toolbar;
               // If there are no results on initial load, open an "autoOpen" toolbar link
               ctrl.toolbar.forEach((link) => {
-                if (link.autoOpen && requestId === 1 && !ctrl.results.length) {
+                if (link.autoOpen && ctrl._runCount === 1 && !ctrl.results.length) {
                   CRM.loadForm(link.url)
                     .on('crmFormSuccess', (e, data) => {
                       ctrl.rowCount = null;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes searchKit regression caused by c003ae406146b50bf179d6e32358a3e9cbf20380

Before
----------------------------------------
Undefined variable warning in console.
With admin UI enabled, "new field" popup doesn't automatically appear after creating new custom group.


After
----------------------------------------
With admin UI enabled, "new field" popup functionality restored.

