### PR TITLE
dev/core#4561 - Ensure mailing widget correctly handles html characters 

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -470,8 +470,8 @@ class AutocompleteAction extends AbstractAction {
     if (!strlen($this->input) || \CRM_Utils_Rule::integer($this->input)) {
       return TRUE;
     }
-    $currentSearchField = $this->getField($this->getCurrentSearchField());
-    return $currentSearchField['data_type'] !== 'Integer';
+    $currentSearchField = $this->getField($this->getCurrentSearchField())['data_type'] ?? '';
+    return $currentSearchField !== 'Integer';
   }
 
 }

--- a/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/MailingRecipientsAutocompleteProvider.php
@@ -54,13 +54,13 @@ class MailingRecipientsAutocompleteProvider extends AutoService implements Event
     $mode = explode('_', $e->fieldName)[1];
     $e->savedSearch['api_params'] = [
       'version' => 4,
-      'select' => ['key', 'label', 'description', 'type', 'icon', 'date', '(is_hidden = 1) AS locked'],
+      'select' => ['key', 'value', 'description', 'type', 'icon', 'date', '(is_hidden = 1) AS locked'],
       'sets' => [
         [
           'UNION ALL', 'Group', 'get', [
             'select' => [
               'CONCAT("groups_", id) AS key',
-              'IF(is_hidden, "' . ts('Search Results') . '", title) AS label',
+              'IF(is_hidden, "' . ts('Search Results') . '", title) AS value',
               'description',
               '"group" AS entity',
               'NULL AS type',
@@ -131,7 +131,7 @@ class MailingRecipientsAutocompleteProvider extends AutoService implements Event
     $e->display['settings'] = [
       'sort' => [
         ['entity', 'ASC'],
-        ['label', 'ASC'],
+        ['value', 'ASC'],
       ],
       'keyField' => 'key',
       'extra' => [
@@ -140,7 +140,7 @@ class MailingRecipientsAutocompleteProvider extends AutoService implements Event
       'columns' => [
         [
           'type' => 'field',
-          'key' => 'label',
+          'key' => 'value',
           'empty_value' => '(' . ts('no name') . ')',
           'icons' => [
             [

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -361,6 +361,24 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     $this->assertEquals('Second Star', $result[0]['label']);
   }
 
+  public function testMailingAutocompleteWithSpecialCharacter(): void {
+    $this->createTestRecord('Group', [
+      'title' => 'Donors contributed > $100',
+      'frontend_title' => 'Donors contributed > $100',
+      'name' => 'Donors_contributed',
+      'group_type:name' => 'Mailing List',
+    ]);
+
+    // search by special character '>'
+    $result = EntitySet::autocomplete()
+      ->setInput('>')
+      ->setFieldName('Mailing.recipients_include')
+      ->setFormName('crmMailing.1')
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals('Donors contributed > $100', $result[0]['label']);
+  }
+
   /**
    * Emulates the behavior of `$.fn.crmAutocomplete` in Common.js
    *

--- a/tests/phpunit/api/v4/Action/EntitySetUnionTest.php
+++ b/tests/phpunit/api/v4/Action/EntitySetUnionTest.php
@@ -36,26 +36,26 @@ class EntitySetUnionTest extends Api4TestBase implements TransactionalInterface 
     $this->saveTestRecords('Group', [
       'records' => [
         ['title' => '1G', 'description' => 'Group 1'],
-        ['title' => '2G', 'description' => 'Group 2'],
+        ['title' => '2>G', 'description' => 'Group > 2'],
         ['title' => '3G', 'group_type:name' => ['Access Control', 'Mailing List']],
       ],
     ]);
     $this->saveTestRecords('Tag', [
       'records' => [
         ['name' => '3T', 'description' => 'Tag 3', 'used_for:name' => ['Contact', 'Activity']],
-        ['name' => '2T', 'description' => 'Tag 2'],
+        ['name' => '2<T', 'description' => 'Tag < 2'],
         ['name' => '1T', 'description' => 'Tag 1'],
       ],
     ]);
     $result = EntitySet::get(FALSE)
       ->addSet('UNION ALL', Group::get()
         ->addSelect('title', 'description', '"group" AS thing')
-        ->addWhere('title', 'IN', ['1G', '2G', '3G'])
+        ->addWhere('title', 'IN', ['1G', '2>G', '3G'])
       )
       ->addSet('UNION ALL', Tag::get()
         // The UNION will automatically alias Tag."name" to "title" because that's the column name in the 1st query
         ->addSelect('name', 'description', '"tag" AS thing')
-        ->addWhere('name', 'IN', ['1T', '2T', '3T'])
+        ->addWhere('name', 'IN', ['1T', '2<T', '3T'])
       )
       ->addOrderBy('title')
       ->setLimit(5)
@@ -64,19 +64,19 @@ class EntitySetUnionTest extends Api4TestBase implements TransactionalInterface 
     $this->assertCount(5, $result);
     $this->assertEquals(['title' => '1G', 'description' => 'Group 1', 'thing' => 'group'], $result[0]);
     $this->assertEquals(['title' => '1T', 'description' => 'Tag 1', 'thing' => 'tag'], $result[1]);
-    $this->assertEquals(['title' => '2G', 'description' => 'Group 2', 'thing' => 'group'], $result[2]);
-    $this->assertEquals(['title' => '2T', 'description' => 'Tag 2', 'thing' => 'tag'], $result[3]);
+    $this->assertEquals(['title' => '2>G', 'description' => 'Group > 2', 'thing' => 'group'], $result[2]);
+    $this->assertEquals(['title' => '2<T', 'description' => 'Tag < 2', 'thing' => 'tag'], $result[3]);
     $this->assertEquals(['title' => '3G', 'description' => NULL, 'thing' => 'group'], $result[4]);
 
     // Try with a "WHERE" clause
     $result = EntitySet::get(FALSE)
       ->addSet('UNION ALL', Group::get()
         ->addSelect('title', 'description', 'group_type:name AS type')
-        ->addWhere('title', 'IN', ['1G', '2G', '3G'])
+        ->addWhere('title', 'IN', ['1G', '2>G', '3G'])
       )
       ->addSet('UNION ALL', Tag::get()
         ->addSelect('name', 'description', 'used_for:name')
-        ->addWhere('name', 'IN', ['1T', '2T', '3T'])
+        ->addWhere('name', 'IN', ['1T', '2<T', '3T'])
       )
       ->addOrderBy('title')
       ->addWhere('title', 'LIKE', '3%')


### PR DESCRIPTION
Overview
----------------------------------------
- Fixes [dev/core#4561](https://lab.civicrm.org/dev/core/-/issues/4561)
- Replaces #33495

Technical Details
----------------------------------------
This was a strange one because Api4 is *supposed* to transparently handle encoding/decoding of html characters. But after some digging I realized that the alias "label" used by the union query is on the list of fields to *not* decode, see `CRM_Utils_API_HTMLInputCoder::getSkipFields`:

https://github.com/civicrm/civicrm-core/blob/4095aad3a52695ba507e822e47197ffd029eef50/CRM/Utils/API/HTMLInputCoder.php#L96-L98

Changing the alias to a non-conflicting name solved the problem, but this entire escape-on-input system is of course terrible and [needs to be ripped out](https://lab.civicrm.org/dev/core/-/issues/1328).
