### PR TITLE
RiverLea: sets min-width on select2 dropdown, adds top border, fixes select border-radius variable name error

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -42,8 +42,6 @@
         // Make this widget very compact
         width: '52px',
         containerCss: {minWidth: '52px'},
-        // Make the dropdown wider than the widget
-        dropdownCss: {width: '250px'}
       };
 
     }

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -536,7 +536,7 @@ input.crm-form-checkbox) + label {
   color: var(--crm-c-text);
   cursor: default;
   border: var(--crm-c-divider);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-input-border-radius);
   background-clip: padding-box;
   user-select: none;
   background-color: var(--crm-form-select-bg);
@@ -567,11 +567,12 @@ input.crm-form-checkbox) + label {
 /* Select dropdown */
 
 .select2-drop.select2-drop-active.crm-container {
+  min-width: var(--crm-big-input);
   background: var(--crm-input-background);
-  border-bottom-left-radius: var(--crm-roundness);
-  border-bottom-right-radius: var(--crm-roundness);
+  border-bottom-left-radius: var(--crm-input-border-radius);
+  border-bottom-right-radius: var(--crm-input-border-radius);
   border-color: var(--crm-c-focus);
-  right: -1px;
+  border-top: 1px solid rgb(from var(--crm-c-focus) r g b / 25%);
 }
 .select2-drop.select2-drop-active.crm-container.select2-drop-above {
   border-bottom-left-radius: 0;
@@ -625,7 +626,7 @@ input.crm-form-checkbox) + label {
 .select2-drop.select2-drop-active.crm-container .crm-entityref-filters input {
   background: var(--crm-c-background);
   border: 1px solid var(--crm-input-border-color);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-input-border-radius);
   box-sizing: border-box;
   height: var(--crm-l);
   margin-top: var(--crm-s);
@@ -855,7 +856,7 @@ input.crm-form-checkbox) + label {
   margin-top: -4px;
 }
 
-/* BS3 radio/checklbox */
+/* BS3 radio/checkbox */
 
 #bootstrap-theme .radio,
 #bootstrap-theme .checkbox {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-for.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-for.html
@@ -23,7 +23,7 @@
       <select class="form-control" ng-model="controls.joinType" ng-options="o.k as o.v for o in ::joinTypes" ></select>
       <input id="crm-search-add-join"
              class="form-control crm-action-menu fa-plus"
-             crm-ui-select="{placeholder: ts('Entity'), data: getJoinEntities, dropdownCss: {width: '275px'}}"
+             crm-ui-select="{placeholder: ts('Entity'), data: getJoinEntities}"
              on-crm-ui-select="$ctrl.addJoin(selection)">
     </div>
   </fieldset>
@@ -40,7 +40,7 @@
   <div class="form-inline crm-search-groupby-add">
     <input id="crm-search-add-groupBy"
            class="form-control crm-action-menu fa-plus"
-           crm-ui-select="{placeholder: ts('Group By'), data: fieldsForGroupBy, dropdownCss: {width: '300px'}}"
+           crm-ui-select="{placeholder: ts('Group By'), data: fieldsForGroupBy}"
            on-crm-ui-select="$ctrl.addParam('groupBy', selection)" >
   </div>
 </fieldset>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplaySort.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplaySort.html
@@ -11,6 +11,6 @@
   <label for="crm-search-display-add-sort">{{ $ctrl.display.settings.sort.length ? ts('Also by') : ts('Sort by') }}</label>
   <input id="crm-search-display-add-sort"
          class="form-control crm-action-menu fa-plus"
-         crm-ui-select="{placeholder: ts('Select field'), data: $ctrl.parent.fieldsForSort, dropdownCss: {width: '300px'}}"
+         crm-ui-select="{placeholder: ts('Select field'), data: $ctrl.parent.fieldsForSort}"
          on-crm-ui-select="$ctrl.parent.pushSetting('sort', [selection, 'ASC'])" >
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -45,8 +45,6 @@
         // Make this widget very compact
         width: '52px',
         containerCss: {minWidth: '52px'},
-        // Make the dropdown wider than the widget
-        dropdownCss: {width: '250px'}
       };
 
     }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -1,5 +1,5 @@
 <span title="{{:: ts('Transform field using a function') }}">
