### PR TITLE
dev/core#6080 New assignScriptVar helper for smarty forms/pages

### DIFF
--- a/CRM/Campaign/Form/Gotv.php
+++ b/CRM/Campaign/Form/Gotv.php
@@ -54,7 +54,7 @@ class CRM_Campaign_Form_Gotv extends CRM_Core_Form {
     }
     $this->assign('force', $this->_force);
     $this->assign('votingTab', $this->_votingTab);
-    $this->assign('searchParams', json_encode($this->get('searchParams')));
+    $this->assignScriptVar('searchParams', $this->get('searchParams'));
     $this->assign('buildSelector', $this->_search);
     $this->assign('searchVoterFor', $this->_searchVoterFor);
     $this->set('searchVoterFor', $this->_searchVoterFor);
@@ -96,7 +96,7 @@ class CRM_Campaign_Form_Gotv extends CRM_Core_Form {
       $this->_searchParams[$name] = $name;
     }
     $this->set('searchParams', $this->_searchParams);
-    $this->assign('searchParams', json_encode($this->_searchParams));
+    $this->assignScriptVar('searchParams', $this->_searchParams);
 
     $defaults = [];
 

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -187,11 +187,11 @@ WHERE {$clause}
     $this->filterVoterIds();
     $this->assign('votingTab', $this->_votingTab);
     $this->assign('componentIds', $this->_contactIds);
-    $this->assign('componentIdsJson', json_encode($this->_contactIds));
+    $this->assignScriptVar('componentIdsJson', $this->_contactIds);
     $this->assign('voterDetails', $voterDetails);
     $this->assign('readOnlyFields', $readOnlyFields);
     $this->assign('interviewerId', $this->_interviewerId);
-    $this->assign('surveyActivityIds', json_encode($activityIds));
+    $this->assignScriptVar('surveyActivityIds', $activityIds);
     $this->assign('allowAjaxReleaseButton', $this->_allowAjaxReleaseButton);
 
     //get the survey values.

--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -787,7 +787,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
           'organization_name',
           'email',
         ]);
-      $this->assign('ruleFields', json_encode($ruleFields));
+      $this->assignScriptVar('ruleFields', $ruleFields);
     }
 
     // build Custom data if Custom data present in edit option
@@ -885,7 +885,7 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
         trim($this->_values['contact_sub_type'], CRM_Core_DAO::VALUE_SEPARATOR)
       );
     }
-    $this->assign('oldSubtypes', json_encode($this->_oldSubtypes));
+    $this->assignScriptVar('oldSubtypes', $this->_oldSubtypes);
 
     $this->addButtons($buttons);
   }

--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -286,7 +286,7 @@ class CRM_Contact_Form_Edit_Address {
             }
           }
         }
-        $form->assign('allAddressFieldValues', json_encode($addressValues));
+        $form->assignScriptVar('allAddressFieldValues', $addressValues);
 
         //hack to handle show/hide address fields.
         $parsedAddress = [];

