### PR TITLE
Riverlea is enabled for all new installs, remove Standalone-specific enabler

### DIFF
--- a/setup/plugins/init/StandaloneRiverlea.civi-setup.php
+++ b/setup/plugins/init/StandaloneRiverlea.civi-setup.php
@@ -2,10 +2,8 @@
 /**
  * @file
  *
- * Enable Riverlea by default on Standalone installs.
- * - this does not *select* a Riverlea theme but removes one step for doing so
+ * Riverlea defaults for Standalone installs:
  * - we set dark_mode setting to inherit instead of always light (which is the default for other CMS)
- *
  */
 
 if (!defined('CIVI_SETUP')) {
@@ -20,7 +18,6 @@ if (!defined('CIVI_SETUP')) {
     }
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
 
-    $e->getModel()->extensions[] = 'riverlea';
     $e->getModel()->settings['riverlea_dark_mode_frontend'] = 'inherit';
     $e->getModel()->settings['riverlea_dark_mode_backend'] = 'inherit';
   });


### PR DESCRIPTION
Overview
----------------------------------------
Remove the Standalone specific code to enable Riverlea.

One of the 3 times Riverlea gets enabled in buildkit builds ( the other is https://github.com/civicrm/civicrm-buildkit/pull/980 )

Once is probably fine :)

_We keep this file because on Riverlea we enable darkmode. On the CMSes darkmode is disabled out of the box._