### PR TITLE
SearchKit - Add css classes to editable table cells

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -290,6 +290,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $cssClass[] = 'crm-search-field-show-linebreaks';
       }
     }
+    if (!empty($out['edit'])) {
+      $cssClass[] = 'crm-search-field-editable';
+    }
     if ($cssClass) {
       $out['cssClass'] = implode(' ', $cssClass);
     }

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatchBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatchBody.html
@@ -1,6 +1,6 @@
 <tr ng-repeat="(rowIndex, row) in $ctrl.resultsPage">
   <td>{{ (($ctrl.page - 1) * $ctrl.limit) + rowIndex + 1 }}</td>
-  <td ng-repeat="(colIndex, col) in $ctrl.settings.columns">
+  <td ng-repeat="(colIndex, col) in $ctrl.settings.columns" class="crm-search-col-type-{{:: col.type + ($ctrl.results.editable[col.key] && $ctrl.results.editable[col.key].input_type !== 'DisplayOnly' ? ' crm-search-field-editable crm-search-field-editing' : '') }}">
     <span class="crm-search-field-value" ng-if="!$ctrl.results.editable[col.key] || $ctrl.results.editable[col.key].input_type === 'DisplayOnly'">{{ row.data[col.key] }}</span>
     <crm-search-input ng-if="$ctrl.results.editable[col.key] && $ctrl.results.editable[col.key].input_type !== 'DisplayOnly'" class="form-inline" field="$ctrl.results.editable[col.key]" ng-model="row.data[col.spec.name]" ng-change="$ctrl.onChangeData(rowIndex)" crm-search-input-focus="false"></crm-search-input>
   </td>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -16,7 +16,7 @@
       </button>
     </div>
   </td>
-  <td ng-repeat="(colIndex, colData) in row.columns" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
+  <td ng-repeat="(colIndex, colData) in row.columns" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">


### PR DESCRIPTION
Overview
----------------------------------------
Improves SearchKit css classes for editable table cells, for theming purposes.

Technical Details
----------------------------------------
Adds 'crm-search-field-editable' to cells with in-place edit enabled, and 'crm-search-field-editing' to those currently being edited.
