### PR TITLE
Payment Processor - Admin screen quietly copies live credentials to testing

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -420,11 +420,16 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
    * @throws \CRM_Core_Exception
    */
   public function updatePaymentProcessor($values, $domainID, $test) {
-    if ($test) {
-      foreach (['user_name', 'password', 'signature', 'url_site', 'url_recur', 'url_api', 'url_button', 'subject'] as $field) {
-        $values[$field] = empty($values["test_{$field}"]) ? ($values[$field] ?? NULL) : $values["test_{$field}"];
+    // The $values array has mixed the fields for two different entities (eg "user_name"/"password" and "test_user_name"/"test_password").
+    //  We are going to call APIv4 PaymentProcessor.save() for -one- side only (live XOR test). Get the APIv4 fields we need.
+    $dualFields = ['user_name', 'password', 'signature', 'url_site', 'url_recur', 'url_api', 'url_button', 'subject'];
+    foreach ($dualFields as $field) {
+      if ($test) {
+        $values[$field] = $values["test_$field"];
       }
+      unset($values["test_$field"]);
     }
+
     if (!empty($values['accept_credit_cards'])) {
       $creditCards = [];
       $accptedCards = array_keys($values['accept_credit_cards']);


### PR DESCRIPTION
Overview
--------

Fix a weird behavior in managing the "Payment Processor" records, where the "Live" credentials are quietly copied for use as "Test" credentials.

Steps to Reproduce
------------------

* Navigate to "Admin > System > Payment Processors"
* Create a new "Payment Processor" of any kind (or edit an existing one)
* Set the live "User Name" to "Bob".
* Set the test "User Name" to "" (blank).
* Save.
* Edit the payment-processor again.
* Observe: What is the test "User Name"?

Before
-------

Any blank value in the "Test" section is autofilled with data from the "Live" section.

After
-----

Live is live, and test is test, and ne'er the twain shall meet.

Comments
---------

Why does the form do this?  I traced the code to https://issues.civicrm.org/jira/browse/CRM-18061 (circa 4.7.3=>4.7.4; d8a74d68c37369d8ebb785d9f0baab98b93ea4c1 and be7255003d221f398723679fbaf90dc6ad53b445), which attempted to fix a different save-bug on these fields.  This looks like an unintended regression.

And it shouldn't be intentional -- that would be kinda crazy.  The manifest purpose of a test payment is to _not_ send a live payment. With this bug, CiviCRM's test payments would (by default) be sent for live execution.

There are mitigating factors, so it's not quite that crazy -- e.g. it only applies if your "Test" field is blank. And for PayPal, several test fields ("Site URL", "API URL", etc) are prefilled with test-values. The outcomes may differ for each payment processor. But even in the best case, it's quite confusing to copy this data. (And in the worst-case, your executing real-but-unwanted transactions.)