### PR TITLE
FormBuilder - Don't wrap headers of afform listing

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -39,7 +39,7 @@
 
   <table class="table table-striped">
     <thead>
-    <tr>
+    <tr class="nowrap">
       <th title="{{:: ts('Click to sort') }}" ng-click="$ctrl.sortBy('title')">
         <i class="crm-i fa-sort disabled" ng-if="$ctrl.sortField !== 'title'"></i>
         <i class="crm-i fa-sort-{{ $ctrl.sortDir ? 'asc' : 'desc' }}" ng-if="$ctrl.sortField === 'title'"></i>


### PR DESCRIPTION
Overview
----------------------------------------
Makes FormBuilder table look less messy by putting table headers all on one line.

Before
----------------------------------------
<img width="2710" height="508" alt="image" src="https://github.com/user-attachments/assets/d2b9ab3c-a6a5-4cb0-b663-a3887cc4a1f1" />

After
----------------------------------------
<img width="2714" height="440" alt="image" src="https://github.com/user-attachments/assets/3f27dd87-38c6-4d2e-b5c3-ed1c2e66152b" />
