### PR TITLE
Update soft credit exception check

### DIFF
--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -337,7 +337,7 @@ class ContributionParser extends ImportParser {
       foreach ($softCreditEntities as $index => $softCreditContact) {
         $softCreditParams[$index]['soft_credit_type_id'] = $softCreditContact['soft_credit_type_id'];
         $softCreditEntities[$index]['id'] = $this->getContactID($softCreditContact, !empty($softCreditContact['id']) ? $softCreditContact['id'] : NULL, 'SoftCreditContact', $this->getDedupeRulesForEntity('SoftCreditContact'));
-        if (empty($softCreditParams[$index]['contact_id']) && in_array($this->getActionForEntity('SoftCreditContact'), ['update', 'select'])) {
+        if (empty($softCreditEntities[$index]['id']) && in_array($this->getActionForEntity('SoftCreditContact'), ['update', 'select'])) {
           throw new \CRM_Core_Exception(ts('Soft Credit Contact not found'));
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Update soft credit exception check

Before
----------------------------------------
in rc + master it is incorrectly throwing an error when the `contact_id` is not present  - but in fact the just set value in the line immediately above is now `$softCreditEntities[$index]['id'] `

After
----------------------------------------
fixed

Technical Details
----------------------------------------
rc changes follow up

Comments
----------------------------------------
