### PR TITLE
dev/core#6043 QuickSearch - Ensure UNION does not return duplicate results

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -250,6 +250,7 @@ class AutocompleteAction extends AbstractAction {
     $result->searchField = $this->searchField ?? end($this->searchFields);
     // All search fields - allows js client to advance to the next one
     $result->searchFields = $this->searchFields;
+    $result->debug = $apiResult->debug;
   }
 
   /**
@@ -455,6 +456,7 @@ class AutocompleteAction extends AbstractAction {
       ->setDisplay($this->display)
       ->setFilters($filters)
       ->setReturn($returnPage)
+      ->setDebug($this->getDebug())
       ->execute();
     return $apiResult;
   }

--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -110,6 +110,15 @@ abstract class Api4Query {
     return FALSE;
   }
 
+  protected function isDistinctUnion(): bool {
+    foreach ($this->api->getSets() as $set) {
+      if ($set[0] === 'UNION DISTINCT') {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
   /**
    * Add LIMIT to query
    *


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#6043

Disables tracking index from EntitySets with distinct unions.

Distinct unions cannot use tracking index (it would break the uniqueness), but they also don't need it, since all sets will be pulling from the same table.