### PR TITLE
RiverLea: simplifies Walbrook bold/italic font-handling, allowing for fewer variables and lots of cleanup

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -186,17 +186,14 @@ body.civicrm-iframe-page {
 .crm-container b,
 .crm-container .bold,
 .crm-container .font-bold {
-  font-family: var(--crm-font-bold);
   font-weight: bold;
 }
 .crm-container em,
 .crm-container .font-italic {
-  font-family: var(--crm-font-italic);
   font-style: italic;
 }
 .crm-container strong em,
 .crm-container em strong {
-  font-family: var(--crm-font-bold-italic);
   font-weight: bold;
   font-style: italic;
 }
@@ -210,7 +207,6 @@ body.civicrm-iframe-page {
 #bootstrap-theme h3 {
   background-color: var(--crm-heading-bg);
   font-size: var(--crm-r1);
-  font-family: var(--crm-font-bold);
   font-weight: bold;
   color: var(--crm-heading-col);
   padding: var(--crm-heading-padding);
@@ -294,7 +290,8 @@ dl dl {
   background-color: var(--crm-c-page-background);
 }
 .crm-container tr.disabled td *:not(.btn,button,i,a),
-.crm-container td.disabled {
+.crm-container td.disabled,
+.crm-container #extensions-main table tr.disabled td {
   font-style: italic;
 }
 .crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column,.crm-extensions-label) {

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -70,7 +70,6 @@
   display: block;
   color: var(--crm-c-text);
   font-style: italic;
-  font-family: var(--crm-font-italic);
   margin: var(--crm-s) 0 var(--crm-m);
   font-size: var(--crm-font-small-size);
 }
@@ -83,7 +82,6 @@
   margin-top: var(--crm-m1);
   margin-bottom: var(--crm-m1);
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   color: var(--crm-c-text);
   line-height: 1.2;
 }
@@ -430,7 +428,6 @@
   font-size: 90%;
 }
 #bootstrap-theme dfn {
-  font-family: var(--crm-font-italic);
   font-style: italic;
 }
 #bootstrap-theme hr {

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -128,7 +128,6 @@ a.crm-expand-row:focus {
   background-color: var(--crm-expand-header-bg-active);
 }
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header {
-  font-family: var(--crm-expand2-header-font);
   font-weight: var(--crm-expand2-header-weight);
   background-color: var(--crm-expand2-header-bg);
   color: var(--crm-expand2-header-color);
@@ -436,8 +435,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   top: 0;;
 }
 .crm-container .tag-tree-wrapper div.tag-info .tdl {
-  font-weight: var(--crm-bold-weight);
-  font-family: var(--crm-font-bold);
+  font-weight: bold;
   color: var(--crm-c-text);
 }
 .crm-container .tag-tree-wrapper div.tag-info .crm-submit-buttons {
@@ -555,8 +553,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   color: inherit;
 }
 #api-generated caption {
-  font-weight: var(--crm-bold-weight);
-  font-family: var(--crm-font-bold);
+  font-weight: bold;
 }
 #api-generated tr td:first-of-type {
   width: var(--crm-input-label-width);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -9,9 +9,6 @@
 /* Fonts */
   --crm-system-fonts: unset;
   --crm-font: unset;
-  --crm-font-bold: unset;
-  --crm-font-italic: unset;
-  --crm-font-bold-italic: unset;
 /* Colour names */
   --crm-c-darkest: #0a0a0a;
   --crm-c-gray-900: #2f2f2e;
@@ -208,7 +205,6 @@
   --crm-expand-header-color: var(--crm-c-secondary-text);
   --crm-expand-header-padding: var(--crm-s) var(--crm-m);
   --crm-expand-header-weight: bold;
-  --crm-expand-header-font: var(--crm-font-bold);
   --crm-expand-header-border: var(--crm-c-divider);
   --crm-expand-header-border-width: 0 0 1px 0;
   --crm-expand-border: var(--crm-c-divider);
@@ -220,7 +216,6 @@
   --crm-expand2-header-bg: unset;
   --crm-expand2-header-bg-active: var(--crm-c-background-2);
   --crm-expand2-header-weight: normal;
-  --crm-expand2-header-font: unset;
   --crm-expand2-header-color: var(--crm-c-text);
   --crm-expand2-header-border: unset;
   --crm-expand2-header-border-width: unset;
@@ -292,7 +287,6 @@
   --crm-tab-padding: var(--crm-s3) var(--crm-m) var(--crm-s) var(--crm-m);
   --crm-tab-col: var(--crm-c-text);
   --crm-tab-weight: normal;
