### PR TITLE
bug fix Pay Later text not replaced when payment is moved to Confirma…

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -248,7 +248,11 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       if ($this->isShowPaymentOnConfirm()) {
         // Setup and load the payment elements on the form
         $this->_paymentProcessorIDs = explode(CRM_Core_DAO::VALUE_SEPARATOR, $this->_values['event']['payment_processor'] ?? NULL);
-        $this->setPayLaterLabel('');
+
+        // assigning payLater label
+        $payLaterLabel = $this->_values['event']['pay_later_text'] ?? '';
+        $this->setPayLaterLabel($payLaterLabel);
+
         $this->assign('pay_later_receipt', '');
         // @fixme These functions all seem to do similar things but take one away and the house of cards falls down..
         $this->assignPaymentProcessor($this->_values['event']['is_pay_later']);


### PR DESCRIPTION
Overview
----------------------------------------
There is an option to set a "Pay Later Label" in "Fees" when setting up an event, which should be used on front end Event registration forms when the "Pay Later" radio button is output. We are finding that text replacement works when the payment form is on the first step of the registration, but not when the payment form is moved to the Confirmation page (see screenshots)

Before
----------------------------------------
<img width="902" height="721" alt="event_config" src="https://github.com/user-attachments/assets/7f0d4385-58ed-49bb-9501-1bc89371ecd7" />
<img width="741" height="749" alt="event_page_payconfirm" src="https://github.com/user-attachments/assets/57634935-547c-4684-9e2a-787c282e9e67" />

After
----------------------------------------
Replacement text now appearing.
<img width="923" height="669" alt="after_fix" src="https://github.com/user-attachments/assets/4852f395-b7d2-4655-9f73-dbd4220b1db9" />


Comments
----------------------------------------

