### PR TITLE
SearchKit - Hide search functions from entities that don't support it.

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-conditions.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-conditions.html
@@ -1,5 +1,5 @@
 <fieldset class="api4-clause-fieldset crm-search-wheres">
-  <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{:: ts('Where') }}" fields="fieldsForWhere" allow-functions="true" ></crm-search-clause>
+  <crm-search-clause clauses="$ctrl.savedSearch.api_params.where" format="string" op="AND" label="{{:: ts('Where') }}" fields="fieldsForWhere" allow-functions="$ctrl.paramExists('groupBy')" ></crm-search-clause>
 </fieldset>
 <fieldset ng-if="$ctrl.paramExists('having')" class="api4-clause-fieldset crm-search-havings">
   <crm-search-clause clauses="$ctrl.savedSearch.api_params.having" format="string" op="AND" label="{{:: ts('Having') }}" help="having" fields="fieldsForHaving" aliases="$ctrl.savedSearch.api_params.select" ></crm-search-clause>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -598,6 +598,9 @@
 
     // Is a column eligible to use an aggregate function?
     this.canAggregate = function(col) {
+      if (!ctrl.paramExists('groupBy')) {
+        return false;
+      }
       // If the query does not use grouping, it's always allowed
       if (!ctrl.savedSearch.api_params.groupBy || !ctrl.savedSearch.api_params.groupBy.length) {
         return true;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.html
@@ -1,8 +1,8 @@
 <div ng-model="$ctrl.select" ui-sortable="$ctrl.sortableOptions">
   <fieldset ng-repeat="col in $ctrl.select" class="crm-draggable">
     <i class="crm-i fa-arrows crm-search-move-icon"></i>
-    <crm-search-function ng-if="!col.isPseudoField" class="form-inline" mode="select" expr="col.key"></crm-search-function>
-    <label ng-if="col.isPseudoField">{{:: col.label }}</label>
+    <crm-search-function ng-if="!col.isPseudoField && $ctrl.crmSearchAdmin.paramExists('groupBy')" class="form-inline" mode="select" expr="col.key"></crm-search-function>
+    <label ng-if="col.isPseudoField || !$ctrl.crmSearchAdmin.paramExists('groupBy')">{{:: col.label }}</label>
     <button type="button" class="btn btn-xs pull-right" ng-if="$ctrl.select.length > 1" ng-click="$ctrl.crmSearchAdmin.clearParam('select', $index)" title="{{:: ts('Remove') }}">
       <i class="crm-i fa-times"></i>
     </button>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -115,7 +115,7 @@
           if (ctrl.mode !== 'groupBy' && ctrl.crmSearchAdmin.canAggregate(ctrl.expr)) {
             allowedTypes.push('aggregate');
             // In addition to aggregate functions, also permit a function used in the groupBy clause
-            ctrl.crmSearchAdmin.savedSearch.api_params.groupBy.forEach(function(fieldStr) {
+            (ctrl.crmSearchAdmin.savedSearch.api_params.groupBy || []).forEach(function(fieldStr) {
               if (fieldStr.includes(ctrl.fieldArg.field.name) && fieldStr.includes('(')) {
                 let fieldExpr = searchMeta.parseExpr(fieldStr);
                 let field = _.findWhere(fieldExpr.args, {type: 'field'});


### PR DESCRIPTION
Overview
----------------------------------------
Ensures the SearchKit UI works well with non-sql entities.

Before
----------------------------------------
Using SearchKit with a non-sql entity like Afform or Permissions would give nonsensical options for SQL functions that would fail if used.

After
----------------------------------------
No fun.