### PR TITLE
RiverLea - Inline edit padding & input sizes, to make batch input look more spreadsheety

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -232,7 +232,7 @@ select.crm-error {
 .crm-container .twelve,
 .crm-container .medium,
 .crm-container input.twelve,
-.crm-container input.medium  {
+.crm-container input.medium {
   width: 12em;
 }
 .crm-container .twenty {
@@ -271,7 +271,6 @@ input.crm-form-entityref {
 .crm-container .crm-editable-form [type="cancel"] {
   color: var(--crm-c-danger) !important;
 }
-/* in place edit  */
 .crm-container .crm-inline-edit,
 .crm-container .crm-editable-disabled,
 .crm-container .crm-editable-enabled {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -232,7 +232,7 @@ select.crm-error {
 .crm-container .twelve,
 .crm-container .medium,
 .crm-container input.twelve,
-.crm-container input.medium {
+.crm-container input.medium  {
   width: 12em;
 }
 .crm-container .twenty {
@@ -271,6 +271,7 @@ input.crm-form-entityref {
 .crm-container .crm-editable-form [type="cancel"] {
   color: var(--crm-c-danger) !important;
 }
+/* in place edit  */
 .crm-container .crm-inline-edit,
 .crm-container .crm-editable-disabled,
 .crm-container .crm-editable-enabled {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -78,8 +78,11 @@
 }
 /* Inline Edit */
 
-#bootstrap-theme .crm-search-field-editing .form-group { /* Fix for < 768px */
-  margin-bottom: 0;
+#bootstrap-theme .crm-search-field-editing .form-group,
+#bootstrap-theme .crm-search-field-editing .radio-inline,
+#bootstrap-theme .crm-search-field-editing .checkbox-inline {
+  margin-bottom: 0; /* Fix for < 768px */
+  display: flex; /* Stops wrap of radios */
 }
 .crm-editable-enabled:has(span.crm-search-field-value:empty)::before {
   content: "\f303";
@@ -94,4 +97,23 @@
   content: 'Edit';
   text-indent: -10000px;
   position: absolute;
+}
+.crm-container td.crm-search-field-editing.crm-search-col-type-field {
+  padding-block: 0; /* Removes top/bottom padding on uneditable fields */
+}
+.crm-container td.crm-search-field-editing.crm-search-field-editable,
+.crm-container .crm-search-field-editing .form-inline {
+  padding: 0;
+}
+.crm-search-display-batch span.crm-form-date-wrapper {
+  flex-wrap: nowrap;
+  gap: 0;
+}
+#bootstrap-theme .crm-search-field-editing
+:where(input,.select2-container):where(:not(.crm-form-date,.crm-form-time,.four,.six,.eight,.twelve,.medium):not([type="checkbox"]):not([type="radio"])) {
+  width: 12ch !important /* vs inline width */;
+}
+.crm-search-display tr:has(.crm-search-field-editing) td.crm-search-ctrl-column:has(.btn-group) { /* Controls for full-row edit */
+  display: inline-table;
+  vertical-align: text-top;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Following discussion - batch processing inline edit on SearchKit tables could be made to look more like a spreadsheet with less padding and narrow inputs/selects. This PR adds this, as well as handling inline radio/checkboxes and the row edit controls.

Before
----------------------------------------
Row edit:
![image](https://github.com/user-attachments/assets/2d8a7ff7-0f60-4600-b98a-cf2cac33da02)
(cont…)
![image](https://github.com/user-attachments/assets/53eb5393-d082-4df4-b87a-5f598e1bb189)

Individual item edit:
![image](https://github.com/user-attachments/assets/575024e8-e48e-4b48-94cb-5e6fad71f80c)

After
----------------------------------------
Row edit:
![image](https://github.com/user-attachments/assets/669cb096-db59-4cc5-8601-bcef2962c184)

Individual item edit:
![image](https://github.com/user-attachments/assets/c0a3cf29-46e1-41af-ac8f-d7d5cb977db8)

Technical Details
----------------------------------------
This needs to be rebased after this is merged - https://github.com/civicrm/civicrm-core/pull/33152.

Comments
----------------------------------------
For people who don't do batch editing, the narrower inputs and select2's might be a step back. Be good to get some feedback from other users of inline-edit in SK tables.