### PR TITLE
Add support for first match in deduping

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1507,6 +1507,10 @@ abstract class CRM_Import_Parser implements UserJobInterface {
         }
       }
       else {
+        $isMatchFirst = str_ends_with($dedupeRule, '.first');
+        if ($isMatchFirst) {
+          $dedupeRule = substr($dedupeRule, 0, -6);
+        }
         $possibleMatches = Contact::getDuplicates(FALSE)
           ->setValues($params)
           ->setDedupeRule($dedupeRule)
@@ -1514,6 +1518,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
 
         foreach ($possibleMatches as $possibleMatch) {
           $matchIDs[(int) $possibleMatch['id']] = (int) $possibleMatch['id'];
+          if ($isMatchFirst) {
+            return $matchIDs;
+          }
         }
       }
     }

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -312,6 +312,7 @@ abstract class ImportParser extends \CRM_Import_Parser {
       $fields = [];
       $name = $dedupeRule['name'];
       $this->dedupeRules[$name] = $dedupeRule;
+      $this->dedupeRules[$name]['title'] = $dedupeRule['title'] . ' (' . ts('Unique Match') . ')';
       $this->dedupeRules[$name]['rule_message'] = $fieldMessage = '';
       // Now we add the fields in a format like ['first_name' => 6, 'custom_8' => 9]
       // The number is the weight and we add both api three & four style fields so the
@@ -356,6 +357,9 @@ abstract class ImportParser extends \CRM_Import_Parser {
       $this->dedupeRules[$name]['rule_message'] = ts('Missing required contact matching fields.') . " $fieldMessage " . ts('(Sum of all weights should be greater than or equal to threshold: %1).', [1 => $this->dedupeRules[$name]['threshold']]) . '<br />' . ts('Or Provide Contact ID or External ID.');
 
       $this->dedupeRules[$name]['fields'] = $fields;
+      $this->dedupeRules[$name . '.first'] = $this->dedupeRules[$name];
+      $this->dedupeRules[$name . '.first']['name'] .= '.first';
+      $this->dedupeRules[$name . '.first']['title'] = str_replace('(' . ts('Unique Match') . ')', '(' . ts('First Match') . ')', $this->dedupeRules[$name . '.first']['title']);
     }
     // Contact type not specified. Return generic rules, maybe update to return
     // Select rules - ie be able to choose a mixture to pick up by type - eg. if a

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -582,6 +582,19 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test using a rule that matches the first matching contact.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportMatchFirst() :void {
+    $this->individualCreate(['email' => 'mum@example.com'], 'mum');
+    $this->individualCreate(['email' => 'mum@example.com'], 'mum2');
+    $this->importContributionsDotCSV([], 'create', ['Contact' => ['dedupe_rule' => 'IndividualUnsupervised.first']]);
+    $contribution = Contribution::get()->execute()->first();
+    $this->assertTrue(in_array($contribution['contact_id'], [$this->ids['Contact']['mum'], $this->ids['Contact']['mum2']]));
+  }
+
+  /**
    * Test whether importing a contribution using email match will match a non-primary.
    *
    * @throws \CRM_Core_Exception
@@ -986,11 +999,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   /**
    * @param array $submittedValues
    * @param string $action
+   * @param array $entityConfiguration
    *
    * @return \CRM_Import_DataSource_CSV
    * @throws \CRM_Core_Exception
    */
-  private function importContributionsDotCSV(array $submittedValues = [], string $action = 'create'): CRM_Import_DataSource_CSV {
+  private function importContributionsDotCSV(array $submittedValues = [], string $action = 'create', array $entityConfiguration = []): CRM_Import_DataSource_CSV {
     $this->importCSV('contributions.csv', [
       ['name' => 'Contact.first_name'],
       ['name' => 'Contribution.total_amount'],
@@ -1000,7 +1014,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'Contribution.source'],
       ['name' => 'note'],
       ['name' => 'Contribution.trxn_id'],
-    ], $submittedValues, $action);
+    ], $submittedValues, $action, $entityConfiguration);
     return new CRM_Import_DataSource_CSV($this->userJobID);
   }
 

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -33,10 +33,12 @@ trait CRMTraits_Import_ParserTrait {
    * @param array $fieldMappings
    * @param array $submittedValues
    * @param string $action
+   * @param array $entityConfiguration
    *
    * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  protected function importCSV(string $csv, array $fieldMappings, array $submittedValues = [], string $action = 'create'): void {
+  protected function importCSV(string $csv, array $fieldMappings, array $submittedValues = [], string $action = 'create', array $entityConfiguration = []): void {
     $submittedValues = array_merge([
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
@@ -55,6 +57,16 @@ trait CRMTraits_Import_ParserTrait {
       ->execute()->first()['metadata'];
     $userJobMetadata['import_mappings'] = $fieldMappings;
     $userJobMetadata['entity_configuration']['Contribution']['action'] = $action;
+    if ($entityConfiguration) {
+      foreach ($entityConfiguration as $entity => $configuration) {
+        if (isset($userJobMetadata['entity_configuration'][$entity])) {
+          $userJobMetadata['entity_configuration'][$entity] = $configuration + $userJobMetadata['entity_configuration'][$entity];
+        }
+        else {
+          $userJobMetadata['entity_configuration'][$entity] = $configuration;
+        }
+      }
+    }
     UserJob::update()
       ->addWhere('id', '=', $this->userJobID)
       ->setValues([


### PR DESCRIPTION
Overview
----------------------------------------
Add support for first match in deduping

Before
----------------------------------------
If importing will potentially match more than one contact then the row is rejected

After
----------------------------------------
It is possible to choose between importing to the first match or only when unique

<img width="1122" height="571" alt="image" src="https://github.com/user-attachments/assets/cc822948-5b90-4eb2-8b63-9983842fc42d" />


Technical Details
----------------------------------------

Comments
----------------------------------------
