### PR TITLE
Small not a dupe UX improvements

### DIFF
--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -151,7 +151,6 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
           throw new CRM_Core_Exception(ts('There is no Supervised dedupe rule configured for contact type %1.', [1 => $this->_contactType]));
         }
       }
-      $this->assign('browseUrl', $browseUrl);
       if ($browseUrl) {
         CRM_Core_Session::singleton()->pushUserContext($browseUrl);
       }
@@ -195,6 +194,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
         }
         $this->assign($position, $this->$position);
       }
+
+      $this->assign('returnUrl', $this->next ?? $browseUrl);
 
       // get user info of other contact.
       $otherUfId = CRM_Core_BAO_UFMatch::getUFId($this->_oid);

--- a/templates/CRM/Contact/Form/Merge.tpl
+++ b/templates/CRM/Contact/Form/Merge.tpl
@@ -40,7 +40,7 @@
   </div>
 
   <div class="action-link">
-    <a href="#" class="action-item crm-hover-button crm-notDuplicate" title="{ts escape='htmlattribute'}Mark this pair as not a duplicate.{/ts}" onClick="processDupes( {$main_cid|escape}, {$other_cid|escape}, 'dupe-nondupe', 'merge-contact', '{$browseUrl}' );return false;">
+    <a href="#" class="action-item crm-hover-button crm-notDuplicate" title="{ts escape='htmlattribute'}Mark this pair as not a duplicate.{/ts}" onClick="processDupes( {$main_cid|escape}, {$other_cid|escape}, 'dupe-nondupe', 'merge-contact', '{$returnUrl}' );return false;">
       <i class="crm-i fa-times-circle" aria-hidden="true"></i>
       {ts}Mark this pair as not a duplicate.{/ts}
     </a>

--- a/templates/CRM/common/dedupe.tpl
+++ b/templates/CRM/common/dedupe.tpl
@@ -1,83 +1,25 @@
 {* common dupe contacts processing *}
-<div id='processDupes' style="display:none;"></div>
 {literal}
 <script type='text/javascript'>
-
-cj( '#processDupes' ).hide( );
-
-function processDupes(cid, oid, oper, context, reloadURL) {
-        //currently we are doing in a single way.
-        //later we might want two way operations.
-
-        if ( !cid || !oid || !oper ) return;
-
-  var title = {/literal}'{ts escape="js"}Mark as Dedupe Exception{/ts}'{literal};
-  var msg = {/literal}'{ts escape="js"}Are you sure you want to mark this pair of contacts as NOT duplicates?{/ts}'{literal};
-        if ( oper == 'nondupe-dupe' ) {
-    var title = {/literal}'{ts escape="js"}Remove Dedupe Exception{/ts}'{literal};
-          var msg = {/literal}'{ts escape="js"}Are you sure you want to remove this dedupe exception.{/ts}'{literal};
-        }
-
-  cj("#processDupes").show( );
-  cj("#processDupes").dialog({
-    title: title,
-    modal: true,
-
-    open:function() {
-       cj( '#processDupes' ).show( ).html( msg );
-    },
-
-    buttons: {
-      "Cancel": function() {
-        cj(this).dialog("close");
-      },
-      "OK": function() {
-              saveProcessDupes( cid, oid, oper, context );
-              cj(this).dialog( 'close' );
-        if ( context == 'merge-contact' && reloadURL ) {
-                                     // redirect after a small delay
-                                     setTimeout("window.location.href = '" + reloadURL + "'", 500);
-        }
-        else {
-          //CRM-15113 this has the effect of causing the alert to display. Also, as they are already 'actioned' Civi sensibly returns the browser to the
-          //search screen
-          setTimeout(function(){
-            window.location.reload();
-          }, 500);
-        }
-      }
-    }
-  });
-}
-
-
-function saveProcessDupes( cid, oid, oper, context ) {
-    //currently we are doing in a single way.
-    //later we might want two way operations.
-
+  function processDupes( cid, oid, oper, context, reloadURL ) {
     if ( !cid || !oid || !oper ) return;
 
-    var statusMsg = {/literal}'{ts escape="js"}Marked as non duplicates.{/ts}'{literal};
-    if ( oper == 'nondupe-dupe' ) {
-       var statusMsg = {/literal}'{ts escape="js"}Marked as duplicates.{/ts}'{literal};
-    }
+    statusMsg = ( oper == 'nondupe-dupe' ) ?
+      {/literal}'{ts escape="js"}Dedupe exception removed.{/ts}'{literal} :
+      {/literal}'{ts escape="js"}Marked as non duplicates.{/ts}'{literal};
 
     var url = {/literal}"{crmURL p='civicrm/ajax/rest' q='className=CRM_Contact_Page_AJAX&fnName=processDupes' h=0}"{literal};
-    //post the data to process dupes.
-    cj.post( url,
-            {cid: cid, oid: oid, op: oper},
-             function( result ) {
-     if ( result.status == oper ) {
-
-        if ( oper == 'dupe-nondupe' &&
-             context == 'dupe-listing' ) {
-              oTable.fnDraw();
-        } else if ( oper == 'nondupe-dupe' ) {
-              cj( "#dupeRow_" + cid + '_' + oid ).hide( );
+    CRM.$.post( url, {cid: cid, oid: oid, op: oper}, function( result ) {
+      if ( result.status == oper ) {
+        CRM.alert('', statusMsg, 'success');
+        if ( context == 'merge-contact' && reloadURL ) {
+          window.location.href = reloadURL;
         }
-                  }
-       },
-       'json' );
-}
+        else {
+          window.location.reload();
+        }
+      }
+    }, 'json' );
+  }
 </script>
 {/literal}


### PR DESCRIPTION
Before
----------------------------------------
After clicking "Mark this pair as not a duplicate" on the dedupe merge form, the user is returned to the browse screen instead of the next pair of dupes as expected.

There is a confirmation dialogue for "Mark this pair as not a duplicate" and "Remove dedupe exception".

After
----------------------------------------
After clicking "Mark this pair as not a duplicate" on the dedupe merge form, the user is taken to the next pair of contacts or the browse screen if there are no more — the same behaviour as after merging two contacts.

No more confirmation dialogue; instead the user is shown an alert indicating success.

Comments
----------------------------------------
This could certainly be better, but without getting into more significant changes, I think this is a significant usability improvement and gets rid of some crufty old js.