### PR TITLE
(dev/core#5960) Support page-tokens when using Form Builder w/embedded search

### DIFF
--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -290,7 +290,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         $event->policy['userMode'] = $jwt['userMode'];
       }
       else {
-        $event->policy['userMode'] = 'ignore';
+        $event->policy['userMode'] = 'optional';
       }
     }
   }

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -261,6 +261,10 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         'allowFields' => ['return', 'savedSearch', 'display', 'sort', 'limit', 'seed', 'filters', 'afform'],
         'checkRequest' => fn($request, $jwt) => ($jwt['afform'] === $request['afform']),
       ],
+      ';^SearchDisplay inlineEdit$;' => [
+        'allowFields' => ['return', 'savedSearch', 'display', 'sort', 'limit', 'seed', 'filters', 'afform', 'rowKey', 'values'],
+        'checkRequest' => fn($request, $jwt) => ($jwt['afform'] === $request['afform']),
+      ],
       // It's been hypothesized that we'll also need this. Haven't seen it yet.
       // ';^Afform getFields;' => [
       //   'allowFields' => [],

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -208,6 +208,10 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         'allowFields' => ['fieldName', 'filters', 'formName', 'ids', 'input', 'page', 'values'],
         'checkRequest' => fn($request, $jwt) => ('afform:' . $jwt['afform']) === $request['formName'],
       ],
