### PR TITLE
Cleanup `<style>` tags by removing obsolete `type` attributes.

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -143,7 +143,7 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
 
         case 'style':
           if (!$allowCmsOverride || !$cms->addStyle($snippet['style'], $this->_name)) {
-            $html .= sprintf("<style type=\"text/css\">\n%s\n</style>\n", $snippet['style']);
+            $html .= sprintf("<style>\n%s\n</style>\n", $snippet['style']);
           }
           break;
 

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -217,7 +217,7 @@ class CRM_Report_Form_Instance {
   <head>
     <title>CiviCRM Report</title>
     <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
-    <style type=\"text/css\">@import url({$userFrameworkResourceURL}css/print.css);</style>
+    <style>@import url({$userFrameworkResourceURL}css/print.css);</style>
     {$htmlHeader}
   </head>
   <body><div id=\"crm-container\">";

--- a/CRM/Utils/PDF/Utils.php
+++ b/CRM/Utils/PDF/Utils.php
@@ -89,7 +89,7 @@ class CRM_Utils_PDF_Utils {
   <head>
     <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>
     <style>@page { margin: {$t}{$metric} {$r}{$metric} {$b}{$metric} {$l}{$metric};$css_page_size }</style>
-    <style type=\"text/css\">@import url(" . CRM_Core_Config::singleton()->userFrameworkResourceURL . "css/print.css);</style>
+    <style>@import url(" . CRM_Core_Config::singleton()->userFrameworkResourceURL . "css/print.css);</style>
     {$htmlHeader}
   </head>
   <body>

--- a/templates/CRM/Activity/Selector/Selector.tpl
+++ b/templates/CRM/Activity/Selector/Selector.tpl
@@ -76,7 +76,7 @@
       })(CRM.$, CRM._);
     </script>
   {/literal}
-  <style type="text/css">
+  <style>
     {crmAPI var='statuses' entity='OptionValue' action='get' return="color,value" option_limit=0 option_group_id="activity_status"}
     {foreach from=$statuses.values item=status}
       {if !empty($status.color)}

--- a/templates/CRM/Case/Audit/Report.tpl
+++ b/templates/CRM/Case/Audit/Report.tpl
@@ -12,7 +12,7 @@
   <title>{$pageTitle}</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <base href="{crmURL p="" a=1}" /><!--[if IE]></base><![endif]-->
-  <style type="text/css" media="screen, print">@import url({$config->userFrameworkResourceURL}css/print.css);</style>
+  <style media="screen, print">@import url({$config->userFrameworkResourceURL}css/print.css);</style>
 </head>
 
 <body>

--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -94,7 +94,7 @@
       })(CRM.$);
     </script>
   {/literal}
-  <style type="text/css">
+  <style>
     {crmAPI var='statuses' entity='OptionValue' action='get' return="color,value" option_limit=0 option_group_id="activity_status"}
     {foreach from=$statuses.values item=status}
     {if !empty($status.color)}

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -332,7 +332,7 @@
 {/if} {* view related cases if end *}
 </div>
 {literal}
-<style type="text/css">
+<style>
   .crm-case-caseview-case_subject span.crm-editable {
     padding-right: 32px;
     position: relative;

--- a/templates/CRM/Contact/Page/View/Print.tpl
+++ b/templates/CRM/Contact/Page/View/Print.tpl
@@ -9,7 +9,7 @@
 *}
 {* Contact Summary template to print contact information *}
 {literal}
-<style type="text/css" media="screen, print">
+<style media="screen, print">
 <!--
   #crm-container div {
     font-size: 12px;

--- a/templates/CRM/Core/Form/ShortCode.tpl
+++ b/templates/CRM/Core/Form/ShortCode.tpl
@@ -27,7 +27,7 @@
 {/foreach}
 
 {* Hack to prevent WP toolbars from popping up above the dialog *}
-{literal}<style type="text/css">
+{literal}<style>
   #wpadminbar,
   .wp-editor-expand #wp-content-editor-tools,
   .wp-editor-expand div.mce-toolbar-grp {

--- a/templates/CRM/Dashlet/Page/Blog.tpl
+++ b/templates/CRM/Dashlet/Page/Blog.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {strip}{literal}
-<style type="text/css">
+<style>
   #civicrm-news-feed {
     border: 0 none;
     font-family: inherit; // Stops JQueryUI's attempt to make this section Verdana

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -364,7 +364,7 @@
     });
   })(CRM.$, CRM._);
 </script>
-<style type="text/css">
+<style>
   div.tag-tree-wrapper {
     position: relative;
     min-height: 250px;

--- a/templates/CRM/common/accesskeys.hlp
+++ b/templates/CRM/common/accesskeys.hlp
@@ -16,7 +16,7 @@
     <li>{$accessKey}+<span>M</span> - {ts}Find menu item...{/ts}</li>
     <li>{$accessKey}+<span>Q</span> - {ts}Quicksearch{/ts}</li>
   </ul>
-  {literal}<style type="text/css">
+  {literal}<style>
     #crmAccessKeyList li {
       margin-top: 5px;
     }

