### PR TITLE
dev/core#5983 - standalone doesn't display smarty errors

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -25,12 +25,6 @@
       </ol></nav>
     {/if}
 
-    {if $standaloneErrors}
-      <div class="standalone-errors">
-        <ul>{$standaloneErrors}</ul>
-      </div>
-    {/if}
-
     {if $pageTitle}
       <div class="crm-page-title-wrapper">
         <h1 class="crm-page-title">{$pageTitle}</h1>
@@ -60,6 +54,21 @@
         {include file="CRM/common/footer.tpl"}
       {/if}
     {/crmRegion}
+
+    {* This has to come at the bottom because the variable may not be populated until some of the templates evaluated inline above get evaluated. *}
+    {if $standaloneErrors}
+      <div class="standalone-errors">
+        <ul>{$standaloneErrors}</ul>
+      </div>
+      <script type="text/javascript">
+      {if $breadcrumb}
+        CRM.$("div.standalone-errors").insertAfter("nav.breadcrumb");
+      {else}
+        CRM.$("div.standalone-errors").prependTo("div#crm-container");
+      {/if}
+      </script>
+    {/if}
+
   </div>
 </body>
 </html>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5983

Before
----------------------------------------
1. Devs be dev'ing, making errors. Testers be testing.
2. No visual of the errors anywhere.

After
----------------------------------------
1. Just like drupal!

Technical Details
----------------------------------------
To reproduce, turn on debugging at administer - system settings - debugging. Edit a tpl to introduce something like a missing variable, e.g. `{foreach from=$form.foo item=bar}{/foreach}`, where `$form['foo']` is not set. Visit the page.

The problem is `{$standaloneErrors}` doesn't get populated by the error handler until it hits the part of standalone.tpl where it evaluates the form/page tpls involved, so having `{$standaloneErrors}` evaluated/output at the top misses errors that come up during the tpl evaluation.

Comments
----------------------------------------
If there's a pure css way to do this some people might find that cleaner.
