### PR TITLE
Upgrader - Tighten bolts to prevent bad/premature reconciliations

### DIFF
--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -113,8 +113,13 @@ class CRM_Upgrade_DispatchPolicy {
     // It's more restrictive, preventing interference from unexpected callpaths.
     $policies['upgrade.main'] = [
       'hook_civicrm_config' => 'run',
+
       // cleanupPermissions() in some UF's can be destructive. Running prematurely could be actively harmful.
       'hook_civicrm_permission' => 'fail',
+
+      // ManagedEntities::reconcile() can remove data. Running prematurely would be actively harmful.
+      'hook_civicrm_managed' => 'fail',
+
       'hook_civicrm_crypto' => 'drop',
       '/^hook_civicrm_(pre|post)$/' => 'drop',
       '/^hook_civicrm_/' => $strict ? 'warn-drop' : 'drop',


### PR DESCRIPTION
Overview
----------------------------------------

During upgrade, we run through a few phases -- e.g. starting with tight phase (`upgrade.main`; extensions-restricted) and then finishing-up a relaxed phase (`upgrade.finish`; extensions-allowed).

This PR tightens the validation during `upgrade.main`.

It's inspired by conversation from https://lab.civicrm.org/dev/core/-/issues/5969. (It doesn't necessarily fix that issue. But it speaks to one theory of causation - for that contingency, it will be clearer/safer.)

Before
----------------------------------------

* During `upgrade.main`...
* If someone runs a premature system-flush (or calls `ManagedEntities::reconcile()` or otherwise fires `hook_civicrm_managed`)...
* _Then the hook is dropped -- so it yields empty data, which means it quietly deletes mgds._

After
----------------------------------------

* During `upgrade.main`...
* If someone runs a premature system-flush (or calls `ManagedEntities::reconcile()` or otherwise fires `hook_civicrm_managed`)...
* _Then it raises an explicit error -- yielding a clearer error-message and tighter backtrace. It also stops the upgrade from auto-deleting records._

Comments
----------------------------------------

In practice, this shouldn't change anything -- it addresses a hypothetical ("if someone runs a premature system-flush"). But there have been a couple hints that this hypothetical may be happening. Here's how it games-out:

* If the hypothetical is false (*as it should be*), then this will have no effect.
* If the hypothetical is true (*as it could be*), then this will help diagnosis and reporting.