--- a/templates/CRM/common/fatal.tpl
+++ b/templates/CRM/common/fatal.tpl
@@ -16,7 +16,7 @@
   <title>{ts}Error{/ts}</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <base href="{$config->resourceBase}" />
-  <style type="text/css" media="screen">
+  <style media="screen">
     @import url({$config->resourceBase}css/civicrm.css);
     @import url({$config->resourceBase}css/crm-i.css);
     @import url({$config->resourceBase}bower_components/font-awesome/css/all.min.css);
@@ -26,7 +26,7 @@
 <div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
 {else}
 <div id="crm-container" class="crm-container" lang="{$config->lcMessages|truncate:2:"":true}" xml:lang="{$config->lcMessages|truncate:2:"":true}">
-  <style type="text/css" media="screen">
+  <style media="screen">
     @import url({$config->resourceBase}css/civicrm.css);
     @import url({$config->resourceBase}css/crm-i.css);
     @import url({$config->resourceBase}bower_components/font-awesome/css/all.min.css);

--- a/templates/CRM/common/print.tpl
+++ b/templates/CRM/common/print.tpl
@@ -16,7 +16,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="ROBOTS" content="NOINDEX, NOFOLLOW">
   {crmRegion name='html-header' allowCmsOverride=0}{/crmRegion}
-  <style type="text/css" media="print">@import url({$config->resourceBase}css/print.css);</style>
+  <style media="print">@import url({$config->resourceBase}css/print.css);</style>
 </head>
 
 <body>

--- a/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php
@@ -293,7 +293,7 @@ class CRM_Contribute_Form_Task_PDFLetterCommonTest extends CiviUnitTestCase {
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <style>@page { margin: 0.75in 0.75in 0.75in 0.75in; }</style>
-    <style type="text/css">@import url(' . CRM_Core_Config::singleton()->userFrameworkResourceURL . 'css/print.css);</style>
+    <style>@import url(' . CRM_Core_Config::singleton()->userFrameworkResourceURL . 'css/print.css);</style>
 ' . "    \n" . '  </head>
   <body>
     <div id="crm-container">

--- a/tests/phpunit/CRM/Core/RegionTest.php
+++ b/tests/phpunit/CRM/Core/RegionTest.php
@@ -127,7 +127,7 @@ class CRM_Core_RegionTest extends CiviUnitTestCase {
       . "<script type=\"text/javascript\">\nalert(\"hi\");\n</script>\n"
       . "<script type=\"text/javascript\">\nCRM.\$(function(\$) {\n\$(\"div\");\n});\n</script>\n"
       . "<link href=\"/foo%20bar.css\" rel=\"stylesheet\" type=\"text/css\"/>\n"
-      . "<style type=\"text/css\">\nbody { background: black; }\n</style>\n";
+      . "<style>\nbody { background: black; }\n</style>\n";
     $this->assertEquals($expected, $actual);
   }
 

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -309,8 +309,8 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
 
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmRegion name="testAddStyle"}{/crmRegion}');
     $expected = ""
-      . "<style type=\"text/css\">\nbody { background: black; }\n</style>\n"
-      . "<style type=\"text/css\">\nbody { text-color: black; }\n</style>\n";
+      . "<style>\nbody { background: black; }\n</style>\n"
+      . "<style>\nbody { text-color: black; }\n</style>\n";
     $this->assertEquals($expected, $actual);
   }
 

--- a/xml/templates/message_templates/sample/Sample Responsive Design Newsletter - Single Column.tpl
+++ b/xml/templates/message_templates/sample/Sample Responsive Design Newsletter - Single Column.tpl
@@ -3,7 +3,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title></title>
 
-  <style type="text/css">
+  <style>
     {literal}
     /* Client-specific Styles */
     #outlook a {padding:0;} /* Force Outlook to provide a "view in browser" menu link. */

--- a/xml/templates/message_templates/sample/Sample Responsive Design Newsletter - Two Column.tpl
+++ b/xml/templates/message_templates/sample/Sample Responsive Design Newsletter - Two Column.tpl
@@ -2,7 +2,7 @@
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
   <meta content="width=device-width, initial-scale=1.0" name="viewport" />
   <title></title>
-  <style type="text/css">
+  <style>
      {literal}
      img {height: auto !important;}
      /* Client-specific Styles */


### PR DESCRIPTION
Overview
----------------------------------------
Refactor all template files to eliminate obsolete `type="text/css"` attributes from `<style>` tags, ensuring consistency and modern HTML practices. Includes updates to templates, CSS imports, and related test cases.

See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#deprecated_attributes