### PR TITLE
dev/core#5967: show name in contributions for ParticipantViews

### DIFF
--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -40,8 +40,8 @@
           {if $context eq 'Search'}
             {assign var=cbName value=$row.checkbox}
             <td>{$form.$cbName.html}</td>
+            <td>{$row.contact_type}</td>
           {/if}
-          <td>{$row.contact_type}</td>
           <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
         {/if}
         <td class="crm-contribution-amount">

--- a/templates/CRM/Contribute/Form/Selector.tpl
+++ b/templates/CRM/Contribute/Form/Selector.tpl
@@ -14,6 +14,7 @@
   <table class="selector row-highlight">
     <thead class="sticky">
     <tr>
+      <th scope="col"></th>
       {if !$single and $context eq 'Search'}
         <th scope="col" title="{ts escape='htmlattribute'}Select rows{/ts}">{$form.toggleSelect.html}</th>
       {/if}
@@ -36,18 +37,17 @@
     {counter start=0 skip=1 print=false}
     {foreach from=$rows item=row}
       <tr id="rowid{$row.contribution_id}" class="{cycle values="odd-row,even-row"} {if $row.contribution_cancel_date} cancelled{/if} crm-contribution_{$row.contribution_id}">
+        <td><a class="nowrap bold crm-expand-row" title="{ts escape='htmlattribute'}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}"></a></td>
         {if !$single}
           {if $context eq 'Search'}
             {assign var=cbName value=$row.checkbox}
             <td>{$form.$cbName.html}</td>
-            <td>{$row.contact_type}</td>
           {/if}
+          <td>{$row.contact_type}</td>
           <td><a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.sort_name}</a></td>
         {/if}
         <td class="crm-contribution-amount">
-             <a class="nowrap bold crm-expand-row" title="{ts escape='htmlattribute'}view payments{/ts}" href="{crmURL p='civicrm/payment' q="view=transaction&component=contribution&action=browse&cid=`$row.contact_id`&id=`$row.contribution_id`&selector=1"}">
-               &nbsp; {$row.total_amount|crmMoney:$row.currency}
-            </a>
+               {$row.total_amount|crmMoney:$row.currency}
           {if $row.amount_level}<br/>({$row.amount_level}){/if}
           {if $row.contribution_recur_id && $row.is_template}
             <br/>{ts}(Recurring Template){/ts}

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -122,7 +122,7 @@
       {/if}
 
       {if $action eq 2 and $accessContribution and array_key_exists(0, $rows) &&  $rows.0.contribution_id}
-      {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
+      {include file="CRM/Contribute/Form/Selector.tpl" context="dashboard" single=false}
       {/if}
 
       <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -115,7 +115,7 @@
     {/if}
     {include file="CRM/Custom/Page/CustomDataView.tpl"}
     {if $accessContribution and array_key_exists(0, $rows) and $rows.0.contribution_id}
-        {include file="CRM/Contribute/Form/Selector.tpl" context="Search" single=false}
+        {include file="CRM/Contribute/Form/Selector.tpl" context="dashboard" single=false}
     {/if}
     <div class="crm-submit-buttons">
       {crmPermission has='edit event participants'}

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -115,7 +115,7 @@
     {/if}
     {include file="CRM/Custom/Page/CustomDataView.tpl"}
     {if $accessContribution and array_key_exists(0, $rows) and $rows.0.contribution_id}
-        {include file="CRM/Contribute/Form/Selector.tpl" context="Search" single=true}
+        {include file="CRM/Contribute/Form/Selector.tpl" context="Search" single=false}
     {/if}
     <div class="crm-submit-buttons">
       {crmPermission has='edit event participants'}


### PR DESCRIPTION
Overview
----------------------------------------
Fills in the Name column of the Contribution information for event fees when viewing the Participant details.

Before
----------------------------------------
The name is not filled in and as a result the other columns are shifted left with respect to their headers
![image](https://github.com/user-attachments/assets/d719c519-901d-4923-bbbc-06f5d987ed3b)

After
----------------------------------------
The name is now filled in and the headers align with the content
![image](https://github.com/user-attachments/assets/e45e574f-66f2-478b-853d-1f8a4a9ca5f5)

Technical Details
----------------------------------------
This PR solves the issue by setting the `single` variable of the Contribute Selector template to false. However, it's not clear that this is the ideal way of doing this long-term. `single` should really just be used to determine whether the search should display results from a single contact. We could extract whether the form should display the name into a separate variable and in doing so decouple that logic. However, this would require a much more significant refactoring.
