### PR TITLE
RiverLea: menus unreachable under notifications

### DIFF
--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -154,7 +154,8 @@
   position: fixed;
   top: 64px;
   right: var(--crm-r2);
-  z-index: 999999;
+  /* one less than #civicrm-menu */
+  z-index: 99998;
 }
 #crm-notification-container div.ui-notify-message-style {
   background: var(--crm-notify-background);


### PR DESCRIPTION
Overview
----------------------------------------


RiverLea core puts notifications over the menu. So when you end up on a screen which keeps posting up notifications (you know the ones) or posts so many you can't click-and-wait-for-it-to-fade-and-animate-away and keep your sanity... you can't access the menus.

This fixes it by putting the notifications one z-index below the notifications.


Before
----------------------------------------

Can't get to Admin/support/right menus:

![image](https://github.com/user-attachments/assets/24b59e76-9f36-451d-b96d-77dee009f0e7)



After
----------------------------------------

![Screenshot From 2025-06-23 18-13-20](https://github.com/user-attachments/assets/2f73c02c-1538-456f-8e04-8bd43ba6fa23)
![Screenshot From 2025-06-23 18-13-00](https://github.com/user-attachments/assets/61f32eff-c8e8-46a2-9441-f70f8c6a28de)
![Screenshot From 2025-06-23 18-12-35](https://github.com/user-attachments/assets/508de8c9-be8d-46f8-b1a3-66af5fe3b49e)
![Screenshot From 2025-06-23 18-10-57](https://github.com/user-attachments/assets/a1eda873-bdb0-4a6b-9e98-f6caca8f6509)

@vingle 
