### PR TITLE
Don't show "My billing address is the same as above" for event payments on confirm

### DIFF
--- a/templates/CRM/Core/BillingBlock.tpl
+++ b/templates/CRM/Core/BillingBlock.tpl
@@ -49,7 +49,7 @@
     {/if}
   {/if}
   {if $billingDetailsFields && $paymentProcessor.payment_processor_type neq 'PayPal_Express'}
-    {if $profileAddressFields && !$ccid}
+    {if $profileAddressFields && !$ccid && !$showPaymentOnConfirm}
       <input type="checkbox" id="billingcheckbox" value="0">
       <label for="billingcheckbox">{ts}My billing address is the same as above{/ts}</label>
     {/if}


### PR DESCRIPTION
Before
----------------------------------------
When using event payment on confirmation, a non-functional "My billing address is the same as above" checkbox is shown to users on the confirmation page, if profile field conditions are met. If the user checks the box, the billing address fields are hidden, but then they get required errors when submitting as there are no values in the fields.

After
----------------------------------------
Checkbox not shown on confirmation page.

Comments
----------------------------------------
Would be nice if this worked, but that's a bigger project. Best not to show a non-functional checkbox for now.
