### PR TITLE
Fix Status Calculation Of Future Memberships

### DIFF
--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -130,6 +130,10 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
           $changeDate, NULL, $membershipParams['num_terms']
         );
         $dates['join_date'] = $membership['join_date'];
+        $dates['start_date'] = strtotime($membership['start_date']) > strtotime(\CRM_Utils_Date::customFormat($dates['start_date'], '%Y-%m-%d')) ?
+          $membership['start_date'] : $dates['start_date'];
+        $dates['end_date'] = strtotime($membership['end_date']) > strtotime(\CRM_Utils_Date::customFormat($dates['end_date'], '%Y-%m-%d')) ?
+          $membership['end_date'] : $dates['end_date'];
         //get the status for membership.
         $calcStatus = \CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($dates['start_date'] ?? NULL,
           $dates['end_date'] ?? NULL,


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the status calculation of memberships when a contribution is marked as completed. Consider a below membership status rule
<img width="1776" height="84" alt="Screenshot 2025-07-17 at 1 47 37 PM" src="https://github.com/user-attachments/assets/9a070b77-e085-4ef8-a3da-71864b5a2fc0" />

Now if there is a fixed period type paid membership with start and join date in future and the above shown status with a pending payment and if user submits the payment which completes the contribution the membership gets the status of **current** whereas it should stay in the **future start**  as the future start status rule still matches the dates of membership. This is due to the fact that [here](https://github.com/civicrm/civicrm-core/blob/35d1dca6a3ca278116e694841dd19540143e7508/Civi/Membership/OrderCompleteSubscriber.php#L141)  when we calculate the status for membership upon contribution completion we use the dates which we get from [this](https://github.com/civicrm/civicrm-core/blob/35d1dca6a3ca278116e694841dd19540143e7508/Civi/Membership/OrderCompleteSubscriber.php#L131) renewal dates calculator function which does not accounts for future start date memberships and calculates the dates based on the date of contribution completion and gives the dates of current year even if the membership was for next year.

This PR fixes the issue by only using the calculated renewal dates if they are greater then the membership start and end dates.
