### PR TITLE
Afform - Remove ts() from form markup

### DIFF
--- a/ang/afform/afformQuickAddIndividual.aff.html
+++ b/ang/afform/afformQuickAddIndividual.aff.html
@@ -14,5 +14,5 @@
       </div>
     </div>
   </fieldset>
-  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">{{:: ts('Submit') }}</button>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
 </af-form>

--- a/ang/afform/afformQuickAddOrganization.aff.html
+++ b/ang/afform/afformQuickAddOrganization.aff.html
@@ -12,5 +12,5 @@
       </div>
     </div>
   </fieldset>
-  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">{{:: ts('Submit') }}</button>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
 </af-form>

--- a/ang/afform/afsearchSiteTokens.aff.html
+++ b/ang/afform/afsearchSiteTokens.aff.html
@@ -1,6 +1,6 @@
 <div class="af-markup">
   <div class="help">
-  <div>{{:: ts('Site Tokens allow you to define pre-set snippets of content which you can then insert via CiviCRM\'s standard token-handling features. Site Tokens marked as "reserved" are also inserted automatically in specific places within CiviCRM features, such as Message Templates.')}} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/common-workflows/tokens-and-mail-merge/#site" target="_blank">{{:: ts('Learn more ...') }}</a></div>
+  <div>Site Tokens allow you to define pre-set snippets of content which you can then insert via CiviCRM's standard token-handling features. Site Tokens marked as "reserved" are also inserted automatically in specific places within CiviCRM features, such as Message Templates. <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/common-workflows/tokens-and-mail-merge/#site" target="_blank">Learn more ...</a></div>
   </div>
 
 </div>

--- a/ang/afform/afsearchTabRel.aff.html
+++ b/ang/afform/afsearchTabRel.aff.html
@@ -1,11 +1,11 @@
 <div af-fieldset="">
   <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.contact_id, is_current: true}"></crm-search-display-table>
-  <h3>{{:: ts('Inactive Relationships') }}</h3>
-  <div class="help">{{:: ts('These relationships are Disabled OR have a past End Date.') }}</div>
+  <h3>Inactive Relationships</h3>
+  <div class="help">These relationships are Disabled OR have a past End Date.</div>
   <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.contact_id, is_current: false}"></crm-search-display-table>
   <div class="help">
-    <strong>{{:: ts('Permissioned Relationships:') }}</strong>
-    <i class="crm-i fa-eye"></i> {{:: ts('This contact can be viewed by the other.') }}
-    <i class="crm-i fa-pencil-square"></i> {{:: ts('This contact can be viewed and edited by the other.') }}
+    <strong>Permissioned Relationships:</strong>
+    <i class="crm-i fa-eye"></i> This contact can be viewed by the other.
+    <i class="crm-i fa-pencil-square"></i> This contact can be viewed and edited by the other.
   </div>
 </div>

--- a/ext/afform/admin/ang/afAdminFormSubmissionList.aff.html
+++ b/ext/afform/admin/ang/afAdminFormSubmissionList.aff.html
@@ -1,5 +1,5 @@
 <div af-fieldset="">
-  <af-field name="status_id" defn="{label: false, input_attrs: {multiple: true, placeholder: ts('Any Status')}}" />
+  <af-field name="status_id" defn="{label: false, input_attrs: {multiple: true, placeholder: 'Any Status'}}" />
   <crm-search-display-table search-name="AfAdmin_Submission_List" display-name="AfAdmin_Submission_List_Display" filters="{afform_name: routeParams.name}">
   </crm-search-display-table>
 </div>

--- a/ext/afform/html/ang/afHtmlEditor.aff.html
+++ b/ext/afform/html/ang/afHtmlEditor.aff.html
@@ -1,7 +1,7 @@
 <div af-api4-ctrl="apiData" af-api4="['Afform', 'get', {layoutFormat: 'html', where: [['name', '=', options.name]]}]">
 
   <div ng-if="apiData.result.length == 0">
-    {{ts('Failed to find requested form.')}}
+    Failed to find requested form.
   </div>
 
   <div ng-repeat="resultForm in apiData.result" ng-if="apiData.result.length > 0" class="container-fluid">
@@ -10,55 +10,55 @@
 
       <div class="col-sm-12 col-md-4">
         <div class="panel panel-default">
-          <div class="panel-heading">{{ts('Properties')}}</div>
+          <div class="panel-heading">Properties</div>
           <div class="panel-body">
 
             <div crm-ui-debug="resultForm"></div>
 
             <div class="form-group">
-              <label class="control-label">{{ts('Name')}}</label>
+              <label class="control-label">Name</label>
               <p class="form-control-static">{{resultForm.name}}</p>
             </div>
             <div class="form-group">
-              <label class="control-label">{{ts('Title')}}</label>
+              <label class="control-label">Title</label>
               <input ng-model="resultForm.title" type="text" class="form-control" />
             </div>
             <div class="form-group">
-              <label class="control-label">{{ts('Description')}}</label>
+              <label class="control-label">Description</label>
               <textarea class="form-control" ng-model="resultForm.description"></textarea>
-              <p class="help-block">{{ts('Semi-private description about the form\'s purpose.')}}</p>
+              <p class="help-block">Semi-private description about the form's purpose.</p>
               <!-- "Semi-private": not generally public, but not audited for secrecy -->
             </div>
             <div class="form-group">
-              <label class="control-label">{{ts('Path')}}</label>
+              <label class="control-label">Path</label>
               <input ng-model="resultForm.server_route" type="text" class="form-control" />
-              <p class="help-block">{{ts('Expose the form as a standalone page on the web site. (Example: "civicrm/my-form")')}}</p>
+              <p class="help-block">Expose the form as a standalone page on the web site. (Example: "civicrm/my-form")</p>
             </div>
             <div class="form-group" ng-if="!!resultForm.server_route">
               <label for="af_config_form_is_public">
                 <input type="checkbox" id="af_config_form_is_public" ng-model="resultForm.is_public">
-                {{ ts('Enable frontend styling') }}
+                Enable frontend styling
               </label>
-              <p class="help-block">{{ts('The general look/feel should match the frontend')}}</p>
+              <p class="help-block">The general look/feel should match the frontend</p>
             </div>
             <div class="form-group" ng-if="!!resultForm.server_route">
               <label for="af_config_form_is_token">
                 <input type="checkbox" id="af_config_form_is_token" ng-model="resultForm.is_token">
-                {{ ts('Enable email token') }}
+                Enable email token
               </label>
-              <p class="help-block">{{ts('Allow email authors to easily link to this form')}}</p>
+              <p class="help-block">Allow email authors to easily link to this form</p>
             </div>
             <div class="form-group">
               <label for="af_config_form_is_dashlet">
                 <input type="checkbox" id="af_config_form_is_dashlet" ng-model="resultForm.is_dashlet">
-                {{ ts('Enable dashlet') }}
+                Enable dashlet
               </label>
-              <p class="help-block">{{ts('Allow backend users to embed the form on the dashboard.')}}</p>
+              <p class="help-block">Allow backend users to embed the form on the dashboard.</p>
             </div>
             <div class="form-group">
