### PR TITLE
Payment Processors - Fix Smarty warning. Allow deactivation of `accept_credit_cards`.

### DIFF
--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -46,10 +46,12 @@
     <tr class="crm-paymentProcessor-form-block-is_default">
         <td></td><td>{$form.is_default.html}&nbsp;{$form.is_default.label}</td>
     </tr>
+    {if !empty($form.accept_credit_cards)}
     <tr class="crm-paymentProcessor-form-block-accept_credit_cards">
         <td class="label">{$form.accept_credit_cards.label}</td><td>{$form.accept_credit_cards.html}<br />
         <span class="description">{ts}Select Credit Card Types that this payment processor can accept{/ts}</span></td>
     </tr>
+    {/if}
   </table>
 <fieldset>
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>


### PR DESCRIPTION
Overview
----------------------------------------

When editing a "Payment Processor" for Stripe (with Smarty 5 on Standalone), one sees a large warning. This fixes the warning by extending the technique of #18324 (cc @mattwire @seamuslee001). 

Before
----------------------------------------

<img width="995" height="440" alt="image" src="https://github.com/user-attachments/assets/13a53c49-9acf-4d58-99bc-04d96759c247" />

After
----------------------------------------

<img width="995" height="440" alt="image" src="https://github.com/user-attachments/assets/1cab8815-252f-45c7-b26b-04abd4400c60" />


Technical Details
----------------------------------------

This arises because Stripe [opts out of using `accept_credit_cards`](https://lab.civicrm.org/extensions/stripe/-/blob/6.12.0/stripe.php?ref_type=tags#L63). Curiously, the description of #18324 actually mentioned that this field would be disabled -- but the corresponding guard didn't appear in the code. This feels like an oversight.

From my POV, I don't really have an opinion whether the opt-out should be done with Quickform's `removeElement()` or with jQuery's `hide()`...

```php
CRM_Core_Region::instance('page-footer')->addScript('
  CRM.$(".crm-paymentProcessor-form-block-accept_credit_cards").hide();
');
```

Either technique can fix the warning. Maybe it makes more of a difference for the other fields. In any case, it seems better if the various fields (`accept_credit_cards`, `url_set`, `url_recur`, etc) follow the same technique.