### PR TITLE
dev/core#4349 Profile Select: do not use the Backbone Profile Editor

### DIFF
--- a/CRM/Campaign/Form/Survey/Questions.php
+++ b/CRM/Campaign/Form/Survey/Questions.php
@@ -66,16 +66,8 @@ class CRM_Campaign_Form_Survey_Questions extends CRM_Campaign_Form_Survey {
     }
 
     $allowCoreTypes = CRM_Campaign_BAO_Survey::surveyProfileTypes();
-    $allowSubTypes = [
-      'ActivityType' => [$subTypeId],
-    ];
-    $entities = [
-      ['entity_name' => 'contact_1', 'entity_type' => 'IndividualModel'],
-      ['entity_name' => 'activity_1', 'entity_type' => 'ActivityModel', 'entity_sub_type' => $subTypeId],
-    ];
-    $this->addProfileSelector('contact_profile_id', ts('Contact Info'), $allowCoreTypes, $allowSubTypes, $entities);
-    $this->addProfileSelector('activity_profile_id', ts('Questions'), $allowCoreTypes, $allowSubTypes, $entities);
-    // Note: Because this is in a tab, we also preload the schema via CRM_Campaign_Form_Survey::preProcess
+    $this->addProfileSelector('contact_profile_id', ts('Contact Info'), $allowCoreTypes);
+    $this->addProfileSelector('activity_profile_id', ts('Questions'), $allowCoreTypes);
 
     parent::buildQuickForm();
   }

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -145,11 +145,12 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     $this->assign('isQuick', $this->isQuickConfig());
     $this->addSelect('price_set_id', [
       'entity' => 'PriceSet',
-      'option_url' => 'civicrm/admin/price',
       'options' => $price,
       'label' => ts('Price Set'),
       'onchange' => "showHideAmountBlock( this.value, 'price_set_id' );",
+      'class' => 'crm-form-select-priceset',
     ]);
+    Civi::resources()->addScriptFile('civicrm', 'js/crm.openRelatedConfig.js');
 
     //CiviPledge fields.
     if (CRM_Core_Component::isEnabled('CiviPledge')) {

--- a/CRM/Contribute/Form/ContributionPage/Custom.php
+++ b/CRM/Contribute/Form/ContributionPage/Custom.php
@@ -36,13 +36,10 @@ class CRM_Contribute_Form_ContributionPage_Custom extends CRM_Contribute_Form_Co
     $entities = [];
     $entities[] = ['entity_name' => 'contact_1', 'entity_type' => 'IndividualModel'];
     $allowCoreTypes = array_merge(['Contact', 'Individual'], CRM_Contact_BAO_ContactType::subTypes('Individual'));
-    $allowSubTypes = [];
 
     // Register 'contribution_1'
     $financialTypeId = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_ContributionPage', $this->_id, 'financial_type_id');
     $allowCoreTypes[] = 'Contribution';
-    //CRM-15427
-    $allowSubTypes['ContributionType'] = [$financialTypeId];
     $entities[] = [
       'entity_name' => 'contribution_1',
       'entity_type' => 'ContributionModel',
@@ -59,12 +56,10 @@ class CRM_Contribute_Form_ContributionPage_Custom extends CRM_Contribute_Form_Co
         'entity_sub_type' => '*',
       ];
       $allowCoreTypes[] = 'Membership';
-      $allowSubTypes['MembershipType'] = explode(',', $member['membership_types']);
     }
-    //CRM-15427
-    $this->addProfileSelector('custom_pre_id', ts('Include Profile') . '<br />' . ts('(top of page)'), $allowCoreTypes, $allowSubTypes, $entities, TRUE);
-    $this->addProfileSelector('custom_post_id', ts('Include Profile') . '<br />' . ts('(bottom of page)'), $allowCoreTypes, $allowSubTypes, $entities, TRUE);
 
+    $this->addProfileSelector('custom_pre_id', ts('Top Profile Fields'), $allowCoreTypes);
+    $this->addProfileSelector('custom_post_id', ts('Bottom Profile Fields'), $allowCoreTypes);
     $this->addFormRule(['CRM_Contribute_Form_ContributionPage_Custom', 'formRule'], $this);
 
     parent::buildQuickForm();

--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -148,27 +148,14 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     // is on behalf of an organization ?
     $this->addElement('checkbox', 'is_organization', ts('Allow individuals to contribute and / or signup for membership on behalf of an organization?'), NULL, ['onclick' => "showHideByValue('is_organization',true,'for_org_text','table-row','radio',false);showHideByValue('is_organization',true,'for_org_option','table-row','radio',false);"]);
 
-    //CRM-15787 - If applicable, register 'membership_1'
+    // Organization profile selector
     $member = CRM_Member_BAO_Membership::getMembershipBlock($this->_id);
     $coreTypes = ['Contact', 'Organization'];
-
-    $entities[] = [
-      'entity_name' => ['contact_1'],
-      'entity_type' => 'OrganizationModel',
-    ];
-
     if ($member && $member['is_active']) {
       $coreTypes[] = 'Membership';
-      $entities[] = [
-        'entity_name' => ['membership_1'],
-        'entity_type' => 'MembershipModel',
-      ];
     }
