### PR TITLE
(dev/core#6022) Rebuilder - Clear statics as part of "system" target

### DIFF
--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -115,6 +115,10 @@ class Rebuilder {
       CRM_Core_DAO_AllCoreTables::flush();
     }
     if (!empty($targets['system'])) {
+      // flush out statics cache
+      // ? could this be bad if we flush "runOnce" type checks ?
+      Civi::$statics = [];
+
       // flush out all cache entries so we can reload new data
       // a bit aggressive, but livable for now
       CRM_Utils_Cache::singleton()->flush();


### PR DESCRIPTION
Overview
----------------------------------------
(Draft) Possible/alternate fix suggested by @ufundo on https://lab.civicrm.org/dev/core/-/issues/6022

Before
----------------------------------------

Whenever one rebuilds the `system` target, it still uses your existing `Civi::$statics`.

After
----------------------------------------

Whenever one rebuilds the `system` target, it resets the `Civi::$statics`.
