### PR TITLE
Standalone - Add nav menu for 'User Permissions'

### DIFF
--- a/ext/standaloneusers/ang/afsearchPermissions.aff.php
+++ b/ext/standaloneusers/ang/afsearchPermissions.aff.php
@@ -7,4 +7,9 @@ return [
   'icon' => 'fa-list-alt',
   'server_route' => 'civicrm/admin/rolepermissions',
   'permission' => ['cms:administer users'],
+  'navigation' => [
+    'parent' => 'Users and Permissions',
+    'label' => E::ts('User Permissions'),
+    'weight' => 0,
+  ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
This adds an item to the "Users and Permissions" nav menu in standalone which lets you go directly to the permissions screen instead of needing to click through the User Roles screen first.