### PR TITLE
(dev/core#5925) Upgrader - Map historical Ribe Amt to modern Syddanmark

### DIFF
--- a/CRM/Upgrade/Incremental/sql/6.2.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.2.alpha1.mysql.tpl
@@ -37,7 +37,7 @@ UPDATE civicrm_address
 SET state_province_id = @nordjylland
 WHERE state_province_id IN (
 SELECT id FROM civicrm_state_province
-WHERE name IN ('North Jutland', 'Ribe')
+WHERE name IN ('North Jutland')
 AND country_id = @country_id
 );
 
@@ -53,7 +53,7 @@ UPDATE civicrm_address
 SET state_province_id = @syddanmark
 WHERE state_province_id IN (
 SELECT id FROM civicrm_state_province
-WHERE name IN ('Fyn', 'South Jutland', 'Vejle')
+WHERE name IN ('Fyn', 'Ribe', 'South Jutland', 'Vejle')
 AND country_id = @country_id
 );
 


### PR DESCRIPTION
Overview
----------------------------------------

The upgrade step for 6.2 modernizes the state-province list for Denmark (#32549). However, one of the conversions appears to be misplaced. (The historical jurisdiction "Ribe Amt" is in the south. Per [Wikipedia](https://en.wikipedia.org/wiki/Ribe), it is part of modern Syddanmark.)

This does the straight-forward part of https://lab.civicrm.org/dev/core/-/issues/5925 (cc @eileenmcnaughton @demeritcowboy) and will prevent any further corruption of addresses from Ribe Amt.

Steps to Reproduce
----------------------------------------

* Install CiviCRM 6.0
* Create some contact records with addresses in various amters (e.g. "Ribe" and "Vejle"). (For ease of investigation, I made addresses in `city=Ribe, state_province=Ribe` and `city=Vejle, state_province=Vejle`)
    <img width="1137" height="140" alt="Screenshot 2025-09-04 at 5 14 43 PM" src="https://github.com/user-attachments/assets/a386b35b-2ab7-4563-b601-5e6deb6d4480" />
* Upgrade to current 6.x

Before
----------------------------------------

Upgrader converts Ribe to Nordjylland

<img width="1140" height="142" alt="Screenshot 2025-09-04 at 5 15 00 PM" src="https://github.com/user-attachments/assets/8c90e45b-4e04-4e93-a067-05c03ce2029c" />


After
----------------------------------------

Upgrader converts Ribe to Syddanmark

<img width="1140" height="142" alt="Screenshot 2025-09-04 at 5 14 29 PM" src="https://github.com/user-attachments/assets/2b0064dc-ba24-4c1f-8413-08959cbd3ad3" />


Comments
----------------------------------------

This fix prevents new problems from new upgrades (e.g. 6.0=>6.7).

Unfortunately, if someone applied an intermediate upgrade (e.g. 6.0=>6.2; then 6.2=>6.7), then any addresses in historic Ribe amter will be miscategorized. Their cleanup options are:

1. Search for `Addresses` in Nordjylland and manually pick which ones to update.
2. Run the addresses through an external validation/cleanup service.
3. Define some heuristic cleanup. (Like... make a list of 10 largest towns from historical Ribe Amt and cleanup corresponding addresses)
4. Do nothing. (If you don't live in Denmark, then you might be satisfied with this option. But don't feel too satisfied --  you are missing out on the joys of _Den Klassike Musikquiz_.)


