### PR TITLE
use preexisting metadata cache rather than static for AbstractEntity::getInfo

### DIFF
--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -136,76 +136,86 @@ abstract class AbstractEntity implements EntityInterface {
   /**
    * Reflection function called by Entity::get()
    *
+   * Note results are cached together in ActionObjectProvider
+   *
+   * @see \Civi\Api4\Provider\ActionObjectProvider
    * @see \Civi\Api4\Action\Entity\Get
    * @return array{name: string, title: string, description: string, title_plural: string, type: string, paths: array, class: string, primary_key: array, searchable: string, dao: string, label_field: string, icon: string}
    */
   public static function getInfo() {
     $entityName = static::getEntityName();
-    if (!isset(\Civi::$statics[__CLASS__]['getInfo'][$entityName])) {
-      $info = [
-        'name' => $entityName,
-        'title' => static::getEntityTitle(),
-        'title_plural' => static::getEntityTitle(TRUE),
-        'type' => [CoreUtil::stripNamespace(get_parent_class(static::class))],
-        'paths' => [],
-        'class' => static::class,
-        'primary_key' => ['id'],
-        // Entities without a @searchable annotation will default to secondary,
-        // which makes them visible in SearchKit but not at the top of the list.
-        'searchable' => 'secondary',
-      ];
-      // Add info for entities with a corresponding DAO
-      $dao = static::getDaoName();
-      if ($dao) {
-        $info['paths'] = $dao::getEntityPaths();
-        $info['primary_key'] = $dao::$_primaryKey;
-        $info['icon'] = $dao::getEntityIcon($entityName);
-        $info['label_field'] = $dao::getLabelField();
-        $info['dao'] = $dao;
-        $info['table_name'] = $dao::getTableName();
-        $info['icon_field'] = (array) ($dao::fields()['icon']['name'] ?? NULL);
-        if (method_exists($dao, 'indices')) {
-          foreach (\CRM_Utils_Array::findAll($dao::indices(FALSE), ['unique' => TRUE, 'localizable' => FALSE]) as $index) {
-            foreach ($index['field'] as $field) {
-              // Trim `field(length)` to just `field`
-              [$field] = explode('(', $field);
-              $info['match_fields'][] = $field;
-            }
-          }
-        }
-      }
-      foreach (ReflectionUtils::getTraits(static::class) as $trait) {
-        $info['type'][] = CoreUtil::stripNamespace($trait);
-      }
-      // Get DocBlock from APIv4 Entity class
-      $reflection = new \ReflectionClass(static::class);
-      $docBlock = ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]);
-      // Convert docblock keys to snake_case
-      foreach ($docBlock as $key => $val) {
-        $docBlock[\CRM_Utils_String::convertStringToSnakeCase($key)] = $val;
-      }
-      // Filter docblock to only declared entity fields
-      foreach (\Civi\Api4\Entity::$entityFields as $field) {
-        if (isset($docBlock[$field['name']])) {
-          $val = $docBlock[$field['name']];
-          // Convert to array if data_type == Array
-          if (isset($field['data_type']) && $field['data_type'] === 'Array' && is_string($val)) {
-            $val = \CRM_Core_DAO::unSerializeField($val, \CRM_Core_DAO::SERIALIZE_COMMA);
-          }
-          $info[$field['name']] = $val;
-        }
-      }
-      // search_fields defaults to label_field
-      if (empty($info['search_fields']) && !empty($info['label_field'])) {
-        $info['search_fields'] = [$info['label_field']];
-      }
-      if ($dao) {
-        $info['description'] = $dao::getEntityDescription() ?? $info['description'] ?? NULL;
-      }
-      \Civi::$statics[__CLASS__]['getInfo'][$entityName] = $info;
+
+    $cache = \Civi::cache('metadata')->get('api4.entities.info', []);
+    if ($cache[$entityName] ?? NULL) {
+      return $cache[$entityName];
     }
 
-    return \Civi::$statics[__CLASS__]['getInfo'][$entityName];
+    return self::loadInfo();
+  }
+
+  private static function loadInfo(): array {
+    $entityName = static::getEntityName();
+    $info = [
+      'name' => $entityName,
+      'title' => static::getEntityTitle(),
+      'title_plural' => static::getEntityTitle(TRUE),
+      'type' => [CoreUtil::stripNamespace(get_parent_class(static::class))],
+      'paths' => [],
+      'class' => static::class,
+      'primary_key' => ['id'],
+      // Entities without a @searchable annotation will default to secondary,
+      // which makes them visible in SearchKit but not at the top of the list.
+      'searchable' => 'secondary',
+    ];
+    // Add info for entities with a corresponding DAO
+    $dao = static::getDaoName();
+    if ($dao) {
+      $info['paths'] = $dao::getEntityPaths();
+      $info['primary_key'] = $dao::$_primaryKey;
+      $info['icon'] = $dao::getEntityIcon($entityName);
+      $info['label_field'] = $dao::getLabelField();
+      $info['dao'] = $dao;
+      $info['table_name'] = $dao::getTableName();
+      $info['icon_field'] = (array) ($dao::fields()['icon']['name'] ?? NULL);
+      if (method_exists($dao, 'indices')) {
+        foreach (\CRM_Utils_Array::findAll($dao::indices(FALSE), ['unique' => TRUE, 'localizable' => FALSE]) as $index) {
+          foreach ($index['field'] as $field) {
+            // Trim `field(length)` to just `field`
+            [$field] = explode('(', $field);
+            $info['match_fields'][] = $field;
+          }
+        }
+      }
+    }
+    foreach (ReflectionUtils::getTraits(static::class) as $trait) {
+      $info['type'][] = CoreUtil::stripNamespace($trait);
+    }
+    // Get DocBlock from APIv4 Entity class
+    $reflection = new \ReflectionClass(static::class);
+    $docBlock = ReflectionUtils::getCodeDocs($reflection, NULL, ['entity' => $info['name']]);
+    // Convert docblock keys to snake_case
+    foreach ($docBlock as $key => $val) {
+      $docBlock[\CRM_Utils_String::convertStringToSnakeCase($key)] = $val;
+    }
+    // Filter docblock to only declared entity fields
+    foreach (\Civi\Api4\Entity::$entityFields as $field) {
+      if (isset($docBlock[$field['name']])) {
+        $val = $docBlock[$field['name']];
+        // Convert to array if data_type == Array
+        if (isset($field['data_type']) && $field['data_type'] === 'Array' && is_string($val)) {
+          $val = \CRM_Core_DAO::unSerializeField($val, \CRM_Core_DAO::SERIALIZE_COMMA);
+        }
+        $info[$field['name']] = $val;
+      }
+    }
+    // search_fields defaults to label_field
+    if (empty($info['search_fields']) && !empty($info['label_field'])) {
+      $info['search_fields'] = [$info['label_field']];
+    }
+    if ($dao) {
+      $info['description'] = $dao::getEntityDescription() ?? $info['description'] ?? NULL;
+    }
+    return $info;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/commit/05ef6d4553e4414794cfac5a6f34d28e6ed865b9 added a cache for the results of getInfo. But its results are already cached immediately above. When these two things get out of sync, bad things happen: https://lab.civicrm.org/dev/core/-/issues/6022  https://lab.civicrm.org/dev/core/-/issues/6051

Before
----------------------------------------
- Two caches one on top of the other

After
----------------------------------------
- One canonical cache 

Technical Details
----------------------------------------
Given the results are already cached, why was @mattwire seeing it called so much? 

If you have a lot of extension then it will just called a lot during flushes.... But I also noticed that it's getting called twice for every entity - once in the ClassScanner pass, and once in the LegacyEntityScanner. I've got a separate PR coming to avoid that.

There are a few other calls to `getInfo` in e.g. `Civi\Api4\Generic\Traits\EntityBridge`. Not sure how relevant they are.

Comments
----------------------------------------
Not sure if this should be against 6.4 now given it's missed 6.4.1. Will raise against 6.5 and 6.6 also.

cc @totten 