### PR TITLE
issue#5970: api3 attachment.get crashes if given the id for a file belonging to a custom field of type file

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -567,10 +567,12 @@ class Container {
          FROM civicrm_file cf
          LEFT JOIN civicrm_entity_file cef ON cf.id = cef.file_id
          WHERE cf.id = %1',
-      // Get a list of custom fields (field_name,table_name,extends)
+      // Get a list of custom fields (field_name, table_name,extends, data_type, fk_entity)
       'SELECT concat("custom_",fld.id) as field_name,
         grp.table_name as table_name,
-        grp.extends as extends
+        grp.extends as extends,
+        fld.data_type as data_type,
+        fld.fk_entity as fk_entity
        FROM civicrm_custom_field fld
        INNER JOIN civicrm_custom_group grp ON fld.custom_group_id = grp.id
        WHERE fld.data_type = "File"


### PR DESCRIPTION
Overview
----------------------------------------
Running : 
```
$result = civicrm_api3('Attachment', 'get', [
  'sequential' => 1,
  'id' => 499,
]);
```
in 6.3+ leads to

Before
----------------------------------------
Fatal error : Failed to match record to related entity.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Related to https://github.com/civicrm/civicrm-core/pull/32319

Comments
----------------------------------------
ping @colemanw @demeritcowboy @MegaphoneJon 