-
-    $allowCoreTypes = array_merge($coreTypes, CRM_Contact_BAO_ContactType::subTypes('Organization'));
-    $allowSubTypes = [];
-
-    $this->addProfileSelector('onbehalf_profile_id', ts('Organization Profile'), $allowCoreTypes, $allowSubTypes, $entities);
+    $allowCoreTypes = array_merge(['Organization'], CRM_Contact_BAO_ContactType::subTypes('Organization'));
+    $this->addProfileSelector('onbehalf_profile_id', ts('Organization Profile'), $allowCoreTypes);
 
     $this->addRadio('is_for_organization', '', [1 => ts('Optional'), 2 => ts('Required')]);
     $this->add('textarea', 'for_organization', ts('On behalf of Label'), ['rows' => 2, 'cols' => 50]);
@@ -201,22 +188,13 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
       'class' => 'huge',
     ]);
 
-    $entities = [
-      [
-        'entity_name' => 'contact_1',
-        'entity_type' => 'IndividualModel',
-      ],
-    ];
-
     $allowCoreTypes = array_merge([
       'Contact',
       'Individual',
       'Organization',
       'Household',
     ], CRM_Contact_BAO_ContactType::subTypes('Individual'));
-    $allowSubTypes = [];
-
-    $this->addProfileSelector('honoree_profile', ts('Honoree Profile'), $allowCoreTypes, $allowSubTypes, $entities);
+    $this->addProfileSelector('honoree_profile', ts('Honoree Profile'), $allowCoreTypes);
 
     if (!empty($this->_submitValues['honor_block_is_active'])) {
       $this->addRule('soft_credit_types', ts('At least one value must be selected if Honor Section is active'), 'required');

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -277,11 +277,12 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
     }
     $this->addSelect('price_set_id', [
       'entity' => 'PriceSet',
-      'option_url' => 'civicrm/admin/price',
       'options' => $price,
       'label' => ts('Price Set'),
       'onchange' => "return showHideByValue('price_set_id', '', 'map-field', 'block', 'select', false);",
+      'class' => 'crm-form-select-priceset',
     ]);
+    Civi::resources()->addScriptFile('civicrm', 'js/crm.openRelatedConfig.js');
 
     $default = [0 => NULL];
     $this->add('hidden', 'price_field_id', '', ['id' => 'price_field_id']);

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -69,7 +69,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $addProfileBottomAdd = $_POST['additional_custom_post_id_multiple'] ?? NULL;
     if ($addProfileBottomAdd) {
       foreach (array_keys($addProfileBottomAdd) as $profileNum) {
-        self::buildMultipleProfileBottom($this, $profileNum, 'additional_', ts('Profile for Additional Participants'));
+        self::buildMultipleProfileBottom($this, $profileNum, 'additional_', ts('Bottom Profile for Additional Participants'));
       }
     }
   }
@@ -148,7 +148,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
           $this->_profilePostMultipleAdd = $defaults['additional_custom_post'];
           foreach ($defaults['additional_custom_post'] as $key => $value) {
-            self::buildMultipleProfileBottom($this, $key, 'additional_', ts('Profile for Additional Participants'));
+            self::buildMultipleProfileBottom($this, $key, 'additional_', ts('Bottom Profile for Additional Participants'));
             $defaults["additional_custom_post_id_multiple[$key]"] = $value;
           }
         }
@@ -208,7 +208,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     }
 
     if ($this->_addProfileBottomAdd) {
-      return self::buildMultipleProfileBottom($this, $this->_profileBottomNumAdd, 'additional_', ts('Profile for Additional Participants'));
+      return self::buildMultipleProfileBottom($this, $this->_profileBottomNumAdd, 'additional_', ts('Bottom Profile for Additional Participants'));
     }
 
     $this->applyFilter('__ALL__', 'trim');
@@ -302,12 +302,10 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $form->add('wysiwyg', 'footer_text', ts('Footer Text'), $attributes);
 
     extract(self::getProfileSelectorTypes());
-    //CRM-15427
-    $form->addProfileSelector('custom_pre_id', ts('Include Profile') . '<br />' . ts('(top of page)'), $allowCoreTypes, $allowSubTypes, $profileEntities, TRUE, $usedFor);
-    $form->addProfileSelector('custom_post_id', ts('Include Profile') . '<br />' . ts('(bottom of page)'), $allowCoreTypes, $allowSubTypes, $profileEntities, TRUE, $usedFor);
-
-    $form->addProfileSelector('additional_custom_pre_id', ts('Profile for Additional Participants') . '<br />' . ts('(top of page)'), $allowCoreTypes, $allowSubTypes, $profileEntities, TRUE, $usedFor);
-    $form->addProfileSelector('additional_custom_post_id', ts('Profile for Additional Participants') . '<br />' . ts('(bottom of page)'), $allowCoreTypes, $allowSubTypes, $profileEntities, TRUE, $usedFor);
+    $form->addProfileSelector('custom_pre_id', ts('Top Profile Fields'), $allowCoreTypes);
+    $form->addProfileSelector('custom_post_id', ts('Bottom Profile Fields'), $allowCoreTypes);
+    $form->addProfileSelector('additional_custom_pre_id', ts('Top Profile Fields for Additional Participants'), $allowCoreTypes);
+    $form->addProfileSelector('additional_custom_post_id', ts('Bottom Profile Fields for Additional Participants'), $allowCoreTypes);
   }
 
   /**
@@ -324,11 +322,11 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    * @param array $configs
    *   Optional, for addProfileSelector(), defaults to using getProfileSelectorTypes().
    */
