### PR TITLE
Api4 - Make primary email/phone/address/im fields writable

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -249,7 +249,7 @@ trait DAOActionTrait {
       }
       [$fieldName, $fkField] = explode('.', $key);
       $field = $this->entityFields()[$fieldName] ?? NULL;
-      if (!$field || empty($field['fk_entity'])) {
+      if (!$field || $field['type'] !== 'Field' || empty($field['fk_entity'])) {
         continue;
       }
       $fkDao = CoreUtil::getBAOFromApiName($field['fk_entity']);

--- a/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
@@ -47,52 +47,6 @@ class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Gene
         ->setDescription(ts('Date closed or disbanded'));
     }
 
-    // All other fields in this file are specific to the `get` action.
-    if ($spec->getAction() !== 'get') {
-      return;
-    }
-
-    // Groups field
-    $field = new FieldSpec('groups', $spec->getEntity(), 'Array');
-    $field->setLabel(ts('In Groups'))
-      ->setTitle(ts('Groups'))
-      ->setColumnName('id')
-      ->setDescription(ts('Groups (or sub-groups of groups) to which this contact belongs'))
-      ->setType('Filter')
-      ->setInputType('Select')
-      ->setOperators(['IN', 'NOT IN'])
-      ->addSqlFilter([__CLASS__, 'getContactGroupSql'])
-      ->setSuffixes(['name', 'label'])
-      ->setOptionsCallback([__CLASS__, 'getGroupList']);
-    $spec->addFieldSpec($field);
-
-    // The following fields are specific to Individuals
-    if (!$spec->getValue('contact_type') || $spec->getValue('contact_type') === 'Individual') {
-      // Age field
-      $field = new FieldSpec('age_years', $spec->getEntity(), 'Integer');
-      $field->setLabel(ts('Age (years)'))
-        ->setTitle(ts('Age (years)'))
-        ->setColumnName('birth_date')
-        ->setInputType('Number')
-        ->setDescription(ts('Age of individual (in years)'))
-        ->setType('Extra')
-        ->setReadonly(TRUE)
-        ->setSqlRenderer([__CLASS__, 'calculateAge']);
-      $spec->addFieldSpec($field);
-
-      // Birthday field
-      $field = new FieldSpec('next_birthday', $spec->getEntity(), 'Integer');
-      $field->setLabel(ts('Next Birthday in (days)'))
-        ->setTitle(ts('Next Birthday in (days)'))
-        ->setColumnName('birth_date')
-        ->setInputType('Number')
-        ->setDescription(ts('Number of days until next birthday'))
-        ->setType('Extra')
-        ->setReadonly(TRUE)
-        ->setSqlRenderer([__CLASS__, 'calculateBirthday']);
-      $spec->addFieldSpec($field);
-    }
-
     // Address, Email, Phone, IM primary/billing virtual fields
     // This exposes the joins created by
     // \Civi\Api4\Event\Subscriber\ContactSchemaMapSubscriber::onSchemaBuild()
@@ -150,6 +104,52 @@ class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Gene
           ->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
         $spec->addFieldSpec($field);
       }
