### PR TITLE
dev/financial#234 Update the Financial Type of linked Price Field Val…

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Settings.php
+++ b/CRM/Contribute/Form/ContributionPage/Settings.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\PriceField;
+use Civi\Api4\PriceFieldValue;
+
 /**
  *
  * @package CRM
@@ -337,6 +340,18 @@ class CRM_Contribute_Form_ContributionPage_Settings extends CRM_Contribute_Form_
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, 'ContributionPage');
 
     $dao = CRM_Contribute_BAO_ContributionPage::writeRecord($params);
+
+    $priceSetId = CRM_Price_BAO_PriceSet::getFor('civicrm_contribution_page', $dao->id, NULL);
+    if (!empty($priceSetId) && CRM_Price_BAO_PriceSet::isQuickConfig($priceSetId)) {
+      $priceFieldIds = PriceField::get(FALSE)
+        ->addWhere('price_set_id', '=', $priceSetId)
+        ->execute()
+        ->column('id');
+      PriceFieldValue::update(FALSE)
+        ->addValue('financial_type_id', $params['financial_type_id'])
+        ->addWhere('price_field_id', 'IN', $priceFieldIds)
+        ->execute();
+    }
 
     $ufJoinParams = [
       'is_organization' => [


### PR DESCRIPTION
…ues of a contribution page when it is changed if the price set is a quick config

Overview
----------------------------------------
This makes sure that when a financial type is changed on a contribution page that uses a Quick Config price set that the financial type id of any linked Price Field Value records get updated

Before
----------------------------------------
Price Field Value financial type might not match the page's financial type

After
----------------------------------------
Price Field Value is corrected

ping @eileenmcnaughton @Edzelopez 