### PR TITLE
dev/core#6019 Update logging triggers to ignore changes to cache_fill_took on civic…

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -976,6 +976,8 @@ COLS;
         $tableExceptions = array_key_exists('exceptions', $this->logTableSpec[$table]) ? $this->logTableSpec[$table]['exceptions'] : [];
         // ignore modified_date changes
         $tableExceptions[] = 'modified_date';
+        // Ignore cache_fill_took column on civicrm_group.
+        $tableExceptions[] = 'cache_fill_took';
         // exceptions may be provided with or without backticks
         $excludeColumn = in_array($column, $tableExceptions) ||
           in_array(str_replace('`', '', $column), $tableExceptions);


### PR DESCRIPTION
…rm_group

Overview
----------------------------------------
This is a compainon PR to #33296 in that one the query that updates this field is ignored from logging but this PR also makes sure that the triggers don't try to record updates to this column as well

Before
----------------------------------------
cache_fill_took considered by logging triggers

After
----------------------------------------
cache_fill_took not considered by logging triggers

ping @andrew-cormick-dockery @johntwyman @eileenmcnaughton @MegaphoneJon @colemanw 