### PR TITLE
Core - Autofill 'title'/'frontend_title' on admin forms

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -2002,6 +2002,31 @@ if (!CRM.vars) CRM.vars = {};
     return len ? name.substring(0, len) : name;
   };
 
+  CRM.utils.syncFields = function (sourceSelector, targetSelector) {
+    // Ensure selectors are valid
+    const $source = $(sourceSelector);
+    const $target = $(targetSelector);
+
+    if (!$source.length || !$target.length) {
+      console.warn('CRM.syncFields - one or both selectors not found:', sourceSelector, targetSelector);
+      return;
+    }
+
+    // Initialize the last known value
+    $source.data('lastValue', $source.val());
+
+    $source.on('input', function() {
+      const sourceValue = $(this).val();
+      const targetValue = $target.val();
+
+      // Only update target if it currently matches source's previous value
+      if ($source.data('lastValue') === targetValue) {
+        $target.val(sourceValue);
+      }
+      $source.data('lastValue', sourceValue);
+    });
+  };
+
   // CVE-2015-9251 - Prevent auto-execution of scripts when no explicit dataType was provided
   $.ajaxPrefilter(function(s) {
     if (s.crossDomain) {

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -147,13 +147,18 @@
   <script type="text/javascript">
   {literal}
     CRM.$(function($) {
-      $('#payment_processor_type_id').change(function() {
+      const $form = $('form.{/literal}{$form.formClass}{literal}');
+      $('#payment_processor_type_id', $form).change(function() {
         var url = {/literal}"{$refreshURL}"{literal} + "&pp=" + $(this).val();
-        $(this).closest('form').attr('data-warn-changes', 'false')
+        $form.attr('data-warn-changes', 'false')
           // Ajax refresh (works in a popup or full-screen)
           .closest('.crm-ajax-container, #crm-main-content-wrapper')
           .crmSnippet({url: url}).crmSnippet('refresh');
       });
+      const $elements = $('input[name=frontend_title], input[name=title]', $form);
+      if ($elements.length === 2) {
+        CRM.utils.syncFields($elements.first(), $elements.last());
+      }
     });
   {/literal}
   </script>

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.tpl
@@ -140,9 +140,14 @@
 {literal}
 <script type="text/javascript">
   CRM.$(function($) {
-    $('#financial_type_id').change( function() {
-      CRM.buildCustomData('ContributionPage', $('#financial_type_id').val(), false, false, false, false, false, false);
+    const $form = $('form.{/literal}{$form.formClass}{literal}');
+    $('#financial_type_id', $form).change(function() {
+      CRM.buildCustomData('ContributionPage', $(this).val(), false, false, false, false, false, false);
     });
+    const $elements = $('input[name=frontend_title], input[name=title]', $form);
+    if ($elements.length === 2) {
+      CRM.utils.syncFields($elements.first(), $elements.last());
+    }
   });
 </script>
 {/literal}

--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -112,6 +112,14 @@
     cj('input[type=checkbox][name="group_type[{/literal}{$hideMailingList}{literal}]"]').hide();
     cj('label[for="group_type[{/literal}{$hideMailingList}{literal}]"]').hide();
     {/literal}{/if}{literal}
+
+    CRM.$(function($) {
+      const $form = $('form.{/literal}{$form.formClass}{literal}');
+      const $elements = $('input[name=frontend_title], input[name=title]', $form);
+      if ($elements.length === 2) {
+        CRM.utils.syncFields($elements.first(), $elements.last());
+      }
+    });
   </script>
   {/literal}
 </div>

--- a/templates/CRM/UF/Form/Group.tpl
+++ b/templates/CRM/UF/Form/Group.tpl
@@ -58,3 +58,14 @@
 <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 {include file="CRM/common/showHide.tpl"}
+{literal}
+<script type="text/javascript">
+  CRM.$(function($) {
+    const $form = $('form.{/literal}{$form.formClass}{literal}');
+    const $elements = $('input[name=frontend_title], input[name=title]', $form);
+    if ($elements.length === 2) {
+      CRM.utils.syncFields($elements.first(), $elements.last());
+    }
+  });
+</script>
+{/literal}


### PR DESCRIPTION
Overview
----------------------------------------
The following admin forms have a title + frontend_title combo:

- New/Edit Contribution Page
- New/Edit Group
- New/Edit Profile
- New/Edit Payment Processor

Now on those forms, typing into the first field will autofill the second, while still allowing the user to manually change either without affecting the other.

Technical Details
----------
There's inconsistency about which field comes first or second. On 2 forms frontend_title comes first, on the other 2 title comes first. And there's a chance they'll get moved or reordered by customizations or future cleanup.
Problem solved: with a bit of jQuery magic, the js will follow whatever order the fields happen to be in and will always treat the first as the field to be copied from & the second as the field to be copied to.