### PR TITLE
dev/core#5965 Fix race condition when loading row count in SearchKit

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -240,6 +240,10 @@
             } else if (ctrl.settings.pager || ctrl.settings.headerCount) {
               var params = ctrl.getApiParams('row_count');
               crmApi4('SearchDisplay', apiCalls.run[1], params).then(function(result) {
+                if (requestId < ctrl._runCount) {
+                  return; // Another request started after this one
+                }
+
                 ctrl.rowCount = result.count;
               });
             }


### PR DESCRIPTION
Overview
----------------------------------------
Fix race condition when loading row count in SearchKit

Fixes https://lab.civicrm.org/dev/core/-/issues/5965

Before
----------------------------------------
A race condition can occur when:

1. Embed a SearchKit table on the front-end, via a FormBuilder search form with filters,
2. Wait until the table data displays,
3. Immediately enter a search term that will generate no results
4. Observe that the table starts re-loading results

The row count for the initial request can load in after the second search with no results has finished.

After
----------------------------------------
The existing condition in https://github.com/civicrm/civicrm-core/pull/21394 is also used for the row count request.

Technical Details
----------------------------------------
This is especially likely to occur on very complex queries that take a few seconds to load the full row count.