### PR TITLE
Remove always-true-if

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -578,10 +578,8 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       }
     }
 
-    if (!empty($params['pledge_id'])) {
-      if (CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge', $params['pledge_id'], 'contact_id') != $contributionContactID) {
-        throw new CRM_Core_Exception('Invalid Pledge ID provided. Contribution row was skipped.', CRM_Import_Parser::ERROR);
-      }
+    if (CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge', $params['pledge_id'], 'contact_id') != $contributionContactID) {
+      throw new CRM_Core_Exception('Invalid Pledge ID provided. Contribution row was skipped.', CRM_Import_Parser::ERROR);
     }
 
     // we need to check if oldest payment amount equal to contribution amount

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -555,11 +555,11 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
     if (empty($params['pledge_id'])) {
       return;
     }
+    if (CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge', $params['pledge_id'], 'contact_id') != $params['contact_id']) {
+      throw new CRM_Core_Exception('Invalid Pledge ID provided. Contribution row was skipped.', CRM_Import_Parser::ERROR);
+    }
     // get total amount of from import fields
     $totalAmount = $params['total_amount'] ?? NULL;
-    $contributionContactID = $params['contact_id'];
-    // we need to get contact id $contributionContactID to
-    // retrieve pledge details as well as to validate pledge ID
 
     // first need to check for update mode
     if (!empty($params['id'])) {
@@ -576,10 +576,6 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
       else {
         throw new CRM_Core_Exception('No match found for specified contact in pledge payment data. Row was skipped.', CRM_Import_Parser::ERROR);
       }
-    }
-
-    if (CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge', $params['pledge_id'], 'contact_id') != $contributionContactID) {
-      throw new CRM_Core_Exception('Invalid Pledge ID provided. Contribution row was skipped.', CRM_Import_Parser::ERROR);
     }
 
     // we need to check if oldest payment amount equal to contribution amount


### PR DESCRIPTION
Overview
----------------------------------------
Remove always-true-if

Before
----------------------------------------
There is an early return if pledge_id is empty so it can never not be empty

<img width="775" height="455" alt="image" src="https://github.com/user-attachments/assets/4e18d253-eb5c-41cc-927a-1b65885cb341" />


After
----------------------------------------
If gone - I also moved the exception handling earlier in the function to get away from assigning contact ID to a variable & later using it

Technical Details
----------------------------------------

Comments
----------------------------------------

