### PR TITLE
(DEMO) smartyup - Demonstration of auto-updating *.tpls

### DIFF
--- a/templates/CRM/Contact/Form/Edit/Address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address.tpl
@@ -29,10 +29,10 @@
    {if $className eq 'CRM_Contact_Form_Contact'}
      <tr>
         <td id='Address-Primary-html' colspan="2">
-           <span class="crm-address-element location_type_id-address-element">{$form.address.$blockId.location_type_id.label}
-           {$form.address.$blockId.location_type_id.html}</span>
-           <span class="crm-address-element is_primary-address-element">{$form.address.$blockId.is_primary.html}</span>
-           <span class="crm-address-element is_billing-address-element">{$form.address.$blockId.is_billing.html}</span>
+           <span class="crm-address-element location_type_id-address-element">{$form.address.$blockId.location_type_id.label nofilter}
+           {$form.address.$blockId.location_type_id.html nofilter}</span>
+           <span class="crm-address-element is_primary-address-element">{$form.address.$blockId.is_primary.html nofilter}</span>
+           <span class="crm-address-element is_billing-address-element">{$form.address.$blockId.is_billing.html nofilter}</span>
         </td>
      {if $blockId gt 0}
          <td>

--- a/templates/CRM/Contact/Form/Edit/Address/address_name.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/address_name.tpl
@@ -10,9 +10,9 @@
 {if array_key_exists('name', $form.address.$blockId)}
   <tr>
       <td colspan="2">
-        {$form.address.$blockId.name.label}
+        {$form.address.$blockId.name.label nofilter}
         {help id="id-address-name" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.name.textLabel}<br />
-        {$form.address.$blockId.name.html}
+        {$form.address.$blockId.name.html nofilter}
       </td>
   </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/Address/city_postal_code.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/city_postal_code.tpl
@@ -12,20 +12,20 @@
 <tr>
     {if !empty($form.address.$blockId.city)}
        <td>
-          {$form.address.$blockId.city.label}<br />
-          {$form.address.$blockId.city.html}
+          {$form.address.$blockId.city.label nofilter}<br />
+          {$form.address.$blockId.city.html nofilter}
        </td>
     {/if}
     {if !empty($form.address.$blockId.postal_code)}
        <td>
-          {$form.address.$blockId.postal_code.label}<br />
-          {$form.address.$blockId.postal_code.html}
+          {$form.address.$blockId.postal_code.label nofilter}<br />
+          {$form.address.$blockId.postal_code.html nofilter}
        </td>
       {if array_key_exists('postal_code_suffix', $form.address.$blockId)}
           <td>
-            {$form.address.$blockId.postal_code_suffix.label}
+            {$form.address.$blockId.postal_code_suffix.label nofilter}
             {help id="id-postal-code-suffix" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.postal_code_suffix.textLabel}<br/>
-            {$form.address.$blockId.postal_code_suffix.html}
+            {$form.address.$blockId.postal_code_suffix.html nofilter}
           <td>
       {/if}
     {/if}

--- a/templates/CRM/Contact/Form/Edit/Address/country_state_province.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/country_state_province.tpl
@@ -12,14 +12,14 @@
 <tr>
    {if !empty($form.address.$blockId.country_id)}
      <td>
-        {$form.address.$blockId.country_id.label}<br />
-        {$form.address.$blockId.country_id.html}
+        {$form.address.$blockId.country_id.label nofilter}<br />
+        {$form.address.$blockId.country_id.html nofilter}
      </td>
    {/if}
    {if !empty($form.address.$blockId.state_province_id)}
      <td>
-        {$form.address.$blockId.state_province_id.label}<br />
-        {$form.address.$blockId.state_province_id.html}
+        {$form.address.$blockId.state_province_id.label nofilter}<br />
+        {$form.address.$blockId.state_province_id.html nofilter}
      </td>
    {/if}
    <td colspan="2">&nbsp;&nbsp;</td>

--- a/templates/CRM/Contact/Form/Edit/Address/county.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/county.tpl
@@ -10,8 +10,8 @@
 {if !empty($form.address.$blockId.county_id)}
    <tr>
      <td colspan="2">
-        {$form.address.$blockId.county_id.label}<br />
-        {$form.address.$blockId.county_id.html}<br />
+        {$form.address.$blockId.county_id.label nofilter}<br />
+        {$form.address.$blockId.county_id.html nofilter}<br />
      </td>
    </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/Address/geo_code.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/geo_code.tpl
@@ -10,16 +10,16 @@
 {if array_key_exists('geo_code_1', $form.address.$blockId) && array_key_exists('geo_code_2', $form.address.$blockId)}
   <tr>
     <td colspan="2">
-      {$form.address.$blockId.geo_code_1.label},&nbsp;{$form.address.$blockId.geo_code_2.label}
+      {$form.address.$blockId.geo_code_1.label nofilter},&nbsp;{$form.address.$blockId.geo_code_2.label nofilter}
       {help id="id-geo-code" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.geo_code_1.textLabel}<br />
-      {$form.address.$blockId.geo_code_1.html},&nbsp;{$form.address.$blockId.geo_code_2.html}<br />
+      {$form.address.$blockId.geo_code_1.html nofilter},&nbsp;{$form.address.$blockId.geo_code_2.html nofilter}<br />
     </td>
   </tr>
   {if array_key_exists('manual_geo_code', $form.address.$blockId)}
     <tr>
       <td colspan="2">
-        {$form.address.$blockId.manual_geo_code.html}
-        {$form.address.$blockId.manual_geo_code.label}
+        {$form.address.$blockId.manual_geo_code.html nofilter}
+        {$form.address.$blockId.manual_geo_code.label nofilter}
         {help id="id-geo-code-override" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.manual_geo_code.textLabel}
       </td>
     </tr>

--- a/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/street_address.tpl
@@ -10,9 +10,9 @@
 {if !empty($form.address.$blockId.street_address)}
    <tr id="streetAddress_{$blockId}">
      <td colspan="2">
-       {$form.address.$blockId.street_address.label}
+       {$form.address.$blockId.street_address.label nofilter}
        {help id="id-street-address" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.street_address.textLabel}<br />
-       {$form.address.$blockId.street_address.html}
+       {$form.address.$blockId.street_address.html nofilter}
        {if $parseStreetAddress eq 1 && ($action eq 1 || $action eq 2)}
           &nbsp;&nbsp;<a href="#" title="{ts escape='htmlattribute'}Edit Address Elements{/ts}" onClick="processAddressFields( 'addressElements' , '{$blockId}', 1 );return false;">{ts}Edit Address Elements{/ts}</a>
           {help id="id-edit-street-elements" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.street_address.textLabel}
@@ -23,18 +23,18 @@
   {if $parseStreetAddress eq 1 && ($action eq 1 || $action eq 2)}
     <tr id="addressElements_{$blockId}" class=hiddenElement>
       <td>
-         {$form.address.$blockId.street_number.label}<br />
-         {$form.address.$blockId.street_number.html}
+         {$form.address.$blockId.street_number.label nofilter}<br />
+         {$form.address.$blockId.street_number.html nofilter}
        </td>
 
       <td>
-         {$form.address.$blockId.street_name.label}<br />
-         {$form.address.$blockId.street_name.html}<br />
+         {$form.address.$blockId.street_name.label nofilter}<br />
+         {$form.address.$blockId.street_name.html nofilter}<br />
       </td>
 
       <td colspan="2">
-        {$form.address.$blockId.street_unit.label}<br />
-        {$form.address.$blockId.street_unit.html}
+        {$form.address.$blockId.street_unit.label nofilter}<br />
+        {$form.address.$blockId.street_unit.html nofilter}
         <a href="#" title="{ts escape='htmlattribute'}Edit Street Address{/ts}" onClick="processAddressFields( 'streetAddress', '{$blockId}', 1 );return false;">{ts}Edit Complete Street Address{/ts}</a>
         {help id="id-edit-complete-street" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.street_address.textLabel}
       </td>

--- a/templates/CRM/Contact/Form/Edit/Address/supplemental_address_1.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/supplemental_address_1.tpl
@@ -10,9 +10,9 @@
 {if !empty($form.address.$blockId.supplemental_address_1)}
   <tr>
      <td colspan="2">
-         {$form.address.$blockId.supplemental_address_1.label}
+         {$form.address.$blockId.supplemental_address_1.label nofilter}
          {help id="id-supplemental-address" file="CRM/Contact/Form/Contact.hlp" title=$form.address.$blockId.supplemental_address_1.textLabel}<br />
-         {$form.address.$blockId.supplemental_address_1.html}
+         {$form.address.$blockId.supplemental_address_1.html nofilter}
      </td>
   </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/Address/supplemental_address_2.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/supplemental_address_2.tpl
@@ -10,8 +10,8 @@
 {if !empty($form.address.$blockId.supplemental_address_2)}
    <tr>
       <td colspan="2">
-          {$form.address.$blockId.supplemental_address_2.label}<br />
-          {$form.address.$blockId.supplemental_address_2.html}
+          {$form.address.$blockId.supplemental_address_2.label nofilter}<br />
+          {$form.address.$blockId.supplemental_address_2.html nofilter}
       </td>
    </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/Address/supplemental_address_3.tpl
+++ b/templates/CRM/Contact/Form/Edit/Address/supplemental_address_3.tpl
@@ -10,8 +10,8 @@
 {if !empty($form.address.$blockId.supplemental_address_3)}
    <tr>
       <td colspan="2">
-          {$form.address.$blockId.supplemental_address_3.label}<br />
-          {$form.address.$blockId.supplemental_address_3.html}
+          {$form.address.$blockId.supplemental_address_3.label nofilter}<br />
+          {$form.address.$blockId.supplemental_address_3.html nofilter}
       </td>
    </tr>
 {/if}

