### PR TITLE
dev/core#6056 Searchkit filter on IS NOT NULL with no gives wrong results 

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -293,6 +293,10 @@ trait SavedSearchInspectorTrait {
     foreach ($fieldNames as $fieldName) {
       $field = $this->getField($fieldName);
       $dataType = $field['data_type'] ?? NULL;
+      if (empty($field)) {
+        $expr = $this->getSelectExpression($fieldName);
+        $dataType = $expr['dataType'] ?? NULL;
+      }
       $operators = array_values($field['operators'] ?? []) ?: CoreUtil::getOperators();
       // Array is either associative `OP => VAL` or sequential `IN (...)`
       if (is_array($value)) {

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -146,6 +146,15 @@ class FormattingUtil {
       case 'Date':
         $value = self::formatDateValue('Ymd', $value, $operator, $index);
         break;
+
+      case 'Boolean':
+        if ($operator === 'CONTAINS' || $operator === 'NOT CONTAINS') {
+          // When the operator is Contains and the data type is a boolean and the value is false
+          // it results in an empty string. So we hard code here the true value to 1 and the false value to 0.
+          // So that the SQL becomes LIKE '%1%' OR LIKE '%0%'
+          $value = $value ? '1' : '0';
+        }
+        break;
     }
 
     $hic = \CRM_Utils_API_HTMLInputCoder::singleton();


### PR DESCRIPTION
Overview
----------------------------------------

A having clause on the Api4 on a function field creates a wrong sql. The issue appears in search kit, however it is an api4 issue.


Reproduction steps in search kit
----------------------------------------
1. Create a new search kit (I did a search on Cases and a join on case role of Benefit Specialist)
2. Add a field with a function IS NOT NULL (I did this on the case role id field)
3. Add a form to the search kit
4. On this form add the filter for the IS NOT NULL field
5. Change the field from checkbox to radio
6. See screenshot below for how the filter looks like on a form
7. Set the filter to No (in the screenshot this is Nee)

<img width="638" height="337" alt="2025-08-12_15-23" src="https://github.com/user-attachments/assets/ba34bfe7-51ad-4d86-af71-efd69951b25b" />


Current behaviour
----------------------------------------

Results where the field is not null also appears in the result set

Expected behaviour
----------------------------------------

Only results with with no value (NULL) in the selected results are shown

Environment information
----------------------------------------

* __CiviCRM:__ Standalone 5.4.0

Comments
----------------------------------------

I tracked the search kit down to an Api4 call an the Case entity. With a having clause on the IS NOT NULL field. That clause has an operator of Contains. Contains true results in sql to `LIKE '%1%'` and the contains false results in sql statment: `LIKE '%%'`. Which should be `LIKE '%0%'`. The 0 is missing, so I assume the false is translated into an empty string and not into a 0.