### PR TITLE
SearchKit - Change base permission

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -425,7 +425,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
   }
 
   /**
-   * Check related contact access.
+   * Check SavedSearch access.
    * @see \Civi\Api4\Utils\CoreUtil::checkAccessRecord
    */
   public static function self_civi_api4_authorizeRecord(AuthorizeRecordEvent $e): void {
@@ -442,11 +442,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     }
 
     try {
-      // Make sure we have a user ID to compare against
-      $userID = $e->getUserID() ?? CRM_Core_Session::getLoggedInContactID();
-      self::checkManageOwnPermission($record, $userID);
+      self::checkManageOwnPermission($record, $e->getUserID());
     }
-    catch (CRM_Core_Exception) {
+    catch (\Civi\API\Exception\UnauthorizedException) {
       $e->setAuthorized(FALSE);
     }
   }

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -443,7 +443,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
 
     $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
     if (!empty($created_id)) {
-      if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && CRM_Core_Permission::check('manage own search_kit') && ($userID !== (int) $created_id)) {
+      if (!CRM_Core_Permission::check('administer search_kit') && CRM_Core_Permission::check('manage own search_kit') && ($userID !== (int) $created_id)) {
         $e->setAuthorized(FALSE);
       }
     }
@@ -478,7 +478,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public static function checkManageOwnPermission(array $record): void {
-    if (!CRM_Core_Permission::check('all CiviCRM permissions and ACLs') && !empty($record['id']) && CRM_Core_Permission::check('manage own search_kit')) {
+    if (!CRM_Core_Permission::check('administer search_kit') && !empty($record['id']) && CRM_Core_Permission::check('manage own search_kit')) {
       $created_id = empty($record['created_id']) ? self::getFieldValue(parent::class, $record['id'], 'created_id') : $record['created_id'];
       if ($created_id != CRM_Core_Session::getLoggedInContactID()) {
         throw new \Civi\API\Exception\UnauthorizedException('You do not have permission to manage this SavedSearch.');

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -455,7 +455,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    * @inheritDoc
    */
   public static function writeRecord(array $record): CRM_Contact_DAO_SavedSearch {
-    if (!empty($record['check_permission'])) {
+    if (!empty($record['check_permission']) && !CRM_Core_Permission::check('administer search_kit') && !empty($record['id'])) {
       self::checkManageOwnPermission($record, CRM_Core_Session::getLoggedInContactID());
     }
     return parent::writeRecord($record);
@@ -465,7 +465,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    * @inheritDoc
    */
   public static function deleteRecord(array $record): CRM_Contact_DAO_SavedSearch {
-    if (!empty($record['check_permission'])) {
+    if (!empty($record['check_permission']) && !CRM_Core_Permission::check('administer search_kit')) {
       self::checkManageOwnPermission($record, CRM_Core_Session::getLoggedInContactID());
     }
     return parent::deleteRecord($record);

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -383,7 +383,7 @@ trait SavedSearchInspectorTrait {
   protected function checkPermissionToLoadSearch() {
     if (
       (is_array($this->savedSearch) || (isset($this->display) && is_array($this->display))) && $this->checkPermissions &&
-      !\CRM_Core_Permission::check('administer search_kit')
+      !\CRM_Core_Permission::check('manage own search_kit')
     ) {
       throw new UnauthorizedException('Access denied');
     }

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -173,7 +173,7 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
             ->setSavedSearch($displayTag['search-name']);
         }
         $display = $displayGet
-          ->addSelect('*', 'type:name', 'type:icon', 'saved_search_id.name', 'saved_search_id.label', 'saved_search_id.api_entity', 'saved_search_id.api_params', 'saved_search_id.form_values')
+          ->addSelect('*', 'type:name', 'type:icon', 'saved_search_id.name', 'saved_search_id.label', 'saved_search_id.api_entity', 'saved_search_id.api_params', 'saved_search_id.form_values', 'saved_search_id.created_id')
           ->execute()->first();
         if (!$display) {
           continue;

--- a/ext/afform/admin/ang/afAdmin.ang.php
+++ b/ext/afform/admin/ang/afAdmin.ang.php
@@ -15,5 +15,9 @@ return [
   'permissions' => [
     'administer afform',
     'manage own afform',
+    // Used to check permissions by afGuiSearchDisplay component
+    'all CiviCRM permissions and ACLs',
+    'administer search_kit',
+    'manage own search_kit',
   ],
 ];

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.component.js
@@ -13,8 +13,25 @@
 
       this.$onInit = function() {
         ctrl.display = afGui.getSearchDisplay(ctrl.node['search-name'], ctrl.node['display-name']);
-        ctrl.editUrl = CRM.url('civicrm/admin/search#/edit/' + ctrl.display.saved_search_id);
+        if (checkEditAccess(ctrl.display)) {
+          ctrl.editUrl = CRM.url('civicrm/admin/search#/edit/' + ctrl.display.saved_search_id);
+        }
       };
+
+      function checkEditAccess(display) {
+        if (CRM.checkPerm('all CiviCRM permissions and ACLs')) {
+          return true;
+        }
+        // Only super-admins can edit displays with acl_bypass
+        if (display.acl_bypass) {
+          return false;
+        }
+        if (CRM.checkPerm('administer search_kit')) {
+          return true;
+        }
+        // Check manage-own permission
+        return (CRM.checkPerm('manage own search_kit') && (display['saved_search_id.created_id'] === CRM.config.cid));
+      }
 
     }
   });

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiSearchDisplay.html
@@ -1,7 +1,7 @@
 <div class="af-gui-bar">
   <div class="form-inline">
     <span>{{:: $ctrl.display['saved_search_id.label'] }}: {{:: $ctrl.display.label }}</span>
-    <div class="btn-group pull-right" af-gui-menu>
+    <div class="btn-group pull-right" af-gui-menu ng-if="$ctrl.editUrl">
       <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
         <span><i class="crm-i fa-gear"></i></span>
       </button>

--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -64,7 +64,7 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay implemen
         return;
       }
       // Must be at least a SearchKit administrator
-      if (!CRM_Core_Permission::check('administer search_kit', $userCID)) {
+      if (!CRM_Core_Permission::check('manage own search_kit', $userCID)) {
         $e->setAuthorized(FALSE);
         return;
       }

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchKitSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchKitSubscriber.php
@@ -31,7 +31,7 @@ class SearchKitSubscriber extends \Civi\Core\Service\AutoService implements Even
   }
 
   /**
-   * Alters APIv4 permissions to allow users with 'administer search_kit' to create/delete a SavedSearch
+   * Alters APIv4 permissions to allow users with 'manage own search_kit' to create/delete a SavedSearch
    *
    * @param \Civi\API\Event\AuthorizeEvent $event
    *   API authorization event.
@@ -40,7 +40,7 @@ class SearchKitSubscriber extends \Civi\Core\Service\AutoService implements Even
     /** @var \Civi\Api4\Generic\AbstractAction $apiRequest */
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] == 4 && $apiRequest->getEntityName() === 'SavedSearch') {
-      if (\CRM_Core_Permission::check('administer search_kit')) {
+      if (\CRM_Core_Permission::check('manage own search_kit')) {
         $event->authorize();
         $event->stopPropagation();
       }

--- a/ext/search_kit/Civi/Api4/SKEntity.php
+++ b/ext/search_kit/Civi/Api4/SKEntity.php
@@ -88,8 +88,8 @@ class SKEntity {
     $permissions = [
       'meta' => ['access CiviCRM'],
       'default' => ['administer CiviCRM'],
-      'refresh' => ['administer search_kit'],
-      'getRefreshDate' => ['administer search_kit'],
+      'refresh' => ['manage own search_kit'],
+      'getRefreshDate' => ['manage own search_kit'],
     ];
     // Permissions based on search display
     [, $displayName] = explode('_', $entityName, 2);

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -73,7 +73,7 @@ class SearchDisplay extends Generic\DAOEntity {
 
   public static function permissions() {
     $permissions = parent::permissions();
-    $permissions['default'] = ['administer search_kit'];
+    $permissions['default'] = ['manage own search_kit'];
     // Anyone with access to CiviCRM can view search displays (but not necessarily the results)
     $permissions['get'] = $permissions['getDefault'] = ['access CiviCRM'];
     // Anyone with access to CiviCRM can do search tasks (but not necessarily all of them)

--- a/ext/search_kit/Civi/Api4/SearchSegment.php
+++ b/ext/search_kit/Civi/Api4/SearchSegment.php
@@ -12,7 +12,7 @@ class SearchSegment extends Generic\DAOEntity {
 
   public static function permissions() {
     $permissions = parent::permissions();
-    $permissions['default'] = ['administer search_kit'];
+    $permissions['default'] = ['manage own search_kit'];
     return $permissions;
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -21,6 +21,7 @@ return [
     // Note the super permission "all CiviCRM permissions and ACLs" is used in the JS layer to determine if users can create search displays that bypass ACLs
     'all CiviCRM permissions and ACLs',
     'administer CiviCRM',
+    'administer search_kit',
     'manage own afform',
     'view debug output',
     'schedule communications',

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -107,7 +107,7 @@
         _.each(apiResults.run, function(row) {
           row.permissionToEdit = CRM.checkPerm('all CiviCRM permissions and ACLs') || !_.includes(row.data.display_acl_bypass, true);
           // If someone has manage own permission, we need to override and only allow if they are the owner.
-          if (!CRM.checkPerm('all CiviCRM permissions and ACLs') && CRM.checkPerm('manage own search_kit') && (CRM.config.cid !== row.data.created_id)) {
+          if (!CRM.checkPerm('administer search_kit') && CRM.checkPerm('manage own search_kit') && (CRM.config.cid !== row.data.created_id)) {
             row.permissionToEdit = false;
           }
 

--- a/ext/search_kit/managed/Navigation_search_kit.mgd.php
+++ b/ext/search_kit/managed/Navigation_search_kit.mgd.php
@@ -15,7 +15,7 @@ return [
         'url' => 'civicrm/admin/search',
         'icon' => 'crm-i fa-search-plus',
         'permission' => [
-          'administer search_kit',
+          'manage own search_kit',
         ],
         'permission_operator' => 'OR',
         'parent_id.name' => 'Search',

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3093,14 +3093,12 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     }
     $this->assertStringContainsString('permission', $error);
 
-    $this->userLogout();
     $config->userPermissionClass->permissions = [
       'access CiviCRM',
       'administer search_kit',
     ];
 
     // Make sure a `administer search_kit` user can edit any SavedSearch record using API4.
-    $error = '';
     try {
       $result = \Civi\Api4\SavedSearch::update(TRUE)
         ->addValue('label', 'Update Test Search')
@@ -3108,12 +3106,10 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
         ->execute();
     }
     catch (UnauthorizedException $e) {
-      $error = $e->getMessage();
+      $this->fail();
     }
-    $this->assertStringNotContainsString('failed', $error);
 
     // Make sure a `administer search_kit` user can edit any SavedSearch using BAO.
-    $error = '';
     try {
       \CRM_Contact_BAO_SavedSearch::writeRecord([
         'check_permission' => TRUE,
@@ -3122,24 +3118,20 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       ]);
     }
     catch (UnauthorizedException $e) {
-      $error = $e->getMessage();
+      $this->fail();
     }
-    $this->assertStringNotContainsString('permission', $error);
 
     // Make sure a `administer search_kit` user can delete any SavedSearch record using API4.
-    $error = '';
     try {
       $result = \Civi\Api4\SavedSearch::delete(TRUE)
         ->addWhere('id', '=', $savedSearchAPI['id'])
         ->execute();
     }
     catch (UnauthorizedException $e) {
-      $error = $e->getMessage();
+      $this->fail();
     }
-    $this->assertStringNotContainsString('failed', $error);
 
     // Make sure a `administer search_kit` user can delete any SavedSearch using BAO.
-    $error = '';
     try {
       \CRM_Contact_BAO_SavedSearch::deleteRecord([
         'check_permission' => TRUE,
@@ -3147,9 +3139,8 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       ]);
     }
     catch (UnauthorizedException $e) {
-      $error = $e->getMessage();
+      $this->fail();
     }
-    $this->assertStringNotContainsString('permission', $error);
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3012,32 +3012,144 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
 
   public function testManageOwn(): void {
     $config = \CRM_Core_Config::singleton();
-    $savedSearch = \Civi\Api4\SavedSearch::create(FALSE)
-      ->addValue('name', 'Test Search')
+    $savedSearchAPI = \Civi\Api4\SavedSearch::create(FALSE)
+      ->addValue('name', ' API Test Search')
       ->addValue('api_entity', 'Contact')
       ->addValue('api_params', [
         'version' => 4,
-        'select' => ['id', 'sort_name', 'contact_type:label', 'contact_sub_type:label'],
+        'select' => [
+          'id',
+          'sort_name',
+          'contact_type:label',
+          'contact_sub_type:label',
+        ],
         'orderBy' => [],
         'where' => [['contact_type:name', '=', 'Individual']],
       ])
       ->addValue('created_id', 1)
       ->addValue('modified_id', 1)
       ->execute()->first();
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
+    $savedSearchBAO = \CRM_Contact_BAO_SavedSearch::writeRecord([
+      'check_permission' => FALSE,
+      'name' => 'BAO Test Search',
+      'created_id' => 1,
+      'modified_id' => 1,
+    ]);
+    $config->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'manage own search_kit',
+    ];
     $this->createLoggedInUser();
 
+    // Make sure a `manage own search_kit` user can't edit a SavedSearch owned by someone else using API4.
+    $error = '';
+    try {
+      $result = \Civi\Api4\SavedSearch::update(TRUE)
+        ->addValue('label', 'Update API Test Search')
+        ->addWhere('id', '=', $savedSearchAPI['id'])
+        ->execute();
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringContainsString('failed', $error);
+
+    // Make sure a `manage own search_kit` user can't edit a SavedSearch owned by someone else using BAO.
+    $error = '';
+    try {
+      \CRM_Contact_BAO_SavedSearch::writeRecord([
+        'check_permission' => TRUE,
+        'label' => 'Update BAO Test Search',
+        'id' => $savedSearchBAO->id,
+      ]);
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringContainsString('permission', $error);
+
+    // Make sure a `manage own search_kit` user can't delete a SavedSearch owned by someone else using API4.
+    $error = '';
+    try {
+      $result = \Civi\Api4\SavedSearch::delete(TRUE)
+        ->addWhere('id', '=', $savedSearchAPI['id'])
+        ->execute();
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringContainsString('failed', $error);
+
+    // Make sure a `manage own search_kit` user can't delete a SavedSearch owned by someone else using BAO.
+    $error = '';
+    try {
+      \CRM_Contact_BAO_SavedSearch::deleteRecord([
+        'check_permission' => TRUE,
+        'id' => $savedSearchBAO->id,
+      ]);
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringContainsString('permission', $error);
+
+    $this->userLogout();
+    $config->userPermissionClass->permissions = [
+      'access CiviCRM',
+      'administer search_kit',
+    ];
+
+    // Make sure a `administer search_kit` user can edit any SavedSearch record using API4.
     $error = '';
     try {
       $result = \Civi\Api4\SavedSearch::update(TRUE)
         ->addValue('label', 'Update Test Search')
-        ->addWhere('id', '=', $savedSearch['id'])
+        ->addWhere('id', '=', $savedSearchAPI['id'])
         ->execute();
     }
-    catch(UnauthorizedException $e) {
+    catch (UnauthorizedException $e) {
       $error = $e->getMessage();
     }
-    $this->assertStringContainsString('failed', $error);
+    $this->assertStringNotContainsString('failed', $error);
+
+    // Make sure a `administer search_kit` user can edit any SavedSearch using BAO.
+    $error = '';
+    try {
+      \CRM_Contact_BAO_SavedSearch::writeRecord([
+        'check_permission' => TRUE,
+        'label' => 'Update BAO Test Search',
+        'id' => $savedSearchBAO->id,
+      ]);
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringNotContainsString('permission', $error);
+
+    // Make sure a `administer search_kit` user can delete any SavedSearch record using API4.
+    $error = '';
+    try {
+      $result = \Civi\Api4\SavedSearch::delete(TRUE)
+        ->addWhere('id', '=', $savedSearchAPI['id'])
+        ->execute();
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringNotContainsString('failed', $error);
+
+    // Make sure a `administer search_kit` user can delete any SavedSearch using BAO.
+    $error = '';
+    try {
+      \CRM_Contact_BAO_SavedSearch::deleteRecord([
+        'check_permission' => TRUE,
+        'id' => $savedSearchBAO->id,
+      ]);
+    }
+    catch (UnauthorizedException $e) {
+      $error = $e->getMessage();
+    }
+    $this->assertStringNotContainsString('permission', $error);
   }
 
 }

--- a/ext/search_kit/xml/Menu/search_kit.xml
+++ b/ext/search_kit/xml/Menu/search_kit.xml
@@ -8,11 +8,11 @@
   <item>
     <path>civicrm/admin/search</path>
     <page_callback>CRM_Search_Page_Admin</page_callback>
-    <access_arguments>administer CiviCRM data;administer search_kit</access_arguments>
+    <access_arguments>administer CiviCRM data;manage own search_kit</access_arguments>
   </item>
   <item>
     <path>civicrm/ajax/admin/search</path>
     <page_callback>CRM_Search_Page_AJAX</page_callback>
-    <access_arguments>administer CiviCRM data;administer search_kit</access_arguments>
+    <access_arguments>administer CiviCRM data;manage own search_kit</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
This is an extension to #32885 in that with the addition of `manage own search_kit` permission, this PR resets the base permission to access SearchKit by the new `manage own search_kit` permission. This follows along with #33358 in how we set the base permission for afform to be the new "manage own" permission as well.

With this change, you only need `access CiviCRM`, `access CiviCRM data`, and `manage own search_kit` in order to create and manage SearchKit. The limitation to only managing those SearchKit items that the user created is still in place. This PR is just to allow the base level of permissions to access and provide CRUD to a lower level user.

With this change, we don't need to rely on `all CiviCRM permissions and ACLs` anymore as we can just check between `administer search_kit` and `manage own search_kit`