### PR TITLE
Ensure that the civicrm_mailing.status field is saved in the database…

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1131,6 +1131,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // If we are scheduling vai Mailing.create then also update the status to scheduled.
     if (empty($params['skip_legacy_scheduling']) && !empty($params['scheduled_date']) && $params['scheduled_date'] !== 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
       $mailing->status = 'Scheduled';
+      $mailing->save();
     }
     if (!empty($params['search_id']) && !empty($params['group_id'])) {
       $mg->reset();


### PR DESCRIPTION
… to Scheduled when mailing is scheduled

Overview
----------------------------------------
This splits off a part of the patch from #33387 which fixes the saving of the Mailing Status in the database when the mailing is Scheduled which is demonstrated by the Unit test contained in #33408

Before
----------------------------------------
CiviCRM Mailing table Status is not changed from Draft to Scheduled when mailing is scheduled

After
----------------------------------------
Status is correctly updated in the database of the civicrm_mailing table.

ping @eileenmcnaughton @demeritcowboy 