### PR TITLE
dev/core#6068: Prevent deletion of user when merging contacts on standalone

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -2817,7 +2817,14 @@ SELECT contact_id
         // Exclude references to other columns
         $coreReference->getTargetKey() === 'id'
       ) {
-        $contactReferences[$coreReference->getReferenceTable()][] = $coreReference->getReferenceKey();
+        $referenceTable = $coreReference->getReferenceTable();
+        $referenceKey = $coreReference->getReferenceKey();
+        if (!(
+          array_key_exists($referenceTable, $contactReferences) &&
+          in_array($referenceKey, $contactReferences[$referenceTable])
+        )) {
+          $contactReferences[$referenceTable][] = $referenceKey;
+        }
       }
     }
     self::appendCustomTablesExtendingContacts($contactReferences);


### PR DESCRIPTION
Overview
----------------------------------------
In standalone, if a contact with a user account is deduped into another contact, the user account is deleted when you try to move it from the duplicate to the original contact.

See Lab issue for details and reproduction steps.

Before
----------------------------------------
On standalone, if merging a contact with the user account into another contact, the user is deleted.

After
----------------------------------------
User is transferred to remaining contact as usual.