### PR TITLE
EntityProvider - Add new 'civi.entity.fields' event

### DIFF
--- a/CRM/Core/DAO/Base.php
+++ b/CRM/Core/DAO/Base.php
@@ -14,12 +14,14 @@
  */
 abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
 
+  private static $_entityProviders = [];
+
   public function __construct() {
     parent::__construct();
     // Historically a generated DAO would have one class variable per field.
     // To prevent undefined property warnings, this dynamic DAO mimics that by
     // initializing the object with a property for each field.
-    foreach (static::getEntityDefinition()['getFields']() as $name => $field) {
+    foreach (static::getEntityProvider()->getFields() as $name => $field) {
       $this->$name = NULL;
     }
   }
@@ -29,7 +31,7 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
    */
   public function keys(): array {
     $keys = [];
-    foreach (static::getEntityDefinition()['getFields']() as $name => $field) {
+    foreach (static::getEntityProvider()->getFields() as $name => $field) {
       if (!empty($field['primary_key'])) {
         $keys[] = $name;
       }
@@ -38,65 +40,65 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
   }
 
   public static function getEntityTitle($plural = FALSE) {
-    $info = static::getEntityInfo();
-    return ($plural && isset($info['title_plural'])) ? $info['title_plural'] : $info['title'];
+    $entityProvider = static::getEntityProvider();
+    $title = $entityProvider->getMeta('title');
+    if ($plural) {
+      return $entityProvider->getMeta('title_plural') ?? $title;
+    }
+    return $title;
   }
 
   /**
    * @inheritDoc
    */
   public static function getEntityPaths(): array {
-    $definition = static::getEntityDefinition();
-    if (isset($definition['getPaths'])) {
-      return $definition['getPaths']();
-    }
-    return [];
+    return static::getEntityProvider()->getMeta('paths');
   }
 
   public static function getLabelField(): ?string {
-    return static::getEntityInfo()['label_field'] ?? NULL;
+    return static::getEntityProvider()->getMeta('label_field');
   }
 
   /**
    * @inheritDoc
    */
   public static function getEntityDescription(): ?string {
-    return static::getEntityInfo()['description'] ?? NULL;
+    return static::getEntityProvider()->getMeta('description');
   }
 
   /**
    * @inheritDoc
    */
   public static function getTableName() {
-    return static::getEntityDefinition()['table'];
+    return static::getEntityProvider()->getMeta('table');
   }
 
   /**
    * @inheritDoc
    */
   public function getLog(): bool {
-    return static::getEntityInfo()['log'] ?? FALSE;
+    return static::getEntityProvider()->getMeta('log');
   }
 
   /**
    * @inheritDoc
    */
   public static function getEntityIcon(string $entityName, ?int $entityId = NULL): ?string {
-    return static::getEntityInfo()['icon'] ?? NULL;
+    return static::getEntityProvider()->getMeta('icon');
   }
 
   /**
    * @inheritDoc
    */
   protected static function getTableAddVersion(): string {
-    return static::getEntityInfo()['add'] ?? '1.0';
+    return static::getEntityProvider()->getMeta('add') ?? '1.0';
   }
 
   /**
    * @inheritDoc
    */
   public static function getExtensionName(): ?string {
-    return static::getEntityDefinition()['module'];
+    return static::getEntityProvider()->getMeta('module');
   }
 
   /**
@@ -123,10 +125,10 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
 
   private static function loadSchemaFields(): array {
     $fields = [];
-    $entityDef = static::getEntityDefinition();
+    $entityProvider = static::getEntityProvider();
     $baoName = CRM_Core_DAO_AllCoreTables::getBAOClassName(static::class);
 
-    foreach ($entityDef['getFields']() as $fieldName => $fieldSpec) {
+    foreach ($entityProvider->getFields() as $fieldName => $fieldSpec) {
       $field = [
         'name' => $fieldName,
         'type' => !empty($fieldSpec['data_type']) ? \CRM_Utils_Type::getValidTypes()[$fieldSpec['data_type']] : CRM_Utils_Schema::getCrmTypeFromSqlType($fieldSpec['sql_type']),
@@ -165,7 +167,7 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
       if ($field['usage']['import']) {
         $field['import'] = TRUE;
       }
-      $field['where'] = $entityDef['table'] . '.' . $field['name'];
+      $field['where'] = $entityProvider->getMeta('table') . '.' . $field['name'];
       if ($field['usage']['export'] || (!$field['usage']['export'] && $field['usage']['import'])) {
         $field['export'] = $field['usage']['export'];
       }
@@ -181,8 +183,8 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
           $field['default'] = $fieldSpec['default'] ? '1' : '0';
         }
       }
-      $field['table_name'] = $entityDef['table'];
-      $field['entity'] = $entityDef['name'];
+      $field['table_name'] = $entityProvider->getMeta('table');
+      $field['entity'] = $entityProvider->getMeta('name');
       $field['bao'] = $baoName;
       $field['localizable'] = intval($fieldSpec['localizable'] ?? 0);
       if (!empty($fieldSpec['localize_context'])) {
@@ -237,11 +239,12 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
    * @inheritDoc
    */
   public static function indices(bool $localize = TRUE): array {
-    $definition = static::getEntityDefinition();
+    $entityProvider = static::getEntityProvider();
+    $entityIndices = $entityProvider->getMeta('indices');
     $indices = [];
-    if (isset($definition['getIndices'])) {
-      $fields = $definition['getFields']();
-      foreach ($definition['getIndices']() as $name => $info) {
+    if ($entityIndices) {
+      $fields = $entityProvider->getFields();
+      foreach ($entityIndices as $name => $info) {
         $index = [
           'name' => $name,
           'field' => [],
@@ -259,20 +262,17 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
         if (!empty($info['unique'])) {
           $index['unique'] = TRUE;
         }
-        $index['sig'] = ($definition['table']) . '::' . intval($info['unique'] ?? 0) . '::' . implode('::', $index['field']);
+        $index['sig'] = $entityProvider->getMeta('table') . '::' . intval($info['unique'] ?? 0) . '::' . implode('::', $index['field']);
         $indices[$name] = $index;
       }
     }
     return ($localize && $indices) ? CRM_Core_DAO_AllCoreTables::multilingualize(static::class, $indices) : $indices;
   }
 
-  private static function getEntityDefinition(): array {
+  private static function getEntityProvider(): \Civi\Schema\EntityProvider {
     $entityName = CRM_Core_DAO_AllCoreTables::getEntityNameForClass(static::class);
-    return \Civi\Schema\EntityRepository::getEntity($entityName);
-  }
-
-  private static function getEntityInfo(): array {
-    return static::getEntityDefinition()['getInfo']();
+    self::$_entityProviders[$entityName] ??= Civi::entity($entityName);
+    return self::$_entityProviders[$entityName];
   }
 
 }

--- a/CRM/Core/DAO/Base.php
+++ b/CRM/Core/DAO/Base.php
@@ -115,6 +115,7 @@ abstract class CRM_Core_DAO_Base extends CRM_Core_DAO {
   private static function getSchemaFields(): array {
     if (!isset(Civi::$statics[static::class]['fields'])) {
       Civi::$statics[static::class]['fields'] = static::loadSchemaFields();
+      // Note: `fields_callback` is now deprecated in favor of the `civi.entity.fields` event.
       CRM_Core_DAO_AllCoreTables::invoke(static::class, 'fields_callback', Civi::$statics[static::class]['fields']);
     }
     return Civi::$statics[static::class]['fields'];

--- a/Civi/Api4/Service/Spec/Provider/DAOFieldsCallbackAdapterSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/DAOFieldsCallbackAdapterSpecProvider.php
@@ -23,6 +23,8 @@ use Civi\Schema\EntityRepository;
 /**
  * Legacy adapter for the DAO `fields_callback` quasi-hook
  *
+ * Note: `fields_callback` is now deprecated in favor of the `civi.entity.fields` event.
+ *
  * @service
  * @internal
  */

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -31,19 +31,8 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     return EntityRepository::getEntity($this->entityName);
   }
 
-  public function getField(string $fieldName): ?array {
-    $field = $this->getFields()[$fieldName] ?? NULL;
-    // If not a core field, may be a custom field
-    if (!$field && str_contains($fieldName, '.')) {
-      [$customGroupName] = explode('.', $fieldName);
-      // Include disabled custom fields so that getOptions handles them consistently
-      $field = $this->getCustomFields(['name' => $customGroupName, 'is_active' => NULL])[$fieldName] ?? NULL;
-    }
-    return $field;
-  }
-
   public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array {
-    $field = $this->getField($fieldName);
+    $field = \Civi::entity($this->entityName)->getField($fieldName);
     $options = NULL;
     $hookParams = [
       'entity' => $this->entityName,

--- a/Civi/Schema/EntityMetadataInterface.php
+++ b/Civi/Schema/EntityMetadataInterface.php
@@ -19,8 +19,6 @@ interface EntityMetadataInterface {
 
   public function getCustomFields(array $customGroupFilters = []): array;
 
-  public function getField(string $fieldName): ?array;
-
   public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array;
 
 }

--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -59,7 +59,7 @@ final class EntityProvider {
    *   Ex: ['field_1' => ['title' => ..., 'sqlType' => ...]]
    */
   public function getSupportedFields(): array {
-    $fields = $this->getMetaProvider()->getFields();
+    $fields = $this->getFields();
     if ($this->getMeta('module') === 'civicrm') {
       // Exclude fields yet not added by pending upgrades
       $dbVer = \CRM_Core_BAO_Domain::version();
@@ -75,7 +75,14 @@ final class EntityProvider {
   }
 
   public function getField(string $fieldName): ?array {
-    return $this->getMetaProvider()->getField($fieldName);
+    $field = $this->getFields()[$fieldName] ?? NULL;
+    // If not a core field, may be a custom field
+    if (!$field && str_contains($fieldName, '.')) {
+      [$customGroupName] = explode('.', $fieldName);
+      // Include disabled custom fields so that getOptions handles them consistently
+      $field = $this->getCustomFields(['name' => $customGroupName, 'is_active' => NULL])[$fieldName] ?? NULL;
+    }
+    return $field;
   }
 
   public function getOptions(string $fieldName, array $values = [], bool $includeDisabled = FALSE, bool $checkPermissions = FALSE, ?int $userId = NULL, bool $isView = FALSE): ?array {

--- a/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
+++ b/tests/phpunit/CRM/Core/DAO/AllCoreTablesTest.php
@@ -39,6 +39,8 @@ class CRM_Core_DAO_AllCoreTablesTest extends CiviUnitTestCase {
   /**
    * Implements hook_civicrm_entityTypes().
    *
+   * Note: `fields_callback` is now deprecated in favor of the `civi.entity.fields` event.
+   * @deprecated
    * @see CRM_Utils_Hook::entityTypes()
    */
   public function _hook_civicrm_entityTypes(&$entityTypes) {

--- a/tests/phpunit/Civi/Schema/EntityTest.php
+++ b/tests/phpunit/Civi/Schema/EntityTest.php
@@ -2,7 +2,9 @@
 
 namespace Civi\Schema;
 
+use Civi\Api4\Activity;
 use Civi\Core\Event\GenericHookEvent;
+use CRM_Activity_BAO_Activity;
 
 class EntityTest extends \CiviUnitTestCase {
 
@@ -27,7 +29,12 @@ class EntityTest extends \CiviUnitTestCase {
     }
   }
 
-  public function testGetFields(): void {
+  /**
+   * Ensures getFields returns expected results and tests the `civi.entity.fields` listener.
+   *
+   * @return void
+   */
+  public function testGetFieldsWithHookAlterations(): void {
     $dispatcher = \Civi::service('dispatcher');
     $dispatcher->addListener('civi.entity.fields::Activity', [$this, 'onActivityFields']);
 
@@ -55,11 +62,41 @@ class EntityTest extends \CiviUnitTestCase {
     $this->assertSame('Altered ID Title', $fields['id']['title']);
     // Ensure it also works with getField
     $this->assertSame('Altered ID Title', $entity->getField('id')['title']);
+    // Test new field
+    $this->assertSame('New Field', $fields['new_field']['title']);
+
+    // Test with legacy DAO adapter
+    $baoFields = CRM_Activity_BAO_Activity::fields();
+    $this->assertSame('Altered ID Title', $baoFields['activity_id']['title']);
+    $this->assertSame('New Field', $baoFields['new_field']['title']);
+
+    // Test with Api4 getFields
+    $apiFields = Activity::getFields(FALSE)
+      ->execute()->indexBy('name');
+    // Test hook alterations
+    $this->assertSame('Altered ID Title', $apiFields['id']['title']);
+    // Test new field
+    $this->assertSame('New Field', $apiFields['new_field']['title']);
+    $this->assertSame('New fake field', $apiFields['new_field']['description']);
   }
 
   public function onActivityFields(GenericHookEvent $event): void {
     $this->assertSame('Activity', $event->entity);
+    // Alter existing field
     $event->fields['id']['title'] = 'Altered ID Title';
+
+    // Insert new field
+    $event->fields['new_field'] = [
+      'title' => 'New Field',
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Text',
+      'description' => 'New fake field',
+      'usage' => [
+        'import',
+        'export',
+        'duplicate_matching',
+      ],
+    ];
   }
 
 }

--- a/tests/phpunit/api/v4/Action/FieldsCallbackTest.php
+++ b/tests/phpunit/api/v4/Action/FieldsCallbackTest.php
@@ -24,6 +24,8 @@ use Civi\Api4\Email;
 
 /**
  * @group headless
+ * @deprecated
+ * Note: `fields_callback` is now deprecated in favor of the `civi.entity.fields` event.
  */
 class FieldsCallbackTest extends Api4TestBase {
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new EFv2 replacement for the legacy DAO `fields_callback` functions. Marks the latter as deprecated.