### PR TITLE
Fix menubar search; use UNIONs for performance

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -128,6 +128,10 @@ class AutocompleteAction extends AbstractAction {
    */
   private $trustedFilters = [];
 
+  private $trustedSavedSearch;
+
+  private $trustedDisplay;
+
   /**
    * List of searchable fields for this display
    *
@@ -158,6 +162,10 @@ class AutocompleteAction extends AbstractAction {
     $this->checkPermissionToLoadSearch();
 
     $entityName = $this->getEntityName();
+
+    // Load trusted overrides
+    $this->savedSearch = $this->trustedSavedSearch ?? $this->savedSearch;
+    $this->display = $this->trustedDisplay ?? $this->display;
 
     // Get default display from system settings
     if (!$this->display) {
@@ -249,10 +257,36 @@ class AutocompleteAction extends AbstractAction {
    *
    * @param string $fieldName
    * @param mixed $value
+   * return $this
    */
   public function addFilter(string $fieldName, $value) {
     $this->filters[$fieldName] = $value;
     $this->trustedFilters[$fieldName] = $value;
+    return $this;
+  }
+
+  /**
+   * Method for `civi.api.prepare` listener to override the savedSearch.
+   *
+   * @param string|array $savedSearch
+   * return $this
+   */
+  public function overrideSavedSearch(mixed $savedSearch) {
+    $this->trustedSavedSearch = $savedSearch;
+    $this->savedSearch = NULL;
+    return $this;
+  }
+
+  /**
+   * Method for `civi.api.prepare` listener to override the display.
+   *
+   * @param string|array $display
+   * return $this
+   */
+  public function overrideDisplay(mixed $display) {
+    $this->trustedDisplay = $display;
+    $this->display = NULL;
+    return $this;
   }
 
   private function getCurrentSearchField(): ?string {

--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -25,7 +25,7 @@ use Civi\Core\HookInterface;
 class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService implements HookInterface {
 
   /**
-   * Set filters for the menubar quicksearch.
+   * Custom autocomplete for the menubar quicksearch.
    *
    * @param \Civi\API\Event\PrepareEvent $event
    */
@@ -36,37 +36,128 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
       $apiRequest->getFormName() === 'crmMenubar' &&
       $apiRequest->getFieldName() === 'crm-qsearch-input'
     ) {
-      $allowedFilters = \Civi::settings()->get('quicksearch_options');
-      foreach ($apiRequest->getFilters() as $fieldName => $val) {
-        if (in_array($fieldName, $allowedFilters)) {
-          $apiRequest->addFilter($fieldName, $val);
-        }
-      }
-    }
-  }
 
-  /**
-   */
-  public static function on_civi_search_autocompleteDefault(GenericHookEvent $e) {
-    // Adjust search params for menubar-quicksearch
-    if ($e->formName === 'crmMenubar' && $e->fieldName === 'crm-qsearch-input') {
-      // If doing a search by a field other than the default,
-      // add that field to the main column
-      if ($e->filters) {
-        $filterField = array_keys($e->filters)[0];
-        // If the filter is from a multi-record custom field set, add necessary join to the query
-        if (str_contains($filterField, '.')) {
-          [$customGroupName, $customFieldName] = explode('.', $filterField);
-          $customGroup = \CRM_Core_BAO_CustomGroup::getGroup(['name' => $customGroupName]);
-          if (!empty($customGroup['is_multiple'])) {
-            $e->savedSearch['api_params']['join'][] = [
-              "Custom_$customGroupName AS $customGroupName",
-              'INNER',
-              ['id', '=', "$customGroupName.entity_id"],
-            ];
+      // Override savedSearch
+      $savedSearch = [
+        'api_entity' => 'Contact',
+      ];
+      $apiParams = [];
+
+      $allowedFilters = \Civi::settings()->get('quicksearch_options');
+      foreach ($apiRequest->getFilters() as $filterField => $val) {
+        if (in_array($filterField, $allowedFilters)) {
+          // Add trusted filter
+          $apiRequest->addFilter($filterField, $val);
+          $apiRequest->setInput($val);
+
+          // If the filter is from a multi-record custom field set, add necessary join to the savedSearch query
+          if (str_contains($filterField, '.')) {
+            [$customGroupName, $customFieldName] = explode('.', $filterField);
+            $customGroup = \CRM_Core_BAO_CustomGroup::getGroup(['name' => $customGroupName]);
+            if (!empty($customGroup['is_multiple'])) {
+              $apiParams['join'][] = [
+                "Custom_$customGroupName AS $customGroupName",
+                'INNER',
+                ['id', '=', "$customGroupName.entity_id"],
+              ];
+            }
           }
         }
       }
+
+      // Override searchDisplay
+      $display = [
+        'settings' => [
+          'sort' => [
+            ['sort_name', 'ASC'],
+          ],
+        ],
+      ];
+
+      $columns = [
+        ['type' => 'field', 'key' => 'sort_name'],
+      ];
+
+      // Map contact_autocomplete_options settings to v4 format
+      $autocompleteOptionsMap = [
+        2 => 'email_primary.email',
+        3 => 'phone_primary.phone',
+        4 => 'address_primary.street_address',
+        5 => 'address_primary.city',
+        6 => 'address_primary.state_province_id:abbr',
+        7 => 'address_primary.country_id:label',
+        8 => 'address_primary.postal_code',
+      ];
+      // If doing a search by a field other than the default,
+      // add that field as the column
+      if ($apiRequest->getFilters()) {
+        $filterFields = array_keys($apiRequest->getFilters());
+        $columns[0]['rewrite'] = "[sort_name] :: [" . implode('] :: [', $filterFields) . "]";
+      }
+      else {
+        $filterFields = ['sort_name'];
+        if (\Civi::settings()->get('includeEmailInName')) {
+          $filterFields[] = 'email_primary.email';
+          $columns[] = ['type' => 'field', 'key' => 'email_primary.email'];
+        }
+        if (\Civi::settings()->get('includeNickNameInName')) {
+          $filterFields[] = 'nick_name';
+          $columns[0] = [
+            'type' => 'field',
+            'key' => 'nick_name',
+            'rewrite' => '[sort_name] "[nick_name]"',
+            'empty_value' => '[sort_name]',
+          ];
+        }
+      }
+      $autocompleteOptionsMap = array_diff($autocompleteOptionsMap, $filterFields);
+
+      // Add extra columns based on search preferences
+      $extraFields = [];
+      $autocompleteOptions = Setting::get(FALSE)
+        ->addSelect('contact_autocomplete_options')->execute()
+        ->first();
+      foreach ($autocompleteOptions['value'] ?? [] as $option) {
+        if (isset($autocompleteOptionsMap[$option])) {
+          $extraFields[] = $autocompleteOptionsMap[$option];
+          $columns[] = [
+            'type' => 'field',
+            'key' => $autocompleteOptionsMap[$option],
+          ];
+        }
+      }
+
+      $apiParams['select'] = array_unique(array_merge(['id'], $filterFields, $extraFields));
+      $display['settings']['columns'] = $columns;
+
+      // Single filter
+      if (count($filterFields) === 1) {
+        $display['settings']['searchFields'] = $filterFields;
+        $savedSearch['api_params'] = $apiParams;
+      }
+      // With multiple filters, a UNION is more performant
+      else {
+        $savedSearch['api_entity'] = 'EntitySet';
+        $savedSearch['api_params'] = [
+          'select' => $apiParams['select'],
+          'sets' => [],
+        ];
+        // Add limit to each subset for max efficiency
+        $apiParams['orderBy'] = ['sort_name' => 'ASC'];
+        $apiParams['limit'] = \Civi::settings()->get('search_autocomplete_count') ?: 15;
+        // Add a UNION per search field
+        $prefix = \Civi::settings()->get('includeWildCardInName') ? '%' : '';
+        foreach ($filterFields as $field) {
+          $params = $apiParams;
+          $params['where'] = [[$field, 'LIKE', $prefix . $apiRequest->getInput() . '%']];
+          $savedSearch['api_params']['sets'][] = ['UNION DISTINCT', 'Contact', 'get', $params];
+        }
+        // Remove filter as we've already embedded it in the WHERE clauses of each UNION
+        $apiRequest->setInput('');
+      }
+
+      $apiRequest->overrideSavedSearch($savedSearch);
+      $apiRequest->overrideDisplay($display);
     }
   }
 
@@ -106,62 +197,6 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
         ],
       ],
     ];
-    // Adjust search display for menubar-quicksearch
-    // The display only needs one column as the menubar autocomplete does not support descriptions
-    if (($e->context['formName'] ?? NULL) === 'crmMenubar' && ($e->context['fieldName'] ?? NULL) === 'crm-qsearch-input') {
-      $column = ['type' => 'field'];
-      // Map contact_autocomplete_options settings to v4 format
-      $autocompleteOptionsMap = [
-        2 => 'email_primary.email',
-        3 => 'phone_primary.phone',
-        4 => 'address_primary.street_address',
-        5 => 'address_primary.city',
-        6 => 'address_primary.state_province_id:abbr',
-        7 => 'address_primary.country_id:label',
-        8 => 'address_primary.postal_code',
-      ];
-      $filterFields = [];
-      // If doing a search by a field other than the default,
-      // add that field to the main column
-      if (!empty($e->context['filters'])) {
-        $filterFields[] = array_keys($e->context['filters'])[0];
-      }
-      else {
-        if (\Civi::settings()->get('includeEmailInName')) {
-          $filterFields[] = 'email_primary.email';
-        }
-        if (\Civi::settings()->get('includeNickNameInName')) {
-          $filterFields[] = 'nick_name';
-        }
-      }
-      if (!empty($filterFields)) {
-        // Take the first one as the key.
-        $column['key'] = $filterFields[0];
-        $column['empty_value'] = '[sort_name]';
-        $column['rewrite'] = "[sort_name]";
-        foreach ($filterFields as $filterField) {
-          $column['rewrite'] .= " :: [$filterField]";
-          $autocompleteOptionsMap = array_diff($autocompleteOptionsMap, [$filterField]);
-        }
-      }
-      // No filter & email search disabled: search on name only
-      else {
-        $column['key'] = 'sort_name';
-      }
-      $e->display['settings']['columns'] = [$column];
-      // Add exta columns based on search preferences
-      $autocompleteOptions = Setting::get(FALSE)
-        ->addSelect('contact_autocomplete_options')->execute()
-        ->first();
-      foreach ($autocompleteOptions['value'] ?? [] as $option) {
-        if (isset($autocompleteOptionsMap[$option])) {
-          $e->display['settings']['columns'][] = [
-            'type' => 'field',
-            'key' => $autocompleteOptionsMap[$option],
-          ];
-        }
-      }
-    }
   }
 
 }

