### PR TITLE
dev/user-interface#82 Implement accordion sticky states for the Advanced Search settings

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1742,7 +1742,23 @@ if (!CRM.vars) CRM.vars = {};
         }
         $(this).parent().toggleClass('collapsed');
         e.preventDefault();
+      })
+
+      // Save the state for sticky accordions
+      .on('click', 'details.crm-accordion-sticky', function(e) {
+        // Workaround to run last, otherwise the open attribute is not yet updated
+        setTimeout(() => {
+          CRM.cache.set('sticky-' + this.id, document.getElementById(this.id).hasAttribute('open'));
+        }, 0);
       });
+
+    // Expand sticky accordions
+    Array.from(document.querySelectorAll('.crm-container details.crm-accordion-sticky')).forEach((expander) => {
+      var state = CRM.cache.get('sticky-' + expander.id);
+      if (state === true || state === false) {
+        expander.toggleAttribute('open', state);
+      }
+    });
 
     $().crmtooltip();
   });

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -86,7 +86,7 @@ CRM.$(function($) {
 {/if}
 
 {strip}
-  <details class="crm-accordion-settings crm-search_criteria_basic-accordion">
+  <details id="crm-advsearch-settings-accordion" class="crm-accordion-settings crm-search_criteria_basic-accordion crm-accordion-sticky">
     <summary>
       {ts}Search Settings{/ts}
     </summary>


### PR DESCRIPTION
Overview
----------------------------------------

Provides sticky state for specific accordions, currently only the Advanced Search .. Search Settings.

Alternative to #33056, following #31226, and related to dev/user-interface#82.

Before
----------------------------------------

- Go to Advanced Search
- Click Search Settings
- Select "Display Results As" = "Contributions"
- Search

Then do a new Advanced Search from a new tab, and the "Search Settings" are hidden/closed (default state), which can be annoying for someone who mostly does advanced-searches displayed as Contributions.

After
----------------------------------------

When going back to the Advanced Search after having clicked the "Search Settings", that fieldset will always be open by default (when using the same browser).

![image](https://github.com/user-attachments/assets/24a2e846-93cf-41e0-97d5-34acad956573)

Technical Details
----------------------------------------

Uses the browser's localStorage (`CRM.cache`) to store the preference.

Comments
----------------------------------------

This could be interesting in many other areas, but we should be careful about how it's deployed. I would rather start with something specific, and see what people think about the idea.

For example:

- New Contact > Address, Demographics, Tag/Groups, etc.
- Advanced Search > Custom Fields  (but maybe not any accordion, since some of them load dynamically? or users might find it weird?)

It's also why I added it to `js/Common.js` instead of `js/crm.searchForm.js`.

For an accordion to be sticky, it needs : the `crm-expand-sticky` class, and it needs to have an ID.

cc @wikimediaWfan @eileenmcnaughton @ufundo @colemanw @vingle 