### PR TITLE
Add (basic) import actions

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1294,47 +1294,6 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
-   * Get bundled actions.
-   *
-   * A bundled action is a configured api call. It needs to be created in a secure way
-   * as it can the be offered up to the caller to be attached to (e.g.) an import, possibly under different
-   * permissions.
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
-   */
-  public static function getBundledActions(): array {
-    $className = CRM_Core_DAO_AllCoreTables::getCanonicalClassName(static::class);
-    if ($className === 'CRM_Core_DAO') {
-      throw new CRM_Core_Exception('Function deleteRecord must be called on a subclass of CRM_Core_DAO');
-    }
-    $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($className);
-    // The theory would be to fire off a listener here but for now let's just populate with some
-    // actions for contact (only)
-    $actions = [];
-    if ($entityName === 'Contact') {
-      // for now we check permissions so this always runs as the logged in user ....
-      // Tags, send workflow messages are also ones that could be added
-      // programmatically.
-      foreach (\Civi\Api4\Group::get()->execute() as $group) {
-        $actions['add_to_group.' . $group['name']] = [
-          'id' => 'add_to_group.' . $group['name'],
-          'name' => 'Add to group ' . $group['title'],
-          'text' => ts('Add to group %1', [1 => $group['title']]),
-          'api' => \Civi\Api4\GroupContact::save()
-            ->addRecord([
-              'status' => 'Added',
-              'group_id' => $group['id'],
-              'contact_id' => '$id',
-            ])->setMatch(['contact_id', 'group_id']),
-        ];
-      }
-    }
-    return $actions;
-  }
-
-  /**
    * Gets the names of all enabled schema tables.
    *
    * - Includes tables from core, components & enabled extensions.

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1294,6 +1294,47 @@ class CRM_Core_DAO extends DB_DataObject {
   }
 
   /**
+   * Get bundled actions.
+   *
+   * A bundled action is a configured api call. It needs to be created in a secure way
+   * as it can the be offered up to the caller to be attached to (e.g.) an import, possibly under different
+   * permissions.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function getBundledActions(): array {
+    $className = CRM_Core_DAO_AllCoreTables::getCanonicalClassName(static::class);
+    if ($className === 'CRM_Core_DAO') {
+      throw new CRM_Core_Exception('Function deleteRecord must be called on a subclass of CRM_Core_DAO');
+    }
+    $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass($className);
+    // The theory would be to fire off a listener here but for now let's just populate with some
+    // actions for contact (only)
+    $actions = [];
+    if ($entityName === 'Contact') {
+      // for now we check permissions so this always runs as the logged in user ....
+      // Tags, send workflow messages are also ones that could be added
+      // programmatically.
+      foreach (\Civi\Api4\Group::get()->execute() as $group) {
+        $actions['add_to_group.' . $group['name']] = [
+          'id' => 'add_to_group.' . $group['name'],
+          'name' => 'Add to group ' . $group['title'],
+          'text' => ts('Add to group %1', [1 => $group['title']]),
+          'api' => \Civi\Api4\GroupContact::save()
+            ->addRecord([
+              'status' => 'Added',
+              'group_id' => $group['id'],
+              'contact_id' => '$id',
+            ])->setMatch(['contact_id', 'group_id']),
+        ];
+      }
+    }
+    return $actions;
+  }
+
+  /**
    * Gets the names of all enabled schema tables.
    *
    * - Includes tables from core, components & enabled extensions.

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -283,6 +283,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
           $this->updateUserJobMetadata('template_id', $templateID);
           $this->updateUserJobMetadata('import_mappings', $this->getTemplateJob()['metadata']['import_mappings']);
           $this->updateUserJobMetadata('import_options', $this->getTemplateJob()['metadata']['import_options']);
+          $this->updateUserJobMetadata('import_actions', $this->getTemplateJob()['metadata']['import_actions']);
         }
         if ($submittedValues['use_existing_upload']) {
           // Use the already saved value.

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -283,7 +283,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
           $this->updateUserJobMetadata('template_id', $templateID);
           $this->updateUserJobMetadata('import_mappings', $this->getTemplateJob()['metadata']['import_mappings']);
           $this->updateUserJobMetadata('import_options', $this->getTemplateJob()['metadata']['import_options']);
-          $this->updateUserJobMetadata('import_actions', $this->getTemplateJob()['metadata']['import_actions']);
+          $this->updateUserJobMetadata('bundled_actions', $this->getTemplateJob()['metadata']['bundled_actions']);
         }
         if ($submittedValues['use_existing_upload']) {
           // Use the already saved value.

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -450,7 +450,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
           'Template' => ['mapping_id' => $this->getSavedMappingID()],
           'import_mappings' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_mappings'] : [],
           'import_options' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_options'] : [],
-          'import_actions' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_actions'] : ['action' => NULL, 'entity' => NULL, 'condition' => NULL],
+          'bundled_actions' => $this->getTemplateJob() ? ($this->getTemplateJob()['metadata']['bundled_actions'] ?? []) : [],
           'base_entity' => $this->getBaseEntity(),
         ],
       ])

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -450,6 +450,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
           'Template' => ['mapping_id' => $this->getSavedMappingID()],
           'import_mappings' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_mappings'] : [],
           'import_options' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_options'] : [],
+          'import_actions' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_actions'] : ['action' => NULL, 'entity' => NULL, 'condition' => NULL],
           'base_entity' => $this->getBaseEntity(),
         ],
       ])

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Import\ImportParser;
+
 class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
 
   public function preProcess(): void {
@@ -49,7 +51,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
       'dateFormats' => $this->getDateFormats(),
       'isTemplate' => $this->getUserJob()['is_template'],
       'isStandalone' => $this->isStandalone(),
-      'bundledActions' => ['Contact' => array_values(CRM_Contact_BAO_Contact::getBundledActions())],
+      'bundledActions' => ImportParser::getBundledActions(),
     ]);
   }
 

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -49,6 +49,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
       'dateFormats' => $this->getDateFormats(),
       'isTemplate' => $this->getUserJob()['is_template'],
       'isStandalone' => $this->isStandalone(),
+      'bundledActions' => ['Contact' => array_values(CRM_Contact_BAO_Contact::getBundledActions())],
     ]);
   }
 

--- a/ext/civiimport/Civi/Import/ActivityParser.php
+++ b/ext/civiimport/Civi/Import/ActivityParser.php
@@ -115,7 +115,7 @@ class ActivityParser extends ImportParser {
       'Activity' => [
         'text' => ts('Activity Fields'),
         'entity_title' => ts('Activity'),
-        'is_contact' => FALSE,
+        'entity_type' => 'Activity',
         'actions' => [
           ['id' => 'save', 'text' => ts('Create or Update using ID'), 'description' => ts('Skip if no match found')],
         ],
@@ -128,7 +128,7 @@ class ActivityParser extends ImportParser {
       'TargetContact' => [
         'text' => ts('Target Contact Fields'),
         'entity_title' => ts('Target Contact'),
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'unique_fields' => ['external_identifier', 'id'],
         'supports_multiple' => TRUE,
         'actions' => $this->getActions(['select', 'ignore', 'update']),
@@ -143,7 +143,7 @@ class ActivityParser extends ImportParser {
       'SourceContact' => [
         'text' => ts('Source Contact Fields'),
         'entity_title' => ts('Source Contact'),
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'unique_fields' => ['external_identifier', 'id'],
         'supports_multiple' => FALSE,
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore']) : $this->getActions(['ignore', 'select', 'update', 'save']),
@@ -157,7 +157,7 @@ class ActivityParser extends ImportParser {
       'AssigneeContact' => [
         'text' => ts('assignee Contact Fields'),
         'entity_title' => ts('Assignee Contact'),
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'unique_fields' => ['external_identifier', 'id'],
         'supports_multiple' => TRUE,
         'actions' => $this->getActions(['select', 'ignore']),

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -255,12 +255,13 @@ class ContributionParser extends ImportParser {
         'default_action' => 'create',
         'entity_name' => 'Contribution',
         'entity_title' => ts('Contribution'),
+        'entity_type' => 'Contribution',
         'selected' => ['action' => 'create'],
       ],
       'Contact' => [
         'text' => ts('Contact Fields'),
         'unique_fields' => ['external_identifier', 'id'],
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'supports_multiple' => FALSE,
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),
         'selected' => [
@@ -277,7 +278,7 @@ class ContributionParser extends ImportParser {
         // It turns out there is actually currently no limit - you can import multiple of the same type.
         'supports_multiple' => TRUE,
         'unique_fields' => ['external_identifier', 'id'],
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'is_required' => FALSE,
         'actions' => array_merge([['id' => 'ignore', 'text' => ts('Do not import')]], $this->getActions(['select', 'update', 'save'])),
         'selected' => [

--- a/ext/civiimport/Civi/Import/CustomValueParser.php
+++ b/ext/civiimport/Civi/Import/CustomValueParser.php
@@ -38,10 +38,11 @@ class CustomValueParser extends ImportParser {
    * @return array
    */
   public function getImportEntities() : array {
+    $groupName = $this->getGroupName();
     return [
-      $this->getGroupName() => [
+      $groupName => [
         'text' => ts('Custom Fields'),
-        'is_contact' => FALSE,
+        'entity_type' => "Custom_$groupName",
         'required_fields_update' => [],
         'required_fields_create' => [],
         'is_base_entity' => TRUE,
@@ -50,14 +51,14 @@ class CustomValueParser extends ImportParser {
         // For now we stick with the action selected on the DataSource page.
         'actions' => [['id' => 'create', 'text' => ts('Create'), 'description' => ts('Skip if already exists')]],
         'default_action' => 'create',
-        'entity_name' => $this->getGroupName(),
+        'entity_name' => $groupName,
         'entity_title' => $this->getGroupTitle(),
         'entity_field_prefix' => '',
         'selected' => ['action' => 'create'],
       ],
       'Contact' => [
         'text' => ts('Contact Fields'),
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'entity_field_prefix' => 'Contact.',
         'unique_fields' => ['external_identifier', 'id'],
         'supports_multiple' => FALSE,

--- a/ext/civiimport/Civi/Import/GenericParser.php
+++ b/ext/civiimport/Civi/Import/GenericParser.php
@@ -114,7 +114,7 @@ class GenericParser extends ImportParser {
       $entities['Contact'] = [
         'text' => ts('Contact Fields'),
         'unique_fields' => ['external_identifier', 'id'],
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'supports_multiple' => FALSE,
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),
         'selected' => [

--- a/ext/civiimport/Civi/Import/MembershipParser.php
+++ b/ext/civiimport/Civi/Import/MembershipParser.php
@@ -64,7 +64,7 @@ class MembershipParser extends ImportParser {
     return [
       'Membership' => [
         'text' => ts('Membership Fields'),
-        'is_contact' => FALSE,
+        'entity_type' => 'Membership',
         'required_fields_update' => $this->getRequiredFieldsForMatch(),
         'required_fields_create' => $this->getRequiredFieldsForCreate(),
         'is_base_entity' => TRUE,
@@ -81,7 +81,7 @@ class MembershipParser extends ImportParser {
       ],
       'Contact' => [
         'text' => ts('Contact Fields'),
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'unique_fields' => ['external_identifier', 'id'],
         'supports_multiple' => FALSE,
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),

--- a/ext/civiimport/Civi/Import/ParticipantParser.php
+++ b/ext/civiimport/Civi/Import/ParticipantParser.php
@@ -65,7 +65,7 @@ class ParticipantParser extends ImportParser {
     return [
       'Participant' => [
         'text' => ts('Participant Fields'),
-        'is_contact' => FALSE,
+        'entity_type' => 'Participant',
         'required_fields_update' => $this->getRequiredFieldsForMatch(),
         'required_fields_create' => $this->getRequiredFieldsForCreate(),
         'is_base_entity' => TRUE,
@@ -82,7 +82,7 @@ class ParticipantParser extends ImportParser {
       ],
       'Contact' => [
         'text' => ts('Contact Fields'),
-        'is_contact' => TRUE,
+        'entity_type' => 'Contact',
         'unique_fields' => ['external_identifier', 'id'],
         'supports_multiple' => FALSE,
         'actions' => $this->isUpdateExisting() ? $this->getActions(['ignore', 'update']) : $this->getActions(['select', 'update', 'save']),

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -167,7 +167,7 @@
         $scope.getBundledActionConditions = function() {
           const conditions = [
             {id : 'always', text: ts('Always')},
-            {id : 'on_multiple_match', text: ts('On multiple match')},
+            {id : 'on_multiple_match', text: ts('On multiple match (with first match dedupe rule)')},
           ];
           return {results : conditions};
         };

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -21,7 +21,12 @@
           // The defaults here are derived in the php layer from the saved mapping or the column
           // headers. The latter involves some regex.
           $scope.data.defaults = CRM.vars.crmImportUi.defaults;
+          $scope.data.bundledActions = CRM.vars.crmImportUi.bundledActions;
           $scope.userJob = CRM.vars.crmImportUi.userJob;
+          if ($scope.userJob.metadata.actions === undefined) {
+            // Yeah nah - we just hard-code them cos what else would anyone ever want.
+            $scope.userJob.metadata.actions = {'entity' : null, 'action' : null, 'condition' : 'always'};
+          }
           $scope.data.showColumnNames = $scope.userJob.metadata.submitted_values.skipColumnHeader;
           $scope.data.savedMapping = CRM.vars.crmImportUi.savedMapping;
           $scope.isStandalone = CRM.vars.crmImportUi.isStandalone;
@@ -119,6 +124,30 @@
             }
           });
           return {results: fields};
+        });
+        $scope.getSelectedEntities = (function () {
+          var entities = [];
+          _.each($scope.data.entities, function(entity) {
+            if (entity.is_contact) {
+              entities.push({ 'id': entity.id, 'name': entity.id, 'text': entity.text });
+            }
+          });
+          return {results : entities};
+        });
+
+        $scope.getActions = (function () {
+          // Currently contact is the only entity.
+          var bundledActions = $scope.data.bundledActions.Contact;
+          console.log(bundledActions);
+          return {results : bundledActions};
+        });
+
+        $scope.getConditions = (function () {
+          var conditions = [
+            {'id' : 'always', 'text' : 'Always'},
+            {'id' : 'on_multiple_match', 'text' : 'On Multiple match (note yet implemented)'},
+          ];
+          return {results : conditions};
         });
 
         /**

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -67,7 +67,7 @@
               id: entityMetadata.entity_name,
               text: entityMetadata.entity_title,
               actions: entityMetadata.actions,
-              is_contact: Boolean(entityMetadata.is_contact),
+              entity_type: entityMetadata.entity_type,
               entity_data: entityMetadata.entity_data,
               dedupe_rules: entityMetadata.dedupe_rules,
             });
@@ -119,7 +119,7 @@
             var selected = $scope.data.entities[entity.entity_name].selected;
             if (selected.action !== 'ignore') {
               availableEntity = _.clone(entity);
-              availableEntity.children = filterEntityFields(entity.is_contact, entity.children, selected, entity.entity_name + '.');
+              availableEntity.children = filterEntityFields(entity.entity_type, entity.children, selected, entity.entity_name + '.');
               fields.push(availableEntity);
             }
           });
@@ -128,7 +128,7 @@
         $scope.getSelectedEntities = (function () {
           var entities = [];
           _.each($scope.data.entities, function(entity) {
-            if (entity.is_contact) {
+            if (entity.entity_type === 'Contact') {
               entities.push({ 'id': entity.id, 'name': entity.id, 'text': entity.text });
             }
           });
@@ -138,7 +138,6 @@
         $scope.getActions = (function () {
           // Currently contact is the only entity.
           var bundledActions = $scope.data.bundledActions.Contact;
-          console.log(bundledActions);
           return {results : bundledActions};
         });
 
@@ -158,8 +157,8 @@
          *
          * @type {(function(*=, *=, *=, *=): (*))|*}
          */
-        function filterEntityFields(isContact, fields, selection, entityFieldPrefix) {
-          if (isContact) {
+        function filterEntityFields(entityType, fields, selection, entityFieldPrefix) {
+          if (entityType === 'Contact') {
             return filterContactFields(fields, selection, entityFieldPrefix);
           }
           return fields;

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -35,7 +35,7 @@
       <div class="crm-grid-cell">
         <div>
           <div>
-            <label ng-if="entity.is_contact && entity.selected.action !== 'ignore'">
+            <label ng-if="entity.entity_type === 'Contact' && entity.selected.action !== 'ignore'">
               {{:: ts('Contact type') }}
               <input  class="big" ng-change="updateContactType(entity)"
                 crm-ui-select='{data: data.contactTypes, allowClear: true, placeholder: ts("Any type")}' ng-model="entity.selected.contact_type" />
@@ -46,7 +46,7 @@
       <div class="crm-grid-cell">
         <div>
           <div>
-            <label ng-if="entity.is_contact && entity.selected.action !== 'ignore'">
+            <label ng-if="entity.entity_type === 'Contact' && entity.selected.action !== 'ignore'">
               {{:: ts('Dedupe rule') }}  <input class="big" crm-ui-select='{data: getDedupeRule, multiple: true}' ng-model="entity.selected.dedupe_rule" placeholder="{{:: data.dedupeRules.unique_identifier_match.title }}" ng-list />
             </label>
           </div>

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -69,6 +69,15 @@
     <div >{{:: ts('Date format') }}  <input class="huge" crm-ui-select='{data : dateFormats}' ng-model="userJob.metadata.import_options.date_format" /></div>
   </div>
   <hr>
+  <div id="import-actions">
+    <h3>{{:: ts('Actions') }}</h3>
+    <div >
+      {{:: ts('Entity') }}<input class="big" crm-ui-select='{data : getSelectedEntities}' ng-model="userJob.metadata.import_actions.entity" />
+      {{:: ts('Action') }}<input class="big" crm-ui-select='{data : getActions}' ng-model="userJob.metadata.import_actions.action" />
+      {{:: ts('When') }}<input class="big" crm-ui-select='{data : getConditions}' ng-model="userJob.metadata.import_actions.condition" />
+    </div>
+  </div>
+  <hr>
   <div id="map-field">
     <h3>{{:: ts('Data mapping') }}</h3>
     <table class="selector">

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -71,10 +71,20 @@
   <hr>
   <div id="import-actions">
     <h3>{{:: ts('Actions') }}</h3>
-    <div >
-      {{:: ts('Entity') }}<input class="big" crm-ui-select='{data : getSelectedEntities}' ng-model="userJob.metadata.import_actions.entity" />
-      {{:: ts('Action') }}<input class="big" crm-ui-select='{data : getActions}' ng-model="userJob.metadata.import_actions.action" />
-      {{:: ts('When') }}<input class="big" crm-ui-select='{data : getConditions}' ng-model="userJob.metadata.import_actions.condition" />
+    <div ng-repeat="actionItem in userJob.metadata.bundled_actions">
+      <label for="action-item-entity-{{ $index }}">{{:: ts('Entity') }}</label>
+      <input class="big" id="action-item-entity-{{ $index }}" crm-ui-select='{data: getEntitiesWithBundledActions, allowClear: false}' ng-model="actionItem.entity" />
+      <label for="action-item-action-{{ $index }}">{{:: ts('Action') }}</label>
+      <input class="big" id="action-item-action-{{ $index }}" crm-ui-select='{data: getBundledActionsForEntity(actionItem.entity), allowClear: false}' ng-model="actionItem.action" />
+      <label for="action-item-when-{{ $index }}">{{:: ts('When') }}</label>
+      <input class="big" id="action-item-when-{{ $index }}" crm-ui-select='{data: getBundledActionConditions, allowClear: false}' ng-model="actionItem.condition" />
+      <a href class="crm-hover-button" ng-click="removeAction($index)">
+        <i class="crm-i fa-x"></i>
+      </a>
+    </div>
+    <div>
+      <label for="action-items-add-new">{{:: ts('Add Action') }}</label>
+      <input class="big" id="action-items-add-new" crm-ui-select='{data: getEntitiesWithBundledActions}' on-crm-ui-select="addBundledAction(selection)" />
     </div>
   </div>
   <hr>

--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -67,7 +67,7 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
           'dedupe_rule_id' => NULL,
         ],
         'import_options' => ['date_format' => CRM_Utils_Date::DATE_yyyy_mm_dd],
-        'import_actions' => ['action' => NULL, 'entity' => NULL, 'condition' => NULL],
+        'bundled_actions' => [],
         'import_mappings' => [
           ['name' => 'Contact.external_identifier'],
           ['name' => 'Contribution.total_amount'],

--- a/ext/civiimport/tests/phpunit/CiviApiImportTest.php
+++ b/ext/civiimport/tests/phpunit/CiviApiImportTest.php
@@ -67,6 +67,7 @@ class CiviApiImportTest extends TestCase implements HeadlessInterface, HookInter
           'dedupe_rule_id' => NULL,
         ],
         'import_options' => ['date_format' => CRM_Utils_Date::DATE_yyyy_mm_dd],
+        'import_actions' => ['action' => NULL, 'entity' => NULL, 'condition' => NULL],
         'import_mappings' => [
           ['name' => 'Contact.external_identifier'],
           ['name' => 'Contribution.total_amount'],


### PR DESCRIPTION
Overview
----------------------------------------
This is the first cut of my idea it should be possible to attach pre-configured bundled actions to any entity during import.

For simplicity (& to reflect where the demand is) I have

1) limited it to the Contact entities
2) only created add to group actions
3) only added a single row/ action, rather than being flexible about adding more
4) only implemented the 'always' condition - if this seems doable I will make the 'on_multiple_match' condition work since there is demand to put contacts that might need deduping into a group

<img width="1176" height="832" alt="image" src="https://github.com/user-attachments/assets/1b9d10d7-6d11-4e88-ba89-b5d76b21b3ef" />



Before
----------------------------------------
It is only possible to add Contacts to groups in the Contact import

After
----------------------------------------
Any Contact in any civiimport can be added to a group (subject to limitation 3 above at the moment)

Technical Details
----------------------------------------
This is ultimately a fairly simple implementation but I was trying to think about more generic expansion. The Bundled Actions are configured api calls which are just added to the main api call using `addChain` - I imagine that a listener could allow more to be added / we could add them for other entities/ these could be attached from other places.

Expanding this opens up challenges around security and broken configuration. This blocks those out by
1) running everything in the context of the logged in user
2) only attempting to run the actions if they are 'current' - ie there is an existing Group::get call in there 
3) no UI action configuration - code only

While it is not a requirement of doing this that it is the start of a larger framework it would be nice to at least consider the possibility. Regardless, as long as there is not something blocking next steps would be to review the limitations in the introduction & possibly add caching.

 If this does look like a useful start for a broader approach the next steps would be to make  `getBundledActions()` an api call (possibly not returning the Actual api call - just name, id, description) and thinking about a listener. Or things could percolate

Comments
----------------------------------------
