### PR TITLE
gracefully handle google geocoding failures

### DIFF
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -144,7 +144,14 @@ class CRM_Utils_Geocode_Google {
     $query = 'https://' . self::$_server . self::$_uri . $add;
 
     $client = new GuzzleHttp\Client();
-    $request = $client->request('GET', $query, ['timeout' => \Civi::settings()->get('http_timeout')]);
+    try {
+      $request = $client->request('GET', $query, ['timeout' => \Civi::settings()->get('http_timeout')]);
+    }
+    catch (GuzzleHttp\Exception\ClientException $e) {
+      CRM_Core_Error::debug_var('Geocoding failed.  Message from Guzzle:', $e->getMessage());
+      $coords['geo_code_error'] = $e->getMessage();
+      return $coords;
+    }
     $string = $request->getBody();
 
     libxml_use_internal_errors(TRUE);


### PR DESCRIPTION
Overview
----------------------------------------

If a Google responds to a geo coding request with a 400 or 500 error, CiviCRM barfs. We should catch any errors to continue without geocoding the address.

Before
----------------------------------------

We received this screen shot from a user:

<img width="1840" height="192" alt="image" src="https://github.com/user-attachments/assets/13e2c6f3-682e-4b03-a311-a648372e39ae" />

The mighty Google felled by a 500 error. It's the only instance in our logs - there were successful requests before and after so it seems like an intermittent Google failure.

Unfortunately, it meant that the might CiviEvent registration that triggered the geocoding request also failed.


After
----------------------------------------
We catch any guzzle errors and continue with no geo-coding of the address.

Technical Details
-----------------------------------------

I couldn't trigger the error with a 500 response, so I tested by temporarily change the URI for the google lookup to get a 404 error instead. It seems to be the same Guzzle exception.