### PR TITLE
dev/core#5991 - fix contact type input display in formbuilder

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -183,6 +183,9 @@
 
       function inputTypeCanBe(type) {
         var defn = ctrl.getDefn();
+        if (defn.input_type === type) {
+          return true;
+        }
         if (defn.readonly) {
           switch (type) {
             case 'DisplayOnly':
@@ -192,9 +195,6 @@
             default:
               return false;
           }
-        }
-        if (defn.input_type === type) {
-          return true;
         }
         switch (type) {
           case 'CheckBox':


### PR DESCRIPTION
Overview
----------------------------------------
Fix for part 2 of https://lab.civicrm.org/dev/core/-/issues/5991 

Ensure the selected input type is in the local list of input types for read only fields

Before
----------------------------------------
- `afField` controller thinks readonly fields have to be DisplayOnly or Hidden input type.
- when a field like `contact_type` is on a search form, it can be other types, like Select
- following https://github.com/civicrm/civicrm-core/pull/33127 - it being an invalid type throws a more visible error in the editor
<img width="1070" height="531" alt="image" src="https://github.com/user-attachments/assets/fb9b00d5-0f93-45f2-8aa4-73bc06c74f9b" />


After
----------------------------------------
- the current type is assumed to be allowed, even for readonly fields
- the editor doesn't bug out


Technical Details
----------------------------------------
I don't know how Select gets added to the list of type options for `contact_type`, given it would always fail this check.