-  public static function buildMultipleProfileBottom(&$form, $count, $prefix = '', $label = 'Include Profile', $configs = NULL) {
+  public static function buildMultipleProfileBottom(&$form, $count, $prefix = '', $label = NULL, $configs = NULL) {
+    $label ??= ts('Bottom Profile Fields');
     extract((is_null($configs)) ? self::getProfileSelectorTypes() : $configs);
     $element = $prefix . "custom_post_id_multiple[$count]";
-    $label .= '<br />' . ts('(bottom of page)');
-    $form->addProfileSelector($element, $label, $allowCoreTypes, $allowSubTypes, $profileEntities, TRUE, $usedFor);
+    $form->addProfileSelector($element, $label, $allowCoreTypes, $allowSubTypes);
   }
 
   /**
@@ -384,7 +382,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $is_monetary = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_id, 'is_monetary');
     $form->assign('is_monetary', $is_monetary);
     if ($is_monetary == "0") {
-      $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen?'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
+      $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
     }
     $form->add('text', 'confirm_title', ts('Title'), $attributes['confirm_title']);
     $form->add('wysiwyg', 'confirm_text', ts('Introductory Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
@@ -399,7 +397,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
   public function buildMailBlock(&$form) {
     $form->registerRule('emailList', 'callback', 'emailList', 'CRM_Utils_Rule');
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
-    $form->addYesNo('is_email_confirm', ts('Send Confirmation Email?'), NULL, NULL, ['onclick' => "return showHideByValue('is_email_confirm','','confirmEmail','block','radio',false);"]);
+    $form->addYesNo('is_email_confirm', ts('Send a confirmation email'), NULL, NULL, ['onclick' => "return showHideByValue('is_email_confirm','','confirmEmail','block','radio',false);"]);
     $form->add('wysiwyg', 'confirm_email_text', ts('Text'), $attributes['confirm_email_text']);
     $form->add('text', 'cc_confirm', ts('CC Confirmation To'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'cc_confirm'));
     $form->addRule('cc_confirm', ts('Please enter a valid list of comma delimited email addresses'), 'emailList');

--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -127,7 +127,7 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       $this->setTitle(ts('New CiviCRM Profile'));
     }
 
-    $this->assign('uf_group_type_extra', $this->getOtherModuleString());
+    $this->assign('uf_group_type_extra', CRM_Core_BAO_UFGroup::getProfileUsedByString($this->_id));
   }
 
   /**
@@ -375,48 +375,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
    * We do this from the constructor in order to do a translation.
    */
   public function setDeleteMessage() {
-  }
-
-  /**
-   * Returns a string describing which forms/modules are using this profile
-   * Ex: Used in Forms: CiviContribute (1, 3, 5), CiviEvent (40, 42, 55, 123 and XX more)
-   *
-   * @return string|null
-   */
-  protected function getOtherModuleString() {
-    $otherModules = \Civi\Api4\UFJoin::get(TRUE)
-      ->addWhere('uf_group_id', '=', $this->_id)
-      ->addWhere('module', '!=', 'Profile')
-      ->addOrderBy('entity_id', 'ASC')
-      ->execute();
-    if (empty($otherModules)) {
-      return NULL;
-    }
-    $otherModulesTranslations = [
-      'on_behalf' => ts('On Behalf Of Organization'),
-      'User Account' => ts('User Account'),
-      'User Registration' => ts('User Registration'),
-      'CiviContribute' => ts('CiviContribute'),
-      'CiviEvent' => ts('CiviEvent'),
-      'CiviEvent_Additional' => ts('CiviEvent Additional Participant'),
-    ];
-    $modulesByComponent = [];
-    foreach ($otherModules as $join) {
-      $modulesByComponent[$join['module']][] = $join['entity_id'];
-    }
-    $modulesByComponentReformat = [];
-    foreach ($modulesByComponent as $key => $vals) {
-      $count = count($vals);
-      if ($count > 7) {
-        // Keep only 5 and say "and X more"
-        $vals = array_slice($vals, 0, 5);
-        $modulesByComponentReformat[] = ($otherModulesTranslations[$key] ?? $key) . ' (' . implode(', ', $vals) . ' ' . ts('and %count more', ['count' => $count - 5, 'plural' => 'and %count more']) . ')';
-      }
-      else {
-        $modulesByComponentReformat[] = ($otherModulesTranslations[$key] ?? $key) . ' (' . implode(', ', $vals) . ')';
-      }
-    }
-    return implode(', ', $modulesByComponentReformat);
   }
 
 }

