### PR TITLE
Ensure Membership import contact_id field is correctly upgraded

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFive.php
+++ b/CRM/Upgrade/Incremental/php/SixFive.php
@@ -67,7 +67,21 @@ class CRM_Upgrade_Incremental_php_SixFive extends CRM_Upgrade_Incremental_Base {
    */
   public function upgrade_6_5_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Update Membership mappings', 'upgradeImportMappingFields', 'Membership');
     $this->addTask('Install legacyprofiles extension', 'installLegacyProfiles');
+  }
+
+  /**
+   * @param \CRM_Queue_TaskContext|null $context
+   * @param string $entity
+   *
+   * @return true
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
+  public static function upgradeImportMappingFields($context, string $entity): bool {
+    CRM_Upgrade_Incremental_php_SixTwo::upgradeImportMappingFields($context, $entity);
+    return TRUE;
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixTwo.php
+++ b/CRM/Upgrade/Incremental/php/SixTwo.php
@@ -257,6 +257,9 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
         return $preSixOneMappings[$mappingFieldsName];
       }
     }
+    if ($type === 'Membership' && in_array($mappingFieldsName, ['Contact.id', 'Membership.contact_id', 'contact_id'])) {
+      return 'Contact.id';
+    }
 
     if (!isset($prefixMap[$prefix])) {
       // This is a 'native' mapping, add a prefix.


### PR DESCRIPTION
Overview
----------------------------------------
Ensure Membership import contact_id field is correctly upgraded

Before
----------------------------------------
Per comment on https://github.com/civicrm/civicrm-core/pull/33110#issuecomment-3031168890 the field *should* be Contact.id in Membership import mappings but in some cases it is either contact_id or Membership.contact_id

After
----------------------------------------
Fixed to Contact.id

Technical Details
----------------------------------------

Comments
----------------------------------------
