### PR TITLE
Redirect from the MapField form to DataSource if DataSource not complete

### DIFF
--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -3,6 +3,12 @@
 class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
 
   public function preProcess(): void {
+    if ($this->isStandalone() && !$this->hasValidDataSource()) {
+      $job = $this->getUserJob();
+      CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/import/' . str_replace('_import', '', $job['job_type']), [
+        'id' => $job['id'],
+      ]));
+    }
     parent::preProcess();
     // Add import-ui app
     Civi::service('angularjs.loader')->addModules('crmCiviimport');
@@ -13,6 +19,11 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
     if ($templateJob) {
       Civi::resources()->addVars('crmImportUi', ['savedMapping' => ['name' => substr($templateJob['name'], 7)]]);
     }
+  }
+
+  private function hasValidDataSource(): bool {
+    $table = $this->getUserJob()['metadata']['DataSource']['table_name'] ?? '';
+    return $table && CRM_Core_DAO::checkTableExists($table);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Redirect from the MapField form to DataSource if DataSource not complete

There is now a 'continue' button on the my imports screen which takes users to the MapField screen to continue their import. However, if they have not completed the DataSource screen (perceived as being a less common workflow) then we should detect that & send them there - rather than give a nasty error

Before
----------------------------------------

If the continue button is used but the datasource does not exist the user gets an error

<img width="1106" height="358" alt="image" src="https://github.com/user-attachments/assets/aba79716-09af-4923-b038-a795baf56036" />

After
----------------------------------------
They land on the datasource screen instead

Technical Details
----------------------------------------

Comments
----------------------------------------