-              <label class="control-label">{{ts('Permission')}}</label>
+              <label class="control-label">Permission</label>
               <input ng-model="resultForm.permission" type="text" class="form-control" />
-              <p class="help-block">{{ts('What permission is required to use this form?')}}</p>
+              <p class="help-block">What permission is required to use this form?</p>
             </div>
           </div>
         </div>
@@ -66,13 +66,13 @@
         <div class="clearfix"></div>
 
         <div class="panel panel-default">
-          <div class="panel-heading">{{ts('Submit Actions')}}</div>
+          <div class="panel-heading">Submit Actions</div>
           <div class="panel-body">
             <ng-form name="submitActions">
               <div class="form-group" ng-class="{'has-error': !!submitActions.redirect.$error.pattern}">
-                <label class="control-label" for="af_config_redirect">{{ ts('Post-Submit Page') }}</label>
-                <input ng-model="resultForm.redirect" name="redirect" class="form-control" id="af_result_from_redirect" title="{{ ts('Post-Submit Page') }}" pattern="^((http|https):\/\/|\/|civicrm\/)[-0-9a-zA-Z\/_.]\S+$" title="{{ ts('Post-Submit Page must be either an absolute url, a relative url or a path starting with CiviCRM') }}"/>
-                <p class="help-block">{{ts('Enter a URL or path that the form should redirect to following a successful submission.') }}</p>
+                <label class="control-label" for="af_config_redirect">Post-Submit Page</label>
+                <input ng-model="resultForm.redirect" name="redirect" class="form-control" id="af_result_from_redirect" title="Post-Submit Page" pattern="^((http|https):\/\/|\/|civicrm\/)[-0-9a-zA-Z\/_.]\S+$" title="Post-Submit Page must be either an absolute url, a relative url or a path starting with CiviCRM"/>
+                <p class="help-block">Enter a URL or path that the form should redirect to following a successful submission.</p>
               </div>
             </ng-form>
           </div>
@@ -85,22 +85,22 @@
       <div class="col-sm-12 col-md-8">
         <div class="panel panel-default">
           <div class="panel-heading">
-            <div class="btn-group btn-group-xs pull-right" role="group" aria-label="{{ts('Actions')}}">
+            <div class="btn-group btn-group-xs pull-right" role="group" aria-label="Actions">
 
               <a class="btn btn-default" target="_blank" ng-href="{{crmUrl(resultForm.server_route)}}"  ng-if="resultForm.server_route">
                 <i class="crm-i fa-location-arrow"></i>
-                {{ts('Open')}}
+                Open
               </a>
 
               <a class="btn btn-default"
                  af-api4-action="['Afform', 'update', {layoutFormat: 'html', where: [['name', '=', resultForm.name]], values:resultForm}]">
                 <i class="crm-i fa-floppy-o"></i>
-                {{ts('Save')}}
+                Save
               </a>
 
             </div>
 
-            {{ts('Markup')}}
+            Markup
           </div>
           <div class="panel-body">
             <div crm-monaco ng-model="resultForm.layout"></div>

--- a/ext/afform/html/ang/afHtmlList.aff.html
+++ b/ext/afform/html/ang/afHtmlList.aff.html
@@ -3,16 +3,16 @@
   af-api4-ctrl="listCtrl">
 
   <div ng-if="apiData.result.length == 0">
-    {{ts('There are no forms! Tell Aristotle!')}}
+    There are no forms! Tell Aristotle!
   </div>
 
   <table>
     <thead>
       <tr>
-        <th>{{ts('Name')}}</th>
-        <th>{{ts('Title')}}</th>
-        <th>{{ts('Server Route')}}</th>
-        <th>{{ts('Frontend?')}}</th>
+        <th>Name</th>
+        <th>Title</th>
+        <th>Server Route</th>
+        <th>Frontend?</th>
         <th></th>
       </tr>
     </thead>
@@ -27,23 +27,23 @@
           <code>{{availForm.server_route}}</code>
         </a>
       </td>
-      <td>{{availForm.is_public ? ts('Frontend') : ts('Backend')}}</td>
+      <td>{{availForm.is_public ? 'Frontend' : 'Backend'}}</td>
       <td>
-        <!--<a ng-click="crmStatus({start: ts('Reverting...'), success: ts('Reverted')}, crmApi4('Afform', 'revert', {where: [['name', '=', availForm.name]]}))">{{ts('Revert')}}</a>-->
+        <!--<a ng-click="crmStatus({start: 'Reverting...', success: 'Reverted'}, crmApi4('Afform', 'revert', {where: [['name', '=', availForm.name]]}))">Revert</a>-->
         <a af-api4-action="['Afform', 'revert', {where: [['name','=', availForm.name]]}]"
-           af-api4-start-msg="ts('Reverting...')"
-           af-api4-success-msg="ts('Reverted')"
+           af-api4-start-msg="'Reverting...'"
+           af-api4-success-msg="'Reverted'"
            af-api4-success="listCtrl.refresh()"
            class="btn btn-xs btn-default"
            ng-if="availForm.has_local && availForm.has_base"
-          >{{ts('Revert')}}</a>
+          >Revert</a>
         <a af-api4-action="['Afform', 'revert', {where: [['name','=', availForm.name]]}]"
-           af-api4-start-msg="ts('Deleting...')"
-           af-api4-success-msg="ts('Deleted')"
+           af-api4-start-msg="'Deleting...'"
+           af-api4-success-msg="'Deleted'"
            af-api4-success="listCtrl.refresh()"
            class="btn btn-xs btn-default"
            ng-if="availForm.has_local && !availForm.has_base"
-        >{{ts('Delete')}}</a>
+        >Delete</a>
       </td>
     </tr>
     </tbody>

--- a/ext/afform/mock/ang/testAfform.aff.html
+++ b/ext/afform/mock/ang/testAfform.aff.html
@@ -20,8 +20,8 @@
   <div af-fieldset="spouse" ng-if="modelListCtrl.getData('parent')['constituent_information.Marital_Status'] == 'M'">
     <h3 class="af-text text-center">About Your Spouse</h3>
     <p class="af-text">Only visible if you are married.</p>
-    <af-field name="first_name" defn='{title: ts("Spouse First Name")}' />
-    <af-field name="last_name" defn='{title: ts("Spouse Last Name")}' />
+    <af-field name="first_name" defn='{title: "Spouse First Name"}' />
+    <af-field name="last_name" defn='{title: "Spouse Last Name"}' />
     <af-field name="do_not_email" />
   </div>
 

--- a/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afformTabMember.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.contact_id, 'status_id.is_current_member': true}"></crm-search-display-table>
-  <h3>{{:: ts('Pending and Inactive Memberships') }}</h3>
+  <h3>Pending and Inactive Memberships</h3>
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.contact_id, 'status_id.is_current_member': false}"></crm-search-display-table>
 </div>
 <div class="af-markup">

--- a/ext/civicrm_admin_ui/ang/afsearchAdminBadgelayout.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminBadgelayout.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-    <div>{{:: ts('Badge Layout screen for creating custom labels') }}
+    <div>Badge Layout screen for creating custom labels
     </div>
     </div>
 

