### PR TITLE
Remove fallback to quickform from Contribution parser

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -74,14 +74,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
    */
   protected function getFieldMappings(): array {
     $mappedFields = $this->getUserJob()['metadata']['import_mappings'] ?? [];
-    if (empty($mappedFields)) {
-      foreach ($this->getSubmittedValue('mapper') as $i => $mapperRow) {
-        $mappedField = $this->getMappingFieldFromMapperInput($mapperRow, 0, $i);
-        // Just for clarity since 0 is a pseudo-value
-        unset($mappedField['mapping_id']);
-        $mappedFields[] = $mappedField;
-      }
-    }
     foreach ($mappedFields as $index => $mappedField) {
       $mappedFields[$index]['column_number'] = 0;
       // This is the same data as entity_data - it is stored to the database in the contact_type field

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -203,6 +203,9 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       $mappedFieldData = $this->userJob['metadata']['import_mappings'][$columnNumber];
       $mappedField = array_intersect_key($mappedFieldData, array_fill_keys(['name', 'column_number', 'entity_data'], TRUE));
       $mappedField['mapping_id'] = $mappingID;
+      if (!isset($mappedField['column_number'])) {
+        $mappedField['column_number'] = $columnNumber;
+      }
     }
     else {
       $fieldMapping = (array) $this->getSubmittedValue('mapper')[$columnNumber];

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -57,30 +57,6 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ->execute();
   }
 
-  /**
-   * Update saved userJob metadata - as the angular screen would do.
-   *
-   * @param array $mappings
-   * @param string $contactType
-   *
-   * @return void
-   * @throws \CRM_Core_Exception
-   */
-  public function updateJobMetadata(array $mappings, string $contactType): void {
-    $metadata = UserJob::get()->addWhere('id', '=', $this->userJobID)
-      ->execute()->single()['metadata'];
-    if ($mappings) {
-      $metadata['import_mappings'] = $mappings;
-    }
-    if ($contactType) {
-      $metadata['entity_configuration']['Contact']['contact_type'] = $contactType;
-    }
-    UserJob::update()
-      ->addWhere('id', '=', $this->userJobID)
-      ->addValue('metadata', $metadata)
-      ->execute();
-  }
-
   protected function setUp(): void {
     parent::setUp();
     $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -192,4 +192,33 @@ trait CRMTraits_Import_ParserTrait {
     ]);
   }
 
+  /**
+   * Update saved userJob metadata - as the angular screen would do.
+   *
+   * @param array $mappings
+   * @param string $contactType
+   *
+   * @return void
+   *
+   */
+  public function updateJobMetadata(array $mappings, string $contactType): void {
+    try {
+      $metadata = UserJob::get()->addWhere('id', '=', $this->userJobID)
+        ->execute()->single()['metadata'];
+      if ($mappings) {
+        $metadata['import_mappings'] = $mappings;
+      }
+      if ($contactType) {
+        $metadata['entity_configuration']['Contact']['contact_type'] = $contactType;
+      }
+      UserJob::update()
+        ->addWhere('id', '=', $this->userJobID)
+        ->addValue('metadata', $metadata)
+        ->execute();
+    }
+    catch (CRM_Core_Exception $e) {
+      $this->fail('Failed to update UserJob: ' . $e->getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove fallback to quickform from Contribution parser

Before
----------------------------------------
Contribution import has a fall back to Quickform for when civiimport was optional - it is no longer reachable

After
----------------------------------------
It is gone

Technical Details
----------------------------------------

Comments
----------------------------------------
