### PR TITLE
Avoid fatal on imports when table name is missing

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -225,6 +225,9 @@ abstract class CRM_Import_DataSource implements DataSourceInterface {
    * @throws \CRM_Core_Exception
    */
   public function getRowCount(array $statuses = []): int {
+    if (!$this->getTableName()) {
+      return 0;
+    }
     $this->statuses = $statuses;
     $query = 'SELECT count(*) FROM ' . $this->getTableName() . ' ' . $this->getStatusClause();
     return CRM_Core_DAO::singleValueQuery($query);


### PR DESCRIPTION


Overview
----------------------------------------
I didn't replicate this bug that Tim hit over at https://github.com/civicrm/civicrm-core/pull/33050#issuecomment-3014726053 - but I think it occurs on imports that are upgraded. Either way, fatals are not very cool

Before
----------------------------------------
error

After
----------------------------------------
handling for missing table name

Technical Details
----------------------------------------

Comments
----------------------------------------
