### PR TITLE
Set Timeout for Weasyprint to max_execution_time #5968

### DIFF
--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -168,6 +168,7 @@ class CRM_Utils_PDF_Utils {
    */
   public static function _html2pdf_weasyprint($html, $output, $fileName) {
     $weasyprint = new Pontedilana\PhpWeasyPrint\Pdf(\Civi::settings()->get('weasyprint_path'));
+    $weasyprint->setTimeout((int) ini_get('max_execution_time'));
     $pdf = $weasyprint->getOutputFromHtml($html);
     if ($output) {
       return $pdf;


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/5968

Comments
----------------------------------------
Now the timeout is set to  max_execution_time instead of a fixed value like 300 seconds