### PR TITLE
RiverLea: add fallback font-family and size for iframes

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -169,6 +169,13 @@ body {
   color: var(--crm-c-text);
 }
 
+/* iFrame */
+
+body.civicrm-iframe-page {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 100%;
+}
+
 /* Core type */
 
 .crm-container strong,


### PR DESCRIPTION
Overview
----------------------------------------
If a RiverLea stream sets a font then Civi iFrames using RiverLea will render in that font. However Minetta doesn't set a font - it inherits the parent CMS font, same as Greenwich. In Standalone - where there's no parent CMS - this defaulted to browser defaults, ie Times New Roman / serif. That was fixed by calling system sans-serif fonts, ensuring there's no Times/serif in Standalone.

This PR applies the same idea to iframes where the Stream hasn't set a font. It also resets the font-size to 100%, which should be 100% of the browser font-size default, normally 16px.

Follows discussion [here](https://chat.civicrm.org/civicrm/pl/mkpn6stmcff5i8hk7fh3nobhya).

Before
----------------------------------------
/iframe.php/civicrm/contribute/transact?reset=1&id=1 renders as:

![image](https://github.com/user-attachments/assets/707c9870-9fdc-4bca-96c5-587247f29604)

After
----------------------------------------
It looks like:

![image](https://github.com/user-attachments/assets/3b3b1259-37f5-4159-bd39-b572ffe7f287)

Other stream iframes remain the same, loading their font

![image](https://github.com/user-attachments/assets/53e9b4bd-3374-44b7-923f-eadf4391923f)
![image](https://github.com/user-attachments/assets/92c70112-3a3f-4363-bc94-87332a1f2d23)

Comments
----------------------------------------
Testing this requires the iframe extension - enabled via API3. Then iframe.php needs generating. Then `iframe` can be inserted into paths.