### PR TITLE
Handle legacy user jobs with no baseEntity

### DIFF
--- a/ext/civiimport/CRM/CiviImport/Form/Generic/GenericTrait.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Generic/GenericTrait.php
@@ -11,8 +11,13 @@ trait CRM_CiviImport_Form_Generic_GenericTrait {
     if (!$this->isStandalone()) {
       return $this->controller->getStateMachine()->getEntity();
     }
-    elseif ($this->getUserJobID()) {
+    elseif ($this->getUserJobID() && isset($this->getUserJob()['metadata']['base_entity'])) {
       return $this->getUserJob()['metadata']['base_entity'];
+    }
+    // We don't try this for import_generic as that import will either get it from the url (below)
+    // or have it saved in the metadata already (above).
+    elseif ($this->getUserJobID() && $this->getUserJobType() !== 'import_generic') {
+      return $this->getParser()->getBaseEntity();
     }
     $pathArguments = explode('/', (CRM_Utils_System::currentPath() ?: ''));
     unset($pathArguments[0], $pathArguments[1]);


### PR DESCRIPTION
Overview
----------------------------------------
Handle legacy user jobs with no baseEntity

Before
----------------------------------------
When attempting to edit template jobs older jobs may not have a saved baseEntity

<img width="1807" height="575" alt="image" src="https://github.com/user-attachments/assets/c4281593-9eca-47cf-9980-88f883ecd757" />

After
----------------------------------------
handled

Technical Details
----------------------------------------

Comments
----------------------------------------
