### PR TITLE
Update test / Contribution formRule to not rely on UserJob template

### DIFF
--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -51,8 +51,8 @@ class CRM_Contribute_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
     $this->addSavedMappingFields();
 
     $this->addFormRule([
-      'CRM_Contribute_Import_Form_MapField',
-      'formRule',
+      'CRM_CiviImport_Form_MapField',
+      'validateMapping',
     ], $this);
 
     $selectColumn1 = $this->getAvailableFields();
@@ -97,35 +97,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
       $return[$name] = $field['html']['label'] ?? $field['title'];
     }
     return $return;
-  }
-
-  /**
-   * Global validation rules for the form.
-   *
-   * @param array $fields
-   *   Posted values of the form.
-   *
-   * @param $files
-   * @param self $self
-   *
-   * @return array|true
-   *   list of errors to be posted back to the form
-   */
-  public static function formRule($fields, $files, $self) {
-    $mapperError = [];
-    try {
-      $parser = $self->getParser();
-      $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
-      $mapperError = $self->validateContactFields($rule, $fields['mapper'], ['contact_id', 'external_identifier']);
-      $parser->validateMapping($fields['mapper']);
-    }
-    catch (CRM_Core_Exception $e) {
-      $mapperError[] = $e->getMessage();
-    }
-    if (!empty($mapperError)) {
-      return ['_qf_default' => implode('<br/>', $mapperError)];
-    }
-    return TRUE;
   }
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -535,7 +535,8 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       // Because api v4 style fields have a . and QuickForm multiselect js does
       // not cope with a . the quick form layer will use a double underscore
       // as a stand in (the angular layer will not)
-      $fieldName = $mapping[0];
+      // The mapping['name'] is the civiimport format - mapping[0] is being phased out.
+      $fieldName = $mapping['name'] ?? $mapping[0];
       if (str_contains($fieldName, '.')) {
         // If the field name contains a . - eg. address_primary.street_address
         // we just want the part after the .

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -722,7 +722,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   public function validateMapping($mapping): void {
     $mappedFields = [];
     foreach ($mapping as $mappingField) {
-      $mappedFields[$mappingField[0]] = $mappingField[0];
+      // Civiimport uses MappingField['name'] - $mappingField[0] is (soft) deprecated.
+      $mappingFieldName = $mappingField['name'] ?? $mappingField[0] ?? '';
+      $mappedFields[$mappingFieldName] = $mappingFieldName;
     }
     $entity = $this->baseEntity;
     $missingFields = $this->getMissingFields($this->getRequiredFieldsForEntity($entity, $this->getActionForEntity($entity)), $mappedFields);

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -74,4 +74,34 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
     $defaults["mapper[$rowNumber]"] = [$fieldName];
   }
 
+  /**
+   * Global validation rules for the form.
+   *
+   * @param array $fields
+   *   Posted values of the form.
+   *
+   * @param array $files
+   * @param CRM_CiviImport_Form_MapField $self
+   *
+   * @return array|true
+   *   list of errors to be posted back to the form
+   */
+  public static function validateMapping(array $fields, array $files, CRM_CiviImport_Form_MapField $self): bool|array {
+    $mapperError = [];
+    try {
+      $parser = $self->getParser();
+      $mappings = $self->getFieldMappings();
+      $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
+      $mapperError = $self->validateContactFields($rule, $mappings, ['contact_id', 'external_identifier']);
+      $parser->validateMapping($mappings);
+    }
+    catch (CRM_Core_Exception $e) {
+      $mapperError[] = $e->getMessage();
+    }
+    if (!empty($mapperError)) {
+      return ['_qf_default' => implode('<br/>', $mapperError)];
+    }
+    return TRUE;
+  }
+
 }

--- a/tests/phpunit/CRM/Import/DataSource/FormsTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/FormsTest.php
@@ -146,7 +146,7 @@ class CRM_Import_FormsTest extends CiviUnitTestCase {
    * @param string $class
    * @param array $formValues
    *
-   * @return \CRM_Core_Form
+   * @return \CRM_Import_Forms
    */
   protected function getImportForm(string $class, array $formValues = []): CRM_Core_Form {
     $formValues = array_merge($this->getDefaultValues(), $formValues);

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -131,14 +131,13 @@ trait CRMTraits_Import_ParserTrait {
    * @param string $csv
    * @param array $submittedValues
    */
-  protected function submitDataSourceForm(string $csv, $submittedValues): void {
+  protected function submitDataSourceForm(string $csv, array $submittedValues = []): void {
     $reflector = new ReflectionClass(get_class($this));
     $directory = dirname($reflector->getFileName());
     $submittedValues = array_merge([
       'uploadFile' => ['name' => $directory . '/data/' . $csv],
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => 'Individual',
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],
       'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,


### PR DESCRIPTION
Overview
----------------------------------------
Update test to not rely on UserJob template

Before
----------------------------------------
Import code no longer expects a `Mapping` entry to exist and relies on the `UserJob` template - however, many tests not updated to reflect this as shown by failing tests on https://github.com/civicrm/civicrm-core/pull/33195

After
----------------------------------------
Some of the tests updated to set up the correct UserJob template - still some more to go. I had to update the `formRule` to not require the QuickForm mapper & to instead check the UserJob - but it still checks the mapper on the other forms (all forms still submit the mapper so that is fine, albeit changing)

Technical Details
----------------------------------------
Includes cover for https://github.com/civicrm/civicrm-core/pull/33199 as I chose to make the code more robust rather than fix the header definition in the test

Comments
----------------------------------------