--- a/CRM/UF/Page/Field.php
+++ b/CRM/UF/Page/Field.php
@@ -187,6 +187,7 @@ class CRM_UF_Page_Field extends CRM_Core_Page {
 
     $this->assign('ufField', $ufField);
     $this->assign('legacyprofiles', function_exists('legacyprofiles_civicrm_config'));
+    $this->assign('uf_group_type_extra', CRM_Core_BAO_UFGroup::getProfileUsedByString($this->_gid));
 
     // retrieve showBestResult from session
     $session = CRM_Core_Session::singleton();

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -19,6 +19,8 @@ class CRM_UF_Page_ProfileEditor extends CRM_Core_Page {
 
   /**
    * Register profile scripts.
+   *
+   * @deprecated since 6.5 by dev/core#4349 and PR#33076 but still used by Contact Layout Summary Editor
    */
   public static function registerProfileScripts() {
     static $loaded = FALSE;

--- a/ext/civicrm_admin_ui/ang/afsearchProfiles.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchProfiles.aff.html
@@ -4,7 +4,7 @@
 
 
 
-  <div class="help">{{:: ts('CiviCRM Profile(s) allow you to aggregate groups of fields and include them in your site as input forms, contact display pages, and search and listings features. They provide a powerful set of tools for you to collect information from constituents and selectively share contact information.') }} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/" target="_blank">{{:: ts('Learn more...') }}</a></div>
+  <div class="help">{{:: ts('Profiles allow you to aggregate groups of fields and include them in your site as input forms, contact display pages, and search and listings features. They provide a powerful set of tools for you to collect information from constituents and selectively share contact information.') }} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/" target="_blank">{{:: ts('Learn more...') }}</a></div>
 
 
 

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -502,14 +502,6 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   box-shadow: none;
   background: var(--crm-tab-bg-active);
 }
-/* Include profile (contribtuion page and events  */
-.crm-contribution-contributionpage-custom-form-block-custom_pre_id td.html-adjust > div > div,
-.crm-contribution-contributionpage-custom-form-block-custom_post_id td.html-adjust > div > div,
-.crm-event-manage-registration-form-block-custom_pre_id td > div > div,
-.crm-event-manage-registration-form-block-custom_post_id td > div > div {
-  display: flex;
-  gap: var(--crm-s);
-}
 /* Event dashboard */
 .CRM_Event_Form_Search .button {
   float: left;

--- a/js/crm.openRelatedConfig.js
+++ b/js/crm.openRelatedConfig.js
@@ -1,0 +1,41 @@
+// https://civicrm.org/licensing
+CRM.$(function($) {
+  /**
+   * Set the href for the "Fields" button associated with a select field
+   * or hide the button if there was no value selected.
+   */
+  function setRelatedConfigLink($select, path, params) {
+    var val = $select.val();
+    if (val) {
+      params[params.key] = val;
+      // Most URLs expect reset=1
+      params.reset = 1;
+      params.action = 'browse';
+      var url = CRM.url(path, params);
+      $select.siblings('.crm-button').attr('href', url).show();
+    }
+    else {
+      $select.siblings('.crm-button').attr('href', '#').hide();
+    }
+  }
+
+  $('body')
+    // Let administrators to view the related configuration
+    // for a Profile or a PriceSet
+    .on('change', 'select.crm-form-select-profile', function() {
+      setRelatedConfigLink($(this), 'civicrm/admin/uf/group/field', {key: 'gid'});
+    })
+    .on('change', 'select.crm-form-select-priceset', function() {
+      setRelatedConfigLink($(this), 'civicrm/admin/price/field', {key: 'sid'});
+    });
+
+  // Initial state (and additional profiles, ex: for Events)
+  $('body').on('crmLoad', function() {
+    $('select.crm-form-select-profile', this).each(function() {
+      setRelatedConfigLink($(this), 'civicrm/admin/uf/group/field', {key: 'gid'});
+    });
+    $('select.crm-form-select-priceset', this).each(function() {
+      setRelatedConfigLink($(this), 'civicrm/admin/price/field', {key: 'sid'});
+    });
+  });
+});

--- a/schema/Core/UFGroup.entityType.php
+++ b/schema/Core/UFGroup.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Profile'),
     'title_plural' => ts('Profiles'),
-    'description' => ts('User framework groups. Each group represents a form which encompasses a set of fields defined in civicrm_uf_fields table. Initially will be used for CiviCRM Profile form(s). Subsequently we anticipate using this to define other public facing forms (e.g. online donation solicitation forms, mailing list preferences, etc.).'),
+    'description' => ts('Group of profile fields (formerly known as User Framework Groups). Typically used for creating sets of fields that are embedded in Contribution or Event forms, or in standalone profile forms (being phased out in favor of FormBuilder).'),
     'log' => TRUE,
     'add' => '1.1',
     'label_field' => 'title',

--- a/schema/Core/UFJoin.entityType.php
+++ b/schema/Core/UFJoin.entityType.php
@@ -7,7 +7,7 @@ return [
   'getInfo' => fn() => [
     'title' => ts('Profile Use'),
     'title_plural' => ts('Profile Uses'),
-    'description' => ts('User framework join table. This links various internal civicrm object with a profile. Initial use cases are the donation object and the user module'),
+    'description' => ts('Profile join table (formerly User Framework Join). Links various internal CiviCRM entities with a profile, such as which Contribution Pages embed a specific Profile.'),
     'log' => TRUE,
     'add' => '1.3',
   ],

--- a/templates/CRM/Campaign/Form/Survey/Questions.tpl
+++ b/templates/CRM/Campaign/Form/Survey/Questions.tpl
@@ -8,14 +8,22 @@
  +--------------------------------------------------------------------+
 *}
 <div class="crm-block crm-form-block crm-campaign-survey-questions-form-block">
+  <div class="help">
+    <p>{ts}Select the Profiles to include on the survey. The contact information are questions that are associated with the contact record. If a contact responds to multiple surveys, the contact information will be updated. The other questions should be a profile of activity fields. Every new survey response will create a new activity.{/ts}</p>
+    <p>{ts}To create new questions, go to to <a href="{crmURL p="civicrm/admin/custom/group" q="reset=1"}" target="_blank">Administer Custom Fields</a>.{/ts} {ts}Custom fields must then be included in profiles.{/ts} {ts}To create a new profile, go to <a href="{crmURL p="civicrm/admin/uf/group" q="reset=1"}" target="_blank">Administer Profiles</a>.{/ts}</p>
+  </div>
   <table class="form-layout-compressed">
     <tr class="crm-campaign-survey-questions-form-block-contact_profile_id">
       <td class="label">{$form.contact_profile_id.label}</td>
-      <td class="view-value">{$form.contact_profile_id.html}</td>
+      <td class="view-value">{$form.contact_profile_id.html}
+        <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+      </td>
     </tr>
     <tr class="crm-campaign-survey-questions-form-block-activity_profile_id">
       <td class="label">{$form.activity_profile_id.label}</td>
-      <td class="view-value">{$form.activity_profile_id.html}</td>
+      <td class="view-value">{$form.activity_profile_id.html}
+        <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+      </td>
     </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Amount.tpl
@@ -66,7 +66,11 @@
         </tr>
         <tr id="priceSet" class="crm-contribution-contributionpage-amount-form-block-priceSet">
             <td scope="row" class="label">{$form.price_set_id.label}</td>
-            <td>{$form.price_set_id.html} <br /><span class="description">{ts}Select a Price Set to offer more complex amount options. Otherwise, leave this empty and enter fixed contribution options below.{/ts}</span></td>
+            <td>{$form.price_set_id.html}
+              <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+              <div class="description">{ts}Select a Price Set to offer more complex amount options. Otherwise, leave this empty and enter fixed contribution options below.{/ts}</div>
+              <div class="description">{ts}To create a new Price Set, go to <a href="{crmURL p="civicrm/admin/price" q="reset=1"}" target="_blank">Administer Price Sets</a>.{/ts}</p>
+            </td>
         </tr>
     </table>
 

--- a/templates/CRM/Contribute/Form/ContributionPage/Custom.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Custom.hlp
@@ -32,3 +32,15 @@
   {ts 1=$docLinkCustom 2=$docLinkProfile}Refer to the online documentation for more details on creating %1 and %2.{/ts}
 </p>
 {/htxt}
+{htxt id="contrib-profile-top-title"}
+  {ts}Top Profile Fields{/ts}
+{/htxt}
+{htxt id="contrib-profile-top"}
+  {ts}Profile to be included above the billing information (but after the introductory message, amounts, and honoree section).{/ts}
+{/htxt}
+{htxt id="contrib-profile-bottom-title"}
+  {ts}Bottom Profile Fields{/ts}
+{/htxt}
+{htxt id="contrib-profile-bottom"}
+  {ts}Profile to be included at the bottom of the form, before the submit button.{/ts}
+{/htxt}

--- a/templates/CRM/Contribute/Form/ContributionPage/Custom.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Custom.tpl
@@ -11,17 +11,20 @@
 <div class="crm-block crm-form-block crm-contribution-contributionpage-custom-form-block">
 <div class="help">
     <p>{ts}You may want to collect information from contributors beyond what is required to make a contribution. For example, you may want to inquire about volunteer availability and skills. Add any number of fields to your contribution form by selecting CiviCRM Profiles (collections of fields) to include at the beginning of the page, and/or at the bottom.{/ts} {help id="contrib-profile"}</p>
+    <p>{ts}To create a new profile, go to <a href="{crmURL p="civicrm/admin/uf/group" q="reset=1"}" target="_blank">Administer Profiles</a>.{/ts}</p>
 </div>
     <table class="form-layout-compressed">
     <tr class="crm-contribution-contributionpage-custom-form-block-custom_pre_id">
-       <td class="label">{$form.custom_pre_id.label}</td>
+       <td class="label">{$form.custom_pre_id.label} {help id="contrib-profile-top"}</td>
        <td class="html-adjust">{$form.custom_pre_id.html}
-          <span class="description">{ts}Profile to be included above the billing information (but after the introductory message, amounts, and honoree section).{/ts}</span>
-          </td>
+         <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+       </td>
     </tr>
     <tr class="crm-contribution-contributionpage-custom-form-block-custom_post_id">
-       <td class="label">{$form.custom_post_id.label}</td>
-       <td class="html-adjust">{$form.custom_post_id.html}</td>
+       <td class="label">{$form.custom_post_id.label} {help id="contrib-profile-bottom"}</td>
+       <td class="html-adjust">{$form.custom_post_id.html}
+         <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+       </td>
     </tr>
 </table>
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -46,7 +46,9 @@
         <table class="form-layout-compressed">
           <tr class="crm-contribution-onbehalf_profile_id">
             <td class="label">{$form.onbehalf_profile_id.label}</td>
-            <td>{$form.onbehalf_profile_id.html}</td>
+            <td>{$form.onbehalf_profile_id.html}
+              <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+            </td>
           </tr>
           <tr id="for_org_text" class="crm-contribution-contributionpage-settings-form-block-for_organization">
             <td class="label">{$form.for_organization.label} {help id="id-for_organization"}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -90,7 +90,10 @@
             <tr class="crm-event-manage-fee-form-block-price_set_id">
                <td class="label">{$form.price_set_id.label}</td>
                <td>{$form.price_set_id.html}
-                 <div class="description">{ts}Select a Price Set to offer multiple individually priced options for event registrants. Otherwise, leave this empty and enter fixed fee levels below.{/ts}</div></td>
+                 <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+                 <div class="description">{ts}Select a Price Set to offer multiple individually priced options for event registrants. Otherwise, leave this empty and enter fixed fee levels below.{/ts}</div>
+                 <div class="description">{ts}To create a new Price Set, go to <a href="{crmURL p="civicrm/admin/price" q="reset=1"}" target="_blank">Administer Price Sets</a>.{/ts}</p>
+               </td>
             </tr>
       </table>
 

--- a/templates/CRM/Event/Form/ManageEvent/Registration.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.hlp
@@ -36,6 +36,12 @@
         {ts 1=$docLinkCustom 2=$docLinkProfile}Refer to the online documentation for more details on creating %1 and %2.{/ts}
 </p>
 {/htxt}
+{htxt id="event-profile-bottom-title"}
+  {ts}Bottom Profile Fields{/ts}
+{/htxt}
+{htxt id="event-profile-bottom"}
+  {ts}Profile to be included at the bottom of the form, before the submit button.{/ts}
+{/htxt}
 {htxt id="id-link_text-title"}
   {ts}Registration Link{/ts}
 {/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -14,9 +14,9 @@
   <td>
     {if $addProfileBottomAdd}{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].html}
     {else}{$form.custom_post_id_multiple[$profileBottomNum].html}{/if}
+    <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
     <span class='profile_bottom_link_remove'><a href="#" class="crm-hover-button crm-button-rem-profile" data-addtlPartc="{$addProfileBottomAdd}"><i class="crm-i fa-trash" aria-hidden="true"></i> {ts}remove profile{/ts}</a></span>
-    <span class='profile_bottom_link'>&nbsp;<a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile (bottom of page){/ts}</a></span>
-    <br/><span class="profile-links"></span>
+    <p class='profile_bottom_link'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile{/ts}</a></p>
   </td>
 {else}
 {assign var=eventID value=$id}
@@ -115,14 +115,16 @@
     </table>
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-custom_pre_id">
-        <td scope="row" class="label" width="20%">{$form.custom_pre_id.label} {help id="event-profile"}</td>
-        <td>{$form.custom_pre_id.html}</td>
+        <td class="label">{$form.custom_pre_id.label} {help id="event-profile"}</td>
+        <td class="html-adjust">{$form.custom_pre_id.html}
+          <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+        </td>
       </tr>
       <tr id="profile_post" class="crm-event-manage-registration-form-block-custom_post_id">
-        <td scope="row" class="label" width="20%">{$form.custom_post_id.label}</td>
-        <td>{$form.custom_post_id.html}
-          <span class='profile_bottom_link_main {if $profilePostMultiple}hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile (bottom of page){/ts}</a></span>
-          <br/>
+        <td class="label">{$form.custom_post_id.label} {help id="event-profile-bottom"}</td>
+        <td class="html-adjust">{$form.custom_post_id.html}
+          <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+          <p class='profile_bottom_link_main {if $profilePostMultiple}hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile{/ts}</a></p>
         </td>
       </tr>
 
@@ -130,22 +132,19 @@
         {foreach from=$profilePostMultiple item=profilePostId key=profilePostNum name=profilePostIdName}
           <tr id="custom_post_id_multiple_{$profilePostNum}_wrapper"
               class='crm-event-manage-registration-form-block-custom_post_multiple'>
-            <td scope="row" class="label" width="20%">{$form.custom_post_id_multiple.$profilePostNum.label}</td>
-            <td>{$form.custom_post_id_multiple.$profilePostNum.html}
-              &nbsp;
+            <td class="label">{$form.custom_post_id_multiple.$profilePostNum.label}</td>
+            <td class="html-adjust">{$form.custom_post_id_multiple.$profilePostNum.html}
               <span class='profile_bottom_link_remove'>
                 <a href="#" class="crm-hover-button crm-button-rem-profile">
                   <i class="crm-i fa-trash" aria-hidden="true"></i> {ts}remove profile{/ts}
                 </a>
               </span>
-              &nbsp;&nbsp;
-              <span class='profile_bottom_link' {if !$smarty.foreach.profilePostIdName.last} style="display: none"{/if}>
+              <p class='profile_bottom_link'{if !$smarty.foreach.profilePostIdName.last} style="display: none"{/if}>
                 <a href="#" class="crm-hover-button crm-button-add-profile">
                   <i class="crm-i fa-plus-circle" aria-hidden="true"></i>
-                  {ts}add another profile (bottom of page){/ts}
+                  {ts}add another profile{/ts}
                 </a>
-              </span>
-              <br/><span class="profile-links"></span>
+              </p>
             </td>
           </tr>
         {/foreach}
@@ -155,36 +154,33 @@
       <tr id="additional_profile_pre" class="crm-event-manage-registration-form-block-additional_custom_pre_id">
         <td scope="row" class="label" width="20%">{$form.additional_custom_pre_id.label}</td>
         <td>{$form.additional_custom_pre_id.html}
-          <span class="profile-links"></span>
+          <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
         </td>
       </tr>
       <tr id="additional_profile_post" class="crm-event-manage-registration-form-block-additional_custom_post_id">
         <td scope="row" class="label" width="20%">{$form.additional_custom_post_id.label}</td>
         <td>{$form.additional_custom_post_id.html}
-          <span class='profile_bottom_add_link_main{if $profilePostMultipleAdd} hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile (bottom of page){/ts}</a></span>
-          <br/><span class="profile-links"></span>
+          <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
+          <p class='profile_bottom_add_link_main{if $profilePostMultipleAdd} hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" aria-hidden="true"></i> {ts}add another profile{/ts}</a></p>
         </td>
       </tr>
       {if $profilePostMultipleAdd}
         {foreach from=$profilePostMultipleAdd item=profilePostIdA key=profilePostNumA name=profilePostIdAName}
           <tr id='additional_custom_post_id_multiple_{$profilePostNumA}_wrapper'
               class='crm-event-manage-registration-form-block-additional_custom_post_multiple'>
-            <td scope="row" class="label"
-                width="20%">{$form.additional_custom_post_id_multiple.$profilePostNumA.label}</td>
-            <td>{$form.additional_custom_post_id_multiple.$profilePostNumA.html}
-              &nbsp;
+            <td class="label">{$form.additional_custom_post_id_multiple.$profilePostNumA.label}</td>
+            <td class="html-adjust">{$form.additional_custom_post_id_multiple.$profilePostNumA.html}
               <span class='profile_bottom_add_link_remove'>
                 <a href="#" class="crm-hover-button crm-button-rem-profile">
                   <i class="crm-i fa-trash" aria-hidden="true"></i> {ts}remove profile{/ts}
                 </a>
               </span>
-              <span class='profile_bottom_add_link' {if !$smarty.foreach.profilePostIdAName.last} style="display: none"{/if}>
+              <p class='profile_bottom_add_link'{if !$smarty.foreach.profilePostIdAName.last} style="display: none"{/if}>
                 <a href="#" class="crm-hover-button crm-button-add-profile">
                   <i class="crm-i fa-plus-circle" aria-hidden="true"></i>
-                  {ts}add another profile (bottom of page){/ts}
+                  {ts}add another profile{/ts}
                 </a>
-              </span>
-              <br/><span class="profile-links"></span>
+              </p>
             </td>
           </tr>
         {/foreach}
@@ -202,7 +198,7 @@
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
         <td scope="row" class="label" width="20%">{$form.is_confirm_enabled.label}</td>
         <td>{$form.is_confirm_enabled.html}
-          <div class="description">{ts}Optionally hide the confirmation screen for free events.{/ts}</div>
+          <div class="description">{ts}The confirmation screen is optional for free events.{/ts}</div>
         </td>
       </tr>
     </table>
@@ -341,8 +337,8 @@ invert              = 0
 {include file="CRM/common/buildProfileLink.tpl"}
 
 <script type="text/javascript">
-{literal}    (function($, _) { // Generic Closure
-
+{literal}
+(function($, _) {
     $(".crm-submit-buttons button").click( function() {
       $(".dedupenotify .ui-notify-close").click();
     });
@@ -350,16 +346,17 @@ invert              = 0
     var profileBottomCount = Number({/literal}{$profilePostMultiple|@count}{literal});
     var profileBottomCountAdd = Number({/literal}{$profilePostMultipleAdd|@count}{literal});
 
-    function addBottomProfile( e ) {
+    function addBottomProfile(e) {
         var urlPath;
         e.preventDefault();
 
         var addtlPartc = $(this).data('addtlPartc');
 
-        if ($(this).closest("td").children("input").attr("name").indexOf("additional_custom_post") > -1 || addtlPartc) {
+        if ($(this).closest("td").children("select").attr("name").indexOf("additional_custom_post") > -1 || addtlPartc) {
             profileBottomCountAdd++
             urlPath = CRM.url('civicrm/event/manage/registration', { addProfileBottomAdd: 1, addProfileNumAdd: profileBottomCountAdd, snippet: 4 } ) ;
-        } else {
+        }
+        else {
             profileBottomCount++;
             urlPath = CRM.url('civicrm/event/manage/registration', { addProfileBottom: 1 , addProfileNum : profileBottomCount, snippet: 4 } ) ;
         }
@@ -371,10 +368,9 @@ invert              = 0
         $el.find(".profile_bottom_link_main, .profile_bottom_link, .profile_bottom_add_link_main").show();
     }
 
-    function removeBottomProfile( e ) {
+    function removeBottomProfile(e) {
         e.preventDefault();
-
-        $(e.target).closest('tr').hide().find('.crm-profile-selector').val('');
+        $(e.target).closest('tr').hide().find('select').val('');
         $(e.target).closest('tbody').find('tr:visible:last .profile_bottom_link_main,tr:visible:last .profile_bottom_add_link, tr:visible:last .profile_bottom_link, tr:visible:last .profile_bottom_add_link_main').show();
     }
 
@@ -396,8 +392,7 @@ invert              = 0
         });
     });
 
-$(function($) {
-
+  $(function($) {
     var allow_multiple = $("#is_multiple_registrations");
     if ( !allow_multiple.prop('checked') ) {
         $('#additional_profile_pre,#additional_profile_post,#id-max-additional-participants').hide();
@@ -442,9 +437,8 @@ $(function($) {
             }
         });
     });
-
-}); // END onReady
-}(CRM.$, CRM._)); //Generic Closure
+  });
+}(CRM.$, CRM._));
 {/literal}
 </script>
 {/if}

