### PR TITLE
SearchUI Find Contributions - use Line Item for Financial Type

### DIFF
--- a/ext/civicrm_search_ui/ang/afsearchFindContributions.aff.html
+++ b/ext/civicrm_search_ui/ang/afsearchFindContributions.aff.html
@@ -12,7 +12,7 @@
     <af-field name="total_amount" defn="{required: false, input_attrs: {}, input_type: 'Number', search_range: true, label: 'Total Amount (min, max)'}" />
     <af-field name="contribution_status_id" defn="{input_attrs: {multiple: true}, afform_default: ['1']}" />
     <af-field name="currency" defn="{input_attrs: {multiple: true}}" />
-    <af-field name="financial_type_id" defn="{input_attrs: {multiple: true}}" />
+    <af-field name="Contribution_LineItem_contribution_id_01.financial_type_id" defn="{label: 'Financial Type', input_attrs: {multiple: true}}" />
     <af-field name="contribution_page_id" defn="{input_attrs: {multiple: true}}" />
     <af-field name="source" />
     <af-field name="id" defn="{required: false, input_attrs: {}}" />

--- a/ext/civicrm_search_ui/managed/SavedSearch_Find_Contributions.mgd.php
+++ b/ext/civicrm_search_ui/managed/SavedSearch_Find_Contributions.mgd.php
@@ -22,7 +22,7 @@ return [
           'select' => [
             'Contribution_Contact_contact_id_01.display_name',
             'total_amount',
-            'financial_type_id:label',
+            'GROUP_CONCAT(DISTINCT Contribution_LineItem_contribution_id_01.financial_type_id:label) AS GROUP_CONCAT_Contribution_LineItem_contribution_id_01_financial_type_id_label',
             'source',
             'receive_date',
             'ISNULL(thankyou_date) AS ISNULL_thankyou_date',
@@ -33,7 +33,9 @@ return [
           ],
           'orderBy' => [],
           'where' => [],
-          'groupBy' => [],
+          'groupBy' => [
+            'id',
+          ],
           'join' => [
             [
               'Contact AS Contribution_Contact_contact_id_01',
@@ -60,6 +62,15 @@ return [
                 'Contribution_ContributionSoft_contribution_id_01.pcp_id',
                 '=',
                 'Contribution_ContributionSoft_contribution_id_01_ContributionSoft_PCP_pcp_id_01.id',
+              ],
+            ],
+            [
+              'LineItem AS Contribution_LineItem_contribution_id_01',
+              'LEFT',
+              [
+                'id',
+                '=',
+                'Contribution_LineItem_contribution_id_01.contribution_id',
               ],
             ],
           ],
@@ -120,7 +131,7 @@ return [
             ],
             [
               'type' => 'field',
-              'key' => 'financial_type_id:label',
+              'key' => 'GROUP_CONCAT_Contribution_LineItem_contribution_id_01_financial_type_id_label',
               'label' => E::ts('Type'),
               'sortable' => TRUE,
             ],


### PR DESCRIPTION
Overview
----------------------------------------
This amends the Find Contributions search in SearchUI to use Financial Type from Line Item rather than Contribution - as per https://lab.civicrm.org/dev/core/-/issues/6024

Before
----------------------------------------
- Financial Type from civicrm_contribution table

After
----------------------------------------
- grouped Financial Type from civicrm_line_item table
