### PR TITLE
patches - Generate test failure if the patch-list is not suitable for distribution

### DIFF
--- a/tests/phpunit/CRM/Core/ComposerConfigTest.php
+++ b/tests/phpunit/CRM/Core/ComposerConfigTest.php
@@ -43,4 +43,10 @@ class CRM_Core_ComposerConfigTest extends \PHPUnit\Framework\TestCase {
       'composer.lock should have references to all hardlocks');
   }
 
+  public function testPatchUrls(): void {
+    $patchmgr = Civi::paths()->getPath('[civicrm.root]/tools/patches/bin/patchmgr.php');
+    exec("$patchmgr validate", $output, $exit);
+    $this->assertEquals(0, $exit, "Failed to run 'patchmgr validate'. Please consider re-generating the patch-list by calling 'patchmgr use-remote'.\nResults:\n" . implode("\n", $output));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

The `composer.json` stores a list of patch URLs. These URLs should meet certain conventions, i.e.

* Pointing to `download.civicrm.org` 
* Using the current SHA256 of the patch

If you edit patches by hand -- without using [the `patchmgr` workflow](https://github.com/civicrm/civicrm-core/blob/master/tools/patches/README.md) (or if there's any subtle mistake/omission in that process)-- then you may produce a nonconformant `composer.json`. We should prevent that.

(ping @eileenmcnaughton)

Example Scenario
----------------------------------------

(*This is just one possible example of a mistake/omission in updating the patches.*)

1. Edit any single patch-file in `tools/patches/`.
2. Run `composer install`
3. Commit the patch file
4. Push to Github and run tests

Before
----------------------------------------

In the example scenario:

* You might think the edit works -- because there are no hard failures in `composer install` and no hard failures in CI.
* However, it doesn't actually work -- because `composer.json` points to a URL with the old patch-file. You're testing the wrong thing.
* You need an update to `composer.json` with a new URL for the new patch-file.

After
----------------------------------------

The test-suite will complain because the committed patch-file is mismatched for the patch-URL.
