### PR TITLE
Further fix on handling of the default values for added import rows

### DIFF
--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -456,10 +456,10 @@ abstract class ImportParser extends \CRM_Import_Parser {
         continue;
       }
       $fieldSpec = $this->getFieldMetadata($mappedField['name']);
-      // If there is no column header we are dealing with an added value mapping, do not use
-      // the database value as it will be for (e.g.) `_status`
-      $headers = $this->getUserJob()['metadata']['DataSource']['column_headers'];
-      if (array_key_exists($i, $headers) && empty($headers[$i])) {
+      // $values has some system fields in it. We can identify these as their index
+      // will be greater than the number_of_columns.
+      $numberOfColumns = $this->getUserJob()['metadata']['DataSource']['number_of_columns'];
+      if (($i + 1) > $numberOfColumns) {
         $fieldValue = '';
       }
       else {

--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -58,7 +58,7 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
     $this->createUserJobTable();
     $userJobParameters = [
       'metadata' => [
-        'DataSource' => ['table_name' => 'abc', 'column_headers' => ['External Identifier', 'Amount Given', 'Contribution Date', 'Financial Type', 'In honor']],
+        'DataSource' => ['table_name' => 'abc', 'number_of_columns' => 5, 'column_headers' => ['External Identifier', 'Amount Given', 'Contribution Date', 'Financial Type', 'In honor']],
         'submitted_values' => [
           'contactType' => 'Individual',
           'contactSubType' => '',

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -396,16 +396,19 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
    * @noinspection PhpDocMissingThrowsInspection
    */
   protected function getUserJobID(array $submittedValues = []): int {
+    $queryFields = ['first_name'];
+    foreach (array_keys($submittedValues['mapper']) as $key) {
+      if ($key > 0) {
+        $queryFields[] = '"value_' . $key . '" AS field_' . $key;
+      }
+    }
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
           'contactType' => 'Individual',
           'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
-          'sqlQuery' => 'SELECT first_name FROM civicrm_contact',
-          'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-          'dedupe_rule_id' => NULL,
-          'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
+          'sqlQuery' => 'SELECT ' . implode(', ', $queryFields) . ' FROM civicrm_contact',
         ], $submittedValues),
       ],
       'status_id:name' => 'draft',

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -873,11 +873,17 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       }
       $submittedValues['sqlQuery'] .= implode(',', $submittedClauses);
     }
+    $queryFields = ['first_name'];
+    foreach (array_keys($importMappings) as $key) {
+      if ($key > 0) {
+        $queryFields[] = '"value_' . $key . '" AS field_' . $key;
+      }
+    }
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
           'dataSource' => 'CRM_Import_DataSource_SQL',
-          'sqlQuery' => 'SELECT first_name FROM civicrm_contact',
+          'sqlQuery' => 'SELECT ' . implode(', ', $queryFields) . ' FROM civicrm_contact',
           'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
         ], $submittedValues),
         'import_mappings' => $importMappings,

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -332,16 +332,17 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
    * @return int
    */
   protected function getUserJobID(array $submittedValues = []): int {
+    $queryFields = ['first_name'];
+    foreach (array_keys($submittedValues['mapper']) as $key) {
+      if ($key > 0) {
+        $queryFields[] = '"value_' . $key . '" AS field_' . $key;
+      }
+    }
     $userJobID = UserJob::create()->setValues([
       'metadata' => [
         'submitted_values' => array_merge([
-          'contactType' => 'Individual',
-          'contactSubType' => '',
           'dataSource' => 'CRM_Import_DataSource_SQL',
-          'sqlQuery' => 'SELECT first_name FROM civicrm_contact',
-          'onDuplicate' => CRM_Import_Parser::DUPLICATE_SKIP,
-          'dedupe_rule_id' => NULL,
-          'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
+          'sqlQuery' => 'SELECT ' . implode(', ', $queryFields) . ' FROM civicrm_contact',
         ], $submittedValues),
       ],
       'status_id:name' => 'draft',


### PR DESCRIPTION
Overview
----------------------------------------
In some cases the default value is not picked up on additional rows - this is a bit  of a rare issue but comes up a bit in testing - ie if you want to add an extra row that will never be mapped but will always pick up the default value it can, mostly in testing, pick up the value from the system field - this makes the existing fix more robust 

Before
----------------------------------------

After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
