### PR TITLE
RiverLea: two colour contrast bug fixes: FB dropdown trash icon & notification link

### DIFF
--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -221,6 +221,7 @@
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:hover,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:focus {
   background: var(--crm-notify-danger);
+  color: var(--crm-c-danger-text);
   border: 0;
 }
 

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -416,7 +416,8 @@
   justify-content: center;
   background: var(--crm-dropdown-danger-bg);
 }
-#afGuiEditor .dropdown-menu .text-danger {
+#afGuiEditor .dropdown-menu .text-danger,
+#afGuiEditor .dropdown-menu .text-danger i.crm-i::before {
   color: var(--crm-c-danger-text);
 }
 


### PR DESCRIPTION
Two instances of the 'danger' text colour not being specified correctly: 

1. FormBuilder dropdown 'text-danger' button trash icon. Impacts hover state on Minetta and Walbrook, and both states on Hackney and Thames. On Hackney the trash icon isn't even visible (as it sets its own danger colour for trash icons). Dark mode in all Streams was fine.
2. Notification button link in Thames and Minetta. Dark mode was fine.

Before
----------------------------------------
**1. FormBuilder dropdown delete button icon**

Minetta hover
<img width="277" height="106" alt="image" src="https://github.com/user-attachments/assets/01d41537-3c65-4299-8c65-ef64ab0afa8f" />

Walbrook hover
<img width="289" height="106" alt="image" src="https://github.com/user-attachments/assets/0587e88d-7f76-48a2-951c-8fdf214a5068" />

Hackney (both)
<img width="257" height="90" alt="image" src="https://github.com/user-attachments/assets/f3aee54f-5a43-4732-9ecd-6ba8ace93d20" />

Thames (both)
<img width="254" height="126" alt="image" src="https://github.com/user-attachments/assets/8e0d0549-ae16-4621-ac3b-39b7c68e3ce9" />

**2. Notification link**

Walbrook
<img width="383" height="149" alt="image" src="https://github.com/user-attachments/assets/dd337a90-5b9d-4203-8f50-543b63e5a91c" />

Thames
<img width="395" height="180" alt="image" src="https://github.com/user-attachments/assets/6da8365e-fa91-4aa2-8027-312510be88fd" />

After
----------------------------------------
**1. FormBuilder dropdown delete button icon**

Minetta hover
<img width="288" height="163" alt="image" src="https://github.com/user-attachments/assets/7b982506-e6be-42a0-9288-25d3d4b66190" />

Walbrook
<img width="248" height="94" alt="image" src="https://github.com/user-attachments/assets/8c67446b-3680-4853-8bda-a46af8285f19" />

Hackney
<img width="242" height="104" alt="image" src="https://github.com/user-attachments/assets/d44c130f-ae0a-44ee-b2b3-1f7f1c5d86f1" />

Thames
<img width="249" height="85" alt="image" src="https://github.com/user-attachments/assets/b8e3a0dd-4153-41c1-be03-30fab75c3b47" />

**2. Notification link**

Walbrook
<img width="394" height="178" alt="image" src="https://github.com/user-attachments/assets/c0e00e7f-0d27-485c-91fe-e637dab96942" />

Thames
<img width="389" height="177" alt="image" src="https://github.com/user-attachments/assets/d9ad52d3-85cd-4cd6-a53d-09d79172714b" />

Technical Details
----------------------------------------
These changes are quite tightly scoped to the components in the screen-grabs, so shouldn't leak elsewhere. The other streams and all streams in Dark mode have been checked - without any problems seen.

Comments
----------------------------------------
cc-ing @artfulrobot as this impacts Thames.