### PR TITLE
Remove redundant membership load in order.complete

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1081,7 +1081,7 @@ AND civicrm_membership.is_test = %2";
       throw new CRM_Core_Exception(ts('Oops, it looks like there is no valid membership status corresponding to the membership start and end dates for this membership. Contact the site administrator for assistance.'));
     }
 
-    if ($status['id'] !== $currentMembership['status_id']) {
+    if ((int) $status['id'] !== (int) $currentMembership['status_id']) {
       $oldStatus = $currentMembership['status_id'];
       $memberDAO = new CRM_Member_DAO_Membership();
       $memberDAO->id = $currentMembership['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Remove redundant membership load in order.complete

Before
----------------------------------------
We load a list of `$memberships` and during that iteration we load `$currentMembership` based on the current id - and then do a conditional `if ` it that exists - but it has to exist because of how it is loaded

After
----------------------------------------
We just use the loaded membership

Technical Details
----------------------------------------
This code used to live elsewhere & it probably made sense once. Test cover is good

Comments
----------------------------------------
