### PR TITLE
dev/core#5828 Create a page listing all imports permitted …

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -19,6 +19,7 @@ use Civi\Api4\LineItem;
 use Civi\Api4\ContributionSoft;
 use Civi\Api4\PaymentProcessor;
 use Civi\Api4\UFJoin;
+use Civi\Core\Event\GenericHookEvent;
 use Civi\Core\Event\PreEvent;
 use Civi\Core\Event\PostEvent;
 use Civi\Order\Event\OrderCompleteEvent;
@@ -4472,6 +4473,22 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
       default:
         throw new CRM_Core_Exception('Unknown unit: ' . $unit);
+    }
+  }
+
+  public static function on_civi_imports(GenericHookEvent $event) {
+    if (CRM_Core_Permission::check([
+      'access CiviContribute',
+      'edit contributions',
+    ])) {
+      $event->imports = array_merge($event->imports, [
+        'contribution_import' => [
+          'label' => ts('Import Contributions'),
+          'name' => 'contribution_import',
+          'url' => CRM_Utils_System::url('civicrm/import/contribution', 'reset=1', FALSE, FALSE, TRUE, FALSE, TRUE),
+          'no_ts_label' => 'Import Contributions',
+        ],
+      ]);
     }
   }
 

--- a/CRM/Core/xml/Menu/Import.xml
+++ b/CRM/Core/xml/Menu/Import.xml
@@ -6,7 +6,7 @@
      <title>Import</title>
      <access_arguments>import contacts,access CiviCRM</access_arguments>
      <page_type>1</page_type>
-     <page_callback>CRM_Import_Controller</page_callback>
+     <page_callback>CRM_Import_Page_Imports</page_callback>
      <weight>400</weight>
   </item>
   <item>

--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -10,6 +10,8 @@
 
  */
 
+use Civi\Core\Event\GenericHookEvent;
+
 /**
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -1935,6 +1937,22 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
       $participantRoleClause = "REGEXP '{$regexp}'";
     }
     return $participantRoleClause ?? '';
+  }
+
+  public static function on_civi_imports(GenericHookEvent $event) {
+    if (CRM_Core_Permission::check([
+      'access CiviEvent',
+      'edit event participants',
+    ])) {
+      $event->imports = array_merge($event->imports, [
+        'participant_import' => [
+          'label' => ts('Import Participants'),
+          'name' => 'participant_import',
+          'url' => CRM_Utils_System::url('civicrm/import/participant', 'reset=1', FALSE, FALSE, TRUE, FALSE, TRUE),
+          'no_ts_label' => 'Import Participants',
+        ],
+      ]);
+    }
   }
 
 }

--- a/CRM/Import/Page/Imports.php
+++ b/CRM/Import/Page/Imports.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Import_Page_Imports extends CRM_Core_Page {
+
+  public function run() {
+    $imports = [
+      'contact_import' => [
+        'label' => ts('Import Contacts'),
+        'name' => 'contact_import',
+        'url' => CRM_Utils_System::url('civicrm/import/contact', 'reset=1', FALSE, FALSE, TRUE, FALSE, TRUE),
+        'no_ts_label' => 'Import Contacts',
+      ],
+      'multi_record_custom_field_import' => [
+        'label' => ts('Import Multi-value Custom Data'),
+        'name' => 'multi_record_custom_field_import',
+        'url' => CRM_Utils_System::url('civicrm/import/custom', 'reset=1', FALSE, FALSE, TRUE, FALSE, TRUE),
+        'no_ts_label' => 'Import Multi-value Custom Data',
+      ],
+      'activity_import' => [
+        'label' => ts('Import Activities'),
+        'name' => 'activity_import',
+        'url' => CRM_Utils_System::url('civicrm/import/activity', 'reset=1', FALSE, FALSE, TRUE, FALSE, TRUE),
+        'no_ts_label' => 'Import Activities',
+      ],
+    ];
+    $event = Civi\Core\Event\GenericHookEvent::create(['imports' => &$imports]);
+    Civi::dispatcher()->dispatch('civi.imports', $event);
+    $this->assign('imports', $imports);
+    parent::run();
+    CRM_Utils_System::setTitle('Import Options');
+  }
+
+}

--- a/templates/CRM/Import/Page/Imports.tpl
+++ b/templates/CRM/Import/Page/Imports.tpl
@@ -1,0 +1,6 @@
+<p>{ts}You can use the following import options to import data into your CiviCRM System{/ts}</p>
+<ul>
+{foreach item=import from=$imports}
+  <li><a href="{$import.url}" alt="{ts 1=$import.no_ts_label escape='htmlattribute'}%1{/ts}">{$import.label}</a></li>
+{/foreach}
+</ul>


### PR DESCRIPTION
…to prevent breakage on breadcrumb

Overview
----------------------------------------
This Creates a standalone page which lists all known imports to be used for the import breadcrumb. 

Before
----------------------------------------
Clicking on the "Import" breadcrumb shows an error

After
----------------------------------------
No error and shows a list of known imports

Technical Details
----------------------------------------
This creates a new event civi.imports to allow extensions (core components) to modify the list of known imports

ping @MegaphoneJon @eileenmcnaughton 