### PR TITLE
Alpha order financial types

### DIFF
--- a/CRM/Financial/BAO/FinancialType.php
+++ b/CRM/Financial/BAO/FinancialType.php
@@ -248,6 +248,7 @@ class CRM_Financial_BAO_FinancialType extends CRM_Financial_DAO_FinancialType im
     if (!$includeDisabled) {
       $query .= ' WHERE is_active = 1';
     }
+    $query .= ' ORDER BY label';
     $financialTypeOptions = CRM_Core_DAO::executeQuery($query)->fetchAll();
     if (!empty($financialTypes)) {
       $financialTypeOptions = array_column($financialTypeOptions, NULL, 'id');


### PR DESCRIPTION
Overview
----------------------------------------
These used to be ordered alphabetically, but looks like this was lost in #32189.

Before
----------------------------------------
For example, go to Contributions - New Contribution. The financial types are ordered by ID rather than alphabetically.

After
----------------------------------------
Now ordered alphabetically.