### PR TITLE
(dev/core#5814) Email - Use standards-compliant line-wrapping (redux)

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -144,7 +144,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
     else {
       $fromName = empty($eq->display_name) ? $eq->email : "{$eq->display_name} ({$eq->email})";
 
-      $message = new Mail_mime("\n");
+      $message = new Mail_mime();
 
       $headers = [
         'Subject' => "Re: {$mailing->subject}",

--- a/ext/flexmailer/src/MailParams.php
+++ b/ext/flexmailer/src/MailParams.php
@@ -45,7 +45,7 @@ class MailParams {
     // pass through as email headers, but there are several special-cases
     // (e.g. 'toName', 'toEmail', 'text', 'html', 'attachments', 'headers').
 
-    $message = new \Mail_mime("\n");
+    $message = new \Mail_mime();
 
     // 1. Consolidate: 'toName' and 'toEmail' should be 'To'.
     $toName = trim($mailParams['toName']);


### PR DESCRIPTION
Overview
----------------------------------------

This is the same idea as #33064 ([dev/core#5814](https://lab.civicrm.org/dev/core/-/issues/5814))... but applied in more places. In particular, #33064 fixed headers generated for _individual emails_. But it turns out the buggy line was duplicated elsewhere.

This specifically fixes it for mass-mailings (https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/issues/678).

Steps to Reproduce
----------------------------------------

To reproduce/work on this, my steps were...

* Configure [`mail()`-based delivery with `fakemail`](https://lab.civicrm.org/dev/core/-/issues/5814#note_181607).
* Send a mass-mailing with Mosaico. Use a very long `Subject:` line.
* Inspect the generated data-files to see what kind of whitespace they use.

Before
----------------------------------------

In generated messages, there were newline discrepancies in two headers:

* For `Content-Type:`, the data was wrapped  with `LF` (instead of `CR`+`LF`).
* For `Subject:`, the data was initially wrapped with `LF`, but `Subject` has extra processing, and the extra `LF` was ultimately replaced by a `SP`. This creates multiple spaces in the `Subject` line.

After
----------------------------------------

Both `Content-Type` and `Subject` are wrapped with `CR`+`LF`.

