### PR TITLE
Move contact type to MapField, permit id-only match

### DIFF
--- a/CRM/Contribute/Import/Form/DataSource.php
+++ b/CRM/Contribute/Import/Form/DataSource.php
@@ -39,7 +39,6 @@ class CRM_Contribute_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_SKIP => ts('Insert new contributions'),
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing contributions'),
     ]);
-    $this->addContactTypeSelector();
   }
 
   /**

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -342,7 +342,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDedupeRule($this->getContactType())['name'],
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',
@@ -360,7 +360,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
           'contact_type' => 'Individual',
           'soft_credit_type_id' => $defaultSoftCreditTypeID,
           'action' => 'ignore',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'ignore',
         'entity_name' => 'SoftCreditContact',

--- a/CRM/Custom/Import/Form/DataSource.php
+++ b/CRM/Custom/Import/Form/DataSource.php
@@ -110,7 +110,6 @@ class CRM_Custom_Import_Form_DataSource extends CRM_Import_Form_DataSource {
   public function buildQuickForm(): void {
     parent::buildQuickForm();
     $this->add('select', 'multipleCustomData', ts('Multi-value Custom Data'), ['' => ts('- select -')] + $this->getCustomGroups(), TRUE);
-    $this->addContactTypeSelector();
   }
 
   /**

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -63,7 +63,7 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
         'selected' => [
           'action' => 'select',
           'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDedupeRule($this->getContactType())['name'],
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/CRM/Event/Import/Form/DataSource.php
+++ b/CRM/Event/Import/Form/DataSource.php
@@ -42,8 +42,6 @@ class CRM_Event_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update'),
       CRM_Import_Parser::DUPLICATE_NOCHECK => ts('No Duplicate Checking'),
     ]);
-
-    $this->addContactTypeSelector();
   }
 
   /**

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -85,7 +85,7 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDedupeRule($this->getContactType())['name'],
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -172,28 +172,6 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
   }
 
   /**
-   * A long-winded way to add one radio element to the form.
-   */
-  protected function addContactTypeSelector() {
-    //contact types option
-    $contactTypeOptions = [];
-    if (CRM_Contact_BAO_ContactType::isActive('Individual')) {
-      $contactTypeOptions['Individual'] = ts('Individual');
-    }
-    if (CRM_Contact_BAO_ContactType::isActive('Household')) {
-      $contactTypeOptions['Household'] = ts('Household');
-    }
-    if (CRM_Contact_BAO_ContactType::isActive('Organization')) {
-      $contactTypeOptions['Organization'] = ts('Organization');
-    }
-    $this->addRadio('contactType', ts('Contact Type'), $contactTypeOptions);
-
-    $this->setDefaults([
-      'contactType' => 'Individual',
-    ]);
-  }
-
-  /**
    * Store form values.
    *
    * @param array $names

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -392,12 +392,12 @@ class CRM_Import_Forms extends CRM_Core_Form {
   /**
    * Get the contact type selected for the import (on the datasource form).
    *
-   * @return string
+   * @return string|null
    *   e.g Individual, Organization, Household.
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getContactType(): string {
+  protected function getContactType(): ?string {
     return $this->getSubmittedValue('contactType') ?? $this->getUserJob()['metadata']['entity_configuration']['Contact']['contact_type'];
   }
 

--- a/CRM/Member/Import/Form/DataSource.php
+++ b/CRM/Member/Import/Form/DataSource.php
@@ -41,8 +41,6 @@ class CRM_Member_Import_Form_DataSource extends CRM_Import_Form_DataSource {
       CRM_Import_Parser::DUPLICATE_SKIP => ts('Insert new Membership'),
       CRM_Import_Parser::DUPLICATE_UPDATE => ts('Update existing Membership'),
     ]);
-
-    $this->addContactTypeSelector();
   }
 
   /**

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -86,7 +86,7 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDedupeRule($this->getContactType())['name'],
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -51,7 +51,7 @@
             }
 
             entityMetadata.dedupe_rules = [];
-            if (Boolean(entityMetadata.selected) && Boolean(selected.contact_type)) {
+            if (Boolean(entityMetadata.selected)) {
               entityMetadata.dedupe_rules = $scope.getDedupeRules(selected.contact_type);
             }
 
@@ -205,6 +205,9 @@
         $scope.getDedupeRules = function (selectedEntity) {
           var dedupeRules = [];
           _.each($scope.data.dedupeRules, function (rule) {
+            if (selectedEntity === '') {
+              selectedEntity = null;
+            }
             if (rule.contact_type === selectedEntity) {
               dedupeRules.push({'id': rule.name, 'text': rule.title, 'is_default': rule.used === 'Unsupervised'});
             }

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -38,7 +38,7 @@
             <label ng-if="entity.is_contact && entity.selected.action !== 'ignore'">
               {{:: ts('Contact type') }}
               <input  class="big" ng-change="updateContactType(entity)"
-                crm-ui-select='{data: data.contactTypes, allowClear: false}' ng-model="entity.selected.contact_type" />
+                crm-ui-select='{data: data.contactTypes, allowClear: true, placeholder: ts("Any type")}' ng-model="entity.selected.contact_type" />
             </label>
           </div>
         </div>
@@ -46,7 +46,7 @@
       <div class="crm-grid-cell">
         <div>
           <div>
-            <label ng-if="entity.is_contact && entity.selected.action !== 'ignore' && entity.selected.contact_type">
+            <label ng-if="entity.is_contact && entity.selected.action !== 'ignore'">
               {{:: ts('Dedupe rule') }}  <input class="big" crm-ui-select='{data: getDedupeRule}' ng-model="entity.selected.dedupe_rule" />
             </label>
           </div>

--- a/tests/phpunit/CRM/Import/DataSource/FormsTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/FormsTest.php
@@ -39,7 +39,6 @@ class CRM_Import_FormsTest extends CiviUnitTestCase {
     $form->buildForm();
     $defaults = $this->getFormDefaults($form);
     // These next 2 fields should be loaded as defaults from the UserJob template.
-    $this->assertEquals('Organization', $defaults['contactType']);
     $this->assertEquals([$mapping['id']], $defaults['savedMapping']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Make it possible to import contributions to any contact type if you have the contact ID or external identifier




Before
----------------------------------------
The contact type is required on the datasource form - this means that if you actually have the contact ID you still need to do separate imports for Individuals and Organizations. The field is required on the datasource form, even though it is also present on the MapField screen

![image](https://github.com/user-attachments/assets/4d4c88ee-f7d8-44b7-9225-a67e47f7f5d7)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/4ca9a1c8-401f-44cb-835a-fa01d322b188)


Technical Details
----------------------------------------

Comments
----------------------------------------
