### PR TITLE
Test fix - ensure civiimport enabled

### DIFF
--- a/tests/phpunit/CRM/Import/DataSource/FormsTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/FormsTest.php
@@ -20,6 +20,11 @@ use Civi\Api4\UserJob;
  */
 class CRM_Import_FormsTest extends CiviUnitTestCase {
 
+  protected function setUp(): void {
+    parent::setUp();
+    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+  }
+
   public function tearDown(): void {
     $this->quickCleanup(['civicrm_user_job', 'civicrm_mapping', 'civicrm_mapping_field', 'civicrm_queue']);
     parent::tearDown();


### PR DESCRIPTION
This addresses a situation where tests failed due to this not being enabled - that PR is resolved now but exposed a gotcha here

Targetting 6.5 to help reduce confusion if the issue re-surfaces