--- a/tests/phpunit/api/v4/Action/AutocompleteQuicksearchTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteQuicksearchTest.php
@@ -30,6 +30,7 @@ class AutocompleteQuicksearchTest extends \api\v4\Api4TestBase {
   public function tearDown(): void {
     \Civi::settings()->revert('quicksearch_options');
     \Civi::settings()->revert('contact_autocomplete_options');
+    \Civi::settings()->revert('includeNickNameInName');
     parent::tearDown();
   }
 
@@ -37,6 +38,8 @@ class AutocompleteQuicksearchTest extends \api\v4\Api4TestBase {
     // Name + email
     Setting::set(FALSE)
       ->addValue('contact_autocomplete_options', [1, 2])
+      ->addValue('includeEmailInName', TRUE)
+      ->addValue('includeNickNameInName', FALSE)
       ->execute();
 
     $contacts = $this->saveTestRecords('Contact', [
@@ -51,7 +54,8 @@ class AutocompleteQuicksearchTest extends \api\v4\Api4TestBase {
       ->setInput('Aaa, A')
       ->execute()->indexBy('id');
 
-    $this->assertEquals('Aaa, A :: a@a.a', $result[$contacts[0]['id']]['label']);
+    $this->assertEquals('Aaa, A', $result[$contacts[0]['id']]['label']);
+    $this->assertEquals('a@a.a', $result[$contacts[0]['id']]['description'][0]);
     $this->assertArrayNotHasKey($contacts[1]['id'], $result);
 
     // Name + city
@@ -65,8 +69,9 @@ class AutocompleteQuicksearchTest extends \api\v4\Api4TestBase {
       ->setInput('Bbb, b')
       ->execute()->indexBy('id');
 
-    $this->assertEquals('Bbb, B :: b@b.b', $result[$contacts[1]['id']]['label']);
-    $this->assertEquals('B Town', $result[$contacts[1]['id']]['description'][0]);
+    $this->assertEquals('Bbb, B', $result[$contacts[1]['id']]['label']);
+    $this->assertEquals('b@b.b', $result[$contacts[1]['id']]['description'][0]);
+    $this->assertEquals('B Town', $result[$contacts[1]['id']]['description'][1]);
     $this->assertArrayNotHasKey($contacts[0]['id'], $result);
   }
 
@@ -113,6 +118,171 @@ class AutocompleteQuicksearchTest extends \api\v4\Api4TestBase {
     $this->assertEquals('Aaa, A :: Righto', $result[$contacts[0]['id']]['label']);
     $this->assertArrayNotHasKey($contacts[1]['id'], $result);
     $this->assertArrayNotHasKey($contacts[2]['id'], $result);
+  }
+
+  public function testQuicksearchAutocompleteWithNickname(): void {
+    // Set includeNickNameInName to true
+    Setting::set(FALSE)
+      ->addValue('includeNickNameInName', TRUE)
+      ->addValue('includeEmailInName', TRUE)
+      ->addValue('contact_autocomplete_options', [1, 2])
+      ->execute();
+
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        [
+          'first_name' => 'Robert',
+          'last_name' => 'Smith',
+          'nick_name' => 'Bob',
+          'email_primary.email' => 'bob@example.com',
+        ],
+        [
+          'first_name' => 'William',
+          'last_name' => 'Jones',
+          'nick_name' => 'Bill',
+          'email_primary.email' => 'bill@example.com',
+        ],
+        [
+          'first_name' => 'Mary',
+          'last_name' => 'Smith',
+          'nick_name' => '',
+          'email_primary.email' => 'mary@example.com',
+        ],
+      ],
+    ]);
+
+    // Test contact with nickname
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('Smith, Robert')
+      ->execute()->indexBy('id');
+
+    $this->assertEquals('Smith, Robert "Bob"', $result[$contacts[0]['id']]['label']);
+    $this->assertEquals('bob@example.com', $result[$contacts[0]['id']]['description'][0]);
+    $this->assertArrayNotHasKey($contacts[1]['id'], $result);
+    $this->assertArrayNotHasKey($contacts[2]['id'], $result);
+
+    // Test contact without nickname
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('Smith, Mary')
+      ->execute()->indexBy('id');
+
+    $this->assertEquals('Smith, Mary', $result[$contacts[2]['id']]['label']);
+    $this->assertEquals('mary@example.com', $result[$contacts[2]['id']]['description'][0]);
+    $this->assertArrayNotHasKey($contacts[0]['id'], $result);
+    $this->assertArrayNotHasKey($contacts[1]['id'], $result);
+
+    // Test searching by nickname
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('Bill')
+      ->execute()->indexBy('id');
+
+    $this->assertEquals('Jones, William "Bill"', $result[$contacts[1]['id']]['label']);
+    $this->assertEquals('bill@example.com', $result[$contacts[1]['id']]['description'][0]);
+    $this->assertArrayNotHasKey($contacts[0]['id'], $result);
+    $this->assertArrayNotHasKey($contacts[2]['id'], $result);
+
+    // Test searching by last name returns both Smith contacts
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('Smith')
+      ->execute()->indexBy('id');
+
+    $this->assertCount(2, $result);
+    $this->assertEquals('Smith, Robert "Bob"', $result[$contacts[0]['id']]['label']);
+    $this->assertEquals('Smith, Mary', $result[$contacts[2]['id']]['label']);
+  }
+
+  public function testQuicksearchAutocompleteWithWildcard(): void {
+    // Set includeWildCardInName to true
+    Setting::set(FALSE)
+      ->addValue('includeWildCardInName', TRUE)
+      ->addValue('includeEmailInName', TRUE)
+      ->addValue('contact_autocomplete_options', [1, 2])
+      ->execute();
+
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        [
+          'first_name' => 'Robert',
+          'last_name' => 'AttestXYZsmith',
+          'email_primary.email' => 'bob@example.com',
+        ],
+        [
+          'first_name' => 'William',
+          'last_name' => 'TestXYZsmithson',
+          'email_primary.email' => 'bill@example.com',
+        ],
+        [
+          'first_name' => 'Mary',
+          'last_name' => 'TestXYZblacksmith',
+          'email_primary.email' => 'mary@example.com',
+        ],
+      ],
+    ]);
+
+    // Test that partial last name returns all matching contacts
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('testXYZsmith')
+      ->execute()->indexBy('id');
+
+    // Should return all contacts containing 'TestXYZsmith' in alphabetical order
+    $this->assertCount(2, $result);
+    $this->assertEquals('AttestXYZsmith, Robert', $result[$contacts[0]['id']]['label']);
+    $this->assertEquals('bob@example.com', $result[$contacts[0]['id']]['description'][0]);
+    $this->assertEquals('TestXYZsmithson, William', $result[$contacts[1]['id']]['label']);
+
+    // Test that exact match still works
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('AttestXYZsmith, Robert')
+      ->execute()->indexBy('id');
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('AttestXYZsmith, Robert', $result[$contacts[0]['id']]['label']);
+
+    // Turn off email. Now it won't use a UNION but should behave the same
+    Setting::set(FALSE)
+      ->addValue('contact_autocomplete_options', [1])
+      ->addValue('includeEmailInName', FALSE)
+      ->execute();
+
+    // Test that partial last name returns all matching contacts
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('testXYZsmith')
+      ->execute()->indexBy('id');
+
+    // Should return all contacts containing 'TestXYZsmith' in alphabetical order
+    $this->assertCount(2, $result);
+    $this->assertEquals('AttestXYZsmith, Robert', $result[$contacts[0]['id']]['label']);
+    $this->assertEmpty($result[$contacts[0]['id']]['description']);
+    $this->assertEquals('TestXYZsmithson, William', $result[$contacts[1]['id']]['label']);
+
+    // Turn off wildcard and verify behavior change
+    Setting::set(FALSE)
+      ->addValue('includeWildCardInName', FALSE)
+      ->execute();
+
+    $result = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setInput('AttestXYZ')
+      ->execute()->indexBy('id');
+
+    // Should only return exact matches now
+    $this->assertCount(1, $result);
+    $this->assertEquals('AttestXYZsmith, Robert', $result[$contacts[0]['id']]['label']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes breakage caused by #33237, and brings back the UNIONs that were used in the `Api3.getquick` action.