+      ';^civicrm/ajax/api4/SearchDisplay/run$;' => [
+        'allowFields' => ['return', 'savedSearch', 'display', 'sort', 'limit', 'seed', 'filters', 'afform'],
+        'checkRequest' => fn($request, $jwt) => ($jwt['afform'] === $request['afform']),
+      ],
       // It's been hypothesized that we'll also need this. Haven't seen it yet.
       // ';^civicrm/ajax/api4/Afform/getFields;' => [
       //   'allowFields' => [],

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -132,32 +132,22 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
   public function checkAllowedRoute(string $route, array $jwt): bool {
     $allowedForm = $jwt['afform'];
 
-    $ajaxRoutes = $this->getAllowedRoutes();
-    foreach ($ajaxRoutes as $regex => $routeInfo) {
-      if (preg_match($regex, $route)) {
-        $parsed = json_decode(\CRM_Utils_Request::retrieve('params', 'String'), 1);
-        if (empty($parsed)) {
-          \Civi::log()->warning("Malformed request. Routes matching $regex must submit params as JSON field.");
-          return FALSE;
-        }
-
-        $extraFields = array_diff(array_keys($parsed), $routeInfo['allowFields']);
-        if (!empty($extraFields)) {
-          \Civi::log()->warning("Malformed request. Routes matching $regex only support these input fields: " . json_encode($routeInfo['allowFields']));
-          return FALSE;
-        }
-
-        if (empty($routeInfo['checkRequest'])) {
-          throw new \LogicException("Route ($regex) doesn't define checkRequest.");
-        }
-        $checkRequest = $routeInfo['checkRequest'];
-        if (!$checkRequest($parsed, $jwt)) {
-          \Civi::log()->warning("Malformed request. Requested form does not match allowed name ($allowedForm).");
-          return FALSE;
-        }
-
-        return TRUE;
+    // Afform screens are generally built around APIv4. If it's an APIv4 request, then we check whitelist for entities/actions/fields.
+    if (preg_match(';^civicrm/ajax/api4/(\w+)/(\w+);', $route, $m)) {
+      $parsed = json_decode(\CRM_Utils_Request::retrieve('params', 'String'), 1);
+      if (empty($parsed)) {
+        \Civi::log()->warning("Malformed request. APIv4 call requires \"params\" be JSON.");
+        return FALSE;
       }
+      return $this->checkAllowedApi4Call($m[1], $m[2], $parsed, $jwt);
+    }
+    elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && preg_match(';^civicrm/ajax/api4/?;', $route)) {
+      $calls = json_decode(\CRM_Utils_Request::retrieve('calls', 'String'), 1);
+      if (empty($calls)) {
+        \Civi::log()->warning("Malformed request. APIv4 calls requires \"calls\" be JSON.");
+        return FALSE;
+      }
+      return $this->checkAllowedApi4Calls($calls, $jwt);
     }
 
     // Actually, we may not need this? aiming for model where top page-request auth is irrelevant to subrequests...
@@ -173,14 +163,73 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
   }
 
   /**
+   * Determine if a batch of APIv4 calls are permitted by this JWT.
+   *
+   * @param array $calls
+   *   List of APIv4 requests
+   * @param array $jwt
+   *   Validated credential describing allowed usages.
+   * @return bool
+   *   TRUE if _ALL_ calls are allowed.
+   */
+  protected function checkAllowedApi4Calls(array $calls, array $jwt): bool {
+    foreach ($calls as $callId => $callDetails) {
+      if (!$this->checkAllowedApi4Call($callDetails[0], $callDetails[1], $callDetails[2], $jwt)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * Determine if a specific APIv4 call is permitted by this JWT.
+   *
+   * @param string $entity
+   * @param string $action
+   * @param array $params
+   * @param array $jwt
+   *   Validated credential describing allowed usages.
+   * @return bool
+   *   TRUE if this call is permitted by this credential
+   */
+  protected function checkAllowedApi4Call(string $entity, string $action, array $params, array $jwt): bool {
+    $allowedForm = $jwt['afform'];
+
+    $api4Call = "$entity $action";
+    $api4Calls = $this->getAllowedApi4Calls();
+    foreach ($api4Calls as $callRegex => $callInfo) {
+      if (preg_match($callRegex, $api4Call)) {
+        $extraFields = array_diff(array_keys($params), $callInfo['allowFields']);
+        if (!empty($extraFields)) {
+          \Civi::log()->warning("Malformed request. Routes matching $callRegex only support these input fields: " . json_encode($callInfo['allowFields']));
+          return FALSE;
+        }
+
+        if (empty($callInfo['checkRequest'])) {
+          throw new \LogicException("Route ($callRegex) doesn't define checkRequest.");
+        }
+        $checkRequest = $callInfo['checkRequest'];
+        if (!$checkRequest($params, $jwt)) {
+          \Civi::log()->warning("Malformed request. Requested form does not match allowed name ($allowedForm).");
+          return FALSE;
+        }
+
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
    * @return array[]
    */
-  protected function getAllowedRoutes(): array {
+  protected function getAllowedApi4Calls(): array {
     // These params are common to many Afform actions.
     $abstractProcessorParams = ['name', 'args', 'fillMode'];
 
     return [
-      // ';civicrm/path/to/some/page;' => [
+      // ';^EntityName ActionName$;' => [
       //
       //    // All the fields that are allowed for this API call.
       //    // N.B. Fields like "chain" are NOT allowed.
@@ -192,28 +241,28 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
       //
       // ],
 
-      ';^civicrm/ajax/api4/Afform/prefill$;' => [
+      ';^Afform prefill$;' => [
         'allowFields' => $abstractProcessorParams,
         'checkRequest' => fn($request, $jwt) => ($request['name'] === $jwt['afform']),
       ],
-      ';^civicrm/ajax/api4/Afform/submit$;' => [
+      ';^Afform submit$;' => [
         'allowFields' => [...$abstractProcessorParams, 'values'],
         'checkRequest' => fn($request, $jwt) => ($request['name'] === $jwt['afform']),
       ],
-      ';^civicrm/ajax/api4/Afform/submitFile$;' => [
+      ';^Afform submitFile$;' => [
         'allowFields' => [...$abstractProcessorParams, 'token', 'modelName', 'fieldName', 'joinEntity', 'entityIndex', 'joinIndex'],
         'checkRequest' => fn($request, $jwt) => ($request['name'] === $jwt['afform']),
       ],
-      ';^civicrm/ajax/api4/\w+/autocomplete$;' => [
+      ';^\w+ autocomplete$;' => [
         'allowFields' => ['fieldName', 'filters', 'formName', 'ids', 'input', 'page', 'values'],
         'checkRequest' => fn($request, $jwt) => ('afform:' . $jwt['afform']) === $request['formName'],
       ],
-      ';^civicrm/ajax/api4/SearchDisplay/run$;' => [
+      ';^SearchDisplay run$;' => [
         'allowFields' => ['return', 'savedSearch', 'display', 'sort', 'limit', 'seed', 'filters', 'afform'],
         'checkRequest' => fn($request, $jwt) => ($jwt['afform'] === $request['afform']),
       ],
       // It's been hypothesized that we'll also need this. Haven't seen it yet.
-      // ';^civicrm/ajax/api4/Afform/getFields;' => [
+      // ';^Afform getFields;' => [
       //   'allowFields' => [],
       //   'checkRequest' => fn($expected, $request) => TRUE,
       // ],

--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -133,7 +133,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
     $allowedForm = $jwt['afform'];
 
     // Afform screens are generally built around APIv4. If it's an APIv4 request, then we check whitelist for entities/actions/fields.
-    if (preg_match(';^civicrm/ajax/api4/(\w+)/(\w+);', $route, $m)) {
+    if (preg_match(';^civicrm/ajax/api4/(\w+)/(\w+)/?$;', $route, $m)) {
       $parsed = json_decode(\CRM_Utils_Request::retrieve('params', 'String'), 1);
       if (empty($parsed)) {
         \Civi::log()->warning("Malformed request. APIv4 call requires \"params\" be JSON.");
@@ -141,7 +141,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
       }
       return $this->checkAllowedApi4Call($m[1], $m[2], $parsed, $jwt);
     }
-    elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && preg_match(';^civicrm/ajax/api4/?;', $route)) {
+    elseif ($_SERVER['REQUEST_METHOD'] === 'POST' && preg_match(';^civicrm/ajax/api4/?$;', $route)) {
       $calls = json_decode(\CRM_Utils_Request::retrieve('calls', 'String'), 1);
       if (empty($calls)) {
         \Civi::log()->warning("Malformed request. APIv4 calls requires \"calls\" be JSON.");


### PR DESCRIPTION
Overview
----------------------------------------

If you follow the steps from https://lab.civicrm.org/dev/core/-/issues/5960, then you wind up viewing an Afform page and making an AJAX call to `SearchDisplay.run`. This AJAX request is rejected for two reasons:

1. The entity/action haven't been approved yet. (This PR includes @ufundo's #33154 to approve the entity/action.)
2. The HTTP request is sent as an HTTP POST in batch format. The authorization mechanism doesn't know how to authorize such requests.

Before
----------------------------------------

Requests like this fail:

> <img width="751" alt="Screenshot 2025-07-09 at 7 19 44 PM" src="https://github.com/user-attachments/assets/713c7359-57b4-4b30-a63d-6b2c5011eb39" />

Consequently, the form shows empty data:

> <img width="642" alt="Screenshot 2025-07-09 at 7 25 01 PM" src="https://github.com/user-attachments/assets/b60311ee-0eff-48fe-b11f-03bfb69c2f92" />


After
----------------------------------------

The request succeeds.

> <img width="750" alt="Screenshot 2025-07-09 at 7 23 09 PM" src="https://github.com/user-attachments/assets/a86946e2-a3d8-4cee-bbbf-639e10f3db75" />

Consequently, the form shows data:

> <img width="661" alt="Screenshot 2025-07-09 at 7 24 35 PM" src="https://github.com/user-attachments/assets/29074594-19d6-403f-b985-5c67de865d7a" />
