### PR TITLE
Remove functions deprecated by flexmailer

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -75,50 +75,6 @@ class CRM_Utils_Token {
   ];
 
   /**
-   * Check a string (mailing body) for required tokens.
-   *
-   * @param string $str
-   *   The message.
-   *
-   * @return bool|array
-   *   true if all required tokens are found,
-   *    else an array of the missing tokens
-   *
-   * @deprecated since 5.78 will be removed around 5.90
-   */
-  public static function requiredTokens(&$str) {
-    CRM_Core_Error::deprecatedFunctionWarning('use flexmailer');
-    $requiredTokens = Civi\Core\Resolver::singleton()->call('call://civi_flexmailer_required_tokens/getRequiredTokens', []);
-
-    $missing = [];
-    foreach ($requiredTokens as $token => $value) {
-      if (!is_array($value)) {
-        if (!preg_match('/(^|[^\{])' . preg_quote('{' . $token . '}') . '/', $str)) {
-          $missing[$token] = $value;
-        }
-      }
-      else {
-        $present = FALSE;
-        $desc = NULL;
-        foreach ($value as $t => $d) {
-          $desc = $d;
-          if (preg_match('/(^|[^\{])' . preg_quote('{' . $t . '}') . '/', $str)) {
-            $present = TRUE;
-          }
-        }
-        if (!$present) {
-          $missing[$token] = $desc;
-        }
-      }
-    }
-
-    if (empty($missing)) {
-      return TRUE;
-    }
-    return $missing;
-  }
-
-  /**
    * Wrapper for token matching.
    *
    * @param string $type

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -75,27 +75,6 @@ class CRM_Utils_Token {
   ];
 
   /**
-   * @deprecated
-   *   This is used by CiviMail but will be made redundant by FlexMailer.
-   * @return array
-   */
-  public static function getRequiredTokens() {
-    CRM_Core_Error::deprecatedFunctionWarning('token processor');
-    if (self::$_requiredTokens == NULL) {
-      self::$_requiredTokens = [
-        'domain.address' => ts("Domain address - displays your organization's postal address."),
-        'action.optOutUrl or action.unsubscribeUrl' => [
-          'action.optOut' => ts("'Opt out via email' - displays an email address for recipients to opt out of receiving emails from your organization."),
-          'action.optOutUrl' => ts("'Opt out via web page' - creates a link for recipients to click if they want to opt out of receiving emails from your organization. Alternatively, you can include the 'Opt out via email' token."),
-          'action.unsubscribe' => ts("'Unsubscribe via email' - displays an email address for recipients to unsubscribe from the specific mailing list used to send this message."),
-          'action.unsubscribeUrl' => ts("'Unsubscribe via web page' - creates a link for recipients to unsubscribe from the specific mailing list used to send this message. Alternatively, you can include the 'Unsubscribe via email' token or one of the Opt-out tokens."),
-        ],
-      ];
-    }
-    return self::$_requiredTokens;
-  }
-
-  /**
    * Check a string (mailing body) for required tokens.
    *
    * @param string $str


### PR DESCRIPTION
Overview
----------------------------------------
Remove functions deprecated by flexmailer 

Before
----------------------------------------
Only universe caller for either one is in a function that is already broken due to calling a removed function

![image](https://github.com/user-attachments/assets/9aaebea7-7d68-435a-98b2-ae05d934fe6a)

![image](https://github.com/user-attachments/assets/0e338816-77a9-4d6a-b0e4-e7d214ae1168)


After
----------------------------------------
poof

Technical Details
----------------------------------------

Comments
----------------------------------------
