### PR TITLE
(REF) Swap-in calls to `Civi::rebuild()`

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -248,7 +248,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     // note this also resets any ACL cache
     Civi::cache('fields')->flush();
     // reset ACL and system caches.
-    CRM_Core_BAO_Cache::resetCaches();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_ACL_BAO_ACL::deleteRecord(['id' => $this->_id]);

--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -170,7 +170,7 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       try {

--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -204,7 +204,7 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
    */
   public function postProcess() {
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     $redirectUrl = CRM_Utils_System::url('civicrm/admin/job', 'reset=1');
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Core_BAO_Job::deleteRecord(['id' => $this->_id]);

--- a/CRM/Admin/Form/OptionGroup.php
+++ b/CRM/Admin/Form/OptionGroup.php
@@ -117,7 +117,7 @@ class CRM_Admin_Form_OptionGroup extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Core_BAO_OptionGroup::deleteRecord(['id' => $this->_id]);

--- a/CRM/Admin/Form/PaymentProcessorType.php
+++ b/CRM/Admin/Form/PaymentProcessorType.php
@@ -192,7 +192,7 @@ class CRM_Admin_Form_PaymentProcessorType extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Financial_BAO_PaymentProcessorType::del($this->_id);

--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -114,7 +114,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
       throw new CRM_Core_Exception('Unrecognized setting. This may be a config field which has not been properly migrated to a setting. (' . implode(', ', array_keys($params)) . ')');
     }
 
-    CRM_Core_Config::clearDBCache();
+    Civi::rebuild(['tables' => TRUE])->execute();
     // This doesn't make a lot of sense to me, but it maintains pre-existing behavior.
     Civi::cache('session')->clear();
     Civi::rebuild(['system' => TRUE])->execute();

--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -117,7 +117,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     CRM_Core_Config::clearDBCache();
     // This doesn't make a lot of sense to me, but it maintains pre-existing behavior.
     Civi::cache('session')->clear();
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     CRM_Core_Resources::singleton()->resetCacheCode();
     $this->rebuildMenu();
 

--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -170,7 +170,7 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Setting {
     //CRM-8559, cache navigation do not respect locale if it is changed, so reseting cache.
     Civi::cache('navigation')->clear();
     // reset ACL and System caches
-    CRM_Core_BAO_Cache::resetCaches();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     // make the site multi-lang if requested
     if (!empty($values['makeMultilingual'])) {

--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -79,7 +79,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
   public function postProcess() {
     // flush caches so we reload details for future requests
     // CRM-11967
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     $formValues = $this->controller->exportValues($this->_name);
 

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -450,7 +450,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
    * (Actually probably some overkill at the moment.)
    */
   protected static function flushCaches() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     unset(Civi::$statics['CRM_Core_PseudoConstant']['groups']);
     unset(Civi::$statics['CRM_ACL_API']);
     unset(Civi::$statics['CRM_ACL_BAO_ACL']['permissioned_groups']);

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -37,7 +37,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
    * Cleanup ACL and System Level caches
    */
   public static function resetCaches() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
 
   /**

--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -35,6 +35,14 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
 
   /**
    * Cleanup ACL and System Level caches
+   *
+   * @deprecated
+   *  Deprecated Jun 2025 in favor of Civi::rebuild().
+   *     Reassess after Jun 2026.
+   *     For an extension bridging before+after, suggest guard like:
+   *       if (version_compare(CRM_Utils_System::version(), 'X.Y.Z', '>=')) Civi::rebuild(...)->execute()
+   *       else CRM_Core_BAO_Cache::resetCaches();
+   *     Choose an 'X.Y.Z' after determining that your preferred rebuild-target(s) are specifically available in X.Y.Z.
    */
   public static function resetCaches() {
     Civi::rebuild(['system' => TRUE])->execute();

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -284,7 +284,7 @@ class CRM_Core_BAO_ConfigSetting {
     $moveStatus .= ts('Template cache and upload directory have been cleared.') . '<br />';
 
     // clear all caches
-    CRM_Core_Config::clearDBCache();
+    Civi::rebuild(['tables' => TRUE])->execute();
     Civi::cache('session')->clear();
     $moveStatus .= ts('Database cache tables cleared.') . '<br />';
 

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -171,7 +171,8 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
 
     CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField);
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
+
     CRM_Utils_API_HTMLInputCoder::singleton()->flushCache();
     // Flush caches is not aggressive about clearing the specific cache we know we want to clear
     // so do it manually. Ideally we wouldn't need to clear others...
@@ -249,7 +250,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       CRM_Core_DAO::executeQuery($query);
     }
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     CRM_Utils_API_HTMLInputCoder::singleton()->flushCache();
     Civi::cache('metadata')->clear();
 
@@ -282,7 +283,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
    */
   public static function setIsActive($id, $is_active) {
     CRM_Core_Error::deprecatedFunctionWarning('writeRecord');
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     //enable-disable CustomField
     CRM_Core_BAO_UFField::setUFField($id, $is_active);
@@ -1012,7 +1013,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
     if ($event->action === 'delete') {
-      CRM_Utils_System::flushCache();
+      Civi::rebuild(['system' => TRUE])->execute();
 
       // first delete the custom option group and values associated with this field
       if (!empty($event->object->option_group_id)) {
@@ -1899,7 +1900,7 @@ WHERE  id IN ( %1, %2 )
 
     $add->save();
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     CRM_Utils_API_HTMLInputCoder::singleton()->flushCache();
   }
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -403,7 +403,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     // reset the cache
     Civi::cache('fields')->flush();
     // reset ACL and system caches.
-    CRM_Core_BAO_Cache::resetCaches();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if (!$is_active) {
       CRM_Core_BAO_UFField::setUFFieldStatus($id, $is_active);

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -359,7 +359,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     $transaction->commit();
 
     // reset the cache
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     CRM_Utils_Hook::post($op, 'CustomGroup', $group->id, $group);
 

--- a/CRM/Core/BAO/LocationType.php
+++ b/CRM/Core/BAO/LocationType.php
@@ -122,7 +122,7 @@ class CRM_Core_BAO_LocationType extends CRM_Core_DAO_LocationType implements \Ci
       }
     }
     // Todo: This was moved from CRM_Admin_Form_LocationType::postProcess but is probably unnecessarily broad.
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
 
 }

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -471,7 +471,7 @@ ORDER BY weight";
       CRM_Core_DAO::executeQuery($query);
       Civi::cache('navigation')->flush();
       // reset ACL and System caches
-      CRM_Core_BAO_Cache::resetCaches();
+      Civi::rebuild(['system' => TRUE])->execute();
     }
     else {
       // before inserting check if contact id exists in db

--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -1240,7 +1240,7 @@ class CRM_Core_CodeGen_GenerateData {
     //But at the end of setup we are appending sample custom data, so for consistency
     //reset the cache.
     Civi::cache('fields')->flush();
-    CRM_Core_BAO_Cache::resetCaches();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
 
   /**

--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -297,7 +297,7 @@ class CRM_Custom_Form_Group extends CRM_Admin_Form {
     // reset the cache
     Civi::cache('fields')->flush();
     // reset ACL and system caches.
-    CRM_Core_BAO_Cache::resetCaches();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if ($this->_action & CRM_Core_Action::UPDATE) {
       CRM_Core_Session::setStatus(ts('Your custom field set \'%1 \' has been saved.', [1 => $group['title']]), ts('Saved'), 'success');

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1010,7 +1010,7 @@ WHERE civicrm_event.is_active = 1
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_event', $copyEvent->id);
     }
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     CRM_Utils_Hook::copy('Event', $copyEvent, $id);
 
     return $copyEvent;

--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -288,7 +288,7 @@ WHERE  title = %1
    * Process the form when submitted.
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     $updateNestingCache = FALSE;
     if ($this->_action & CRM_Core_Action::DELETE) {

--- a/CRM/SMS/Form/Provider.php
+++ b/CRM/SMS/Form/Provider.php
@@ -148,7 +148,7 @@ class CRM_SMS_Form_Provider extends CRM_Core_Form {
    */
   public function postProcess() {
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_SMS_BAO_SmsProvider::del($this->_id);

--- a/CRM/Tag/Form/Tag.php
+++ b/CRM/Tag/Form/Tag.php
@@ -95,7 +95,7 @@ class CRM_Tag_Form_Tag extends CRM_Core_Form {
    * @return void
    */
   public function postProcess() {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     // array contains the posted values
     // exportvalues is not used because its give value 1 of the checkbox which were checked by default,

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -747,7 +747,7 @@ SET    version = '$version'
   public static function doIncrementalUpgradeFinish(CRM_Queue_TaskContext $ctx, $rev, $currentVer, $latestVer, $postUpgradeMessageFile) {
     $upgrade = new CRM_Upgrade_Form();
     $upgrade->setVersion($rev);
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     return TRUE;
   }

--- a/CRM/Utils/Migrate/Import.php
+++ b/CRM/Utils/Migrate/Import.php
@@ -71,7 +71,7 @@ class CRM_Utils_Migrate_Import {
     $this->profileJoins($xml, $idMap);
 
     // clean up all caches etc
-    CRM_Core_Config::clearDBCache();
+    Civi::rebuild(['tables' => TRUE])->execute();
   }
 
   /**

--- a/CRM/Utils/Migrate/ImportJSON.php
+++ b/CRM/Utils/Migrate/ImportJSON.php
@@ -56,7 +56,7 @@ class CRM_Utils_Migrate_ImportJSON {
     );
 
     // clean up all caches etc
-    CRM_Core_Config::clearDBCache();
+    Civi::rebuild(['tables' => TRUE])->execute();
   }
 
   /**

--- a/Civi/Test/CiviTestListener.php
+++ b/Civi/Test/CiviTestListener.php
@@ -122,7 +122,7 @@ else {
 
       $test->setUpHeadless();
 
-      \CRM_Utils_System::flushCache();
+      \Civi::rebuild(['system' => TRUE])->execute();
       \Civi::reset();
       \CRM_Core_Session::singleton()->set('userID', NULL);
       // ugh, performance

--- a/Civi/Test/CiviTestListenerPHPUnit7.php
+++ b/Civi/Test/CiviTestListenerPHPUnit7.php
@@ -110,7 +110,7 @@ class CiviTestListenerPHPUnit7 implements \PHPUnit\Framework\TestListener {
     $session->set('userID', NULL);
     $test->setUpHeadless();
 
-    \CRM_Utils_System::flushCache();
+    \Civi::rebuild(['system' => TRUE])->execute();
     \Civi::reset();
     \CRM_Core_Session::singleton()->set('userID', NULL);
     // ugh, performance

--- a/Civi/Test/Legacy/CiviTestListener.php
+++ b/Civi/Test/Legacy/CiviTestListener.php
@@ -112,7 +112,7 @@ class CiviTestListener extends \PHPUnit_Framework_BaseTestListener {
 
     $test->setUpHeadless();
 
-    \CRM_Utils_System::flushCache();
+    \Civi::rebuild(['system' => TRUE])->execute();
     \Civi::reset();
     \CRM_Core_Session::singleton()->set('userID', NULL);
     // ugh, performance

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -334,7 +334,7 @@ function civicrm_api3_custom_field_setvalue($params) {
   require_once 'api/v3/Generic/Setvalue.php';
   $result = civicrm_api3_generic_setValue(["entity" => 'CustomField', 'params' => $params]);
   if (empty($result['is_error'])) {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
   return $result;
 }

--- a/api/v3/CustomGroup.php
+++ b/api/v3/CustomGroup.php
@@ -116,7 +116,7 @@ function civicrm_api3_custom_group_setvalue($params) {
   require_once 'api/v3/Generic/Setvalue.php';
   $result = civicrm_api3_generic_setValue(["entity" => 'CustomGroup', 'params' => $params]);
   if (empty($result['is_error'])) {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
   return $result;
 }

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -659,7 +659,7 @@ function civicrm_api3_job_cleanup($params) {
   }
 
   if ($dbCache) {
-    CRM_Core_Config::clearDBCache();
+    Civi::rebuild(['tables' => TRUE])->execute();
   }
 
   if ($memCache) {

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -663,7 +663,7 @@ function civicrm_api3_job_cleanup($params) {
   }
 
   if ($memCache) {
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
 
   if ($wordRplc) {

--- a/sql/GenerateReportData.php
+++ b/sql/GenerateReportData.php
@@ -1147,7 +1147,7 @@ class CRM_GCD {
     //But at the end of setup we are appending sample custom data, so for consistency
     //reset the cache.
     Civi::cache('fields')->flush();
-    CRM_Core_BAO_Cache::resetCaches();
+    Civi::rebuild(['system' => TRUE])->execute();
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/SystemTest.php
+++ b/tests/phpunit/CRM/Utils/SystemTest.php
@@ -291,7 +291,7 @@ class CRM_Utils_SystemTest extends CiviUnitTestCase {
     \Civi::dispatcher()->addListener('hook_civicrm_buildAsset', [$this, 'flushCacheClearsAssetCache_buildAsset']);
     $fakeFile = \Civi::service("asset_builder")->getPath('fakeFile.json');
 
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     $fileList = scandir(dirname($fakeFile));
     // count should be 2, just the standard . and ..

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -697,7 +697,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    */
   public function membershipTypeCreate(array $params = [], string $identifer = 'test'): int {
     CRM_Member_PseudoConstant::flush('membershipType');
-    CRM_Core_Config::clearDBCache();
+    Civi::rebuild(['tables' => TRUE])->execute();
     $this->setupIDs['contact'] = $memberOfOrganization = $this->organizationCreate();
     $params = array_merge([
       'name' => 'General',

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -357,7 +357,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     // disable any left-over test extensions
     CRM_Core_DAO::executeQuery('DELETE FROM civicrm_extension WHERE full_name LIKE "test.%"');
     // reset all the caches
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
 
     // initialize the object once db is loaded
     \Civi::$statics = [];

--- a/tests/phpunit/api/v3/JobTestCustomDataTest.php
+++ b/tests/phpunit/api/v3/JobTestCustomDataTest.php
@@ -321,7 +321,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeDateCustomFieldConflictAndNoCheckPerms(): void {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit my contact'];
     CRM_Core_DAO::executeQuery("DELETE FROM civicrm_cache");
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate([$customFieldLabel => '2012-11-03']);
     $this->individualCreate([$customFieldLabel => '2013-11-03']);
@@ -340,7 +340,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeDateCustomFieldNoConflictAndNoCheckPerms(): void {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit my contact'];
     CRM_Core_DAO::executeQuery("DELETE FROM civicrm_cache");
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     $customFieldLabel = 'custom_' . $this->customFieldID;
     $contactID = $this->individualCreate();
     $this->individualCreate([$customFieldLabel => '2013-11-03']);
@@ -359,7 +359,7 @@ class api_v3_JobTestCustomDataTest extends CiviUnitTestCase {
   public function testBatchMergeIntCustomFieldNoConflictAndNoCheckPerms(): void {
     CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM', 'edit my contact'];
     CRM_Core_DAO::executeQuery("DELETE FROM civicrm_cache");
-    CRM_Utils_System::flushCache();
+    Civi::rebuild(['system' => TRUE])->execute();
     $customFieldLabel = 'custom_' . $this->customIntFieldID;
     $contactID = $this->individualCreate(['custom_' . $this->customBoolFieldID => 1]);
     $this->individualCreate([$customFieldLabel => 1, 'custom_' . $this->customBoolFieldID => 1]);


### PR DESCRIPTION
Overview
----------------------------------------

This is similar in spirit to #32993 -- we take some of the intermediate cache-functions and swap them with equivalent calls to `Civi::rebuild()`.

Technical Details
----------------------------------------

This swaps some calls with literal equivalents.

| Old | New/Equivalent |
| -- | -- |
| `CRM_Utils_System::flushCache()` |  `Civi::rebuild(['system' => TRUE])->execute()` |
| `CRM_Core_BAO_Cache::resetCaches()`  | `CRM_Utils_System::flushCache()` aka...<br/> `Civi::rebuild(['system' => TRUE])->execute()` |
| `CRM_Core_Config::clearDBCache()` |  `Civi::rebuild(['tables' => TRUE])->execute()`

Comments
---------------

Several of these modified lines are the middle of longer sequences. After merging this, I suspect we can consolidate some of those further. But the logic that consolidation will be different, so I leave it for a future PR.