### PR TITLE
ensure we show unique contacts on survey interview page

### DIFF
--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -123,7 +123,7 @@ class CRM_Campaign_Form_Task_Interview extends CRM_Campaign_Form_Task {
     if (!empty($this->_contactIds) && $orderClause) {
       $clause = 'contact_a.id IN ( ' . implode(',', $this->_contactIds) . ' ) ';
       $sql = "
-SELECT contact_a.id
+SELECT DISTINCT(contact_a.id)
 FROM civicrm_contact contact_a
 LEFT JOIN civicrm_address ON contact_a.id = civicrm_address.contact_id
 WHERE {$clause}


### PR DESCRIPTION
Overview
----------------------------------------
When interviewing respondents via CiviCampaign, each respondent shows up twice when they should only show up once.

Before
----------------------------------------

If you create a survey, reserve contacts to call and then start the interview process, you end up with duplicate contacts on the interview page:

<img width="1626" height="632" alt="image" src="https://github.com/user-attachments/assets/1664b920-5f34-4564-baec-5353a887be51" />


After
----------------------------------------
By ensuring we only return distinct contacts, we only see one contact:

<img width="1626" height="508" alt="image" src="https://github.com/user-attachments/assets/6ab656ae-0d2a-4461-88cc-522cc2f59233" />

Technical Details
----------------------------------------
We carefully call `array_unique` before the query, so adding `DISTINCT` to the query seems like a reasonable step.


