### PR TITLE
standalone: apply trim() to given username on login form

### DIFF
--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -39,7 +39,7 @@
         // Remove the current status popup messages.
         CRM.$('#crm-notification-container .ui-notify-message').remove();
         const response = await CRM.api4('User', 'login', {
-          identifier: username.value,
+          identifier: username.value.trim(),
           password: password.value,
           originalUrl
         });


### PR DESCRIPTION
On standalone, if you accidentally have a space character at start or end of your username, your credentials won't match. This will infuriate and panic visual users because you can't see what's wrong. 

This change simply applies trim() to the value of username sent to the API which should avoid this papercut.

Yes it means that usernames cannot start or end with a space. I can't imagine that would be a use-case we'd recommend supporting though!

[Pain and sympathy](https://chat.civicrm.org/civicrm/pl/g4gm4cxi9t88bqnw4zt7iom1xr)