### PR TITLE
Api4 - Ensure the 'user_contact_id' placeholder works for both read & write

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -121,7 +121,7 @@ class FormattingUtil {
     }
 
     // Special handling for 'current_user' and user lookups
-    $exactMatch = [NULL, '=', '!=', '<>', 'IN', 'NOT IN'];
+    $exactMatch = [NULL, '=', '!=', '<>', 'IN', 'NOT IN', 'CONTAINS', 'NOT CONTAINS'];
     if (is_string($fk) && CoreUtil::isContact($fk) && in_array($operator, $exactMatch, TRUE)) {
       $value = self::resolveContactID($fieldSpec['name'], $value);
     }

--- a/tests/phpunit/api/v4/Entity/ActivityTest.php
+++ b/tests/phpunit/api/v4/Entity/ActivityTest.php
@@ -29,11 +29,14 @@ use Civi\Test\TransactionalInterface;
 class ActivityTest extends Api4TestBase implements TransactionalInterface {
 
   public function testActivityContactVirtualFields(): void {
-    $c = $this->saveTestRecords('Contact', ['records' => 5])->column('id');
+    $c = $this->saveTestRecords('Contact', ['records' => 4])->column('id');
+    $uid = $this->createLoggedInUser();
 
     $sourceContactId = $c[2];
     $targetContactIds = [$c[0], $c[1]];
-    $assigneeContactIds = [$c[3], $c[4]];
+    // Ensure the 'user_contact_id' placeholder works for both read & write
+    $assigneeContactIds = [$c[3], 'user_contact_id'];
+    $expectedAssigneeContactIds = [$c[3], $uid];
 
     // Test that we can write to and read from the virtual fields.
     $activityID = $this->createTestRecord('Activity', [
@@ -44,7 +47,7 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
 
     $activity = Activity::get(FALSE)
       ->addSelect('source_contact_id', 'target_contact_id', 'assignee_contact_id')
-      ->addWhere('id', '=', $activityID)
+      ->addWhere('target_contact_id', 'CONTAINS', $targetContactIds)
       ->execute()->first();
     $this->assertEquals($sourceContactId, $activity['source_contact_id']);
     $this->assertEquals($targetContactIds, $activity['target_contact_id']);
@@ -60,11 +63,11 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     // Affirm that assignee_contact_id was set and other fields remain unchanged
     $activity = Activity::get(FALSE)
       ->addSelect('source_contact_id', 'target_contact_id', 'assignee_contact_id')
-      ->addWhere('id', '=', $activityID)
+      ->addWhere('assignee_contact_id', 'CONTAINS', $assigneeContactIds)
       ->execute()->single();
     $this->assertEquals($sourceContactId, $activity['source_contact_id']);
     $this->assertEquals($targetContactIds, $activity['target_contact_id']);
-    $this->assertEquals($assigneeContactIds, $activity['assignee_contact_id']);
+    $this->assertEquals($expectedAssigneeContactIds, $activity['assignee_contact_id']);
 
     // Sanity check for https://lab.civicrm.org/dev/core/-/issues/1428
     // Updating nothing should change nothing.
@@ -85,7 +88,7 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('1234', $contactGet['activity.subject']);
     $this->assertEquals($sourceContactId, $contactGet['activity.source_contact_id']);
     $this->assertEquals($targetContactIds, $contactGet['activity.target_contact_id']);
-    $this->assertEquals($assigneeContactIds, $contactGet['activity.assignee_contact_id']);
+    $this->assertEquals($expectedAssigneeContactIds, $contactGet['activity.assignee_contact_id']);
   }
 
   public function testAllowedActivityTypes(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Ensures the CONTAINS operator works with 'user_contact_id' in the array.

Fixes [dev/core#5993](https://lab.civicrm.org/dev/core/-/issues/5993)