### PR TITLE
[REF] Work on removing the join to mailing job when using the Mailing…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1131,6 +1131,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // If we are scheduling vai Mailing.create then also update the status to scheduled.
     if (empty($params['skip_legacy_scheduling']) && !empty($params['scheduled_date']) && $params['scheduled_date'] !== 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
       $mailing->status = 'Scheduled';
+      $mailing->save();
     }
     if (!empty($params['search_id']) && !empty($params['group_id'])) {
       $mg->reset();

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -2239,9 +2239,9 @@ AND    e.id NOT IN ( SELECT email_id FROM civicrm_mailing_recipients mr WHERE ma
 
     if (empty($list)) {
       $query = "
-SELECT civicrm_mailing.id, civicrm_mailing.name, civicrm_mailing_job.end_date
+SELECT civicrm_mailing.id, civicrm_mailing.name, civicrm_mailing.end_date
 FROM   civicrm_mailing
-INNER JOIN civicrm_mailing_job ON civicrm_mailing.id = civicrm_mailing_job.mailing_id {$where}
+{$where}
 ORDER BY civicrm_mailing.id DESC";
       $mailing = CRM_Core_DAO::executeQuery($query);
 

--- a/CRM/Mailing/BAO/Query.php
+++ b/CRM/Mailing/BAO/Query.php
@@ -123,11 +123,6 @@ class CRM_Mailing_BAO_Query {
       $query->_tables['civicrm_campaign'] = 1;
     }
 
-    if ($query->_mode & CRM_Contact_BAO_QUERY::MODE_CONTACTS) {
-      // base table is contact, so join recipients to it
-      $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients']
-        = " INNER JOIN civicrm_mailing_recipients ON civicrm_mailing_recipients.contact_id = contact_a.id ";
-    }
   }
 
   /**
@@ -254,6 +249,8 @@ class CRM_Mailing_BAO_Query {
   public static function whereClauseSingle(&$values, &$query) {
     [$name, $op, $value, $grouping, $wildcard] = $values;
 
+    $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
+
     switch ($name) {
       case 'mailing_id':
         $selectedMailings = array_flip($value);
@@ -269,7 +266,6 @@ class CRM_Mailing_BAO_Query {
 
         $query->_qill[$grouping][] = "Mailing Name $op \"$selectedMailings\"";
         $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;
-        $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
         return;
 
       case 'mailing_name':
@@ -282,7 +278,6 @@ class CRM_Mailing_BAO_Query {
         $query->_where[$grouping][] = "civicrm_mailing.name $op '$value'";
         $query->_qill[$grouping][] = "Mailing Namename $op \"$value\"";
         $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;
-        $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
         return;
 
       case 'mailing_date':
@@ -323,7 +318,7 @@ class CRM_Mailing_BAO_Query {
         $values = [$name, $op, $value, $grouping, $wildcard];
         $daoOptions = Civi::entity('MailingEventBounce')->getOptions('bounce_type_id');
         $options = [];
-        foreach ($daoOptions as $option)  {
+        foreach ($daoOptions as $option) {
           $options[$option['id']] = $option['label'];
         }
         self::mailingEventQueryBuilder($query, $values,
@@ -400,7 +395,6 @@ class CRM_Mailing_BAO_Query {
         [$op, $value] = CRM_Contact_BAO_Query::buildQillForFieldValue('CRM_Mailing_DAO_Mailing', $name, $value, $op);
         $query->_qill[$grouping][] = ts('Campaign %1 %2', [1 => $op, 2 => $value]);
         $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;
-        $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
         return;
     }
   }
@@ -436,7 +430,7 @@ class CRM_Mailing_BAO_Query {
 
     $daoOptions = Civi::entity('MailingEventBounce')->getOptions('bounce_type_id');
     $mailingBounceTypes = [];
-    foreach ($daoOptions as $option)  {
+    foreach ($daoOptions as $option) {
       $mailingBounceTypes[$option['id']] = $option['label'];
     }
     $form->add('select', 'mailing_bounce_types', ts('Bounce Types'), $mailingBounceTypes, FALSE,
@@ -510,7 +504,6 @@ class CRM_Mailing_BAO_Query {
 
     $query->_tables['civicrm_mailing'] = $query->_whereTables['civicrm_mailing'] = 1;
     $query->_tables['civicrm_mailing_event_queue'] = $query->_whereTables['civicrm_mailing_event_queue'] = 1;
-    $query->_tables['civicrm_mailing_recipients'] = $query->_whereTables['civicrm_mailing_recipients'] = 1;
     $query->_tables[$tableName] = $query->_whereTables[$tableName] = 1;
   }
 

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -200,7 +200,6 @@ class CRM_Mailing_Selector_Browse extends CRM_Core_Selector_Base implements CRM_
     $query = "
    SELECT  COUNT( DISTINCT $mailing.id ) as count
      FROM  $mailing
-LEFT JOIN  $job ON ( $mailing.id = $job.mailing_id AND civicrm_mailing_job.is_test = 0 AND civicrm_mailing_job.parent_id IS NULL )
 LEFT JOIN  civicrm_contact createdContact   ON ( $mailing.created_id   = createdContact.id )
 LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = scheduledContact.id )
     WHERE  $whereClause";
@@ -517,8 +516,8 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
         $dateClause1[] = 'civicrm_mailing.created_date >= %2';
       }
       else {
-        $dateClause1[] = 'civicrm_mailing_job.start_date >= %2';
-        $dateClause2[] = 'civicrm_mailing_job.scheduled_date >= %2';
+        $dateClause1[] = 'civicrm_mailing.start_date >= %2';
+        $dateClause2[] = 'civicrm_mailing.scheduled_date >= %2';
       }
       $params[2] = [$from, 'String'];
     }
@@ -529,8 +528,8 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
         $dateClause1[] = ' civicrm_mailing.created_date <= %3 ';
       }
       else {
-        $dateClause1[] = 'civicrm_mailing_job.start_date <= %3';
-        $dateClause2[] = 'civicrm_mailing_job.scheduled_date <= %3';
+        $dateClause1[] = 'civicrm_mailing.start_date <= %3';
+        $dateClause2[] = 'civicrm_mailing.scheduled_date <= %3';
       }
       $params[3] = [$to, 'String'];
     }
@@ -578,8 +577,9 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
       $statusClauses[] = "civicrm_mailing.scheduled_id IS NULL";
     }
     if (!empty($mailingStatus)) {
-      $statusClauses[] = "civicrm_mailing_job.status IN ('" . implode("', '", array_keys($mailingStatus)) . "')";
+      $statusClauses[] = "civicrm_mailing.status IN ('" . implode("', '", array_keys($mailingStatus)) . "')";
     }
+
     if (!empty($statusClauses)) {
       $clauses[] = "(" . implode(' OR ', $statusClauses) . ")";
     }
@@ -650,7 +650,6 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
     $query = "
 SELECT DISTINCT UPPER(LEFT(name, 1)) as sort_name
 FROM civicrm_mailing
-LEFT JOIN civicrm_mailing_job ON (civicrm_mailing_job.mailing_id = civicrm_mailing.id)
 LEFT JOIN civicrm_contact createdContact ON ( civicrm_mailing.created_id = createdContact.id )
 LEFT JOIN civicrm_contact scheduledContact ON ( civicrm_mailing.scheduled_id = scheduledContact.id )
 WHERE $whereClause

--- a/CRM/Mailing/Selector/Search.php
+++ b/CRM/Mailing/Selector/Search.php
@@ -50,8 +50,8 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
     'mailing_subject',
     'email_on_hold',
     'contact_opt_out',
-    'mailing_job_status',
-    'mailing_job_end_date',
+    'mailing_status',
+    'mailing_end_date',
   ];
 
   /**
@@ -363,12 +363,12 @@ class CRM_Mailing_Selector_Search extends CRM_Core_Selector_Base implements CRM_
         ],
         [
           'name' => ts('Mailing Status'),
-          'sort' => 'mailing_job_status',
+          'sort' => 'mailing_status',
           'direction' => CRM_Utils_Sort::DONTCARE,
         ],
         [
           'name' => ts('Completed Date'),
-          'sort' => 'mailing_job_end_date',
+          'sort' => 'mailing_end_date',
           'direction' => CRM_Utils_Sort::DONTCARE,
         ],
         ['desc' => ts('Actions')],

--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -399,6 +399,7 @@ return [
       ],
       'readonly' => TRUE,
       'add' => 5.76,
+      'unique_name' => 'mailing_start_date',
     ],
     'end_date' => [
       'sql_type' => 'timestamp',

--- a/templates/CRM/Mailing/Form/Search.tpl
+++ b/templates/CRM/Mailing/Form/Search.tpl
@@ -30,9 +30,11 @@
          <td width="100%"><label>{if $sms eq 1}{ts}SMS Status{/ts}{else}{ts}Mailing Status{/ts}{/if}</label><br />
            <div class="listing-box" style="height: auto">
              {foreach from=$form.mailing_status item="mailing_status_val"}
-               <div class="{cycle values="odd-row,even-row"}">
-                 {$mailing_status_val.html}
-               </div>
+              <div class="{cycle values="odd-row,even-row"}">
+                {if is_array($mailing_status_val) and array_key_exists('html', $mailing_status_val)}
+                  {$mailing_status_val.html}
+                {/if}
+              </div>
             {/foreach}
             <div class="{cycle values="odd-row,even-row"}">
               {$form.status_unscheduled.html}

--- a/templates/CRM/Mailing/Form/Search/Common.tpl
+++ b/templates/CRM/Mailing/Form/Search/Common.tpl
@@ -5,13 +5,13 @@
   {$form.mailing_id.html}
   </td>
 <td>
-  {$form.mailing_job_status.label}
+  {$form.mailing_status.label}
     <br />
-  {$form.mailing_job_status.html}
+  {$form.mailing_status.html}
 </td>
 </tr>
 <tr>
-{include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="mailing_job_start_date" to='' from='' colspan='' class='' hideRelativeLabel=0}
+{include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="mailing_start_date" to='' from='' colspan='' class='' hideRelativeLabel=0}
 </tr>
 <tr>
   <td>

--- a/tests/phpunit/CRM/Mailing/BAO/queryDataset.xml
+++ b/tests/phpunit/CRM/Mailing/BAO/queryDataset.xml
@@ -45,8 +45,8 @@
   <civicrm_email id="101" contact_id="110" location_type_id="1" email="test06@civicrm.org" is_primary="1" is_billing="0" on_hold="0" is_bulkmail="0" signature_text="" signature_html=""/>
   <civicrm_email id="102" contact_id="111" location_type_id="1" email="test07@civicrm.org" is_primary="1" is_billing="0" on_hold="0" is_bulkmail="0" signature_text="" signature_html=""/>
   <civicrm_email id="103" contact_id="112" location_type_id="1" email="test08@civicrm.org" is_primary="1" is_billing="0" on_hold="0" is_bulkmail="0" signature_text="" signature_html=""/>
-  <civicrm_mailing id="14" domain_id="1" header_id="1" footer_id="2" reply_id="8" unsubscribe_id="5" resubscribe_id="6" optout_id="7" name="First Mailing Events" from_name="FIXME" from_email="info@cividev.yook.civicrm.org" replyto_email="info@cividev.yook.civicrm.org" subject="Hello {contact.display_name}" body_text="" body_html="&lt;p&gt;&#13;&#10;&#9;Hello {contact.display_name},&lt;/p&gt;&#13;&#10;&lt;p&gt;&#13;&#10;&#9;You should check &lt;a href=&quot;http://drupal.org&quot;&gt;drupal.org&lt;/a&gt; and &lt;a href=&quot;http://civicrm.org&quot;&gt;civicrm.org&lt;/a&gt;.&lt;/p&gt;&#13;&#10;" url_tracking="1" forward_replies="0" auto_responder="0" open_tracking="1" is_completed="1" override_verp="0" created_id="102" created_date="2011-05-26 13:03:50" scheduled_id="102" scheduled_date="2011-05-25 13:06:08" approver_id="102" approval_date="2011-05-25 13:06:08" approval_status_id="1" approval_note="" is_archived="0" visibility="User and User Admin Only" />
-  <civicrm_mailing id="15" domain_id="1" header_id="1" footer_id="2" reply_id="8" unsubscribe_id="5" resubscribe_id="6" optout_id="7" name="Second Test Mailing Events" from_name="FIXME" from_email="info@cividev.yook.civicrm.org" replyto_email="info@cividev.yook.civicrm.org" subject="Hello again, {contact.display_name}" body_text="" body_html="&lt;p&gt;&#13;&#10;&#9;Hello {contact.display_name},&lt;/p&gt;&#13;&#10;&lt;p&gt;&#13;&#10;&#9;You should check &lt;a href=&quot;http://drupal.org&quot;&gt;drupal.org&lt;/a&gt; and &lt;a href=&quot;http://civicrm.org&quot;&gt;civicrm.org&lt;/a&gt;.&lt;/p&gt;&#13;&#10;" url_tracking="1" forward_replies="0" auto_responder="0" open_tracking="1" is_completed="1" override_verp="0" created_id="102" created_date="2011-05-26 13:08:05" scheduled_id="102" scheduled_date="2011-05-26 13:08:46" approver_id="102" approval_date="2011-05-26 13:08:46" approval_status_id="1" approval_note="" is_archived="0" visibility="User and User Admin Only" />
+  <civicrm_mailing id="14" domain_id="1" header_id="1" footer_id="2" reply_id="8" unsubscribe_id="5" resubscribe_id="6" optout_id="7" name="First Mailing Events" from_name="FIXME" from_email="info@cividev.yook.civicrm.org" replyto_email="info@cividev.yook.civicrm.org" subject="Hello {contact.display_name}" body_text="" body_html="&lt;p&gt;&#13;&#10;&#9;Hello {contact.display_name},&lt;/p&gt;&#13;&#10;&lt;p&gt;&#13;&#10;&#9;You should check &lt;a href=&quot;http://drupal.org&quot;&gt;drupal.org&lt;/a&gt; and &lt;a href=&quot;http://civicrm.org&quot;&gt;civicrm.org&lt;/a&gt;.&lt;/p&gt;&#13;&#10;" url_tracking="1" forward_replies="0" auto_responder="0" open_tracking="1" is_completed="1" override_verp="0" created_id="102" created_date="2011-05-26 13:03:50" scheduled_id="102" scheduled_date="2011-05-25 13:06:08" approver_id="102" approval_date="2011-05-25 13:06:08" approval_status_id="1" approval_note="" is_archived="0" visibility="User and User Admin Only" start_date="2011-05-25 13:06:34" status="Complete" end_date="2011-05-25 13:06:35" />
+  <civicrm_mailing id="15" domain_id="1" header_id="1" footer_id="2" reply_id="8" unsubscribe_id="5" resubscribe_id="6" optout_id="7" name="Second Test Mailing Events" from_name="FIXME" from_email="info@cividev.yook.civicrm.org" replyto_email="info@cividev.yook.civicrm.org" subject="Hello again, {contact.display_name}" body_text="" body_html="&lt;p&gt;&#13;&#10;&#9;Hello {contact.display_name},&lt;/p&gt;&#13;&#10;&lt;p&gt;&#13;&#10;&#9;You should check &lt;a href=&quot;http://drupal.org&quot;&gt;drupal.org&lt;/a&gt; and &lt;a href=&quot;http://civicrm.org&quot;&gt;civicrm.org&lt;/a&gt;.&lt;/p&gt;&#13;&#10;" url_tracking="1" forward_replies="0" auto_responder="0" open_tracking="1" is_completed="1" override_verp="0" created_id="102" created_date="2011-05-26 13:08:05" scheduled_id="102" scheduled_date="2011-05-26 13:08:46" approver_id="102" approval_date="2011-05-26 13:08:46" approval_status_id="1" approval_note="" is_archived="0" visibility="User and User Admin Only" start_date="2011-05-26 13:08:49"  status="Complete" end_date="2011-05-26 13:08:51"/>
   <civicrm_mailing_recipients id="1" mailing_id="14" email_id="96" contact_id="105"/>
   <civicrm_mailing_recipients id="2" mailing_id="14" email_id="93" contact_id="102"/>
   <civicrm_mailing_recipients id="3" mailing_id="14" email_id="94" contact_id="103"/>
@@ -72,23 +72,23 @@
   <civicrm_mailing_trackable_url id="13" url="http://civicrm.org" mailing_id="14"/>
   <civicrm_mailing_trackable_url id="14" url="http://drupal.org" mailing_id="15"/>
   <civicrm_mailing_trackable_url id="15" url="http://civicrm.org" mailing_id="15"/>
-  <civicrm_mailing_event_queue id="44" job_id="24" email_id="93" contact_id="102" hash="07705f3169d0fc84"/>
-  <civicrm_mailing_event_queue id="45" job_id="24" email_id="94" contact_id="103" hash="8f6d859e31948f31"/>
-  <civicrm_mailing_event_queue id="46" job_id="24" email_id="95" contact_id="104" hash="e9694c902fafa150"/>
-  <civicrm_mailing_event_queue id="47" job_id="24" email_id="96" contact_id="105" hash="96a8f2de0d12ddf4"/>
-  <civicrm_mailing_event_queue id="48" job_id="24" email_id="99" contact_id="108" hash="a3e9c35a0f8b8cf9"/>
-  <civicrm_mailing_event_queue id="49" job_id="24" email_id="100" contact_id="109" hash="a32756fa40596d57"/>
-  <civicrm_mailing_event_queue id="50" job_id="24" email_id="101" contact_id="110" hash="20d8df8676546473"/>
-  <civicrm_mailing_event_queue id="51" job_id="24" email_id="102" contact_id="111" hash="2a2ea3816a403ccd"/>
-  <civicrm_mailing_event_queue id="52" job_id="24" email_id="103" contact_id="112" hash="d429695899514370"/>
-  <civicrm_mailing_event_queue id="53" job_id="26" email_id="93" contact_id="102" hash="98c5893b97ff170a"/>
-  <civicrm_mailing_event_queue id="54" job_id="26" email_id="94" contact_id="103" hash="0ad8d95c73f56332"/>
-  <civicrm_mailing_event_queue id="55" job_id="26" email_id="95" contact_id="104" hash="15035deafe89f4b0"/>
-  <civicrm_mailing_event_queue id="56" job_id="26" email_id="99" contact_id="108" hash="c7df7cc740a7c105"/>
-  <civicrm_mailing_event_queue id="57" job_id="26" email_id="100" contact_id="109" hash="c81c306117ca7fbd"/>
-  <civicrm_mailing_event_queue id="58" job_id="26" email_id="101" contact_id="110" hash="a9ae5b99441f1dda"/>
-  <civicrm_mailing_event_queue id="59" job_id="26" email_id="102" contact_id="111" hash="32fbff2a4814bb77"/>
-  <civicrm_mailing_event_queue id="60" job_id="26" email_id="103" contact_id="112" hash="bcd3cfd309c8c117"/>
+  <civicrm_mailing_event_queue id="44" job_id="24" email_id="93" contact_id="102" hash="07705f3169d0fc84" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="45" job_id="24" email_id="94" contact_id="103" hash="8f6d859e31948f31" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="46" job_id="24" email_id="95" contact_id="104" hash="e9694c902fafa150" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="47" job_id="24" email_id="96" contact_id="105" hash="96a8f2de0d12ddf4" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="48" job_id="24" email_id="99" contact_id="108" hash="a3e9c35a0f8b8cf9" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="49" job_id="24" email_id="100" contact_id="109" hash="a32756fa40596d57" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="50" job_id="24" email_id="101" contact_id="110" hash="20d8df8676546473" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="51" job_id="24" email_id="102" contact_id="111" hash="2a2ea3816a403ccd" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="52" job_id="24" email_id="103" contact_id="112" hash="d429695899514370" mailing_id="14"/>
+  <civicrm_mailing_event_queue id="53" job_id="26" email_id="93" contact_id="102" hash="98c5893b97ff170a" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="54" job_id="26" email_id="94" contact_id="103" hash="0ad8d95c73f56332" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="55" job_id="26" email_id="95" contact_id="104" hash="15035deafe89f4b0" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="56" job_id="26" email_id="99" contact_id="108" hash="c7df7cc740a7c105" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="57" job_id="26" email_id="100" contact_id="109" hash="c81c306117ca7fbd" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="58" job_id="26" email_id="101" contact_id="110" hash="a9ae5b99441f1dda" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="59" job_id="26" email_id="102" contact_id="111" hash="32fbff2a4814bb77" mailing_id="15"/>
+  <civicrm_mailing_event_queue id="60" job_id="26" email_id="103" contact_id="112" hash="bcd3cfd309c8c117" mailing_id="15"/>
   <civicrm_mailing_event_bounce id="2" event_queue_id="47" bounce_type_id="6" bounce_reason="Unknown bounce type: Could not parse bounce email" time_stamp="2011-05-25 13:06:57"/>
   <civicrm_mailing_event_delivered id="44" event_queue_id="44" time_stamp="2011-05-25 13:06:34"/>
   <civicrm_mailing_event_delivered id="45" event_queue_id="45" time_stamp="2011-05-25 13:06:34"/>


### PR DESCRIPTION
… Advanced Search pane and modernise the looking up of bounce options and switch to using the status and start date fields on the civicrm mailing table

Overview
----------------------------------------
This aims to progress the goal of allowing rows to be deleted out of the civicrm mailing job table by switching the advanced search pane to not needing it and also various code improvements

Before
----------------------------------------
Advanced search pane filters join through the mailing job table

After
----------------------------------------
Advance search pane doesn't need mailing job

ping @eileenmcnaughton 