### PR TITLE
Api4 - Allow fields to be specified by reload option

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -479,6 +479,25 @@ abstract class AbstractAction implements \ArrayAccess {
   }
 
   /**
+   * @param array $savedRecords
+   * @param array|bool $select
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function reloadResults(array $savedRecords, mixed $select = TRUE): array {
+    $idField = CoreUtil::getIdFieldName($this->getEntityName());
+    /** @var AbstractGetAction $get */
+    $get = \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4]);
+    $get
+      ->setCheckPermissions($this->getCheckPermissions())
+      ->addWhere($idField, 'IN', array_column($savedRecords, $idField));
+    if (is_array($select) && !empty($select)) {
+      $get->setSelect($select);
+    }
+    return (array) $get->execute();
+  }
+
+  /**
    * Validates required fields for actions which create a new object.
    *
    * @param $values

--- a/Civi/Api4/Generic/AbstractBatchAction.php
+++ b/Civi/Api4/Generic/AbstractBatchAction.php
@@ -56,8 +56,14 @@ abstract class AbstractBatchAction extends AbstractQueryAction {
       'limit' => $this->limit,
       'offset' => $this->offset,
     ];
+    // If reload not needed, only select necessary fields
     if (empty($this->reload)) {
       $params['select'] = $this->getSelect();
+    }
+    // If reload needed, select necessary + requested fields
+    else {
+      $reload = is_array($this->reload) ? $this->reload : ['*'];
+      $params['select'] = array_unique(array_merge($this->getSelect(), $reload));
     }
     return \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4] + $params);
   }

--- a/Civi/Api4/Generic/AbstractSaveAction.php
+++ b/Civi/Api4/Generic/AbstractSaveAction.php
@@ -30,7 +30,7 @@ use Civi\Api4\Utils\CoreUtil;
  * @method array getRecords()
  * @method $this setDefaults(array $defaults) Array of defaults.
  * @method array getDefaults()
- * @method $this setReload(bool $reload) Specify whether complete objects will be returned after saving.
+ * @method $this setReload(?array $reload) Optionally reload $ENTITIES after saving with an extra SELECT.
  * @method bool getReload()
  * @method $this setMatch(array $match) Specify fields to match for update.
  * @method bool getMatch()
@@ -62,15 +62,15 @@ abstract class AbstractSaveAction extends AbstractAction {
   protected $defaults = [];
 
   /**
-   * Reload $ENTITIES after saving.
+   * Optionally reload $ENTITIES after saving with an extra SELECT.
    *
-   * By default this action typically returns partial records containing only the fields
-   * that were updated. Set `reload` to `true` to do an additional lookup after saving
-   * to return complete values for every $ENTITY.
+   * By default, this action typically returns partial records containing only the fields
+   * that were updated. If more is needed, set `reload` to an array of fields to SELECT
+   * (use `['*']` to select all) and they will be returned via an extra get request.
    *
-   * @var bool
+   * @var array|bool
    */
-  protected $reload = FALSE;
+  protected $reload;
 
   /**
    * @throws \CRM_Core_Exception

--- a/Civi/Api4/Generic/AbstractUpdateAction.php
+++ b/Civi/Api4/Generic/AbstractUpdateAction.php
@@ -21,7 +21,7 @@ use Civi\Api4\Utils\CoreUtil;
  *
  * @method $this setValues(array $values) Set all field values from an array of key => value pairs.
  * @method array getValues() Get field values.
- * @method $this setReload(bool $reload) Specify whether complete objects will be returned after saving.
+ * @method $this setReload(?array $reload) Optionally reload $ENTITIES after saving with an extra SELECT.
  * @method bool getReload()
  *
  * @package Civi\Api4\Generic
@@ -39,14 +39,15 @@ abstract class AbstractUpdateAction extends AbstractBatchAction {
   protected $values = [];
 
   /**
-   * Reload $ENTITIES after saving.
+   * Optionally reload $ENTITIES after saving with an extra SELECT.
    *
-   * Setting to `true` will load complete records and return them as the api result.
-   * If `false` the api usually returns only the fields specified to be updated.
+   * By default, this action typically returns partial records containing only the fields
+   * that were updated. If more is needed, set `reload` to an array of fields to SELECT
+   * (use `['*']` to select all) and they will be returned via an extra get request.
    *
-   * @var bool
+   * @var array|bool
    */
