### PR TITLE
SearchKit Batch - Fix e-notice in serialized field handling

### DIFF
--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
@@ -55,7 +55,7 @@ class SKBatchSpecProvider extends AutoService implements SpecProviderInterface {
       $field->setTitle(ts('Import field') . ': ' . $column['label']);
       $field->setLabel($column['label']);
       $field->setType('Field');
-      $field->setSerialize($column['serialize']);
+      $field->setSerialize($column['serialize'] ?? NULL);
       $field->setNullable($column['nullable'] ?? TRUE);
       $field->setColumnName($column['name']);
       if (!empty($column['options'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes php notice since #33232 


Technical Details
----------------------------------------
Going forward this array key will always be set, but it produces an annoying notice for existing batches.
Might as well add this fallback.
