### PR TITLE
Make import icons consistent

### DIFF
--- a/ext/civiimport/ang/afsearchAllImports.aff.php
+++ b/ext/civiimport/ang/afsearchAllImports.aff.php
@@ -4,7 +4,7 @@ use CRM_Civiimport_ExtensionUtil as E;
 return [
   'type' => 'search',
   'title' => E::ts('All Imports'),
-  'icon' => 'fa-list-alt',
+  'icon' => 'fa-file-import',
   'server_route' => 'civicrm/imports/all-imports',
   'permission' => ['administer queues'],
   'navigation' => [

--- a/ext/civiimport/ang/afsearchMyImports.aff.php
+++ b/ext/civiimport/ang/afsearchMyImports.aff.php
@@ -5,6 +5,7 @@ return [
   'type' => 'search',
   'title' => E::ts('My Imports'),
   'server_route' => 'civicrm/imports/my-listing',
+  'icon' => 'fa-file-import',
   'permission' => ['access CiviCRM'],
   'navigation' => [
     'parent' => 'Reports',

--- a/ext/civiimport/ang/afsearchTemplates.aff.php
+++ b/ext/civiimport/ang/afsearchTemplates.aff.php
@@ -4,7 +4,7 @@ use CRM_Civiimport_ExtensionUtil as E;
 return [
   'type' => 'search',
   'title' => E::ts('Import Templates'),
-  'icon' => 'fa-list-alt',
+  'icon' => 'fa-file-import',
   'server_route' => 'civicrm/imports/templates',
   'permission' => ['access CiviCRM'],
   'navigation' => [


### PR DESCRIPTION
Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
I noticed that 2/3  of the import menu items here have icons - I also found an icon that is possibly more appropriate

![image](https://github.com/user-attachments/assets/95718a98-0c9e-4d33-b9a0-b55dc3c85fe2)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/1f19cdc8-b5a6-49ff-8135-303b58197277)

Technical Details
----------------------------------------
Obviously the elephant in the room is why are these links in the reports menu - my personal preference would be a new top level import menu and all import links below it - and maybe some batch data entry too. But I don't know where others are at. I guess they landed here in the first place because imports are a constant task for some users and it allowed the primary links used for managing imports to not be hidden too far down (ie for users who do lots of imports the import templates page is the main ingress to the import system, not the entity specific ones. That might change a bit once accessing the imports directly has feature parity with accessing via a template. Currently when you access directly you only get the legacy mappings loaded & not necessarily things like the selected date format, contact type, dedupe rule etc

Comments
----------------------------------------
