### PR TITLE
[NFC] remove empty function riverlea_civicrm_alterBundle

### DIFF
--- a/ext/riverlea/riverlea.php
+++ b/ext/riverlea/riverlea.php
@@ -17,14 +17,6 @@ function riverlea_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_alterBundle().
- *
- * Add Bootstrap JS.
- */
-function riverlea_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install


### PR DESCRIPTION
Overview
----------------------------------------
The previous contents of this hook has been moved to the `Civi\Riverlea\StyleLoader` listener