### PR TITLE
Enable ts() for inline editable component (crmSearchDisplayEditable)

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -14,6 +14,7 @@
     },
     templateUrl: '~/crmSearchDisplay/crmSearchDisplayEditable.html',
     controller: function($scope, $element, crmApi4, crmStatus) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
       const ctrl = this;
       let initialValue;
       let editableInfo;


### PR DESCRIPTION
Overview
----------------------------------------
Adds ts() to crmSearchDisplayEditable so the sr-only elements on the Save and Cancel buttons contains text.

Before
----------------------------------------
In crmSearchDisplayEditable, ts() was not loaded and the screenreader-only elements on the Save and Cancel buttons were empty.

After
----------------------------------------
ts() is loaded

Comments
----------------------------------------
See Mattermost conversation: https://chat.civicrm.org/civicrm/pl/pep69ho8npddzpd7f566i5xf8h
