### PR TITLE
dev/core#5974 SearchKit - Remove unused dataType from unit tests

### DIFF
--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -393,19 +393,16 @@ EOHTML;
           [
             'type' => 'field',
             'key' => 'activity_type_id:label',
-            'dataType' => 'Integer',
             'sortable' => TRUE,
           ],
           [
             'type' => 'field',
             'key' => 'Activity_ActivityContact_Contact_01.sort_name',
-            'dataType' => 'String',
             'sortable' => TRUE,
           ],
           [
             'type' => 'field',
             'key' => 'Activity_ActivityContact_Contact_01.test_af_autocomplete_search.select_auto:label',
-            'dataType' => 'String',
             'sortable' => TRUE,
           ],
         ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/AbstractRunActionTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/AbstractRunActionTest.php
@@ -111,7 +111,6 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
                 [
                   'type' => 'field',
                   'key' => 'display_name',
-                  'dataType' => 'String',
                   'label' => 'Display Name',
                   'sortable' => TRUE,
                   'link' =>
@@ -127,7 +126,6 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
                 [
                   'type' => 'field',
                   'key' => 'Foods.I_Like:label',
-                  'dataType' => 'String',
                   'label' => 'Foods: I Like',
                   'sortable' => TRUE,
                   'rewrite' => '[Foods.I_Like:label]',
@@ -163,7 +161,6 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
             [
               'type' => 'field',
               'key' => 'display_name',
-              'dataType' => 'String',
               'label' => 'Display Name',
               'sortable' => TRUE,
               'link' =>
@@ -179,7 +176,6 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
             [
               'type' => 'field',
               'key' => 'Foods.I_Like:label',
-              'dataType' => 'String',
               'label' => 'Foods: I Like',
               'sortable' => TRUE,
               'rewrite' => '[Foods.I_Like:label]',
@@ -261,21 +257,18 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
                 [
                   'type' => 'field',
                   'key' => 'id',
-                  'dataType' => 'Integer',
                   'label' => 'Mailing ID',
                   'sortable' => TRUE,
                 ],
                 [
                   'type' => 'field',
                   'key' => 'name',
-                  'dataType' => 'String',
                   'label' => 'Mailing Name',
                   'sortable' => TRUE,
                 ],
                 [
                   'type' => 'field',
                   'key' => 'domain_id:label',
-                  'dataType' => 'Integer',
                   'label' => 'Domain',
                   'sortable' => TRUE,
                 ],
@@ -356,21 +349,18 @@ class AbstractRunActionTest extends \PHPUnit\Framework\TestCase implements Headl
             [
               'type' => 'field',
               'key' => 'id',
-              'dataType' => 'Integer',
               'label' => 'Mailing ID',
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'name',
-              'dataType' => 'String',
               'label' => 'Mailing Name',
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'domain_id:label',
-              'dataType' => 'Integer',
               'label' => 'Domain',
               'sortable' => TRUE,
             ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
@@ -266,21 +266,18 @@ class EditableSearchTest extends Api4TestBase {
             [
               'key' => 'first_name',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
               'editable' => TRUE,
             ],
             [
               'key' => 'organization_name',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
               'editable' => TRUE,
             ],
             [
               'key' => 'household_name',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
               'editable' => TRUE,
             ],
@@ -371,14 +368,12 @@ class EditableSearchTest extends Api4TestBase {
             [
               'key' => 'subject',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
               'editable' => TRUE,
             ],
             [
               'key' => 'meeting_phone.sub_field',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
               'editable' => TRUE,
             ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/ManagedSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/ManagedSearchTest.php
@@ -74,7 +74,6 @@ class ManagedSearchTest extends \PHPUnit\Framework\TestCase implements HeadlessI
               [
                 'key' => 'id',
                 'label' => 'Contact ID',
-                'dataType' => 'Integer',
                 'type' => 'field',
               ],
             ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -77,25 +77,21 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
             [
               'key' => 'display_name',
               'label' => 'Display Name',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'GROUP_CONCAT_Contact_Email_contact_id_01_email',
               'label' => 'Emails',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'YEAR_birth_date',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
           ],
@@ -275,19 +271,16 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
             [
               'key' => 'display_name',
               'label' => 'Display Name',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'GROUP_CONCAT_Contact_Email_contact_id_01_email',
               'label' => 'Emails',
-              'dataType' => 'String',
               'type' => 'field',
             ],
           ],
@@ -379,7 +372,6 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
           ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -58,7 +58,6 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
             [
               'key' => 'subject',
               'label' => 'Duration Subject',
-              'dataType' => 'String',
               'type' => 'field',
               'rewrite' => '[duration] [subject]',
             ],
@@ -70,7 +69,6 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
             [
               'key' => 'details',
               'label' => 'Details',
-              'dataType' => 'String',
               'type' => 'html',
             ],
           ],
@@ -142,7 +140,6 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
             [
               'key' => 'last_name',
               'label' => 'First Last',
-              'dataType' => 'String',
               'type' => 'field',
               'rewrite' => '[first_name] [last_name]',
             ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchExportTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchExportTest.php
@@ -46,7 +46,6 @@ class SearchExportTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
           ],
@@ -98,7 +97,6 @@ class SearchExportTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
           ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -97,31 +97,26 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
             [
               'key' => 'first_name',
               'label' => 'First Name',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'last_name',
               'label' => 'Last Name',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'contact_sub_type:label',
               'label' => 'Type',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'is_deceased',
               'label' => 'Deceased',
-              'dataType' => 'Boolean',
               'type' => 'field',
             ],
           ],
@@ -285,13 +280,11 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'id',
               'label' => 'Contact ID',
-              'dataType' => 'Integer',
               'type' => 'field',
             ],
             [
               'key' => 'display_name',
               'label' => 'Display Name',
-              'dataType' => 'String',
               'type' => 'field',
               'link' => [
                 'path' => 'civicrm/test/token-[sort_name]',
@@ -358,7 +351,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'contact_id.display_name',
               'label' => 'Contact',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
@@ -435,7 +427,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'title',
               'label' => 'Title',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
@@ -506,7 +497,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'near_contact_id.display_name',
               'label' => 'Contact',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
@@ -809,13 +799,11 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
               [
                 'key' => 'id',
                 'label' => 'Contact ID',
-                'dataType' => 'Integer',
                 'type' => 'field',
               ],
               [
                 'key' => 'first_name',
                 'label' => 'First Name',
-                'dataType' => 'String',
                 'type' => 'field',
                 'link' => [
                   'entity' => 'Contact',
@@ -825,7 +813,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
               [
                 'key' => 'last_name',
                 'label' => 'Last Name',
-                'dataType' => 'String',
                 'type' => 'field',
               ],
             ],
@@ -913,19 +900,16 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
               [
                 'key' => 'id',
                 'label' => 'Contact ID',
-                'dataType' => 'Integer',
                 'type' => 'field',
               ],
               [
                 'key' => 'first_name',
                 'label' => 'First Name',
-                'dataType' => 'String',
                 'type' => 'field',
               ],
               [
                 'key' => 'last_name',
                 'label' => 'Last Name',
-                'dataType' => 'String',
                 'type' => 'field',
               ],
             ],
@@ -1089,7 +1073,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'first_name',
               'label' => 'First Name',
-              'dataType' => 'String',
               'type' => 'field',
             ],
           ],
@@ -1225,7 +1208,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'id',
-            'dataType' => 'Integer',
             'label' => 'Contact ID',
             'sortable' => TRUE,
             'alignment' => 'text-center',
@@ -1233,7 +1215,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'display_name',
-            'dataType' => 'String',
             'label' => 'Display Name',
             'sortable' => TRUE,
             'link' => [
@@ -1246,7 +1227,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'GROUP_CONCAT_Contact_Email_contact_id_01_email',
-            'dataType' => 'String',
             'label' => '(List) Contact Emails: Email',
             'sortable' => TRUE,
             'alignment' => 'text-right',
@@ -1270,7 +1250,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'birth_date',
-            'dataType' => 'String',
             'label' => 'Birthday',
             'sortable' => TRUE,
             'cssRules' => [
@@ -1376,7 +1355,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'id',
-            'dataType' => 'Integer',
             'label' => 'Activity ID',
             'sortable' => TRUE,
             'icons' => [
@@ -1444,7 +1422,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'id',
-            'dataType' => 'Integer',
             'label' => 'Contact ID',
             'sortable' => TRUE,
             'alignment' => 'text-center',
@@ -1452,7 +1429,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           [
             'type' => 'field',
             'key' => 'nick_name',
-            'dataType' => 'String',
             'label' => 'Display Name',
             'sortable' => TRUE,
             'rewrite' => '[nick_name] [last_name]',
@@ -2383,14 +2359,12 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'type' => 'field',
               'key' => 'id',
-              'dataType' => 'Integer',
               'label' => 'Contribution ID',
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'contact_id.sort_name',
-              'dataType' => 'String',
               'label' => 'Contact Sort Name',
               'sortable' => TRUE,
               'link' => [
@@ -2405,14 +2379,12 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'type' => 'field',
               'key' => 'total_amount',
-              'dataType' => 'Money',
               'label' => 'Total Amount',
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'financial_type_id:label',
-              'dataType' => 'Integer',
               'label' => 'Financial Type',
               'sortable' => TRUE,
             ],
@@ -2487,7 +2459,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'first_name',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
               'icons' => [
                 ['field' => 'contact_sub_type:icon'],
@@ -2541,7 +2512,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'email',
               'label' => 'Email',
-              'dataType' => 'String',
               'type' => 'field',
             ],
           ],
@@ -2588,7 +2558,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'key' => 'first_name',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
             ],
           ],
@@ -2800,14 +2769,12 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
             [
               'type' => 'field',
               'key' => 'id',
-              'dataType' => 'Integer',
               'label' => 'ID',
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'GROUP_CONCAT_Note_EntityFile_File_01_file_name',
-              'dataType' => 'String',
               'label' => ts('Attachments'),
               'sortable' => TRUE,
               'link' => [

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -154,13 +154,11 @@ class SearchRunWithCustomFieldTest extends Api4TestBase {
             [
               'key' => 'first_name',
               'label' => 'First',
-              'dataType' => 'String',
               'type' => 'field',
             ],
             [
               'key' => 'last_name',
               'label' => 'Last',
-              'dataType' => 'String',
               'type' => 'field',
               'rewrite' => '[last_name] [my_test.my_field:label]',
             ],
@@ -289,14 +287,12 @@ class SearchRunWithCustomFieldTest extends Api4TestBase {
             [
               'type' => 'field',
               'key' => 'id',
-              'dataType' => 'Integer',
               'label' => 'Contact ID',
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'GROUP_CONCAT_Contact_ActivityContact_Activity_01_testactivity2_testactivity__label',
-              'dataType' => 'Boolean',
               'label' => '(List) Contact Activities: testactivity2: testactivity_',
               'sortable' => TRUE,
             ],


### PR DESCRIPTION
Overview
----------------------------------------
Partial commit pulled from #30938 - this only updates the tests ahead of the change so this PR is NFC.
See [dev/core#5974](https://lab.civicrm.org/dev/core/-/issues/5974)

Technical Details
----------------------------------------
The `dataType` is no longer needed in search display column definitions so shouldn't be included in tests.