### PR TITLE
RiverLea fixes broken ol list style in notifications

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -52,7 +52,7 @@ body {
   list-style: none;
 }
 /* Restores list styles for rich text output to UA stylesheet definition */
-.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body,.crm-search-col-type-html,.af-markup) :is(ol,ul) {
+.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body,.crm-search-col-type-html,.af-markup,.notify-content) :is(ol,ul) {
   list-style: revert;
   padding: revert;
   margin: revert;

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -204,21 +204,8 @@
   float: left;
   margin: 0;
 }
-#crm-notification-container div.ui-notify-message-style {
-  color: var(--crm-notify-col);
-}
-#crm-notification-container div.ui-notify-message .notify-content ul,
-#crm-notification-container div.ui-notify-message .alert.notify-content ul {
-  margin: 0 var(--crm-r);
-  padding: var(--crm-m) 0 var(--crm-m) var(--crm-m);
-  color: var(--crm-notify-col);
-  list-style: unset;
-}
-#crm-notification-container div.ui-notify-message .notify-content ul li,
-#crm-notification-container div.ui-notify-message.alert .notify-content ul li {
-  color: var(--crm-notify-col);
-}
-#crm-notification-container div.ui-notify-message .notify-content p {
+#crm-notification-container div.ui-notify-message-style,
+#crm-notification-container div.ui-notify-message .notify-content :is(p,ul,ol) {
   color: var(--crm-notify-col);
 }
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget,

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -208,6 +208,10 @@
 #crm-notification-container div.ui-notify-message .notify-content :is(p,ul,ol) {
   color: var(--crm-notify-col);
 }
+#crm-notification-container div.ui-notify-message .notify-content :is(ul,ol) {
+  padding-left: var(--crm-r2);
+  margin-block: var(--crm-m);
+}
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:hover,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:focus {


### PR DESCRIPTION
Overview
----------------------------------------
This is an alternative to https://github.com/civicrm/civicrm-core/pull/33544 - that keeps the ul/ol resets in the same place in _base.css, which alllows to then remove some redundant padding/margin. All that's left then is three selectors defining colour, these have been grouped allowing ~a dozen lines to be deleted.

| Before   |  After |
|----------|-------------|
| <img width="746" height="1368" alt="image" src="https://github.com/user-attachments/assets/a84a90e5-a555-4402-aabd-f9407382f178" />| <img width="750" height="1416" alt="image" src="https://github.com/user-attachments/assets/d37a66cc-d20a-4200-b085-d46180a546f5" /> |

Comments
----------------------------------------
The left padding is now larger as a result of this - it's the same as all lists across Civi. Obvs could also override this.
