### PR TITLE
RiverLea: swaps icon/checkbox order for inactive rows in tables

### DIFF
--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -235,6 +235,14 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   color: var(--crm-alert-danger-text);
   font-style: normal;
 }
+.crm-container tr:has(.disabled) td:first-of-type:has(input[type='checkbox']),
+.crm-container tr.disabled td:first-of-type:has(input[type='checkbox']) {
+  /* puts checkbox first if cell has checkbox */
+  display: flex;
+  flex-direction: row-reverse;
+  gap: var(--crm-flex-gap);
+  justify-content: start;
+}
 
 /* Jqueery UI icons (tags) */
 .crm-container .jstree-wholerow-ul {


### PR DESCRIPTION
Overview
----------------------------------------
Follows comment from @colemanw on https://github.com/civicrm/civicrm-core/pull/33278 - 

> "I don't love the way the checkboxes no longer all align vertically, but I can live with it. "

Before
----------------------------------------
Icon comes first if there's a checkbox
<img width="698" height="318" alt="image" src="https://github.com/user-attachments/assets/8fed8825-957a-47ed-9182-1243c0c71fb3" />


After
----------------------------------------
Icon comes last if there's a checkbox

<img width="849" height="313" alt="image" src="https://github.com/user-attachments/assets/e041214c-7c92-4538-8714-b4eac384919f" />

also content that isn't a checkbox doesn't trigger this change, ie it's still on right here.

<img width="671" height="337" alt="image" src="https://github.com/user-attachments/assets/616e1c20-3fd2-4fa3-b1b0-325bdeee094d" />
