### PR TITLE
SearchKit - Fix hierarchical table style in Riverlea theme

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -45,3 +45,67 @@ table.crm-sticky-header > thead > tr {
   border: var(--crm-table-outside-border);
   box-shadow: var(--crm-block-shadow);
 }
+
+/* Nested styling for hierarchical rows */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-row {
+  position: relative;
+}
+#bootstrap-theme .crm-search-display-table crm-search-display-toggle-collapse {
+  position: relative;
+  z-index: 1;
+}
+/* Depth >= 1 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child {
+  padding-left: 35px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 15px;
+  width: 15px;
+  height: calc(100%/2);
+  border-bottom: 2px dotted currentColor;
+  border-left: 2px dotted currentColor;
+}
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-1 crm-search-display-toggle-collapse {
+  left: 30px;
+}
+/* Depth = 2 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2 {
+  padding-left: 65px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2:before {
+  left: 45px;
+}
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-2 crm-search-display-toggle-collapse {
+  left: 60px;
+}
+/* Depth = 3 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3 {
+  padding-left: 95px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3:before {
+  left: 75px;
+}
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-3 crm-search-display-toggle-collapse {
+  left: 90px;
+}
+/* Depth = 4 */
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column),
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4 {
+  padding-left: 125px;
+}
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column):before,
+#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4:before {
+  left: 105px;
+}
+#bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-4 crm-search-display-toggle-collapse {
+  left: 120px;
+}

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -54,58 +54,58 @@ table.crm-sticky-header > thead > tr {
   position: relative;
   z-index: 1;
 }
+
 /* Depth >= 1 */
-#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column),
-#bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child {
-  padding-left: 35px;
+#bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column), #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child {
+  padding-left: 2.5rem;
 }
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-child:first-child:not(.crm-search-ctrl-column):before,
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-child:before {
   content: "";
   position: absolute;
   top: 0;
-  left: 15px;
-  width: 15px;
-  height: calc(100%/2);
+  left: 1rem;
+  width: 1rem;
+  height: 50%;
   border-bottom: 2px dotted currentColor;
   border-left: 2px dotted currentColor;
 }
 #bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-1 crm-search-display-toggle-collapse {
-  left: 30px;
+  left: 1.5rem;
 }
 /* Depth = 2 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column),
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2 {
-  padding-left: 65px;
+  padding-left: 4rem;
 }
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-2:first-child:not(.crm-search-ctrl-column):before,
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-2:before {
-  left: 45px;
+  left: 2.5rem;
 }
 #bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-2 crm-search-display-toggle-collapse {
-  left: 60px;
+  left: 3rem;
 }
 /* Depth = 3 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column),
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3 {
-  padding-left: 95px;
+  padding-left: 5.5rem;
 }
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-3:first-child:not(.crm-search-ctrl-column):before,
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-3:before {
-  left: 75px;
+  left: 4rem;
 }
 #bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-3 crm-search-display-toggle-collapse {
-  left: 90px;
+  left: 4.5rem;
 }
 /* Depth = 4 */
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column),
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4 {
-  padding-left: 125px;
+  padding-left: 7rem;
 }
 #bootstrap-theme .crm-search-display-table tr td.crm-hierarchical-depth-4:first-child:not(.crm-search-ctrl-column):before,
 #bootstrap-theme .crm-search-display-table tr td.crm-search-ctrl-column + td.crm-hierarchical-depth-4:before {
-  left: 105px;
+  left: 5.5rem;
 }
 #bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-4 crm-search-display-toggle-collapse {
-  left: 120px;
+  left: 6rem;
 }


### PR DESCRIPTION
Overview
----------------------------------------
This copies the missing "nested styling for hierarchical rows" into the Riverlea theme.

Before
----------------------------------------
Hierarchical table appears flat (e.g. Manage Groups or User Permissions screens).

After
----------------------------------------
<img width="2162" height="1526" alt="image" src="https://github.com/user-attachments/assets/29ca7ce7-6540-467c-b36a-7fa1bb8e77ab" />
