### PR TITLE
Fix userId 0 vs NULL confusion in CRM_Core_Permission_Joomla::check()

### DIFF
--- a/CRM/Core/Permission/Joomla.php
+++ b/CRM/Core/Permission/Joomla.php
@@ -16,7 +16,7 @@
  */
 
 /**
- *
+ * Joomla specific stuff goes here.
  */
 class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
 
@@ -62,7 +62,7 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
         $user = JFactory::getUser($userId);
       }
       else {
-        if ($userId == NULL) {
+        if ($userId === NULL) {
           $user = \Joomla\CMS\Factory::getApplication()->getIdentity() ?? \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById(0);
         }
         else {
@@ -79,14 +79,13 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
           $user = JFactory::getUser($uid);
         }
         else {
-          if ($uid == NULL) {
+          if ($uid === NULL) {
             $user = \Joomla\CMS\Factory::getApplication()->getIdentity() ?? \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById(0);
           }
           else {
             $user = \Joomla\CMS\Factory::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById($uid);
           }
         }
-
       }
 
       return $user->authorise($translated[0], $translated[1]);


### PR DESCRIPTION
Overview
----------------------------------------
Fix for issue [#6089](https://lab.civicrm.org/dev/core/-/issues/6089). Type safety related issue.

Before
----------------------------------------
From CiviCRM 6.6.0+, a false error message is displayed on the status page.

![image](https://lab.civicrm.org/-/project/70/uploads/e9b5fde358737fbf5b02c6b8b6237f5f/image.png)

After
----------------------------------------
False error message goes away.

Technical Details
----------------------------------------
This fixes a regression introduced by #32830 which solved many Joomla 4/5+ compatibility issues.

Comments
----------------------------------------
Tested and working on CiviCRM 6.6.1.

Suggest this be prioritised as a security fix. Because this is a common routine called widely throughout CiviCRM, the issue could occur elsewhere, where permissions are evaluated for an elevated user instead of the anonymous user, so should be fixed ASAP.
