### PR TITLE
SearchKit - Add 'nowrap' styling option

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -285,6 +285,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     if (!empty($column['alignment'])) {
       $cssClass[] = $column['alignment'];
     }
+    if (!empty($column['nowrap'])) {
+      $cssClass[] = 'nowrap';
+    }
     if (!empty($column['show_linebreaks'])) {
       if ($column['type'] === 'html') {
         $out['val'] = nl2br($out['val']);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/buttons.html
@@ -2,7 +2,7 @@
   <label for="crm-search-admin-col-size-{{$index}}">
     {{:: ts('Button Size') }}
   </label>
-  <select id="crm-search-admin-col-size-{{$index}}" class="form-control" ng-model="col.size">
+  <select id="crm-search-admin-col-size-{{$index}}" class="form-control crm-auto-width" ng-model="col.size">
     <option value="btn-lg">{{:: ts('Large') }}</option>
     <option value="">{{:: ts('Regular') }}</option>
     <option value="btn-sm">{{:: ts('Small') }}</option>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
@@ -31,8 +31,16 @@
       </button>
       <details>
         <summary> {{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline" title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
-          <label><input type="checkbox" ng-model="col.break"> {{:: ts('New Line') }}</label>
+        <div class="form-inline">
+          <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
+            <input type="checkbox" ng-model="col.break">
+            {{:: ts('New Line') }}
+          </label>
+          &nbsp;
+          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+            <input type="checkbox" ng-model="col.nowrap" >
+            {{:: ts('Prevent Wrapping') }}
+          </label>
         </div>
         <div class="form-inline crm-search-admin-flex-row">
           <label>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -45,8 +45,16 @@
       </button>
       <details>
         <summary>{{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline" title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
-          <label><input type="checkbox" ng-model="col.break"> {{:: ts('New Line') }}</label>
+        <div class="form-inline">
+          <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
+            <input type="checkbox" ng-model="col.break">
+            {{:: ts('New Line') }}
+          </label>
+          &nbsp;
+          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+            <input type="checkbox" ng-model="col.nowrap" >
+            {{:: ts('Prevent Wrapping') }}
+          </label>
         </div>
         <div class="form-inline crm-search-admin-flex-row">
           <label>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -121,12 +121,19 @@
           <input id="crm-search-admin-edit-header-{{ $index }}" class="form-control crm-flex-1" type="text" ng-model="col.label" >
         </div>
         <div class="form-inline">
-          <label>{{:: ts('Alignment') }}</label>
-          <select ng-model="col.alignment" class="form-control crm-auto-width">
-            <option value="">{{:: ts('Left') }}</option>
-            <option value="text-center">{{:: ts('Center') }}</option>
-            <option value="text-right">{{:: ts('Right') }}</option>
-          </select>
+          <label>
+            {{:: ts('Alignment') }}
+            <select ng-model="col.alignment" class="form-control crm-auto-width">
+              <option value="">{{:: ts('Left') }}</option>
+              <option value="text-center">{{:: ts('Center') }}</option>
+              <option value="text-right">{{:: ts('Right') }}</option>
+            </select>
+          </label>
+          &nbsp;
+          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+            <input type="checkbox" ng-model="col.nowrap" >
+            {{:: ts('Prevent Wrapping') }}
+          </label>
         </div>
         <div class="form-inline" ng-if="$ctrl.parent.canBeSortable(col)">
           <label title="{{:: ts('Allow user to click on header to sort table by this column') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.html
@@ -58,8 +58,16 @@
       </button>
       <details>
         <summary> {{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline" title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
-          <label><input type="checkbox" ng-model="col.break"> {{:: ts('New Line') }}</label>
+        <div class="form-inline">
+          <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
+            <input type="checkbox" ng-model="col.break">
+            {{:: ts('New Line') }}
+          </label>
+          &nbsp;
+          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+            <input type="checkbox" ng-model="col.nowrap" >
+            {{:: ts('Prevent Wrapping') }}
+          </label>
         </div>
         <div class="form-inline crm-search-admin-flex-row">
           <label>


### PR DESCRIPTION


Overview
----------------------------------------
This new option can be used to keep buttons and other stuff inline

<img width="1248" height="384" alt="image" src="https://github.com/user-attachments/assets/3b4dfb20-4291-45ed-9d49-993988cae42c" />

Based on @vingle's suggestion from https://github.com/civicrm/civicrm-core/pull/33464#issuecomment-3227502090