### PR TITLE
Smaller font for inactive dashlet titles, so they don't get cutoff

### DIFF
--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -107,7 +107,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 .crm-container .crm-inactive-dashlet {
   display: inline-block;
-  width: 230px;
+  width: 340px;
   height: var(--crm-xxl);
   margin: 10px;
   box-shadow: 1px 1px 4px 1px rgba(0,0,0,0.2);
@@ -120,7 +120,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border-radius: var(--crm-dashlet-radius) var(--crm-dashlet-radius) 0 0;
 }
 .crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {
-  font-size: 100%;
+  font-size: 75%;
   padding-left: var(--crm-s1);
 }
 #civicrm-dashboard .ui-sortable-placeholder {


### PR DESCRIPTION
Overview
----------------------------------------
If your dashlet title is longer than a couple words, it will get cutoff when inactive, making it hard to find the right dashlet if you have 100 or so and some of them start with the same words.

Before
----------------------------------------
<img width="3636" height="302" alt="image" src="https://github.com/user-attachments/assets/dfaa5f14-ef64-4e8e-8c2b-bcd8db961754" />


After
----------------------------------------
<img width="1822" height="240" alt="image" src="https://github.com/user-attachments/assets/6cb9bdb1-415b-479c-a275-d99629d46ff5" />