### PR TITLE
[NFC] Follow up to #33400 ensure that showPaymentOnConfirm is always …

### DIFF
--- a/templates/CRM/Contribute/Form/AdditionalInfo/CreditCard.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/CreditCard.tpl
@@ -9,7 +9,7 @@
 *}
 {* this template is used for adding Credit Cart and billing details *}
 <div id="id-creditCard" class="section-shown">
-    {include file='CRM/Core/BillingBlockWrapper.tpl'}
+    {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=false}
 </div>
 
 {include file="CRM/Contribute/Form/AdditionalInfo/Payment.tpl"}

--- a/templates/CRM/Contribute/Form/AdditionalInfo/DirectDebit.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/DirectDebit.tpl
@@ -9,6 +9,6 @@
 *}
 {* this template is used for adding Credit Cart and billing details *}
 <div id="id-directDebit" class="section-shown">
-  {include file='CRM/Core/BillingBlockWrapper.tpl'}
+  {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=false}
 </div>
 {include file="CRM/Contribute/Form/AdditionalInfo/Payment.tpl"}

--- a/templates/CRM/Contribute/Form/AdditionalPayment.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalPayment.tpl
@@ -102,7 +102,7 @@
         </table>
       </div>
       {/if}
-      {include file='CRM/Core/BillingBlockWrapper.tpl' currency=false}
+      {include file='CRM/Core/BillingBlockWrapper.tpl' currency=false showPaymentOnConfirm=false}
     </details>
 
     {include file="CRM/common/customDataBlock.tpl" customDataType='FinancialTrxn'}

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -253,7 +253,7 @@
     {/if}
 
     {if !$isUsePaymentBlock}
-      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+      {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=false}
     {/if}
 
     <!-- start of soft credit -->

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -278,7 +278,7 @@
       </fieldset>
     {/if}
 
-    {include file="CRM/Core/BillingBlockWrapper.tpl"}
+    {include file="CRM/Core/BillingBlockWrapper.tpl" showPaymentOnConfirm=false}
 
     <div class="crm-public-form-item crm-group custom_post_profile-group">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}

--- a/templates/CRM/Contribute/Form/UpdateBilling.tpl
+++ b/templates/CRM/Contribute/Form/UpdateBilling.tpl
@@ -20,6 +20,6 @@
   {/if}
 </div>
 
-{include file="CRM/Core/BillingBlockWrapper.tpl"}
+{include file="CRM/Core/BillingBlockWrapper.tpl" showPaymentOnConfirm=false}
 
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Core/BillingBlockWrapper.tpl
+++ b/templates/CRM/Core/BillingBlockWrapper.tpl
@@ -11,6 +11,6 @@
 {* wrapper for the billing block including the div to make the block swappable & the js to make that happen
 This allows the billing block to change when the card type changes *}
 <div id="billing-payment-block">
-  {include file="CRM/Core/BillingBlock.tpl"}
+  {include file="CRM/Core/BillingBlock.tpl" showPaymentOnConfirm=$showPaymentOnConfirm}
 </div>
 {include file="CRM/common/paymentBlock.tpl"}

--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -86,7 +86,7 @@
 {/if}
 
 {if $isShowBillingBlock}
-  {include file='CRM/Core/BillingBlockWrapper.tpl'}
+  {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=false}
 {/if}
 
 {if ($email OR $batchEmail) and $outBound_option != 2}

--- a/templates/CRM/Event/Form/Registration/Confirm.tpl
+++ b/templates/CRM/Event/Form/Registration/Confirm.tpl
@@ -93,7 +93,7 @@
       </fieldset>
     {/if}
     {if $totalAmount > 0}
-      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+      {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=$showPaymentOnConfirm}
     {/if}
     {literal}<script>function calculateTotalFee() { return {/literal}{$totalAmount}{literal} }</script>{/literal}
     </div>

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -131,7 +131,7 @@
     {/if}
 
     {if !$suppressPaymentBlock && !$showPaymentOnConfirm}
-      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+      {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=$showPaymentOnConfirm}
     {/if}
 
     <div class="crm-public-form-item crm-section custom_post-section">

--- a/templates/CRM/Financial/Form/Payment.tpl
+++ b/templates/CRM/Financial/Form/Payment.tpl
@@ -9,5 +9,5 @@
 *}
 
 <div id="billing-payment-block">
-  {include file="CRM/Core/BillingBlock.tpl"}
+  {include file="CRM/Core/BillingBlock.tpl" showPaymentOnConfirm=false}
 </div>

--- a/templates/CRM/Member/Form/MembershipCommon.tpl
+++ b/templates/CRM/Member/Form/MembershipCommon.tpl
@@ -51,7 +51,7 @@
 
         <tr class="crm-membership-form-block-billing">
           <td colspan="2">
-            {include file='CRM/Core/BillingBlockWrapper.tpl'}
+            {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=false}
           </td>
         </tr>
       </table>
@@ -105,7 +105,7 @@
   </tr>
   <tr class="crm-membership-form-block-billing">
     <td colspan="2">
-      {include file='CRM/Core/BillingBlockWrapper.tpl'}
+      {include file='CRM/Core/BillingBlockWrapper.tpl' showPaymentOnConfirm=false}
     </td>
   </tr>
 {/if}


### PR DESCRIPTION
…assigned to BillingBlock tpl

Overview
----------------------------------------
Given that the showPaymentOnConfirm is only assigned from the PHP layer in Event context now using the variable in a template in non event context we should make sure that it is always set in the BillingBlock.tpl file

ping @eileenmcnaughton @larssandergreen 