### PR TITLE
Fully hide pricesetTotal div when not needed

### DIFF
--- a/templates/CRM/Price/Form/Calculate.tpl
+++ b/templates/CRM/Price/Form/Calculate.tpl
@@ -8,8 +8,8 @@
  +--------------------------------------------------------------------+
 *}
 
-<div id="pricesetTotal" class="crm-section section-pricesetTotal">
-  <div id="pricelabel" class="label {if $hideTotal}hiddenElement{/if}">
+<div id="pricesetTotal" class="crm-section section-pricesetTotal{if $hideTotal} hiddenElement{/if}">
+  <div id="pricelabel" class="label">
     {if ($extends eq 'Contribution') || ($extends eq 'Membership')}
       <span id='amount_sum_label'>{ts}Total Amount{/ts}</span>
     {else}
@@ -20,7 +20,7 @@
       {/if}
     {/if}
   </div>
-  <div class="content calc-value" {if $hideTotal}style="display:none;"{/if} id="pricevalue"></div>
+  <div class="content calc-value" id="pricevalue"></div>
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
Before
----------------------------------------
Instead of hiding the pricesetTotal div when not needed, we hide its two children, using two different methods. The result is that if the pricesetTotal div has margins (as it does in Riverlea), we end up with empty space
![image](https://github.com/user-attachments/assets/4fca05ae-308b-458d-98e6-fb536bb1c5ec)

After
----------------------------------------
Just hide the whole div if not needed. No more empty space.
![image](https://github.com/user-attachments/assets/c6214c05-4b6c-4d08-afef-ebfbaa767d1b)