### PR TITLE
dev/core#6045 Re-trigger setting of timezone after Authx has authenti…

### DIFF
--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -322,6 +322,8 @@ class Authenticator extends AutoService implements HookInterface {
     \CRM_Core_DAO::executeQuery('SET @civicrm_user_id = %1',
       [1 => [$tgt->contactId, 'Integer']]
     );
+    // Re-set the timezone incase the User System supports user records overriding the system timezone.
+    \CRM_Core_Config::singleton()->userSystem->setTimeZone();
   }
 
   /**


### PR DESCRIPTION
…cated user in case user timezone is different to that of the system

Overview
----------------------------------------
When using APIv4 rest the timezone offset is always set to the server timezone no matter what the user record is set to where applicable

Before
----------------------------------------
Server timezone used on DB connection

After
----------------------------------------
User timezone used if applicable otherwise Server timezone still used

Technical Details
----------------------------------------
In the v3 legacy rest the timezone was always set after the user had been loaded and therefore the initial timezone set was always correct https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/System.php#L1536

@johntwyman 