### PR TITLE
Standalone civi-setup: avoid infinite loop if cant find app root

### DIFF
--- a/setup/plugins/init/Standalone.civi-setup.php
+++ b/setup/plugins/init/Standalone.civi-setup.php
@@ -59,7 +59,7 @@ function _standalone_setup_scheme(): string {
     // sometimes when using cv these global won't be set
     if (!$appRootPath) {
       $appRootCandidate = $model->srcPath;
-      while ($appRootCandidate) {
+      while ($appRootCandidate && $appRootCandidate != '/') {
         $appRootCandidate = dirname($appRootCandidate);
 
         if (file_exists(implode(DIRECTORY_SEPARATOR, [$appRootCandidate, 'civicrm.standalone.php']))) {


### PR DESCRIPTION
Overview
----------------------------------------

An incorrect homemade setup with `cv`  can result in an infinite loop.

Admittedly, my setup was wrong, and I'm doing a non-standard setup, but a safeguard won't hurt (and I doubt anyone hosts their civicrm on `/`, even on a Docker image).

Before
----------------------------------------

Infinite loop.

After
----------------------------------------

Throws an error because the root was not found.
