### PR TITLE
SearchKit - Allow `<summary>` and `<details>` in html rewrites

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -679,6 +679,9 @@ class CRM_Utils_String {
       if (!empty($def)) {
         $def->addElement('figcaption', 'Block', 'Flow', 'Common');
         $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
+        // Allow `<summary>` and `<details>`
+        $def->addElement('details', 'Block', 'Flow', 'Common');
+        $def->addElement('summary', 'Inline', 'Inline', 'Common');
       }
       $_filter = new HTMLPurifier($config);
     }

--- a/ext/search_kit/ang/crmSearchDisplay/colType/html.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/html.html
@@ -1,2 +1,2 @@
-<span ng-bind-html="colData.val">
+<span ng-bind-html="$ctrl.getRawHtml(colData.val)">
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -2,7 +2,7 @@
   "use strict";
 
   // Trait provides base methods and properties common to all search display types
-  angular.module('crmSearchDisplay').factory('searchDisplayBaseTrait', function($timeout, $interval, crmApi4, crmStatus) {
+  angular.module('crmSearchDisplay').factory('searchDisplayBaseTrait', function($timeout, $interval, $sce, crmApi4, crmStatus) {
 
     // Return a base trait shared by all search display controllers
     // Gets mixed in using angular.extend()
@@ -190,6 +190,12 @@
         return _.pick(this.afFieldset ? this.afFieldset.getFieldData() : {}, function(val) {
           return typeof val !== 'undefined' && val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length);
         });
+      },
+
+      // WARNING: Only to be used with trusted/sanitized markup.
+      // This is safe to use on html columns because `AbstractRunAction::formatColumn` already runs it through `CRM_Utils_String::purifyHTML()`.
+      getRawHtml(html) {
+        return $sce.trustAsHtml(html);
       },
 
       // Generate params for the SearchDisplay.run api


### PR DESCRIPTION
Overview
----------------------------------------
Enables html rewritten columns to include a disclosure widget (`<summary>` and `<details>` markup).

See discussion at https://chat.civicrm.org/civicrm/pl/njddzmjc9fnoddmyceg3ffftgw

<img width="1722" height="1746" alt="image" src="https://github.com/user-attachments/assets/cbf014cd-5550-459e-a036-c26c1c7ed830" />


Technical Details
----------------------------------------
Investigating this I found that html in SearchDisplays was being sanitized twice:

- By `CRM_Utils_String::purifyHTML()` in `AbstractRunAction::formatColumn`
- By `ngSanitize` via `ng-bind-html` in crmSearchDisplay/colType/html.html

Well, better twice than never! But it turns out both sanitizers are out-of-date and don't include html5 elements like `<summary>` and `<details>`.

I've added those tags to the `CRM_Utils_String::purifyHTML`, and bypassed `ngSanitize` for these columns as I think sanitizing twice is redundant.