### PR TITLE
[NFC] Remove method from doc block

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -25,7 +25,6 @@ use GuzzleHttp\Psr7\Response;
  * FIXME: This is a massive and random collection that could be split into smaller services
  *
  * @method static array getCMSPermissionsUrlParams() Return the CMS-specific url for its permissions page.
- * @method static void getCMSPermissionsUrlParams() Immediately stop script execution and display a 401 "Access Denied" page.
  * @method static string getContentTemplate(int|string $print = 0) Get the template path to render whole content.
  * @method static mixed logout() Log out the current user.
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.


### PR DESCRIPTION
The function name appears to have been accidentally changed in https://github.com/civicrm/civicrm-core/commit/0d829976dba9f7dd2bb4ecca4710501b4b1d8a5c. ~~This changes it back to what it was before.~~

This removes the line - see feedback below.