### PR TITLE
message_admin - Remove undeclared dependency on civi_mail

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1410,6 +1410,11 @@ class CRM_Core_Permission {
         'access CiviCRM',
         ['access CiviMail', 'schedule mailings'],
       ],
+      'gettokens' => [
+        'access CiviCRM',
+        [...$civiMailBasePerms, 'edit message templates'],
+        // FIXME: When there's an API that provides tokens for a MessageTemplate, these permissions can be re-tightened.
+      ],
       'default' => [
         'access CiviCRM',
         $civiMailBasePerms,

--- a/ext/message_admin/ang/crmMsgadm.ang.php
+++ b/ext/message_admin/ang/crmMsgadm.ang.php
@@ -22,7 +22,6 @@ return [
     'crmUi',
     'crmUtil',
     'crmDialog',
-    'crmMailing',
     'crmMonaco',
     'jsonFormatter',
     'ngRoute',

--- a/ext/message_admin/ang/crmMsgadm/Edit.js
+++ b/ext/message_admin/ang/crmMsgadm/Edit.js
@@ -142,8 +142,14 @@
 
             return crmStatus({start: ts('Loading...'), success: ''}, crmApi4(requests).then(respMergeTranslations).then(pickFirsts));
           },
-          tokenList: function () {
-            return CRM.crmMailing.mailTokens;
+          tokenList: function (crmApi) {
+            // FIXME: Use an API that provides tokens more attuned to the particular template.
+            return crmApi('Mailing', 'gettokens', {
+              entity: ['contact', 'mailing'],
+              sequential: 1
+            }).then((r) => {
+              return r.values;
+            });
           }
         }
       });


### PR DESCRIPTION
Overview
----------------------------------------

Suppose you install a new site while unchecking "CiviMail". It creates a configuration with these extensions:

* `civi_mail`: Disabled
* `message_admin`: Enabled

Now... can you edit "Message Templates"?

Before
----------------------------------------

No, you cannot edit "Message Templates" -- because it fails to load a particular Angular module. (On a high-level, `message_admin` does not depend on `civi_mail`. But on a low level, `crmMsgAdm` does depend on `crmMailing`.)

<img width="973" height="172" alt="Screenshot 2025-09-03 at 7 15 57 PM" src="https://github.com/user-attachments/assets/bc374375-9187-4a04-8567-ae8299cdc700" />

It appears that `crmMsgAdm` is using `crmMailing` as a way to get access to a list of tokens.

After
----------------------------------------

Yes, you can edit "Message Templates". And it lists the same tokens as before.

<img width="730" height="467" alt="Screenshot 2025-09-03 at 7 22 50 PM" src="https://github.com/user-attachments/assets/8acfcfda-a3f3-4b78-bc37-d39c51a0a982" />

Comments
----------------------------------------

* This is arguably fixing a regression, but it's not particularly recent (*affected 5.81 too*), and I don't think it's a common configuration. So I've submitted to `master`.
* We should probably look to exposing `TokenProcessor::listTokens()` somehow, but that's a bigger thing. This is a quick like-for-like swap.