### PR TITLE
SearchKit - Inline-edit creation of contact primary phone/email/address

### DIFF
--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
@@ -159,10 +159,9 @@ class EditableSearchTest extends Api4TestBase {
     $this->assertEquals('123456', $result[1]['columns'][2]['val']);
     $this->assertTrue($result[1]['columns'][2]['edit']);
     // Contact 2 address can be created
-    // TODO: Not working yet
-    //    $this->assertEquals('', $result[1]['columns'][4]['val']);
-    //    $this->assertEquals('', $result[1]['columns'][5]['val']);
-    //    $this->assertTrue($result[1]['columns'][4]['edit']);
+    $this->assertEquals('', $result[1]['columns'][4]['val']);
+    $this->assertEquals('', $result[1]['columns'][5]['val']);
+    $this->assertTrue($result[1]['columns'][4]['edit']);
 
     $this->assertNotEmpty($result->editable['gender_id:label']['options']);
     $this->assertEquals('Select', $result->editable['gender_id:label']['input_type']);


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #32070 which enabled inline-edit of virtual joins, this allows them to be created as well.

Also see https://lab.civicrm.org/dev/core/-/issues/5995



Technical Details
----------------------------------------

This relies on support in the BAO for saving.