### PR TITLE
Afform - Add link to view results

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -32,6 +32,9 @@ class AfformAdminInjector extends AutoSubscriber {
 
   /**
    * @param \Civi\Core\Event\GenericHookEvent $e
+   *
+   * This injects static html to render a small admin-only menu at the top corner of each form.
+   * Permissions are checked client-side.
    * @see afCoreDirective.checkLinkPerm
    */
   public static function preprocess($e) {
@@ -41,7 +44,7 @@ class AfformAdminInjector extends AutoSubscriber {
           // Inject gear menu with edit links which will be shown if the user has permission
           $afform = Afform::get(FALSE)
             ->addWhere('module_name', '=', basename($path, '.aff.html'))
-            ->addSelect('name', 'search_displays', 'title', 'created_id')
+            ->addSelect('name', 'search_displays', 'title', 'created_id', 'type', 'create_submission')
             ->execute()->single();
           // Create a link to edit the form, plus all embedded SavedSearches
           $links = [
@@ -53,6 +56,15 @@ class AfformAdminInjector extends AutoSubscriber {
               'created_id' => $afform['created_id'] ?: 'null',
             ],
           ];
+          if ($afform['type'] === 'form' && $afform['create_submission']) {
+            $links[] = [
+              'url' => \CRM_Utils_System::url('civicrm/admin/afform/submissions', NULL, FALSE, "/?name={$afform['name']}", TRUE, FALSE, TRUE),
+              'text' => E::ts('View Submissions'),
+              'icon' => 'fa-list',
+              'permission' => 'manage own afform',
+              'created_id' => $afform['created_id'] ?: 'null',
+            ];
+          }
           if ($afform['search_displays']) {
             $searchNames = [];
             foreach ($afform['search_displays'] as $searchAndDisplayName) {


### PR DESCRIPTION
Overview
----------------------------------------
Adds an item to the little gear menu floating above Afforms to view the submission results:

<img width="724" height="284" alt="image" src="https://github.com/user-attachments/assets/f2322872-65a3-4e37-9e3a-2f0413e0db80" />
