### PR TITLE
FormBuilder - Enable combining search filters in UI

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -24,25 +24,7 @@
 
       // Live results for the select2 of filter fields
       this.getFilterFields = function() {
-        var fieldGroups = [],
-          entities = getEntities();
-        if (ctrl.display.settings.calc_fields && ctrl.display.settings.calc_fields.length) {
-          fieldGroups.push({
-            text: ts('Calculated Fields'),
-            children: _.transform(ctrl.display.settings.calc_fields, function(fields, el) {
-              fields.push({id: el.name, text: el.label, disabled: ctrl.fieldInUse(el.name)});
-            }, [])
-          });
-        }
-        _.each(entities, function(entity) {
-          fieldGroups.push({
-            text: entity.label,
-            children: _.transform(entity.fields, function(fields, field) {
-              fields.push({id: entity.prefix + field.name, text: entity.label + ' ' + field.label, disabled: ctrl.fieldInUse(entity.prefix + field.name)});
-            }, [])
-          });
-        });
-        return {results: fieldGroups};
+        return afGui.getSearchDisplayFields(ctrl.display.settings, ctrl.fieldInUse);
       };
 
       this.buildPaletteLists = function() {
@@ -108,54 +90,10 @@
         });
       }
 
-      // Fetch all entities used in search (main entity + joins)
-      function getEntities() {
-        var
-          mainEntity = afGui.getEntity(ctrl.display.settings['saved_search_id.api_entity']),
-          entityCount = {},
-          entities = [{
-            name: mainEntity.entity,
-            prefix: '',
-            label: mainEntity.label,
-            fields: mainEntity.fields
-          }];
-
-        // Increment count of entityName and return a suffix string if > 1
-        function countEntity(entityName) {
-          entityCount[entityName] = (entityCount[entityName] || 0) + 1;
-          return entityCount[entityName] > 1 ? ' ' + entityCount[entityName] : '';
-        }
-        countEntity(mainEntity.entity);
-
-        _.each(ctrl.display.settings['saved_search_id.api_params'].join, function(join) {
-          const joinInfo = join[0].split(' AS ');
-          const entity = afGui.getEntity(joinInfo[0]);
-          const bridgeEntity = afGui.getEntity(join[2]);
-          // Form values contain join aliases; defaults are filled in by Civi\Api4\Action\Afform\LoadAdminData()
-          const formValues = ctrl.display.settings['saved_search_id.form_values'];
-          entities.push({
-            name: entity.entity,
-            prefix: joinInfo[1] + '.',
-            label: formValues.join[joinInfo[1]],
-            fields: entity.fields,
-          });
-          if (bridgeEntity) {
-            entities.push({
-              name: bridgeEntity.entity,
-              prefix: joinInfo[1] + '.',
-              label: bridgeEntity.label + countEntity(bridgeEntity.entity),
-              fields: _.omit(bridgeEntity.fields, _.keys(entity.fields)),
-            });
-          }
-        });
-
-        return entities;
-      }
-
       function buildFieldList(search) {
         $scope.fieldList.length = 0;
-        var entities = getEntities();
-        _.each(entities, function(entity) {
+        const entities = afGui.getSearchDisplayEntities(ctrl.display.settings);
+        entities.forEach((entity) => {
           $scope.fieldList.push({
             entityType: entity.name,
             label: ts('%1 Fields', {1: entity.label}),

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -14,8 +14,8 @@
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'Text' || $ctrl.fieldDefn.input_type === 'TextArea'">
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
-    <label for="{{:: $ctrl.node.name}}-maxlength">{{:: ts('Max Length:') }}</label>
-    <input id="{{:: $ctrl.node.name}}-maxlength" type="number" min="1" step="1" class="form-control" ng-model="getSet('input_attrs.maxlength')" ng-model-options="{getterSetter: true}">
+    <label for="{{:: $ctrl.getFieldName() }}-maxlength">{{:: ts('Max Length:') }}</label>
+    <input id="{{:: $ctrl.getFieldName() }}-maxlength" type="number" min="1" step="1" class="form-control" ng-model="getSet('input_attrs.maxlength')" ng-model-options="{getterSetter: true}">
   </form>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'Number' && $ctrl.fieldDefn.data_type === 'Float'">
@@ -51,7 +51,7 @@
   </div>
 </li>
 <li ng-if="$ctrl.fieldDefn.input_type === 'EntityRef'" title="{{:: ts('Allow a new entity to be created via quick-add popup') }}">
-  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+  <div href ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <input crm-ui-select="{data: $ctrl.quickAddLinks, multiple: true, separator: '\u0001', placeholder: ts('Quick Add')}" ng-model="getSet('input_attrs.quickAdd')" ng-model-options="{getterSetter: true}" ng-list="" class="form-control">
   </div>
 </li>
@@ -117,7 +117,7 @@
   </a>
 </li>
 
-<li role="separator" class="divider" ng-if="$ctrl.canBeRange() || $ctrl.canBeMultiple()"></li>
+<li role="separator" class="divider" ng-if="$ctrl.isSearch()"></li>
 <li ng-if="$ctrl.canBeMultiple()" ng-click="$event.stopPropagation()">
   <a href ng-click="toggleMultiple()" title="{{:: ts('Search multiple values') }}">
     <i class="crm-i fa-{{ !$ctrl.node.defn.input_attrs.multiple ? '' : 'check-' }}square-o"></i>
@@ -129,6 +129,15 @@
     <i class="crm-i fa-{{ !$ctrl.node.defn.search_range ? '' : 'check-' }}square-o"></i>
     {{:: ts('Search by range') }}
   </a>
+</li>
+<li ng-if="$ctrl.isSearch()" ng-click="$event.stopPropagation()">
+  <a href ng-click="$ctrl.toggleMultiFieldFilter(); $event.target.blur();" title="{{:: ts('Filter search results based on multiple fields') }}">
+    <i class="crm-i fa-{{ !$ctrl.isMultiFieldFilter ? '' : 'check-' }}square-o"></i>
+    {{:: ts('Combine multiple fields') }}
+  </a>
+  <div class="af-gui-field-select-in-dropdown" ng-if="$ctrl.isMultiFieldFilter">
+    <input crm-ui-select="{data: $ctrl.getSearchFilterFields, multiple: true}" ng-model="$ctrl.node.name" class="form-control" title="{{:: ts('Filter search results based on multiple fields') }}">
+  </div>
 </li>
 <li ng-if="$ctrl.isSearch()" ng-click="$event.stopPropagation()">
   <div class="af-gui-field-select-in-dropdown">

--- a/ext/civi_campaign/ang/afsearchCampaignDashboard.aff.html
+++ b/ext/civi_campaign/ang/afsearchCampaignDashboard.aff.html
@@ -2,7 +2,7 @@
   <af-tab title="Campaigns">
     <div af-fieldset>
       <fieldset class="af-container af-layout-inline">
-        <af-field name="title,description" defn="{label: false, data_type: 'String', input_type: 'Text', name: 'title', input_attrs: {placeholder: 'Filter by title/description'}}" />
+        <af-field name="title,description" defn="{input_attrs: {placeholder: 'Filter by title/description'}, label: false}" />
         <af-field name="campaign_type_id" defn="{input_attrs: {multiple: true, placeholder: 'Filter by type'}, label: false}" />
         <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: 'Filter by status'}, label: false}" />
       </fieldset>

--- a/ext/civicrm_search_ui/ang/afsearchContactSearch.aff.html
+++ b/ext/civicrm_search_ui/ang/afsearchContactSearch.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-container">
     <div class="af-container af-layout-inline">
-      <af-field name="display_name,sort_name,email_primary.email" defn="{label: 'Name or Email', input_type: 'Text'}" />
+      <af-field name="display_name,sort_name,email_primary.email" defn="{label: 'Name or Email'}" />
       <af-field name="contact_type" defn="{input_attrs: {multiple: true, placeholder: '-any contact type-'}}" />
       <af-field name="contact_sub_type" defn="{input_attrs: {multiple: true, placeholder: '-any contact subtype-'}}" />
       <af-field name="groups" defn="{input_attrs: {multiple: true, placeholder: '-any group-'}}" />


### PR DESCRIPTION
Overview
----------------------------------------
Improves FormBuilder functionality to enable combining search filters. Makes it easier to create an OR condition to search multiple fields. 

Before
----------------------------------------
To search multiple fields, you could put a comma between search filter field names but it was a hidden feature. FormBuilder couldn't work with it.
Here's an example of editing "Find Contacts" from the Search UI Extension:

<img width="1306" height="1028" alt="image" src="https://github.com/user-attachments/assets/80e190df-05a6-4b57-ac2c-668a435073a2" />

After
----------------------------------------
Now there's a UI for it.

<img width="1296" height="988" alt="image" src="https://github.com/user-attachments/assets/eebbff2a-963c-47fc-8f64-3fd1ce4288b2" />


