### PR TITLE
ensure adding wildcard to "quick search -> advanced search workflow" works when automatic wildcard setting is enabled

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -148,6 +148,7 @@ class CRM_Core_Resources_Common {
     $settings = [
       'config' => [
         'isFrontend' => $config->userFrameworkFrontend,
+        'includeWildCardInName' => $config->includeWildCardInName,
       ],
     ];
     // Disable profile creation if user lacks permission

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -408,11 +408,17 @@
             return false;
           }
         }
-        // Form redirects to Advanced Search, which does not automatically search with wildcards,
-        // aside from contact name.
-        // To get comparable results, append wildcard to the search term.
-        else if (searchkey !== 'sort_name' && searchkey !== 'id') {
-          $('#crm-qsearch-input').val(searchValue + '%');
+        // Form redirects to Advanced Search, which does not automatically
+        // search with wildcards, aside from contact name and a few other
+        // fields. To get comparable results, append and possible prepend
+        // wildcard to the search term.
+        else if (searchkey !== 'id') {
+          if (CRM.config.includeWildCardInName == 1) {
+            $('#crm-qsearch-input').val('%' + searchValue + '%');
+          }
+          else {
+            $('#crm-qsearch-input').val(searchValue + '%');
+          }
         }
       });
       $('#civicrm-menu').on('show.smapi', function(e, menu) {


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a regression from https://github.com/civicrm/civicrm-core/pull/32773.

In the conversation, the "Automatic Wildcard" setting is addressed but dismissed as not relevant.

However, there are scenarios when it results in the wrong behavior because advanced search, it turns out, is weird.

Before
----------------------------------------

Here are two examples of things going wrong when Automatic Wildcard setting is configured to yes.

### City Search
1. In Quick Search, the Automatic Wildcard setting is respected, so when I search for "rook" I get the results for '%rook%' (e.g. "Brooklyn" as expected).
2. When I hit enter, a % is added to create "rook%". 
3. And advanced search shows no results because there is no city that starts with rook.

### Phone or street address search

1. Phone search (same happens with street search). In Quick Search, the Automatic Wildcard setting is respected, so when I search for 509, I get 555-509-5555.
2. When I hit enter, a % is added to create "509%"
3. Normally, advanced search both adds a % prefix _and_ suffix to phone numbers and street addresses - even if Automatic Wildcard is turned off. But, now that we are adding a percentage to the end of the string, this [check kicks in](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contact/BAO/Query.php#L3615) which detects the presence of a percentage sign, and then doesn't add anything. 
4. Then I get no results for 509 when quick search showed results.

After
----------------------------------------

Now we simply check for the Automatic wildcard setting and add an extra percentage if necessary.

Technical Details
----------------------------------------
Also, I dropped the check for name. Advanced search won't add two percentages, so there is no harm in adding a percentage to a name field. And, it's not just name that gets percentages added (phone numbers and street addresses do also), so checking for name might lead a future me to thinking that name is the only field with percentages added.