### PR TITLE
CiviImport - Allow multiple dedupe rules to be selected

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -125,9 +125,7 @@ class CRM_Activity_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
         foreach ($fields['mapper'] as $field) {
           $importKeys[] = $field[0];
         }
-        $parser = $self->getParser();
-        $rule = $parser->getDedupeRule('Individual', $self->getUserJob()['metadata']['entity_configuration']['TargetContact']['dedupe_rule'] ?? NULL);
-        $errors = $self->validateContactFields($rule, $fields['mapper'], ['external_identifier', 'id']);
+        $errors = $self->getMissingContactFields('TargetContact', $self->getFieldMappings());
 
         $missingFields = $self->validateRequiredFields($importKeys);
         if ($missingFields) {

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1468,4 +1468,25 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     return $array;
   }
 
+  /**
+   * Given an array of contact values, figure out the contact type.
+   *
+   * @param array $values
+   * @return string
+   */
+  protected function guessContactType(array $values): string {
+    if (!empty($values['contact_type'])) {
+      return $values['contact_type'];
+    }
+    $contactFields = \Civi::entity('Contact')->getFields();
+    foreach (\CRM_Contact_BAO_ContactType::basicTypes() as $contactType) {
+      foreach ($contactFields as $fieldName => $field) {
+        if (($field['contact_type'] ?? NULL) === $contactType && !empty($values[$fieldName])) {
+          return $contactType;
+        }
+      }
+    }
+    return 'Individual';
+  }
+
 }

