### PR TITLE
Mailing - Fix faulty metadata syntax

### DIFF
--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -393,9 +393,9 @@ return [
       ],
       'default' => NULL,
       'localizable' => 0,
-      'html' => [
-        'type' => 'Select Date',
-        'formatType' => 'activityDateTime',
+      'input_type' => 'Select Date',
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
       ],
       'readonly' => TRUE,
       'add' => 5.76,
@@ -413,9 +413,9 @@ return [
       ],
       'default' => NULL,
       'localizable' => 0,
-      'html' => [
-        'type' => 'Select Date',
-        'formatType' => 'activityDateTime',
+      'input_type' => 'Select Date',
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
       ],
       'readonly' => TRUE,
       'add' => 5.76,
@@ -434,9 +434,7 @@ return [
       ],
       'default' => 'Draft',
       'localizable' => 0,
-      'html' => [
-        'type' => 'Select',
-      ],
+      'input_type' => 'Select',
       'pseudoconstant' => [
         'callback' => ['CRM_Core_SelectValues', 'getMailingJobStatus'],
       ],
@@ -612,7 +610,7 @@ return [
     'unsubscribe_mode' => [
       'title' => ts('One Click Unsubscribe Mode'),
       'sql_type' => 'varchar(70)',
-      'input_type' => 'select',
+      'input_type' => 'Select',
       'description' => ts('One Click Unsubscribe mode either unsubscribe or opt-out'),
       'add' => '6.7',
       'input_attrs' => [


### PR DESCRIPTION
Overview
----------------------------------------
Metadata for new fields added in bd1c609e and 99a6bbe4 used some incorrect syntax. Needs to be fixed ASAP.