### PR TITLE
Align Contribution Import header handling with other imports

### DIFF
--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -144,10 +144,15 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         continue;
       }
       $fieldSpec = $this->getFieldMetadata($mappedField['name']);
-      $columnHeader = $this->getUserJob()['metadata']['DataSource']['column_headers'][$i] ?? '';
       // If there is no column header we are dealing with an added value mapping, do not use
       // the database value as it will be for (e.g.) `_status`
-      $fieldValue = $columnHeader ? $values[$i] : '';
+      $headers = $this->getUserJob()['metadata']['DataSource']['column_headers'];
+      if (array_key_exists($i, $headers) && empty($headers[$i])) {
+        $fieldValue = '';
+      }
+      else {
+        $fieldValue = $values[$i];
+      }
       if ($fieldValue === '' && isset($mappedField['default_value'])) {
         $fieldValue = $mappedField['default_value'];
       }

--- a/CRM/Import/DataSource/SQL.php
+++ b/CRM/Import/DataSource/SQL.php
@@ -39,7 +39,7 @@ class CRM_Import_DataSource_SQL extends CRM_Import_DataSource {
 
   /**
    * This is function is called by the form object to get the DataSource's
-   * form snippet. It should add all fields necesarry to get the data
+   * form snippet. It should add all fields necessary to get the data
    * uploaded to the temporary table in the DB.
    *
    * @param CRM_Import_Forms $form

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1357,7 +1357,17 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       if ($mappedField['name']) {
         $fieldSpec = $this->getFieldMetadata($mappedField['name']);
         $entity = $fieldSpec['entity_instance'] ?? $fieldSpec['entity_name'] ?? $fieldSpec['entity'] ?? $fieldSpec['extends'] ?? NULL;
-        $fieldValue = $values[$i];
+
+        // If there is no column header we are dealing with an added value mapping, do not use
+        // the database value as it will be for (e.g.) `_status`
+        $headers = $this->getUserJob()['metadata']['DataSource']['column_headers'];
+        if (array_key_exists($i, $headers) && empty($headers[$i])) {
+          $fieldValue = '';
+        }
+        else {
+          $fieldValue = $values[$i];
+        }
+
         if ($fieldValue === '' && isset($mappedField['default_value'])) {
           $fieldValue = $mappedField['default_value'];
         }


### PR DESCRIPTION
Overview
----------------------------------------
Align Contribution Import header handling with other imports

Before
----------------------------------------
When fixing the default handling regression I put part of the fix in the rc but then part only went into master [here](https://github.com/civicrm/civicrm-core/pull/32524/files#diff-a2daa0eb4d93f084aa2ad66b42fd4a351f38c8f230a0895870c7da8c520ab6dcR1368) - the part that went into master deals with when headers are not properly defined - it may only be hypothetical / hit in tests - but I think the fixed code is more robust

After
----------------------------------------
The fixed code is consistently used in 6.5 (& will be in master once up-merged)

Technical Details
----------------------------------------
I have a test but it's not really viable to put it in 6.5 as there would be merge conflicts when porting to 6.5 & then again when upmerging - once this is merged I can add those to master

`column_headers` is defined in the dataSource - but there is a difference between not defined and defined but empty. Ideally the DataSource should ensure the latter is always the case but at least in tests &, I think, some edge cases I have hit the former

Comments
----------------------------------------