--- a/ext/civicrm_admin_ui/ang/afsearchAdminContactTypes.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminContactTypes.aff.html
@@ -1,8 +1,8 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-      {{:: ts('CiviCRM comes with 3 basic (built-in) contact types: Individual, Household, and Organization. You can create additional contact types based on these basic types to further differentiate contacts (for example you might create Student, Parent, Staff, and /or Volunteer "subtypes" from the basic Individual type...). You can also re-name the built-in types. Contact subtypes are especially useful when you need to collect and display different sets of custom data for different types of contacts.') }}
-      <a href="https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/" target="_blank" class="crm-doc-link no-popup">{{:: ts('Learn more...') }}</a>
+      CiviCRM comes with 3 basic (built-in) contact types: Individual, Household, and Organization. You can create additional contact types based on these basic types to further differentiate contacts (for example you might create Student, Parent, Staff, and /or Volunteer "subtypes" from the basic Individual type...). You can also re-name the built-in types. Contact subtypes are especially useful when you need to collect and display different sets of custom data for different types of contacts.
+      <a href="https://docs.civicrm.org/user/en/latest/organising-your-data/contacts/" target="_blank" class="crm-doc-link no-popup">Learn more...</a>
     </div>
   </div>
   <crm-search-display-table search-name="Administer_Contact_Types" display-name="Contact_Types_Table"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchAdminCustomGroups.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminCustomGroups.aff.html
@@ -1,8 +1,8 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-      {{:: ts('Custom data is stored in custom fields. Custom fields are organized into logically related custom data sets (e.g. Volunteer Info). Use custom fields to collect and store custom data which are not included in the standard CiviCRM forms. You can create one or many sets of custom fields.') }}
-      <a href="https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields" target="_blank" class="crm-doc-link no-popup">{{:: ts('Learn more...') }}</a>
+      Custom data is stored in custom fields. Custom fields are organized into logically related custom data sets (e.g. Volunteer Info). Use custom fields to collect and store custom data which are not included in the standard CiviCRM forms. You can create one or many sets of custom fields.
+      <a href="https://docs.civicrm.org/user/en/latest/organising-your-data/creating-custom-fields" target="_blank" class="crm-doc-link no-popup">Learn more...</a>
     </div>
   </div>
   <div class="af-container af-layout-inline">

--- a/ext/civicrm_admin_ui/ang/afsearchAdminFinancialTypes.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminFinancialTypes.aff.html
@@ -2,13 +2,13 @@
   <div class="af-markup">
     <div class="help">
       <p>
-        {{:: ts('Financial types are used to categorize contributions for reporting and accounting purposes. You may set up as many as needed, including commonly used types such as Donation, Campaign Contribution or Membership Dues.') }}
-        {{:: ts('Additionally, financial types can account for the inventory and expense of premiums.') }}
-        <a ng-href="{{ crmUrl('civicrm/admin/contribute/managePremiums') }}">{{:: ts('View Premiums') }}</a>
+        Financial types are used to categorize contributions for reporting and accounting purposes. You may set up as many as needed, including commonly used types such as Donation, Campaign Contribution or Membership Dues.
+        Additionally, financial types can account for the inventory and expense of premiums.
+        <a ng-href="{{ crmUrl('civicrm/admin/contribute/managePremiums') }}">View Premiums</a>
       </p>
       <p>
-        {{:: ts('Each financial type relates to a number of financial accounts to track income, accounts receivable, and fees.') }}
-        <a ng-href="{{ crmUrl('civicrm/admin/financial/financialAccount') }}">{{:: ts('View Financial Accounts') }}</a>
+        Each financial type relates to a number of financial accounts to track income, accounts receivable, and fees.
+        <a ng-href="{{ crmUrl('civicrm/admin/financial/financialAccount') }}">View Financial Accounts</a>
       </p>
   </div>
 

--- a/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdminScheduledReminders.aff.html
@@ -2,8 +2,8 @@
   <div class="af-markup">
 
     <div class="help">
-      {{:: ts('Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.') }}
-      <a href="https://docs.civicrm.org/user/en/latest/email/scheduled-reminders/" target="_blank" class="crm-doc-link no-popup">{{:: ts('Learn more...') }}</a>
+      Scheduled reminders allow you to automatically send messages to contacts regarding their memberships, participation in events, or other activities.
+      <a href="https://docs.civicrm.org/user/en/latest/email/scheduled-reminders/" target="_blank" class="crm-doc-link no-popup">Learn more...</a>
     </div>
 
   </div>

--- a/ext/civicrm_admin_ui/ang/afsearchAdministerLocationTypes.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdministerLocationTypes.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-      {{:: ts('Location types provide convenient labels to differentiate contacts\' location(s). Administrators may define as many additional types as appropriate for your constituents (examples might be Main Office, School, Vacation Home...).') }}
+      Location types provide convenient labels to differentiate contacts' location(s). Administrators may define as many additional types as appropriate for your constituents (examples might be Main Office, School, Vacation Home...).
     </div>
   </div>
   <crm-search-display-table search-name="Administer_Location_Types" display-name="Location_Types_Table"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchAdministerMembershipStatusRules.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdministerMembershipStatusRules.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-    <p>{{:: ts('The current status of each membership is calculated based on the rules configured here. The status will be set by the first rule that matches the start and end dates of the membership.') }} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/membership/defining-memberships" target="_blank">{{:: ts('Learn more...') }}</a></p>
+    <p>The current status of each membership is calculated based on the rules configured here. The status will be set by the first rule that matches the start and end dates of the membership. <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/membership/defining-memberships" target="_blank">Learn more...</a></p>
     </div>
 
   </div>

--- a/ext/civicrm_admin_ui/ang/afsearchAdministerPaymentProcessors.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdministerPaymentProcessors.aff.html
@@ -1,8 +1,8 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-      {{:: ts('You can configure one or more Payment Processors for your CiviCRM installation. You must then assign an active Payment Processor to each Online Contribution Page and each paid Event.') }}
-      <a href="https://docs.civicrm.org/user/en/latest/contributions/payment-processors/" target="_blank" class="crm-doc-link no-popup">{{:: ts('Learn more...') }}</a>
+      You can configure one or more Payment Processors for your CiviCRM installation. You must then assign an active Payment Processor to each Online Contribution Page and each paid Event.
+      <a href="https://docs.civicrm.org/user/en/latest/contributions/payment-processors/" target="_blank" class="crm-doc-link no-popup">Learn more...</a>
     </div>
   </div>
   <crm-search-display-table search-name="Administer_Payment_Processors" display-name="Administer_Payment_Processors_Table"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchAssignUsersToRoles.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAssignUsersToRoles.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-markup">
