### PR TITLE
When using Order API make sure we always add an invoice ID to the contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -630,8 +630,24 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
       // TODO: the same calculation is done in various places in the form layer
       // would be good to remove
       if (!isset($event->params['invoice_id'])) {
-        $event->params['invoice_id'] = bin2hex(random_bytes(16));
+        $event->params['invoice_id'] = self::generateInvoiceID();
       }
+    }
+  }
+
+  /**
+   * Note: Invoice IDs are generated all over the place.
+   *   This function was added to consolidate that so we have one place where the IDs are generated
+   *
+   * @return string
+   * @throws \Random\RandomException
+   */
+  public static function generateInvoiceID(): string {
+    try {
+      return bin2hex(random_bytes(16));
+    }
+    catch (Random\RandomException $e) {
+      return '';
     }
   }
 

--- a/Civi/Api4/Action/Order/Create.php
+++ b/Civi/Api4/Action/Order/Create.php
@@ -62,6 +62,10 @@ class Create extends AbstractAction {
         throw new \CRM_Core_Exception(ts('Invalid financial type %1', [1 => $financialType]));
       }
     }
+    if (empty($values['invoice_id'])) {
+      $values['invoice_id'] = \CRM_Contribute_BAO_Contribution::generateInvoiceID();
+    }
+    $this->setContributionValues($values);
     return $values;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
When you use the Order API it returns the contribution record.

In 6.5 a pre hook was added to populate the invoice ID for the contribution if not set: https://github.com/civicrm/civicrm-core/pull/32967 - however this is too late for things like the Order API because it will not be returned in the contribution data that is returned.

We could do another API call to get the contribution details including the invoice ID but this seems wasteful and we always want an invoice ID to be set anyway. If we want to pass in our own we can still do so via Order API.

Before
----------------------------------------
Invoice ID populated at the last minute and not returned by Order API.

After
----------------------------------------
Invoice ID populated by Order API v4 when creating a new Order if it was not passed in. That means we get the invoice ID back in the result.

Technical Details
----------------------------------------
Since the actual code to generate an invoice ID is duplicated all over the place I added a static function `generateInvoiceID()` on `CRM_Contribution_BAO_Contribution` that can be used. Ideally we'd switch all instances to use that and then could optionally change the invoice ID generation if we wanted to in the future.

Order Create API4 already looks up and gets financial_type_id and checks/sets a couple of other Contribution parameters. It seems sensible to add invoice_id as well.


Comments
----------------------------------------
Note: One of the main reasons for adding this was while writing shoppingcart and testing afform_payments. I found that contributions were being created without an invoice ID and subsequently failing to match with Stripe Checkout and webhooks. Result, payments not recorded in CiviCRM.

