### PR TITLE
dev/core#5937 Modify the EntityV2 Options to allow for differential o…

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2993,7 +2993,7 @@ SELECT contact_id
     }
     $checkPermissions = (bool) ($values['check_permissions'] ?? ($context == 'create' || $context == 'search'));
     $includeDisabled = ($context == 'validate' || $context == 'get');
-    $options = $entity->getOptions($fieldName, $values, $includeDisabled, $checkPermissions);
+    $options = $entity->getOptions($fieldName, $values, $includeDisabled, $checkPermissions, NULL, ($context == 'get' || $context === 'search'));
     return $options ? CRM_Core_PseudoConstant::formatArrayOptions($context, $options) : $options;
   }
 

--- a/Civi/Schema/Entity/AddressMetadata.php
+++ b/Civi/Schema/Entity/AddressMetadata.php
@@ -15,8 +15,8 @@ use Civi\Schema\SqlEntityMetadata;
 
 class AddressMetadata extends SqlEntityMetadata {
 
-  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL): ?array {
-    $options = parent::getOptions($fieldName, $values, $includeDisabled, $checkPermissions, $userId);
+  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array {
+    $options = parent::getOptions($fieldName, $values, $includeDisabled, $checkPermissions, $userId, $isView);
     if ($fieldName == 'country_id') {
       // The general idea is call the function that does all the stuff, but it
       // wants a different format, so we convert, then merge back in the

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -42,7 +42,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     return $field;
   }
 
-  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL): ?array {
+  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array {
     $field = $this->getField($fieldName);
     $options = NULL;
     $hookParams = [
@@ -52,6 +52,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
       'include_disabled' => $includeDisabled,
       'check_permissions' => $checkPermissions,
       'user_id' => $userId,
+      'is_view' => $isView,
     ];
     $field['pseudoconstant']['condition'] = (array) ($field['pseudoconstant']['condition'] ?? []);
     if (!empty($field['pseudoconstant']['condition_provider'])) {

--- a/Civi/Schema/EntityMetadataInterface.php
+++ b/Civi/Schema/EntityMetadataInterface.php
@@ -21,6 +21,6 @@ interface EntityMetadataInterface {
 
   public function getField(string $fieldName): ?array;
 
-  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL): ?array;
+  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array;
 
 }

--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -78,8 +78,8 @@ final class EntityProvider {
     return $this->getMetaProvider()->getField($fieldName);
   }
 
-  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL): ?array {
-    return $this->getMetaProvider()->getOptions($fieldName, $values, $includeDisabled, $checkPermissions, $userId);
+  public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array {
+    return $this->getMetaProvider()->getOptions($fieldName, $values, $includeDisabled, $checkPermissions, $userId, $isView);
   }
 
   public function writeRecords(array $records): array {

--- a/ext/financialacls/financialacls.php
+++ b/ext/financialacls/financialacls.php
@@ -414,7 +414,7 @@ function financialacls_civicrm_fieldOptions($entity, $field, &$options, $params)
         CRM_Core_Action::ADD => 'add',
         CRM_Core_Action::DELETE => 'delete',
       ];
-      $action = $context === 'search' ? CRM_Core_Action::VIEW : CRM_Core_Action::ADD;
+      $action = ($context === 'search' || $params['is_view']) ? CRM_Core_Action::VIEW : CRM_Core_Action::ADD;
       $cacheKey = 'available_types_' . $context;
       if (!isset(\Civi::$statics['CRM_Financial_BAO_FinancialType'][$cacheKey])) {
         foreach ($options as $finTypeId => $option) {


### PR DESCRIPTION
…ptions on viewing v adding to fix issue with no options found in Financial Type dropdown

Overview
----------------------------------------
This aims to restore functionality for FinancialType ACLs by adding a boolean varaible onto the new version of the fieldOptions hook process. 

In Financial Type ACLs prior to entity schema v2 there was able to be a differentiation when generatng the Select dropdowns between when you were doing searches and when you were creating contributions for example. With the former allowing financial types where the user had permission to view the financial type and in the latter where they had permission to add the financial type. 

This restores that ability but I'm not sure if its the best way.

Before
----------------------------------------
ACLed user with just CMS permission of 'View Contributions of type donation" cannot search for contributions of type Donation

After
----------------------------------------
They can search for them correctly

Coleman I would appreciate your thoughts in regards to the change in the Entityv2 stuff

ping @andyburnsco @colemanw @eileenmcnaughton 