### PR TITLE
(dev/core#6022) Rebuilder - Add option to clear all statics

### DIFF
--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -70,6 +70,7 @@ class Rebuilder {
       'tables' => TRUE,
       'sessions' => TRUE,
       'metadata' => TRUE,
+      'statics' => TRUE,
       'system' => TRUE,
       'userjob' => TRUE,
       'menu' => TRUE,
@@ -109,6 +110,9 @@ class Rebuilder {
     }
     if (!empty($targets['sessions'])) {
       Civi::cache('session')->clear();
+    }
+    if (!empty($targets['statics'])) {
+      Civi::$statics = [];
     }
     if (!empty($targets['metadata'])) {
       Civi::cache('metadata')->clear();


### PR DESCRIPTION
Overview
----------------------------------------

(Draft) Possible/alternate fix for https://lab.civicrm.org/dev/core/-/issues/6022 

Before
----------------------------------------

When doing a general system-flush/rebuild, it leaves `Civi::$statics` in place.

After
----------------------------------------

When doing a general system-flush/rebuild, the `statics` option will default to TRUE. It resets the `Civi::$statics`.

Comments
----------------------------------------

There's on-going discussion in 6022 about how to gauge/manage the risk of this kind of change. Posting the PR to see what Jenkins thinks.