### PR TITLE
Ensure that when installing an extension with localizable columns in …

### DIFF
--- a/CRM/Extension/Manager/Module.php
+++ b/CRM/Extension/Manager/Module.php
@@ -42,6 +42,11 @@ class CRM_Extension_Manager_Module extends CRM_Extension_Manager_Base {
 
   public function onPostInstall(CRM_Extension_Info $info) {
     \Civi\Core\ClassScanner::cache('index')->flush();
+    // If we are in a multilingual site trigger a rebuild of the multilingual schema in case we have installed an entity with translatable columns.
+    if (CRM_Core_I18n::isMultilingual()) {
+      $locales = CRM_Core_I18n::getMultilingual();
+      CRM_Core_I18n_Schema::rebuildMultilingualSchema($locales);
+    }
   }
 
   /**

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -116,7 +116,10 @@ return new class() {
         $primaryKeys[] = "`$fieldName`";
       }
       // if we have localizable columns and we are in multilingual mode generate columns in the multilingual format.
-      if (!empty($field['localizable']) && CRM_Core_I18n::isMultilingual()) {
+      if (!Civi\Core\Container::isContainerBooted()) {
+        $definition[] = "`$fieldName` " . self::generateFieldSql($field);
+      }
+      elseif (!empty($field['localizable']) && CRM_Core_I18n::isMultilingual()) {
         $locales = CRM_Core_I18n::getMultilingual();
         foreach ($locales as $locale) {
           $definition[] = "`$fieldName_{$locale}` " . self::generateFieldSql($field);

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -115,7 +115,16 @@ return new class() {
       if (!empty($field['primary_key'])) {
         $primaryKeys[] = "`$fieldName`";
       }
-      $definition[] = "`$fieldName` " . self::generateFieldSql($field);
+      // if we have localizable columns and we are in multilingual mode generate columns in the multilingual format.
+      if (!empty($field['localizable']) && CRM_Core_I18n::isMultilingual()) {
+        $locales = CRM_Core_I18n::getMultilingual();
+        foreach ($locales as $locale) {
+          $definition[] = "`$fieldName_{$locale}` " . self::generateFieldSql($field);
+        }
+      }
+      else {
+        $definition[] = "`$fieldName` " . self::generateFieldSql($field);
+      }
     }
     if ($primaryKeys) {
       $definition[] = 'PRIMARY KEY (' . implode(', ', $primaryKeys) . ')';


### PR DESCRIPTION
…a multilingual environment that the table is created in the way that the I18n Schema Structure expects

Overview
----------------------------------------
When installing an extension with localizable fields e.g. [Advanced Events](https://lab.civicrm.org/extensions/civicrm-advanced-events) the table is always created in a singlelingual format even if the site is in multilingual.

To reproduce
1. Install blank CiviCRM
2. Configure it to be multilingual
3. Install the Advanced Events extension
4. notice that the title column is just title and not title_en_US or title_{locale} as needed
5. Try and run the system.rebuildmultilingualschema API and find it errors

Before
----------------------------------------
Extensions with localizable columns have tables created incorrectly

After
----------------------------------------
Table is created correctly

ping @colemanw @totten @Edzelopez 