### PR TITLE
Update pear/db to latest (1.12.2) - Remove overly aggressive patching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
     "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
     "brick/money": "~0.5",
     "pear/mail_mime": "~1.10",
-    "pear/db": "~1.12.1",
+    "pear/db": "~1.12.2",
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18 || ^2",

--- a/composer.json
+++ b/composer.json
@@ -292,7 +292,7 @@
       },
       "pear/db": {
         "Ensure that error messages about MySQL-SSL connections are reported": "https://download.civicrm.org/patches/a6e31a769218801fb1fb3d679ff72d3d8a7c5637d3bb7b78680cd7809552e0c6/mysqli-ssl.patch",
-        "Apply CiviCRM Customisations for the pear:db package": "https://download.civicrm.org/patches/83a3d0dd9f8e555a474ee433c453ff741a4dedf1983bad8b3566136e90f9c46b/pear_db_civicrm_changes.patch"
+        "Apply CiviCRM Customisations for the pear:db package": "https://download.civicrm.org/patches/47e125fec0c789b095880fa65c6037210b01179290d5727b22b70fa77333496b/pear_db_civicrm_changes.patch"
       },
       "pear/mail": {
         "Apply CiviCRM Customisations for CRM-1367 and CRM-5946": "https://download.civicrm.org/patches/00da3cfcfe0d24420665f3015a5d3ea72dc331a52636f009883892ed3c7fbf84/pear-mail.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eeca511da0a9751434265fcfb6a7b487",
+    "content-hash": "269c5286f133d79ba6ca3523d9aaeef8",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -2127,16 +2127,16 @@
         },
         {
             "name": "pear/db",
-            "version": "v1.12.1",
+            "version": "v1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/DB.git",
-                "reference": "403775906ed8bb25505cefdee49885de181862da"
+                "reference": "f6cf9399683e1bdc408bdeeaf12fec2f78140896"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/DB/zipball/403775906ed8bb25505cefdee49885de181862da",
-                "reference": "403775906ed8bb25505cefdee49885de181862da",
+                "url": "https://api.github.com/repos/pear/DB/zipball/f6cf9399683e1bdc408bdeeaf12fec2f78140896",
+                "reference": "f6cf9399683e1bdc408bdeeaf12fec2f78140896",
                 "shasum": ""
             },
             "require": {
@@ -2187,7 +2187,7 @@
                 "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=DB",
                 "source": "https://github.com/pear/DB"
             },
-            "time": "2024-01-17T08:06:35+00:00"
+            "time": "2024-04-15T21:14:06+00:00"
         },
         {
             "name": "pear/log",

--- a/tools/patches/raw/pear/db/pear_db_civicrm_changes.patch
+++ b/tools/patches/raw/pear/db/pear_db_civicrm_changes.patch
@@ -1,15 +1,6 @@
 diff -ruN DB/common.php DB/common.php
 --- DB/common.php	2020-04-20 05:45:59.000000000 +1000
 +++ DB/common.php	2020-08-01 14:46:53.146175149 +1000
-@@ -147,7 +147,7 @@
-      */
-     function __construct()
-     {
--        $this->PEAR('DB_Error');
-+        parent::__construct('DB_Error');
-     }
-
-     // }}}
 @@ -1150,7 +1147,22 @@
       */
      function modifyQuery($query)
@@ -107,21 +98,9 @@ diff -ruN DB/mysql.php DB/mysql.php
 +    }
 +
 +    // }}}
- 
+
  }
