### PR TITLE
Afform: handle activity target/assignee ids submitted as comma-list

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -408,6 +408,25 @@ class Submit extends AbstractProcessor {
   }
 
   /**
+   * Handle multiple activity target/assignee ids submitted as comma-separated lists
+   *
+   * @param \Civi\Afform\Event\AfformSubmitEvent $event
+   */
+  public static function preprocessActivity(AfformSubmitEvent $event): void {
+    if ($event->getEntityType() !== 'Activity') {
+      return;
+    }
+    foreach ($event->records as $index => $activity) {
+      foreach (['target_contact_id', 'assignee_contact_id'] as $fieldName) {
+        $field = &$event->records[$index]['fields'][$fieldName];
+        if (isset($field) && !is_array($field)) {
+          $field = explode(',', $field);
+        }
+      }
+    }
+  }
+
+  /**
    * Check if contact(s) meet the minimum requirements to be created (name and/or email).
    *
    * This requires a function because simple required fields validation won't work

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -42,6 +42,7 @@ function afform_civicrm_config(&$config) {
   $dispatcher->addListener('civi.afform.validate', ['\Civi\Api4\Action\Afform\Submit', 'validateFieldInput'], 50);
   $dispatcher->addListener('civi.afform.validate', ['\Civi\Api4\Action\Afform\Submit', 'validateEntityRefFields'], 45);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processGenericEntity'], 0);
+  $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'preprocessActivity'], 10);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'preprocessContact'], 10);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'preprocessParentFormValues'], 100);
   $dispatcher->addListener('civi.afform.submit', ['\Civi\Api4\Action\Afform\Submit', 'processRelationships'], 1);


### PR DESCRIPTION
Overview
----------------------------------------
Allow afform field widgets to more gracefully handle the Activity `target_contact_id` and `assignee_contact_id` fields when multiple ids are passed to those fields through the URL. 

Before
----------------------------------------
Multiple `target_contact_id`s and `assignee_contact_id`s could be passed to a submission form through the URL in the format `target_contact_id=1,2,3`, but the values would only be saved (as ActivityContacts) if the "Autocomplete Contacts" widget was used. "Hidden" didn't work.

After
----------------------------------------
URL params like `target_contact_id=1,2,3` work with the Hidden widget type.

Technical Details
----------------------------------------
I don't love adding more lines to a class that's already over 700 lines. Seems bloat-y, like the function should live somewhere more Activity specific. But anyway this works.