### PR TITLE
[REF] Change visibilty of CustomValueTable::create to be private as n…

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -26,7 +26,7 @@ class CRM_Core_BAO_CustomValueTable {
    *
    * @throws Exception
    */
-  public static function create($customParams, $parentOperation = NULL) {
+  private static function create($customParams, $parentOperation = NULL) {
     if (empty($customParams) ||
       !is_array($customParams)
     ) {


### PR DESCRIPTION
…o other classes directly call this function

Overview
----------------------------------------
This changes the visibilty of the CRM_Core_BAO_CustomValueTable::create method from being public to private to try and abvoid any direct callers. I have done a grep in the Universe and cannot see this being directly called. Extensions can still call CustomValueTable::store or CustomValueTable::setValues or CustomValueTable::postProcess as needed which all intern eventually call this function its self but only from within the class

Before
----------------------------------------
Method is public

After
----------------------------------------
Method is private

ping @demeritcowboy @eileenmcnaughton @colemanw thoughts?