### PR TITLE
fix dev/core#5989

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -218,7 +218,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
 
     // If the entity is Individual, Organization, or Household, add the "Contact" actions
     if (CoreUtil::isContact($entity['name'])) {
-      $tasks[$entity['name']] = array_merge($tasks[$entity['name']], $tasks['Contact']);
+      $tasks[$entity['name']] = array_merge($tasks[$entity['name']], $tasks['Contact'] ?? []);
     }
 
     foreach ($tasks[$entity['name']] as $name => &$task) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a regression which caused SearchKit tasks not to load in some situations.

Before
----------------------------------------
In contact-based SearchDisplays, the "Actions" dropdown would not load in some configurations, for example when CiviMail was disabled.

After
----------------------------------------
Bug fixed.