### PR TITLE
Smarty - Fix notice on help text (again)

### DIFF
--- a/templates/CRM/Core/Form/Field.tpl
+++ b/templates/CRM/Core/Form/Field.tpl
@@ -12,7 +12,7 @@
 {else}
   <td class="label">{$form.$fieldName.label}
     {if array_key_exists('help', $fieldSpec) && $fieldSpec.help.id}
-      {help values=$fieldSpec.help title=$fieldSpec.title}
+      {help values=$fieldSpec.help}
     {/if}
     {if $action == 2 && array_key_exists('is_add_translate_dialog', $fieldSpec)}{include file='CRM/Core/I18n/Dialog.tpl' table=$entityTable field=$fieldName id=$entityID}{/if}
   </td>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a smarty notice on the "New Profile" form.

Before
----------------------------------------
<img width="2300" height="1186" alt="image" src="https://github.com/user-attachments/assets/a3d17cb6-4bad-442e-8f72-ba1c5f0d1adb" />


After
----------------------------------------
<img width="2304" height="672" alt="image" src="https://github.com/user-attachments/assets/cec66f58-0d1a-4ab5-ba50-11c74d88761d" />


Technical Details
----------------------------------------
Commit 423f00e partially fixed this but this extra 'title' param is not needed (it is part of the values, no need to pass it separately). FYI @eileenmcnaughton 