### PR TITLE
Update _form.css to make snooze date easy to view

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -771,7 +771,7 @@ input.crm-form-checkbox) + label {
   margin: 0 var(--crm-m1);
   padding-left: 5px !important;
   font-size: var(--crm-m3);
-  width: 7ch;
+  width: 9ch;
 }
 .ui-datepicker-calendar thead tr {
   border-top: 1px solid var(--crm-c-gray-300);


### PR DESCRIPTION
https://phabricator.wikimedia.org/T397251

Overview
----------------------------------------
The [snooze page](/civicrm/email-snooze) has changed with the latest Civi update. Currently, the date picker only opens if you click on a very specific spot beneath the email field, which is hard to find. Additionally, once it opens, the calendar does not display the year, making it difficult to confirm the correct date. Please see the screenshots below for reference:

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/4cac7ec7-3b2e-4256-b6b0-287bd48e1021)
![image](https://github.com/user-attachments/assets/0bcd8e93-a799-47d2-b432-47e1f6b1c7dd)

After
----------------------------------------
![Screenshot 2025-06-24 at 9 35 59 AM](https://github.com/user-attachments/assets/db4b0c85-bf2b-4e3d-9afe-4b8cda4b5942)

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
