### PR TITLE
Case: default empty date custom field error when filled

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -176,7 +176,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
             $label = $customField['label'];
 
             // before/after values from form
-            $oldValue = $this->_defaults[$fieldKey] ?? NULL;
+            $oldValue = $this->_defaults[$fieldKey] ?? '';
             $newValue = $newCustomValue;
 
             // Convert dropdown and other machine values to human labels.
@@ -194,7 +194,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
     return implode('<br/>', $formattedDetails);
   }
 
-  private function formatDisplayValue(mixed $value, int $customFieldId, string $customFieldDataType): string {
+  private function formatDisplayValue(mixed $value, int $customFieldId, string $customFieldDataType): string|null {
     switch ($customFieldDataType) {
       case 'Money':
         // Money is special for non-US locales because at this point it's in human format so we don't try

--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -176,7 +176,7 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form {
             $label = $customField['label'];
 
             // before/after values from form
-            $oldValue = $this->_defaults[$fieldKey] ?? '';
+            $oldValue = $this->_defaults[$fieldKey] ?? NULL;
             $newValue = $newCustomValue;
 
             // Convert dropdown and other machine values to human labels.


### PR DESCRIPTION
Overview
----------------------------------------
After creating a case that has a date custom field where default is empty or null, when you try to fill the custom field on the case view, it produces an error `PHP Fatal error:  Uncaught TypeError: CRM_Case_Form_CustomData::formatDisplayValue(): Return value must be of type string, null returned`.
Main trace is in CRM/Case/Form/CustomData.php:244.

Before
----------------------------------------
Error on filling the custom field when previous data was null/empty.

After
----------------------------------------
Should accept the data as normal if previous data was empty/null.

Replication
----------------------------------------
1. Create a custom field that extends Cases. The field shout be a date with empty default.
2. Create a Case without filling the custom field
3. In the Case View, fill up the field and submit.
4. This will an error code of 500

Technical Details
----------------------------------------
CiviCRM: 6.5
WP: 
