### PR TITLE
Remove empty translation strings

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Badge_Layouts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Badge_Layouts.mgd.php
@@ -45,7 +45,7 @@ return [
         'saved_search_id.name' => 'Administer_Badge_Layouts',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(''),
+          'description' => '',
           'sort' => [],
           'limit' => 50,
           'pager' => [
@@ -89,7 +89,7 @@ return [
               ],
             ],
             [
-              'text' => E::ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Field_Options.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Field_Options.mgd.php
@@ -44,7 +44,7 @@ return [
         'saved_search_id.name' => 'Administer_Custom_Field_Options',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(''),
+          'description' => '',
           'sort' => [],
           'limit' => 50,
           'pager' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Membership_Status_Rules.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Membership_Status_Rules.mgd.php
@@ -52,7 +52,7 @@ return [
         'saved_search_id.name' => 'Administer_Membership_Status_Rules',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(''),
+          'description' => '',
           'sort' => [],
           'limit' => 50,
           'pager' => [
@@ -120,7 +120,7 @@ return [
               'sortable' => TRUE,
             ],
             [
-              'text' => E::ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',

--- a/ext/civicrm_search_ui/managed/SavedSearch_ActivitySearch.mgd.php
+++ b/ext/civicrm_search_ui/managed/SavedSearch_ActivitySearch.mgd.php
@@ -186,7 +186,7 @@ return [
               'sortable' => TRUE,
             ],
             [
-              'text' => E::ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',

--- a/ext/civicrm_search_ui/managed/SavedSearch_CiviCRM_Reports.mgd.php
+++ b/ext/civicrm_search_ui/managed/SavedSearch_CiviCRM_Reports.mgd.php
@@ -104,7 +104,7 @@ return [
               'alignment' => 'text-right',
             ],
             [
-              'text' => E::ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',
@@ -182,7 +182,7 @@ return [
               ],
               'type' => 'menu',
               'alignment' => 'text-right',
-              'label' => E::ts(''),
+              'label' => '',
             ],
           ],
           'actions' => FALSE,

--- a/ext/search_kit_reports/managed/SavedSearch_SearchKit_Reports.mgd.php
+++ b/ext/search_kit_reports/managed/SavedSearch_SearchKit_Reports.mgd.php
@@ -46,7 +46,7 @@ return [
         'saved_search_id.name' => 'SearchKit_Reports',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(''),
+          'description' => '',
           'sort' => [],
           'limit' => 50,
           'pager' => [],

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -379,7 +379,7 @@
   CRM.UF.UFEntityModel = CRM.Backbone.Model.extend({
     schema: {
       'id': {
-        // title: ts(''),
+        // title: '',
         type: 'Number'
       },
       'entity_name': {
@@ -480,30 +480,30 @@
     },
     schema: {
       'id': {
-        // title: ts(''),
+        // title: '',
         type: 'Number'
       },
       'name': {
-        // title: ts(''),
+        // title: '',
         type: 'Text'
       },
       'title': {
         title: ts('Profile Name'),
-        help: ts(''),
+        help: '',
         type: 'Text',
         editorAttrs: {maxlength: 64},
         validators: ['required']
       },
       'frontend_title': {
         title: ts('Public Title'),
-        help: ts(''),
+        help: '',
         type: 'Text',
         editorAttrs: {maxlength: 64},
         validators: []
       },
       'group_type': {
         // For a description of group_type, see CRM_Core_BAO_UFGroup::updateGroupTypes
-        // title: ts(''),
+        // title: '',
         type: 'Text'
       },
       'add_captcha': {
@@ -533,11 +533,11 @@
         type: 'Text'
       },
       'created_date': {
-        //title: ts(''),
+        //title: '',
         type: 'Text'// FIXME
       },
       'created_id': {
-        //title: ts(''),
+        //title: '',
         type: 'Number'
       },
       'help_post': {
@@ -582,7 +582,7 @@
         options: YESNO // FIXME
       },
       'is_reserved': {
-        // title: ts(''),
+        // title: '',
         type: 'Select',
         options: YESNO
       },

--- a/managed/administer/SavedSearch_Site_Email_Addresses.mgd.php
+++ b/managed/administer/SavedSearch_Site_Email_Addresses.mgd.php
@@ -97,7 +97,7 @@ return [
               'rewrite' => ' ',
             ],
             [
-              'text' => ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',


### PR DESCRIPTION
After discussions on Mattermost, one step to remove all empty ts('') chains to remove this one here: https://app.transifex.com/civicrm/civicrm/translate/#fr/menu/464954261?q=translated%3Ano