### PR TITLE
dev/core#4859 SearchKit - Fix restoring options for date select fields

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditOptions.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditOptions.component.js
@@ -14,11 +14,11 @@
         $scope.options = JSON.parse(angular.toJson(ctrl.field.getOptions()));
         const optionKeys = $scope.options.map(option => option.id);
         // Original options
-        const originalOptions = JSON.parse(angular.toJson(ctrl.field.getDefn().options || []));
+        const originalOptions = JSON.parse(angular.toJson(ctrl.field.getOriginalOptions()));
         // Original options that are not in the current set (if customized)
         $scope.deletedOptions = originalOptions.filter(item => !optionKeys.includes(item.id));
         // Deleted options have no label so fetch original
-        $scope.originalLabels = (ctrl.field.getDefn().options || []).reduce((originalLabels, item) => {
+        $scope.originalLabels = originalOptions.reduce((originalLabels, item) => {
           originalLabels[item.id] = item.label;
           return originalLabels;
         }, {});

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -143,6 +143,10 @@
         if (ctrl.fieldDefn.options) {
           return ctrl.fieldDefn.options;
         }
+        return this.getOriginalOptions();
+      };
+
+      this.getOriginalOptions = function() {
         if (ctrl.getDefn().input_type === 'EntityRef') {
           // Build a list of all entities in this form that can be referenced by this field.
           var newOptions = _.map(ctrl.editor.getEntities({type: ctrl.getDefn().fk_entity}), function(entity) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4859](https://lab.civicrm.org/dev/core/-/issues/4859)

Before
----------------------------------------
In FormBuilder, when customizing the select options in a date field, the deleted options completely disappear.

After
----------------------------------------
They can be restored in the UI.