### PR TITLE
AdminUI - Consistently set 'disabled' class on table row, not cell

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Contribution_Pages.mgd.php
@@ -85,28 +85,12 @@ return [
               'key' => 'title',
               'label' => E::ts('Title'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'type' => 'field',
               'key' => 'id',
               'label' => E::ts('ID'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'type' => 'field',
@@ -114,28 +98,12 @@ return [
               'label' => E::ts('Enabled'),
               'sortable' => TRUE,
               'editable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'type' => 'field',
               'key' => 'financial_type_id:label',
               'label' => E::ts('Financial Type'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'text' => E::ts('Links'),
@@ -249,7 +217,14 @@ return [
               'alignment' => 'text-right',
             ],
           ],
-          'button' => NULL,
+          'cssRules' => [
+            [
+              'disabled',
+              'is_active',
+              '=',
+              FALSE,
+            ],
+          ],
         ],
         'acl_bypass' => FALSE,
       ],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
@@ -81,14 +81,6 @@ return [
               'key' => 'name',
               'label' => E::ts('Job'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
               'rewrite' => '<b>[name]</b><br>[description]',
             ],
             [
@@ -96,28 +88,12 @@ return [
               'key' => 'run_frequency:label',
               'label' => E::ts('Frequency'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'type' => 'field',
               'key' => 'last_run',
               'label' => E::ts('Last Run'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'type' => 'field',
@@ -125,28 +101,12 @@ return [
               'label' => E::ts('Enabled'),
               'sortable' => TRUE,
               'editable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
             ],
             [
               'type' => 'field',
               'key' => 'api_entity',
               'label' => E::ts('API'),
               'sortable' => TRUE,
-              'cssRules' => [
-                [
-                  'disabled',
-                  'is_active',
-                  '=',
-                  FALSE,
-                ],
-              ],
               'rewrite' => '[api_entity].[api_action]',
             ],
             [
@@ -238,6 +198,14 @@ return [
             'table',
             'table-striped',
             'crm-sticky-header',
+          ],
+          'cssRules' => [
+            [
+              'disabled',
+              'is_active',
+              '=',
+              FALSE,
+            ],
           ],
         ],
         'acl_bypass' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
More consistent style rules in AdminUI search displays.

I think this was originally a workaround to the dropdown menus in the right- hand column picking up the disabled style, but we've since fixed that in Riverlea, so let's be consistent.