### PR TITLE
Add ability to continue imports from import listing

### DIFF
--- a/CRM/Import/DataSource.php
+++ b/CRM/Import/DataSource.php
@@ -492,6 +492,7 @@ abstract class CRM_Import_DataSource implements DataSourceInterface {
       'new' => ['new', 'valid'],
       'valid' => ['valid'],
       'imported' => ['imported', 'soft_credit_imported', 'pledge_payment_imported', 'warning_unparsed_address'],
+      'unimported' => ['new', 'valid', 'error', 'invalid', 'soft_credit_error', 'pledge_payment_error', 'invalid_no_match'],
     ];
   }
 

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -127,23 +127,14 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
    * @throws \CRM_Core_Exception
    */
   private function getButtons(): array {
-    // FIXME: This is a hack...
     // The tpl contains javascript that starts the import on form submit
     // Since our back/cancel buttons are of html type "submit" we have to prevent a form submit event when they are clicked
     // Hacking in some onclick js to make them act more like links instead of buttons
-    $path = CRM_Utils_System::currentPath();
-    $query = ['_qf_MapField_display' => 'true'];
-    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
-    if (CRM_Utils_Rule::qfKey($qfKey)) {
-      $query['qfKey'] = $qfKey;
-    }
-    $previousURL = CRM_Utils_System::url($path, $query, FALSE, NULL, FALSE);
-    $cancelURL = CRM_Utils_System::url($path, 'reset=1', FALSE, NULL, FALSE);
     $buttons = [
       [
         'type' => 'back',
         'name' => ts('Previous'),
-        'js' => ['onclick' => "location.href='{$previousURL}'; return false;"],
+        'js' => ['onclick' => "location.href='" . $this->getPreviousUrl() . "'; return false;"],
       ],
     ];
     if ($this->hasImportableRows()) {
@@ -157,10 +148,30 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
     $buttons[] = [
       'type' => 'cancel',
       'name' => ts('Cancel'),
-      'js' => ['onclick' => "location.href='{$cancelURL}'; return false;"],
+      'js' => ['onclick' => "location.href='" . $this->getCancelUrl() . "'; return false;"],
     ];
 
     return $buttons;
+  }
+
+  /**
+   * @return string
+   */
+  protected function getCancelURL(): string {
+    return CRM_Utils_System::url(CRM_Utils_System::currentPath(), 'reset=1', FALSE, NULL, FALSE);
+  }
+
+  /**
+   * @return string
+   * @throws \CRM_Core_Exception
+   */
+  protected function getPreviousURL(): string {
+    $query = ['_qf_MapField_display' => 'true'];
+    $qfKey = CRM_Utils_Request::retrieve('qfKey', 'String');
+    if (CRM_Utils_Rule::qfKey($qfKey)) {
+      $query['qfKey'] = $qfKey;
+    }
+    return CRM_Utils_System::url(CRM_Utils_System::currentPath(), $query, FALSE, NULL, FALSE);
   }
 
 }

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -964,4 +964,17 @@ class CRM_Import_Forms extends CRM_Core_Form {
     return $this->savedMappingID;
   }
 
+  /**
+   * Is the form being run in standalone mode.
+   *
+   * The import historically only runs as connected QuickForm forms
+   * (using the CRM_Import_Controller) - however, the forms will now (often)
+   * load as individual forms, without the controller in standalone mode.
+   *
+   * @return bool
+   */
+  public function isStandalone(): bool {
+    return !$this->controller instanceof CRM_Import_Controller;
+  }
+
 }

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1031,9 +1031,11 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    */
   public function validate(): void {
     $dataSource = $this->getDataSourceObject();
+    $dataSource->setStatuses(['unimported']);
     while ($row = $dataSource->getRow()) {
       $this->validateRow($row);
     }
+    $dataSource->setStatuses([]);
   }
 
   /**
@@ -1351,7 +1353,9 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $dataSource->setLimit($limit);
 
     while ($row = $dataSource->getRow()) {
-      $parser->import($row);
+      if ($parser->validateRow($row)) {
+        $parser->import($row);
+      }
     }
     $parser->doPostImportActions();
     return TRUE;

--- a/CRM/Import/StateMachine.php
+++ b/CRM/Import/StateMachine.php
@@ -73,7 +73,7 @@ class CRM_Import_StateMachine extends CRM_Core_StateMachine {
   }
 
   private function getMapFieldFormName(): string {
-    return $this->classPrefix . '_Form_MapField';
+    return class_exists($this->classPrefix . '_Form_MapField') ? $this->classPrefix . '_Form_MapField' : 'CRM_CiviImport_Form_Generic_MapField';
   }
 
   private function getPreviewFormName(): string {

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -40,7 +40,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
       'columnHeaders' => $this->getColumnHeaders(),
       'dateFormats' => $this->getDateFormats(),
       'isTemplate' => $this->getUserJob()['is_template'],
-      'isStandalone' => !$this->controller instanceof CRM_Import_Controller,
+      'isStandalone' => $this->isStandalone(),
     ]);
   }
 
@@ -213,16 +213,12 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
   }
 
   /**
-   * Process the mapped fields and map it into the uploaded file
-   * preview the file and extract some summary statistics
+   * Do nothing on post process.
    *
-   * @noinspection PhpUnhandledExceptionInspection
+   * The angular form has already done this work & validation is now done on preview.
    */
   public function postProcess(): void {
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
-    $parser = $this->getParser();
-    $parser->init();
-    $parser->validate();
   }
 
 }

