### PR TITLE
dev/core#5996 - Fix every new site showing "pending upgrades" for riverlea

### DIFF
--- a/ext/riverlea/CRM/Riverlea/BAO/RiverleaStream.php
+++ b/ext/riverlea/CRM/Riverlea/BAO/RiverleaStream.php
@@ -1,11 +1,11 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 use Civi\Core\HookInterface;
 use Civi\Core\Event\PreEvent;
 use Civi\Core\Event\PostEvent;
 
-class CRM_riverlea_BAO_RiverleaStream extends CRM_riverlea_DAO_RiverleaStream implements HookInterface {
+class CRM_Riverlea_BAO_RiverleaStream extends CRM_Riverlea_DAO_RiverleaStream implements HookInterface {
 
   public static function self_hook_civicrm_pre(PreEvent $event): void {
     // munge label for default name

--- a/ext/riverlea/CRM/Riverlea/DAO/RiverleaStream.php
+++ b/ext/riverlea/CRM/Riverlea/DAO/RiverleaStream.php
@@ -9,7 +9,7 @@
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. Property annotations may be added, but are not required.
  */
-class CRM_riverlea_DAO_RiverleaStream extends CRM_riverlea_DAO_Base {
+class CRM_Riverlea_DAO_RiverleaStream extends CRM_Riverlea_DAO_Base {
 
   /**
    * Required by older versions of CiviCRM (<5.74).

--- a/ext/riverlea/CRM/Riverlea/Upgrader.php
+++ b/ext/riverlea/CRM/Riverlea/Upgrader.php
@@ -1,10 +1,10 @@
 <?php
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 /**
  * Collection of upgrade steps.
  */
-class CRM_riverlea_Upgrader extends \CRM_Extension_Upgrader_Base {
+class CRM_Riverlea_Upgrader extends \CRM_Extension_Upgrader_Base {
 
   public function upgrade_1000(): bool {
     E::schema()->createEntityTable('schema/upgrader/1000-RiverleaStream.entityType.php');

--- a/ext/riverlea/Civi/Riverlea/DynamicCss.php
+++ b/ext/riverlea/Civi/Riverlea/DynamicCss.php
@@ -2,7 +2,7 @@
 
 namespace Civi\Riverlea;
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 /**
  * This class generates a `river.css` file for Riverlea streams containing

--- a/ext/riverlea/README.md
+++ b/ext/riverlea/README.md
@@ -138,7 +138,7 @@ The Customiser will provide tools to automate some of this process.
 
 2. Copy the template `*.mgd.php` from the `docs` folder of this extension into your extension's `managed` folder (create the managed folder if it doesn't exist). Remove the `.template` part so the file extension is `*.mgd.php`.
 
-3. Update the `use CRM_riverlea_ExtensionUtil` line for the equivalent from your extension.
+3. Update the `use CRM_Riverlea_ExtensionUtil` line for the equivalent from your extension.
 
 4. You can add variable declarations directly to the `vars` and `vars_dark` keys in the `*.mgd.php` file.
 

--- a/ext/riverlea/docs/RiverleaStream_MyStream.mgd.php.template
+++ b/ext/riverlea/docs/RiverleaStream_MyStream.mgd.php.template
@@ -1,7 +1,7 @@
 <?php
 
 // Replace this with your extensions extensionUtil class (if unsure look in your extension's root my_extension.php file)
-// use CRM_riverlea_ExtensionUtil as E;
+// use CRM_Riverlea_ExtensionUtil as E;
 
 // return [
 //   [

--- a/ext/riverlea/managed/RiverleaStream_HackneyBrook.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_HackneyBrook.mgd.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   [

--- a/ext/riverlea/managed/RiverleaStream_Minetta.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Minetta.mgd.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   [

--- a/ext/riverlea/managed/RiverleaStream_Thames.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Thames.mgd.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   [

--- a/ext/riverlea/managed/RiverleaStream_Walbrook.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Walbrook.mgd.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   [

--- a/ext/riverlea/managed/navigationmenu.mgd.php
+++ b/ext/riverlea/managed/navigationmenu.mgd.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
     [

--- a/ext/riverlea/riverlea.civix.php
+++ b/ext/riverlea/riverlea.civix.php
@@ -6,10 +6,10 @@
  * The ExtensionUtil class provides small stubs for accessing resources of this
  * extension.
  */
-class CRM_riverlea_ExtensionUtil {
+class CRM_Riverlea_ExtensionUtil {
   const SHORT_NAME = 'riverlea';
   const LONG_NAME = 'riverlea';
-  const CLASS_PREFIX = 'CRM_riverlea';
+  const CLASS_PREFIX = 'CRM_Riverlea';
 
   /**
    * Translate a string using the extension's domain.
@@ -87,14 +87,14 @@ class CRM_riverlea_ExtensionUtil {
 
 }
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 spl_autoload_register('_riverlea_civix_class_loader', TRUE, TRUE);
 
 function _riverlea_civix_class_loader($class) {
-  if ($class === 'CRM_riverlea_DAO_Base') {
+  if ($class === 'CRM_Riverlea_DAO_Base') {
     if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
-      class_alias('CRM_Core_DAO_Base', 'CRM_riverlea_DAO_Base');
+      class_alias('CRM_Core_DAO_Base', 'CRM_Riverlea_DAO_Base');
       // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
     }
     else {

--- a/ext/riverlea/riverlea.php
+++ b/ext/riverlea/riverlea.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once 'riverlea.civix.php';
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 /**
  * Supply available streams to the theme hook

--- a/ext/riverlea/schema/RiverleaStream.entityType.php
+++ b/ext/riverlea/schema/RiverleaStream.entityType.php
@@ -1,10 +1,10 @@
 <?php
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   'name' => 'RiverleaStream',
   'table' => 'civicrm_riverlea_stream',
-  'class' => 'CRM_riverlea_DAO_RiverleaStream',
+  'class' => 'CRM_Riverlea_DAO_RiverleaStream',
   'getInfo' => fn() => [
     'title' => E::ts('RiverleaStream'),
     'title_plural' => E::ts('RiverleaStreams'),

--- a/ext/riverlea/schema/upgrader/1000-RiverleaStream.entityType.php
+++ b/ext/riverlea/schema/upgrader/1000-RiverleaStream.entityType.php
@@ -1,10 +1,10 @@
 <?php
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   'name' => 'RiverleaStream',
   'table' => 'civicrm_riverlea_stream',
-  'class' => 'CRM_riverlea_DAO_RiverleaStream',
+  'class' => 'CRM_Riverlea_DAO_RiverleaStream',
   'getInfo' => fn() => [
     'title' => E::ts('RiverleaStream'),
     'title_plural' => E::ts('RiverleaStreams'),

--- a/ext/riverlea/settings/riverlea.setting.php
+++ b/ext/riverlea/settings/riverlea.setting.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM_riverlea_ExtensionUtil as E;
+use CRM_Riverlea_ExtensionUtil as E;
 
 return [
   'riverlea_dark_mode_backend' => [


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5996

Before
----------------------------------------
Every new site shows pending upgrades in the status check for riverlea. Started after https://github.com/civicrm/civicrm-core/pull/32127/files#diff-fc1a38df1ab97abcbf124b52b25c5ab6c007861cb7880cc67496a618e1688d9a

After
----------------------------------------


Technical Details
----------------------------------------
The small "r" big "R" mismatch causes the automaticupgrader process to think riverlea doesn't have an upgrader file, so the postinstall in Upgrader_Base that calls setCurrentRevision doesn't happen during the initial site install which installs riverlea as part of the default set of extensions.

Note this doesn't come up on windows.

Comments
----------------------------------------
I'm kind of surprised that
 (a) more stuff in the extension doesn't work because info.xml has the namespace with big R, although the above mentioned PR is recent, and
 (b) didn't a civix upgrade at some point show the mismatch? e.g. with the ts helper big E?