### PR TITLE
(dev/core#5814) Email - Use standards-compliant line-wrapping

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -393,7 +393,7 @@ class CRM_Utils_Mail {
     }
 
     require_once 'Mail/mime.php';
-    $msg = new Mail_mime("\n");
+    $msg = new Mail_mime();
     if ($textMessage) {
       $msg->setTxtBody($textMessage);
     }

--- a/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
@@ -48,7 +48,7 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CiviUnitTestCase {
       'MIME-Version: 1.0',
       'From: "Bob" <bob@example.org>',
       'To: Anthony Anderson <anthony_anderson@civicrm.org>',
-      "Subject: Recurring Contribution Cancellation Notification - Mr. Anthony\n Anderson II",
+      "Subject: Recurring Contribution Cancellation Notification - Mr. Anthony\r\n Anderson II",
       'Return-Path: bob@example.org',
       'Dear Anthony,',
       'Your recurring contribution of $10.00, every 1 month has been cancelled as requested',


### PR DESCRIPTION
Overview
----------------------------------------

As identified in https://lab.civicrm.org/dev/core/-/issues/5814, there is a subtle discrepancy between (a) how CiviCRM formats outbound emails and (b) the specification in RFC-2822 (*et al*), which likely affects compatibility in various email-agents. This patch should improve conformance/compatibility.

It seems that many systems are likely to tolerate this discrepancy, but (in the case of dev/core#5814) it can lead to rejections.

_Note_: The actual symptoms are likely to vary. When faced with a non-conformant message, each email-agent defines its own behavior. (*Some may reject the message; some may accept it, with varying interpretations.*) To fully understand the symptoms, you would need to know the specific chain of email-agents (`/usr/sbin/sendmail` vs `SMTP`; Postfix vs Exim; Outlook vs Gmail; etc). Unfortunately, the error-reports don't present a full chain.

So we have to do some hand-waiving and say: "Let's be conformant."

Before
----------------------------------------

Emails generated by CiviCRM will _mostly_ use `CR LF` (aka `\r\n`) to indicate new-lines. However, when applying line-wrapping to long email headers (such as `Content-Type:` or `CC:`), it uses bare `LF` (`\n`).

After
----------------------------------------

Emails generated by CiviCRM will use `CR LF` (aka `\r\n`) to indicate new-lines.

Technical Details
----------------------------------------

The old code is surprising. In `Mail_mime`, the [default delimiter](https://github.com/pear/Mail_Mime/blob/1.10.11/Mail/mime.php#L154) is the standards-compliant `\r\n`. This code has been overriding it with the non-compliant `\n`.

Why is it doing that? I traced the history through migrations/cleanups/merges, and this [originates in CiviCRM v2.1 (2008)](https://github.com/civicrm/civicrm-svn/commit/229f879f6361f5709d6d26790d1de32e29dad6ae#diff-3f40c5747bc20e9ade5366ae16d7fd5b8a53bb75cdd5a5072252cc1076b9cbecR156). That points to [CRM-2369](https://issues.civicrm.org/jira/browse/CRM-2369), but the scope is quite broad and doesn't really explain this.

My guess that it stems from a misreading of the purpose of the delimiter. For example, CRM-2369 would have likely put the authors/testers into a headspace of "Let's format the email-body as HTML". In that domain, `\n` would be typical (and the choice wouldn't be scrutinized much because HTML is quite forgiving about whitespace). But on this line, the option doesn't deal with HTML body-format -- it deals with RFC 2822 headers, which are standardized on `\r\n`.
