### PR TITLE
Fix help link on "Multi Site Preferences" screen

### DIFF
--- a/settings/Multisite.setting.php
+++ b/settings/Multisite.setting.php
@@ -32,7 +32,7 @@ return [
     'is_domain' => 1,
     'is_contact' => 0,
     'description' => ts('Make CiviCRM aware of multiple domains. You should configure a domain group if enabled'),
-    'documentation_link' => ['page' => 'Multi Site Installation', 'resource' => 'wiki'],
+    'documentation_link' => ['page' => 'sysadmin/setup/multisite', 'resource' => ''],
     'help_text' => NULL,
     'settings_pages' => ['multisite' => ['weight' => 10]],
   ],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the "Learn more..." help link on the "Multi Site Preferences" screen.

Before
----------------------------------------
Link goes to non-existent wiki URL that redirects to a 404 on the current docs.

```
http://wiki.civicrm.org/confluence/display/CRMDOC/Multi+Site+Installation
```

After
----------------------------------------
Link goes to correct docs page:

```
https://docs.civicrm.org/sysadmin/en/latest/setup/multisite/
```

Comments
----------------------------------------
This appears to be an obsolete or deprecated way of show help links, but it's a quick fix so here it is.