-  --crm-tab-font: unset;
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
   --crm-tab-roundness: var(--crm-roundness);

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -5,7 +5,6 @@
 /* Config Task List */
 .crm-container td.tasklist a {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
 }
 .crm-container table.selector td.tasklist {
   border-right: var(--crm-table-row-border);
@@ -108,6 +107,5 @@
   }
   .crm-container .admin-section-items dt {
     font-weight: bold;
-    font-family: var(--crm-font-bold);
   }
 }

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -8,7 +8,6 @@
   list-style: none;
   cursor: var(--crm-hover-clickable);
   font-size: var(--crm-font-size);
-  font-family: var(--crm-expand-header-font);
   font-weight: var(--crm-expand-header-weight);
   color: var(--crm-c-text);
   border-radius: var(--crm-expand-radius);
@@ -63,7 +62,6 @@
   border: var(--crm-expand-header-border);
   border-width: var(--crm-expand-header-border-width);
   font-weight: var(--crm-expand-header-weight);
-  font-family: var(--crm-expand-header-font);
 }
 .crm-container .crm-accordion-bold > summary a {
   color: var(--crm-expand-header-color);
@@ -90,7 +88,6 @@
   background-color: var(--crm-expand2-body-bg);
 }
 .crm-container .crm-accordion-light > summary {
-  font-family: var(--crm-expand2-header-font);
   font-weight: var(--crm-expand2-header-weight);
   background-color: var(--crm-expand2-header-bg);
   color: var(--crm-expand2-header-color);

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -90,7 +90,6 @@
   line-height: 1;
   color: var(--crm-c-darkest) !important;
   text-shadow: 0 1px 0 #fff;
-  font-family: var(--crm-font-bold);
   font-weight: bold;
   opacity: .2;
 }

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -134,7 +134,6 @@ table.advmultiselect {
   color: var(--crm-c-text);
   display: inline-block;
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   line-height: var(--crm-wizard-height);
   padding: 0 var(--crm-l) 0 var(--crm-xl);
   position: relative;
@@ -437,7 +436,6 @@ p.crm-upgrade-large-text {
 p.crm-upgrade-large-text:first-of-type {
   font-size: var(--crm-r1);
   color: var(--crm-alert-success-text);
-  font-family: var(--crm-font-bold);
   font-weight: bold;
 }
 .crm-success-flex {
@@ -512,7 +510,6 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   font-size: var(--crm-font-size);
   color: var(--crm-c-text-light);
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   text-align: center;
   background: var(--crm-c-background2);
 }

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -32,7 +32,6 @@
 .crm-container.ui-dialog .ui-dialog-header .ui-dialog-title,
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-dialog-title {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   padding: 0;
   float: none;
   flex: 1;
@@ -196,7 +195,6 @@
 #crm-notification-container div.ui-notify-message h1 {
   font-size: var(--crm-font-size);
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   margin: 0 2ch var(--m) 0;
   color: var(--crm-notify-col);
 }

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -230,7 +230,6 @@
   font-size: var(--crm-r1);
   padding: var(--crm-m2) var(--crm-r1);
   font-weight: bold;
-  font-family: var(--crm-font-bold);
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(2) > td {
   border-top: var(--crm-c-divider) !important;
@@ -359,7 +358,6 @@
   padding: var(--crm-dropdown-padding);
   white-space: nowrap;
   color: var(--crm-dropdown-col);
-  font-family: var(--crm-font-bold);
   font-weight: bold;
   padding: var(--crm-m) var(--crm-xs) var(--crm-xs) !important;
   border-bottom: 1px solid var(--crm-dropdown-col);

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -111,7 +111,6 @@
 }
 .crm-container fieldset legend {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   padding-inline: var(--crm-s);
   color: var(--crm-c-text);
 }
@@ -616,7 +615,6 @@ input.crm-form-checkbox) + label {
 }
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
   background: var(--crm-c-background3);
   padding: var(--crm-s);
 }

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -4,9 +4,6 @@
 
 .crm-container.crm-public {
   --crm-font: inherit;
-  --crm-font-bold: inherit;
-  --crm-font-italic: inherit;
-  --crm-font-bold-italic: inherit;
 }
 .crm-container.crm-public #crm-main-content-wrapper {
   margin-inline: auto;
