### PR TITLE
(REF) Simplify calls to `Civi::rebuild()`

### DIFF
--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -236,7 +236,7 @@ class CRM_Extension_Manager {
       // It might be useful to reset the container, but (given dev/core#3686) that's not likely to do much.
       // \Civi::reset();
       // \CRM_Core_Config::singleton(TRUE, TRUE);
-      Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+      Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
     }
 
     return $tgtPath;
@@ -327,7 +327,7 @@ class CRM_Extension_Manager {
     if (!CRM_Core_Config::isUpgradeMode()) {
       \Civi::reset();
       \CRM_Core_Config::singleton(TRUE, TRUE);
-      Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+      Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
 
       $schema = new CRM_Logging_Schema();
       $schema->fixSchemaDifferences();
@@ -447,7 +447,7 @@ class CRM_Extension_Manager {
     $this->mapper->refresh();
     \Civi::reset();
     \CRM_Core_Config::singleton(TRUE, TRUE);
-    Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+    Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
 
     $this->popProcess($keys);
   }
@@ -513,7 +513,7 @@ class CRM_Extension_Manager {
     $this->mapper->refresh();
     // At the analogous step of `install()` or `disable()`, it would reset the container.
     // But here, the extension goes from "disabled=>uninstall". All we really need is to reconcile mgd's.
-    Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+    Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
     $this->popProcess($keys);
   }
 

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -112,7 +112,7 @@ class CRM_Extension_QueueTasks {
   }
 
   public static function rebuild(CRM_Queue_TaskContext $ctx): bool {
-    Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+    Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
     // FIXME: For 6.1+:, use: Civi::rebuild(['*' => TRUE, 'sessions' => FALSE]);
     return TRUE;
   }

--- a/api/v3/Extension.php
+++ b/api/v3/Extension.php
@@ -73,7 +73,7 @@ function _civicrm_api3_extension_install_spec(&$fields) {
  *   API result
  */
 function civicrm_api3_extension_upgrade() {
-  Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+  Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
   $queue = CRM_Extension_Upgrades::createQueue();
   $runner = new CRM_Queue_Runner([
     'title' => 'Extension Upgrades',


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #32993 to remove redundant declarations

Comments
----------------------------------------

Consider this:

```diff
-Civi::rebuild(['*' => TRUE, 'triggers' => TRUE, 'sessions' => FALSE])->execute();
+Civi::rebuild(['*' => TRUE, 'sessions' => FALSE])->execute();
```

If you pass `'*'=>TRUE`, then that implies `'triggers'=>TRUE`. So the statement `'triggers'=>TRUE` is redundant.
