### PR TITLE
add stash for line items to Afform/AbstractProcessor

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -72,6 +72,13 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   protected array $_response = [];
 
   /**
+   * Line items gathered from entities on the form - for payment processing
+   *
+   * @var array[]
+   */
+  protected array $_lineItems = [];
+
+  /**
    * @param \Civi\Api4\Generic\Result $result
    * @throws \CRM_Core_Exception
    */
@@ -742,6 +749,22 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   public function setResponseItem(string $key, $value): void {
     $this->_response[$key] = $value;
+  }
+
+  /**
+   * Retrieve stashed line items
+   * @return array
+   */
+  public function getLineItems(): array {
+    return $this->_lineItems;
+  }
+
+  /**
+   * Stash line items from across form entities
+   * @param array $lineItem
+   */
+  public function addLineItem(array $lineItem): void {
+    $this->_lineItems[] = $lineItem;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add a simple stash to AbstractProcessor - so that line items can be gathered from all the entities on a form, in order to create a single contribution.

See: https://lab.civicrm.org/ufundo/afform_payments/-/tree/dev

Technical Details
----------------------------------------
`afform_payments` mostly works using AfformBehavior, listening to afform submit event. But the submit event is called once for each entity on the form -- we need something that persists _at the request level_ in order to be able to bundle all of the line items from the form together into one Contribution.
