### PR TITLE
Fix misleading message on Premiums section of contribution pages

### DIFF
--- a/CRM/Contribute/Page/Premium.php
+++ b/CRM/Contribute/Page/Premium.php
@@ -117,6 +117,11 @@ class CRM_Contribute_Page_Premium extends CRM_Core_Page_Basic {
     $pageID = CRM_Utils_Request::retrieve('id', 'Positive',
       $this, FALSE, 0
     );
+    $premiumsExist = TRUE;
+    if (count(CRM_Contribute_PseudoConstant::products()) === 0) {
+      $premiumsExist = FALSE;
+    }
+    $this->assign('premiumsExist', $premiumsExist);
     $premiumDao = new CRM_Contribute_DAO_Premium();
     $premiumDao->entity_table = 'civicrm_contribution_page';
     $premiumDao->entity_id = $pageID;

--- a/templates/CRM/Contribute/Page/Premium.tpl
+++ b/templates/CRM/Contribute/Page/Premium.tpl
@@ -55,7 +55,11 @@
       {ts 1=$crmURL}There are no premiums offered on this contribution page yet. You can <a href='%1'>add one</a>.{/ts}
     {else}
       {icon icon="fa-info-circle"}{/icon}
+      {if !$premiumsExist}
       {ts 1=$managePremiumsURL}There are no active premiums for your site. You can <a href='%1'>create and/or enable premiums here</a>.{/ts}
+      {else}
+        {ts}Premiums can be added after specifying Premiums Settings above and saving.{/ts}
+      {/if}
     {/if}
   </div>
 {/if}


### PR DESCRIPTION
Overview
----------------------------------------
The premiums section of contribution pages says `There are no active premiums for your site. You can create and/or enable premiums here.` even when active premiums exist.  This occurs when you first enable premiums for a contribution page, but won't recur if you enable then disable the premiums section.

To replicate:
* Ensure at least one active premium exists in your db.
* Go to "Manage Contribution Pages" on a page that doesn't have premiums (i.e. not page 1 on a demo site).
* Go to the **Premiums** tab and check the **Enable Premiums Section** box.

Before
----------------------------------------
`There are no active premiums for your site. You can create and/or enable premiums here.` 

After
----------------------------------------
`Premiums can be added after specifying Premiums Settings above and saving.`

Technical Details
----------------------------------------
This occurs because of the awkward db design.  `civicrm_premiums` is a 1:1 join to `civicrm_contribution_page`, then we have `civicrm_product` and `civicrm_premiums_product`. 

The boolean `$products` won't evaluate to `true` until `civicrm_premiums` exists, so you have to save the contribution page with premiums existing first.  

Comments
----------------------------------------
I tried making the best UX improvement with a minimum of changes so it's clear when you hit the "products exist but premiums were never enabled" it's clear that you must also expand the premiums settings to fill in the required field - just saying "Save with 'Enable Premiums' checked" will frustrate folks who don't realize there's a required field in the accordion.