### PR TITLE
JWT - Simplify implementation. Drop compat w/old library.

### DIFF
--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -62,40 +62,28 @@ class CryptoJwt extends AutoService {
    * @throws CryptoException
    */
   public function decode($token, $keyTag = 'SIGN') {
-    // TODO: Circa mid-2024, make a hard-requirement on firebase/php-jwt v5.5+.
-    // Then we can remove this guard and simplify the `$keysByAlg` stuff.
     $keyRows = $this->getRegistry()->findKeysByTag($keyTag);
 
-    // We want to call JWT::decode(), but there's a slight mismatch -- the
-    // registry contains whitelisted permutations of ($key,$alg), but
-    // JWT::decode() accepts all permutations ($keys x $algs).
-
-    // Grouping by alg will give proper granularity and also produces one
-    // call to JWT::decode() in typical usage.
-
-    // Defn: $keysByAlg[$alg][$keyId] === $keyData
-    $keysByAlg = [];
+    $jwtKeys = [];
     foreach ($keyRows as $key) {
       if ($alg = $this->suiteToAlg($key['suite'])) {
         // Currently, registry only has symmetric keys in $key['key']. For public key-pairs, might need to change.
-        $keysByAlg[$alg][$key['id']] = new Key($key['key'], $alg);
+        $jwtKeys[$key['id']] = new Key($key['key'], $alg);
       }
     }
 
-    foreach ($keysByAlg as $alg => $keys) {
-      try {
-        return (array) JWT::decode($token, $keys);
-      }
-      catch (\UnexpectedValueException $e) {
-        // Depending on the error, we might able to try other algos
-        if (
-          !preg_match(';unable to lookup correct key;', $e->getMessage())
-          &&
-          !preg_match(';Signature verification failed;', $e->getMessage())
-        ) {
-          // Keep our signature independent of the implementation.
-          throw new CryptoException(get_class($e) . ': ' . $e->getMessage());
-        }
+    try {
+      return (array) JWT::decode($token, $jwtKeys);
+    }
+    catch (\UnexpectedValueException $e) {
+      // Depending on the error, we might able to try other algos
+      if (
+        !preg_match(';unable to lookup correct key;', $e->getMessage())
+        &&
+        !preg_match(';Signature verification failed;', $e->getMessage())
+      ) {
+        // Keep our signature independent of the implementation.
+        throw new CryptoException(get_class($e) . ': ' . $e->getMessage());
       }
     }
 

--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -75,19 +75,19 @@ class CryptoJwt extends AutoService {
     try {
       return (array) JWT::decode($token, $jwtKeys);
     }
-    catch (\UnexpectedValueException $e) {
-      // Depending on the error, we might able to try other algos
+    catch (\UnexpectedValueException | \LogicException $e) {
+      // Convert to satisfy `@throws CryptoException` and historical messaging.
       if (
         !preg_match(';unable to lookup correct key;', $e->getMessage())
         &&
         !preg_match(';Signature verification failed;', $e->getMessage())
       ) {
-        // Keep our signature independent of the implementation.
-        throw new CryptoException(get_class($e) . ': ' . $e->getMessage());
+        throw new CryptoException(get_class($e) . ': ' . $e->getMessage(), 0, [], $e);
+      }
+      else {
+        throw new CryptoException('Signature verification failed', 0, [], $e);
       }
     }
-
-    throw new CryptoException('Signature verification failed');
   }
 
   /**

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "ext-xml": "*",
     "composer-runtime-api": "~2.0",
     "dompdf/dompdf": "~2.0.4|| ~3.0",
-    "firebase/php-jwt": ">=3 <7",
+    "firebase/php-jwt": ">=6.0 <7",
     "rubobaquero/phpquery": "^0.9.15",
     "symfony/config": "~4.4 || ~5.4 || ~6.0 || ~7.0",
     "symfony/polyfill-iconv": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "269c5286f133d79ba6ca3523d9aaeef8",
+    "content-hash": "3f5091886efcda6a51c86dac19fbcf6d",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -889,16 +889,16 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.0",
+            "version": "v6.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712"
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/8f718f4dfc9c5d5f0c994cdfd103921b43592712",
-                "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
                 "shasum": ""
             },
             "require": {
@@ -946,9 +946,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
             },
-            "time": "2025-01-23T05:11:06+00:00"
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -5959,7 +5959,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -5975,7 +5975,7 @@
         "ext-xml": "*",
         "composer-runtime-api": "~2.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.0.0"
     },


### PR DESCRIPTION
Overview
----------------------------------------

The `CryptoJwt` class uses the library `firebase/php-jwt`. This simplifies the usage of it.

`php-jwt` 6.0 was released in Jan 2022. At the time, we retained compatibility code for older versions because Drupal-Composer sites were sometimes pegged to older versions of `php-jwt` (or they'd get caught with mixed dependencies). However, it's now pretty old -- so I don't think we need to worry about such builds.

cc @seamuslee001

Before
----------------------------------------

Allow composer users to install php-jwt 3.x-6.x. Require adapter code for old API.

After
----------------------------------------

Require php-jwt 6.x. Use simpler code.

Technical Details
----------------------------------------

There are some historical security considerations on the `php-jwt` version. In use-cases with multiple JWT signing-keys, `php-jwt`'s original APIs didn't work well -- and Civi has always had a work-around for that. However, with `php-jwt` 6.0+, the work-around can be removed.

CiviCRM tar builds already ship with v6.
