### PR TITLE
 Move dateFormat from DataSource form to MapField form

### DIFF
--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -281,6 +281,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
         if ($templateID && $templateID !== $this->getUserJob()['metadata']['template_id'] ?? NULL) {
           $this->updateUserJobMetadata('template_id', $templateID);
           $this->updateUserJobMetadata('import_mappings', $this->getTemplateJob()['metadata']['import_mappings']);
+          $this->updateUserJobMetadata('import_options', $this->getTemplateJob()['metadata']['import_options']);
         }
         if ($submittedValues['use_existing_upload']) {
           // Use the already saved value.

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -51,6 +51,17 @@ class CRM_Import_Forms extends CRM_Core_Form {
   protected $savedMappingID;
 
   /**
+   * @return array
+   */
+  public function getDateFormats(): array {
+    $dateFormats = [];
+    foreach (CRM_Utils_Date::getAvailableInputFormats(TRUE) as $key => $value) {
+      $dateFormats[] = ['id' => (int) $key, 'text' => $value];
+    }
+    return $dateFormats;
+  }
+
+  /**
    * @param int $savedMappingID
    *
    * @return CRM_Import_Forms
@@ -437,6 +448,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
           'template_id' => $this->getTemplateID(),
           'Template' => ['mapping_id' => $this->getSavedMappingID()],
           'import_mappings' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_mappings'] : [],
+          'import_options' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_options'] : [],
         ],
       ])
       ->execute()
@@ -473,7 +485,11 @@ class CRM_Import_Forms extends CRM_Core_Form {
       $this->getUserJob()['metadata'],
       [$key => $data]
     );
-    $this->getUserJob()['metadata'] = $metaData;
+    if (isset($metaData['import_options']['date_format'])) {
+      // The Select is sloppy with typing.
+      $metaData['import_options']['date_format'] = (int) $metaData['import_options']['date_format'];
+    }
+    $this->userJob['metadata'] = $metaData;
     if ($this->isUpdateTemplateJob()) {
       $this->updateTemplateUserJob($metaData);
     }
@@ -914,6 +930,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
       'dedupeRules' => $parser->getAllDedupeRules(),
       'userJob' => $this->getUserJob(),
       'columnHeaders' => $this->getColumnHeaders(),
+      'dateFormats' => $this->getDateFormats(),
     ]);
   }
 

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -945,7 +945,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       return 'invalid_import_value';
     }
     if (in_array($dataType, ['Date', 'Timestamp'], TRUE)) {
-      $value = CRM_Utils_Date::formatDate($importedValue, (int) $this->getSubmittedValue('dateFormats'));
+      $value = CRM_Utils_Date::formatDate($importedValue, (int) $this->getUserJob()['metadata']['import_options']['date_format']);
       return $value ?: 'invalid_import_value';
     }
     $options = $this->getFieldOptions($fieldName);

--- a/Civi/UserJob/UserJobTrait.php
+++ b/Civi/UserJob/UserJobTrait.php
@@ -74,6 +74,9 @@ trait UserJobTrait {
         ->addWhere('id', '=', $this->getUserJobID())
         ->execute()
         ->single();
+      if (!isset($this->userJob['metadata']['import_options']['date_format'])) {
+        $this->userJob['metadata']['import_options']['date_format'] = $this->getSubmittedValue('dateFormats') ?: \CRM_Utils_Date::DATE_yyyy_mm_dd;
+      }
     }
     return $this->userJob;
   }

--- a/ext/civiimport/CRM/CiviImport/Form/DataSource.php
+++ b/ext/civiimport/CRM/CiviImport/Form/DataSource.php
@@ -6,6 +6,66 @@ use CRM_Civiimport_ExtensionUtil as E;
 class CRM_CiviImport_Form_DataSource extends CRM_Import_Form_DataSource {
 
   /**
+   * Common form elements.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm() {
+    $this->assign('errorMessage', $this->getErrorMessage());
+
+    $this->assign('urlPath', 'civicrm/import/datasource');
+    $this->assign('urlPathVar', 'snippet=4&user_job_id=' . $this->get('user_job_id'));
+    if ($this->isImportDataUploaded()) {
+      $this->add('checkbox', 'use_existing_upload', ts('Use data already uploaded'), [
+        'onChange' => "
+          CRM.$('.crm-import-datasource-form-block-dataSource').toggle();
+          CRM.$('#data-source-form-block').toggle()",
+      ]);
+    }
+    if ($this->getTemplateID()) {
+      $this->setTemplateDefaults();
+    }
+
+    $this->add('select', 'dataSource', ts('Data Source'), $this->getDataSources(), TRUE,
+      ['onchange' => 'buildDataSourceFormBlock(this.value);']
+    );
+
+    $this->addMappingSelector();
+
+    // When we call buildDataSourceFields we add them to the form both for purposes of
+    // initial display, but also so they are available during `postProcess`. Hence
+    // we need to add them to the form when first displaying it, or when a csv has been
+    // uploaded or csv described but NOT when the existing file is used. We have
+    // to check `_POST` for this because we want them to be not-added BEFORE validation
+    // as `buildDataSourceFields` also adds rules, which will run before `use_existing_upload`
+    // is treated as submitted.
+    if (empty($_POST['use_existing_upload'])) {
+      $this->buildDataSourceFields();
+    }
+    $this->addButtons([
+      [
+        'type' => 'upload',
+        'name' => ts('Continue'),
+        'spacing' => '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;',
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+  }
+
+  /**
+   * Use the form name to create the tpl file name.
+   *
+   * @return string
+   */
+  public function getTemplateFileName(): string {
+    return 'CRM/Import/DataSource.tpl';
+  }
+
+  /**
    * @return void
    * @throws \CRM_Core_Exception
    */

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -25,6 +25,7 @@
           $scope.data.showColumnNames = $scope.userJob.metadata.submitted_values.skipColumnHeader;
           $scope.data.savedMapping = CRM.vars.crmImportUi.savedMapping;
           $scope.mappingSaving = {updateFieldMapping: 0, newFieldMapping: 0};
+          $scope.dateFormats = CRM.vars.crmImportUi.dateFormats;
           // Used for dedupe rules select options, also for filtering available fields.
           $scope.data.dedupeRules = CRM.vars.crmImportUi.dedupeRules;
           // Used for select contact type select-options.
@@ -298,7 +299,7 @@
               default_value: importRow.defaultValue,
               // At this stage column_number is thrown away but we store it here to have it for when we change that.
               column_number: index,
-              entity_data: entityConfig
+              entity_data: entityConfig,
             });
           });
           crmApi4('UserJob', 'save', {records: [$scope.userJob]})

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -64,6 +64,11 @@
     </div>
   </div>
   <hr>
