### PR TITLE
Avoid PHP Deprecated warning when image URL has no query vars

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -973,7 +973,7 @@ HTACCESS;
   public static function getImageURL($imageURL) {
     // retrieve image name from $imageURL
     $imageURL = CRM_Utils_String::unstupifyUrl($imageURL);
-    parse_str(parse_url($imageURL, PHP_URL_QUERY), $query);
+    parse_str(parse_url($imageURL, PHP_URL_QUERY) ?? '', $query);
 
     $url = NULL;
     if (!empty($query['photo'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Avoid PHP Deprecated warning when Contact Image URL has no query vars, e.g.

```
https://example.org/path/to/contact-image.jpg
```

Before
----------------------------------------
PHP warnings, e.g.

```
PHP Deprecated:  parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in ...
```

After
----------------------------------------
No PHP warnings.