### PR TITLE
RiverLea: fixes bug in FormBuilder admin < 990px hides right panel

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -514,6 +514,6 @@ dl dl {
 @media (max-width: 991px) {
   .crm-container .crm-flex-box,
   .api4-input /* sections/api4-explorer */ {
-    flex-direction: column;
+    flex-flow: column;
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
'flex-direction: column' isn't working as expected losing the right panel on FormBuilder admin under 990px. Have changed to 'flex-flow: column' and that works.

Before
----------------------------------------
<990px side-by-side lost of screen-right…

<img width="811" height="775" alt="image" src="https://github.com/user-attachments/assets/62293ce1-254f-4eae-8b03-0ff8ede7e2c8" />

After
----------------------------------------
<990px Stacked.

<img width="791" height="792" alt="image" src="https://github.com/user-attachments/assets/c24a561c-e921-4aa4-ad34-2d4e7b5709ba" />

Technical Details
----------------------------------------
The cause of this bug is that flexbox items set to go in a column are by default kinda wrapping. Therefore setting `flex-flow:wrap` on `.crm-flex-box` at _base.css#Line450 actually turns off the wrap and makes things go inline. Didn't know this before, not a particularly intuitive bit of css spec. So to preserve the column state you either need to turn `flex-flow:nowrap` or use the combinator `flex-flow:column` (which sets a default of nowrap even if not specified).

Comments
----------------------------------------
Realise this is v last minute for 6.6 - let me know if you want made against 6.7 instead.