--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.js.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.js.tpl
@@ -10,7 +10,7 @@
 {literal}
   <script type="text/javascript">
     CRM.$(function($) {
-      var $form = $('form.{/literal}{$form.formClass}{literal}');
+      var $form = $('form.{/literal}{$form.formClass nofilter}{literal}');
       function triggerCustomValueCommsFields() {
         var fldName = $(this).attr('id');
         if ($(this).val() == 4) {

--- a/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Edit/CommunicationPreferences.tpl
@@ -18,19 +18,19 @@
     <table class="form-layout-compressed" >
         {if array_key_exists('communication_style_id', $form)}
           <tr><td colspan='4'>
-            <span class="label">{$form.communication_style_id.label} {help id="communication_style" file="CRM/Contact/Form/Contact.hlp"}</span>
-            <span class="value">{$form.communication_style_id.html}</span>
+            <span class="label">{$form.communication_style_id.label nofilter} {help id="communication_style" file="CRM/Contact/Form/Contact.hlp"}</span>
+            <span class="value">{$form.communication_style_id.html nofilter}</span>
           </td><tr>
         {/if}
         <tr>
           {if array_key_exists('email_greeting_id', $form)}
-            <td>{$form.email_greeting_id.label}</td>
+            <td>{$form.email_greeting_id.label nofilter}</td>
           {/if}
           {if array_key_exists('postal_greeting_id', $form)}
-            <td>{$form.postal_greeting_id.label}</td>
+            <td>{$form.postal_greeting_id.label nofilter}</td>
           {/if}
           {if array_key_exists('addressee_id', $form)}
-            <td>{$form.addressee_id.label}</td>
+            <td>{$form.addressee_id.label nofilter}</td>
           {/if}
           {if array_key_exists('email_greeting_id', $form) OR array_key_exists('postal_greeting_id', $form) OR array_key_exists('addressee_id', $form)}
             {capture assign='helpTitle'}{ts}Greeting{/ts}{/capture}
@@ -40,7 +40,7 @@
         <tr>
             {if array_key_exists('email_greeting_id', $form)}
                 <td>
-                    <span id="email_greeting" {if !empty($email_greeting_display) and $action eq 2} class="hiddenElement"{/if}>{$form.email_greeting_id.html|crmAddClass:big}</span>
+                    <span id="email_greeting" {if !empty($email_greeting_display) and $action eq 2} class="hiddenElement"{/if}>{$form.email_greeting_id.html|crmAddClass:big nofilter}</span>
                     {if !empty($email_greeting_display) and $action eq 2}
                       <div data-id="email_greeting" class="replace-plain" title="{ts escape='htmlattribute'}Click to edit{/ts}">
                         {$email_greeting_display}
@@ -50,7 +50,7 @@
             {/if}
             {if array_key_exists('postal_greeting_id', $form)}
                 <td>
-                    <span id="postal_greeting" {if !empty($postal_greeting_display) and $action eq 2} class="hiddenElement"{/if}>{$form.postal_greeting_id.html|crmAddClass:big}</span>
+                    <span id="postal_greeting" {if !empty($postal_greeting_display) and $action eq 2} class="hiddenElement"{/if}>{$form.postal_greeting_id.html|crmAddClass:big nofilter}</span>
                     {if !empty($postal_greeting_display) and $action eq 2}
                       <div data-id="postal_greeting" class="replace-plain" title="{ts escape='htmlattribute'}Click to edit{/ts}">
                         {$postal_greeting_display}
@@ -60,7 +60,7 @@
             {/if}
             {if array_key_exists('addressee_id', $form)}
                 <td>
-                    <span id="addressee" {if !empty($addressee_display) and $action eq 2} class="hiddenElement"{/if}>{$form.addressee_id.html|crmAddClass:big}</span>
+                    <span id="addressee" {if !empty($addressee_display) and $action eq 2} class="hiddenElement"{/if}>{$form.addressee_id.html|crmAddClass:big nofilter}</span>
                     {if !empty($addressee_display) and $action eq 2}
                       <div data-id="addressee" class="replace-plain" title="{ts escape='htmlattribute'}Click to edit{/ts}">
                         {$addressee_display}
@@ -71,40 +71,40 @@
         </tr>
         <tr id="greetings1" class="hiddenElement">
           {if array_key_exists('email_greeting_custom', $form)}
-            <td><span id="email_greeting_id_label" class="hiddenElement">{$form.email_greeting_custom.label}</span></td>
+            <td><span id="email_greeting_id_label" class="hiddenElement">{$form.email_greeting_custom.label nofilter}</span></td>
           {/if}
           {if array_key_exists('postal_greeting_custom', $form)}
-            <td><span id="postal_greeting_id_label" class="hiddenElement">{$form.postal_greeting_custom.label}</span></td>
+            <td><span id="postal_greeting_id_label" class="hiddenElement">{$form.postal_greeting_custom.label nofilter}</span></td>
           {/if}
           {if array_key_exists('addressee_custom', $form)}
-            <td><span id="addressee_id_label" class="hiddenElement">{$form.addressee_custom.label}</span></td>
+            <td><span id="addressee_id_label" class="hiddenElement">{$form.addressee_custom.label nofilter}</span></td>
           {/if}
         </tr>
         <tr id="greetings2" class="hiddenElement">
           {if array_key_exists('email_greeting_custom', $form)}
-            <td><span id="email_greeting_id_html" class="hiddenElement">{$form.email_greeting_custom.html|crmAddClass:big}</span></td>
+            <td><span id="email_greeting_id_html" class="hiddenElement">{$form.email_greeting_custom.html|crmAddClass:big nofilter}</span></td>
           {/if}
            {if array_key_exists('postal_greeting_custom', $form)}
-            <td><span id="postal_greeting_id_html" class="hiddenElement">{$form.postal_greeting_custom.html|crmAddClass:big}</span></td>
+            <td><span id="postal_greeting_id_html" class="hiddenElement">{$form.postal_greeting_custom.html|crmAddClass:big nofilter}</span></td>
           {/if}
           {if array_key_exists('addressee_custom', $form)}
-            <td><span id="addressee_id_html" class="hiddenElement">{$form.addressee_custom.html|crmAddClass:big}</span></td>
+            <td><span id="addressee_id_html" class="hiddenElement">{$form.addressee_custom.html|crmAddClass:big nofilter}</span></td>
           {/if}
         </tr>
         <tr>
           {foreach key=key item=item from=$commPreference}
             <td>
-              <br/><span class="label">{$form.$key.label}</span> {help id=$key file="CRM/Contact/Form/Contact.hlp"}
-              <br/>{$form.$key.html}
+              <br/><span class="label">{$form.$key.label nofilter}</span> {help id=$key file="CRM/Contact/Form/Contact.hlp"}
+              <br/>{$form.$key.html nofilter}
             </td>
           {/foreach}
           <td>
-            <br/><span class="label">{$form.preferred_language.label}</span>
-            <br/>{$form.preferred_language.html}
+            <br/><span class="label">{$form.preferred_language.label nofilter}</span>
+            <br/>{$form.preferred_language.html nofilter}
           </td>
         </tr>
         <tr>
-          <td>{$form.is_opt_out.html} {$form.is_opt_out.label} {help id="is_opt_out" file="CRM/Contact/Form/Contact.hlp"}</td>
+          <td>{$form.is_opt_out.html nofilter} {$form.is_opt_out.label nofilter} {help id="is_opt_out" file="CRM/Contact/Form/Contact.hlp"}</td>
         </tr>
     </table>
  </div>

--- a/templates/CRM/Contact/Form/Edit/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Edit/Demographics.tpl
@@ -13,23 +13,23 @@
   </summary>
   <div id="demographics" class="crm-accordion-body">
   <div class="form-item">
-        <span class="label">{$form.gender_id.label}</span>
+        <span class="label">{$form.gender_id.label nofilter}</span>
 
   <span class="value">
-        {$form.gender_id.html}
+        {$form.gender_id.html nofilter}
         </span>
   </div>
   <div class="form-item">
-        <span class="label">{$form.birth_date.label}</span>
-        <span class="fields">{$form.birth_date.html}</span>
+        <span class="label">{$form.birth_date.label nofilter}</span>
+        <span class="fields">{$form.birth_date.html nofilter}</span>
   </div>
   <div class="form-item">
-       {$form.is_deceased.html}
-       {$form.is_deceased.label}
+       {$form.is_deceased.html nofilter}
+       {$form.is_deceased.label nofilter}
   </div>
   <div id="showDeceasedDate" class="form-item">
-       <span class="label">{$form.deceased_date.label}</span>
-       <span class="fields">{$form.deceased_date.html}</span>
+       <span class="label">{$form.deceased_date.label nofilter}</span>
+       <span class="fields">{$form.deceased_date.html nofilter}</span>
   </div>
  </div>
 </details>

--- a/templates/CRM/Contact/Form/Edit/Email.tpl
+++ b/templates/CRM/Contact/Form/Edit/Email.tpl
@@ -32,7 +32,7 @@
 {/if}
 
 <tr id="Email_Block_{$blockId}">
-  <td>{$form.email.$blockId.email.html|crmAddClass:email}&nbsp;{$form.email.$blockId.location_type_id.html}
+  <td>{$form.email.$blockId.email.html|crmAddClass:email nofilter}&nbsp;{$form.email.$blockId.location_type_id.html nofilter}
     {if $isAddSignatureFields}
       <div class="clear"></div>
       <details class="email-signature crm-accordion-light">
@@ -40,16 +40,16 @@
           {ts}Signature{/ts}
         </summary>
         <div id="signatureBlock{$blockId}" class="crm-accordion-body">
-          {$form.email.$blockId.signature_html.label}<br/>{$form.email.$blockId.signature_html.html}<br/>
-          {$form.email.$blockId.signature_text.label}<br/>{$form.email.$blockId.signature_text.html}
+          {$form.email.$blockId.signature_html.label nofilter}<br/>{$form.email.$blockId.signature_html.html nofilter}<br/>
+          {$form.email.$blockId.signature_text.label nofilter}<br/>{$form.email.$blockId.signature_text.html nofilter}
         </div>
       </details>
     {/if}
   </td>
-  <td align="center">{$form.email.$blockId.on_hold.html}</td>
-  <td align="center" id="Email-Bulkmail-html" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html}</td>
+  <td align="center">{$form.email.$blockId.on_hold.html nofilter}</td>
+  <td align="center" id="Email-Bulkmail-html" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html nofilter}</td>
   <td align="center" id="Email-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>
-    {$form.email.$blockId.is_primary.1.html}
+    {$form.email.$blockId.is_primary.1.html nofilter}
   </td>
   {if $blockId gt 1}
     <td>

--- a/templates/CRM/Contact/Form/Edit/Household.tpl
+++ b/templates/CRM/Contact/Form/Edit/Household.tpl
@@ -12,28 +12,28 @@
   {crmRegion name="contact-form-edit-household"}
     <tr>
       <td>
-        {$form.household_name.label}<br/>
-        {$form.household_name.html}
+        {$form.household_name.label nofilter}<br/>
+        {$form.household_name.html nofilter}
       </td>
       <td>
-        {$form.nick_name.label}<br/>
-        {$form.nick_name.html}
+        {$form.nick_name.label nofilter}<br/>
+        {$form.nick_name.html nofilter}
       </td>
     {if array_key_exists('contact_sub_type', $form)}
     </tr>
     <tr>
       <td>
-        {$form.contact_sub_type.label}<br />
-        {$form.contact_sub_type.html}
+        {$form.contact_sub_type.label nofilter}<br />
+        {$form.contact_sub_type.html nofilter}
       </td>
     {/if}
       <td>
-        {$form.is_deceased.label}<br />
-        {$form.is_deceased.html}
+        {$form.is_deceased.label nofilter}<br />
+        {$form.is_deceased.html nofilter}
       </td>
       <td id="showDeceasedDate">
-        {$form.deceased_date.label}<br />
-        {$form.deceased_date.html}
+        {$form.deceased_date.label nofilter}<br />
+        {$form.deceased_date.html nofilter}
       </td>
     </tr>
   {/crmRegion}

--- a/templates/CRM/Contact/Form/Edit/IM.tpl
+++ b/templates/CRM/Contact/Form/Edit/IM.tpl
@@ -21,10 +21,10 @@
 {/if}
 
 <tr id="IM_Block_{$blockId}">
-    <td>{$form.im.$blockId.name.html|crmAddClass:twenty}&nbsp;</td>
-    <td>{$form.im.$blockId.location_type_id.html}</td>
-    <td colspan="2">{$form.im.$blockId.provider_id.html}</td>
-    <td align="center" id="IM-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.im.$blockId.is_primary.1.html}</td>
+    <td>{$form.im.$blockId.name.html|crmAddClass:twenty nofilter}&nbsp;</td>
+    <td>{$form.im.$blockId.location_type_id.html nofilter}</td>
+    <td colspan="2">{$form.im.$blockId.provider_id.html nofilter}</td>
+    <td align="center" id="IM-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.im.$blockId.is_primary.1.html nofilter}</td>
     {if $blockId gt 1}
         <td><a href="#" title="{ts escape='htmlattribute'}Delete IM Block{/ts}" onClick="removeBlock('IM','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
     {/if}

--- a/templates/CRM/Contact/Form/Edit/Individual.tpl
+++ b/templates/CRM/Contact/Form/Edit/Individual.tpl
@@ -13,59 +13,59 @@
     <tr>
       {if !empty($form.prefix_id)}
       <td>
-        {$form.prefix_id.label}<br/>
-        {$form.prefix_id.html}
+        {$form.prefix_id.label nofilter}<br/>
+        {$form.prefix_id.html nofilter}
       </td>
       {/if}
       {if $form.formal_title}
       <td>
-        {$form.formal_title.label}<br/>
-        {$form.formal_title.html}
+        {$form.formal_title.label nofilter}<br/>
+        {$form.formal_title.html nofilter}
       </td>
       {/if}
       {if !empty($form.first_name)}
       <td>
-        {$form.first_name.label}<br />
-        {$form.first_name.html}
+        {$form.first_name.label nofilter}<br />
+        {$form.first_name.html nofilter}
       </td>
       {/if}
       {if !empty($form.middle_name)}
       <td>
-        {$form.middle_name.label}<br />
-        {$form.middle_name.html}
+        {$form.middle_name.label nofilter}<br />
+        {$form.middle_name.html nofilter}
       </td>
       {/if}
       {if !empty($form.last_name)}
       <td>
-        {$form.last_name.label}<br />
-        {$form.last_name.html}
+        {$form.last_name.label nofilter}<br />
+        {$form.last_name.html nofilter}
       </td>
       {/if}
       {if !empty($form.suffix_id)}
       <td>
-        {$form.suffix_id.label}<br/>
-        {$form.suffix_id.html}
+        {$form.suffix_id.label nofilter}<br/>
+        {$form.suffix_id.html nofilter}
       </td>
       {/if}
     </tr>
 
     <tr>
       <td colspan="2">
-        {$form.employer_id.label}&nbsp;{help id="employer_id" file="CRM/Contact/Form/Contact.hlp"}<br />
-        {$form.employer_id.html}
+        {$form.employer_id.label nofilter}&nbsp;{help id="employer_id" file="CRM/Contact/Form/Contact.hlp"}<br />
+        {$form.employer_id.html nofilter}
       </td>
       <td>
-        {$form.job_title.label}<br />
-        {$form.job_title.html}
+        {$form.job_title.label nofilter}<br />
+        {$form.job_title.html nofilter}
       </td>
       <td>
-        {$form.nick_name.label}<br />
-        {$form.nick_name.html}
+        {$form.nick_name.label nofilter}<br />
+        {$form.nick_name.html nofilter}
       </td>
       {if !empty($form.contact_sub_type)}
       <td>
-        {$form.contact_sub_type.label}<br />
-        {$form.contact_sub_type.html}
+        {$form.contact_sub_type.label nofilter}<br />
+        {$form.contact_sub_type.html nofilter}
       </td>
       {/if}
     </tr>

--- a/templates/CRM/Contact/Form/Edit/Notes.tpl
+++ b/templates/CRM/Contact/Form/Edit/Notes.tpl
@@ -15,12 +15,12 @@
   <div class="crm-accordion-body" id="notesBlock">
    <table class="form-layout-compressed">
      <tr>
-       <td colspan=3>{$form.subject.label}<br  >
-        {$form.subject.html}</td>
+       <td colspan=3>{$form.subject.label nofilter}<br  >
+        {$form.subject.html nofilter}</td>
      </tr>
      <tr>
-       <td colspan=3>{$form.note.label}<br />
-        {$form.note.html}
+       <td colspan=3>{$form.note.label nofilter}<br />
+        {$form.note.html nofilter}
        </td>
      </tr>
    </table>

--- a/templates/CRM/Contact/Form/Edit/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Edit/OpenID.tpl
@@ -20,9 +20,9 @@
 {/if}
 
 <tr id="OpenID_Block_{$blockId}">
-    <td>{$form.openid.$blockId.openid.html|crmAddClass:twenty}&nbsp;</td>
-    <td>{$form.openid.$blockId.location_type_id.html}</td>
-    <td align="center" id="OpenID-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.openid.$blockId.is_primary.1.html}</td>
+    <td>{$form.openid.$blockId.openid.html|crmAddClass:twenty nofilter}&nbsp;</td>
+    <td>{$form.openid.$blockId.location_type_id.html nofilter}</td>
+    <td align="center" id="OpenID-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.openid.$blockId.is_primary.1.html nofilter}</td>
     {if $blockId gt 1}
     <td><a href="#" title="{ts escape='htmlattribute'}Delete OpenID Block{/ts}" onClick="removeBlock('OpenID','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
     {/if}

--- a/templates/CRM/Contact/Form/Edit/Organization.tpl
+++ b/templates/CRM/Contact/Form/Edit/Organization.tpl
@@ -12,36 +12,36 @@
   {crmRegion name="contact-form-edit-organization"}
     <tr>
       <td>
-        {$form.organization_name.label|smarty:nodefaults|purify}<br/>
-        {$form.organization_name.html}
+        {$form.organization_name.label|purify nofilter}<br/>
+        {$form.organization_name.html nofilter}
       </td>
       <td>
-        {$form.legal_name.label|smarty:nodefaults|purify}<br/>
-        {$form.legal_name.html}
+        {$form.legal_name.label|purify nofilter}<br/>
+        {$form.legal_name.html nofilter}
       </td>
       <td>
-        {$form.nick_name.label|smarty:nodefaults|purify}<br/>
-        {$form.nick_name.html}
+        {$form.nick_name.label|purify nofilter}<br/>
+        {$form.nick_name.html nofilter}
       </td>
       <td>
-        {$form.sic_code.label|smarty:nodefaults|purify}<br/>
-        {$form.sic_code.html}
+        {$form.sic_code.label|purify nofilter}<br/>
+        {$form.sic_code.html nofilter}
       </td>
     </tr>
     <tr>
       {if array_key_exists('contact_sub_type', $form)}
         <td>
-          {$form.contact_sub_type.label|smarty:nodefaults|purify}<br />
-          {$form.contact_sub_type.html}
+          {$form.contact_sub_type.label|purify nofilter}<br />
+          {$form.contact_sub_type.html nofilter}
         </td>
       {/if}
         <td>
-          {$form.is_deceased.label}<br />
-          {$form.is_deceased.html}
+          {$form.is_deceased.label nofilter}<br />
+          {$form.is_deceased.html nofilter}
         </td>
         <td id="showDeceasedDate">
-          {$form.deceased_date.label}<br />
-          {$form.deceased_date.html}
+          {$form.deceased_date.label nofilter}<br />
+          {$form.deceased_date.html nofilter}
         </td>
     </tr>
   {/crmRegion}

--- a/templates/CRM/Contact/Form/Edit/Phone.tpl
+++ b/templates/CRM/Contact/Form/Edit/Phone.tpl
@@ -25,13 +25,13 @@
   </tr>
 {/if}
 <tr id="Phone_Block_{$blockId}">
-  <td>{$form.phone.$blockId.phone.html}<span class="crm-phone-ext">{ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
+  <td>{$form.phone.$blockId.phone.html nofilter}<span class="crm-phone-ext">{ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four nofilter}&nbsp;</span></td>
   {if $className eq 'CRM_Contact_Form_Contact'}
-  <td>{$form.phone.$blockId.location_type_id.html}</td>
+  <td>{$form.phone.$blockId.location_type_id.html nofilter}</td>
   {/if}
-  <td colspan="2">{$form.phone.$blockId.phone_type_id.html}</td>
+  <td colspan="2">{$form.phone.$blockId.phone_type_id.html nofilter}</td>
   {if $className eq 'CRM_Contact_Form_Contact'}
-    <td align="center" id="Phone-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.phone.$blockId.is_primary.1.html}</td>
+    <td align="center" id="Phone-Primary-html" {if $blockId eq 1}class="hiddenElement"{/if}>{$form.phone.$blockId.is_primary.1.html nofilter}</td>
   {/if}
   {if $blockId gt 1}
     <td><a href="#" title="{ts escape='htmlattribute'}Delete Phone Block{/ts}" onClick="removeBlock('Phone','{$blockId}'); return false;">{ts}delete{/ts}</a></td>

--- a/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
+++ b/templates/CRM/Contact/Form/Edit/TagsAndGroups.tpl
@@ -17,8 +17,8 @@
         <td>
           {if $form.tag}
             <div class="crm-section tag-section">
-              {if !empty($title)}{$form.tag.label}<br>{/if}
-              {$form.tag.html}
+              {if !empty($title)}{$form.tag.label nofilter}<br>{/if}
+              {$form.tag.html nofilter}
             </div>
           {/if}
           {if $context NEQ 'profile'}
@@ -30,13 +30,13 @@
           <td>
             {if $groupElementType eq 'select'}
               <div class="crm-section group-section">
-              {if $title}{$form.group.label}<br>{/if}
-              {$form.group.html}
+              {if $title}{$form.group.label nofilter}<br>{/if}
+              {$form.group.html nofilter}
             </div>
             {else}
               {foreach key=key item=item from=$tagGroup.group}
                 <div class="group-wrapper">
-                  {$form.group.$key.html}
+                  {$form.group.$key.html nofilter}
                     {if $item.description}
                     <div class="description">{$item.description}</div>
                   {/if}

--- a/templates/CRM/Contact/Form/Edit/Tagtree.tpl
+++ b/templates/CRM/Contact/Form/Edit/Tagtree.tpl
@@ -13,7 +13,7 @@
     <li id="tagli_{$id}">
       <input name="tag[{$id}]" id="tag_{$id}" class="form-checkbox" type="checkbox" value="1" {if $node.is_selectable EQ 0}disabled=""{/if} {if $form.tag.value.$id EQ 1}checked="checked"{/if}/>
       <span>
-        <label for="tag_{$id}" id="tagLabel_{$id}" class="crm-tag-item" {if !empty($allTags.$id.color)}style="background-color: {$allTags.$id.color}; color: {$allTags.$id.color|colorContrast};"{/if} title="{$node.description|escape}">{$node.name}</label>
+        <label for="tag_{$id}" id="tagLabel_{$id}" class="crm-tag-item" {if !empty($allTags.$id.color)}style="background-color: {$allTags.$id.color}; color: {$allTags.$id.color|colorContrast};"{/if} title="{$node.description|escape nofilter}">{$node.name}</label>
       </span>
       {if $node.children}
         {* Recurse... *}

--- a/templates/CRM/Contact/Form/Edit/Website.tpl
+++ b/templates/CRM/Contact/Form/Edit/Website.tpl
@@ -24,8 +24,8 @@
 {/if}
 
 <tr id="Website_Block_{$blockId}">
-    <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
-    <td>{$form.website.$blockId.website_type_id.html}</td>
+    <td>{$form.website.$blockId.url.html|crmAddClass:url nofilter}&nbsp;</td>
+    <td>{$form.website.$blockId.website_type_id.html nofilter}</td>
     {if $blockId gt 1}
       <td colspan="3"><a href="#" title="{ts escape='htmlattribute'}Delete Website Block{/ts}" onClick="removeBlock('Website','{$blockId}'); return false;">{ts}delete{/ts}</a></td>
     {/if}

--- a/templates/CRM/Contact/Form/Inline/Address.tpl
+++ b/templates/CRM/Contact/Form/Inline/Address.tpl
@@ -23,14 +23,14 @@
      <tr>
         <td>
            <span class="crm-address-element location_type_id-address-element">
-            {$form.address.$blockId.location_type_id.label}&nbsp;{$form.address.$blockId.location_type_id.html}
+            {$form.address.$blockId.location_type_id.label nofilter}&nbsp;{$form.address.$blockId.location_type_id.html nofilter}
             </span>
         </td>
      </tr>
      <tr>
         <td>
-           <span class="crm-address-element is_primary-address-element">{$form.address.$blockId.is_primary.html}</span>
-           <span class="crm-address-element is_billing-address-element">{$form.address.$blockId.is_billing.html}</span>
+           <span class="crm-address-element is_primary-address-element">{$form.address.$blockId.is_primary.html nofilter}</span>
+           <span class="crm-address-element is_billing-address-element">{$form.address.$blockId.is_billing.html nofilter}</span>
         </td>
      </tr>
 

--- a/templates/CRM/Contact/Form/Inline/BlockCustomData.tpl
+++ b/templates/CRM/Contact/Form/Inline/BlockCustomData.tpl
@@ -13,10 +13,10 @@
 {if array_key_exists($blockId, $customFields)}
   {foreach item='custom_field' from=$customFields.$blockId key='custom_field_name'}
     <tr class="crm-block-entity-{$entity}-{$blockId} {if $blockId gt $actualBlockCount}hiddenElement{/if}">
-      <td colspan="5">{$form.$entity.$blockId.$custom_field_name.label}</td>
+      <td colspan="5">{$form.$entity.$blockId.$custom_field_name.label nofilter}</td>
     </tr>
     <tr class="crm-block-entity-{$entity}-{$blockId} {if $blockId gt $actualBlockCount}hiddenElement{/if}">
-      <td colspan="5">{$form.$entity.$blockId.$custom_field_name.html}</td>
+      <td colspan="5">{$form.$entity.$blockId.$custom_field_name.html nofilter}</td>
     </tr>
   {/foreach}
 {/if}

--- a/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Form/Inline/CommunicationPreferences.tpl
@@ -17,49 +17,49 @@
     <div class="crm-clear">
       {foreach key=key item=item from=$commPreference}
       <div class="crm-summary-row">
-        <div class="crm-label">{$form.$key.label}
+        <div class="crm-label">{$form.$key.label nofilter}
           {help id=$key file="CRM/Contact/Form/Contact.hlp"}
         </div>
         <div class="crm-content">
           {foreach key=k item=i from=$item}
-            {$form.$key.$k.html}<br/>
+            {$form.$key.$k.html nofilter}<br/>
           {/foreach}
         </div>
       </div>
       {if $key eq 'privacy'}
       <div class="crm-summary-row">
         <div class="crm-label">&nbsp;</div>
-        <div class="crm-content">{$form.is_opt_out.html} {$form.is_opt_out.label} {help id="is_opt_out" file="CRM/Contact/Form/Contact.hlp"}
+        <div class="crm-content">{$form.is_opt_out.html nofilter} {$form.is_opt_out.label nofilter} {help id="is_opt_out" file="CRM/Contact/Form/Contact.hlp"}
         </div>
       </div>
       {/if}
       {/foreach}
       <div class="crm-summary-row">
         <div class="crm-label">
-          {$form.preferred_language.label}
+          {$form.preferred_language.label nofilter}
         </div>
         <div class="crm-content">
-          {$form.preferred_language.html}
+          {$form.preferred_language.html nofilter}
         </div>
       </div>
 
       {if !empty($form.communication_style_id)}
       <div class="crm-summary-row">
         <div class="crm-label">
-          {$form.communication_style_id.label} {help id="communication_style" file="CRM/Contact/Form/Contact.hlp"}
+          {$form.communication_style_id.label nofilter} {help id="communication_style" file="CRM/Contact/Form/Contact.hlp"}
         </div>
         <div class="crm-content">
-          {$form.communication_style_id.html}
+          {$form.communication_style_id.html nofilter}
         </div>
       </div>
       {/if}
 
       {if !empty($form.email_greeting_id)}
       <div class="crm-summary-row">
-        <div class="crm-label">{$form.email_greeting_id.label}</div>
+        <div class="crm-label">{$form.email_greeting_id.label nofilter}</div>
         <div class="crm-content">
           <span id="email_greeting" {if !empty($email_greeting_display)} class="hiddenElement"{/if}>
-            {$form.email_greeting_id.html|crmAddClass:big}
+            {$form.email_greeting_id.html|crmAddClass:big nofilter}
           </span>
           {if !empty($email_greeting_display)}
             <div data-id="email_greeting" class="replace-plain big" title="{ts escape='htmlattribute'}Click to edit{/ts}">
@@ -68,7 +68,7 @@
           {/if}
           {if !empty($form.email_greeting_custom)}
             <span id="email_greeting_id_html" class="hiddenElement">
-              <br/>{$form.email_greeting_custom.html|crmAddClass:big}
+              <br/>{$form.email_greeting_custom.html|crmAddClass:big nofilter}
             </span>
           {/if}
          </div>
@@ -78,10 +78,10 @@
 
       {if !empty($form.postal_greeting_id)}
       <div class="crm-summary-row">
-        <div class="crm-label">{$form.postal_greeting_id.label}</div>
+        <div class="crm-label">{$form.postal_greeting_id.label nofilter}</div>
         <div class="crm-content">
           <span id="postal_greeting" {if !empty($postal_greeting_display)} class="hiddenElement"{/if}>
-            {$form.postal_greeting_id.html|crmAddClass:big}
+            {$form.postal_greeting_id.html|crmAddClass:big nofilter}
           </span>
           {if !empty($postal_greeting_display)}
             <div data-id="postal_greeting" class="replace-plain big" title="{ts escape='htmlattribute'}Click to edit{/ts}">
@@ -90,7 +90,7 @@
           {/if}
           {if !empty($form.postal_greeting_custom)}
             <span id="postal_greeting_id_html" class="hiddenElement">
-              <br/>{$form.postal_greeting_custom.html|crmAddClass:big}
+              <br/>{$form.postal_greeting_custom.html|crmAddClass:big nofilter}
             </span>
           {/if}
         </div>
@@ -99,10 +99,10 @@
 
       {if !empty($form.addressee_id)}
       <div class="crm-summary-row">
-        <div class="crm-label">{$form.addressee_id.label}</div>
+        <div class="crm-label">{$form.addressee_id.label nofilter}</div>
         <div class="crm-content">
           <span id="addressee" {if !empty($addressee_display)} class="hiddenElement"{/if}>
-            {$form.addressee_id.html|crmAddClass:big}
+            {$form.addressee_id.html|crmAddClass:big nofilter}
           </span>
           {if !empty($addressee_display)}
             <div data-id="addressee" class="replace-plain big" title="{ts escape='htmlattribute'}Click to edit{/ts}">
@@ -111,7 +111,7 @@
           {/if}
           {if !empty($form.addressee_custom)}
             <span id="addressee_id_html" class="hiddenElement">
-              <br/>{$form.addressee_custom.html|crmAddClass:big}
+              <br/>{$form.addressee_custom.html|crmAddClass:big nofilter}
             </span>
           {/if}
          </div>

--- a/templates/CRM/Contact/Form/Inline/ContactInfo.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactInfo.tpl
@@ -15,42 +15,42 @@
   <div class="crm-clear">
     {if $contactType eq 'Individual'}
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.employer_id.label}&nbsp;{help id="employer_id" file="CRM/Contact/Form/Contact"}</div>
+      <div class="crm-label">{$form.employer_id.label nofilter}&nbsp;{help id="employer_id" file="CRM/Contact/Form/Contact"}</div>
       <div class="crm-content">
-        {$form.employer_id.html|crmAddClass:big}
+        {$form.employer_id.html|crmAddClass:big nofilter}
       </div>
     </div>
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.job_title.label}</div>
-      <div class="crm-content">{$form.job_title.html}</div>
+      <div class="crm-label">{$form.job_title.label nofilter}</div>
+      <div class="crm-content">{$form.job_title.html nofilter}</div>
     </div>
     {/if}
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.nick_name.label}</div>
-      <div class="crm-content">{$form.nick_name.html}</div>
+      <div class="crm-label">{$form.nick_name.label nofilter}</div>
+      <div class="crm-content">{$form.nick_name.html nofilter}</div>
     </div>
     {if $contactType eq 'Organization'}
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.legal_name.label}</div>
-      <div class="crm-content">{$form.legal_name.html}</div>
+      <div class="crm-label">{$form.legal_name.label nofilter}</div>
+      <div class="crm-content">{$form.legal_name.html nofilter}</div>
     </div>
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.sic_code.label}</div>
-      <div class="crm-content">{$form.sic_code.html}</div>
+      <div class="crm-label">{$form.sic_code.label nofilter}</div>
+      <div class="crm-content">{$form.sic_code.html nofilter}</div>
     </div>
     {/if}
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.contact_source.label}</div>
-      <div class="crm-content">{$form.contact_source.html}</div>
+      <div class="crm-label">{$form.contact_source.label nofilter}</div>
+      <div class="crm-content">{$form.contact_source.html nofilter}</div>
     </div>
     {if ($contactType eq 'Organization') OR ($contactType eq 'Household')}
     <div class="crm-summary-row">
       <div class="crm-label"></div>
