### PR TITLE
Profile Admin - Move all help icons to the same position on the form

### DIFF
--- a/CRM/UF/Form/Group.php
+++ b/CRM/UF/Form/Group.php
@@ -36,18 +36,17 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
       'frontend_title' => ['name' => 'frontend_title', 'required' => TRUE],
       'description' => [
         'name' => 'description',
-        'help' => ['id' => 'id-description', 'file' => 'CRM/UF/Form/Group.hlp'],
+        'help' => ['id' => 'id-description'],
       ],
       'uf_group_type' => [
         'name' => 'uf_group_type',
         'not-auto-addable' => TRUE,
-        'help' => ['id' => 'id-used_for', 'file' => 'CRM/UF/Form/Group.hlp'],
+        'help' => ['id' => 'id-used_for'],
       ],
       'cancel_button_text' => [
         'name' => 'cancel_button_text',
         'help' => [
           'id' => 'id-cancel_button_text',
-          'file' => 'CRM/UF/Form/Group.hlp',
         ],
         'class' => 'cancel_button_section',
       ],
@@ -55,7 +54,6 @@ class CRM_UF_Form_Group extends CRM_Core_Form {
         'name' => 'submit_button_text',
         'help' => [
           'id' => 'id-submit_button_text',
-          'file' => 'CRM/UF/Form/Group.hlp',
         ],
         'class' => '',
       ],

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -16,29 +16,29 @@
       <table class="form-layout">
         {if $legacyprofiles}
           <tr class="crm-uf-advancesetting-form-block-group">
-              <td class="label">{$form.group.label}</td>
-              <td>{$form.group.html} {help id='id-limit_group' file="CRM/UF/Form/Group.hlp"}</td>
+              <td class="label">{$form.group.label} {help id='id-limit_group'}</td>
+              <td>{$form.group.html}</td>
           </tr>
         {/if}
         <tr class="crm-uf-advancesetting-form-block-add_contact_to_group">
-            <td class="label">{$form.add_contact_to_group.label}</td>
-            <td>{$form.add_contact_to_group.html} {help id='id-add_group' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{$form.add_contact_to_group.label} {help id='id-add_group'}</td>
+            <td>{$form.add_contact_to_group.html}</td>
         </tr>
         <tr class="crm-uf-advancesetting-form-block-notify">
-            <td class="label">{$form.notify.label}</td>
-            <td>{$form.notify.html} {help id='id-notify_email' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{$form.notify.label} {help id='id-notify_email'}</td>
+            <td>{$form.notify.html}</td>
         </tr>
         <tr class="crm-uf-advancesetting-form-block-post_url">
-            <td class="label">{$form.post_url.label}</td>
-            <td>{$form.post_url.html} {help id='id-post_url' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{$form.post_url.label} {help id='id-post_url'}</td>
+            <td>{$form.post_url.html}</td>
         </tr>
         <tr class="crm-uf-advancesetting-form-block-add_cancel_button">
-            <td class="label"></td>
-            <td>{$form.add_cancel_button.html} {$form.add_cancel_button.label} {help id='id-add_cancel_button' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{help id='id-add_cancel_button'}</td>
+            <td>{$form.add_cancel_button.html} {$form.add_cancel_button.label}</td>
         </tr>
         <tr class="cancel_button_section crm-uf-advancesetting-form-block-cancel_url">
-            <td class="label">{$form.cancel_url.label}</td>
-            <td>{$form.cancel_url.html} {help id='id-cancel_url' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{$form.cancel_url.label} {help id='id-cancel_url'}</td>
+            <td>{$form.cancel_url.html}</td>
         </tr>
         {foreach from=$advancedFieldsConverted item=fieldName}
           {assign var=fieldSpec value=$entityFields.$fieldName}
@@ -47,34 +47,34 @@
           </tr>
         {/foreach}
         <tr class="crm-uf-advancesetting-form-block-is_cms_user">
-                <td class="label">{$form.is_cms_user.label}</td>
-                <td>{$form.is_cms_user.html} {help id='id-is_cms_user' file="CRM/UF/Form/Group.hlp"}</td>
+                <td class="label">{$form.is_cms_user.label} {help id='id-is_cms_user'}</td>
+                <td>{$form.is_cms_user.html}</td>
         </tr>
         <tr class="crm-uf-advancesetting-form-block-is_update_dupe">
-            <td class="label">{$form.is_update_dupe.label}</td>
-            <td>{$form.is_update_dupe.html} {help id='id-is_update_dupe' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{$form.is_update_dupe.label} {help id='id-is_update_dupe'}</td>
+            <td>{$form.is_update_dupe.html}</td>
         </tr>
         {if $legacyprofiles}
           <tr class="crm-uf-advancesetting-form-block-is_proximity_search">
-              <td class="label">{$form.is_proximity_search.label}</td>
-              <td>{$form.is_proximity_search.html} {help id='id-is_proximity_search' file="CRM/UF/Form/Group.hlp"}</td>
+              <td class="label">{$form.is_proximity_search.label} {help id='id-is_proximity_search'}</td>
+              <td>{$form.is_proximity_search.html}</td>
           </tr>
           <tr class="crm-uf-advancesetting-form-block-is_map">
-              <td class="label"></td>
-              <td>{$form.is_map.html} {$form.is_map.label} {help id='id-is_map' file="CRM/UF/Form/Group.hlp"}</td>
+              <td class="label">{help id='id-is_map'}</td>
+              <td>{$form.is_map.html} {$form.is_map.label}</td>
           </tr>
           <tr class="crm-uf-advancesetting-form-block-is_edit_link">
-              <td class="label"></td>
-              <td>{$form.is_edit_link.html} {$form.is_edit_link.label} {help id='id-is_edit_link' file="CRM/UF/Form/Group.hlp"}</td>
+              <td class="label">{help id='id-is_edit_link'}</td>
+              <td>{$form.is_edit_link.html} {$form.is_edit_link.label}</td>
           </tr>
           <tr class="crm-uf-advancesetting-form-block-is_uf_link">
-            <td class="label"></td>
-            <td>{$form.is_uf_link.html} {$form.is_uf_link.label} {help id='id-is_uf_link' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{help id='id-is_uf_link'}</td>
+            <td>{$form.is_uf_link.html} {$form.is_uf_link.label}</td>
           </tr>
         {/if}
         <tr class="crm-uf-advancesetting-form-block-add_captcha">
-            <td class="label"></td>
-            <td>{$form.add_captcha.html} {$form.add_captcha.label} {help id='id-add_captcha' file="CRM/UF/Form/Group.hlp"}</td>
+            <td class="label">{help id='id-add_captcha'}</td>
+            <td>{$form.add_captcha.html} {$form.add_captcha.label}</td>
         </tr>
       </table>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM isn't always consistent about where to put the help icons but has been standardizing on "after the label" instead of "after the field". There are still some forms that do it the other way, and the "New Profile" form is extra special because it does *both* ways.

Before
----------------------------------------
<img width="1286" height="1006" alt="image" src="https://github.com/user-attachments/assets/a89f6a04-cf39-4769-a9d2-9e42591f0199" />


After
----------------------------------------
<img width="1240" height="1104" alt="image" src="https://github.com/user-attachments/assets/31d0c14f-cdf9-48b5-a816-0365a09a1291" />

Technical Details
----------------------------------------
Also removed the overly-verbose 'file' param. Whatever issue required 'file' to be specified in the past, it's solved now.

Comments
--------
This would be even nicer without the unnecessarily-wordy form labels that cause wrapping.