### PR TITLE
fix missing span tag

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -211,7 +211,7 @@ class CRM_Utils_Address {
       'contact.supplemental_address_3' => $address['supplemental_address_3'] ?? '',
       'contact.city' => empty($address['city']) ? '' : "<span class=\"locality\">" . $address['city'] . "</span>",
       'contact.state_province_name' => empty($address['state_province_id:label']) ? '' : "<span class=\"region\">" . $address['state_province_id:label'] . "</span>",
-      'contact.county' => empty($address['county_id:label']) ? '' : "<span class=\"region\">" . $address['county_id:label'],
+      'contact.county' => empty($address['county_id:label']) ? '' : "<span class=\"region\">" . $address['county_id:label'] . "</span>",
       'contact.state_province' => empty($address['state_province_id:abbr']) ? '' : "<span class=\"region\">" . $address['state_province_id:abbr'] . "</span>",
       'contact.postal_code' => !$fullPostalCode ? '' : "<span class=\"postal-code\">" . $fullPostalCode . "</span>",
       'contact.country' => empty($address['country_id:label']) ? '' : "<span class=\"country-name\">" . $address['country_id:label'] . "</span>",


### PR DESCRIPTION
Overview
----------------------------------------
I was doing some cleanup work that was already done in https://github.com/civicrm/civicrm-core/pull/32744. But I noticed one other fix.

Before
----------------------------------------
`<span>` without closing tag.

After
----------------------------------------
Tag is closed.

Comments
----------------------------------------
The surrounding lines all have the `</span>` so this should be an easy review.
