### PR TITLE
Api4 Explorer - Fix debug param showing in generated code

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -290,7 +290,7 @@
           <pre ng-if="debug" class="prettyprint" ng-bind-html="debug"></pre>
           <div ng-if="!debug">
             <p>
-              {{:: ts('To view debugging output, enable the debug param before executing.') }}
+              {{:: ts('Click "Execute" and debug info will be available here.') }}
             </p>
             <p>
               {{:: ts('Enable backtrace in system settings to see error backtraces.') }}

--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -549,9 +549,6 @@
             if (name === 'limit' && $scope.action === 'get') {
               defaultVal = 25;
             }
-            if (name === 'debug') {
-              defaultVal = true;
-            }
             if (name === 'values') {
               defaultVal = defaultValues(defaultVal);
             }
@@ -705,7 +702,6 @@
         index = isInt($scope.index) ? +$scope.index : parseYaml($scope.index),
         result = 'result';
       if ($scope.entity && $scope.action) {
-        delete params.debug;
         if (action.slice(0, 3) === 'get') {
           var args = getEntity(entity).class_args || [];
           result = args[0] ? _.camelCase(args[0]) : entity;
@@ -966,8 +962,11 @@
     $scope.execute = function() {
       $scope.status = 'info';
       $scope.loading = true;
+      const apiParams = getParams();
+      // This is the Api Explorer, so we always want debug info available
+      apiParams.debug = true;
       $http.post(CRM.url('civicrm/ajax/api4/' + $scope.entity + '/' + $scope.action, {
-        params: angular.toJson(getParams()),
+        params: angular.toJson(apiParams),
         index: isInt($scope.index) ? +$scope.index : parseYaml($scope.index)
       }), null, {
         headers: {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a quirk in the Api4 Explorer.

See https://lab.civicrm.org/dev/core/-/issues/2869

Before
----------------------------------------
Generated code did not include `debug` param.

After
----------------------------------------
Now it does.