### PR TITLE
Stop saving Mapping entity from Civiimport imports

### DIFF
--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -104,4 +104,17 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
     return TRUE;
   }
 
+  /**
+   * Process the mapped fields and map it into the uploaded file
+   * preview the file and extract some summary statistics
+   *
+   * @noinspection PhpUnhandledExceptionInspection
+   */
+  public function postProcess(): void {
+    $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
+    $parser = $this->getParser();
+    $parser->init();
+    $parser->validate();
+  }
+
 }


### PR DESCRIPTION

Overview
----------------------------------------
Stop saving Mapping entity from Civiimport imports

Only the UserJob is being read now so we should only save to it


Before
----------------------------------------
Both `civicrm_mapping` and `UserJob` template are saved - but only `UserJob` is used

After
----------------------------------------
Only UserJob template saved for civiimport imports

Technical Details
----------------------------------------

Comments
----------------------------------------
\