-    <div class="help">{{:: ts('ACLs allow you to control access to CiviCRM data. An ACL consists of an Operation (e.g. View or Edit), a set of data that the operation can be performed on (e.g. a group of contacts), and a Role that has permission to do this operation.') }} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control/" target="_blank">{{:: ts('Learn more ...') }}</a></div>
+    <div class="help">ACLs allow you to control access to CiviCRM data. An ACL consists of an Operation (e.g. View or Edit), a set of data that the operation can be performed on (e.g. a group of contacts), and a Role that has permission to do this operation. <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control/" target="_blank">Learn more ...</a></div>
 
   </div>
   <crm-search-display-table search-name="ACL_Roles" display-name="ACL_Roles_Table_1"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchFinancialAccounts.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchFinancialAccounts.aff.html
@@ -1,12 +1,12 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-      {{:: ts('Financial accounts correspond to those in your accounting system.') }}
-      {{:: ts('The following are associated with financial accounts so that they can result in the proper double-entry transactions to export to your accounting system:') }}
-      <a ng-href="{{:: crmUrl('civicrm/admin/financial/financialType?reset=1') }}">{{:: ts('Financial types') }}</a>,
-      <a ng-href="{{:: crmUrl('civicrm/admin/options/payment_instrument?reset=1') }}">{{:: ts('payment methods') }}</a>,
-      {{:: ts('and') }}
-      <a ng-href="{{:: crmUrl('civicrm/admin/contribute/managePremiums?reset=1') }}">{{:: ts('contribution premiums.') }}</a>
+      Financial accounts correspond to those in your accounting system.
+      The following are associated with financial accounts so that they can result in the proper double-entry transactions to export to your accounting system:
+      <a ng-href="{{:: crmUrl('civicrm/admin/financial/financialType?reset=1') }}">Financial types</a>,
+      <a ng-href="{{:: crmUrl('civicrm/admin/options/payment_instrument?reset=1') }}">payment methods</a>,
+      and
+      <a ng-href="{{:: crmUrl('civicrm/admin/contribute/managePremiums?reset=1') }}">contribution premiums.</a>
     </div>
   </div>
   <crm-search-display-table search-name="Administer_Financial_Accounts" display-name="Administer_Financial_Accounts_Table_1"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchImportExportMappings.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchImportExportMappings.aff.html
@@ -1,5 +1,5 @@
 <div class="af-markup">
-  <div class="help">{{:: ts('Saved mappings allow you to easily run the same import or export job multiple times. Mappings are created and updated as part of an Import or Export task. This screen allows you to rename or delete existing mappings.') }}</div>
+  <div class="help">Saved mappings allow you to easily run the same import or export job multiple times. Mappings are created and updated as part of an Import or Export task. This screen allows you to rename or delete existing mappings.</div>
 
 </div>
 <div af-fieldset="">

--- a/ext/civicrm_admin_ui/ang/afsearchLabelFormats.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchLabelFormats.aff.html
@@ -1,17 +1,17 @@
 <div class="help">
 
-  <div>{{:: ts('You can configure one or more Label Formats for your CiviCRM installation. Label Formats are used when creating mailing labels.')}}<br/>
-{{:: ts('You can change which fields are printed on each label in')}} <a ng-href="{{ crmUrl('civicrm/admin/setting/preferences/address?reset=1') }}">{{:: ts('Address Settings')}}</a>.</div>
+  <div>You can configure one or more Label Formats for your CiviCRM installation. Label Formats are used when creating mailing labels.<br/>
+You can change which fields are printed on each label in <a ng-href="{{ crmUrl('civicrm/admin/setting/preferences/address?reset=1') }}">Address Settings</a>.</div>
 
 </div>
 <div crm-ui-tab-set="">
 
-  <div af-fieldset="" crm-ui-tab="" crm-title="ts('Mailing Labels')" id="tab-mailinglabels">
+  <div af-fieldset="" crm-ui-tab="" crm-title="'Mailing Labels'" id="tab-mailinglabels">
     <div class="af-markup">
       <crm-search-display-table search-name="Label_Formats" display-name="Label_Formats_Table_1" filters="{'option_group_id:name': 'label_format'}"/>
     </div>
   </div>
-  <div af-fieldset="" crm-ui-tab="" crm-title="ts('Name Badges')" id="tab-namebadge">
+  <div af-fieldset="" crm-ui-tab="" crm-title="'Name Badges'" id="tab-namebadge">
     <div class="af-markup">
       <crm-search-display-table search-name="Label_Formats" display-name="Label_Formats_Table_1" filters="{'option_group_id:name': 'name_badge'}"/>
     </div>

--- a/ext/civicrm_admin_ui/ang/afsearchManageACLs.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageACLs.aff.html
@@ -1,8 +1,8 @@
 <div af-fieldset="">
   <div class="help">
-    <p>{{:: ts('ACLs allow you to control access to CiviCRM data. An ACL consists of an Operation (e.g. "View" or "Edit"), a set of data the operation can be performed on (e.g. a group of contacts), and a user Role the ACL applies to.') }}</p>
-    <p>{{:: ts('Depending on the chosen mode, each ACL either Allows or Denies permission. When multiple rules contradict each other (e.g. one rule allows and the second rule denies access to the same contacts) the rule with the highest priority takes precidence.') }}</p>
-    <p><a href="https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control/" target="_blank">{{:: ts('Learn more...') }}</a></p>
+    <p>ACLs allow you to control access to CiviCRM data. An ACL consists of an Operation (e.g. "View" or "Edit"), a set of data the operation can be performed on (e.g. a group of contacts), and a user Role the ACL applies to.</p>
+    <p>Depending on the chosen mode, each ACL either Allows or Denies permission. When multiple rules contradict each other (e.g. one rule allows and the second rule denies access to the same contacts) the rule with the highest priority takes precidence.</p>
+    <p><a href="https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control/" target="_blank">Learn more...</a></p>
   </div>
   <crm-search-display-table search-name="Manage_ACLs" display-name="Manage_ACLs_Table_1"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchManageContributionPages.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageContributionPages.aff.html
@@ -1,5 +1,5 @@
 <div class="af-markup">
-  <div class="help">{{:: ts('CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns, and you can customize text, amounts, types of information collected from contributors, etc.') }} </div>
+  <div class="help">CiviContribute allows you to create and maintain any number of Online Contribution Pages. You can create different pages for different programs or campaigns, and you can customize text, amounts, types of information collected from contributors, etc. </div>
 </div>
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
@@ -9,11 +9,11 @@
   <div class="btn-group pull-right">
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/pcp', {reset: 1}) }}">
       <i class="crm-i fa-plus"/>
-      {{:: ts('Manage Personal Campaign Pages') }}
+      Manage Personal Campaign Pages
     </a>
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/contribute/add', {reset: 1, action: 'add'}) }}">
       <i class="crm-i fa-plus"/>
-      {{:: ts('Add Contribution Page') }}
+      Add Contribution Page
     </a>
   </div>
   <crm-search-display-table search-name="Manage_Contribution_Pages" display-name="Manage_Contribution_Pages_Table_1"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageScheduledJobs.aff.html
@@ -1,8 +1,8 @@
 <div class="af-markup">
   <div class="help">
