### PR TITLE
Riverlea: Add variable for dashboard columns, make 40/60 default

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -359,6 +359,7 @@
   --crm-dialog-body-bg: var(--crm-c-background);
   --crm-dialog-body-padding: var(--crm-m);
 /* Dashlet */
+  --crm-dashlet-columns: 2fr 3fr;
   --crm-dashlet-border: unset;
   --crm-dashlet-bg: var(--crm-c-page-background);
   --crm-dashlet-padding: var(--crm-s2);

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -5,7 +5,7 @@
 
 #civicrm-dashboard > .crm-flex-box {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: var(--crm-dashlet-columns);
   gap: var(--crm-r);
   /* avoid total collapse else no droppable area if all widgets removed */
   min-height: var(--crm-r);


### PR DESCRIPTION
Overview
----------------------------------------
Added the variable to make this configurable.
Replaced the 50/50 split with 40/60 like it used to be in Greenwich. My experience is that some dashlets need the wider space and some fit in a narrower column, so I think it makes sense to go back to the 40/60 split as the default.

After
----------------------------------------
Here are the four streams.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b4260e56-f422-463a-9f6c-04622c26148d" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cce139f7-1d20-4097-ad9b-33b9b36b9463" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/71f2e03a-a40c-4be3-813b-de893c379f72" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4e14f251-84f2-481a-af33-acbb008a73d5" />



