### PR TITLE
Afform: Fix multivalued hidden fields

### DIFF
--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -228,7 +228,7 @@ class FormDataModel {
     if ($action === 'get' && strpos($fieldName, '.')) {
       $namesToMatch[] = substr($fieldName, 0, strrpos($fieldName, '.'));
     }
-    $select = ['name', 'label', 'input_type', 'data_type', 'input_attrs', 'help_pre', 'help_post', 'options', 'fk_entity', 'required', 'dfk_entities'];
+    $select = ['name', 'label', 'input_type', 'data_type', 'input_attrs', 'help_pre', 'help_post', 'options', 'fk_entity', 'required', 'dfk_entities', 'serialize'];
     if ($action === 'get') {
       $select[] = 'operators';
     }

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -224,7 +224,8 @@
       this.isMultiple = function() {
         return (
           (['Select', 'EntityRef', 'ChainSelect'].includes(ctrl.defn.input_type) && ctrl.defn.input_attrs.multiple) ||
-          (ctrl.defn.input_type === 'CheckBox' && ctrl.defn.data_type !== 'Boolean')
+          (ctrl.defn.input_type === 'CheckBox' && ctrl.defn.data_type !== 'Boolean') ||
+          ((ctrl.defn.input_type === 'Hidden' || ctrl.defn.input_type === 'DisplayOnly') && (ctrl.defn.serialize || ctrl.defn.data_type === 'Array'))
         );
       };
 

--- a/ext/afform/core/ang/af/fields/Hidden.html
+++ b/ext/afform/core/ang/af/fields/Hidden.html
@@ -1,1 +1,2 @@
-<input type="hidden" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" >
+<input ng-if=":: !$ctrl.isMultiple()" type="hidden" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" >
+<input ng-if=":: $ctrl.isMultiple()" type="hidden" id="{{:: fieldId }}" ng-model="getSetValue" ng-model-options="{getterSetter: true}" ng-list >


### PR DESCRIPTION
Overview
----------------------------------------
Hidden multi-valued fields (e.g. Activity `target_contact_id` and `assignee_contact_id`) will now save correctly if passed multiple values in the URL.

Replaces #33448