### PR TITLE
Fix duplicate Contact ID mapping option on membership import

### DIFF
--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -292,19 +292,16 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         ->addOrderBy('title')
         ->execute()->indexBy('name');
       foreach ($membershipFields as $fieldName => $field) {
+        if ($field['name'] === 'contact_id') {
+          // This is added as Contact.id
+          continue;
+        }
         $field['entity_instance'] = 'Membership';
         $field['entity_prefix'] = 'Membership.';
         $fields['Membership.' . $fieldName] = $field;
       }
 
-      $contactFields = $this->getContactFields($this->getContactType(), 'Contact');
-      $fields['contact_id'] = $contactFields['Contact.id'];
-      $fields['contact_id']['match_rule'] = '*';
-      $fields['contact_id']['entity'] = 'Contact';
-      $fields['contact_id']['html']['label'] = $fields['contact_id']['title'];
-      $fields['contact_id']['title'] .= ' ' . ts('(match to contact)');
-      unset($contactFields['contact.id']);
-      $fields += $contactFields;
+      $fields += $this->getContactFields($this->getContactType(), 'Contact');
       Civi::cache('fields')->set('membership_importable_fields' . $contactType, $fields);
     }
     return $fields;

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -363,7 +363,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $donaldDuckID = $this->individualCreate(['first_name' => 'Donald', 'last_name' => 'Duck']);
     $this->createCustomGroupWithFieldsOfAllTypes(['extends' => 'Membership']);
     $membershipImporter = $this->createImportObject([
-      'Membership.contact_id',
+      'Contact.id',
       'Membership.membership_type_id',
       'Membership.start_date',
       'Membership.' . $this->getCustomFieldName('text', 4),
@@ -397,7 +397,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $mapper = [
       ['name' => 'Membership.membership_type_id'],
       ['name' => 'Membership.id'],
-      ['name' => 'Membership.contact_id'],
+      ['name' => 'Contact.id'],
       ['name' => 'Contact.external_identifier'],
       ['name' => 'Contact.email_primary.email'],
       ['name' => 'Membership.start_date'],
@@ -416,7 +416,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
 
   public function requiredFields(): array {
     return [
-      'contact_id' => [['Membership.contact_id', 'Membership.membership_type_id', 'Membership.start_date']],
+      'contact_id' => [['Contact.id', 'Membership.membership_type_id', 'Membership.start_date']],
       'external_identifier' => [['Contact.external_identifier', 'Membership.membership_type_id', 'Membership.start_date']],
       'email' => [['Contact.email_primary.email', 'Membership.membership_type_id', 'Membership.start_date']],
     ];
@@ -428,7 +428,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
   public function testImportCSV() :void {
     try {
       $this->importCSV('memberships_invalid.csv', [
-        ['name' => 'Membership.contact_id'],
+        ['name' => 'Contact.id'],
         ['name' => 'Membership.source'],
         ['name' => 'Membership.membership_type_id'],
         ['name' => 'Membership.start_date'],


### PR DESCRIPTION
Overview
----------------------------------------
Fix duplicate Contact ID mapping option on membership import
 
Before
----------------------------------------
2 options ... which do NOT work equally well

![image](https://github.com/user-attachments/assets/dad6ae5b-b720-498b-a58c-29a439804e75)


After
----------------------------------------
Just the one that works

![image](https://github.com/user-attachments/assets/76e0a62c-4dc3-4396-8234-efcc40fbcc53)

& the import works

![image](https://github.com/user-attachments/assets/591888ea-feb7-408d-90ba-26fabcad1701)


Technical Details
----------------------------------------

Comments
----------------------------------------
