### PR TITLE
RiverLea: SearchKit display - centre aligns table cells with multiple buttons

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -22,18 +22,9 @@ table.crm-sticky-header > thead > tr {
 }
 
 /* Afform tables */
-.crm-container td.crm-search-col-type-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--crm-s);
-}
-.crm-container td.crm-search-col-type-buttons:has(span:only-child),
-.crm-container td.crm-search-col-type-buttons:has(> .btn:only-child) {
-  /* when button column has only one button, turn cell back to table cell to vertically center */
-  display: table-cell;
-}
-td.crm-search-col-type-buttons.text-right {
-  justify-content: end;
+#bootstrap-theme td.crm-search-col-type-buttons {
+  padding: var(--crm-table-padding) calc(var(--crm-table-padding) - var(--crm-s)) calc(var(--crm-table-padding) - var(--crm-s)) var(--crm-table-padding);
+  --crm-btn-margin: 0 var(--crm-s) var(--crm-s) 0;
 }
 #bootstrap-theme th.crm-search-result-select button.btn {
   background: transparent;


### PR DESCRIPTION
Overview
----------------------------------------
To create padding between buttons in Searchkit tables with multiple buttons, RiverLea turned `td.crm-search-col-type-buttons` into a flex display with wrap and padding (`--crm-s`). But this breaks centre alignment of the cell contents, which looks a bit messy.

A fix needs to support three base scenarios - one button, 2+ buttons in a line, 2+ buttons wrapping - when the row is taller than the buttons (ie three lines tall) and the column is shrunk to the width of the button (ie 6/9 scenarios). In all these scenarios there needs to be padding between buttons, the centre alignment of buttons needs to ignore any bottom margin.

This fix covers all of these scenarios by adding right and bottom margin to all buttons in the cell, while removing the same right and bottom padding from the cell, which is reverted to a table-cell.

Before
----------------------------------------

Two columns - one with two buttons, one with one

<img width="296" height="169" alt="image" src="https://github.com/user-attachments/assets/45e56f90-fcd5-4d92-88f0-919a4214a50a" />

Wrapped version

<img width="234" height="225" alt="image" src="https://github.com/user-attachments/assets/716eb5d6-335f-4d2f-9633-0270482690bc" />

After
----------------------------------------

Two columns - one with two buttons, one with one

<img width="318" height="201" alt="image" src="https://github.com/user-attachments/assets/d507e20c-69a7-4bda-a089-f239e775a6ad" />

Wrapped version

<img width="288" height="191" alt="image" src="https://github.com/user-attachments/assets/c9230c89-35f4-47e2-803e-661d28eac3f8" />

Comments
----------------------------------------
For reasons I don't understand `display: table-cell` adds a tiny bit of padding/width to the right of these spans that wrap the button. So there's a bit of extra space between the buttons than before. But I'm assuming this is a browser rendering issue, so not worth compensating against as it probably varies.

NB - this pattern of tables with multiple buttons is used quite widely, and it's impossible to test all instances as it's SK output, but worth trying a few variations.