### PR TITLE
Add filters to Administer Scheduled Reminders

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.html
@@ -1,9 +1,17 @@
 <div af-fieldset="">
   <div class="af-markup">
+    
     <div class="help">
       {{:: ts('Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.') }}
       <a href="https://docs.civicrm.org/user/en/latest/email/scheduled-reminders/" target="_blank" class="crm-doc-link no-popup">{{:: ts('Learn more...') }}</a>
     </div>
+  
+  </div>
+  <div class="af-container af-layout-inline">
+    <af-field name="is_active" defn="{afform_default: true, input_type: 'Radio'}" />
+    <af-field name="id" defn="{label: 'Reminder ID', input_attrs: {multiple: true}}" />
+    <af-field name="title" />
+    <af-field name="used_for" />
   </div>
   <crm-search-display-table search-name="Administer_Scheduled_Reminders" display-name="Administer_Scheduled_Reminders_Table"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.php
@@ -7,5 +7,7 @@ return [
   'description' => E::ts('Administer scheduled reminders'),
   'icon' => 'fa-list-alt',
   'server_route' => 'civicrm/admin/scheduleReminders',
-  'permission' => ['administer CiviCRM data'],
+  'permission' => [
+    'administer CiviCRM data',
+  ],
 ];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Scheduled_Reminders.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Scheduled_Reminders.mgd.php
@@ -184,6 +184,11 @@ return [
               'icon' => 'fa-plus',
             ],
           ],
+          'actions_display_mode' => 'menu',
+          'cssRules' => [
+            ['disabled', 'is_active', '=', FALSE],
+          ],
+          'headerCount' => TRUE,
         ],
         'acl_bypass' => FALSE,
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Improves AdminUI scheduled reminders

Before
----------------------------------------
No filters, no count, no way to hide disabled ones

After
----------------------------------------
![image](https://github.com/user-attachments/assets/924880c6-e019-4e40-87fa-fc5d677b4dd2)

Filters, count, disabled ones hidden by default

Technical Details
----------------------------------------


Comments
----------------------------------------

