### PR TITLE
dev/core#5879 Extending Afform UI Permissions

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -49,7 +49,7 @@ class AfformAdminInjector extends AutoSubscriber {
               'url' => \CRM_Utils_System::url('civicrm/admin/afform', NULL, FALSE, "/edit/{$afform['name']}", TRUE, FALSE, TRUE),
               'text' => E::ts('Edit %1 in FormBuilder', [1 => "<em>{$afform['title']}</em>"]),
               'icon' => 'fa-pencil',
-              'permission' => 'administer afform',
+              'permission' => 'manage own afform',
             ],
           ];
           if ($afform['search_displays']) {

--- a/ext/afform/admin/ang/afAdmin.ang.php
+++ b/ext/afform/admin/ang/afAdmin.ang.php
@@ -12,4 +12,8 @@ return [
   'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getAdminSettings'],
   'basePages' => ['civicrm/admin/afform'],
   'bundles' => ['bootstrap3'],
+  'permissions' => [
+    'administer afform',
+    'manage own afform'
+  ],
 ];

--- a/ext/afform/admin/ang/afAdmin.ang.php
+++ b/ext/afform/admin/ang/afAdmin.ang.php
@@ -13,7 +13,6 @@ return [
   'basePages' => ['civicrm/admin/afform'],
   'bundles' => ['bootstrap3'],
   'permissions' => [
-    'all CiviCRM permissions and ACLs',
     'administer afform',
     'manage own afform',
   ],

--- a/ext/afform/admin/ang/afAdmin.ang.php
+++ b/ext/afform/admin/ang/afAdmin.ang.php
@@ -13,7 +13,8 @@ return [
   'basePages' => ['civicrm/admin/afform'],
   'bundles' => ['bootstrap3'],
   'permissions' => [
+    'all CiviCRM permissions and ACLs',
     'administer afform',
-    'manage own afform'
+    'manage own afform',
   ],
 ];

--- a/ext/afform/admin/ang/afAdmin.js
+++ b/ext/afform/admin/ang/afAdmin.js
@@ -11,7 +11,7 @@
           // Load data for lists
           afforms: function(crmApi4) {
             return crmApi4('Afform', 'get', {
-              select: ['name', 'title', 'type', 'server_route', 'is_public', 'submission_count', 'submission_date', 'submit_limit', 'submit_enabled', 'submit_currently_open', 'has_local', 'has_base', 'base_module', 'base_module:label', 'placement:label', 'tags:label']
+              select: ['name', 'title', 'type', 'server_route', 'is_public', 'submission_count', 'submission_date', 'submit_limit', 'submit_enabled', 'submit_currently_open', 'has_local', 'has_base', 'base_module', 'base_module:label', 'placement:label', 'tags:label', 'created_id']
             });
           }
         }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -29,6 +29,17 @@
       if (afform.submission_date) {
         afform.submission_date = CRM.utils.formatDate(afform.submission_date);
       }
+      afform.can_manage = CRM.checkPerm('administer afform');
+      // Check for ownership and correct permission
+      if (afform.created_id) {
+        // Permission, manage own afform, is to only manage afform's the user created
+        if (CRM.checkPerm('manage own afform') && (CRM.config.cid !== afform.created_id)) {
+          afform.can_manage = false;
+        }
+      } else if (CRM.checkPerm('manage own afform')) {
+        // No created_id, so user doesn't have permission to manage.
+        afform.can_manage = false;
+      }
       afforms[afform.type] = afforms[afform.type] || [];
       afforms[afform.type].push(afform);
     }, {});

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -33,10 +33,10 @@
       // Check for ownership and correct permission
       if (afform.created_id) {
         // Permission, manage own afform, is to only manage afform's the user created
-        if (CRM.checkPerm('manage own afform') && (CRM.config.cid !== afform.created_id)) {
+        if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('manage own afform') && (CRM.config.cid !== afform.created_id)) {
           afform.can_manage = false;
         }
-      } else if (CRM.checkPerm('manage own afform')) {
+      } else if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('manage own afform')) {
         // No created_id, so user doesn't have permission to manage.
         afform.can_manage = false;
       }
