### PR TITLE
Riverlea - restore explicit order when bundling core assets

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -118,15 +118,17 @@ class StyleLoader implements \Symfony\Component\EventDispatcher\EventSubscriberI
     }
 
     if ($bundle->name === 'coreStyles') {
-      foreach (self::CORE_FILES as $file) {
-        $bundle->addStyleFile('riverlea', "core/css/{$file}");
+      // queue all core files in order (weights starting at -100, so long as we dont
+      // have 100 then all less than 0)
+      foreach (self::CORE_FILES as $i => $file) {
+        $bundle->addStyleFile('riverlea', "core/css/{$file}", ['weight' => -100 + $i]);
       }
-      // get DynamicCss asset
+      // get the URL for dynamic css asset (aka "the river")
       $riverUrl = \Civi::service('asset_builder')->getUrl(
         self::DYNAMIC_FILE,
         $this->getCssParams()
       );
-      // queue after core files to ensure variables override
+      // queue dynamic css late
       $bundle->addStyleUrl($riverUrl, ['weight' => 100]);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Instead of loading in alphabetical order.

Before
----------------------------------------
- riverlea core assets are all queued with weight 0, then loaded in alphabetical order
<img width="922" height="651" alt="image" src="https://github.com/user-attachments/assets/60078c9c-dcad-49a9-9c6b-255b9a7ea93b" />

- numerous small visual bugs, such as these empty counts on Manage Extension page tabs
<img width="412" height="225" alt="image" src="https://github.com/user-attachments/assets/00835a27-62bd-42e7-8b41-0afe256616df" />


After
----------------------------------------
- order is restored
<img width="891" height="634" alt="image" src="https://github.com/user-attachments/assets/41e15dda-1e93-409c-ba1a-85b3193fbdb6" />


Technical Details
----------------------------------------
I've set explicit weights starting at -100. This might bring them slightly earlier (previously they were loaded at 0). But these should be the base css layer, so would be strange if anything needs to jump in before them.

The alternative of starting at 0 would mean if someone has queued an external sheet at say, `10` it would get interleaved between the core assets.

cc @vingle and @GuillaumeSorel (I saw you posted that Extensions tab screenshot earlier, my reply on MM was wrong!)
