### PR TITLE
clearer label for Contribution is_test field

### DIFF
--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -428,7 +428,7 @@ return [
       ],
     ],
     'is_test' => [
-      'title' => ts('Test'),
+      'title' => ts('Test Mode'),
       'sql_type' => 'boolean',
       'input_type' => 'CheckBox',
       'required' => TRUE,

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -442,7 +442,7 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
         'source' => 'Contribution Source',
         'amount_level' => 'Amount Label',
         'contribution_recur_id' => 'Recurring Contribution ID',
-        'is_test:label' => 'Test',
+        'is_test:label' => 'Test Mode',
         'is_pay_later:label' => 'Is Pay Later',
         'contribution_status_id:label' => 'Contribution Status',
         'address_id' => 'Address ID',

--- a/tests/phpunit/CRM/Export/BAO/ExportTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportTest.php
@@ -2391,7 +2391,7 @@ class CRM_Export_BAO_ExportTest extends CiviUnitTestCase {
       98 => 'Currency',
       99 => 'Cancellation / Refund Reason',
       100 => 'Receipt Date',
-      101 => 'Test',
+      101 => 'Test Mode',
       102 => 'Is Pay Later',
       103 => 'Contribution Status',
       104 => 'Recurring Contribution ID',


### PR DESCRIPTION
Clearer label for contribution "Is Test" field.

Pertinent when using this field for Afform Payments configuration.