### PR TITLE
Fix Type Error about passing boolean in where an array should be if u…

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -405,7 +405,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     foreach ($groups as $group) {
       // Filter out arrays in Form Values which are group searchs.
       $groupSearches = array_filter(
-        $group['saved_search_id.form_values'],
+        ($group['saved_search_id.form_values'] === FALSE ? [] : $group['saved_search_id.form_values']),
         function($v) {
           return ($v[0] == 'group');
         }


### PR DESCRIPTION
…nseralize on form values fails

Overview
----------------------------------------
This aims to fix the following possible type error if unsearlize on the form values fails

```
An error of type E_ERROR was caused in line 410 of the file <client domain>wp-content/civicrm/civicrm/CRM/Contact/BAO/SavedSearch.php. Error message: Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, bool given in <client_domain>/wp-content/plugins/civicrm/civicrm/CRM/Contact/BAO/SavedSearch.php:410
```

As per the [PHP docs unserialize returns FALSE](https://www.php.net/manual/en/function.unserialize.php) if it can't do its work

Before
----------------------------------------
Possible for FALSE to be passed in where array_filter is expecting an array

After
----------------------------------------
no E_ERROR

ping @eileenmcnaughton @colemanw @demeritcowboy 