### PR TITLE
fix issue when contact subtype is added via import

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1011,7 +1011,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
   protected function processContact(array $params, bool $isMainContact): ?int {
     $contactID = $this->lookupContactID($params, $isMainContact);
     if ($contactID && !empty($params['contact_sub_type'])) {
-      $contactSubType = $this->getExistingContactValue($contactID, 'contact_sub_type');
+      try {
+        $contactSubType = $this->getExistingContactValue($contactID, 'contact_sub_type');
+      }
+      catch (CRM_Core_Exception $e) {
+        $contactSubType = [];
+      }
       if (!empty($contactSubType) && $contactSubType[0] !== $params['contact_sub_type'] && !CRM_Contact_BAO_ContactType::isAllowEdit($contactID, $contactSubType[0])) {
         throw new CRM_Core_Exception('Mismatched contact SubTypes :', CRM_Import_Parser::NO_MATCH);
       }


### PR DESCRIPTION
Overview
----------------------------------------
If you:
* have a contact with no subtype
* You do an import where a row matches this contact
* The import specifies a subtype

You get an error.

There's code specifically to handle this, but when the API-base EntityLookupTrait was added, this code starting throwing an exception rather than evaluating correctly.

Before
----------------------------------------
"Expected 1 contact but found 0".

After
----------------------------------------
Contact imports correctly.

Technical Details
----------------------------------------
Below is the backtrace.
`CRM_Import_Parser->lookup` is now looking for a contact that already has the subtype, causing the exception.


```
CRM_Utils_Array::single (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Utils/Array.php:1249)
Civi\Api4\Generic\Result->single (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Generic/Result.php:90)
CRM_Import_Parser->lookup (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/API/EntityLookupTrait.php:111)
CRM_Import_Parser->getExistingContactValue (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Import/Parser.php:151)
CRM_Contact_Import_Parser_Contact->processContact (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Contact/Import/Parser/Contact.php:1014)
CRM_Contact_Import_Parser_Contact->import (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Contact/Import/Parser/Contact.php:131)
Civi\Api4\Import\Import->_run (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/civiimport/Civi/Api4/Import/Import.php:34)
Civi\Api4\Provider\ActionObjectProvider->invoke (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Provider/ActionObjectProvider.php:91)
Civi\API\Kernel->runRequest (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/API/Kernel.php:153)
Civi\Api4\Generic\AbstractAction->execute (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Api4/Generic/AbstractAction.php:251)
civicrm_api4 (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/api/api.php:102)
CRM_Api4_Page_AJAX->execute (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Api4/Page/AJAX.php:129)
CRM_Api4_Page_AJAX->run (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Api4/Page/AJAX.php:68)
CRM_Core_Invoke::runItem (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php:276)
CRM_Core_Invoke::_invoke (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php:73)
CRM_Core_Invoke::invoke (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php:38)
CiviCRM_For_WordPress->invoke (/home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm.php:1314)
WP_Hook->apply_filters (/home/jon/local/mysite/web/wp-includes/class-wp-hook.php:324)
WP_Hook->do_action (/home/jon/local/mysite/web/wp-includes/class-wp-hook.php:348)
do_action (/home/jon/local/mysite/web/wp-includes/plugin.php:517)
```

Comments
----------------------------------------
This appears to have regressed in late 2023, so not putting it against the rc.
