### PR TITLE
dev/core#6004: CiviPledge Report undefined array key

### DIFF
--- a/CRM/Report/Form/Pledge/Detail.php
+++ b/CRM/Report/Form/Pledge/Detail.php
@@ -464,9 +464,7 @@ class CRM_Report_Form_Pledge_Detail extends CRM_Report_Form {
       foreach ($display as $key => $value) {
         $row = [];
         foreach ($this->_columnHeaders as $columnKey => $columnValue) {
-          if (array_key_exists($columnKey, $value)) {
-            $row[$columnKey] = !empty($value[$columnKey]) ? $value[$columnKey] : '';
-          }
+          $row[$columnKey] = !empty($value[$columnKey]) ? $value[$columnKey] : '';
         }
         $rows[] = $row;
       }


### PR DESCRIPTION
Overview
----------------------------------------
_On smaster, Pledge detail report shows two undefined array error messages._

Reproduction steps
----------------------------------------
1. Navigate to **Reports > Pledge Reports** then click on **Pledge Details**, click on **Refresh results**.


Current behaviour
----------------------------------------

```
Undefined array key "scheduled_date" [2]
/srv/buildkit/build/smaster/web/private/cache/en_US/e4/dc/15/e4dc157eaeed03cd47a400a1b3e05766cda6b3cf_0.file_Table.tpl.php line 225
Undefined array key "scheduled_amount" [2]
/srv/buildkit/build/smaster/web/private/cache/en_US/e4/dc/15/e4dc157eaeed03cd47a400a1b3e05766cda6b3cf_0.file_Table.tpl.php line 234
```

Expected behaviour
----------------------------------------
_No errors._

Environment information
----------------------------------------

https://smaster.demo.civicrm.org/civicrm/report/instance/18
CiviCRM 6.6.alpha1

