### PR TITLE
dev/core#6065 Ensure that when using the Update Contacts option on a …

### DIFF
--- a/ext/civiimport/Civi/Import/MembershipParser.php
+++ b/ext/civiimport/Civi/Import/MembershipParser.php
@@ -176,7 +176,7 @@ class MembershipParser extends ImportParser {
         $existingMembership = $this->checkEntityExists('Membership', $membershipParams['id']);
         $membershipParams['contact_id'] = !empty($membershipParams['contact_id']) ? (int) $membershipParams['contact_id'] : $existingMembership['contact_id'];
       }
-      $membershipParams['contact_id'] = $this->getContactID($contactParams, $membershipParams['contact_id'] ?? $contactParams['id'] ?? NULL, 'Contact', $this->getDedupeRulesForEntity('Contact'));
+      $membershipParams['contact_id'] = $params['Contact']['id'] = $this->getContactID($contactParams, $membershipParams['contact_id'] ?? $contactParams['id'] ?? NULL, 'Contact', $this->getDedupeRulesForEntity('Contact'));
       $membershipParams['contact_id'] = $this->saveContact('Contact', $params['Contact'] ?? []) ?: $membershipParams['contact_id'];
       $formatted = $formatValues = $membershipParams;
       // don't add to recent items, CRM-4399

--- a/ext/civiimport/Civi/Import/ParticipantParser.php
+++ b/ext/civiimport/Civi/Import/ParticipantParser.php
@@ -120,7 +120,7 @@ class ParticipantParser extends ImportParser {
         $participantParams['contact_id'] = !empty($participantParams['contact_id']) ? (int) $participantParams['contact_id'] : $existingParticipant['contact_id'];
       }
 
-      $participantParams['contact_id'] = $this->getContactID($contactParams, $participantParams['contact_id'] ?? $contactParams['id'] ?? NULL, 'Contact', $this->getDedupeRulesForEntity('Contact'));
+      $participantParams['contact_id'] = $params['Contact']['id'] = $this->getContactID($contactParams, $participantParams['contact_id'] ?? $contactParams['id'] ?? NULL, 'Contact', $this->getDedupeRulesForEntity('Contact'));
       $participantParams['contact_id'] = $this->saveContact('Contact', $params['Contact'] ?? []) ?: $participantParams['contact_id'];
       // don't add to recent items, CRM-4399
       $participantParams['skipRecentView'] = TRUE;


### PR DESCRIPTION
…Membership or Participant import that duplicate contacts don't get created

Overview
----------------------------------------
Title says it all but this also updates to be like how the Contribution Import is coded see https://github.com/civicrm/civicrm-core/blob/master/ext/civiimport/Civi/Import/ContributionParser.php#L332 

Before
----------------------------------------
Duplicates created when using the Update contacts option in Membership or Participant import even tho dedupe rule works

After
----------------------------------------
No Duplicates created

ping @eileenmcnaughton @JoeMurray @Edzelopez 