### PR TITLE
(NFC) Riverlea - Fix linting issue in _form.css

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -232,7 +232,7 @@ select.crm-error {
 .crm-container .twelve,
 .crm-container .medium,
 .crm-container input.twelve,
-.crm-container input.medium  {
+.crm-container input.medium {
   width: 12em;
 }
 .crm-container .twenty {


### PR DESCRIPTION
Overview
----------------------------------------
fix style error where @seamuslee001 found in pr https://github.com/civicrm/civicrm-core/pull/33051

Before
----------------------------------------
    ===========================[ Identify Files ]===========================
    CSS Files:
     * ext/riverlea/core/css/components/_form.css
    =============================[ phpcs (css) ]============================
    
    FILE: ...build/build-4/web/src/ext/riverlea/core/css/components/_form.css
    ----------------------------------------------------------------------
    FOUND 1 ERROR AFFECTING 1 LINE
    ----------------------------------------------------------------------
     235 | ERROR | [x] Expected 1 space before opening brace of class
         |       |     definition; 2 found
    ----------------------------------------------------------------------
    PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
    ----------------------------------------------------------------------
    
    Time: 101ms; Memory: 14MB

After
----------------------------------------
removed extra space 

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