@@ -45,7 +42,6 @@ af-form > fieldset > legend {
   background: var(--crm-c-secondary);
   color: var(--crm-c-text-light);
   padding: var(--crm-m1) var(--crm-f-fieldset-padding);
-  font-family: var(--crm-font-bold);
   font-weight: bold;
   font-size: var(--crm-r1);
   border-radius: var(--crm-roundness);

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -18,7 +18,6 @@
   background-color: var(--crm-table-header-bg);
   border-bottom: var(--crm-table-header-bottom);
   color: var(--crm-table-header-col);
-  font-family: var(--crm-font-bold);
   font-weight: bold;
   padding: var(--crm-table-padding);
   text-align: left;

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -59,7 +59,6 @@
   color: var(--crm-tab-col);
   padding: var(--crm-tab-padding);
   font-weight: var(--crm-tab-weight);
-  font-family: var(--crm-tab-font);
   font-size: var(--crm-font-size);
   line-height: var(--crm-r1);
   text-decoration: none;

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -4,7 +4,6 @@
 
 .crm-container .primary .crm-label {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
 }
 
 /* Contact name/header */

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -479,7 +479,6 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor .af-gui-text-h5,
 #afGuiEditor .af-gui-text-h6 {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
 }
 #afGuiEditor.af-gui-editing-content .panel-heading,
 #afGuiEditor.af-gui-editing-content .af-gui-element,

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -18,7 +18,6 @@ table.crm-sticky-header > thead > tr {
 }
 .crm-search-display.crm-search-display-table tfoot > tr > td {
   font-weight: bold;
-  font-family: var(--crm-font-bold);
 }
 
 /* Afform tables */

--- a/ext/riverlea/streams/thames/_variables.css
+++ b/ext/riverlea/streams/thames/_variables.css
@@ -17,11 +17,6 @@
 /* FONTS */
 /* --crm-system-fonts:; */
   --crm-font: Lato, sans-serif;
-/* --crm-font-bold:Lato; */
-  --crm-bold-weight: bold;
-/* --crm-font-italic:; */
-  --crm-italic-style: italic;
-/* --crm-font-bold-italic:; */
 }
 :root {
 /* COLOUR NAMES */
@@ -223,8 +218,7 @@
   --crm-expand-header-bg-active: var(--crm-c-blue-overlay); /* thames */
   --crm-expand-header-color: var(--crm-c-blue-darker); /* thames */
   --crm-expand-header-padding: 0.6rem 1.6rem 0.6rem 2.8rem; /* thames */
-  --crm-expand-header-weight: var(--crm-bold-weight);
-  --crm-expand-header-font: var(--crm-font-bold);
+  --crm-expand-header-weight: bold;
   --crm-expand-header-border: unset;/*var(--crm-c-divider);*/ /* thames */
   --crm-expand-header-border-width: unset; /*0 0 1px 0*/; /* thames */
   --crm-expand-border: unset; /* thames */
@@ -236,7 +230,6 @@
   --crm-expand2-header-bg: transparent;
   --crm-expand2-header-bg-active: var(--crm-c-background-2);
   --crm-expand2-header-weight: normal;
-  --crm-expand2-header-font: unset;
   --crm-expand2-header-color: var(--crm-c-text);
   --crm-expand2-header-border: unset;
   --crm-expand2-header-border-width: unset;
@@ -309,7 +302,6 @@
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
   --crm-tab-col: var(--crm-c-text);
   --crm-tab-weight: normal;
-  --crm-tab-font: unset;
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
   --crm-tab-roundness: var(--crm-r-3) var(--crm-r-3) 0 0;

--- a/ext/riverlea/streams/walbrook/_variables.css
+++ b/ext/riverlea/streams/walbrook/_variables.css
@@ -9,9 +9,6 @@
 /* Fonts */
   --crm-system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   --crm-font: "Civitype", "Open Sans", var(--crm-system-fonts);
-  --crm-font-bold: "Civitype-bold", var(--crm-system-fonts);
-  --crm-font-italic: "Civitype-italic", var(--crm-system-fonts);
-  --crm-font-bold-italic: "Civitype", var(--crm-system-fonts);
 /* Colour names */
   --crm-c-gray-900: #222831;
   --crm-c-gray-800: #393a3f;
@@ -116,7 +113,6 @@
   --crm-expand2-header-bg: var(--crm-c-primary);
   --crm-expand2-header-bg-active: var(--crm-c-primary-hover);
   --crm-expand2-header-weight: bold;
-  --crm-expand2-header-font: var(--crm-font-bold);
   --crm-expand2-header-color: var(--crm-c-primary-text);
   --crm-expand2-header-padding: var(--crm-expand-header-padding);
   --crm-expand2-border: 0;
@@ -138,7 +134,6 @@
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);
   --crm-input-padding: var(--crm-xs1) var(--crm-m1);
   --crm-input-label-weight: bold;
-  --crm-input-label-font: var(--crm-font-bold);
   --crm-input-radio-color: var(--crm-c-primary);
   --crm-inline-edit-border: 1px solid var(--crm-c-gray-900);
   --crm-fieldset-border-color: unset;
@@ -153,7 +148,7 @@
   --crm-tab-bg-active: var(--crm-c-background);
   --crm-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m);
-  --crm-tab-font: var(--crm-font-bold);
+  --crm-tab-weight: bold;
   --crm-tab-count-bg: transparent;
   --crm-tab-count-col: var(--crm-c-text);
   --crm-tab-border-active: var(--crm-c-divider);

