### PR TITLE
Profile: location types

### DIFF
--- a/CRM/UF/Form/Field.php
+++ b/CRM/UF/Form/Field.php
@@ -1031,6 +1031,7 @@ class CRM_UF_Form_Field extends CRM_Core_Form {
    */
   private function getLocationTypes(): array {
     $locationTypes = \Civi::entity('Address')->getOptions('location_type_id');
+    $locationTypes = array_column($locationTypes, NULL, 'id');
     $defaultLocationTypeID = CRM_Core_BAO_LocationType::getDefault()->id;
     $firstTypes = [0 => 'Primary'];
     // Make the default option show up first.


### PR DESCRIPTION
Overview
----------------------------------------
When adding two Phone field for Primary and Other, and Main as the default location types, Phone Other seems to override Phone Primary.

Reproduction steps
----------------------------------------
1. Create new user-defined profile.
2. Add contact phone field.
   a. Contact -> Phone -> Other -> Phone -> Save
4. Change default LocationTypes to Main.
5. Edit the created Phone Field.
6. Without saving, details suddenly changed: Contact -> Phone -> Primary -> empty. 

Current behaviour
----------------------------------------
When adding two Phone field for Primary and Other, and Main as the default location types, Phone Other seems to override Phone Primary.

Expected behaviour
----------------------------------------
It should not override anything.

Environment information
----------------------------------------
* CiviCRM:__ _6.4.0_
* WordPress:__ _6.8.2_

Issue
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6016