### PR TITLE
RiverLea applies 'inactive' colour variable on Select2 placeholder text

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -489,6 +489,9 @@ input.crm-form-checkbox) + label {
 .crm-container .select2-default {
   color: var(--crm-input-color) !important /* vs important in select2.min.css */;
 }
+.crm-container .select2-default .select2-chosen { /* intended to target placeholder text */
+  color: var(--crm-c-inactive);
+}
 .crm-container .select2-container-multi .select2-choices .select2-search-field input.select2-default {
   color: var(--crm-input-color);
 }


### PR DESCRIPTION
Overview
----------------------------------------
Select 2 placeholder text isn't obvious. This PR is intended to style that text differently using the `--crm-c-inactive` colour also used for disabled/inactive inputs.

Before
----------------------------------------
<img width="864" height="124" alt="image" src="https://github.com/user-attachments/assets/df4f3798-6f31-431a-a851-2ffaad65dc14" />
<img width="649" height="250" alt="image" src="https://github.com/user-attachments/assets/3c63d769-b296-4c13-94d8-74acfc9fe4a0" />

After
----------------------------------------
<img width="680" height="95" alt="image" src="https://github.com/user-attachments/assets/3d5f0958-2281-44d8-bc40-ec356098abb1" />
<img width="668" height="244" alt="image" src="https://github.com/user-attachments/assets/521de997-4931-4e25-a0b1-2087868cb5c7" />

Comments
----------------------------------------
This works for the SearchKit examples above but hasn't been checked in many contexts.