### PR TITLE
Multiple issues with custom-field radio/checkboxes - dev/core/-/issues/6039

### DIFF
--- a/CRM/Core/QuickForm/AdvCheckBoxWithDiv.php
+++ b/CRM/Core/QuickForm/AdvCheckBoxWithDiv.php
@@ -29,10 +29,7 @@ class CRM_Core_QuickForm_AdvCheckBoxWithDiv extends HTML_QuickForm_advcheckbox {
    */
   public function toHtml(): string {
     $html = parent::toHtml();
-    if (is_numeric($this->getAttribute('options_per_line'))) {
-      return '<div class="crm-option-label-pair" >' . $html . '</div>';
-    }
-    return $html;
+    return '<div class="crm-option-label-pair" >' . $html . '</div>';
   }
 
 }

--- a/CRM/Core/QuickForm/RadioWithDiv.php
+++ b/CRM/Core/QuickForm/RadioWithDiv.php
@@ -29,10 +29,7 @@ class CRM_Core_QuickForm_RadioWithDiv extends HTML_QuickForm_radio {
    */
   public function toHtml(): string {
     $html = parent::toHtml();
-    if (is_numeric($this->getAttribute('options_per_line'))) {
-      return '<div class="crm-option-label-pair" >' . $html . '</div>';
-    }
-    return $html;
+    return '<div class="crm-option-label-pair" >' . $html . '</div>';
   }
 
 }

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3393,6 +3393,7 @@ span.crm-select-item-color {
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {
   margin-left: 0;
+  white-space: initial;
 }
 .crm-container .crm-multiple-checkbox-radio-options .crm-option-label-pair {
   display: grid;

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -333,6 +333,16 @@ input.crm-form-checkbox + label,
 .crm-container.crm-public .crm-profile-view .crm-option-label-pair {
   --crm-checkbox-width: auto;
 }
+/* Stacks label for checkbox/radio on contact layout custom field sets */
+.crm-container .contact_panel tr:is(.custom_field-row,.custom_field-help-pre-row) {
+  display: flex;
+  flex-direction: column;
+}
+.crm-container .contact_panel .custom_field-row td.label {
+  white-space: normal;
+  width: 100%;
+  text-align: left;
+}
 /* Override more general styling */
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -321,30 +321,32 @@ input.crm-form-checkbox + label,
   height: auto;
   box-shadow: none;
 }
-/* Checkbox/radio fields with n-per-line. See https://lab.civicrm.org/dev/core/-/issues/4985 */
+/* Checkbox/radio fields with n-per-line. */
 .crm-container .crm-multiple-checkbox-radio-options {
-  --gap: 1em;
-  --checkbox-width: 2em;
+  --crm-gap: 0.5em;
+  --crm-checkbox-width: 1.5em;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--gap);
+  gap: var(--crm-gap);
 }
-/* Reset checkbox width when its rendered as text '(x)' in confirmation screens /dev/core/-/issues/5550 */
+/* Reset checkbox width when its rendered as text '(x)' in confirmations */
 .crm-container.crm-public .crm-profile-view .crm-option-label-pair {
-  --checkbox-width: auto;
+  --crm-checkbox-width: auto;
 }
 /* Override more general styling */
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {
-  margin-left: 0;
+  margin: 0 !important /* vs L309 */;
+  padding: 0;
+  white-space: initial;
 }
 .crm-container .crm-multiple-checkbox-radio-options .crm-option-label-pair {
   display: grid;
-  grid-template-columns: var(--checkbox-width) 1fr;
+  grid-template-columns: var(--crm-checkbox-width) 1fr;
   align-items: baseline;
 }
 .crm-container .crm-multiple-checkbox-radio-options.crm-options-per-line .crm-option-label-pair {
-  flex: 0 0 calc((100% - (var(--crm-opts-per-line) - 1) * var(--gap)) / var(--crm-opts-per-line));
+  flex: 0 0 calc((100% - (var(--crm-opts-per-line) - 1) * var(--crm-gap)) / var(--crm-opts-per-line));
 }
 /* Slider */
 .crm-container .ui-slider {

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -21,17 +21,15 @@
   </tr>
 {elseif $element.options_per_line}
   <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
-    <td class="label"{if $element.html_type === "Radio"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$formElement.textLabel}{/if}</td>
+    <td class="label"{if $element.html_type === "Radio" || $element.html_type === "CheckBox"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}{if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$formElement.textLabel}{/if}</td>
     <td class="html-adjust">
-
-      <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
+      <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};" {if $element.html_type === "CheckBox"}role="group" aria-labelledby="{$element_name}_group"{/if}>
         {foreach name=outer key=key item=item from=$formElement}
           {if is_array($item) && array_key_exists('html', $item)}
             {$formElement.$key.html}
           {/if}
         {/foreach}
       </div>
