### PR TITLE
Fix UserJob templates to load without optional keys

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -288,7 +288,7 @@ abstract class CRM_Import_DataSource implements DataSourceInterface {
    */
   public function getDataSourceMetadata(): array {
     if (!$this->dataSourceMetadata && $this->getUserJobID()) {
-      $this->dataSourceMetadata = $this->getUserJob()['metadata']['DataSource'];
+      $this->dataSourceMetadata = $this->getUserJob()['metadata']['DataSource'] ?? [];
     }
 
     return $this->dataSourceMetadata;

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -98,7 +98,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   protected function getUserJobSubmittedValues(): array {
-    return $this->getUserJob()['metadata']['submitted_values'];
+    return $this->getUserJob()['metadata']['submitted_values'] ?? [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Where import Mappings were created prior to 6.2 with CiviImport disabled the upgrade to Civiimport created user jobs - however, these jobs do not have all the keys in them that a normal one would - the missing keys should reasonably be optional - notably here the contact type is not present because the 'Mapping' does not 'know' it - but the Parser should still load

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/a38b2b11-fb60-48f4-8295-a6cc0a724ec6)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/cf58236d-df9c-4b6f-ad7f-a469a8898a3a)


Technical Details
----------------------------------------
This is a subset of https://github.com/civicrm/civicrm-core/pull/33049

Comments
----------------------------------------