### PR TITLE
SearchKitBatch - More efficient saving

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -80,7 +80,11 @@
         },
         link: function (scope, element, attrs, ngModel) {
           ngModel.$render = function () {
-            element.val(ngModel.$viewValue).change();
+            const viewVal = ngModel.$viewValue || '';
+            // Prevent unnecessarily triggering ngChagne
+            if (element.val() != viewVal) {
+              element.val(viewVal).change();
+            }
           };
           let settings = angular.copy(scope.crmUiDatepicker || {});
           // Set defaults to be non-restrictive

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
@@ -79,7 +79,6 @@ class CreateBatch extends AbstractAction {
     ];
 
     $tableColumns = [];
-    $defaultValues = [];
 
     foreach ($this->display['settings']['columns'] as $column) {
       if (empty($column['spec'])) {
@@ -88,9 +87,6 @@ class CreateBatch extends AbstractAction {
       $fieldSpec = $column['spec'];
       $tableColumns[$fieldSpec['name']] = $this->getSqlType($fieldSpec);
       $fieldSpec['label'] = $column['label'];
-      if (isset($column['default'])) {
-        $defaultValues[$fieldSpec['name']] = $column['default'];
-      }
       $userJob['metadata']['DataSource']['column_headers'][] = $column['label'];
       $userJob['metadata']['DataSource']['column_specs'][$fieldSpec['name']] = $fieldSpec;
       $userJob['metadata']['DataSource']['targets'] = $this->targets;
@@ -111,10 +107,10 @@ class CreateBatch extends AbstractAction {
       ->setValues($userJob)
       ->execute()->single();
 
-    // Add rows of default values per $this->rowCount
+    // Add rows per $this->rowCount (default values will be filled in by the API)
     if ($this->rowCount > 0) {
       $apiName = 'Import_' . $userJob['id'];
-      $values = array_fill(0, $this->rowCount, $defaultValues);
+      $values = array_fill(0, $this->rowCount, []);
       civicrm_api4($apiName, 'save', ['records' => $values]);
     }
 

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/BatchDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/BatchDisplaySubscriber.php
@@ -69,6 +69,7 @@ class BatchDisplaySubscriber extends AutoService implements EventSubscriberInter
         }
         $column['spec']['required'] = !empty($column['required']);
         $column['spec']['nullable'] = empty($column['required']);
+        $column['spec']['api_default'] = $column['default'] ?? NULL;
         $columnNames[] = $column['spec']['name'];
       }
       // Redundant with spec and less-reliable

--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SKBatchSpecProvider.php
@@ -57,6 +57,9 @@ class SKBatchSpecProvider extends AutoService implements SpecProviderInterface {
       $field->setType('Field');
       $field->setSerialize($column['serialize'] ?? NULL);
       $field->setNullable($column['nullable'] ?? TRUE);
+      if ($spec->getAction() === 'create') {
+        $field->setDefaultValue($column['api_default'] ?? NULL);
+      }
       $field->setColumnName($column['name']);
       if (!empty($column['options'])) {
         $field->setSuffixes($column['suffixes']);

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
@@ -48,23 +48,24 @@
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
   <div>
     <div class="btn-group" ng-if="!$ctrl.loading">
-      <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        <i class="crm-i fa-plus"></i>
+      <button type="button" class="btn btn-primary dropdown-toggle" ng-disabled="$ctrl.addingRows" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i class="crm-i fa-plus" ng-if="!$ctrl.addingRows"></i>
+        <i class="crm-i fa-spin fa-spinner" ng-if="$ctrl.addingRows"></i>
         {{:: ts('Add Rows...') }}
         <span class="caret"></span>
       </button>
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu" ng-if="!$ctrl.addingRows">
         <li><a href ng-click="$ctrl.addRows(1)" >{{:: ts('Add 1 Row') }}</a></li>
         <li ng-repeat="n in [5, 10, 25, 50, 100] track by $index">
           <a href ng-click="$ctrl.addRows(n)" >{{:: ts('Add %1 Rows', {1: n}) }}</a>
         </li>
       </ul>
     </div>
-    <button type="button" ng-if="$ctrl.userJobId" class="btn btn-primary" ng-click="$ctrl.saveRows()" ng-disabled="!$ctrl.unsavedChanges || $ctrl.saving">
-      <i ng-if="$ctrl.unsavedChanges && !$ctrl.saving" class="crm-i fa-save"></i>
-      <i ng-if="!$ctrl.unsavedChanges && !$ctrl.saving" class="crm-i fa-check"></i>
+    <button type="button" ng-if="$ctrl.userJobId" class="btn btn-primary" ng-click="$ctrl.saveRows()" ng-disabled="!$ctrl.unsaved.length || $ctrl.saving">
+      <i ng-if="$ctrl.unsaved.length && !$ctrl.saving" class="crm-i fa-save"></i>
+      <i ng-if="!$ctrl.unsaved.length && !$ctrl.saving" class="crm-i fa-check"></i>
       <i ng-if="$ctrl.saving" class="crm-i fa-spin fa-spinner"></i>
-      {{ $ctrl.unsavedChanges || $ctrl.saving ? ts('Save Changes') : ts('Changes Saved') }}
+      {{ $ctrl.unsaved.length || $ctrl.saving ? ts('Save Changes') : ts('Changes Saved') }}
     </button>
     <button type="button" ng-if="$ctrl.userJobId" class="btn btn-{{ $ctrl.isValid() ? 'success' : 'warning' }}" ng-click="$ctrl.doImport()">
       <i class="crm-i fa-download"></i>

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatchBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatchBody.html
@@ -2,7 +2,7 @@
   <td>{{ (($ctrl.page - 1) * $ctrl.limit) + rowIndex + 1 }}</td>
   <td ng-repeat="(colIndex, col) in $ctrl.settings.columns" class="crm-search-col-type-{{:: col.type + ($ctrl.results.editable[col.key] && $ctrl.results.editable[col.key].input_type !== 'DisplayOnly' ? ' crm-search-field-editable crm-search-field-editing' : '') }}">
     <span class="crm-search-field-value" ng-if="!$ctrl.results.editable[col.key] || $ctrl.results.editable[col.key].input_type === 'DisplayOnly'">{{ row.data[col.key] }}</span>
-    <crm-search-input ng-if="$ctrl.results.editable[col.key] && $ctrl.results.editable[col.key].input_type !== 'DisplayOnly'" class="form-inline" field="$ctrl.results.editable[col.key]" name="{{ $ctrl.getFieldName(rowIndex, col.key) }}" ng-model="row.data[col.spec.name]" ng-change="$ctrl.onChangeData(rowIndex)" crm-search-input-focus="false"></crm-search-input>
+    <crm-search-input ng-if="$ctrl.results.editable[col.key] && $ctrl.results.editable[col.key].input_type !== 'DisplayOnly'" class="form-inline" field="$ctrl.results.editable[col.key]" name="{{ $ctrl.getFieldName(rowIndex, col.key) }}" ng-model="row.data[col.spec.name]" ng-change="$ctrl.onChangeData(row)" crm-search-input-focus="false"></crm-search-input>
   </td>
   <td>
     <button type="button" class="btn btn-primary btn-xs" ng-click="$ctrl.deleteRow(rowIndex)">

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -42,6 +42,10 @@
         };
 
         function formatDataType(val) {
+          // Prevent unnecessarily triggering ngChagne
+          if (val === null || val === undefined) {
+            return val;
+          }
           // Do not reformat pseudoconstant values (:name, :label, etc)
           if (ctrl.optionKey && ctrl.optionKey !== 'id') {
             return val;


### PR DESCRIPTION
Overview
----------------------------------------
This increases the max number of rows the display can handle. Instead of saving all rows at once, it watches changes and only saves updated rows, dramatically improving performance and scalability.

Before
----------------------------------------
Slow saves, possible timeouts.

After
----------------------------------------
Super fast saves.
