### PR TITLE
Switch Search operator to CONTAINS on text fields in Admin UI

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchAdminCustomFields.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminCustomFields.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="label" defn="{label: 'Field', input_attrs: {}, required: false}" />
+    <af-field name="label" defn="{label: 'Field', input_attrs: {}, search_operator: 'CONTAINS', required: false}" />
   </div>
   <crm-search-display-table search-name="Administer_Custom_Fields" display-name="Table" filters="{custom_group_id: routeParams.gid}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchAdminCustomGroups.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminCustomGroups.aff.html
@@ -6,9 +6,9 @@
     </div>
   </div>
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{required: false, input_attrs: {}, label: 'Group'}" />
+    <af-field name="title" defn="{required: false, input_attrs: {}, search_operator: 'CONTAINS', label: 'Group'}" />
     <af-field name="extends" defn="{input_attrs: {multiple: true}, label: 'Used For'}" />
-    <af-field name="CustomGroup_CustomField_custom_group_id_01.label" defn="{required: false, input_attrs: {}, label: 'Field'}" />
+    <af-field name="CustomGroup_CustomField_custom_group_id_01.label" defn="{required: false, input_attrs: {}, search_operator: 'CONTAINS', label: 'Field'}" />
   </div>
   <crm-search-display-table search-name="Administer_Custom_Groups" display-name="Table"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.html
@@ -1,16 +1,16 @@
 <div af-fieldset="">
   <div class="af-markup">
-    
+
     <div class="help">
       {{:: ts('Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.') }}
       <a href="https://docs.civicrm.org/user/en/latest/email/scheduled-reminders/" target="_blank" class="crm-doc-link no-popup">{{:: ts('Learn more...') }}</a>
     </div>
-  
+
   </div>
   <div class="af-container af-layout-inline">
     <af-field name="is_active" defn="{afform_default: true, input_type: 'Radio'}" />
     <af-field name="id" defn="{label: 'Reminder ID', input_attrs: {multiple: true}}" />
-    <af-field name="title" />
+    <af-field name="title" defn="{search_operator: 'CONTAINS'}"/>
     <af-field name="used_for" />
   </div>
   <crm-search-display-table search-name="Administer_Scheduled_Reminders" display-name="Administer_Scheduled_Reminders_Table"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchManageContributionPages.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageContributionPages.aff.html
@@ -3,7 +3,7 @@
 </div>
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{label: 'Title', input_attrs: {}}" />
+    <af-field name="title" defn="{label: 'Title', input_attrs: {}, search_operator: 'CONTAINS'}" />
     <af-field name="financial_type_id" defn="{input_type: 'CheckBox', input_attrs: {}}" />
   </div>
   <div class="btn-group pull-right">

--- a/ext/civicrm_admin_ui/ang/afsearchManageGroups.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageGroups.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{label: 'Title', input_attrs: {}}" />
+    <af-field name="title" defn="{label: 'Title', input_attrs: {}, search_operator: 'CONTAINS'}" />
     <af-field name="group_type" defn="{input_attrs: {multiple: true}}" />
     <af-field name="visibility" defn="{label: 'Visibility', input_attrs: {multiple: true}}" />
     <af-field name="is_active" defn="{input_type: 'Radio', label: 'Enabled', afform_default: true}" />

--- a/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
@@ -7,8 +7,8 @@
 </div>
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="name" />
-    <af-field name="description" defn="{input_type: 'Text', input_attrs: {}}" />
+    <af-field name="name" defn="{search_operator: 'CONTAINS'}"/>
+    <af-field name="description" defn="{input_type: 'Text', input_attrs: {}, search_operator: 'CONTAINS'}" />
     <af-field name="is_active" defn="{input_type: 'Radio', input_attrs: {}}" />
   </div>
   <div class="btn-group pull-right">

--- a/ext/civicrm_admin_ui/ang/afsearchProfiles.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchProfiles.aff.html
@@ -13,8 +13,8 @@
 </div>
 <div af-fieldset="" af-title="Filter">
   <div class="af-container af-layout-inline">
-    <af-field name="title" defn="{required: false, input_attrs: {}}" />
-    <af-field name="created_id.display_name" defn="{required: false, input_attrs: {}}" />
+    <af-field name="title" defn="{required: false, input_attrs: {}, search_operator: 'CONTAINS'}" />
+    <af-field name="created_id.display_name" defn="{required: false, input_attrs: {}, search_operator: 'CONTAINS'}" />
     <af-field name="is_reserved" defn="{input_attrs: {}, required: false}" />
   </div>
   <crm-search-display-table search-name="User_defined_Profiles" display-name="User_defined_Profiles"></crm-search-display-table>


### PR DESCRIPTION
Overview
----------------------------------------
Switch Search operator to 'CONTAINS' on text fields in Admin UI

Before
----------------------------------------
The CiviCRM setting Automatic Wildcard determines whether a '%' should be prepended to any field when searching in advanced search. It is useful in this specific context on sites with large datasets - for example is you enter a check number of 123456 it will return almost immediately if you search for `'LIKE 123456%'` but might take 40 seconds if you search for `LIKE '%123456%'`. When it comes to contact name searches there is a usability vs speed trade off. However, this setting is about performance searching on large tables - it should NOT be used on small tables (e.g under 100k rows) such as the admin UI mostly works on - but currently sites with Automatic wildcard will not get the wildcard added when filtering on
- Admin UI
- Search Kit screen
They DO get it on the form builder screen

<img width="1155" height="296" alt="image" src="https://github.com/user-attachments/assets/219ad464-053b-4326-bd80-343975b02879" />


After
----------------------------------------
Admin UI afforms updated to use CONTAINS

Technical Details
----------------------------------------
This was discussed previously between @aydun @colemanw and myself. @aydun leaned towards thinking the 'auto' should be clever enough to make a better choice for smaller tables. @colemanw felt that was getting too magic and where we know what operator we want we should code it in. This does that latter method - the former being both hard AND not universally agreed to be better.

Note I couldn't see how to fix SearchKit itself as it uses different markup - ie

```  
<input class="form-control" type="search" ng-model="tab.filters.label"  placeholder="{{:: ts('Filter by label...') }}">
```

Comments
----------------------------------------
