### PR TITLE
OAuth Client - Allow blank secret

### DIFF
--- a/ext/oauth-client/ang/oauthClientCreator.aff.html
+++ b/ext/oauth-client/ang/oauthClientCreator.aff.html
@@ -12,8 +12,8 @@
       <div class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</div>
     </div>
     <div>
-      <label for="secret">{{ts('Client Secret')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
-      <input class="form-control" ng-model="options.client.secret" type="text" id="secret" required />
+      <label for="secret">{{ts('Client Secret')}}:</label>
+      <input class="form-control" ng-model="options.client.secret" type="text" id="secret" />
     </div>
   </div>
 </div>

--- a/ext/oauth-client/ang/oauthClientEditor.aff.html
+++ b/ext/oauth-client/ang/oauthClientEditor.aff.html
@@ -20,8 +20,8 @@
       <p class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</p>
     </div>
     <div>
-      <label for="secret{{options.client.id}}">{{ts('Client Secret')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
-      <input class="form-control" ng-model="options.client.secret" type="text" id="secret{{options.client.id}}" required/>
+      <label for="secret{{options.client.id}}">{{ts('Client Secret')}}:</label>
+      <input class="form-control" ng-model="options.client.secret" type="text" id="secret{{options.client.id}}"/>
     </div>
     <div ng-if="options.client.created_date">
       <label for="created_date{{options.client.id}}">{{ts('Created Date')}}:</label>


### PR DESCRIPTION
Overview
----------------------------------------

This updates the OAuth client configuration screen:

<img width="558" height="681" alt="Screenshot 2025-09-05 at 6 09 11 PM" src="https://github.com/user-attachments/assets/fd4d9160-fd41-4e21-85f1-5af94d457d46" />

This marks the "Client Secret" field as optional. 

Before
----------------------------------------

"Client Secret" has a little red dot.

After
----------------------------------------

"Client Secret" does not have a little red dot! Freedom! Freedom from the tyranny of the little red dot!

Technical Details
----------------------------------------

The "Client Secret" is *often* required, but not always. For example, the [PKCE](https://datatracker.ietf.org/doc/html/rfc7636) is an OAuth variant that does not require "Client Secret".