### PR TITLE
dev/core#6054: Custom fields for contact subtype also required for parent contact type

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -333,11 +333,11 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       // However, if they are not present in the element index they will
       // not be available from `$this->getSubmittedValue()` in post process.
       // We do not have to set defaults or otherwise render - just add to the element index.
-      $this->addCustomDataFieldsToForm('Contact', array_filter([
+      $this->addCustomDataFieldsToForm('Contact', [
         'id' => $this->getContactID(),
         'contact_type' => $this->_contactType,
         'contact_sub_type' => $this->getSubmittedValue('contact_sub_type'),
-      ]));
+      ]);
     }
 
     // execute preProcess dynamically by js else execute normal preProcess


### PR DESCRIPTION
Overview
----------------------------------------
Tested in Civi 6.4.0, 6.4.1, and 6.7.alpha1.

Steps to replicate:
* Create custom data set for contact subtype (e.g., Parent subtype for Individuals)
* Create at least one field of type radio that is required in that custom data set.
* Attempt to create a new contact of the contact type (e.g., Individual) without specifying the subtype
* Field is flagged as required even though the subtype has not been selected, even though the contact is not using that subtype and the field itself is not visible in the form



Before
----------------------------------------
You can not submit a New Individual form due to the required of that custom fields which is rightfully not exposed on the form.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Regression due to https://github.com/civicrm/civicrm-core/commit/7e267ba04cf87610e2e7f927b42fa487e28e0f7d 

Comments
----------------------------------------
ping @colemanw @eileenmcnaughton @seamuslee001  