### PR TITLE
Do not display 'Continue' for Contact imports

### DIFF
--- a/ext/civiimport/Managed/UserJobSearches.mgd.php
+++ b/ext/civiimport/Managed/UserJobSearches.mgd.php
@@ -127,7 +127,13 @@ return [
                   'style' => 'default',
                   'path' => '',
                   'task' => '',
-                  'condition' => [],
+                  'conditions' => [
+                    [
+                      'status_id:name',
+                      '!=',
+                      'draft',
+                    ],
+                  ],
                 ],
                 [
                   'size' => 'btn-xs',
@@ -159,7 +165,16 @@ return [
                         [
                           'status_id:name',
                           'IN',
-                          ['draft', 'complete_with_errors', 'incomplete'],
+                          [
+                            'draft',
+                            'complete_with_errors',
+                            'incomplete',
+                          ],
+                        ],
+                        [
+                          'job_type:name',
+                          '!=',
+                          'contact_import',
                         ],
                       ],
                       'task' => '',
@@ -485,7 +500,16 @@ return [
                     [
                       'status_id:name',
                       'IN',
-                      ['draft', 'complete_with_errors', 'incomplete'],
+                      [
+                        'draft',
+                        'complete_with_errors',
+                        'incomplete',
+                      ],
+                    ],
+                    [
+                      'job_type:name',
+                      '!=',
+                      'contact_import',
                     ],
                   ],
                   'task' => '',


### PR DESCRIPTION

Overview
----------------------------------------
Contact imports do not use civiimport so it is confusing to have a broken link

Before
----------------------------------------

After
----------------------------------------
<img width="1027" height="593" alt="image" src="https://github.com/user-attachments/assets/ff8e6a50-077e-4b60-af92-efa34387a969" />

Technical Details
----------------------------------------

Comments
----------------------------------------
