### PR TITLE
Fix for deprecation notice when updating older UserJobs

### DIFF
--- a/ext/civiimport/CRM/CiviImport/Form/Generic/GenericTrait.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Generic/GenericTrait.php
@@ -24,4 +24,16 @@ trait CRM_CiviImport_Form_Generic_GenericTrait {
     return CRM_Utils_String::convertStringToCamel(implode('_', $pathArguments));
   }
 
+  /**
+   * Get the name of the type to be stored in civicrm_user_job.type_id.
+   *
+   * @return string
+   */
+  public function getUserJobType(): string {
+    if ($this->getUserJobID()) {
+      return (string) $this->getUserJob()['job_type'];
+    }
+    return 'import_generic';
+  }
+
 }

--- a/ext/civiimport/CRM/CiviImport/Form/Generic/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Generic/MapField.php
@@ -22,5 +22,6 @@
  */
 class CRM_CiviImport_Form_Generic_MapField extends \CRM_CiviImport_Form_MapField {
   use CRM_CiviImport_Form_Generic_GenericTrait;
+  use \Civi\UserJob\UserJobTrait;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix for deprecation notice when updating older UserJobs

Before
----------------------------------------
We now have functionality to update UserJob templates but ones created on older versions of Civi will likely not have the BaseEntity in the metadata and if accessed via the Generic Template they will put out a deprecation notice

After
----------------------------------------
Notice fixed, older jobs updatable

Technical Details
----------------------------------------
This only affects features new in master

Comments
----------------------------------------
