### PR TITLE
Ensure that Entity table is always included in the params passed to t…

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -550,7 +550,9 @@ class CRM_Core_BAO_CustomValueTable {
           ));
         }
 
+        $entity = CRM_Core_BAO_CustomGroup::getEntityFromExtends($fieldInfo['custom_group']['extends']);
         $cvParam = [
+          'entity_table' => CRM_Core_DAO_AllCoreTables::getTableForEntityName($entity),
           'entity_id' => $params['entityID'],
           'value' => $fieldValue['value'],
           'type' => $dataType,

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
@@ -6,9 +6,15 @@
  */
 class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
+  public function setUp(): void {
+    parent::setUp();
+    $this->hookClass->setHook('civicrm_custom', [$this, 'hook_custom']);
+  }
+
   public function tearDown(): void {
     $this->quickCleanup(['civicrm_file', 'civicrm_entity_file'], TRUE);
     parent::tearDown();
+    $this->hookClass->reset();
   }
 
   /**
@@ -270,6 +276,12 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
 
     $this->assertEquals($params['custom_' . $customField['id'] . '_-1'], $result['custom_' . $customField['id']]);
     $this->assertEquals($params['entityID'], $result['entityID']);
+  }
+
+  public function hook_custom($op, $groupID, $entityID, &$params) {
+    foreach ($params as $field) {
+      $this->assertTrue(array_key_exists('entity_table', $field));
+    }
   }
 
 }

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -43,6 +43,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   public function setUp(): void {
     parent::setUp();
+    $this->hookClass->setHook('civicrm_custom', [$this, 'hook_custom']);
     $this->_contactID = $this->individualCreate();
     $this->_membershipTypeID = $this->membershipTypeCreate(['member_of_contact_id' => $this->ids['Contact']['individual_0']]);
     $this->_membershipTypeID2 = $this->membershipTypeCreate([
@@ -1538,6 +1539,12 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals('2009-01-21', $result['start_date']);
     $this->assertEquals('2009-12-21', $result['end_date']);
     $this->assertEquals('Payment', $result['source']);
+  }
+
+  public function hook_custom($op, $groupID, $entityID, &$params) {
+    foreach ($params as $field) {
+      $this->assertTrue(array_key_exists('entity_table', $field));
+    }
   }
 
 }

--- a/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
+++ b/tests/phpunit/api/v4/Custom/BasicCustomFieldTest.php
@@ -121,6 +121,7 @@ class BasicCustomFieldTest extends Api4TestBase {
   }
 
   public function testWithTwoFields(): void {
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_custom', [$this, 'hook_custom']);
     $optionGroupCount = OptionGroup::get(FALSE)->selectRowCount()->execute()->count();
 
     // First custom set - use underscores in the names to ensure the API doesn't have a problem with them
@@ -278,6 +279,7 @@ class BasicCustomFieldTest extends Api4TestBase {
 
     $this->assertNotContains($contactId1, array_keys((array) $search));
     $this->assertNotContains($contactId2, array_keys((array) $search));
+    \CRM_Utils_Hook::singleton()->reset();
   }
 
   public function testRelationshipCacheCustomFields(): void {
@@ -743,6 +745,12 @@ class BasicCustomFieldTest extends Api4TestBase {
     $this->assertEquals('<em>Hello</em><br />APIv3 & RichText!', $dbVal);
     $dbVal = \CRM_Core_DAO::singleValueQuery("SELECT {$field2['column_name']} FROM {$custom['table_name']}");
     $this->assertEquals('<em>Hello</em><br />APIv3 & TextArea!', $dbVal);
+  }
+
+  public function hook_custom($op, $groupID, $entityID, &$params) {
+    foreach ($params as $field) {
+      $this->assertTrue(array_key_exists('entity_table', $field));
+    }
   }
 
 }


### PR DESCRIPTION
…he CustomValueTable::create

Overview
----------------------------------------
This ensures that when the CustomValueTable::create that the entity_table key is populated

Before
----------------------------------------
entity_table array key not always populated

After
----------------------------------------
Entity Table key always populated

ping @colemanw @demeritcowboy @christianwach 