### PR TITLE
[NFC] correct setting override global in comment

### DIFF
--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -364,7 +364,7 @@ class SettingsManager {
    *
    * We now simplify to two simple groups, 'domain' and 'contact'.
    *
-   *    $civicrm_settings['domain']['foo'] = 'bar';
+   *    $civicrm_setting['domain']['foo'] = 'bar';
    *
    * 'Personal Preferences' is still aliased for compatibility (is this still needed in June 2024?).
    *


### PR DESCRIPTION
Overview
----------------------------------------
Global is `civicrm_setting` not `civicrm_settings` - it's only in a comment but would be very annoying if you copied to your `civicrm.settings.php`... 