### PR TITLE
Fix Smarty Notice errors on Event Location tab

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -48,7 +48,7 @@
     </table>
   {/if}
 
-  {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1}
+  {include file="CRM/Contact/Form/Edit/Address.tpl" blockId=1 masterAddress='' parseStreetAddress='' className='CRM_Event_Form_ManageEvent_Location'}
   <table class="form-layout-compressed">
     <tr>
       <td>{$form.email.1.email.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix the following smarty notices when Editing an Event Location

```
Warning: Undefined array key "className" in content_689d23ef9be723_30569414() (line 156 of <client domain>/default/files/civicrm/templates_c/en_US/b5/69/b3/b569b32fea8804659b542c863c33e0bde2b2f735_0.file.Address.tpl.php)
Warning: Undefined array key "parseStreetAddress" in content_689d23efab6081_20332524() (line 106 of client domain>/default/files/civicrm/templates_c/en_US/ab/dd/13/abdd13c3776da67146266765b6132417d0d71c2c_0.file.street_address.tpl.php)
Warning: Undefined array key "masterAddress" in content_689d23ef9be723_30569414() (line 55 of client domain>/default/files/civicrm/templates_c/en_US/b5/69/b3/b569b32fea8804659b542c863c33e0bde2b2f735_0.file.Address.tpl.php)
```

Before
----------------------------------------
Smarty Notices

After
----------------------------------------
no notices

Technical Details
----------------------------------------
This is similar to how the [Domain template is configured](https://github.com/civicrm/civicrm-core/blob/master/templates/CRM/Contact/Form/Domain.tpl#L31) just with the Class name set this time rather than a blank string

@eileenmcnaughton 
