### PR TITLE
Rebuilder - Also, Angular

### DIFF
--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -123,6 +123,7 @@ class Rebuilder {
         Civi::cache('long')->flush();
         Civi::cache('settings')->flush();
         Civi::cache('js_strings')->flush();
+        Civi::cache('angular')->clear();
         Civi::cache('community_messages')->flush();
         Civi::cache('groups')->flush();
         Civi::cache('navigation')->flush();


### PR DESCRIPTION
Overview
----------------------------------------

Possible resolution to https://chat.civicrm.org/civicrm/pl/5hk9wmiurby18gzskn9he7myar

Before + After
----------------------------------------

* In olden times, I believe the Angular indices were stored in the `long` cache.
* Now-a-days, it's in a separate cache. But that cache isn't flushed.
* But if you merge this, then... I guess it will be flushed...

Comments
-----------------------------------

This may be less noticeable on ordinary deployments with SQL caching (where there's a blanket-flush) -- and more noticeable on Redis (where flushes are more targetted).