### PR TITLE
Afform: Fix admin links to properly check permissions

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -176,12 +176,6 @@ function _afform_hook_civicrm_angularModules($e) {
       'exports' => [
         $afform['directive_name'] => 'E',
       ],
-      // Permissions needed for conditionally displaying edit-links
-      'permissions' => [
-        'manage own afform',
-        'administer search_kit',
-        'all CiviCRM permissions and ACLs',
-      ],
     ];
   }
 

--- a/ext/afform/core/ang/afCore.ang.php
+++ b/ext/afform/core/ang/afCore.ang.php
@@ -10,4 +10,13 @@ return [
   'requires' => ['crmUi', 'crmUtil', 'api4', 'checklist-model', 'angularFileUpload', 'ngSanitize'],
   'partials' => ['ang/afCore'],
   'basePages' => [],
+  // Permissions needed for conditionally displaying edit-links
+  // See: \Civi\AfformAdmin\AfformAdminInjector and afCoreDirective.checkLinkPerm
+  'permissions' => [
+    'administer afform',
+    'manage own afform',
+    'administer search_kit',
+    'manage own search_kit',
+    'all CiviCRM permissions and ACLs',
+  ],
 ];

--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -16,7 +16,6 @@
           $scope.crmStatus = crmStatus;
           $scope.crmUiAlert = crmUiAlert;
           $scope.crmUrl = CRM.url;
-          $scope.checkPerm = CRM.checkPerm;
 
           $el.addClass('afform-directive');
 
@@ -45,6 +44,15 @@
           $scope.addTitle = function(addition) {
             $scope.$parent.afformTitle = addition + ' ' + meta.title;
           };
+
+          $scope.checkLinkPerm = function(permissionName, createdId) {
+            // Convert 'manage own [afform|search_kit]' to 'administer [afform|search_kit]' if created_id doesn't match current user
+            if (permissionName.startsWith('manage own') && CRM.config.cid !== createdId) {
+              permissionName = permissionName.replace('manage own', 'administer');
+            }
+            return CRM.checkPerm(permissionName);
+          };
+
         }
       };
       return d;


### PR DESCRIPTION
Overview
----------------------------------------
Ensures both 'manage own' and 'administer' permissions will work as expected so that admin links show correctly (the little gear icon when viewing an Afform as a user).

Technical Details
----------------------------------------
This follows the addition of new 'manage own search_kit' and 'manage own afform' permissions & ensures they get checked correctly when showing admin links to users.