### PR TITLE
Remove legacy contribution type assignment

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -303,9 +303,6 @@ class CRM_Contribute_Form_AdditionalInfo {
    */
   public static function emailReceipt(&$form, &$params, $ccContribution = FALSE) {
     $form->assign('receiptType', 'contribution');
-    // Retrieve Financial Type Name from financial_type_id
-    $params['contributionType_name'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
-      $params['financial_type_id']);
     if (!empty($params['payment_instrument_id'])) {
       $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
       $params['paidBy'] = $paymentInstrument[$params['payment_instrument_id']];

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -122,8 +122,6 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     //  $requestFields[       ''  ]          =  $params[ 'billing_first_name'    ];
     //  $requestFields[       ''  ]          =  $params[ 'billing_middle_name'    ];
     //  $requestFields[       ''  ]          =  $params[ 'billing_last_name'  ];
-
-    //  $requestFields[       ''  ]          =  $params[ 'contributionType_name'  ];
     //  $requestFields[       ''  ]          =  $params[ 'contributionPageID'  ];
     //  $requestFields[       ''  ]          =  $params[ 'contributionType_accounting_code'  ];
     //  $requestFields[       ''  ]          =  $params['amount_level'  ];


### PR DESCRIPTION
Overview
----------------------------------------
Remove legacy contribution type assignment

Before
----------------------------------------
super old `contributionType_name` still assigned to offline receipt templates


After
----------------------------------------
gone

Technical Details
----------------------------------------
This one is soooo old...


Comments
----------------------------------------
