### PR TITLE
Partial payments show the correct amount, then charge the full amount

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -274,7 +274,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
-    $this->_params['amount'] = $this->get('amount');
+    $this->_params['amount'] = $this->getSubmittedValue('total_amount');
     if (isset($this->_params['amount'])) {
       $this->setFormAmountFields($this->getPriceSetID());
     }
@@ -2213,7 +2213,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           }
         }
       }
-      $paymentParams['amount'] = $this->getMainContributionAmount();
+      $paymentParams['amount'] = $this->_params['amount'];
       $paymentParams['line_item'] = [$this->getPriceSetID() => $this->getMainContributionLineItems()];
       $result = $this->processConfirm($paymentParams,
         $contactID,

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1204,7 +1204,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       }
     }
 
-    $params['amount'] = $this->getMainContributionAmount();
+    $params['amount'] = $params['total_amount'];
     $this->set('amount_level', $this->order->getAmountLevel());
     if (!empty($this->getExistingContributionID())) {
       // @todo - verify that this is the same as `$this->>getLineItems()` which it should be & consolidate

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -717,7 +717,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->assign('credit_card_type', $this->_params['credit_card_type'] ?? NULL);
     $this->assign('trxn_id', $this->_params['trxn_id'] ?? NULL);
     $this->assign('amount_level', str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ' ', $this->order->getAmountLevel()));
-    $this->assign('amount', $this->getMainContributionAmount() > 0 ? CRM_Utils_Money::format($this->getMainContributionAmount(), NULL, NULL, TRUE) : NULL);
+    $this->assign('amount', $this->getSubmittedValue('total_amount') > 0 ? CRM_Utils_Money::format($this->getSubmittedValue('total_amount'), NULL, NULL, TRUE) : NULL);
 
     $isRecurEnabled = isset($this->_values['is_recur']) && !empty($this->_paymentProcessor['is_recur']);
     $this->assign('is_recur_enabled', $isRecurEnabled);


### PR DESCRIPTION
Overview
----------------------------------------
Full details at https://lab.civicrm.org/dev/core/-/issues/6057.

Before
----------------------------------------
If you have a contribution for $300, and someone pays $100 toward it, and they pay the balance online, they'll be shown that they're paying $200.  But when the card is charged, they're charged $300.

After
----------------------------------------
They're only charged the $200.

Technical Details
----------------------------------------
Several references to the amount that used to be pulled from the submitted value had been changed to use `getMainContributionAmount()`.  But that's only valid when someone is paying the full amount.

Comments
----------------------------------------
This regressed in 5.69, which is far enough back that I'm putting this against master - especially since this touches the guts of contribution page code.

After the partial payment is submitted, the `total_amount` on the contribution is changed to the partial amount.  That's a bug - but it's also the pre-5.68 behavior, so I'm leaving it out of scope here.