### PR TITLE
dev/core#5991 AfformMetadataInjector - fill af-field metadata for multifield inputs

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -206,6 +206,15 @@ class AfformMetadataInjector {
    */
   private static function fillFieldMetadata($entityNames, string $action, \DOMElement $afField):void {
     $fieldName = $afField->getAttribute('name');
+
+    // for magic munged fields like display_name,sort_name,email_primary.email
+    // we now fill with metadata for the first field. (previously they were ignored entirely)
+    // afform authors should take care that munged fields are of compatible types
+    // or strange things will happen
+    if (\str_contains($fieldName, ',')) {
+      $fieldName = explode(',', $fieldName)[0];
+    }
+
     $fieldInfo = self::getFieldMetadata($entityNames, $action, $fieldName);
     // Merge field definition data with whatever's already in the markup.
     if ($fieldInfo) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/5991

Before
----------------------------------------
- following https://github.com/civicrm/civicrm-core/pull/33127 the af-field input template is calculated server side based on the field input type in [`AfformMetadataInjector`](https://github.com/civicrm/civicrm-core/blob/eec22a7d3a94a1fb51665203a2bb3bfdd684e8b0/ext/afform/core/Civi/Afform/AfformMetadataInjector.php#L124) (which permits hooking and adding new input types in extensions)
- magic multifield af-fields like `display_name,sort_name,email_primary.email` don't get picked up by AfformMetadataInjector because they are not recognised as real valid fields. hence they don't get the input template set in their `defn`, and the field is broken

After
----------------------------------------
- `AfformMetadataInjector` has (slightly naive) handling for these multifield inputs. It will pick the first field in the concatenated list, and fill based on its metadata.
- This might do something quirky if the first field is a date, and the other fields are not. But that was probably quirky before? If there's some clever combo of `defn` values that work in a particular scenario, then afform authors can set these explicitly in the afform code, and these will be preferred to any provided by `AfformMetadataInjector` (it only fills missing keys).