-
       {* Include the edit options list for admins *}
       {if $formElement.html|strstr:"crm-option-edit-link"}
         {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
@@ -41,11 +39,11 @@
   </tr>
 {else}
   <tr class="custom_field-row {$element.element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element.element_name}_group"{/if}>
-    <td class="label"{if $element.html_type === "Radio"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}
+    <td class="label"{if $element.html_type === "Radio" || $element.html_type === "CheckBox"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}
       {if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$formElement.textLabel}{/if}
     </td>
     <td class="html-adjust">
-      {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}<div class="crm-multiple-checkbox-radio-options">{/if}
+      {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}<div class="crm-multiple-checkbox-radio-options" {if $element.html_type === "CheckBox"}role="group" aria-labelledby="{$element_name}_group"{/if}>{/if}
       {$formElement.html}
       {if $element.data_type eq 'File'}
         {if array_key_exists('element_value', $element) && $element.element_value.data}

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -27,7 +27,7 @@
       <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
         {foreach name=outer key=key item=item from=$formElement}
           {if is_array($item) && array_key_exists('html', $item)}
-            <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+            {$formElement.$key.html}
           {/if}
         {/foreach}
       </div>
@@ -45,7 +45,8 @@
       {if $element.help_post}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$formElement.textLabel}{/if}
     </td>
     <td class="html-adjust">
-      {$formElement.html}&nbsp;
+      {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}<div class="crm-multiple-checkbox-radio-options">{/if}
+      {$formElement.html}
       {if $element.data_type eq 'File'}
         {if array_key_exists('element_value', $element) && $element.element_value.data}
           <div class="crm-attachment-wrapper crm-entity" id="file_{$element.element_name}">
@@ -75,6 +76,7 @@
           {include file="CRM/Custom/Form/ContactReference.tpl"}
         {/if}
       {/if}
+      {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}</div>{/if}
     </td>
   </tr>
 {/if}

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -36,27 +36,21 @@
   {if !empty($element.options_per_line)}
         {assign var="element_name" value=$element.element_name}
         <tr class="custom-field-row {$element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
-         <td class="label"{if $element.html_type === "Radio"} id="{$element.element_name}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}</td>
-         <td>
-            {assign var="count" value=1}
-                <table class="form-layout-compressed">
-                 <tr>
-                   {* sort by fails for option per line. Added a variable to iterate through the element array*}
-                   {foreach name=outer key=key item=item from=$form.$element_name}
-                     {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
-                     {if is_array($item) && array_key_exists('html', $item)}
-                          <td class="labels font-light">{$form.$element_name.$key.html}</td>
-                              {if $count == $element.options_per_line}
-                                {assign var="count" value=1}
-                           </tr>
-                            {else}
-                                {assign var="count" value=$count+1}
-                            {/if}
-                         {/if}
-                    {/foreach}
-                 </tr>
-                </table>
-         </td>
+          <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}
+          </td>
+          <td>
+            <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
+              {foreach name=outer key=key item=item from=$form.$element_name}
+                {if is_array($item) && array_key_exists('html', $item)}
+                  {$form.$element_name.$key.html}
+                {/if}
+              {/foreach}
+              {* Include the edit options list for admins *}
+              {if $formElement.html|strstr:"crm-option-edit-link"}
+                {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+              {/if}
+            </div>
+          </td>
         </tr>
   {else}
         {capture assign="name"}{if !empty($element.name)}{$element.name}{/if}{/capture}
@@ -64,12 +58,18 @@
         <tr class="custom-field-row {$element_name}-row"  {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
           <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}</td>
         <td>
-          {$form.$element_name.html}&nbsp;
+            {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}<div class="crm-multiple-checkbox-radio-options">{/if}
+            {$form.$element_name.html}
+            {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}</div>{/if}
       {if $element.html_type eq 'Autocomplete-Select'}
           {if $element.data_type eq 'ContactReference'}
                   {include file="CRM/Custom/Form/ContactReference.tpl"}
                 {/if}
         {/if}
+          {* Include the edit options list for admins *}
+          {if $formElement.html|strstr:"crm-option-edit-link"}
+            {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+          {/if}
           </td>
   {/if}
      {/if}

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -36,10 +36,10 @@
   {if !empty($element.options_per_line)}
         {assign var="element_name" value=$element.element_name}
         <tr class="custom-field-row {$element_name}-row" {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
-          <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}
+          <td class="label">{if $element.html_type === "Radio" || $element.html_type === "CheckBox"}<span id="{$element_name}_group">{$form.$element_name.label|regex_replace:"/\<(\/|)label\>/":""}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}
           </td>
           <td>
-            <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
+            <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};" {if $element.html_type === "CheckBox"}role="group" aria-labelledby="{$element_name}_group"{/if}>
               {foreach name=outer key=key item=item from=$form.$element_name}
                 {if is_array($item) && array_key_exists('html', $item)}
                   {$form.$element_name.$key.html}
