### PR TITLE
More consistent titles and copy on Extension pages and forms

### DIFF
--- a/CRM/Admin/Form/Extensions.php
+++ b/CRM/Admin/Form/Extensions.php
@@ -59,6 +59,26 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
     $this->assign('id', $this->_id);
     $this->assign('key', $this->_key);
 
+    // Set appropriate page title.
+    switch ($this->_action) {
+      case CRM_Core_Action::ADD:
+        $this->setTitle(ts('Install Extension'));
+        break;
+
+      case CRM_Core_Action::DELETE:
+        $this->setTitle(ts('Uninstall Extension'));
+        break;
+
+      case CRM_Core_Action::ENABLE:
+        $this->setTitle(ts('Enable Extension'));
+        break;
+
+      case CRM_Core_Action::DISABLE:
+        $this->setTitle(ts('Disable Extension'));
+        break;
+
+    }
+
     switch ($this->_action) {
       case CRM_Core_Action::ADD:
       case CRM_Core_Action::DELETE:
@@ -99,35 +119,35 @@ class CRM_Admin_Form_Extensions extends CRM_Admin_Form {
     switch ($this->_action) {
       case CRM_Core_Action::ADD:
         $buttonName = ts('Install');
-        $title = ts('Install "%1"?', [
+        $title = ts('You are about to install "%1"', [
           1 => $this->label,
         ]);
         break;
 
       case CRM_Core_Action::UPDATE:
         $buttonName = ts('Download and Install');
-        $title = ts('Download and Install "%1"?', [
+        $title = ts('You are about to download and install "%1"', [
           1 => $this->label,
         ]);
         break;
 
       case CRM_Core_Action::DELETE:
         $buttonName = ts('Uninstall');
-        $title = ts('Uninstall "%1"?', [
+        $title = ts('You are about to uninstall "%1"', [
           1 => $this->label,
         ]);
         break;
 
       case CRM_Core_Action::ENABLE:
         $buttonName = ts('Enable');
-        $title = ts('Enable "%1"?', [
+        $title = ts('You are about to enable "%1"', [
           1 => $this->label,
         ]);
         break;
 
       case CRM_Core_Action::DISABLE:
         $buttonName = ts('Disable');
-        $title = ts('Disable "%1"?', [
+        $title = ts('You are about to disable "%1"', [
           1 => $this->label,
         ]);
         break;

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -730,7 +730,6 @@ class CRM_Extension_Manager {
     if ($dao->find(TRUE)) {
       try {
         CRM_Core_BAO_Extension::deleteRecord(['id' => $dao->id]);
-        CRM_Core_Session::setStatus(ts('Selected option value has been deleted.'), ts('Deleted'), 'success');
       }
       catch (CRM_Core_Exception $e) {
         throw new CRM_Extension_Exception("Failed to remove extension entry $dao->id");

--- a/templates/CRM/Admin/Form/Extensions.tpl
+++ b/templates/CRM/Admin/Form/Extensions.tpl
@@ -7,13 +7,14 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* this template is used for install /uninstall extensions  *}
+
+{* this template is used for rendering the form for performing actions on extensions *}
 <h3>{$title|smarty:nodefaults}</h3>
 <div class="crm-block crm-form-block crm-admin-optionvalue-form-block">
-   {if $action eq 8}
-      <div class="messages status no-popup">
+   {if $action eq 2}
+     <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
-        {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone. Please review the extension information below before you make final decision.{/ts} {ts}Do you want to continue?{/ts}
+        {ts}Downloading this extension will provide you with new functionality. Please make sure that the extension you're installing or upgrading comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 1}
@@ -22,14 +23,26 @@
         {ts}Installing this extension will provide you with new functionality.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
-   {if $action eq 2}
-     <div class="messages status no-popup">
+   {if $action eq 8}
+      <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
-        {ts}Downloading this extension will provide you with new functionality. Please make sure that the extension you're installing or upgrading comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
+        {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone. Please review the extension information below before you make final decision.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
-   {if $action eq 8 or $action eq 1 or $action eq 2}
-        {include file="CRM/Admin/Page/ExtensionDetails.tpl"}
+   {if $action eq 32}
+      <div class="messages status no-popup">
+        {icon icon="fa-info-circle"}{/icon}
+        {ts}Enabling this extension will restore the functionality that it provides.{/ts} {ts}Any records which use this extension will be become available again.{/ts} {ts}Do you want to continue?{/ts}
+      </div>
+   {/if}
+   {if $action eq 64}
+      <div class="messages status no-popup">
+        {icon icon="fa-info-circle"}{/icon}
+        {ts}Disabling this extension will remove the functionality that it provides.{/ts} {ts}Any records which use this extension will be retained, but will only become available when it is enabled again.{/ts} {ts}Do you want to continue?{/ts}
+      </div>
+   {/if}
+   {if $action eq 2 or $action eq 1 or $action eq 8 or $action eq 32 or $action eq 64}
+     {include file="CRM/Admin/Page/ExtensionDetails.tpl"}
    {/if}
    <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Admin/Form/Extensions.tpl
+++ b/templates/CRM/Admin/Form/Extensions.tpl
@@ -26,7 +26,7 @@
    {if $action eq 8}
       <div class="messages status no-popup">
         {icon icon="fa-info-circle"}{/icon}
-        {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone. Please review the extension information below before you make final decision.{/ts} {ts}Do you want to continue?{/ts}
+        {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 32}


### PR DESCRIPTION
Overview
----------------------------------------
As promised in #33084 this PR modifies the wording of pages/forms that handle the Extension lifecycle to be more consistent with the actions being performed.

Before
----------------------------------------
Inconsistent and often confusing titles and wording. Details in [this comment](https://github.com/civicrm/civicrm-core/pull/33084#issuecomment-3025785466).

After
----------------------------------------
* More consistent and less confusing titles and wording.
* Extension details always shown on form pages where an action is taken. Because why not.
* Remove unnecessary "Selected option value has been deleted" feedback popup.