### PR TITLE
FormBuilder - Fix using readonly fields as filters

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -186,7 +186,7 @@
         if (defn.input_type === type) {
           return true;
         }
-        if (defn.readonly) {
+        if (defn.readonly && !ctrl.isSearch()) {
           switch (type) {
             case 'DisplayOnly':
             case 'Hidden':


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a FormBuilder problem where readonly fields cannot be used as search filters.

I think this regressed with be2efb5b7d6bd81aa5abf584ca01730f185cdee1

Before
----------------------------------------
1. Create a search for contacts
2. Add it to a form
3. Try to drag the Contact "Created Date" field onto the form
4. Error configuring field

After
----------------------------------------
Back to normal.