### PR TITLE
(dev/core#6093) Standalone Installer - Ensure web request does not fail due to missing session class

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -645,13 +645,14 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     }
     else {
       $session_cookie_name = 'SESSCIVISO';
-    }
-    if (ini_get('session.save_handler') === 'redis') {
-      // We'll just use the default, take no action.
-    }
-    else {
-      $session_handler = new SessionHandler();
-      session_set_save_handler($session_handler);
+
+      if (ini_get('session.save_handler') === 'redis') {
+        // We'll just use the default, take no action.
+      }
+      else {
+        $session_handler = new SessionHandler();
+        session_set_save_handler($session_handler);
+      }
     }
 
     // session lifetime in seconds (default = 24 minutes)


### PR DESCRIPTION
Overview
----------------------------------------

There was a [complicated fix for standalone web installations (dev/core#4988)](https://lab.civicrm.org/dev/core/-/issues/4988) to ensure a session can be started before extensions were available. Unfortunately, it was undone with a [recent regression](https://github.com/civicrm/civicrm-core/commit/da157e777d58732dceba05d93d3d519c9a67b362). Fortunately, it can be easily fixed :).

Before
----------------------------------------

When trying to install Standalone via the web, the web page would display a 500 error and the logs would report: Uncaught Error: Class "Civi\\Standalone\\SessionHandler" not found in /.../web/core/CRM/Utils/System/Standalone.php:653

This is the same error fixed via [4988](https://lab.civicrm.org/dev/core/-/issues/4988).


After
----------------------------------------

The installation works!

Technical Details
----------------------------------------

It was a small if/then error that was introduced by da157e777d58732dceba05d93d3d519c9a67b362

In short: if we are installing, do not set a custom session handler at all. If we are not installing, then set a session handler if we are not using redis.