### PR TITLE
split out interface from CaseFormTrait and implement on other case forms

### DIFF
--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -16,11 +16,11 @@
  */
 
 /**
- * This class generates form components for case activity.
+ * This class generates form components for case actions.
  */
-class CRM_Case_Form_Case extends CRM_Core_Form {
+class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseFormInterface {
   use CRM_Custom_Form_CustomDataTrait;
-  use CRM_Case_Form_CaseFormTrait;
+  use CRM_Case_Form_CaseLookupTrait;
 
   /**
    * The context

--- a/CRM/Case/Form/Case.php
+++ b/CRM/Case/Form/Case.php
@@ -112,7 +112,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
    * @return int|null
    */
   public function getEntityId() {
-    return $this->_caseId;
+    return $this->getCaseID();
   }
 
   /**
@@ -125,8 +125,8 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
       $this->_action = CRM_Core_Action::ADD;
     }
 
-    $this->_caseId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-
+    // retrieve case ID from the request params
+    $this->getCaseID();
     $this->_currentlyViewedContactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     if ($this->_action & CRM_Core_Action::ADD && !$this->_currentlyViewedContactId) {
@@ -146,7 +146,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
       return TRUE;
     }
 
-    if (!$this->_caseId) {
+    if (!$this->getCaseID()) {
       $caseAttributes = [
         'case_type_id' => ts('Case Type'),
         'status_id' => ts('Case Status'),
@@ -237,6 +237,13 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
       $this->_caseId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
     }
     return $this->_caseId;
+  }
+
+  /**
+   * Used to set case ID  in submit
+   */
+  protected function setCaseID(int $id): void {
+    $this->_caseId = $id;
   }
 
   /**
@@ -372,7 +379,8 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
       $params['details'] = $params['activity_details'];
     }
     $caseObj = CRM_Case_BAO_Case::create($params);
-    $this->_caseId = $params['case_id'] = $caseObj->id;
+    $this->setCaseID($caseObj->id);
+    $params['case_id'] = $this->getCaseID();
     // unset any ids, custom data
     unset($params['id'], $params['custom']);
 
@@ -387,16 +395,16 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
         $tagParams[$tag] = 1;
       }
     }
-    CRM_Core_BAO_EntityTag::create($tagParams, 'civicrm_case', $caseObj->id);
+    CRM_Core_BAO_EntityTag::create($tagParams, 'civicrm_case', $this->getCaseID());
 
     //save free tags
     if (isset($params['case_taglist']) && !empty($params['case_taglist'])) {
-      CRM_Core_Form_Tag::postProcess($params['case_taglist'], $caseObj->id, 'civicrm_case', $this);
+      CRM_Core_Form_Tag::postProcess($params['case_taglist'], $this->getCaseID(), 'civicrm_case', $this);
     }
 
     // user context
     $url = CRM_Utils_System::url('civicrm/contact/view/case',
-      "reset=1&action=view&cid={$this->_currentlyViewedContactId}&id={$caseObj->id}"
+      "reset=1&action=view&cid={$this->_currentlyViewedContactId}&id={$this->getCaseID()}"
     );
     CRM_Core_Session::singleton()->pushUserContext($url);
 
@@ -427,7 +435,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
     }
 
     if ($this->_action & CRM_Core_Action::DELETE) {
-      $caseDelete = CRM_Case_BAO_Case::deleteCase($this->_caseId, TRUE);
+      $caseDelete = CRM_Case_BAO_Case::deleteCase($this->getCaseID(), TRUE);
       if ($caseDelete) {
         CRM_Core_Session::setStatus(ts('You can view and / or restore deleted cases by checking the "Deleted Cases" option under Find Cases.'), ts('Case Deleted'), 'success');
       }
@@ -435,7 +443,7 @@ class CRM_Case_Form_Case extends CRM_Core_Form implements CRM_Case_Form_CaseForm
     }
 
     if ($this->_action & CRM_Core_Action::RENEW) {
-      $caseRestore = CRM_Case_BAO_Case::restoreCase($this->_caseId);
+      $caseRestore = CRM_Case_BAO_Case::restoreCase($this->getCaseID());
       if ($caseRestore) {
         CRM_Core_Session::setStatus(ts('The selected case has been restored.'), ts('Restored'), 'success');
       }

--- a/CRM/Case/Form/CaseFormInterface.php
+++ b/CRM/Case/Form/CaseFormInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Interface to provide standardised behaviour from case form classes
+ */
+interface CRM_Case_Form_CaseFormInterface {
+
+  /**
+   * Get the selected Case ID.
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
+   */
+  public function getCaseID(): ?int;
+
+}

--- a/CRM/Case/Form/CaseLookupTrait.php
+++ b/CRM/Case/Form/CaseLookupTrait.php
@@ -3,9 +3,11 @@
 use Civi\API\EntityLookupTrait;
 
 /**
- * Trait implements functions to retrieve activity related values.
+ * A wrapper around EntityLookupTrait for case forms
+ *
+ * Your form must implement CaseFormInterface.
  */
-trait CRM_Case_Form_CaseFormTrait {
+trait CRM_Case_Form_CaseLookupTrait {
 
   use EntityLookupTrait;
 
@@ -33,19 +35,6 @@ trait CRM_Case_Form_CaseFormTrait {
       return $this->lookup('Case', $fieldName);
     }
     return NULL;
-  }
-
-  /**
-   * Get the selected Case ID.
-   *
-   * @api This function will not change in a minor release and is supported for
-   * use outside of core. This annotation / external support for properties
-   * is only given where there is specific test cover.
-   *
-   * @noinspection PhpUnhandledExceptionInspection
-   */
-  public function getCaseID(): ?int {
-    throw new CRM_Core_Exception('`getCaseID` must be implemented');
   }
 
 }

--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -18,7 +18,14 @@
 /**
  * This class generates form components for custom data
  */
-class CRM_Case_Form_CustomData extends CRM_Core_Form {
+class CRM_Case_Form_CustomData extends CRM_Core_Form implements CRM_Case_Form_CaseFormInterface {
+
+  public function getCaseID(): int {
+    if (!isset($this->_entityID)) {
+      $this->_entityID = (int) CRM_Utils_Request::retrieve('entityID', 'Positive', $this, TRUE);
+    }
+    return $this->_entityID;
+  }
 
   /**
    * The entity id, used when editing/creating custom data
@@ -49,7 +56,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
    */
   public function preProcess(): void {
     $groupID = CRM_Utils_Request::retrieve('groupID', 'Positive', $this, TRUE);
-    $this->_entityID = CRM_Utils_Request::retrieve('entityID', 'Positive', $this, TRUE);
+    $this->getCaseID();
     $this->_subTypeID = CRM_Utils_Request::retrieve('subType', 'Positive', $this, TRUE);
     $contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
 

--- a/CRM/Case/Form/DeleteClient.php
+++ b/CRM/Case/Form/DeleteClient.php
@@ -19,7 +19,8 @@ use Civi\Api4\CaseContact;
 /**
  * This class assigns the current case to another client.
  */
-class CRM_Case_Form_DeleteClient extends CRM_Core_Form {
+class CRM_Case_Form_DeleteClient extends CRM_Core_Form implements CRM_Case_Form_CaseFormInterface {
+  use CRM_Case_Form_CaseLookupTrait;
 
   /**
    * case ID
@@ -44,7 +45,6 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form {
    */
   public function preProcess() {
     $this->cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
-    $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
     $this->returnContactId  = CRM_Utils_Request::retrieve('rcid', 'Positive', $this, TRUE);
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
@@ -122,6 +122,13 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form {
     );
     CRM_Utils_System::redirect($url);
 
+  }
+
+  public function getCaseID(): ?int {
+    if (!isset($this->id)) {
+      $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+    }
+    return $this->id;
   }
 
 }

--- a/CRM/Case/Form/DeleteClient.php
+++ b/CRM/Case/Form/DeleteClient.php
@@ -20,7 +20,6 @@ use Civi\Api4\CaseContact;
  * This class assigns the current case to another client.
  */
 class CRM_Case_Form_DeleteClient extends CRM_Core_Form implements CRM_Case_Form_CaseFormInterface {
-  use CRM_Case_Form_CaseLookupTrait;
 
   /**
    * case ID
@@ -44,13 +43,14 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form implements CRM_Case_Form_
    * Build all the data structures needed to build the form.
    */
   public function preProcess() {
+    $this->assign('id', $this->getCaseID());
+
     $this->cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
     $this->returnContactId  = CRM_Utils_Request::retrieve('rcid', 'Positive', $this, TRUE);
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
 
     //get current client name.
     $this->assign('currentClientName', CRM_Contact_BAO_Contact::displayName($this->cid));
-    $this->assign('id', $this->id);
 
     //set the context.
     $url = CRM_Utils_System::url('civicrm/contact/view', "reset=1&force=1&cid={$this->cid}&selectedChild=case");
@@ -71,7 +71,7 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form implements CRM_Case_Form_
     }
     $session = CRM_Core_Session::singleton();
     $session->pushUserContext($url);
-    $caseContacts = CaseContact::get()->addWhere('case_id', '=', $this->id)->execute();
+    $caseContacts = CaseContact::get()->addWhere('case_id', '=', $this->getCaseID())->execute();
     if (count($caseContacts) === 1) {
       CRM_Core_Error::statusBounce(ts('Cannot Remove Client from case as is the only client on the case'), $url);
     }
@@ -81,7 +81,7 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form implements CRM_Case_Form_
    * Build the form object.
    */
   public function buildQuickForm() {
-    $this->add('hidden', 'id', $this->id);
+    $this->add('hidden', 'id', $this->getCaseID());
     $this->add('hidden', 'contact_id', $this->cid);
     $this->addButtons([
       [
@@ -124,9 +124,9 @@ class CRM_Case_Form_DeleteClient extends CRM_Core_Form implements CRM_Case_Form_
 
   }
 
-  public function getCaseID(): ?int {
+  public function getCaseID(): int {
     if (!isset($this->id)) {
-      $this->id = CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
+      $this->id = (int) CRM_Utils_Request::retrieve('id', 'Positive', $this, TRUE);
     }
     return $this->id;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Improve consistency in Case form classes using an interface

Before
----------------------------------------
- CaseFormTrait is only used by one class
- `getCaseID()` isnt very useful because you don't know if it will throw an error

After
----------------------------------------
- CaseFormInterface is implemented by a few more classes
- you can reliably do `$caseId = class_implements($form, 'CRM_Case_Form_CaseFormInterface') ? $form->getCaseID() : NULL;` in a build form hook

Technical Details
----------------------------------------
Doing the `CRM_Utils_Request::retrieve` in the getter isn't perfect - the result *could* be inconsistent depending on when in the request it is first called, if someone is tampering with the session. But it's the existing pattern in CRM_Case_Form_Case, and the getter is typically called at the beginning of `preProcess`, and I'm fairly sure it will maintain existing behaviour.


Comments
---------------------------------------
I did Case Activity form too but have kept for a follow up because it's a little more involved.