### PR TITLE
RiverLea: datepicker inactive dates, fix alignment & dark-mode contrast

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -758,6 +758,11 @@ input.crm-form-checkbox) + label {
   opacity: 1;
   padding: var(--crm-s);
 }
+#ui-datepicker-div .ui-state-default,
+#ui-datepicker-div .ui-widget-content .ui-state-default {
+  color: var(--crm-c-text);
+  text-align: center;
+}
 #ui-datepicker-div .ui-datepicker-calendar .ui-state-disabled {
   opacity: 0.35;
 }


### PR DESCRIPTION
Overview
----------------------------------------
While making the screen-caps for https://github.com/civicrm/civicrm-core/pull/33455 I noticed than none of the inactive dates (e.g. future dates) were visible. They also aren't centered in either light or dark mode, and the text colour is set by Jquery (`#555`) so doesn't respond to any Stream settings. This fixes that on all Streams.

Before
----------------------------------------
<img width="366" height="321" alt="image" src="https://github.com/user-attachments/assets/653a2203-db85-4dbb-a9e8-596b7603ea07" />
<img width="371" height="325" alt="image" src="https://github.com/user-attachments/assets/8433558f-4dad-4df2-8c96-a4bb0aead67b" />

After
----------------------------------------
<img width="372" height="330" alt="image" src="https://github.com/user-attachments/assets/7cce01db-bda8-42a9-9b68-af155e5b4200" />
<img width="374" height="331" alt="image" src="https://github.com/user-attachments/assets/d59efc02-37bc-41d9-83c7-abe12b27f9ed" />