### PR TITLE
Allow backend price options to be un-selected or selected even when full

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -495,11 +495,6 @@ SELECT  id, html_type
               $optionFullTotalAmount += $option['amount'] ?? 0;
             }
           }
-          else {
-            if (!empty($defaultPricefieldIds) && in_array($optId, $defaultPricefieldIds)) {
-              unset($optionFullIds[$optId]);
-            }
-          }
         }
         $option['is_full'] = $isFull;
         $option['total_option_count'] = $dbTotalCount + $currentTotalCount;

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -192,7 +192,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
   }
 
   /**
-   * Freeze form if the event is full.
+   * Freeze price option if full and on front end
    *
    * @param $element
    * @param $fieldOptions
@@ -200,7 +200,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
    * @return null
    */
   public static function freezeIfEnabled(&$element, $fieldOptions) {
-    if (!empty($fieldOptions['is_full'])) {
+    if ((!empty($fieldOptions['is_full'])) && CRM_Utils_System::isFrontendPage()) {
       $element->freeze();
     }
     return NULL;
@@ -439,7 +439,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           }
           // CRM-14696 - Improve display for sold out price set options
           else {
-            $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
+            if (CRM_Utils_System::isFrontendPage()) {
+              $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
+            }
             $priceOptionText['label'] = $priceOptionText['label'] . ' (' . ts('Sold out') . ')';
           }
 
@@ -474,7 +476,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         // CRM-6902 - Add "max" option for a price set field
         $button = substr($qf->controller->getButtonName(), -4);
-        if (!empty($freezeOptions) && $button != 'skip') {
+        if (!empty($freezeOptions) && $button != 'skip' && CRM_Utils_System::isFrontendPage()) {
           $qf->addRule($elementName, ts('Sorry, this option is currently sold out.'), 'regex', "/" . implode('|', $allowedOptions) . "/");
         }
         break;


### PR DESCRIPTION
Before
----------------------------------------
From Change selections for an event participant, full price options are frozen, which means that users cannot remove participants from full options (e.g. if the contact wants to cancel that option, staff cannot remove them without adjusting the max for the price option). It is also not possible to add participants to full options (which is a reasonable thing for staff to be able to do, as long as they are aware they are doing it).

Selects were the exception, as these were not frozen (but also were not marked as sold out).

After
----------------------------------------
In Change selections, all options that are full are marked as sold out and they can be selected or un-selected.

Comments
----------------------------------------
Note that there is no change to the backend New Event Registration form, which allows selection of all sold out items already, but does not mark them as sold out. This is a whole other kettle of fish.

No change to frontend event registrations.
