### PR TITLE
Prevent soft credit amounts > contribution amount on edit

### DIFF
--- a/CRM/Contribute/Form/SoftCredit.php
+++ b/CRM/Contribute/Form/SoftCredit.php
@@ -192,7 +192,8 @@ class CRM_Contribute_Form_SoftCredit {
           if ($repeat[$fields['soft_credit_contact_id'][$key]] > 1) {
             $errors["soft_credit_contact_id[$key]"] = ts('You cannot enter multiple soft credits for the same contact.');
           }
-          if ($self->_action == CRM_Core_Action::ADD && $fields['soft_credit_amount'][$key]
+          // If this contribution uses a price set, $fields['total_amount'] is not set, so we don't try to validate.
+          if ($fields['soft_credit_amount'][$key] && $fields['total_amount']
             && (CRM_Utils_Rule::cleanMoney($fields['soft_credit_amount'][$key]) > CRM_Utils_Rule::cleanMoney($fields['total_amount']))
           ) {
             $errors["soft_credit_amount[$key]"] = ts('Soft credit amount cannot be more than the total amount.');


### PR DESCRIPTION
Before
----------------------------------------
Validate that soft credit amount is not greater than contribution total when adding a contribution, but not when editing.

After
----------------------------------------
Validate that soft credit amount is not greater than contribution total when adding and editing. This is a useful reminder if you edit the contribution total to lower it, but forget to lower the soft credit amount.