### PR TITLE
dev/core#5960 allow search displays to run on form token afforms

### DIFF
--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -208,6 +208,10 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         'allowFields' => ['fieldName', 'filters', 'formName', 'ids', 'input', 'page', 'values'],
         'checkRequest' => fn($request, $jwt) => ('afform:' . $jwt['afform']) === $request['formName'],
       ],
+      ';^civicrm/ajax/api4/SearchDisplay/run$;' => [
+        'allowFields' => ['return', 'savedSearch', 'display', 'sort', 'limit', 'seed', 'filters', 'afform'],
+        'checkRequest' => fn($request, $jwt) => ($jwt['afform'] === $request['afform']),
+      ],
       // It's been hypothesized that we'll also need this. Haven't seen it yet.
       // ';^civicrm/ajax/api4/Afform/getFields;' => [
       //   'allowFields' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Attempt to fix https://lab.civicrm.org/dev/core/-/issues/5960

Before
----------------------------------------
- form tokens dont permit fetching search display results for search displays on the form

After
----------------------------------------
- hopefully they do

Technical Details
----------------------------------------
I'm not sure if checking the `afform` name matches is good enough to prevent running arbitrary search displays, woudl be good to verify that with testing.

