### PR TITLE
use meta rather than string concatenation for af-field ng-include

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -238,6 +238,8 @@ class AfformAdminMeta {
         $inputTypes[] = [
           'name' => $name,
           'label' => $inputTypeLabels[$name] ?? E::ts($name),
+          'template' => '~/af/fields/' . $name . '.html',
+          'admin_template' => '~/afGuiEditor/inputType/' . $name . '.html',
         ];
       }
 

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -161,6 +161,17 @@
         return ctrl.getDefn().options || (ctrl.getDefn().data_type === 'Boolean' ? yesNo : null);
       };
 
+      this.getInputTypeTemplate = () => {
+        const selectedType = $scope.getProp('input_type');
+        const meta = this.inputTypes.find((type) => type.name === selectedType);
+
+        if (!meta || !meta.admin_template) {
+          return '~/afGuiEditor/inputType/Missing.html';
+        }
+
+        return meta.admin_template;
+      };
+
       $scope.resetOptions = function() {
         delete ctrl.node.defn.options;
       };
@@ -220,11 +231,18 @@
         const path = propName.split('.');
         const item = path.pop();
         const localDefn = drillDown(ctrl.node.defn || {}, path);
+        console.log(ctrl.node.defn);
         if (typeof localDefn[item] !== 'undefined') {
+          if (propName === 'input_type') {
+            console.log(localDefn);
+          }
           return localDefn[item];
         }
         const fieldDefn = drillDown(ctrl.getDefn(), path);
         if (typeof fieldDefn[item] !== 'undefined') {
+          if (propName === 'input_type') {
+            console.log(fieldDefn);
+          }
           return fieldDefn[item];
         }
         return defaultValue;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.html
@@ -17,7 +17,7 @@
   <div class="af-gui-field-help" ng-if="propIsset('help_pre')">
     <span crm-ui-editable ng-model="getSet('help_pre')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().help_pre">{{ getProp('help_pre') }}</span>
   </div>
-  <div class="af-gui-field-input af-gui-field-input-type-{{ getProp('input_type').toLowerCase() }}" ng-include="'~/afGuiEditor/inputType/' + getProp('input_type', 'Missing') + '.html'"></div>
+  <div class="af-gui-field-input af-gui-field-input-type-{{ getProp('input_type').toLowerCase() }}" ng-include="$ctrl.getInputTypeTemplate()"></div>
   <div class="af-gui-field-help" ng-if="propIsset('help_post')">
     <span crm-ui-editable ng-model="getSet('help_post')" ng-model-options="{getterSetter: true}" default-value="$ctrl.getDefn().help_post">{{ getProp('help_post') }}</span>
   </div>

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -280,6 +280,13 @@ class FormDataModel {
    * @return string path to the angular template for this input type
    */
   protected static function getInputTypeTemplate(string $inputType): ?string {
+    // if afform admin is not enabled, there is no hook
+    // to add custom input types so we can just use the
+    // naive string concatenation
+    if (!class_exists('\\Civi\\AfformAdmin\\AfformAdminMeta')) {
+      return '~/af/fields/' . $inputType . '.html';
+    }
+
     $inputTypes = AfformAdminMeta::getMetadata()['inputTypes'];
 
     foreach ($inputTypes as $type) {

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -4,6 +4,7 @@ namespace Civi\Afform;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Afform;
+use Civi\AfformAdmin\AfformAdminMeta;
 use Civi\Api4\Utils\CoreUtil;
 use CRM_Afform_ExtensionUtil as E;
 
@@ -249,6 +250,9 @@ class FormDataModel {
     if (!isset($field)) {
       return NULL;
     }
+    // add template based on input_type
+    $field['template'] = self::getInputTypeTemplate($field['input_type']);
+
     // Id field for selecting existing entity
     if ($field['name'] === CoreUtil::getIdFieldName($entityName)) {
       $entityTitle = CoreUtil::getInfoItem($entityName, 'title');
@@ -269,6 +273,21 @@ class FormDataModel {
       }
     }
     return $field;
+  }
+
+  /**
+   * @param string $inputType name of input type
+   * @return string path to the angular template for this input type
+   */
+  protected static function getInputTypeTemplate(string $inputType): ?string {
+    $inputTypes = AfformAdminMeta::getMetadata()['inputTypes'];
+
+    foreach ($inputTypes as $type) {
+      if ($type['name'] === $inputType) {
+        return $type['template'];
+      }
+    }
+    return NULL;
   }
 
   /**

--- a/ext/afform/core/ang/af/afField.html
+++ b/ext/afform/core/ang/af/afField.html
@@ -3,6 +3,6 @@
   <span class="crm-marker" title="{{:: ts('Required') }}" ng-if=":: $ctrl.defn.required">*</span>
 </label>
 <p class="crm-af-field-help-pre" ng-if=":: $ctrl.defn.help_pre">{{:: $ctrl.defn.help_pre }}</p>
-<div class="crm-af-field" ng-if="!$ctrl.defn.expose_operator" ng-include="'~/af/fields/' + $ctrl.defn.input_type + '.html'"></div>
+<div class="crm-af-field" ng-if="!$ctrl.defn.expose_operator" ng-include="$ctrl.defn.template"></div>
 <div class="input-group" ng-if="$ctrl.defn.expose_operator" ng-include="'~/af/afFieldWithSearchOperator.html'"></div>
 <p class="crm-af-field-help-post" ng-if=":: $ctrl.defn.help_post">{{:: $ctrl.defn.help_post }}</p>

--- a/ext/afform/core/ang/af/afFieldWithSearchOperator.html
+++ b/ext/afform/core/ang/af/afFieldWithSearchOperator.html
@@ -1,4 +1,4 @@
 <select class="form-control afform-search-operator" crm-ui-select ng-model="$ctrl.search_operator" ng-change="$ctrl.onChangeOperator()">
   <option ng-repeat="(name, label) in $ctrl.defn.operators" value="{{ name }}">{{ label }}</option>
 </select>
-<div class="crm-af-field" ng-include="'~/af/fields/' + $ctrl.defn.input_type + '.html'"></div>
+<div class="crm-af-field" ng-include="$ctrl.defn.template"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Provide the angular partial to use directly with meta. Allows adding new input types through `afform_admin.metadata` hook.

Before
----------------------------------------
- input type templates use string concatenation e.g. `~/af/fields/DisplayOnly.html`
- adding a new input type requires getting your input type template into `~/af`

After
----------------------------------------
- input type templates are included in the metadata
- extension author can successfully add a new input type through the `afform_admin.metadata` hook 
- it is possible to override the template for a core field type if you wanted to - either globally using the `afform_admin.metadata` hook, or for a specific input on a specific form by adding to the local `defn`

Comments
----------------------------------------
See e.g. https://lab.civicrm.org/ufundo/afform_payments/-/blob/dev/Civi/AfformPayment/AngularManager.php?ref_type=heads#L72

Q: is it at all risky that an afform code editor can provide any template whatsoever with `<af-field defn="{template: '~/myMaliciousTemplate.html'}">`? It seems to me like they can probably do anything they want to outside of the `af-field` component anyway, within the `af-form` scope.