### PR TITLE
RiverLea: restores crm-tooltip-down behaviour on contact layout & search

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -157,15 +157,23 @@
   background-color: var(--crm-dropdown-hover-bg);
 }
 
-/* Tooltip - used on the contact dashboard but no-where else? */
+/* Tooltip - contact dashboard/contact search */
 
+.crm-container .crm-tooltip-active {
+  position: relative;
+}
 .crm-container .crm-tooltip-wrapper {
   position: absolute;
-  z-index: 10000;
+  z-index: 100;
   background: none;
   padding-bottom: 0;
-  margin: -12px;
+  margin-left: -12px;
+  bottom: 0;
   display: none;
+}
+.crm-container .crm-tooltip-down .crm-tooltip-wrapper {
+  top: 0;
+  bottom: unset;
 }
 .crm-container .crm-summary-display_name .crm-tooltip-wrapper {
   margin: -10px -5px;
@@ -178,7 +186,16 @@
   background: var(--crm-c-background);
   border-radius: var(--crm-roundness);
 }
-.crm-container .crm-tooltip-wrapper::before {
+.crm-container .crm-tooltip-active:not(.crm-tooltip-down) .crm-tooltip-wrapper::after {
+  border-top: 10px solid var(--crm-c-background);
+  border-left: 10px solid rgba(0,0,0,0);
+  border-right: 10px solid rgba(0,0,0,0);
+  content: "";
+  left: var(--crm-m2);
+  position: relative;
+  bottom: -7px;
+}
+.crm-container .crm-tooltip-active.crm-tooltip-down .crm-tooltip-wrapper::before {
   border-bottom: 10px solid var(--crm-c-background2);
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);


### PR DESCRIPTION
Overview
----------------------------------------
Issue: "Contact details pop-up from search results can open outside viewport" https://lab.civicrm.org/dev/core/-/issues/6072

Before
----------------------------------------
Bottom of viewport tooltips can load outside of viewport, ignore the `.crm-tooltip-down` class

<img width="869" height="229" alt="image" src="https://github.com/user-attachments/assets/cdb4975a-2fed-446a-982f-65e26c10f1b6" />

After
----------------------------------------
Bottom of viewport tooltips respond to the `.crm-tooltip-down` class

<img width="771" height="370" alt="image" src="https://github.com/user-attachments/assets/2a7102b7-a7f2-4e05-97ac-eea1de28941f" />

Comments
----------------------------------------
In this PR also lowered the Z-index, and fixed an issue with positioning (lack of a container set to `position: relative`) and margin.