### PR TITLE
Prevent deletion of users when merging

### DIFF
--- a/CRM/Dedupe/MergeHandler.php
+++ b/CRM/Dedupe/MergeHandler.php
@@ -108,9 +108,7 @@ class CRM_Dedupe_MergeHandler {
     $activeRelTables = CRM_Dedupe_Merger::getActiveRelTables($this->toRemoveID);
     $activeMainRelTables = CRM_Dedupe_Merger::getActiveRelTables($this->toKeepID);
     foreach ($relTables as $name => $null) {
-      if (!in_array($name, $activeRelTables, TRUE) &&
-        !(($name === 'rel_table_users') && in_array($name, $activeMainRelTables, TRUE))
-      ) {
+      if (!in_array($name, $activeRelTables, TRUE)) {
         unset($relTables[$name]);
       }
     }


### PR DESCRIPTION
Before
----------------------------------------
If using Deduper on Standalone and you:

1. Create a contact with a user account
2. Create a second contact
3. Merge the two contacts in Deduper

The user account will be deleted.

After
----------------------------------------
User account is no longer deleted.

Technical Details
----------------------------------------
If we don't unset the users table from ```$relTables```, then the [user is always deleted](https://github.com/civicrm/civicrm-core/blob/6132d8a4f8fd82022d9cadb9a1674f38e20a0662/CRM/Dedupe/Merger.php#L446) before [merging even begins](https://github.com/civicrm/civicrm-core/blob/6132d8a4f8fd82022d9cadb9a1674f38e20a0662/CRM/Dedupe/Merger.php#L580).

I looked to see why this code was added but couldn't [find anything informative](https://github.com/civicrm/civicrm-svn/commit/dc06654d3cdbd42f30247c460d40e6332cd69f8f). I can't see why we would ever need to do anything to users when the contact that is being merged (the left side contact) has no user. There's nothing to do because there is nothing to move.
