### PR TITLE
Add cross contact-type email import support

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -131,6 +131,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         'selected' => [
           'action' => 'select',
           'contact_type' => 'Individual',
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'select',
         'entity_name' => 'TargetContact',
@@ -144,6 +145,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore']) : $this->getActions(['select', 'update', 'save']),
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
+          'dedupe_rule' => $this->getDefaultDedupeRule(),
         ],
         'default_action' => 'select',
         'entity_name' => 'SourceContact',


### PR DESCRIPTION
Overview
----------------------------------------
Add cross contact-type email import support

Before
----------------------------------------
The only option for importing to 'any' contact type is to match on ID or external identifier - however the existing Civiimport functionality works off a hard-coded email only look up - so this makes that generally available - it also feels kinda useful

![image](https://github.com/user-attachments/assets/f828f636-8133-44bc-90c0-d2b76ec4bedb)



After
----------------------------------------
![image](https://github.com/user-attachments/assets/f4c36a9a-7755-45c4-a43b-e2b206799004)

Technical Details
----------------------------------------

Comments
----------------------------------------
