### PR TITLE
RiverLea: moves disabled icon on extension table

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -297,7 +297,7 @@ dl dl {
 .crm-container td.disabled {
   font-style: italic;
 }
-.crm-container tr.disabled td:first-of-type {
+.crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column,.crm-extensions-label) {
   display: inline-flex;
 }
 

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -30,6 +30,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container td.disabled:first-of-type:not(.crm-search-ctrl-column)::before,
 .crm-container tr.disabled td.crm-search-ctrl-column::after,
 .crm-container td.disabled.crm-search-ctrl-column::after,
+.crm-container tr.disabled td.crm-extensions-status::before,
 .crm-container .delete-icon,
 .crm-container span.batch-valid,
 .crm-container span.batch-invalid,
@@ -231,9 +232,10 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 
 /* Inactive icon */
-.crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column)::before,
+.crm-container tr.disabled > td:first-of-type:not(.crm-search-ctrl-column,.crm-extensions-label)::before,
 .crm-container td.disabled:first-of-type:not(.crm-search-ctrl-column)::before,
 .crm-container tr.disabled td.crm-search-ctrl-column::after,
+.crm-container tr.disabled td.crm-extensions-status::before,
 .crm-container td.disabled.crm-search-ctrl-column::after {
   content: "\f05e" / "Disabled row.";
   font-style: normal;


### PR DESCRIPTION
Overview
----------------------------------------
The inactive row icon is in an awkward place on disabled extension rows. This moves it.

Before
----------------------------------------
<img width="1281" height="314" alt="image" src="https://github.com/user-attachments/assets/52386634-d6f3-4d68-a1b9-dd0e609b7fa3" />

After
----------------------------------------
<img width="1255" height="293" alt="image" src="https://github.com/user-attachments/assets/1c68530f-7a17-4d31-b2e1-f0f44bd29b13" />

Comments
----------------------------------------
Follows discussion [here](https://chat.civicrm.org/civicrm/pl/p9ztczajbi8wuepr8aq4gyi8ic). Worth noting this icon is decorative and isn't read by screen-readers.