### PR TITLE
Smarty - Update icon markup for accessibility

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -522,13 +522,17 @@ class CRM_Core_Page {
     $classes[] = $icon;
     $attribs['class'] = implode(' ', array_unique($classes));
 
-    $standardAttribs = ['aria-hidden' => 'true'];
+    $standardAttribs = [
+      'role' => 'img',
+      'aria-hidden' => 'true',
+    ];
     if ($text === NULL || $text === '') {
       $sr = '';
     }
     else {
       $standardAttribs['title'] = $text;
-      $sr = "<span class=\"sr-only\">$text</span>";
+      $srText = htmlspecialchars($text, ENT_NOQUOTES);
+      $sr = "<span class=\"sr-only\">$srText</span>";
     }
 
     // Assemble attribs

--- a/CRM/Core/Smarty/plugins/function.copyIcon.php
+++ b/CRM/Core/Smarty/plugins/function.copyIcon.php
@@ -27,8 +27,10 @@
  * @return string
  */
 function smarty_function_copyIcon($params, &$smarty) {
-  $text = ts('Click to copy %1 from row one to all rows.', [1 => $params['title']]);
+  $text = ts('Click to copy %1 from row one to all rows.', [1 => $params['title'], 'escape' => 'htmlattribute']);
   return <<<HEREDOC
-<i class="crm-i fa-clone action-icon" fname="{$params['name']}" title="$text"><span class="sr-only">$text</span></i>
+<span class="action-icon" fname="{$params['name']}" aria-label="$text" title="$text" role="button">
+  <i class="crm-i fa-clone" role="img" aria-hidden="true"></i>
+</span>
 HEREDOC;
 }

--- a/CRM/Core/Smarty/plugins/function.privacyFlag.php
+++ b/CRM/Core/Smarty/plugins/function.privacyFlag.php
@@ -42,15 +42,22 @@ function smarty_function_privacyFlag($params, &$smarty) {
   ];
   $titles = CRM_Core_SelectValues::privacy();
   $field = $params['field'] ?? 'do_not_mail';
-  if ($field == 'on_hold') {
-    $text = ts('Email on hold - generally due to bouncing.');
+  if ($field === 'on_hold') {
+    $text = ts('Email on hold - generally due to bouncing.', ['escape' => 'htmlattribute']);
     return <<<HEREDOC
-<span class="privacy-flag email-hold" title="$text"><i class="crm-i fa-exclamation-triangle fa-lg font-red" aria-hidden="true"></i></span><span class="sr-only">$text</span>
+<span class="privacy-flag email-hold" title="$text">
+  <i class="crm-i fa-exclamation-triangle fa-lg font-red" role="img" aria-hidden="true"></i>
+</span>
+<span class="sr-only">$text</span>
 HEREDOC;
   }
   $class = str_replace('_', '-', $field);
-  $text = ts('Privacy flag: %1', [1 => $titles[$field]]);
+  $text = ts('Privacy flag: %1', [1 => $titles[$field], 'escape' => 'htmlattribute']);
   return <<<HEREDOC
-<span class="fa-stack privacy-flag $class" title="$text" aria-hidden="true"><i class="crm-i {$icons[$field]} fa-stack-1x"></i><i class="crm-i fa-ban fa-stack-2x font-red"></i></span><span class="sr-only">$text</span>
+<span class="fa-stack privacy-flag $class" title="$text">
+  <i class="crm-i {$icons[$field]} fa-stack-1x" role="img" aria-hidden="true"></i>
+  <i class="crm-i fa-ban fa-stack-2x font-red" role="img" aria-hidden="true"></i>
+</span>
+<span class="sr-only">$text</span>
 HEREDOC;
 }

--- a/tests/phpunit/CRM/Core/PageTest.php
+++ b/tests/phpunit/CRM/Core/PageTest.php
@@ -12,12 +12,12 @@ class CRM_Core_PageTest extends CiviUnitTestCase {
    * @return array
    */
   public static function iconTestData() {
-    // first item is icon, text, condition, and attribs, second is expected markup
+    // First item is expected markup, second is php params and third is equivalent smarty syntax for the same params
     return [
       [
-        '<i aria-hidden="true" title="We have a winner" class="crm-i fa-trophy"></i><span class="sr-only">We have a winner</span>',
-        ['fa-trophy', 'We have a winner', TRUE, []],
-        '{icon icon="fa-trophy"}We have a winner{/icon}',
+        '<i role="img" aria-hidden="true" title="Test 1 &amp; 2" class="crm-i fa-trophy"></i><span class="sr-only">Test 1 &amp; 2</span>',
+        ['fa-trophy', 'Test 1 & 2', TRUE, []],
+        '{icon icon="fa-trophy"}Test 1 & 2{/icon}',
       ],
       [
         '',
@@ -25,27 +25,27 @@ class CRM_Core_PageTest extends CiviUnitTestCase {
         '{icon icon="fa-trophy" condition=0}We have a winner{/icon}',
       ],
       [
-        '<i aria-hidden="true" title="Favorite" class="action-icon test-icon crm-i fa-heart"></i><span class="sr-only">Favorite</span>',
-        ['fa-heart', 'Favorite', TRUE, ['class' => 'action-icon test-icon']],
-        '{icon icon="fa-heart" class="action-icon test-icon"}Favorite{/icon}',
+        '<i role="img" aria-hidden="true" title="Favorite &lt;3" class="action-icon test-icon crm-i fa-heart"></i><span class="sr-only">Favorite &lt;3</span>',
+        ['fa-heart', 'Favorite <3', TRUE, ['class' => 'action-icon test-icon']],
+        '{icon icon="fa-heart" class="action-icon test-icon"}Favorite <3{/icon}',
       ],
       [
-        '<i aria-hidden="true" title="I &quot;choo-choo&quot; choose you" class="crm-i fa-train"></i><span class="sr-only">I "choo-choo" choose you</span>',
+        '<i role="img" aria-hidden="true" title="I &quot;choo-choo&quot; choose you" class="crm-i fa-train"></i><span class="sr-only">I "choo-choo" choose you</span>',
         ['fa-train', 'I "choo-choo" choose you', TRUE, []],
         '{icon icon="fa-train"}I "choo-choo" choose you{/icon}',
       ],
       [
-        '<i aria-hidden="true" class="crm-i fa-trash"></i><span class="sr-only">Trash</span>',
+        '<i role="img" aria-hidden="true" class="crm-i fa-trash"></i><span class="sr-only">Trash</span>',
         ['fa-trash', 'Trash', TRUE, ['title' => '']],
         '{icon icon="fa-trash" title=""}Trash{/icon}',
       ],
       [
-        '<i title="It\'s bedtime" class="crm-i fa-bed"></i><span class="sr-only">It\'s bedtime</span>',
+        '<i role="img" title="It\'s bedtime" class="crm-i fa-bed"></i><span class="sr-only">It\'s bedtime</span>',
         ['fa-bed', "It's bedtime", TRUE, ['aria-hidden' => '']],
         // Ye olde Smarty 2 doesn't support hyphenated function parameters
       ],
       [
-        '<i aria-hidden="true" class="crm-i fa-snowflake-o"></i>',
+        '<i role="img" aria-hidden="true" class="crm-i fa-snowflake-o"></i>',
         ['fa-snowflake-o', NULL, TRUE, []],
         '{icon icon="fa-snowflake-o"}{/icon}',
       ],


### PR DESCRIPTION
Overview
----------------------------------------
Uses standard aria attributes for icons generated with smarty functions.

Partially carved out from https://github.com/civicrm/civicrm-core/pull/33588

See [#5041 Making Font Awesome icons accessible](https://lab.civicrm.org/dev/core/-/issues/5041)