### PR TITLE
SearchKitBatch: Change "View Import Batches" links to only show batch imports 

### DIFF
--- a/ext/civiimport/ang/afsearchAllImports.aff.html
+++ b/ext/civiimport/ang/afsearchAllImports.aff.html
@@ -1,3 +1,3 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="all_imports" display-name="all_imports"></crm-search-display-table>
+  <crm-search-display-table search-name="all_imports" display-name="all_imports" filters="{job_type: routeParams.job_type}"></crm-search-display-table>
 </div>

--- a/ext/civiimport/ang/afsearchMyImports.aff.html
+++ b/ext/civiimport/ang/afsearchMyImports.aff.html
@@ -1,3 +1,3 @@
 <div af-fieldset="">
-  <crm-search-display-table search-name="My_imports" display-name="My_imports_display"></crm-search-display-table>
+  <crm-search-display-table search-name="My_imports" display-name="My_imports_display" filters="{job_type: routeParams.job_type}"></crm-search-display-table>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -57,14 +57,14 @@
           this.reportLinks = [
             {
               title: ts('View My Import Batches'),
-              href: CRM.url('civicrm/imports/my-listing'),
+              href: CRM.url('civicrm/imports/my-listing#/?job_type=search_batch_import'),
               icon: 'fa-user-tag',
             },
           ];
           if (CRM.checkPerm('administer queues')) {
             this.reportLinks.push({
               title: ts('View All Import Batches'),
-              href: CRM.url('civicrm/imports/all-imports'),
+              href: CRM.url('civicrm/imports/all-imports#/?job_type=search_batch_import'),
               icon: 'fa-list-alt',
             });
           }


### PR DESCRIPTION
Before
----------------------------------------
Links from the new SearchKitBatch first screen:
<img width="239" height="91" alt="image" src="https://github.com/user-attachments/assets/afd844c1-35e1-4fcb-803d-f6188f12efbc" />
take you to the generic My Imports and All Imports SKs, showing imports of all types.

After
----------------------------------------
These links only show the batch imports specifically.