### PR TITLE
Fix regression using import mappings

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -190,6 +190,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   protected function getMappingName(): string {
+    if ($this->getSubmittedValue('saveMappingName')) {
+      return $this->getSubmittedValue('saveMappingName');
+    }
     if ($this->mappingName === NULL) {
       $savedMappingID = $this->getSavedMappingID();
       if ($savedMappingID) {
@@ -453,7 +456,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
       'created_id' => CRM_Core_Session::getLoggedInContactID(),
       'job_type' => $this->getUserJobType(),
       'status_id:name' => 'draft',
-      'name' => 'import_' . $this->getSubmittedValue('saveMappingName'),
+      'name' => 'import_' . $this->getMappingName(),
       'metadata' => ['submitted_values' => $this->getSubmittedValues()],
     ])->execute()->first()['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression using import mappings

Before
----------------------------------------
- Do a contact import, saving the field mapping
- Do another import - saving another field mapping
- try to import, selecting one of the mappings - it gives a fatal or popup error, failing to procede
<img width="513" height="313" alt="image" src="https://github.com/user-attachments/assets/11c3bff9-f8b6-499f-b06d-0812a01012f8" />


After
----------------------------------------
Can procede

Technical Details
----------------------------------------
The issue is that the `civicrm_user_job` table requires a unique name - the name follows the format
`import_{$mappingName}` - in the non-civiimport import there is no value found for `$mappingName` so on the second attempt it hits a non-unique key and fails.

This is not an issue for the civiimport imports as it only happens on the `DataSource` screen when the mapping exists but not the UserJob template - the civiimports have all had the import templates created by now - with the possible exception of the Custom Data import which I'm about to test - but which is non-blocking on this 

Comments
----------------------------------------
