### PR TITLE
Add form name to 'Silently ignoring exception' error message when submitting FormBuilder form

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -462,7 +462,7 @@ class Submit extends AbstractProcessor {
       catch (\CRM_Core_Exception $e) {
         // What to do here? Sometimes we should silently ignore errors, e.g. an optional entity
         // intentionally left blank. Other times it's a real error the user should know about.
-        \Civi::log('afform')->debug('Silently ignoring exception in Afform processGenericEntity call for "' . $event->getEntityName() . '". Message: ' . $e->getMessage());
+        \Civi::log('afform')->debug('Afform: ' . $event->getAfform()['name'] . ': Silently ignoring exception on submit in processGenericEntity call for "' . $event->getEntityName() . '". Message: ' . $e->getMessage());
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

When you submit a FormBuilder Form and you didn't fill in all the mandatory fields for an entity it will still submit but will fail to save that entity. That's often fine, because you might have optional entities on there. But the message itself is not very helpful because it tells you which `Entity` failed but not which form!

Before
----------------------------------------
Error message:
`Silently ignoring exception in Afform processGenericEntity call for "Activity1". Message: Mandatory values missing from Api4 Activity::save: activity_type_id`

After
----------------------------------------
Error message:
`Afform: afformTest: Silently ignoring exception on submit in processGenericEntity call for "Activity1". Message: Mandatory values missing from Api4 Activity::save: activity_type_id`

Technical Details
----------------------------------------
Change wording of message to make it more helpful.

Comments
----------------------------------------

