### PR TITLE
Standardise template presentation of billing name & address

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1126,9 +1126,11 @@ DESC limit 1");
       $result = NULL;
 
       $this->_params = $formValues;
+      $contributionAddressID = CRM_Contribute_BAO_Contribution::createAddress($this->getSubmittedValues());
       $contribution = civicrm_api3('Order', 'create',
         [
           'contact_id' => $this->_contributorContactID,
+          'address_id' => $contributionAddressID,
           'line_items' => $this->getLineItemForOrderApi(),
           'is_test' => $this->isTest(),
           'campaign_id' => $this->getSubmittedValue('campaign_id'),

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1173,7 +1173,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'Test Last',
       '10 Test St',
       'Test, AR 90210',
-      'US',
+      'United States',
       'Membership Information',
       'AnnualFixed',
       '************1111',

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -79,7 +79,6 @@
   {if !empty($isBillingAddressRequiredForPayLater)}
   isBillingAddressRequiredForPayLater:::{$isBillingAddressRequiredForPayLater}
   {/if}
-  billingName:::{$billingName}
   address:::{$address}
   {if !empty($credit_card_type)}
   credit_card_type:::{$credit_card_type}

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -187,7 +187,7 @@
       </tr>
      {/if}
 
-     {if !empty($ccContribution)}
+      {if {contribution.address_id.display|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Billing Address{/ts}
@@ -195,8 +195,8 @@
       </tr>
       <tr>
        <td colspan="2" {$valueStyle}>
-        {$billingName}<br />
-        {$address|nl2br}
+         {contribution.address_id.name}<br/>
+         {contribution.address_id.display}
        </td>
       </tr>
       <tr>

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -288,7 +288,7 @@
       </tr>
      {/if}
 
-     {if !empty($billingName)}
+     {if {contribution.address_id.display|boolean}}
        <tr>
         <th {$headerStyle}>
          {ts}Billing Address{/ts}
@@ -296,8 +296,8 @@
        </tr>
        <tr>
         <td colspan="2" {$valueStyle}>
-         {$billingName}<br />
-         {$address|nl2br}<br />
+          {contribution.address_id.name}<br/>
+          {contribution.address_id.display}
          {$email}
         </td>
        </tr>

--- a/xml/templates/message_templates/contribution_recurring_billing_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_billing_html.tpl
@@ -35,8 +35,8 @@
        </tr>
        <tr>
         <td colspan="2" {$valueStyle}>
-         {$billingName}<br />
-         {$address|nl2br}<br />
+          {contribution.address_id.name}<br/>
+          {contribution.address_id.display}
          {$email}
         </td>
        </tr>

--- a/xml/templates/message_templates/membership_autorenew_billing_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_billing_html.tpl
@@ -35,8 +35,8 @@
        </tr>
        <tr>
         <td colspan="2" {$valueStyle}>
-         {$billingName}<br />
-         {$address|nl2br}<br />
+         {contribution.address_id.name}<br/>
+         {contribution.address_id.display}
          {$email}
         </td>
        </tr>

--- a/xml/templates/message_templates/membership_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_offline_receipt_html.tpl
@@ -201,7 +201,7 @@
         <td>
           <table style="border: 1px solid #999; margin: 1em 0em 1em; border-collapse: collapse; width:100%;">
 
-            {if !empty($billingName)}
+            {if {contribution.address_id.display|boolean}}
               <tr>
                 <th {$headerStyle}>
                   {ts}Billing Address{/ts}
@@ -209,8 +209,8 @@
               </tr>
               <tr>
                 <td {$labelStyle}>
-                  {$billingName}<br/>
-                  {$address}
+                  {contribution.address_id.name}<br/>
+                  {contribution.address_id.display}
                 </td>
               </tr>
             {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Standardise template presentation of billing name & address

Before
----------------------------------------
Some templates rely on `$billingName` having been assigned & others use the token

After
----------------------------------------
Consistent token use

Technical Details
----------------------------------------

Comments
----------------------------------------
