### PR TITLE
SearchKit - Add "Any Value" as an operator

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -31,6 +31,7 @@
         'NOT LIKE': ts('Not Like'),
         'IS EMPTY': ts('Is Empty'),
         'IS NOT EMPTY': ts('Not Empty'),
+        'IS NOT NULL': ts('Any Value'),
       };
 
       this.$onInit = function() {
@@ -79,7 +80,7 @@
         var field = ctrl.field || {},
           allowedOps = field.operators;
         if (!allowedOps && field.data_type === 'Boolean') {
-          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT EMPTY'];
+          allowedOps = ['=', '!=', 'IS NOT NULL'];
         }
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -105,6 +105,7 @@ class Admin {
       'NOT BETWEEN' => E::ts('Not Between'),
       'IS EMPTY' => E::ts('Is Empty'),
       'IS NOT EMPTY' => E::ts('Not Empty'),
+      'IS NOT NULL' => E::ts('Any value'),
     ];
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
@@ -86,7 +86,7 @@
         var field = ctrl.field || {},
           allowedOps = field.operators;
         if (!allowedOps && field.data_type === 'Boolean') {
-          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT EMPTY'];
+          allowedOps = ['=', '!=', 'IS NOT NULL'];
         }
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];


### PR DESCRIPTION
Overview
----------------------------------------

Makes it easier to get around the defaults for `is_test` fields.

See [dev/core#5470](https://lab.civicrm.org/dev/core/-/issues/5470)