### PR TITLE
dev/core#3302: Add accessible fieldset for checkboxes and radio buttons of price set and payment options

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -412,6 +412,17 @@ input.crm-form-entityref {
   width: auto;
 }
 
+.crm-container .crm-sr-fieldset {
+  border: 0;
+  padding: 0;
+  margin-left: 0px;
+}
+
+.crm-container .crm-sr-fieldset legend {
+  position: absolute;
+  font-weight: normal;
+}
+
 .crm-container fieldset.form-layout {
   margin: .25em 0 .5em 0;
   padding: 1px 10px 1px 10px;

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -258,9 +258,11 @@
       <fieldset class="crm-public-form-item crm-group payment_options-group" style="display:none;">
         <legend>{ts}Payment Options{/ts}</legend>
         <div class="crm-public-form-item crm-section payment_processor-section">
-          <div class="label">{$form.payment_processor_id.label}</div>
-          <div class="content">{$form.payment_processor_id.html}</div>
-          <div class="clear"></div>
+          <fieldset class="crm-sr-fieldset">
+            <legend class="label">{$form.payment_processor_id.label|strip_tags}</legend>
+            <div class="content">{$form.payment_processor_id.html}</div>
+            <div class="clear"></div>
+          </fieldset>
         </div>
       </fieldset>
     {/if}

--- a/templates/CRM/Price/Form/PriceSet.tpl
+++ b/templates/CRM/Price/Form/PriceSet.tpl
@@ -29,31 +29,33 @@
             <div class="crm-section {$element.name|escape}-section crm-price-field-id-{$field_id}">
             {if ($element.html_type eq 'CheckBox' || $element.html_type == 'Radio') && $element.options_per_line}
               {assign var="element_name" value="price_`$field_id`"}
-              <div class="label">{$form.$element_name.label}</div>
-              <div class="content {$element.name|escape}-content">
-              {if $element.help_pre}<div class="description">{$element.help_pre|purify}</div>{/if}
-                {assign var="elementCount" value="0"}
-                {assign var="optionCount" value="0"}
-                {assign var="rowCount" value="0"}
-                {foreach name=outer key=key item=item from=$form.$element_name}
-                  {assign var="elementCount" value=$elementCount+1}
-                  {if is_numeric($key)}
-                    {assign var="optionCount" value=$optionCount+1}
-                    {if $optionCount == 1}
-                      {assign var="rowCount" value=$rowCount+1}
-                      <div class="price-set-row {$element.name|escape}-row{$rowCount}">
+              <fieldset class="crm-sr-fieldset">
+                <legend class="label">{$form.$element_name.label}</legend>
+                  <div class="content {$element.name|escape}-content">
+                    {if $element.help_pre}<div class="description">{$element.help_pre|purify}</div>{/if}
+                    {assign var="elementCount" value="0"}
+                    {assign var="optionCount" value="0"}
+                    {assign var="rowCount" value="0"}
+                    {foreach name=outer key=key item=item from=$form.$element_name}
+                      {assign var="elementCount" value=$elementCount+1}
+                      {if is_numeric($key)}
+                        {assign var="optionCount" value=$optionCount+1}
+                        {if $optionCount == 1}
+                          {assign var="rowCount" value=$rowCount+1}
+                          <div class="price-set-row {$element.name|escape}-row{$rowCount}">
+                        {/if}
+                        <span class="price-set-option-content">{$form.$element_name.$key.html}</span>
+                        {if $optionCount == $element.options_per_line || $elementCount == $form.$element_name|@count}
+                          </div>
+                          {assign var="optionCount" value="0"}
+                        {/if}
+                       {/if}
+                    {/foreach}
+                    {if $element.help_post}
+                      <div class="description">{$element.help_post|purify}</div>
                     {/if}
-                    <span class="price-set-option-content">{$form.$element_name.$key.html}</span>
-                    {if $optionCount == $element.options_per_line || $elementCount == $form.$element_name|@count}
-                      </div>
-                      {assign var="optionCount" value="0"}
-                    {/if}
-                  {/if}
-                {/foreach}
-                {if $element.help_post}
-                  <div class="description">{$element.help_post|purify}</div>
-                {/if}
-              </div>
+                </div>
+              </fieldset>
             {else}
 
                 {assign var="element_name" value="price_"|cat:$field_id}


### PR DESCRIPTION
Overview
----------------------------------------

As per https://www.w3.org/WAI/tutorials/forms/grouping , grouped form controls like radio buttons/checkboxes must be enclosed in `<fieldset>` and the `<legend>` element act as a header to identify the group of elements. Currently, when we review such block with WAVE accessibility tool, it complains about:

## Proposal

1. Enclose the checkbox/radio button block in a fieldset
2. Add a special class to that fieldset say `crm-sr-fieldset` which hides it in front-end forms (public and backoffice forms)
3. Use label of checkbox/radio buttons as its legend header.

Before
----------------------------------------
<img width="1006" height="603" alt="before-1" src="https://github.com/user-attachments/assets/afb210f8-724c-4657-bf18-4db08fa6db89" />
<img width="707" height="327" alt="before-2" src="https://github.com/user-attachments/assets/b63621b8-6ccb-466b-9dc7-ed09b9ef62ce" />


After
----------------------------------------
<img width="974" height="700" alt="after-1" src="https://github.com/user-attachments/assets/1ff5e068-f538-4cf0-a5ed-df573140aaa3" />
<img width="720" height="134" alt="after-2" src="https://github.com/user-attachments/assets/7e7f9a63-d901-4643-9dc5-2aafd68e07c4" />


Comments
----------------------------------------
ping @colemanw @vingle @seamuslee001 