--- a/Civi/Api4/Action/Contact/GetDuplicates.php
+++ b/Civi/Api4/Action/Contact/GetDuplicates.php
@@ -87,7 +87,7 @@ class GetDuplicates extends \Civi\Api4\Generic\DAOCreateAction {
     $this->formatDedupeParams($item, $dedupeParams);
 
     foreach (\CRM_Contact_BAO_Contact::findDuplicates($dedupeParams) as $id) {
-      $result[] = ['id' => $id];
+      $result[] = ['id' => (int) $id];
     }
   }
 

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -183,6 +183,9 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
   public static function validateMapping(array $fields, array $files, CRM_CiviImport_Form_MapField $self): bool|array {
     $mapperError = [];
     try {
+      $parser = $self->getParser();
+      $mappings = $self->getFieldMappings();
+      $parser->validateMapping($mappings);
       $mapperError = $self->getMissingContactFields('Contact', $self->getFieldMappings());
     }
     catch (CRM_Core_Exception $e) {

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -185,7 +185,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
     try {
       $parser = $self->getParser();
       $mappings = $self->getFieldMappings();
-      $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'] ?? NULL);
+      $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'][0] ?? NULL);
       $mapperError = $self->validateContactFields($rule, $mappings, ['contact_id', 'external_identifier']);
       $parser->validateMapping($mappings);
     }

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -183,11 +183,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
   public static function validateMapping(array $fields, array $files, CRM_CiviImport_Form_MapField $self): bool|array {
     $mapperError = [];
     try {
-      $parser = $self->getParser();
-      $mappings = $self->getFieldMappings();
-      $rule = $parser->getDedupeRule($self->getContactType(), $self->getUserJob()['metadata']['entity_configuration']['Contact']['dedupe_rule'][0] ?? NULL);
-      $mapperError = $self->validateContactFields($rule, $mappings, ['contact_id', 'external_identifier']);
-      $parser->validateMapping($mappings);
+      $mapperError = $self->getMissingContactFields('Contact', $self->getFieldMappings());
     }
     catch (CRM_Core_Exception $e) {
       $mapperError[] = $e->getMessage();
@@ -196,6 +192,23 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
       return ['_qf_default' => implode('<br/>', $mapperError)];
     }
     return TRUE;
+  }
+
+  /**
+   * @param string $entity
+   * @param array $mapper
+   * @return array
+   * @throws CRM_Core_Exception
+   */
+  public function getMissingContactFields(string $entity, array $mapper): array {
+    $parser = $this->getParser();
+    $rules = $this->getUserJob()['metadata']['entity_configuration'][$entity]['dedupe_rule'] ?? ['unique_identifier_match'];
+    $missingError = [];
+    foreach ($rules as $rule) {
+      $rule = $parser->getDedupeRule($this->getContactType(), $rule);
+      $missingError = array_merge($missingError, $this->validateContactFields($rule, $this->getImportKeys($mapper), ['external_identifier', 'contact_id', 'id']));
+    }
+    return array_filter($missingError);
   }
 
   /**
@@ -215,9 +228,11 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
         $mapper[] = [$field['name']];
       }
     }
-    $parser = $this->getParser();
-    $rule = $parser->getDedupeRule($this->getContactType(), $this->getUserJob()['metadata']['entity_configuration'][$entity]['dedupe_rule'] ?? NULL);
-    return $this->validateContactFields($rule, $this->getImportKeys($mapper), ['external_identifier', 'contact_id', 'id']);
+    $missing = $this->getMissingContactFields($entity, $mapper);
+    if (empty($missing)) {
+      return [];
+    }
+    return ['_qf_default' => implode(' + ', $missing)];
   }
 
   /**

--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -35,10 +35,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   private function assignCiviimportVariables(): void {
-    $contactTypes = [];
-    foreach (CRM_Contact_BAO_ContactType::basicTypeInfo() as $contactType) {
-      $contactTypes[] = ['id' => $contactType['name'], 'text' => $contactType['label']];
-    }
+    $contactTypes = CRM_Utils_Array::formatForSelect2(CRM_Contact_BAO_ContactType::basicTypeInfo(), 'name', 'label');
     $parser = $this->getParser();
     $this->isQuickFormMode = FALSE;
     Civi::resources()->addVars('crmImportUi', [

--- a/ext/civiimport/Civi/Api4/Service/Spec/Provider/UserJobSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Service/Spec/Provider/UserJobSpecProvider.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class UserJobSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $spec->getFieldByName('metadata')->addOutputFormatter([__CLASS__, 'formatMetadata']);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'UserJob';
+  }
+
+  public static function formatMetadata(&$metadata): void {
+    if (is_string($metadata)) {
+      $metadata = json_decode($metadata, TRUE);
+    }
+    if (!empty($metadata['entity_configuration']) && is_array($metadata['entity_configuration'])) {
+      foreach ($metadata['entity_configuration'] as &$entityConfig) {
+        // Backward-compat for single-valued dedupe_rule (now expects an array)
+        if (isset($entityConfig['dedupe_rule']) && !is_array($entityConfig['dedupe_rule'])) {
+          // Backward-compat for rule id provided instead of name
+          if (is_numeric($entityConfig['dedupe_rule'])) {
+            $entityConfig['dedupe_rule'] = \CRM_Dedupe_BAO_DedupeRuleGroup::getDbVal('name', $entityConfig['dedupe_rule']);
+          }
+          $entityConfig['dedupe_rule'] = [$entityConfig['dedupe_rule']];
+        }
+      }
+    }
+  }
+
+}

--- a/ext/civiimport/Civi/Import/ActivityParser.php
+++ b/ext/civiimport/Civi/Import/ActivityParser.php
@@ -135,7 +135,7 @@ class ActivityParser extends ImportParser {
         'selected' => [
           'action' => 'select',
           'contact_type' => NULL,
-          'dedupe_rule' => 'unique_identifier_match',
+          'dedupe_rule' => ['unique_identifier_match'],
         ],
         'default_action' => 'select',
         'entity_name' => 'TargetContact',

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -266,7 +266,7 @@ class ContributionParser extends ImportParser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => 'Individual',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => (array) $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',
@@ -284,7 +284,7 @@ class ContributionParser extends ImportParser {
           'contact_type' => 'Individual',
           'soft_credit_type_id' => $defaultSoftCreditTypeID,
           'action' => 'ignore',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => (array) $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'ignore',
         'entity_name' => 'SoftCreditContact',

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -331,10 +331,11 @@ class ContributionParser extends ImportParser {
       $contributionParams['contact_id'] = $params['Contact']['id'] = $this->getContactID($params['Contact'] ?? [], $contributionParams['contact_id'] ?? ($existingContribution['contact_id'] ?? NULL), 'Contact', $this->getDedupeRulesForEntity('Contact'));
 
       $softCreditParams = [];
-      $softCreditEntities = isset($params['SoftCreditContact']) ? [$params['SoftCreditContact']] : [];
+      // A hook could have change it to be an array of arrays.
+      $softCreditEntities = isset($params['SoftCreditContact']['soft_credit_type_id']) ? [$params['SoftCreditContact']] : $params['SoftCreditContact'] ?? [];
       foreach ($softCreditEntities as $index => $softCreditContact) {
         $softCreditParams[$index]['soft_credit_type_id'] = $softCreditContact['soft_credit_type_id'];
-        $softCreditParams[$index]['contact_id'] = $this->getContactID($softCreditContact, !empty($softCreditContact['id']) ? $softCreditContact['id'] : NULL, 'SoftCreditContact', $this->getDedupeRulesForEntity('SoftCreditContact'));
+        $softCreditEntities[$index]['id'] = $this->getContactID($softCreditContact, !empty($softCreditContact['id']) ? $softCreditContact['id'] : NULL, 'SoftCreditContact', $this->getDedupeRulesForEntity('SoftCreditContact'));
         if (empty($softCreditParams[$index]['contact_id']) && in_array($this->getActionForEntity('SoftCreditContact'), ['update', 'select'])) {
           throw new \CRM_Core_Exception(ts('Soft Credit Contact not found'));
         }
@@ -346,7 +347,7 @@ class ContributionParser extends ImportParser {
       // if the lookups failed.
 
       foreach ($softCreditEntities as $index => $softCreditContact) {
-        $softCreditParams[$index]['contact_id'] = $this->saveContact('SoftCreditContact', $softCreditContact) ?: $softCreditParams[$index]['contact_id'];
+        $softCreditParams[$index]['contact_id'] = $this->saveContact('SoftCreditContact', $softCreditContact) ?: $softCreditContact['id'];
       }
       $contributionParams['contact_id'] = $this->saveContact('Contact', $params['Contact'] ?? []) ?: $contributionParams['contact_id'];
 

--- a/ext/civiimport/Civi/Import/CustomValueParser.php
+++ b/ext/civiimport/Civi/Import/CustomValueParser.php
@@ -65,7 +65,7 @@ class CustomValueParser extends ImportParser {
         'selected' => [
           'action' => 'select',
           'contact_type' => 'Individual',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => (array) $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/ext/civiimport/Civi/Import/GenericParser.php
+++ b/ext/civiimport/Civi/Import/GenericParser.php
@@ -120,7 +120,7 @@ class GenericParser extends ImportParser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => 'Individual',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => (array) $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -538,15 +538,15 @@ abstract class ImportParser extends \CRM_Import_Parser {
    * Get contacts that match the input parameters, using a dedupe rule.
    *
    * @param array $params
-   * @param int|null|array $dedupeRuleID
+   * @param int|null|array $dedupeRuleNames
    *
    * @return array
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getPossibleMatchesByDedupeRule(array $params, $dedupeRuleID = NULL): array {
+  protected function getPossibleMatchesByDedupeRule(array $params, ?array $dedupeRuleNames = NULL): array {
     $matchIDs = [];
-    $dedupeRules = $this->getDedupeRules((array) $dedupeRuleID, $params['contact_type'] ?? NULL);
+    $dedupeRules = $this->getDedupeRules($dedupeRuleNames, $this->guessContactType($params));
     foreach ($dedupeRules as $dedupeRule) {
       if ($dedupeRule === 'unique_email_match') {
         if (empty($params['email_primary.email'])) {
@@ -563,7 +563,7 @@ abstract class ImportParser extends \CRM_Import_Parser {
           $matchIDs[$match['contact_id']] = $match['contact_id'];
         }
       }
-      else {
+      elseif ($dedupeRule !== 'unique_identifier_match') {
         $isMatchFirst = str_ends_with($dedupeRule, '.first');
         if ($isMatchFirst) {
           $dedupeRule = substr($dedupeRule, 0, -6);
@@ -588,23 +588,25 @@ abstract class ImportParser extends \CRM_Import_Parser {
   /**
    * Get the dedupe rules to use to lookup a contact.
    *
-   * @param array $dedupeRuleIDs
-   * @param string|array|null $contact_type
+   * @param array|null $dedupeRuleNames
+   * @param string $contact_type
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function getDedupeRules(array $dedupeRuleIDs, $contact_type) {
+  protected function getDedupeRules(?array $dedupeRuleNames, string $contact_type) {
     $dedupeRules = [];
-    if (!empty($dedupeRuleIDs)) {
-      foreach ($dedupeRuleIDs as $dedupeRuleID) {
-        $dedupeRules[] = is_numeric($dedupeRuleID) ? $this->getDedupeRuleName($dedupeRuleID) : $dedupeRuleID;
+    if (!empty($dedupeRuleNames)) {
+      foreach ($dedupeRuleNames as $dedupeRuleName) {
+        $ruleInfo = $this->getDedupeRule($contact_type, $dedupeRuleName);
+        if (!$ruleInfo['contact_type'] || $contact_type === $ruleInfo['contact_type']) {
+          $dedupeRules[] = $dedupeRuleName;
+        }
       }
       return $dedupeRules;
     }
-    $contactTypes = $contact_type ? (array) $contact_type : \CRM_Contact_BAO_ContactType::basicTypes();
-    foreach ($contactTypes as $contactType) {
-      $dedupeRules[] = $this->getDefaultRuleForContactType($contactType);
+    if (empty($dedupeRules)) {
+      $dedupeRules[] = 'unique_identifier_match';
     }
     return $dedupeRules;
   }

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -302,7 +302,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
       $name = $this->getDefaultRuleForContactType($contactType);
     }
     if (empty($this->dedupeRules[$name])) {
-      $where = [['name', '=', $name]];
+      $canonicalName = str_ends_with($name, '.first') ? substr($name, 0, -6) : $name;
+      $where = [['name', '=', $canonicalName]];
       $this->loadRules($where);
     }
     return $this->dedupeRules[$name];

--- a/ext/civiimport/Civi/Import/MembershipParser.php
+++ b/ext/civiimport/Civi/Import/MembershipParser.php
@@ -88,7 +88,7 @@ class MembershipParser extends ImportParser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => 'Individual',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => (array) $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/ext/civiimport/Civi/Import/ParticipantParser.php
+++ b/ext/civiimport/Civi/Import/ParticipantParser.php
@@ -89,7 +89,7 @@ class ParticipantParser extends ImportParser {
         'selected' => [
           'action' => $this->isUpdateExisting() ? 'ignore' : 'select',
           'contact_type' => 'Individual',
-          'dedupe_rule' => $this->getDedupeRule('Individual')['name'],
+          'dedupe_rule' => (array) $this->getDedupeRule('Individual')['name'],
         ],
         'default_action' => 'select',
         'entity_name' => 'Contact',

--- a/ext/civiimport/ang/crmCiviimport/Import.html
+++ b/ext/civiimport/ang/crmCiviimport/Import.html
@@ -47,7 +47,7 @@
         <div>
           <div>
             <label ng-if="entity.is_contact && entity.selected.action !== 'ignore'">
-              {{:: ts('Dedupe rule') }}  <input class="big" crm-ui-select='{data: getDedupeRule}' ng-model="entity.selected.dedupe_rule" />
+              {{:: ts('Dedupe rule') }}  <input class="big" crm-ui-select='{data: getDedupeRule, multiple: true}' ng-model="entity.selected.dedupe_rule" placeholder="{{:: data.dedupeRules.unique_identifier_match.title }}" ng-list />
             </label>
           </div>
         </div>

--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -346,10 +346,10 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
       ['name' => 'Activity.location'],
       ['name' => 'Activity.subject'],
       ['name' => 'do_not_import'],
-    ]);
+    ], [], 'create', ['TargetContact' => ['dedupe_rule' => ['unique_email_match'], 'contact_type' => NULL]]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
     $row = $dataSource->getRow();
-    $this->assertEquals('IMPORTED', $row['_status']);
+    $this->assertEquals('IMPORTED', $row['_status'], $row['_status_message']);
     $this->callAPISuccessGetSingle('Activity', ['priority_id' => 'Urgent']);
   }
 

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -145,10 +145,10 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'external_identifier' => 'ext-1',
       'contact_type' => 'Individual',
     ]);
-    $softCreditContactID = $this->individualCreate([
+    $softCreditContactID = $this->organizationCreate([
       'organization_name' => 'The firm',
       'external_identifier' => 'ext-2',
-      'email' => 'the-firm@example.com',
+      'email_primary.email' => 'the-firm@example.com',
       'contact_type' => 'Organization',
     ]);
 
@@ -161,7 +161,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'Contact.email_primary.email'],
       ['name' => 'SoftCreditContact.email_primary.email', 'entity_data' => ['soft_credit' => ['soft_credit_type_id' => 1]]],
     ];
-    $this->importCSV('contributions_amount_validate.csv', $mapping);
+    $this->importCSV('contributions_amount_validate.csv', $mapping, [], 'create', ['SoftCreditContact' => ['dedupe_rule' => ['OrganizationUnsupervised'], 'contact_type' => 'Organization', 'action' => 'save']]);
 
     $contributionsOfMainContact = Contribution::get()->addWhere('contact_id', '=', $mainContactID)->execute();
     // Although there are 2 rows in the csv, 1 should fail each time due to conflicting money formats.

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -347,12 +347,12 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       'Contact' => [
         'action' => 'create',
         'contact_type' => 'Organization',
-        'dedupe_rule' => 'OrganizationUnsupervised',
+        'dedupe_rule' => ['OrganizationUnsupervised'],
       ],
       'SoftCreditContact' => [
         'contact_type' => 'Individual',
         'action' => 'create',
-        'dedupe_rule' => 'IndividualSupervised',
+        'dedupe_rule' => ['IndividualSupervised'],
         'soft_credit_type_id' => 1,
       ],
     ];

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -662,7 +662,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     }
     $contactType = 'Individual';
     $this->submitDataSourceForm('contributions.csv');
-    $this->updateJobMetadata($mappings, $contactType);
+    $this->updateJobMetadata($mappings, $contactType, ['IndividualUnsupervised']);
     $form = $this->getMapFieldForm();
     $form->setUserJobID($this->userJobID);
     $form->buildForm();
@@ -716,7 +716,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     // First we try to create without total_amount mapped.
     // It will fail in create mode as total_amount is required for create.
     $this->submitDataSourceForm('contributions.csv');
-    $this->updateJobMetadata($fieldMappings, 'Individual');
+    $this->updateJobMetadata($fieldMappings, 'Individual', ['IndividualUnsupervised']);
     $form = $this->getMapFieldForm([
       'mapper' => $this->getMapperFromFieldMappings($fieldMappings),
       'contactType' => 'Individual',

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -461,7 +461,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ['name' => 'Contribution.financial_type_id'],
     ]);
     $dataSource = new CRM_Import_DataSource_CSV($this->userJobID);
-    $this->assertEquals(1, $dataSource->getRowCount([\CRM_Import_Parser::PLEDGE_PAYMENT]));
+    $this->assertEquals(1, $dataSource->getRowCount([\CRM_Import_Parser::PLEDGE_PAYMENT]), $dataSource->getRow()['_status_message']);
     $this->assertEquals(1, $dataSource->getRowCount([CRM_Import_Parser::VALID]));
     $contribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $contactID]);
     $this->callAPISuccessGetSingle('PledgePayment', ['pledge_id' => $pledgeID, 'contribution_id' => $contribution['id']]);

--- a/tests/phpunit/CRM/Import/ParserTest.php
+++ b/tests/phpunit/CRM/Import/ParserTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ *   This file is part of CiviCRM
+ *
+ *   CiviCRM is free software; you can redistribute it and/or
+ *   modify it under the terms of the GNU Affero General Public License
+ *   as published by the Free Software Foundation; either version 3 of
+ *   the License, or (at your option) any later version.
+ *
+ *   CiviCRM is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Affero General Public License for more details.
+ *
+ *   You should have received a copy of the GNU Affero General Public
+ *   License along with this program.  If not, see
+ *   <http://www.gnu.org/licenses/>.
+ */
+
+use Civi\Import\ActivityParser;
+use Civi\Test\Invasive;
+
+/**
+ * Test general Import Parser functions
+ *
+ * @package   CiviCRM
+ * @group headless
+ * @group import
+ */
+class CRM_Import_ParserTest extends CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+  }
+
+  /**
+   * Provides test cases for contact type guessing
+   */
+  public function contactTypeProvider(): array {
+    return [
+      'explicit contact type' => [
+        ['contact_type' => 'Organization'],
+        'Organization',
+      ],
+      'individual field 1' => [
+        ['first_name' => 'John'],
+        'Individual',
+      ],
+      'individual field 2' => [
+        ['formal_title' => 'Sir John'],
+        'Individual',
+      ],
+      // `organization_name` is used to cache the individual's current employer's name
+      // So this test case ensures the guesser doesn't get confused by that.
+      'individual field 3' => [
+        ['organization_name' => 'Smith Corp', 'last_name' => 'Smith'],
+        'Individual',
+      ],
+      'organization field 1' => [
+        ['organization_name' => 'ACME Corp'],
+        'Organization',
+      ],
+      'organization field 2' => [
+        ['sic_code' => 123],
+        'Organization',
+      ],
+      'household field 1' => [
+        ['household_name' => 'Smith Family'],
+        'Household',
+      ],
+      'household field 2' => [
+        ['primary_contact_id' => 123],
+        'Household',
+      ],
+      'non-specific field' => [
+        ['email' => 'test@example.com'],
+        'Individual',
+      ],
+      'empty values' => [
+        [],
+        'Individual',
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider contactTypeProvider
+   */
+  public function testGuessContactType(array $values, string $expectedType): void {
+    $activityParser = new ActivityParser();
+    $result = Invasive::call([$activityParser, 'guessContactType'], [$values]);
+    $this->assertEquals($expectedType, $result);
+  }
+
+}

--- a/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Import/Parser/MembershipTest.php
@@ -167,7 +167,6 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
     $membershipImporter = new MembershipParser();
     $membershipImporter->setUserJobID($this->getUserJobID([
       'mapper' => [['Contact.email_primary.email'], ['Membership.membership_type_id'], ['Membership.start_date'], ['Membership.is_override']],
-      'onDuplicate' => CRM_Import_Parser::DUPLICATE_UPDATE,
     ]));
     $membershipImporter->init();
 
@@ -319,7 +318,7 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
       $mapper[] = [$field];
     }
 
-    $membershipImporter = new MembershipParser($fieldMapper);
+    $membershipImporter = new MembershipParser();
     $membershipImporter->setUserJobID($this->getUserJobID(['mapper' => $mapper]));
     $membershipImporter->init();
     $membershipImporter->_contactType = 'Individual';
@@ -344,9 +343,13 @@ class CRM_Member_Import_Parser_MembershipTest extends CiviUnitTestCase {
           'dataSource' => 'CRM_Import_DataSource_SQL',
           'sqlQuery' => 'SELECT ' . implode(', ', $queryFields) . ' FROM civicrm_contact',
         ], $submittedValues),
+        'entity_configuration' => [
+          'Contact' => ['contact_type' => 'Individual', 'dedupe_rule' => 'IndividualUnsupervised'],
+          'Membership' => ['action' => 'update'],
+        ],
       ],
       'status_id:name' => 'draft',
