### PR TITLE
Check for CiviReport access by role in WordPress

### DIFF
--- a/CRM/Core/Permission/WordPress.php
+++ b/CRM/Core/Permission/WordPress.php
@@ -87,6 +87,28 @@ class CRM_Core_Permission_WordPress extends CRM_Core_Permission_Base {
   /**
    * @inheritDoc
    */
+  public function checkGroupRole($array) {
+    // Determine access by role.
+    $allowed = FALSE;
+    foreach ($array as $role) {
+      if (current_user_can($role)) {
+        $allowed = TRUE;
+        break;
+      }
+    }
+
+    /**
+     * Filters access by role.
+     *
+     * @param bool  $allowed Return FALSE to retain existing behaviour, return TRUE according to your needs.
+     * @param array $array The array of role names.
+     */
+    return apply_filters('civicrm_permissions_check_group_role', $allowed, $array);
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getAvailablePermissions() {
     // We want to list *only* WordPress perms, so we'll *skip* Civi perms.
     $mungedCorePerms = array_map(


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #33214 with the addition of a filter that allows others to modify the behaviour of the method.

See https://lab.civicrm.org/dev/core/-/issues/6008

Before
----------------------------------------
Roles ignored.

After
----------------------------------------
Roles respected.

Technical Details
----------------------------------------
The filter allows modifications to be made, e.g. to deny access to a particular user (below with ID 234) even though they may have one of the the required roles:

```php
add_filter('civicrm_permissions_check_group_role', 'my_group_role_check', 10, 2);
function my_group_role_check($permission_granted, $roles) {
  $user_id = get_current_user_id();
  if (234 === (int) $user_id) {
    return FALSE;
  }
  return $permission_granted;
}
```