### PR TITLE
Smarty - Escalate system check from warning to error for unsupported versions

### DIFF
--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -25,23 +25,24 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
    */
   public function checkSmartyVersion(): array {
     $messages = [];
-    $smarty2Path = \Civi::paths()->getPath('[civicrm.packages]/Smarty/Smarty.class.php');
-    $path = CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
-    if ($path === $smarty2Path) {
-      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php');
-
+    $settingNames = ['CIVICRM_SMARTY_AUTOLOAD_PATH', 'CIVICRM_SMARTY3_AUTOLOAD_PATH'];
+    foreach ($settingNames as $settingName) {
+      if (CRM_Utils_Constant::value($settingName)) {
+        $pathSetting = CRM_Utils_Constant::value($settingName);
+        break;
+      }
+    }
+    if ($pathSetting && !str_ends_with($pathSetting, 'smarty5/Smarty.php')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        '<p>' . (ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security and php 8.3 compatibility. The update is currently optional, but will be required soon.')) . '</p>'
-        . '<p>' . (ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
-        . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1))) . '</p>'
-        . '<p>' . ('Some extensions may not work yet with Smarty v5. If you encounter problems, then you can continue with the deprecated Smarty 2 for now but you should consider uninstalling any extensions that do not support Smarty5.') . '</p>'
-        . '<p>' . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v6.4-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+        '<p>' . (ts('The site settings are overriding the Smarty path with an older version of Smarty. CiviCRM only officially supports Smarty version 5.')) . '</p>'
+        . '<p>' . (ts("It's recommended to remove this override ASAP by deleting lines with <code>%1</code> from the <code>civicrm.settings.php</code> file.", [1 => $settingName])) . '</p>'
+        . '<p>' . (ts('CiviCRM <a %1>v6.4-ESR</a> provides extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
         ])),
-        ts('Smarty Update (v2 => v5)'),
-        LogLevel::WARNING,
+        ts('Unsupported Smarty Version'),
+        LogLevel::ERROR,
         'fa-lock'
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
As we are now past the point of officially supporting old Smarty versions, update system check to be more sternly worded.

- Followup to #32998

Before: Warning
----------------------------------------
<img width="2320" height="938" alt="image" src="https://github.com/user-attachments/assets/54bd368a-d4a4-4517-806f-b040207da0e2" />




After: Error
----------------------------------------
<img width="1159" height="288" alt="image" src="https://github.com/user-attachments/assets/48691cd6-6338-467c-80c2-f78cccdd9e61" />