-    {{:: ts('CiviCRM relies on a number of scheduled jobs that run automatically on a regular basis. These jobs keep data up-to-date and perform other important tasks.') }}
-    {{:: ts('For most sites, your system administrator should set up one or more "cron" tasks to run the enabled jobs. You can also run all scheduled jobs using the button below, or specific jobs from this screen using the "Execute Now" buttons.') }}
-    <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/sysadmin/en/latest/setup/jobs" target="_blank" title="{{:: ts('Opens documentation in a new window.', {'escape': 'js'}) }}">{{:: ts('(How to setup cron on the command line...)') }}</a>
+    CiviCRM relies on a number of scheduled jobs that run automatically on a regular basis. These jobs keep data up-to-date and perform other important tasks.
+    For most sites, your system administrator should set up one or more "cron" tasks to run the enabled jobs. You can also run all scheduled jobs using the button below, or specific jobs from this screen using the "Execute Now" buttons.
+    <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/sysadmin/en/latest/setup/jobs" target="_blank" title="Opens documentation in a new window.">(How to setup cron on the command line...)</a>
   </div>
 </div>
 <div af-fieldset="">
@@ -14,15 +14,15 @@
   <div class="btn-group pull-right">
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/job/add', {reset: 1, action: 'add'}) }}">
       <i class="crm-i fa-plus-circle"/>
-      {{:: ts('Add Scheduled Job') }}
+      Add Scheduled Job
     </a>
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/runjobs', {reset: 1}) }}">
       <i class="crm-i fa-forward"/>
-      {{:: ts('Execute All Scheduled Jobs') }}
+      Execute All Scheduled Jobs
     </a>
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/joblog', {reset: 1}) }}">
       <i class="crm-i fa-list-alt"/>
-      {{:: ts('View Log') }}
+      View Log
     </a>
   </div>
   <crm-search-display-table search-name="Scheduled_Jobs" display-name="Scheduled_Jobs_Table_2"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchPremiumProducts.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchPremiumProducts.aff.html
@@ -1,9 +1,9 @@
 <div class="af-container">
   <div class="af-markup">
     <div class="help">