-  protected $reload = FALSE;
+  protected $reload;
 
   /**
    * Criteria for selecting items to update.

--- a/Civi/Api4/Generic/BasicReplaceAction.php
+++ b/Civi/Api4/Generic/BasicReplaceAction.php
@@ -26,7 +26,7 @@ namespace Civi\Api4\Generic;
  * @method array getRecords()
  * @method $this setDefaults(array $defaults) Set array of defaults.
  * @method array getDefaults()
- * @method $this setReload(bool $reload) Specify whether complete objects will be returned after saving.
+ * @method $this setReload(?array $reload) Optionally reload $ENTITIES after saving with an extra SELECT.
  * @method bool getReload()
  */
 class BasicReplaceAction extends AbstractBatchAction {
@@ -57,15 +57,15 @@ class BasicReplaceAction extends AbstractBatchAction {
   protected $defaults = [];
 
   /**
-   * Reload $ENTITIES after saving.
+   * Optionally reload $ENTITIES after saving with an extra SELECT.
    *
-   * By default this action typically returns partial records containing only the fields
-   * that were updated. Set `reload` to `true` to do an additional lookup after saving
-   * to return complete values for every $ENTITY.
+   * By default, this action typically returns partial records containing only the fields
+   * that were updated. If more is needed, set `reload` to an array of fields to SELECT
+   * (use `['*']` to select all) and they will be returned via an extra get request.
    *
-   * @var bool
+   * @var array|bool
    */
-  protected $reload = FALSE;
+  protected $reload;
 
   /**
    * @return \Civi\Api4\Result\ReplaceResult

--- a/Civi/Api4/Generic/BasicSaveAction.php
+++ b/Civi/Api4/Generic/BasicSaveAction.php
@@ -13,7 +13,6 @@
 namespace Civi\Api4\Generic;
 
 use Civi\API\Exception\NotImplementedException;
-use Civi\Api4\Utils\CoreUtil;
 
 /**
  * @inheritDoc
@@ -64,13 +63,7 @@ class BasicSaveAction extends AbstractSaveAction {
     $savedRecords = $this->updateRecords($this->records);
     $result->setCountMatched($matched);
     if ($this->reload) {
-      $idField = CoreUtil::getIdFieldName($this->getEntityName());
-      /** @var BasicGetAction $get */
-      $get = \Civi\API\Request::create($this->getEntityName(), 'get', ['version' => 4]);
-      $get
-        ->setCheckPermissions($this->getCheckPermissions())
-        ->addWhere($idField, 'IN', array_column($savedRecords, $idField));
-      $result->exchangeArray((array) $get->execute());
+      $result->exchangeArray($this->reloadResults($savedRecords, $this->reload));
     }
     else {
       $result->exchangeArray(array_values($savedRecords));

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -177,16 +177,25 @@ trait DAOActionTrait {
     // Ensure array keys start at 0
     $items = array_values($items);
 
-    foreach ($this->write($items) as $index => $dao) {
-      if (!$dao) {
-        $errMessage = sprintf('%s write operation failed', $this->getEntityName());
-        throw new \CRM_Core_Exception($errMessage);
-      }
-      $result[] = $this->baoToArray($dao, $items[$index]);
+    $daos = $this->write($items);
+
+    // Some legacy DAOs return false on error instead of throwing an exception
+    if (in_array(FALSE, $daos)) {
+      $errMessage = sprintf('%s write operation failed', $this->getEntityName());
+      throw new \CRM_Core_Exception($errMessage);
     }
 
-    \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
-    FormattingUtil::formatOutputValues($result, $this->entityFields());
+    if (empty($this->reload)) {
+      foreach ($daos as $index => $dao) {
+        $result[] = $this->baoToArray($dao, $items[$index]);
+      }
+      \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
+      FormattingUtil::formatOutputValues($result, $this->entityFields());
+    }
+    else {
+      $result = $this->reloadResults($daos, $this->reload);
+    }
+
     return $result;
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -222,8 +222,11 @@
       _.remove(params.displays, {trashed: true});
       if (params.displays && params.displays.length) {
         fireHooks('preSaveDisplay', params.displays, apiCalls);
-        chain.amendDisplays = ['SearchDisplay', 'replace', {where: [['saved_search_id', '=', '$id']], records: params.displays}];
-        chain.displays = ['SearchDisplay', 'get', {where: [['saved_search_id', '=', '$id']], select: ['*', 'is_autocomplete_default']}];
+        chain.displays = ['SearchDisplay', 'replace', {
+          where: [['saved_search_id', '=', '$id']],
+          records: params.displays,
+          reload: ['*', 'is_autocomplete_default'],
+        }];
       } else if (params.id) {
         apiCalls.deleteDisplays = ['SearchDisplay', 'delete', {where: [['saved_search_id', '=', params.id]]}];
       }

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -301,21 +301,21 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
     $updatedUser = User::update(FALSE)
       ->setValues($user)
       ->addWhere('id', '=', $user['id'])
-      ->setReload(TRUE)
+      ->setReload(['*'])
       ->execute()->first();
     $this->assertEquals($user['hashed_password'], $updatedUser['hashed_password']);
 
     // Ditto save
     User::save(FALSE)
       ->setRecords([$user])
-      ->setReload(TRUE)
+      ->setReload(['*'])
       ->execute()->first();
     $updatedUser = User::get(FALSE)->addWhere('id', '=', $user['id'])->execute()->first();
     $this->assertEquals($user['hashed_password'], $updatedUser['hashed_password']);
 
     // Test we can force saving a raw hashed password
     $updatedUser = User::update(FALSE)
-      ->setReload(TRUE)
+      ->setReload(['*'])
       ->addValue('hashed_password', '$shhh')
       ->addWhere('id', '=', $user['id'])
       ->execute()->first();
@@ -323,7 +323,7 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
 
     // Test we can saving a new password. (This also resets the fixture's nonadmin user's password to secret2)
     $updatedUser = User::update(FALSE)
-      ->setReload(TRUE)
+      ->setReload(['*'])
       ->addValue('password', 'secret2')
       ->addWhere('id', '=', $user['id'])
       ->execute()->first();
@@ -346,7 +346,7 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
       ->addValue('password', 'topSecret')
       ->addWhere('id', '=', $this->nonAdminUserID)
       ->setActorPassword('secret1')
-      ->setReload(TRUE)
+      ->setReload(['*'])
       ->execute()->first();
     $this->assertNotEquals($previousHash, $updatedUser['hashed_password'], "Expected that the password was changed, but it wasn't.");
     $previousHash = $updatedUser['hashed_password'];
@@ -400,12 +400,13 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
 
     // We are allowed to update our own password if we provide the current one.
     $previousHash = $nonAdminUser['hashed_password'];
-    $updatedUser = User::update(TRUE)
+    User::update(TRUE)
       ->setActorPassword('secret2')
       ->addValue('password', 'ourNewSecret')
       ->addWhere('id', '=', $this->nonAdminUserID)
-      ->setReload(TRUE)
       ->execute()->first();
+    // `reload` option would not return hashed_password due to permissions
+    $updatedUser = User::get(FALSE)->addWhere('id', '=', $this->nonAdminUserID)->execute()->first();
     $this->assertNotEquals($previousHash, $updatedUser['hashed_password'], "Expected that the password was changed, but it wasn't.");
     $previousHash = $updatedUser['hashed_password'];
 

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -96,7 +96,7 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
       ->addRecord(['identifier' => $id2, 'group:label' => 'Second'])
       ->addRecord(['foo' => 'three'])
       ->addDefault('color', 'pink')
-      ->setReload(TRUE)
+      ->setReload(['*', 'group:name'])
       ->execute()
       ->indexBy('identifier');
 
@@ -108,7 +108,9 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
     // Check updated values
     $this->assertTrue(5 === $result[$id1]['weight']);
     $this->assertEquals('new', $result[$id2]['foo']);
-    $this->assertEquals('two', $result[$id2]['group']);
+    $this->assertEquals('two', $result[$id2]['group:name']);
+    // We didn't select this field in the `reload` param
+    $this->assertFalse(isset($result[$id2]['group:label']));
     $this->assertEquals('three', $result->last()['foo']);
     $this->assertCount(3, $result);
     foreach ($result as $item) {

--- a/tests/phpunit/api/v4/Action/NullValueTest.php
+++ b/tests/phpunit/api/v4/Action/NullValueTest.php
@@ -94,7 +94,7 @@ class NullValueTest extends Api4TestBase implements TransactionalInterface {
 
     $saved = Activity::save(FALSE)
       ->addRecord(['id' => $activity['id'], 'subject' => NULL])
-      ->setReload(TRUE)
+      ->setReload(['*'])
       ->execute()
       ->first();
 


### PR DESCRIPTION
Overview
----------------------------------------
Api4 improvement adds more functionality to the `reload` option.

Technical Details
----------------------------------------
Updated the `setReload` method across multiple actions to allow specifying an array of fields for reloading instead of a simple boolean. This allows extra fields and pseudoconstant suffixes to be included in the reloaded result.