--- a/CRM/Contact/Form/Merge.php
+++ b/CRM/Contact/Form/Merge.php
@@ -225,8 +225,8 @@ class CRM_Contact_Form_Merge extends CRM_Core_Form {
 
       $this->addElement('checkbox', 'toggleSelect', NULL, NULL, ['class' => 'select-rows']);
 
-      $this->assign('mainLocBlock', json_encode($rowsElementsAndInfo['main_details']['location_blocks']));
-      $this->assign('locationBlockInfo', json_encode(CRM_Dedupe_Merger::getLocationBlockInfo()));
+      $this->assignScriptVar('mainLocBlock', $rowsElementsAndInfo['main_details']['location_blocks']);
+      $this->assignScriptVar('locationBlockInfo', CRM_Dedupe_Merger::getLocationBlockInfo());
       $this->assign('mainContactTypeIcon', CRM_Contact_BAO_Contact_Utils::getImage($contacts[$this->_cid]['contact_sub_type'] ?: $contacts[$this->_cid]['contact_type'],
         FALSE,
         $this->_cid

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -145,7 +145,7 @@ class CRM_Contact_Form_Search_Criteria {
     );
 
     $componentModes = CRM_Contact_Form_Search::getModeSelect();
-    $form->assign('component_mappings', json_encode(CRM_Contact_Form_Search::getModeToComponentMapping()));
+    $form->assignScriptVar('component_mappings', CRM_Contact_Form_Search::getModeToComponentMapping());
     if (count($componentModes) > 1) {
       $form->add('select',
         'component_mode',

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -231,7 +231,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
       }
     }
 
-    $this->assign('toContact', json_encode($toArray));
+    $this->assignScriptVar('toContact', $toArray);
 
     $this->assign('suppressedEmails', count($this->suppressedEmails));
 

--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -185,7 +185,7 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
             $highlightedRelFields[$key][] = $k;
           }
         }
-        $this->assign('highlightedRelFields', json_encode($highlightedRelFields));
+        $this->assignScriptVar('highlightedRelFields', $highlightedRelFields);
         $sel2[$key] = $this->_formattedFieldNames[$relatedContactType];
 
         if (!empty($relatedContactSubType)) {

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -608,8 +608,8 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     $allPanes = [];
 
     //tax rate from financialType
-    $this->assign('taxRates', json_encode(CRM_Core_PseudoConstant::getTaxRates()));
-    $this->assign('currencies', json_encode(CRM_Core_OptionGroup::values('currencies_enabled')));
+    $this->assignScriptVar('taxRates', CRM_Core_PseudoConstant::getTaxRates());
+    $this->assignScriptVar('currencies', CRM_Core_OptionGroup::values('currencies_enabled'));
 
     // build price set form.
     $buildPriceSet = FALSE;

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -763,7 +763,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->assign('showRadio', FALSE);
       $this->assignTotalAmounts();
       $this->assign('membershipTypes', $membershipTypes);
-      $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
+      $this->assignScriptVar('autoRenewMembershipTypeOptions', $autoRenewMembershipTypeOptions);
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());
       $this->assign('takeUserSubmittedAutoRenew', $takeUserSubmittedAutoRenew);

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -692,7 +692,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->assign('renewal_mode', $this->contactHasRenewableMembership());
       $this->assign('membershipTypes', $membershipTypes);
       $this->assign('allowAutoRenewMembership', $allowAutoRenewMembership);
-      $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
+      $this->assignScriptVar('autoRenewMembershipTypeOptions', $autoRenewMembershipTypeOptions);
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());
       $this->assign('takeUserSubmittedAutoRenew', $takeUserSubmittedAutoRenew);

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -405,7 +405,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
 
       $this->assign('showRadio', FALSE);
       $this->assign('membershipTypes', $membershipTypes);
-      $this->assign('autoRenewMembershipTypeOptions', json_encode($autoRenewMembershipTypeOptions));
+      $this->assignScriptVar('autoRenewMembershipTypeOptions', $autoRenewMembershipTypeOptions);
       //give preference to user submitted auto_renew value.
       $takeUserSubmittedAutoRenew = (!empty($_POST) || $this->isSubmitted());
       $this->assign('takeUserSubmittedAutoRenew', $takeUserSubmittedAutoRenew);

--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -212,7 +212,7 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
     $this->assign('hasYearlyChart', $yearlyChart);
     $this->assign('hasByMonthChart', $monthlyChart);
     $this->assign('hasChart', !empty($chartData));
