### PR TITLE
distmaker - Fix typo that prevents Joomla 5 builds

### DIFF
--- a/distmaker/distmaker.sh
+++ b/distmaker/distmaker.sh
@@ -218,7 +218,7 @@ case $1 in
   BPACK=1
   D7PACK=1
   J4PACK=1
-  J5BCPACK=1
+  J5PACKBC=1
   WPPACK=1
   PATCHPACK=1
   STANDALONEPACK=1
@@ -324,7 +324,7 @@ if [ "$REPOREPORT" = 1 ]; then
     D7PACK="$D7PACK" \
     D7DIR="$D7DIR" \
     J4PACK="$J4PACK" \
-    J5BCPACK="$J5BCPACK" \
+    J5PACKBC="$J5PACKBC" \
     WPPACK="$WPPACK" \
     STANDALONEPACK="$STANDALONEPACK" \
     bash $P/dists/repo-report.sh

--- a/distmaker/dists/repo-report.sh
+++ b/distmaker/dists/repo-report.sh
@@ -31,7 +31,7 @@ env \
   D7DIR="$D7DIR" \
   SKPACK="$SKPACK" \
   J4PACK="$J4PACK" \
-  J5BCPACK="$J5BCPACK" \
+  J5PACKBC="$J5PACKBC" \
   WPPACK="$WPPACK" \
   php "$DM_SOURCEDIR/distmaker/utils/repo-report.php" \
   > "$REPORT"


### PR DESCRIPTION
Overview
----------

Fix a bug in `distmaker.sh` where Joomla 5 only builds _sometimes_.

ping @seamuslee001 

Before
-------

If you look in the code for `distmaker.sh`, it uses two different variables which look identical (J5PACKBC and J5BCPACK) and serve the same purpose -- determining whether to make the Joomla 5 zipfile. But they're actually different... and it only generates the zipfile if you set the right variable.

| Use Case | Command | Comment |
| -- | -- | -- |
| Generate Joomla 5 by itself | `distmaker.sh j5bc` | Sets `J5PACKBC=1` and works |
| Generate all releases | `distmaker.sh all` |  Sets `J5BCPACK=1` and does not work |

After
-----

Both modes use the same variable (`J5PACKBC`). Both modes work.