### PR TITLE
Stop assigning paidBy variable to receipt templates

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -865,10 +865,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    */
   protected function emailReceipt($form, &$formValues): bool {
     // @todo figure out how much of the stuff below is genuinely shared with the batch form & a logical shared place.
-    if (!empty($formValues['payment_instrument_id'])) {
-      $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
-      $formValues['paidBy'] = $paymentInstrument[$formValues['payment_instrument_id']];
-    }
 
     // @todo - as of 5.74 module is noisy deprecated - can stop assigning around 5.80.
     $form->assign('module', 'Membership');

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2762,10 +2762,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $template->assign('isPrimary', 1);
       $template->assign('amount', $primaryAmount);
       $template->assign('register_date', CRM_Utils_Date::isoToMysql($this->_relatedObjects['participant']->register_date));
-      if ($this->payment_instrument_id) {
-        $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
-        $template->assign('paidBy', $paymentInstrument[$this->payment_instrument_id]);
-      }
       // carry paylater, since we did not created billing,
       // so need to pull email from primary location, CRM-4395
       $values['params']['is_pay_later'] = $this->_relatedObjects['participant']->is_pay_later;

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -303,13 +303,6 @@ class CRM_Contribute_Form_AdditionalInfo {
    */
   public static function emailReceipt(&$form, &$params, $ccContribution = FALSE) {
     $form->assign('receiptType', 'contribution');
-    if (!empty($params['payment_instrument_id'])) {
-      $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
-      $params['paidBy'] = $paymentInstrument[$params['payment_instrument_id']];
-      if ($params['paidBy'] !== 'Check' && isset($params['check_number'])) {
-        unset($params['check_number']);
-      }
-    }
 
     // retrieve individual prefix value for honoree
     if (isset($params['soft_credit'])) {

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -626,13 +626,6 @@ SELECT  id, html_type
     $this->assign('event', $event);
 
     if ($this->_isPaidEvent) {
-      $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
-      if (!$this->_mode) {
-        if (isset($params['payment_instrument_id'])) {
-          $this->assign('paidBy', $paymentInstrument[$params['payment_instrument_id']] ?? NULL);
-        }
-      }
-
       $this->assign('totalAmount', $this->contributionAmt);
       $this->assign('checkNumber', $params['check_number'] ?? NULL);
     }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -394,7 +394,6 @@ class CRM_Financial_BAO_Payment {
       'paymentAmount' => $entities['payment']['total_amount'],
       'checkNumber' => $entities['payment']['check_number'] ?? NULL,
       'receive_date' => $entities['payment']['trxn_date'],
-      'paidBy' => CRM_Core_PseudoConstant::getLabel('CRM_Core_BAO_FinancialTrxn', 'payment_instrument_id', $entities['payment']['payment_instrument_id']),
       'isShowLocation' => (!empty($entities['event']) ? $entities['event']['is_show_location'] : FALSE),
       'event' => $entities['event'] ?? NULL,
       'component' => (!empty($entities['event']) ? 'event' : 'contribution'),

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -939,10 +939,6 @@ DESC limit 1");
     $receiptFrom = $formValues['from_email_address'] ?? NULL;
 
     // @todo figure out how much of the stuff below is genuinely shared with the batch form & a logical shared place.
-    if (!empty($formValues['payment_instrument_id'])) {
-      $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
-      $formValues['paidBy'] = $paymentInstrument[$formValues['payment_instrument_id']];
-    }
     // @todo - as of 5.74 module is noisy deprecated - can stop assigning around 5.80.
     $this->assign('module', 'Membership');
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -651,11 +651,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
    */
   protected function sendReceipt() {
     $receiptFrom = $this->_params['from_email_address'];
-
-    if (!empty($this->_params['payment_instrument_id'])) {
-      $paymentInstrument = CRM_Contribute_PseudoConstant::paymentInstrument();
-      $this->_params['paidBy'] = $paymentInstrument[$this->_params['payment_instrument_id']];
-    }
     //get the group Tree
     $this->_groupTree = CRM_Core_BAO_CustomGroup::getTree('Membership', NULL, $this->_id, FALSE, $this->_memType);
 

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1514,6 +1514,7 @@ class CRM_Utils_Token {
           '$formValues' => 'use relevant token/s',
           '$module' => 'unknown',
           '$currency' => 'contribution.currency',
+          '$paidBy' => 'contribution.payment_instrument_id:label',
         ],
         'membership_online_receipt' => [
           '$dataArray' => ts('see default template for how to show this'),
@@ -1529,6 +1530,7 @@ class CRM_Utils_Token {
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',
           '$getTaxDetails' => ts('no longer available / relevant'),
+          '$paidBy' => 'contribution.payment_instrument_id:label',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),


### PR DESCRIPTION

Overview
----------------------------------------
Stop assigning paidBy variable to receipt templates



Before
----------------------------------------
`$paidBy` is assigned to the template in various places for offline receipts - however, it was removed from them back in 2023 - with an upgrade step for offline membership in 5.75. Deprecation warnings have been in place for offline event since then too. 

After
----------------------------------------
We no longer assign it - I added the variable to the status warning for Membership & Contribution in case anyone still has it - but note that this was gone before we did the upgrade-with-noise telling people to update those templates. If anyone has not since then they will still have some much more problematic things in their templates so anything that pushes them to a bigger sync is probably good.

Technical Details
----------------------------------------
I'm getting ready to move the core batch data entry off to an extension but trying to tidy up stuff before that so we don't have it forever more

Comments
----------------------------------------
