### PR TITLE
WIP: FormBuilder afforms with EntitySet-based SearchDisplays: make fields available

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -102,7 +102,7 @@ class AfformAdminMeta {
    *
    * @return array
    */
-  public static function getFields(string $entityName, array $searchDisplays, array $params = []) {
+  public static function getFields(string $entityName, array $params = []) {
     $params += [
       'checkPermissions' => FALSE,
       'loadOptions' => ['id', 'label'],
@@ -126,25 +126,6 @@ class AfformAdminMeta {
       $params['where'][] = ['fk_entity', 'IS NULL'];
     }
     $fields = (array) civicrm_api4($entityName, 'getFields', $params);
-    // Each EntitySet instance has a different set of fields.
-    // Just use fields from the SearchDisplay.
-    if (($entityName === 'EntitySet') && isset($searchDisplays)) {
-      foreach ($searchDisplays as $display) {
-        if ($display['saved_search_id.api_entity'] === 'EntitySet') {
-          $entitySetGet = \Civi\API\Request::create(
-            'EntitySet', 'get', ['version' => 4] + $display['saved_search_id.api_params']);
-          $entitySetQuery = new \Civi\Api4\Query\Api4EntitySetQuery($entitySetGet);
-          $entitySetQuery->getSql();
-          foreach ($display["saved_search_id.api_params"]["select"] as $expr) {
-            $entitySetFields[$expr] = $entitySetQuery->getField($expr);
-            $entitySetFields[$expr]['label'] ??= $entitySetFields[$expr]['title'] ?? $entitySetFields[$expr]['name'];
-            $entitySetFields[$expr]['name'] = $expr;
-            $entitySetFields[$expr]['entity'] = NULL;
-          }
-        }
-      }
-      $fields = array_merge($fields, array_values($entitySetFields));
-    }
     // Add implicit joins to search fields
     if ($params['action'] === 'get') {
       foreach (array_reverse($fields, TRUE) as $index => $field) {

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -178,15 +178,19 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
         if (!$display) {
           continue;
         }
-        $display['calc_fields'] = \Civi\Search\Meta::getCalcFields($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']);
+        [$savedSearchEntityName, $savedSearchApiParams] =
+          $this->getFirstNonEntitySetEntity($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']);
+        // If it's an EntitySet SavedSearch, we deal with its first sub-entity instead
+        $display['saved_search_id.api_entity'] = $savedSearchEntityName;
+        $display['calc_fields'] = \Civi\Search\Meta::getCalcFields($savedSearchEntityName, $savedSearchApiParams);
         $display['filters'] = empty($displayTag['filters']) ? NULL : (\CRM_Utils_JS::getRawProps($displayTag['filters']) ?: NULL);
         if ($newForm) {
           $info['definition']['layout'][0]['#children'][] = $displayTag + ['#tag' => $display['type:name']];
         }
-        $entities[] = $display['saved_search_id.api_entity'];
-        $joinCount = [$display['saved_search_id.api_entity'] => 1];
+        $entities[] = $savedSearchEntityName;
+        $joinCount = [$savedSearchEntityName => 1];
         $display['saved_search_id.form_values'] ??= [];
-        foreach ($display['saved_search_id.api_params']['join'] ?? [] as $join) {
+        foreach ($savedSearchApiParams['join'] ?? [] as $join) {
           [$entityName, $joinAlias] = explode(' AS ', $join[0]);
           $entities[] = $entityName;
           // Set default join labels
@@ -219,7 +223,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
 
     foreach (array_diff($entities, $this->skipEntities) as $entity) {
       $info['entities'][$entity] = AfformAdminMeta::getApiEntity($entity);
-      $info['fields'][$entity] = AfformAdminMeta::getFields($entity, $info['search_displays'] ?? [], ['action' => $getFieldsMode]);
+      $info['fields'][$entity] = AfformAdminMeta::getFields($entity, ['action' => $getFieldsMode]);
       foreach ($info['fields'][$entity] as $key => $field) {
         $info['fields'][$entity][$key]['original_input_type'] = $field['input_type'];
       }
@@ -320,6 +324,23 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
   public function setDefinition(array $definition) {
     $this->definition = $definition;
     return $this;
+  }
+
+  /**
+   * Given the params for an APIv4 'get' action, return the first non-EntitySet
+   * entity name and API params from inside it.
+   *
+   * @param string $entityName
+   * @param array $apiParams
+   *
+   * @return array{entityName: string, apiParams: array}
+   */
+  private function getFirstNonEntitySetEntity(string $entityName, array $apiParams): array {
+    if ('EntitySet' !== $entityName) {
+      return [$entityName, $apiParams];
+    }
+    $firstSet = array_shift($apiParams['sets']);
+    return $this->getFirstNonEntitySetEntity($firstSet[1], $firstSet[3] + ['version' => 4]);
   }
 
 }

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -219,7 +219,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
 
     foreach (array_diff($entities, $this->skipEntities) as $entity) {
       $info['entities'][$entity] = AfformAdminMeta::getApiEntity($entity);
-      $info['fields'][$entity] = AfformAdminMeta::getFields($entity, ['action' => $getFieldsMode]);
+      $info['fields'][$entity] = AfformAdminMeta::getFields($entity, $info['search_displays'] ?? [], ['action' => $getFieldsMode]);
       foreach ($info['fields'][$entity] as $key => $field) {
         $info['fields'][$entity][$key]['original_input_type'] = $field['input_type'];
       }

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -307,6 +307,13 @@ class FormDataModel {
    */
   public static function getSearchEntities(array $savedSearch): array {
     $entityList = [$savedSearch['api_entity']];
+    if ($entityList === ['EntitySet']) {
+      $firstSet = array_shift($savedSearch['api_params']['sets']);
+      return self::getSearchEntities([
+        'api_entity' => $firstSet[1],
+        'api_params' => $firstSet[3]
+      ]);
+    }
     foreach ($savedSearch['api_params']['join'] ?? [] as $join) {
       $entityList[] = $join[0];
       if (is_string($join[2] ?? NULL)) {

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
@@ -25,7 +25,7 @@ class AfformMetadataTest extends \PHPUnit\Framework\TestCase implements Headless
   }
 
   public function testGetIndividualFields():void {
-    $individualFields = \Civi\AfformAdmin\AfformAdminMeta::getFields('Individual');
+    $individualFields = \Civi\AfformAdmin\AfformAdminMeta::getFields('Individual', []);
 
     // Ensure the "Existing Contact" `id` field exists
     $this->assertEquals('Existing Individual', $individualFields['id']['label']);
@@ -33,7 +33,7 @@ class AfformMetadataTest extends \PHPUnit\Framework\TestCase implements Headless
   }
 
   public function testGetLocBlockFields():void {
-    $fields = \Civi\AfformAdmin\AfformAdminMeta::getFields('LocBlock');
+    $fields = \Civi\AfformAdmin\AfformAdminMeta::getFields('LocBlock', []);
 
     // Ensure the "Existing" `id` field exists
     $this->assertEquals('Existing Location', $fields['id']['label']);


### PR DESCRIPTION
Overview
----------------------------------------
APIv4 supports SQL `UNION` queries through an entity called `EntitySet`. SavedSearches can be created from these API calls, SearchDisplays can be created on top of those, and FormBuilder afforms can contain those SearchDisplays. However currently the SearchKit and FormBuilder GUIs don't really handle `EntitySet`-based searches.

This PR makes the SavedSearch's fields show up in the FormBuilder interface.

**Try it out**: https://gist.github.com/highfalutin/e80c0970b9a0a614b435fbe4d912fc8e

Before
----------------------------------------
No fields are shown under "Entity Set Fields":
<img width="456" height="299" alt="Screenshot 2025-08-13 at 20 19 39" src="https://github.com/user-attachments/assets/45ca7bb2-353f-40b8-8840-19a6d689793a" />

After
----------------------------------------
Fields are available to drag onto the search form:
<img width="353" height="244" alt="Screenshot 2025-08-13 at 20 17 33" src="https://github.com/user-attachments/assets/98781565-416b-4bea-b1cc-ad5361b2f667" />

Comments
----------------------------------------
This only partially works and I may not have taken the best approach. Collaboration needed!
