### PR TITLE
Replace tokenClasse with more generic getClassesByProperty

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -97,9 +97,12 @@ class CRM_Core_DAO_AllCoreTables {
    * Get the declared token classes.
    * @return string[]
    *   [table_name => token class]
+   *
+   * @deprecated since 6.6 will be removed around 6.20.
    */
-  public static function tokenClasses() {
-    return array_column(self::getEntities(), 'token_class', 'name');
+  public static function tokenClasses(): array {
+    CRM_Core_Error::deprecatedFunctionWarning('use getClassesByProperty');
+    return \CRM_Core_DAO_AllCoreTables::getClassesByProperty('token_class');
   }
 
   /**
@@ -501,6 +504,15 @@ class CRM_Core_DAO_AllCoreTables {
         \Civi\Core\Resolver::singleton()->call($filter, $args);
       }
     }
+  }
+
+  /**
+   * @param string $property
+   *
+   * @return array
+   */
+  public static function getClassesByProperty(string $property): array {
+    return array_column(self::getEntities(), $property, 'name');
   }
 
 }

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -392,7 +392,8 @@ class Container {
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
     // For each DAO that supports tokens by declaring the token class...
-    $entities = \CRM_Core_DAO_AllCoreTables::tokenClasses();
+    $entities = \CRM_Core_DAO_AllCoreTables::getClassesByProperty('token_class');
+
     foreach ($entities as $entity => $class) {
       $container->setDefinition('crm_entity_token_' . strtolower($entity), new Definition(
         $class,


### PR DESCRIPTION
Overview
----------------------------------------
Replace tokenClasse with more generic getClassesByProperty

Before
----------------------------------------
`tokenClasses()` was added last year to use for the generic tokens work - but is specific where we could be generic. No other known or expected callers

After
----------------------------------------
More generic `getClassesByProperty()`

Technical Details
----------------------------------------
I have an upcoming PR that will leverage this but it stands alone as a sensible thing to do

Comments
----------------------------------------
