### PR TITLE
SmartyConsistencyTest - Add E2E test to compare common notations across Smarty versions

### DIFF
--- a/CRM/Core/Page/RemoteTestFunction.php
+++ b/CRM/Core/Page/RemoteTestFunction.php
@@ -11,6 +11,7 @@
 
 
 use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Handle requests for civicrm/dev/rtf
@@ -94,6 +95,30 @@ class CRM_Core_Page_RemoteTestFunction extends CRM_Core_Page {
         }
       },
     ];
+  }
+
+  public static function convertResponseToArray($response) {
+    if ($response instanceof ResponseInterface) {
+      return [
+        'code' => $response->getStatusCode(),
+        'body' => $response->getBody()->getContents(),
+        'headers' => $response->getHeaders(),
+      ];
+    }
+    elseif (is_string($response)) {
+      return [
+        'code' => 200,
+        'body' => "<html><body>$response</body></html>",
+        'headers' => ['Content-Type' => 'text/html'],
+      ];
+    }
+    else {
+      throw new \RuntimeException("Unrecognized response type: " . gettype($response));
+    }
+  }
+
+  public static function convertArrayToResponse(array $array): ResponseInterface {
+    return new Response($array['code'], $array['headers'], $array['body']);
   }
 
 }

--- a/Civi/Test/Exception/ProcessErrorException.php
+++ b/Civi/Test/Exception/ProcessErrorException.php
@@ -20,7 +20,7 @@ class ProcessErrorException extends \RuntimeException {
     $this->stderr = $stderr;
     $this->exit = $exit;
     if (empty($message)) {
-      $message = ProcessHelper::formatOutput($cmd, $stdout, $stdout, $exit);
+      $message = ProcessHelper::formatOutput($cmd, $stdout, $stderr, $exit);
     }
     parent::__construct($message, $code, $previous);
   }

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -230,6 +230,29 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
     );
   }
 
+  public function testBlockParamFilters(): void {
+    // PORTABLE: {block param=$x|filter}
+    $this->checkPortable(
+      '{ts 1=$x|escape}hello %1{/ts}',
+      ['x' => '&'],
+      'hello &amp;'
+    );
+
+    // PORTABLE: {block 1=$x|filter_a 2=$x|filter_b 3=$x|filter_c}
+    $this->checkPortable(
+      implode('', [
+        '{ts',
+        ' 1=$x|escape',
+        ' 2=$x|escape:"url"',
+        ' 3=$x|escape:html',
+        ' 4=$x|escape|escape:url',
+        '}hello %1 - %2 - %3 - %4{/ts}',
+      ]),
+      ['x' => '&'],
+      'hello &amp; - %26 - &amp; - %26amp%3B'
+    );
+  }
+
   public function testPurifyInteractions(): void {
     // Old code with `|smarty:nodefaults` is sometimes combined with `|purify`. What does it mean? What's the replacemnet?
     // The tests here show that:

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -51,6 +51,31 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       ['contact' => ['name' => 'Run & Hide']],
       'var dragon = {"name":"Run & Hide"};'
     );
