### PR TITLE
Fix fatal error when event is free

### DIFF
--- a/templates/CRM/Event/Form/Selector.tpl
+++ b/templates/CRM/Event/Form/Selector.tpl
@@ -48,7 +48,7 @@
     </td>
     <td class="crm-participant-participant_fee_level">
       {assign var="participant_id" value=$row.participant_id}
-      {if array_key_exists($participant_id, $lineItems)}
+      {if !empty($lineItems) && array_key_exists($participant_id, $lineItems)}
         {foreach from=$lineItems.$participant_id item=line name=lineItemsIter}
           {if $line.html_type eq 'Text'}{$line.label}{else}{$line.field_title} - {$line.label}{/if}: {$line.qty}
           {if ! $smarty.foreach.lineItemsIter.last}<br />{/if}


### PR DESCRIPTION
Overview
----------------------------------------
Steps to Reproduce:

1. Enable Smarty 4 in CiviCRM settings.
2. Create event participants (both free and paid) using online or offline registration.
3. Go to Advanced Search
4. Select "Display Results As" → "Event Participants"
5. Apply filters to search for participants based on specific events.

**Fatal Error:**

TypeError: array_key_exists(): Argument #2 ($array) must be of type array, null given in content_68945c5fe551c0_91472356() (line 101 of /var/sites/drupal10/web/sites/default/files/civicrm/templates_c/en_GB/65/62/ef/6562ef926191aff00b4e022562086c024299e782_0.file.Selector.tpl.php).


Before
----------------------------------------
A fatal error is thrown during the search.

After
----------------------------------------
Search results display matching participants without error.

