### PR TITLE
Fix Message Preview crash on sites with only quick config pricesets

### DIFF
--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
@@ -30,6 +30,8 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
           'title' => ts('Completed Contribution') . ' : ' . $currency,
           'tags' => $workflow === 'contribution_offline_receipt' ? ['phpunit', 'preview'] : ['preview'],
           'workflow' => $workflow,
+          // If there are no non-quick-config we have no show line items example.
+          'is_show_line_items' => $this->getNonQuickConfigPriceSet() ? TRUE : FALSE,
         ];
       }
       yield [
@@ -37,7 +39,7 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
         'title' => ts('Partially Paid Contribution') . ' : ' . $currency,
         'tags' => ['preview'],
         'workflow' => $workflow,
-        'is_show_line_items' => TRUE,
+        'is_show_line_items' => $this->getNonQuickConfigPriceSet() ? TRUE : FALSE,
         'contribution_params' => ['contribution_status_id' => \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Partially paid')],
       ];
       $priceSet = $this->getNonQuickConfigPriceSet();


### PR DESCRIPTION


Overview
----------------------------------------
Fix Message Preview crash on sites with only quick config pricesets

Before
----------------------------------------
The message preview is not loading for sites where all price sets have is_quick_config = 1 because it is
still trying to load a representative non-quick-config price set

After
----------------------------------------
<img width="1148" height="847" alt="image" src="https://github.com/user-attachments/assets/6cc1b517-023c-435b-91a0-76f22df7a4d6" />


Technical Details
----------------------------------------

Comments
----------------------------------------
