### PR TITLE
Api4 - Restore 'readonly' property of auto-increment fields

### DIFF
--- a/Civi/Api4/Service/Spec/SpecFormatter.php
+++ b/Civi/Api4/Service/Spec/SpecFormatter.php
@@ -86,7 +86,8 @@ class SpecFormatter {
       }
       $field->setSuffixes($suffixes);
     }
-    $field->setReadonly(!empty($data['readonly']));
+    // Primary keys are also considered readonly, since they cannot be changed
+    $field->setReadonly(!empty($data['readonly']) || !empty($data['primary_key']));
     if (isset($data['usage'])) {
       $field->setUsage($data['usage']);
     }

--- a/ext/civiimport/Civi/Import/ActivityParser.php
+++ b/ext/civiimport/Civi/Import/ActivityParser.php
@@ -180,7 +180,8 @@ class ActivityParser extends ImportParser {
     if (empty($this->importableFieldsMetadata)) {
       $fields = ['' => ['title' => '- ' . ts('do not import') . ' -']];
       $activityFields = (array) Activity::getFields()
-        ->addWhere('readonly', '=', FALSE)
+        // Exclude readonly fields, except for the id
+        ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
         ->addWhere('usage', 'CONTAINS', 'import')
         ->setAction('save')
         ->addOrderBy('title')

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -241,7 +241,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
    */
   protected function getAllContactFields(string $prefix = 'Contact.'): array {
     $allContactFields = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
@@ -249,7 +250,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
       ->execute()->indexBy('name');
 
     $contactTypeFields['Individual'] = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
@@ -259,7 +261,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
       ->execute()->indexBy('name');
 
     $contactTypeFields['Organization'] = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
@@ -269,7 +272,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
       ->execute()->indexBy('name');
 
     $contactTypeFields['Household'] = (array) Contact::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->addWhere('fk_entity', 'IS EMPTY')
       ->setAction('save')
@@ -290,7 +294,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
     }
 
     $addressFields = (array) Address::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->setAction('save')
       ->addOrderBy('title')
@@ -306,7 +311,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
     }
 
     $phoneFields = (array) Phone::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary
@@ -321,7 +327,8 @@ abstract class ImportParser extends \CRM_Import_Parser {
     }
 
     $emailFields = (array) Email::getFields()
-      ->addWhere('readonly', '=', FALSE)
+      // Exclude readonly fields, except for the id
+      ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
       ->addWhere('usage', 'CONTAINS', 'import')
       ->setAction('save')
       // Exclude these fields to keep it simpler for now - we just map to primary

--- a/ext/civiimport/Civi/Import/MembershipParser.php
+++ b/ext/civiimport/Civi/Import/MembershipParser.php
@@ -291,7 +291,8 @@ class MembershipParser extends ImportParser {
     if (!$fields) {
       $fields = ['' => ['title' => '- ' . ts('do not import') . ' -']];
       $membershipFields = (array) Membership::getFields()
-        ->addWhere('readonly', '=', FALSE)
+        // Exclude readonly fields, except for the id
+        ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
         ->addWhere('usage', 'CONTAINS', 'import')
         ->setAction('save')
         ->addOrderBy('title')

--- a/ext/civiimport/Civi/Import/ParticipantParser.php
+++ b/ext/civiimport/Civi/Import/ParticipantParser.php
@@ -174,7 +174,8 @@ class ParticipantParser extends ImportParser {
     if (empty($this->importableFieldsMetadata)) {
       $fields = ['' => ['title' => ts('- do not import -')]];
       $allParticipantFields = (array) Participant::getFields()
-        ->addWhere('readonly', '=', FALSE)
+        // Exclude readonly fields, except for the id
+        ->addClause('OR', ['readonly', '=', FALSE], ['name', '=', 'id'])
         ->addWhere('usage', 'CONTAINS', 'import')
         ->setAction('save')
         ->addOrderBy('title')

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -75,6 +75,12 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(['name', 'label', 'icon'], $fields['contact_type']['suffixes']);
     $this->assertEquals(['name', 'label', 'icon'], $fields['contact_sub_type']['suffixes']);
 
+    // Check `readonly`
+    $this->assertTrue($fields['display_name']['readonly']);
+    $this->assertTrue($fields['sort_name']['readonly']);
+    $this->assertFalse($fields['first_name']['readonly']);
+    $this->assertTrue($fields['id']['readonly']);
+
     // Check `required` and `nullable`
     $this->assertFalse($fields['is_opt_out']['required']);
     $this->assertFalse($fields['is_deleted']['required']);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes oddities in Api4-based UIs like the SearchKit bulk update task.

Before
----------------------------------------
In SearchKit, the bulk "Update" task lets you select ID as an editable field (even though it's not).

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
The description of Api4.getFields.readonly is:

> "True for auto-increment, calculated, or otherwise non-editable fields."

This was the case until it was inadvertently changed in the move to EFv2, when auto-increment was no longer passed to Api4 as `readonly`. The EFv1 code did this:
https://github.com/civicrm/civicrm-core/blob/3dda48bcfc9b1a7beca78e1389e6fb638ec3973a/xml/templates/dao.tpl#L222-L224

This restores the original behavior.