### PR TITLE
ContactSummary - Remove redundant disclosure wrapper on custom fields

### DIFF
--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -95,6 +95,11 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
     $this->addElement('hidden', 'hidden_custom', 1);
     $this->addElement('hidden', "hidden_custom_group_count[{$this->_groupID}]", CRM_Utils_Request::retrieve('cgcount', 'Positive', $this, FALSE, 1));
     CRM_Core_BAO_CustomGroup::buildQuickForm($this, $this->_groupTree);
+    // This form only applies to a single group so this loop always runs once
+    foreach ($this->_groupTree as $group_id => $cd_edit) {
+      $this->assign('group_id', $group_id);
+      $this->assign('cd_edit', $cd_edit);
+    }
   }
 
   /**

--- a/templates/CRM/Contact/Form/Inline/CustomData.tpl
+++ b/templates/CRM/Contact/Form/Inline/CustomData.tpl
@@ -12,5 +12,6 @@
   <div class="crm-inline-button">
     {include file="CRM/common/formButtons.tpl" location=''}
   </div>
-  {include file="CRM/Custom/Form/CustomData.tpl" skipTitle=true}
-</div> <!-- end of main -->
+  {include file="CRM/Custom/Form/Edit/CustomData.tpl" skipTitle=true customDataEntity='' isSingleRecordEdit=false}
+  {include file="CRM/Form/attachmentjs.tpl"}
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#5997](https://lab.civicrm.org/dev/core/-/issues/5997)

Before
----------------------------------------
When inline-editing a custom field, an extra collapsible accordion was being added, leading to some confusion.

<img width="1404" height="694" alt="image" src="https://github.com/user-attachments/assets/92f2c616-cf14-4597-9ad1-c7f188f8c623" />


After
----------------------------------------
Just the one.

<img width="1320" height="582" alt="image" src="https://github.com/user-attachments/assets/066d499b-dc6f-4d57-b3ca-4fa01df9a029" />


Technical Details
----------------------------------------
The templates are also pretty confusing, so I removed one of the layers of nesting, instead just assigning the variables directly from the form.

