### PR TITLE
CiviContribute - Extraneous email sent after importing or batch-updating contributions

### DIFF
--- a/CRM/Contribute/Form/Task/Batch.php
+++ b/CRM/Contribute/Form/Task/Batch.php
@@ -215,6 +215,7 @@ class CRM_Contribute_Form_Task_Batch extends CRM_Contribute_Form_Task {
         if ('Completed' === $currentStatus &&
           in_array($contribution['contribution_status_id:name'], ['Pending', 'Partially paid'], TRUE)) {
           Payment::create(FALSE)
+            ->setNotificationForCompleteOrder(FALSE)
             ->setValues([
               'contribution_id' => $contribution['id'],
               'trxn_date' => date('Y-m-d H:i:s'),

--- a/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
@@ -21,7 +21,7 @@ use Civi\Api4\Utils\FormattingUtil;
  *
  * @method $this setNotificationForPayment(bool $notificationForPayment) Set whether to disable Notification for Payment
  * @method bool getNotificationForPayment() Get notificationForPayment Param
- * @method $this setnotificationForCompleteOrder(bool $notificationForCompleteOrder) Set whether to disable Notification on complete order
+ * @method $this setNotificationForCompleteOrder(bool $notificationForCompleteOrder) Set whether to disable Notification on complete order
  * @method bool getNotificationForCompleteOrder() Get notificationForCompleteOrder Param
  * @method $this setDisableActionsOnCompleteOrder(bool $disableActionsOnCompleteOrder) Set whether to disable actions on complete order
  * @method bool getDisableActionsOnCompleteOrder() Get disableActionsOnCompleteOrder Param

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -387,6 +387,7 @@ class ContributionParser extends ImportParser {
               ->addWhere('id', '=', $contributionID)
               ->execute()->single();
             Payment::create()
+              ->setNotificationForCompleteOrder(FALSE)
               ->setValues(($params['Payment'] ?? []) + [
                 'contribution_id' => $contributionID,
                 'check_number' => $contribution['check_number'],


### PR DESCRIPTION
Backport of #33536 from 6.7-rc to 6.6-stable.