### PR TITLE
dev/core#6062 - Use `scan-classes` to load CiviCase entities

### DIFF
--- a/ext/civi_case/civi_case.php
+++ b/ext/civi_case/civi_case.php
@@ -4,24 +4,6 @@ require_once 'civi_case.civix.php';
 use CRM_Case_ExtensionUtil as E;
 
 /**
- * Implements hook_civicrm_scanClasses().
- */
-function civi_case_civicrm_scanClasses(array &$classes) {
-  /**
-   * CiviCase is a CiviCRM Component. Which means it is loaded
-   * before the afform extension is enabled.
-   * And if afform is not enabled the classes under Civi\Afform\ will give a fatal error
-   * because their parent class could not be found (yet).
-   *
-   * The code below checks whether the Afform is enabled and if not it will the skip the classes under the
-   * Civi\Afform namespace.
-   */
-  $extMap = CRM_Extension_System::singleton()->getMapper();
-  $excludeRegex = $extMap->isActiveModule('afform') ? NULL : '/Afform/';
-  \Civi\Core\ClassScanner::scanFolders($classes, __DIR__ . '/', 'Civi', '\\', $excludeRegex);
-}
-
-/**
  * Implements hook_civicrm_managed().
  */
 function civi_case_civicrm_managed(&$entities, $modules) {

--- a/ext/civi_case/info.xml
+++ b/ext/civi_case/info.xml
@@ -40,6 +40,7 @@
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Case</namespace>

--- a/sql/civicrm_data/civicrm_extension.sqldata.php
+++ b/sql/civicrm_data/civicrm_extension.sqldata.php
@@ -53,37 +53,46 @@ return CRM_Core_CodeGen_SqlData::create('civicrm_extension', 'INSERT IGNORE INTO
       'name' => 'FlexMailer',
       'file' => 'flexmailer',
     ],
+    // Insert component-extensions initially disabled. They'll be enabled by InstallComponents.civi-setup.php.
     [
       'full_name' => 'civi_campaign',
       'name' => 'CiviCampaign',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_case',
       'name' => 'CiviCase',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_contribute',
       'name' => 'CiviContribute',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_event',
       'name' => 'CiviEvent',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_mail',
       'name' => 'CiviMail',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_member',
       'name' => 'CiviMember',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_pledge',
       'name' => 'CiviPledge',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'civi_report',
       'name' => 'CiviReport',
+      'is_active' => 0,
     ],
     [
       'full_name' => 'legacybatchentry',


### PR DESCRIPTION
Overview
----------------------------------------
Followup to d400b557, this avoids a deprecation warning.

Fixes [dev/core#6062](https://lab.civicrm.org/dev/core/-/issues/6062)

Technical Details
-------

This solves the race-condition encountered in #32600 by moving the `\Civi\Afform\AbstractBehavior` class into core; thus allowing `scan-classes` to be re-enabled in the `civi_case` extension, and making it easier for other extensions to extend this class without encountering the same load-order issues.