### PR TITLE
SearchKit - Make option format selectable in main search 

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -357,6 +357,25 @@
       }
     };
 
+    // Because angular dropdowns must be a by-reference variable
+    const suffixOptionCache = {};
+
+    this.getSuffixOptions = function(expr) {
+      const info = searchMeta.parseExpr(expr);
+      if (!info.fn && info.args[0] && info.args[0].field && info.args[0].field.suffixes) {
+        let cacheKey = info.args[0].field.suffixes.join();
+        if (!(cacheKey in suffixOptionCache)) {
+          suffixOptionCache[cacheKey] = Object.keys(CRM.crmSearchAdmin.optionAttributes)
+            .filter(key => info.args[0].field.suffixes.includes(key))
+            .reduce((filteredOptions, key) => {
+              filteredOptions[key] = CRM.crmSearchAdmin.optionAttributes[key];
+              return filteredOptions;
+            }, {});
+        }
+        return suffixOptionCache[cacheKey];
+      }
+    };
+
     function addNum(name, num) {
       return name + (num < 10 ? '_0' : '_') + num;
     }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -202,24 +202,9 @@
         }
       };
 
-      // Because angular dropdowns must be a by-reference variable
-      const suffixOptionCache = {};
-
       this.getSuffixOptions = function(col) {
-        let expr = ctrl.getExprFromSelect(col.key),
-          info = searchMeta.parseExpr(expr);
-        if (!info.fn && info.args[0] && info.args[0].field && info.args[0].field.suffixes) {
-          let cacheKey = info.args[0].field.suffixes.join();
-          if (!(cacheKey in suffixOptionCache)) {
-            suffixOptionCache[cacheKey] = Object.keys(CRM.crmSearchAdmin.optionAttributes)
-              .filter(key => info.args[0].field.suffixes.includes(key))
-              .reduce((filteredOptions, key) => {
-                filteredOptions[key] = CRM.crmSearchAdmin.optionAttributes[key];
-                return filteredOptions;
-              }, {});
-          }
-          return suffixOptionCache[cacheKey];
-        }
+        let expr = ctrl.getExprFromSelect(col.key);
+        return ctrl.crmSearchAdmin.getSuffixOptions(expr);
       };
 
       function getSetSuffix(index, val) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -11,9 +11,8 @@
     },
     template: function() {
       // Dynamic template generates switch condition for each display type
-      let html =
-        '<div ng-switch="$ctrl.display.type">\n';
-      _.each(CRM.crmSearchAdmin.displayTypes, function(type) {
+      let html = '<div ng-switch="$ctrl.display.type">\n';
+      CRM.crmSearchAdmin.displayTypes.forEach(function(type) {
         html +=
           '<div ng-switch-when="' + type.id + '">\n' +
           '  <div class="help-block"><i class="crm-i ' + type.icon + '" role="img" aria-hidden="true"></i> ' + _.escape(type.description) + '</div>' +
@@ -317,7 +316,7 @@
           };
           ctrl.links[''] = _.filter(ctrl.links['*'], {join: ''});
           searchMeta.getSearchTasks(ctrl.savedSearch.api_entity).then(function(tasks) {
-            _.each(tasks, function (task) {
+            tasks.forEach(function (task) {
               if (task.number === '> 0' || task.number === '=== 1') {
                 const link = {
                   text: task.title,
@@ -443,8 +442,9 @@
 
       // Add or remove an item from an array
       this.toggle = function(collection, item) {
-        if (_.includes(collection, item)) {
-          _.pull(collection, item);
+        const index = collection.indexOf(item);
+        if (index > -1) {
+          collection.splice(index, 1);
         } else {
           collection.push(item);
         }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.component.js
@@ -30,7 +30,9 @@
             ctrl.select[index] = {
               key: key,
               label: ctrl.crmSearchAdmin.getFieldLabel(key),
-              isPseudoField: ctrl.crmSearchAdmin.isPseudoField(key)
+              isPseudoField: ctrl.crmSearchAdmin.isPseudoField(key),
+              rawKey: key.split(':')[0],
+              suffixOptions: ctrl.crmSearchAdmin.getSuffixOptions(key),
             };
           }
         });

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminFields.html
@@ -1,8 +1,15 @@
 <div ng-model="$ctrl.select" ui-sortable="$ctrl.sortableOptions">
-  <fieldset ng-repeat="col in $ctrl.select" class="crm-draggable">
+  <fieldset ng-repeat="col in $ctrl.select" class="crm-draggable form-inline">
     <i class="crm-i fa-arrows crm-search-move-icon" role="img" aria-hidden="true"></i>
     <crm-search-function ng-if="!col.isPseudoField && $ctrl.crmSearchAdmin.paramExists('groupBy')" class="form-inline" mode="select" expr="col.key"></crm-search-function>
     <label ng-if="col.isPseudoField || !$ctrl.crmSearchAdmin.paramExists('groupBy')">{{:: col.label }}</label>
+    <label ng-if="col.suffixOptions" title="{{:: ts('Format for %1', {1: col.label}) }}">
+      <span class="sr-only">{{:: ts('Format for %1', {1: col.label}) }}</span>
+      <select ng-model="col.key" class="form-control crm-auto-width">
+        <option value="{{ col.rawKey }}">{{:: ts('Raw Value') }}</option>
+        <option ng-repeat="(k, v) in col.suffixOptions" value="{{ col.rawKey + ':' + k }}">{{ v }}</option>
+      </select>
+    </label>
     <button type="button" class="btn btn-xs pull-right" ng-if="$ctrl.select.length > 1" ng-click="$ctrl.crmSearchAdmin.clearParam('select', $index)" title="{{:: ts('Remove') }}">
       <i class="crm-i fa-times" role="img" aria-hidden="true"></i>
     </button>


### PR DESCRIPTION
Overview
----------------------------------------
As of https://github.com/civicrm/civicrm-core/commit/ef030d8d04adc319d1b474ad98154fe632193e5a it's possible to select option format when configuring a display.
Now it's possible on the main search as well.

<img width="963" height="316" alt="Screenshot 2025-09-15 at 9 11 51 PM" src="https://github.com/user-attachments/assets/97b201f4-34f5-4d01-a244-561aca228330" />
