### PR TITLE
Revert "fix unnecessary dialog bottom margin when no buttons"

### DIFF
--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -84,13 +84,10 @@
   background: var(--crm-dialog-body-bg);
   color: var(--crm-c-text);
   height: auto !important;
-  margin: var(--crm-dialog-padding) 0;
+  margin: var(--crm-dialog-padding) 0 calc(var(--crm-btn-height) + var(--crm-m) + var(--crm-m));
   position: static;
   z-index: 1;
   padding: var(--crm-dialog-body-padding);
-}
-.crm-container.ui-dialog .ui-dialog-content:has(.ui-dialog-buttonpane) {
-  margin-bottom: calc(var(--crm-btn-height) + var(--crm-m) + var(--crm-m));
 }
 .crm-container.ui-dialog .ui-dialog-content .crm-container {
   background: var(--crm-dialog-bg);


### PR DESCRIPTION
Overview
-----
Reverts civicrm/civicrm-core#33310 because it causes dialog content to get clipped.

WIth PR
--------
SearchKit tasks get their bottom field clipped off:
<img width="1396" height="560" alt="image" src="https://github.com/user-attachments/assets/82e45b53-e018-4803-98ed-b1caab27f2b0" />

PR Reverted
---------
<img width="1398" height="650" alt="image" src="https://github.com/user-attachments/assets/8a880df9-3928-4242-a135-8ef95f81caf8" />


