### PR TITLE
Afform - Set format of DisplayOnly fields based on input type

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -115,10 +115,13 @@ class AfformMetadataInjector {
 
     // Get field defn from afform markup
     $fieldDefn = $existingFieldDefn ? \CRM_Utils_JS::getRawProps($existingFieldDefn) : [];
-    // This is the input type set on the form (may be different from the default input type in the field spec)
+    // Uses input type set on the form if specified (else falls back to the input type in the field spec)
     $inputType = !empty($fieldDefn['input_type']) ? \CRM_Utils_JS::decode($fieldDefn['input_type']) : $fieldInfo['input_type'];
     // On a search form, search_range will present a pair of fields (or possibly 3 fields for date select + range)
     $isSearchRange = !empty($fieldDefn['search_range']) && \CRM_Utils_JS::decode($fieldDefn['search_range']);
+
+    // Set template based on input_type
+    $fieldInfo['template'] = FormDataModel::getInputTypeTemplate($inputType);
 
     // On a search form, the exposed operator requires a list of options.
     if (!empty($fieldDefn['expose_operator'])) {

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -123,6 +123,17 @@ class AfformMetadataInjector {
     // Set template based on input_type
     $fieldInfo['template'] = FormDataModel::getInputTypeTemplate($inputType);
 
+    // Set format of DisplayOnly fields based on original input type
+    if ($inputType === 'DisplayOnly' && $fieldInfo['input_type'] === 'RichTextEditor') {
+      $fieldInfo['display_format'] = 'html';
+    }
+    if ($inputType === 'DisplayOnly' && $fieldInfo['input_type'] === 'File') {
+      $fieldInfo['display_format'] = 'file';
+    }
+    if ($inputType === 'DisplayOnly' && $fieldInfo['input_type'] === 'Url') {
+      $fieldInfo['display_format'] = 'url';
+    }
+
     // On a search form, the exposed operator requires a list of options.
     if (!empty($fieldDefn['expose_operator'])) {
       $operators = Utils::getSearchOperators();

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -250,8 +250,6 @@ class FormDataModel {
     if (!isset($field)) {
       return NULL;
     }
-    // add template based on input_type
-    $field['template'] = self::getInputTypeTemplate($field['input_type']);
 
     // Id field for selecting existing entity
     if ($field['name'] === CoreUtil::getIdFieldName($entityName)) {
@@ -279,7 +277,7 @@ class FormDataModel {
    * @param string $inputType name of input type
    * @return string path to the angular template for this input type
    */
-  protected static function getInputTypeTemplate(string $inputType): ?string {
+  public static function getInputTypeTemplate(string $inputType): ?string {
     // if afform admin is not enabled, there is no hook
     // to add custom input types so we can just use the
     // naive string concatenation

--- a/ext/afform/core/ang/af/fields/DisplayOnly.html
+++ b/ext/afform/core/ang/af/fields/DisplayOnly.html
@@ -1,4 +1,4 @@
-<span ng-if="dataProvider.getFieldData()[$ctrl.fieldName].file_name">
+<span ng-if="$ctrl.defn.display_format === 'file' && dataProvider.getFieldData()[$ctrl.fieldName].file_name">
   <a ng-if="dataProvider.getFieldData()[$ctrl.fieldName].url" ng-href="{{:: dataProvider.getFieldData()[$ctrl.fieldName].url }}">
     <i class="crm-i {{ dataProvider.getFieldData()[$ctrl.fieldName].icon }}"></i>
     {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
@@ -8,6 +8,13 @@
     {{ dataProvider.getFieldData()[$ctrl.fieldName].file_name }}
   </span>
 </span>
-<span ng-if="!dataProvider.getFieldData()[$ctrl.fieldName].file_name">
+<span ng-if="$ctrl.defn.display_format === 'html'" ng-bind-html="$ctrl.getDisplayValue(dataProvider.getFieldData()[$ctrl.fieldName])">
+</span>
+<span ng-if="$ctrl.defn.display_format === 'url'">
+  <a ng-if="dataProvider.getFieldData()[$ctrl.fieldName]" ng-href="{{:: dataProvider.getFieldData()[$ctrl.fieldName] }}">
+    {{ $ctrl.getDisplayValue(dataProvider.getFieldData()[$ctrl.fieldName]) }}
+  </a>
+</span>
+<span ng-if="!$ctrl.defn.display_format">
   {{ $ctrl.getDisplayValue(dataProvider.getFieldData()[$ctrl.fieldName]) }}
 </span>

--- a/ext/afform/core/ang/afCore.ang.php
+++ b/ext/afform/core/ang/afCore.ang.php
@@ -7,7 +7,7 @@ return [
     'ang/afCore/*/*.js',
   ],
   'css' => ['ang/afCore.css'],
-  'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model', 'angularFileUpload'],
+  'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model', 'angularFileUpload', 'ngSanitize'],
   'partials' => ['ang/afCore'],
   'basePages' => [],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug introduced by #33127 and also improves the rendering of DisplayOnly fields in FormBuilder to support Rich Text (html) and links.

Fixes https://lab.civicrm.org/dev/core/-/issues/5628
