### PR TITLE
RiverLea: improve inline edit - icon for empty inline edit, wrap controls, shrink input

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -250,7 +250,7 @@ input.crm-form-entityref {
 /* Inline edit */
 
 .crm-container .crm-editable-form,
-.crm-container form:has(> .form-inline) /* SK */ {
+.crm-container .crm-search-field-editable form /* SK */ {
   display: flex;
   gap: var(--crm-flex-gap);
   flex-wrap: wrap;
@@ -327,7 +327,7 @@ input.crm-form-entityref {
   margin: 0;
 }
 .crm-container .crm-editable-form input,
-.crm-container crm-search-display-editable input.form-control {
+.crm-container .crm-search-field-editable input.form-control {
   width: 100%;
   min-width: 14ch;
 }

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -249,14 +249,11 @@ input.crm-form-entityref {
 
 /* Inline edit */
 
-.crm-inline-edit {
-  border: var(--crm-dash-edit-border);
-  border-color: transparent;
-  background: none;
-  position: relative;
-}
-.crm-container .crm-editable-form {
+.crm-container .crm-editable-form,
+.crm-container form:has(> .form-inline) /* SK */ {
   display: flex;
+  gap: var(--crm-flex-gap);
+  flex-wrap: wrap;
 }
 .crm-container .crm-editable-form input {
   height: var(--crm-input-height);
@@ -274,12 +271,13 @@ input.crm-form-entityref {
 .crm-container .crm-editable-form [type="cancel"] {
   color: var(--crm-c-danger) !important;
 }
-/* in place edit  */
 .crm-container .crm-inline-edit,
 .crm-container .crm-editable-disabled,
 .crm-container .crm-editable-enabled {
   border: var(--crm-dash-edit-border);
   border-color: transparent;
+  background: none;
+  position: relative;
 }
 .crm-container .crm-editable-textarea-enabled {
   white-space: normal;
@@ -298,15 +296,18 @@ input.crm-form-entityref {
   display: inline-block;
   padding-right: var(--crm-s);
   min-height: var(--crm-r);
-  min-width: 3em;
 }
-.crm-container .crm-editable-enabled .crm-i {
+.crm-container .crm-editable-enabled .crm-i,
+.crm-editable-enabled:has(span.crm-search-field-value:empty) {
   opacity: .5;
 }
 .crm-container .replace-plain a:active:before,
 .crm-container .replace-plain:focus:before,
 .crm-container .replace-plain:hover:before,
-.crm-container .crm-editable-enabled:hover .crm-i {
+.crm-container .crm-editable-enabled:hover .crm-i,
+.crm-container .crm-editable-enabled:focus .crm-i,
+.crm-editable-enabled:has(span.crm-search-field-value:empty):hover,
+.crm-editable-enabled:has(span.crm-search-field-value:empty):focus {
   opacity: 1;
 }
 .crm-container .crm-editable-saving {
@@ -317,7 +318,6 @@ input.crm-form-entityref {
   margin: 0;
   padding: 0;
   width: auto !important;
-  /* position: relative; */
   overflow: visible;
   display: flex;
   gap: 0;
@@ -326,7 +326,9 @@ input.crm-form-entityref {
 .crm-editable-form > * {
   margin: 0;
 }
-.crm-editable-form input {
+.crm-container .crm-editable-form input,
+.crm-container crm-search-display-editable input.form-control {
+  width: 100%;
   min-width: 14ch;
 }
 .crm-container .crm-editable-form button {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -78,8 +78,8 @@
 }
 /* Inline Edit */
 
-#bootstrap-theme crm-search-input .form-group { /* Fix for < 768px */
-    margin-bottom: 0;
+#bootstrap-theme .crm-search-field-editing .form-group { /* Fix for < 768px */
+  margin-bottom: 0;
 }
 .crm-editable-enabled:has(span.crm-search-field-value:empty)::before {
   content: "\f303";

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -76,3 +76,22 @@
 .crm-contact-page .crm-search-display-pager {
   padding: 0 var(--crm-r) var(--crm-r) var(--crm-r);
 }
+/* Inline Edit */
+
+#bootstrap-theme crm-search-input .form-group { /* Fix for < 768px */
+    margin-bottom: 0;
+}
+.crm-editable-enabled:has(span.crm-search-field-value:empty)::before {
+  content: "\f303";
+  font-family: "Font Awesome 6 Free", "Font Awesome 6 Brands", "FontAwesome";
+  font-weight: 400;
+  font-size: inherit;
+  font-style: normal;
+  font-variant: normal;
+}
+.crm-editable-enabled:has(span.crm-search-field-value:empty)::after {
+  /* This is a short-term anglo-centric a11y hack for the icon added above */
+  content: 'Edit';
+  text-indent: -10000px;
+  position: absolute;
+}


### PR DESCRIPTION
Overview
----------------------------------------
There's several changes to the inline edit behaviour in this one PR here. In short this PR adds an edit icon to SearchKit inline-edit fields when they're empty, and neatens the behaviour of inline edit controls. 

In more detail, working thru both files:

On _form.css:
 - a little duplicate css is merged
 - .form-inline is re-enforced on the edit controls via wrapping flexbox to put the save/cancel icons inline when space allows
 - a min-width on the crm-editable-enabled block is removed. This shouldn't be needed now that empty SK editable blocks will have an edit icon (see below)
 - an opacity with hover effect is added to that edit icon (see below)
 - form control inputs have 100% width, rather than auto, or the RiverLee min input width which is quite large. See: https://chat.civicrm.org/civicrm/pl/azsxhn7f6tbp58ztcpyn5jtp9c

On crmSearchDisplay.css:
  - Bootstrap's 15px margin on the inline-edit input field on screens under 768px is removed (responsive UI bug/quirk)
  - An edit icon is added to empty inline edit fields, as discussed [here](https://github.com/civicrm/civicrm-core/pull/33051), and the same as in other non-searchkit empty inline edit fields:
![image](https://github.com/user-attachments/assets/363334df-2843-4c87-976e-18ebbf925141)
 - As this icon is being added via a CSS psuedo element rather than markup, another pseudo element 'edit' is added, then hidden. This string isn't translatable as it's inserted as css content. This isn't good practice; I address that below.

Before
----------------------------------------
Inline edit indicator, with hover on left:
![image](https://github.com/user-attachments/assets/c3dd3a14-657f-465a-8d1a-675547b31aed)
Inline edit:
![image](https://github.com/user-attachments/assets/1aa992fc-123c-4118-a4e7-172c9810d335)
Narrower inline edit (unchanged other than a 15px margin has appeared):
![image](https://github.com/user-attachments/assets/cb115885-4994-430f-bde7-2666ba0517b9)

After
----------------------------------------
Inline edit indicator, with hover:
![image](https://github.com/user-attachments/assets/2675a147-901f-4fb6-84d7-a4c4d62ee6d1)
Inline edit:
![image](https://github.com/user-attachments/assets/ec054e31-c03d-4db7-b07c-4fc7524eee30)
Narrower inline edit:
![image](https://github.com/user-attachments/assets/25356062-dcfc-4cc2-ab9e-a8ce3ffb645e)

Notes to reviewers
----------------------------------------
The last two points above are flawed short-term fixes. They are better than what's there (no visual indication that a region is editable) but do not achieve accessibility compliance in addressing that. I still think its worthwhile as a PR because visual indication improves accessibility for anyone with mobility restrictions (you don't have to move a mouse around to spot the editable region), but for someone with visual impairment the behaviour of the hidden 'edit' text in screen readers may be unpredictable, and doesn't work for those who don't recognise English (this string isn't translatable)

That said, I'm not confident inline edit is sufficiently accessible as it is - it doesn't seem keyboard targetable. Addresing that is a bigger fix - these last two points on the list of work above is intended as a short-term fix until the markup is improved with an screen-reader friendly icon added, and a keyboard targetable UX. At that point this can be removed.