### PR TITLE
Update AdvancedCriteria.tpl to default open search setting open

### DIFF
--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -86,7 +86,7 @@ CRM.$(function($) {
 {/if}
 
 {strip}
-  <details class="crm-accordion-settings crm-search_criteria_basic-accordion">
+  <details class="crm-accordion-settings crm-search_criteria_basic-accordion" open>
     <summary>
       {ts}Search Settings{/ts}
     </summary>


### PR DESCRIPTION
Overview
----------------------------------------
Update the default of search setting to open as requested https://phabricator.wikimedia.org/T397342
related with this issue https://lab.civicrm.org/dev/user-interface/-/issues/82

Before
----------------------------------------
default the search setting is closed
![Screenshot 2025-06-24 at 8 25 34 PM](https://github.com/user-attachments/assets/bb4e68c3-d984-49b0-b886-b5be6a4be332)

After
----------------------------------------
![Screenshot 2025-06-24 at 8 25 38 PM](https://github.com/user-attachments/assets/c79ae18c-ffca-48ac-92e8-13aeeb29023f)


Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
