### PR TITLE
dev/core#5971 Use regex replace to ensure we keep the required asteri…

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -2928,7 +2928,10 @@ tbody.scrollContent tr.alternateRow {
 .crm-container .form-layout td.label,
 .crm-container form table.report .label,
 .crm-container form table label,
-.crm-container form table.report label {
+.crm-container form table.report label,
+.crm-container .form-layout-compressed tr[role="radiogroup"] td.label,
+.crm-container .form-layout tr[role="radiogroup"] td.label,
+.crm-container #customFields div.contact_panel tr[role="radiogroup"] td.label {
   color: #3e3e3e;
 }
 

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -21,7 +21,7 @@
   </tr>
 {elseif $element.options_per_line}
   <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
-    <td class="label">{if $element.html_type === "Radio"}<span id="{$element.element_name}_group">{$element.label}</span>{else}{$formElement.label}{/if}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
+    <td class="label"{if $element.html_type === "Radio"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}</td>
     <td class="html-adjust">
 
       <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
@@ -41,7 +41,7 @@
   </tr>
 {else}
   <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
-    <td class="label">{if $element.html_type === "Radio"}<span id="{$element.element_name}_group">{$element.label}</span>{else}{$formElement.label}{/if}
+    <td class="label"{if $element.html_type === "Radio"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}
       {if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$element.label}{/if}
     </td>
     <td class="html-adjust">

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -36,7 +36,7 @@
   {if !empty($element.options_per_line)}
         {assign var="element_name" value=$element.element_name}
         <tr class="custom-field-row {$element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
-         <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
+         <td class="label"{if $element.html_type === "Radio"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.label}{/if}</td>
          <td>
             {assign var="count" value=1}
                 <table class="form-layout-compressed">


### PR DESCRIPTION
…sk if needed and add new style rules to ensure lable isn't dimmed in a radiogroup, not sure what impact this would have on Riverlea etc.

ping @demeritcowboy @vingle 

Before
----
![image](https://github.com/user-attachments/assets/bc8227cb-7144-4887-a0aa-7ec9c70fd65c)

After
----
![image](https://github.com/user-attachments/assets/9d862e1d-9c48-4696-b9d9-c5dcc4b7bdca)
