### PR TITLE
dev/core#6005 check for db data before cleaning up Managed Custom Fields/Groups

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1030,6 +1030,32 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
   }
 
   /**
+   * Get the number of rows in the value table with a not NULL value for this field
+   * - this will prevent automatic cleanup of the CustomField if there is data for it
+   */
+  public static function on_hook_civicrm_referenceCounts($e) {
+    $dao = $e->dao;
+    if (!is_a($dao, \CRM_Core_DAO_CustomField::class)) {
+      return;
+    }
+    $dao->find(TRUE);
+    $columnName = $dao->column_name;
+
+    $customGroup = CRM_Core_DAO_CustomGroup::findById($dao->custom_group_id);
+
+    $tableName = $customGroup->table_name;
+    $rows = intval(\CRM_Core_DAO::singleValueQuery("SELECT COUNT(1) FROM {$tableName} WHERE {$columnName} IS NOT NULL;"));
+
+    if ($rows) {
+      $e->refCounts[] = [
+        'type' => 'sql',
+        'name' => 'custom_field_non_null_column_entries',
+        'count' => $rows,
+      ];
+    }
+  }
+
+  /**
    * @param string|int|array|null $value
    * @param int $fieldID
    * @param ?int $entityID

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1121,6 +1121,32 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
   }
 
   /**
+   * Get the number of rows in the value table with a not NULL value for this field
+   * - this will prevent automatic cleanup of the CustomField if there is data for it
+   */
+  public static function on_hook_civicrm_referenceCounts($e) {
+    $dao = $e->dao;
+    if (!is_a($dao, \CRM_Core_DAO_CustomField::class)) {
+      return;
+    }
+    $dao->find(TRUE);
+    $columnName = $dao->column_name;
+
+    $customGroup = CRM_Core_DAO_CustomGroup::findById($dao->custom_group_id);
+
+    $tableName = $customGroup->table_name;
+    $rows = intval(\CRM_Core_DAO::singleValueQuery("SELECT COUNT(1) FROM {$tableName} WHERE {$columnName} IS NOT NULL;"));
+
+    if ($rows) {
+      $e->refCounts[] = [
+        'type' => 'sql',
+        'name' => 'custom_field_non_null_column_entries',
+        'count' => $rows,
+      ];
+    }
+  }
+
+  /**
    * @param string|int|array|null $value
    * @param int $fieldID
    * @param ?int $entityID

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -88,6 +88,39 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements Event
   }
 
   /**
+   * Get the number of value columns in the value table for this CustomGroup
+   * - this will prevent automatic cleanup of the CustomGroup if there is data for it
+   */
+  public static function on_hook_civicrm_referenceCounts($e) {
+    $dao = $e->dao;
+    if (!is_a($dao, \CRM_Core_DAO_CustomGroup::class)) {
+      return;
+    }
+    $dao->find(TRUE);
+    $tableName = $dao->table_name;
+
+    $dbName = $dao->_database;
+    $tableColumns = intval(\CRM_Core_DAO::singleValueQuery("
+     SELECT COUNT(1)
+       FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = '{$dbName}'
+         AND TABLE_NAME = '{$tableName}'
+    "));
+
+    // custom value tables always have `id` and `entity_id` but these are meaningless
+    // by themselves - count how many more columns it has
+    $valueColumns = $tableColumns - 2;
+
+    if ($valueColumns) {
+      $e->refCounts[] = [
+        'type' => 'sql',
+        'name' => 'custom_group_value_table_value_columns',
+        'count' => $valueColumns,
+      ];
+    }
+  }
+
+  /**
    * Retrieve a group by id, name, etc.
    *
    * @param array $filter

--- a/tests/phpunit/CRM/Core/ManagedEntitiesTest.php
+++ b/tests/phpunit/CRM/Core/ManagedEntitiesTest.php
@@ -303,6 +303,56 @@ class CRM_Core_ManagedEntitiesTest extends CiviUnitTestCase {
   }
 
   /**
+   * Set up managed Custom Group and Custom Field and check
+   * cleanup=>unused respects the custom getRefCount
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testRemoveDeclaration_CleanupUnusedCustomData(): void {
+    $this->managedEntities = [
+      array_merge($this->fixtures['com.example.one-CustomGroup'], ['cleanup' => 'unused']),
+      array_merge($this->fixtures['com.example.one-CustomField'], ['cleanup' => 'unused']),
+    ];
+
+    // reconcile to create the Group and Field
+    $me = new CRM_Core_ManagedEntities($this->modules);
+    $me->reconcile();
+
+    // check Field is created
+    $getField = \Civi\Api4\CustomField::get(FALSE)->addWhere('name', '=', 'test_custom_field')->execute();
+    $this->assertEquals(1, count($getField));
+
+    // add some data to the field
+    $contactId = \Civi\Api4\Contact::get(FALSE)->setLimit(1)->addSelect('id')->execute()->single()['id'];
+    \Civi\Api4\Contact::update(FALSE)->addWhere('id', '=', $contactId)->addValue('test_custom_group.test_custom_field', 'test_value')->execute();
+
+    // Later on, entity definition disappears; but we should not cleanup while there is data in the field
+    $this->managedEntities = [];
+    $me = new CRM_Core_ManagedEntities($this->modules);
+    $me->reconcile();
+
+    // Check we can still read the value from the field
+    $value = \Civi\Api4\Contact::get(FALSE)->addWhere('id', '=', $contactId)->addSelect('test_custom_group.test_custom_field')->execute()->single()['test_custom_group.test_custom_field'];
+    $this->assertEquals('test_value', $value);
+
+    // Now delete the data
+    \Civi\Api4\Contact::update(FALSE)->addWhere('id', '=', $contactId)->addValue('test_custom_group.test_custom_field', NULL)->execute();
+
+    // Reconcile again -- now there is no data in the field, we expect it to be deleted
+    $this->managedEntities = [];
+    $me = new CRM_Core_ManagedEntities($this->modules);
+    $me->reconcile();
+
+    // check field has been deleted
+    $getField = \Civi\Api4\CustomField::get(FALSE)->addWhere('name', '=', 'test_custom_field')->execute();
+    $this->assertEquals(0, count($getField));
+
+    // check group has also been cleaned up
+    $getGroup = \Civi\Api4\CustomGroup::get(FALSE)->addWhere('name', '=', 'test_custom_group')->execute();
+    $this->assertEquals(0, count($getGroup));
+  }
+
+  /**
    * Set up an active module with one managed-entity using the
    * policy "cleanup=>unused". When the managed-entity goes away,
    * ensure that the policy is followed (ie the entity is conditionally


### PR DESCRIPTION
Overview
----------------------------------------
Implement hook_civicrm_referenceCounts for CustomField / CustomGroup to check for data in the value table. This effects whether custom fields/groups are deleted when disabling/uninstalling/missing code for an extension.

Before
----------------------------------------
- Managed Custom Fields will be cleaned up if there are no foreign key references to the Custom Field row (which is rare) => they are often deleted when there is data in the custom value table
- custom groups are cleaned up if there are no foreign key references to the Custom Group (typically if there are no CustomFields left in the group)

After
----------------------------------------
- Managed Custom Fields clean up will also check if there are any non-NULL values in the custom value column - and preserve the field if so.
- Custom Groups also check if there are any value columns left in the value table. This should be equivalent to the foreign key check (rows in `civicrm_custom_field` referencing the group should be equivalent to columns in the value table) - but it is a safety check in case that constraint has come unstuck.

Comments
----------------------------------------
One important use case - if for some reason the extension code goes missing (due to a bad deploy, or when moving the extension) then the managed records go away, and fields can get cleaned up / data deleted. This change removes this footgun.

The fields will still be disabled if disabling/uninstalling the extension so won't clutter the UI. But can be more safely reinstated.

I suppose `NULL` could be a meaningful value in the custom value column if the default for the column is `1` and in some rare cases you NULL it. But a) that's not a good db column; b) if you have NULLed every row, it ceases to be meaningful.

