### PR TITLE
Regression: Don't send contribution receipts when importing contributions

### DIFF
--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -398,6 +398,7 @@ class ContributionParser extends ImportParser {
                 'trxn_id' => $contribution['trxn_id'],
                 'currency' => $contribution['currency'],
               ])
+              ->setNotificationForCompleteOrder(FALSE)
               ->execute();
           }
           elseif ($contributionStatus !== 'Pending') {


### PR DESCRIPTION
This was a regression in 6.6. Previously, when importing, no contribution receipts were sent, but in 6.6 they were. This fix restores the previous behaviour so once again no receipts are sent on import.