### PR TITLE
RiverLea: adds @artfulrobot's flexbox utility classes

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -463,6 +463,40 @@ dl dl {
 .crm-container .nowrap {
   white-space: nowrap
 }
+
+/* Flexbox utility classes */
+
+.crm-flex-align-start /* align top */ {
+  align-items: flex-start;
+}
+.crm-flex-align-center /* align middle */ {
+  align-items: center;
+}
+.crm-flex-align-end /* align bottom */ {
+  align-items: flex-end;
+}
+.crm-flex-justify-start /* align left */ {
+  justify-content: flex-start;
+}
+.crm-flex-justify-center /* align center */ {
+  justify-content: center;
+}
+.crm-flex-justify-between
+/* first/last items aligned left/right, rest spread evenly */ {
+  justify-content: space-between;
+}
+.crm-flex-justify-space-evenly
+/* space between each item & edges the same */ {
+  justify-content: space-evenly;
+}
+.crm-flex-justify-around
+/* same except edge-spacing is half */ {
+  justify-content: space-around;
+}
+.crm-flex-justify-end /* align right */ {
+  justify-content: flex-end;
+}
+
 /* Responsive  */
 
 @media (max-width: 991px) {

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -469,31 +469,28 @@ dl dl {
 .crm-flex-align-start /* align top */ {
   align-items: flex-start;
 }
-.crm-flex-align-center /* align middle */ {
+.crm-flex-align-center {
   align-items: center;
 }
-.crm-flex-align-end /* align bottom */ {
+.crm-flex-align-end {
   align-items: flex-end;
 }
 .crm-flex-justify-start /* align left */ {
   justify-content: flex-start;
 }
-.crm-flex-justify-center /* align center */ {
+.crm-flex-justify-center {
   justify-content: center;
 }
-.crm-flex-justify-between
-/* first/last items aligned left/right, rest spread evenly */ {
+.crm-flex-justify-between {
   justify-content: space-between;
 }
-.crm-flex-justify-space-evenly
-/* space between each item & edges the same */ {
+.crm-flex-justify-space-evenly {
   justify-content: space-evenly;
 }
-.crm-flex-justify-around
-/* same except edge-spacing is half */ {
+.crm-flex-justify-around {
   justify-content: space-around;
 }
-.crm-flex-justify-end /* align right */ {
+.crm-flex-justify-end {
   justify-content: flex-end;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR resolves https://lab.civicrm.org/dev/core/-/issues/5966 by adding utility positioning classes for Flexbox (aka `.crm-flex`). It includes the eight classes proposed by @artfulrobot there plus `.crm-flex-justify-space-evenly`.

Before
----------------------------------------
No utility classes for Flexbox positioning.

After
----------------------------------------
9 new classes.

Technical Details
----------------------------------------
We've gone for verbose names, rather than short-hand. These are defined in full [here](https://www.w3.org/TR/css-flexbox-1/) and summarised more accessibly [here](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).

Comments
----------------------------------------
This PR doesn't change any existing CiviCRM or RiverLea appearance, these are classes that can be made use of by extensions and other components trying to position elements using Flexbox.
