### PR TITLE
Alternate to #33151 do not handle extension entities that have column…

### DIFF
--- a/CRM/Core/I18n/SchemaStructure.php
+++ b/CRM/Core/I18n/SchemaStructure.php
@@ -28,6 +28,9 @@ class CRM_Core_I18n_SchemaStructure {
       global $civicrm_root;
       $sqlGenerator = require "$civicrm_root/mixin/lib/civimix-schema@5/src/SqlGenerator.php";
       foreach (\Civi\Schema\EntityRepository::getEntities() as $entity) {
+        if ($entity['module'] !== 'civicrm') {
+          continue;
+        }
         if (empty($entity['getFields'])) {
           continue;
         }


### PR DESCRIPTION
…s flagged as localizable in the same way as core

Overview
----------------------------------------
This is an alternate to #33151 where that PR aims to standarise the way extension tables get installed to be like how core is when there is a translatable field flagged in its schema.  This PR aims to keep what was the current practice prior to 6.0 when the whole schema rebuild was done. That is that extension tables never had the locale fields added and never were included in the i18n schema rewrite process.

see also https://lab.civicrm.org/extensions/contact_roles/-/merge_requests/4 and https://lab.civicrm.org/dev/core/-/issues/2396

ping @mlutfy @colemanw @mattwire @eileenmcnaughton @totten 