### PR TITLE
dev/core#6018 SearchKit - Fix dragging in Safari

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -54,8 +54,7 @@
       };
 
       this.sortableOptions = {
-        containment: $element,
-        axis: 'y',
+        containment: $element.children('table').first(),
         helper: function(e, ui) {
           // Prevent table row width from changing during drag
           ui.children().each(function() {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -44,8 +44,7 @@
 
         if (ctrl.settings.draggable) {
           ctrl.draggableOptions = {
-            containment: $element,
-            direction: 'vertical',
+            containment: $element.children('div').first(),
             handle: '.crm-draggable',
             forcePlaceholderSize: true,
             helper: function(e, ui) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6018](https://lab.civicrm.org/dev/core/-/issues/6018)

Before
----------------------------------------
Dragging a sortable SearchKit table (e.g. Custom Fields screen with AdminUI enabled) fails.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
The 'bug' in Safari is that you can't use an inline element as `containment`. Since angular components are unstyled html tags, we could either use css to style them display:block or just pick the first child element as the `containment`.

I've also seen (unconfirmed) reports that [Safari doesn't like direction: vertical](https://stackoverflow.com/questions/12878523/jquery-ui-sortable-safari-glitch) so I removed it for good measure; doesn't hurt.