### PR TITLE
issue#5943 : Activity: Cannot delete activity with a required custom field (having radio button options)

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -53,7 +53,8 @@ trait CRM_Custom_Form_CustomDataTrait {
     // Reuse the same spec-gatherer from Api4.getFields
     $spec = new \Civi\Api4\Service\Spec\RequestSpec($entity, 'create', $filters);
     $fieldFilters = Civi::service('spec_gatherer')->getCustomGroupFilters($spec);
-    if ($fieldFilters === NULL) {
+    // dev/issue#5943 : ignore rebuilding custom fields when the form is submitted for deletion
+    if ($fieldFilters === NULL || ($this->_action & CRM_Core_Action::DELETE)) {
       return;
     }
     // Api4 normally filters out multivalued groups but forms include them


### PR DESCRIPTION
Overview
----------------------------------------
Activity cannot be deleted when a custom field is required. The custom field is required, with options. It is a radio button.

## steps to replicate the issue:

1. Create custom field, set it to required, a radio button, has existing options.
2. Create an activity, set the custom field. Save
3. Delete the activity. A prompt will then show.

Before
----------------------------------------
It prompts that the custom field is required when deleting.

After
----------------------------------------
It should be deleted without issue.

Technical Details
----------------------------------------
This is affecting all those form where `addCustomDataFieldsToForm()` is called : 
```
CRM/Contact/Form/Contact.php:334:      $this->addCustomDataFieldsToForm('Contact', array_filter([
CRM/Contact/Form/Task/SaveSearch.php:73:      $this->addCustomDataFieldsToForm('Group');
CRM/Contact/Form/Task/AddToGroup.php:127:      $this->addCustomDataFieldsToForm('Group');
CRM/Contact/Form/Relationship.php:213:      $this->addCustomDataFieldsToForm('Relationship', array_filter([
CRM/Core/Form/EntityFormTrait.php:171:    $this->addCustomDataFieldsToForm($this->getDefaultEntity(), array_filter([
CRM/Core/Form/EntityFormTrait.php:194:          $this->addCustomDataFieldsToForm($this->getDefaultEntity(), array_filter([
CRM/Financial/Form/FinancialAccount.php:78:      $this->addCustomDataFieldsToForm('FinancialAccount');
CRM/Financial/Form/PaymentEdit.php:129:      $this->addCustomDataFieldsToForm('FinancialTrxn', array_filter([
CRM/Group/Form/Edit.php:237:      $this->addCustomDataFieldsToForm('Group');
CRM/Activity/Form/Activity.php:440:      $this->addCustomDataFieldsToForm('Activity', array_filter([
CRM/Member/Form.php:638:      $this->addCustomDataFieldsToForm('Membership', array_filter([
CRM/Admin/Form/Options.php:116:      $this->addCustomDataFieldsToForm('OptionValue', array_filter([
CRM/Pledge/Form/Pledge.php:338:      $this->addCustomDataFieldsToForm('Pledge', array_filter([
CRM/Price/Form/Option.php:69:      $this->addCustomDataFieldsToForm('PriceFieldValue');
CRM/Contribute/Form/AdditionalPayment.php:238:      $this->addCustomDataFieldsToForm('FinancialTrxn');
CRM/Contribute/Form/ManagePremiums.php:83:      $this->addCustomDataFieldsToForm('Product', array_filter([
CRM/Contribute/Form/UpdateSubscription.php:96:      $this->addCustomDataFieldsToForm('ContributionRecur', array_filter([
CRM/Contribute/Form/ContributionPage/Settings.php:36:      $this->addCustomDataFieldsToForm('ContributionPage');
CRM/Contribute/Form/Contribution.php:329:      $this->addCustomDataFieldsToForm('Contribution', array_filter([
CRM/Campaign/Form/Survey.php:95:      $this->addCustomDataFieldsToForm('Survey', array_filter([
CRM/Campaign/Form/Campaign.php:112:      $this->addCustomDataFieldsToForm('Campaign', array_filter([
CRM/Campaign/Form/Petition.php:96:      $this->addCustomDataFieldsToForm('Survey', array_filter([
CRM/Campaign/Form/Survey/Main.php:58:      $this->addCustomDataFieldsToForm('Survey', array_filter([
CRM/Case/Form/Case.php:213:      $this->addCustomDataFieldsToForm('Case', array_filter([
CRM/Case/Form/Case.php:217:      $this->addCustomDataFieldsToForm('Activity', [
CRM/Custom/Form/CustomData.php:41:   *   $this->addCustomDataFieldsToForm('Membership', array_filter([
CRM/Custom/Form/CustomData.php:95:   *   $this->addCustomDataFieldsToForm('FinancialAccount');
CRM/Custom/Form/CustomDataTrait.php:52:  protected function addCustomDataFieldsToForm(string $entity, array $filters = []): void {
CRM/Event/Form/ManageEvent/EventInfo.php:192:      $this->addCustomDataFieldsToForm('Event', array_filter([
CRM/Event/Form/Participant.php:554:      $this->addCustomDataFieldsToForm('Participant', array_filter([
```
Linked to https://github.com/civicrm/civicrm-core/pull/29656 changes

I can't think of any consequences of bypassing custom field rendering on delete screen, so why not!

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton 