### PR TITLE
Move some civi-import only functions to CiviImport

### DIFF
--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -397,51 +397,6 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
   }
 
   /**
-   * This transforms the lists of fields for each contact type & component
-   * into a single unified list suitable for select2.
-   *
-   * @return array
-   */
-  public function getFieldOptions(): array {
-    $fields = $this->getFields();
-    $entity = $this->getBaseEntity();
-    $categories = $this->getImportEntities();
-    $highlightedFields = $this->getParser()->getRequiredFieldsForEntity($entity, $this->getParser()->getActionForEntity($entity));
-    foreach ($fields as $fieldName => $field) {
-      if ($fieldName === '') {
-        // @todo stop setting 'do not import' in the first place.
-        continue;
-      }
-      $childField = [
-        'text' => $field['label'] ?? ($field['html']['label'] ?? $field['title']),
-        'id' => $fieldName,
-        'has_location' => !empty($field['hasLocationType']),
-        'default_value' => $field['default_value'] ?? '',
-        'contact_type' => $field['contact_type'] ?? NULL,
-        'match_rule' => $field['match_rule'] ?? NULL,
-      ];
-      if (in_array($fieldName, $highlightedFields, TRUE)) {
-        $childField['text'] .= '*';
-      }
-      $category = ($childField['has_location'] || $field['name'] === 'contact_id') ? 'Contact' : $field['entity_instance'] ?? ($field['entity'] ?? $entity);
-      if (empty($categories[$category])) {
-        $category = $entity;
-      }
-      $categories[$category]['children'][$fieldName] = $childField;
-    }
-
-    foreach ($categories as $index => $category) {
-      if (empty($category['children'])) {
-        unset($categories[$index]);
-      }
-      else {
-        $categories[$index]['children'] = array_values($category['children']);
-      }
-    }
-    return array_values($categories);
-  }
-
-  /**
    * Get the 'best' mapping default from the column headers.
    *
    * @param string $columnHeader

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -755,17 +755,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
   }
 
   /**
-   * Get the fields available for import selection.
-   *
-   * @return array
-   *   e.g ['first_name' => 'First Name', 'last_name' => 'Last Name'....
-   *
-   */
-  protected function getImportEntities(): array {
-    return $this->getParser()->getImportEntities();
-  }
-
-  /**
    * Get an instance of the parser class.
    *
    * @return \CRM_Contact_Import_Parser_Contact|\CRM_Contribute_Import_Parser_Contribution
@@ -905,33 +894,6 @@ class CRM_Import_Forms extends CRM_Core_Form {
       return reset($info)['entity'];
     }
     return CRM_Core_BAO_UserJob::getTypeValue($this->getUserJobType(), 'entity');
-  }
-
-  /**
-   * Assign values for civiimport.
-   *
-   * I wanted to put this in the extension - but there are a lot of protected functions
-   * we would need to revisit and make public - do we want to?
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function assignCiviimportVariables(): void {
-    $contactTypes = [];
-    foreach (CRM_Contact_BAO_ContactType::basicTypeInfo() as $contactType) {
-      $contactTypes[] = ['id' => $contactType['name'], 'text' => $contactType['label']];
-    }
-    $parser = $this->getParser();
-    $this->isQuickFormMode = FALSE;
-    Civi::resources()->addVars('crmImportUi', [
-      'defaults' => $this->getDefaults(),
-      'rows' => $this->getDataRows([], 2),
-      'contactTypes' => $contactTypes,
-      'entityMetadata' => $this->getFieldOptions(),
-      'dedupeRules' => $parser->getAllDedupeRules(),
-      'userJob' => $this->getUserJob(),
-      'columnHeaders' => $this->getColumnHeaders(),
-      'dateFormats' => $this->getDateFormats(),
-    ]);
   }
 
   /**

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -28,36 +28,8 @@ class CRM_Member_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
   public function buildQuickForm(): void {
     $this->addSavedMappingFields();
     $this->addFormRule([__CLASS__, 'formRule'], $this);
-
-    $options = $this->getFieldOptions();
-    // Suppress non-match contact fields at the QuickForm layer as
-    // their use will only be on the angular layer.
-    foreach ($options as &$option) {
-      if ($option['is_contact']) {
-        foreach ($option['children'] as $index => $contactField) {
-          if (empty($contactField['match_rule'])) {
-            unset($option['children'][$index]);
-          }
-        }
-      }
-      else {
-        foreach ($option['children'] as $index => $membershipField) {
-          // Swap out dots for double underscores so as not to break the quick form js.
-          // We swap this back on postProcess.
-          // Arg - we need to swap out _. first as it seems some groups end in a trailing underscore,
-          // which is indistinguishable to convert back - ie ___ could be _. or ._.
-          // https://lab.civicrm.org/dev/core/-/issues/4317#note_91322
-          $name = $membershipField['id'];
-          $option['children'][$index]['id'] = $name;
-        }
-      }
-    }
-    foreach ($this->getColumnHeaders() as $i => $columnHeader) {
-      $this->add('select2', "mapper[$i]", ts('Mapper for Field %1', [1 => $i]), $options, FALSE, ['class' => 'big', 'placeholder' => ts('- do not import -')]);
-    }
-
+    $this->addMapper();
     $this->setDefaults($this->getDefaults());
-
     $this->addFormButtons();
   }
 


### PR DESCRIPTION


Overview
----------------------------------------
 Move some civi-import only functions to CiviImport

Before
----------------------------------------
Functions only used by Civiimport but they live in the class shared with the legacy Contact & apiv3 csv import extension MapField

After
----------------------------------------
Moved to CiviImport specific class

Technical Details
----------------------------------------
Now that Civiimport uses a MapField class we can make these non-public too - originally these were called through a listener & so had to be public

Comments
----------------------------------------