### PR TITLE
Import: do not crash if importing an invalid country

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -1042,8 +1042,9 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       return $stateProvince;
     }
     // Try to disambiguate since we likely have the country now.
+    // or it might be 'invalid_import_value'
     $possibleStates = $this->ambiguousOptions['state_province_id'][mb_strtolower($stateProvince)];
-    if ($countryID) {
+    if (is_numeric($countryID)) {
       return $this->checkStatesForCountry($countryID, $possibleStates) ?: 'invalid_import_value';
     }
     // Try the default country next.


### PR DESCRIPTION
Overview
----------------------------------------

When importing contacts, if the country is invalid, the import will fail at the validation step.

To reproduce: create a CSV file with a record:

- First Name: Jane
- Last Name: Doe
- Country: USA

Since USA is not a valid country, it causes a WSOD.

Before
----------------------------------------

Crash / PHP fatal.

TypeError: CRM_Contact_Import_Parser_Contact::checkStatesForCountry(): Argument #1 $countryID) must be of type int, string given, called in CRM/Contact/Import/Parser/Contact.php on line 1123 in CRM_Contact_Import_Parser_Contact->checkStatesForCountry() (line 1191 of  CRM/Contact/Import/Parser/Contact.php).

After
----------------------------------------

Import reports an invalid country.

Comments
----------------------------------------

I couldn't find where we could add some fuzzyness in the import, to support things like:

- USA, United-States, United States of America => United States
- England, Great Britain => United Kingdom
- Czechia => Czech Republic
- UAE => United Arab Emirates
- Korea => "Korea, Republic of" (although this formulation is silly, but it's a bigger problem)
- Iran => "Iran, Islamic Republic of" (same as above)
