### PR TITLE
Add more helpful error logs when things go wrong with searchkit/formbuilder

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -749,7 +749,13 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       $records = $this->replaceReferences($entityName, $entityValues[$entityName]);
       $this->fillIdFields($records, $entityName);
       $event = new AfformSubmitEvent($this->_afform, $this->_formDataModel, $this, $records, $entityType, $entityName, $this->_entityIds);
-      \Civi::dispatcher()->dispatch('civi.afform.submit', $event);
+      try {
+        \Civi::dispatcher()->dispatch('civi.afform.submit', $event);
+      }
+      catch (\Throwable $e) {
+        \Civi::log('afform')->error('Afform: ' . $event->getAfform()['name'] . ': civi.afform.submit crashed with error: ' . $e->getMessage());
+        throw $e;
+      }
     }
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -108,7 +108,13 @@ class Run extends AbstractRunAction {
         }
     }
 
-    $apiResult = civicrm_api4($entityName, 'get', $apiParams, $index);
+    try {
+      $apiResult = civicrm_api4($entityName, 'get', $apiParams, $index);
+    }
+    catch (\Throwable $e) {
+      \Civi::log()->error("SearchDisplay.Run error: " . get_class($e) . ": {$entityName}.get: [display_id] " . $this->display['id'] . ' [saved_search_id] ' . $this->display['saved_search_id'] . ' [label] ' . $this->display['label'] . ' [error] ' . $e->getMessage());
+      throw $e;
+    }
     // Copy over meta properties to this result
     $result->rowCount = $apiResult->rowCount;
     $result->debug = $apiResult->debug;


### PR DESCRIPTION
Overview
----------------------------------------
This adds two log messages that help with troubleshooting.

1. Adds a try/catch with error log around civi.afform.submit which will log an error if the submit event fails (eg. custom code is crashing).
2. When calling SearchDisplay.Run if entity.get crashes a useful log message is recorded containing the search name/id.

Both of these things tend to happen with non-admin / reduced privileges users and it can be quite difficult to troubleshoot as you either get unhelpful backtraces in the logs or nothing at all.

Before
----------------------------------------
Difficult to debug permissions / code errors.

After
----------------------------------------
Easier.

Technical Details
----------------------------------------

Comments
----------------------------------------

