### PR TITLE
RiverLea - Improve field width handling

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.html
@@ -1,5 +1,5 @@
 <span title="{{:: ts('Insert Token') }}">
-  <input class="form-control crm-action-menu fa-code collapsible-optgroups"
+  <input class="form-control crm-auto-width crm-action-menu fa-code collapsible-optgroups"
          crm-ui-select="$ctrl.tokenSelectSettings"
          on-crm-ui-select="$ctrl.insertToken(selection)"
   />

--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -39,9 +39,6 @@
         data: this.getTokens,
         // The crm-action-menu icon doesn't show without a placeholder
         placeholder: ' ',
-        // Make this widget very compact
-        width: '52px',
-        containerCss: {minWidth: '52px'},
       };
 
     }

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -209,44 +209,6 @@ select.crm-error {
   min-width: auto !important /* vs front.css */;
 }
 
-/* Input size modifiers */
-
-.crm-container .two {
-  width: 3rem; /* .two is used on number inputs that need 1rem for the controls */
-}
-.crm-container .four,
-.crm-container input.four,
-.crm-container .crm-form-select.four {
-  width: 4em;
-}
-.crm-container .six,
-.crm-container input.six,
-.crm-container .crm-form-select.six {
-  width: 6em;
-}
-.crm-container .eight,
-.crm-container input.eight,
-.crm-container .crm-form-select.eight {
-  width: 8em;
-}
-.crm-container .twelve,
-.crm-container .medium,
-.crm-container input.twelve,
-.crm-container input.medium {
-  width: 12em;
-}
-.crm-container .twenty {
-  width: 20em;
-}
-.crm-container .big {
-  width: var(--crm-big-input);
-}
-.crm-container .huge,
-input.crm-form-autocomplete,
-input.crm-form-entityref {
-  width: var(--crm-huge-input);
-}
-
 /* Inline edit */
 
 .crm-container .crm-editable-form,