+    }
+
+    // All other fields in this file are specific to the `get` action.
+    if ($spec->getAction() !== 'get') {
+      return;
+    }
+
+    // Groups field
+    $field = new FieldSpec('groups', $spec->getEntity(), 'Array');
+    $field->setLabel(ts('In Groups'))
+      ->setTitle(ts('Groups'))
+      ->setColumnName('id')
+      ->setDescription(ts('Groups (or sub-groups of groups) to which this contact belongs'))
+      ->setType('Filter')
+      ->setInputType('Select')
+      ->setOperators(['IN', 'NOT IN'])
+      ->addSqlFilter([__CLASS__, 'getContactGroupSql'])
+      ->setSuffixes(['name', 'label'])
+      ->setOptionsCallback([__CLASS__, 'getGroupList']);
+    $spec->addFieldSpec($field);
+
+    // The following fields are specific to Individuals
+    if (!$spec->getValue('contact_type') || $spec->getValue('contact_type') === 'Individual') {
+      // Age field
+      $field = new FieldSpec('age_years', $spec->getEntity(), 'Integer');
+      $field->setLabel(ts('Age (years)'))
+        ->setTitle(ts('Age (years)'))
+        ->setColumnName('birth_date')
+        ->setInputType('Number')
+        ->setDescription(ts('Age of individual (in years)'))
+        ->setType('Extra')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'calculateAge']);
+      $spec->addFieldSpec($field);
+
+      // Birthday field
+      $field = new FieldSpec('next_birthday', $spec->getEntity(), 'Integer');
+      $field->setLabel(ts('Next Birthday in (days)'))
+        ->setTitle(ts('Next Birthday in (days)'))
+        ->setColumnName('birth_date')
+        ->setInputType('Number')
+        ->setDescription(ts('Number of days until next birthday'))
+        ->setType('Extra')
+        ->setReadonly(TRUE)
+        ->setSqlRenderer([__CLASS__, 'calculateBirthday']);
+      $spec->addFieldSpec($field);
     }
 
   }

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -92,6 +92,10 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue($fields['birth_date']['input_attrs']['date']);
     $this->assertFalse($fields['birth_date']['input_attrs']['time']);
     $this->assertArrayNotHasKey('format_type', $fields['birth_date']['input_attrs']);
+
+    // Check extra fields
+    $this->assertEquals('Integer', $fields['address_primary']['data_type']);
+    $this->assertEquals('Email', $fields['email_primary']['fk_entity']);
   }
 
   public function testComponentFields(): void {

--- a/tests/phpunit/api/v4/Entity/AddressTest.php
+++ b/tests/phpunit/api/v4/Entity/AddressTest.php
@@ -48,14 +48,14 @@ class AddressTest extends Api4TestBase implements TransactionalInterface {
       ->addValue('contact_id', $cid)
       ->addValue('location_type_id', 1)
       ->addValue('city', 'Somewhere')
-      ->execute();
+      ->execute()->single();
 
     $a2 = Address::create(FALSE)
       ->addValue('is_primary', TRUE)
       ->addValue('contact_id', $cid)
       ->addValue('location_type_id', 2)
       ->addValue('city', 'Elsewhere')
-      ->execute();
+      ->execute()->single();
 
     $addresses = Address::get(FALSE)
       ->addWhere('contact_id', '=', $cid)
@@ -64,6 +64,12 @@ class AddressTest extends Api4TestBase implements TransactionalInterface {
 
     $this->assertFalse($addresses[0]['is_primary']);
     $this->assertTrue($addresses[1]['is_primary']);
+
+    $contact = Contact::get(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addSelect('address_primary')
+      ->execute()->single();
+    $this->assertEquals($a2['id'], $contact['address_primary']);
   }
 
   public function testSearchProximity(): void {

--- a/tests/phpunit/api/v4/Entity/ContactJoinTest.php
+++ b/tests/phpunit/api/v4/Entity/ContactJoinTest.php
@@ -157,10 +157,22 @@ class ContactJoinTest extends Api4TestBase {
   }
 
   public function testUpdateDeletePrimaryAndBilling(): void {
+    $billingPhone = $this->createTestRecord('Phone', [
+      'phone' => '54321',
+    ]);
     $contact = $this->createTestRecord('Contact', [
       'phone_primary.phone' => '12345',
-      'phone_billing.phone' => '54321',
+      'phone_billing' => $billingPhone['id'],
     ]);
+    // Ensure billing phone was assigned to contact
+    $contactGet = Contact::get(FALSE)
+      ->addWhere('id', '=', $contact['id'])
+      ->addSelect('phone_primary.phone', 'phone_billing.phone')
+      ->execute()->single();
+    $this->assertEquals('12345', $contactGet['phone_primary.phone']);
+    $this->assertEquals('54321', $contactGet['phone_billing.phone']);
+    $billingPhone = $this->getTestRecord('Phone', $billingPhone['id']);
+    $this->assertTrue($billingPhone['is_billing']);
     Contact::update(FALSE)
       ->addValue('id', $contact['id'])
       // Delete primary phone, update billing phone


### PR DESCRIPTION
Overview
----------------------------------------
Followup to 88ef1525, this exposes the primary fields to getFields for all actions not just get. Allows primary entities to be updated by id as well.