### PR TITLE
OAuth Client - Show button to manually refresh token

### DIFF
--- a/ext/oauth-client/ang/oauthClientTokens.aff.html
+++ b/ext/oauth-client/ang/oauthClientTokens.aff.html
@@ -28,6 +28,7 @@
         >{{ts('Inspect')}}</a>
 
         <a class="btn btn-default"
+           ng-disabled="!token.refresh_token"
            af-api4-action="['OAuthSysToken', 'refresh', {where: [['id', '=', token.id]]}]"
            af-api4-start-msg="ts('Refreshing...')"
            af-api4-success-msg="ts('Refreshed')"

--- a/ext/oauth-client/ang/oauthClientTokens.aff.html
+++ b/ext/oauth-client/ang/oauthClientTokens.aff.html
@@ -27,6 +27,13 @@
            target="_blank"
         >{{ts('Inspect')}}</a>
 
+        <a class="btn btn-default"
+           af-api4-action="['OAuthSysToken', 'refresh', {where: [['id', '=', token.id]]}]"
+           af-api4-start-msg="ts('Refreshing...')"
+           af-api4-success-msg="ts('Refreshed')"
+           af-api4-success="tokens.refresh()"
+        >{{ts('Refresh')}}</a>
+
         <a class="btn btn-danger"
            af-api4-action="['OAuthSysToken', 'delete', {where: [['id', '=', token.id]]}]"
            af-api4-start-msg="ts('Deleting...')"


### PR DESCRIPTION
Overview
----------------------------------------

Update the screen "Admin => System Settings => OAuth" with another button that helps with debugging/development/etc.

<img width="1308" height="597" alt="Screenshot 2025-09-05 at 6 23 12 PM" src="https://github.com/user-attachments/assets/7b1d938a-4f59-4854-8ffe-088d312c2544" />

Before
----------------------------------------

You can refresh tokens by making an API call -- but there is no option in the GUI.

After
----------------------------------------

There is a button. It's in the GUI. It is square and grey.

