### PR TITLE
dev/core#6085 Get site's root for backdrop multisite sets

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -696,8 +696,10 @@ AND    u.status = 1
    * @inheritDoc
    */
   public function cmsSitePath() {
-    $cmsSitePath = realpath(BACKDROP_ROOT . '/' . conf_path());
-    return $cmsSitePath;
+    if (defined('BACKDROP_ROOT')) {
+      $cmsSitePath = realpath(BACKDROP_ROOT . '/' . conf_path());
+      return $cmsSitePath;
+    }
   }
 
   /**

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -695,6 +695,14 @@ AND    u.status = 1
   /**
    * @inheritDoc
    */
+  public function cmsSitePath() {
+    $cmsSitePath = realpath(BACKDROP_ROOT . '/' . conf_path());
+    return $cmsSitePath;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function isUserLoggedIn() {
     $isloggedIn = FALSE;
     if (function_exists('user_is_logged_in')) {

--- a/setup/plugins/init/Backdrop.civi-setup.php
+++ b/setup/plugins/init/Backdrop.civi-setup.php
@@ -30,7 +30,7 @@ if (!defined('CIVI_SETUP')) {
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'init'));
 
     $object = new \CRM_Utils_System_Backdrop();
-    $cmsPath = $object->cmsRootPath();
+    $cmsPath = $object->cmsSitePath();
 
     // Compute settingsPath.
     $model->settingsPath = $cmsPath . DIRECTORY_SEPARATOR . 'civicrm.settings.php';


### PR DESCRIPTION
added public function to get the site's root path under sites dir for multisites settings

Overview
----------------------------------------
as discussed in gitlab: https://lab.civicrm.org/dev/core/-/issues/6085

adds new function to get the root of a multisite and uses during backdrop setup

