### PR TITLE
(dev/core#5973) New Activity - Don't generate broken links

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -955,7 +955,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         $url = CRM_Utils_System::url('civicrm/contact/view', ['cid' => CRM_Utils_Array::first($params['target_contact_id']), 'selectedChild' => 'activity']);
       }
       else {
-        $url = CRM_Utils_System::url('civicrm/activity', ['action' => 'view', 'reset' => 1, 'id' => $this->_activityId]);
+        $url = CRM_Utils_System::url('civicrm/activity', ['action' => 'view', 'reset' => 1, 'id' => $this->_activityId, 'cid' => $params['source_contact_id']]);
       }
       CRM_Core_Session::singleton()->pushUserContext($url);
     }


### PR DESCRIPTION
Overview
----------------------------------------

In [dev/core#5973](https://lab.civicrm.org/dev/core/-/issues/5973), we find that the "New Activity" form will redirect to a screen where you can view the newly created activity. However, the choice of redirection target is uneven:

* :smile:  If there is a clear _target_ contact, then it goes to the "Activities" tab (i.e.  `civicrm/contact/view?id=CONTACT&selectedChild=activity`).
* :japanese_ogre:  In any other case (_zero_ targets or _multiple_ targets), it goes to standalone/un-embedded activity view (`civicrm/activity?action=view&id=ACTIVITY`).

However, this latter case is problematic. The page will offer broken links. We focus on this scenario.

Before
----------------------------------------

Redirect to `civicrm/activity?action=view&reset=1&id=ACTIVITY`

There is _no_ contact ID specified. When you click links like "Delete", it wants to use some guards ([example](https://github.com/civicrm/civicrm-core/blob/207c3b89b13cc26672773ba4d2e9eaffb750962c/CRM/Activity/Page/Tab.php#L122-L132)) which are ill-defined. So the "Delete" button fails:

![Screenshot from 2025-07-01 17-41-30](https://github.com/user-attachments/assets/deddfe13-167d-4a82-b4dd-2fb41c474585)

After
----------------------------------------

Redirect to `civicrm/activity?action=view&reset=1&id=ACTIVITY&cid=SOURCE_CONTACT`

There is _always_ a contact ID. When you click links like "Delete", it operates in the context of the source-contact (which is always _defined_ and _singular_ and _suitable_).

The "Delete" button works.

Comments
----------------------------------------

I have half a mind to [skip `civicrm/activity` completely and always go to the same Activities tab`](https://github.com/civicrm/civicrm-core/compare/master...totten:civicrm-core:6.x-activity-redirect?expand=1). Arguably, that's more consistent UX. But that is also more aggressive, and it's not really needed, and I don't care a whole lot about the difference. This is a simpler patch.
