### PR TITLE
Fix for dev/core#6088: Users with "edit event participants" get error…

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -271,6 +271,8 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
     parent::preProcess();
     $this->assign('feeBlockPaid', FALSE);
 
+    $this->assign('accessCiviContribute', CRM_Core_Permission::access('CiviContribute'));
+
     // @todo eliminate this duplication.
     $this->_contactId = $this->getContactID();
     $this->_eID = CRM_Utils_Request::retrieve('eid', 'Positive', $this);

--- a/CRM/Event/Form/ParticipantView.php
+++ b/CRM/Event/Form/ParticipantView.php
@@ -50,6 +50,7 @@ class CRM_Event_Form_ParticipantView extends CRM_Core_Form {
       CRM_Event_BAO_Participant::fixEventLevel($values[$participantID]['fee_level']);
     }
 
+    $this->assign('accessCiviContribute', CRM_Core_Permission::access('CiviContribute'));
     $this->assign('contactId', $contactID);
     $this->assign('participantId', $participantID);
 

--- a/templates/CRM/Event/Form/Participant.tpl
+++ b/templates/CRM/Event/Form/Participant.tpl
@@ -94,7 +94,7 @@
             </tr>
           {/if}
         </table>
-       {if $participantId and $hasPayment}
+       {if $participantId and $hasPayment && $accessCiviContribute}
         <table class='form-layout'>
           <tr>
             <td class='label'>{ts}Fees{/ts}</td>

--- a/templates/CRM/Event/Form/ParticipantView.tpl
+++ b/templates/CRM/Event/Form/ParticipantView.tpl
@@ -109,7 +109,7 @@
       <div class="messages status no-popup">{icon icon="fa-info-circle"}{/icon} {ts}Note:{/ts} {$rec|escape|nl2br}</div>
     {/if}
   {/foreach}
-    {if $participantId and $hasPayment}
+    {if $participantId and $hasPayment and $accessCiviContribute}
       <div id="payment-info"></div>
       {include file="CRM/Contribute/Page/PaymentInfo.tpl" show='payments'}
     {/if}


### PR DESCRIPTION
This is a proposed fix for issue: https://lab.civicrm.org/dev/core/-/issues/6088

Overview
----------------------------------------
In attempting to populate the Fees section of the Edit Participant form, CiviCRM generates an error message if the user does not have 'access CiviContribute' permission.

Before
----------------------------------------
- Per tpl design, if the edit form contains a Fees section, an AJAX call is issue to pull fee-related data.
- This AJAX call encounters, and then displays, an error, if the user lacks 'access CiviContribute'.

After
----------------------------------------
- Edit Participant form class checks whether the user has 'access civicontribute', and assigns that finding to a boolean tpl var.
- Template checks that boolean in deciding whether to display the Fees section of the form. If user doesn't have the permission, Fees section is not displayed, and therefore the AJAX call is not issued.

Technical Details
----------------------------------------
- I don't especially like the idea of checking permissions one-by-one like this, but it's easy and it's essentially what the AJAX call is doing anyway.
- It might be better if CiviCRM AJAX api had some way to say "if there's an access error, don't bother the user about it; just return empty", but I don't think that exists, and the idea is a potential can-of-worms conversation.

Comments
----------------------------------------
I hope this is useful. I'm using it myself, hopeful that something equivalent is suitable for core.