+
+    // PORTABLE: {if isset($variable)}
+    // PORTABLE: {if empty($variable)}
+    $this->checkPortable(
+    // PORTABLE: isset($variable)
+      '{if isset($known)}isset-known=yes{/if}, '
+      . '{if isset($unknown)}isset-unknown=yes{/if}, '
+      . '{if empty($known)}empty-known=yes{/if}, '
+      . '{if empty($unknown)}empty-unknown=yes{/if}',
+      ['known' => 'yes'],
+      'isset-known=yes, , , empty-unknown=yes'
+    );
+
+    // PORTABLE: {if isset($array.field)}
+    // PORTABLE: {if empty($array.field)}
+    $this->checkPortable(
+    // PORTABLE: isset($variable)
+      '{if isset($array.known)}isset-known=yes{/if}, '
+      . '{if isset($array.unknown)}isset-unknown=yes{/if}, '
+      . '{if empty($array.known)}empty-known=yes{/if}, '
+      . '{if empty($array.unknown)}empty-unknown=yes{/if}',
+      ['array' => ['known' => 'yes']],
+      'isset-known=yes, , , empty-unknown=yes'
+    );
+
   }
 
   public function testNonPortable() {

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace E2E\Core;
+
+use Civi\Test\RemoteTestFunction;
+
+/**
+ * Check that common syntax evaluates as expected on different versions of Smarty.
+ *
+ * @package E2E\Core
+ * @group e2e
+ */
+class SmartyConsistencyTest extends \CiviEndToEndTestCase {
+
+  /**
+   * @var \Civi\Test\RemoteTestFunction[]
+   */
+  protected array $smarty;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->smarty = $this->createSmartyRenderers();
+  }
+
+  public function testPortable() {
+    // Observe: {$string nofilter} IS portable
+    $this->check('Dragon {$name nofilter}!',
+      ['name' => 'Run & Hide'],
+      [
+        '2_plain' => 'Dragon Run & Hide!',
+        '4_plain' => 'Dragon Run & Hide!',
+        '5_plain' => 'Dragon Run & Hide!',
+        '5_auto' => 'Dragon Run & Hide!',
+      ]
+    );
+
+    // Observe: {$string|escape nofilter} IS portable
+    $this->check(
+      'Dragon {$name|escape nofilter}',
+      ['name' => 'Run & Hide'],
+      [
+        '2_plain' => 'Dragon Run &amp; Hide',
+        '4_plain' => 'Dragon Run &amp; Hide',
+        '5_plain' => 'Dragon Run &amp; Hide',
+        '5_auto' => 'Dragon Run &amp; Hide',
+      ]
+    );
+
+    // Observe: {$object|@json_encode nofilter} IS portable
+    $this->check(
+      'var dragon = {$contact|@json_encode nofilter};',
+      ['contact' => ['name' => 'Run & Hide']],
+      [
+        '2_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_auto' => 'var dragon = {"name":"Run & Hide"};',
+      ]
+    );
+  }
+
+  public function testNonPortable() {
+    // Observe: {$string} is NOT portable
+    $this->check('Dragon {$name}!',
+      ['name' => 'Run & Hide'],
+      [
+        '2_plain' => 'Dragon Run & Hide!',
+        '4_plain' => 'Dragon Run & Hide!',
+        '5_plain' => 'Dragon Run & Hide!',
+        '5_auto' => 'Dragon Run &amp; Hide!', /* outlier */
+      ]
+    );
+
+    // Observe: {$string|smarty:nodefaults} is NOT portable
+    $this->check(
+      'Dragon {$name|smarty:nodefaults}',
+      ['name' => 'Run & Hide'],
+      [
+        '2_plain' => 'Dragon Run & Hide',
+        '4_plain' => 'Dragon Run & Hide',
+        '5_plain' => 'Dragon Run & Hide',
+        '5_auto' => 'Dragon Run &amp; Hide', /* outlier */
+      ]
+    );
+
+    // Observe: {$data|@json_encode} IS NOT portable.
+    $this->check(
+      'var dragon = {$contact|@json_encode};',
+      ['contact' => ['name' => 'Run & Hide']],
+      [
+        '2_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_auto' => 'var dragon = {&quot;name&quot;:&quot;Run &amp; Hide&quot;};', /* outlier */
+      ]
+    );
+
+    // Observe: {$data|json_encode nofilter} is NOT portable
+    $this->check(
+      'var dragon = {$contact|json_encode nofilter};',
+      ['contact' => ['name' => 'Run & Hide']],
+      [
+        '2_plain' => 'var dragon = Array;', /* outlier */
+        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_auto' => 'var dragon = {"name":"Run & Hide"};',
+      ]
+    );
+  }
+
+  /**
+   * Render a Smarty template.
+   *
+   * @param string $version
+   *   Smarty version/configuration to use.
+   * @param string $template
+   *   The template we wish to evaluate.
+   * @param array $vars
+   *   Any Smarty variables to include.
+   * @return string
+   */
+  protected function render(string $version, string $template, array $vars = []): string {
+    [$expectVer] = explode('_', $version);
+    return $this->smarty[$version]->execute([$expectVer, $template, $vars]);
+  }
+
+  /**
+   * Render a Smarty template across several versions. Compare results.
+   *
+   * @param string $template
+   * @param array $vars
+   * @param array $versions
+   * @return void
+   */
+  protected function check(string $template, array $vars, array $versions): void {
+    foreach ($versions as $version => $expectResult) {
+      $result = $this->render($version, $template, $vars);
+      $this->assertEquals($expectResult, $result, "Test Smarty v{$version} with template: {$template}");
+    }
+  }
+
+  /**
+   * @return array
+   */
+  protected function createSmartyRenderers(): array {
+    $smartyFuncs = [];
+    $versions = [
+      '2_plain' => [
+        'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 0,
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.packages]/Smarty/Smarty.class.php'),
+      ],
+      '4_plain' => [
+        'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 0,
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.packages]/smarty4/vendor/autoload.php'),
+      ],
+      '5_plain' => [
+        'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 0,
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php'),
+      ],
+      '5_auto' => [
+        'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 1,
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php'),
+      ],
+    ];
+
+    foreach ($versions as $version => $env) {
+      $f = RemoteTestFunction::register(__CLASS__, 'render_' . $version, function (int $expectVer, string $template, $vars = []) {
+        $actualVer = \CRM_Core_Smarty::findVersion();
+        if ($actualVer !== $expectVer) {
+          throw new \RuntimeException("Tried to load Smarty v$expectVer but found v$actualVer");
+        }
+        try {
+          return \CRM_Utils_String::parseOneOffStringThroughSmarty($template, $vars);
+        }
+        catch (\CRM_Core_Exception $e) {
+          return 'EXCEPTION: ' . $e->getMessage();
+        }
+      });
+      $f->setClient($f->createCvClient($env));
+      $smartyFuncs[$version] = $f;
+    }
+    return $smartyFuncs;
+  }
+
+}

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -85,6 +85,15 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       "x=null, , y!=null"
     );
 