--- a/ext/civiimport/CRM/CiviImport/Form/Preview.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Preview.php
@@ -12,11 +12,35 @@ class CRM_CiviImport_Form_Preview extends CRM_Import_Form_Preview {
   }
 
   public function preProcess(): void {
+    $parser = $this->getParser();
+    $parser->init();
+    $parser->validate();
     parent::preProcess();
     $this->assign('isOpenResultsInNewTab', TRUE);
     $this->assign('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $this->getUserJobID() . '/Import_' . $this->getUserJobID() . '?_status=ERROR', FALSE));
     $this->assign('allRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $this->getUserJobID() . '/Import_' . $this->getUserJobID(), FALSE));
     $this->assign('importedRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $this->getUserJobID() . '/Import_' . $this->getUserJobID() . '?_status=IMPORTED', FALSE));
+  }
+
+  /**
+   * @return string
+   */
+  protected function getCancelURL(): string {
+    if ($this->isStandalone()) {
+      return CRM_Utils_System::url('civicrm/imports/my-listing');
+    }
+    return parent::getCancelURL();
+  }
+
+  /**
+   * @return string
+   * @throws \CRM_Core_Exception
+   */
+  protected function getPreviousURL(): string {
+    if ($this->isStandalone()) {
+      return CRM_Utils_System::url('civicrm/import_mapping', ['id' => $this->getUserJobID()]);
+    }
+    return parent::getPreviousURL();
   }
 
 }

--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -129,6 +129,49 @@ return [
                   'task' => '',
                   'condition' => [],
                 ],
+                [
+                  'size' => 'btn-xs',
+                  'links' => [
+                    [
+                      'entity' => 'UserJob',
+                      'action' => 'view',
+                      'join' => '',
+                      'target' => 'crm-popup',
+                      'icon' => '',
+                      'text' => E::ts('View User Job'),
+                      'style' => 'default',
+                      'path' => '',
+                      'task' => '',
+                      'conditions' => [
+                        [
+                          'status_id:name',
+                          '!=',
+                          'draft',
+                        ],
+                      ],
+                    ],
+                    [
+                      'path' => 'civicrm/import_mapping?id=[id]',
+                      'icon' => 'fa-external-link',
+                      'text' => E::ts('Continue'),
+                      'style' => 'default',
+                      'conditions' => [
+                        [
+                          'status_id:name',
+                          '=',
+                          'draft',
+                        ],
+                      ],
+                      'task' => '',
+                      'entity' => '',
+                      'action' => '',
+                      'join' => '',
+                      'target' => '',
+                    ],
+                  ],
+                  'type' => 'buttons',
+                  'alignment' => 'text-right',
+                ],
               ],
               'type' => 'buttons',
               'alignment' => 'text-right',
@@ -407,6 +450,12 @@ return [
               'sortable' => TRUE,
             ],
             [
+              'type' => 'field',
+              'key' => 'status_id:label',
+              'label' => E::ts('Status'),
+              'sortable' => TRUE,
+            ],
+            [
               'size' => 'btn-xs',
               'links' => [
                 [
@@ -419,7 +468,31 @@ return [
                   'style' => 'default',
                   'path' => '',
                   'task' => '',
-                  'condition' => [],
+                  'conditions' => [
+                    [
+                      'status_id:name',
+                      '!=',
+                      'draft',
+                    ],
+                  ],
+                ],
+                [
+                  'path' => 'civicrm/import_mapping?id=[id]',
+                  'icon' => 'fa-external-link',
+                  'text' => E::ts('Continue'),
+                  'style' => 'default',
+                  'conditions' => [
+                    [
+                      'status_id:name',
+                      '=',
+                      'draft',
+                    ],
+                  ],
+                  'task' => '',
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
                 ],
               ],
               'type' => 'buttons',

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -310,6 +310,9 @@
                 // Just redirect to the template listing.
                 window.location.href = CRM.url('civicrm/imports/templates');
               }
+              else if ($scope.isStandalone) {
+                window.location.href = CRM.url('civicrm/import_preview', {'id' : $scope.userJob.id});
+              }
               else {
                 // Only post the form if the save succeeds.
                 document.getElementById("MapField").submit();

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -9,9 +9,9 @@
 </div>
 
 <div class="crm-submit-buttons" ng-if="!isTemplate">
-  <button class="crm-form-submit cancel crm-button crm-button-type-back crm-button_qf_MapField_back" value="1" type="submit" name="_qf_MapField_back" ng-click="save" id="_qf_MapField_back-top"><i aria-hidden="true" class="crm-i fa-chevron-left"></i> Previous</button>
-  <button class="crm-form-submit default validate crm-button crm-button-type-next crm-button_qf_MapField_next" value="1" type="submit" name="_qf_MapField_next" ng-click="save($event)" id="_qf_MapField_next-top"><i aria-hidden="true" class="crm-i fa-check"></i> Continue</button>
-  <button class="crm-form-submit cancel crm-button crm-button-type-cancel crm-button_qf_MapField_cancel" value="1" type="submit" name="_qf_MapField_cancel" ng-click="save($event)" id="_qf_MapField_cancel-top"><i aria-hidden="true" class="crm-i fa-times"></i> Cancel</button>
+  <button ng-if="!isStandalone" class="crm-form-submit cancel crm-button crm-button-type-back crm-button_qf_MapField_back" value="1" type="submit" name="_qf_MapField_back" id="_qf_MapField_back-bottom"><i aria-hidden="true" class="crm-i fa-chevron-left"></i>{{:: ts('Previous') }}</button>
+  <button ng-click="save($event)" class="crm-form-submit default validate crm-button crm-button-type-next crm-button_qf_MapField_next" value="1" type="submit" name="_qf_MapField_next" id="_qf_MapField_next-bottom"><i aria-hidden="true" class="crm-i fa-check"></i><span ng-if="!isStandalone">{{:: ts('Continue') }}</span><span ng-if="isTemplate">{{:: ts('Save Template') }}</span><span ng-if="!isTemplate && isStandalone">{{:: ts('Continue') }}</span></button>
+  <button ng-if="!isStandalone" class="crm-form-submit cancel crm-button crm-button-type-cancel crm-button_qf_MapField_cancel" value="1" type="submit" name="_qf_MapField_cancel" id="_qf_MapField_cancel-bottom"><i aria-hidden="true" class="crm-i fa-times"></i>{{:: ts('Cancel') }}</button>
 </div>
 
 <div class="crm-block crm-form-block crm-import-mappings-form-block">

--- a/ext/civiimport/xml/Menu/Import.xml
+++ b/ext/civiimport/xml/Menu/Import.xml
@@ -8,4 +8,11 @@
     <access_arguments>access CiviCRM</access_arguments>
     <weight>520</weight>
   </item>
+  <item>
+    <path>civicrm/import_preview</path>
+    <title>Import Preview</title>
+    <page_callback>CRM_CiviImport_Form_Generic_Preview</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+    <weight>520</weight>
+  </item>
 </menu>

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -189,7 +189,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
 
     $values = ['Contribution.contact_id' => $contactID, 'Contribution.total_amount' => 10, 'Contribution.financial_type_id' => 'Donation', 'Contribution.payment_instrument_id' => 'not at all random'];
     $this->runImport($values, 'create');
-    $contribution = $this->callAPISuccessGetSingle('Contribution', ['ontact_id' => $contactID, 'payment_instrument_id' => 'random']);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $contactID, 'payment_instrument_id' => 'random']);
     $this->assertEquals('not at all random', $contribution['payment_instrument']);
   }
 
