### PR TITLE
RiverLea: Reduces SK button/menu cells to width of only button/menus

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -26,6 +26,9 @@ table.crm-sticky-header > thead > tr {
   padding: var(--crm-table-padding) calc(var(--crm-table-padding) - var(--crm-s)) calc(var(--crm-table-padding) - var(--crm-s)) var(--crm-table-padding);
   --crm-btn-margin: 0 var(--crm-s) var(--crm-s) 0;
 }
+#bootstrap-theme td:is(.crm-search-col-type-buttons,.crm-search-col-type-menu) {
+  width: 1px; /* shrinks cell to width of button/menu */
+}
 #bootstrap-theme th.crm-search-result-select button.btn {
   background: transparent;
   padding: var(--crm-xs1) var(--crm-m1);


### PR DESCRIPTION
Overview
----------------------------------------
Table cells automatically distribute width, which is generally desire. However, if the cells only contain buttons or drop-down menus and several appear in consequtive columns, the spacing looks a bit messy. This reduces SearchKit table cells to only the width of the button/menu plus cell padding.

Before
----------------------------------------
<img width="1629" height="244" alt="image" src="https://github.com/user-attachments/assets/760c3276-95dd-45b0-8f54-13d70150103b" />

Walbrook:
<img width="1632" height="314" alt="image" src="https://github.com/user-attachments/assets/0271f830-829a-4cbc-92fe-9ee7a2776c9e" />

Greenwich:
<img width="1631" height="370" alt="image" src="https://github.com/user-attachments/assets/1dc21458-42ce-4bb2-82fc-0f161f205731" />

After
----------------------------------------
<img width="1618" height="253" alt="image" src="https://github.com/user-attachments/assets/2f2a9971-8ce9-4952-b102-8878472f887b" />

Walbrook
<img width="1628" height="320" alt="image" src="https://github.com/user-attachments/assets/cf88ee8d-1979-4358-a325-4356884341c4" />

Technical Details
----------------------------------------
The method for doing this looks a bit hacky - it sets the cell width on button/menu cells to 1px - so the cells try to shrink as much as possible, but respect the button/menu width. 

Comments
----------------------------------------
I can't think of problems with this 1px trick - other than if someone added a button or menu with position absolute, rather than relative (which they currently are) - but that's a customisation outside of Civi, so I don't think it's worth considering.