### PR TITLE
EntityProvider - Localized strings should be cached separately

### DIFF
--- a/Civi/Schema/EntityProvider.php
+++ b/Civi/Schema/EntityProvider.php
@@ -47,17 +47,19 @@ final class EntityProvider {
    *   Ex: ['field_1' => ['title' => ..., 'sqlType' => ...]]
    */
   public function getFields(): array {
-    if (!isset(Civi::$statics['civi.entity.fields'][$this->entityName])) {
-      Civi::$statics['civi.entity.fields'][$this->entityName] = $this->getMetaProvider()->getFields();
+    $locale = \CRM_Core_I18N::getLocale();
+    $cacheKey = $locale . ' ' . $this->entityName;
+    if (!isset(Civi::$statics['civi.entity.fields'][$cacheKey])) {
+      Civi::$statics['civi.entity.fields'][$cacheKey] = $this->getMetaProvider()->getFields();
       $hookParams = [
         'entity' => $this->entityName,
-        'fields' => &Civi::$statics['civi.entity.fields'][$this->entityName],
+        'fields' => &Civi::$statics['civi.entity.fields'][$cacheKey],
       ];
       $event = GenericHookEvent::create($hookParams);
       Civi::service('dispatcher')->dispatch('civi.entity.fields', $event);
       Civi::service('dispatcher')->dispatch("civi.entity.fields::$this->entityName", $event);
     }
-    return Civi::$statics['civi.entity.fields'][$this->entityName];
+    return Civi::$statics['civi.entity.fields'][$cacheKey];
   }
 
   public function getCustomFields(array $customGroupFilters = []): array {


### PR DESCRIPTION
Overview
----------------------------------------

The recent #33447 introduced a static-cache for effective entity-metadata. However, this includes some localized strings. So if you have a use-case that switches between different locales, then you need those strings to be stored in separate cache-rows.

This appears to fix an interaction with some of the newer tests in #32859.
