### PR TITLE
Add support for complex array parsing to codeDocs

### DIFF
--- a/Civi/Api4/Utils/ReflectionUtils.php
+++ b/Civi/Api4/Utils/ReflectionUtils.php
@@ -73,8 +73,10 @@ class ReflectionUtils {
     $bufferedVar = '';
     $parsingVarArray = FALSE;
 
-    foreach (preg_split("/((\r?\n)|(\r\n?))/", $comment) as $num => $line) {
-      if (!$num || str_contains($line, '*/')) {
+    $lines = preg_split("/((\r?\n)|(\r\n?))/", $comment);
+
+    foreach ($lines as $num => $line) {
+      if ($num === 0 || str_contains($line, '*/')) {
         continue;
       }
 
@@ -156,6 +158,7 @@ class ReflectionUtils {
         $info['comment'] = isset($info['comment']) ? "{$info['comment']}\n$line" : $line;
       }
     }
+
     if (isset($info['comment'])) {
       $info['comment'] = rtrim($info['comment']);
     }

--- a/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
+++ b/tests/phpunit/api/v4/Utils/ReflectionUtilsTest.php
@@ -114,6 +114,75 @@ This is the base class.';
           'shape' => ['a' => ['string'], 'z' => ['int'], 'x' => ['float', 'string', 'int']],
         ],
       ],
+      'params_with_nested_array_shape' => [
+        'doc_block' => '/**
+           * @param array{ name: string, phone: string|null } $first
+           * @param array{
+           *   limit: int,
+           *   offset: int,
+           *   thresholds: double[],
+           *   color: array{red: int, green: int, blue: int}
+           * } $second
+           * @return array{
+           *     id: int,
+           *     name: string,
+           *     contact: array{
+           *         email: string,
+           *         phone: string|null
+           *     },
+           *     preferences: array{notifications: bool, theme: string}
+           * }
+           */',
+        'parsed' => [
+          'params' => [
+            '$first' => [
+              'type' => ['array'],
+              'shape' => ['name' => ['string'], 'phone' => ['string', 'null']],
+              'description' => '',
+              'comment' => '',
+            ],
+            '$second' => [
+              'type' => ['array'],
+              'shape' => [
+                'limit' => ['int'],
+                'offset' => ['int'],
+                'thresholds' => ['double[]'],
+                'color' => [
+                  'type' => ['array'],
+                  'shape' => [
+                    'red' => ['int'],
+                    'green' => ['int'],
+                    'blue' => ['int'],
+                  ],
+                ],
+              ],
+              'description' => '',
+              'comment' => '',
+            ],
+          ],
+          'return' => [
+            'type' => ['array'],
+            'shape' => [
+              'id' => ['int'],
+              'name' => ['string'],
+              'contact' => [
+                'type' => ['array'],
+                'shape' => [
+                  'email' => ['string'],
+                  'phone' => ['string', 'null'],
+                ],
+              ],
+              'preferences' => [
+                'type' => ['array'],
+                'shape' => [
+                  'notifications' => ['bool'],
+                  'theme' => ['string'],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add support for complex array parsing to codeDocs

Follow on from https://github.com/civicrm/civicrm-core/pull/33286

Before
----------------------------------------
Code docs handled array shapes but not nested array shapes

After
----------------------------------------
Handling for this more complex array shape
https://github.com/civicrm/civicrm-core/pull/33288/files#diff-b8f48e78c06ae9b23bb31874973177331ed54e97b7785b102a5721c7c3f64cf5R117-R185

Technical Details
----------------------------------------
If the opening and closing `{` are lopsided the line will be skipped - this seems a safer way to deal with bad data than including it.

Comments
----------------------------------------
ChatGPT couldn't get me there - it did an admirable job of parsing the array shape but it failed to re-write the line parsing to get the greediness right & it got more & more complicated - I feel like going back & showing it the right answer but ChapGPT does not care so I will not.