### PR TITLE
Allow activities with > 50 contact targets to be edited

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -557,10 +557,10 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $defaults['target_contact_id'] = $this->_contactIds;
     }
 
-    // CRM-15472 - 50 is around the practical limit of how many items a select2 entityRef can handle
+    // CRM-15472 - there is a practical limit of how many items a select2 entityRef can handle
     if ($this->_action == CRM_Core_Action::UPDATE && !empty($defaults['target_contact_id'])) {
       $count = count(is_array($defaults['target_contact_id']) ? $defaults['target_contact_id'] : explode(',', $defaults['target_contact_id']));
-      if ($count > 50) {
+      if ($count > 1000) {
         $this->freeze(['target_contact_id']);
         $this->assign('disable_swap_button', TRUE);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Change code that prevents target contacts being edited on activities with more than 50 target contacts.

Before
----------------------------------------
When editing an activity with <= 50 target contacts, the list of contacts is editable. But > 50, the list is frozen preventing any additions or deletions.

After
----------------------------------------
The limit is raised to 1000, so Activities with <= 1000 target contacts are editable as expected.

Comments
--------------

