### PR TITLE
RiverLea: fixes layout bug on FormBuilder inline layout inside Details

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -65,6 +65,12 @@ details.af-container > *:nth-of-type(1):not(summary) {
 details.af-container > *:last-of-type {
   padding-bottom: var(--crm-m);
 }
+details.af-container.af-layout-inline {
+  flex-direction: column;
+}
+details.af-container.af-layout-inline > *:not(summary) {
+  display: inline-block;
+}
 
 /* Card style */
 .af-container-style-pane {


### PR DESCRIPTION
Overview
----------------------------------------
Replaces this closed PR: https://github.com/civicrm/civicrm-core/pull/33025.  The class`af-layout-inline` doesn't work in RiverLea inside Details/collapsible elements. This is best seen in the 'experimental' SK searches like 'Find Members'.

One fix would be to wrap all the elements in `crm-accordion-body` but that would require re-writing [this](https://github.com/civicrm/civicrm-core/blob/ece0bc14c5a0e2762b70a130dd457b7c1f4f37b1/ext/afform/core/ang/af/afTitle.directive.js). 

This PR fixes this by forcing inline block alignment for all but the first element (the summary).

Before
----------------------------------------
Broken
<img width="1817" height="604" alt="image" src="https://github.com/user-attachments/assets/e2e40db1-fca5-46a7-a77d-5861305d5530" />

After
----------------------------------------
Not broken
<img width="1804" height="390" alt="image" src="https://github.com/user-attachments/assets/3ef66d6d-4c0a-4624-b366-4ffb0d94151e" />