### PR TITLE
CiviMail - Send back 400 invalid parameters response if url_id…

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -31,7 +31,10 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
    */
   public function run() {
     $queue_id = CRM_Utils_Request::retrieveValue('qid', 'Integer');
-    $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer', NULL, TRUE);
+    $url_id = CRM_Utils_Request::retrieveValue('u', 'Integer');
+    if (!$url_id) {
+      CRM_Utils_System::sendInvalidRequestResponse(ts("Missing input parameters"));
+    }
     $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($queue_id, $url_id));
     $query_string = $this->extractPassthroughParameters();
 


### PR DESCRIPTION
… is not validated rather than a 500 error

Overview
----------------------------------------
This modifies the trackable URL tracking to be similar to how page opens https://github.com/civicrm/civicrm-core/blob/master/CRM/Mailing/Page/Open.php#L38C1-L41C1 and opt out and unsubscribe works by sending a 400 InvalidRequestParameter response if url_id is not valid 

Before
----------------------------------------
500 Error from Exception being thrown

After
----------------------------------------
400 InvalidRequestParameters error thrown

ping @colemanw @mattwire @totten 