### PR TITLE
Fix RiverLea theming issues

### DIFF
--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -183,6 +183,12 @@ table.advmultiselect {
   background-color: var(--crm-wizard-active-bg);
   color: var(--crm-wizard-active-col);
 }
+.crm-container .nav > li.active > a:hover,
+.crm-container .nav > li.active > a:focus {
+  background-color: var(--crm-wizard-active-bg);
+  color: var(--crm-wizard-active-col);
+}
+
 .crm-container ul.wizard-bar > li.current-step::before,
 .crm_wizard__title ul > li.active::before {
   border-left-color: var(--crm-wizard-active-bg);

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -183,8 +183,8 @@ table.advmultiselect {
   background-color: var(--crm-wizard-active-bg);
   color: var(--crm-wizard-active-col);
 }
-.crm-container .nav > li.active > a:hover,
-.crm-container .nav > li.active > a:focus {
+.crm_wizard__title .nav-pills > li.active > a:hover,
+.crm_wizard__title .nav-pills > li.active > a:focus {
   background-color: var(--crm-wizard-active-bg);
   color: var(--crm-wizard-active-col);
 }

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -22,12 +22,9 @@ a.af-api4-action-idle {
 .af-container.af-layout-inline {
   flex-direction: row;
 }
-.af-container.af-layout-cols > .af-title {
-  flex: 0 0 100%;
-}
+.af-container.af-layout-cols > .af-title,
 .af-container.af-layout-inline > .af-title {
-  display: block;
-  width: 100%;
+  flex: 0 0 100%;
 }
 .afform-directive,
 af-form {

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -22,9 +22,12 @@ a.af-api4-action-idle {
 .af-container.af-layout-inline {
   flex-direction: row;
 }
-.af-container.af-layout-cols > .af-title,
-.af-container.af-layout-inline > .af-title {
+.af-container.af-layout-cols > .af-title {
   flex: 0 0 100%;
+}
+.af-container.af-layout-inline > .af-title {
+  display: block;
+  width: 100%;
 }
 .afform-directive,
 af-form {

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -467,7 +467,7 @@ html.crm-standalone  nav.breadcrumb>ol {
 }
 
 /* e.g. search buttons followed by count of matches on SK screen */
-.crm-search-display .form-inline {
+.crm-search-display .form-inline:not(th,td) {
   padding: var(--crm-padding-reg) 0;
   display: flex;
   flex-wrap: wrap;
@@ -667,4 +667,5 @@ ul.crm-quickSearch-results a:active {
   0% { transform: translateY(-50%); }
   100% { transform: translateY(-50%) rotateZ(360deg); }
 }
+
 

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -35,7 +35,7 @@ html.cms-standalone body {
 .crm-container details>summary::before /* accordion8 (recommended) */,
 .crm-container .crm-accordion-header::before, /* accordion1, accordion2, accordion6 */
 .crm-container .crm-collapsible .collapsible-title::before /* accordion3 */ {
-  content: "";
+  --crm-expand-icon: '';
   border: .4rem solid transparent;
   border-left-color: var(--crm-expand-icon-color);
   position: absolute;
@@ -44,6 +44,10 @@ html.cms-standalone body {
   transform: rotate(0);
   transform-origin: .2rem 50%;
   transition: transform .25s ease;
+}
+/* fight the fixes.css */
+.crm-container .civicrm-community-messages .collapsible-title::before {
+  transform-origin: .2rem 50% !important;
 }
 /* we have to sort of re-state these rules because the specificity of the above overrules the 'open' state
  * note that a lot of non-recommended patterns use .collapsed, whereas details uses [open] - reverse logic.

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -394,48 +394,6 @@ div:has(> table .dropdown-toggle[aria-expanded="true"]) {
   padding-bottom: 20rem;
 }
 
-/* ...and adjust the individual row checkboxes to be in line
- * Ah, no we have no way to target these.
- * Would be nice if core markup identified this type of <td>
- */
-
-/* apply hanging indent to sorting buttons */
-.crm-container tr a.sorting,
-.crm-container tr a.sorting_asc,
-.crm-container tr a.sorting_desc,
-.crm-container table.dataTable thead th.sorting,
-.crm-container table.dataTable thead th.sorting_asc,
-.crm-container table.dataTable thead th.sorting_desc,
-.crm-search-display th.crm-sortable-col {
-  padding-left: calc(var(--crm-table-padding, 0) + 1ch);
-}
-.crm-container tr a.sorting::after,
-.crm-container tr a.sorting_asc::after,
-.crm-container tr a.sorting_desc::after,
-.crm-container table.dataTable thead th.sorting::after,
-.crm-container table.dataTable thead th.sorting_asc::after,
-.crm-container table.dataTable thead th.sorting_desc::after,
-.crm-search-display th.crm-sortable-col::after,
-.crm-container tr a.sorting::before,
-.crm-container tr a.sorting_asc::before,
-.crm-container tr a.sorting_desc::before,
-.crm-container table.dataTable thead th.sorting::before,
-.crm-container table.dataTable thead th.sorting_asc::before,
-.crm-container table.dataTable thead th.sorting_desc::before,
-.crm-search-display th.crm-sortable-col::before {
-  position: absolute;
-  margin-left: -1em;
-}
-
-/* ...and in searchkit, this is terribly awkward and could be fixed with a core PR to provide more classes */
-.crm-container .table > thead > tr > th:has(.crm-search-table-column-sort-icon) {
-  padding-left: 1.5ch;
-}
-.crm-search-display-table > table.table > thead > tr > th i.crm-search-table-column-sort-icon {
-  position: absolute;
-  margin-left: -1.5ch;
-}
-
 /* Advanced search: override searchForm.css for slightly better aligned fields */
 .advanced-search-fields {
   align-items: end;

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -49,6 +49,11 @@ html.cms-standalone body {
 .crm-container .civicrm-community-messages .collapsible-title::before {
   transform-origin: .2rem 50% !important;
 }
+/* advanced search */
+.crm-container details.crm-accordion-settings summary::before {
+  content:'';
+}
+
 /* we have to sort of re-state these rules because the specificity of the above overrules the 'open' state
  * note that a lot of non-recommended patterns use .collapsed, whereas details uses [open] - reverse logic.
  * This covers accordion1, accordion2, accordion6.

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -645,3 +645,60 @@ ul.crm-quickSearch-results .ui-state-active a /* mouse,keyboard nav */ {
 ul.crm-quickSearch-results a:active {
   background: white;
 }
+
+
+/* ajax status/saving notifications */
+.crm-status-box-msg {
+  color: white;
+}
+
+.crm-status-box-outer {
+  position: fixed;
+  top: 2px;
+  right: 2px;
+  z-index: 100000;
+  background-image:none;
+  background-color: var(--crm-c-blue-dark);
+  padding: 0 1rem;
+  border-radius: 3px;
+  min-width: 8rem;
+  max-width: 13rem;
+  text-align: left;
+  --crm-c-background2: transparent;
+
+  .crm-status-box-msg {
+    color: white;
+  }
+
+  &.status-success {
+    background-color: var(--crm-c-green-dark);
+  }
+
+  &.status-error {
+    background-color: var(--crm-c-red-dark);
+  }
+}
+.crm-status-box-outer.status-start .crm-status-box-inner {
+  padding-left: 2.5ch;
+}
+.crm-status-box-outer.status-start .crm-status-box-inner::before {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: -2.5ch;
+  display: block;
+  content: '';
+  line-height: 1;
+  animation: loading-status-message 1s infinite;
+  transform-origin: center;
+  width: 1.5ch;
+  height: 1.5ch;
+  border: dashed 1px white;
+  border-radius: 2ch;
+}
+
+@keyframes loading-status-message {
+  0% { transform: translateY(-50%); }
+  100% { transform: translateY(-50%) rotateZ(360deg); }
+}
+

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -53,6 +53,14 @@ html.cms-standalone body {
 .crm-container details.crm-accordion-settings summary::before {
   content:'';
 }
+/* extensions */
+.crm-container #extensions-main table.dataTable summary,
+.crm-container #extensions-addnew table.dataTable summary {
+  padding: 0 0 0 2rem !important;
+}
+.crm-container #extensions-main  details {
+  border: none;
+}
 
 /* we have to sort of re-state these rules because the specificity of the above overrules the 'open' state
  * note that a lot of non-recommended patterns use .collapsed, whereas details uses [open] - reverse logic.

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -51,7 +51,7 @@ html.cms-standalone body {
 }
 /* advanced search */
 .crm-container details.crm-accordion-settings summary::before {
-  content:'';
+  content: '';
 }
 /* extensions */
 .crm-container #extensions-main table.dataTable summary,
@@ -161,7 +161,9 @@ html.cms-standalone body {
 .crm-container a.button.delete:hover {
   color: var(--crm-c-red-bright);
 }
-.crm-icon-picker-button { float:none; }
+.crm-icon-picker-button {
+  float: none;
+}
 .crm-container .ui-button:not(.ui-button-icon-only).crm-icon-picker-button {
   display: inline-flex;
 }
@@ -636,7 +638,7 @@ ul.crm-quickSearch-results a:active {
   top: 2px;
   right: 2px;
   z-index: 100000;
-  background-image:none;
+  background-image: none;
   background-color: var(--crm-c-blue-dark);
   padding: 0 1rem;
   border-radius: 3px;
@@ -677,8 +679,10 @@ ul.crm-quickSearch-results a:active {
 }
 
 @keyframes loading-status-message {
-  0% { transform: translateY(-50%); }
-  100% { transform: translateY(-50%) rotateZ(360deg); }
+  0% {
+    transform: translateY(-50%);
+  }
+  100% {
+    transform: translateY(-50%) rotateZ(360deg);
+  }
 }
-
-

--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -148,6 +148,10 @@ html.cms-standalone body {
 .crm-container a.button.delete:hover {
   color: var(--crm-c-red-bright);
 }
+.crm-icon-picker-button { float:none; }
+.crm-container .ui-button:not(.ui-button-icon-only).crm-icon-picker-button {
+  display: inline-flex;
+}
 
 /* DIALOGS */
 


### PR DESCRIPTION
Overview
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/5761

Most of these issues were with Thames, one or two were with RiverLea core.

RL core: Fix Mosaico nav pills previousy unreadable on hover:

![image](https://github.com/user-attachments/assets/0f3ab3cc-637f-493a-bc07-f0ec64ebc668)

Thames: fix community messages

![image](https://github.com/user-attachments/assets/62eebdd4-d7ee-4f3b-b52a-dc4469aaf291)

Thames: fix icon picker alignment

![image](https://github.com/user-attachments/assets/4254757c-af0c-489f-ba98-948cbb10b16d)

Thames: **remove** attempt to nicely do a hanging indent on table headers with sort icons.

Thames: Fix unable to read the temporary ajax notifications top right  "saving..."

![image](https://github.com/user-attachments/assets/6c001ce5-3521-49e1-b630-debb4f77cdc8)


I think this closes https://lab.civicrm.org/dev/core/-/issues/5761 

I'm also doing a PR to themetest to include some of these.

@vingle 