### PR TITLE
fix unnecessary dialog bottom margin when no buttons

### DIFF
--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -84,10 +84,13 @@
   background: var(--crm-dialog-body-bg);
   color: var(--crm-c-text);
   height: auto !important;
-  margin: var(--crm-dialog-padding) 0 calc(var(--crm-btn-height) + var(--crm-m) + var(--crm-m));
+  margin: var(--crm-dialog-padding) 0;
   position: static;
   z-index: 1;
   padding: var(--crm-dialog-body-padding);
+}
+.crm-container.ui-dialog .ui-dialog-content:has(.ui-dialog-buttonpane) {
+  margin-bottom: calc(var(--crm-btn-height) + var(--crm-m) + var(--crm-m));
 }
 .crm-container.ui-dialog .ui-dialog-content .crm-container {
   background: var(--crm-dialog-bg);


### PR DESCRIPTION
Good example is the Add Role form on Standalone Adminster Roles page.

Before
----------------------------------------
- all jQuery UI dialogs have bottom margin to make room for a buttonpane
<img width="1644" height="1196" alt="image" src="https://github.com/user-attachments/assets/5ce299a6-ca09-4911-b057-d52341377095" />


- jQuery dialogs with no buttons (e.g. for afforms) look weird cause of this trailing margin

<img width="1724" height="850" alt="image" src="https://github.com/user-attachments/assets/0f511de9-fb12-42e8-96a3-8585ca10c733" />


After
----------------------------------------
- forms with button pane still have the margin:
<img width="1741" height="1182" alt="image" src="https://github.com/user-attachments/assets/771d6f4a-7c91-468d-a2df-4fe1ebc97bb6" />

- forms without dont have the weird trailing space
<img width="1925" height="879" alt="image" src="https://github.com/user-attachments/assets/165a4f0d-cf43-4f2f-ac77-98b91ff3f542" />
