### PR TITLE
set Contribution default search columns explicitly, include receive_date

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Contribution.php
+++ b/ext/civi_contribute/Civi/Api4/Contribution.php
@@ -14,7 +14,7 @@ namespace Civi\Api4;
  * Contribution entity.
  *
  * @searchable primary
- * @searchFields contact_id.sort_name,total_amount
+ * @searchFields receive_date,contact_id.sort_name,total_amount,financial_type_id:label,contribution_status_id:label
  * @since 5.19
  * @package Civi\Api4
  */

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -205,7 +205,10 @@ class Admin {
       $possibleColumns[$column] = "$column:label";
     }
     // Other possible relevant columns... now we're just guessing
-    $possibleColumns['financial_type_id'] = 'financial_type_id:label';
+    //
+    // TODO: these can be specified using the @searchColumns annotation on
+    // the Api4 entity class so would probably be better to specify sensible
+    // options for core entities explicitly - which allows you to order logically too
     $possibleColumns['description'] = 'description';
     // E.g. "activity_status_id"
     $possibleColumns[strtolower($entity['name']) . 'status_id'] = strtolower($entity['name']) . 'status_id:label';


### PR DESCRIPTION
Before
----------------------------------------
- Every time I make a Contribution search I have to add `receive_date` to the column list

After
----------------------------------------
- `receive_date` included by default when creating new Contribution search