-    $this->assign('chartData', json_encode($chartData ?? []));
+    $this->assignScriptVar('chartData', $chartData ?? []);
   }
 
   /**

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -98,7 +98,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     if (count($recurringPaymentProcessor)) {
       $this->assign('recurringPaymentProcessor', $recurringPaymentProcessor);
     }
-    $this->assign('futurePaymentProcessor', json_encode($futurePaymentProcessor ?? [], TRUE));
+    $this->assignScriptVar('futurePaymentProcessor', $futurePaymentProcessor ?? []);
     if (count($paymentProcessor)) {
       $this->assign('paymentProcessor', $paymentProcessor);
     }

--- a/CRM/Contribute/Page/ContributionRecurPayments.php
+++ b/CRM/Contribute/Page/ContributionRecurPayments.php
@@ -62,7 +62,7 @@ class CRM_Contribute_Page_ContributionRecurPayments extends CRM_Core_Page {
 
     if (count($relatedContributions) > 0) {
       $this->assign('contributionsCount', count($relatedContributions));
-      $this->assign('relatedContributions', json_encode($relatedContributions));
+      $this->assignScriptVar('relatedContributions', $relatedContributions);
     }
   }
 

--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -32,6 +32,7 @@ require_once 'HTML/QuickForm/Action/Direct.php';
  * Class CRM_Core_Controller
  */
 class CRM_Core_Controller extends HTML_QuickForm_Controller {
+  use CRM_Core_SmartyPageTrait;
 
   /**
    * The title associated with this controller.
@@ -105,13 +106,6 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    * @var string
    */
   public $_QFResponseType = 'html';
-
-  /**
-   * Cache the smarty template for efficiency reasons.
-   *
-   * @var CRM_Core_Smarty
-   */
-  static protected $_template;
 
   /**
    * Cache the session for efficiency reasons.
@@ -585,65 +579,6 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       'subStepPrefixFuture' => '&nbsp;&nbsp;',
       'showTitle' => 1,
     ];
-  }
-
-  /**
-   * Assign value to name in template.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   Value of variable.
-   */
-  public function assign($var, $value = NULL) {
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Assign value to name in template by reference.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   (reference) value of variable.
-   *
-   * @deprecated since 5.72 will be removed around 5.84
-   */
-  public function assign_by_ref($var, &$value) {
-    CRM_Core_Error::deprecatedFunctionWarning('assign');
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Appends values to template variables.
-   *
-   * @param array|string $tpl_var the template variable name(s)
-   * @param mixed $value
-   *   The value to append.
-   * @param bool $merge
-   */
-  public function append($tpl_var, $value = NULL, $merge = FALSE) {
-    self::$_template->append($tpl_var, $value, $merge);
-  }
-
-  /**
-   * Returns an array containing template variables.
-   *
-   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
-   *
-   * @param string $name
-   *
-   * @return array
-   */
-  public function get_template_vars($name = NULL) {
-    return $this->getTemplateVars($name);
-  }
-
-  /**
-   * Get the value/s assigned to the Template Engine (Smarty).
-   *
-   * @param string|null $name
-   */
-  public function getTemplateVars($name = NULL) {
-    return self::$_template->getTemplateVars($name);
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -26,6 +26,7 @@ require_once 'HTML/QuickForm/Page.php';
  * Class CRM_Core_Form
  */
 class CRM_Core_Form extends HTML_QuickForm_Page {
+  use CRM_Core_SmartyPageTrait;
 
   /**
    * The state object that this form belongs to
@@ -122,13 +123,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @var object
    */
   protected $_renderer;
-
-  /**
-   * Cache the smarty template for efficiency reasons
-   *
-   * @var CRM_Core_Smarty
-   */
-  static protected $_template;
 
   /**
    *  Indicate if this form should warn users of unsaved changes
@@ -1230,27 +1224,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param string $elementName
-   */
-  public function addExpectedSmartyVariable(string $elementName): void {
-    $this->expectedSmartyVariables[] = $elementName;
-  }
-
-  /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param array $elementNames
-   */
-  public function addExpectedSmartyVariables(array $elementNames): void {
-    foreach ($elementNames as $elementName) {
-      // Duplicates don't actually matter....
-      $this->addExpectedSmartyVariable($elementName);
-    }
-  }
-
-  /**
    * Render form and return contents.
    *
    * @return string
@@ -1291,6 +1264,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return string
    */
   public function getTemplateFileName() {
+    // TODO: Why is this bit missing from `CRM_Core_Page::getTemplateFileName`?
     $ext = CRM_Extension_System::singleton()->getMapper();
     if ($ext->isExtensionClass(CRM_Utils_System::getClassName($this))) {
       $filename = $ext->getTemplateName(CRM_Utils_System::getClassName($this));
@@ -1306,28 +1280,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       ) . '.tpl';
     }
     return $tplname;
-  }
-
-  /**
-   * A wrapper for getTemplateFileName.
-   *
-   * This includes calling the hook to prevent us from having to copy & paste the logic of calling the hook.
-   */
-  public function getHookedTemplateFileName() {
-    $pageTemplateFile = $this->getTemplateFileName();
-    CRM_Utils_Hook::alterTemplateFile(get_class($this), $this, 'page', $pageTemplateFile);
-    return $pageTemplateFile;
-  }
-
-  /**
-   * Default extra tpl file basically just replaces .tpl with .extra.tpl.
-   *
-   * i.e. we do not override.
-   *
-   * @return string
-   */
-  public function overrideExtraTemplateFileName() {
-    return NULL;
   }
 
   /**
@@ -1404,67 +1356,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       CRM_Core_Error::deprecatedWarning('action should be an integer');
       $this->_action = $action;
     }
-  }
-
-  /**
-   * Assign value to name in template.
-   *
-   * @param string $var
-   *   Name of variable.
-   * @param mixed $value
-   *   Value of variable.
-   */
-  public function assign($var, $value = NULL) {
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Assign value to name in template by reference.
-   *
-   * @param string $var
-   *   Name of variable.
-   * @param mixed $value
-   *   Value of variable.
-   *
-   * @deprecated since 5.72 will be removed around 5.84
-   */
-  public function assign_by_ref($var, &$value) {
-    CRM_Core_Error::deprecatedFunctionWarning('assign');
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Appends values to template variables.
-   *
-   * @param array|string $tpl_var the template variable name(s)
-   * @param mixed $value
-   *   The value to append.
-   * @param bool $merge
-   */
-  public function append($tpl_var, $value = NULL, $merge = FALSE) {
-    self::$_template->append($tpl_var, $value, $merge);
-  }
-
-  /**
-   * Returns an array containing template variables.
-   *
-   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
-   *
-   * @param string $name
-   *
-   * @return array
-   */
-  public function get_template_vars($name = NULL) {
-    return $this->getTemplateVars($name);
-  }
-
-  /**
-   * Get the value/s assigned to the Template Engine (Smarty).
-   *
-   * @param string|null $name
-   */
-  public function getTemplateVars($name = NULL) {
-    return self::$_template->getTemplateVars($name);
   }
 
   /**
@@ -2097,13 +1988,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function getCompleteTitle() {
     return $this->getRootTitle() . $this->getTitle();
-  }
-
-  /**
-   * @return CRM_Core_Smarty
-   */
-  public static function &getTemplate() {
-    return self::$_template;
   }
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -24,6 +24,7 @@
  *
  */
 class CRM_Core_Page {
+  use CRM_Core_SmartyPageTrait;
 
   /**
    * The name of the page (auto generated from class name)
@@ -64,13 +65,6 @@ class CRM_Core_Page {
    *   or equal 0 if not in print mode
    */
   protected $_print = FALSE;
-
-  /**
-   * Cache the smarty template for efficiency reasons
-   *
-   * @var CRM_Core_Smarty
-   */
-  static protected $_template;
 
   /**
    * Cache the session for efficiency reasons
@@ -300,65 +294,6 @@ class CRM_Core_Page {
   }
 
   /**
-   * Assign value to name in template.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   Value of variable.
-   */
-  public function assign($var, $value = NULL) {
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Assign value to name in template by reference.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   (reference) value of variable.
-   *
-   * @deprecated since 5.72 will be removed around 5.84
-   */
-  public function assign_by_ref($var, &$value) {
-    CRM_Core_Error::deprecatedFunctionWarning('assign');
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Appends values to template variables.
-   *
-   * @param array|string $tpl_var the template variable name(s)
-   * @param mixed $value
-   *   The value to append.
-   * @param bool $merge
-   */
-  public function append($tpl_var, $value = NULL, $merge = FALSE) {
-    self::$_template->append($tpl_var, $value, $merge);
-  }
-
-  /**
-   * Returns an array containing template variables.
-   *
-   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
-   *
-   * @param string $name
-   *
-   * @return array
-   */
-  public function get_template_vars($name = NULL) {
-    return $this->getTemplateVars($name);
-  }
-
-  /**
-   * Get the value/s assigned to the Template Engine (Smarty).
-   *
-   * @param string|null $name
-   */
-  public function getTemplateVars($name = NULL) {
-    return self::$_template->getTemplateVars($name);
-  }
-
-  /**
    * Destroy all the session state of this page.
    */
   public function reset() {
@@ -367,6 +302,8 @@ class CRM_Core_Page {
 
   /**
    * Use the form name to create the tpl file name.
+   *
+   * TODO: Why is this different from `CRM_Core_Form::getTemplateFileName`?
    *
    * @return string
    */
@@ -378,26 +315,6 @@ class CRM_Core_Page {
         '\\' => DIRECTORY_SEPARATOR,
       ]
     ) . '.tpl';
-  }
-
-  /**
-   * A wrapper for getTemplateFileName that includes calling the hook to
-   * prevent us from having to copy & paste the logic of calling the hook
-   */
-  public function getHookedTemplateFileName() {
-    $pageTemplateFile = $this->getTemplateFileName();
-    CRM_Utils_Hook::alterTemplateFile(get_class($this), $this, 'page', $pageTemplateFile);
-    return $pageTemplateFile;
-  }
-
-  /**
-   * Default extra tpl file basically just replaces .tpl with .extra.tpl
-   * i.e. we dont override
-   *
-   * @return string
-   */
-  public function overrideExtraTemplateFileName() {
-    return NULL;
   }
 
   /**
@@ -441,13 +358,6 @@ class CRM_Core_Page {
    */
   public function getPrint() {
     return $this->_print;
-  }
-
-  /**
-   * @return CRM_Core_Smarty
-   */
-  public static function &getTemplate() {
-    return self::$_template;
   }
 
   /**
@@ -547,27 +457,6 @@ class CRM_Core_Page {
     }
 
     return "<i$attribString></i>$sr";
-  }
-
-  /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param string $elementName
-   */
-  public function addExpectedSmartyVariable(string $elementName): void {
-    $this->expectedSmartyVariables[] = $elementName;
-  }
-
-  /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param array $elementNames
-   */
-  public function addExpectedSmartyVariables(array $elementNames): void {
-    foreach ($elementNames as $elementName) {
-      // Duplicates don't actually matter....
-      $this->addExpectedSmartyVariable($elementName);
-    }
   }
 
   public function invalidKey() {

--- a/CRM/Core/Smarty/plugins/function.crmAPI.php
+++ b/CRM/Core/Smarty/plugins/function.crmAPI.php
@@ -45,7 +45,7 @@ function smarty_function_crmAPI($params, &$smarty) {
     return json_encode($result);
   }
   if (!empty($params['json'])) {
-    $smarty->assign($var, json_encode($result));
+    $smarty->assignScriptVar($var, $result);
   }
   else {
     $smarty->assign($var, $result);

--- a/CRM/Core/Smarty/plugins/function.crmSetting.php
+++ b/CRM/Core/Smarty/plugins/function.crmSetting.php
@@ -40,7 +40,7 @@ function smarty_function_crmSetting($params, &$smarty) {
     return is_numeric($result) ? $result : json_encode($result);
   }
   if (!empty($params['json'])) {
-    $smarty->assign($params["var"], json_encode($result));
+    $smarty->assignScriptVar($params["var"], $result);
   }
   else {
     $smarty->assign($params["var"], $result);

--- a/CRM/Core/SmartyPageTrait.php
+++ b/CRM/Core/SmartyPageTrait.php
@@ -62,6 +62,16 @@ trait CRM_Core_SmartyPageTrait {
   }
 
   /**
+   * Encodes and assigns a variable that will be printed inside a `<script>` tag.
+   *
+   * @param string $var
+   * @param mixed $value
+   */
+  public function assignScriptVar(string $var, $value): void {
+    $this->assign($var, CRM_Utils_JSON::encodeScriptVar($value));
+  }
+
+  /**
    * Get the value/s assigned to the Template Engine (Smarty).
    *
    * @param string|null $name

--- a/CRM/Core/SmartyPageTrait.php
+++ b/CRM/Core/SmartyPageTrait.php
@@ -1,0 +1,144 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Trait for template management.
+ *
+ * Shared by CRM_Core_Controller, CRM_Core_Form & CRM_Core_Page
+ */
+trait CRM_Core_SmartyPageTrait {
+
+  /**
+   * Global smarty template
+   *
+   * @var CRM_Core_Smarty
+   * @see CRM_Core_Smarty::singleton()
+   */
+  static protected $_template;
+
+  /**
+   * @return CRM_Core_Smarty
+   */
+  public static function getTemplate() {
+    return self::$_template;
+  }
+
+  /**
+   * Assign value to name in template.
+   *
+   * @param string $var
+   *   Name of variable.
+   * @param mixed $value
+   *   Value of variable.
+   */
+  public function assign($var, $value = NULL) {
+    self::$_template->assign($var, $value);
+  }
+
+  /**
+   * Appends values to template variables.
+   *
+   * @param array|string $tpl_var the template variable name(s)
+   * @param mixed $value
+   *   The value to append.
+   * @param bool $merge
+   */
+  public function append($tpl_var, $value = NULL, $merge = FALSE) {
+    self::$_template->append($tpl_var, $value, $merge);
+  }
+
+  /**
+   * Get the value/s assigned to the Template Engine (Smarty).
+   *
+   * @param string|null $name
+   */
+  public function getTemplateVars($name = NULL) {
+    return self::$_template->getTemplateVars($name);
+  }
+
+  /**
+   * A wrapper for getTemplateFileName.
+   *
+   * This includes calling the hook to prevent us from having to copy & paste the logic of calling the hook.
+   */
+  public function getHookedTemplateFileName() {
+    $pageTemplateFile = $this->getTemplateFileName();
+    CRM_Utils_Hook::alterTemplateFile(get_class($this), $this, 'page', $pageTemplateFile);
+    return $pageTemplateFile;
+  }
+
+  /**
+   * Default extra tpl file basically just replaces .tpl with .extra.tpl.
+   *
+   * i.e. we do not override.
+   *
+   * @return string
+   */
+  public function overrideExtraTemplateFileName() {
+    return NULL;
+  }
+
+  /**
+   * Add an expected smarty variable to the array.
+   *
+   * @param string $elementName
+   */
+  public function addExpectedSmartyVariable(string $elementName): void {
+    $this->expectedSmartyVariables[] = $elementName;
+  }
+
+  /**
+   * Add an expected smarty variable to the array.
+   *
+   * @param array $elementNames
+   */
+  public function addExpectedSmartyVariables(array $elementNames): void {
+    foreach ($elementNames as $elementName) {
+      // Duplicates don't actually matter....
+      $this->addExpectedSmartyVariable($elementName);
+    }
+  }
+
+  /**
+   * Assign value to name in template by reference.
+   *
+   * @param string $var
+   *   Name of variable.
+   * @param mixed $value
+   *   Value of variable.
+   *
+   * @deprecated since 5.72 will be removed around 5.84
+   */
+  public function assign_by_ref($var, &$value) {
+    CRM_Core_Error::deprecatedFunctionWarning('assign');
+    self::$_template->assign($var, $value);
+  }
+
+  /**
+   * Returns an array containing template variables.
+   *
+   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
+   *
+   * @param string $name
+   *
+   * @return array
+   */
+  public function get_template_vars($name = NULL) {
+    return $this->getTemplateVars($name);
+  }
+
+}

--- a/CRM/Core/SmartyPageTrait.php
+++ b/CRM/Core/SmartyPageTrait.php
@@ -148,6 +148,7 @@ trait CRM_Core_SmartyPageTrait {
    * @return array
    */
   public function get_template_vars($name = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('getTemplateVars');
     return $this->getTemplateVars($name);
   }
 

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -258,7 +258,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       'allow_same_participant_emails',
       ts('Allow same email and multiple registrations?')
     );
-    $this->assign('ruleFields', json_encode($ruleFields));
+    $this->assignScriptVar('ruleFields', $ruleFields);
 
     $dedupeRules = [
       '' => ts('- Unsupervised rule -'),

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -2115,7 +2115,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
           $elementJS[$fee['amount_id']] = $totalAmountJs;
         }
       }
-      $form->assign('eventFeeBlockValues', json_encode($eventFeeBlockValues));
+      $form->assignScriptVar('eventFeeBlockValues', $eventFeeBlockValues);
 
       $form->_defaults['amount'] = $form->_values['event']['default_fee_id'] ?? NULL;
       $element = &$form->addRadio('amount', ts('Event Fee(s)'), $elements, [], '<br />', FALSE, $elementJS);

--- a/CRM/Financial/Form/SalesTaxTrait.php
+++ b/CRM/Financial/Form/SalesTaxTrait.php
@@ -30,7 +30,7 @@ trait CRM_Financial_Form_SalesTaxTrait {
    * Assign sales tax rates to the template.
    */
   public function assignSalesTaxRates() {
-    $this->assign('taxRates', json_encode(CRM_Core_PseudoConstant::getTaxRates()));
+    $this->assignScriptVar('taxRates', CRM_Core_PseudoConstant::getTaxRates());
   }
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -62,7 +62,7 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $this->addExpectedSmartyVariables(['highlightedRelFields', 'initHideBoxes']);
     $this->assign('columnNames', $this->getColumnHeaders());
     $this->assign('showColumnNames', $this->getSubmittedValue('skipColumnHeader') || $this->getSubmittedValue('dataSource') !== 'CRM_Import_DataSource');
-    $this->assign('highlightedFields', json_encode($this->getHighlightedFields()));
+    $this->assignScriptVar('highlightedFields', $this->getHighlightedFields());
     $this->assign('dataValues', array_values($this->getDataRows([], 2)));
     $this->_mapperFields = $this->getAvailableFields();
     $fieldMappings = $this->getFieldMappings();

--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -302,7 +302,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
 
     $this->addPaymentProcessorSelect(TRUE, FALSE, TRUE);
     CRM_Core_Payment_Form::buildPaymentForm($this, $this->_paymentProcessor, FALSE, TRUE, $this->getDefaultPaymentInstrumentId());
-    $this->assign('recurProcessor', json_encode($this->_recurPaymentProcessors));
+    $this->assignScriptVar('recurProcessor', $this->_recurPaymentProcessors);
     // Build the form for auto renew. This is displayed when in credit card mode or update mode.
     // The reason for showing it in update mode is not that clear.
     $this->assign('allowAutoRenew', $this->_mode && !empty($this->_recurPaymentProcessors));
@@ -321,7 +321,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
       );
 
     }
-    $this->assign('autoRenewOptions', json_encode($this->membershipTypeRenewalStatus));
+    $this->assignScriptVar('autoRenewOptions', $this->membershipTypeRenewalStatus);
 
     if ($this->_action & CRM_Core_Action::RENEW) {
       $this->addButtons([

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -438,7 +438,7 @@ DESC limit 1");
       ];
     }
 
-    $this->assign('allMembershipInfo', json_encode($allMembershipInfo));
+    $this->assignScriptVar('allMembershipInfo', $allMembershipInfo);
 
     // show organization by default, if only one organization in
     // the list

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -296,7 +296,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       }
     }
 
-    $this->assign('allMembershipInfo', json_encode($allMembershipInfo));
+    $this->assignScriptVar('allMembershipInfo', $allMembershipInfo);
 
     if ($this->_memType) {
       $this->assign('orgName', $selMemTypeOrg[$this->allMembershipTypeDetails[$this->_memType]['member_of_contact_id']]);

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -278,7 +278,7 @@ class CRM_Utils_Chart {
         // assign chart data to template
         $template = CRM_Core_Smarty::singleton();
         $template->assign('uniqueId', $uniqueId);
-        $template->assign("chartData", json_encode($theChart ?? []));
+        $template->assignScriptVar("chartData", $theChart ?? []);
       }
     }
 

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/ConferenceEvents.php
@@ -93,7 +93,7 @@ EOS;
     $this->assign('mer_participant', $this->main_participant);
     $this->assign('events_by_slot', $this->events_by_slot);
     $this->assign('slot_fields', $slot_fields);
-    $this->assign('session_options', json_encode($session_options));
+    $this->assignScriptVar('session_options', $session_options);
 
     $buttons = [];
     $buttons[] = [


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #33553, fixes up smarty js variable assignments to go through a new helper function that ensures they are properly sanitized.

Comments
---------
Instead of adding it in 3 places, I created a trait.

Technical Details
----------------------------------------
Helper function eases DX for remembering the "right way" to encode & assign a js variable.
Output is identical to json_encode with the added safety of escaping all html tag characters.