### PR TITLE
[REF] - Switch the switch to match

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -69,35 +69,23 @@ abstract class CRM_Utils_System_Base {
    * @var int|string $print
    *   Should match a CRM_Core_Smarty::PRINT_* constant,
    *   or equal 0 if not in print mode.
-   *
-   * @todo when php7.4 is no more, switch the `switch` to a `match`
    */
   public static function getContentTemplate($print = 0): string {
     // I fear some callers of this function may still pass FALSE
     // let's make sure any falsey value is exactly 0
     $print = $print ?: 0;
 
-    // switch uses lazy type comparison
-    // on php < 8 this causes strange results when comparing
-    // string like 'json' with integer 0
-    // so we use this workaround
-    switch (TRUE) {
-      case ($print === 0):
-        // Not a print context.
-        // Despite what the template is called
-        return 'CRM/common/CMSPrint.tpl';
+    return match($print) {
+      // Not a print context (despite what the template is called)
+      0 => 'CRM/common/CMSPrint.tpl',
 
-      case ($print === CRM_Core_Smarty::PRINT_PAGE):
-        return 'CRM/common/print.tpl';
+      CRM_Core_Smarty::PRINT_PAGE => 'CRM/common/print.tpl',
 
-      case ($print === 'xls'):
-      case ($print === 'doc'):
-        return 'CRM/Contact/Form/Task/Excel.tpl';
+      'xls', 'doc' => 'CRM/Contact/Form/Task/Excel.tpl',
 
-      case ($print === CRM_Core_Smarty::PRINT_JSON):
-      default:
-        return 'CRM/common/snippet.tpl';
-    }
+      // Ex: CRM_Core_Smarty::PRINT_JSON
+      default => 'CRM/common/snippet.tpl',
+    };
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Per code comment, this does the TODO and changes to a PHP8-only language construct.

Technical Details
--------
We switched our minimum version of PHP to 8.0 [in Civi 6.0](https://github.com/civicrm/civicrm-core/pull/31765), however it was a soft-ish requirement, with a system check and a [blog post](https://civicrm.org/blog/eileen/php-74-going-end-life-php-84-ramping) nudging people to upgrade ASAP, but no hard fail.

This change will most certainly cause a hard fail 💣. Are we ready for that?