### PR TITLE
Move validateContactFields from generic MapField parent to CiviImport parent

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -604,26 +604,4 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     return $mappedFields;
   }
 
-  /**
-   * @param string $entity
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  protected function validateRequiredContactFields(string $entity = 'Contact'): array {
-    $mapper = [];
-    $fields = $this->getUserJob()['metadata']['import_mappings'];
-    foreach ($fields as $field) {
-      if (!isset($field['name'])) {
-        continue;
-      }
-      if (str_starts_with($field['name'], $entity . '.') || str_starts_with($field['name'], $this->getBaseEntity() . '.')) {
-        $mapper[] = [$field['name']];
-      }
-    }
-    $parser = $this->getParser();
-    $rule = $parser->getDedupeRule($this->getContactType(), $this->getUserJob()['metadata']['entity_configuration'][$entity]['dedupe_rule'] ?? NULL);
-    return $this->validateContactFields($rule, $this->getImportKeys($mapper), ['external_identifier', 'contact_id', 'id']);
-  }
-
 }

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -105,6 +105,28 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
   }
 
   /**
+   * @param string $entity
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function validateRequiredContactFields(string $entity = 'Contact'): array {
+    $mapper = [];
+    $fields = $this->getUserJob()['metadata']['import_mappings'];
+    foreach ($fields as $field) {
+      if (!isset($field['name'])) {
+        continue;
+      }
+      if (str_starts_with($field['name'], $entity . '.') || str_starts_with($field['name'], $this->getBaseEntity() . '.')) {
+        $mapper[] = [$field['name']];
+      }
+    }
+    $parser = $this->getParser();
+    $rule = $parser->getDedupeRule($this->getContactType(), $this->getUserJob()['metadata']['entity_configuration'][$entity]['dedupe_rule'] ?? NULL);
+    return $this->validateContactFields($rule, $this->getImportKeys($mapper), ['external_identifier', 'contact_id', 'id']);
+  }
+
+  /**
    * Process the mapped fields and map it into the uploaded file
    * preview the file and extract some summary statistics
    *


### PR DESCRIPTION
Overview
----------------------------------------
Move validateContactFields from generic MapField parent to CiviImport parent

Before
----------------------------------------
Function is on parent of `CRM_CiviImport_Form_MapField` but is only called by `CRM_CiviImport_Form_MapField` and it's children

After
----------------------------------------
Function on `CRM_CiviImport_Form_MapField`

Technical Details
----------------------------------------
At a high level I'm separating out functions between the classes with a view to the CiviImport one not inheriting from the other - and generally being separate code - the other only supports Contact Import & the outside-of-core csv import extension

Comments
----------------------------------------
