### PR TITLE
FormBuilder: render display-only entityref fields client-side

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -313,7 +313,26 @@
           }
         }
         if (ctrl.defn.fk_entity) {
-          // TODO: EntityRef fields
+          // EntityRef fields: fetch label via API if not already present
+          // This is async, so we return a placeholder and update later
+          let entity = ctrl.fkEntity || ctrl.defn.fk_entity;
+          let fieldName = ctrl.fieldName || ctrl.defn.name;
+          let id = Array.isArray(value) ? value[0] : value;
+          if (!id) return '';
+          // If we already have a cached label, use it
+          if (!$scope._entityLabels) $scope._entityLabels = {};
+          if ($scope._entityLabels[id]) return $scope._entityLabels[id];
+          // Otherwise, fetch label
+          crmApi4(entity, 'autocomplete', {
+            ids: [value],
+            fieldName: fieldName,
+          })
+          .then(function(result) {
+            if (result && result.length) {
+              $scope._entityLabels[id] = result[0]['label'];
+            }
+          });
+          return ts('Loading...');
         }
         return value;
       };

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -297,7 +297,7 @@
       };
 
       ctrl.getDisplayValue = function(value) {
-        if (value === undefined || value === null || value === '') {
+        if (value === undefined || value === null || value === '' || (Array.isArray(value) && !value.length)) {
           return '';
         }
         if (fieldOptions) {
@@ -312,27 +312,25 @@
             return '';
           }
         }
-        if (ctrl.defn.fk_entity) {
+        if (ctrl.fkEntity) {
           // EntityRef fields: fetch label via API if not already present
           // This is async, so we return a placeholder and update later
-          let entity = ctrl.fkEntity || ctrl.defn.fk_entity;
-          let fieldName = ctrl.fieldName || ctrl.defn.name;
-          let id = Array.isArray(value) ? value[0] : value;
-          if (!id) return '';
-          // If we already have a cached label, use it
-          if (!$scope._entityLabels) $scope._entityLabels = {};
-          if ($scope._entityLabels[id]) return $scope._entityLabels[id];
-          // Otherwise, fetch label
-          crmApi4(entity, 'autocomplete', {
-            ids: [value],
-            fieldName: fieldName,
-          })
-          .then(function(result) {
-            if (result && result.length) {
-              $scope._entityLabels[id] = result[0]['label'];
-            }
-          });
-          return ts('Loading...');
+          const ids = Array.isArray(value) ? value : [value];
+          if (!ctrl._entityLabels) {
+            ctrl._entityLabels = {};
+          }
+          // Call autocomplete api
+          if (!(ids.join() in ctrl._entityLabels)) {
+            ctrl._entityLabels[ids.join()] = null;
+            const params = ctrl.getAutocompleteParams();
+            params.ids = ids;
+            crmApi4(ctrl.fkEntity, 'autocomplete', params)
+              .then(function(result) {
+                // Join all labels
+                ctrl._entityLabels[ids.join()] = result.map((item) => item.label).join(', ');
+              });
+          }
+          return ctrl._entityLabels[ids.join()] || ts('Loading...');
         }
         return value;
       };


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/5424 regressed in Civi 6.3, when "Display Only" fields were shifted to be rendered client-side (https://github.com/civicrm/civicrm-core/pull/31462).  There was a TODO to fix EntityRef fields so it's a known issue, but caught me off-guard.

Before
----------------------------------------
Display Only entityref fields show the primary key of the entity.

After
----------------------------------------
Display Only entityref fields resolve the correct name/label of the entity, same as if the field wasn't display-only.

Comments
----------------------------------------
Placing this against the RC because it's a recent regression.

Parts of this PR were written by AI since async makes my head hurt.  I cleaned it up a bunch but I don't want to waste reviewers' time wondering why something is the way it is.

To replicate this issue, replicate the form screenshotted below. Those fields are all display-only.  Accept IDs from the URL for both membership and participant, then load the form, using IDs in the URL for both membership and participant.
<img width="977" height="825" alt="Selection_2603" src="https://github.com/user-attachments/assets/a0788f96-d605-4cd2-ab6c-c95e379b83e3" />