### PR TITLE
Fix for issue #2641

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -154,6 +154,17 @@ WHERE  modified_date IS NULL
     ];
     CRM_Core_DAO::singleValueQuery($query, $params);
     self::flushACLContactCache();
+
+    // Rebuild the cache for the user whose action triggered the reset.
+    // There may be a better way to solve the problem, but this seems to fix
+    // the permission dropouts described in issue #2641:
+    // https://lab.civicrm.org/dev/core/-/issues/2641
+    $session = CRM_Core_Session::singleton();
+    $contactId = $session->get('userID');
+    if ($contactId !== NULL) {
+      self::build($contactId);
+    }
+
   }
 
   /**


### PR DESCRIPTION
When users are affected by multiple ACLs, they will intermittently lose access to some of these ACL groups. This change appears to mitigate the problem, but it may also cause the cache to be rebuilt more frequently than it otherwise would. It would be great if someone more familiar with Civi's ACL cache system could review and possibly suggest alternatives.

Overview
----------------------------------------
At the end of CRM_ACL_BAO_Cache::resetCache, rebuild the cache for the user whose action triggered the reset (to solve [issue #2641](https://lab.civicrm.org/dev/core/-/issues/2641)).

Before
----------------------------------------
When a user affected by multiple ACLs edits a record, they sometimes lose access to the contact (or potentially another Entity) they're editing. In my latest test, there were 11 successful edits of a contact's Preferred Name, and then the 12th edit failed.

After
----------------------------------------
The same user can edit records without intermittent failures.

Technical Details
----------------------------------------
The failure can occur on systems where only one user is active; it does not seem to be related to concurrent activity from mulitple users.

Comments
----------------------------------------
I've been applying this patch to every Civi release we've installed for the last four years. It "works", but I suspect a better solution to the problem is possible.