@@ -118,7 +118,7 @@
           }, 0]);
         }
         var apiCall = crmStatus(
-          afform.has_base ? {start: ts('Reverting...')} : {start: ts('Deleting...'), success: ts('Deleted')},
+          afform.has_base ? {start: ts('Reverting...')} : {start: ts('Deleting...'), success: ts('Deleted'), error: ts('Error deleting')},
           crmApi4(apiOps)
         );
         if (afform.has_base) {
@@ -127,7 +127,9 @@
             ctrl.afforms[ctrl.tab][index] = result[1];
           });
         } else {
-          ctrl.afforms[ctrl.tab].splice(index, 1);
+          apiCall.then(function() {
+            ctrl.afforms[ctrl.tab].splice(index, 1);
+          });
         }
       }
     };

--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -33,10 +33,10 @@
       // Check for ownership and correct permission
       if (afform.created_id) {
         // Permission, manage own afform, is to only manage afform's the user created
-        if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('manage own afform') && (CRM.config.cid !== afform.created_id)) {
-          afform.can_manage = false;
+        if (CRM.checkPerm('manage own afform') && (CRM.config.cid === afform.created_id)) {
+          afform.can_manage = true;
         }
-      } else if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('manage own afform')) {
+      } else if (CRM.checkPerm('manage own afform')) {
         // No created_id, so user doesn't have permission to manage.
         afform.can_manage = false;
       }

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -119,9 +119,9 @@
         {{:: afform.tags.join(', ') }}
       </td>
       <td class="text-right">
-        <a ng-if="afform.type !== 'system'" ng-href="#/edit/{{:: afform.name }}" class="btn btn-xs btn-primary">{{:: ts('Edit') }}</a>
+        <a ng-if="afform.type !== 'system' && afform.can_manage" ng-href="#/edit/{{:: afform.name }}" class="btn btn-xs btn-primary">{{:: ts('Edit') }}</a>
         <a ng-if="afform.type !== 'system'" ng-href="#/clone/{{:: afform.name }}" class="btn btn-xs btn-secondary">{{:: ts('Clone') }}</a>
-        <a href ng-if="afform.has_local" class="btn btn-xs btn-{{ afform.has_base ? 'warning' : 'danger' }}" crm-confirm="{type: afform.has_base ? 'revert' : 'delete', obj: afform}" on-yes="$ctrl.revert(afform)">
+        <a href ng-if="afform.has_local && afform.can_manage" class="btn btn-xs btn-{{ afform.has_base ? 'warning' : 'danger' }}" crm-confirm="{type: afform.has_base ? 'revert' : 'delete', obj: afform}" on-yes="$ctrl.revert(afform)">
           {{ afform.has_base ? ts('Revert') : ts('Delete') }}
         </a>
       </td>

--- a/ext/afform/admin/ang/afAdminFormSubmissionList.aff.php
+++ b/ext/afform/admin/ang/afAdminFormSubmissionList.aff.php
@@ -5,5 +5,5 @@ return [
   'type' => 'system',
   'title' => E::ts('Submissions'),
   'server_route' => 'civicrm/admin/afform/submissions',
-  'permission' => ['administer afform'],
+  'permission' => ['manage own afform'],
 ];

--- a/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
+++ b/ext/afform/admin/managed/Navigation_afform_admin.mgd.php
@@ -13,7 +13,7 @@ return [
         'name' => 'afform_admin',
         'label' => E::ts('FormBuilder'),
         'permission' => [
-          'administer afform',
+          'manage own afform',
         ],
         'parent_id.name' => 'Customize Data and Screens',
         'weight' => 1,

--- a/ext/afform/admin/xml/Menu/afform_admin.xml
+++ b/ext/afform/admin/xml/Menu/afform_admin.xml
@@ -3,6 +3,6 @@
   <item>
     <path>civicrm/admin/afform</path>
     <page_callback>CRM_AfformAdmin_Page_Base</page_callback>
-    <access_arguments>administer afform</access_arguments>
+    <access_arguments>manage own afform</access_arguments>
   </item>
 </menu>

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -55,7 +55,7 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
     ];
 
     // Check permissions to Revert