@@ -56,11 +56,10 @@
         {capture assign="name"}{if !empty($element.name)}{$element.name}{/if}{/capture}
         {capture assign="element_name"}{if !empty($element.element_name)}{$element.element_name}{/if}{/capture}
         <tr class="custom-field-row {$element_name}-row"  {if $element.html_type === "Radio"}role="radiogroup" aria-labelledby="{$element_name}_group"{/if}>
-          <td class="label">{if $element.html_type === "Radio"}<span id="{$element_name}_group">{$element.label}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}</td>
+          <td class="label">{if $element.html_type === "Radio" || $element.html_type === "CheckBox"}<span id="{$element_name}_group">{$form.$element_name.label|regex_replace:"/\<(\/|)label\>/":""}</span>{else}{$form.$element_name.label}{/if}{if !empty($element.help_post)}{help id=$element.id file="CRM/Custom/Form/CustomField.hlp" title=$form.$element_name.textLabel}{/if}</td>
         <td>
-            {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}<div class="crm-multiple-checkbox-radio-options">{/if}
-            {$form.$element_name.html}
-            {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}</div>{/if}
+            {if $element.html_type === "CheckBox" || $element.html_type === "Radio"}<div class="crm-multiple-checkbox-radio-options" {if $element.html_type === "CheckBox"}role="group" aria-labelledby="{$element_name}_group"{/if}>{$form.$element_name.html}</div>
+            {else}{$form.$element_name.html}{/if}
       {if $element.html_type eq 'Autocomplete-Select'}
           {if $element.data_type eq 'ContactReference'}
                   {include file="CRM/Custom/Form/ContactReference.tpl"}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -24,20 +24,16 @@
       </div>
     {/if}
     {if array_key_exists('options_per_line', $field) && $field.options_per_line != 0}
-      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
-        <div class="label option-label">{$formElement.label}</div>
+      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
+        <div class="label option-label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group"{/if}>{$formElement.label}</div>
         <div class="content">
-          <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$field.options_per_line};">
-            {$formElement.html}
-          </div>
+          {$formElement.html}
         </div>
         <div class="clear"></div>
       </div>
     {else}
-      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}">
-        <div class="label">
-          {$formElement.label}
-        </div>
+      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
+        <div class="label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group"{/if}>{$formElement.label}</div>
         <div class="content">
           {if $profileFieldName|str_starts_with:'im-'}
             {assign var="provider" value=profileFieldNamen|cat:"-provider_id"}
@@ -115,10 +111,10 @@
             {elseif $field.html_type eq 'File' && $viewOnlyFileValues}
               {$viewOnlyFileValues.$profileFieldName}
             {elseif $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox' && $field.data_type neq "Boolean"}
-              <div class="crm-multiple-checkbox-radio-options" >
+              <div class="crm-multiple-checkbox-radio-options">
                 {foreach name=outer key=key item=item from=$formElement}
                   {if is_array($item) && array_key_exists('html', $item)}
-                    <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+                    {$formElement.$key.html}
                   {/if}
                 {/foreach}
               </div>

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -25,7 +25,7 @@
     {/if}
     {if array_key_exists('options_per_line', $field) && $field.options_per_line != 0}
       <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}" {if $field.html_type eq 'Radio'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
