### PR TITLE
allow configuring No results message for list displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -15,10 +15,20 @@
           {{ symbol.label }}
         </option>
       </select>
-      <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
     </div>
+  </fieldset>
+  <fieldset>
+    <div class="form-inline crm-search-admin-flex-row" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+    <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if no results.') }}">
+      <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+      <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+    </div>
+  </fieldset>
+  <fieldset>
     <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
     <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
+  </fieldset>
+  <fieldset>
     <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
   </fieldset>
 </details>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/afforms.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/afforms.html
@@ -18,7 +18,7 @@
     <li ng-if="!row.afform_count" class="disabled">
       <a href>
         <i ng-if="!$ctrl.afforms" class="crm-i fa-spinner fa-spin"></i>
-        <em ng-if="$ctrl.afforms && !$ctrl.afforms[row.data.name]">{{:: ts('None Found') }}</em>
+        <em ng-if="$ctrl.afforms && !$ctrl.afforms[row.data.name]">{{:: ts('None found.') }}</em>
       </a>
     </li>
     <li ng-if="$ctrl.afforms" ng-repeat="afform in $ctrl.afforms[row.data.name]" title="{{:: $ctrl.afformAdminEnabled ? ts('Edit form') : '' }}">

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -17,5 +17,10 @@
     ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'"
     ng-style="{'list-style': $ctrl.settings.symbol}"
     ></ul>
+   <div ng-if="$ctrl.rowCount === 0" class="crm-search-display-list-no-results">
+      <p class="alert alert-info text-center">
+        {{ $ctrl.settings.noResultsText || ts('None found.') }}
+      </p>
+    </div>
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -22,7 +22,7 @@
 <tr ng-if="$ctrl.rowCount === 0">
   <td colspan="{{ $ctrl.settings.columns.length + 2 }}">
     <p class="alert alert-info text-center">
-      {{ $ctrl.settings.noResultsText || ts('None Found') }}
+      {{ $ctrl.settings.noResultsText || ts('None found.') }}
     </p>
   </td>
 </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Copy functionality from table display to list display.

Before
----------------------------------------
- List displays go blank if there are no results
- User doesn't know if no results, or error
- No way to configure the message
- List settings options are very squished together

After
----------------------------------------
- List displays have a default message if no results
- Message can be configured in the admin
- List settings options are less squished together, broken into more logical fieldset groups
