### PR TITLE
dev/core#5483 - SearchKit - Fix actions for relationship searches

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -46,6 +46,8 @@ class SearchDisplayTasksSubscriber extends \Civi\Core\Service\AutoService implem
   public function filterTasksForDisplay(GenericHookEvent $event): void {
     $enabledActions = $event->display['settings']['actions'] ?? NULL;
     $entityName = $event->search['api_entity'] ?? NULL;
+    // Hack to support relationships
+    $entityName = ($entityName === 'RelationshipCache') ? 'Relationship' : $entityName;
     if ($entityName && is_array($enabledActions)) {
       $event->tasks[$entityName] = array_intersect_key($event->tasks[$entityName], array_flip($enabledActions));
     }


### PR DESCRIPTION
Before
----------------------------------------
SK displays based on relationships would fail to display any Actions (menu/buttons) if ALL the actions were not enabled.

After
----------------------------------------
It works. Enable all or any subset of actions in the search display, and, as expected, only the enabled ones will display.

Technical Details
----------------------------------------
This fix is taken from:
https://github.com/civicrm/civicrm-core/blob/4973c389644e091b4e89a4c620acdc25febb2563/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php#L37

