### PR TITLE
Ensure that if an Event is configured to show a map and that he map p…

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -431,7 +431,11 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
       if (isset($address->master_id) && !CRM_Utils_System::isNull($address->master_id)) {
         $values['use_shared_address'] = 1;
       }
-
+      // Ensure that for Event Info at least that geo_code array keys are always returned even if NULL in the database;
+      if (!array_key_exists('geo_code_1', $values)) {
+        $values['geo_code_1'] = NULL;
+        $values['geo_code_2'] = NULL;
+      }
       $addresses[$count] = $values;
 
       //There should never be more than one primary blocks, hence set is_primary = 0 other than first


### PR DESCRIPTION
…rovider exists that if the address is ungeocoded that no notice error is generated from smarty

Overview
----------------------------------------
If an Event is configured to show a map and there is a validly configured map provider but the address has not been geocoded i.e. geo_code_1 is NULL in the database Smarty generates an undefined index notice in [this code](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Event/Page/EventInfo.tpl#L144). One option would be to fix this at the smarty layer however I think that it is better to fix here because then it becomes slightly more consistent with doing an APIv4 Address.get

Before
----------------------------------------
geo_code_1 key not always returned from getValues

After
----------------------------------------
geo_code_1 key always returned

ping @eileenmcnaughton @colemanw 