### PR TITLE
Use angular component for Standalone login

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -22,12 +22,13 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
 
     CRM_Utils_System::setTitle(E::ts('Log In'));
     $this->assign('pageTitle', '');
-    $this->assign('forgottenPasswordURL', CRM_Utils_System::url('civicrm/login/password'));
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);
 
     // Add the jQuery notify library because this library is only loaded whne the user is logged in. And we need this for CRM.alert
     CRM_Core_Resources::singleton()->addScriptFile('civicrm.packages', "jquery/plugins/jquery.notify.min.js", ['region' => 'html-header']);
+
+    \Civi::service('angularjs.loader')->addModules('crmLogin');
 
     parent::run();
   }

--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -137,8 +137,9 @@ class Login extends AbstractAction {
     Civi::dispatcher()->dispatch('civi.standalone.login', $event);
 
     if ($event->stopReason) {
+      # note: if providing a stop reason through civi.standalone.login listener
+      # you should probably provide user feedback on /civicrm/login?[mystopreason]
       $result['url'] = '/civicrm/login?' . $event->stopReason;
-      $result['publicError'] = "Invalid request";
       return;
     }
 

--- a/ext/standaloneusers/ang/crmLogin.ang.php
+++ b/ext/standaloneusers/ang/crmLogin.ang.php
@@ -1,0 +1,14 @@
+<?php
+return [
+  'js' => [
+    'ang/crmLogin/crmLogin.js',
+  ],
+  'css' => ['ang/crmLogin/crmLogin.css'],
+  'partials' => ['ang/crmLogin'],
+  'requires' => ['crmUi', 'crmUtil', 'api4'],
+  'basePages' => ['civicrm/login'],
+  'exports' => [
+    // Export the module as an [E]lement
+    'crm-login' => 'E',
+  ],
+];

--- a/ext/standaloneusers/ang/crmLogin/crmLogin.css
+++ b/ext/standaloneusers/ang/crmLogin/crmLogin.css
@@ -1,0 +1,31 @@
+.crm-login {
+  /* avoid height jump between loader and form */
+  min-height: 12rem;
+}
+
+.crm-login-loading {
+  text-align: center;
+}
+
+.crm-login .crm-loading-spinner {
+  --crm-loading-spinner-size: 48px;
+  width: var(--crm-loading-spinner-size);
+  height: var(--crm-loading-spinner-size);
+  border: 5px solid var(--crm-c-info-text);
+  border-bottom-color: var(--crm-c-info);
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: crmLoadingSpinner 1s linear infinite;
+  margin: 2rem;
+}
+
+@keyframes crmLoadingSpinner {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/ext/standaloneusers/ang/crmLogin/crmLogin.html
+++ b/ext/standaloneusers/ang/crmLogin/crmLogin.html
@@ -1,0 +1,20 @@
+<div ng-if="$ctrl.loading" class="crm-login crm-login-loading">
+  <div class="sr-only">{{:: ts('Loading...') }}</div>
+  <div class="crm-loading-spinner"></div>
+</div>
+<div ng-if="!$ctrl.loading" class="crm-login">
+  <form ng-submit="$ctrl.attemptLogin()">
+    <div class="input-wrapper">
+      <label for="usernameInput" class="form-label">{{:: ts('Username') }}</label>
+      <input type="text" class="form-control crm-form-text" id="usernameInput" ng-model="$ctrl.identifier" required />
+    </div>
+    <div class="input-wrapper">
+      <label for="passwordInput" class="form-label">{{:: ts('Password') }}</label>
+      <input type="password" class="form-control crm-form-text" id="passwordInput" ng-model="$ctrl.password" required />
+    </div>
+    <div class="login-or-forgot">
+      <a href="{{:: $ctrl.forgottenPasswordUrl }}">{{:: ts('Forgotten password?') }}</a>
+      <button type="submit" class="btn btn-primary crm-button">{{:: ts('Log In') }}</button>
+    </div>
+  </form>
+</div>

--- a/ext/standaloneusers/ang/crmLogin/crmLogin.js
+++ b/ext/standaloneusers/ang/crmLogin/crmLogin.js
@@ -1,0 +1,56 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmLogin', CRM.angRequires('crmLogin'));
+
+  angular.module('crmLogin').component('crmLogin', {
+    templateUrl: '~/crmLogin/crmLogin.html',
+    bindings: {},
+    controller: function($scope, $window, $timeout, crmApi4, crmStatus) {
+      var ts = $scope.ts = CRM.ts('standaloneusers');
+
+      this.loading = false;
+
+      this.forgottenPasswordUrl = CRM.url('civicrm/login/password');
+
+      this.canSubmit = () => {
+        return this.identifier && this.password && !this.loading;
+      };
+
+      this.attemptLogin = () => {
+        if (!this.canSubmit()) {
+          throw new Error('Invalid login');
+        }
+
+        this.loading = true;
+
+        let originalUrl = location.href;
+
+        // Remove the current status popup messages.
+        $('#crm-notification-container .ui-notify-message').remove();
+
+        let publicError = ts('Unexpected error');
+
+        crmApi4('User', 'login', {
+          identifier: this.identifier,
+          password: this.password,
+          originalUrl
+        })
+        .then((response) => {
+          if (response.url) {
+            $window.location = response.url;
+            return;
+          }
+          if (response.publicError) {
+            publicError = response.publicError;
+            throw new Error('Login failed');
+          }
+        })
+        .catch((e) => {
+          this.loading = false;
+          CRM.alert('', publicError, 'error', {'expires': 10000});
+        });
+      };
+    }
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/Login.tpl
@@ -1,60 +1,15 @@
 {crmScope extensionKey="standaloneusers"}
+
 <div class="standalone-auth-form">
   <div class="standalone-auth-box">
-    <form id=login-form>
       {include file='CRM/common/logo.tpl'}
-      <div class="input-wrapper">
-        <label for="usernameInput" name=username class="form-label">{ts}Username{/ts}</label>
-        <input type="text" class="form-control crm-form-text" id="usernameInput" >
-      </div>
-      <div class="input-wrapper">
-        <label for="passwordInput" class="form-label">{ts}Password{/ts}</label>
-        <input type="password" class="form-control crm-form-text" id="passwordInput">
-      </div>
-      <div class="login-or-forgot">
-        <a href="{$forgottenPasswordURL}">{ts}Forgotten password?{/ts}</a>
-        <button id="loginSubmit" type="submit" class="btn btn-primary crm-button">{ts}Log In{/ts}</button>
-      </div>
-    </form>
+      <crm-angular-js modules="crmLogin">
+        <crm-login></crm-login>
+      </crm-angular-js>
   </div>
 </div>
 
 {* The notification template is not loaded when the user is logged out. And we need this for CRM.alert *}
 {include file="CRM/common/notifications.tpl"}
 
-{literal}
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-
-    const form = document.getElementById('login-form'),
-      username = document.getElementById('usernameInput'),
-      password = document.getElementById('passwordInput');
-
-    form.addEventListener('submit', async e => {
-      e.preventDefault();
-
-      let errorMsg = '{/literal}{ts escape="js"}Unexpected error{/ts}{literal}';
-      try {
-        let originalUrl = location.href;
-        // Remove the current status popup messages.
-        CRM.$('#crm-notification-container .ui-notify-message').remove();
-        const response = await CRM.api4('User', 'login', {
-          identifier: username.value,
-          password: password.value,
-          originalUrl
-        });
-        if (response.url) {
-          window.location = response.url;
-          return;
-        }
-        errorMsg = response.publicError || "{/literal}{ts escape="js"}Unexpected error{/ts}{literal}";
-      }
-      catch (e) {
-        console.error('caught', e);
-      }
-      CRM.alert('', errorMsg, 'error', {'expires': 10000});
-    });
-  });
-</script>
-{/literal}
 {/crmScope}


### PR DESCRIPTION
Overview
----------------------------------------
This replaces the Standalone login page with an angular component (like password reset page / change password).

Before
----------------------------------------
- Standalone login page uses html + javascript in a smarty template
- you can submit the form without filling in username and password
- no loading indication on submit


After
----------------------------------------
- Standalone login page uses an angular component
- you cant submit until you've filled a username and password
- loading indicator when you submit
- step towards including as a widget on custom landing pages

Technical Details
----------------------------------------
The css for the loading element is copied from searchkit. I couldn't find loading css that seemed to work out of the box on the frontpage. 

For now I've left the CiviCRM logo display in the smarty template. Maybe that should move to the component.