### PR TITLE
RiverLea: Resets radio/checkbox border-color to CMS default in WordPress

### DIFF
--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -185,6 +185,7 @@ body.wp-admin .crm-container input[type="checkbox"],
 body.wp-admin .crm-container input[type="radio"] {
   appearance: none;
   border-radius: var(--crm-s);
+  border-color: #8c8f94 /* reset to WP default border col */;
   background: #fff;
   height: var(--crm-r);
   width: var(--crm-r);


### PR DESCRIPTION
Every RiverLea stream can set an in put border colour (`--crm-input-border-color`), which doesn't apply to Radios and Checkboxes, which are normally styled by the browser or CMS. However, WordPress Radio/Checkboxes have `appearance` set to `none` to prevent dark-mode leakage.

This has the consequences of then inheriting `--crm-input-border-color` from the Stream. In the case of Thames, that's too faint to be accessible - 

<img width="967" height="417" alt="image" src="https://github.com/user-attachments/assets/cc10433a-545f-4fc4-852d-8d9f2ca1f10e" />

As this only applies to WordPress it's been missed until now. There's a few ways to fix this. We could add `border:initial` on WordPress check/radios to use the browser defaults, but that's quite dark:

<img width="638" height="218" alt="image" src="https://github.com/user-attachments/assets/50980ef8-3249-47b8-a38b-27e3b4efcde7" />

We could change the Thames input border colour to something darker, but that impacts all borders, so changes the Stream:

<img width="634" height="128" alt="image" src="https://github.com/user-attachments/assets/acbeb2d5-86d0-4a8a-9ac7-0e0c8f3aa5f7" />

Instead, adding the WordPress system border-colour for radios/checkboxes makes them consistent with all of WordPress, without impacting the Stream's decision for input border colours elsewhere.

Issue raised by @marcusjwilson at https://lab.civcrm.org/extensions/riverlea/-/issues/143

Before
----------------------------------------
Radio/checkboxes too faint in WordPress + Thames (+ any Stream with light input bordercol):

<img width="639" height="130" alt="image" src="https://github.com/user-attachments/assets/c6d63487-de0b-4dc2-af99-2bc66aa4a263" />

<img width="630" height="121" alt="image" src="https://github.com/user-attachments/assets/be3d3b6b-c267-4760-93ed-98f51c3d7cc1" />


After
----------------------------------------
Radio/checkboxes in WP use WP's system-wide colour for radio/checkbox borders.

<img width="639" height="126" alt="image" src="https://github.com/user-attachments/assets/1aa847a0-07ac-4d22-b955-8c85b431ab87" />

<img width="633" height="119" alt="image" src="https://github.com/user-attachments/assets/9dc0e0d1-518e-41ed-9242-8753a9bce28c" />

Comments
----------------------------------------
cc @artfulrobot as this relates to Thames, tho the change is negligible.
This change only impacts WordPress so the generated demo isn't of much use.