- 
-diff -ruN DB/storage.php DB/storage.php
---- DB/storage.php   2020-04-20 05:45:59.000000000 +1000
-+++ DB/storage.php       2020-08-01 15:24:40.814621336 +1000
-@@ -96,7 +96,7 @@
-      */
-     function __construct($table, $keycolumn, &$dbh, $validator = null)
-     {
--        $this->PEAR('DB_Error');
-+        parent::__construct('DB_Error');
-         $this->_table = $table;
-         $this->_keycolumn = $keycolumn;
-         $this->_dbh = $dbh;
+
 diff -ruN DB.php DB.php
 --- DB.php	2020-04-20 05:45:59.000000000 +1000
 +++ DB.php	2020-08-01 14:43:45.338870953 +1000

--- a/tools/patches/raw/pear/db/pear_db_civicrm_changes.patch
+++ b/tools/patches/raw/pear/db/pear_db_civicrm_changes.patch
@@ -23,38 +23,8 @@ diff -ruN DB/common.php DB/common.php
 +        // CRM-20445 ends.
 +        return $e->query;
      }
- 
+
      // }}}
-@@ -1882,7 +1894,7 @@
-      *
-      * @see PEAR_Error
-      */
--    function &raiseError($code = DB_ERROR, $mode = null, $options = null,
-+    function raiseError($code = DB_ERROR, $mode = null, $options = null,
-                          $userinfo = null, $nativecode = null, $dummy1 = null,
-                          $dummy2 = null)
-     {
-@@ -2255,6 +2267,20 @@
-     }
- 
-     // }}}
-+    // {{{ lastInsertId()
-+
-+   /**
-+    * Get the most recently inserted Id
-+    *
-+    * @throws RuntimeException
-+    */
-+    function lastInsertId()
-+    {
-+        throw new \RuntimeException("Not implemented: " . get_class($this) . '::lastInsertId');
-+    }
-+
-+    // }}}
-+
- }
- 
- /*
 diff -ruN DB/mysqli.php DB/mysqli.php
 --- DB/mysqli.php	2020-04-20 05:45:59.000000000 +1000
 +++ DB/mysqli.php	2020-08-01 14:51:11.871272253 +1000

--- a/tools/patches/raw/pear/db/pear_db_civicrm_changes.patch
+++ b/tools/patches/raw/pear/db/pear_db_civicrm_changes.patch
@@ -50,24 +50,6 @@ diff -ruN DB/mysqli.php DB/mysqli.php
 +    }
 +
 +    // }}}
- 
- }
- 
-diff -ruN DB/mysql.php DB/mysql.php
---- DB/mysql.php	2020-04-20 05:45:59.000000000 +1000
-+++ DB/mysql.php	2020-08-01 14:48:58.276132870 +1000
-@@ -1021,6 +1024,14 @@
-     }
- 
-     // }}}
-+    // {{{ lastInsertId()
-+
-+    function lastInsertId()
-+    {
-+        return mysql_insert_id($this->connection);
-+    }
-+
-+    // }}}
 
  }
 


### PR DESCRIPTION
**Overly aggressive patch 1**
A very long time ago someone went through our PEAR library and patched it up to use constructors
https://github.com/civicrm/civicrm-packages/commit/ab29b06cc80ef2305ed96b7c470d62876e037003#diff-196b5050ffc7913d5a41efb809b8c2923e7965de24da885016c435dcd59c353d

However, the upstream patch, also merged a very long time ago, only adopted part of this change

https://github.com/pear/DB/commit/e3575856aa5b26aedc6ad711b175e4a516301ed9

Given we made these changes as part of adapting
for Php 7 & upstream has recently been made
compatible with php 8 I think we should accept upstream on this

**Overly aggressive patch 2**

Upstream still has the &
https://github.com/pear/DB/blob/trunk/DB/common.php#L1908

We supposedly switched back to the upstream signature

https://github.com/civicrm/civicrm-packages/commit/2722ad0044acf94372760fbedc3993ff922a45e8

But kept the &

The & appears to have been removed purely as a by-product of
the static change

https://github.com/civicrm/civicrm-packages/commit/ddee11457b57207d1a9336ce93a54755b1223768

And upstream has not adopted it - even though upstream now supports php 8.4 & this was
a php 7.x fix


**Overly aggressive patch 3  Remove patch on mysql.php file **

This driver is fully deprecated - no point
us carrying a patch that we maybe once thought
we would use to help get it upstreamed

** Finally - upgrade to latest version**