### PR TITLE
dev/core#5970 - (alternate to 33075) - fix attachment get api3 for custom file field

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -567,10 +567,11 @@ class Container {
          FROM civicrm_file cf
          LEFT JOIN civicrm_entity_file cef ON cf.id = cef.file_id
          WHERE cf.id = %1',
-      // Get a list of custom fields (field_name,table_name,extends)
+      // Get a list of custom fields (field_name,table_name,extends,column_name)
       'SELECT concat("custom_",fld.id) as field_name,
         grp.table_name as table_name,
-        grp.extends as extends
+        grp.extends as extends,
+        fld.column_name
        FROM civicrm_custom_field fld
        INNER JOIN civicrm_custom_group grp ON fld.custom_group_id = grp.id
        WHERE fld.data_type = "File"

--- a/api/v3/Attachment.php
+++ b/api/v3/Attachment.php
@@ -280,8 +280,9 @@ function __civicrm_api3_attachment_find($params, $id, $file, $entityFile, $isTru
     }
   }
 
+  $join_type = empty($entityFile) ? 'LEFT' : 'INNER';
   $select = CRM_Utils_SQL_Select::from('civicrm_file cf')
-    ->join('cef', 'INNER JOIN civicrm_entity_file cef ON cf.id = cef.file_id')
+    ->join('cef', $join_type . ' JOIN civicrm_entity_file cef ON cf.id = cef.file_id')
     ->select([
       'cf.id',
       'cf.uri',


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5970
Alternate to https://github.com/civicrm/civicrm-core/pull/33075

Before
----------------------------------------
1. Create a custom file field.
2. Add a file to it.
3. Call api3 attachment.get
4. php error about passing null as a parameter. Crash about "Failed to match record to related entity".

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
test fails before the patch