-      <div class="crm-content">{$form.is_deceased.html}{$form.is_deceased.label}</div>
+      <div class="crm-content">{$form.is_deceased.html nofilter}{$form.is_deceased.label nofilter}</div>
     </div>
     <div class="crm-summary-row" id="showDeceasedDate">
-      <div class="crm-label">{$form.deceased_date.label}</div>
-      <div class="crm-content">{$form.deceased_date.html}</div>
+      <div class="crm-label">{$form.deceased_date.label nofilter}</div>
+      <div class="crm-content">{$form.deceased_date.html nofilter}</div>
     </div>
     {/if}
   </div> <!-- end of main -->

--- a/templates/CRM/Contact/Form/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Form/Inline/ContactName.tpl
@@ -16,46 +16,46 @@
     {if $contactType eq 'Individual'}
       {if !empty($form.prefix_id)}
         <div class="crm-inline-edit-field">
-          {$form.prefix_id.label}<br/>
-          {$form.prefix_id.html}
+          {$form.prefix_id.label nofilter}<br/>
+          {$form.prefix_id.html nofilter}
         </div>
       {/if}
       {if !empty($form.formal_title)}
         <div class="crm-inline-edit-field">
-          {$form.formal_title.label}<br/>
-          {$form.formal_title.html}
+          {$form.formal_title.label nofilter}<br/>
+          {$form.formal_title.html nofilter}
         </div>
       {/if}
       {if !empty($form.first_name)}
         <div class="crm-inline-edit-field">
-          {$form.first_name.label}<br />
-          {$form.first_name.html}
+          {$form.first_name.label nofilter}<br />
+          {$form.first_name.html nofilter}
         </div>
       {/if}
       {if !empty($form.middle_name)}
         <div class="crm-inline-edit-field">
-          {$form.middle_name.label}<br />
-          {$form.middle_name.html}
+          {$form.middle_name.label nofilter}<br />
+          {$form.middle_name.html nofilter}
         </div>
       {/if}
       {if !empty($form.last_name)}
         <div class="crm-inline-edit-field">
-          {$form.last_name.label}<br />
-          {$form.last_name.html}
+          {$form.last_name.label nofilter}<br />
+          {$form.last_name.html nofilter}
         </div>
       {/if}
       {if !empty($form.suffix_id)}
         <div class="crm-inline-edit-field">
-          {$form.suffix_id.label}<br/>
-          {$form.suffix_id.html}
+          {$form.suffix_id.label nofilter}<br/>
+          {$form.suffix_id.html nofilter}
         </div>
       {/if}
     {elseif $contactType eq 'Organization'}
-      <div class="crm-inline-edit-field">{$form.organization_name.label}&nbsp;
-      {$form.organization_name.html}</div>
+      <div class="crm-inline-edit-field">{$form.organization_name.label nofilter}&nbsp;
+      {$form.organization_name.html nofilter}</div>
     {elseif $contactType eq 'Household'}
