### PR TITLE
RiverLea Fixes: adds wordwrap on contact layout tabs to avoid UI break in Walbrook/Thames/Hackney

### DIFF
--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -146,6 +146,7 @@
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li {
   background: var(--crm-dash-tab-bg);
   margin: var(--crm-dash-tab-hang);
+  word-break: break-word;
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li .ui-tabs-anchor {
   display: grid;


### PR DESCRIPTION
Longer words don't break in the side tabs as used on the Contact Layout editor for Walbrook, Thames and Hackney. This is a particular issue with languages like German:

<img width="444" height="708" alt="image" src="https://github.com/user-attachments/assets/1780f333-1af3-4970-93c3-1297bce5bbca" />

Raised by Joya in https://lab.civicrm.org/extensions/riverlea/-/issues/146. Am posting this into 6.7 as it seems a breaking UX issue.

Before
----------------------------------------
<img width="512" height="381" alt="image" src="https://github.com/user-attachments/assets/db1ed29d-2f52-4ab1-85a2-c0dd9451d30c" />
<img width="445" height="246" alt="image" src="https://github.com/user-attachments/assets/48ed1cad-8a12-447a-8d60-d7960c20dbaf" />
<img width="477" height="375" alt="image" src="https://github.com/user-attachments/assets/d31e5336-7d9a-4ebd-9221-1e9a933d82a4" />

After
----------------------------------------
<img width="475" height="363" alt="image" src="https://github.com/user-attachments/assets/22915f9c-4f37-4c48-bba2-5be1ec37a89f" />
<img width="362" height="273" alt="image" src="https://github.com/user-attachments/assets/7e5807b3-be02-4182-8a91-c5244ec608c2" />
<img width="409" height="233" alt="image" src="https://github.com/user-attachments/assets/d78cc9ec-5b0e-40e1-a297-f4dc6d5142b7" />