### PR TITLE
Fix jQuery selector for jQuery 3 support

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -362,7 +362,7 @@
   });
 
   var dialogCount = 0,
-    exclude = '[href^=#], [href^=javascript], [onclick], .no-popup, .cancel';
+    exclude = '[href^="#"], [href^=javascript], [onclick], .no-popup, .cancel';
 
   CRM.loadPage = function(url, options) {
     var settings = {


### PR DESCRIPTION
Overview
----------------------------------------
I've been looking at what would be needed to run CiviCRM with jQuery 3 (less than you might expect).

This fixes one of the few issues I have found: `[href^=#]` is not a valid selector, but `[href^="#"]` is.

Without this fix, the edit modals don't work with jQuery 3, and always trigger a full page load.