### PR TITLE
Add support for importing payment_field in contribution import

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1063,7 +1063,7 @@ class CRM_Financial_BAO_Order {
         $lineItem['line_total_inclusive'] = $lineItem['line_total'];
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] ? $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100)) : 0;
         $lineItem['tax_amount'] = round($lineItem['line_total_inclusive'] - $lineItem['line_total'], 2);
-        // Make sure they still add up to each other afer the rounding.
+        // Make sure they still add up to each other after the rounding.
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] - $lineItem['tax_amount'];
         $lineItem['qty'] = 1;
         $lineItem['unit_price'] = $lineItem['line_total'];
@@ -1237,12 +1237,20 @@ class CRM_Financial_BAO_Order {
         $lineItem['price_field_value_id'] = (int) $lineItem['price_field_value_id'];
         $lineItem = array_merge($this->getPriceFieldValueDefaults($lineItem['price_field_value_id']), $lineItem);
       }
-      if (!isset($lineItem['line_total'])) {
-        $lineItem['line_total'] = $lineItem['qty'] * $lineItem['unit_price'];
-      }
       $lineItem['tax_rate'] = $this->getTaxRate($lineItem['financial_type_id']);
-      $lineItem['tax_amount'] = ($lineItem['tax_rate'] / 100) * $lineItem['line_total'];
-      $lineItem['line_total_inclusive'] = $lineItem['tax_amount'] + $lineItem['line_total'];
+      if (isset($lineItem['line_total_inclusive'])) {
+        $lineItem['line_total'] = $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100));
+        $lineItem['tax_amount'] = $lineItem['line_total_inclusive'] - $lineItem['line_total'];
+        $lineItem['qty'] = 1;
+        $lineItem['unit_price'] = $lineItem['line_total'];
+      }
+      else {
+        if (!isset($lineItem['line_total'])) {
+          $lineItem['line_total'] = $lineItem['qty'] * $lineItem['unit_price'];
+        }
+        $lineItem['tax_amount'] = ($lineItem['tax_rate'] / 100) * $lineItem['line_total'];
+        $lineItem['line_total_inclusive'] = $lineItem['tax_amount'] + $lineItem['line_total'];
+      }
     }
     if (!empty($lineItem['membership_type_id'])) {
       $lineItem['entity_table'] = 'civicrm_membership';

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1020,6 +1020,16 @@ WHERE li.contribution_id = %1";
   protected static function getTaxAmountForLineItem(array $params): float {
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
     $taxRate = $taxRates[$params['financial_type_id']] ?? 0;
+    if (isset($params['line_total_inclusive'])) {
+      // Pseudo-field line_total_inclusive takes precedent as it is only
+      // set when we are calculating the rounding back from the inclusive total.
+      // An alternative might be to return a passed-in tax_amount IF i
+      $lineTotalExclusive = $params['line_total_inclusive'] / (1 + ($taxRate / 100));
+      $taxAmount = round($params['line_total_inclusive'] - $lineTotalExclusive, 2);
+      if ($taxAmount === $params['tax_amount']) {
+        return $taxAmount;
+      }
+    }
     return ($taxRate / 100) * $params['line_total'];
   }
 

--- a/schema/Financial/FinancialTrxn.entityType.php
+++ b/schema/Financial/FinancialTrxn.entityType.php
@@ -120,9 +120,7 @@ return [
       'add' => '1.3',
       'default' => NULL,
       'usage' => [
-        'import',
         'export',
-        'duplicate_matching',
       ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
@@ -142,9 +140,7 @@ return [
       'add' => '4.7',
       'default' => FALSE,
       'usage' => [
-        'import',
         'export',
-        'duplicate_matching',
       ],
     ],
     'trxn_id' => [
@@ -171,9 +167,7 @@ return [
       'description' => ts('pseudo FK to civicrm_option_value of contribution_status_id option_group'),
       'add' => '4.3',
       'usage' => [
-        'import',
         'export',
-        'duplicate_matching',
       ],
       'pseudoconstant' => [
         'option_group_name' => 'contribution_status',
@@ -241,6 +235,9 @@ return [
       'unique_name' => 'financial_trxn_pan_truncation',
       'input_attrs' => [
         'size' => '4',
+      ],
+      'usage' => [
+        'import',
       ],
     ],
     'order_reference' => [


### PR DESCRIPTION
Overview
----------------------------------------
Add support for importing payment_field in contribution import

Before
----------------------------------------
It is not possible to import payment specific field `pan_truncation` for Contributions - this field is recorded for some offline payment processing houses and they use it as part of their search criteria within their portal (!) so importing it is of value.

After
----------------------------------------
- `pan_truncation` is available as in import field
- Contribution import uses the 2-step Order->Payment flow - this is in-line with the SearchKit importer and our general expectations. It also lays the ground work for us to add `Membership` as an optional additional entity in contribution imports (& potentially Participant too) - permitted more coherent imported entities. Note @colemanw is going to look at how to make more import entities available in the UI (if declared) without adding the 'always there' clutter
- This exposed in issue with the Order api which also affects the SearchKit importer - when the known amount is potentially tax inclusive we need to ensure the line items treat it as such (if there were demand it would be potentially easy after this to offer the tax exclusive amount as a field

Technical Details
----------------------------------------
Prior to this PR there are NO importable fields on the Payment entity - I updated the metadata so that only this known field in importable - obviously someone could make the case to add other fields to `import` but I have left that out of scope deliberately & any addition should be a follow up. Also note that as of now these `import` fields are more important as there is now (unadvertised / unlinked)  generic import functionality in core which relies on this metadata.

Comments
----------------------------------------
