### PR TITLE
 fix: display double-opt-in group setting

### DIFF
--- a/ext/civi_mail/settings/Mailing.setting.php
+++ b/ext/civi_mail/settings/Mailing.setting.php
@@ -149,6 +149,7 @@ return [
     'is_contact' => 0,
     'description' => ts('When CiviMail is enabled and a profile uses the "Add to Group" setting, users who complete the profile form will receive a confirmation email. They must respond (opt-in) before they are added to the group.'),
     'help_text' => NULL,
+    'settings_pages' => ['mailing' => ['weight' => 10]],
   ],
   'disable_mandatory_tokens_check' => [
     'group_name' => 'Mailing Preferences',


### PR DESCRIPTION
Overview
----------------------------------------
Fix for missing CiviMail setting 'Enable Double Opt-in for Profiles which use the "Add to Group" setting'  according to https://lab.civicrm.org/dev/core/-/issues/6049

Before
----------------------------------------
The [documented](https://docs.civicrm.org/user/en/latest/organising-your-data/profiles/#add-new-contacts-to-a-group) setting "Enable Double Opt-in for Profiles which use the "Add to Group" setting" is missing in the mailing component settings:
<img width="1287" height="183" alt="image" src="https://github.com/user-attachments/assets/7b0f0019-6d83-4328-9666-aec2adb8cfbb" />


After
----------------------------------------
The checkbox for "Enable Double Opt-in for Profiles which use the "Add to Group" setting" appears right after "Enable Double Opt-in for Profile Group(s) field".
<img width="1379" height="251" alt="image" src="https://github.com/user-attachments/assets/50d6c7bf-5106-450e-beb9-861e0508e783" />
Similar to the screenshot from the docs
<img width="1028" height="214" alt="docs-screenshot" src="https://github.com/user-attachments/assets/b4e5465f-7fcc-4813-a13f-b500eeb4d702" />
