### PR TITLE
dev/core#4561 : On new mailing screen the widget for include/exclude double-escapes characters

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -476,8 +476,8 @@ class AutocompleteAction extends AbstractAction {
     if (!strlen($this->input) || \CRM_Utils_Rule::integer($this->input)) {
       return TRUE;
     }
-    $currentSearchField = $this->getField($this->getCurrentSearchField());
-    return $currentSearchField['data_type'] !== 'Integer';
+    $currentSearchField = $this->getField($this->getCurrentSearchField())['data_type'] ?? '';
+    return $currentSearchField !== 'Integer';
   }
 
 }

--- a/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
@@ -139,7 +139,7 @@ class MailingRecipientsAutocompleteProvider extends AutoService implements Event
       ],
       'columns' => [
         [
-          'type' => 'field',
+          'type' => 'html',
           'key' => 'label',
           'empty_value' => '(' . ts('no name') . ')',
           'icons' => [

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -361,6 +361,24 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     $this->assertEquals('Second Star', $result[0]['label']);
   }
 
+  public function testMailingAutocompleteWithSpecialCharacter(): void {
+    $this->createTestRecord('Group', [
+      'title' => 'Donors contributed > $100',
+      'frontend_title' => 'Donors contributed > $100',
+      'name' => 'Donors_contributed',
+      'group_type:name' => 'Mailing List',
+    ]);
+
+    // search by special character '>'
+    $result = EntitySet::autocomplete()
+      ->setInput('>')
+      ->setFieldName('Mailing.recipients_include')
+      ->setFormName('crmMailing.1')
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals('Donors contributed > $100', $result[0]['label']);
+  }
+
   /**
    * Emulates the behavior of `$.fn.crmAutocomplete` in Common.js
    *


### PR DESCRIPTION
Overview
----------------------------------------
1. Create a group like "2023 Donated >$100". You don't have to actually create a search, just manually create a group with that title.
2. On the new mailing screen, try filtering by typing ">$100". It won't find it because the title displays as `&gt;$100`. Searching for `gt;` will find it but that's silly.

Before
----------------------------------------
<img width="801" height="594" alt="Screenshot 2025-09-01 at 4 45 52 PM" src="https://github.com/user-attachments/assets/7d939b5d-5b06-43c1-887a-8d2cf3c3183e" />


After
----------------------------------------
<img width="842" height="491" alt="after" src="https://github.com/user-attachments/assets/07b1b01d-8fcd-4b42-a165-6e539882399f" />

Comments
----------------------------------------
ping @colemanw @seamuslee001 
