### PR TITLE
Riverlea - add `safe_css` param for "safe mode"

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -125,6 +125,10 @@ class StyleLoader implements \Symfony\Component\EventDispatcher\EventSubscriberI
       foreach (self::CORE_FILES as $i => $file) {
         $bundle->addStyleFile('riverlea', "core/css/{$file}", ['weight' => -100 + ($i / $j)]);
       }
+      if (\CRM_Utils_Request::retrieve('safe_css', 'Boolean')) {
+        // safe mode - dont load dynamic styles
+        return;
+      }
       // get the URL for dynamic css asset (aka "the river")
       $riverUrl = \Civi::service('asset_builder')->getUrl(
         self::DYNAMIC_FILE,


### PR DESCRIPTION
Overview
----------------------------------------
URL param to disable dynamic CSS loading. Provides a get out of jail card if you somehow add some quirky variables to your active stream (like tiny tiny font)

CC: @vingle 
