### PR TITLE
fixes core/#6019: Don't add `cache_fill_took` updates to logging tables.

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -193,6 +193,7 @@ UPDATE civicrm_group
 SET    cache_date = $now$setCacheFillTook
 WHERE  id IN ( $groupIDs )
 ";
+    CRM_Logging_Schema::disableLoggingForThisConnection();
     CRM_Core_DAO::executeQuery($sql);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
[`cache_fill_took` was ](https://lab.civicrm.org/dev/core/-/issues/6019).

Before
----------------------------------------
A row added to `log_civicrm_group` for each smart group every time the smart group cache is updated.

After
----------------------------------------
No update.

Comments
----------------------------------------
More details on the ticket.
