### PR TITLE
SearchKit - Fix refreshing search results after batch tasks

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -90,7 +90,7 @@
       this.refreshAfterTask = function(result, ids) {
         displayCtrl.selectedRows = [];
         displayCtrl.allRowsSelected = false;
-        if (ids && result.action === 'inlineEdit' && ids.length === 1) {
+        if (result && ids && result.action === 'inlineEdit' && ids.length === 1) {
           displayCtrl.refreshAfterEditing(result, ids[0]);
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to 60a15973 which fixed some but not all errors after batch tasks.
 
Before
----------------------------------------
After using the "Update Contacts" batch action in SearchKit, the display fails to refresh. Error msg in the browser console.

After
----------------------------------------
Fixed.