-        <div class="label option-label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}</div>
+        <div class="label option-label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group">{$formElement.textLabel}{else}>{$formElement.label}{/if}</div>
         <div class="content" {if $field.html_type eq 'CheckBox'}role="group"  aria-labelledby="{$profileFieldName}_group"{/if}>
           {$formElement.html}
         </div>
@@ -33,7 +33,7 @@
       </div>
     {else}
       <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}"  {if $field.html_type eq 'Radio'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
-        <div class="label"{if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}</div>
+        <div class="label"{if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group">{$formElement.textLabel}{else}>{$formElement.label}{/if}</div>
         <div class="content" {if $field.html_type eq 'CheckBox'}role="group"  aria-labelledby="{$profileFieldName}_group"{/if}>
           {if $profileFieldName|str_starts_with:'im-'}
             {assign var="provider" value=profileFieldNamen|cat:"-provider_id"}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -24,17 +24,17 @@
       </div>
     {/if}
     {if array_key_exists('options_per_line', $field) && $field.options_per_line != 0}
-      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
-        <div class="label option-label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group"{/if}>{$formElement.label}</div>
-        <div class="content">
+      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}" {if $field.html_type eq 'Radio'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
+        <div class="label option-label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}</div>
+        <div class="content" {if $field.html_type eq 'CheckBox'}role="group"  aria-labelledby="{$profileFieldName}_group"{/if}>
           {$formElement.html}
         </div>
         <div class="clear"></div>
       </div>
     {else}
