### PR TITLE
Update Smarty SystemCheck to reflect new default, deadline

### DIFF
--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -19,28 +19,30 @@ use Psr\Log\LogLevel;
 class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
 
   /**
-   * Check if Smarty3 has been enabled.
+   * Check if the Smarty version has been overridden.
    *
    * @return CRM_Utils_Check_Message[]
    */
   public function checkSmartyVersion(): array {
     $messages = [];
-    $smarty2Path = \Civi::paths()->getPath('[civicrm.packages]/Smarty/Smarty.class.php');
-    $path = CRM_Utils_Constant::value('CIVICRM_SMARTY_AUTOLOAD_PATH') ?: CRM_Utils_Constant::value('CIVICRM_SMARTY3_AUTOLOAD_PATH');
-    if ($path === $smarty2Path) {
-      $smartyPath = \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php');
-
+    $settingNames = ['CIVICRM_SMARTY_AUTOLOAD_PATH', 'CIVICRM_SMARTY3_AUTOLOAD_PATH'];
+    foreach ($settingNames as $settingName) {
+      if (CRM_Utils_Constant::value($settingName)) {
+        $pathSetting = CRM_Utils_Constant::value($settingName);
+        break;
+      }
+    }
+    if ($pathSetting && !str_ends_with($pathSetting, 'smarty5/Smarty.php')) {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        '<p>' . (ts('CiviCRM is updating a major library (<em>Smarty</em>) to improve performance and security and php 8.3 compatibility. The update is currently optional, but will be required soon.')) . '</p>'
-        . '<p>' . (ts('To apply the update, add this statement to <code>civicrm.settings.php</code>:'))
-        . sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smartyPath, 1))) . '</p>'
-        . '<p>' . ('Some extensions may not work yet with Smarty v5. If you encounter problems, then you can continue with the deprecated Smarty 2 for now but you should consider uninstalling any extensions that do not support Smarty5.') . '</p>'
-        . '<p>' . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v6.4-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+      "
+        <p>" . (ts("CiviCRM recommends Smarty version 5. This site is overriding that default with an older version of Smarty.")) . "</p>
+        <p>" . (ts("CiviCRM will support such overrides until version 6.10. By v6.11, Smarty 5 will be required. You can try out Smarty 5 before then by deleting the line starting with <code>%1</code> from the <code>%2</code> file.", [1 => "define($settingName", 2 => 'civicrm.settings.php'])) . "</p>
+        <p>" . (ts('CiviCRM <a %1>v6.10-ESR</a> provides extended support for Smarty v2 and v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
         ])),
-        ts('Smarty Update (v2 => v5)'),
+        ts('Smarty Version Override'),
         LogLevel::WARNING,
         'fa-lock'
       );


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/32998 the default version of Smarty was changed, but the status message needs a corresponding update to reflect the new default.

Before
-----
<img width="2320" height="938" alt="image" src="https://github.com/user-attachments/assets/2b1edd31-6586-49b3-9063-2304dd6964ce" />

After
------
<img width="1047" height="308" alt="image" src="https://github.com/user-attachments/assets/2e51a9c2-08c8-497f-9130-3aea1e22bb2f" />

