### PR TITLE
Redirect skip postprocess hook, replaced it with replaceUserContext

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -275,7 +275,8 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
       CRM_Core_Session::setStatus($msg, ts('Warning: Update Greeting job enabled'), 'alert');
     }
 
-    CRM_Utils_System::redirect($redirectUrl);
+    $session = CRM_Core_Session::singleton();
+    $session->replaceUserContext($redirectUrl);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The fix is done here: https://github.com/civicrm/civicrm-core/pull/30381. Skip the postprocess hook.

In the custom extension, we have additional changes on job form submit; however, we noticed that the redirect function is not allowing us to call the `hook_civicrm_postProcess` hook.

Replacing the `redirect` with the `replaceUserContext` function allows the `postprocess` hook to get called.

Before
----------------------------------------

`hook_civicrm_postProcess` not getting called.

After
----------------------------------------

`hook_civicrm_postProcess` gets called.

