### PR TITLE
Fix permission denied in logs when uninstalling extension

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -466,6 +466,7 @@ function afform_civicrm_referenceCounts($dao, &$counts) {
     ];
     try {
       $displays = civicrm_api4('SearchDisplay', 'get', [
+        'checkPermissions' => FALSE,
         'where' => [['saved_search_id', '=', $dao->id]],
       ], ['name']);
       foreach ($displays as $displayName) {


### PR DESCRIPTION
Overview
----------------------------------------
While trying (as yet, unsuccessfully) to debug https://github.com/systopia/de.systopia.eck/issues/177 I found that a bunch of permission denied errors appear in the logs every time you uninstall an extension using cv ext:uninstall.

The extension needs to ship some Afforms to trigger the error.

Eg.
```
[debug] $API Request Authorization failed = #0 /home/matthew-wire/buildkit/build/so/web/core/Civi/API/Kernel.php(148): CRM_Core_Error::backtrace("API Request Authorization failed", TRUE)
#1 /home/matthew-wire/buildkit/build/so/web/core/Civi/Api4/Generic/AbstractAction.php(251): Civi\API\Kernel->runRequest(Object(Civi\Api4\Generic\DAOGetAction))
#2 /home/matthew-wire/buildkit/build/so/web/core/api/api.php(102): Civi\Api4\Generic\AbstractAction->execute()
#3 /home/matthew-wire/buildkit/build/so/web/core/ext/afform/core/afform.php(468): civicrm_api4("SearchDisplay", "get", (Array:1), (Array:1))
#4 /home/matthew-wire/buildkit/build/so/web/core/CRM/Utils/Hook.php(276): afform_civicrm_referenceCounts(Object(CRM_Contact_DAO_SavedSearch), (Array:0))
#5 /home/matthew-wire/buildkit/build/so/web/core/CRM/Utils/Hook.php(194): CRM_Utils_Hook->runHooks((Array:20), "civicrm_referenceCounts", 2, Object(CRM_Contact_DAO_SavedSearch), (Array:0), NULL, NULL, NULL, NULL)
#6 /home/matthew-wire/buildkit/build/so/web/core/CRM/Utils/Hook/Standalone.php(43): CRM_Utils_Hook->commonInvoke(2, Object(CRM_Contact_DAO_SavedSearch), (Array:0), NULL, NULL, NULL, NULL, "civicrm_referenceCounts", "")
#7 /home/matthew-wire/buildkit/build/so/web/core/Civi/Core/CiviEventDispatcher.php(314): CRM_Utils_Hook_Standalone->invokeViaUF(2, Object(CRM_Contact_DAO_SavedSearch), (Array:0), NULL, NULL, NULL, NULL, "civicrm_referenceCounts")
#8 /home/matthew-wire/buildkit/build/so/web/core/vendor/symfony/event-dispatcher/EventDispatcher.php(230): Civi\Core\CiviEventDispatcher::delegateToUF(Object(Civi\Core\Event\GenericHookEvent), "hook_civicrm_referenceCounts", Object(Civi\Core\UnoptimizedEventDispatcher))
#9 /home/matthew-wire/buildkit/build/so/web/core/vendor/symfony/event-dispatcher/EventDispatcher.php(59): Symfony\Component\EventDispatcher\EventDispatcher->callListeners((Array:1), "hook_civicrm_referenceCounts", Object(Civi\Core\Event\GenericHookEvent))
#10 /home/matthew-wire/buildkit/build/so/web/core/Civi/Core/CiviEventDispatcher.php(263): Symfony\Component\EventDispatcher\EventDispatcher->dispatch(Object(Civi\Core\Event\GenericHookEvent), "hook_civicrm_referenceCounts")
#11 /home/matthew-wire/buildkit/build/so/web/core/CRM/Utils/Hook.php(168): Civi\Core\CiviEventDispatcher->dispatch("hook_civicrm_referenceCounts", Object(Civi\Core\Event\GenericHookEvent))
#12 /home/matthew-wire/buildkit/build/so/web/core/CRM/Utils/Hook.php(871): CRM_Utils_Hook->invoke((Array:2), Object(CRM_Contact_DAO_SavedSearch), (Array:0), NULL, NULL, NULL, NULL, "civicrm_referenceCounts")
#13 /home/matthew-wire/buildkit/build/so/web/core/Civi/Schema/SqlEntityStorage.php(61): CRM_Utils_Hook::referenceCounts(Object(CRM_Contact_DAO_SavedSearch), (Array:0))
#14 /home/matthew-wire/buildkit/build/so/web/core/Civi/Schema/EntityProvider.php(94): Civi\Schema\SqlEntityStorage->getReferenceCounts((Array:1))
#15 /home/matthew-wire/buildkit/build/so/web/core/Civi/Api4/Utils/CoreUtil.php(337): Civi\Schema\EntityProvider->getReferenceCounts((Array:1))
#16 /home/matthew-wire/buildkit/build/so/web/core/CRM/Core/ManagedEntities.php(405): Civi\Api4\Utils\CoreUtil::getRefCount("SavedSearch", 73)
#17 /home/matthew-wire/buildkit/build/so/web/core/CRM/Core/ManagedEntities.php(156): CRM_Core_ManagedEntities->removeStaleEntity((Array:9))
#18 /home/matthew-wire/buildkit/build/so/web/core/CRM/Core/ManagedEntities.php(90): CRM_Core_ManagedEntities->reconcileEntities((Array:22))
#19 /home/matthew-wire/buildkit/build/so/web/core/Civi/Core/Rebuilder.php(202): CRM_Core_ManagedEntities->reconcile()
#20 /home/matthew-wire/buildkit/build/so/web/core/CRM/Extension/Manager.php(516): Civi\Core\Rebuilder->execute()
#21 /home/matthew-wire/buildkit/build/so/web/core/api/v3/Extension.php(178): CRM_Extension_Manager->uninstall((Array:1))
#22 /home/matthew-wire/buildkit/build/so/web/core/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_extension_uninstall((Array:3))
#23 /home/matthew-wire/buildkit/build/so/web/core/Civi/API/Kernel.php(153): Civi\API\Provider\MagicFunctionProvider->invoke((Array:8))
#24 /home/matthew-wire/buildkit/build/so/web/core/Civi/API/Kernel.php(79): Civi\API\Kernel->runRequest((Array:8))
#25 /home/matthew-wire/buildkit/build/so/web/core/api/api.php(28): Civi\API\Kernel->runSafe("Extension", "uninstall", (Array:3))
#26 phar:///home/matthew-wire/buildkit/bin/cv/src/Util/VerboseApi.php(17): civicrm_api("Extension", "uninstall", (Array:3))
#27 phar:///home/matthew-wire/buildkit/bin/cv/src/Command/ExtensionUninstallCommand.php(49): Civi\Cv\Util\VerboseApi::callApi3Success("Extension", "uninstall", (Array:3))
#28 phar:///home/matthew-wire/buildkit/bin/cv/vendor/symfony/console/Command/Command.php(155): Civi\Cv\Command\ExtensionUninstallCommand->execute(Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#29 phar:///home/matthew-wire/buildkit/bin/cv/vendor/symfony/console/Application.php(680): Cvphar\Symfony\Component\Console\Command\Command->run(Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#30 phar:///home/matthew-wire/buildkit/bin/cv/vendor/symfony/console/Application.php(218): Cvphar\Symfony\Component\Console\Application->doRunCommand(Object(Civi\Cv\Command\ExtensionUninstallCommand), Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#31 phar:///home/matthew-wire/buildkit/bin/cv/lib/src/BaseApplication.php(99): Cvphar\Symfony\Component\Console\Application->doRun(Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#32 phar:///home/matthew-wire/buildkit/bin/cv/vendor/symfony/console/Application.php(124): Civi\Cv\BaseApplication->doRun(Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#33 phar:///home/matthew-wire/buildkit/bin/cv/lib/src/BaseApplication.php(66): Cvphar\Symfony\Component\Console\Application->run(Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#34 phar:///home/matthew-wire/buildkit/bin/cv/lib/src/BaseApplication.php(28): Civi\Cv\BaseApplication->run(Object(Civi\Cv\Util\CvArgvInput), Object(Cvphar\Symfony\Component\Console\Output\ConsoleOutput))
#35 phar:///home/matthew-wire/buildkit/bin/cv/bin/cv(32): Civi\Cv\BaseApplication::main("cv", "phar:///home/matthew-wire/buildkit/bin/cv/bin", (Array:3))
#36 /home/matthew-wire/buildkit/bin/cv(15): require("phar:///home/matthew-wire/buildkit/bin/cv/bin/cv")
#37 {main}
```

Before
----------------------------------------
Multiple `$API Request Authorization failed` errors in the CiviCRM logs

After
----------------------------------------
No errors in the logs

Technical Details
----------------------------------------
There are a few API4 calls in `afform_civicrm_referenceCounts()`. All are set to checkPermissions=FALSE except SearchDisplay::get which does not specify. Looking at the callers and the code it seems like this is an omission and should also specify checkPermissions=FALSE

Comments
----------------------------------------
@colemanw 
