### PR TITLE
Remove unused js calls from Civiimport Datasource.tpl

### DIFF
--- a/ext/civiimport/templates/CRM/Import/DataSource.tpl
+++ b/ext/civiimport/templates/CRM/Import/DataSource.tpl
@@ -70,8 +70,6 @@
     CRM.$(function($) {
       // build data source form block
       buildDataSourceFormBlock();
-      buildSubTypes();
-      buildDedupeRules();
     });
 
     function buildDataSourceFormBlock(dataSource) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused js calls from Civiimport Datasource.tpl

Before
----------------------------------------
The contactType & dedupeRules fields have been removed from the Civiimport Datasource form - but the tpl still needs more clean up related to them - the js functions related to them are still called

After
----------------------------------------
js functions removed

Technical Details
----------------------------------------
These are actually causing a js error - but the regression is master only & only obvious with console tab displayed

Comments
----------------------------------------
