### PR TITLE
SearchKit - Fix inline-edit when using groupBy

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -139,7 +139,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    */
   protected function formatResult(iterable $result): array {
     $rows = [];
-    $keyName = CoreUtil::getIdFieldName($this->savedSearch['api_entity']);
+    $keyName = $this->getRowKeyName();
     if ($this->savedSearch['api_entity'] === 'RelationshipCache') {
       $keyName = 'relationship_id';
     }
@@ -1847,6 +1847,20 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       }
     }
     return $values;
+  }
+
+  protected function getRowKeyName(): string {
+    // If grouping by a primary key, use that field
+    $groupBy = $this->savedSearch['api_params']['groupBy'] ?? [];
+    foreach ($groupBy as $fieldName) {
+      $field = $this->getField($fieldName);
+      if ($field && (CoreUtil::getIdFieldName($field['entity']) === $field['name'])) {
+        return $fieldName;
+      }
+    }
+    // Use primary key of main entity
+    $entityName = $this->savedSearch['api_entity'];
+    return CoreUtil::getIdFieldName($entityName);
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
@@ -61,7 +61,7 @@ class InlineEdit extends Run {
   public function updateExistingRow(): void {
     // Apply rowKey to filters
     $entityName = $this->savedSearch['api_entity'];
-    $keyName = $filterKey = CoreUtil::getIdFieldName($entityName);
+    $keyName = $filterKey = $this->getRowKeyName();
     // Hack to support relationships
     if ($entityName === 'RelationshipCache') {
       $filterKey = 'relationship_id';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes issue [dev/core#6048](https://lab.civicrm.org/dev/core/-/issues/6048): "If you create a SearchKit which selects Contacts and joins Activity Contacts, then group by Activity ID, in-place editing of Activity fields fails with "Cannot create new item in search display"."

Technical Details
----------------------------------------
When grouping on the id of a joined entity, that effectively becomes the primary key for the row, and switching to that as the row_key allows inline-edit to work.

Todo: deal with the relationshipCache hacks