### PR TITLE
Api4 - Add GROUP_NTH sql function

### DIFF
--- a/Civi/Api4/Query/SqlFunctionGROUP_NTH.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_NTH.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * Sql function returns the nth item in a GROUP_CONCAT set (per the ORDER_BY param)
+ * Values start at 1 (not zero like PHP arrays)
+ * If N is negative, it will count from the end: -1 is the last item, etc.
+ * @since 6.6
+ */
+class SqlFunctionGROUP_NTH extends SqlFunction {
+
+  public $supportsExpansion = TRUE;
+
+  protected static $category = self::CATEGORY_AGGREGATE;
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'must_be' => ['SqlField', 'SqlFunction', 'SqlEquation'],
+        'optional' => FALSE,
+      ],
+      [
+        'name' => 'N=',
+        'max_expr' => 1,
+        'must_be' => ['SqlNumber'],
+        'optional' => FALSE,
+      ],
+      [
+        'name' => 'ORDER BY',
+        'label' => ts('Order by'),
+        'max_expr' => 1,
+        'flag_after' => ['ASC' => ts('Ascending'), 'DESC' => ts('Descending')],
+        'must_be' => ['SqlField'],
+        'optional' => TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('Nth');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Nth value in the grouping.');
+  }
+
+  /**
+   * Render the final expression
+   * @param string $output
+   * @return string
+   */
+  public static function renderExpression(string $output): string {
+    // Extract number after 'N= ' and store it
+    preg_match('/N=\s*(-?\d+)/', $output, $matches);
+    if (empty($matches)) {
+      throw new \CRM_Core_Exception('Invalid GROUP_NTH expression: (' . $output . '). Must provide N= x after the field name.');
+    }
+    $n = (int) $matches[1];
+    // Remove 'N= x' from the output
+    $output = preg_replace('/N=\s*-?\d+/', '', $output);
+
+    $sep = \CRM_Core_DAO::VALUE_SEPARATOR;
+    if ($n === 1) {
+      return "SUBSTRING_INDEX(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', 1)";
+    }
+    elseif ($n > 0) {
+      return "CASE
+            WHEN $n <= (LENGTH(GROUP_CONCAT($output SEPARATOR '$sep')) - LENGTH(REPLACE(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', '')) + 1)
+            THEN SUBSTRING_INDEX(SUBSTRING_INDEX(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', $n), '$sep', -1)
+            ELSE NULL
+        END";
+    }
+    else {
+      // For negative indices, count from the end
+      $abs = abs($n);
+      return "CASE
+            WHEN $abs <= (LENGTH(GROUP_CONCAT($output SEPARATOR '$sep')) - LENGTH(REPLACE(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', '')) + 1)
+            THEN SUBSTRING_INDEX(SUBSTRING_INDEX(GROUP_CONCAT($output SEPARATOR '$sep'), '$sep', -$abs), '$sep', 1)
+            ELSE NULL
+        END";
+    }
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -201,7 +201,9 @@
 
       // Make a sql-friendly alias for this expression
       function makeAlias() {
-        var args = _.pluck(_.filter(_.filter(ctrl.args, 'value'), {type: 'field'}), 'value');
+        const args = ctrl.args
+          .filter(arg => arg.value && (arg.type === 'field' || arg.type === 'number'))
+          .map(arg => arg.value);
         return (ctrl.fnName + '_' + args.join('_')).replace(/[.:]/g, '_');
       }
 

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -55,6 +55,30 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
       ])
       ->execute();
 
+    // Test GROUP_NTH
+    $agg = Contribution::get(FALSE)
+      ->addGroupBy('contact_id')
+      ->addWhere('contact_id', '=', $cid)
+      ->addSelect('GROUP_NTH(total_amount N= 2 ORDER BY id) AS second_amount')
+      ->addSelect('GROUP_NTH(total_amount N= -2 ORDER BY id) AS second_to_last_amount')
+      ->addSelect('GROUP_NTH(financial_type_id:name N= 1 ORDER BY id) AS first_type')
+      ->addSelect('GROUP_NTH(financial_type_id:name N= 3 ORDER BY id) AS third_type')
+      ->addSelect('GROUP_NTH(financial_type_id:name N= -1 ORDER BY id) AS last_type')
+      ->addSelect('GROUP_NTH(financial_type_id:name N= 5 ORDER BY id) AS fifth_type')
+      ->addSelect('GROUP_NTH(MONTH(receive_date):label N= 2 ORDER BY id) AS second_month')
+      ->addSelect('COUNT(*) AS count')
+      ->execute()
+      ->first();
+
+    $this->assertTrue(4 === $agg['count']);
+    $this->assertEquals(200, $agg['second_amount']);
+    $this->assertEquals(300, $agg['second_to_last_amount']);
+    $this->assertEquals('Donation', $agg['first_type']);
+    $this->assertEquals('Member Dues', $agg['third_type']);
+    $this->assertEquals('Event Fee', $agg['last_type']);
+    $this->assertNull($agg['fifth_type']);
+    $this->assertEquals('February', $agg['second_month']);
+
     // Test AVG, SUM, MAX, MIN, COUNT
     $agg = Contribution::get(FALSE)
       ->addGroupBy('contact_id')


### PR DESCRIPTION
Overview
----------------------------------------
New functionality for SearchKit: select Nth item in a grouping.

<img width="1958" height="1710" alt="image" src="https://github.com/user-attachments/assets/aa4eeef2-0c11-48e5-a92c-ae17884e7521" />


Technical Details
----------------------------------------
This works just like GROUP_FIRST but allows any value for N. Values start at 1 (not zero like PHP arrays).
If N is negative, it will count from the end: -1 is the last item, etc.
