### PR TITLE
Small Riverlea fixes: Tab count padding and front end radio alignment

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -73,6 +73,9 @@ body {
 .crm-container table {
   border-collapse: collapse;
 }
+.crm-container input[type="checkbox"],.crm-container input[type="radio"] {
+  padding: 0;
+}
 
 /* JQueryUI resets (!important vs JQuery UI css) */
 

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -128,11 +128,11 @@ af-form > fieldset > legend {
   min-width: unset;
 }
 .crm-container.crm-public input[type="radio"] {
-  margin: var(--crm-s2) var(--crm-s3) 0 0;
+  margin: 0;
   min-width: auto;
 }
 .crm-container.crm-public input[type="checkbox"] {
-  margin: var(--crm-s2) var(--crm-s3) 0 0;
+  margin: 0;
   min-width: auto;
 }
 .crm-container.crm-public .crm-checkbox-list input[type="checkbox"] {

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -82,7 +82,7 @@
   display: inline-block;
   text-align: center;
   font-size: var(--crm-m2);
-  /* padding: 0;   */
+  padding: 0 0.2rem;
 }
 .crm-container #mainTabContainer ul.ui-tabs-nav a em {
   background: var(--crm-dash-tab-count-bg);

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -247,12 +247,6 @@ html.cms-standalone body {
   box-shadow: 0 0 50px rgba(0, 0, 0, 0.2);
 }
 
-/* make count badges more readable */
-.crm-container .ui-tabs ul.ui-tabs-nav a em,
-.crm-container .nav-tabs a .badge {
-  padding: 0 0.2rem;
-}
-
 /* RL has no margin-bottom so the actions ribbon touches the main contact block */
 div.crm-summary-contactname-block+.crm-actions-ribbon {
   margin-bottom: var(--crm-r1) !important;


### PR DESCRIPTION
Before
----------------------------------------
<img width="222" alt="image" src="https://github.com/user-attachments/assets/3da6cebc-396e-4f7d-ab31-2a890f0f53aa" /><br />
Hard to read.

<img width="334" alt="image" src="https://github.com/user-attachments/assets/ace8367c-9945-43bc-9706-faf3badf0519" /><br />
Wonky alignment on front end.

After
----------------------------------------
<img width="222" alt="image" src="https://github.com/user-attachments/assets/5f1478c4-9600-4c66-8e82-34d6f12f9622" /><br />
Padding was already in place in Thames, just needed to apply it in Riverlea core.


<img width="318" alt="image" src="https://github.com/user-attachments/assets/28db1a30-e56c-41cb-8ddf-4f9ec9986df8" /><br />
Alignment improved by resetting margins to 0.

Comments
----------------------------------------
@nicol looks like you added those [margins here](https://lab.civicrm.org/extensions/riverlea/-/merge_requests/7) — do you recall if they were for something specific?