-    <p>{{:: ts(&#39;CiviContribute allows you to configure any number of Premiums which can be offered to contributors as incentives / thank-you gifts. Premiums may be tangible items (i.e. a coffee mug or t-shirt), or they may be a membership or subscription with a pre-determined duration.&#39;) }}</p>
+    <p>CiviContribute allows you to configure any number of Premiums which can be offered to contributors as incentives / thank-you gifts. Premiums may be tangible items (i.e. a coffee mug or t-shirt), or they may be a membership or subscription with a pre-determined duration.</p>
 
-    <p>{{:: ts(&#39;Use this section to enter and update all premiums that you want to offer on any of your Online Contribution pages. Then you can assign one or more premiums to a specific Contribution page from Contributions &raquo; Manage Contribution Pages &raquo; Configure &raquo; Premiums.&#39;) }}</p>
+    <p>Use this section to enter and update all premiums that you want to offer on any of your Online Contribution pages. Then you can assign one or more premiums to a specific Contribution page from Contributions &raquo; Manage Contribution Pages &raquo; Configure &raquo; Premiums.</p>
     </div>
 
   </div>

--- a/ext/civicrm_admin_ui/ang/afsearchPrintPagePDFFormats.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchPrintPagePDFFormats.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-markup">
     <div class="help">
-    <div>{{:: ts('You can configure one or more PDF Page Formats for your CiviCRM installation. PDF Page Formats may be assigned to Message Templates to use when creating PDF letters.')}}</div>
+    <div>You can configure one or more PDF Page Formats for your CiviCRM installation. PDF Page Formats may be assigned to Message Templates to use when creating PDF letters.</div>
     </div>
   </div>
   <crm-search-display-table search-name="Print_Page_PDF_Formats" display-name="Option_Values_Table_1"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchProfiles.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchProfiles.aff.html
@@ -4,7 +4,7 @@
 
 
 
-  <div class="help">{{:: ts('Profiles allow you to aggregate groups of fields and include them in your site as input forms, contact display pages, and search and listings features. They provide a powerful set of tools for you to collect information from constituents and selectively share contact information.') }} <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/" target="_blank">{{:: ts('Learn more...') }}</a></div>
+  <div class="help">Profiles allow you to aggregate groups of fields and include them in your site as input forms, contact display pages, and search and listings features. They provide a powerful set of tools for you to collect information from constituents and selectively share contact information. <a class="crm-doc-link no-popup" href="https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/" target="_blank">Learn more...</a></div>
 
 
 

--- a/ext/civicrm_admin_ui/ang/afsearchRelationshipTypes.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchRelationshipTypes.aff.html
@@ -1,9 +1,9 @@
 <div class="af-container">
   <div class="af-markup">
     <div class="help">
-      <p>{{:: ts('Relationship types describe relationships between people, households and organizations. Relationship types labels describe the relationship from the perspective of each of the two entities (e.g. Parent &gt;-&lt; Child, Employer &gt;-&lt; Employee). For some types of relationships, the labels may be the same in both directions (e.g. Spouse &gt;-&lt; Spouse).') }} <a class="crm-doc-link no-popup"
-          href="https://docs.civicrm.org/user/en/latest/organising-your-data/relationships" target="_blank">{{:: ts('(Learn more...)') }}</a></p>
-      <p>{{:: ts('You can define as many additional relationships types as needed to cover the types of relationships you want to track. Once a relationship type is created, you may also define custom fields to extend relationship information for that type from ') }} <a ng-href="{{ crmUrl('civicrm/admin/custom/group?reset=1') }}">{{:: ts('Administer CiviCRM &raquo; Custom Data') }}</a></p>
+      <p>Relationship types describe relationships between people, households and organizations. Relationship types labels describe the relationship from the perspective of each of the two entities (e.g. Parent &gt;-&lt; Child, Employer &gt;-&lt; Employee). For some types of relationships, the labels may be the same in both directions (e.g. Spouse &gt;-&lt; Spouse). <a class="crm-doc-link no-popup"
+          href="https://docs.civicrm.org/user/en/latest/organising-your-data/relationships" target="_blank">(Learn more...)</a></p>
+      <p>You can define as many additional relationships types as needed to cover the types of relationships you want to track. Once a relationship type is created, you may also define custom fields to extend relationship information for that type from  <a ng-href="{{ crmUrl('civicrm/admin/custom/group?reset=1') }}">Administer CiviCRM &raquo; Custom Data</a></p>
     </div>
   </div>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchSMSProvider.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchSMSProvider.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-markup">
-    <div class="help">{{:: ts('You can configure one or more SMS Providers for your CiviCRM installation..') }} <a ng-href="https://docs.civicrm.org/user/en/latest/sms-text-messaging/set-up" target="_blank">{{:: ts('(Learn more...)') }}</a></div>
+    <div class="help">You can configure one or more SMS Providers for your CiviCRM installation.. <a ng-href="https://docs.civicrm.org/user/en/latest/sms-text-messaging/set-up" target="_blank">(Learn more...)</a></div>
 
   </div>
   <crm-search-display-table search-name="SMS_Provider" display-name="SMS_Provider_Table_1"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchScheduledJobsLog.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchScheduledJobsLog.aff.html
@@ -1,15 +1,15 @@
 <div af-fieldset="">
   <div class="btn-group pull-right">
-    
-    
-    
+
+
+
     <a class="btn btn-primary" ng-href="{{:: crmUrl('civicrm/admin/job', {reset: 1}) }}">
       <i class="crm-i fa-list-alt"/>
-      {{:: ts('Scheduled Jobs Listing') }}
+      Scheduled Jobs Listing
     </a>
-  
-  
-  
+
+
+
   </div>
   <crm-search-display-table search-name="Scheduled_Jobs_Log" display-name="Scheduled_Jobs_Log_Table_1" filters="{job_id: routeParams.job_id}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchSettingsDatePreferences.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchSettingsDatePreferences.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-markup">
-    <div class="help">{{:: ts('Changing the parameters here affects the input and display for specific fields types. Setting the default date format for the entire site is a Localisation setting.') }} <a ng-href="{{:: crmUrl('civicrm/admin/setting/date?action=reset=1') }}">{{:: ts('See Administer > Localization > Date Formats.') }}</a></div>
+    <div class="help">Changing the parameters here affects the input and display for specific fields types. Setting the default date format for the entire site is a Localisation setting. <a ng-href="{{:: crmUrl('civicrm/admin/setting/date?action=reset=1') }}">See Administer > Localization > Date Formats.</a></div>
 
   </div>
   <crm-search-display-table search-name="Settings_Date_Preferences" display-name="Settings_Date_Preferences"></crm-search-display-table>

--- a/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.html
@@ -1,9 +1,9 @@
 <div af-fieldset="" store-values="1">
   <div class="af-container af-layout-inline">
-    <af-field name="activity_type_id" defn="{input_attrs: {multiple: true, placeholder: ts('Include')}, label: false, search_operator: 'IN'}" />
-    <af-field name="activity_type_id" defn="{input_attrs: {multiple: true, placeholder: ts('Exclude')}, label: false, search_operator: 'NOT IN'}" />
-    <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: ts('Status')}, label: false}" />
-    <af-field name="activity_date_time" defn="{input_type: 'Select', search_range: true, input_attrs: {placeholder: ts('Date')}, label: false}" />
+    <af-field name="activity_type_id" defn="{input_attrs: {multiple: true, placeholder: 'Include'}, label: false, search_operator: 'IN'}" />
+    <af-field name="activity_type_id" defn="{input_attrs: {multiple: true, placeholder: 'Exclude'}, label: false, search_operator: 'NOT IN'}" />
+    <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: 'Status'}, label: false}" />
+    <af-field name="activity_date_time" defn="{input_type: 'Select', search_range: true, input_attrs: {placeholder: 'Date'}, label: false}" />
   </div>
   <crm-search-display-table search-name="Contact_Summary_Activities" display-name="Contact_Summary_Activities_Tab" filters="{'Activity_ActivityContact_Contact_01.id': options.contact_id}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchTabMember.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchTabMember.aff.html
@@ -1,5 +1,5 @@
 <div af-fieldset="">
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Active" filters="{contact_id: options.contact_id, 'status_id.is_current_member': true}"></crm-search-display-table>
-  <h3>{{:: ts('Pending and Inactive Memberships') }}</h3>
+  <h3>Pending and Inactive Memberships</h3>
   <crm-search-display-table search-name="Contact_Summary_Memberships" display-name="Contact_Summary_Memberships_Inactive" filters="{contact_id: options.contact_id, 'status_id.is_current_member': false}"></crm-search-display-table>
 </div>

--- a/ext/oauth-client/ang/oauthClientCreateHelp.aff.html
+++ b/ext/oauth-client/ang/oauthClientCreateHelp.aff.html
@@ -1,32 +1,32 @@
 <div oauth-util-import="CRM.oauthUtil.redirectUrl" to="redirectUrl"></div>
 <div class="help">
-  <p>{{ts('Please register with your web-service provider first. Be sure to:')}}</p>
+  <p>Please register with your web-service provider first. Be sure to:</p>
   <ul>
     <li>
       <p>
-        {{ts('Configure the "Redirect URL":')}}
+        Configure the "Redirect URL":
       </p>
       <pre>{{redirectUrl}}</pre>
       <div ng-if="redirectUrl.startsWith('http:/') &amp;&amp; !redirectUrl.match('//(localhost|127\.0\.0\.1)')">
         <p>
-          {{ts('WARNING: Most web-service providers require "https://" URLs. Alternatively, "http://" may be accepted for strictly local URLs ("localhost" or "127.0.0.1").')}}
+          WARNING: Most web-service providers require "https://" URLs. Alternatively, "http://" may be accepted for strictly local URLs ("localhost" or "127.0.0.1").
         </p>
         <p>
-          {{ts('If you are doing development or testing on a local HTTP virtual-host, then consider a work-around like "bin/local-redir.sh".')}}
+          If you are doing development or testing on a local HTTP virtual-host, then consider a work-around like "bin/local-redir.sh".
         </p>
       </div>
     </li>
 
     <li ng-if="options.provider.options.scopes.length">
       <p>
-        {{ts('Configure the scopes:')}}
+        Configure the scopes:
       </p>
       <pre>{{options.provider.options.scopes.join("\n")}}</pre>
     </li>
 
     <li>
-      {{ts('Determine the client credentials, including a client ID and secret.')}}
+      Determine the client credentials, including a client ID and secret.
     </li>
   </ul>
-  <p>{{ts('Finally, enter the client credentials below.')}}</p>
+  <p>Finally, enter the client credentials below.</p>
 </div>

--- a/ext/oauth-client/ang/oauthClientCreator.aff.html
+++ b/ext/oauth-client/ang/oauthClientCreator.aff.html
@@ -3,16 +3,16 @@
 <div ng-form="create" class="form-horizontal">
   <div class="form-group">
     <div>
-      <label for="guid">{{ts('Client ID')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
+      <label for="guid">Client ID: <span class="crm-marker" title="Required">*</span></label>
       <input class="form-control" ng-model="options.client.guid" type="text" id="guid" required />
     </div>
     <div ng-if="theProviders[options.client.provider].options.tenancy">
-      <label for="tenant">{{ts('Tenant ID')}}:</label>
+      <label for="tenant">Tenant ID:</label>
       <input class="form-control" ng-model="options.client.tenant" type="text" id="tenant" />
-      <div class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</div>
+      <div class="help-block">Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.</div>
     </div>
     <div>
-      <label for="secret">{{ts('Client Secret')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
+      <label for="secret">Client Secret: <span class="crm-marker" title="Required">*</span></label>
       <input class="form-control" ng-model="options.client.secret" type="text" id="secret" required />
     </div>
   </div>

--- a/ext/oauth-client/ang/oauthClientEditor.aff.html
+++ b/ext/oauth-client/ang/oauthClientEditor.aff.html
@@ -3,33 +3,33 @@
 <div ng-form="update" class="form-horizontal">
   <div class="form-group">
     <div>
-      <label for="provider{{options.client.id}}">{{ts('Provider')}}:</label>
+      <label for="provider{{options.client.id}}">Provider:</label>
       <input class="form-control" ng-model="options.client.provider" disabled id="provider{{options.client.id}}">
     </div>
     <div>
-      <label for="id{{options.client.id}}">{{ts('Client ID (Private)')}}:</label>
+      <label for="id{{options.client.id}}">Client ID (Private):</label>
       <input class="form-control" ng-model="options.client.id" type="text" id="id{{options.client.id}}" disabled/>
     </div>
     <div>
-      <label for="guid{{options.client.id}}">{{ts('Client ID (Public)')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
+      <label for="guid{{options.client.id}}">Client ID (Public): <span class="crm-marker" title="Required">*</span></label>
       <input class="form-control" ng-model="options.client.guid" type="text" id="guid{{options.client.id}}" required/>
     </div>
     <div ng-if="theProviders[options.client.provider].options.tenancy">
-      <label for="tenant{{options.client.id}}">{{ts('Tenant ID')}}:</label>
+      <label for="tenant{{options.client.id}}">Tenant ID:</label>
       <input class="form-control" ng-model="options.client.tenant" type="text" id="tenant{{options.client.id}}"/>
-      <p class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</p>
+      <p class="help-block">Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.</p>
     </div>
     <div>
-      <label for="secret{{options.client.id}}">{{ts('Client Secret')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
+      <label for="secret{{options.client.id}}">Client Secret: <span class="crm-marker" title="Required">*</span></label>
       <input class="form-control" ng-model="options.client.secret" type="text" id="secret{{options.client.id}}" required/>
     </div>
     <div ng-if="options.client.created_date">
-      <label for="created_date{{options.client.id}}">{{ts('Created Date')}}:</label>
+      <label for="created_date{{options.client.id}}">Created Date:</label>
       <input class="form-control" ng-model="options.client.created_date" disabled
              id="created_date{{options.client.id}}">
     </div>
     <div ng-if="options.client.modified_date">
-      <label for="modified_date{{options.client.id}}">{{ts('Modified Date')}}:</label>
+      <label for="modified_date{{options.client.id}}">Modified Date:</label>
       <input class="form-control" ng-model="options.client.modified_date" disabled
              id="modified_date{{options.client.id}}">
     </div>

--- a/ext/oauth-client/ang/oauthClientList.aff.html
+++ b/ext/oauth-client/ang/oauthClientList.aff.html
@@ -3,15 +3,15 @@
   af-api4-ctrl="listCtrl">
 
   <div ng-if="apiData.result.length == 0">
-    {{ts('There are no clients!')}}
+    There are no clients!
   </div>
 
   <table>
     <thead>
       <tr>
-        <th>{{ts('ID')}}</th>
-        <th>{{ts('Provider')}}</th>
-        <th>{{ts('GUID')}}</th>
+        <th>ID</th>
+        <th>Provider</th>
+        <th>GUID</th>
         <th></th>
       </tr>
     </thead>
@@ -25,19 +25,19 @@
       <td>
       <!--
         <a af-api4-action="['Afform', 'revert', {where: [['name','=', availClient.name]]}]"
-           af-api4-start-msg="ts('Reverting...')"
-           af-api4-success-msg="ts('Reverted')"
+           af-api4-start-msg="'Reverting...'"
+           af-api4-success-msg="'Reverted'"
            af-api4-success="listCtrl.refresh()"
            class="btn btn-xs btn-default"
            ng-if="availClient.has_local && availClient.has_base"
-          >{{ts('Revert')}}</a>
+          >Revert</a>
           -->
         <a af-api4-action="['OAuthClient', 'delete', {where: [['id','=', availClient.id]]}]"
-           af-api4-start-msg="ts('Deleting...')"
-           af-api4-success-msg="ts('Deleted')"
+           af-api4-start-msg="'Deleting...'"
+           af-api4-success-msg="'Deleted'"
            af-api4-success="listCtrl.refresh()"
            class="btn btn-xs btn-default"
-        >{{ts('Delete')}}</a>
+        >Delete</a>
       </td>
     </tr>
     </tbody>

--- a/ext/oauth-client/ang/oauthClientTokens.aff.html
+++ b/ext/oauth-client/ang/oauthClientTokens.aff.html
@@ -1,17 +1,17 @@
 <div af-api4-ctrl="tokens" af-api4="['OAuthSysToken', 'get', {'where': [['client_id', '=', options.clientId]]}]">
 </div>
 <div ng-if="tokens.result.length == 0">
-  {{ts('No tokens found')}}
+  No tokens found
 </div>
 
 <table class="table" ng-if="tokens.result.length > 0">
   <tr>
-    <th>{{ts('ID')}}</th>
-    <th>{{ts('Tag')}}</th>
-    <th>{{ts('On Behalf Of')}}</th>
-    <th>{{ts('Scopes')}}</th>
-    <th>{{ts('Created Date')}}</th>
-    <th>{{ts('Actions')}}</th>
+    <th>ID</th>
+    <th>Tag</th>
+    <th>On Behalf Of</th>
+    <th>Scopes</th>
+    <th>Created Date</th>
+    <th>Actions</th>
   </tr>
   <tr ng-repeat="token in tokens.result">
     <td>{{token.id}}</td>
@@ -25,14 +25,14 @@
            ng-if="token.access_token"
            ng-href="{{crmUrl('civicrm/admin/oauth-jwt-debug#!/', {id: token.id})}}"
            target="_blank"
-        >{{ts('Inspect')}}</a>
+        >Inspect</a>
 
         <a class="btn btn-danger"
            af-api4-action="['OAuthSysToken', 'delete', {where: [['id', '=', token.id]]}]"
-           af-api4-start-msg="ts('Deleting...')"
-           af-api4-success-msg="ts('Deleted')"
+           af-api4-start-msg="'Deleting...'"
+           af-api4-success-msg="'Deleted'"
            af-api4-success="tokens.refresh()"
-        >{{ts('Delete')}}</a>
+        >Delete</a>
       </div>
     </td>
   </tr>

--- a/ext/oauth-client/ang/oauthProviderDetail.aff.html
+++ b/ext/oauth-client/ang/oauthProviderDetail.aff.html
@@ -5,9 +5,9 @@
 <div ng-if="!theClients.loading">
   <div class="panel panel-info" ng-init="selected = {tab: theClients.result.length > 0 ? 'client_' + theClients.result[0].id : 'new'}">
     <ul class="panel-heading nav nav-tabs">
-      <li role="tab" ng-repeat="theClient in theClients.result" ng-class="{active: selected.tab === 'client_' + theClient.id}"><a ng-click="selected.tab = 'client_' + theClient.id">{{ts('Client #%1', {1: theClient.id})}}</a></li>
-      <li role="tab" ng-class="{active: selected.tab === 'new'}"><a ng-click="selected.tab = 'new'">{{ts('Register Client')}}</a></li>
-      <li role="tab" ng-class="{active: selected.tab === 'details'}"><a ng-click="selected.tab = 'details'">{{ts('Details')}}</a></li>
+      <li role="tab" ng-repeat="theClient in theClients.result" ng-class="{active: selected.tab === 'client_' + theClient.id}"><a ng-click="selected.tab = 'client_' + theClient.id">Client #{{theClient.id}}</a></li>
+      <li role="tab" ng-class="{active: selected.tab === 'new'}"><a ng-click="selected.tab = 'new'">Register Client</a></li>
+      <li role="tab" ng-class="{active: selected.tab === 'details'}"><a ng-click="selected.tab = 'details'">Details</a></li>
     </ul>
 
     <div role="tabpanel" class="panel-body" ng-if="selected.tab === 'details'">
@@ -16,24 +16,24 @@
 
     <div role="tabpanel" class="panel-body" ng-repeat="resultClient in theClients.result" ng-if="selected.tab === 'client_'+resultClient.id">
       <div ng-form="editClientForm">
-        <h4>{{ts('Tokens')}}</h4>
+        <h4>Tokens</h4>
 
         <oauth-client-tokens options="{clientId: resultClient.id}"></oauth-client-tokens>
 
         <div class="btn-group" oauth-util-grant-ctrl="granter">
-          <a class="btn btn-primary" ng-click="granter.authCode(resultClient.id)">{{ts('Add (Auth Code)')}}</a>
+          <a class="btn btn-primary" ng-click="granter.authCode(resultClient.id)">Add (Auth Code)</a>
         </div>
 
-        <h4>{{ts('Properties')}}</h4>
+        <h4>Properties</h4>
 
         <oauth-client-editor options="{client: resultClient}"></oauth-client-editor>
         <div class="btn-group">
           <a class="btn btn-primary"
-             af-api4-action="['OAuthClient', 'update', {where: [['id', '=', resultClient.id]], values:resultClient}]">{{ts('Save')}}</a>
+             af-api4-action="['OAuthClient', 'update', {where: [['id', '=', resultClient.id]], values:resultClient}]">Save</a>
           <a class="btn btn-danger"
              af-api4-action="['OAuthClient', 'delete', {where: [['id', '=', resultClient.id]]}]"
              af-api4-success="selected.tab = 'details'; theClients.refresh()"
-          >{{ts('Delete')}}</a>
+          >Delete</a>
         </div>
 
       </div>
@@ -47,7 +47,7 @@
         <a class="btn btn-primary"
            af-api4-action="['OAuthClient', 'create', {values:theNew}]"
            af-api4-success="theNew = {provider: options.provider.name}; theClients.refresh(); selected.tab = 'client_' + response[0].id"
-        >{{ts('Add')}}</a>
+        >Add</a>
       </div>
     </div>
   </div>

--- a/ext/oauth-client/ang/oauthProviderList.aff.html
+++ b/ext/oauth-client/ang/oauthProviderList.aff.html
@@ -2,7 +2,7 @@
 
 <div class="help">
   <p>
-    {{ts('CiviCRM may be configured as a client that interacts with remote web-services, such as Google Mail or Microsoft Exchange. Please choose the type of web-service you wish to connect to:')}}
+    CiviCRM may be configured as a client that interacts with remote web-services, such as Google Mail or Microsoft Exchange. Please choose the type of web-service you wish to connect to:
   </p>
 
   <!--
@@ -13,8 +13,8 @@
 <table>
   <thead>
   <tr>
-    <th>{{ts('Name')}}</th>
-    <th>{{ts('Title')}}</th>
+    <th>Name</th>
+    <th>Title</th>
   </tr>
   </thead>
   <tbody>

--- a/ext/standaloneusers/ang/afformEditUserAccount.aff.html
+++ b/ext/standaloneusers/ang/afformEditUserAccount.aff.html
@@ -4,10 +4,10 @@
     <af-field name="roles" />
     <af-field name="username" />
     <af-field name="contact_id" defn="{required: true, input_attrs: {quickAdd: ['civicrm/quick-add/Individual']}}" />
-    <af-field name="uf_name" defn="{help_pre: ts('Email used for password resets.'), input_attrs: {placeholder: ts('Leave blank to use the primary email from the selected contact')}}" />
+    <af-field name="uf_name" defn="{help_pre: 'Email used for password resets.', input_attrs: {placeholder: 'Leave blank to use the primary email from the selected contact'}}" />
     <af-field name="is_active" />
-    <af-field name="timezone" defn="{help_pre: ts('Set the timezone of the user. Date and times will be shown in this timezone. You can also leave it empty to use the default system timezone (which is a server setting).'), input_attrs: {placeholder: ts('Server default timezone')}}" />
-    <af-field name="language" defn="{help_pre: ts('Set the user interface language of this user. You can also leave it empty to use the default system language.'), input_attrs: {placeholder: ts('System default language')}}" />
+    <af-field name="timezone" defn="{help_pre: 'Set the timezone of the user. Date and times will be shown in this timezone. You can also leave it empty to use the default system timezone (which is a server setting).', input_attrs: {placeholder: 'Server default timezone'}}" />
+    <af-field name="language" defn="{help_pre: 'Set the user interface language of this user. You can also leave it empty to use the default system language.', input_attrs: {placeholder: 'System default language'}}" />
   </fieldset>
   <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
 </af-form>

--- a/ext/standaloneusers/ang/afsearchAdministerRoles.aff.html
+++ b/ext/standaloneusers/ang/afsearchAdministerRoles.aff.html
@@ -1,6 +1,6 @@
 <div class="af-markup">
   <div class="help">
-  <p>{{:: ts('Roles define sets of permissions for different types of users. You can give users roles to grant them permissions appropriate to their needs.') }}</p>
+  <p>Roles define sets of permissions for different types of users. You can give users roles to grant them permissions appropriate to their needs.</p>
   </div>
 
 </div>

--- a/ext/standaloneusers/ang/afsearchAdministerUserAccounts.aff.html
+++ b/ext/standaloneusers/ang/afsearchAdministerUserAccounts.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-markup">
-    <div class="help"><p>{{:: ts('User accounts allow people to access CiviCRM. What they can access is determined by which roles the users have, and what permissions are granted to those roles.') }}</p>
+    <div class="help"><p>User accounts allow people to access CiviCRM. What they can access is determined by which roles the users have, and what permissions are granted to those roles.</p>
     </div>
   </div>
   <div class="af-container af-layout-cols" af-title="Filters">

--- a/ext/standaloneusers/ang/afsearchPermissions.aff.html
+++ b/ext/standaloneusers/ang/afsearchPermissions.aff.html
@@ -1,6 +1,6 @@
 <div af-fieldset="">
   <div class="af-container af-layout-inline">
-    <af-field name="title,name,description" defn="{label: false, search_operator: 'CONTAINS', input_attrs: {placeholder: ts('Search Permissions')}}" />
+    <af-field name="title,name,description" defn="{label: false, search_operator: 'CONTAINS', input_attrs: {placeholder: 'Search Permissions'}}" />
   </div>
   <crm-search-display-table search-name="Permissions" display-name="Permissions_Table_1"></crm-search-display-table>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Followup from https://github.com/civicrm/civicrm-core/pull/32859 this removes inline `ts()` from translatable strings as it's no longer required in the form markup.
