### PR TITLE
dev/core#6079 - fix Add Note link

### DIFF
--- a/CRM/Contact/Selector.php
+++ b/CRM/Contact/Selector.php
@@ -310,7 +310,7 @@ class CRM_Contact_Selector extends CRM_Core_Selector_Base implements CRM_Core_Se
           }
           elseif ($value['key'] === 'note') {
             $url = 'civicrm/note';
-            $qs = "reset=1&action=add&entity_table=civicrm_contact&entity_id='%%id%%{$extraParams}";
+            $qs = "reset=1&action=add&entity_table=civicrm_contact&entity_id=%%id%%{$extraParams}";
           }
 
           self::$_links[$counter++] = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the "Add Note" action link in the "Contacts in Group" list. 

Before
----------------------------------------
"Add Note" form submissions failed with `DB Error: unknown error`

After
----------------------------------------
"Add Note" form submissions succeed without error.

Technical Details
----------------------------------------
There was an extra apostrophe in the "Add Note" link URL. This apostrophe was getting carried through to form submission and interfering with the process of defining the "entity ID", which is required in the database insert statement. Removing the extra apostrophe fixes the problem.
