### PR TITLE
Import - Fix 'Help file not found' error

### DIFF
--- a/templates/CRM/Import/Form/DataSource.tpl
+++ b/templates/CRM/Import/Form/DataSource.tpl
@@ -36,7 +36,7 @@
       {/if}
       <tr class="crm-import-datasource-form-block-dataSource">
         <td class="label">{$form.dataSource.label}</td>
-        <td>{$form.dataSource.html} {help id='data-source-selection'  file='CRM/Contact/Import/Form/DataSource'}</td>
+        <td>{$form.dataSource.html} {help id='data-source-selection' file='CRM/Contact/Import/Form/DataSource'}</td>
       </tr>
     </table>
   </div>
@@ -63,20 +63,20 @@
       {if array_key_exists('contactSubType', $form)}
         <tr>
           <td class="label">{$form.contactSubType.label}</td>
-          <td><span id="contact-subtype">{$form.contactSubType.html} {help id='contact-sub-type'}</span></td>
+          <td><span id="contact-subtype">{$form.contactSubType.html} {help id='contact-sub-type' file="CRM/Contact/Import/Form/DataSource"}</span></td>
         </tr>
       {/if}
 
       {if array_key_exists('onDuplicate', $form)}
         <tr class="crm-import-uploadfile-from-block-onDuplicate">
           <td class="label">{$form.onDuplicate.label}</td>
-          <td>{$form.onDuplicate.html} {help id="dupes" file="CRM/Contact/Import/Form/DataSource.hlp"}</td>
+          <td>{$form.onDuplicate.html} {help id="dupes" file="CRM/Contact/Import/Form/DataSource"}</td>
         </tr>
       {/if}
       {if array_key_exists('dedupe_rule_id', $form)}
         <tr class="crm-import-datasource-form-block-dedupe">
           <td class="label">{$form.dedupe_rule_id.label}</td>
-          <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule' file="CRM/Contact/Import/Form/DataSource.hlp"}</td>
+          <td><span id="contact-dedupe_rule_id">{$form.dedupe_rule_id.html}</span> {help id='id-dedupe_rule' file="CRM/Contact/Import/Form/DataSource"}</td>
         </tr>
       {/if}
       {if array_key_exists('multipleCustomData', $form)}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a broken help link on the Contact Import screen

Before
----------------------------------------
<img width="2062" height="1588" alt="image" src="https://github.com/user-attachments/assets/2391ae76-1cba-4fc4-95aa-6c2bb85bf847" />


After
----------------------------------------
<img width="2076" height="1566" alt="image" src="https://github.com/user-attachments/assets/b3737837-4683-4605-8064-20fb16e7046b" />


Comments
-------
The `.hlp` extension is not needed, and was being inconsistently added to some items in this file and not others, so I standardized them while I was at it.