-    if (\CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
+    if ($this->getCheckPermissions() && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
       throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
     }
 
@@ -89,7 +89,7 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
    * @return string[]
    */
   protected function getSelect() {
-    return ['name', 'title', 'placement', 'server_route', 'created_id'];
+    return ['name', 'title', 'placement', 'server_route', 'created_id', 'check_permission'];
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -53,13 +53,6 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
       \CRM_Afform_AfformScanner::METADATA_JSON,
       \CRM_Afform_AfformScanner::LAYOUT_FILE,
     ];
-    // Get user as we need to check for Test user
-    $user_id = \CRM_Core_Session::getLoggedInContactID();
-
-    // Check permissions to Revert
-    if ($this->getCheckPermissions() && !empty($user_id) && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== $user_id)) {
-      throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
-    }
 
     foreach ($files as $file) {
       $metaPath = $scanner->createSiteLocalPath($item['name'], $file);
@@ -91,7 +84,7 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
    * @return string[]
    */
   protected function getSelect() {
-    return ['name', 'title', 'placement', 'server_route', 'created_id', 'check_permission'];
+    return ['name', 'title', 'placement', 'server_route', 'created_id'];
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -53,9 +53,11 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
       \CRM_Afform_AfformScanner::METADATA_JSON,
       \CRM_Afform_AfformScanner::LAYOUT_FILE,
     ];
+    // Get user as we need to check for Test user
+    $user_id = \CRM_Core_Session::getLoggedInContactID();
 
     // Check permissions to Revert
-    if ($this->getCheckPermissions() && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
+    if ($this->getCheckPermissions() && !empty($user_id) && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== $user_id)) {
       throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
     }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -54,6 +54,11 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
       \CRM_Afform_AfformScanner::LAYOUT_FILE,
     ];
 
