### PR TITLE
RiverLea: maintain aspect ratio in some image blocks, ref /extensions/riverlea/133

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -61,6 +61,7 @@ body {
 .crm-container img {
   max-inline-size: 100%;
   max-block-size: 100%;
+  block-size: auto;
 }
 .crm-container img.olTileImage {
   max-block-size: unset; /* open street map exception */


### PR DESCRIPTION
Overview
----------------------------------------
From Kurund three months ago (sorry, it got lost!) – "images in SK tables take the aspect ratio of the first image despite the height and width being set in the SK config"

This is because of:

```
.crm-container img {
  max-inline-size: 100%;
  max-block-size: 100%;
```

Which is a reset designed to prevent overflowing their containers. This has a consequence in some SK tables of changing the aspect ratio of images.

Before
----------------------------------------
[Block-size](https://developer.mozilla.org/en-US/docs/Web/CSS/block-size) on images inherits from the browser (when sets it to 'auto') or from the parent CMS theme. If the parent CMS uses anything other than 'auto' that may create unpredictable image aspect ratios.

After
----------------------------------------
Block size is set to auto in all cases on images.

Technical Details
----------------------------------------
Original issue: https://lab.civicrm.org/extensions/riverlea/-/issues/133
Original PR: https://lab.civicrm.org/extensions/riverlea/-/merge_requests/52

Comments
----------------------------------------
@kurund - can you confirm this is still an active issue?