### PR TITLE
Make site tokens exportable

### DIFF
--- a/Civi/Api4/SiteToken.php
+++ b/Civi/Api4/SiteToken.php
@@ -19,5 +19,6 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class SiteToken extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
From @vurt2: 
A very small change to make the SiteTokens entity a managed entity. So it is exportable by Api4 ("civix export SiteToken ID").