### PR TITLE
[REF] Refactor text fields in price sets

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -291,26 +291,15 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
     //use value field.
     $valueFieldName = 'amount';
-    $separator = '|';
-    $taxTerm = Civi::settings()->get('tax_term');
-    $displayOpt = Civi::settings()->get('tax_display_settings');
-    $invoicing = Civi::settings()->get('invoicing');
     switch ($field->html_type) {
       case 'Text':
         $optionKey = key($customOption);
-        $count = $customOption[$optionKey]['count'] ?? '';
-        $max_value = $customOption[$optionKey]['max_value'] ?? '';
-        $taxAmount = $customOption[$optionKey]['tax_amount'] ?? NULL;
-        if (isset($taxAmount) && $taxAmount && $displayOpt && $invoicing) {
-          $qf->assign('displayOpt', $displayOpt);
-          $qf->assign('taxTerm', $taxTerm);
-          $qf->assign('invoicing', $invoicing);
-        }
-        $priceVal = implode($separator, [
-          $customOption[$optionKey][$valueFieldName] + $taxAmount,
-          $count,
-          $max_value,
-        ]);
+        // Text elements have a label before and then a second label after with amount, etc
+        // The second label is added here, we start by clearing out the existing text which is the first label.
+        $customOption[$optionKey]['label'] = NULL;
+        $priceOptionText = self::buildPriceOptionText($customOption[$optionKey], $field->is_display_amounts, $valueFieldName);
+        // This second label is then added to the form as a second form element which just carries the label and is not otherwise used.
+        $elementLabelAfter = $qf->add('static', $elementName . '_label_after', $priceOptionText['label']);
 
         if (!empty($fieldOptions[$optionKey]['label'])) {
           //check for label.
@@ -327,7 +316,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $element = &$qf->add('text', $elementName, $label,
           array_merge($extra,
             [
-              'price' => json_encode([$optionKey, $priceVal]),
+              'price' => json_encode([$optionKey, $priceOptionText['priceVal']]),
               'size' => '4',
             ]
           ),
@@ -341,7 +330,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         if (in_array($optionKey, $freezeOptions)) {
           self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
           // CRM-14696 - Improve display for sold out price set options
-          $element->setLabel($label . '&nbsp;<span class="sold-out-option">' . ts('Sold out') . '</span>');
+          $elementLabelAfter->setLabel('<span class="sold-out-option">' . $elementLabelAfter->getLabel() . '&nbsp;(' . ts('Sold out') . ')</span>');
         }
 
         //CRM-10117
@@ -772,7 +761,7 @@ WHERE  id IN (" . implode(',', array_keys($priceFields)) . ')';
    * @return array
    *   Price field option label, price value
    */
-  public static function buildPriceOptionText($opt, $isDisplayAmounts, $valueFieldName) {
+  protected static function buildPriceOptionText($opt, $isDisplayAmounts, $valueFieldName) {
     $preHelpText = $postHelpText = '';
     $optionLabel = !empty($opt['label']) ? '<span class="crm-price-amount-label">' . CRM_Utils_String::purifyHTML($opt['label']) . '</span>' : '';
     if (CRM_Utils_String::purifyHTML($opt['help_pre'] ?? '')) {

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -26,12 +26,12 @@
     {foreach from=$priceSet.fields item=element key=field_id}
         {* Skip 'Admin' visibility price fields WHEN this tpl is used in online registration unless user has administer CiviCRM permission. *}
         {if $element.visibility !== 'admin' || $isShowAdminVisibilityFields}
-            {if $element.help_pre}<span class="content description">{$element.help_pre|purify}</span><br />{/if}
             <div class="crm-section {$element.name|escape}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_`$field_id`"}
               <div class="label">{$form.$element_name.label}</div>
               <div class="content {$element.name|escape}-content">
+              {if $element.help_pre}<div class="description">{$element.help_pre|purify}</div>{/if}
                 {assign var="elementCount" value="0"}
                 {assign var="optionCount" value="0"}
                 {assign var="rowCount" value="0"}
@@ -60,36 +60,13 @@
 
                 <div class="label">{$form.$element_name.label}</div>
                 <div class="content {$element.name|escape}-content">
+                  {if $element.help_pre}<div class="description">{$element.help_pre|purify}</div>{/if}
                   {$form.$element_name.html}
-                  {if $element.html_type eq 'Text'}
-                    {if $element.is_display_amounts}
-                    <span class="price-field-amount{if $form.$element_name.frozen EQ 1} sold-out-option{/if}">
-                    {foreach item=option from=$element.options}
-                      {if ($option.tax_amount || $option.tax_amount == "0") && $displayOpt && $invoicing}
-                        {assign var="amount" value=$option.amount+$option.tax_amount}
-                        {if $displayOpt == 'Do_not_show'}
-                          {$amount|crmMoney:$currency}
-                        {elseif $displayOpt == 'Inclusive'}
-                          {$amount|crmMoney:$currency}
-                          <span class='crm-price-amount-tax'> {ts 1=$taxTerm 2=$option.tax_amount|crmMoney:$currency}(includes %1 of %2){/ts}</span>
-                        {else}
-                          {$option.amount|crmMoney:$currency}
-                          <span class='crm-price-amount-tax'> + {$option.tax_amount|crmMoney:$currency} {$taxTerm}</span>
-                        {/if}
-                      {else}
-                        {$option.amount|crmMoney:$currency}
-                      {/if}
-                      {if $form.$element_name.frozen EQ 1} ({ts}Sold out{/ts}){/if}
-                    {/foreach}
-                    </span>
-                    {else}
-                      {* Not showing amount, but still need to conditionally show Sold out marker *}
-                      {if $form.$element_name.frozen EQ 1}
-                        <span class="sold-out-option">({ts}Sold out{/ts})<span>
-                      {/if}
+                    {if $element.html_type eq 'Text'}
+                      {assign var="element_name_label_after" value="`$element_name`_label_after"}
+                      {$form.$element_name_label_after.label}
                     {/if}
-                  {/if}
-                  {if $element.help_post}<br /><span class="description">{$element.help_post|purify}</span>{/if}
+                  {if $element.help_post}<div class="description">{$element.help_post|purify}</div>{/if}
                 </div>
 
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
This PR simplifies the display of text price fields in price sets, making them behave more like other price fields and options. This allows removal of separate handling in the template for text price fields.

This PR is part of a series that [will allow participants to be removed from or added to sold out price options on the backend and to optionally show how many spaces are remaining on the front end.](https://lab.civicrm.org/dev/core/-/issues/5961)

Before
----------------------------------------
Text fields are partly put together in the BAO and partly in the tpl. As all the other kinds of price fields are put together exclusively in the BAO, this is confusing and hard to maintain. It also causes sold out options to be labelled Sold Out twice.

Pre and post help display is a little wonky, it isn't clear which pre or post help goes with which field.

![image](https://github.com/user-attachments/assets/d518677d-55a3-4728-ad3f-cd1897879d7c)

After
----------------------------------------
Text fields are handled in the same way as other price fields / options. Text fields only say Sold Out only once.

Pre and post help display are a little less wonky, but at least clearly spatially associated with the price field (and within the div for the price field).

![image](https://github.com/user-attachments/assets/5ab49c08-3f0f-41a8-885c-435c954579ad)

Technical Details
----------------------------------------
Text price fields are kind of weird in that they are both fields and options at the same time, so there is a little bit of a work around in here for the labels in order to make them behave in the same way as all the price options, which will make it feasible to show the number of spaces remaining in the future. I think this is a reasonable way around that weirdness.

Comments
----------------------------------------
Also makes the new ```buildPriceOptionText()``` from my previous PR protected.
This is a redo of #26445.

