### PR TITLE
OAuth Client - Basic work toward a general "templates" property

### DIFF
--- a/ext/oauth-client/CRM/OAuth/MailSetup.php
+++ b/ext/oauth-client/CRM/OAuth/MailSetup.php
@@ -57,6 +57,14 @@ class CRM_OAuth_MailSetup {
   }
 
   /**
+   * @deprecated
+   * @see Civi\OAuth\OAuthTemplates::evaluate()
+   */
+  public static function evalArrayTemplate($template, $vars) {
+    return Civi::service('oauth_client.templates')->evaluate($template, $vars);
+  }
+
+  /**
    * When the user returns with a token, we add a new record to
    * civicrm_mail_settings with defaults and redirect to the edit screen.
    *
@@ -95,52 +103,6 @@ class CRM_OAuth_MailSetup {
       'id' => $mailSettings['id'],
       'reset' => 1,
     ], TRUE, NULL, FALSE);
-  }
-
-  /**
-   * @param array $template
-   *   List of key-value expressions.
-   *   Ex: ['name' => '{{person.first}} {{person.last}}']
-   *   Expressions begin with the dotted-name of a variable.
-   *   Optionally, the value may be piped through other functions
-   * @param array $vars
-   *   Array tree of data to interpolate.
-   * @return array
-   *   The template array, with '{{...}}' expressions evaluated.
-   */
-  public static function evalArrayTemplate($template, $vars) {
-    $filters = [
-      'getMailDomain' => function($v) {
-        $parts = explode('@', $v);
-        return $parts[1] ?? NULL;
-      },
-      'getMailUser' => function($v) {
-        $parts = explode('@', $v);
-        return $parts[0] ?? NULL;
-      },
-    ];
-
-    $lookupVars = function($m) use ($vars, $filters) {
-      $parts = explode('|', $m[1]);
-      $value = (string) CRM_Utils_Array::pathGet($vars, explode('.', array_shift($parts)));
-      foreach ($parts as $part) {
-        if (isset($filters[$part])) {
-          $value = $filters[$part]($value);
-        }
-        else {
-          $value = NULL;
-        }
-      }
-      return $value;
-    };
-
-    $values = [];
-    foreach ($template as $key => $value) {
-      $values[$key] = is_string($value)
-        ? preg_replace_callback(';{{([a-zA-Z0-9_\.\|]+)}};', $lookupVars, $value)
-        : $value;
-    }
-    return $values;
   }
 
   /**

--- a/ext/oauth-client/Civi/Api4/OAuthProvider.php
+++ b/ext/oauth-client/Civi/Api4/OAuthProvider.php
@@ -61,9 +61,15 @@ class OAuthProvider extends Generic\AbstractEntity {
         ],
         [
           'name' => 'contactTemplate',
+          // TODO: Migrate to templates['Contact']
         ],
         [
           'name' => 'mailSettingsTemplate',
+          // TODO: Migrate to templates['MailStore']
+        ],
+        [
+          'name' => 'templates',
+          'description' => 'Open-ended list of templates. Generally, these will be used after an OAuth connection is established. Details vary by tag/workflow.',
         ],
       ];
     });

--- a/ext/oauth-client/Civi/OAuth/OAuthTemplates.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTemplates.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Civi\OAuth;
+
+use CRM_OAuth_ExtensionUtil as E;
+use Civi\Core\Service\AutoService;
+
+/**
+ * Automatically link an OAuth token with a PaymentProcessor.
+ *
+ * Usage:
+ *
+ * 1. In the OAuthProvider JSON, specify the `templates['PaymentProcessor']`.
+ *    This is a list of `PaymentProcessor` properties to initialize.
+ *    Ex: ['user_name' => '{{token.raw.stripe_publishable_key}}', 'password' => '{{token.access_token}}']
+ * 2. Initiate OAuth process and set the relevant payment-processor.
+ *    Ex: OAuthClient::authorizationCode()->setTag('PaymentProcessor:123')->...execute()
+ * 3. Whenever this token is initialized or refreshed, this helper will
+ *    update the `user_name` and `password` for `PaymentProcessor:123`.
+ *
+ * @service oauth_client.templates
+ */
+class OAuthTemplates extends AutoService {
+
+  /**
+   * Evaluate an array and interpolating bits of data.
+   *
+   * @param array $template
+   *   List of key-value expressions.
+   *   Ex: ['name' => '{{person.first}} {{person.last}}']
+   *   Expressions begin with the dotted-name of a variable.
+   *   Optionally, the value may be piped through other functions
+   * @param array $vars
+   *   Array tree of data to interpolate.
+   * @return array
+   *   The template array, with '{{...}}' expressions evaluated.
+   */
+  public function evaluate(array $template, array $vars): array {
+    $filters = [
+      'getMailDomain' => function($v) {
+        $parts = explode('@', $v);
+        return $parts[1] ?? NULL;
+      },
+      'getMailUser' => function($v) {
+        $parts = explode('@', $v);
+        return $parts[0] ?? NULL;
+      },
+    ];
+
+    $lookupVars = function($m) use ($vars, $filters) {
+      $parts = explode('|', $m[1]);
+      $value = (string) \CRM_Utils_Array::pathGet($vars, explode('.', array_shift($parts)));
+      foreach ($parts as $part) {
+        if (isset($filters[$part])) {
+          $value = $filters[$part]($value);
+        }
+        else {
+          $value = NULL;
+        }
+      }
+      return $value;
+    };
+
+    $values = [];
+    foreach ($template as $key => $value) {
+      $values[$key] = is_string($value)
+        ? preg_replace_callback(';{{([a-zA-Z0-9_\.\|]+)}};', $lookupVars, $value)
+        : $value;
+    }
+    return $values;
+  }
+
+}

