### PR TITLE
Make formatting more consistent in import

### DIFF
--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -65,7 +65,7 @@
   </div>
   <hr>
   <div id="map-field">
-    {{:: ts('Data mapping') }}
+    <h3>{{:: ts('Data mapping') }}</h3>
     <table class="selector">
       <tr ng-if="data.savedMapping.name" class="columnheader-dark"><th colspan="4">
         {{:: ts('Saved Field Mapping: %1', {1: data.savedMapping.name}) }}</th>


### PR DESCRIPTION
Overview
----------------------------------------
Make formatting more consistent in import - ie Data Mapping is a section header like Import To

Before
----------------------------------------
<img width="947" height="377" alt="image" src="https://github.com/user-attachments/assets/84db9ef3-939a-4bd3-b030-4dd27364d97a" />


After
----------------------------------------
<img width="590" height="370" alt="image" src="https://github.com/user-attachments/assets/e0068690-c0c7-4856-8595-6b7f076a9593" />


Technical Details
----------------------------------------

Comments
----------------------------------------