--- a/templates/CRM/UF/Page/Field.tpl
+++ b/templates/CRM/UF/Page/Field.tpl
@@ -25,6 +25,9 @@
       </div>
     {/if}
     <div id="field_page">
+      {if $uf_group_type_extra}
+        <p>{ts}Used in Forms{/ts} {help id='id-used_for_extra' file="CRM/UF/Form/Group.hlp"}<br>{$uf_group_type_extra}</p>
+      {/if}
       {strip}
       {* handle enable/disable actions*}
       {include file="CRM/common/enableDisableApi.tpl"}

--- a/templates/CRM/UF/Page/Group.tpl
+++ b/templates/CRM/UF/Page/Group.tpl
@@ -32,7 +32,7 @@
 
 {else}
   <div class="help">
-    {ts}CiviCRM Profile(s) allow you to aggregate groups of fields and include them in your site as input forms, contact display pages, and search and listings features. They provide a powerful set of tools for you to collect information from constituents and selectively share contact information.{/ts} {help id='profile_overview'}
+    {ts}Profiles allow you to aggregate groups of fields and include them in your site as input forms, contact display pages, and search and listings features. They provide a powerful set of tools for you to collect information from constituents and selectively share contact information.{/ts} {help id='profile_overview'}
   </div>
 
   <div class="crm-content-block crm-block">