-  <input class="form-control fa-crm-formula" style="min-width: 20px" ng-model="$ctrl.fnName" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ' ', width: 'off', dropdownCss: {width: '275px'}}" ng-change="$ctrl.selectFunction()">
+  <input class="form-control fa-crm-formula" style="min-width: 20px" ng-model="$ctrl.fnName" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ' ', width: 'off'}" ng-change="$ctrl.selectFunction()">
 </span>
 <label ng-hide="$ctrl.mode !== 'select' && !$ctrl.fn">{{ $ctrl.fieldArg.field.label }}</label>
 

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -19,7 +19,7 @@
         </th>
         <th class="form-inline text-right">
           <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
-                 crm-ui-select="::{data: fieldsForSelect, placeholder: ' ', width: '48px', containerCss: {minWidth: '48px'}, dropdownCss: {width: '300px'}}"
+                 crm-ui-select="::{data: fieldsForSelect, placeholder: ' ', width: '48px', containerCss: {minWidth: '48px'}}"
                  on-crm-ui-select="addColumn(selection)" >
         </th>
       </tr>


### PR DESCRIPTION
Overview
----------------------------------------
This recent PR https://github.com/civicrm/civicrm-core/pull/33165 shrunk RL Select2 when in tables, but also shrunk the dropdown. This PR, [following discussion](https://chat.civicrm.org/civicrm/pl/9kpmzoutm7ru3xhtr878cj7enc), sets a minimum width for dropdowns to match the default Select2 width, and adds a faint top border.

While fixing this I noticed that Select2 in a few places was using `--crm-roundness` for border-radius, rather than `--crm-input-border-radius` which used across the rest of input styling. This meant a 1px difference in radius in Minetta and Hackney, had no impact in Walbrook, but in Thames meant square borders to parts of Select2 because Thames sets `--crm-roundness` to 0. 

Two other tiny things - corrected a typo and remove a `right: -1px` which doesn't seem to do anything.

Before
----------------------------------------
<img width="373" height="257" alt="image" src="https://github.com/user-attachments/assets/7e072bc8-c35e-48d2-a9d3-951f5f8149e2" />
<img width="290" height="204" alt="image" src="https://github.com/user-attachments/assets/5d0b95b6-e8ce-4bcc-a607-e30e26f152ae" />

After
----------------------------------------
<img width="403" height="268" alt="image" src="https://github.com/user-attachments/assets/1c2bb2f9-43cf-4547-bd59-226ba8e1d440" />
<img width="296" height="199" alt="image" src="https://github.com/user-attachments/assets/c8086312-35a9-4ca8-ac47-ac946d2f0fb6" />

Technical Details
----------------------------------------
This colour tint used in line 575 uses relative css colours, which at time of writing [is supported by '88.7% of browsers'](https://caniuse.com/css-relative-colors). This is to reflect stream colours. I _think_ for the 11.3% of browsers who don't support it, the line won't be loaded (tho I've not tested) - but the impact is just a reduction in prettiness, not usability.

Comments
----------------------------------------
cc-ing @artfulrobot as the PR impacts Thames, but in a way that I think was always intended - and is visible in the screengrabs from Thames above.

NB - min-width of the drop-down uses the same variable for the width of the main select2-container. When that container is modified to be narrower the dropdown will be wider. There may be times when users want the dropdown to be as narrow as the container.. e.g. a dropdown with a list of numbers from 1 to 99 you could shrink the select container with 'six' which then takes a width of `6em` but the dropdown will not get that width after this PR - it will have a min-width of `--crm-big-input`, which is 15em in RiverLea. There's ways to work around this if anyone thinks that's a problem.