### PR TITLE
dev/core#6069 - ext/eventcart - fix Event Cart checkout participant registration failure

### DIFF
--- a/ext/eventcart/CRM/Event/Cart/Form/Cart.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Cart.php
@@ -57,6 +57,7 @@ class CRM_Event_Cart_Form_Cart extends CRM_Core_Form {
     foreach ($this->cart->get_main_events_in_carts() as $event_in_cart) {
       if (empty($event_in_cart->participants)) {
         $participant_params = [
+          'cart_id' => $this->cart->id,
           'event_id' => $event_in_cart->event_id,
           'contact_id' => self::find_or_create_contact(),
         ];

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
@@ -204,7 +204,7 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
         continue;
       }
 
-      [$params, $lineItem] = self::getLine($params, $lineItem, $priceSetID, $field, $id);
+      [$params, $lineItem] = CRM_Price_BAO_PriceSet::getLine($params, $lineItem, $priceSetID, $field, $id);
     }
     $order = new CRM_Financial_BAO_Order();
     $order->setLineItems((array) $lineItem);


### PR DESCRIPTION
Overview
----------------------------------------
See dev/core#6069
Participant registration from event cart checkout was failing: contact name and email not pre-filled and wouldn't save.

Before
----------------------------------------
**Steps to replicate on a demo installation**
1. Install the core Event Cart extension.
2. Visit an event info page, e.g. Fall Fundraiser Dinner, as a logged-in user.
3. Click the Add to Cart button.
4. Click the Checkout button.
5. On Cart Checkout, note the heading "Participant 0" (should be "Participant 1") and that under "Your Registration Info", the user's first+last name and email address are not pre-filled.
6. Enter first+last name, email address and any other required registration fields.
7. Click Continue.
8. Note the form validation error saying that first+last name and email are required fields; these fields are blank again.

After
----------------------------------------
At step 5, the heading is "Participant 1" and under "Your Registration Info", the user's first+last name and email address are pre-filled.
At step 8, the submission succeeds with no form validation error. The user is registered as a participant for the event.

Technical Details
----------------------------------------
The issue was tracked down to code refactoring in commit 83f2ab5 . The intention there was to stop passing parameter `cart_id` when creating a participant record, because that field was removed from `civicrm_participant`. However one of the places where `cart_id` was removed was passing it to function `CRM_Event_Cart_BAO_MerParticipant::create()` which has special handling for this parameter, using it to create an `EventCartParticipant` record. Without this, the cart is not linked to a participant record.

A further code issue was found stemming from PR #30577, where function `CRM_Price_BAO_PriceSet::processAmount()` was copied to the Event Cart extension as `CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices::processCartAmount()`. The original function included a call to `self::getLine()` which would resolve in the original function to `CRM_Price_BAO_PriceSet::getLine()`. This call was copied over unchanged and function `getLine()` was not copied.
I ran into a consequent error of class `CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices::getLine()` not being found, when updating a customised copy of event cart to Civi 6.4.1 . I have not replicated this error on an uncustomised version: there is only one call to `processCartAmount()` and it occurs in the same file under a comment "Probably unreachable." So this may be difficult to replicate but I think inspection of the code indicates that the change should be made. The change fixed the error on the customised version.
