### PR TITLE
Move more functions to civiimport ImportParser

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -757,7 +757,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
   /**
    * Get an instance of the parser class.
    *
-   * @return \CRM_Contact_Import_Parser_Contact|\CRM_Contribute_Import_Parser_Contribution
+   * @return \CRM_Contact_Import_Parser_Contact|\Civi\Import\ContributionParser
    * @throws \CRM_Core_Exception
    */
   protected function getParser() {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -9,15 +9,11 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Api4\Address;
 use Civi\Api4\Campaign;
 use Civi\Api4\Contact;
-use Civi\Api4\CustomField;
-use Civi\Api4\DedupeRule;
 use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Email;
 use Civi\Api4\Event;
-use Civi\Api4\Phone;
 use Civi\Api4\UserJob;
 use Civi\UserJob\UserJobInterface;
 
@@ -178,8 +174,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   protected $_errors;
 
-  private $dedupeRules = [];
-
   /**
    * Metadata for all available fields, keyed by unique name.
    *
@@ -206,47 +200,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   public function setImportableFieldsMetadata(array $importableFieldsMetadata): void {
     $this->importableFieldsMetadata = $importableFieldsMetadata;
-  }
-
-  /**
-   * @param string|null $contactType
-   * @param string|null $prefix
-   *
-   * @return array[]
-   * @throws \CRM_Core_Exception
-   */
-  protected function getContactFields(?string $contactType, ?string $prefix = ''): array {
-    $contactFields = $this->getAllContactFields('');
-    $matchText = ' ' . ts('(match to %1)', [1 => $prefix]);
-    $contactTypes = [$contactType];
-    if (!$contactType) {
-      $contactTypes = ['Individual', 'Organization', 'Household'];
-    }
-    foreach ($contactTypes as $type) {
-      $dedupeFields = $this->getDedupeFields($type);
-      foreach ($dedupeFields as $fieldName => $dedupeField) {
-        if (!isset($contactFields[$fieldName])) {
-          continue;
-        }
-        $contactFields[$fieldName]['title'] .= $matchText;
-        $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($type);
-      }
-    }
-
-    $contactFields['external_identifier']['title'] .= $matchText;
-    $contactFields['external_identifier']['match_rule'] = '*';
-    $contactFields['id']['match_rule'] = '*';
-    if ($prefix) {
-      $prefixedFields = [];
-      foreach ($contactFields as $name => $contactField) {
-        $contactField['entity_prefix'] = $prefix . '.';
-        $contactField['entity'] = 'Contact';
-        $contactField['entity_instance'] = ucfirst($prefix);
-        $prefixedFields[$prefix . '.' . $name] = $contactField;
-      }
-      return $prefixedFields;
-    }
-    return $contactFields;
   }
 
   /**
@@ -642,44 +595,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       ->addWhere('id', '=', $id)
       ->addSelect('name')
       ->execute()->first()['name'];
-  }
-
-  /**
-   * Get the dedupe rule, including an array of fields with weights.
-   *
-   * The fields are keyed according to the metadata.
-   *
-   * @param string|null $contactType
-   * @param string|null $name
-   *
-   * @return array
-   * @noinspection PhpUnhandledExceptionInspection
-   * @noinspection PhpDocMissingThrowsInspection
-   */
-  public function getDedupeRule(?string $contactType, ?string $name = NULL): array {
-    if (!$contactType && !$name) {
-      $name = 'unique_identifier_match';
-    }
-    if (!$name) {
-      $name = $this->getDefaultRuleForContactType($contactType);
-    }
-    if (empty($this->dedupeRules[$name])) {
-      $where = [['name', '=', $name]];
-      $this->loadRules($where);
-    }
-    return $this->dedupeRules[$name];
-  }
-
-  /**
-   * Get all dedupe rules.
-   *
-   * @return array
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function getAllDedupeRules(): array {
-    $this->loadRules();
-    return $this->dedupeRules;
   }
 
   /**
@@ -1680,214 +1595,6 @@ abstract class CRM_Import_Parser implements UserJobInterface {
       }
     }
     return $contactID;
-  }
-
-  /**
-   * Get the fields for the dedupe rule.
-   *
-   * @param string $contactType
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  protected function getDedupeFields(string $contactType): array {
-    return $this->getDedupeRule($contactType)['fields'];
-  }
-
-  /**
-   * Get all contact import fields metadata.
-   *
-   * @param string $prefix
-   *
-   * @return array
-   *
-   * @noinspection PhpUnhandledExceptionInspection
-   */
-  protected function getAllContactFields(string $prefix = 'Contact.'): array {
-    $allContactFields = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
-      ->setAction('save')
-      ->addOrderBy('title')
-      ->execute()->indexBy('name');
-
-    $contactTypeFields['Individual'] = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
-      ->setAction('save')
-      ->setSelect(['name'])
-      ->addValue('contact_type', 'Individual')
-      ->addOrderBy('title')
-      ->execute()->indexBy('name');
-
-    $contactTypeFields['Organization'] = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
-      ->setAction('save')
-      ->setSelect(['name'])
-      ->addValue('contact_type', 'Organization')
-      ->addOrderBy('title')
-      ->execute()->indexBy('name');
-
-    $contactTypeFields['Household'] = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->addWhere('fk_entity', 'IS EMPTY')
-      ->setAction('save')
-      ->setSelect(['name'])
-      ->addOrderBy('title')
-      ->execute()->indexBy('name');
-
-    $prefixedFields = [];
-    foreach ($allContactFields as $fieldName => $field) {
-      $field['contact_type'] = [];
-      foreach ($contactTypeFields as $contactTypeName => $fields) {
-        if (array_key_exists($fieldName, $fields)) {
-          $field['contact_type'][$contactTypeName] = $contactTypeName;
-        }
-      }
-      $fieldName = $prefix . $fieldName;
-      $prefixedFields[$fieldName] = $field;
-    }
-
-    $addressFields = (array) Address::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->setAction('save')
-      ->addOrderBy('title')
-      // Exclude these fields to keep it simpler for now - we just map to primary
-      ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'master_id'])
-      ->execute()->indexBy('name');
-    foreach ($addressFields as $fieldName => $field) {
-      // Set entity to contact as primary fields used in Contact actions
-      $field['entity'] = 'Contact';
-      $field['name'] = 'address_primary.' . $fieldName;
-      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
-      $prefixedFields[$prefix . 'address_primary.' . $fieldName] = $field;
-    }
-
-    $phoneFields = (array) Phone::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->setAction('save')
-      // Exclude these fields to keep it simpler for now - we just map to primary
-      ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'phone_type_id'])
-      ->addOrderBy('title')
-      ->execute()->indexBy('name');
-    foreach ($phoneFields as $fieldName => $field) {
-      $field['entity'] = 'Contact';
-      $field['name'] = 'phone_primary.' . $fieldName;
-      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
-      $prefixedFields[$prefix . 'phone_primary.' . $fieldName] = $field;
-    }
-
-    $emailFields = (array) Email::getFields()
-      ->addWhere('readonly', '=', FALSE)
-      ->addWhere('usage', 'CONTAINS', 'import')
-      ->setAction('save')
-      // Exclude these fields to keep it simpler for now - we just map to primary
-      ->addWhere('name', 'NOT IN', ['id', 'location_type_id'])
-      ->addOrderBy('title')
-      ->execute()->indexBy('name');
-
-    foreach ($emailFields as $fieldName => $field) {
-      $field['entity'] = 'Contact';
-      $field['name'] = 'email_primary.' . $fieldName;
-      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
-      $prefixedFields[$prefix . 'email_primary.' . $fieldName] = $field;
-    }
-    return $prefixedFields;
-  }
-
-  /**
-   * @param array $where
-   *
-   * @return mixed
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  protected function loadRules(array $where = []) {
-    $rules = DedupeRuleGroup::get(FALSE)
-      ->setWhere($where)
-      ->addSelect('threshold', 'name', 'id', 'title', 'contact_type')
-      ->execute();
-    foreach ($rules as $dedupeRule) {
-      $fields = [];
-      $name = $dedupeRule['name'];
-      $this->dedupeRules[$name] = $dedupeRule;
-      $this->dedupeRules[$name]['rule_message'] = $fieldMessage = '';
-      // Now we add the fields in a format like ['first_name' => 6, 'custom_8' => 9]
-      // The number is the weight and we add both api three & four style fields so the
-      // array can be used for converted & unconverted.
-      $ruleFields = DedupeRule::get(FALSE)
-        ->addWhere('dedupe_rule_group_id', '=', $this->dedupeRules[$name]['id'])
-        ->addSelect('id', 'rule_table', 'rule_field', 'rule_weight')
-        ->execute();
-      foreach ($ruleFields as $ruleField) {
-        $fieldMessage .= ' ' . $ruleField['rule_field'] . '(weight ' . $ruleField['rule_weight'] . ')';
-        if ($ruleField['rule_table'] === 'civicrm_contact') {
-          $fields[$ruleField['rule_field']] = $ruleField['rule_weight'];
-        }
-        // If not a contact field we add both api variants of fields.
-        elseif ($ruleField['rule_table'] === 'civicrm_phone') {
-          // Actually the dedupe rule for phone should always be phone_numeric. so checking 'phone' is probably unncessary
-          if (in_array($ruleField['rule_field'], ['phone', 'phone_numeric'], TRUE)) {
-            $fields['phone'] = $ruleField['rule_weight'];
-            $fields['phone_primary.phone'] = $ruleField['rule_weight'];
-          }
-        }
-        elseif ($ruleField['rule_field'] === 'email') {
-          $fields['email'] = $ruleField['rule_weight'];
-          $fields['email_primary.email'] = $ruleField['rule_weight'];
-        }
-        elseif ($ruleField['rule_table'] === 'civicrm_address') {
-          $fields[$ruleField['rule_field']] = $ruleField['rule_weight'];
-          $fields['address_primary.' . $ruleField['rule_field']] = $ruleField['rule_weight'];
-        }
-        else {
-          // At this point it must be a custom field.
-          $customField = CustomField::get(FALSE)
-            ->addWhere('custom_group_id.table_name', '=', $ruleField['rule_table'])
-            ->addWhere('column_name', '=', $ruleField['rule_field'])
-            ->addSelect('id', 'name', 'custom_group_id.name')
-            ->execute()
-            ->first();
-          $fields['custom_' . $customField['id']] = $ruleField['rule_weight'];
-          $fields[$customField['custom_group_id.name'] . '.' . $customField['name']] = $ruleField['rule_weight'];
-        }
-      }
-      $this->dedupeRules[$name]['rule_message'] = ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', [1 => $this->dedupeRules[$name]['threshold']]) . '<br />' . ts('Or Provide Contact ID or External ID.');
-
-      $this->dedupeRules[$name]['fields'] = $fields;
-    }
-    // Contact type not specified. Return generic rules, maybe update to return
-    // Select rules - ie be able to choose a mixture to pick up by type - eg. if a
-    // row is clearly individual it could use that row.
-    $this->dedupeRules['unique_identifier_match'] = [
-      'name' => 'unique_identifier_match',
-      'threshold' => 1,
-      'title' => ts('ID or external identifier'),
-      'rule_message' => ts('Contact ID or external identifier must be provided'),
-      'fields' => [
-        'id' => 1,
-        'external_identifier' => 1,
-      ],
-      'contact_type' => NULL,
-    ];
-    $this->dedupeRules['unique_email_match'] = [
-      'name' => 'unique_email_match',
-      'threshold' => 1,
-      'title' => ts('Unique email'),
-      'rule_message' => ts('Email must be provided'),
-      'fields' => [
-        'email' => 1,
-        'email_primary.email' => 1,
-      ],
-      'contact_type' => NULL,
-    ];
   }
 
   /**

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -11,7 +11,13 @@
 
 namespace Civi\Import;
 
+use Civi\Api4\Address;
 use Civi\api4\Contact;
+use Civi\Api4\CustomField;
+use Civi\Api4\DedupeRule;
+use Civi\Api4\DedupeRuleGroup;
+use Civi\Api4\Email;
+use Civi\Api4\Phone;
 
 /**
  *
@@ -23,6 +29,8 @@ use Civi\api4\Contact;
  * Class to parse contribution csv files.
  */
 abstract class ImportParser extends \CRM_Import_Parser {
+
+  private array $dedupeRules = [];
 
   /**
    * Validate that the mapping has the required fields.
@@ -101,6 +109,290 @@ abstract class ImportParser extends \CRM_Import_Parser {
         ->first()['id'];
     }
     return NULL;
+  }
+
+  /**
+   * @param string|null $contactType
+   * @param string|null $prefix
+   *
+   * @return array[]
+   * @throws \CRM_Core_Exception
+   */
+  protected function getContactFields(?string $contactType, ?string $prefix = ''): array {
+    $contactFields = $this->getAllContactFields('');
+    $matchText = ' ' . ts('(match to %1)', [1 => $prefix]);
+    $contactTypes = [$contactType];
+    if (!$contactType) {
+      $contactTypes = ['Individual', 'Organization', 'Household'];
+    }
+    foreach ($contactTypes as $type) {
+      $dedupeFields = $this->getDedupeFields($type);
+      foreach ($dedupeFields as $fieldName => $dedupeField) {
+        if (!isset($contactFields[$fieldName])) {
+          continue;
+        }
+        $contactFields[$fieldName]['title'] .= $matchText;
+        $contactFields[$fieldName]['match_rule'] = $this->getDefaultRuleForContactType($type);
+      }
+    }
+
+    $contactFields['external_identifier']['title'] .= $matchText;
+    $contactFields['external_identifier']['match_rule'] = '*';
+    $contactFields['id']['match_rule'] = '*';
+    if ($prefix) {
+      $prefixedFields = [];
+      foreach ($contactFields as $name => $contactField) {
+        $contactField['entity_prefix'] = $prefix . '.';
+        $contactField['entity'] = 'Contact';
+        $contactField['entity_instance'] = ucfirst($prefix);
+        $prefixedFields[$prefix . '.' . $name] = $contactField;
+      }
+      return $prefixedFields;
+    }
+    return $contactFields;
+  }
+
+  /**
+   * Get all contact import fields metadata.
+   *
+   * @param string $prefix
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function getAllContactFields(string $prefix = 'Contact.'): array {
+    $allContactFields = (array) Contact::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
+      ->addOrderBy('title')
+      ->execute()->indexBy('name');
+
+    $contactTypeFields['Individual'] = (array) Contact::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
+      ->setSelect(['name'])
+      ->addValue('contact_type', 'Individual')
+      ->addOrderBy('title')
+      ->execute()->indexBy('name');
+
+    $contactTypeFields['Organization'] = (array) Contact::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
+      ->setSelect(['name'])
+      ->addValue('contact_type', 'Organization')
+      ->addOrderBy('title')
+      ->execute()->indexBy('name');
+
+    $contactTypeFields['Household'] = (array) Contact::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->addWhere('fk_entity', 'IS EMPTY')
+      ->setAction('save')
+      ->setSelect(['name'])
+      ->addOrderBy('title')
+      ->execute()->indexBy('name');
+
+    $prefixedFields = [];
+    foreach ($allContactFields as $fieldName => $field) {
+      $field['contact_type'] = [];
+      foreach ($contactTypeFields as $contactTypeName => $fields) {
+        if (array_key_exists($fieldName, $fields)) {
+          $field['contact_type'][$contactTypeName] = $contactTypeName;
+        }
+      }
+      $fieldName = $prefix . $fieldName;
+      $prefixedFields[$fieldName] = $field;
+    }
+
+    $addressFields = (array) Address::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->setAction('save')
+      ->addOrderBy('title')
+      // Exclude these fields to keep it simpler for now - we just map to primary
+      ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'master_id'])
+      ->execute()->indexBy('name');
+    foreach ($addressFields as $fieldName => $field) {
+      // Set entity to contact as primary fields used in Contact actions
+      $field['entity'] = 'Contact';
+      $field['name'] = 'address_primary.' . $fieldName;
+      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
+      $prefixedFields[$prefix . 'address_primary.' . $fieldName] = $field;
+    }
+
+    $phoneFields = (array) Phone::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->setAction('save')
+      // Exclude these fields to keep it simpler for now - we just map to primary
+      ->addWhere('name', 'NOT IN', ['id', 'location_type_id', 'phone_type_id'])
+      ->addOrderBy('title')
+      ->execute()->indexBy('name');
+    foreach ($phoneFields as $fieldName => $field) {
+      $field['entity'] = 'Contact';
+      $field['name'] = 'phone_primary.' . $fieldName;
+      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
+      $prefixedFields[$prefix . 'phone_primary.' . $fieldName] = $field;
+    }
+
+    $emailFields = (array) Email::getFields()
+      ->addWhere('readonly', '=', FALSE)
+      ->addWhere('usage', 'CONTAINS', 'import')
+      ->setAction('save')
+      // Exclude these fields to keep it simpler for now - we just map to primary
+      ->addWhere('name', 'NOT IN', ['id', 'location_type_id'])
+      ->addOrderBy('title')
+      ->execute()->indexBy('name');
+
+    foreach ($emailFields as $fieldName => $field) {
+      $field['entity'] = 'Contact';
+      $field['name'] = 'email_primary.' . $fieldName;
+      $field['contact_type'] = ['Individual' => 'Individual', 'Organization' => 'Organization', 'Household' => 'Household'];
+      $prefixedFields[$prefix . 'email_primary.' . $fieldName] = $field;
+    }
+    return $prefixedFields;
+  }
+
+  /**
+   * Get the dedupe rule, including an array of fields with weights.
+   *
+   * The fields are keyed according to the metadata.
+   *
+   * @param string|null $contactType
+   * @param string|null $name
+   *
+   * @return array
+   * @noinspection PhpUnhandledExceptionInspection
+   * @noinspection PhpDocMissingThrowsInspection
+   */
+  public function getDedupeRule(?string $contactType, ?string $name = NULL): array {
+    if (!$contactType && !$name) {
+      $name = 'unique_identifier_match';
+    }
+    if (!$name) {
+      $name = $this->getDefaultRuleForContactType($contactType);
+    }
+    if (empty($this->dedupeRules[$name])) {
+      $where = [['name', '=', $name]];
+      $this->loadRules($where);
+    }
+    return $this->dedupeRules[$name];
+  }
+
+  /**
+   * Get all dedupe rules.
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getAllDedupeRules(): array {
+    $this->loadRules();
+    return $this->dedupeRules;
+  }
+
+  /**
+   * @param array $where
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function loadRules(array $where = []): void {
+    $rules = DedupeRuleGroup::get(FALSE)
+      ->setWhere($where)
+      ->addSelect('threshold', 'name', 'id', 'title', 'contact_type')
+      ->execute();
+    foreach ($rules as $dedupeRule) {
+      $fields = [];
+      $name = $dedupeRule['name'];
+      $this->dedupeRules[$name] = $dedupeRule;
+      $this->dedupeRules[$name]['rule_message'] = $fieldMessage = '';
+      // Now we add the fields in a format like ['first_name' => 6, 'custom_8' => 9]
+      // The number is the weight and we add both api three & four style fields so the
+      // array can be used for converted & unconverted.
+      $ruleFields = DedupeRule::get(FALSE)
+        ->addWhere('dedupe_rule_group_id', '=', $this->dedupeRules[$name]['id'])
+        ->addSelect('id', 'rule_table', 'rule_field', 'rule_weight')
+        ->execute();
+      foreach ($ruleFields as $ruleField) {
+        $fieldMessage .= ' ' . $ruleField['rule_field'] . '(weight ' . $ruleField['rule_weight'] . ')';
+        if ($ruleField['rule_table'] === 'civicrm_contact') {
+          $fields[$ruleField['rule_field']] = $ruleField['rule_weight'];
+        }
+        // If not a contact field we add both api variants of fields.
+        elseif ($ruleField['rule_table'] === 'civicrm_phone') {
+          // Actually the dedupe rule for phone should always be phone_numeric. so checking 'phone' is probably unnecessary
+          if (in_array($ruleField['rule_field'], ['phone', 'phone_numeric'], TRUE)) {
+            $fields['phone'] = $ruleField['rule_weight'];
+            $fields['phone_primary.phone'] = $ruleField['rule_weight'];
+          }
+        }
+        elseif ($ruleField['rule_field'] === 'email') {
+          $fields['email'] = $ruleField['rule_weight'];
+          $fields['email_primary.email'] = $ruleField['rule_weight'];
+        }
+        elseif ($ruleField['rule_table'] === 'civicrm_address') {
+          $fields[$ruleField['rule_field']] = $ruleField['rule_weight'];
+          $fields['address_primary.' . $ruleField['rule_field']] = $ruleField['rule_weight'];
+        }
+        else {
+          // At this point it must be a custom field.
+          $customField = CustomField::get(FALSE)
+            ->addWhere('custom_group_id.table_name', '=', $ruleField['rule_table'])
+            ->addWhere('column_name', '=', $ruleField['rule_field'])
+            ->addSelect('id', 'name', 'custom_group_id.name')
+            ->execute()
+            ->first();
+          $fields['custom_' . $customField['id']] = $ruleField['rule_weight'];
+          $fields[$customField['custom_group_id.name'] . '.' . $customField['name']] = $ruleField['rule_weight'];
+        }
+      }
+      $this->dedupeRules[$name]['rule_message'] = ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', [1 => $this->dedupeRules[$name]['threshold']]) . '<br />' . ts('Or Provide Contact ID or External ID.');
+
+      $this->dedupeRules[$name]['fields'] = $fields;
+    }
+    // Contact type not specified. Return generic rules, maybe update to return
+    // Select rules - ie be able to choose a mixture to pick up by type - eg. if a
+    // row is clearly individual it could use that row.
+    $this->dedupeRules['unique_identifier_match'] = [
+      'name' => 'unique_identifier_match',
+      'threshold' => 1,
+      'title' => ts('ID or external identifier'),
+      'rule_message' => ts('Contact ID or external identifier must be provided'),
+      'fields' => [
+        'id' => 1,
+        'external_identifier' => 1,
+      ],
+      'contact_type' => NULL,
+    ];
+    $this->dedupeRules['unique_email_match'] = [
+      'name' => 'unique_email_match',
+      'threshold' => 1,
+      'title' => ts('Unique email'),
+      'rule_message' => ts('Email must be provided'),
+      'fields' => [
+        'email' => 1,
+        'email_primary.email' => 1,
+      ],
+      'contact_type' => NULL,
+    ];
+  }
+
+  /**
+   * Get the fields for the dedupe rule.
+   *
+   * @param string $contactType
+   *
+   * @return array
+   */
+  protected function getDedupeFields(string $contactType): array {
+    return $this->getDedupeRule($contactType)['fields'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Move more functions to civiimport ImportParser
Before
----------------------------------------
`ImportParser` is inheritted by all civiimport children - the goal is to put functions not shared with the legacy Contact import & api extension import in there - this qualifies
 
<img width="1066" height="358" alt="image" src="https://github.com/user-attachments/assets/073097b0-60df-45fc-a873-9eb43d0e97f1" />


After
----------------------------------------
moved

Technical Details
----------------------------------------

Comments
----------------------------------------
