### PR TITLE
Remove handling for back-office renewal for form not called from there

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -849,13 +849,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
     // CRM-8141
     if ($onlySameParentOrg && $memType) {
       // see if there is a membership that has same parent as $memType but different parent than $membershipID
-      if ($dao->id && CRM_Core_Permission::check('edit memberships')) {
-        // CRM-10016, This is probably a backend renewal, and make sure we return the same membership thats being renewed.
-        $dao->whereAdd();
-      }
-      else {
-        unset($dao->id);
-      }
+      unset($dao->id);
 
       unset($dao->membership_type_id);
       if ($dao->find(TRUE)) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove handling for back-office renewal for form not called from there

Before
----------------------------------------
Per https://issues.civicrm.org/jira/browse/CRM-10016 there is handling for confirming memberships when called from the Renewal form - but in a function that is no longer called from there

After
----------------------------------------
poof

Technical Details
----------------------------------------
There is only one function that STILL  calls this function with `$onlineSameParentOrg` set to TRUE and `$dao->id` potentially set (by virtue of `$membershipId` being passed in) and that calling function is NOT a backoffice renewal per [CRM-10016](https://issues.civicrm.org/jira/browse/CRM-10016) - so I feel confident this nuance relates to code paths that no longer exist

The one caller is commented as follows.

```
    // CRM-7297 - allow membership type to be be changed during renewal so long as the parent org of new membershipType
    // is the same as the parent org of an existing membership of the contact
    $currentMembership = CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,
      $is_test, $membershipID, TRUE
    );
```

Comments
----------------------------------------
