### PR TITLE
(NFC) api_v3_SystemTest - Fix for newer MySQL and MariaDB versions

### DIFF
--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -95,9 +95,8 @@ class api_v3_SystemTest extends CiviUnitTestCase {
       $this->callAPISuccess('System', 'utf8conversion', ['is_revert' => 1]);
       $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');
       $table->fetch();
-      $version = CRM_Utils_SQL::getDatabaseVersion();
-      $charset = (version_compare($version, '8', '>=') && stripos($version, 'mariadb') === FALSE) ? 'utf8mb3' : 'utf8';
-      $this->assertStringEndsWith('DEFAULT CHARSET=' . $charset . ' COLLATE=utf8_unicode_ci ROW_FORMAT=DYNAMIC', $table->Create_Table);
+      // "utf8" are "utf8mb3" synonymous, but the canonical form gets flipfloppy depending on the specific versions of MySQL/MariaDB.
+      $this->assertMatchesRegularExpression(';DEFAULT CHARSET=utf8(mb3)? COLLATE=utf8(mb3)?_unicode_ci ROW_FORMAT=DYNAMIC;', $table->Create_Table);
     }
     else {
       $this->markTestSkipped('MySQL Version does not support ut8mb4 testing');


### PR DESCRIPTION
Overview
----------------------------------------

Partial backport of #33058 from 6.5-dev to 6.4-rc (*forthcoming 6.4-stable*) to improve compatibility with MySQL 8.0.42.

While it's not a functional change, it will help with maintenance for 6.4-stable and 6.4-esr.

Before
----------------------------------------

`testSystemUTFMB8Conversion` fails on MySQL 8.0.42.

After
----------------------------------------

`testSystemUTFMB8Conversion` passes on MySQL 8.0.42.

Technical Details
----------------------------------------

The recent https://github.com/civicrm/civicrm-buildkit/pull/961/ had the effect of upgrading MySQL 8.0 from 8.0.29 to 8.0.42. It seems that this newer revision changes the canonical name for aliased collations (`utf8_unicode_ci` <=>  `utf8mb3_unicode_ci`), which causes the test [testSystemUTFMB8Conversion](https://test.civicrm.org/job/CiviCRM-Test-QLow/180218/testReport/(root)/api_v3_SystemTest/testSystemUTFMB8Conversion/) to fail.

The test failures don't appear on PRs (because the PRs are focused on the faster MySQL 5.7) -- but they do appear in nightly runs on of `phpXXm80` on Civi 5.81, 6.3, 6.4. The `phpXXm80` only passes on `master`.

Fortunately, that's because `master` already has a patch (previously submitted in #33058 to address similar problem on MySQL 8.4/9.0). So this is a backport.