### PR TITLE
dev/core#5998 - Api4 - Handle EMPTY operators for multi-value contact reference fields

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -465,7 +465,7 @@ abstract class Api4Query {
       $operator = str_replace('EMPTY', 'NULL', $operator);
       // For strings & numbers, create an OR grouping of empty value OR null
       if (in_array($field['data_type'] ?? NULL, ['String', 'Integer', 'Float', 'Boolean'], TRUE)) {
-        $emptyVal = $field['data_type'] === 'String' ? '""' : '0';
+        $emptyVal = ($field['data_type'] === 'String' || $field['serialize']) ? '""' : '0';
         $isEmptyClause = $operator === 'IS NULL' ? "= $emptyVal OR" : "<> $emptyVal AND";
         return "($fieldAlias $isEmptyClause $fieldAlias $operator)";
       }

--- a/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomContactRefTest.php
@@ -86,37 +86,66 @@ class CustomContactRefTest extends Api4TestBase {
       'MyContactRef.FavPeople' => [$favPeopleId2],
     ])['id'];
 
-    $result = Contact::get(FALSE)
+    $contactId3 = $this->createTestRecord('Individual', [
+      'first_name' => 'Bop',
+      'last_name' => 'Tester',
+      'MyContactRef.FavPerson' => $favPersonId,
+      'MyContactRef.FavPeople' => [],
+    ])['id'];
+
+    $results = Contact::get(FALSE)
       ->addSelect('display_name')
       ->addSelect('MyContactRef.FavPerson.first_name')
       ->addSelect('MyContactRef.FavPerson.last_name')
       ->addSelect('MyContactRef.FavPeople')
       ->addSelect('MyContactRef.FavPeople.last_name')
       ->addWhere('MyContactRef.FavPerson.first_name', '=', $firstName)
-      ->execute()
-      ->single();
+      ->addOrderBy('id')
+      ->execute();
+    $this->assertCount(2, $results);
 
-    $this->assertEquals($firstName, $result['MyContactRef.FavPerson.first_name']);
-    $this->assertEquals('Person', $result['MyContactRef.FavPerson.last_name']);
+    // First result is contactId1
+    $this->assertEquals($contactId1, $results[0]['id']);
+    $this->assertEquals($firstName, $results[0]['MyContactRef.FavPerson.first_name']);
+    $this->assertEquals('Person', $results[0]['MyContactRef.FavPerson.last_name']);
     // Ensure serialized values are returned in order
-    $this->assertEquals([$favPeopleId2, $favPeopleId1], $result['MyContactRef.FavPeople']);
+    $this->assertEquals([$favPeopleId2, $favPeopleId1], $results[0]['MyContactRef.FavPeople']);
     // Values returned from virtual join should be in the same order
-    $this->assertEquals(['People2', 'People1'], $result['MyContactRef.FavPeople.last_name']);
+    $this->assertEquals(['People2', 'People1'], $results[0]['MyContactRef.FavPeople.last_name']);
+
+    // Second result is contactId3
+    $this->assertEquals($contactId3, $results[1]['id']);
+    $this->assertEquals($firstName, $results[1]['MyContactRef.FavPerson.first_name']);
+    $this->assertEmpty($results[1]['MyContactRef.FavPeople.last_name']);
 
     $result = Contact::get(FALSE)
       ->addSelect('id')
       ->addWhere('MyContactRef.FavPeople.first_name', 'CONTAINS', 'FirstFav')
       ->execute()
       ->single();
-
     $this->assertEquals($contactId1, $result['id']);
 
     $result = Contact::get(FALSE)
       ->addSelect('id')
       ->addWhere('MyContactRef.FavPeople.first_name', 'CONTAINS', 'SecondFav')
       ->execute();
-
     $this->assertCount(2, $result);
+
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('MyContactRef.FavPeople', 'IS EMPTY')
+      ->execute()->column('id');
+    $this->assertContains($contactId3, $result);
+    $this->assertNotContains($contactId1, $result);
+    $this->assertNotContains($contactId2, $result);
+
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('MyContactRef.FavPeople', 'IS NOT EMPTY')
+      ->execute()->column('id');
+    $this->assertNotContains($contactId3, $result);
+    $this->assertContains($contactId1, $result);
+    $this->assertContains($contactId2, $result);
   }
 
   public function testCurrentUser(): void {


### PR DESCRIPTION
Before
----------------------------------------
SearchKit / Api4 queries on multi-value ContactReference custom fields using the IS EMPTY / IS NOT EMPTY where clauses yield erroneous results.

After
----------------------------------------
The results are correctly filtered by the IS EMPTY / IS NOT EMPTY where clause.

