### PR TITLE
FormBuilder Admin: set stability to Stable

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -14,7 +14,7 @@
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
   <version>[civicrm.version]</version>
-  <develStage>beta</develStage>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>
   </compatibility>


### PR DESCRIPTION
Overview
----------------------------------------

Changes the develState of `afform_admin` to stable

Before
----------------------------------------

<img width="1606" height="222" alt="image" src="https://github.com/user-attachments/assets/699fb591-a27b-4881-a93c-11c39d43abbd" />

After
----------------------------------------

<img width="1626" height="235" alt="image" src="https://github.com/user-attachments/assets/2dea89ba-6e83-452c-bad5-d88bb3aca210" />

Comments
----------------------------------------

I wasn't sure about the HTML editor?

cc @colemanw 