-      <div class="crm-inline-edit-field">{$form.household_name.label}&nbsp;
-      {$form.household_name.html}</div>
+      <div class="crm-inline-edit-field">{$form.household_name.label nofilter}&nbsp;
+      {$form.household_name.html nofilter}</div>
     {/if}
   {/crmRegion}
 </div>

--- a/templates/CRM/Contact/Form/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Inline/Demographics.tpl
@@ -14,26 +14,26 @@
 
   <div class="crm-clear">
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.gender_id.label}</div>
-      <div class="crm-content">{$form.gender_id.html}</div>
+      <div class="crm-label">{$form.gender_id.label nofilter}</div>
+      <div class="crm-content">{$form.gender_id.html nofilter}</div>
     </div>
     <div class="crm-summary-row">
-      <div class="crm-label">{$form.birth_date.label}</div>
+      <div class="crm-label">{$form.birth_date.label nofilter}</div>
       <div class="crm-content">
-        {$form.birth_date.html}
+        {$form.birth_date.html nofilter}
       </div>
     </div>
     <div class="crm-summary-row">
       <div class="crm-label">&nbsp;</div>
       <div class="crm-content">
-        {$form.is_deceased.html}
-        {$form.is_deceased.label}
+        {$form.is_deceased.html nofilter}
+        {$form.is_deceased.label nofilter}
       </div>
     </div>
     <div class="crm-summary-row" id="showDeceasedDate">
-      <div class="crm-label crm-deceased-date">{$form.deceased_date.label}</div>
+      <div class="crm-label crm-deceased-date">{$form.deceased_date.label nofilter}</div>
       <div class="crm-content crm-deceased-date">
-        {$form.deceased_date.html}
+        {$form.deceased_date.html nofilter}
       </div>
     </div>
   </div>

--- a/templates/CRM/Contact/Form/Inline/Email.tpl
+++ b/templates/CRM/Contact/Form/Inline/Email.tpl
@@ -38,10 +38,10 @@
   {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
     <tr data-entity='email' data-block-number={$blockId} id="Email_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-      <td>{$form.email.$blockId.email.html|crmAddClass:email}&nbsp;{$form.email.$blockId.location_type_id.html}</td>
-      <td align="center">{$form.email.$blockId.on_hold.html}</td>
-      <td align="center" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html}</td>
-      <td align="center" class="crm-email-is_primary">{$form.email.$blockId.is_primary.1.html}</td>
+      <td>{$form.email.$blockId.email.html|crmAddClass:email nofilter}&nbsp;{$form.email.$blockId.location_type_id.html nofilter}</td>
+      <td align="center">{$form.email.$blockId.on_hold.html nofilter}</td>
+      <td align="center" {if !$multipleBulk}class="crm-email-bulkmail"{/if}>{$form.email.$blockId.is_bulkmail.html nofilter}</td>
+      <td align="center" class="crm-email-is_primary">{$form.email.$blockId.is_primary.1.html nofilter}</td>
       <td><a title="{ts escape='htmlattribute'}Delete Email{/ts}" class="crm-delete-inline crm-hover-button" href="#"><span class="icon delete-icon"></span></a></td>
     </tr>
     {include file="CRM/Contact/Form/Inline/BlockCustomData.tpl" entity=email customFields=$custom_fields_email blockId=$blockId actualBlockCount=$actualBlockCount}

--- a/templates/CRM/Contact/Form/Inline/IM.tpl
+++ b/templates/CRM/Contact/Form/Inline/IM.tpl
@@ -30,10 +30,10 @@
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
     <tr data-entity='im' data-block-number={$blockId} id="IM_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-        <td>{$form.im.$blockId.name.html}&nbsp;</td>
-        <td>{$form.im.$blockId.location_type_id.html}</td>
-        <td>{$form.im.$blockId.provider_id.html}</td>
-        <td align="center" class="crm-im-is_primary">{$form.im.$blockId.is_primary.1.html}</td>
+        <td>{$form.im.$blockId.name.html nofilter}&nbsp;</td>
+        <td>{$form.im.$blockId.location_type_id.html nofilter}</td>
+        <td>{$form.im.$blockId.provider_id.html nofilter}</td>
+        <td align="center" class="crm-im-is_primary">{$form.im.$blockId.is_primary.1.html nofilter}</td>
         <td>
           {if $blockId gt 1}
             <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete IM{/ts}"><span class="icon delete-icon"></span></a>

--- a/templates/CRM/Contact/Form/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Form/Inline/OpenID.tpl
@@ -31,9 +31,9 @@
   {section name='i' start=1 loop=$totalBlocks}
   {assign var='blockId' value=$smarty.section.i.index}
   <tr data-entity='openid' data-block-number={$blockId} id="OpenID_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-    <td>{$form.openid.$blockId.openid.html|crmAddClass:twenty}&nbsp;</td>
-    <td>{$form.openid.$blockId.location_type_id.html}</td>
-    <td align="center" id="OpenID-Primary-html" class="crm-openid-is_primary">{$form.openid.$blockId.is_primary.1.html}</td>
+    <td>{$form.openid.$blockId.openid.html|crmAddClass:twenty nofilter}&nbsp;</td>
+    <td>{$form.openid.$blockId.location_type_id.html nofilter}</td>
+    <td align="center" id="OpenID-Primary-html" class="crm-openid-is_primary">{$form.openid.$blockId.is_primary.1.html nofilter}</td>
     <td>
       {if $blockId gt 1}
         <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete OpenID{/ts}"><span class="icon delete-icon"></span></a>

--- a/templates/CRM/Contact/Form/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Form/Inline/Phone.tpl
@@ -30,10 +30,10 @@
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
       <tr data-entity='phone' data-block-number={$blockId} id="Phone_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-        <td>{$form.phone.$blockId.phone.html}<span class="crm-phone-ext"> {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four}&nbsp;</span></td>
-        <td>{$form.phone.$blockId.location_type_id.html}</td>
-        <td>{$form.phone.$blockId.phone_type_id.html}</td>
-        <td align="center" class="crm-phone-is_primary">{$form.phone.$blockId.is_primary.1.html}</td>
+        <td>{$form.phone.$blockId.phone.html nofilter}<span class="crm-phone-ext"> {ts context="phone_ext"}ext.{/ts}&nbsp;{$form.phone.$blockId.phone_ext.html|crmAddClass:four nofilter}&nbsp;</span></td>
+        <td>{$form.phone.$blockId.location_type_id.html nofilter}</td>
+        <td>{$form.phone.$blockId.phone_type_id.html nofilter}</td>
+        <td align="center" class="crm-phone-is_primary">{$form.phone.$blockId.is_primary.1.html nofilter}</td>
         <td>
           {if $blockId gt 1}
             <a class="crm-delete-inline crm-hover-button" href="#" title="{ts escape='htmlattribute'}Delete phone{/ts}"><span class="icon delete-icon"></span></a>

--- a/templates/CRM/Contact/Form/Inline/Website.tpl
+++ b/templates/CRM/Contact/Form/Inline/Website.tpl
@@ -32,8 +32,8 @@
     {section name='i' start=1 loop=$totalBlocks}
     {assign var='blockId' value=$smarty.section.i.index}
     <tr id="Website_Block_{$blockId}" {if $blockId gt $actualBlockCount}class="hiddenElement"{/if}>
-      <td>{$form.website.$blockId.url.html|crmAddClass:url}&nbsp;</td>
-      <td>{$form.website.$blockId.website_type_id.html}</td>
+      <td>{$form.website.$blockId.url.html|crmAddClass:url nofilter}&nbsp;</td>
+      <td>{$form.website.$blockId.website_type_id.html nofilter}</td>
       {if $blockId gt 1}
         <td><a class="crm-delete-inline crm-hover-button action-item" href="#" title="{ts escape='htmlattribute'}Delete Website{/ts}"><span class="icon delete-icon"></span></a></td>
       {/if}

--- a/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/AdvancedCriteria.tpl
@@ -38,7 +38,7 @@ CRM.$(function($) {
     return false;
   });
   // TODO: Why are the modes numeric? If they used the string there would be no need for this map