+  <div id="import-options">
+    <h3>{{:: ts('Import Options') }}</h3>
+    <div >{{:: ts('Date format') }}  <input class="huge" crm-ui-select='{data : dateFormats}' ng-model="userJob.metadata.import_options.date_format" /></div>
+  </div>
+  <hr>
   <div id="map-field">
     <h3>{{:: ts('Data mapping') }}</h3>
     <table class="selector">

--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -65,8 +65,8 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
           'dedupe_rule_id' => NULL,
-          'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
         ],
+        'import_options' => ['date_format' => CRM_Utils_Date::DATE_yyyy_mm_dd],
         'import_mappings' => [
           ['name' => 'Contact.external_identifier'],
           ['name' => 'Contribution.total_amount'],


### PR DESCRIPTION
Overview
----------------------------------------
 Move dateFormat from DataSource form to MapField form

Before
----------------------------------------
It's quite common for people to get the date format wrong on the DataSource screen - requiring them to go back to fix it - this puts it on the same screen as the rest of the Import Mapping configuration - leaving only the actual datasource to be configured on the DataSource screen. This also means that anything saved in the userJob template can be loaded by selecting the template on the Datasource screen.

The one thing that is data related that is still on the DataSource screen is the choice of multiple custom data field groups - which is a less common import but the field group choice is effectively selecting a different entity

After
----------------------------------------
<img width="1221" height="571" alt="image" src="https://github.com/user-attachments/assets/3154a38d-7332-4974-87de-f9dce653c4fe" />

Technical Details
----------------------------------------

Comments
----------------------------------------
