### PR TITLE
Add support for generic imports

### DIFF
--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -72,7 +72,7 @@ class CRM_Event_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    *
    * @return void
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->addSavedMappingFields();
     $this->addFormRule(['CRM_Event_Import_Form_MapField', 'formRule'], $this);
     $this->addMapper();

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -449,6 +449,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
           'Template' => ['mapping_id' => $this->getSavedMappingID()],
           'import_mappings' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_mappings'] : [],
           'import_options' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_options'] : [],
+          'base_entity' => $this->getBaseEntity(),
         ],
       ])
       ->execute()
@@ -480,7 +481,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  protected function updateUserJobMetadata(string $key, array|int $data): void {
+  protected function updateUserJobMetadata(string $key, array|int|string $data): void {
     $metaData = array_merge(
       $this->getUserJob()['metadata'],
       [$key => $data]

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -674,7 +674,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @return array
    */
   public function getRequiredFieldsForEntity(string $entity, string $action): array {
-    $entityMetadata = $this->getImportEntities()[$entity];
+    $entityMetadata = $this->getAvailableImportEntities()[$entity];
     if ($action === 'select') {
       // Select uses the same lookup as update.
       $action = 'update';
@@ -1058,10 +1058,10 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @throws \CRM_Core_Exception
    */
   protected function validateParams(array $params): void {
-    if (empty($params['id']) && empty($params[$this->baseEntity]['id'])) {
-      $entityConfiguration = $this->getImportEntities()[$this->baseEntity];
+    if (empty($params['id']) && empty($params[$this->getBaseEntity()]['id'])) {
+      $entityConfiguration = $this->getAvailableImportEntities()[$this->getBaseEntity()];
       $entity = $entityConfiguration['entity_name'] ?? '';
-      $this->validateRequiredFields($this->getRequiredFields(), $params[$this->baseEntity] ?? $params, $entity);
+      $this->validateRequiredFields($this->getRequiredFields(), $params[$this->getBaseEntity()] ?? $params, $entity);
     }
     $errors = [];
     foreach ($params as $key => $value) {
@@ -1223,6 +1223,10 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     return [
       'Contact' => ['text' => ts('Contact Fields'), 'is_contact' => TRUE],
     ];
+  }
+
+  public function getAvailableImportEntities(): array {
+    return $this->getImportEntities();
   }
 
   /**

--- a/CRM/Import/StateMachine.php
+++ b/CRM/Import/StateMachine.php
@@ -53,7 +53,11 @@ class CRM_Import_StateMachine extends CRM_Core_StateMachine {
       $this->classPrefix = $classPrefix;
     }
     elseif ($this->entity) {
-      $entityPath = explode('_', CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->entity));
+      $entityName = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->entity);
+      if (!$entityName) {
+        throw new CRM_Core_Exception(ts('Invalid import entity %1', [htmlentities($this->entity), 'String']));
+      }
+      $entityPath = explode('_', $entityName);
       $this->classPrefix = $entityPath[0] . '_' . $entityPath[1] . '_Import';
     }
     else {
@@ -69,7 +73,7 @@ class CRM_Import_StateMachine extends CRM_Core_StateMachine {
   }
 
   private function getDataSourceFormName(): string {
-    return $this->classPrefix . '_Form_DataSource';
+    return class_exists($this->classPrefix . '_Form_DataSource') ? $this->classPrefix . '_Form_DataSource' : 'CRM_CiviImport_Form_Generic_DataSource';
   }
 
   private function getMapFieldFormName(): string {

--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -157,6 +157,7 @@ return [
       'description' => E::ts('Type of grant. Implicit FK to civicrm_option_value in grant_type option_group.'),
       'add' => '1.8',
       'usage' => [
+        'import',
         'export',
         'token',
       ],

--- a/ext/civiimport/CRM/CiviImport/Form/Generic/DataSource.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Generic/DataSource.php
@@ -14,13 +14,31 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Import\GenericParser;
 
 /**
  * This class provides a generic import MapField form.
  *
  * It can be loaded outside the form controller.
  */
-class CRM_CiviImport_Form_Generic_MapField extends \CRM_CiviImport_Form_MapField {
+class CRM_CiviImport_Form_Generic_DataSource extends \CRM_CiviImport_Form_DataSource {
+
   use CRM_CiviImport_Form_Generic_GenericTrait;
+
+  /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    return 'import_generic';
+  }
+
+  public function getParser(): GenericParser {
+    /* @var \Civi\Import\GenericParser $parser */
+    $parser = parent::getParser();
+    $parser->setBaseEntity($this->getBaseEntity());
+    return $parser;
+  }
 
 }

--- a/ext/civiimport/CRM/CiviImport/Form/Generic/GenericTrait.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Generic/GenericTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+trait CRM_CiviImport_Form_Generic_GenericTrait {
+
+  /**
+   * Get the base entity for the import.
+   *
+   * @return string
+   */
+  protected function getBaseEntity(): string {
+    if (!$this->isStandalone()) {
+      return $this->controller->getStateMachine()->getEntity();
+    }
+    elseif ($this->getUserJobID()) {
+      return $this->getUserJob()['metadata']['base_entity'];
+    }
+    $pathArguments = explode('/', (CRM_Utils_System::currentPath() ?: ''));
+    unset($pathArguments[0], $pathArguments[1]);
+    return CRM_Utils_String::convertStringToCamel(implode('_', $pathArguments));
+  }
+
+}

--- a/ext/civiimport/CRM/CiviImport/Form/Generic/Preview.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Generic/Preview.php
@@ -21,6 +21,7 @@
  * It can be loaded outside the form controller.
  */
 class CRM_CiviImport_Form_Generic_Preview extends \CRM_CiviImport_Form_Preview {
+  use CRM_CiviImport_Form_Generic_GenericTrait;
 
   /**
    * Use the form name to create the tpl file name.

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -97,7 +97,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
    *
    */
   protected function getAvailableImportEntities(): array {
-    return $this->getParser()->getImportEntities();
+    return $this->getParser()->getAvailableImportEntities();
   }
 
   /**
@@ -219,6 +219,16 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
    */
   public function postProcess(): void {
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
+  }
+
+  /**
+   * Build the form object.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm(): void {
+    $this->addSavedMappingFields();
+    $this->addFormButtons();
   }
 
 }

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -82,15 +82,6 @@ class ContributionParser extends ImportParser {
   }
 
   /**
-   * Get the required fields.
-   *
-   * @return array
-   */
-  public function getRequiredFields(): array {
-    return [[$this->getRequiredFieldsForMatch(), $this->getRequiredFieldsForCreate()]];
-  }
-
-  /**
    * Get required fields to create a contribution.
    *
    * @return array

--- a/ext/civiimport/Civi/Import/GenericParser.php
+++ b/ext/civiimport/Civi/Import/GenericParser.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Import;
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * class to parse import csv files
+ */
+class GenericParser extends ImportParser {
+
+  protected string $baseEntity;
+
+  public function getBaseEntity(): string {
+    if (!isset($this->baseEntity)) {
+      $this->baseEntity = $this->getUserJob()['metadata']['base_entity'] ?? '';
+    }
+    return $this->baseEntity;
+  }
+
+  public function setBaseEntity(string $entity) {
+    $this->baseEntity = $entity;
+  }
+
+  /**
+   * Get information about the provided job.
+   *
+   *  - name
+   *  - id (generally the same as name)
+   *  - label
+   *
+   * @return array
+   */
+  public static function getUserJobInfo(): array {
+    return [
+      'import_generic' => [
+        'id' => 'import_generic',
+        'name' => 'import_generic',
+        'label' => ts('Import'),
+        'entity' => '%',
+        'url' => 'civicrm/import/%',
+      ],
+    ];
+  }
+
+  /**
+   * Set field metadata.
+   */
+  protected function setFieldMetadata(): void {
+    if (empty($this->importableFieldsMetadata)) {
+      $fields = ['' => ['title' => ts('- do not import -')]];
+      foreach ($this->getImportFieldsForEntity($this->getBaseEntity()) as $field) {
+        $field['entity_instance'] = $this->getBaseEntity();
+        $field['entity_prefix'] = 'Contribution.';
+        $fields[$this->getBaseEntity() . '.' . $field['name']] = $field;
+      }
+      if (isset($fields[$this->getBaseEntity() . '.' . 'contact_id'])) {
+        $fields += $this->getContactFields($this->getContactType(), 'Contact');
+        unset($fields[$this->getBaseEntity() . '.contact_id']);
+      }
+      $this->importableFieldsMetadata = $fields;
+    }
+  }
+
+  public function getImportableFieldsMetadata():array {
+    if (empty($this->importableFieldsMetadata)) {
+      $this->setFieldMetadata();
+    }
+    return parent::getImportableFieldsMetadata();
+  }
+
+  /**
+   * Get a list of entities this import supports.
+   *
+   * @return array
+   */
+  public function getAvailableImportEntities() : array {
+    $fields = $this->getImportableFieldsMetadata();
+    $entities = [
+      $this->getBaseEntity() => [
+        'text' => $this->getBaseEntity(),
+        'required_fields_update' => $this->getRequiredFieldsForMatch(),
+        'required_fields_create' => $this->getRequiredFieldsForCreate(),
+        'is_base_entity' => TRUE,
+        'supports_multiple' => FALSE,
+        'is_required' => TRUE,
+        'actions' => [
+          ['id' => 'update', 'text' => ts('Update existing'), 'description' => ts('Skip if no match found')],
+          ['id' => 'create', 'text' => ts('Create'), 'description' => ts('Skip if already exists')],
+        ],
+        'default_action' => 'create',
+        'entity_name' => $this->getBaseEntity(),
+        'entity_title' => $this->getBaseEntity(),
+        'selected' => ['action' => 'create'],
+      ],
+    ];
+    // Just add the most basic contact entity for now.
+    // We could run of FKs but we also need to consider the complexity of the UI
+    // for a new-to-civi task like importing.
+    if (isset($fields['Contact.id'])) {
+      $entities['Contact'] = [
+        'text' => ts('Contact Fields'),
+        'unique_fields' => ['external_identifier', 'id'],
+        'is_contact' => TRUE,
+        'supports_multiple' => FALSE,
+        'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),
+        'selected' => [
+          'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
+          'contact_type' => 'Individual',
+          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+        ],
+        'default_action' => 'select',
+        'entity_name' => 'Contact',
+        'entity_title' => ts('Contact'),
+      ];
+    }
+    return $entities;
+  }
+
+  /**
+   * Get required fields to match a contribution.
+   *
+   * @return array
+   */
+  public function getRequiredFieldsForMatch(): array {
+    return [[$this->getBaseEntity() . '.id']];
+  }
+
+  /**
+   * Get required fields to create a contribution.
+   *
+   * @return array
+   */
+  protected function getRequiredFieldsForCreate(): array {
+    $fields = [];
+    foreach ($this->getImportableFieldsMetadata() as $field) {
+      if (!empty($field['required']) && $field['entity'] === $this->getBaseEntity()
+        // We should probably require the fields required for contact ID
+        // but for now we leave this to fail on import.
+        && $field['name'] !== 'contact_id'
+      ) {
+        $fields[] = $this->getBaseEntity() . '.' . $field['name'];
+      }
+    }
+    return $fields;
+  }
+
+  /**
+   * Handle the values in import mode.
+   *
+   * @param array $values
+   *   The array of values belonging to this line.
+   *
+   * @return int
+   *   the result of this processing - which is ignored
+   */
+  public function import(array $values) {
+    $values = array_values($values);
+    $rowNumber = (int) ($values[array_key_last($values)]);
+    try {
+      $params = $this->getMappedRow($values);
+      $this->removeEmptyValues($params);
+      \CRM_Utils_Hook::importAlterMappedRow('import', $this->getBaseEntity() . '_import', $params, $values, $this->getUserJobID());
+
+      $existing = !isset($params[$this->getBaseEntity()]['id']) ? [] : civicrm_api4($this->getBaseEntity(), 'get', [
+        'where' => [['id', '=', $this->getBaseEntity()]['id']],
+      ])->single();
+      if (!empty($params['Contact'])) {
+        $params['Contact']['id'] = $this->getContactID($params['Contact'] ?? [], ($existing['contact_id'] ?? NULL), 'Contact', $this->getDedupeRulesForEntity('Contact'));
+        $params[$this->getBaseEntity()]['contact_id'] = $this->saveContact('Contact', $params['Contact'] ?? []) ?: $params['Contact']['id'];
+      }
+      $entity = civicrm_api4($this->baseEntity, 'save', [
+        'records' => [$params[$this->baseEntity]],
+      ])->first();
+      $this->setImportStatus($rowNumber, 'IMPORTED', '', $entity['id']);
+      return \CRM_Import_Parser::VALID;
+
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->setImportStatus($rowNumber, 'ERROR', $e->getMessage());
+      return \CRM_Import_Parser::ERROR;
+    }
+  }
+
+}

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -399,4 +399,13 @@ abstract class ImportParser extends \CRM_Import_Parser {
     return $this->getDedupeRule($contactType)['fields'];
   }
 
+  /**
+   * Get the required fields.
+   *
+   * @return array
+   */
+  protected function getRequiredFields(): array {
+    return [[$this->getRequiredFieldsForMatch(), $this->getRequiredFieldsForCreate()]];
+  }
+
 }

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -39,7 +39,7 @@
           $scope.entitySelection = [];
           var entityConfiguration = $scope.userJob.metadata.entity_configuration;
           _.each($scope.data.entityMetadata, function (entityMetadata) {
-            var selected = Boolean(entityConfiguration) ? entityConfiguration[entityMetadata.entity_name] : entityMetadata.selected;
+            var selected = (Boolean(entityConfiguration) && Boolean(entityConfiguration[entityMetadata.entity_name])) ? entityConfiguration[entityMetadata.entity_name] : entityMetadata.selected;
             // If our selected action is not available then fall back to the entity default.
             // This would happen if we went back to the DataSource screen & made a change, as the
             // php layer filters on that configuration options


### PR DESCRIPTION
Overview
----------------------------------------
Add support for generic imports **No navigation menu items are added - this is a hidden feature - and I expect to iterate**

Before
----------------------------------------
It is not possible to import (e.g) grants without installing an extension

After
----------------------------------------
the url `civicrm/import/grant`  will allow for grants to be imported


Technical Details
----------------------------------------
The url specifies the entity - so a range of entities can be imported this way - although I am sure various challenges will arise when actually testing it.

The fields available to import depend on the metadata - hence in this PR I had to update the usage for `grant_type_id` to include `import` to make it available.

Note the import permits update & create and also does dedupe finds of contacts - these are features of other imports but preclude much sharing with the SK batch data class or leveraging of that logic. Instead I've kept it really simple for now, permitting the base entity and any contact specifically referenced by `contact_id`. There is a hope to expand on this

In terms of which entities are available - it will basically attempt any valid entity - all api calls are v4 & should use check_permissions. However, an earlier iteration of this PR considered defining availability on the entity type - ie

<img width="557" height="540" alt="image" src="https://github.com/user-attachments/assets/63be01d2-1a88-4f99-a579-4a6ae101294a" />

**No navigation menu items are added - this is a hidden feature - although csvimporter might start to expose it in lieu of ... doing anything actually in the extension**


Comments
----------------------------------------
