### PR TITLE
Remove calls to addSavedMappingFields

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -78,7 +78,6 @@ class CRM_Activity_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm(): void {
-    $this->addSavedMappingFields();
     $this->addFormRule(['CRM_Activity_Import_Form_MapField', 'formRule'], $this);
 
     foreach ($this->getColumnHeaders() as $i => $columnHeader) {

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -310,7 +310,42 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
     }
     $this->assign('savedMappingName', $this->getMappingName());
     $this->addElement('checkbox', 'saveMapping', $saveDetailsName, NULL);
-    $this->addFormRule(['CRM_Import_Form_MapField', 'mappingRule']);
+    $this->addFormRule(['CRM_Contact_Import_Form_MapField', 'mappingRule']);
+  }
+
+  /**
+   * Global validation rules for the form.
+   *
+   * @param array $fields
+   *   Posted values of the form.
+   *
+   * @return array|true
+   *   list of errors to be posted back to the form
+   */
+  public static function mappingRule($fields) {
+    $errors = [];
+    if (!empty($fields['saveMapping'])) {
+      $nameField = $fields['saveMappingName'] ?? NULL;
+      if (empty($nameField)) {
+        $errors['saveMappingName'] = ts('Name is required to save Import Mapping');
+      }
+      else {
+        $mappingTypeId = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Contact');
+        $mapping = new CRM_Core_DAO_Mapping();
+        $mapping->name = $nameField;
+        $mapping->mapping_type_id = $mappingTypeId;
+        if ($mapping->find(TRUE)) {
+          $errors['saveMappingName'] = ts('Duplicate Import Mapping Name');
+        }
+      }
+    }
+    // This is horrible & should be removed once gone from tpl
+    if (!empty($errors['saveMappingName'])) {
+      $_flag = 1;
+      $assignError = new CRM_Core_Page();
+      $assignError->assign('mappingDetailsError', $_flag);
+    }
+    return empty($errors) ? TRUE : $errors;
   }
 
   /**

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -287,6 +287,33 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
   }
 
   /**
+   * Add the saved mapping fields to the form.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function addSavedMappingFields(): void {
+    $savedMappingID = $this->getSavedMappingID();
+    //to save the current mappings
+    if (!$savedMappingID && !$this->getTemplateJob()) {
+      $saveDetailsName = ts('Save this field mapping');
+      $this->applyFilter('saveMappingName', 'trim');
+      $this->add('text', 'saveMappingName', ts('Name'));
+      $this->add('text', 'saveMappingDesc', ts('Description'));
+    }
+    else {
+      $this->add('hidden', 'mappingId', $savedMappingID);
+
+      $this->addElement('checkbox', 'updateMapping', ts('Update this field mapping'), NULL);
+      $saveDetailsName = ts('Save as a new field mapping');
+      $this->add('text', 'saveMappingName', ts('Name'));
+      $this->add('text', 'saveMappingDesc', ts('Description'));
+    }
+    $this->assign('savedMappingName', $this->getMappingName());
+    $this->addElement('checkbox', 'saveMapping', $saveDetailsName, NULL);
+    $this->addFormRule(['CRM_Import_Form_MapField', 'mappingRule']);
+  }
+
+  /**
    * Format custom field name.
    *
    * Combine group and field name to avoid conflict.

--- a/CRM/Contribute/Import/Form/MapField.php
+++ b/CRM/Contribute/Import/Form/MapField.php
@@ -50,7 +50,6 @@ class CRM_Contribute_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm(): void {
-    $this->addSavedMappingFields();
 
     $this->addFormRule([
       'CRM_CiviImport_Form_MapField',

--- a/CRM/Core/BAO/Mapping.php
+++ b/CRM/Core/BAO/Mapping.php
@@ -227,8 +227,11 @@ class CRM_Core_BAO_Mapping extends CRM_Core_DAO_Mapping implements \Civi\Core\Ho
    *   mapping Type.
    *
    * @return bool
+   *
+   * @deprecated since 6.6 will be removed around 6.12
    */
   public static function checkMapping($nameField, $mapTypeId) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative - take a copy');
     $mapping = new CRM_Core_DAO_Mapping();
     $mapping->name = $nameField;
     $mapping->mapping_type_id = $mapTypeId;

--- a/CRM/Custom/Import/Form/MapField.php
+++ b/CRM/Custom/Import/Form/MapField.php
@@ -22,7 +22,6 @@ class CRM_Custom_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm(): void {
-    $this->addSavedMappingFields();
     $this->addFormRule([__CLASS__, 'formRule'], $this);
     $this->addMapper();
     $this->addFormButtons();

--- a/CRM/Event/Import/Form/MapField.php
+++ b/CRM/Event/Import/Form/MapField.php
@@ -50,7 +50,6 @@ class CRM_Event_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    * @return void
    */
   public function buildQuickForm(): void {
-    $this->addSavedMappingFields();
     $this->addFormRule(['CRM_Event_Import_Form_MapField', 'formRule'], $this);
     $this->addMapper();
     $this->addFormButtons();

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -366,7 +366,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     }
     $this->assign('savedMappingName', $this->getMappingName());
     $this->addElement('checkbox', 'saveMapping', $saveDetailsName, NULL);
-    $this->addFormRule(['CRM_Import_Form_MapField', 'mappingRule']);
+    $this->addFormRule(['CRM_Contact_Import_Form_MapField', 'mappingRule']);
   }
 
   /**
@@ -377,8 +377,11 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    *
    * @return array|true
    *   list of errors to be posted back to the form
+   *
+   * @deprecated since 6.6 will be removed around 6.12
    */
   public static function mappingRule($fields) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative - take a copy');
     $errors = [];
     if (!empty($fields['saveMapping'])) {
       $nameField = $fields['saveMappingName'] ?? NULL;
@@ -387,7 +390,10 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
       }
       else {
         $mappingTypeId = CRM_Core_PseudoConstant::getKey('CRM_Core_BAO_Mapping', 'mapping_type_id', 'Import Contact');
-        if (CRM_Core_BAO_Mapping::checkMapping($nameField, $mappingTypeId)) {
+        $mapping = new CRM_Core_DAO_Mapping();
+        $mapping->name = $nameField;
+        $mapping->mapping_type_id = $mappingTypeId;
+        if ($mapping->find(TRUE)) {
           $errors['saveMappingName'] = ts('Duplicate Import Mapping Name');
         }
       }

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -343,8 +343,11 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
    * Add the saved mapping fields to the form.
    *
    * @throws \CRM_Core_Exception
+   *
+   * @deprecated since 6.6 will be removed around 6.12
    */
   protected function addSavedMappingFields(): void {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative - take a copy');
     $savedMappingID = $this->getSavedMappingID();
     //to save the current mappings
     if (!$savedMappingID && !$this->getTemplateJob()) {

--- a/CRM/Member/Import/Form/MapField.php
+++ b/CRM/Member/Import/Form/MapField.php
@@ -28,7 +28,6 @@ class CRM_Member_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm(): void {
-    $this->addSavedMappingFields();
     $this->addFormRule([__CLASS__, 'formRule'], $this);
     $this->addMapper();
     $this->setDefaults($this->getDefaults());


### PR DESCRIPTION
Overview
----------------------------------------
Remove calls to addSavedMappingFields

Before
----------------------------------------
Fields still added to QuickForms but entirely handled in the js layer

After
----------------------------------------
Fields no longer added - various related functions unshared onto the Contact Import with the original functions deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
