### PR TITLE
JSON - Use unescaped unicode & unescaped slashes when appropriate

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -44,7 +44,7 @@ class CRM_Admin_Page_AJAX {
       CRM_Utils_System::setHttpHeader('Expires', gmdate('D, d M Y H:i:s \G\M\T', time() + $ttl));
       CRM_Utils_System::setHttpHeader('Cache-Control', "max-age=$ttl, public");
       CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
-      print (json_encode($output));
+      print (json_encode($output, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
     CRM_Utils_System::civiExit();
   }

--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -192,7 +192,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
   private function returnJSON(array $response): void {
     http_response_code($this->httpResponseCode);
     CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
-    echo json_encode($response);
+    echo json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     CRM_Utils_System::civiExit();
   }
 

--- a/CRM/Core/Page/AJAX.php
+++ b/CRM/Core/Page/AJAX.php
@@ -183,7 +183,7 @@ class CRM_Core_Page_AJAX {
     if ($session->getStatus(FALSE)) {
       $response['crmMessages'] = $session->getStatus(TRUE);
     }
-    $output = json_encode($response);
+    $output = json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
     CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
 

--- a/CRM/Utils/JSON.php
+++ b/CRM/Utils/JSON.php
@@ -29,7 +29,7 @@ class CRM_Utils_JSON {
    * @return int|string
    */
   public static function encodeScriptVar($input) {
-    return json_encode($input, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES);
+    return json_encode($input, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
   }
 
   /**
@@ -41,7 +41,7 @@ class CRM_Utils_JSON {
       throw new CRM_Core_Exception_PrematureExitException('civiExit called', $input);
     }
     CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
-    echo json_encode($input);
+    echo json_encode($input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     CRM_Utils_System::civiExit();
   }
 

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -132,10 +132,10 @@ class CRM_Utils_REST {
     if (!empty($requestParams['json'])) {
       if (!empty($requestParams['prettyprint'])) {
         // Don't set content-type header for api explorer output
-        return json_encode(array_merge($result), JSON_PRETTY_PRINT + JSON_UNESCAPED_SLASHES + JSON_UNESCAPED_UNICODE);
+        return json_encode(array_merge($result), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
       }
       CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
-      return json_encode(array_merge($result));
+      return json_encode(array_merge($result), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }
 
     if (isset($result['count'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #33553 @totten 

Technical Details
----------------------------------------
CiviCRM already outputs unicode all over the place. E.g. we've done this in `CRM_Core_I18n::escape:js` for the past 5 years with no complaints:

https://github.com/civicrm/civicrm-core/blob/650f37600255182fb3ab0d28763877eb43b52a82/CRM/Core/I18n.php#L52-L53

Unescaped slashes is appropriate for pure-json responses where the slashes would not interfere with the document. It's also fine when document-appropriate escaping has already happened.