### PR TITLE
SearchKit Batch - Fix serialized fields

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/BatchDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/BatchDisplaySubscriber.php
@@ -67,6 +67,8 @@ class BatchDisplaySubscriber extends AutoService implements EventSubscriberInter
         if (in_array($column['spec']['name'], $columnNames)) {
           $column['spec']['name'] .= $i;
         }
+        $column['spec']['required'] = !empty($column['required']);
+        $column['spec']['nullable'] = empty($column['required']);
         $columnNames[] = $column['spec']['name'];
       }
       // Redundant with spec and less-reliable

--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
@@ -55,6 +55,8 @@ class SKBatchSpecProvider extends AutoService implements SpecProviderInterface {
       $field->setTitle(ts('Import field') . ': ' . $column['label']);
       $field->setLabel($column['label']);
       $field->setType('Field');
+      $field->setSerialize($column['serialize']);
+      $field->setNullable($column['nullable'] ?? TRUE);
       $field->setColumnName($column['name']);
       if (!empty($column['options'])) {
         $field->setSuffixes($column['suffixes']);

--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -140,6 +140,7 @@ class Meta {
       'data_type' => $expr['dataType'],
       'suffixes' => $suffix ? ['id', $suffix] : NULL,
       'options' => FALSE,
+      'serialize' => NULL,
     ];
     $field = \CRM_Utils_Array::first($expr['fields']);
     $spec['original_field_name'] = $field['name'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes search kit batch imports to handle multi-select fields.

Before
----------------------------------------
An import with a multi-select (Participant type, Contact subtype, etc) would fail.

After
----------------------------------------
Now it works.

Technical Details
----------------------------------------
Adds necessary metadata for serialized fields to be handled properly.
