### PR TITLE
[REF] Add setting to support showing an introduction message when on …

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -22,6 +22,7 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
 
     CRM_Utils_System::setTitle(E::ts('Log In'));
     $this->assign('pageTitle', '');
+    $this->assign('introductionMesage', Civi::settings()->get('standaloneusers_login_introduction_message') ?? '');
     $this->assign('forgottenPasswordURL', CRM_Utils_System::url('civicrm/login/password'));
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);

--- a/ext/standaloneusers/settings/standaloneusers.setting.php
+++ b/ext/standaloneusers/settings/standaloneusers.setting.php
@@ -30,4 +30,14 @@ return [
     ],
     'pseudoconstant' => ['callback' => '\\Civi\\Standalone\\MFA\\Base::getMFAclasses'],
   ],
+  'standaloneusers_login_introduction_message' => [
+    'name' => 'standaloneusers_login_introduction_message',
+    'type' => 'String',
+    'title' => ts('Standlone Login Introduction Message'),
+    'description' => ts('Introduction Message for Standlone login page'),
+    'default' => '',
+    'html_type' => 'text',
+    'is_domain' => 1,
+    'is_contact' => 0,
+  ],
 ];

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -1,4 +1,9 @@
 {crmScope extensionKey="standaloneusers"}
+{if $introductionMesage}
+  <div class="standalone-login-introduction-message">
+    {$introductionMesage|purify}
+  </div>
+{/if}
 <div class="standalone-auth-form">
   <div class="standalone-auth-box">
     <form id=login-form>


### PR DESCRIPTION
…Standlone login page

Overview
----------------------------------------
At the moment when you land on c.o's [Standalone demo site](https://smaster.demo.civicrm.org) There is no welcome text or anything that points you to the standard loging details unlike on like the [Backdrop](https://bmaster.demo.civicrm.org) or [WordPress](https://wpmaster.demo.civicrm.org) demos. My thought that having a setting might be a way for buildkit to inject something here and also it might be nice for Site authors to be able to add a simple message on the login screen as well.

Before
----------------------------------------
No introduction message on the login screen

After
----------------------------------------
Introduction mesage

ping @ufundo @artfulrobot @mlutfy @eileenmcnaughton @totten 