### PR TITLE
dev/core#6080 Safely encode vars inside script tags

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -148,7 +148,7 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
           break;
 
         case 'settings':
-          $settingsData = json_encode($this->getSettings());
+          $settingsData = CRM_Utils_JSON::encodeScriptVar($this->getSettings());
           $js = "(function(vars) {
             if (window.CRM) CRM.$.extend(true, CRM, vars); else window.CRM = vars;
             })($settingsData)";

--- a/CRM/Core/Smarty/plugins/modifier.json.php
+++ b/CRM/Core/Smarty/plugins/modifier.json.php
@@ -16,7 +16,7 @@
  */
 
 /**
- * Convert the data to a JSON string
+ * Safely outputs a variable for use inside a `<script>` tag.
  *
  * Example usage: {$myArray|@json}
  *
@@ -26,5 +26,5 @@
  *   JSON
  */
 function smarty_modifier_json($data) {
-  return json_encode($data);
+  return \CRM_Utils_JSON::encodeScriptVar($data);
 }

--- a/CRM/Utils/JSON.php
+++ b/CRM/Utils/JSON.php
@@ -21,6 +21,18 @@
 class CRM_Utils_JSON {
 
   /**
+   * Safely encodes a variable that will be printed inside a `<script>` tag.
+   *
+   * See https://lab.civicrm.org/dev/core/-/issues/6080
+   *
+   * @param mixed $input
+   * @return int|string
+   */
+  public static function encodeScriptVar($input) {
+    return json_encode($input, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES);
+  }
+
+  /**
    * Output json to the client.
    * @param mixed $input
    */


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/6080 for full discussion.

This adds a new function `CRM_Utils_JSON::encodeScriptVar` and makes use of it in 2 places that print js vars inside script tags.