### PR TITLE
Stop deleting UserJobs if mapping is deleted

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -15,7 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Api4\Mapping;
 use Civi\Api4\Queue;
 use Civi\Api4\UserJob;
 use Civi\Core\ClassScanner;
@@ -97,12 +96,6 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
       unset($params['metadata']['MapField']['saveMapping'], $params['metadata']['MapField']['updateMapping']);
     }
 
-    // If the related mapping is deleted then delete the UserJob template
-    // This almost never happens in practice...
-    if ($event->entity === 'Mapping' && $event->action === 'delete') {
-      $mappingName = Mapping::get(FALSE)->addWhere('id', '=', $event->id)->addSelect('name')->execute()->first()['name'];
-      UserJob::delete(FALSE)->addWhere('name', '=', 'import_' . $mappingName)->execute();
-    }
     if ($event->entity === 'UserJob' && $event->action === 'delete') {
       Queue::delete(FALSE)->addWhere('name', '=', 'user_job_' . $event->id)->execute();
     }


### PR DESCRIPTION
Overview
----------------------------------------
Stop deleting UserJobs if mapping is deleted

In 6.5 the User Job template is the primary mapping template - the Mapping entity still exists but is close to being deleted - so it is no longer appropriate to delete the user job (if it ever was) when the Mapping is deleted

Before
----------------------------------------
User Job template removed when related Mapping deleted

After
----------------------------------------
No longer happens

Technical Details
----------------------------------------
This mitigates against people cleaning up the mappings & accidentally deleting user jobs - I thought about reversing it to delete the Mappings when the user jobs are deleted but I think we will just delete them all in an upgrade - hopefully in 6.6

Comments
----------------------------------------
