### PR TITLE
CustomField - Avoid crash when blank value is passed to format date

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1206,7 +1206,9 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
             $customFormat = implode(" ", $customTimeFormat);
           }
         }
-        $display = CRM_Utils_Date::processDate($value, NULL, FALSE, $customFormat);
+        if ($value !== '') {
+          $display = CRM_Utils_Date::processDate($value, NULL, FALSE, $customFormat);
+        }
         break;
 
       case 'File':

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -242,7 +242,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
       unset($params['tests']);
       $createdField = $this->callAPISuccess('customField', 'create', $params);
       foreach ($field['tests'] as $expected => $input) {
-        $this->assertEquals($expected, CRM_Core_BAO_CustomField::displayValue($input, $createdField['id']));
+        $this->assertSame($expected, CRM_Core_BAO_CustomField::displayValue($input, $createdField['id']));
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6059](https://lab.civicrm.org/dev/core/-/issues/6059)

Technical Details
------
There was a unit test for this, but it wasn't catching the problem because it didn't use strict type checking. Changed that & now the test fails without this patch.