### PR DESCRIPTION
Overview
----------------------------------------

Remove the backbone Manage Event and Manage Contribution profile selectors.

https://lab.civicrm.org/dev/core/-/issues/4349

Before
----------------------------------------

![image](https://github.com/user-attachments/assets/b0ecef31-5677-4726-bcaf-a8e5c8825999)

After
----------------------------------------

Manage Events

![image](https://github.com/user-attachments/assets/31d89052-2bdf-4231-8b73-34e683a10fe7)

Manage Contribution Pages

<img width="1547" height="751" alt="image" src="https://github.com/user-attachments/assets/268ba825-4858-40e0-9978-f0c37bba19b6" />

(older screenshot)

![image](https://github.com/user-attachments/assets/b9f49936-d9ca-4a9e-b5a3-6073e69076ca)


Technical Details
----------------------------------------

Towards removing Backbone from CiviCRM core, and a lot of confusing code.

Comments
-------------------

Not really a user-interface-improvement, more like a downgrade functionally, but we need to cleanup.

Todo
---------------------

- [x] `CRM_Core_Form::addProfileSelector`: build an option list of profiles that roughly match the "used for"?
- [x] Add wrench icons so that we can quickly administer profiles

One day, when CSLE and CiviVolunteer no longer depend on these:

- Remove `CRM_UF_Page_ProfileEditor` and related routes and JS (however, I added a deprecation tag)
- Remove `js/jquery/jquery.crmProfileSelector.js`
- Remove `js/model/crm.uf.js`
- Eventually remove Backbone library (CiviBooking also uses this, as well as Volunteer and CSLE)