### PR TITLE
Fix logo not spinning in quicksearch on Thames

### DIFF
--- a/ext/riverlea/streams/thames/css/civicrm.css
+++ b/ext/riverlea/streams/thames/css/civicrm.css
@@ -490,9 +490,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   border-radius: 1rem;
   animation: thames-spinner 1s infinite;
 }
-.fa-spin {
-  animation: none; /* placing animation on an odd-shaped item is a PITA for getting it 100% centred. */
-}
+
 /* Spinner for notifications .status-start notifications e.g. loading/saving. */
 .crm-status-box-outer.status-start .crm-status-box-inner {
   /* Allow space for spinner.*/


### PR DESCRIPTION
Overview
----------------------------------------

The CiviCRM logo is supposed to spin while waiting for quicksearch results. On Thames it didn't.

![spinner](https://github.com/user-attachments/assets/d504cf06-b07d-4236-9b0f-31d6f77d6a6f)
