### PR TITLE
Riverlea - allow sourcing fonts locally

### DIFF
--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -529,7 +529,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 400;
-  src: url('../../../fonts/lato-v24-latin-regular.woff2') format('woff2');
+  src: local('Lato-Regular') local('Lato Regular') local('Lato') url('../../../fonts/lato-v24-latin-regular.woff2') format('woff2');
 }
 
 /* lato-italic - latin */
@@ -538,7 +538,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   font-family: 'Lato';
   font-style: italic;
   font-weight: 400;
-  src: url('../../../fonts/lato-v24-latin-italic.woff2') format('woff2');
+  src: local('Lato-Italic') local('Lato Italic') url('../../../fonts/lato-v24-latin-italic.woff2') format('woff2');
 }
 
 /* lato-700 - latin */
@@ -547,7 +547,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   font-family: 'Lato';
   font-style: normal;
   font-weight: 700;
-  src: url('../../../fonts/lato-v24-latin-700.woff2') format('woff2');
+  src: local('Lato-Bold') local('Lato Bold') url('../../../fonts/lato-v24-latin-700.woff2') format('woff2');
 }
 
 /* lato-700italic - latin */
@@ -556,7 +556,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   font-family: 'Lato';
   font-style: italic;
   font-weight: 700;
-  src: url('../../../fonts/lato-v24-latin-700italic.woff2') format('woff2');
+  src: local('Lato-BoldItalic') local('Lato BoldItalic') url('../../../fonts/lato-v24-latin-700italic.woff2') format('woff2');
 }
 
 /* Searchkit preview table headers go weird because of the button margin for the select-all button. */

--- a/ext/riverlea/streams/walbrook/css/civicrm.css
+++ b/ext/riverlea/streams/walbrook/css/civicrm.css
@@ -5,26 +5,26 @@
   font-style: normal;
   font-weight: normal;
   font-display: swap;
-  src: url("../../../fonts/inter-v18-latin-regular.woff2") format("woff2");
+  src: local('Inter-Regular') local('Inter Regular') local('Inter') url('../../../fonts/inter-v18-latin-regular.woff2') format("woff2");
 }
 @font-face {
   font-family: Inter;
   font-style: italic;
   font-weight: normal;
   font-display: swap;
-  src: url("../../../fonts/inter-v18-latin-italic.woff2") format("woff2");
+  src: local('Inter-Italic') local('Inter Italic') url('../../../fonts/inter-v18-latin-italic.woff2') format("woff2");
 }
 @font-face {
   font-family: Inter;
   font-style: normal;
   font-weight: bold;
   font-display: swap;
-  src: url("../../../fonts/inter-v18-latin-600.woff2") format("woff2");
+  src: local('Inter-Bold') local('Inter Bold') url('../../../fonts/inter-v18-latin-600.woff2') format("woff2");
 }
 @font-face {
   font-family: Inter;
   font-style: italic;
   font-weight: bold;
   font-display: swap;
-  src: url("../../../fonts/inter-v18-latin-600.woff2") format("woff2");
+  src: local('Inter-BoldItalic') ('Inter BoldItalic') url('../../../fonts/inter-v18-latin-600.woff2') format("woff2");
 }


### PR DESCRIPTION
Overview
----------------------------------------
I think this is what's needed to allow using local copies of fonts.

Before
----------------------------------------
- browser will always download Civi's copy of font for Thames/Walbrook

After
----------------------------------------
- browser will use local copy of font if present, and then only download Civi's copy if it needs to

Technical Details
----------------------------------------
I'm not 100% sure how it works with the font weights and italics and stuff. Could do with some testing.

Comments
----------------------------------------
Complements https://github.com/civicrm/civicrm-core/pull/33610

cc @vingle @artfulrobot 
