### PR TITLE
Fix default dedupe rule adjust to move to MapField

### DIFF
--- a/CRM/Activity/Import/Parser/Activity.php
+++ b/CRM/Activity/Import/Parser/Activity.php
@@ -131,7 +131,7 @@ class CRM_Activity_Import_Parser_Activity extends CRM_Import_Parser {
         'selected' => [
           'action' => 'select',
           'contact_type' => NULL,
-          'dedupe_rule' => $this->getDefaultDedupeRule(),
+          'dedupe_rule' => 'unique_identifier_match',
         ],
         'default_action' => 'select',
         'entity_name' => 'TargetContact',

--- a/CRM/Contribute/Import/Parser/Contribution.php
+++ b/CRM/Contribute/Import/Parser/Contribution.php
@@ -340,7 +340,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => 'Individual',
-          'dedupe_rule' => $this->getDefaultDedupeRule(),
+          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',
@@ -358,7 +358,7 @@ class CRM_Contribute_Import_Parser_Contribution extends CRM_Import_Parser {
           'contact_type' => 'Individual',
           'soft_credit_type_id' => $defaultSoftCreditTypeID,
           'action' => 'ignore',
-          'dedupe_rule' => $this->getDefaultDedupeRule(),
+          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'ignore',
         'entity_name' => 'SoftCreditContact',

--- a/CRM/Custom/Import/Parser/Api.php
+++ b/CRM/Custom/Import/Parser/Api.php
@@ -62,8 +62,8 @@ class CRM_Custom_Import_Parser_Api extends CRM_Import_Parser {
         'actions' => $this->getActions(['select', 'update', 'save']),
         'selected' => [
           'action' => 'select',
-          'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDefaultDedupeRule(),
+          'contact_type' => 'Individual',
+          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/CRM/Event/Import/Parser/Participant.php
+++ b/CRM/Event/Import/Parser/Participant.php
@@ -84,8 +84,8 @@ class CRM_Event_Import_Parser_Participant extends CRM_Import_Parser {
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
-          'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDefaultDedupeRule(),
+          'contact_type' => 'Individual',
+          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -2024,11 +2024,4 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     return NULL;
   }
 
-  /**
-   * @return string
-   */
-  protected function getDefaultDedupeRule(): string {
-    return $this->getContactType() ? $this->getDedupeRule($this->getContactType())['name'] : 'unique_identifier_match';
-  }
-
 }

--- a/CRM/Member/Import/Parser/Membership.php
+++ b/CRM/Member/Import/Parser/Membership.php
@@ -85,8 +85,8 @@ class CRM_Member_Import_Parser_Membership extends CRM_Import_Parser {
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
-          'contact_type' => $this->getSubmittedValue('contactType'),
-          'dedupe_rule' => $this->getDefaultDedupeRule(),
+          'contact_type' => 'Individual',
+          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',


### PR DESCRIPTION
Overview
----------------------------------------
Fix default dedupe rule adjust to move to MapField - this is a follow on from moving the Contact Type to the MapField form in master

Before
----------------------------------------
When first loading the form no default rule loads for the Dedupe Rule - this is a regression but in master only

<img width="1253" height="541" alt="image" src="https://github.com/user-attachments/assets/f7e883d9-8c22-44f2-b4c1-505e45d5e09e" />


After
----------------------------------------
The dedupe rule relevant to the contact type loads

<img width="1253" height="541" alt="image" src="https://github.com/user-attachments/assets/460d3db6-8b00-4c9c-bd1c-22370fa7efdd" />


Technical Details
----------------------------------------

Comments
----------------------------------------
