### PR TITLE
Add new UserJob statuses for incomplete import

### DIFF
--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\UserJob;
 
 /**
  * This class previews the uploaded file and returns summary statistics.
@@ -117,6 +118,8 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
         'reset' => 1,
       ], FALSE, NULL, FALSE),
     ]);
+    UserJob::update()->addWhere('id', '=', $this->getUserJobID())
+      ->setValues(['status_id:name', '=', 'scheduled'])->execute();
     $runner->runAllInteractive();
   }
 

--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -158,8 +158,8 @@ return [
                       'conditions' => [
                         [
                           'status_id:name',
-                          '=',
-                          'draft',
+                          'IN',
+                          ['draft', 'complete_with_errors', 'incomplete'],
                         ],
                       ],
                       'task' => '',
@@ -484,8 +484,8 @@ return [
                   'conditions' => [
                     [
                       'status_id:name',
-                      '=',
-                      'draft',
+                      'IN',
+                      ['draft', 'complete_with_errors', 'incomplete'],
                     ],
                   ],
                   'task' => '',

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -438,7 +438,12 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $row = $dataSource->getRow();
     $this->assertEquals('ERROR', $row['_status']);
     $this->assertEquals('Invalid value for field(s) : Membership Type', $row['_status_message']);
-    return;
+    $userJob = UserJob::get()
+      ->addSelect('status_id:name', 'status_id:label')
+      ->addWhere('id', '=', $this->userJobID)
+      ->execute()->single();
+    $this->assertEquals('complete_with_errors', $userJob['status_id:name']);
+    $this->assertEquals('Complete with Errors', $userJob['status_id:label']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add new UserJob statuses for incomplete import

Before
----------------------------------------
It's not possible to see the difference between jobs that completed with all rows exported vs those with errors

After
----------------------------------------
<img width="1030" height="301" alt="image" src="https://github.com/user-attachments/assets/346daa4c-0ba1-4212-90ca-364d65172562" />


Technical Details
----------------------------------------

I discussed with @mattwire  & @Detsieber  on chat what to call the status https://chat.civicrm.org/civicrm/pl/1yh6mhku8pgdfxsdh37rn66efc

Comments
----------------------------------------