-  var modes = {/literal}{$component_mappings|smarty:nodefaults}{literal};
+  var modes = {/literal}{$component_mappings nofilter}{literal};
   // Handle change of results mode
   $('#component_mode').change(function() {
     // Reset task dropdown

--- a/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
+++ b/templates/CRM/Contact/Form/Search/BasicCriteria.tpl
@@ -27,10 +27,10 @@
     <div class="crm-accordion-body">
         <div class="crm-section sort_name-section">
           <div class="label">
-            {$form.sort_name.label}
+            {$form.sort_name.label nofilter}
           </div>
           <div class="content">
-            {$form.sort_name.html}
+            {$form.sort_name.html nofilter}
           </div>
           <div class="clear"></div>
         </div>
@@ -38,10 +38,10 @@
         {if !empty($form.contact_type)}
           <div class="crm-section contact_type-section">
             <div class="label">
-              {$form.contact_type.label}
+              {$form.contact_type.label nofilter}
             </div>
               <div class="content">
-                {$form.contact_type.html}
+                {$form.contact_type.html nofilter}
               </div>
               <div class="clear"></div>
           </div>
@@ -51,16 +51,16 @@
         <div class="crm-section group_selection-section">
           <div class="label">
             {if $context EQ 'smog'}
-              {$form.group_contact_status.label}
+              {$form.group_contact_status.label nofilter}
             {else}
-              {$form.group.label}
+              {$form.group.label nofilter}
             {/if}
           </div>
           <div class="content">
             {if $context EQ 'smog'}
-              {$form.group_contact_status.html}
+              {$form.group_contact_status.html nofilter}
             {else}
-              {$form.group.html|crmAddClass:big}
+              {$form.group.html|crmAddClass:big nofilter}
             {/if}
           </div>
           <div class="clear"></div>
@@ -70,10 +70,10 @@
         {if !empty($form.tag)}
             <div class="crm-section tag-section">
               <div class="label">
-                {$form.tag.label}
+                {$form.tag.label nofilter}
               </div>
               <div class="content">
-                {$form.tag.html|crmAddClass:medium}
+                {$form.tag.html|crmAddClass:medium nofilter}
               </div>
               <div class="clear"></div>
             </div>

--- a/templates/CRM/Contact/Form/Search/Builder.tpl
+++ b/templates/CRM/Contact/Form/Search/Builder.tpl
@@ -24,7 +24,7 @@
         {include file="CRM/Contact/Form/Search/table.tpl"}
         <div class="clear"></div>
         <div id="crm-submit-buttons" class="crm-submit-buttons">
-          {$form.buttons.html}
+          {$form.buttons.html nofilter}
         </div>
       </div>
     </div>
@@ -56,5 +56,5 @@
 {/if}
 </div>
 {/if}
-{$initHideBoxes|smarty:nodefaults}
+{$initHideBoxes nofilter}
 {include file="CRM/Form/validate.tpl"}

--- a/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
+++ b/templates/CRM/Contact/Form/Search/ContactSearchFields.tpl
@@ -1,17 +1,17 @@
 <tr>
   <td>
-    {$form.sort_name.label}
+    {$form.sort_name.label nofilter}
     <br>
-    {$form.sort_name.html|crmAddClass:'twenty'}
+    {$form.sort_name.html|crmAddClass:'twenty' nofilter}
   </td>
-  <td>{$form.buttons.html}</td>
+  <td>{$form.buttons.html nofilter}</td>
 </tr>
 <tr>
   {if !empty($form.contact_tags)}
     <td>
-      <label>{$form.contact_tags.label}</label>
+      <label>{$form.contact_tags.label nofilter}</label>
       <br>
-      {$form.contact_tags.html}
+      {$form.contact_tags.html nofilter}
     </td>
   {else}
     <td>&nbsp;</td>
@@ -19,9 +19,9 @@
 
   {if !empty($form.group)}
     <td>
-      <label>{$form.group.label}</label>
+      <label>{$form.group.label nofilter}</label>
       <br>
-      {$form.group.html}
+      {$form.group.html nofilter}
     </td>
   {else}
     <td>&nbsp;</td>
@@ -29,13 +29,13 @@
 </tr>
 <tr class="crm-event-search-form-block-deleted_contacts">
   <td>
-    {$form.contact_type.label}
+    {$form.contact_type.label nofilter}
     <br>
-    {$form.contact_type.html}
+    {$form.contact_type.html nofilter}
   </td>
   <td>
     {if !empty($form.deleted_contacts)}
-      {$form.deleted_contacts.html}&nbsp;&nbsp;{$form.deleted_contacts.label}
+      {$form.deleted_contacts.html nofilter}&nbsp;&nbsp;{$form.deleted_contacts.label nofilter}
     {/if}
   </td>
 </tr>

--- a/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Basic.tpl
@@ -11,7 +11,7 @@
   {foreach from=$basicSearchFields item=fieldSpec}
     {assign var=field value=$form[$fieldSpec.name]}
     {if $field && !in_array($fieldSpec.name, array('first_name', 'last_name'))}
-      <div class="search-field {if !empty($fieldSpec.class)}{$fieldSpec.class|escape}{/if}">
+      <div class="search-field {if !empty($fieldSpec.class)}{$fieldSpec.class|escape nofilter}{/if}">
         {if !empty($fieldSpec.template)}
           {include file=$fieldSpec.template}
         {else}
@@ -34,7 +34,7 @@
   {/foreach}
   {if !empty($form.deleted_contacts)}
     <div class="search-field">
-      {$form.deleted_contacts.html} {$form.deleted_contacts.label}
+      {$form.deleted_contacts.html nofilter} {$form.deleted_contacts.label nofilter}
     </div>
   {/if}
 </div>

--- a/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/ChangeLog.tpl
@@ -13,7 +13,7 @@
       {include file="CRM/Core/DatePickerRangeWrapper.tpl" fieldName="modified_date" to='' from='' class='' colspan='' hideRelativeLabel=0}
       <td>
         <span class="modifiedBy"><label>{ts}Modified By{/ts}</label></span><br/>
-        {$form.changed_by.html}<br><span class="description">{ts}Note this field just filters on who made a change no matter when that change happened, It doesn't have any link to the modified date field.{/ts}</span>
+        {$form.changed_by.html nofilter}<br><span class="description">{ts}Note this field just filters on who made a change no matter when that change happened, It doesn't have any link to the modified date field.{/ts}</span>
       </td>
     </tr>
     <tr>

--- a/templates/CRM/Contact/Form/Search/Criteria/Demographics.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Demographics.tpl
@@ -22,8 +22,8 @@
     </tr>
     <tr>
       <td>
-        {$form.is_deceased.label}<br />
-        {$form.is_deceased.html}
+        {$form.is_deceased.label nofilter}<br />
+        {$form.is_deceased.html nofilter}
       </td>
     </tr>
     <tr>
@@ -31,8 +31,8 @@
     </tr>
     <tr>
       <td>
-        {$form.gender_id.label}<br />
-        {$form.gender_id.html}
+        {$form.gender_id.label nofilter}<br />
+        {$form.gender_id.html nofilter}
       </td>
     </tr>
   </table>

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/group.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/group.tpl
@@ -5,7 +5,7 @@
     </span>
   </label>
   <br/>
-  {$form.group.html}
+  {$form.group.html nofilter}
 </div>
 <div id='grouptypeselect'>
   <label>
@@ -15,7 +15,7 @@
     </span>
   </label>
   <br/>
-  {$form.group_type.html}
+  {$form.group_type.html nofilter}
   {literal}
     <script type="text/javascript">
       CRM.$(function ($) {

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/preferred_communication_method.tpl
@@ -1,16 +1,16 @@
-{$form.preferred_communication_method.label}
+{$form.preferred_communication_method.label nofilter}
 <br/>
-{$form.preferred_communication_method.html}
+{$form.preferred_communication_method.html nofilter}
 <br/>
 
 {if $form.email_on_hold.type == 'select'}
   <br/>
-  {$form.email_on_hold.label}
+  {$form.email_on_hold.label nofilter}
   <br/>
-  {$form.email_on_hold.html}
+  {$form.email_on_hold.html nofilter}
   <br/>
 {elseif $form.email_on_hold.type == 'checkbox'}
   <div class="spacer"></div>
-  {$form.email_on_hold.html}
-  {$form.email_on_hold.label}
+  {$form.email_on_hold.html nofilter}
+  {$form.email_on_hold.label nofilter}
 {/if}

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/privacy_toggle.tpl
@@ -1,16 +1,16 @@
 <table class="form-layout-compressed">
   <tr>
     <td colspan="2">
-      {$form.privacy_toggle.html} {help id="privacy_toggle"}
+      {$form.privacy_toggle.html nofilter} {help id="privacy_toggle"}
     </td>
   </tr>
   <tr>
     <td>
-      {$form.privacy_options.html}
+      {$form.privacy_options.html nofilter}
     </td>
     <td style="vertical-align:middle">
       <div id="privacy-operator-wrapper">
-        {$form.privacy_operator.html} {help id="privacy_operator"}
+        {$form.privacy_operator.html nofilter} {help id="privacy_operator"}
       </div>
     </td>
   </tr>

--- a/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Fields/sort_name.tpl
@@ -1,10 +1,10 @@
 <div id="sortnameselect">
   <label>{ts}Name{/ts} <span class="description">(<a href="#" id='searchbyindivflds'>{ts}search by individual name fields{/ts}</a>)</span></label><br />
-  {$form.sort_name.html}
+  {$form.sort_name.html nofilter}
 </div>
 <div id="indivfldselect">
   <label>{ts}First/Last Name{/ts}<span class="description"> (<a href="#" id='searchbysortname'>{ts}search by full name{/ts}</a>)</span></label><br />
-  {$form.first_name.html} {$form.last_name.html}
+  {$form.first_name.html nofilter} {$form.last_name.html nofilter}
 </div>
 
 {literal}

--- a/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
@@ -12,8 +12,8 @@
     <tr>
       <td>
         <div id="streetAddress" class="crm-field-wrapper">
-          {$form.street_address.label}<br />
-          {$form.street_address.html|crmAddClass:big}
+          {$form.street_address.label nofilter}<br />
+          {$form.street_address.html|crmAddClass:big nofilter}
           {if $parseStreetAddress}
             <div>
               <a href="#" title="{ts escape='htmlattribute'}Use Address Elements{/ts}" rel="addressElements" class="address-elements-toggle">{ts}Use Address Elements{/ts}</a>
@@ -23,9 +23,9 @@
         {if $parseStreetAddress}
         <div id="addressElements" class="crm-field-wrapper" style="display: none;">
           <table class="crm-block crm-form-block advanced-search-address-elements">
-            <tr><td>{$form.street_number.label}<br />{$form.street_number.html}<br /><span class="description nowrap">{ts}or ODD / EVEN{/ts}</td>
-              <td>{$form.street_name.label}<br />{$form.street_name.html}</td>
-              <td>{$form.street_unit.label}<br />{$form.street_unit.html|crmAddClass:four}</td>
+            <tr><td>{$form.street_number.label nofilter}<br />{$form.street_number.html nofilter}<br /><span class="description nowrap">{ts}or ODD / EVEN{/ts}</td>
+              <td>{$form.street_name.label nofilter}<br />{$form.street_name.html nofilter}</td>
+              <td>{$form.street_unit.label nofilter}<br />{$form.street_unit.html|crmAddClass:four nofilter}</td>
             </tr>
             <tr>
               <td colspan="3"><a href="#" title="{ts escape='htmlattribute'}Use Complete Address{/ts}" rel="streetAddress" class="address-elements-toggle">{ts}Use Street Address{/ts}</a></td>
@@ -34,60 +34,60 @@
         </div>
         {/if}
         <div class="crm-field-wrapper">
-          {$form.supplemental_address_1.label}<br />
-          {$form.supplemental_address_1.html}
+          {$form.supplemental_address_1.label nofilter}<br />
+          {$form.supplemental_address_1.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.supplemental_address_2.label}<br />
-          {$form.supplemental_address_2.html}
+          {$form.supplemental_address_2.label nofilter}<br />
+          {$form.supplemental_address_2.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.supplemental_address_3.label}<br />
-          {$form.supplemental_address_3.html}
+          {$form.supplemental_address_3.label nofilter}<br />
+          {$form.supplemental_address_3.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.city.label}<br />
-          {$form.city.html}
+          {$form.city.label nofilter}<br />
+          {$form.city.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.country.label}<br />
-          {$form.country.html}
+          {$form.country.label nofilter}<br />
+          {$form.country.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.state_province.label}<br />
-          {$form.state_province.html}
+          {$form.state_province.label nofilter}<br />
+          {$form.state_province.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.county.label}<br />
-          {$form.county.html}
+          {$form.county.label nofilter}<br />
+          {$form.county.html nofilter}
         </div>
         <div class="crm-field-wrapper">
-          {$form.world_region.label}<br />
-          {$form.world_region.html}
+          {$form.world_region.label nofilter}<br />
+          {$form.world_region.html nofilter}
         </div>
       </td>
 
       <td>
         <div class="crm-field-wrapper">
-          <div>{$form.location_type.label} {help id="location_type"}</div>
-          {$form.location_type.html}
+          <div>{$form.location_type.label nofilter} {help id="location_type"}</div>
+          {$form.location_type.html nofilter}
         </div>
         {if !empty($form.address_name.html)}
           <div class="crm-field-wrapper">
-            {$form.address_name.label}<br />
-            {$form.address_name.html}
+            {$form.address_name.label nofilter}<br />
+            {$form.address_name.html nofilter}
           </div>
         {/if}
         {if !empty($form.postal_code.html)}
           <div class="crm-field-wrapper">
-            {$form.postal_code.label}
+            {$form.postal_code.label nofilter}
             <input type="checkbox" id="postal-code-range-toggle" value="1"/>
             <label for="postal-code-range-toggle">{ts}Range{/ts}</label><br />
             <div class="postal_code-wrapper">
-              {$form.postal_code.html}
+              {$form.postal_code.html nofilter}
             </div>
             <div class="postal_code_range-wrapper" style="display: none;">
-              {$form.postal_code_low.html}&nbsp;-&nbsp;{$form.postal_code_high.html}
+              {$form.postal_code_low.html nofilter}&nbsp;-&nbsp;{$form.postal_code_high.html nofilter}
             </div>
           </div>
           <script type="text/javascript">
@@ -111,8 +111,8 @@
         {/if}
         {if !empty($form.prox_distance.html)}
           <div class="crm-field-wrapper">
-            {$form.prox_distance.label}<br />
-            {$form.prox_distance.html}&nbsp;{$form.prox_distance_unit.html}
+            {$form.prox_distance.label nofilter}<br />
+            {$form.prox_distance.html nofilter}&nbsp;{$form.prox_distance_unit.html nofilter}
           </div>
         {/if}
       </td>

--- a/templates/CRM/Contact/Form/Search/Criteria/Notes.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Notes.tpl
@@ -11,12 +11,12 @@
   <table class="form-layout">
     <tr>
       <td>
-        {$form.note.label}<br />
-        {$form.note.html}
+        {$form.note.label nofilter}<br />
+        {$form.note.html nofilter}
       </td>
       <td>
-        {$form.note_option.label}<br />
-        {$form.note_option.html}
+        {$form.note_option.label nofilter}<br />
+        {$form.note_option.html nofilter}
       </td>
     </tr>
   </table>

--- a/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Relationship.tpl
@@ -11,13 +11,13 @@
   <table class="form-layout">
     <tr>
       <td>
-        {$form.relation_type_id.label}<br />
-        {$form.relation_type_id.html}
+        {$form.relation_type_id.label nofilter}<br />
+        {$form.relation_type_id.html nofilter}
       </td>
       <td>
          <div>
-           {$form.relation_target_name.label}<br />
-           {$form.relation_target_name.html|crmAddClass:huge}
+           {$form.relation_target_name.label nofilter}<br />
+           {$form.relation_target_name.html|crmAddClass:huge nofilter}
             <div class="description font-italic">
                 {ts}Complete OR partial contact name.{/ts}
             </div>
@@ -26,21 +26,21 @@
     </tr>
     <tr>
       <td>
-         {$form.relation_status.label}<br />
-         {$form.relation_status.html}
+         {$form.relation_status.label nofilter}<br />
+         {$form.relation_status.html nofilter}
          </p>
-         {$form.relation_permission.label}<br />
-         {$form.relation_permission.html}
+         {$form.relation_permission.label nofilter}<br />
+         {$form.relation_permission.html nofilter}
       </td>
       <td>
-        {$form.relation_target_group.label} {help id="relation_target_group" file="CRM/Contact/Form/Search/Advanced.hlp"}<br />
-        {$form.relation_target_group.html|crmAddClass:huge}
+        {$form.relation_target_group.label nofilter} {help id="relation_target_group" file="CRM/Contact/Form/Search/Advanced.hlp"}<br />
+        {$form.relation_target_group.html|crmAddClass:huge nofilter}
       </td>
     </tr>
     <tr>
       <td colspan="2">
-        {$form.relation_description.label}<br />
-        {$form.relation_description.html}
+        {$form.relation_description.label nofilter}<br />
+        {$form.relation_description.html nofilter}
       </td>
     </tr>
     <tr>

--- a/templates/CRM/Contact/Form/Search/Criteria/SearchSettings.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/SearchSettings.tpl
@@ -1,18 +1,18 @@
 <div id="display-settings" class="advanced-search-fields basic-fields form-layout">
   <div class="search-field">
     {if !empty($form.component_mode)}
-      {$form.component_mode.label} {help id="component_mode"}
+      {$form.component_mode.label nofilter} {help id="component_mode"}
       <br />
-      {$form.component_mode.html}
+      {$form.component_mode.html nofilter}
       {if !empty($form.display_relationship_type)}
-        <div id="crm-display_relationship_type">{$form.display_relationship_type.html}</div>
+        <div id="crm-display_relationship_type">{$form.display_relationship_type.html nofilter}</div>
       {/if}
     {else}
       &nbsp;
     {/if}
   </div>
   <div class="search-field">
-    {$form.uf_group_id.label} {help id="uf_group_id"}<br />{$form.uf_group_id.html}
+    {$form.uf_group_id.label nofilter} {help id="uf_group_id"}<br />{$form.uf_group_id.html nofilter}
     {crmPermission has='administer CiviCRM'}
       <a class="crm-hover-button" target="_blank" href="{crmURL p="civicrm/admin/uf/group" q="reset=1" fb=1}">
         {icon icon="fa-wrench"}{ts}Manage Profiles{/ts}{/icon}
@@ -20,6 +20,6 @@
     {/crmPermission}
   </div>
   <div class="search-field">
-    {$form.operator.label} {help id="operator"}<br />{$form.operator.html}
+    {$form.operator.label nofilter} {help id="operator"}<br />{$form.operator.html nofilter}
   </div>
 </div>

--- a/templates/CRM/Contact/Form/Search/Criteria/Task.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Task.tpl
@@ -12,16 +12,16 @@
     <table class="form-layout">
          <tr>
             <td class="label">
-                {$form.task_id.label}
+                {$form.task_id.label nofilter}
             </td>
             <td>
-                {$form.task_id.html}
+                {$form.task_id.html nofilter}
             </td>
             <td class="label">
-                {$form.task_status_id.label}
+                {$form.task_status_id.label nofilter}
             </td>
             <td>
-                {$form.task_status_id.html}
+                {$form.task_status_id.html nofilter}
             </td>
         </tr>
       </table>

--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -49,9 +49,9 @@
     <td> {ts}Select Records{/ts}:</td>
     <td class="nowrap">
       {assign var="checked" value=$selectedContactIds|@count}
-      {$form.radio_ts.ts_all.html} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural="All %count records"}The found record{/ts}</label>
+      {$form.radio_ts.ts_all.html nofilter} <label for="{$ts_all_id}">{ts count=$pager->_totalItems plural="All %count records"}The found record{/ts}</label>
       {if $pager->_totalItems > 1}
-        &nbsp; {$form.radio_ts.ts_sel.html} <label for="{$ts_sel_id}">{ts 1="<span>$checked</span>"}%1 Selected records only{/ts}</label>
+        &nbsp; {$form.radio_ts.ts_sel.html nofilter} <label for="{$ts_sel_id}">{ts 1="<span>$checked</span>"}%1 Selected records only{/ts}</label>
       {/if}
     </td>
   </tr>
@@ -59,19 +59,19 @@
     <td colspan="2">
      {* Hide export button in 'Add Members to Group' context. *}
      {if $context NEQ 'amtg'}
-        {$form.task.html}
+        {$form.task.html nofilter}
      {/if}
      {if $action eq 512}
-       {$form.$actionButtonName.html}
+       {$form.$actionButtonName.html nofilter}
      {elseif $action eq 8192}
        {* todo - just use action button name per above  - test *}
-       {$form._qf_Builder_next_action.html}&nbsp;&nbsp;
+       {$form._qf_Builder_next_action.html nofilter}&nbsp;&nbsp;
      {elseif $action eq 16384}
        {* todo - just use action button name per above - test *}
-       {$form._qf_Custom_next_action.html}&nbsp;&nbsp;
+       {$form._qf_Custom_next_action.html nofilter}&nbsp;&nbsp;
      {else}
        {* todo - just use action button name per above  - test *}
-       {$form._qf_Basic_next_action.html}
+       {$form._qf_Basic_next_action.html nofilter}
      {/if}
      </td>
   </tr>

--- a/templates/CRM/Contact/Form/Search/table.tpl
+++ b/templates/CRM/Contact/Form/Search/table.tpl
@@ -19,10 +19,10 @@
           {assign var="i" value=$smarty.section.cols.index}
           <tr>
             <td class="form-item even-row">
-              {$form.mapper[$x][$i].html}
-              {$form.operator[$x][$i].html|crmAddClass:'required'}&nbsp;&nbsp;
+              {$form.mapper[$x][$i].html nofilter}
+              {$form.operator[$x][$i].html|crmAddClass:'required' nofilter}&nbsp;&nbsp;
               <span class="crm-search-value" id="crm_search_value_{$x}_{$i}">
-                {$form.value[$x][$i].html|crmAddClass:'required'}
+                {$form.value[$x][$i].html|crmAddClass:'required' nofilter}
               </span>
               {if $i gt 0 or $x gt 1}
                 &nbsp;<a href="#" class="crm-reset-builder-row crm-hover-button" title="{ts escape='htmlattribute'}Remove this row{/ts}"><i class="crm-i fa-times" role="img" aria-hidden="true"></i></a>
@@ -33,12 +33,12 @@
 
         <tr class="crm-search-builder-add-row">
           <td class="form-item even-row underline-effect">
-            {$form.addMore[$x].html}
+            {$form.addMore[$x].html nofilter}
           </td>
         </tr>
       </table>
     </div>
   {/section}
-  <h3 class="crm-search-builder-add-block underline-effect">{$form.addBlock.html}</h3>
+  <h3 class="crm-search-builder-add-block underline-effect">{$form.addBlock.html nofilter}</h3>
 {/strip}
 </div>

--- a/templates/CRM/Contact/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToGroup.tpl
@@ -12,14 +12,14 @@
     {if $form.group_id.value}
        <tr class="crm-contact-task-addtogroup-form-block-group_id">
           <td class="label">{ts}Group{/ts}</td>
-          <td>{$form.group_id.html}</td>
+          <td>{$form.group_id.html nofilter}</td>
        </tr>
     {else}
-        <tr><td>{$form.group_option.html}</td></tr>
+        <tr><td>{$form.group_option.html nofilter}</td></tr>
         <tr id="id_existing_group">
             <td>
                 <table class="form-layout">
-                <tr><td class="label">{$form.group_id.label}<span class="crm-marker">*</span></td><td>{$form.group_id.html}</td></tr>
+                <tr><td class="label">{$form.group_id.label nofilter}<span class="crm-marker">*</span></td><td>{$form.group_id.html nofilter}</td></tr>
                 </table>
             </td>
         </tr>
@@ -27,16 +27,16 @@
             <td>
                 <table class="form-layout">
                 <tr class="crm-contact-task-addtogroup-form-block-title">
-                   <td class="label">{$form.title.label}<span class="crm-marker">*</span></td>
-                   <td>{$form.title.html}</td>
+                   <td class="label">{$form.title.label nofilter}<span class="crm-marker">*</span></td>
+                   <td>{$form.title.html nofilter}</td>
                 <tr>
                 <tr class="crm-contact-task-addtogroup-form-block-description">
-                   <td class="label">{$form.description.label}</td>
-                   <td>{$form.description.html}</td></tr>
+                   <td class="label">{$form.description.label nofilter}</td>
+                   <td>{$form.description.html nofilter}</td></tr>
                 {if !empty($form.group_type)}
                 <tr class="crm-contact-task-addtogroup-form-block-group_type">
-        <td class="label">{$form.group_type.label}</td>
-                    <td>{$form.group_type.html}</td>
+        <td class="label">{$form.group_type.label nofilter}</td>
+                    <td>{$form.group_type.html nofilter}</td>
                 </tr>
                 {/if}
                 <tr>

--- a/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToParentClass.tpl
@@ -20,15 +20,15 @@
                 <tr><td><label>{$sort_name}</label></td></tr>
             {else} {* action = add *}
                 <tr class="crm-contact-task-addto{$contactType}-form-block-relationship_type_id">
-                    <td>{$form.relationship_type_id.label}</td>
-                    <td>{$form.relationship_type_id.html}</td>
+                    <td>{$form.relationship_type_id.label nofilter}</td>
+                    <td>{$form.relationship_type_id.html nofilter}</td>
                 </tr>
                 <tr><td></td></tr>
                 <tr class="crm-contact-task-addto{$contactType}-form-block-name">
-                    <td>{$form.name.label}</td>
-                    <td>{$form.name.html}</td>
+                    <td>{$form.name.label nofilter}</td>
+                    <td>{$form.name.html nofilter}</td>
                 </tr>
-                <tr><td></td><td>{$form.$refresh.html}&nbsp;&nbsp;{$form.$cancel.html}</td></tr>
+                <tr><td></td><td>{$form.$refresh.html nofilter}&nbsp;&nbsp;{$form.$cancel.html nofilter}</td></tr>
      </table>
          {if $searchDone} {* Search button clicked *}
              {if $searchCount}
@@ -49,7 +49,7 @@
                         </tr>
                         {foreach from=$searchRows item=row}
                         <tr class="{cycle values="odd-row,even-row"}">
-                            <td>{$form.contact_check[$row.id].html}</td>
+                            <td>{$form.contact_check[$row.id].html nofilter}</td>
                             <td>{$row.type} {$row.name}</td>
                             <td>{$row.city}</td>
                             <td>{$row.state}</td>

--- a/templates/CRM/Contact/Form/Task/AlterPreferences.tpl
+++ b/templates/CRM/Contact/Form/Task/AlterPreferences.tpl
@@ -10,7 +10,7 @@
 <div class="crm-form-block crm-block crm-contact-task-addtodonot-form-block">
   <h3>{ts}Communication Preferences{/ts}</h3>
   <table class="form-layout-compressed">
-    <tr><td>{$form.actionTypeOption.html}</td></tr>
+    <tr><td>{$form.actionTypeOption.html nofilter}</td></tr>
     <tr class="crm-contact-task-addtodonot-form-block-pref">
         <td>
             <div class="listing-box">

--- a/templates/CRM/Contact/Form/Task/Batch.tpl
+++ b/templates/CRM/Contact/Form/Task/Batch.tpl
@@ -46,7 +46,7 @@
               {foreach name=optionOuter key=optionKey item=optionItem from=$form.field.$cid.$n}
                 {* There are both numeric and non-numeric keys mixed in here, where the non-numeric are metadata that aren't arrays with html members. *}
                 {if is_array($optionItem) && array_key_exists('html', $optionItem)}
-                  <td class="labels font-light">{$form.field.$cid.$n.$optionKey.html}</td>
+                  <td class="labels font-light">{$form.field.$cid.$n.$optionKey.html nofilter}</td>
                   {if $count == $field.options_per_line}
                   </tr>
                   <tr>
@@ -63,19 +63,19 @@
       {elseif $n|substr:0:5 eq 'phone'}
         <td class="compressed">
           {assign var="phone_ext_field" value=$n|replace:'phone':'phone_ext'}
-          {$form.field.$cid.$n.html}
+          {$form.field.$cid.$n.html nofilter}
           {if $form.field.$cid.$phone_ext_field.html}
-            &nbsp;{$form.field.$cid.$phone_ext_field.html}
+            &nbsp;{$form.field.$cid.$phone_ext_field.html nofilter}
           {/if}
         </td>
       {else}
-        <td class="compressed">{$form.field.$cid.$n.html}</td>
+        <td class="compressed">{$form.field.$cid.$n.html nofilter}</td>
       {/if}
     {/foreach}
   {/foreach}
   </tr>
   </table>
-{if $fields}{$form._qf_BatchUpdateProfile_refresh.html}{/if} &nbsp;<div class="crm-submit-buttons">{$form.buttons.html}</div>
+{if $fields}{$form._qf_BatchUpdateProfile_refresh.html nofilter}{/if} &nbsp;<div class="crm-submit-buttons">{$form.buttons.html nofilter}</div>
 
 </div>
 

--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -17,29 +17,29 @@
 
 <table class="form-layout-compressed">
   <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
-    <td class="label">{$form.from_email_address.label}</td>
+    <td class="label">{$form.from_email_address.label nofilter}</td>
     <td>
-      {$form.from_email_address.html}
+      {$form.from_email_address.html nofilter}
       {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp" title=$tokenTitle}
     </td>
   </tr>
     <tr class="crm-contactEmail-form-block-recipient">
-       <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>
+       <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label nofilter}{/if}</td>
        <td>
-         {$form.to.html} {help id="to" file="CRM/Contact/Form/Task/Email.hlp"}
+         {$form.to.html nofilter} {help id="to" file="CRM/Contact/Form/Task/Email.hlp"}
        </td>
     </tr>
     <tr class="crm-contactEmail-form-block-cc_id" {if empty($form.cc_id.value)}style="display:none;"{/if}>
-      <td class="label">{$form.cc_id.label}</td>
+      <td class="label">{$form.cc_id.label nofilter}</td>
       <td>
-        {$form.cc_id.html}
+        {$form.cc_id.html nofilter}
         <a class="crm-hover-button clear-cc-link" rel="cc_id" title="{ts escape='htmlattribute'}Clear{/ts}" href="#"><i class="crm-i fa-times" role="img" aria-hidden="true"></i></a>
       </td>
     </tr>
     <tr class="crm-contactEmail-form-block-bcc_id" {if empty($form.bcc_id.value)}style="display:none;"{/if}>
-      <td class="label">{$form.bcc_id.label}</td>
+      <td class="label">{$form.bcc_id.label nofilter}</td>
       <td>
-        {$form.bcc_id.html}
+        {$form.bcc_id.html nofilter}
         <a class="crm-hover-button clear-cc-link" rel="bcc_id" title="{ts escape='htmlattribute'}Clear{/ts}" href="#"><i class="crm-i fa-times" role="img" aria-hidden="true"></i></a>
       </td>
     </tr>
@@ -55,14 +55,14 @@
 
 {if $emailTask}
     <tr class="crm-contactEmail-form-block-template">
-        <td class="label">{$form.template.label}</td>
-        <td>{$form.template.html}</td>
+        <td class="label">{$form.template.label nofilter}</td>
+        <td>{$form.template.html nofilter}</td>
     </tr>
 {/if}
     <tr class="crm-contactEmail-form-block-subject">
-       <td class="label">{$form.subject.label}</td>
+       <td class="label">{$form.subject.label nofilter}</td>
        <td>
-         {$form.subject.html|crmAddClass:huge}&nbsp;
+         {$form.subject.html|crmAddClass:huge nofilter}&nbsp;
          <input class="crm-token-selector big" data-field="subject" />
          {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}
        </td>
@@ -88,7 +88,7 @@
 
 {literal}
 CRM.$(function($) {
-  var $form = $("form.{/literal}{$form.formClass}{literal}");
+  var $form = $("form.{/literal}{$form.formClass nofilter}{literal}");
 
   $('.add-cc-link', $form).click(function(e) {
     e.preventDefault();

--- a/templates/CRM/Contact/Form/Task/EmailCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/EmailCommon.tpl
@@ -20,7 +20,7 @@
   </div>
   <div class="clear"></div>
     <div class='html'>
-      {$form.html_message.html}<br />
+      {$form.html_message.html nofilter}<br />
     </div>
   </div>
 </details>
@@ -36,24 +36,24 @@
      {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}
    </div>
     <div class='text'>
-      {$form.text_message.html}<br />
+      {$form.text_message.html nofilter}<br />
     </div>
   </div>
 </details>
 
 <div id="editMessageDetails">
   <div id="updateDetails" >
-    {if array_key_exists('updateTemplate', $form)}{$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}{/if}
+    {if array_key_exists('updateTemplate', $form)}{$form.updateTemplate.html nofilter}&nbsp;{$form.updateTemplate.label nofilter}{/if}
   </div>
   <div>
-    {if array_key_exists('saveTemplate', $form)}{$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}{/if}
+    {if array_key_exists('saveTemplate', $form)}{$form.saveTemplate.html nofilter}&nbsp;{$form.saveTemplate.label nofilter}{/if}
   </div>
 </div>
 
 <div id="saveDetails" class="section">
   {if array_key_exists('saveTemplateName', $form)}
-    <div class="label">{$form.saveTemplateName.label}</div>
-    <div class="content">{$form.saveTemplateName.html|crmAddClass:huge}</div>
+    <div class="label">{$form.saveTemplateName.label nofilter}</div>
+    <div class="content">{$form.saveTemplateName.html|crmAddClass:huge nofilter}</div>
   {/if}
 </div>
 

--- a/templates/CRM/Contact/Form/Task/Label.tpl
+++ b/templates/CRM/Contact/Form/Task/Label.tpl
@@ -11,21 +11,21 @@
   <div class="messages status no-popup">{include file="CRM/Contact/Form/Task.tpl"}</div>
   <table class="form-layout-compressed">
      <tr class="crm-contact-task-mailing-label-form-block-label_name">
-        <td class="label">{$form.label_name.label}</td>
-        <td>{$form.label_name.html} {help id="label_name" file="CRM/Contact/Form/Task/Label.hlp"}</td>
+        <td class="label">{$form.label_name.label nofilter}</td>
+        <td>{$form.label_name.html nofilter} {help id="label_name" file="CRM/Contact/Form/Task/Label.hlp"}</td>
      </tr>
      <tr class="crm-contact-task-mailing-label-form-block-location_type_id">
-        <td class="label">{$form.location_type_id.label}</td>
-        <td>{$form.location_type_id.html}</td>
+        <td class="label">{$form.location_type_id.label nofilter}</td>
+        <td>{$form.location_type_id.html nofilter}</td>
      </tr>
      <tr class="crm-contact-task-mailing-label-form-block-do_not_mail">
-        <td></td> <td>{$form.do_not_mail.html} {$form.do_not_mail.label}</td>
+        <td></td> <td>{$form.do_not_mail.html nofilter} {$form.do_not_mail.label nofilter}</td>
      </tr>
      <tr class="crm-contact-task-mailing-label-form-block-merge_same_address">
-        <td></td><td>{$form.merge_same_address.html} {$form.merge_same_address.label}</td>
+        <td></td><td>{$form.merge_same_address.html nofilter} {$form.merge_same_address.label nofilter}</td>
      </tr>
      <tr class="crm-contact-task-mailing-label-form-block-merge_same_household">
-        <td></td><td>{$form.merge_same_household.html} {$form.merge_same_household.label}</td>
+        <td></td><td>{$form.merge_same_household.html nofilter} {$form.merge_same_household.label nofilter}</td>
      </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>

--- a/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/PDFLetterCommon.tpl
@@ -13,21 +13,21 @@
 <table class="form-layout-compressed">
     <tr>
       <td class="label-left">
-        {$form.template.label}
+        {$form.template.label nofilter}
         {help id="template" file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}
       </td>
       <td>
-        {$form.template.html} {ts}OR{/ts} {$form.document_file.html}
+        {$form.template.html nofilter} {ts}OR{/ts} {$form.document_file.html nofilter}
       </td>
     </tr>
     <tr>
-      <td class="label-left">{$form.subject.label}</td>
-      <td>{$form.subject.html}</td>
+      <td class="label-left">{$form.subject.label nofilter}</td>
+      <td>{$form.subject.html nofilter}</td>
     </tr>
     {if !empty($form.campaign_id)}
     <tr>
-      <td class="label-left">{$form.campaign_id.label}</td>
-      <td>{$form.campaign_id.html}</td>
+      <td class="label-left">{$form.campaign_id.label nofilter}</td>
+      <td>{$form.campaign_id.html nofilter}</td>
     </tr>
     {/if}
 </table>
@@ -41,15 +41,15 @@
       <div class="crm-block crm-form-block">
     <table class="form-layout-compressed">
       <tr>
-        <td class="label-left">{$form.format_id.label} {help id="format_id" file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}</td>
-        <td>{$form.format_id.html}</td>
+        <td class="label-left">{$form.format_id.label nofilter} {help id="format_id" file="CRM/Contact/Form/Task/PDFLetterCommon.hlp"}</td>
+        <td>{$form.format_id.html nofilter}</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.paper_size.label}</td><td>{$form.paper_size.html}</td>
-        <td class="label-left">{$form.orientation.label}</td><td>{$form.orientation.html}</td>
+        <td class="label-left">{$form.paper_size.label nofilter}</td><td>{$form.paper_size.html nofilter}</td>
+        <td class="label-left">{$form.orientation.label nofilter}</td><td>{$form.orientation.html nofilter}</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.metric.label}</td><td>{$form.metric.html}</td>
+        <td class="label-left">{$form.metric.label nofilter}</td><td>{$form.metric.html nofilter}</td>
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>
@@ -57,12 +57,12 @@
         <td colspan="2">&nbsp;</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.margin_top.label}</td><td>{$form.margin_top.html}</td>
-        <td class="label-left">{$form.margin_bottom.label}</td><td>{$form.margin_bottom.html}</td>
+        <td class="label-left">{$form.margin_top.label nofilter}</td><td>{$form.margin_top.html nofilter}</td>
+        <td class="label-left">{$form.margin_bottom.label nofilter}</td><td>{$form.margin_bottom.html nofilter}</td>
       </tr>
       <tr>
-        <td class="label-left">{$form.margin_left.label}</td><td>{$form.margin_left.html}</td>
-        <td class="label-left">{$form.margin_right.label}</td><td>{$form.margin_right.html}</td>
+        <td class="label-left">{$form.margin_left.label nofilter}</td><td>{$form.margin_left.html nofilter}</td>
+        <td class="label-left">{$form.margin_right.label nofilter}</td><td>{$form.margin_right.html nofilter}</td>
       </tr>
       {* CRM-15883 Suppressing stationery until switch from DOMPDF.
       <tr>
@@ -71,8 +71,8 @@
       </tr>
       *}
     </table>
-        <div id="bindFormat">{$form.bind_format.html}&nbsp;{$form.bind_format.label}</div>
-        <div id="updateFormat" style="display: none">{$form.update_format.html}&nbsp;{$form.update_format.label}</div>
+        <div id="bindFormat">{$form.bind_format.html nofilter}&nbsp;{$form.bind_format.label nofilter}</div>
+        <div id="updateFormat" style="display: none">{$form.update_format.html nofilter}&nbsp;{$form.update_format.label nofilter}</div>
       </div>
   </div>
 </details>
@@ -88,7 +88,7 @@
 
 <details class="crm-accordion-bold crm-html_email-accordion " open>
 <summary>
-    {$form.html_message.label}
+    {$form.html_message.label nofilter}
 </summary>
  <div class="crm-accordion-body">
    <div class="helpIcon" id="helphtml">
@@ -97,22 +97,22 @@
    </div>
     <div class="clear"></div>
     <div class='html'>
-  {$form.html_message.html}<br />
+  {$form.html_message.html nofilter}<br />
     </div>
 
 <div id="editMessageDetails">
     <div id="updateDetails" >
-      {if array_key_exists('updateTemplate', $form)}{$form.updateTemplate.html}&nbsp;{$form.updateTemplate.label}{/if}
+      {if array_key_exists('updateTemplate', $form)}{$form.updateTemplate.html nofilter}&nbsp;{$form.updateTemplate.label nofilter}{/if}
     </div>
     <div>
-      {if array_key_exists('saveTemplate', $form)}{$form.saveTemplate.html}&nbsp;{$form.saveTemplate.label}{/if}
+      {if array_key_exists('saveTemplate', $form)}{$form.saveTemplate.html nofilter}&nbsp;{$form.saveTemplate.label nofilter}{/if}
     </div>
 </div>
 
 <div id="saveDetails" class="section">
   {if array_key_exists('saveTemplateName', $form)}
-    <div class="label">{$form.saveTemplateName.label}</div>
-    <div class="content">{$form.saveTemplateName.html|crmAddClass:huge}</div>
+    <div class="label">{$form.saveTemplateName.label nofilter}</div>
+    <div class="content">{$form.saveTemplateName.html|crmAddClass:huge nofilter}</div>
   {/if}
 </div>
 
@@ -121,8 +121,8 @@
 
 <table class="form-layout-compressed">
   <tr>
-    <td class="label-left">{$form.document_type.label}</td>
-    <td>{$form.document_type.html}</td>
+    <td class="label-left">{$form.document_type.label nofilter}</td>
+    <td>{$form.document_type.html nofilter}</td>
   </tr>
 </table>
 
@@ -131,7 +131,7 @@
 {literal}
 <script type="text/javascript">
 CRM.$(function($) {
-  var $form = $('form.{/literal}{$form.formClass}{literal}');
+  var $form = $('form.{/literal}{$form.formClass nofilter}{literal}');
 
   {/literal}{if $form.formName eq 'PDF'}{literal}
     $('.crm-document-accordion').hide();

--- a/templates/CRM/Contact/Form/Task/PickProfile.tpl
+++ b/templates/CRM/Contact/Form/Task/PickProfile.tpl
@@ -11,8 +11,8 @@
 <div class="crm-block crm-form-block crm-contact-task-pickprofile-form-block">
  <table class="form-layout-compressed">
     <tr class="crm-contact-task-pickprofile-form-block-uf_group_id">
-       <td class="label">{$form.uf_group_id.label}</td>
-       <td>{$form.uf_group_id.html}</td>
+       <td class="label">{$form.uf_group_id.label nofilter}</td>
+       <td>{$form.uf_group_id.html nofilter}</td>
     </tr>
     <tr>
         <td class="label"></td>

--- a/templates/CRM/Contact/Form/Task/ProximityCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/ProximityCommon.tpl
@@ -10,12 +10,12 @@
 <fieldset>
     <legend>{ts}By Distance from a Location{/ts}</legend>
     <table class="form-layout-compressed">
-       <tr><td class="label">{$form.prox_distance.label}</td><td>{$form.prox_distance.html|crmAddClass:four} {$form.prox_distance_unit.html}</td></tr>
+       <tr><td class="label">{$form.prox_distance.label nofilter}</td><td>{$form.prox_distance.html|crmAddClass:four nofilter} {$form.prox_distance_unit.html nofilter}</td></tr>
        <tr><td class="label">{ts}FROM...{/ts}</td><td></td></tr>
-       <tr><td class="label">{$form.prox_street_address.label}</td><td>{$form.prox_street_address.html}</td></tr>
-       <tr><td class="label">{$form.prox_city.label}</td><td>{$form.prox_city.html}</td></tr>
-       <tr><td class="label">{$form.prox_postal_code.label}</td><td>{$form.prox_postal_code.html}</td></tr>
-       <tr><td class="label">{$form.prox_country_id.label}</td><td>{$form.prox_country_id.html}</td></tr>
-       <tr><td class="label" style="white-space: nowrap;">{$form.prox_state_province_id.label}</td><td>{$form.prox_state_province_id.html}</td></tr>
+       <tr><td class="label">{$form.prox_street_address.label nofilter}</td><td>{$form.prox_street_address.html nofilter}</td></tr>
+       <tr><td class="label">{$form.prox_city.label nofilter}</td><td>{$form.prox_city.html nofilter}</td></tr>
+       <tr><td class="label">{$form.prox_postal_code.label nofilter}</td><td>{$form.prox_postal_code.html nofilter}</td></tr>
+       <tr><td class="label">{$form.prox_country_id.label nofilter}</td><td>{$form.prox_country_id.html nofilter}</td></tr>
+       <tr><td class="label" style="white-space: nowrap;">{$form.prox_state_province_id.label nofilter}</td><td>{$form.prox_state_province_id.html nofilter}</td></tr>
     </table>
 </fieldset>

--- a/templates/CRM/Contact/Form/Task/RemoveFromGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/RemoveFromGroup.tpl
@@ -10,8 +10,8 @@
 <div class="crm-form-block crm-block crm-contact-task-removefromgroup-form-block">
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-removefromgroupform-block-group_id">
-      <td class="label">{if $group.id}{ts}Group{/ts}{else}{$form.group_id.label}{/if}</td>
-      <td>{$form.group_id.html}</td>
+      <td class="label">{if $group.id}{ts}Group{/ts}{else}{$form.group_id.label nofilter}{/if}</td>
+      <td>{$form.group_id.html nofilter}</td>
     </tr>
     <tr>
       <td></td><td>{include file="CRM/Contact/Form/Task.tpl"}</td>

--- a/templates/CRM/Contact/Form/Task/Result.tpl
+++ b/templates/CRM/Contact/Form/Task/Result.tpl
@@ -11,7 +11,7 @@
 
 <div class="crm-submit-buttons">
     <p>
-    {$form.buttons.html}
+    {$form.buttons.html nofilter}
     </p>
 </div>
 

--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -26,24 +26,24 @@
 
 <table class="form-layout-compressed">
     <tr class="crm-contactProvider-form-block-Provider">
-       <td class="label">{$form.sms_provider_id.label}</td>
-       <td>{$form.sms_provider_id.html} {help id="sms_provider_id" file="CRM/Contact/Form/Task/SMS.hlp"}</td>
+       <td class="label">{$form.sms_provider_id.label nofilter}</td>
+       <td>{$form.sms_provider_id.html nofilter} {help id="sms_provider_id" file="CRM/Contact/Form/Task/SMS.hlp"}</td>
     </tr>
     <tr class="crm-contactsms-form-block-recipient">
-       <td class="label">{$form.to.label}</td>
-       <td>{$form.to.html}
+       <td class="label">{$form.to.label nofilter}</td>
+       <td>{$form.to.html nofilter}
     <div class="spacer"></div>
       </td>
      </tr>
-   <tr><td class="label">{$form.activity_subject.label}</td>
-        <td class="value">{$form.activity_subject.html}</td>
+   <tr><td class="label">{$form.activity_subject.label nofilter}</td>
+        <td class="value">{$form.activity_subject.html nofilter}</td>
    </tr>
 
 
 {if array_key_exists('SMStemplate', $form)}
     <tr class="crm-contactPhone-form-block-template">
-        <td class="label">{$form.SMStemplate.label}</td>
-        <td>{$form.SMStemplate.html}</td>
+        <td class="label">{$form.SMStemplate.label nofilter}</td>
+        <td>{$form.SMStemplate.html nofilter}</td>
     </tr>
 {/if}
 

--- a/templates/CRM/Contact/Form/Task/SMSCommon.tpl
+++ b/templates/CRM/Contact/Form/Task/SMSCommon.tpl
@@ -11,7 +11,7 @@
 {capture assign='tokenTitle'}{ts}Tokens{/ts}{/capture}
 <details class="crm-accordion-bold crm-plaint_text_sms-accordion " open>
 <summary>
-  {$form.sms_text_message.label}
+  {$form.sms_text_message.label nofilter}
   </summary>
  <div class="crm-accordion-body">
  <div><span id="char-count-message"></span> <span id="char-count-help">{help id="sms_text_message" tplFile=$tplFile file="CRM/Contact/Form/Task/SMS.hlp"}</span></div>
@@ -20,23 +20,23 @@
      {help id="id-token-text" tplFile=$tplFile file="CRM/Contact/Form/Task/SMS.hlp" title=$tokenTitle}
    </div>
     <div class='text'>
-  {$form.sms_text_message.html}<br />
+  {$form.sms_text_message.html nofilter}<br />
     </div>
   </div>
 </details>
 <div id="SMSeditMessageDetails" class="section">
   <div id="SMSupdateDetails" class="section" >
-    {if array_key_exists('SMSupdateTemplate', $form)}{$form.SMSupdateTemplate.html}&nbsp;{$form.SMSupdateTemplate.label}{/if}
+    {if array_key_exists('SMSupdateTemplate', $form)}{$form.SMSupdateTemplate.html nofilter}&nbsp;{$form.SMSupdateTemplate.label nofilter}{/if}
   </div>
   <div class="section">
-    {if array_key_exists('SMSsaveTemplate', $form)}{$form.SMSsaveTemplate.html}&nbsp;{$form.SMSsaveTemplate.label}{/if}
+    {if array_key_exists('SMSsaveTemplate', $form)}{$form.SMSsaveTemplate.html nofilter}&nbsp;{$form.SMSsaveTemplate.label nofilter}{/if}
   </div>
 </div>
 
 <div id="SMSsaveDetails" class="section">
   {if array_key_exists('SMSsaveTemplateName', $form)}
-    <div class="label">{$form.SMSsaveTemplateName.label}</div>
-    <div class="content">{$form.SMSsaveTemplateName.html|crmAddClass:huge}</div>
+    <div class="label">{$form.SMSsaveTemplateName.label nofilter}</div>
+    <div class="content">{$form.SMSsaveTemplateName.html|crmAddClass:huge nofilter}</div>
   {/if}
 </div>
 

--- a/templates/CRM/Contact/Form/Task/SaveSearch.tpl
+++ b/templates/CRM/Contact/Form/Task/SaveSearch.tpl
@@ -27,17 +27,17 @@
   </div>
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-createsmartgroup-form-block-title">
-      <td class="label">{$form.title.label}</td>
-      <td>{$form.title.html}</td>
+      <td class="label">{$form.title.label nofilter}</td>
+      <td>{$form.title.html nofilter}</td>
     </tr>
     <tr class="crm-contact-task-createsmartgroup-form-block-description">
-      <td class="label">{$form.description.label}</td>
-      <td>{$form.description.html}</td>
+      <td class="label">{$form.description.label nofilter}</td>
+      <td>{$form.description.html nofilter}</td>
     </tr>
     {if !empty($form.group_type)}
       <tr class="crm-contact-task-createsmartgroup-form-block-group_type">
-        <td class="label">{$form.group_type.label}</td>
-        <td>{$form.group_type.html}</td>
+        <td class="label">{$form.group_type.label nofilter}</td>
+        <td>{$form.group_type.html nofilter}</td>
       </tr>
       <tr>
         <td colspan=2>{include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='Group' customDataSubType=false cid=false}</td>

--- a/templates/CRM/Contact/Import/Form/CSV.tpl
+++ b/templates/CRM/Contact/Import/Form/CSV.tpl
@@ -10,8 +10,8 @@
 <h3>{ts}Upload CSV File{/ts}</h3>
   <table class="form-layout">
     <tr>
-        <td class="label">{$form.uploadFile.label}</td>
-        <td>{$form.uploadFile.html}<br />
+        <td class="label">{$form.uploadFile.label nofilter}</td>
+        <td>{$form.uploadFile.html nofilter}<br />
             <div class="description">
               {ts}File format must be comma-separated-values (CSV). File must be UTF8 encoded if it contains special characters (e.g. accented letters, etc.).{/ts}<br />
               {ts 1=$uploadSize}Maximum Upload File Size: %1 MB{/ts}
@@ -20,11 +20,11 @@
     </tr>
     <tr>
         <td></td>
-        <td>{$form.skipColumnHeader.html} {$form.skipColumnHeader.label}</td>
+        <td>{$form.skipColumnHeader.html nofilter} {$form.skipColumnHeader.label nofilter}</td>
     </tr>
     <tr class="crm-import-datasource-form-block-fieldSeparator">
-      <td class="label">{$form.fieldSeparator.label} {help id='fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
-      <td>{$form.fieldSeparator.html}</td>
+      <td class="label">{$form.fieldSeparator.label nofilter} {help id='fieldSeparator' file='CRM/Contact/Import/Form/DataSource'}</td>
+      <td>{$form.fieldSeparator.html nofilter}</td>
     </tr>
   </table>
 

--- a/templates/CRM/Contact/Import/Form/MapField.tpl
+++ b/templates/CRM/Contact/Import/Form/MapField.tpl
@@ -40,6 +40,6 @@
  {/literal}
 
  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
- {$initHideBoxes|smarty:nodefaults}
+ {$initHideBoxes nofilter}
 
 </div>

--- a/templates/CRM/Contact/Import/Form/Mapper.tpl
+++ b/templates/CRM/Contact/Import/Form/Mapper.tpl
@@ -15,7 +15,7 @@
    <dl>
      {section name=count start=1 loop=`$maxMapper`}
      {assign var='i' value=$smarty.section.count.index}
-       <dt>{$form.mapper[$i].label}</dt><dd>{$form.mapper[$i].html|smarty:nodefaults}<span class="tundra" id="id_map_mapper[{$i}]_1"><span id="id_mapper[{$i}]_1"></span></span><span class="tundra" id="id_map_mapper[{$i}]_2"><span id="id_mapper[{$i}]_2"></span></span><span class="tundra" id="id_map_mapper[{$i}]_3"><span id="id_mapper[{$i}]_3"></span></span></dd>
+       <dt>{$form.mapper[$i].label nofilter}</dt><dd>{$form.mapper[$i].html nofilter}<span class="tundra" id="id_map_mapper[{$i}]_1"><span id="id_mapper[{$i}]_1"></span></span><span class="tundra" id="id_map_mapper[{$i}]_2"><span id="id_mapper[{$i}]_2"></span></span><span class="tundra" id="id_map_mapper[{$i}]_3"><span id="id_mapper[{$i}]_3"></span></span></dd>
 
        {literal}
         <script type="text/javascript">
@@ -34,7 +34,7 @@
 
 <div id="crm-submit-buttons" class="form-item">
 <dl>
-   <dt>&nbsp;</dt><dd>{$form.buttons.html}</dd>
+   <dt>&nbsp;</dt><dd>{$form.buttons.html nofilter}</dd>
 </dl>
 </div>
 

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -39,7 +39,7 @@
       <tr class="error"><td class="label crm-grid-cell">{ts}Rows with Errors{/ts}</td>
         <td class="data">{$invalidRowCount}</td>
         <td class="explanation">{ts}Rows with invalid data in one or more fields (for example, invalid email address formatting). These rows will be skipped (not imported).{/ts}
-          <div class="action-link"><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}"><i class="crm-i fa-download" role="img" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
+          <div class="action-link"><a href="{$downloadErrorRecordsUrl nofilter}"><i class="crm-i fa-download" role="img" aria-hidden="true"></i> {ts}Download Errors{/ts}</a></div>
         </td>
       </tr>
     {/if}
@@ -63,16 +63,16 @@
  <div class="crm-accordion-body">
             <table class="form-layout-compressed">
              <tr>
-               <td class="description label">{$form.newGroupName.label}</td>
-               <td>{$form.newGroupName.html}</td>
+               <td class="description label">{$form.newGroupName.label nofilter}</td>
+               <td>{$form.newGroupName.html nofilter}</td>
              </tr>
              <tr>
-               <td class="description label">{$form.newGroupDesc.label}</td>
-               <td>{$form.newGroupDesc.html}</td>
+               <td class="description label">{$form.newGroupDesc.label nofilter}</td>
+               <td>{$form.newGroupDesc.html nofilter}</td>
              </tr>
              <tr>
-               <td class="description label">{$form.newGroupType.label}</td>
-               <td>{$form.newGroupType.html}</td>
+               <td class="description label">{$form.newGroupType.label nofilter}</td>
+               <td>{$form.newGroupType.html nofilter}</td>
              </tr>
             </table>
  </div>
@@ -83,12 +83,12 @@
 
 <details id="existing-groups" class="crm-accordion-bold crm-existing_group-accordion" {if !empty($form.groups)}open{/if}>
  <summary>
-  {$form.groups.label}
+  {$form.groups.label nofilter}
  </summary>
  <div class="crm-accordion-body">
 
         <div class="form-item">
-        <table><tr><td style="width: 14em;"></td><td>{$form.groups.html}</td></tr></table>
+        <table><tr><td style="width: 14em;"></td><td>{$form.groups.html nofilter}</td></tr></table>
         </div>
  </div>
 </details>
@@ -104,12 +104,12 @@
   <div class="form-item">
   <table class="form-layout-compressed">
            <tr>
-               <td class="description label">{$form.newTagName.label}</td>
-              <td>{$form.newTagName.html}</td>
+               <td class="description label">{$form.newTagName.label nofilter}</td>
+              <td>{$form.newTagName.html nofilter}</td>
            </tr>
            <tr>
-        <td class="description label">{$form.newTagDesc.label}</td>
-              <td>{$form.newTagDesc.html}</td>
+        <td class="description label">{$form.newTagDesc.label nofilter}</td>
+              <td>{$form.newTagDesc.html nofilter}</td>
            </tr>
         </table>
     </div>
@@ -126,7 +126,7 @@
         <table class="form-layout-compressed">
             <tr><td style="width: 14em;"></td>
              <td class="listing-box" style="margin-bottom: 0em; width: 15em;">
-               {$form.tag.html}
+               {$form.tag.html nofilter}
             </td>
           </tr>
         </table>

--- a/templates/CRM/Contact/Import/Form/SQL.tpl
+++ b/templates/CRM/Contact/Import/Form/SQL.tpl
@@ -11,8 +11,8 @@
   <h3>{ts}SQL Import{/ts}</h3>
     <table class="form-layout-compressed">
       <tr class ="crm-import_sql-form-block-sqlQuery">
-         <td class="label">{$form.sqlQuery.label}</td>
-         <td>{$form.sqlQuery.html}<br />
+         <td class="label">{$form.sqlQuery.label nofilter}</td>
+         <td>{$form.sqlQuery.html nofilter}<br />
          <span class="description">{ts}SQL Query must be a SELECT query that returns one or more rows of data to be imported. Specify the database name(s) AND table name(s) in the query (e.g. "SELECT * FROM my_database.my_table WHERE date_entered BETWEEN '1999-01-01' AND '2000-07-31'").{/ts}</span></td>
     </tr>
    </table>

--- a/templates/CRM/Contact/Import/Form/Summary.tpl
+++ b/templates/CRM/Contact/Import/Form/Summary.tpl
@@ -78,7 +78,7 @@
       <tr class="error"><td class="label crm-grid-cell">{ts}Invalid Rows (skipped){/ts}</td>
         <td class="data">{$invalidRowCount}</td>
         <td class="explanation">{ts}Rows with invalid data in one or more fields (for example, invalid email address formatting). These rows will be skipped (not imported).{/ts}
-          <div class="action-link"><a href="{$downloadErrorRecordsUrl|smarty:nodefaults}"><i class="crm-i fa-download" role="img" aria-hidden="true"></i> {ts}See Errors{/ts}</a></div>
+          <div class="action-link"><a href="{$downloadErrorRecordsUrl nofilter}"><i class="crm-i fa-download" role="img" aria-hidden="true"></i> {ts}See Errors{/ts}</a></div>
         </td>
       </tr>
     {/if}

--- a/templates/CRM/Contact/Page/DedupeException.tpl
+++ b/templates/CRM/Contact/Page/DedupeException.tpl
@@ -91,7 +91,7 @@
     CRM.$(function($) {
 
       {/literal}
-        var $form = $({if empty($form.formClass)}'#crm-main-content-wrapper'{else}'form.{$form.formClass}'{/if});
+        var $form = $({if empty($form.formClass)}'#crm-main-content-wrapper'{else}'form.{$form.formClass nofilter}'{/if});
         var currentLocation = {$pager->_response.currentLocation|json_encode};
       {literal}
 

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -310,7 +310,7 @@
       var is_selected = CRM.$('.crm-dedupe-select-all').prop('checked') ? 1 : 0;
     }
 
-    var cacheKey = {/literal}'{$cacheKey|escape}'{literal};
+    var cacheKey = {/literal}'{$cacheKey|escape nofilter}'{literal};
 
     var dataUrl = {/literal}"{crmURL p='civicrm/ajax/toggleDedupeSelect' h=0 q='snippet=4'}"{literal};
 

--- a/templates/CRM/Contact/Page/DedupeRules.tpl
+++ b/templates/CRM/Contact/Page/DedupeRules.tpl
@@ -38,7 +38,7 @@
               <tr class="{cycle values="odd-row,even-row"}">
                 <td>{$row.title}</td>
                 <td>{$row.used_display}</td>
-                <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>
+                <td>{$row.action|replace:'xx':$row.id nofilter}</td>
               </tr>
             {/foreach}
           </table>

--- a/templates/CRM/Contact/Page/Inline/Actions.tpl
+++ b/templates/CRM/Contact/Page/Inline/Actions.tpl
@@ -24,7 +24,7 @@
               {foreach from=$actionsMenuList.otherActions item='row'}
                 {if !empty($row.href) or !empty($row.tab)}
                 <li class="crm-contact-{$row.ref}">
-                  <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>
+                  <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape nofilter}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>
                     <span><i {if !empty($row.icon)}class="{$row.icon}"{/if} role="img" aria-hidden="true"></i> {$row.title}</span>
                   </a>
                 </li>
@@ -37,7 +37,7 @@
             {foreach from=$actionsMenuList.moreActions item='row'}
             {if !empty($row.href) or !empty($row.tab)}
             <li class="crm-action-{$row.ref}">
-              <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>{$row.title}</a>
+              <a href="{if !empty($row.href)}{$row.href}{if strstr($row.href, '?')}&cid={$contactId}{/if}{else}#{/if}" title="{$row.title|escape nofilter}" data-tab="{$row.tab}" {if !empty($row.class)}class="{$row.class}"{/if}>{$row.title}</a>
             </li>
             {/if}
           {/foreach}

--- a/templates/CRM/Contact/Page/Inline/Basic.tpl
+++ b/templates/CRM/Contact/Page/Inline/Basic.tpl
@@ -6,7 +6,7 @@
     </div>
     <div class="crm-content" id="tags">
       {foreach from=$contactTag item=tagName key=tagId}
-        <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape}">
+        <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape nofilter}">
           {$tagName}
         </span>
       {/foreach}

--- a/templates/CRM/Contact/Page/View/Email.tpl
+++ b/templates/CRM/Contact/Page/View/Email.tpl
@@ -12,8 +12,8 @@
 <legend>{ts}Sent Email Message{/ts}</legend>
 <dl>
 <dt>{ts}Date Sent{/ts}</dt><dd>{$sentDate|crmDate}</dd>
-<dt>{ts}From{/ts}</dt><dd>{if $fromName}{$fromName|escape}{else}{ts}(display name not available){/ts}{/if}</dd>
-<dt>{ts}To{/ts}</dt><dd>{$toName|escape}</dd>
+<dt>{ts}From{/ts}</dt><dd>{if $fromName}{$fromName|escape nofilter}{else}{ts}(display name not available){/ts}{/if}</dd>
+<dt>{ts}To{/ts}</dt><dd>{$toName|escape nofilter}</dd>
 <dt>{ts}Subject{/ts}</dt><dd>{$subject}</dd>
 <dt>{ts}Message{/ts}</dt><dd>{$message}</dd>
 <dt>&nbsp;</dt><dd>{crmButton class="cancel" icon="times" p='civicrm/contact/view' q="history=1&show=1&selectedChild=activity"}">{ts}Done{/ts}{/crmButton}</dd>

--- a/templates/CRM/Contact/Page/View/Useradd.tpl
+++ b/templates/CRM/Contact/Page/View/Useradd.tpl
@@ -10,22 +10,22 @@
 <div class="crm-block crm-form-block crm-useradd-form-block">
   <table class="form-layout-compressed">
     <tr>
-      <td class="label">{$form.name.label}</td><td>{$form.name.html}</td>
+      <td class="label">{$form.name.label nofilter}</td><td>{$form.name.html nofilter}</td>
     </tr>
     <tr>
-      <td class="label">{$form.cms_name.label}</td>
-      <td>{$form.cms_name.html} <a id="checkavailability" href="#" onClick="return false;">{ts}<strong>Check Availability</strong>{/ts}</a> <span id="msgbox" style="display:none"></span><br />
+      <td class="label">{$form.cms_name.label nofilter}</td>
+      <td>{$form.cms_name.html nofilter} <a id="checkavailability" href="#" onClick="return false;">{ts}<strong>Check Availability</strong>{/ts}</a> <span id="msgbox" style="display:none"></span><br />
         <span class="description">{ts}Select a username; punctuation is not allowed except for periods, hyphens, and underscores.{/ts}</span>
       </td>
     </tr>
     <tr>
-      <td class="label">{$form.cms_pass.label}</td><td>{$form.cms_pass.html}</td>
+      <td class="label">{$form.cms_pass.label nofilter}</td><td>{$form.cms_pass.html nofilter}</td>
     </tr>
     <tr>
-      <td class="label">{$form.cms_confirm_pass.label}</td><td>{$form.cms_confirm_pass.html}</td>
+      <td class="label">{$form.cms_confirm_pass.label nofilter}</td><td>{$form.cms_confirm_pass.html nofilter}</td>
     </tr>
     <tr>
-      <td class="label">{$form.email.label}</td><td>{$form.email.html}</td>
+      <td class="label">{$form.email.label nofilter}</td><td>{$form.email.html nofilter}</td>
     </tr>
   </table>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>


### PR DESCRIPTION
Preamble
----------------------------------------

In https://lab.civicrm.org/dev/core/-/issues/1328, one significant proposal/subproject is to change Smarty's policy from explicit/manual escaping to implicit/automatic escaping. Choosing between those modes (explicit/implicit) is a bit like choosing whether to drive on the left or ride side of the highway.  (*You can drive safely on the left; and you can drive safely on the right; but everyone needs to do it the same way; and if you want to switch an entire country from left to right, then it takes... a lot of careful coordination... :car: :car:*)

There was a big effort (by @eileenmcnaughton et al) to do this on Smarty v2 and involved `CIVICRM_SMARTY_DEFAULT_ESCAPE` and the modifier `|smarty:nodefaults` (and, IIRC, a lot of whack-a-mole). It got reasonably far, but the adoption of Smarty v5 forced a reset (because v5 doesn't support `|smarty:nodefaults`). (For a fuller report on interoperability of Smarty notations, see https://github.com/civicrm/civicrm-core/pull/33565.)

Recently, @colemanw has revived this effort with an eye for v5.

My thesis is this: if we're going to pursue a switch through `CIVICRM_SMARTY_DEFAULT_ESCAPE`, then it must involve migrations for core, contrib, and user-data. That is only viable if the migration can run automatically. So I want to explore the viability of automatic conversion.

Overview
----------------------------------------

[smartyup](https://github.com/totten/smartyup) is a draft/experimental tool to update Smarty `*.tpl`s. It has a mix of automatic rewrites and interactive suggestions. This branch shows sample output for a large subfolder.

I want to put some focus on discussing the markup itself -- which changes are good/bad/feasible/necessary/sufficient, and I think that's easier to imagine with some concrete diff's. How should adjust the converter?

Technical Details / Comments
----------------------------------------

* The PR only shows some of the current transformations. Other transformations involve a series of prompts, such as:

    <img width="1097" height="689" alt="image" src="https://github.com/user-attachments/assets/0d7027ab-28c7-4d2f-9af8-5e345c5767dd" />

* TBH, the deeper I got into this, the more I started to think... maybe these prompts aren't necessary. Maybe the policy in the transitional period should be this: _simply put, all Smarty `{$expressions}` must specify `nofilter`_.  AFAICS, that global change is a safe refactor within 5.x, and it is the only practice that _guarantees interoperability during a transition period_, and it can be automated.

* In the Civi-Smarty integration, the current auto-escaping is [based](https://github.com/civicrm/civicrm-packages/blob/6.7/smarty5/EscapeModifierCompilerOverride.php#L22) on the ["htmlall" heuristic encoder](https://github.com/civicrm/civicrm-core/blob/6.7/CRM/Core/Smarty.php#L512). Personally, I feel like `htmlall` is OK for some prototyping -- but in real usage, it would be a cure that's worse than the disease. Can we use v5's built-in auto-escaper? I haven't tried it -- are there drawbacks? If we're using the heavy-ammo to rewrite all templates, does that make the drawbacks go away?