@@ -278,9 +278,6 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       [],
     ];
     $submittedValues = $this->doUserJobImport($importMappings);
-    $row = $this->getDataSource()->getRow();
-    // a valid status here means it has been able to incorporate the default_value.
-    $this->assertEquals('VALID', $row['_status']);
 
     $this->submitPreviewForm($submittedValues);
     $row = $this->getDataSource()->getRow();
@@ -331,6 +328,8 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $form->buildForm();
     $this->assertTrue($form->validate());
     $form->postProcess();
+    $form = $this->getPreviewForm($submittedValues);
+    $form->preProcess();
     return $submittedValues;
   }
 
@@ -769,6 +768,8 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $form->buildForm();
     $this->assertTrue($form->validate());
     $form->postProcess();
+    $form = $this->getPreviewForm($submittedValues);
+    $form->preProcess();
     $row = $this->getDataSource()->getRows()[0];
     $this->assertEquals('ERROR', $row[10]);
     $this->assertEquals('Invalid value for field(s) : Contribution Campaign', $row[11]);

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -188,31 +188,26 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
     // When setting up for the test make sure the IDs match those in the csv.
     $this->assertEquals(1, $this->eventCreatePaid(['is_template' => TRUE])['id']);
     $this->assertEquals(3, $this->individualCreate());
