### PR TITLE
Prevent CiviCRM upgrade routine interfering with non-CiviCRM permissions on Joomla

### DIFF
--- a/CRM/Core/Permission/Joomla.php
+++ b/CRM/Core/Permission/Joomla.php
@@ -21,6 +21,12 @@
 class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
 
   /**
+   * The prefix for CiviCRM-related permissions in Joomla, when
+   * saving into the `#__assets` table for example.
+   */
+  const CIVICRM_PERMISSION_PREFIX = 'civicrm.';
+
+  /**
    * Given a permission string, check for access requirements
    *
    * @param string $str
@@ -117,7 +123,7 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
         return CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
 
       case NULL:
-        return ['civicrm.' . CRM_Utils_String::munge(strtolower($name)), 'com_civicrm'];
+        return [self::CIVICRM_PERMISSION_PREFIX . CRM_Utils_String::munge(strtolower($name)), 'com_civicrm'];
 
       default:
         return CRM_Core_Permission::ALWAYS_DENY_PERMISSION;
@@ -154,7 +160,7 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
     $associations = $this->getUserGroupPermsAssociations();
     $cmsPermsHaveGoneStale = FALSE;
     foreach (array_keys(get_object_vars($associations)) as $permName) {
-      if (!in_array($permName, $translatedPerms)) {
+      if (str_starts_with($permName, self::CIVICRM_PERMISSION_PREFIX) && !in_array($permName, $translatedPerms)) {
         unset($associations->$permName);
         $cmsPermsHaveGoneStale = TRUE;
       }


### PR DESCRIPTION
Overview
----------------------------------------
This is a proposed fix for part 1 of [core#3711](https://lab.civicrm.org/dev/core/-/issues/3711), where every time the cache is rebuilt on CiviCRM, the user permission to "See CiviCRM is installed" is reset for all users.

Before
----------------------------------------
Permissions configured as follows:

| See CiviCRM is installed = Allowed | CiviCRM visible in main menu |
|--------|--------|
| <img width="1058" height="459" alt="Screenshot 2025-08-25 131038" src="https://github.com/user-attachments/assets/ff22ee86-5d6e-49f2-b49b-12149172f5de" /> | <img width="285" height="405" alt="Screenshot 2025-08-25 131113" src="https://github.com/user-attachments/assets/c5f12a11-53f8-44fe-aaf5-56511ccf7c3e" /> | 

Then do **Administer > System Settings > Clear Caches**.

Permissions have been erroneously reset as follows:

| See CiviCRM is installed = Not Allowed (Inherited) | CiviCRM not visible in main menu |
|--------|--------|
| <img width="1057" height="456" alt="Screenshot 2025-08-25 131234" src="https://github.com/user-attachments/assets/a88a8ae0-236a-4285-a53f-b3cd7e4f3228" /> | <img width="287" height="358" alt="Screenshot 2025-08-25 131259" src="https://github.com/user-attachments/assets/b66a04f6-a3f5-45f8-9a05-a027bdcdc91b" /> |

This is because the `core.manage` permission has been removed from the `rules` of the `com_civicrm` entry in the Joomla `#__assets` table:

<img width="1786" height="538" alt="image" src="https://github.com/user-attachments/assets/173437cd-3ce6-43c8-b5ad-9e1ab4a5d592" />

After
----------------------------------------
Set up permissions as before.

Then do **Administer > System Settings > Clear Caches**.

Joomla permissions are no longer affected:

| See CiviCRM is installed = Allowed | CiviCRM visible in main menu |
|--------|--------|
| <img width="1058" height="459" alt="Screenshot 2025-08-25 131038" src="https://github.com/user-attachments/assets/ff22ee86-5d6e-49f2-b49b-12149172f5de" /> | <img width="285" height="405" alt="Screenshot 2025-08-25 131113" src="https://github.com/user-attachments/assets/c5f12a11-53f8-44fe-aaf5-56511ccf7c3e" /> | 

Entry in `#__assets` remains correct.

Technical Details
----------------------------------------
This change works by filtering the action in `CRM_Core_Permission_Joomla::upgradePermissions()` to only remove permissions where the name begins with `'civicrm.'`. This is on the basis that CiviCRM should not be touching other permissions!

Tested and working on CiviCRM 6.2.0 and Joomla 4.4.13.

Comments
----------------------------------------
Includes factoring out of the string prefix to a class constant, because it is shared with `translateJoomlaPermission()`.
