### PR TITLE
Add a notice level check if a site defines the smarty version that is…

### DIFF
--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -46,6 +46,16 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
         'fa-lock'
       );
     }
+    if ($pathSetting) {
+      $messages[] = new CRM_Utils_Check_Message(
+        __FUNCTION__ . '_unnecessary_define',
+        '<p>' . (ts('This site settings currently are manually overriding the default smarty version with the same version as the current default 5.')) . '</P>'
+        . '<p>' . (ts('It is recommended to remove the override as it may cause issues in the future')),
+        ts('Unnecessary Smarty Version Override'),
+        LogLevel::NOTICE,
+        'fa-lock',
+      );
+    }
     return $messages;
   }
 


### PR DESCRIPTION
… the same as smarty 5

Overview
----------------------------------------
This is a bit of a follow up to #33556 and this adds a notice level check indicating if a site has set a smarty version override that is the same as smarty 5. 

Before
----------------------------------------
No indication that a site is overriding the smarty version with smarty version 5 unneeded

After
----------------------------------------
Notice level check

ping @eileenmcnaughton @mlutfy @colemanw 