### PR TITLE
new const CIVICRM_DB_CACHE_DATABASE for Redis/ValKey database usage

### DIFF
--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -62,6 +62,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     $port = $config['port'] ?? self::DEFAULT_PORT;
     // Ugh.
     $pass = CRM_Utils_Constant::value('CIVICRM_DB_CACHE_PASSWORD');
+    $base = CRM_Utils_Constant::value('CIVICRM_DB_CACHE_DATABASE');
     $id = implode(':', ['connect', $host, $port /* $pass is constant */]);
     if (!isset(Civi::$statics[__CLASS__][$id])) {
       // Ideally, we'd track the connection in the service-container, but the
@@ -74,6 +75,9 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
       }
       if ($pass) {
         $redis->auth($pass);
+      }
+      if ($base) {
+        $redis->select($base);
       }
       Civi::$statics[__CLASS__][$id] = $redis;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Redis/Valkey engines have the feature of creating different internal [databases](https://valkey.io/commands/select/), defined by an integer index.  
If you want to use Redis/Valkey for cache storage, now only works for database 0 by default, and cannot be changed.  
I've added a new constant, where it can be defined the DB number in case you don't want to use the 0 (specially in a multi-site environment, to isolate db per web site)

Before
----------------------------------------
When using Redis/ValKey for cache storage, only database zero is used

After
----------------------------------------
you can define your constant `define('CIVICRM_DB_CACHE_DATABASE', 11);`  to use a different database number

Technical Details
----------------------------------------
the change in the code is very straight-forward

Comments
----------------------------------------
@eileenmcnaughton maybe you interested in this one...
I wasn't sure how to name the new constant because is only valid in a Redis/Valkey cache context.. another alternative could be `CIVICRM_DB_CACHE_REDIS_DB`.

PS: We are using Valkey, instead of Redis, seems a better option due to the Redis License model..