### PR TITLE
dev/core#5713 dont check permissions during import form generation

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -212,36 +212,26 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
    * @throws \CRM_Core_Exception
    */
   public static function getImportForms(): array {
-    $cacheKey = 'civiimport_forms_' . \CRM_Core_Config::domainID() . '_' . (int) \CRM_Core_Session::getLoggedInContactID();
-    if (\Civi::cache('metadata')->has($cacheKey)) {
-      return \Civi::cache('metadata')->get($cacheKey);
-    }
     $forms = [];
-    try {
-      $importSearches = SearchDisplay::get()
-        ->addWhere('saved_search_id.name', 'LIKE', 'Import\_Summary\_%')
-        ->addWhere('saved_search_id.expires_date', '>', 'now')
-        ->addSelect('name', 'label')
-        ->execute();
-      foreach ($importSearches as $importSearch) {
-        $userJobID = str_replace('Import_Summary_', '', $importSearch['name']);
-        $forms[$importSearch['name']] = [
-          'name' => $importSearch['name'],
-          'type' => 'search',
-          'title' => $importSearch['label'],
-          'base_module' => E::LONG_NAME,
-          'permission' => 'access CiviCRM',
-          'requires' => ['crmSearchDisplayTable'],
-          'layout' => '<div af-fieldset="">
-  <crm-search-display-table search-name="Import_Summary_' . $userJobID . '" display-name="Import_Summary_' . $userJobID . '">
-</crm-search-display-table></div>',
-        ];
-      }
+    $importSearches = SearchDisplay::get(FALSE)
+      ->addWhere('saved_search_id.name', 'LIKE', 'Import\_Summary\_%')
+      ->addWhere('saved_search_id.expires_date', '>', 'now')
+      ->addSelect('name', 'label')
+      ->execute();
+    foreach ($importSearches as $importSearch) {
+      $userJobID = str_replace('Import_Summary_', '', $importSearch['name']);
+      $forms[$importSearch['name']] = [
+        'name' => $importSearch['name'],
+        'type' => 'search',
+        'title' => $importSearch['label'],
+        'base_module' => E::LONG_NAME,
+        'permission' => 'access CiviCRM',
+        'requires' => ['crmSearchDisplayTable'],
+        'layout' => '<div af-fieldset="">
+  <c-search-display-table search-name="Import_Summary_' . $userJobID . '" display-name="Import_Summary_' . $userJobID . '">
+</crsearch-display-table></div>',
+      ];
     }
-    catch (UnauthorizedException $e) {
-      // No access - return the empty array.
-    }
-    \Civi::cache('metadata')->set($cacheKey, $forms);
     return $forms;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Respond to https://github.com/civicrm/civicrm-core/pull/32108#issuecomment-2663055748

Before
----------------------------------------
- SavedSearch permissions are checked when the sitewide list of afforms is generated. This means whether import forms are registered depends arbitrarily on the permissions of the user who visits the site first after cache clear.
- If the import forms are generated, their access control is `access CiviCRM`
- If the arbitrary user doesnt have permissions, an error is thrown (sometimes this bubbles up to log, maybe UF dependent)
- There's a specific cache for import forms. But Afforms are cached anyway

After
----------------------------------------
- No specific cache for import forms
- Don't check permissions - the afform list will always have the import forms
- The form access permissions will continue to be `access CiviCRM`


Comments
---------------------------------------
Possibly the access param on the forms should actually be tighter? That isn't affected by this PR, so could be done separately. But if there is a clear answer to what it should be, happy to include here