### PR TITLE
dev/core#5963 - Don't crash if trigger-based logging table doesn't have a contact_id column

### DIFF
--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -112,6 +112,11 @@ LEFT JOIN civicrm_activity_contact source ON source.activity_id = lt.id AND sour
             break;
           }
 
+          if (str_contains($table, 'civicrm_value')) {
+            $contactIdClause = "AND entity_id = %3";
+            break;
+          }
+
           // allow tables to be extended by report hook query objects
           list($contactIdClause, $join) = CRM_Report_BAO_Hook::singleton()->logDiffClause($this, $table);
 
@@ -126,9 +131,6 @@ LEFT JOIN civicrm_activity_contact source ON source.activity_id = lt.id AND sour
               // e.g. civicrm_batch.created_id
               return [];
             }
-          }
-          if (str_contains($table, 'civicrm_value')) {
-            $contactIdClause = "AND entity_id = %3";
           }
       }
     }

--- a/CRM/Logging/Differ.php
+++ b/CRM/Logging/Differ.php
@@ -116,7 +116,16 @@ LEFT JOIN civicrm_activity_contact source ON source.activity_id = lt.id AND sour
           list($contactIdClause, $join) = CRM_Report_BAO_Hook::singleton()->logDiffClause($this, $table);
 
           if (empty($contactIdClause)) {
-            $contactIdClause = "AND contact_id = %3";
+            $contactTables = CRM_Core_DAO::getReferencesToContactTable();
+            if (isset($contactTables[$table]) && in_array('contact_id', $contactTables[$table], TRUE)) {
+              $contactIdClause = "AND contact_id = %3";
+            }
+            else {
+              // Avoid syntax error for nonexistent contact_id column. The
+              // real column is probably meaningless anyway in this context,
+              // e.g. civicrm_batch.created_id
+              return [];
+            }
           }
           if (str_contains($table, 'civicrm_value')) {
             $contactIdClause = "AND entity_id = %3";


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5963

Before
----------------------------------------
One way to reproduce is:
1. Turn on logging at administer - system settings - misc.
2. Create a contact.
3. Wait a year, or more than 10 seconds at least.
4. Edit the contact.
5. Decide you want to clean out older log records, so delete everything from log_civicrm_contact except the most recent 'Update' record.
6. Visit the changelog tab for the contact and click on the update record to view it.
7. Crash about DB Error: no such field".

After
----------------------------------------
It gives a message about no diffs to display, which is pretty close to the truth in this case.

Technical Details
----------------------------------------
Long analysis in the lab ticket, but I figured what it comes down to is that this function accepts any table as input, but assumes it will have a contact_id column. And most of the ones with a contact-related column with a different column name are meaningless in the context of the differ, e.g. civicrm_batch.created_id is technically a contact id, but not relevant to showing how a _contact_ changed.

Comments
----------------------------------------
The attached test fails without the patch with "DB Error: no such field".
