### PR TITLE
Fix overzealous redirect fix

### DIFF
--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -3,7 +3,7 @@
 class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
 
   public function preProcess(): void {
-    if ($this->isStandalone() && !$this->hasValidDataSource()) {
+    if ($this->isStandalone() && !$this->getUserJob()['is_template'] && !$this->hasValidDataSource()) {
       $job = $this->getUserJob();
       CRM_Utils_System::redirect(CRM_Utils_System::url('civicrm/import/' . str_replace('_import', '', $job['job_type']), [
         'id' => $job['id'],


### PR DESCRIPTION
Overview
----------------------------------------
Fix overzealous redirect fix

Before
----------------------------------------
A just-merged fix set up a redirect for the MapField screen to redirect to the DataSource screen when there is no valid datasource - but I forgot to add a carve out for when the UserJob has no valid DataSource because it is a template

After
----------------------------------------
Tiny change, big difference

Mapping form load for Template User Job 

<img width="1030" height="301" alt="image" src="https://github.com/user-attachments/assets/f05a8645-a1b2-4636-9e09-5ba5a249ddc7" />


Technical Details
----------------------------------------

Comments
----------------------------------------
