### PR TITLE
SearchKitBatch - Refresh display after creating new batch

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -104,6 +104,8 @@
           rowCount: this.newBatchRowCount,
         }, 0).then(function(userJob) {
           $location.search('batch', userJob.id);
+          // Re-init display to switch modes from creating batch to editing batch
+          ctrl.$onInit();
         });
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the new SearchKit batch entry display.

Before
----------------------------------------
When the data entry display is embedded in an Afform, clicking the "Start New Batch" button just spins.

After
----------------------------------------
Properly refreshes the display.