### PR TITLE
don't add % wildcard to quick search external id search

### DIFF
--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -412,7 +412,7 @@
         // search with wildcards, aside from contact name and a few other
         // fields. To get comparable results, append and possible prepend
         // wildcard to the search term.
-        else if (searchkey !== 'id') {
+        else if (searchkey !== 'id' && searchkey !== 'external_identifier') {
           if (CRM.config.includeWildCardInName == 1) {
             $('#crm-qsearch-input').val('%' + searchValue + '%');
           }


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow up to https://github.com/civicrm/civicrm-core/pull/33488 in response to @colemanw's suggestion to exclude external id as well as id.

In short: in quick search, we add a % to the search terms to make them wild card searches. This is well and good for all fields except id and external_identifier - in which there is an expectation that it's  an exact search.

The previous PR only exclude id, this PR finishes the job.


Before
----------------------------------------

If you search for an external id in quick search you get all records that match the external id or a portion of the external id being search for.

After
----------------------------------------

Now you only get an exact match on the external id.


