### PR TITLE
dev/core#5989 - SearchKit - Fix actions for searches on individuals

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -218,7 +218,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
 
     // If the entity is Individual, Organization, or Household, add the "Contact" actions
     if (CoreUtil::isContact($entity['name'])) {
-      $tasks[$entity['name']] = array_merge($tasks[$entity['name']], $tasks['Contact']);
+      $tasks[$entity['name']] = array_merge($tasks[$entity['name']], $tasks['Contact'] ?? []);
     }
 
     foreach ($tasks[$entity['name']] as $name => &$task) {


### PR DESCRIPTION
Before
----------------------------------------
SK displays based on "Individuals" would fail to display any actions in certain cases. See issue for details.

After
----------------------------------------
Actions load properly. No errors throw in api4 calls when loading the actions for the display.
