### PR TITLE
Always call constructor for ECK entities so we always have valid field definitions and joins work

### DIFF
--- a/Civi/Schema/LegacySqlEntityMetadata.php
+++ b/Civi/Schema/LegacySqlEntityMetadata.php
@@ -58,7 +58,16 @@ class LegacySqlEntityMetadata extends EntityMetadataBase {
   public function getFields(): array {
     $fields = [];
     $primaryKeys = $this->getProperty('primary_keys');
-    foreach ($this->getClassName()::fields() as $uniqueName => $legacyField) {
+    $className = $this->getClassName();
+    if (isset($this->entityName)) {
+      // Make sure we always call the constructor for ECK entities
+      $class = new $className($this->entityName);
+      $daoFields = $class::fields();
+    }
+    else {
+      $daoFields = $className()::fields();
+    }
+    foreach ($daoFields as $uniqueName => $legacyField) {
       $fieldName = $legacyField['name'];
       $field = [
         'title' => $legacyField['title'] ?? $fieldName,


### PR DESCRIPTION
Overview
----------------------------------------
This fixes https://github.com/systopia/de.systopia.eck/issues/177

Before
----------------------------------------
Sometimes metadata is rebuilt without calling the constructor for the DAO (see https://github.com/systopia/de.systopia.eck/blob/master/CRM/Eck/DAO/Entity.php#L112)

That results in all the joins being missing

After
----------------------------------------
Explicitly call the constructor for LegacySqlEntityMetadata. `fields()` always returns valid data

Technical Details
----------------------------------------
This is hard to reproduce, except when it's easy. Eventually I reliably reproduced on a local WordPress dev site by running `cv ext:uninstall civirules`

Running `cv flush` afterwards fixed the problem.

Comments
----------------------------------------
@colemanw 