@@ -412,17 +374,15 @@ input.crm-form-checkbox) + label {
 
 /* Select2 */
 
-.crm-container .select2-container:not(.select2-container-multi,
-.collapsible-optgroups) {
-  width: auto;
+.crm-container .select2-container {
   max-width: 100%;
 }
-.crm-container .select2-container:not(.four,.six,.eight,.twelve,.medium) {
+/* Set width using !important to override the inline fixed width given by select2.js */
+.crm-container .select2-container {
   width: var(--crm-big-input) !important /* vs inline fixed width */;
 }
 .crm-container .select2-container-multi {
   min-width: 96px;
-  max-width: 100%;
 }
 .crm-container select.form-control,
 .crm-container .select2-container-multi .select2-choices,
@@ -857,6 +817,38 @@ input.crm-form-checkbox) + label {
 .crm-container .ui-spinner a.ui-spinner-down span::before {
   content: var(--crm-icon-sort-desc);
   margin-top: -4px;
+}
+
+/* Input size modifiers */
+/* Must use !important to override bootstrap css and select2 inline width */
+
+.crm-container .two {
+  width: 3rem !important; /* .two is used on number inputs that need 1rem for the controls */
+}
+.crm-container .four {
+  width: 4em !important;
+}
+.crm-container .six {
+  width: 6em !important;
+}
+.crm-container .eight {
+  width: 8em !important;
+}
+.crm-container .twelve,
+.crm-container .medium {
+  width: 12em !important;
+}
+.crm-container .twenty {
+  width: 20em !important;
+}
+.crm-container .big {
+  width: var(--crm-big-input) !important;
+}
+.crm-container .huge {
+  width: var(--crm-huge-input) !important;
+}
+.crm-container .crm-auto-width {
+  width: auto !important;
 }
 
 /* BS3 radio/checkbox */

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -168,9 +168,6 @@
 .crm-search .ui-sortable-helper .api4-clause-badge .crm-i {
   display: inline-block;
 }
-.crm-search .api4-operator {
-  width: 235px;
-}
 .crm-search .crm-search-admin-relative .api4-clause-group-sortable {
   margin: var(--crm-r) 0;
 }
@@ -286,19 +283,10 @@ i.crm-i.crm-search-move-icon {
   padding: var(--crm-padding-reg);
   font-size: inherit;
 }
-.crm-search details label {
-  min-width: var(--crm-input-label-width);
-}
-.crm-search details label:has(~ a.helpicon) {
-  min-width: calc(var(--crm-input-label-width) - 19px);
-}
 /* Various */
 
 .crm-search .help-block.bg-warning {
   padding: var(--crm-padding-reg);
-}
-.crm-search .form-control.huge {
-  width: var(--crm-big-input);
 }
 /* Style expires_date date/time width */
 .crm-search #expires_date + input,
@@ -345,9 +333,6 @@ i.crm-i.crm-search-move-icon {
 .crm-draggable:hover > i.crm-i.crm-search-move-icon,
 .crm-draggable:hover > * > i.crm-i.crm-search-move-icon {
   opacity: 1;
-}
-.crm-search input[type=number] {
-  width: 90px;
 }
 /* For display.settings.limit field */
 .crm-search .checkbox-inline.form-control input[type=number] {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-for.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-for.html
@@ -1,14 +1,14 @@
 <div class="form-inline">
   <label for="crm-search-main-entity">{{:: ts('Search for') }}</label>
-  <input id="crm-search-main-entity" class="form-control huge collapsible-optgroups" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: mainEntitySelect}" ng-disabled="$ctrl.savedSearch.id">
+  <input id="crm-search-main-entity" class="form-control twenty collapsible-optgroups" ng-model="$ctrl.savedSearch.api_entity" crm-ui-select="::{allowClear: false, data: mainEntitySelect}" ng-disabled="$ctrl.savedSearch.id">
 </div>
 <div ng-if=":: $ctrl.paramExists('join')" class="crm-search-joins">
   <fieldset ng-repeat="join in $ctrl.savedSearch.api_params.join" class="crm-search-join">
     <div class="form-inline">
-      <select class="form-control" ng-model="join[1]" ng-change="$ctrl.changeJoinType(join)" ng-options="o.k as o.v for o in ::joinTypes" ></select>
+      <select class="form-control crm-auto-width" ng-model="join[1]" ng-change="$ctrl.changeJoinType(join)" ng-options="o.k as o.v for o in ::joinTypes" ></select>
       <div class="input-group">
         <span class="input-group-addon" title="{{:: getJoin(join[0]).defaultLabel }}"><i class="crm-i {{:: getJoin(join[0]).icon }}"></i></span>
-        <input class="form-control crm-search-join-label huge" ng-model="$ctrl.getSetJoinLabel(join[0])" ng-model-options="{getterSetter: true, updateOn: 'blur'}" placeholder="{{:: getJoin(join[0]).defaultLabel }}" title="{{:: ts('Optional label for this join') }}">
+        <input class="form-control crm-search-join-label twenty" ng-model="$ctrl.getSetJoinLabel(join[0])" ng-model-options="{getterSetter: true, updateOn: 'blur'}" placeholder="{{:: getJoin(join[0]).defaultLabel }}" title="{{:: ts('Optional label for this join') }}">
       </div>
       <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.removeJoin($index)" title="{{:: ts('Remove join') }}">
         <i class="crm-i fa-trash" aria-hidden="true"></i>
@@ -20,7 +20,7 @@
   </fieldset>
   <fieldset class="crm-search-join-add">
     <div class="form-inline">
-      <select class="form-control" ng-model="controls.joinType" ng-options="o.k as o.v for o in ::joinTypes" ></select>
+      <select class="form-control crm-auto-width" ng-model="controls.joinType" ng-options="o.k as o.v for o in ::joinTypes" ></select>
       <input id="crm-search-add-join"
              class="form-control crm-action-menu fa-plus"
              crm-ui-select="{placeholder: ts('Entity'), data: getJoinEntities}"
@@ -33,7 +33,7 @@
     <label for="crm-search-groupBy-{{ $index }}">{{:: ts('Group By') }}</label>
     <crm-search-function class="form-group" expr="$ctrl.savedSearch.api_params.groupBy[$index]" mode="groupBy"></crm-search-function>
     <span ng-if="!$ctrl.hasFunction($ctrl.savedSearch.api_params.groupBy[$index])">
-          <input id="crm-search-groupBy-{{ $index }}" class="form-control huge" ng-model="$ctrl.savedSearch.api_params.groupBy[$index]" crm-ui-select="{placeholder: ' ', data: fieldsForGroupBy}" ng-change="changeGroupBy($index)" />
+          <input id="crm-search-groupBy-{{ $index }}" class="form-control crm-auto-width" ng-model="$ctrl.savedSearch.api_params.groupBy[$index]" crm-ui-select="{placeholder: ' ', data: fieldsForGroupBy}" ng-change="changeGroupBy($index)" />
         </span>
     <hr>
   </div>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-group.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-group.html
@@ -6,7 +6,7 @@
   <label for="crm-search-admin-group-title">{{:: ts('Group Title') }} <span class="crm-marker">*</span></label>
   <input id="crm-search-admin-group-title" class="form-control" placeholder="{{:: ts('Untitled') }}" ng-model="$ctrl.savedSearch.groups[0].title" ng-disabled="!smartGroupColumns.length" ng-required="smartGroupColumns.length">
   <label for="api-save-search-select-column">{{:: ts('Contact Column') }}</label>
-  <input id="api-save-search-select-column" ng-model="$ctrl.savedSearch.api_params.select[0]" class="form-control huge" crm-ui-select="{data: smartGroupColumns}"/>
+  <input id="api-save-search-select-column" ng-model="$ctrl.savedSearch.api_params.select[0]" class="form-control" crm-ui-select="{data: smartGroupColumns}"/>
 </div>
 <fieldset ng-show="smartGroupColumns.length">
   <label>{{:: getField('description', 'Group').label }}</label>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplaySort.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplaySort.html
@@ -1,7 +1,7 @@
 <div class="form-inline crm-search-admin-display-sorts" ng-repeat="sort in $ctrl.display.settings.sort">
   <label for="crm-search-display-sort-{{$index}}">{{ $index ? ts('Also by') : ts('Sort by') }}</label>
-  <input id="crm-search-display-sort-{{$index}}" class="form-control huge" ng-model="sort[0]" crm-ui-select="{data: $ctrl.parent.fieldsForSort}" />
-  <select class="form-control" ng-model="sort[1]" ng-show="sort[0] !== 'RAND()'">
+  <input id="crm-search-display-sort-{{$index}}" class="form-control" ng-model="sort[0]" crm-ui-select="{data: $ctrl.parent.fieldsForSort}" />
+  <select class="form-control crm-auto-width" ng-model="sort[1]" ng-show="sort[0] !== 'RAND()'">
     <option value="ASC">{{:: ts('Ascending') }}</option>
     <option value="DESC">{{:: ts('Descending') }}</option>
   </select>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.html
@@ -8,6 +8,6 @@
     </button>
   </fieldset>
 </div>
-<input class="form-control crm-action-menu fa-plus collapsible-optgroups"
-       crm-ui-select="::{data: $ctrl.crmSearchAdmin.fieldsForSelect, placeholder: ts('Add')}"
+<input class="form-control crm-action-menu fa-plus collapsible-optgroups crm-auto-width"
+       crm-ui-select="::{data: $ctrl.crmSearchAdmin.fieldsForSelect, placeholder: ts('Add Field')}"
        on-crm-ui-select="$ctrl.crmSearchAdmin.addParam('select', selection)" >

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -25,7 +25,7 @@
         </span>
       </td>
       <td>
-        <select class="form-control" ng-model="item.target">
+        <select class="form-control crm-auto-width" ng-model="item.target">
           <option value>{{:: ts('Normal') }}</option>
           <option value="_blank">{{:: ts('New tab') }}</option>
           <option value="crm-popup">{{:: ts('Popup dialog') }}</option>
@@ -39,7 +39,7 @@
         <div class="form-inline" ng-repeat="condition in item.conditions">
           <input ng-model="condition[0]" crm-ui-select="{placeholder: ' ', data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition(item, $index)">
           <div class="form-group" ng-if="condition[0] === 'check user permission'">
-            <select class="form-control api4-operator" ng-model="condition[1]" ng-options="o.key as o.value for o in $ctrl.permissionOperators"></select>
+            <select class="form-control crm-auto-width" crm-ui-select ng-model="condition[1]" ng-options="o.key as o.value for o in $ctrl.permissionOperators"></select>
             <input class="form-control" crm-ui-select="{data: $ctrl.permissions, multiple: true}" ng-model="condition[2]" ng-list>
           </div>
           <crm-search-condition class="form-group"
@@ -52,11 +52,11 @@
         </div>
         <!-- Add condition button uses a trick of ngModel that will push in a new row to the conditions array -->
         <div ng-if="item.conditions.length < 1">
-          <input ng-model="item.conditions[0][0]" crm-ui-select="{placeholder: ts('Add Condition...'), data: $ctrl.fields}">
+          <input class="form-control crm-auto-width" ng-model="item.conditions[0][0]" crm-ui-select="{placeholder: ts('Add Condition...'), data: $ctrl.fields}">
         </div>
         <!-- Subsequent Add Condition button has a different placeholder to clarify that the operator is AND -->
         <div ng-if="item.conditions.length >= 1">
-          <input ng-model="item.conditions[$ctrl.conditionCount[itemIndex]][0]" crm-ui-select="{placeholder: ts('And...'), data: $ctrl.fields}">
+          <input class="form-control crm-auto-width" ng-model="item.conditions[$ctrl.conditionCount[itemIndex]][0]" crm-ui-select="{placeholder: ts('And...'), data: $ctrl.fields}">
         </div>
       </td>
       <td>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.component.js
@@ -42,9 +42,6 @@
         data: this.getTokens,
         // The crm-action-menu icon doesn't show without a placeholder
         placeholder: ' ',
-        // Make this widget very compact
-        width: '52px',
-        containerCss: {minWidth: '52px'},
       };
 
     }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminTokenSelect.html
@@ -1,5 +1,5 @@
 <span title="{{:: ts('Insert Token') }}">
-  <input class="form-control crm-action-menu fa-code collapsible-optgroups"
+  <input class="form-control crm-auto-width crm-action-menu fa-code collapsible-optgroups"
          crm-ui-select="$ctrl.tokenSelectSettings"
          on-crm-ui-select="$ctrl.insertToken(selection)"
   />

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.html
@@ -20,7 +20,7 @@
       <div ng-if="!$ctrl.conjunctions[clause[0]]" class="api4-input-group">
         <crm-search-function ng-if="$ctrl.areFunctionsAllowed(clause[0])" class="form-group" expr="clause[0]" mode="clause"></crm-search-function>
         <span ng-if="!$ctrl.hasFunction(clause[0])">
-          <input class="form-control collapsible-optgroups" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
+          <input class="form-control collapsible-optgroups crm-auto-width" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
         </span>
         <crm-search-condition clause="clause" field="$ctrl.getFieldOrFunction(clause[0])" fields="$ctrl.fields" offset="1" option-key="$ctrl.getOptionKey(clause[0])" format="$ctrl.format" class="form-group"></crm-search-condition>
       </div>
@@ -43,7 +43,7 @@
       </ul>
     </div>
   </div>
-  <input class="form-control collapsible-optgroups"
+  <input class="form-control collapsible-optgroups crm-auto-width"
          on-crm-ui-select="$ctrl.addClause(selection)"
          crm-ui-select="{data: $ctrl.fields, placeholder: $ctrl.placeholder || ts('Select field')}" >
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.html
@@ -1,9 +1,13 @@
-<select class="form-control api4-operator" ng-model="$ctrl.getSetOperator" ng-if="$ctrl.getOperators().length > 1" ng-model-options="{getterSetter: true}" ng-options="o.key as o.value for o in $ctrl.getOperators()" ng-change="$ctrl.changeClauseOperator()" ></select>
-<select class="form-control crm-search-input-mode" ng-if="$ctrl.fields" ng-model="$ctrl.inputMode" ng-change="$ctrl.changeInputMode(clause, index)" >
-  <option value="value">{{:: ts('Value') }}</option>
-  <option value="field">{{:: ts('Field') }}</option>
-</select>
+<span ng-if="$ctrl.getOperators().length > 1">
+  <select class="form-control api4-operator crm-auto-width" ng-model="$ctrl.getSetOperator" crm-ui-select ng-model-options="{getterSetter: true}" ng-options="o.key as o.value for o in $ctrl.getOperators()" ng-change="$ctrl.changeClauseOperator()" ></select>
+</span>
+<span ng-if="$ctrl.fields">
+  <select class="form-control crm-search-input-mode crm-auto-width" crm-ui-select ng-model="$ctrl.inputMode" ng-change="$ctrl.changeInputMode(clause, index)" >
+    <option value="value">{{:: ts('Value') }}</option>
+    <option value="field">{{:: ts('Field') }}</option>
+  </select>
+</span>
 <crm-search-input ng-if="$ctrl.inputMode === 'value' && $ctrl.operatorTakesInput()" ng-model="$ctrl.getSetValue" ng-model-options="{getterSetter: true}" field="$ctrl.field" option-key="$ctrl.optionKey" op="$ctrl.getSetOperator()" format="$ctrl.format" class="form-group"></crm-search-input>
 <span ng-if="$ctrl.inputMode === 'field' && $ctrl.operatorTakesInput()">
-  <input class="form-control collapsible-optgroups" ng-model="$ctrl.getSetValue" ng-model-options="{getterSetter: true}" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" />
+  <input class="form-control collapsible-optgroups crm-auto-width" ng-model="$ctrl.getSetValue" ng-model-options="{getterSetter: true}" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" />
 </span>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.html
@@ -1,10 +1,13 @@
 <span title="{{:: ts('Transform field using a function') }}">
-  <input class="form-control fa-crm-formula" style="min-width: 20px" ng-model="$ctrl.fnName" crm-ui-select="{data: $ctrl.getFunctions, placeholder: ' ', width: 'off'}" ng-change="$ctrl.selectFunction()">
+  <input class="form-control fa-crm-formula crm-auto-width"
+         ng-model="$ctrl.fnName"
+         crm-ui-select="{data: $ctrl.getFunctions, placeholder: ' '}"
+         ng-change="$ctrl.selectFunction()">
 </span>
 <label ng-hide="$ctrl.mode !== 'select' && !$ctrl.fn">{{ $ctrl.fieldArg.field.label }}</label>
 
 <div class="form-group" ng-repeat="arg in $ctrl.args">
-  &nbsp;
+
   <crm-search-function-flag ng-if="$ctrl.fn" flag="flag_before" arg="arg" param="$ctrl.getParam($index)" write-expr="$ctrl.writeExpr()"></crm-search-function-flag>
   <div class="input-group" ng-if="arg !== $ctrl.fieldArg" title="{{ $ctrl.getParam($index).label }}">
     <div class="input-group-btn">
@@ -21,10 +24,10 @@
         </li>
       </ul>
     </div>
-    <input ng-if="arg.type === 'number'" class="form-control" type="number" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.writeExpr()" ng-required="!$ctrl.getParam($index).can_be_empty && !$ctrl.getParam($index).optional" ng-model-options="{updateOn: 'blur'}">
+    <input ng-if="arg.type === 'number'" class="form-control six" type="number" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.writeExpr()" ng-required="!$ctrl.getParam($index).can_be_empty && !$ctrl.getParam($index).optional" ng-model-options="{updateOn: 'blur'}">
     <input ng-if="arg.type === 'string'" class="form-control" ng-model="arg.value" placeholder="{{ $ctrl.getParam($index).label }}" ng-change="$ctrl.writeExpr()" ng-trim="false" ng-required="!$ctrl.getParam($index).can_be_empty && !$ctrl.getParam($index).optional" ng-model-options="{updateOn: 'blur'}">
     <span ng-if="arg.type === 'field'">
-      <input class="form-control" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label, allowClear: false}" required ng-change="$ctrl.writeExpr()">
+      <input class="form-control crm-auto-width" ng-model="arg.value" crm-ui-select="{data: $ctrl.getFields, placeholder: $ctrl.getParam($index).label, allowClear: false}" required ng-change="$ctrl.writeExpr()">
     </span>
     <span class="input-group-btn" ng-if="$ctrl.canRemoveArg($index)">
       <button class="btn btn-danger" type="button" ng-click="$ctrl.removeArg($index)">x</button>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunctionFlag.html
@@ -5,7 +5,7 @@
       {{ label }}
     </label>
   </span>
-  <select ng-switch-when="select" class="form-control" ng-model="$ctrl.arg[$ctrl.flag]" ng-change="$ctrl.writeExpr();">
+  <select ng-switch-when="select" class="form-control crm-auto-width" ng-model="$ctrl.arg[$ctrl.flag]" ng-change="$ctrl.writeExpr();">
     <option ng-repeat="(val, label) in $ctrl.param[$ctrl.flag]" value="{{ val }}">
       {{ label }}
     </option>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminCssRules.html
@@ -21,7 +21,7 @@
     </div>
   </div>
   <label>{{:: ts('If') }}</label>
-  <input class="form-control collapsible-optgroups" ng-model="clause[1]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(clause)" />
+  <input class="form-control collapsible-optgroups crm-auto-width" ng-model="clause[1]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(clause)" />
   <crm-search-condition ng-if="clause[1]" clause="clause" field="$ctrl.getField(clause[1])" offset="2" option-key="'name'" format="$ctrl.format" class="form-group"></crm-search-condition>
   <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.item.cssRules.splice($index, 1);" title="{{:: ts('Remove style') }}">
     <i class="crm-i fa-times"></i>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminIcons.html
@@ -19,13 +19,13 @@
   <div class="form-group crm-search-admin-field-icon" ng-if="icon.icon">
     <input required ng-model="icon.icon" crm-ui-icon-picker class="form-control crm-icon-picker">
   </div>
-  <select class="form-control" ng-model="icon.side" title="{{:: ts('Show icon on left or right side of the field') }}">
+  <select class="form-control crm-auto-width" ng-model="icon.side" title="{{:: ts('Show icon on left or right side of the field') }}">
     <option value="left">{{:: ts('Align left') }}</option>
     <option value="right">{{:: ts('Align right') }}</option>
   </select>
   <div class="form-group" ng-if="icon.if">
     <label>{{:: ts('If') }}</label>
-    <input class="form-control collapsible-optgroups" ng-model="icon.if[0]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(icon.if)" />
+    <input class="form-control collapsible-optgroups crm-auto-width" ng-model="icon.if[0]" crm-ui-select="::{data: $ctrl.fields, allowClear: true, placeholder: ts('Always')}" ng-change="$ctrl.onSelectField(icon.if)" />
     <crm-search-condition ng-if="icon.if[0]" clause="icon.if" field="$ctrl.getField(icon.if[0])" offset="1" option-key="'name'" format="$ctrl.format" class="form-group"></crm-search-condition>
   </div>
   <button type="button" class="btn btn-xs btn-danger-outline" ng-click="$ctrl.item.icons.splice($index, 1);" title="{{:: ts('Remove icon') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
@@ -10,13 +10,13 @@
       <input type="checkbox" ng-checked="$ctrl.display.settings.limit" ng-click="$ctrl.toggleLimit()">
       <span>{{:: ts('Limit Results') }}</span>
     </label>
-    <input ng-if="$ctrl.display.settings.limit" type="number" min="1" step="1" class="form-control" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
+    <input ng-if="$ctrl.display.settings.limit" type="number" min="1" step="1" class="form-control four" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
   </div>
   <div class="form-group" ng-if="$ctrl.display.settings.pager">
     <label for="crm-search-admin-display-limit">
       {{:: ts('Page Size') }}
     </label>
-    <input id="crm-search-admin-display-limit" type="number" min="1" step="1" class="form-control" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
+    <input id="crm-search-admin-display-limit" type="number" min="1" step="1" class="form-control four" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
     <div class="checkbox-inline form-control">
       <label>
         <input type="checkbox" ng-model="$ctrl.display.settings.pager.expose_limit" >

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPlaceholderConfig.html
@@ -4,6 +4,6 @@
       <input type="checkbox" ng-checked="$ctrl.display.settings.placeholder" ng-click="$ctrl.togglePlaceholder()">
       <span>{{:: ts('Loading Placeholders') }}</span>
     </label>
-    <input ng-if="$ctrl.display.settings.placeholder" type="number" min="0" step="1" class="form-control" ng-model="$ctrl.display.settings.placeholder" ng-model-options="{updateOn: 'blur'}">
+    <input ng-if="$ctrl.display.settings.placeholder" type="number" min="0" step="1" class="form-control four" ng-model="$ctrl.display.settings.placeholder" ng-model-options="{updateOn: 'blur'}">
   </div>
 </div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -122,7 +122,7 @@
         </div>
         <div class="form-inline">
           <label>{{:: ts('Alignment') }}</label>
-          <select ng-model="col.alignment" class="form-control">
+          <select ng-model="col.alignment" class="form-control crm-auto-width">
             <option value="">{{:: ts('Left') }}</option>
             <option value="text-center">{{:: ts('Center') }}</option>
             <option value="text-right">{{:: ts('Right') }}</option>

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -18,8 +18,8 @@
           </span>
         </th>
         <th class="form-inline text-right">
-          <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
-                 crm-ui-select="::{data: fieldsForSelect, placeholder: ' ', width: '48px', containerCss: {minWidth: '48px'}}"
+          <input class="form-control crm-auto-width crm-action-menu fa-plus collapsible-optgroups"
+                 crm-ui-select="::{data: fieldsForSelect, placeholder: ' '}"
                  on-crm-ui-select="addColumn(selection)" >
         </th>
       </tr>

--- a/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchSegment/crmSearchAdminSegment.html
@@ -9,7 +9,7 @@
     <br>
     <div class="form-inline">
       <label for="search-segment-entity_name">{{:: ts('For') }} <span class="crm-marker">*</span></label>
-      <input id="search-segment-entity_name" class="form-control huge collapsible-optgroups" required ng-model="$ctrl.segment.entity_name" ng-change="$ctrl.onChangeEntity()" crm-ui-select="{allowClear: false, data: $ctrl.entitySelect, placeholder: ts('Entity')}">
+      <input id="search-segment-entity_name" class="form-control twenty collapsible-optgroups" required ng-model="$ctrl.segment.entity_name" ng-change="$ctrl.onChangeEntity()" crm-ui-select="{allowClear: false, data: $ctrl.entitySelect, placeholder: ts('Entity')}">
     </div>
     <br>
     <fieldset>
@@ -33,7 +33,7 @@
             </td>
             <td>
               <div ng-repeat="condition in item.when" class="form-inline">
-                <input class="form-control" ng-model="condition[0]" crm-ui-select="{data: $ctrl.selectFields, allowClear: false}" >
+                <input class="form-control crm-auto-width" ng-model="condition[0]" crm-ui-select="{data: $ctrl.selectFields, allowClear: false}" >
                 <crm-search-condition clause="condition" field="$ctrl.getField(condition[0])" offset="1" option-key="$ctrl.getOptionKey(condition[0])" class="form-group"></crm-search-condition>
                 <a class="crm-hover-button" ng-if="$index" ng-click="item.when.splice($index, 1)">
                   <i class="crm-i fa-times" aria-hidden="true"></i>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
@@ -2,11 +2,11 @@
   <form name="crmSearchTaskUpdateForm" ng-controller="crmSearchTaskUpdate as $ctrl">
     <p><strong>{{:: ts('Update the %1 selected %2 with the following values:', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</strong></p>
     <div class="form-inline" ng-repeat="clause in $ctrl.values" >
-      <input class="form-control" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: 'Field'}" />
+      <input class="form-control crm-auto-width" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: 'Field'}" />
       <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
     </div>
     <div class="form-inline" ng-hide="$ctrl.run">
-      <input class="form-control twenty" style="width: 15em;" ng-model="$ctrl.add" ng-change="$ctrl.addField()" ng-disabled="!$ctrl.fields" ng-class="{loading: !$ctrl.fields}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Value')}"/>
+      <input class="form-control" style="width: 15em;" ng-model="$ctrl.add" ng-change="$ctrl.addField()" ng-disabled="!$ctrl.fields" ng-class="{loading: !$ctrl.fields}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Value')}"/>
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Updating %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>


### PR DESCRIPTION
Overview
----------------------------------------
This significantly improves the SearchKit UI by setting sensible input widths, enabling inline-forms to appear much less cluttered.

Before
----------------------------------------
<img width="2076" height="1654" alt="image" src="https://github.com/user-attachments/assets/78670968-dbfc-424c-9a3d-b52bbaa969da" />


After
----------------------------------------
<img width="2080" height="1428" alt="image" src="https://github.com/user-attachments/assets/ac22c9c0-a716-4537-b5bd-2a110b7f73ee" />


Technical Details
----------------------------------------
In Riverlea, !important was added to the width override classes, because they are overrides. And a new `crm-auto-width` class was added which allows a Select2 to only use as much width as it needs.