### PR TITLE
[REF] For DB Query Exceptions when generating the Yellow Screen data …

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -417,6 +417,9 @@ class CRM_Core_Error extends PEAR_ErrorStack {
       'code' => NULL,
       'exception' => $exception,
     ];
+    if (is_a($exception, '\Civi\Core\Exception\DBQueryException')) {
+      $vars['message'] = $exception->getUserMessage();
+    }
     if (!$vars['message']) {
       $vars['message'] = ts('We experienced an unexpected error. You may have found a bug. For more information on how to provide a bug report, please read: %1', [1 => 'https://civicrm.org/bug-reporting']);
     }


### PR DESCRIPTION
…use the getUserMessage function

Overview
----------------------------------------
When we generate the CiviCRM Fatal Error screen if the exception is being generated by a DBQueryException then we should use its getUserMessage to generate the UserMessage which would probably include mroe information on the underlying SQL issue

Before
----------------------------------------
Generic Error message printed

After
----------------------------------------
More details on DB error printed

@eileenmcnaughton @ufundo @totten thoughts?