+    // PORTABLE: {if $x === true}
+    $this->checkPortable(
+      '{if $x === true}x=true{/if}, '
+      . '{if $x !== true}x!=true{/if}, '
+      . '{if $y !== true}y!=true{/if}',
+      ['x' => TRUE, 'y' => 'FALSE'],
+      "x=true, , y!=true"
+    );
+
     // PORTABLE: {elseif} and {else if}
     $this->checkPortable(
       '{if $x == 1}one{elseif $x == 2}two{else}three{/if}',
@@ -104,6 +113,18 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
     // INVALID: {if $x === NULL}
     $this->checkRegex(
       '{if $x === NULL}x=null{/if}',
+      ['x' => NULL],
+      [
+        '2_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
+        '4_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
+        '5_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
+        '5_auto' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
+      ]
+    );
+
+    // INVALID: {if $x === TRUE}
+    $this->checkRegex(
+      '{if $x === TRUE}x=true{/if}',
       ['x' => NULL],
       [
         '2_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -109,33 +109,31 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
     );
   }
 
-  public function testInvalid(): void {
-    // INVALID: {if $x === NULL}
+  public function testNonPortable() {
+    // NOT PORTABLE: {if $x === NULL} (*legal in TPL files but not in TPL strings*}
     $this->checkRegex(
       '{if $x === NULL}x=null{/if}',
       ['x' => NULL],
       [
-        '2_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
-        '4_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
-        '5_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
-        '5_auto' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
+        '2_plain' => ['/^EXCEPTION.*\(secure mode\) .*NULL.* not allowed/'],
+        '4_plain' => ['/^EXCEPTION.*access to constants not permitted/'],
+        '5_plain' => ['/^EXCEPTION.*access to constants not permitted/'],
+        '5_auto' => ['/^EXCEPTION.*access to constants not permitted/'],
       ]
     );
 
-    // INVALID: {if $x === TRUE}
+    // NOT PORTABLE: {if $x === TRUE} (*legal in TPL files but not in TPL strings*}
     $this->checkRegex(
       '{if $x === TRUE}x=true{/if}',
       ['x' => NULL],
       [
-        '2_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
-        '4_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
-        '5_plain' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
-        '5_auto' => ['/^EXCEPTION: Message was not parsed due to invalid smarty syntax/'],
+        '2_plain' => ['/^EXCEPTION.*\(secure mode\) .*TRUE.* not allowed/'],
+        '4_plain' => ['/^EXCEPTION.*access to constants not permitted/'],
+        '5_plain' => ['/^EXCEPTION.*access to constants not permitted/'],
+        '5_auto' => ['/^EXCEPTION.*access to constants not permitted/'],
       ]
     );
-  }
 
-  public function testNonPortable() {
     // NOT PORTABLE: {else if}
     $this->checkRegex(
       '{if $x == 1}one{else if $x == 2}two{else}three{/if}',

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -27,50 +27,29 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
 
   public function testPortable() {
     // PORTABLE: {$string nofilter}
-    $this->check('Dragon {$name nofilter}!',
+    $this->checkPortable('Dragon {$name nofilter}!',
       ['name' => 'Run & Hide'],
-      [
-        '2_plain' => 'Dragon Run & Hide!',
-        '4_plain' => 'Dragon Run & Hide!',
-        '5_plain' => 'Dragon Run & Hide!',
-        '5_auto' => 'Dragon Run & Hide!',
-      ]
+      'Dragon Run & Hide!'
     );
 
     // PORTABLE: {$string|escape nofilter}
-    $this->check(
-      'Dragon {$name|escape nofilter}',
+    $this->checkPortable('Dragon {$name|escape nofilter}',
       ['name' => 'Run & Hide'],
-      [
-        '2_plain' => 'Dragon Run &amp; Hide',
-        '4_plain' => 'Dragon Run &amp; Hide',
-        '5_plain' => 'Dragon Run &amp; Hide',
-        '5_auto' => 'Dragon Run &amp; Hide',
-      ]
+      'Dragon Run &amp; Hide'
     );
 
     // PORTABLE: {$object|@json_encode nofilter}
-    $this->check(
+    $this->checkPortable(
       'var dragon = {$contact|@json_encode nofilter};',
       ['contact' => ['name' => 'Run & Hide']],
-      [
-        '2_plain' => 'var dragon = {"name":"Run & Hide"};',
-        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
-        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
-        '5_auto' => 'var dragon = {"name":"Run & Hide"};',
-      ]
+      'var dragon = {"name":"Run & Hide"};'
     );
 
     // PORTABLE: {$object|@json nofilter}
-    $this->check(
+    $this->checkPortable(
       'var dragon = {$contact|@json nofilter};',
       ['contact' => ['name' => 'Run & Hide']],
-      [
-        '2_plain' => 'var dragon = {"name":"Run & Hide"};',
-        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
-        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
-        '5_auto' => 'var dragon = {"name":"Run & Hide"};',
-      ]
+      'var dragon = {"name":"Run & Hide"};'
     );
   }
 
@@ -172,10 +151,30 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
    * @return void
    */
   protected function check(string $template, array $vars, array $versions): void {
+    $actualResults = [];
     foreach ($versions as $version => $expectResult) {
       $result = $this->render($version, $template, $vars);
-      $this->assertEquals($expectResult, $result, "Test Smarty v{$version} with template: {$template}");
+      $actualResults[$version] = $result;
     }
+    $this->assertEquals($versions, $actualResults, "Test Smarty template: {$template}");
+  }
+
+  /**
+   * Render a smarty template across several versions. All versions should yield
+   * the same output.
+   *
+   * @param string $template
+   * @param array $vars
+   * @param string $expect
+   * @return void
+   */
+  protected function checkPortable(string $template, array $vars, string $expect): void {
+    $this->check($template, $vars, [
+      '2_plain' => $expect,
+      '4_plain' => $expect,
+      '5_plain' => $expect,
+      '5_auto' => $expect,
+    ]);
   }
 
   /**

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -7,6 +7,9 @@ use Civi\Test\RemoteTestFunction;
 /**
  * Check that common syntax evaluates as expected on different versions of Smarty.
  *
+ * TIP: Every example is flagged as "PORTABLE" or "NOT PORTABLE". To get a summary,
+ * run: `grep PORTABLE tests/phpunit/E2E/Core/SmartyConsistencyTest.php`
+ *
  * @package E2E\Core
  * @group e2e
  */
@@ -23,7 +26,7 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
   }
 
   public function testPortable() {
-    // Observe: {$string nofilter} IS portable
+    // PORTABLE: {$string nofilter}
     $this->check('Dragon {$name nofilter}!',
       ['name' => 'Run & Hide'],
       [
@@ -34,7 +37,7 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       ]
     );
 
-    // Observe: {$string|escape nofilter} IS portable
+    // PORTABLE: {$string|escape nofilter}
     $this->check(
       'Dragon {$name|escape nofilter}',
       ['name' => 'Run & Hide'],
@@ -46,9 +49,21 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       ]
     );
 
-    // Observe: {$object|@json_encode nofilter} IS portable
+    // PORTABLE: {$object|@json_encode nofilter}
     $this->check(
       'var dragon = {$contact|@json_encode nofilter};',
+      ['contact' => ['name' => 'Run & Hide']],
+      [
+        '2_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_auto' => 'var dragon = {"name":"Run & Hide"};',
+      ]
+    );
+
+    // PORTABLE: {$object|@json nofilter}
+    $this->check(
+      'var dragon = {$contact|@json nofilter};',
       ['contact' => ['name' => 'Run & Hide']],
       [
         '2_plain' => 'var dragon = {"name":"Run & Hide"};',
@@ -60,7 +75,7 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
   }
 
   public function testNonPortable() {
-    // Observe: {$string} is NOT portable
+    // NOT PORTABLE: {$string}
     $this->check('Dragon {$name}!',
       ['name' => 'Run & Hide'],
       [
@@ -71,7 +86,7 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       ]
     );
 
-    // Observe: {$string|smarty:nodefaults} is NOT portable
+    // NOT PORTABLE: {$string|smarty:nodefaults}
     $this->check(
       'Dragon {$name|smarty:nodefaults}',
       ['name' => 'Run & Hide'],
@@ -83,7 +98,7 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       ]
     );
 
-    // Observe: {$data|@json_encode} IS NOT portable.
+    // NOT PORTABLE: {$data|@json_encode}
     $this->check(
       'var dragon = {$contact|@json_encode};',
       ['contact' => ['name' => 'Run & Hide']],
@@ -95,7 +110,7 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
       ]
     );
 
-    // Observe: {$data|json_encode nofilter} is NOT portable
+    // NOT PORTABLE: {$data|json_encode nofilter}
     $this->check(
       'var dragon = {$contact|json_encode nofilter};',
       ['contact' => ['name' => 'Run & Hide']],
@@ -104,6 +119,30 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
         '4_plain' => 'var dragon = {"name":"Run & Hide"};',
         '5_plain' => 'var dragon = {"name":"Run & Hide"};',
         '5_auto' => 'var dragon = {"name":"Run & Hide"};',
+      ]
+    );
+
+    // NOT PORTABLE: {$data|json nofilter}
+    $this->check(
+      'var dragon = {$contact|json nofilter};',
+      ['contact' => ['name' => 'Run & Hide']],
+      [
+        '2_plain' => 'var dragon = Array;', /* outlier */
+        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_auto' => 'var dragon = {"name":"Run & Hide"};',
+      ]
+    );
+
+    // NOT PORTABLE: {$data|@json|smarty:nodefaults}
+    $this->check(
+      'var dragon = {$contact|@json|smarty:nodefaults};',
+      ['contact' => ['name' => 'Run & Hide']],
+      [
+        '2_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '4_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_plain' => 'var dragon = {"name":"Run & Hide"};',
+        '5_auto' => 'var dragon = {&quot;name&quot;:&quot;Run &amp; Hide&quot;};', /* outlier */
       ]
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM can be configured with some heavyweight Smarty options:

* `CIVICRM_SMARTY_AUTOLOAD_PATH` (Point to Smarty v2, v4, or v5)
* `CIVICRM_SMARTY_DEFAULT_ESCAPE` (Enable or disable automatic escaping)

These change the semantics handling in notable ways... which leads to the obvious questions:

* What notations are safe to use across different configurations? (i.e. producing consistent outputs)
* What notations are unsafe to use across different configurations? (i.e. producing inconsistent outputs)

There is a little bit of guidance about how formulate (e.g. [Dev Guide: Security: Outputs: Escape by Default](https://docs.civicrm.org/dev/en/latest/security/outputs/#escape-by-default)), but it's pretty thin. Understandably - it's fairly taxing to actually test-out notations across different configurations.

This adds an E2E unit-test which can assess whether a notation is consistent or inconsistent across Smarty configurations.

Before
----------------------------------------

Hard to compare versions

After
----------------------------------------

We can see that these notations are portable (working across configurations)

* `{$name nofilter}` (always present `$name` in its immediate form)
* `{$name|escape nofilter}` (always present `$name` with escaping)

And these notations are not portable:

* `{$name}` (varies)
* `{$name|smarty:nodefaults}` (does not always work)

Technical Details
----------------------------------------

In preparing a test that compares versions, the major constraint is that a given PHP process can only load one of `packages/Smarty` xor `packages/smarty4` xor `packages/smarty5` -- and the decision is generally indicated by constant/env-var during bootstrap.

To work with this limitation, the `SmartyConsistencyTest` spawns separate PHP processes for each rendering. Each subprocess runs in `cv` and has different environment-variables (`CIVICRM_SMARTY_AUTOLOAD_PATH`, `CIVICRM_SMARTY_DEFAULT_ESCAPE`).

Unfortunately, that means it's a multi-process test. It is challenging to use XDebug with multi-process tests. However, you can still do basic development with it, and it's much easier to use the test than to run all the combinations manually.