### PR TITLE
Use default Redis handler if configured

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -644,9 +644,14 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       $session_cookie_name = 'SESSCIVISOFALLBACK';
     }
     else {
+      $session_cookie_name = 'SESSCIVISO';
+    }
+    if (ini_get('session.save_handler') === 'redis') {
+      // We'll just use the default, take no action.
+    }
+    else {
       $session_handler = new SessionHandler();
       session_set_save_handler($session_handler);
-      $session_cookie_name = 'SESSCIVISO';
     }
 
     // session lifetime in seconds (default = 24 minutes)


### PR DESCRIPTION
Overview
----------------------------------------
Use default Redis handler if configured

This is an alternative to https://github.com/civicrm/civicrm-core/pull/32949 suggested by @totten which appears to work!

Before
----------------------------------------


After
----------------------------------------

Technical Details
----------------------------------------

Comments
----------------------------------------
Docs update https://lab.civicrm.org/documentation/docs/sysadmin/-/commit/2b3440b4e4ab6d98e21c6993a3a13c5cae0233c5