### PR TITLE
Autocomplete - Configurable multi-field search without UNION or OR 

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Generic;
 
+use Civi\Api4\Result\SearchDisplayRunResult;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 
@@ -23,8 +24,8 @@ use Civi\Core\Event\GenericHookEvent;
  * @method string getInput()
  * @method $this setIds(array $ids) Set array of ids.
  * @method array getIds()
- * @method $this setPage(int $page) Set current page.
- * @method array getPage()
+ * @method $this setSearchField(string $searchField) Set searchField.
+ * @method string getSearchField()
  * @method $this setFormName(string $formName) Set formName.
  * @method string getFormName()
  * @method $this setFieldName(string $fieldName) Set fieldName.
@@ -33,6 +34,8 @@ use Civi\Core\Event\GenericHookEvent;
  * @method string getKey()
  * @method $this setFilters(array $filters)
  * @method array getFilters()
+ * @method $this setExclude(array $exclude)
+ * @method array getExclude()
  */
 class AutocompleteAction extends AbstractAction {
   use Traits\SavedSearchInspectorTrait;
@@ -53,9 +56,11 @@ class AutocompleteAction extends AbstractAction {
   protected $ids;
 
   /**
-   * @var int
+   * Name of field currently being searched
+   *
+   * @var string
    */
-  protected $page = 1;
+  protected $searchField;
 
   /**
    * Name of SavedSearch to use for filtering.
@@ -109,6 +114,13 @@ class AutocompleteAction extends AbstractAction {
   public $filters = [];
 
   /**
+   * Array of keys to exclude from the results
+   *
+   * @var array
+   */
+  public $exclude = [];
+
+  /**
    * Filters set programmatically by `civi.api.prepare` listener. Automatically trusted.
    *
    * Format: [fieldName => value][]
@@ -117,16 +129,31 @@ class AutocompleteAction extends AbstractAction {
   private $trustedFilters = [];
 
   /**
+   * List of searchable fields for this display
+   *
+   * @var array
+   */
+  private $searchFields = [];
+
+  /**
    * @var string
    * @see \Civi\Api4\Generic\Traits\SavedSearchInspectorTrait::loadSearchDisplay
    */
   protected $_displayType = 'autocomplete';
 
   /**
+   * @return \Civi\Api4\Result\AutocompleteResult
+   */
+  public function execute() {
+    return parent::execute();
+  }
+
+  /**
    * Fetch results.
    *
-   * @param \Civi\Api4\Generic\Result $result
+   * @param \Civi\Api4\Result\AutocompleteResult $result
    */
+  // @phpcs:ignore Generic.Arrays.TypeHintDeclaration.MismatchingHintAndType
   public function _run(Result $result) {
     $this->checkPermissionToLoadSearch();
 
@@ -149,6 +176,7 @@ class AutocompleteAction extends AbstractAction {
     }
     $this->loadSavedSearch();
     $this->loadSearchDisplay();
+    $this->loadSearchFields();
 
     // Pass-through this parameter
     $this->display['acl_bypass'] = !$this->getCheckPermissions();
@@ -161,47 +189,33 @@ class AutocompleteAction extends AbstractAction {
     if ($this->ids) {
       $this->addFilter($keyField, ['IN' => $this->ids]);
       unset($this->display['settings']['pager']);
-      $return = NULL;
+      $apiResult = $this->getApiResult(NULL);
     }
     // Search mode: fetch a page of results based on input
     else {
-      // Default search and sort field
-      $labelField = $this->display['settings']['columns'][0]['key'];
-      $primaryKeys = CoreUtil::getInfoItem($this->savedSearch['api_entity'], 'primary_key');
-      $this->display['settings'] += [
-        'sort' => [$labelField, 'ASC'],
-      ];
-      // Always search on the first line of the display
-      $searchFields = [$labelField];
-      // If input is an integer...
-      $searchById = \CRM_Utils_Rule::positiveInteger($this->input) &&
-        // ...and there is exactly one primary key (e.g. EntitySet has zero, others might have compound keys)
-        count($primaryKeys) === 1 &&
-        // ...and the primary key field is type Integer (e.g. Afform.name is a String)
-        ($this->getField($primaryKeys[0])['data_type'] ?? NULL) === 'Integer';
-      // ...then search by primary key on first page
-      $initialSearchById = $searchById && $this->page == 1;
-      if ($initialSearchById) {
-        $searchFields = $primaryKeys;
-      }
-      // For subsequent pages when searching by id, subtract the "extra" first page
-      elseif ($searchById && $this->page > 1) {
-        $this->page -= 1;
-        // Record with that id was already returned on page one so exclude it from subsequent pages
-        $this->savedSearch['api_params']['where'][] = [$primaryKeys[0], '!=', $this->input];
-      }
-      // If first line uses a rewrite, search on those fields too
-      if (!$initialSearchById && !empty($this->display['settings']['columns'][0]['rewrite'])) {
-        $searchFields = array_merge($searchFields, $this->getTokens($this->display['settings']['columns'][0]['rewrite']));
+      // If no sort specified, default to sort by label
+      if (empty($this->display['settings']['sort'])) {
+        $labelField = $this->display['settings']['columns'][0]['key'];
+        $this->display['settings']['sort'] = [[$labelField, 'ASC']];
       }
       $this->display['settings']['limit'] ??= \Civi::settings()->get('search_autocomplete_count');
       $this->display['settings']['pager'] = [];
-      $return = 'scroll:' . $this->page;
-      // SearchKit treats comma-separated fieldnames as OR clauses
-      $this->addFilter(implode(',', array_unique($searchFields)), $this->input);
+      $apiResult = new SearchDisplayRunResult();
+      // Loop through all search terms
+      while ($apiResult->countFetched() === 0 && $this->getCurrentSearchField()) {
+        // If current search field is numeric and input is not, skip
+        if (!$this->inputMatchesDataType()) {
+          $this->searchField = $this->getNextSearchField();
+          continue;
+        }
+        // The "page number" is always 1 because previous results are excluded by the where clause
+        $apiResult = $this->getApiResult('scroll:1');
+        // No results found for this field — skip to the next
+        if ($apiResult->countFetched() === 0) {
+          $this->searchField = $this->getNextSearchField();
+        }
+      }
     }
-
-    $apiResult = $this->getApiResult($return);
 
     foreach ($apiResult as $row) {
       $item = [
@@ -224,10 +238,10 @@ class AutocompleteAction extends AbstractAction {
     $countMatched = $apiResult->hasCountMatched() ? $apiResult->countMatched() : $apiResult->count();
     $result->setCountMatched($countMatched);
     $result->rowCount = $apiResult->count();
-    if (!empty($initialSearchById)) {
-      // Trigger "more results" after searching by exact id
-      $result->setCountMatched($countMatched + 1);
-    }
+    // Field that was actually searched on
+    $result->searchField = $this->searchField ?? end($this->searchFields);
+    // All search fields - allows js client to advance to the next one
+    $result->searchFields = $this->searchFields;
   }
 
   /**
@@ -239,6 +253,20 @@ class AutocompleteAction extends AbstractAction {
   public function addFilter(string $fieldName, $value) {
     $this->filters[$fieldName] = $value;
     $this->trustedFilters[$fieldName] = $value;
+  }
+
+  private function getCurrentSearchField(): ?string {
+    // Security check: only return passed-in searchField if allowed
+    if ($this->searchField && !in_array($this->searchField, $this->searchFields, TRUE)) {
+      throw new \CRM_Core_Exception("Invalid searchField: $this->searchField");
+    }
+    return $this->searchField;
+  }
+
+  private function getNextSearchField(): ?string {
+    $currentSearchField = $this->getCurrentSearchField();
+    $nextIndex = 1 + array_search($currentSearchField, $this->searchFields);
+    return $this->searchFields[$nextIndex] ?? NULL;
   }
 
   /**
@@ -257,6 +285,34 @@ class AutocompleteAction extends AbstractAction {
       }
     }
     return array_unique($fields);
+  }
+
+  private function loadSearchFields() {
+    // Search fields ought to be declared as part of the display
+    if (!empty($this->display['settings']['searchFields'])) {
+      $this->searchFields = $this->display['settings']['searchFields'];
+    }
+
+    // Legacy handling for older displays missing searchFields
+    else {
+      $searchFields = [];
+      $primaryKeys = CoreUtil::getInfoItem($this->savedSearch['api_entity'], 'primary_key');
+      // Search by id
+      if (count($primaryKeys) === 1) {
+        $searchFields[] = $primaryKeys[0];
+      }
+      // If first line uses a rewrite, search on those fields
+      if (!empty($this->display['settings']['columns'][0]['rewrite'])) {
+        $searchFields = array_merge($searchFields, $this->getTokens($this->display['settings']['columns'][0]['rewrite']));
+      }
+      else {
+        $searchFields[] = $this->display['settings']['columns'][0]['key'];
+      }
+      $this->searchFields = $searchFields;
+    }
+
+    // Set searchField if not passed in
+    $this->searchField = $this->searchField ?: $this->searchFields[0];
   }
 
   /**
@@ -282,6 +338,8 @@ class AutocompleteAction extends AbstractAction {
     foreach ($this->trustedFilters as $fields => $val) {
       $additions = array_merge($additions, explode(',', $fields));
     }
+    // Add searchFields
+    $additions = array_merge($additions, $this->searchFields);
     // Add 'extra' fields defined by the display
     $additions = array_merge($additions, array_keys($this->display['settings']['extra'] ?? []));
     // Add 'sort' fields
@@ -346,17 +404,38 @@ class AutocompleteAction extends AbstractAction {
   }
 
   /**
-   * @param string|null $return
+   * @param string|null $returnPage
    * @return \Civi\Api4\Result\SearchDisplayRunResult
    */
-  private function getApiResult(?string $return): \Civi\Api4\Result\SearchDisplayRunResult {
+  private function getApiResult(?string $returnPage): SearchDisplayRunResult {
+    $filters = $this->filters;
+    // If in search mode (not fetching by id) add main search term as filter
+    if ($returnPage) {
+      $filters[$this->getCurrentSearchField()] = $this->input;
+    }
+    if ($this->exclude) {
+      $this->savedSearch['api_params']['where'][] = [$this->getKeyField(), 'NOT IN', $this->exclude];
+    }
     $apiResult = \Civi\Api4\SearchDisplay::run(FALSE)
       ->setSavedSearch($this->savedSearch)
       ->setDisplay($this->display)
-      ->setFilters($this->filters)
-      ->setReturn($return)
+      ->setFilters($filters)
+      ->setReturn($returnPage)
       ->execute();
     return $apiResult;
+  }
+
+  /**
+   * If search field only accepts integers and search term is not numeric, return false
+   *
+   * @return bool
+   */
+  private function inputMatchesDataType(): bool {
+    if (!strlen($this->input) || \CRM_Utils_Rule::integer($this->input)) {
+      return TRUE;
+    }
+    $currentSearchField = $this->getField($this->getCurrentSearchField());
+    return $currentSearchField['data_type'] !== 'Integer';
   }
 
 }

--- a/Civi/Api4/Result/AutocompleteResult.php
+++ b/Civi/Api4/Result/AutocompleteResult.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Result;
+
+/**
+ * Result class for autocomplete actions
+ *
+ * @package Civi\Api4\Result
+ */
+class AutocompleteResult extends \Civi\Api4\Generic\Result {
+
+  /**
+   * List of fields applicable to this autocomplete
+   *
+   * @var array
+   */
+  public $searchFields = [];
+
+  /**
+   * Current field being searched
+   *
+   * @var string
+   */
+  public $searchField = '';
+
+}

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -58,6 +58,7 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
     if (!$entityName) {
       throw new \CRM_Core_Exception("Entity name is required to get autocomplete default display.");
     }
+    $primaryKeys = CoreUtil::getInfoItem($entityName, 'primary_key');
     $idField = CoreUtil::getIdFieldName($entityName);
 
     // If there's no label field, fall back on id. That's a pretty lame autocomplete but better than nothing.
@@ -101,6 +102,12 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
       'rewrite' => "#[$idField]" . (isset($columns[1]) ? " [$columns[1]]" : ''),
       'empty_value' => "#[$idField]",
     ];
+
+    // Set search fields. Include primary key if singular.
+    $e->display['settings']['searchFields'] = $searchFields;
+    if (count($primaryKeys) === 1 && !in_array($primaryKeys[0], $searchFields)) {
+      array_unshift($e->display['settings']['searchFields'], $primaryKeys[0]);
+    }
 
     // Default icons
     $iconFields = CoreUtil::getInfoItem($entityName, 'icon_field') ?? [];

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -396,7 +396,7 @@
 
       this.fieldsForSort = function() {
         function disabledIf(key) {
-          return _.findIndex(ctrl.display.settings.sort, [key]) >= 0;
+          return ctrl.display.settings.sort.findIndex(sort => sort[0] === key) >= 0;
         }
         return {
           results: [
@@ -411,6 +411,15 @@
               children: ctrl.crmSearchAdmin.getSelectFields(disabledIf)
             }
           ].concat(ctrl.crmSearchAdmin.getAllFields('', ['Field', 'Custom', 'Extra'], disabledIf))
+        };
+      };
+
+      this.fieldsForSearch = function() {
+        function disabledIf(key) {
+          return ctrl.display.settings.searchFields.findIndex(field => field === key) >= 0;
+        }
+        return {
+          results: ctrl.crmSearchAdmin.getAllFields('', ['Field', 'Custom', 'Extra'], disabledIf),
         };
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.component.js
@@ -32,6 +32,18 @@
           });
         }
         ctrl.parent.initColumns({});
+        ctrl.display.settings.searchFields = ctrl.display.settings.searchFields || [];
+        if (!ctrl.display.settings.searchFields.length) {
+          const baseEntity = searchMeta.getBaseEntity();
+          if (searchMeta.getField('id')) {
+            ctrl.display.settings.searchFields.push('id');
+          }
+          if (baseEntity.search_fields && baseEntity.search_fields.length) {
+            ctrl.display.settings.searchFields.push(...baseEntity.search_fields);
+          }
+        }
+        // Ensure array is unique
+        ctrl.display.settings.searchFields = _.uniq(ctrl.display.settings.searchFields);
       };
 
     }

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayAutocomplete.html
@@ -8,16 +8,37 @@
     {{:: ts('Make Default Autocomplete for %1', {1: $ctrl.parent.getMainEntity().title_plural}) }}
   </label>
 </div>
+
+<fieldset>
+  <div class="crm-draggable" ng-model="$ctrl.display.settings.searchFields" ui-sortable="sortableColumnOptions">
+    <div class="form-inline" ng-repeat="field in $ctrl.display.settings.searchFields">
+      <i class="crm-i fa-arrows crm-search-move-icon"></i>
+      <label for="crm-admin-autocomplete-search-field-{{$index}}">{{:: ts('Search by') }} <i class="crm-marker" ng-show="!$index">*</i></label>
+      <input class="form-control" id="crm-admin-autocomplete-search-field-{{$index}}" ng-model="$ctrl.display.settings.searchFields[$index]" crm-ui-select="{data: $ctrl.parent.fieldsForSearch, allowClear: false}" />
+      <a href class="crm-hover-button" class="crm-hover-button" ng-show="$ctrl.display.settings.searchFields.length > 1" ng-click="$ctrl.display.settings.searchFields.splice($index, 1)" title="{{:: ts('Remove') }}">
+        <i class="crm-i fa-times"></i>
+      </a>
+    </div>
+  </div>
+  <div class="form-inline">
+    <label for="crm-admin-autocomplete-search-field-add">
+      {{ $ctrl.display.settings.searchFields.length ? ts('Also by') : ts('Search by') }}
+      <i class="crm-marker" ng-show="!$ctrl.display.settings.searchFields.length">*</i>
+    </label>
+    <input class="form-control crm-action-menu fa-plus"
+           id="crm-admin-autocomplete-search-field-add"
+           crm-ui-select="{placeholder: ts('Search field'), data: $ctrl.parent.fieldsForSearch}"
+           on-crm-ui-select="$ctrl.parent.pushSetting('searchFields', selection)" >
+  </div>
+</fieldset>
+
 <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
 
 <fieldset class="crm-search-admin-edit-columns-wrapper">
-  <legend>
-    {{:: ts('Fields') }}
-  </legend>
   <div ng-include="'~/crmSearchAdmin/displays/common/addColMenu.html'"></div>
   <p class="help-block">
-    {{:: ts("The top-most line will be shown as the searchable title (combine multiple fields using rewrite + tokens).") }}
-    {{:: ts("Other lines will be shown below in smaller text, and will not be searchable (except for ID which is always searchable).") }}
+    {{:: ts("The top-most line will be shown as the autocomplte result title (combine multiple fields using rewrite + tokens).") }}
+    {{:: ts("Other lines will be shown below in smaller text.") }}
   </p>
   <fieldset class="crm-search-admin-edit-columns" ng-model="$ctrl.display.settings.columns" ui-sortable="$ctrl.parent.sortableOptions">
     <fieldset ng-repeat="col in $ctrl.display.settings.columns" class="crm-draggable">

--- a/js/Common.js
+++ b/js/Common.js
@@ -608,23 +608,31 @@ if (!CRM.vars) CRM.vars = {};
         ajax: {
           quietMillis: 250,
           url: CRM.url('civicrm/ajax/api4/' + entityName + '/autocomplete'),
-          data: function (input, pageNum) {
+          data: function (input, page, context) {
             return {params: JSON.stringify(_.assign({
               input: input,
-              page: pageNum || 1
+              searchField: context && context.searchField || null,
+              exclude: context && context.previousIds || null,
             }, getApiParams()))};
           },
           results: function(response, page, query) {
             const data = {
               results: response.values,
               more: response.countMatched > response.countFetched,
+              context: query.context || {},
             };
-            if (!data.results.length && data.more) {
-              data.results.push({
-                id: '',
-                label: ts('ID %1 not found.', {1: query.term}),
-                disabled: true,
-              });
+            // Set context for use in the data function above
+            // `searchFields` will be an array like [id, sort_name, email_primary.email]
+            // and `searchField` will be the current field searched
+            data.context.searchField = response.searchField;
+            data.context.searchFields = response.searchFields;
+            data.context.previousIds = data.context.previousIds || [];
+            data.context.previousIds.push(...data.results.map(item => item.id));
+            // If no more results for this searchField, advance to the next
+            const fieldIndex = data.context.searchFields.indexOf(data.context.searchField);
+            if (!data.more && query.term.length && response.searchField && fieldIndex < (data.context.searchFields.length - 1)) {
+              data.context.searchField = data.context.searchFields[fieldIndex + 1];
+              data.more = true;
             }
             return data;
           },


### PR DESCRIPTION
Overview
----------------------------------------
New, improved Autocomplete architecture allows greater configurability and efficiency.

Before
----------------------------------------
- Autocomplete search displays can't configure search fields explicitly, it's inferred from the fields shown in the display.
- Autocomplete sql uses OR operator, resulting in a slow query
- Special extra ajax request to search by ID

After
----------------------------------------
- Refactored autocomplete displays to let the admin configure multiple sequential search fields.
- Instead of OR operator, each searchable field runs a separate query
- Instead of a special extra request for ID, now every search field gets its own ajax request (including ID, if configured)

Technical Details
----------------------------------------
This abandons the concept of "pages" which were never really that relevant to Select2's infinite-scroll model anyway. Instead, it keeps track of which field is being searched, and which results have already been returned, and fires ajax requests for each field in order until no results remain (or the user stops scrolling through them).