### PR TITLE
RiverLea: Restores lists to SearchKit, adjusts paragraph margin in Claro

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -58,9 +58,10 @@ body {
   list-style: none;
 }
 /* Restores list styles for rich text output to UA stylesheet definition */
-.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body) :is(ol,ul) {
+.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body,.crm-search-col-type-html,.af-markup) :is(ol,ul) {
   list-style: revert;
   padding: revert;
+  margin: revert;
 }
 /* For images to not be able to exceed their container */
 .crm-container img {
@@ -181,6 +182,12 @@ body.civicrm-iframe-page {
 
 /* Core type */
 
+.crm-container p:first-of-type {
+  margin-top: 0;
+}
+.crm-container p:last-of-type {
+  margin-bottom: 0;
+}
 .crm-container strong,
 .crm-container b,
 .crm-container .bold,

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -182,10 +182,10 @@ body.civicrm-iframe-page {
 
 /* Core type */
 
-.crm-container p:first-of-type {
+.crm-container p:first-child {
   margin-top: 0;
 }
-.crm-container p:last-of-type {
+.crm-container p:last-child {
   margin-bottom: 0;
 }
 .crm-container strong,

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -88,8 +88,6 @@ body.page-civicrm .breadcrumb__link {
   --crm-page-width: calc(100% - var(--crm-page-padding) - var(--crm-page-padding));
 }
 #block-claro-content .crm-container:not(.crm-public) .form-item,
-#block-claro-content .crm-container p,
-#block-claro-content .crm-container .help p,
 #block-claro-content .crm-container .button {
   margin: 0;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Addresses two issues raised by Noah, and two that came from that:
 - https://lab.civicrm.org/extensions/riverlea/-/issues/144 - Rich Text paragraphs in Drupal Claro lose their margin
 - https://lab.civicrm.org/extensions/riverlea/-/issues/145 - Rich Text paragraphs in SearchKit everywhere lose their margin & ul/ol in SearchKit lose their list icons/numbers.
 - RichText paragraphs in FormBuilder - builder and rendered layout also don't have functioning ul/ol.
 - Handling of first/last paragraphs isn't very consistent (ie default browser user agent gives margin to `p` above and below, but this normally should be removed for the first/last paragraph items.

Before
----------------------------------------
Rich Text (144)

<img width="826" height="406" alt="image" src="https://github.com/user-attachments/assets/5c82c2f6-afa5-4640-92cc-ddeecc5a6312" />

SearchKit (145)

<img width="817" height="451" alt="image" src="https://github.com/user-attachments/assets/95d7dfd3-5af2-461b-a047-a23e91f9e125" />

FormBuilder

<img width="402" height="491" alt="image" src="https://github.com/user-attachments/assets/2652a36a-7e3d-462d-bf41-1dfacb706b4f" />

After
----------------------------------------
Rich Text (144)

<img width="620" height="443" alt="image" src="https://github.com/user-attachments/assets/c48e2d6f-2c87-4c64-aede-38c3702f854f" />

SearchKit (155)

<img width="839" height="543" alt="image" src="https://github.com/user-attachments/assets/cbee6d58-7c86-4b8e-b8d2-10c60481545e" />

FormBuilder builder

<img width="512" height="536" alt="image" src="https://github.com/user-attachments/assets/f3b83606-69f9-4830-91fd-50be46e26d25" />

Technical Details
----------------------------------------
Perhaps the FB/SK fixes need to go into 6.6? 

Comments
----------------------------------------
The margin top/bottom resets on `p` is a bit broad and a tiny bit opinionated. Pinging @artfulrobot for their thoughts if that's useful/too much. Without it tho there's lots of ugly margins at the top and bottom of 1/2 line alerts/messages/descriptions/etc.