### PR TITLE
Fixing Layout when editing custom fields with multiple options per line

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -27,7 +27,7 @@
       <div class="crm-multiple-checkbox-radio-options crm-options-per-line" style="--crm-opts-per-line:{$element.options_per_line};">
         {foreach name=outer key=key item=item from=$formElement}
           {if is_array($item) && array_key_exists('html', $item)}
-            <div class="crm-option-label-pair" >{$formElement.$key.html}</div>
+            {$formElement.$key.html}
           {/if}
         {/foreach}
       </div>


### PR DESCRIPTION
This commit fixes the UI bug when editing custom fields with multiple options per line as documented in this issue: https://lab.civicrm.org/dev/user-interface/-/issues/88

