### PR TITLE
CiviCase - Fix errant dependency on CiviMail

### DIFF
--- a/ext/civi_case/Civi/Api4/Service/CaseTasksProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/CaseTasksProvider.php
@@ -12,7 +12,7 @@
 namespace Civi\Api4\Service;
 
 use Civi\Api4\CaseType;
-use CRM_Mailing_ExtensionUtil as E;
+use CRM_Case_ExtensionUtil as E;
 use Civi\Core\Event\GenericHookEvent;
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------

If a site has CiviCase enabled _without_ CiviMail, then it leads to a crash.

This smells to be a copy-paste error from #33298 (e.g. example code copied from `civi_mail` to `civi_case` and needed a little more adaptation).

Before
----------------------------------------

On the main dashboard, I get crash:

<img width="1068" height="153" alt="Screenshot 2025-09-03 at 6 45 08 PM" src="https://github.com/user-attachments/assets/29395e58-f39f-482d-9a53-a6ec804a1281" />

After
----------------------------------------

# 🟢 

