### PR TITLE
CiviReport - Show collapse/expand icon on collapsible tabs

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -331,7 +331,12 @@ trait SavedSearchInspectorTrait {
           foreach ($value as $operator => $val) {
             $andGroup[] = [$fieldName, $operator, $val];
           }
-          $filterClauses[] = ['AND', $andGroup];
+          if (count($andGroup) === 1) {
+            $filterClauses[] = $andGroup[0];
+          }
+          elseif (count($andGroup) > 1) {
+            $filterClauses[] = ['AND', $andGroup];
+          }
         }
       }
       elseif (!empty($field['serialize']) && in_array('CONTAINS', $operators, TRUE)) {

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -41,7 +41,9 @@ details.af-collapsible > .af-title::before,
 .crm-container .crm-collapsible .collapsible-title::before,
 .crm-container a.crm-expand-row:not(.expanded)::before,
 .crm-container .civicrm-community-messages .crm-collapsible .collapsible-title::before,
-.crm-container .show-children.collapsed::before {
+.crm-container .show-children.collapsed::before,
+/* For jQuery ui collapsible tabs in CiviReport */
+.crm-container .ui-tabs-collapsible > ul.ui-tabs-nav::before {
   font-size: var(--crm-font-size);
   font-style: normal;
   text-rendering: auto;
@@ -61,7 +63,8 @@ details.af-collapsible.af-collapsed > .af-title::before,
 .crm-container a.collapsed:not(.expanded)::before,
 .crm-container a.crm-expand-row::before,
 .crm-container .crm-collapsible.collapsed .collapsible-title::before,
-.crm-container .civicrm-community-messages .crm-collapsible.collapsed .collapsible-title::before {
+.crm-container .civicrm-community-messages .crm-collapsible.collapsed .collapsible-title::before,
+.crm-container .ui-tabs-collapsible > ul.ui-tabs-nav::before {
   transform: none;
   transform-origin: center center;
   transition: var(--crm-expand-transition);
@@ -75,7 +78,8 @@ details.af-collapsible[open] > .af-title::before,
 .crm-container a.expanded::before,
 .crm-container a.crm-expand-row.expanded::before,
 .crm-container .civicrm-community-messages .crm-collapsible .collapsible-title::before,
-.crm-container .show-children.expanded::before {
+.crm-container .show-children.expanded::before,
+.crm-container .ui-tabs-collapsible > ul.ui-tabs-nav:has(li.ui-tabs-active)::before {
   content: var(--crm-expand-icon);
   transform: var(--crm-expand-transform);
   transform-origin: center center;

--- a/templates/CRM/Report/Form/Fields.tpl
+++ b/templates/CRM/Report/Form/Fields.tpl
@@ -58,6 +58,13 @@
         tabSettings.active = $('.civireport-criteria').index($('.civireport-criteria:has(".crm-error")')[0]);
       }
       $("#mainTabContainer").tabs(tabSettings);
+      // When clicking the header, toggle collapsed state
+      $('#mainTabContainer > ul.ui-widget-header').click(function(e) {
+        if ($(e.target).is('ul.ui-widget-header')) {
+          const activeTab = $('#mainTabContainer').tabs('option', 'active');
+          $('#mainTabContainer').tabs('option', 'active', activeTab === false ? 0 : false);
+        }
+      });
     });
 
   </script>


### PR DESCRIPTION
Overview
----------------------------------------
In CiviReport you can click on tabs to collapse them. This adds a little icon to make that more obvious.


<img width="2114" height="534" alt="image" src="https://github.com/user-attachments/assets/cc5d0e16-60c3-4078-85be-74714dbbff7f" />


<img width="2112" height="764" alt="image" src="https://github.com/user-attachments/assets/1bce62b1-d291-42bf-800f-d84e5b052b96" />
