### PR TITLE
Add php & smarty compatibility info to core extensions

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>FormBuilder provides a UI to administer and edit forms. It is an optional admin tool and not required for the forms to function.</comments>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -17,6 +17,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <develStage>stable</develStage>
   <tags>
     <tag>mgmt:required</tag>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>
   </requires>

--- a/ext/afform/login_token/info.xml
+++ b/ext/afform/login_token/info.xml
@@ -22,6 +22,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>
     <ext>authx</ext>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <requires>
     <ext>org.civicrm.afform</ext>
   </requires>

--- a/ext/authx/info.xml
+++ b/ext/authx/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>AuthX enables remote applications to connect to CiviCRM. Use it to enable and disable different forms of authentication (such as username-password, API key, and/or JWT).</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/chart_kit/info.xml
+++ b/ext/chart_kit/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/civi_campaign/info.xml
+++ b/ext/civi_campaign/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_mail/info.xml
+++ b/ext/civi_mail/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_member/info.xml
+++ b/ext/civi_member/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_pledge/info.xml
+++ b/ext/civi_pledge/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civi_report/info.xml
+++ b/ext/civi_report/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Core Component</comments>
   <upgrader>CRM_Extension_Upgrader_Component</upgrader>
   <classloader>

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Key CiviCRM interfaces are being rewritten as configurable Search Display Forms. This extension lets you try these updates now, before the screens are permanently replaced in core.</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/civicrm_search_ui/info.xml
+++ b/ext/civicrm_search_ui/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Replacement SearchKit/FormBuilder pages for core Search pages.</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>CiviGrant was originally a core component before migrating to an extension</comments>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>CiviCRM import functionality</comments>
   <requires>
     <ext>org.civicrm.afform</ext>

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is the version of CKEditor that originally shipped with CiviCRM core</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/contributioncancelactions/info.xml
+++ b/ext/contributioncancelactions/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This code has been moved from core to a separate extension in 5.32. Note that if you disable it failed or cancelled contributions will not cause related memberships and participant records to be updated</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/elavon/info.xml
+++ b/ext/elavon/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments/>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/eventcart/info.xml
+++ b/ext/eventcart/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/ewaysingle/info.xml
+++ b/ext/ewaysingle/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is an extension to contain the eWAY Single Currency Payment Processor</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/financialacls/info.xml
+++ b/ext/financialacls/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This code was previously in core and the extension can now be disabled if you do not use ACLs for contributions</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/flexmailer/info.xml
+++ b/ext/flexmailer/info.xml
@@ -25,6 +25,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <tags>
     <tag>mgmt:required</tag>
   </tags>

--- a/ext/greenwich/info.xml
+++ b/ext/greenwich/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/iframe/info.xml
+++ b/ext/iframe/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/legacycustomsearches/info.xml
+++ b/ext/legacycustomsearches/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is our old search system which has limited support. All new effort is on SearchKit</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/legacydedupefinder/info.xml
+++ b/ext/legacydedupefinder/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Adds backwards compatibility for dedupe hooks. If you do not need them, you can improve dedupe performance by disabling this extension.</comments>
   <mixins>
     <mixin>scan-classes@1.0.0</mixin>

--- a/ext/legacyprofiles/info.xml
+++ b/ext/legacyprofiles/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>These features have been replaced by SearchKit and FormBuilder</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/message_admin/info.xml
+++ b/ext/message_admin/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments/>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/oauth-client/info.xml
+++ b/ext/oauth-client/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <requires>
     <ext version="~4.5">org.civicrm.afform</ext>
   </requires>

--- a/ext/oembed/info.xml
+++ b/ext/oembed/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/payflowpro/info.xml
+++ b/ext/payflowpro/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This extension is extraction of the original Core Payflow Pro Payment Processor</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/recaptcha/info.xml
+++ b/ext/recaptcha/info.xml
@@ -21,6 +21,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -17,6 +17,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>A cross-CMS CiviCRM theme framework.</comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/scheduled_communications/info.xml
+++ b/ext/scheduled_communications/info.xml
@@ -18,6 +18,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/search_kit_reports/info.xml
+++ b/ext/search_kit_reports/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>SearchKit-based reporting UI</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/sequentialcreditnotes/info.xml
+++ b/ext/sequentialcreditnotes/info.xml
@@ -23,6 +23,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <mixins>
     <mixin>setting-php@1.0.0</mixin>
   </mixins>

--- a/ext/standaloneusers/info.xml
+++ b/ext/standaloneusers/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <requires>
     <ext>org.civicrm.search_kit</ext>
     <ext>authx</ext>

--- a/ext/tellafriend/info.xml
+++ b/ext/tellafriend/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This used to be a core CiviCRM functionality and is slowly being phased out. See dev/core#1036</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/user_dashboard/info.xml
+++ b/ext/user_dashboard/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This extension is still experimental</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/tools/extensions/event_check/info.xml
+++ b/tools/extensions/event_check/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments></comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/tools/extensions/org.civicrm.demoqueue/info.xml
+++ b/tools/extensions/org.civicrm.demoqueue/info.xml
@@ -15,6 +15,16 @@
   <compatibility>
     <ver>4.1</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is a new, undeveloped module</comments>
   <civix>
     <namespace>CRM/Demoqueue</namespace>

--- a/tools/extensions/phpstorm/info.xml
+++ b/tools/extensions/phpstorm/info.xml
@@ -20,6 +20,16 @@
   <compatibility>
     <ver>5.66</ver>
   </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
   <comments>This is a new, undeveloped module</comments>
   <classloader>
     <psr0 prefix="CRM_" path="."/>


### PR DESCRIPTION
Overview
----------------------------------------
Add php & smarty compatibility info to core extensions

Before
----------------------------------------
<img width="1253" height="548" alt="image" src="https://github.com/user-attachments/assets/833531f9-d34c-4a33-b0ea-bf70f11f743b" />

After
----------------------------------------
<img width="670" height="407" alt="image" src="https://github.com/user-attachments/assets/33fca8de-0102-4054-ae5f-213269362309" />


Technical Details
----------------------------------------
Encouraging declaring compatibility allows sites to see which extensions are compatible with Smarty5 & which work on various php versions.

Updating info.xml once a year is also a good proxy for whether an extension is maintained

Comments
----------------------------------------
