### PR TITLE
api_v3_SystemTest - Fix for newer MySQL and MariaDB versions

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -829,9 +829,9 @@ MODIFY      {$columnName} varchar( $length )
    * @return bool
    */
   public static function migrateUtf8mb4($revert = FALSE, $patterns = [], $databaseList = NULL) {
-    $newCharSet = $revert ? 'utf8' : 'utf8mb4';
-    $newCollation = $revert ? 'utf8_unicode_ci' : 'utf8mb4_unicode_ci';
-    $newBinaryCollation = $revert ? 'utf8_bin' : 'utf8mb4_bin';
+    $newCharSet = $revert ? 'utf8mb3' : 'utf8mb4';
+    $newCollation = $revert ? 'utf8mb3_unicode_ci' : 'utf8mb4_unicode_ci';
+    $newBinaryCollation = $revert ? 'utf8mb3_bin' : 'utf8mb4_bin';
     $tables = [];
     $dao = new CRM_Core_DAO();
     $databases = $databaseList ?? [$dao->_database];

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -95,9 +95,8 @@ class api_v3_SystemTest extends CiviUnitTestCase {
       $this->callAPISuccess('System', 'utf8conversion', ['is_revert' => 1]);
       $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');
       $table->fetch();
-      $version = CRM_Utils_SQL::getDatabaseVersion();
-      $charset = (version_compare($version, '8', '>=') && stripos($version, 'mariadb') === FALSE) ? 'utf8mb3' : 'utf8';
-      $this->assertStringEndsWith('DEFAULT CHARSET=' . $charset . ' COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC', $table->Create_Table);
+      // "utf8" are "utf8mb3" synonymous, but the canonical form gets flipfloppy depending on the specific versions of MySQL/MariaDB.
+      $this->assertMatchesRegularExpression(';DEFAULT CHARSET=utf8(mb3)? COLLATE=utf8(mb3)?_unicode_ci ROW_FORMAT=DYNAMIC;', $table->Create_Table);
     }
     else {
       $this->markTestSkipped('MySQL Version does not support ut8mb4 testing');


### PR DESCRIPTION
Overview
----------------------------------------

Update the test-case to fix failures on `edge-sql` (i.e. newer versions of MySQL; [example](https://test.civicrm.org/job/CiviCRM-Test-QLow/177861/testReport/(root)/api_v3_SystemTest/testSystemUTFMB8Conversion/)).

Before and After
----------------------------------------

Since the versions of MySQL and MariaDB are it issue, I did a local/targeted run-through with several versions of MySQL and MariaDB.

| Profile       | Before        | After
|---------------|---------------|--------------
| `php83m57`    | PASS          | PASS
| `php83m80`    | PASS          | PASS
| `php83m84`    | FAIL          | PASS
| `php83m90`    | FAIL          | PASS
| `php83m93`    | FAIL          | PASS
| `php83r106`   | FAIL          | PASS
| `php83r1011`  | FAIL          | PASS

Technical Details
----------------------------------------

The underlying issue is that MySQL's `utf8` is a synonym for `utf8mb3`. (Of course, `utf8mb4` proved to be more useful -- which is why Civi has a helper and test-case for converting.) However, once you have aliasing, then there will be some questions about _canonical_ form. (*What expression is literally stored in the metadata? How is it reported back upon inspection?*) And this behavior seems to vary for (a) charsets vs collations and (b) different versions of MySQL/MariaDB. 
