### PR TITLE
dev/core#5996 - Fix every new site showing "pending upgrades" for riverlea

### DIFF
--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -23,7 +23,7 @@
     <psr0 prefix="CRM_" path="."/>
   </classloader>
   <civix>
-    <namespace>CRM/Riverlea</namespace>
+    <namespace>CRM/riverlea</namespace>
     <format>25.01.1</format>
   </civix>
   <mixins>


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5996

Before
----------------------------------------
Every new site shows pending upgrades in the status check for riverlea. Started after https://github.com/civicrm/civicrm-core/pull/32127/files#diff-fc1a38df1ab97abcbf124b52b25c5ab6c007861cb7880cc67496a618e1688d9a

After
----------------------------------------


Technical Details
----------------------------------------
The small "r" big "R" mismatch causes the automaticupgrader process to think riverlea doesn't have an upgrader file, so the postinstall in Upgrader_Base that calls setCurrentRevision doesn't happen during the initial site install which installs riverlea as part of the default set of extensions.

Note this doesn't come up on windows.

Comments
----------------------------------------
I'm kind of surprised that
 (a) more stuff in the extension doesn't work because info.xml has the namespace with big R, although the above mentioned PR is recent, and
 (b) didn't a civix upgrade at some point show the mismatch? e.g. with the ts helper big E?