### PR TITLE
Api4 - Fix DAO fields_callback handling of default value

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/DAOFieldsCallbackAdapterSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/DAOFieldsCallbackAdapterSpecProvider.php
@@ -104,7 +104,8 @@ class DAOFieldsCallbackAdapterSpecProvider extends \Civi\Core\Service\AutoServic
     if (isset($data['usage'])) {
       $field->setUsage(array_keys(array_filter($data['usage'])));
     }
-    if ($hasDefault) {
+    // Per SpecGatherer::getSpec — default value only makes sense for create actions
+    if ($hasDefault && $spec->getAction() === 'create') {
       $field->setDefaultValue(FormattingUtil::convertDataType($data['default'], $dataTypeName));
     }
     $field->setSerialize($data['serialize'] ?? NULL);

--- a/tests/phpunit/api/v4/Action/FieldsCallbackTest.php
+++ b/tests/phpunit/api/v4/Action/FieldsCallbackTest.php
@@ -56,6 +56,9 @@ class FieldsCallbackTest extends Api4TestBase {
     // Check modified fields
     $this->assertEquals('Test ID Title', $getFields['id']['title']);
     $this->assertTrue($getFields['email']['readonly']);
+    $this->assertEquals('Test Primary Title', $getFields['is_primary']['title']);
+    // Default should not have been affected simply by changing the title
+    $this->assertNull($getFields['is_primary']['default_value']);
   }
 
   /**
@@ -77,6 +80,7 @@ class FieldsCallbackTest extends Api4TestBase {
       ];
       // Test modifying some fields
       $fields['id']['title'] = 'Test ID Title';
+      $fields['is_primary']['title'] = 'Test Primary Title';
       $fields['email']['readonly'] = TRUE;
     };
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix to Api4's legacy fields_callback handling

Ensure default values are only set for 'create' actions per Api4 norms. Test added.