--- a/ext/oauth-client/Civi/OAuth/OAuthTemplates.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTemplates.php
@@ -2,6 +2,8 @@
 
 namespace Civi\OAuth;
 
+use Civi\Api4\OAuthClient;
+use Civi\Api4\OAuthProvider;
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Core\Service\AutoService;
 
@@ -21,6 +23,37 @@ use Civi\Core\Service\AutoService;
  * @service oauth_client.templates
  */
 class OAuthTemplates extends AutoService {
+
+  /**
+   * Determine which (if any) template is available for a given client.
+   *
+   * TODO: Support contact and mail-settings. Migrate 'contactTemplate' and 'mailSettingsTemplate' to generic 'templates'.
+   *
+   * @param int $clientId
+   *   Local ID of the OAuthClient
+   * @param string $template
+   *   Symbolic name of the template.
+   * @return array|null
+   */
+  public function getByClientId(int $clientId, string $template): ?array {
+    $client = OAuthClient::get(FALSE)
+      ->addWhere('id', '=', $clientId)
+      ->addSelect('provider')
+      ->execute()->first();
+    if (!$client) {
+      return NULL;
+    }
+
+    $provider = OAuthProvider::get(FALSE)
+      ->addWhere('name', '=', $client['provider'])
+      ->addSelect('templates')
+      ->execute()->first();
+    if (!$provider) {
+      return NULL;
+    }
+
+    return $provider['templates'][$template] ?? NULL;
+  }
 
   /**
    * Evaluate an array and interpolating bits of data.

--- a/ext/oauth-client/tests/phpunit/Civi/OAuth/OAuthTemplatesTest.php
+++ b/ext/oauth-client/tests/phpunit/Civi/OAuth/OAuthTemplatesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Civi\OAuth;
+
 use CRM_OAuth_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
 use Civi\Core\HookInterface;
@@ -10,7 +12,7 @@ use Civi\Test\TransactionalInterface;
  *
  * @group headless
  */
-class CRM_OAuth_MailSetupTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class OAuthTemplatesTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   public function setUpHeadless() {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
@@ -77,7 +79,9 @@ class CRM_OAuth_MailSetupTest extends \PHPUnit\Framework\TestCase implements Hea
       'password' => '',
       'is_ssl' => TRUE,
     ];
-    $actual = \CRM_OAuth_MailSetup::evalArrayTemplate($vars['provider']['mailSettingsTemplate'], $vars);
+
+    $instance = \Civi::service('oauth_client.templates');
+    $actual = $instance->evaluate($vars['provider']['mailSettingsTemplate'], $vars);
     $this->assertEquals($expected, $actual);
     $this->assertTrue($actual['localpart'] === NULL);
   }


### PR DESCRIPTION
Overview
----------------------------------------

After initiating an OAuth connection, it is typical to setup some kind of record in the Civi database, e.g.

* _Email_: After connecting to GMail or MS Exchange, it is typical to create/update some `MailSetting`s. (In fact, that's the basic purpose of the GMail/Exchange connection.)
* _OIDC_: After using "Login with Google" or "Login with Facebook", it is typical to create/update a `Contact`. (In fact, that's the basic purpose of an OIDC integration.)
* _Payment_: After connecting to Stripe or PayPal account, it is typical to create/update a `PaymentProcessor`. (In fact, that's the basic purpose.)

Each provider is also a little bit different in how they report back relevant data. (The OAuth response may provide an IMAP-hostname or a REST API-key, but the relevant attribute comes from a different place.) So we wind up needing some templates to map from the OAuth-response into Civi data. (Example: [gmail.dist.json](https://github.com/civicrm/civicrm-core/blob/fdb3d2bdcefebc55e8b423df65387c2f45aef634/ext/oauth-client/providers/gmail.dist.json#L16-L26) and [ms-exchange.dist.json](https://github.com/civicrm/civicrm-core/blob/8e454e9ae7ae3fe0f62cd7037fb3e2f9bb436d0f/ext/oauth-client/providers/ms-exchange.dist.json#L18-L28) define the `mailSettingsTemplate`)

The `oauth-client` already supports two specific templates (`mailSettingsTemplate` and `contactTemplate`). But now we need a third kind of template for payment processors (e.g. Stripe vs PayPal).

Before
----------------------------------------

Every kind of template has to be declared in `Civi\Api4\OAuthProvider.php`. The only way to make more templates is to patch core.

After
----------------------------------------

There is a generic property in `Civi\Api4\OAuthProvider` where you can define additional templates (for payment-processors and other future applications).

Comments
----------------------------------------

(A) This involves a refactor of `CRM_OAuth_MailSetup::evalArrayTemplate()`. There's a similar function in `CRM_OAuth_ContactFromToken::evalArrayTemplate`, but it has some differences which I haven't looked at closely. But it maybe it's faster to ask @highfalutin -- do you have any sense for what's required to merge these?

1. I think we need the same list of filters. (Which looks easy.)
2. There's also a difference in `array_walk()`. (What's the goal/difference?)

(B) I haven't tried to remove the old properties. That's theoretically more disruptive (but practically, maybe not?). In any case, main goal for me is to have a place to put the payment-processor template. I'm happy to kick that can down the road. (But if y'all think it's ripe, then 