### PR TITLE
RiverLea: right-align icon in control columns on disabled table rows

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -280,7 +280,7 @@ dl dl {
 }
 .crm-container .disabled,
 .crm-container .crm-disabled,
-.crm-container .disabled *:not(.btn,button,i,span),
+.crm-container .disabled *:not(.btn,button,i,span,a),
 .crm-container .cancelled,
 .crm-container .cancelled td,
 .crm-container li.disabled a.ui-tabs-anchor {
@@ -292,7 +292,7 @@ dl dl {
 .crm-container .table-striped > tbody > tr:has(td.disabled) {
   background-color: var(--crm-c-page-background);
 }
-.crm-container tr.disabled td *:not(.btn,button),
+.crm-container tr.disabled td *:not(.btn,button,i,a),
 .crm-container td.disabled {
   font-style: italic;
 }

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -27,9 +27,9 @@ input#crm-qsearch-input::placeholder {
 .crm-container #crm-notification-container div.ui-notify-message h1::before,
 div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column)::before,
-.crm-container tr:has(.disabled) td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container td.disabled:first-of-type:not(.crm-search-ctrl-column)::before,
 .crm-container tr.disabled td.crm-search-ctrl-column::after,
-.crm-container tr:has(.disabled) td.crm-search-ctrl-column::after,
+.crm-container td.disabled.crm-search-ctrl-column::after,
 .crm-container .delete-icon,
 .crm-container span.batch-valid,
 .crm-container span.batch-invalid,
@@ -232,9 +232,9 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 
 /* Inactive icon */
 .crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column)::before,
-.crm-container tr:has(.disabled) td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container td.disabled:first-of-type:not(.crm-search-ctrl-column)::before,
 .crm-container tr.disabled td.crm-search-ctrl-column::after,
-.crm-container tr:has(.disabled) td.crm-search-ctrl-column::after {
+.crm-container td.disabled.crm-search-ctrl-column::after {
   content: "\f05e" / "Disabled row.";
   font-style: normal;
 }

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -26,8 +26,10 @@ input#crm-qsearch-input::placeholder {
 #crm-notification-container .ui-notify-message a.ui-notify-cross::before,
 .crm-container #crm-notification-container div.ui-notify-message h1::before,
 div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
-.crm-container tr.disabled td:first-of-type::before,
-.crm-container tr:has(.disabled) td:first-of-type::before,
+.crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container tr:has(.disabled) td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container tr.disabled td.crm-search-ctrl-column::after,
+.crm-container tr:has(.disabled) td.crm-search-ctrl-column::after,
 .crm-container .delete-icon,
 .crm-container span.batch-valid,
 .crm-container span.batch-invalid,
@@ -229,8 +231,10 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 
 /* Inactive icon */
-.crm-container tr.disabled td:first-of-type::before,
-.crm-container tr:has(.disabled) td:first-of-type::before {
+.crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container tr:has(.disabled) td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container tr.disabled td.crm-search-ctrl-column::after,
+.crm-container tr:has(.disabled) td.crm-search-ctrl-column::after {
   content: "\f05e" / "Disabled row.";
   color: var(--crm-alert-danger-text);
   font-style: normal;

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -236,7 +236,6 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container tr.disabled td.crm-search-ctrl-column::after,
 .crm-container tr:has(.disabled) td.crm-search-ctrl-column::after {
   content: "\f05e" / "Disabled row.";
-  color: var(--crm-alert-danger-text);
   font-style: normal;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is a replacement to this PR - https://github.com/civicrm/civicrm-core/pull/33325 - which offered an attempt to resolve feedback on https://github.com/civicrm/civicrm-core/pull/33278 about the alignment of the disabled/inactive red icon on control cells.

Before
----------------------------------------
All inactive red icons are left, putting lines of control checkboxes out of alignment.

<img width="1396" height="636" alt="image" src="https://github.com/user-attachments/assets/dd2d9cec-690e-4b27-9795-b6a3b4e7fcfe" />

After
----------------------------------------
No more…

<img width="461" height="182" alt="image" src="https://github.com/user-attachments/assets/e986cc97-20b5-43d5-9121-206f8a9d543e" />

Tables with drag-handles are fine:
<img width="393" height="209" alt="image" src="https://github.com/user-attachments/assets/3d75c101-993e-414f-a662-d35b913e4720" />

And tables without control checkboxes are unchanged:
<img width="373" height="195" alt="image" src="https://github.com/user-attachments/assets/89ac78f0-96ad-4531-979c-2391cb968e55" />

Technical Details
----------------------------------------
Sidenot: `tr:has(.disabled) td:first-of-type:not(.crm-search-ctrl-column)::before,` - four psuedo-classes on one element is a record for me. I've not found any evidence this has the slightest browser-rendering impact, but mentioning in case one day that changes.