### PR TITLE
dev/core#5972 fix failure to handle default_value on participant import

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -305,7 +305,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       if ($this->getSubmittedValue('savedMapping')) {
         $fieldMapping = $fieldMappings[$i] ?? NULL;
         if (isset($fieldMappings[$i])) {
-          if ($fieldMapping['name'] !== ts('do_not_import')) {
+          if (!empty($fieldMapping['name']) && $fieldMapping['name'] !== ts('do_not_import')) {
             $defaults["mapper[$i]"] = [$fieldMapping['name']];
           }
           else {
@@ -620,6 +620,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $mapper = [];
     $fields = $this->getUserJob()['metadata']['import_mappings'];
     foreach ($fields as $field) {
+      if (!isset($field['name'])) {
+        continue;
+      }
       if (str_starts_with($field['name'], $entity . '.') || str_starts_with($field['name'], $this->getBaseEntity() . '.')) {
         $mapper[] = [$field['name']];
       }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1351,14 +1351,18 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       if ($mappedField['name']) {
         $fieldSpec = $this->getFieldMetadata($mappedField['name']);
         $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity_name'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
+        $fieldValue = $values[$i];
+        if ($fieldValue === '' && isset($mappedField['default_value'])) {
+          $fieldValue = $mappedField['default_value'];
+        }
         if ($entity) {
           // Split values into arrays by entity.
           // Apiv4 name is currently only set for contact, & only in cases where it would
           // be used for the dedupe rule (ie Membership import).
-          $params[$entity][$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+          $params[$entity][$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $fieldValue);
         }
         else {
-          $params[$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+          $params[$fieldSpec['name']] = $this->getTransformedFieldValue($mappedField['name'], $fieldValue);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#5972 fix failure to handle default_value on participant import

Before
----------------------------------------
Civiimport permits adding additional rows with default values - but this data was only being processed for the contribution import

After
----------------------------------------
processed for all civi-imports

Technical Details
----------------------------------------
Some notice fixes too

Comments
----------------------------------------