+    // Check permissions to Revert
+    if (\CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
+      throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
+    }
+
     foreach ($files as $file) {
       $metaPath = $scanner->createSiteLocalPath($item['name'], $file);
       if (file_exists($metaPath)) {
@@ -84,7 +89,7 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
    * @return string[]
    */
   protected function getSelect() {
-    return ['name', 'title', 'placement', 'server_route'];
+    return ['name', 'title', 'placement', 'server_route', 'created_id'];
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -308,6 +308,18 @@ class Afform extends Generic\AbstractEntity {
           'title' => E::ts('Confirmation Message'),
           'input_type' => 'Text',
         ],
+        [
+          'name' => 'created_id',
+          'title' => ts('Created By Contact ID'),
+          'data_type' => 'Integer',
+          'fk_entity' => 'Contact',
+          'fk_column' => 'id',
+          'input_type' => 'EntityRef',
+          'label' => ts('Created By'),
+          'default_value' => NULL,
+          'readonly' => TRUE,
+          'required' => FALSE,
+        ],
       ];
       // Calculated fields returned by get action
       if ($self->getAction() === 'get') {

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -401,7 +401,7 @@ class Afform extends Generic\AbstractEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'default' => ['administer afform'],
+      'default' => ['manage own afform'],
       // These all check form-level permissions
       'get' => [],
       'getOptions' => [],

--- a/ext/afform/core/Civi/Api4/AfformBehavior.php
+++ b/ext/afform/core/Civi/Api4/AfformBehavior.php
@@ -28,7 +28,7 @@ class AfformBehavior extends Generic\AbstractEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'get' => ['administer afform'],
+      'get' => ['manage own afform'],
     ];
   }
 

--- a/ext/afform/core/Civi/Api4/AfformSubmission.php
+++ b/ext/afform/core/Civi/Api4/AfformSubmission.php
@@ -18,7 +18,7 @@ class AfformSubmission extends Generic\DAOEntity {
   public static function permissions() {
     return [
       'meta' => ['access CiviCRM'],
-      'default' => ['administer afform'],
+      'default' => ['manage own afform'],
     ];
   }
 

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAccessSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAccessSubscriber.php
@@ -82,7 +82,7 @@ class AfformAccessSubscriber extends AutoService implements EventSubscriberInter
    */
   protected function checkAccess($apiRequest, $afform, $user_id) {
     // Check permissions to Revert
-    if ($apiRequest->getCheckPermissions() && !\CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && \CRM_Core_Permission::check('manage own afform') && (empty($afform['created_id']) || $afform['created_id'] !== $user_id)) {
+    if ($apiRequest->getCheckPermissions() && !\CRM_Core_Permission::check('administer afform') && \CRM_Core_Permission::check('manage own afform') && (empty($afform['created_id']) || $afform['created_id'] !== $user_id)) {
       return FALSE;
     }
     return TRUE;

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAccessSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAccessSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Subscriber;
+
+use Civi\Api4\Event\AuthorizeRecordEvent;
+use Civi\Api4\Utils\AfformSaveTrait;
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Preprocess api authorize requests
+ * @service
+ * @internal
+ */
+class AfformAccessSubscriber extends AutoService implements EventSubscriberInterface {
+  use AfformSaveTrait;
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.api4.authorizeRecord::Afform' => ['onApiAuthorizeRecord', 500],
+    ];
+  }
+
+  /**
+   * @param \Civi\Api4\Event\AuthorizeRecordEvent $event
+   *   API record authorize event
+   */
+  public function onApiAuthorizeRecord(AuthorizeRecordEvent $event) {
+    $apiRequest = $event->getApiRequest();
+    $action = $apiRequest->getActionName();
+
+    if (!in_array($action, ['revert', 'delete', 'update'], TRUE)) {
+      // We only care about these actions.
+      return;
+    }
+
+    /** @var \CRM_Afform_AfformScanner $scanner */
+    $scanner = \Civi::service('afform_scanner');
+    $afform = $event->getRecord();
+
+    // Get user as we need to check for Test user
+    $user_id = \CRM_Core_Session::getLoggedInContactID();
+    if ('update' === $action) {
+      $orig = [];
+      $this->checkNameForAfform($afform, $orig, $scanner);
+      // Check if updating or creating
+      if ($orig) {
+        // We have an existing afform, so we need to check `manage own afform` permissions
+        if (!$this->checkAccess($apiRequest, $afform, $user_id)) {
+          $event->setAuthorized(FALSE);
+        }
+      }
+    }
+    else {
+      if (!$this->checkAccess($apiRequest, $afform, $user_id)) {
+        $event->setAuthorized(FALSE);
+      }
+    }
+
+  }
+
+  /**
+   * Checks for access based on permissions and created_id if exists.
+   *
+   * @param array|\Civi\Api4\Generic\AbstractAction $apiRequest The current request.
+   * @param array $afform The current afform entity for the request.
+   * @param int $user_id The current user id.
+   *
+   * @return bool
+   */
+  protected function checkAccess($apiRequest, $afform, $user_id) {
+    // Check permissions to Revert
+    if ($apiRequest->getCheckPermissions() && !\CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && \CRM_Core_Permission::check('manage own afform') && (empty($afform['created_id']) || $afform['created_id'] !== $user_id)) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+}

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -143,7 +143,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
    * @param \Civi\Api4\Generic\AutocompleteAction $apiRequest
    */
   private function processAfformAdminAutocomplete(string $fieldName, AutocompleteAction $apiRequest):void {
-    if (!\CRM_Core_Permission::check('administer afform')) {
+    if (!\CRM_Core_Permission::check('manage own afform')) {
       return;
     }
     switch ($fieldName) {

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -41,6 +41,16 @@ trait AfformSaveTrait {
       $orig = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->setSelect($fields)->execute()->first();
     }
 
+    // Check if updating or creating
+    if ($orig) {
+      // We have an existing afform, so we need to check `manage own afform` permissions
+      if (\CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
+        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
+      }
+    } else {
+      $item['created_id'] = \CRM_Core_Session::getLoggedInContactID();
+    }
+
     // FIXME validate all field data.
     $item = _afform_fields_filter($item);
 

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -18,38 +18,11 @@ trait AfformSaveTrait {
     $scanner = \Civi::service('afform_scanner');
 
     // If no name given, create a unique name based on the title
-    if (empty($item['name'])) {
-      $prefix = 'af' . ($item['type'] ?? '');
-      $item['name'] = _afform_angular_module_name($prefix . '-' . \CRM_Utils_String::munge($item['title'], '-'));
-      $suffix = '';
-      while (
-        file_exists($scanner->createSiteLocalPath($item['name'] . $suffix, \CRM_Afform_AfformScanner::METADATA_JSON))
-        || file_exists($scanner->createSiteLocalPath($item['name'] . $suffix, \CRM_Afform_AfformScanner::LAYOUT_FILE))
-      ) {
-        $suffix++;
-      }
-      $item['name'] .= $suffix;
-      $orig = NULL;
-    }
-    elseif (!preg_match('/^[a-zA-Z][-_a-zA-Z0-9]*$/', $item['name'])) {
-      throw new \CRM_Core_Exception("Afform.{$this->getActionName()}: name should begin with a letter and only contain alphanumerics underscores and dashes.");
-    }
-    else {
-      // Fetch existing metadata
-      $fields = \Civi\Api4\Afform::getfields()->setCheckPermissions(FALSE)->setAction('create')->addSelect('name')->execute()->column('name');
-      unset($fields[array_search('layout', $fields)]);
-      $orig = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->setSelect($fields)->execute()->first();
-    }
+    $orig = [];
+    $this->checkNameForAfform($item, $orig, $scanner);
 
     // Check if updating or creating
-    if ($orig) {
-      // Get user as we need to check for Test user
-      $user_id = \CRM_Core_Session::getLoggedInContactID();
-      // We have an existing afform, so we need to check `manage own afform` permissions
-      if ($this->getCheckPermissions() && !empty($user_id) && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== $user_id)) {
-        throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
-      }
-    } else {
+    if (!$orig) {
       $item['created_id'] = \CRM_Core_Session::getLoggedInContactID();
     }
 
@@ -92,6 +65,40 @@ trait AfformSaveTrait {
     $item['module_name'] = _afform_angular_module_name($item['name'], 'camel');
     $item['directive_name'] = _afform_angular_module_name($item['name'], 'dash');
     return $meta + $item;
+  }
+
+  /**
+   * @param array $item The afform item being processed.
+   * @param array $orig The existing afform if already created.
+   * @param \CRM_Afform_AfformScanner $scanner
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  protected function checkNameForAfform(&$item, &$orig, $scanner) {
+    if (empty($item['name'])) {
+      $prefix = 'af' . ($item['type'] ?? '');
+      $item['name'] = _afform_angular_module_name($prefix . '-' . \CRM_Utils_String::munge($item['title'], '-'));
+      $suffix = '';
+      while (
+        file_exists($scanner->createSiteLocalPath($item['name'] . $suffix, \CRM_Afform_AfformScanner::METADATA_JSON))
+        || file_exists($scanner->createSiteLocalPath($item['name'] . $suffix, \CRM_Afform_AfformScanner::LAYOUT_FILE))
+      ) {
+        $suffix++;
+      }
+      $item['name'] .= $suffix;
+      $orig = NULL;
+    }
+    elseif (!preg_match('/^[a-zA-Z][-_a-zA-Z0-9]*$/', $item['name'])) {
+      throw new \CRM_Core_Exception("Afform.{$this->getActionName()}: name should begin with a letter and only contain alphanumerics underscores and dashes.");
+    }
+    else {
+      // Fetch existing metadata
+      $fields = \Civi\Api4\Afform::getfields()->setCheckPermissions(FALSE)->setAction('create')->addSelect('name')->execute()->column('name');
+      unset($fields[array_search('layout', $fields)]);
+      $orig = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->setSelect($fields)->execute()->first();
+    }
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -43,8 +43,10 @@ trait AfformSaveTrait {
 
     // Check if updating or creating
     if ($orig) {
+      // Get user as we need to check for Test user
+      $user_id = \CRM_Core_Session::getLoggedInContactID();
       // We have an existing afform, so we need to check `manage own afform` permissions
-      if ($this->getCheckPermissions() && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
+      if ($this->getCheckPermissions() && !empty($user_id) && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== $user_id)) {
         throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
       }
     } else {

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -44,7 +44,7 @@ trait AfformSaveTrait {
     // Check if updating or creating
     if ($orig) {
       // We have an existing afform, so we need to check `manage own afform` permissions
-      if (\CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
+      if ($this->getCheckPermissions() && \CRM_Core_Permission::check('manage own afform') && (empty($item['created_id']) || $item['created_id'] !== \CRM_Core_Session::getLoggedInContactID())) {
         throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this afform.');
       }
     } else {

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -178,7 +178,7 @@ function _afform_hook_civicrm_angularModules($e) {
       ],
       // Permissions needed for conditionally displaying edit-links
       'permissions' => [
-        'administer afform',
+        'manage own afform',
         'administer search_kit',
         'all CiviCRM permissions and ACLs',
       ],
@@ -322,7 +322,7 @@ function afform_civicrm_permission_check($permission, &$granted, $contactId) {
       // Check authx token
       isset($data['jwt']['scope'], $data['flow']) && $data['jwt']['scope'] === 'afform' && $data['flow'] === 'afformpage'
       // Allow admins to edit forms without requiring a token
-      || CRM_Core_Permission::check('administer afform');
+      || CRM_Core_Permission::check('manage own afform');
   }
 }
 
@@ -552,7 +552,7 @@ function afform_civicrm_searchKitTasks(array &$tasks, bool $checkPermissions, ?i
         ],
       ],
       'conditions' => [
-        ['check user permission', '=', ['administer afform']],
+        ['check user permission', '=', ['manage own afform']],
       ],
       'confirmMsg' => E::ts('Confirm processing %1 %2.'),
       'runMsg' => E::ts('Processing %1 %2...'),

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -284,6 +284,11 @@ function afform_civicrm_permission(&$permissions) {
     'description' => E::ts('Allows non-admin users to create, update and delete forms'),
     'implied_by' => ['administer CiviCRM'],
   ];
+  $permissions['manage own afform'] = [
+    'label' => E::ts('FormBuilder: edit and delete own forms'),
+    'description' => E::ts('Gives non-admin users the permission to manage their own forms.'),
+    'implied_by' => ['administer afform'],
+  ];
 }
 
 /**

--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -21,7 +21,7 @@ return [
     // Note the super permission "all CiviCRM permissions and ACLs" is used in the JS layer to determine if users can create search displays that bypass ACLs
     'all CiviCRM permissions and ACLs',
     'administer CiviCRM',
-    'administer afform',
+    'manage own afform',
     'view debug output',
     'schedule communications',
     'manage own search_kit',

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -35,7 +35,7 @@
     $scope.hs = crmUiHelp({file: 'CRM/Search/Help/Compose'});
 
     this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
-    this.afformAdminEnabled = CRM.checkPerm('administer afform') &&
+    this.afformAdminEnabled = CRM.checkPerm('manage own afform') &&
       'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
     this.displayTypes = _.indexBy(CRM.crmSearchAdmin.displayTypes, 'id');
     this.searchDisplayPath = CRM.url('civicrm/search');

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -18,7 +18,7 @@
       this.searchDisplayPath = CRM.url('civicrm/search');
       this.afformPath = CRM.url('civicrm/admin/afform');
       this.afformEnabled = 'org.civicrm.afform' in CRM.crmSearchAdmin.modules;
-      this.afformAdminEnabled = CRM.checkPerm('administer afform') &&
+      this.afformAdminEnabled = CRM.checkPerm('manage own afform') &&
         'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
       const scheduledCommunicationsEnabled = 'scheduled_communications' in CRM.crmSearchAdmin.modules;
       const scheduledCommunicationsAllowed = scheduledCommunicationsEnabled && CRM.checkPerm('schedule communications');


### PR DESCRIPTION
Overview
----------------------------------------
_By default, a user inherits the `administer afform` permission or is granted the permission in order to manage Form Builder. This permission grants full control over all afforms created by other users or by packages/system. This PR adds another permission, `manage own afform`, that limits management of afforms to only those that the user created themselves. They can clone or create, but they can't edit/delete afform's that they don't own._

This PR add functionality for https://lab.civicrm.org/dev/core/-/issues/5879

Before
----------------------------------------
_If you could manage afform, then you had full control._

After
----------------------------------------
_With the new permission, you can limit a user to only being able to manage afforms that they create on their own. It will prevent them from editing other user's afforms or package/system afforms. This helps in providing a user access to create an afform for their use, but restricts them to just their items._

Technical Details
----------------------------------------
_This PR adds a `created_id` field to the `Afform` entity. By default, it is set to `NULL` and is only set when an `Afform` is created via the UI/API. Any `Afform` that is part of a package or in the core code, will default to `NULL`. This PR also introduces a new permission, `manage own afform`. This permission limits the user to only managing their own afforms. They are only allowed to manage an `Afform` where the `created_id` has a value and the value matches their user ID. When importing an `Afform` from another site, the `created_id` will be forced as the user who is importing._