--- a/ext/riverlea/streams/walbrook/css/civicrm.css
+++ b/ext/riverlea/streams/walbrook/css/civicrm.css
@@ -3,21 +3,28 @@
 @font-face {
   font-family: Civitype;
   font-style: normal;
-  font-weight: 400;
+  font-weight: normal;
   font-display: swap;
   src: url("../../../fonts/inter-v18-latin-regular.woff2") format("woff2");
 }
 @font-face {
-  font-family: Civitype-italic;
+  font-family: Civitype;
   font-style: italic;
-  font-weight: 400;
+  font-weight: normal;
   font-display: swap;
   src: url("../../../fonts/inter-v18-latin-italic.woff2") format("woff2");
 }
 @font-face {
-  font-family: Civitype-bold;
+  font-family: Civitype;
   font-style: normal;
-  font-weight: 600;
+  font-weight: bold;
+  font-display: swap;
+  src: url("../../../fonts/inter-v18-latin-600.woff2") format("woff2");
+}
+@font-face {
+  font-family: Civitype;
+  font-style: italic;
+  font-weight: bold;
   font-display: swap;
   src: url("../../../fonts/inter-v18-latin-600.woff2") format("woff2");
 }


### PR DESCRIPTION
This PR:
 - Renames Walbrooks bold italic fonts to the same, the browser is able to find the bold/italic versions.
 - Removes `var(--crm-font-bold)`, `var(--crm-font-italic)`, `var(--crm-font-bold-italic)` css custom properties: they were only needed for Walbrook, and Walbrook doesn't need them any more
 - Removes `--crm-bold-weight` and `--crm-italic-style` variables - italic wasn't used anywhere and bold weight used in two places - it was a leftover from an earlier attempt.
 - Removes `--crm-expand-header-font`, `--crm-expand2-header-font`, `--crm-tab-font` - these were performing the same function of making details > summaries and tab buttons bold, when the weight variable can do that alone now.
 - Removes all references to these variables in streams and core RiverLea, as the bold/italic
 - Adds a specific declaration to apply italic on all cells on disabled rows in extension manager (it was fixing this bug which led to the question of why Walbrook's italic fonts weren't loading as expected, which led to this issue).
 - Adds `font-display: swap;` to Walbrook's fonts, same as Thames ([more info](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)).

Before
----------------------------------------
The only place where this change should be noticeable is on the extensions manager. Before not all disabled row cells are italic and Walbrook fakes italic/bold.

Minetta
<img width="1507" height="292" alt="image" src="https://github.com/user-attachments/assets/6ea3a9f6-1b34-4b5d-88bb-b3e545f583d0" />

Wallbrook
  <img width="1522" height="260" alt="image" src="https://github.com/user-attachments/assets/c02e12b7-df90-41c1-b252-2f44bec9ac07" />

After
----------------------------------------
Now all cells are italic, and Walbrook loads the correct italic font (and will load the right italic/bold fonts whenever those elements are used)

Wallbrook
<img width="1516" height="289" alt="image" src="https://github.com/user-attachments/assets/0fd4594e-28e0-4541-b084-e124f3839fab" />

<img width="1515" height="192" alt="image" src="https://github.com/user-attachments/assets/1e9260dc-09a5-4cae-9212-16e199ed4932" />

Minetta:
<img width="1511" height="301" alt="image" src="https://github.com/user-attachments/assets/e845fe88-7fa8-4b56-b2a0-f797b03db1d9" />

Thames:
<img width="1513" height="260" alt="image" src="https://github.com/user-attachments/assets/2d1c7655-fdc6-420a-9ec7-b37e8339aadd" />

Hackney:
<img width="1501" height="171" alt="image" src="https://github.com/user-attachments/assets/bd4903a5-0c34-4061-bc2f-17b65a976e89" />

Technical Details
----------------------------------------
NB - there isn't a bold-italic font shipping for Walbrook, it was removed in an earlier RiverLea - with this fix that now appears just bold, not italic. This could be fixed in the future by restoring `Inter-600italic` - but it's a lot of a font to bundle with every Civi install for this one context.

Comments
----------------------------------------
This is a big-ish change in files impacted, but it shouldn't have any noticeable impacts beyond a few parts of Walbrook loading the right font if you're very typographically focussed. But because the 20 files it changes are regularly being changed - an early review is appreciated to avoid too big a rebase later.

A huge thanks to @artfulrobot for this - their method of avoiding the need to name/declare each font has been sitting there in Thames since the start. I missed that and kept name each font variation as I've always done, presumably because of some old browser support issues. But the process of figuring out why Walbrook extension manager disabled rows wasn't loading the right fonts but Thames were, led me to realise I'd been doing it wrong - and remove eight variables and 40+ lines as a result.