### PR TITLE
Clean up entity_data tracking in import

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -211,6 +211,8 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   protected function getImportFieldsForEntity(string $entity): array {
     return (array) civicrm_api4($entity, 'getFields', [
       'where' => [['usage', 'CONTAINS', 'import']],
+      'orderBy' => ['title'],
+      'action' => 'save',
     ])->indexBy('name');
   }
 

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -56,6 +56,16 @@ abstract class ImportParser extends \CRM_Import_Parser {
   }
 
   /**
+   * @param string $entity
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getEntityInstanceConfiguration(string $entity): array {
+    return $this->getUserJob()['metadata']['entity_configuration'][$entity] ?? [];
+  }
+
+  /**
    * Get the actions to display in the rich UI.
    *
    * Filter by the input actions - e.g ['update' 'select'] will only return those keys.

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -287,21 +287,12 @@
             $scope.userJob.metadata.entity_configuration[entity.id] = entity.selected;
           });
           _.each($scope.data.importMappings, function (importRow, index) {
-            selectedEntity = $scope.getEntityForField(importRow.selectedField);
-            var entityConfig = {};
-            if (selectedEntity === 'SoftCreditContact') {
-              // For now we just hard-code this - mapping to soft_credit a bit undefined - but
-              // we are mimicking getMappingFieldFromMapperInput on the php layer.
-              // Could get it from entity_data but .... later.
-              entityConfig = {'soft_credit': $scope.userJob.metadata.entity_configuration[selectedEntity]};
-            }
 
             $scope.userJob.metadata.import_mappings.push({
               name: importRow.selectedField,
               default_value: importRow.defaultValue,
               // At this stage column_number is thrown away but we store it here to have it for when we change that.
               column_number: index,
-              entity_data: entityConfig,
             });
           });
           crmApi4('UserJob', 'save', {records: [$scope.userJob]})

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -112,7 +112,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'Contribution.financial_type_id'],
       ['name' => 'Contact.external_identifier'],
       ['name' => 'SoftCreditContact.external_identifier', 'entity_data' => ['soft_credit' => ['soft_credit_type_id' => 1]]],
-      ['name' => 'note'],
+      ['name' => 'Contribution.note'],
     ];
     $this->importCSV('contributions_amount_validate.csv', $mapping);
 
@@ -296,9 +296,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $submittedValues = [
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => 'Organization',
       'dataSource' => 'CRM_Import_DataSource_CSV',
-      'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
     ];
     $this->submitDataSourceForm('soft_credit_extended.csv', $submittedValues);
     $metadata = UserJob::get()->addWhere('id', '=', $this->userJobID)->addSelect('metadata')->execute()->first()['metadata'];
@@ -314,11 +312,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
         'contact_type' => 'Individual',
         'action' => 'create',
         'dedupe_rule' => 'IndividualSupervised',
-        'entity_data' => [
-          'soft_credit' => [
-            'soft_credit_type_id' => 1,
-          ],
-        ],
+        'soft_credit_type_id' => 1,
       ],
     ];
     UserJob::update()->addWhere('id', '=', $this->userJobID)
@@ -536,7 +530,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'Contact.email_primary.email'],
       ['name' => 'Contact.address_primary.state_province_id'],
       ['name' => 'Contribution.source'],
-      ['name' => 'note'],
+      ['name' => 'Contribution.note'],
       [],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
@@ -1013,7 +1007,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'Contribution.financial_type_id'],
       ['name' => 'Contact.email_primary.email'],
       ['name' => 'Contribution.source'],
-      ['name' => 'note'],
+      ['name' => 'Contribution.note'],
       ['name' => 'Contribution.trxn_id'],
     ], $submittedValues, $action, $entityConfiguration);
     return new CRM_Import_DataSource_CSV($this->userJobID);

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -165,7 +165,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
       ['name' => 'Participant.id'],
       ['name' => 'Participant.status_id'],
       ['name' => 'Participant.' . $this->getCustomFieldName('radio', 4)],
-    ], ['onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE]);
+    ], [], 'update');
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();
     $this->assertEquals('IMPORTED', $row['_status'], $row['_status_message']);

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -55,8 +55,15 @@ trait CRMTraits_Import_ParserTrait {
     $userJobMetadata = UserJob::get()
       ->addWhere('id', '=', $this->userJobID)
       ->execute()->first()['metadata'];
+    $userJobMetadata['entity_configuration'][$userJobMetadata['base_entity']]['action'] = $action;
+    $userJobMetadata['entity_configuration']['Contact']['contact_type'] = $submittedValues['contactType'];
+    foreach ($fieldMappings as $index => $mapping) {
+      if (isset($mapping['entity_data'])) {
+        $userJobMetadata['entity_configuration']['SoftCreditContact'] = $mapping['entity_data']['soft_credit'];
+        unset($fieldMappings[$index]['entity_data']);
+      }
+    }
     $userJobMetadata['import_mappings'] = $fieldMappings;
-    $userJobMetadata['entity_configuration']['Contribution']['action'] = $action;
     if ($entityConfiguration) {
       foreach ($entityConfiguration as $entity => $configuration) {
         if (isset($userJobMetadata['entity_configuration'][$entity])) {


### PR DESCRIPTION


Overview
----------------------------------------
Clean up entity_data tracking in import

Before
----------------------------------------
entity_data is saved at the row level & at the import level - the former being a copy of the latter.

After
----------------------------------------

This simplifies to the latter, although the row level links to the latter with the prefix ie SoftCreditContact.first_name implicitly links to the config for SoftCreditContact

Technical Details
----------------------------------------

Comments
----------------------------------------
