### PR TITLE
Standalone - WIP favicon setting

### DIFF
--- a/ext/standaloneusers/settings/standaloneusers.setting.php
+++ b/ext/standaloneusers/settings/standaloneusers.setting.php
@@ -30,4 +30,15 @@ return [
     ],
     'pseudoconstant' => ['callback' => '\\Civi\\Standalone\\MFA\\Base::getMFAclasses'],
   ],
+  'standalone_favicon' => [
+    'name' => 'standalone_favicon',
+    'group' => 'standaloneusers',
+    'type' => 'String',
+    'title' => ts('Site Favicon'),
+    'description' => ts('URL to a favicon for the site.'),
+    'default' => '',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'html_type' => 'text',
+  ],
 ];

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -3,7 +3,8 @@
  <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" type="image/png" href="{$config->resourceBase}i/logo_lg.png" >
+   {crmSetting var="favicon" name="standalone_favicon"}
+  <link rel="icon" type="image/png" href="{if $favicon}{$favicon}{else}{$config->resourceBase}i/logo_lg.png{/if}" >
 
   {crmRegion name='html-header'}
   {/crmRegion}


### PR DESCRIPTION
Overview
----------------------------------------
Draft/POC for a configurable favicon on standalone. It works but...

<img width="2486" height="952" alt="image" src="https://github.com/user-attachments/assets/2c585ecb-c1b3-4a7c-a235-0bd8e88edd68" />


Questions
----------
1. "Login settings" doesn't seem like the right settings screen for this. OTOH the settings screen ambiguously has 2 names (the menu item is "Login settings" but the page title is "Standalone Users Settings"). So maybe we could change them both to a) match and b) encompass this setting too, like "Website Configuration".
2. I don't think this field should be a text input, that was just easiest for POC. Ought to be a file upload.
3. I don't think there *is* a file upload field type for settings screens. So... that's fun.
4. Ought the setting store the file id instead of the url? I guess there's pros and cons to that. It would make the simple `{crmSetting}` lookup in the tpl a little more tricky, but it would be more portable.