### PR TITLE
dev/core#6083: Regression: Re-add Is Empty for boolean fields to SK

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -80,7 +80,7 @@
         var field = ctrl.field || {},
           allowedOps = field.operators;
         if (!allowedOps && field.data_type === 'Boolean') {
-          allowedOps = ['=', '!=', 'IS NOT NULL'];
+          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT NULL'];
         }
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
@@ -86,7 +86,7 @@
         var field = ctrl.field || {},
           allowedOps = field.operators;
         if (!allowedOps && field.data_type === 'Boolean') {
-          allowedOps = ['=', '!=', 'IS NOT NULL'];
+          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT NULL'];
         }
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];


### PR DESCRIPTION
Overview
----------------------------------------
#33072 removed Is Empty as an operator for boolean fields in SK. It turns out this is needed, because Is Empty is the only way to search for "is not equal to yes" on a boolean custom field where some custom group rows might not exist or might have a null value. This works because EMPTY is true when the field is null or when it is false (thanks @colemanw).

It would be nice if there were a way to make this clearer to users (who would likely try to use != Yes instead), but without being able to label the operator per field type, I don't see any way to do this. At least this restores the previous functionality and prevents existing SKs from being broken.