### PR TITLE
dev/core#6056 SearchKit - Fix filters on boolean functions

### DIFF
--- a/Civi/Api4/Query/Api4EntitySetQuery.php
+++ b/Civi/Api4/Query/Api4EntitySetQuery.php
@@ -134,7 +134,7 @@ class Api4EntitySetQuery extends Api4Query {
    * @param string $expr
    * @return array|null
    */
-  public function getField($expr) {
+  public function getField(string $expr):? array {
     $col = strpos($expr, ':');
     $fieldName = $col ? substr($expr, 0, $col) : $expr;
     return $this->apiFieldSpec[$fieldName] ?? NULL;

--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -64,6 +64,8 @@ abstract class Api4Query {
     $this->api = $api;
   }
 
+  abstract public function getField(string $expr):? array;
+
   /**
    * Builds main final sql statement after initialization.
    *
@@ -328,7 +330,7 @@ abstract class Api4Query {
           $expr = $this->getExpression($this->selectAliases[$fieldAlias], ['SqlFunction']);
           $fauxField = [
             'name' => NULL,
-            'data_type' => $expr->getRenderedDataType($this->apiFieldSpec),
+            'data_type' => $expr->getRenderedDataType($this),
           ];
           FormattingUtil::formatInputValue($value, NULL, $fauxField, $this->entityValues, $operator);
         }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -394,11 +394,11 @@ class Api4SelectQuery extends Api4Query {
    * @param bool $strict
    *   In strict mode, this will throw an exception if the field doesn't exist
    *
-   * @return array|bool|null
+   * @return array|null
    * @throws \CRM_Core_Exception
    * @throws UnauthorizedException
    */
-  public function getField($expr, $strict = FALSE) {
+  public function getField(string $expr, bool $strict = FALSE):? array {
     // If the expression contains a pseudoconstant filter like activity_type_id:label,
     // strip it to look up the base field name, then add the field:filter key to apiFieldSpec
     $col = strpos($expr, ':');
@@ -420,7 +420,7 @@ class Api4SelectQuery extends Api4Query {
     if ($field) {
       $this->apiFieldSpec[$expr] = $field;
     }
-    return $field;
+    return $field ?: NULL;
   }
 
   public function getFieldSibling(array $field, string $siblingFieldName) {

--- a/Civi/Api4/Query/SqlExpression.php
+++ b/Civi/Api4/Query/SqlExpression.php
@@ -228,6 +228,10 @@ abstract class SqlExpression {
     return static::$dataType;
   }
 
+  public function getRenderedDataType(?Api4Query $query):? string {
+    return static::getDataType();
+  }
+
   /**
    * Shift a keyword off the beginning of the argument string and return it.
    *

--- a/Civi/Api4/Query/SqlField.php
+++ b/Civi/Api4/Query/SqlField.php
@@ -38,4 +38,18 @@ class SqlField extends SqlExpression {
     return ts('Field');
   }
 
+  /**
+   * Returns the output dataType based on field definition
+   *
+   * @param
+   * @return string|null
+   */
+  public function getRenderedDataType(?Api4Query $query): ?string {
+    $field = $query?->getField($this->expr);
+    if (!empty($field['serialize'])) {
+      return 'Array';
+    }
+    return $field['data_type'] ?? NULL;
+  }
+
 }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -285,11 +285,10 @@ abstract class SqlFunction extends SqlExpression {
   /**
    * Returns the dataType of rendered output, based on the fields passed into the function
    *
-   * @param array $fieldSpecs
-   *   List of available fields, e.g. Api4Query::$apiFieldSpec
+   * @param
    * @return string|null
    */
-  public function getRenderedDataType(array $fieldSpecs): ?string {
+  public function getRenderedDataType(?Api4Query $query): ?string {
     $dataType = $this::getDataType();
     if ($dataType) {
       return $dataType;
@@ -298,8 +297,9 @@ abstract class SqlFunction extends SqlExpression {
       return 'Array';
     }
     $fields = $this->getFields();
-    if (!empty($fields[0])) {
-      return $fieldSpecs[$fields[0]]['data_type'] ?? NULL;
+    if ($query && !empty($fields[0])) {
+      $sqlField = parent::convert($fields[0]);
+      return $sqlField->getRenderedDataType($query);
     }
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
When exposing a filter for a transformed field e.g. IS_NOT_NULL, this ensures the `=` operator is used instead of defaulting to `CONTAINS`.

Fixes [dev/core#6056](https://lab.civicrm.org/dev/core/-/issues/6056)

Replaces https://github.com/civicrm/civicrm-core/pull/33396

Technical Details 
-----------
Adjusts the filter code to use SqlFunction metadata, not just field metadata, as appropriate.