### PR TITLE
RiverLea: Responsive improvement : container query on contact summary stacks label/value

### DIFF
--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -358,9 +358,23 @@ div.crm-inline-edit-form div.crm-clear {
   border-radius: var(--crm-roundness);
   box-shadow: var(--crm-block-shadow);
   margin-bottom: var(--crm-dash-panel-padding);
+  container-name: crm-summary-block;
+  container-type: inline-size;
 }
 .crm-contact-page .crm-summary-block .crm-summary-block {
   box-shadow: none;
+}
+@container crm-summary-block (width < 430px) {
+  /* Stacks label + input on narrower screens */
+  .crm-container .crm-summary-row {
+    flex-direction: column;
+  }
+  .crm-container .crm-summary-row .crm-label {
+    padding-bottom: var(--crm-s);
+  }
+  .crm-container .crm-summary-row .crm-content {
+    padding-top: 0;
+  }
 }
 .crm-contact-page div.crm-clear {
   padding: var(--crm-dash-block-padding);
@@ -414,8 +428,7 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
     --crm-dash-heading-inset: 0; /* resets any inset on the title/action links */
     --crm-side-tabs-width: auto; /* resets offset inline edit */
   }
-  .crm-container #mainTabContainer,
-  .crm-container div.crm-summary-row {
+  .crm-container #mainTabContainer {
     flex-direction: column;
   }
   .crm-container .crm-actions-ribbon ul#actions {


### PR DESCRIPTION
Overview
----------------------------------------
Contact layout has inline label and content, which can squash the content at some viewports (and create the issues found by @andyburnsco [here](https://lab.civicrm.org/extensions/riverlea/-/issues/129#note_183683).

Before
----------------------------------------
Label and content are inline until we get to 767px width and then they stack with a lot of space.
https://github.com/user-attachments/assets/1e94db47-dc3c-4ef9-bb20-ea1a7400f6cf

Minetta:
![image](https://github.com/user-attachments/assets/1f76e03f-b1ff-414f-ba55-f3c093860c6b)

Hackney:
![image](https://github.com/user-attachments/assets/1554c801-35ea-4471-80a5-b1a4df4d5591)

After
----------------------------------------
Label and content are inline until the `crm-summary-block` region is 430px or under in width, then they stack, with reduced top/bottom padding between them.
https://github.com/user-attachments/assets/b21fdcc8-c85f-4393-a5f5-49955e14144a

Minetta:
![image](https://github.com/user-attachments/assets/792937e2-4da1-45eb-b6dd-9801b80e6c01)

Hackney:
![image](https://github.com/user-attachments/assets/44640307-09d4-436c-9dcf-338668d6e2bd)

Technical Details
----------------------------------------
This uses Container Queries to check the size of an element rather than the full display viewport. As a result the inline/stack pattern changes several times as the width shrinks: when there's two columns, it first shifts from inline to stack, and then with the jump to one column at 991px viewport, it goes back to inline again, because the div has more room. Then as that viewport width shrinks it goes back to stacked finally.

Container queries [have been supported](https://caniuse.com/css-container-queries) in modern browsers for several years.

Comments
----------------------------------------
Thames is unchanged by this PR because it implements its own `display:grid` rather than RL core's Flex for contact-summary label/content/. cc @artfulrobot 

There was a basic responsive stacking behaviour in place before, that kicked in at 767px viewport width, that's been removed in this PR as it's superseded.