### PR TITLE
Address passing of NULL to string functions in spreadsheet uploads 

### DIFF
--- a/ext/civiimport/Civi/Import/DataSource/Spreadsheet.php
+++ b/ext/civiimport/Civi/Import/DataSource/Spreadsheet.php
@@ -156,6 +156,9 @@ class Spreadsheet extends \CRM_Import_DataSource implements DataSourceInterface 
     // Re-key data using the headers
     $sql = [];
     foreach ($dataRows as $row) {
+      // Ensure data type is string - this is consistent with other data sources and,
+      // importantly, avoids passing NULL to string functions.
+      $row = array_map('strval', $row);
       // CRM-17859 Trim non-breaking spaces from columns.
       $row = array_map([__CLASS__, 'trimWhiteSpace'], $row);
       $row = array_map(['CRM_Core_DAO', 'escapeString'], $row);


### PR DESCRIPTION


Overview
----------------------------------------
A type hint introduced in 6.3 https://github.com/civicrm/civicrm-core/commit/000ec9c83ab4efd04eed2b1b75db80e80bf4b650 can cause a fatal error on empty cells in spread sheet imports

Before
----------------------------------------
Importing a spreadsheet with empty cells can hit a type-hint fatal

After
----------------------------------------
All cells cast to string before being passed into string functions

Technical Details
----------------------------------------
The trimWhiteSpace function is shared with the csv import, but that seems to treat empy as an empty string & the spreadsheet class treats empty as NULL - this makes the spreadsheet cast convert to a string per the csv - avoiding issues with type hints

Comments
----------------------------------------
