### PR TITLE
RiverLea: makes inactive/disabled row state clearer visually

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -287,6 +287,18 @@ dl dl {
   color: var(--crm-c-inactive);
   opacity: 1;
 }
+.crm-container tr.disabled,
+.crm-container tr:has(td.disabled),
+.crm-container .table-striped > tbody > tr:has(td.disabled) {
+  background-color: var(--crm-c-page-background);
+}
+.crm-container tr.disabled td *:not(.btn,button),
+.crm-container td.disabled {
+  font-style: italic;
+}
+.crm-container tr.disabled td:first-of-type {
+  display: inline-flex;
+}
 
 /* BS3 type styles */
 

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -231,7 +231,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 /* Inactive icon */
 .crm-container tr.disabled td:first-of-type::before,
 .crm-container tr:has(.disabled) td:first-of-type::before {
-  content: "\f05e";
+  content: "\f05e" / "Disabled row.";
   color: var(--crm-alert-danger-text);
   font-style: normal;
 }

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -26,6 +26,8 @@ input#crm-qsearch-input::placeholder {
 #crm-notification-container .ui-notify-message a.ui-notify-cross::before,
 .crm-container #crm-notification-container div.ui-notify-message h1::before,
 div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
+.crm-container tr.disabled td:first-of-type::before,
+.crm-container tr:has(.disabled) td:first-of-type::before,
 .crm-container .delete-icon,
 .crm-container span.batch-valid,
 .crm-container span.batch-invalid,
@@ -224,6 +226,14 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .delete-icon:hover::before,
 .crm-container .delete-icon:focus::before {
   color: var(--crm-icon-danger-color);
+}
+
+/* Inactive icon */
+.crm-container tr.disabled td:first-of-type::before,
+.crm-container tr:has(.disabled) td:first-of-type::before {
+  content: "\f05e";
+  color: var(--crm-alert-danger-text);
+  font-style: normal;
 }
 
 /* Jqueery UI icons (tags) */


### PR DESCRIPTION
Overview
----------------------------------------
When a row in a table is enabled/disabled, it's visual appearance changes. In Greenwich this was done by reducing opacity of the row, but this lower the colour contrast ratio on the text to something far below WCAG AA. RiverLea addressed this with a colour variable `--crm-c-inactive` but this is set so close to the text colour it's almost impossible to see, which is both bad UX and bad for accessibility.

This PR makes three visual changes to a row that's not been enabled:
 - changes the row's background colour to the Stream's page-background colour, normally different to either striped row colour.
 - Adds italic/emphasis styling to the text
 - Adds a 'danger-colour 'ban' FontAwesome icon with the first table of a delete row. This isn't the perfect icon, but it's the closest I could think of with Font Awesome.
 
Before: disabled and enabled rows are very similar
----------------------------------------
<img width="3194" height="610" alt="image" src="https://github.com/user-attachments/assets/49b534a9-e4e1-4cb1-8505-6cb434398245" />
<img width="2224" height="624" alt="image" src="https://github.com/user-attachments/assets/67c4b87e-8e7f-406b-a69e-b634335a1273" />

After: they're not
----------------------------------------
<img width="2466" height="600" alt="image" src="https://github.com/user-attachments/assets/80e19835-0f9e-405c-89d8-19674a81ca62" />
<img width="2232" height="584" alt="image" src="https://github.com/user-attachments/assets/d600567c-2f09-4d01-9868-0dd25d5fd8ff" />

### Other streams:
<img width="2092" height="408" alt="image" src="https://github.com/user-attachments/assets/33bebeb6-9470-4dd0-a65b-b596065fc28c" />
<img width="1796" height="330" alt="image" src="https://github.com/user-attachments/assets/c8e998fd-8998-4b57-9477-1f6768c70852" />
<img width="2152" height="380" alt="image" src="https://github.com/user-attachments/assets/b7f4951d-ba1d-4ebf-95da-21bf2ff78a08" />
<img width="2466" height="700" alt="image" src="https://github.com/user-attachments/assets/9584db86-762f-4782-8489-d5d245cb60de" />

Technical Details
----------------------------------------
This applies on `<tr class="disabled">` and `<td class="disabled">`. It's not been applied to the `cancelled` class, or tested against `<tr class="disabled"><td class="disabled">` if that exists somewhere.

Comments
----------------------------------------
Tables behave in lots of ways in Civi, so testing this against a range of table scenarios would be good. cc-ing @artfulrobot as impacts Thames UI.

Also worth noting the PR doesn't resolve wide problems around the inaccessibility of inactive row states, [as discussed here](https://chat.civicrm.org/civicrm/pl/1iyfms1w5fn35nnaaaa6isqurr). cc @JoeMurray. 

Problem originally flagged [in this issue](https://lab.civicrm.org/dev/core/-/issues/5912).