### PR TITLE
Afform - Fix permission fallback check

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -31,14 +31,11 @@
       }
       afform.can_manage = CRM.checkPerm('administer afform');
       // Check for ownership and correct permission
-      if (afform.created_id) {
+      if (!afform.can_manage && afform.created_id) {
         // Permission, manage own afform, is to only manage afform's the user created
         if (CRM.checkPerm('manage own afform') && (CRM.config.cid === afform.created_id)) {
           afform.can_manage = true;
         }
-      } else if (CRM.checkPerm('manage own afform')) {
-        // No created_id, so user doesn't have permission to manage.
-        afform.can_manage = false;
       }
       afforms[afform.type] = afforms[afform.type] || [];
       afforms[afform.type].push(afform);


### PR DESCRIPTION
Overview
----------------------------------------
_In #33358, we introduced a new base level permission. The [fallback permission](https://github.com/rbaugh/civicrm-core/blob/83ff84512693d221f84df9d22e729acf45d29250/ext/afform/admin/ang/afAdmin/afAdminList.controller.js#L39) needs to have an additional check to make sure the user doesn't have the `administer afform` permission when the afform doesn't have a `created_id`.