### PR TITLE
Deal with possiblity that API result from cron is a throwable Excepti…

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -264,16 +264,25 @@ class CRM_Core_JobManager {
    * @return string
    */
   private function apiResultToMessage($apiResult) {
-    $status = ($apiResult['is_error'] ?? FALSE) ? ts('Failure') : ts('Success');
-    $msg = $apiResult['error_message'] ?? 'empty error_message!';
-    $vals = $apiResult['values'] ?? 'empty values!';
+    if ($apiResult instanceof \Throwable) {
+      $status = ts('Failure');
+      $msg = $apiResult->getMessage();
+      $vals = 'empty values!';
+      $is_error = TRUE;
+    }
+    else {
+      $status = ($apiResult['is_error'] ?? FALSE) ? ts('Failure') : ts('Success');
+      $msg = $apiResult['error_message'] ?? 'empty error_message!';
+      $vals = $apiResult['values'] ?? 'empty values!';
+      $is_error = ($apiResult['is_error'] ?? FALSE);
+    }
     if (is_array($msg)) {
       $msg = serialize($msg);
     }
     if (is_array($vals)) {
       $vals = serialize($vals);
     }
-    $message = ($apiResult['is_error'] ?? FALSE) ? ', Error message: ' . $msg : " (" . $vals . ")";
+    $message = $is_error ? ', Error message: ' . $msg : " (" . $vals . ")";
     return $status . $message;
   }
 


### PR DESCRIPTION
…on e.g. TypeError and should not be accessed like an array

Overview
----------------------------------------
On a client site I was finding that we were getting the following in the cron logs

```
In JobManager.php line 267:

  Cannot use object of type TypeError as array


api3 [--in IN] [--out OUT] [--flat [FLAT]] [-T|--out=table] [-I|--out=list] [--level LEVEL] [--hostname HOSTNAME] [-t|--test] [-U|--user USER] [--] <Entity.action> [<key=value>...]
```

Before
----------------------------------------
In APIResulttoMessage it assumes we always have an array as the passed in parameter

After
----------------------------------------
Deal with the possibly that there is an throwable exception passed through

Technical Details
----------------------------------------
as per [L178](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/JobManager.php#L178) it is possible thtat $result is a throwable exception so we need to handle this better in this function 

ping @colemanw @eileenmcnaughton @totten @monishdeb @Edzelopez 