### PR TITLE
RiverLea, Thames: Removes Form Builder colour over-ride rendering dropdown 'danger' links illegible

### DIFF
--- a/ext/riverlea/streams/thames/css/_variables.css
+++ b/ext/riverlea/streams/thames/css/_variables.css
@@ -413,7 +413,7 @@
   --crm-dropdown-hover-bg: var(--crm-c-blue-light); /* thames */
   --crm-dropdown-border: 0;
   --crm-dropdown-width: 23ch; /* thames */
-  --crm-dropdown-danger-bg: transparent; /* thames */
+  --crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns */
   --crm-dropdown-2-bg: var(--crm-c-secondary);
   --crm-dropdown-2-col: var(--crm-c-text);
   --crm-dropdown-2-padding: var(--crm-padding-small);


### PR DESCRIPTION
Overview
----------------------------------------
Thames sets the background colour for `--crm-dropdown-danger-bg` to transparent, which resets the 'danger' colour, and makes the white text that appears on top illegible. This fix restores a bg colour. 

It's possible this is a regression triggered by https://github.com/civicrm/civicrm-core/pull/32507. cc @artfulrobot  

Before
----------------------------------------
<img width="249" height="233" alt="image" src="https://github.com/user-attachments/assets/394e2d8d-df44-41bd-b399-66c3785a96a0" />

After
----------------------------------------
<img width="260" height="233" alt="image" src="https://github.com/user-attachments/assets/fb4ccd47-9465-4650-b0ae-5a37e0564cfc" />

Technical Details
----------------------------------------
I appreciate there's another way to fix this same bug (darken the foreground text colour and keep a transparent bg) but because the text is centred it looks more button-ey, hence this approach.

Rather than delete this line of the variables file to inherit the main theme version, I've copied the Thames pattern of listing the original RiverLea variable, including it's original inline comment.

Comments
----------------------------------------
The contrast ratio issue on the trash icon impacts all Streams and I need to resolve in a separate PR.