### PR TITLE
RiverLea: SearchKit, dont reverse table cell with text-right

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -33,7 +33,7 @@ table.crm-sticky-header > thead > tr {
   display: table-cell;
 }
 td.crm-search-col-type-buttons.text-right {
-  flex-direction: row-reverse;
+  justify-content: end;
 }
 #bootstrap-theme th.crm-search-result-select button.btn {
   background: transparent;


### PR DESCRIPTION
Overview
----------------------------------------
RiverLea makes table cells containing more than one button use flexbox to manage spacing, wrap and alignment. For reasons I don't remember, to right-align buttons with the 'text-right' class I used flexbox 'row-reverse'. I can sort of picture a scenario where it was a fix, but there's far more scenarios (≥ 3 buttons, eg) where it will do weird things (change the order), ntm mess with readers. If the goal is right align, then `justify-content: end` will be better in almost every scenario.

Before
----------------------------------------
'text-right' on table cell button groups is applied with flexbox `row-reverse`

After
----------------------------------------
'text-right' on table cell button groups is applied with flexbox `justify-content: end`

Technical Details
----------------------------------------
There won't be an obvious visual change in most SKs. As discussed [here](https://chat.civicrm.org/civicrm/channels/dev-clientside/gt54jyebbjffbqtasqzipxhqsc).