### PR TITLE
RiverLea: Joomla bugs: bootstrap secondary bg + sticky header offset

### DIFF
--- a/ext/riverlea/core/css/joomla.css
+++ b/ext/riverlea/core/css/joomla.css
@@ -45,7 +45,7 @@ body.admin.com_civicrm .modal-dialog {
   pointer-events: all;
 }
 
-/* Joomla 4 - body.com_civicrm.layout-default */
+/* Joomla - body.com_civicrm.layout-default */
 
 body.admin.com_civicrm.layout-default {
   --crm-page-padding: 1rem;
@@ -72,4 +72,10 @@ body.com_civicm.layout-default .table tbody a:not(.badge):not(.btn):not(.dropdow
 }
 .table tbody a:not(.badge):not(.btn):not(.dropdown-item) {
   text-decoration: none; /* Reset theme */
+}
+body.com_civicm #bootstrap-theme .bg-secondary {
+  background-color: var(--crm-c-secondary) !important; /* vs !important bg colour in Atum theme */
+}
+body.com_civicrm.layout-default table .crm-sticky-header {
+  --crm-menubar-bottom: 0;
 }


### PR DESCRIPTION
Fixes two Joomla UI bugs in J4.

Before
----------------------------------------

1. `bg-secondary`'s colour is set by Joomla's admin theme with an `!important` declaration, overriding RiverLea

<img width="198" height="192" alt="image" src="https://github.com/user-attachments/assets/d497b0ab-3f15-4b1e-b043-188f9ddfd4c6" />

2. the Sticky header on tables has a 106px offset, via a variable set on `--crm-menubar-bottom`.

<img width="1481" height="213" alt="image" src="https://github.com/user-attachments/assets/f48b3291-f3cd-4bec-84c4-461c9d25c4df" />

After
----------------------------------------
1. `bg-secondary` colour follows the theme/stream

<img width="194" height="163" alt="image" src="https://github.com/user-attachments/assets/c462dfad-4300-4f5d-abda-4e067d995106" />

3. sticky header is flush with the top of the viewport.

<img width="1367" height="159" alt="image" src="https://github.com/user-attachments/assets/8021bdfb-9f5a-4626-809c-fefad19092b5" />

Technical Details
----------------------------------------
Tested against J4 - J5 users might want to test this change. For testing both together at the same time - the SearchKit display for Contribution pages shows both these problems.