### PR TITLE
avoid duplication in Api4 LegacyEntityScanner

### DIFF
--- a/Civi/Api4/Service/LegacyEntityScanner.php
+++ b/Civi/Api4/Service/LegacyEntityScanner.php
@@ -21,6 +21,7 @@ class LegacyEntityScanner extends AutoSubscriber {
   public static function getSubscribedEvents(): array {
     return [
       'civi.api4.entityTypes' => 'addEntities',
+      'hook_civicrm_check' => 'check',
     ];
   }
 
@@ -115,6 +116,24 @@ class LegacyEntityScanner extends AutoSubscriber {
       }
     }
     return FALSE;
+  }
+
+  public function check(GenericHookEvent $e): void {
+    $legacyEntities = self::getEntitiesFromClasses();
+
+    if ($legacyEntities) {
+      $intro = ts('Some of your extensions are providing entities through the Legacy Entity Scanner. These should be updated to use <code>scan-classes</code> mixin for better performance and future proofing.');
+      $entityList = implode('', array_map(fn ($info) => "<li><code>{$info['name']}</code></li>", $legacyEntities));
+      $message = "<p>{$intro}</p><ul>{$entityList}</ul>";
+      $e->messages[] = new \CRM_Utils_Check_Message(
+        'api4_legacy_entity_scan',
+        $message,
+        ts('Api4 Entities using Legacy Entity Scanner'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-box'
+      );
+
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
In investigating the cache for Api4 entities, have noticed building it takes twice the time because of duplication between scan-classes and LegacyEntityScanner. This avoids the duplication.

Before
----------------------------------------
- extension entities get scanned once by the class scanner, then immediately again by the LegacyEntityScanner

After
----------------------------------------
- extension entities get scanned once by the class scanner if they have `scan-classes`
- only entities in extensions that don't have scan-classes are picked up by LegacyEntityScanner
- performance improves
- added a status check to warn if your extensions are using the Legacy method

