### PR TITLE
dev/core#5911 Update label of Site Email Address to be Site From Emai…

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -105,7 +105,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Setting {
 
         if (!$domainEmailAddress || $domainEmailAddress === 'info@EXAMPLE.ORG') {
           $fixUrl = CRM_Utils_System::url('civicrm/admin/options/site_email_address');
-          CRM_Core_Error::statusBounce(ts('The site administrator needs to enter a valid "Site Email Address" in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
+          CRM_Core_Error::statusBounce(ts('The site administrator needs to enter a valid "Site From Email Address" in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
         }
         if (!$toEmail) {
           CRM_Core_Error::statusBounce(ts('Cannot send a test email because your user record does not have a valid email address.'));

--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -113,7 +113,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
     $url = CRM_Utils_System::url('civicrm/admin/options/site_email_address',
       'reset=1'
     );
-    $status = ts("There is no valid default email address configured for the site. <a href='%1'>Configure Site Email Addresses.</a>", [1 => $url]);
+    $status = ts("There is no valid default email address configured for the site. <a href='%1'>Configure Site From Email Addresses.</a>", [1 => $url]);
     return $status;
   }
 

--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -272,7 +272,7 @@
         stub along with the legacy redirect.
      -->
      <path>civicrm/admin/options/from_email_address</path>
-     <title>Site Email Addresses</title>
+     <title>Site From Email Addresses</title>
      <desc>List of email addresses which can be used when sending emails to contacts.</desc>
      <page_callback>CRM_Core_Page_Redirect</page_callback>
      <page_arguments>url=civicrm/admin/options/site_email_address</page_arguments>

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -674,7 +674,7 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
 
     if (!$domainEmailAddress || $domainEmailAddress == 'info@EXAMPLE.ORG') {
       $fixUrl = CRM_Utils_System::url('civicrm/admin/options/site_email_address');
-      throw new CRM_Core_Exception(ts('The site administrator needs to enter a valid "Site Email Address" in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
+      throw new CRM_Core_Exception(ts('The site administrator needs to enter a valid "Site From Email Address" in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
     }
 
     $receiptFrom = '"' . $domainEmailName . '" <' . $domainEmailAddress . '>';

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -300,7 +300,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
 
       if (!$domainEmailAddress || $domainEmailAddress == 'info@EXAMPLE.ORG') {
         $fixUrl = CRM_Utils_System::url('civicrm/admin/options/site_email_address');
-        CRM_Core_Error::statusBounce(ts('The site administrator needs to enter a valid "Site Email Address" in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
+        CRM_Core_Error::statusBounce(ts('The site administrator needs to enter a valid "Site From Email Address" in <a href="%1">Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a>. The email address used may need to be a valid mail account with your email service provider.', [1 => $fixUrl]));
       }
 
       //if more than one email present for PCP notification ,

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -188,7 +188,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
 
     if (!$domainEmailAddress || $domainEmailAddress == 'info@EXAMPLE.ORG') {
       if (!$domainName || $domainName == 'Default Domain Name') {
-        $msg = ts("Please enter your organization's <a href=\"%1\">name, primary address </a> and <a href=\"%2\">default Site Email Address </a> (for system-generated emails).",
+        $msg = ts("Please enter your organization's <a href=\"%1\">name, primary address </a> and <a href=\"%2\">default Site From Email Address </a> (for system-generated emails).",
           [
             1 => $fixDomainName,
             2 => $fixEmailUrl,
@@ -196,7 +196,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         );
       }
       else {
-        $msg = ts('Please enter a <a href="%1">default Site Email Address</a> (for system-generated emails).',
+        $msg = ts('Please enter a <a href="%1">default Site From Email Address</a> (for system-generated emails).',
           [1 => $fixEmailUrl]);
       }
     }

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -446,7 +446,7 @@ class CRM_Utils_Mail {
       $message .= '<ul>' . '<li>' . ts('Your Sendmail path is incorrect.') . '</li>' . '<li>' . ts('Your Sendmail argument is incorrect.') . '</li>';
     }
 
-    $message .= '<li>' . ts('The Site Email Address configured for this feature may not be a valid sender based on your email service provider rules.') . '</li>' . '</ul>' . '<p>' . ts('Check <a href="%1">this page</a> for more information.', [
+    $message .= '<li>' . ts('The Site From Email Address configured for this feature may not be a valid sender based on your email service provider rules.') . '</li>' . '</ul>' . '<p>' . ts('Check <a href="%1">this page</a> for more information.', [
       1 => CRM_Utils_System::docURL2('user/advanced-configuration/email-system-configuration', TRUE),
     ]) . '</p>';
 

--- a/ang/afform/afformSiteEmailAddress.aff.html
+++ b/ang/afform/afformSiteEmailAddress.aff.html
@@ -1,5 +1,5 @@
 <af-form ctrl="afform">
-  <af-entity actions="{create: true, update: true}" type="SiteEmailAddress" name="email" label="Site Email Address 1" security="RBAC" url-autofill="1" />
+  <af-entity actions="{create: true, update: true}" type="SiteEmailAddress" name="email" label="Site From Email Address 1" security="RBAC" url-autofill="1" />
   <fieldset af-fieldset="email" class="af-container">
     <div class="af-container af-layout-inline">
       <af-field name="display_name" />

--- a/ang/afform/afformSiteEmailAddress.aff.php
+++ b/ang/afform/afformSiteEmailAddress.aff.php
@@ -2,7 +2,7 @@
 
 return [
   'type' => 'form',
-  'title' => ts('Site Email Address'),
+  'title' => ts('Site From Email Address'),
   'icon' => 'fa-list-alt',
   'server_route' => 'civicrm/admin/form/site_email_address',
   'permission' => [

--- a/ang/afform/afsearchSiteEmailAddresses.aff.php
+++ b/ang/afform/afsearchSiteEmailAddresses.aff.php
@@ -2,7 +2,7 @@
 
 return [
   'type' => 'search',
-  'title' => ts('Site Email Addresses'),
+  'title' => ts('Site From Email Addresses'),
   'icon' => 'fa-list-alt',
   'server_route' => 'civicrm/admin/options/site_email_address',
   'permission' => [

--- a/managed/administer/SavedSearch_Site_Email_Addresses.mgd.php
+++ b/managed/administer/SavedSearch_Site_Email_Addresses.mgd.php
@@ -10,7 +10,7 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'Site_Email_Addresses',
-        'label' => ts('Site Email Addresses'),
+        'label' => ts('Site From Email Addresses'),
         'api_entity' => 'SiteEmailAddress',
         'api_params' => [
           'version' => 4,
@@ -42,7 +42,7 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'Site_Email_Addresses',
-        'label' => ts('Site Email Addresses'),
+        'label' => ts('Site From Email Addresses'),
         'saved_search_id.name' => 'Site_Email_Addresses',
         'type' => 'table',
         'settings' => [

--- a/schema/Core/SiteEmailAddress.entityType.php
+++ b/schema/Core/SiteEmailAddress.entityType.php
@@ -5,8 +5,8 @@ return [
   'table' => 'civicrm_site_email_address',
   'class' => 'CRM_Core_DAO_SiteEmailAddress',
   'getInfo' => fn() => [
-    'title' => ts('Site Email Address'),
-    'title_plural' => ts('Site Email Addresses'),
+    'title' => ts('Site From Email Address'),
+    'title_plural' => ts('Site From Email Addresses'),
     'description' => ts('Sender addresses to use for outbound emails.'),
     'log' => TRUE,
     'add' => '6.0',

--- a/templates/CRM/Admin/Form/ScheduleReminders.hlp
+++ b/templates/CRM/Admin/Form/ScheduleReminders.hlp
@@ -33,7 +33,7 @@
 {/htxt}
 
 {htxt id="id-from_name_email"}
-  {ts}You can set the FROM name and email address for this reminder in these fields. If you leave these fields blank, the default FROM name and email address for your site will be used (Administer > Communications > Site Email Addresses).{/ts}
+  {ts}You can set the FROM name and email address for this reminder in these fields. If you leave these fields blank, the default FROM name and email address for your site will be used (Administer > Communications > Site From Email Addresses).{/ts}
 {/htxt}
 
 {htxt id="filter_contact_language"}

--- a/templates/CRM/Admin/Page/ConfigTaskList.tpl
+++ b/templates/CRM/Admin/Page/ConfigTaskList.tpl
@@ -63,7 +63,7 @@
         <td colspan="2">{ts}Sending Emails (also used for contribution receipts and event confirmations){/ts}</td>
     </tr>
     <tr class="even">
-        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/options/site_email_address" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Site Email Addresses{/ts}</a></td>
+        <td class="tasklist nowrap"><a href="{crmURL p="civicrm/admin/options/site_email_address" q="reset=1&civicrmDestination=`$destination`"}" title="{$linkTitle|escape}">{ts}Site From Email Addresses{/ts}</a></td>
         <td>{ts}Sender addresses to use for outbound emails.{/ts}</td>
     </tr>
     <tr class="even">

--- a/templates/CRM/Contact/Form/Task/Help/Email/id-from_email.hlp
+++ b/templates/CRM/Contact/Form/Task/Help/Email/id-from_email.hlp
@@ -14,6 +14,6 @@
 {/if}
 {crmPermission has='administer CiviCRM'}
     {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/site_email_address"}{/capture}
-  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
+  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; Site From Email Addresses</a> to add or edit general email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
 {/crmPermission}
 {/htxt}

--- a/templates/CRM/Mailing/MailingUI.hlp
+++ b/templates/CRM/Mailing/MailingUI.hlp
@@ -19,7 +19,7 @@
   <p>{ts}Select the "FROM" Email Address for this mailing from the dropdown list. Available email addresses are configurable by users with Administer CiviCRM permission. EXAMPLE: "Client Services" &lt;clientservices@example.org&gt;{/ts}</p>
 {crmPermission has='administer CiviCRM'}
   {capture assign="fromConfig"}{crmURL p="civicrm/admin/options/site_email_address"}{/capture}
-  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; Site Email Addresses</a> to add or edit email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
+  <p>{ts 1=$fromConfig}Go to <a href='%1'>Administer CiviCRM &raquo; Communications &raquo; Site From Email Addresses</a> to add or edit email addresses. Make sure these email addresses are valid email accounts with your email service provider.{/ts}</p>
 {/crmPermission}
 {crmPermission not='administer CiviCRM'}
   {ts}Contact your site administrator if you need to use a "FROM" Email Address which is not in the dropdown list.{/ts}

--- a/xml/templates/civicrm_navigation.tpl
+++ b/xml/templates/civicrm_navigation.tpl
@@ -178,7 +178,7 @@ VALUES
     ( @domainID, 'civicrm/report/list?compid=4&reset=1', '{ts escape="sql" skip="true"}Mailing Reports{/ts}', 'Mailing Reports', 'access CiviMail', '', @mailinglastID, '1', 1,    5 ),
     ( @domainID, 'civicrm/admin/component?reset=1',                         '{ts escape="sql" skip="true"}Headers, Footers, and Automated Messages{/ts}', 'Headers, Footers, and Automated Messages', 'access CiviMail,administer CiviCRM', 'AND', @mailinglastID, '1', NULL, 6 ),
     ( @domainID, 'civicrm/admin/messageTemplates?reset=1',                  '{ts escape="sql" skip="true"}Message Templates{/ts}', 'Message Templates',                 'edit message templates,edit user-driven message templates,edit system workflow message templates', 'OR', @mailinglastID, '1', NULL, 7 ),
-    ( @domainID, 'civicrm/admin/options/site_email_address', '{ts escape="sql" skip="true"}Site Email Addresses{/ts}', 'CiviMail Site Email Addresses', 'administer CiviCRM', '', @mailinglastID, '1', 1, 8 ),
+    ( @domainID, 'civicrm/admin/options/site_email_address', '{ts escape="sql" skip="true"}Site From Email Addresses{/ts}', 'CiviMail Site From Email Addresses', 'administer CiviCRM', '', @mailinglastID, '1', 1, 8 ),
     ( @domainID, 'civicrm/sms/send?reset=1',  '{ts escape="sql" skip="true"}New SMS{/ts}', 'New SMS', 'send SMS', NULL, @mailinglastID, '1', NULL, 9 ),
     ( @domainID, 'civicrm/mailing/browse?reset=1&sms=1', '{ts escape="sql" skip="true"}Find Mass SMS{/ts}', 'Find Mass SMS', 'send SMS', NULL, @mailinglastID, '1', 1, 10 ),
     ( @domainID, 'civicrm/a/#/abtest/new',                                  '{ts escape="sql" skip="true"}New A/B Test{/ts}', 'New A/B Test',                                        'access CiviMail', '', @mailinglastID, '1', NULL, 15 ),
@@ -302,7 +302,7 @@ INSERT INTO civicrm_navigation
     ( domain_id, url, label, name, permission, permission_operator, parent_id, is_active, has_separator, weight )
 VALUES
     ( @domainID, 'civicrm/admin/domain?action=update&reset=1',         '{ts escape="sql" skip="true"}Organization Address and Contact Info{/ts}', 'Organization Address and Contact Info',                                      'administer CiviCRM', '', @communicationslastID, '1', NULL, 1 ),
-    ( @domainID, 'civicrm/admin/options/site_email_address', '{ts escape="sql" skip="true"}Site Email Addresses{/ts}', 'Site Email Addresses',                                                 'administer CiviCRM', '', @communicationslastID, '1', NULL, 2 ),
+    ( @domainID, 'civicrm/admin/options/site_email_address', '{ts escape="sql" skip="true"}Site From Email Addresses{/ts}', 'Site From Email Addresses',                                                 'administer CiviCRM', '', @communicationslastID, '1', NULL, 2 ),
     ( @domainID, 'civicrm/admin/messageTemplates?reset=1',             '{ts escape="sql" skip="true"}Message Templates{/ts}',      'Message Templates',                                                                         'administer CiviCRM', '', @communicationslastID, '1', NULL, 3 ),
     ( @domainID, 'civicrm/admin/scheduleReminders?reset=1',              '{ts escape="sql" skip="true"}Schedule Reminders{/ts}',    'Schedule Reminders',                                                                       'administer CiviCRM', '', @communicationslastID, '1', NULL, 4 ),
     ( @domainID, 'civicrm/admin/options/preferred_communication_method?reset=1',  '{ts escape="sql" skip="true"}Preferred Communication Methods{/ts}', 'Preferred Communication Methods',  'administer CiviCRM', '', @communicationslastID, '1', NULL, 5 ),
@@ -457,7 +457,7 @@ INSERT INTO civicrm_navigation
 VALUES
     ( @domainID, 'civicrm/admin/component?reset=1',            '{ts escape="sql" skip="true"}Headers, Footers, and Automated Messages{/ts}', 'Headers, Footers, and Automated Messages', 'access CiviMail,administer CiviCRM', 'AND', @adminMailinglastID, '1', NULL, 1 ),
     ( @domainID, 'civicrm/admin/messageTemplates?reset=1',     '{ts escape="sql" skip="true"}Message Templates{/ts}', 'Message Templates', 'administer CiviCRM', '',   @adminMailinglastID, '1', NULL, 2 ),
-    ( @domainID, 'civicrm/admin/options/site_email_address', '{ts escape="sql" skip="true"}Site Email Addresses{/ts}', 'CiviMail Admin Site Email Addresses', 'administer CiviCRM', '', @adminMailinglastID, '1', NULL, 3 ),
+    ( @domainID, 'civicrm/admin/options/site_email_address', '{ts escape="sql" skip="true"}Site From Email Addresses{/ts}', 'CiviMail Admin Site From Email Addresses', 'administer CiviCRM', '', @adminMailinglastID, '1', NULL, 3 ),
     ( @domainID, 'civicrm/admin/mailSettings?reset=1',         '{ts escape="sql" skip="true"}Mail Accounts{/ts}', 'Mail Accounts', 'access CiviMail,administer CiviCRM', 'AND',           @adminMailinglastID, '1', NULL, 4 ),
     ( @domainID, 'civicrm/admin/mail?reset=1',                 '{ts escape="sql" skip="true"}Mailer Settings{/ts}', 'Mailer Settings', 'access CiviMail,administer CiviCRM', 'AND',           @adminMailinglastID, '1', NULL, 5 ),
     ( @domainID, 'civicrm/admin/setting/preferences/mailing?reset=1', '{ts escape="sql" skip="true"}CiviMail Component Settings{/ts}', 'CiviMail Component Settings','access CiviMail,administer CiviCRM', 'AND', @adminMailinglastID, '1', NULL, 6 );


### PR DESCRIPTION
…l Address to reduce confusion

Overview
----------------------------------------
This aims to change the front end labels for the Site Email Address entity and associated strings to be Site From Email Address to reduce confusion among users

Before
----------------------------------------
Known as Site Email Address

After
----------------------------------------
Known as Site From Email Address

@colemanw @Stoob @andyburnsco @kcristiano 