### PR TITLE
dev/core#6096 : Grant Statistics report columns, tabs and table list are not visible

### DIFF
--- a/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
+++ b/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
@@ -300,6 +300,7 @@ WHERE {$this->_aliases['civicrm_grant']}.amount_total IS NOT NULL
 
   public function preProcess() {
     \Civi::resources()->addBundle('visual');
+    parent::preProcess();
   }
 
   public function postProcess() {


### PR DESCRIPTION

Overview
----------------------------------------
Grant Statistics report columns, tabs and table list are not visible

Before
----------------------------------------
<img width="1490" height="667" alt="Screenshot 2025-09-17 at 12 20 31 PM" src="https://github.com/user-attachments/assets/a268df33-b91d-43e9-be3d-941e0fbf039d" />


After
----------------------------------------
<img width="1308" height="589" alt="Screenshot 2025-09-17 at 1 20 19 PM" src="https://github.com/user-attachments/assets/79b9106d-43f7-4a1a-8c92-df1b7a111908" />


Technical Details
----------------------------------------
Regression caused by this [change](https://github.com/civicrm/civicrm-core/commit/6bf62137de84c4dc8a3d7e604beaa513405debe4#diff-d09dcae3f32a420c0b3147fba66ec6a182bd918eee6999d0c506b3d3aea493cfR303-R307) Overriding the preprocess has bypass various check and essential variable setting, like in this case `$criteriaForm` was defaulted to FALSE but supposed to be set to TRUE as it has the essential permission to show the report tabs and result. This regression is affecting the Grant Statistics report since 5.79. 

Comments
----------------------------------------
ping @ufundo @colemanw @seamuslee001 
