### PR TITLE
(NFC) Core Extensions - Remove unneeded phpcs comment

### DIFF
--- a/ext/chart_kit/chart_kit.php
+++ b/ext/chart_kit/chart_kit.php
@@ -1,9 +1,7 @@
 <?php
 
 require_once 'chart_kit.civix.php';
-// phpcs:disable
 use CRM_ChartKit_ExtensionUtil as E;
-// phpcs:enable
 
 /**
  * Implements hook_civicrm_config().

--- a/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
+++ b/ext/civicrm_admin_ui/CRM/CivicrmAdminUi/Upgrader.php
@@ -1,7 +1,5 @@
 <?php
-// phpcs:disable
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
-// phpcs:enable
 
 /**
  * Collection of upgrade steps.

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.php
@@ -1,9 +1,7 @@
 <?php
 
 require_once 'civicrm_admin_ui.civix.php';
-// phpcs:disable
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
-// phpcs:enable
 
 /**
  * Implements hook_civicrm_config().

--- a/ext/greenwich/greenwich.php
+++ b/ext/greenwich/greenwich.php
@@ -1,9 +1,7 @@
 <?php
 
 require_once 'greenwich.civix.php';
-// phpcs:disable
 use CRM_Greenwich_ExtensionUtil as E;
-// phpcs:enable
 
 /**
  * Implements hook_civicrm_config().


### PR DESCRIPTION
Overview
----------------------------------------
Removes unnecessary comments

Technical Details
----------------------------------------
We've already whitelisted `E` in `civilint` to prevent "unused use statement" warnings, so no need for the inline comments.