### PR TITLE
Remove implicit permission

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -18,7 +18,6 @@ return [
   'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'api4', 'crmSearchTasks', 'crmRouteBinder', 'crmDialog', 'md5'],
   'settingsFactory' => ['\Civi\Search\Admin', 'getAdminSettings'],
   'permissions' => [
-    'all CiviCRM permissions and ACLs',
     'administer CiviCRM',
     'administer afform',
     'view debug output',


### PR DESCRIPTION
Overview
----------------------------------------
Remove implicit permission

Before
----------------------------------------
Super permission `'all CiviCRM permissions and ACLs',` explicitly added to SearchDisplay - but this is implict by virtue of `Administer CiviCRM` being in the list

After
----------------------------------------
Removed, rely on implicit permissions

Technical Details
----------------------------------------
Best practice would be not to allocate either the super permission or administer CiviCRM but to allocate one of

```
    'administer CiviCRM system',
   'administer CiviCRM data',
```
both of which are implied by the other 2.
I'm just not totally sure in this case which it would be - probably the latter but....

Comments
----------------------------------------
