### PR TITLE
dev/core#6060 Run the Status Check once per day per user, not once per login

### DIFF
--- a/CRM/Core/BAO/StatusPreference.php
+++ b/CRM/Core/BAO/StatusPreference.php
@@ -66,6 +66,9 @@ class CRM_Core_BAO_StatusPreference extends CRM_Core_DAO_StatusPreference {
 
     CRM_Utils_Hook::post($op, 'StatusPreference', $statusPreference->id, $statusPreference);
 
+    // Clear the static cache of the CRM_Utils_Check so that the newly created message is available.
+    unset(\Civi::$statics['CRM_Utils_Check']);
+
     return $statusPreference;
   }
 

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -326,8 +326,7 @@ class CRM_Core_Invoke {
     if (CRM_Core_Config::isUpgradeMode() || !CRM_Core_Permission::check('administer CiviCRM')) {
       return;
     }
-    // always use cached results - they will be refreshed by the session timer
-    $status = Civi::cache('checks')->get('systemStatusCheckResult');
+    $status = CRM_Utils_Check::getMaxSeverity();
     $template->assign('footer_status_severity', $status);
     $template->assign('footer_status_message', CRM_Utils_Check::toStatusLabel($status));
 

--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -81,28 +81,30 @@ class CRM_Utils_Check {
    */
   public function showPeriodicAlerts() {
     if (CRM_Core_Permission::check('administer CiviCRM system')) {
-      $session = CRM_Core_Session::singleton();
-      if ($session->timer('check_' . __CLASS__, self::CHECK_TIMER)) {
-
-        // Best attempt at re-securing folders
-        $config = CRM_Core_Config::singleton();
-        $config->cleanup(0, FALSE);
-
-        $statusMessages = [];
-        $maxSeverity = 0;
-        foreach ($this->checkAll() as $message) {
-          if (!$message->isVisible()) {
-            continue;
+      $userId = CRM_Core_Session::getLoggedInContactID();
+      $statusCheckedForUser = Civi::cache('checks')->get('status_checked_for_user_' . $userId);
+      if (!$statusCheckedForUser) {
+        $statusMessages = Civi::cache('checks')->get('status_messages');
+        if (!is_array($statusMessages)) {
+          // Best attempt at re-securing folders
+          $config = CRM_Core_Config::singleton();
+          $config->cleanup(0, FALSE);
+          $statusMessages = [];
+          foreach (self::checkAll() as $message) {
+            if (!$message->isVisible()) {
+              continue;
+            }
+            if ($message->getLevel() >= 3) {
+              $statusMessage = $message->getMessage();
+              $statusMessages[] = $statusTitle = $message->getTitle();
+            }
           }
-          if ($message->getLevel() >= 3) {
-            $maxSeverity = max($maxSeverity, $message->getLevel());
-            $statusMessage = $message->getMessage();
-            $statusMessages[] = $statusTitle = $message->getTitle();
-          }
+          Civi::cache('checks')->set('status_messages', $statusMessages, self::CHECK_TIMER);
         }
 
         if ($statusMessages) {
           if (count($statusMessages) > 1) {
+            $maxSeverity = self::getMaxSeverity(TRUE);
             $statusTitle = self::toStatusLabel($maxSeverity);
             $statusMessage = '<ul><li>' . implode('</li><li>', $statusMessages) . '</li></ul>';
           }
@@ -112,8 +114,31 @@ class CRM_Utils_Check {
           $statusType = $maxSeverity >= 4 ? 'error' : 'alert';
           CRM_Core_Session::setStatus($statusMessage, $statusTitle, $statusType);
         }
+        Civi::cache('checks')->set('status_checked_for_user_' . $userId, TRUE, self::CHECK_TIMER);
       }
     }
+  }
+
+  /**
+   * Returns the max severity of the status checks.
+   * The result is cahced as this status is shown in the footer of the CiviCRM page. So no need to refresh this.
+   *
+   * @param bool $force
+   *   Force refresh the max severity calculation.
+   * @return int
+   */
+  public static function getMaxSeverity(bool $force = FALSE): int {
+    $maxSeverity = Civi::cache('checks')->get('systemStatusCheckResult');
+    if ($maxSeverity === NULL || $force) {
+      $maxSeverity = 1;
+      foreach (self::checkAll() as $message) {
+        if ($message->isVisible()) {
+          $maxSeverity = max($maxSeverity, $message->getLevel());
+        }
+      }
+      Civi::cache('checks')->set('systemStatusCheckResult', $maxSeverity, self::CHECK_TIMER);
+    }
+    return $maxSeverity ?? 0;
   }
 
   /**
@@ -176,24 +201,13 @@ class CRM_Utils_Check {
    * Calls hook_civicrm_check() for extensions to add or modify messages.
    * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_check/
    *
-   * @param bool $max
-   *   Whether to return just the maximum non-hushed severity
-   *
    * @return CRM_Utils_Check_Message[]
    */
-  public static function checkAll($max = FALSE) {
-    $messages = self::checkStatus();
-
-    $maxSeverity = 1;
-    foreach ($messages as $message) {
-      if ($message->isVisible()) {
-        $maxSeverity = max($maxSeverity, $message->getLevel());
-      }
+  public static function checkAll() {
+    if (!isset(\Civi::$statics['CRM_Utils_Check']['messages'])) {
+      \Civi::$statics['CRM_Utils_Check']['messages'] = self::checkStatus();
     }
-
-    Civi::cache('checks')->set('systemStatusCheckResult', $maxSeverity);
-
-    return ($max) ? $maxSeverity : $messages;
+    return \Civi::$statics['CRM_Utils_Check']['messages'];
   }
 
   /**

--- a/Civi/Test/PageWrapper.php
+++ b/Civi/Test/PageWrapper.php
@@ -40,7 +40,8 @@ class PageWrapper {
     // Ensure the system checks do not run in this context.
     // The `checkAngularModuleSettings()` check is specifically likely
     // to cause crashes but also there are other tests for the checks.
-    \CRM_Core_Session::singleton()->timer('check_CRM_Utils_Check', 86400);
+    $userId = \CRM_Core_Session::getLoggedInContactID();
+    \Civi::cache('checks')->set('status_checked_for_user_' . $userId, TRUE, 86400);
     ob_start();
     $this->page->run();
     $this->output = ob_get_clean();


### PR DESCRIPTION
Overview
----------------------------------------

In https://lab.civicrm.org/dev/core/-/issues/6060 I found that the status check is run after logging in. The status check should only be run once a day. However the timer for checking whether the status check needs to happen is stored in a session. 
And when the user is logging in it means we have a new session.

Before
----------------------------------------

Status check is only done once a day per session (so after logging out and in again the status check will happen again)


After
----------------------------------------

The result of the status check is stored in the cache and whether the message is shown to the user is also stored in the cache (with a key of the user id). So logging out and in again twice a day will result in showing the message only the first time. (Unless the civicrm cache is cleared)


Technical Details
----------------------------------------

This PR also improves the way the max severity is calculated as the one in the footer is empty on the first run (that is now fixed). 

There is a function in `CRM_Core_Session::timer`  which is not used anymore that function can probably go away as well. 
