### PR TITLE
distmaker - Update build-report for Joomla 5

### DIFF
--- a/distmaker/dists/repo-report.sh
+++ b/distmaker/dists/repo-report.sh
@@ -32,6 +32,7 @@ env \
   SKPACK="$SKPACK" \
   J4PACK="$J4PACK" \
   J5PACKBC="$J5PACKBC" \
+  STANDALONEPACK="$STANDALONEPACK" \
   WPPACK="$WPPACK" \
   php "$DM_SOURCEDIR/distmaker/utils/repo-report.php" \
   > "$REPORT"

--- a/distmaker/utils/repo-report.php
+++ b/distmaker/utils/repo-report.php
@@ -55,6 +55,9 @@ if (getenv('J5PACKBC')) {
 if (getenv('D7PACK')) {
   $data['tar']['Drupal'] = "civicrm-$DM_VERSION-drupal.tar.gz";
 }
+if (getenv('STANDALONEPACK')) {
+  $data['tar']['Standalone'] = "civicrm-$DM_VERSION-standalone.tar.gz";
+}
 if (getenv('WPPACK')) {
   $data['tar']['WordPress'] = "civicrm-$DM_VERSION-wordpress.zip";
 }

--- a/distmaker/utils/repo-report.php
+++ b/distmaker/utils/repo-report.php
@@ -44,7 +44,7 @@ $data = array(
 );
 
 if (getenv('BPACK')) {
-  $data['tar']['Backdrop'] = "civicrm-$DM_VERSION-backdrop-unstable.tar.gz";
+  $data['tar']['Backdrop'] = "civicrm-$DM_VERSION-backdrop.tar.gz";
 }
 if (getenv('J4PACK')) {
   $data['tar']['Joomla'] = "civicrm-$DM_VERSION-joomla.zip";

--- a/distmaker/utils/repo-report.php
+++ b/distmaker/utils/repo-report.php
@@ -66,4 +66,4 @@ ksort($data);
 ksort($data['tar']);
 ksort($data['git']);
 $data['rev'] = $DM_VERSION . '-' . md5(json_encode($data));
-echo json_encode($data);
+echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/distmaker/utils/repo-report.php
+++ b/distmaker/utils/repo-report.php
@@ -50,7 +50,7 @@ if (getenv('J4PACK')) {
   $data['tar']['Joomla'] = "civicrm-$DM_VERSION-joomla.zip";
 }
 if (getenv('J5PACKBC')) {
-  $data['tar']['Joomla'] = "civicrm-$DM_VERSION-joomla5bc.zip";
+  $data['tar']['Joomla5BC'] = "civicrm-$DM_VERSION-joomla5bc.zip";
 }
 if (getenv('D7PACK')) {
   $data['tar']['Drupal'] = "civicrm-$DM_VERSION-drupal.tar.gz";


### PR DESCRIPTION
Overview
----------------------------------------

When generating a full set of tar+zip files (`distmaker.sh all`), it generates a report. This fixes some issues in the report.

Specifically, after merging the recent #33053, it revealed a slight regression in the report-generator. Info about Joomla 5's build would overwrite the info about the J4 build. This fix ensures that both are reported.

(cc @seamuslee001)

Before
----------------------------------------

In CiviCRM 4.7 to 6.x (up until #33053), the report had this list of generated artifacts

```javascript
"tar" : {
    "Backdrop" : "civicrm-6.5.alpha1-backdrop-unstable.tar.gz",
    "Drupal" : "civicrm-6.5.alpha1-drupal.tar.gz",
    "Joomla" : "civicrm-6.5.alpha1-joomla.zip",
    "L10n" : "civicrm-6.5.alpha1-l10n.tar.gz",
    "WordPress" : "civicrm-6.5.alpha1-wordpress.zip"
},
```

(*Well, back in 4.7, it also would have reported the `Drupal6` tarball... but nevermind that...*)

After 33053, the `Joomla` section is munged.

```javascript
"tar" : {
    "Backdrop" : "civicrm-6.5.alpha1-backdrop-unstable.tar.gz",
    "Drupal" : "civicrm-6.5.alpha1-drupal.tar.gz",
    "Joomla" : "civicrm-6.5.alpha1-joomla5bc.zip",
    "L10n" : "civicrm-6.5.alpha1-l10n.tar.gz",
    "WordPress" : "civicrm-6.5.alpha1-wordpress.zip"
 },
```

After
--------------------------------------

With the patch, it generates:

```javascript
"tar": {
    "Backdrop": "civicrm-6.5.alpha1-backdrop-unstable.tar.gz",
    "Drupal": "civicrm-6.5.alpha1-drupal.tar.gz",
    "Joomla": "civicrm-6.5.alpha1-joomla.zip",
    "Joomla5BC": "civicrm-6.5.alpha1-joomla5bc.zip",
    "L10n": "civicrm-6.5.alpha1-l10n.tar.gz",
    "Standalone": "civicrm-6.5.alpha1-standalone.tar.gz",
    "WordPress": "civicrm-6.5.alpha1-wordpress.zip"
},
```

Technical Details
--------------------------------------

The before+after both show the relevant excerpt with pretty-printing. In reality, the prior JSON files were not pretty-printed. But now they are. 🖨️ 🖼️ 