### PR TITLE
Fix comments to specify form, remove pass-by-ref

### DIFF
--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -199,10 +199,10 @@ WHERE  inst.report_id = %1";
   }
 
   /**
-   * @param CRM_Core_Form $form
+   * @param CRM_Report_Form $form
    * @param array $rows
    */
-  public static function export2csv(&$form, &$rows) {
+  public static function export2csv($form, &$rows) {
     //Mark as a CSV file.
     CRM_Utils_System::setHttpHeader('Content-Type', 'text/csv');
 
@@ -217,12 +217,12 @@ WHERE  inst.report_id = %1";
    * Utility function for export2csv and CRM_Report_Form::endPostProcess
    * - make CSV file content and return as string.
    *
-   * @param CRM_Core_Form $form
+   * @param CRM_Report_Form $form
    * @param array $rows
    *
    * @return string
    */
-  public static function makeCsv(&$form, &$rows) {
+  public static function makeCsv($form, $rows) {
     $config = CRM_Core_Config::singleton();
 
     // Output UTF BOM so that MS Excel copes with diacritics. This is recommended as


### PR DESCRIPTION
Overview
----------------------------------------
Fix comments to specify form, remove pass-by-ref

Before
----------------------------------------
Function does not use pass-by-ref

<img width="815" height="150" alt="image" src="https://github.com/user-attachments/assets/7d1cb200-e02d-4056-a98a-dc544a96c8df" />

Function has 2 callers - one directly in `CRM_Report_OutputHandler_Csv` which passes the result of `$this->getForm()` - a function that is Type hinted to `CRM_Report_Form`

The other caller is `CRM_Report_Utils_Report::export2csv` - but that has only one caller, also on  `CRM_Report_OutputHandler_Csv` which also passes the result of `$this->getForm()`


After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
