### PR TITLE
Missing user ID on contact screen

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -65,6 +65,24 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   }
 
   /**
+   * Get Url to view user record.
+   *
+   * @param int $contactID
+   *   Contact ID.
+   *
+   * @return string|null
+   */
+  public function getUserRecordUrl($contactID) {
+    if (CRM_Core_Permission::check('cms:administer users')) {
+      $uid = (int) CRM_Core_BAO_UFMatch::getUFId($contactID);
+      if ($uid) {
+        return (string) Civi::url("backend://civicrm/admin/user#User=[uid]")->addVars(compact('uid'));
+      }
+    }
+    return NULL;
+  }
+
+  /**
    * @inheritdoc
    *
    * In Standalone the UF is CiviCRM, so we're never

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -20,14 +20,19 @@
   </div>
   <div class="crm-summary-row">
     <div class="crm-label">
-      {ts}Contact ID{/ts}{if $userRecordUrl} / {ts}User ID{/ts}{/if}
+      {ts}Contact ID{/ts}{if $userRecordId} / {ts}User ID{/ts}{/if}
     </div>
     <div class="crm-content">
       <span class="crm-contact-contact_id">{$contactId}</span>
-      {if $userRecordUrl}
+      {if $userRecordId}
         <span class="crm-contact-user_record_id">
-          &nbsp;/&nbsp;<a title="{ts escape='htmlattribute'}View user record{/ts}" class="user-record-link"
+          &nbsp;/&nbsp;
+          {if $userRecordUrl}
+          <a title="{ts escape='htmlattribute'}View user record{/ts}" class="user-record-link"
                           href="{$userRecordUrl}">{$userRecordId}</a>
+          {else}
+            {$userRecordId}
+          {/if}
         </span>
       {/if}
     </div>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes:
https://lab.civicrm.org/dev/core/-/issues/6078



Before
----------------------------------------

- when there's no view contact url, the user ID is not shown at all. The existence of a User ID is important to expose to all users, whether they can view users or not, and whether the UF supports "view user" url or not.
- Standalone did not supply a view user URL.

Result:

<img width="319" height="77" alt="image" src="https://github.com/user-attachments/assets/bc7bac2c-39ab-4a56-b93d-ac8eeb74c4ff" />



After
----------------------------------------

- if there is a User ID, it is shown.
- as before, if there is a View User URL, the User ID is shown as a hyperlink to that URL.
- Standalone implements View User URL _if the logged in user has administer users permission_

Result:

<img width="330" height="92" alt="image" src="https://github.com/user-attachments/assets/0967d794-959d-4682-9eb9-455fc95b4604" />

or 

<img width="330" height="92" alt="image" src="https://github.com/user-attachments/assets/90c688cd-d268-42eb-8472-682b3aec14a7" />