-      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
-        <div class="label" {if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group"{/if}>{$formElement.label}</div>
-        <div class="content">
+      <div class="crm-section editrow_{$profileFieldName}-section form-item" id="editrow-{$rowIdentifier}"  {if $field.html_type eq 'Radio'}role="radiogroup" aria-labelledby="{$profileFieldName}_group"{/if}>
+        <div class="label"{if $field.html_type eq 'Radio' or $field.html_type eq 'CheckBox'}id="{$profileFieldName}_group">{$formElement.label|regex_replace:"/\<(\/|)label\>/":""}{else}>{$formElement.label}{/if}</div>
+        <div class="content" {if $field.html_type eq 'CheckBox'}role="group"  aria-labelledby="{$profileFieldName}_group"{/if}>
           {if $profileFieldName|str_starts_with:'im-'}
             {assign var="provider" value=profileFieldNamen|cat:"-provider_id"}
             {if array_key_exists($provider, $form)}{$form.$provider.html}{/if}&nbsp;


### PR DESCRIPTION
Overview
----------------------------------------
As identified [here](https://lab.civicrm.org/dev/core/-/issues/6039), there's multiple issues with radio/checkboxes:
1. if no column count is set (ie it's null) the radio/checkbox label+inputs aren't wrapped in a div, and so can wrap orphaning a label (so that the wrong select item appears alone next to a label). Not a bug but a UX danger, especially as the default setting is no column. The wrapping also applies in some contexts but in others it creates a very long line.
2. in the custom field previewer no label appears *unless* no columns are set.
3. also the custom field previewer isn't giving an accurate preview - it shows the older table/td column/radio layout which isn't what appears in contribution pages
4. the contact layout screen preview of these elements can lead to clipping and overlapping.
5. Front-end the radio & checkbox groups aren't have orphaned labels / lack a11y roles/arialabels.

My answer here has been to:
 - change two QuickForm files to wrap all radio/checkboxes in `crm-option-label-pair` regardless if they are set to be in columns or not.
 - table cells containing column-free radio/checkboxes get a div with `.crm-multiple-checkbox-radio-options` class which applies flexbox wrap and gap (and prevents clipping).
 - update custom field preview.php to use the same label display setting used elsewhere.
 - change the preview.php output foreach loop to match the loop elsewhere.
 - remove various elements which ended up getting duplicated as a result of this
 - a few small css tweaks on top.

Before
----------------------------------------

**Contact Layout Editor - no wrapping, and clipping**
<img width="1103" height="269" alt="image" src="https://github.com/user-attachments/assets/d9e55349-7ab6-462d-96e5-e3d38fb4922e" />

**Custom Field Group Preview - four variations - orphaned input/labels, no label on items with columns set**

<img width="605" height="337" alt="image" src="https://github.com/user-attachments/assets/cf184fb5-8740-4016-90c9-94ad642f7aa4" />

**Contribution page + Profile - four variations (works as expected)**

<img width="919" height="493" alt="image" src="https://github.com/user-attachments/assets/6d7b81a1-545f-4fcd-9fa3-b7962307fae1" />

**New Contribution + Profile - several issues**

<img width="1128" height="552" alt="image" src="https://github.com/user-attachments/assets/166f2591-e1a2-4699-89c7-55ad60daf3e5" />

**Contribution page WAVE a11y - 24 alerts**

<img width="663" height="377" alt="image" src="https://github.com/user-attachments/assets/e63006d9-4aff-4fb1-9777-5f27839b2fde" />

After
----------------------------------------

**Contact Layout Editor - four variations**
(Null and 3 column for each of radio & checkbox)

<img width="623" height="536" alt="image" src="https://github.com/user-attachments/assets/2aa153e9-6dfb-4efa-82c7-08e7e225fcb5" />

**Custom Field Group Preview - four variations**
(Null and 3 column for each of radio & checkbox)

<img width="637" height="615" alt="image" src="https://github.com/user-attachments/assets/b57fd5f2-68b4-4c7b-b48b-3626b4359583" />

**Contribution page + Profile - four variations**

<img width="851" height="535" alt="image" src="https://github.com/user-attachments/assets/7e5f0222-586e-4167-8d9b-add4e77e6b23" />

**New Contribution + Profile / null and 2 column** 

<img width="1061" height="305" alt="image" src="https://github.com/user-attachments/assets/f86e0b19-b412-44c6-9b65-5a70d3bbed8a" />

**Contribution page WAVE a11y - 20 alerts**

<img width="618" height="528" alt="image" src="https://github.com/user-attachments/assets/ba0e8824-c145-4c25-8fe5-0dbb60ac6abd" />

**FormBuilder**

<img width="960" height="298" alt="image" src="https://github.com/user-attachments/assets/680c9920-635f-4cf3-95ed-d537a7ff3269" />

Same screens in RiverLea/Minetta:

<img width="756" height="526" alt="image" src="https://github.com/user-attachments/assets/5085af24-ef7e-4afd-97b7-3250b8b4e4dc" />
<img width="813" height="482" alt="image" src="https://github.com/user-attachments/assets/0c9e50f6-46ec-4cf3-b12d-e84cbfa271ac" />

Technical Details
----------------------------------------
For testing I've been looking at:
 - custom fields with checkbox and radio - one with columns set, one without - then preview
 - these fields in a profile on a contribution page - form and confirmation screen
 - these fields in a profile on 'new contribution' layout
 - this field group on the contact layout 
 - these fields in SK/FB (they're re-rendered and all of the above is ignored, so not worth testing)

Frustratingly these all need to be created to test!

Comments
----------------------------------------
Some of the changed lines here are just me changing the indent!

Of the rest, a lot is copy/paste. e.g. https://github.com/civicrm/civicrm-core/compare/master...vingle:civicrm-core:checkbox-issues2?expand=1#diff-20a513cb87e770eddfe52a14917ea6ead2b67550ab5ae480cb2a3eee2a395378R42-R52 where I replaced the table/td layout in preview is taken from `uf/form/fields.tpl` with just a changes to `$formElement`.

Stepping beyond CSS into smarty/quickform is outside my normal comfort zone - I've no idea about wider consequences over what to me seem relatively simple improvements. So I'd appreciate someone reading my changes as well as functionally testing, because this all works in the layouts I tested, and these elements are used in lots of places and probably have extensions/custom JS talking to them.

Final note - two things I didn't manage to fix here - get the spanner icon to appear in the custom fields preview when a column is set, it only appears when one isn't. Also there's a `nbsp;` appearing between the items in Contact Layout (CustomFields.tpl) - and I can't find it anywhere! I deleted a few but it's still appearing and messes with the layout a bit. But these are relatively v small compared to the other fixes in this PR.