### PR TITLE
[REF] CRM_Core - Move shared smarty functionality into a trait 

### DIFF
--- a/CRM/Core/Controller.php
+++ b/CRM/Core/Controller.php
@@ -32,6 +32,7 @@ require_once 'HTML/QuickForm/Action/Direct.php';
  * Class CRM_Core_Controller
  */
 class CRM_Core_Controller extends HTML_QuickForm_Controller {
+  use CRM_Core_SmartyPageTrait;
 
   /**
    * The title associated with this controller.
@@ -105,13 +106,6 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
    * @var string
    */
   public $_QFResponseType = 'html';
-
-  /**
-   * Cache the smarty template for efficiency reasons.
-   *
-   * @var CRM_Core_Smarty
-   */
-  static protected $_template;
 
   /**
    * Cache the session for efficiency reasons.
@@ -585,65 +579,6 @@ class CRM_Core_Controller extends HTML_QuickForm_Controller {
       'subStepPrefixFuture' => '&nbsp;&nbsp;',
       'showTitle' => 1,
     ];
-  }
-
-  /**
-   * Assign value to name in template.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   Value of variable.
-   */
-  public function assign($var, $value = NULL) {
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Assign value to name in template by reference.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   (reference) value of variable.
-   *
-   * @deprecated since 5.72 will be removed around 5.84
-   */
-  public function assign_by_ref($var, &$value) {
-    CRM_Core_Error::deprecatedFunctionWarning('assign');
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Appends values to template variables.
-   *
-   * @param array|string $tpl_var the template variable name(s)
-   * @param mixed $value
-   *   The value to append.
-   * @param bool $merge
-   */
-  public function append($tpl_var, $value = NULL, $merge = FALSE) {
-    self::$_template->append($tpl_var, $value, $merge);
-  }
-
-  /**
-   * Returns an array containing template variables.
-   *
-   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
-   *
-   * @param string $name
-   *
-   * @return array
-   */
-  public function get_template_vars($name = NULL) {
-    return $this->getTemplateVars($name);
-  }
-
-  /**
-   * Get the value/s assigned to the Template Engine (Smarty).
-   *
-   * @param string|null $name
-   */
-  public function getTemplateVars($name = NULL) {
-    return self::$_template->getTemplateVars($name);
   }
 
   /**

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -26,6 +26,7 @@ require_once 'HTML/QuickForm/Page.php';
  * Class CRM_Core_Form
  */
 class CRM_Core_Form extends HTML_QuickForm_Page {
+  use CRM_Core_SmartyPageTrait;
 
   /**
    * The state object that this form belongs to
@@ -122,13 +123,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @var object
    */
   protected $_renderer;
-
-  /**
-   * Cache the smarty template for efficiency reasons
-   *
-   * @var CRM_Core_Smarty
-   */
-  static protected $_template;
 
   /**
    *  Indicate if this form should warn users of unsaved changes
@@ -1230,27 +1224,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param string $elementName
-   */
-  public function addExpectedSmartyVariable(string $elementName): void {
-    $this->expectedSmartyVariables[] = $elementName;
-  }
-
-  /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param array $elementNames
-   */
-  public function addExpectedSmartyVariables(array $elementNames): void {
-    foreach ($elementNames as $elementName) {
-      // Duplicates don't actually matter....
-      $this->addExpectedSmartyVariable($elementName);
-    }
-  }
-
-  /**
    * Render form and return contents.
    *
    * @return string
@@ -1291,6 +1264,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @return string
    */
   public function getTemplateFileName() {
+    // TODO: Why is this bit missing from `CRM_Core_Page::getTemplateFileName`?
     $ext = CRM_Extension_System::singleton()->getMapper();
     if ($ext->isExtensionClass(CRM_Utils_System::getClassName($this))) {
       $filename = $ext->getTemplateName(CRM_Utils_System::getClassName($this));
@@ -1306,28 +1280,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       ) . '.tpl';
     }
     return $tplname;
-  }
-
-  /**
-   * A wrapper for getTemplateFileName.
-   *
-   * This includes calling the hook to prevent us from having to copy & paste the logic of calling the hook.
-   */
-  public function getHookedTemplateFileName() {
-    $pageTemplateFile = $this->getTemplateFileName();
-    CRM_Utils_Hook::alterTemplateFile(get_class($this), $this, 'page', $pageTemplateFile);
-    return $pageTemplateFile;
-  }
-
-  /**
-   * Default extra tpl file basically just replaces .tpl with .extra.tpl.
-   *
-   * i.e. we do not override.
-   *
-   * @return string
-   */
-  public function overrideExtraTemplateFileName() {
-    return NULL;
   }
 
   /**
@@ -1404,67 +1356,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       CRM_Core_Error::deprecatedWarning('action should be an integer');
       $this->_action = $action;
     }
-  }
-
-  /**
-   * Assign value to name in template.
-   *
-   * @param string $var
-   *   Name of variable.
-   * @param mixed $value
-   *   Value of variable.
-   */
-  public function assign($var, $value = NULL) {
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Assign value to name in template by reference.
-   *
-   * @param string $var
-   *   Name of variable.
-   * @param mixed $value
-   *   Value of variable.
-   *
-   * @deprecated since 5.72 will be removed around 5.84
-   */
-  public function assign_by_ref($var, &$value) {
-    CRM_Core_Error::deprecatedFunctionWarning('assign');
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Appends values to template variables.
-   *
-   * @param array|string $tpl_var the template variable name(s)
-   * @param mixed $value
-   *   The value to append.
-   * @param bool $merge
-   */
-  public function append($tpl_var, $value = NULL, $merge = FALSE) {
-    self::$_template->append($tpl_var, $value, $merge);
-  }
-
-  /**
-   * Returns an array containing template variables.
-   *
-   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
-   *
-   * @param string $name
-   *
-   * @return array
-   */
-  public function get_template_vars($name = NULL) {
-    return $this->getTemplateVars($name);
-  }
-
-  /**
-   * Get the value/s assigned to the Template Engine (Smarty).
-   *
-   * @param string|null $name
-   */
-  public function getTemplateVars($name = NULL) {
-    return self::$_template->getTemplateVars($name);
   }
 
   /**
@@ -2097,13 +1988,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    */
   public function getCompleteTitle() {
     return $this->getRootTitle() . $this->getTitle();
-  }
-
-  /**
-   * @return CRM_Core_Smarty
-   */
-  public static function &getTemplate() {
-    return self::$_template;
   }
 
   /**

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -24,6 +24,7 @@
  *
  */
 class CRM_Core_Page {
+  use CRM_Core_SmartyPageTrait;
 
   /**
    * The name of the page (auto generated from class name)
@@ -64,13 +65,6 @@ class CRM_Core_Page {
    *   or equal 0 if not in print mode
    */
   protected $_print = FALSE;
-
-  /**
-   * Cache the smarty template for efficiency reasons
-   *
-   * @var CRM_Core_Smarty
-   */
-  static protected $_template;
 
   /**
    * Cache the session for efficiency reasons
@@ -300,65 +294,6 @@ class CRM_Core_Page {
   }
 
   /**
-   * Assign value to name in template.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   Value of variable.
-   */
-  public function assign($var, $value = NULL) {
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Assign value to name in template by reference.
-   *
-   * @param string $var
-   * @param mixed $value
-   *   (reference) value of variable.
-   *
-   * @deprecated since 5.72 will be removed around 5.84
-   */
-  public function assign_by_ref($var, &$value) {
-    CRM_Core_Error::deprecatedFunctionWarning('assign');
-    self::$_template->assign($var, $value);
-  }
-
-  /**
-   * Appends values to template variables.
-   *
-   * @param array|string $tpl_var the template variable name(s)
-   * @param mixed $value
-   *   The value to append.
-   * @param bool $merge
-   */
-  public function append($tpl_var, $value = NULL, $merge = FALSE) {
-    self::$_template->append($tpl_var, $value, $merge);
-  }
-
-  /**
-   * Returns an array containing template variables.
-   *
-   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
-   *
-   * @param string $name
-   *
-   * @return array
-   */
-  public function get_template_vars($name = NULL) {
-    return $this->getTemplateVars($name);
-  }
-
-  /**
-   * Get the value/s assigned to the Template Engine (Smarty).
-   *
-   * @param string|null $name
-   */
-  public function getTemplateVars($name = NULL) {
-    return self::$_template->getTemplateVars($name);
-  }
-
-  /**
    * Destroy all the session state of this page.
    */
   public function reset() {
@@ -367,6 +302,8 @@ class CRM_Core_Page {
 
   /**
    * Use the form name to create the tpl file name.
+   *
+   * TODO: Why is this different from `CRM_Core_Form::getTemplateFileName`?
    *
    * @return string
    */
@@ -378,26 +315,6 @@ class CRM_Core_Page {
         '\\' => DIRECTORY_SEPARATOR,
       ]
     ) . '.tpl';
-  }
-
-  /**
-   * A wrapper for getTemplateFileName that includes calling the hook to
-   * prevent us from having to copy & paste the logic of calling the hook
-   */
-  public function getHookedTemplateFileName() {
-    $pageTemplateFile = $this->getTemplateFileName();
-    CRM_Utils_Hook::alterTemplateFile(get_class($this), $this, 'page', $pageTemplateFile);
-    return $pageTemplateFile;
-  }
-
-  /**
-   * Default extra tpl file basically just replaces .tpl with .extra.tpl
-   * i.e. we dont override
-   *
-   * @return string
-   */
-  public function overrideExtraTemplateFileName() {
-    return NULL;
   }
 
   /**
@@ -441,13 +358,6 @@ class CRM_Core_Page {
    */
   public function getPrint() {
     return $this->_print;
-  }
-
-  /**
-   * @return CRM_Core_Smarty
-   */
-  public static function &getTemplate() {
-    return self::$_template;
   }
 
   /**
@@ -547,27 +457,6 @@ class CRM_Core_Page {
     }
 
     return "<i$attribString></i>$sr";
-  }
-
-  /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param string $elementName
-   */
-  public function addExpectedSmartyVariable(string $elementName): void {
-    $this->expectedSmartyVariables[] = $elementName;
-  }
-
-  /**
-   * Add an expected smarty variable to the array.
-   *
-   * @param array $elementNames
-   */
-  public function addExpectedSmartyVariables(array $elementNames): void {
-    foreach ($elementNames as $elementName) {
-      // Duplicates don't actually matter....
-      $this->addExpectedSmartyVariable($elementName);
-    }
   }
 
   public function invalidKey() {

--- a/CRM/Core/SmartyPageTrait.php
+++ b/CRM/Core/SmartyPageTrait.php
@@ -1,0 +1,144 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Trait for template management.
+ *
+ * Shared by CRM_Core_Controller, CRM_Core_Form & CRM_Core_Page
+ */
+trait CRM_Core_SmartyPageTrait {
+
+  /**
+   * Global smarty template
+   *
+   * @var CRM_Core_Smarty
+   * @see CRM_Core_Smarty::singleton()
+   */
+  static protected $_template;
+
+  /**
+   * @return CRM_Core_Smarty
+   */
+  public static function getTemplate() {
+    return self::$_template;
+  }
+
+  /**
+   * Assign value to name in template.
+   *
+   * @param string $var
+   *   Name of variable.
+   * @param mixed $value
+   *   Value of variable.
+   */
+  public function assign($var, $value = NULL) {
+    self::$_template->assign($var, $value);
+  }
+
+  /**
+   * Appends values to template variables.
+   *
+   * @param array|string $tpl_var the template variable name(s)
+   * @param mixed $value
+   *   The value to append.
+   * @param bool $merge
+   */
+  public function append($tpl_var, $value = NULL, $merge = FALSE) {
+    self::$_template->append($tpl_var, $value, $merge);
+  }
+
+  /**
+   * Get the value/s assigned to the Template Engine (Smarty).
+   *
+   * @param string|null $name
+   */
+  public function getTemplateVars($name = NULL) {
+    return self::$_template->getTemplateVars($name);
+  }
+
+  /**
+   * A wrapper for getTemplateFileName.
+   *
+   * This includes calling the hook to prevent us from having to copy & paste the logic of calling the hook.
+   */
+  public function getHookedTemplateFileName() {
+    $pageTemplateFile = $this->getTemplateFileName();
+    CRM_Utils_Hook::alterTemplateFile(get_class($this), $this, 'page', $pageTemplateFile);
+    return $pageTemplateFile;
+  }
+
+  /**
+   * Default extra tpl file basically just replaces .tpl with .extra.tpl.
+   *
+   * i.e. we do not override.
+   *
+   * @return string
+   */
+  public function overrideExtraTemplateFileName() {
+    return NULL;
+  }
+
+  /**
+   * Add an expected smarty variable to the array.
+   *
+   * @param string $elementName
+   */
+  public function addExpectedSmartyVariable(string $elementName): void {
+    $this->expectedSmartyVariables[] = $elementName;
+  }
+
+  /**
+   * Add an expected smarty variable to the array.
+   *
+   * @param array $elementNames
+   */
+  public function addExpectedSmartyVariables(array $elementNames): void {
+    foreach ($elementNames as $elementName) {
+      // Duplicates don't actually matter....
+      $this->addExpectedSmartyVariable($elementName);
+    }
+  }
+
+  /**
+   * Assign value to name in template by reference.
+   *
+   * @param string $var
+   *   Name of variable.
+   * @param mixed $value
+   *   Value of variable.
+   *
+   * @deprecated since 5.72 will be removed around 5.84
+   */
+  public function assign_by_ref($var, &$value) {
+    CRM_Core_Error::deprecatedFunctionWarning('assign');
+    self::$_template->assign($var, $value);
+  }
+
+  /**
+   * Returns an array containing template variables.
+   *
+   * @deprecated since 5.69 will be removed around 5.93. use getTemplateVars.
+   *
+   * @param string $name
+   *
+   * @return array
+   */
+  public function get_template_vars($name = NULL) {
+    return $this->getTemplateVars($name);
+  }
+
+}

--- a/CRM/Core/SmartyPageTrait.php
+++ b/CRM/Core/SmartyPageTrait.php
@@ -138,6 +138,7 @@ trait CRM_Core_SmartyPageTrait {
    * @return array
    */
   public function get_template_vars($name = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('getTemplateVars');
     return $this->getTemplateVars($name);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Moves shared code into a trait.

Technical Details
--------
This is mostly a straight move. The only change is to add a noisy deprecated warning to [old get_template_vars function](https://github.com/civicrm/civicrm-core/pull/33620/commits/2a1bf5f8ef52577d5ba82b642d8756e5cc3da4ec).