-    try {
-      $this->importCSV('participant_with_event_id.csv', [
-        ['name' => 'Participant.event_id'],
-        ['name' => 'do_not_import'],
-        ['name' => 'Participant.contact_id'],
-        ['name' => 'Participant.fee_amount'],
-        ['name' => 'do_not_import'],
-        ['name' => 'Participant.fee_level'],
-        ['name' => 'Participant.is_pay_later'],
-        ['name' => 'Participant.role_id'],
-        ['name' => 'Participant.source'],
-        ['name' => 'Participant.status_id'],
-        ['name' => 'Participant.register_date'],
-        ['name' => 'do_not_import'],
-        ['name' => 'do_not_import'],
-      ], ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
-    }
-    catch (CRM_Core_Exception $e) {
-      $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
-      $row = $dataSource->getRow();
-      $this->assertEquals('ERROR', $row['_status']);
-      $this->assertEquals('Missing required fields: Participant ID OR Event ID', $row['_status_message']);
-      return;
-    }
-    $this->fail('exception expected');
+
+    $this->importCSV('participant_with_event_id.csv', [
+      ['name' => 'Participant.event_id'],
+      ['name' => 'do_not_import'],
+      ['name' => 'Participant.contact_id'],
+      ['name' => 'Participant.fee_amount'],
+      ['name' => 'do_not_import'],
+      ['name' => 'Participant.fee_level'],
+      ['name' => 'Participant.is_pay_later'],
+      ['name' => 'Participant.role_id'],
+      ['name' => 'Participant.source'],
+      ['name' => 'Participant.status_id'],
+      ['name' => 'Participant.register_date'],
+      ['name' => 'do_not_import'],
+      ['name' => 'do_not_import'],
+    ], ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
+    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
+    $row = $dataSource->getRow();
+    $this->assertEquals('ERROR', $row['_status']);
+    $this->assertEquals('Missing required fields: Participant ID OR Event ID', $row['_status_message']);
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -427,23 +427,18 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    * Test the full form-flow import.
    */
   public function testImportCSV() :void {
-    try {
-      $this->importCSV('memberships_invalid.csv', [
-        ['name' => 'Contact.id'],
-        ['name' => 'Membership.source'],
-        ['name' => 'Membership.membership_type_id'],
-        ['name' => 'Membership.start_date'],
-        ['name' => 'do_not_import'],
-      ]);
-    }
-    catch (CRM_Core_Exception $e) {
-      $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
-      $row = $dataSource->getRow();
-      $this->assertEquals('ERROR', $row['_status']);
-      $this->assertEquals('Invalid value for field(s) : Membership Type', $row['_status_message']);
-      return;
-    }
-    $this->fail('should have thrown an exception');
+    $this->importCSV('memberships_invalid.csv', [
+      ['name' => 'Contact.id'],
+      ['name' => 'Membership.source'],
+      ['name' => 'Membership.membership_type_id'],
+      ['name' => 'Membership.start_date'],
+      ['name' => 'do_not_import'],
+    ]);
+    $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
+    $row = $dataSource->getRow();
+    $this->assertEquals('ERROR', $row['_status']);
+    $this->assertEquals('Invalid value for field(s) : Membership Type', $row['_status_message']);
+    return;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add ability to continue imports from import listing

Before
----------------------------------------
It can be a bit of a pain if you start an import and then something is not right & to get back to where you were you have to start again


After
----------------------------------------
<img width="1068" height="448" alt="image" src="https://github.com/user-attachments/assets/ebafce31-f066-4952-bc96-55de800f5e25" />

The form is the same as the wizard form - but it does not have the previous or cancel buttons - the import can be picked up from here

<img width="1055" height="908" alt="image" src="https://github.com/user-attachments/assets/1996ba42-1b2b-4e95-93fb-31a8ba6ba8a2" />


Technical Details
----------------------------------------
I'm only showing the links for drafts at the moment - actually it is potentially useful even for 'completed' ones as completed means that all the rows are processed, but does not preclude the possibility that same rows failed & you might want to fix the mapping and re-run the failed ones. I have left that condition on the links view for now but might revisit that

Comments
----------------------------------------
