### PR TITLE
dev/core#6021 SearchKit - Allow form filters to target specific join

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -260,8 +260,11 @@ trait SavedSearchInspectorTrait {
    * @param string|array $fieldName
    *   If multiple field names are given they will be combined in an OR clause
    * @param mixed $value
+   *   Filter value
+   * @param array|null $formFields
+   *   Afform filters
    */
-  protected function applyFilter($fieldName, $value) {
+  protected function applyFilter($fieldName, $value, ?array $formFields = NULL) {
     // Global setting determines if % wildcard should be added to both sides (default) or only the end of a search string
     $prefixWithWildcard = \Civi::settings()->get('includeWildCardInName');
 
@@ -273,6 +276,14 @@ trait SavedSearchInspectorTrait {
     if (!$field) {
       $this->_apiParams += ['having' => []];
       $clause =& $this->_apiParams['having'];
+    }
+    // If form filter specified a target join
+    elseif (!empty($formFields[$fieldName]['defn']['join_clause'])) {
+      foreach ($this->_apiParams['join'] ?? [] as $idx => $join) {
+        if ((explode(' AS ', $join[0])[1] ?? '') === $formFields[$fieldName]['defn']['join_clause']) {
+          $clause =& $this->_apiParams['join'][$idx];
+        }
+      }
     }
     // If field belongs to an EXCLUDE join, it should be added as a join condition
     else {

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -313,14 +313,14 @@ trait SavedSearchInspectorTrait {
           // Use IN for regular fields
           if (empty($field['serialize'])) {
             $op = in_array('IN', $operators, TRUE) ? 'IN' : $operators[0];
-            $filterClauses[] = [$fieldName, $op, $value];
+            $filterClauses[] = [$fieldName, $op, $value, FALSE];
           }
           // Use an OR group of CONTAINS for array fields
           else {
             $op = in_array('CONTAINS', $operators, TRUE) ? 'CONTAINS' : $operators[0];
             $orGroup = [];
             foreach ($value as $val) {
-              $orGroup[] = [$fieldName, $op, $val];
+              $orGroup[] = [$fieldName, $op, $val, FALSE];
             }
             $filterClauses[] = ['OR', $orGroup];
           }
@@ -335,23 +335,23 @@ trait SavedSearchInspectorTrait {
         }
       }
       elseif (!empty($field['serialize']) && in_array('CONTAINS', $operators, TRUE)) {
-        $filterClauses[] = [$fieldName, 'CONTAINS', $value];
+        $filterClauses[] = [$fieldName, 'CONTAINS', $value, FALSE];
       }
       elseif ((!empty($field['options']) || in_array($dataType, ['Integer', 'Boolean', 'Date', 'Timestamp'])) && in_array('=', $operators, TRUE)) {
-        $filterClauses[] = [$fieldName, '=', $value];
+        $filterClauses[] = [$fieldName, '=', $value, FALSE];
       }
       elseif ($prefixWithWildcard && in_array('CONTAINS', $operators, TRUE)) {
-        $filterClauses[] = [$fieldName, 'CONTAINS', $value];
+        $filterClauses[] = [$fieldName, 'CONTAINS', $value, FALSE];
       }
       elseif (in_array('LIKE', $operators, TRUE)) {
-        $filterClauses[] = [$fieldName, 'LIKE', $value . '%'];
+        $filterClauses[] = [$fieldName, 'LIKE', $value . '%', FALSE];
       }
       elseif (in_array('IN', $operators, TRUE)) {
-        $filterClauses[] = [$fieldName, 'IN', (array) $value];
+        $filterClauses[] = [$fieldName, 'IN', (array) $value, FALSE];
       }
       else {
         $op = in_array('=', $operators, TRUE) ? '=' : $operators[0];
-        $filterClauses[] = [$fieldName, $op, $value];
+        $filterClauses[] = [$fieldName, $op, $value, FALSE];
       }
     }
     // Single field

--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -286,32 +286,16 @@ abstract class Api4Query {
   public function composeClause(array $clause, string $type, int $depth) {
     $field = NULL;
     // Pad array for unary operators
-    [$expr, $operator, $value] = array_pad($clause, 3, NULL);
-    $isExpression = $clause[3] ?? FALSE;
+    [$expr, $operator, $value, $isExpression] = array_pad($clause, 4, NULL);
+    // isExpression defaults to FALSE in WHERE & HAVING clauses, and defaults to TRUE in ON clauses
+    $isExpression ??= ($type === 'ON');
     if (!in_array($operator, CoreUtil::getOperators(), TRUE)) {
       throw new \CRM_Core_Exception('Illegal operator');
     }
     $fieldAlias = NULL;
 
-    // For WHERE clause, expr must be the name of a field.
-    if ($type === 'WHERE' && !$isExpression) {
-      $expr = $this->getExpression($expr, ['SqlField', 'SqlFunction', 'SqlEquation']);
-      if ($expr->getType() === 'SqlField') {
-        $fieldName = count($expr->getFields()) === 1 ? $expr->getFields()[0] : NULL;
-        $field = $this->getField($fieldName, TRUE);
-        FormattingUtil::formatInputValue($value, $fieldName, $field, $this->entityValues, $operator);
-      }
-      elseif ($expr->getType() === 'SqlFunction') {
-        $fauxField = [
-          'name' => NULL,
-          'data_type' => $expr::getDataType(),
-        ];
-        FormattingUtil::formatInputValue($value, NULL, $fauxField, $this->entityValues, $operator);
-      }
-      $fieldAlias = $expr->render($this);
-    }
     // For HAVING, expr must be an item in the SELECT clause
-    elseif ($type === 'HAVING') {
+    if ($type === 'HAVING') {
       // Expr references a fieldName or alias
       if (isset($this->selectAliases[$expr])) {
         $fieldAlias = $expr;
@@ -370,7 +354,28 @@ abstract class Api4Query {
         return sprintf('%s %s `%s`', $fieldAlias, $operator, $targetField);
       }
     }
-    elseif ($type === 'ON' || ($type === 'WHERE' && $isExpression)) {
+
+    // $isExpression is usually FALSE for WHERE clauses unless explicitly enabled by 4th param
+    elseif (!$isExpression) {
+      // 1st param is always treated as a sql expression
+      $expr = $this->getExpression($expr, ['SqlField', 'SqlFunction', 'SqlEquation']);
+      if ($expr->getType() === 'SqlField') {
+        $fieldName = count($expr->getFields()) === 1 ? $expr->getFields()[0] : NULL;
+        $field = $this->getField($fieldName, TRUE);
+        FormattingUtil::formatInputValue($value, $fieldName, $field, $this->entityValues, $operator);
+      }
+      elseif ($expr->getType() === 'SqlFunction') {
+        $fauxField = [
+          'name' => NULL,
+          'data_type' => $expr::getDataType(),
+        ];
+        FormattingUtil::formatInputValue($value, NULL, $fauxField, $this->entityValues, $operator);
+      }
+      $fieldAlias = $expr->render($this);
+    }
+
+    // $isExpression is usually TRUE for ON clauses unless explicitly disabled by 4th param
+    elseif ($isExpression) {
       $expr = $this->getExpression($expr);
       $fieldName = count($expr->getFields()) === 1 ? $expr->getFields()[0] : NULL;
       $fieldAlias = $expr->render($this);

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -180,13 +180,27 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
         }
         $display['calc_fields'] = \Civi\Search\Meta::getCalcFields($display['saved_search_id.api_entity'], $display['saved_search_id.api_params']);
         $display['filters'] = empty($displayTag['filters']) ? NULL : (\CRM_Utils_JS::getRawProps($displayTag['filters']) ?: NULL);
-        $info['search_displays'][] = $display;
         if ($newForm) {
           $info['definition']['layout'][0]['#children'][] = $displayTag + ['#tag' => $display['type:name']];
         }
         $entities[] = $display['saved_search_id.api_entity'];
+        $joinCount = [$display['saved_search_id.api_entity'] => 1];
+        $display['saved_search_id.form_values'] ??= [];
         foreach ($display['saved_search_id.api_params']['join'] ?? [] as $join) {
-          $entities[] = explode(' AS ', $join[0])[0];
+          [$entityName, $joinAlias] = explode(' AS ', $join[0]);
+          $entities[] = $entityName;
+          // Set default join labels
+          $num = '';
+          if (!empty($joinCount[$entityName])) {
+            $num = ' ' . (++$joinCount[$entityName]);
+          }
+          else {
+            $joinCount[$entityName] = 1;
+          }
+          if (empty($display['saved_search_id.form_values']['join'][$joinAlias])) {
+            $label = CoreUtil::getInfoItem($entityName, 'title');
+            $display['saved_search_id.form_values']['join'][$joinAlias] = "$label$num";
+          }
           // Add bridge entities (but only if they are tagged searchable e.g. RelationshipCache)
           if (is_string($join[2] ?? NULL) &&
             in_array(CoreUtil::getInfoItem($join[2], 'searchable'), ['primary', 'secondary'])
@@ -194,6 +208,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
             $entities[] = $join[2];
           }
         }
+        $info['search_displays'][] = $display;
       }
       if (!$newForm) {
         $scanBlocks($info['definition']['layout']);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -131,12 +131,12 @@
           const joinInfo = join[0].split(' AS ');
           const entity = afGui.getEntity(joinInfo[0]);
           const bridgeEntity = afGui.getEntity(join[2]);
-          const defaultLabel = entity.label + countEntity(entity.entity);
-          const formValues = ctrl.display.settings['saved_search_id.form_values'] || {};
+          // Form values contain join aliases; defaults are filled in by Civi\Api4\Action\Afform\LoadAdminData()
+          const formValues = ctrl.display.settings['saved_search_id.form_values'];
           entities.push({
             name: entity.entity,
             prefix: joinInfo[1] + '.',
-            label: (formValues && formValues.join && formValues.join[joinInfo[1]]) || defaultLabel,
+            label: formValues.join[joinInfo[1]],
             fields: entity.fields,
           });
           if (bridgeEntity) {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -145,6 +145,13 @@
       <option ng-repeat="(name, label) in $ctrl.searchOperators" value="{{ name }}">{{ label }}</option>
     </select>
   </div>
+  <div class="af-gui-field-select-in-dropdown" ng-if="$ctrl.getSearchJoins().length">
+    <label>{{:: ts('Filter by:') }}</label>
+    <select class="form-control" ng-model="getSet('join_clause')" ng-model-options="{getterSetter: true}" title="{{:: ts('Apply this filter to the entire search or just one joined entity.') }}">
+      <option value="">{{:: ts('Entire Search') }}</option>
+      <option ng-repeat="join in $ctrl.getSearchJoins()" value="{{:: join.id }}">{{:: join.text }}</option>
+    </select>
+  </div>
 </li>
 
 <li af-gui-conditional-menu="$ctrl.node" ng-if="$ctrl.editor.getEntities().length"></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -1,5 +1,5 @@
 <li ng-if="!$ctrl.fieldDefn.input_attrs || !$ctrl.fieldDefn.input_attrs.autofill">
-  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Type:') }}</label>
     <select class="form-control" ng-model="getSet('input_type')" ng-model-options="{getterSetter: true}" title="{{:: ts('Field type') }}">
       <option ng-repeat="type in $ctrl.inputTypes" value="{{ type.name }}">{{ type.label }}</option>
@@ -19,7 +19,7 @@
   </form>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'Number' && $ctrl.fieldDefn.data_type === 'Float'">
-  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Decimal places:') }}</label>
     <select class="form-control" ng-model="getSet('input_attrs.step')" ng-model-options="{getterSetter: true}" title="{{:: ts('Decimal places') }}">
       <option ng-value="1">0</option>
@@ -36,22 +36,22 @@
   </div>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'" title="{{:: ts('Use a saved search to filter the autocomplete results') }}">
-  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <input placeholder="{{:: ts('Saved Search') }}" class="form-control" crm-autocomplete="'SavedSearch'" crm-autocomplete-params="{key: 'name', filters: {api_entity: $ctrl.fieldDefn.fk_entity}, formName: 'afformAdmin', fieldName: 'autocompleteSavedSearch'}" auto-open="true" ng-model="getSet('saved_search')" ng-model-options="{getterSetter: true}" ng-change="getSet('search_display')(null)">
   </div>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef' && $ctrl.fieldDefn.saved_search" title="{{:: ts('Use a saved search to filter the autocomplete results') }}">
-  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <input placeholder="{{:: ts('Default Display') }}" class="form-control" crm-autocomplete="'SearchDisplay'" crm-autocomplete-params="{key: 'name', filters: {'saved_search_id.name': $ctrl.fieldDefn.saved_search}, formName: 'afformAdmin', fieldName: 'autocompleteDisplay'}" auto-open="true" ng-model="getSet('search_display')" ng-model-options="{getterSetter: true}">
   </div>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'" title="{{:: ts('Should permissions be checked when autocompleting existing entities') }}">
-  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <input crm-ui-select="{data: $ctrl.editor.securityModes}" ng-model="getSet('security')" ng-model-options="{getterSetter: true}" class="form-control">
   </div>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'" title="{{:: ts('Allow a new entity to be created via quick-add popup') }}">
-  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <input crm-ui-select="{data: $ctrl.quickAddLinks, multiple: true, separator: '\u0001', placeholder: ts('Quick Add')}" ng-model="getSet('input_attrs.quickAdd')" ng-model-options="{getterSetter: true}" ng-list="" class="form-control">
   </div>
 </li>
@@ -131,7 +131,7 @@
   </a>
 </li>
 <li ng-if="$ctrl.isSearch()" ng-click="$event.stopPropagation()">
-  <div href class="af-gui-field-select-in-dropdown">
+  <div class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Operator:') }}</label>
     <select class="form-control" ng-model="getSetOperator" ng-model-options="{getterSetter: true}" title="{{:: ts('Set the search operator for this field or allow the user to select it on the form') }}">
       <option value="">{{:: ts('Auto') }}</option>
@@ -139,7 +139,7 @@
       <option ng-repeat="(name, label) in $ctrl.searchOperators" value="{{ name }}">{{ label }}</option>
     </select>
   </div>
-  <div href class="af-gui-field-select-in-dropdown" ng-if="$ctrl.getSet('expose_operator')">
+  <div class="af-gui-field-select-in-dropdown" ng-if="$ctrl.getSet('expose_operator')">
     <label>{{:: ts('Default:') }}</label>
     <select class="form-control" ng-model="getSet('search_operator')" ng-model-options="{getterSetter: true}" title="{{:: ts('Default search operator for the user to select') }}">
       <option ng-repeat="(name, label) in $ctrl.searchOperators" value="{{ name }}">{{ label }}</option>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -25,6 +25,7 @@
       ];
 
       let entityRefOptions = [];
+      let searchJoins = null;
 
       $scope.editingOptions = false;
 
@@ -465,6 +466,23 @@
 
       this.setEditingOptions = function(val) {
         $scope.editingOptions = val;
+      };
+
+      this.getSearchJoins = function() {
+        if (Array.isArray(searchJoins)) {
+          return searchJoins;
+        }
+        searchJoins = [];
+        const searchDisplay = ctrl.container.getSearchDisplay();
+        if (searchDisplay) {
+          Object.keys(searchDisplay['saved_search_id.form_values'].join).forEach((joinName) => {
+            searchJoins.push({
+              id: joinName,
+              text: searchDisplay['saved_search_id.form_values'].join[joinName],
+            });
+          });
+        }
+        return searchJoins;
       };
 
       // Returns a reference to a path n-levels deep within an object

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -13,17 +13,19 @@
       container: '^^afGuiContainer'
     },
     controller: function($scope, afGui, $timeout) {
-      var ts = $scope.ts = CRM.ts('org.civicrm.afform_admin'),
-        ctrl = this,
-        entityRefOptions = [],
-        singleElement = [''],
-        // When search-by-range is enabled the second element gets a suffix for some properties like "placeholder2"
-        rangeElements = ['', '2'],
-        dateRangeElements = ['1', '2'],
-        yesNo = [
-          {id: true, label: ts('Yes')},
-          {id: false, label: ts('No')}
-        ];
+      const ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
+      const ctrl = this;
+      const singleElement = [''];
+      // When search-by-range is enabled the second element gets a suffix for some properties like "placeholder2"
+      const rangeElements = ['', '2'];
+      const dateRangeElements = ['1', '2'];
+      const yesNo = [
+        {id: true, label: ts('Yes')},
+        {id: false, label: ts('No')}
+      ];
+
+      let entityRefOptions = [];
+
       $scope.editingOptions = false;
 
       this.$onInit = function() {
@@ -33,7 +35,7 @@
           if (inputTypeCanBe(type.name)) {
             // Change labels for EntityRef fields
             if (ctrl.getDefn().input_type === 'EntityRef') {
-              var entity = ctrl.getFkEntity();
+              const entity = ctrl.getFkEntity();
               if (entity && type.name === 'EntityRef') {
                 type.label = ts('Autocomplete %1', {1: entity.label});
               }
@@ -68,7 +70,7 @@
       };
 
       this.getFkEntity = function() {
-        var fkEntity = ctrl.getDefn().fk_entity;
+        const fkEntity = ctrl.getDefn().fk_entity;
         return ctrl.editor.meta.entities[fkEntity];
       };
 
@@ -104,10 +106,10 @@
 
       // Returns the original field definition from metadata
       this.getDefn = function() {
-        var defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name);
+        let defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.node.name), ctrl.node.name);
         // Calc fields are specific to a search display, not part of the schema
         if (!defn && ctrl.container.getSearchDisplay()) {
-          var searchDisplay = ctrl.container.getSearchDisplay();
+          const searchDisplay = ctrl.container.getSearchDisplay();
           defn = _.findWhere(searchDisplay.calc_fields, {name: ctrl.node.name});
         }
         defn = defn || {
@@ -135,7 +137,7 @@
       };
 
       $scope.hasOptions = function() {
-        var inputType = $scope.getProp('input_type');
+        const inputType = $scope.getProp('input_type');
         return _.contains(['CheckBox', 'Radio', 'Select'], inputType) && !(inputType === 'CheckBox' && ctrl.getDefn().data_type === 'Boolean');
       };
 
@@ -149,7 +151,7 @@
       this.getOriginalOptions = function() {
         if (ctrl.getDefn().input_type === 'EntityRef') {
           // Build a list of all entities in this form that can be referenced by this field.
-          var newOptions = _.map(ctrl.editor.getEntities({type: ctrl.getDefn().fk_entity}), function(entity) {
+          const newOptions = _.map(ctrl.editor.getEntities({type: ctrl.getDefn().fk_entity}), (entity) => {
             return {id: entity.name, label: entity.label};
           }, []);
           // Store it in a stable variable for the sake of ng-repeat
@@ -186,7 +188,7 @@
       };
 
       function inputTypeCanBe(type) {
-        var defn = ctrl.getDefn();
+        const defn = ctrl.getDefn();
         if (defn.input_type === type) {
           return true;
         }
@@ -247,7 +249,7 @@
 
       // Checks for a value in either the local field defn or the base defn
       $scope.propIsset = function(propName) {
-        var val = $scope.getProp(propName);
+        const val = $scope.getProp(propName);
         return !(typeof val === 'undefined' || val === null);
       };
 
@@ -261,14 +263,14 @@
       };
 
       $scope.toggleMultiple = function() {
-        var newVal = getSet('input_attrs.multiple', !getSet('input_attrs.multiple'));
+        const newVal = getSet('input_attrs.multiple', !getSet('input_attrs.multiple'));
         if (newVal && getSet('search_range')) {
           getSet('search_range', false);
         }
       };
 
       $scope.toggleSearchRange = function() {
-        var newVal = getSet('search_range', !getSet('search_range'));
+        const newVal = getSet('search_range', !getSet('search_range'));
         if (newVal && getSet('input_attrs.multiple')) {
           getSet('input_attrs.multiple', false);
         }
@@ -364,9 +366,8 @@
       };
 
       $scope.defaultValueContains = function(val) {
-        var defaultVal = getSet('afform_default');
-        return defaultVal === val || (_.isArray(defaultVal) && _.includes(defaultVal, val));
-      };
+        const defaultVal = getSet('afform_default');
+        return defaultVal === val || (Array.isArray(defaultVal) && defaultVal.includes(val));      };
 
       $scope.toggleDefaultValueItem = function(val) {
         if (defaultValueShouldBeArray()) {
@@ -375,7 +376,7 @@
             ctrl.node.defn.afform_default = [];
           }
           if (_.includes(ctrl.node.defn.afform_default, val)) {
-            var newVal = _.without(ctrl.node.defn.afform_default, val);
+            const newVal = _.without(ctrl.node.defn.afform_default, val);
             getSet('afform_default', newVal.length ? newVal : undefined);
             ctrl.hasDefaultValue = !!newVal.length;
           } else {
@@ -416,7 +417,7 @@
       // Getter/setter callback
       function getSet(propName, val) {
         if (arguments.length > 1) {
-          var path = propName.split('.'),
+          const path = propName.split('.'),
             item = path.pop(),
             localDefn = drillDown(ctrl.node, ['defn'].concat(path)),
             fieldDefn = drillDown(ctrl.getDefn(), path);
@@ -468,8 +469,8 @@
 
       // Returns a reference to a path n-levels deep within an object
       function drillDown(parent, path) {
-        var container = parent;
-        _.each(path, function(level) {
+        let container = parent;
+        path.forEach((level) => {
           container[level] = container[level] || {};
           container = container[level];
         });
@@ -483,7 +484,7 @@
 
       // Recursively clears out empty arrays and objects
       function clearOut(parent, path) {
-        var item;
+        let item;
         while (path.length && _.every(drillDown(parent, path), isEmpty)) {
           item = path.pop();
           delete drillDown(parent, path)[item];

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1294,7 +1294,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     // Allow all filters that are included in SELECT clause or are fields on the Afform.
     $fieldFilters = $this->getAfformFilterFields();
     $directiveFilters = $this->getAfformDirectiveFilters();
-    $allowedFilters = array_merge($this->getSelectAliases(), $fieldFilters, $directiveFilters);
+    $allowedFilters = array_merge($this->getSelectAliases(), array_keys($fieldFilters), $directiveFilters);
 
     // Ignore empty strings
     $filters = array_filter($this->filters, [$this, 'hasValue']);
@@ -1312,7 +1312,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     foreach ($filters as $key => $value) {
       $fieldNames = explode(',', $key);
       if (in_array($key, $allowedFilters, TRUE) || !array_diff($fieldNames, $allowedFilters)) {
-        $this->applyFilter($fieldNames, $value);
+        $this->applyFilter($fieldNames, $value, $fieldFilters);
       }
     }
     // After adding filters, set filter labels
@@ -1634,7 +1634,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       return array_column(\CRM_Utils_Array::findAll(
         $afform['searchDisplay']['fieldset'],
         ['#tag' => 'af-field']
-      ), 'name');
+      ), NULL, 'name');
     }
     return [];
   }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -11,6 +11,7 @@ use Civi\Api4\Phone;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\SearchDisplay;
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Test\Api4TestTrait;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
@@ -18,6 +19,8 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+
+  use Api4TestTrait;
 
   public function setUpHeadless() {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
@@ -29,6 +32,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
 
   public function tearDown(): void {
     Afform::revert(FALSE)->addWhere('has_local', '=', TRUE)->execute();
+    $this->conditionallyDeleteTestRecords();
     parent::tearDown();
   }
 
@@ -533,6 +537,107 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $params['filters']['label'] = 'b';
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $this->assertCount(0, $result);
+  }
+
+  public function testRunWithJoinFilters(): void {
+    $lastName = uniqid();
+
+    $this->createTestRecord('SavedSearch', [
+      'name' => 'Contacts_and_activities',
+      'label' => 'Contacts and activities',
+      'form_values' => [
+        'join' => [
+          'Contact_ActivityContact_Activity_01' => 'The Activities',
+        ],
+      ],
+      'api_entity' => 'Individual',
+      'api_params' => [
+        'version' => 4,
+        'select' => [
+          'id',
+          'sort_name',
+          'Contact_ActivityContact_Activity_01.subject',
+        ],
+        'orderBy' => [],
+        'where' => [
+          ['last_name', '=', $lastName],
+        ],
+        'groupBy' => [],
+        'join' => [
+          [
+            'Activity AS Contact_ActivityContact_Activity_01',
+            'LEFT',
+            'ActivityContact',
+            ['id', '=', 'Contact_ActivityContact_Activity_01.contact_id'],
+            ['Contact_ActivityContact_Activity_01.record_type_id:name', '=', '"Activity Source"'],
+          ],
+        ],
+        'having' => [],
+      ],
+    ]);
+
+    $markupWithJoinClause = <<<HTML
+      <div af-fieldset="">
+        <af-field name="Contact_ActivityContact_Activity_01.status_id" defn="{input_attrs: {multiple: true}, join_clause: 'Contact_ActivityContact_Activity_01'}" />
+        <crm-search-display-table search-name="Contacts_and_activities" display-name=""></crm-search-display-table>
+      </div>
+      HTML;
+
+    $markupWithoutJoinClause = <<<HTML
+      <div af-fieldset="">
+        <af-field name="Contact_ActivityContact_Activity_01.status_id" defn="{input_attrs: {multiple: true}, join_clause: ''}" />
+        <crm-search-display-table search-name="Contacts_and_activities" display-name=""></crm-search-display-table>
+      </div>
+      HTML;
+
+    Afform::create(FALSE)
+      ->addValue('name', 'TestAfformWithSearch')
+      ->addValue('title', 'TestAfformWithSearch')
+      ->setLayoutFormat('html')
+      ->addValue('layout', $markupWithJoinClause)
+      ->execute();
+
+    $cid = $this->saveTestRecords('Individual', [
+      'records' => 5,
+      'defaults' => ['last_name' => $lastName],
+    ])->column('id');
+
+    $this->saveTestRecords('Activity', [
+      'records' => [
+        ['source_contact_id' => $cid[0], 'status_id' => 1, 'subject' => 'Activity 1'],
+        ['source_contact_id' => $cid[1], 'status_id' => 2, 'subject' => 'Activity 2'],
+        ['source_contact_id' => $cid[2], 'status_id' => 2, 'subject' => 'Activity 3'],
+      ],
+    ]);
+
+    $params = [
+      'return' => 'page:1',
+      'savedSearch' => 'Contacts_and_activities',
+      'afform' => 'TestAfformWithSearch',
+      'filters' => [
+        'Contact_ActivityContact_Activity_01.status_id' => [2],
+      ],
+      'sort' => [['id', 'ASC']],
+      'debug' => TRUE,
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(5, $result);
+    $this->assertNull($result[0]['data']['Contact_ActivityContact_Activity_01.subject']);
+    $this->assertEquals('Activity 2', $result[1]['data']['Contact_ActivityContact_Activity_01.subject']);
+    $this->assertEquals('Activity 3', $result[2]['data']['Contact_ActivityContact_Activity_01.subject']);
+    $this->assertNull($result[3]['data']['Contact_ActivityContact_Activity_01.subject']);
+    $this->assertNull($result[4]['data']['Contact_ActivityContact_Activity_01.subject']);
+
+    Afform::update(FALSE)
+      ->addWhere('name', '=', 'TestAfformWithSearch')
+      ->addValue('layout', $markupWithoutJoinClause)
+      ->execute();
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(2, $result);
+    $this->assertEquals('Activity 2', $result[0]['data']['Contact_ActivityContact_Activity_01.subject']);
+    $this->assertEquals('Activity 3', $result[1]['data']['Contact_ActivityContact_Activity_01.subject']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible to apply a filter to the conditions of a join instead of the whole search. For Optional (LEFT) joins, this means the row will not be completely filtered out from the search, only the joined columns. 

<img width="2122" height="1130" alt="image" src="https://github.com/user-attachments/assets/7e4a0162-65ee-46bc-b3c9-dc8a3065ff51" />
