### PR TITLE
Remove redundant message variables

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -412,12 +412,6 @@ class CRM_Contribute_Form_AdditionalInfo {
     list($contributorDisplayName,
       $contributorEmail
       ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($params['contact_id']);
-    $form->assign('contactID', $params['contact_id']);
-    $form->assign('contributionID', $params['contribution_id']);
-
-    if (!empty($params['currency'])) {
-      $form->assign('currency', $params['currency']);
-    }
 
     if (!empty($params['receive_date'])) {
       $form->assign('receive_date', CRM_Utils_Date::processDate($params['receive_date']));
@@ -426,12 +420,6 @@ class CRM_Contribute_Form_AdditionalInfo {
     [$sendReceipt] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'workflow' => 'contribution_offline_receipt',
-        // @todo - IDs are being passed in multiple ways - the non-deprecated
-        // one is `modelProps`
-        // The others are probably redundant after merging https://github.com/civicrm/civicrm-core/pull/32036
-        'contactId' => $params['contact_id'],
-        'contributionId' => $params['contribution_id'],
-        'tokenContext' => ['contributionId' => (int) $params['contribution_id'], 'contactId' => $params['contact_id']],
         'from' => $params['from_email_address'],
         'toName' => $contributorDisplayName,
         'toEmail' => $contributorEmail,


### PR DESCRIPTION
Overview
----------------------------------------
Remove redundant message variables

Before
----------------------------------------
Variables assigned to the message template in multiple ways - per the code comment `modelProps` is the correct one & as long as it they are there none of the others matter - [`contributionID`](https://github.com/civicrm/civicrm-core/blob/29bdf6e83f97184842be697e19caa96a5fd7a328/CRM/Contribute/WorkflowMessage/ContributionTrait.php#L39)  and [`currency`](https://github.com/civicrm/civicrm-core/blob/29bdf6e83f97184842be697e19caa96a5fd7a328/CRM/Contribute/WorkflowMessage/ContributionTrait.php#L297) are assigned in the ContributionTrait & contactID in the parent 

After
----------------------------------------
less assigns, less noise

Technical Details
----------------------------------------

Comments
----------------------------------------