-      'job_type' => 'contact_import',
+      'job_type' => 'membership_import',
     ])->execute()->first()['id'];
     if ($submittedValues['dataSource'] ?? NULL === 'CRM_Import_DataSource') {
       $dataSource = new CRM_Import_DataSource_CSV($userJobID);

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -55,7 +55,7 @@ trait CRMTraits_Import_ParserTrait {
       ->execute()->first()['metadata'];
     $userJobMetadata['entity_configuration'][$userJobMetadata['base_entity']]['action'] = $action;
     $userJobMetadata['entity_configuration']['Contact']['contact_type'] = $submittedValues['contactType'] ?? 'Individual';
-    $userJobMetadata['entity_configuration']['Contact']['dedupe_rule'] = ['IndividualSupervised'];
+    $userJobMetadata['entity_configuration']['Contact']['dedupe_rule'] = ['IndividualUnsupervised'];
     foreach ($fieldMappings as $index => $mapping) {
       if (isset($mapping['entity_data'])) {
         $userJobMetadata['entity_configuration']['SoftCreditContact'] = $mapping['entity_data']['soft_credit'];

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -42,11 +42,9 @@ trait CRMTraits_Import_ParserTrait {
     $submittedValues = array_merge([
       'skipColumnHeader' => TRUE,
       'fieldSeparator' => ',',
-      'contactType' => 'Individual',
       'mapper' => $this->getMapperFromFieldMappings($fieldMappings),
       'dataSource' => 'CRM_Import_DataSource_CSV',
       'file' => ['name' => $csv],
-      'dateFormats' => CRM_Utils_Date::DATE_yyyy_mm_dd,
       'groups' => [],
     ], $submittedValues);
     $this->submitDataSourceForm($csv, $submittedValues);
@@ -56,7 +54,8 @@ trait CRMTraits_Import_ParserTrait {
       ->addWhere('id', '=', $this->userJobID)
       ->execute()->first()['metadata'];
     $userJobMetadata['entity_configuration'][$userJobMetadata['base_entity']]['action'] = $action;
-    $userJobMetadata['entity_configuration']['Contact']['contact_type'] = $submittedValues['contactType'];
+    $userJobMetadata['entity_configuration']['Contact']['contact_type'] = $submittedValues['contactType'] ?? 'Individual';
+    $userJobMetadata['entity_configuration']['Contact']['dedupe_rule'] = ['IndividualSupervised'];
     foreach ($fieldMappings as $index => $mapping) {
       if (isset($mapping['entity_data'])) {
         $userJobMetadata['entity_configuration']['SoftCreditContact'] = $mapping['entity_data']['soft_credit'];
@@ -81,7 +80,7 @@ trait CRMTraits_Import_ParserTrait {
       ])
       ->execute();
     $form->buildForm();
-    $this->assertTrue($form->validate());
+    $this->assertTrue($form->validate(), 'Form failed to validate that the fields submitted met the dedupe rule requirements');
     $form->postProcess();
     $this->submitPreviewForm($submittedValues);
   }

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -80,7 +80,7 @@ trait CRMTraits_Import_ParserTrait {
       ])
       ->execute();
     $form->buildForm();
-    $this->assertTrue($form->validate(), 'Form failed to validate that the fields submitted met the dedupe rule requirements');
+    $this->assertTrue($form->validate(), 'Form failed to validate that the fields submitted met the form / dedupe rule requirements ' . print_r($form->_errors, TRUE));
     $form->postProcess();
     $this->submitPreviewForm($submittedValues);
   }

--- a/tests/phpunit/CRMTraits/Import/ParserTrait.php
+++ b/tests/phpunit/CRMTraits/Import/ParserTrait.php
@@ -215,11 +215,11 @@ trait CRMTraits_Import_ParserTrait {
    *
    * @param array $mappings
    * @param string $contactType
+   * @param array|null $dedupeRules
    *
    * @return void
-   *
    */
-  public function updateJobMetadata(array $mappings, string $contactType): void {
+  public function updateJobMetadata(array $mappings, string $contactType, ?array $dedupeRules = NULL): void {
     try {
       $metadata = UserJob::get()->addWhere('id', '=', $this->userJobID)
         ->execute()->single()['metadata'];
@@ -228,6 +228,9 @@ trait CRMTraits_Import_ParserTrait {
       }
       if ($contactType) {
         $metadata['entity_configuration']['Contact']['contact_type'] = $contactType;
+      }
+      if ($dedupeRules) {
+        $metadata['entity_configuration']['Contact']['dedupe_rule'] = $dedupeRules;
       }
       UserJob::update()
         ->addWhere('id', '=', $this->userJobID)


### PR DESCRIPTION
Overview
----------------------------------------
Alters the CIviImport UI to allow multiple dedupe rules. Especially useful with the Contact Type is unspecified:

<img width="1910" height="556" alt="image" src="https://github.com/user-attachments/assets/e8201144-8c0e-4ba8-ae8f-987534196c8f" />



Comments
----------------------------------------
@eileenmcnaughton - updated PR to add icons and optgroups.