### PR TITLE
Riverlea, fixes colour issue on disabled table row buttons and icons

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -280,7 +280,7 @@ dl dl {
 }
 .crm-container .disabled,
 .crm-container .crm-disabled,
-.crm-container .disabled *,
+.crm-container .disabled *:not(.btn,button,i,span),
 .crm-container .cancelled,
 .crm-container .cancelled td,
 .crm-container li.disabled a.ui-tabs-anchor {


### PR DESCRIPTION
Overview
----------------------------------------
My recent PR https://github.com/civicrm/civicrm-core/pull/33278 had a couple of regressions with the row text colour inherited by buttons, rendering them illegible. This fixes that.

Before
----------------------------------------
Buttons illegible:

<img width="1548" height="420" alt="image" src="https://github.com/user-attachments/assets/3f4c3e25-198b-4e92-8ec9-29589737bae4" />

After
----------------------------------------
Buttons legible:

<img width="1522" height="448" alt="image" src="https://github.com/user-attachments/assets/8141d8b8-b80e-464f-8901-7b305c37f7f6" />

Technical Details
----------------------------------------
This just excludes elements - if more or found or needed they can be added to the `:not` array.