### PR TITLE
checkGroupRole for WP

### DIFF
--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -87,6 +87,19 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
   /**
    * @inheritDoc
    */
+  public function checkGroupRole($array)
+  {
+    foreach ($array as $role) {
+      if (current_user_can($role)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getAvailablePermissions() {
     // We want to list *only* WordPress perms, so we'll *skip* Civi perms.
     $mungedCorePerms = array_map(


### PR DESCRIPTION
Overview
----------------------------------------
CiviReport allows granting access by role.  But the relevant function is only present for Drupal/Drupal8/Backdrop/Joomla.

Before
----------------------------------------
Roles ignored.

After
----------------------------------------
Roles respected.
