### PR TITLE
RiverLea: #149 Colours, part 1: takes --crm-bg4 out of RL core, removes --crm-bg5, adds 3 new variables

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -365,7 +365,7 @@ dl dl {
 .crm-container code {
   display: inline;
   background-color: var(--crm-c-code-background);
-  border: 1px solid var(--crm-c-background4);
+  border: var(--crm-c-code-border);
   color: var(--crm-c-text);
   border-radius: 2px;
   padding: 2px;
@@ -380,7 +380,7 @@ dl dl {
   line-height: 1.4  !important /* vs inline css on api3 */;
   color: var(--crm-c-text);
   background-color: var(--crm-c-code-background);
-  border: 1px solid var(--crm-c-background4);
+  border: var(--crm-c-code-border);
   border-radius: var(--crm-roundness);
 }
 .crm-container pre code {

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -3395,17 +3395,16 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme a.label:hover,
 #bootstrap-theme a.label:focus {
-  color: var(--crm-c-text-light);
   text-decoration: none;
   cursor: var(--crm-hover-clickable);
 }
 #bootstrap-theme .label-default {
-  background-color: var(--crm-c-text);
+  background: var(--crm-c-darkest);
   color: var(--crm-c-text-light);
 }
 #bootstrap-theme .label-default[href]:hover,
 #bootstrap-theme .label-default[href]:focus {
-  background-color: var(--crm-c-background4);
+  background: color-mix(in srgb, var(--crm-c-darkest) 87.5%, #fff 12.5%);
 }
 #bootstrap-theme .label-primary {
   background: var(--crm-c-primary);
@@ -3421,7 +3420,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme .label-success[href]:hover,
 #bootstrap-theme .label-success[href]:focus {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-success);
+  background: color-mix(in srgb, var(--crm-c-success) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label-info {
   background: var(--crm-c-info);
@@ -3429,7 +3428,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme .label-info[href]:hover,
 #bootstrap-theme .label-info[href]:focus {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-info);
+  background: color-mix(in srgb, var(--crm-c-info) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label-warning {
   background: var(--crm-c-warning);
@@ -3437,7 +3436,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme .label-warning[href]:hover,
 #bootstrap-theme .label-warning[href]:focus {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-warning);
+  background: color-mix(in srgb, var(--crm-c-warning) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label-danger {
   background: var(--crm-c-danger);
@@ -3445,10 +3444,10 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme .label-danger[href]:hover,
 #bootstrap-theme .label-danger[href]:focus {
-  background: linear-gradient(to top,rgba(0, 0, 0, 0.125),rgba(0, 0, 0, 0.125)) var(--crm-c-danger);
+  background: color-mix(in srgb, var(--crm-c-danger) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label i.crm-i {
-  color: inherit; /* resets icons inside lables to use the label text colour */
+  color: inherit; /* resets icons inside labels to use the label text colour */
 }
 
 /* Panels */

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -50,12 +50,12 @@
   --crm-c-divider: 1px solid var(--crm-c-gray-300);
   --crm-c-page-background: #fff; /* background to page body */
   --crm-c-background: #f4f4ed; /* background to page header, often form block & dialog bg */
-  --crm-c-background2: var(--crm-c-gray-050); /* 2-5 = progressively darker backgrounds */
+  --crm-c-background2: var(--crm-c-gray-050); /* 2-4 = progressively darker backgrounds */
   --crm-c-background3: var(--crm-c-gray-100);
   --crm-c-background4: var(--crm-c-gray-200);
-  --crm-c-background5: var(--crm-c-gray-700);
   --crm-c-drag-background: var(--crm-c-background3); /* background for drag/drop regions, select2 highlight */
-  --crm-c-code-background: var(--crm-c-background2); /* background for code regions */
+  --crm-c-code-background: var(--crm-c-background2); /* for code regions */
+  --crm-c-code-border: 1px solid var(--crm-c-background4);
   --crm-c-focus: var(--crm-c-blue-dark);
   --crm-c-inactive: #696969;
 /* Emphasis colours */
@@ -162,7 +162,7 @@
   --crm-btn-icon-padding: var(--crm-btn-padding-block);
   --crm-btn-margin: 0; /* used to add padding block between multiple stacked buttons */
 /* Tables */
-  --crm-table-outside-border: 1px solid var(--crm-c-background3);
+  --crm-table-outside-border: var(--crm-c-divider);
   --crm-table-background: var(--crm-c-page-background);
   --crm-table-row-border: var(--crm-c-divider);
   --crm-table-column-border: 0 solid transparent;
@@ -245,6 +245,7 @@
   --crm-form-block-background: var(--crm-c-background);
   --crm-form-block-padding: var(--crm-m);
   --crm-form-block-border-radius: var(--crm-roundness);
+  --crm-form-block-header: var(--crm-c-gray-700);
   --crm-input-background: var(--crm-c-page-background);
   --crm-input-background-image: linear-gradient(top, #eee 1%, #fff 15%);
   --crm-input-color: var(--crm-c-text);
@@ -404,6 +405,8 @@
   --crm-icon-success-color: inherit;
   --crm-icon-warning-color: inherit;
   --crm-icon-info-color: inherit;
+/* Form Builder UI */
+  --crm-fb-header-bg: var(--crm-c-background3);
 /* Wizard */
   --crm-wizard-width: fit-content;
   --crm-wizard-margin: 0.5rem auto;

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -290,11 +290,6 @@
 #bootstrap-theme .btn-secondary.dropdown-toggle:focus {
   background: var(--crm-c-secondary-hover);
 }
-.crm-container .crm-search-display button.dropdown-toggle:not(.btn-default):not(.btn-secondary),
-#bootstrap-theme .crm-search-display th .btn-group .btn {
-  background-color: var(--crm-c-background4);
-  color: var(--crm-c-text);
-}
 
 /* BS3 Button groups and dropdowns  */
 

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -162,7 +162,7 @@ select.crm-form-multiselect {
   border: 1px solid var(--crm-c-darkest);
 }
 .crm-container .replace-plain {
-  background-color: var(--crm-c-background3);
+  background-color: var(--crm-input-background);
   min-width: var(--crm-huge-input);
 }
 input.crm-form-text:focus,
@@ -348,11 +348,16 @@ input.crm-form-checkbox) + label {
 }
 /* Slider */
 .crm-container .ui-slider {
-  background: var(--crm-c-background4);
+  background: var(--crm-input-background);
+  border: 1px solid var(--crm-input-border-color);
 }
 .crm-container .ui-slider .ui-slider-handle {
+  border: var(--crm-btn-border);
+  background: var(--crm-c-secondary);
+}
+.crm-container .ui-slider .ui-slider-range {
   border: 0;
-  background: var(--crm-c-background5);
+  border-radius: 0;
 }
 
 /* Input types */

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -124,8 +124,7 @@
 .crm-container .pagination > li {
   display: inline;
 }
-.crm-container .pagination > li > a,
-.crm-container .pagination > li > span {
+.crm-container .pagination > li > :is(a,span) {
   position: relative;
   float: left;
   padding: var(--crm-s) var(--crm-m);
@@ -136,78 +135,56 @@
   background-color: var(--crm-c-page-background);
   border: var(--crm-c-divider);
 }
-.crm-container .pagination > li > a:hover,
-.crm-container .pagination > li > a:focus,
-.crm-container .pagination > li > span:hover,
-.crm-container .pagination > li > span:focus {
+.crm-container .pagination > li > :is(a:hover,a:focus,span:hover,span:focus) {
   z-index: 2;
   color: var(--crm-c-link-hover);
   background-color: var(--crm-c-background);
-  border-color: var(--crm-c-background4);
 }
-.crm-container .pagination > li:first-child > a,
-.crm-container .pagination > li:first-child > span {
+.crm-container .pagination > li:first-child > :is(a,span) {
   margin-left: 0;
   border-top-left-radius: var(--crm-roundness);
   border-bottom-left-radius: var(--crm-roundness);
 }
-.crm-container .pagination > li:last-child > a,
-.crm-container .pagination > li:last-child > span {
+.crm-container .pagination > li:last-child > :is(a,span) {
   border-top-right-radius: var(--crm-roundness);
   border-bottom-right-radius: var(--crm-roundness);
 }
-.crm-container .pagination > .active > a,
-.crm-container .pagination > .active > a:hover,
-.crm-container .pagination > .active > a:focus,
-.crm-container .pagination > .active > span,
-.crm-container .pagination > .active > span:hover,
-.crm-container .pagination > .active > span:focus {
+.crm-container .pagination > .active > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
   z-index: 3;
   color: var(--crm-c-primary-text);
   cursor: default;
   background-color: var(--crm-c-primary);
   border: var(--crm-c-divider);
 }
-.crm-container .pagination > .disabled > span,
-.crm-container .pagination > .disabled > span:hover,
-.crm-container .pagination > .disabled > span:focus,
-.crm-container .pagination > .disabled > a,
-.crm-container .pagination > .disabled > a:hover,
-.crm-container .pagination > .disabled > a:focus {
+.crm-container .pagination > .disabled > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
   color: var(--crm-c-inactive);
   cursor: not-allowed;
   background-color: transparent;
   border: var(--crm-c-divider);
 }
-.crm-container .pagination-lg > li > a,
-.crm-container .pagination-lg > li > span {
+.crm-container .pagination-lg > li > :is(a,span) {
   padding: var(--crm-m2) var(--crm-r);
   font-size: var(--crm-r1);
   line-height: 1.3;
 }
-.crm-container .pagination-lg > li:first-child > a,
-.crm-container .pagination-lg > li:first-child > span {
+.crm-container .pagination-lg > li:first-child > :is(a,span) {
   border-top-left-radius: calc(1.5 * var(--crm-roundness));
   border-bottom-left-radius: calc(1.5 * var(--crm-roundness));
 }
-.crm-container .pagination-lg > li:last-child > a,
-.crm-container .pagination-lg > li:last-child > span {
+.crm-container .pagination-lg > li:last-child > :is(a,span) {
   border-top-right-radius: calc(1.5 * var(--crm-roundness));
   border-bottom-right-radius: calc(1.5 * var(--crm-roundness));
 }
-.crm-container .pagination-sm > li > a,
-.crm-container .pagination-sm > li > span {
+.crm-container .pagination-sm > li > :is(a,span) {
   padding: var(--crm-padding-small);
   font-size: var(--crm-font-size-small);
   line-height: 1.5;
 }
-.crm-container .pagination-sm > li:first-child > a,
-.crm-container .pagination-sm > li:first-child > span {
+.crm-container .pagination-sm > li:first-child > :is(a,span) {
   border-top-left-radius: calc(0.75 * var(--crm-roundness));
   border-bottom-left-radius: calc(0.75 * var(--crm-roundness));
 }
-.crm-container .pagination-sm > li:last-child > a,
-.crm-container .pagination-sm > li:last-child > span {
+.crm-container .pagination-sm > li:last-child > :is(a,span) {
   border-top-right-radius: calc(0.75 * var(--crm-roundness));
   border-bottom-right-radius: calc(0.75 * var(--crm-roundness));
 }

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -93,8 +93,8 @@
 }
 .crm-container .ui-tabs ul.ui-tabs-nav .crm-count-0 a em,
 .crm-container #mainTabContainer ul.ui-tabs-nav .crm-count-0 a em {
-  background: var(--crm-c-background5);
-  color: var(--crm-c-text-light);
+  background: var(--crm-c-secondary);
+  color: var(--crm-c-secondary-text);
 }
 .crm-container .ui-tabs ul li em:empty,
 .crm-container .nav-tabs .badge:empty { /* this is to keep the height of tabs with empty badges */

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -21,7 +21,7 @@
 .crm-container .ui-sortable-helper.crm-dashlet {
   box-shadow: var(--crm-block-shadow);
 }
-.crm-container #civicrm-dashboard .crm-dashlet-header {
+.crm-container .crm-dashlet-header {
   background-color: var(--crm-dashlet-header-bg);
   border-radius: var(--crm-dashlet-radius);
   border: var(--crm-dashlet-header-border);
@@ -109,10 +109,8 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   display: inline-block;
   width: 340px;
   height: var(--crm-xxl);
-  margin: 10px;
-  box-shadow: 1px 1px 4px 1px rgba(0,0,0,0.2);
   box-shadow: var(--crm-popup-shadow);
-  background-color: var(--crm-c-background4);
+  background-color: color-mix(in srgb, var(--crm-dashlet-bg) 90%, #fff 10%);
   border-radius: var(--crm-dashlet-radius);
   margin: 0;
 }

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -82,7 +82,7 @@ details.af-container.af-layout-inline > *:not(summary) {
   padding-top: 50px !important;
 }
 #bootstrap-theme .af-container-style-pane > .af-title {
-  background-color: var(--crm-c-background5);
+  background-color: var(--crm-form-block-header);
   color: var(--crm-c-text-light);
   border-radius: var(--crm-form-block-border-radius) var(--crm-form-block-border-radius) 0 0;
   position: absolute;

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -246,7 +246,7 @@
   width: 100%;
   border-radius: 0;
   transition: opacity .2s;
-  background-color: var(--crm-c-background3);
+  background-color: var(--crm-fb-header-bg);
   padding-inline: var(--crm-xs);
   cursor: move;
   display: flex;
@@ -293,7 +293,7 @@
 /* Dragging related */
 #afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar,
 #afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-container-title span:empty {
-  background-color: var(--crm-c-background4);
+  background-color: color-mix(in srgb, var(--crm-fb-header-bg) 80%, #000 20%);
   opacity: 1;
   transition: opacity .1s;
 }
@@ -375,7 +375,8 @@ af-gui-container > .af-gui-bar,
 
 /* Card style */
 #afGuiEditor .af-gui-search-display {
-  border: 1px dotted var(--crm-c-background5);
+  border: var(--crm-c-divider);
+  border-style: dotted;
   color: var(--crm-c-text);
   padding: var(--crm-padding-reg);
   background-color: var(--crm-c-background2);
@@ -436,7 +437,7 @@ af-gui-container > .af-gui-bar,
 }
 #afGuiEditor .af-gui-field-required:after {
   content: '*';
-  color: var(--crm-c-danger);
+  color: var(--crm-notify-danger);
   position: relative;
   left: -4px;
 }
@@ -674,7 +675,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 
 /* Misc - aka stuff I can't identify but don't want to risk removing*/
 #bootstrap-theme #afGuiEditor .af-gui-bar .btn.active {
-  background-color: var(--crm-c-background5);
+  background-color: color-mix(in srgb, var(--crm-fb-header-bg) 80%, #000);
 }
 #afGuiEditor .af-gui-bar > .form-inline > span {
   color: var(--crm-c-text);

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -29,12 +29,13 @@ table.crm-sticky-header > thead > tr {
   width: 1px; /* shrinks cell to width of button/menu */
 }
 #bootstrap-theme th.crm-search-result-select button.btn {
-  background: transparent;
+  background-color: color-mix(in srgb,var(--crm-c-text) 15%,transparent);
+  color: var(--crm-c-text);
   padding: var(--crm-xs1) var(--crm-m1);
 }
 #bootstrap-theme th.crm-search-result-select button.btn:hover,
 #bootstrap-theme th.crm-search-result-select button.btn:focus {
-  background: transparent;
+  background-color: color-mix(in srgb,var(--crm-c-text) 25%,transparent);
 }
 #bootstrap-theme th.crm-search-result-select button.btn i.crm-i {
   color: var(--crm-c-text);

--- a/ext/riverlea/streams/hackneybrook/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/_variables.css
@@ -51,8 +51,6 @@
   --crm-btn-icon-bg: rgba(256,256,256,0.25);
   --crm-btn-icon-border: var(--crm-btn-border);
   --crm-btn-icon-padding: 0px;
-  /* Tables */
-  --crm-table-outside-border: var(--crm-c-divider);
   /* Accordions */
   /* .crm-accordion-bold */
   --crm-expand-header-bg: var(--crm-c-gray-200);

--- a/ext/riverlea/streams/minetta/_variables.css
+++ b/ext/riverlea/streams/minetta/_variables.css
@@ -4,6 +4,13 @@
     Riverlea version: 1.3.8;
 */
 
+:root {
+/* Tables */
+  --crm-table-outside-border: 1px solid var(--crm-c-gray-200);
+}
+
+/* Custom CSS */
+
 .contactCardRight:has(#crm-contact-thumbnail) .float-left {
   width: calc(100% - var(--crm-flex-gap) - var(--crm-dash-image-size));
 }

--- a/ext/riverlea/streams/thames/_variables.css
+++ b/ext/riverlea/streams/thames/_variables.css
@@ -65,7 +65,6 @@
   --crm-c-background2: var(--crm-c-gray-050); /* 2-5 = progressively darker backgrounds*/
   --crm-c-background3: var(--crm-c-gray-100);
   --crm-c-background4: var(--crm-c-gray-200);
-  --crm-c-background5: var(--crm-c-gray-700);
   --crm-c-drag-background: var(--crm-c-blue-overlay2); /* background for drag/drop regions, select2 highlight */
   --crm-c-code-background: var(--crm-c-blue-overlay2); /* background for code regions */
   --crm-c-focus: var(--crm-c-blue-dark);

--- a/ext/riverlea/streams/walbrook/_variables.css
+++ b/ext/riverlea/streams/walbrook/_variables.css
@@ -80,7 +80,6 @@
   --crm-btn-small-padding: var(--crm-s1) var(--crm-m1);
   --crm-btn-height: 40px;
 /* Tables */
-  --crm-table-outside-border: var(--crm-c-divider);
   --crm-table-background: var(--crm-c-background);
   --crm-table-header-bottom: var(--crm-c-divider);
   --crm-table-header-bg: var(--crm-c-background);


### PR DESCRIPTION
TLDR: RiverLea isn't built in an optimal way for a customiser when it comes to colour palettes, changing a colour in one variable can see it change in other unexpected places that can't be over-ridden with more variables because it's in RL core. [RL#149](https://lab.civicrm.org/extensions/riverlea/-/issues/149) sets out the work to address this - and this is the first step, removing `crm-c-background4` and `crm-c-background5` from core, allowing for `crm-c-background5` to be removed altogether.

This first PR illustrates why this is complex: when a variable leaves core RL file something else is needed in its place. The ways this is handled varies:
 - Add a new variable, assigned to the background variable it's replacing. There's a couple of these here, that usually means the UI remains the same
 - Swap for an appropriate other variable (ah this is actually an input, we can just use `--crm-input-bg` instead) - this sometimes means a UI change, ie on the range input, point 2 below.
 - Use the `color-mix` css function to generate an appropriate colour from some other colour present. E.g. making a hover state a bit darker than it's original state, this usually means the UI remains the same.
 - Rework the css.

Also as I go I sometimes spot other bugs and clean those up, as well as reducing the css if there's something obvious like swapping a long list of selectors for a single selector using `:is()`.

In UI changing instances, I've checked across all four Streams and screengrabbed. This is why this colours work needs to happen as a priority before the customiser / end-users create more streams, but these will be big PRs - this is the first of three or four, I think.

Overview
----------------------------------------

1. Make inner and outer table borders the same, other than for Minetta - setting up a Minetta over-ride - maintains UI
2. Remove crm-background4 + 5 from core range-slides - changes UI, see below
3. Removes crm-background4 from code block border, **creates new variable - crm-code-border** - maintains UI
4. Removes crm-background4 from bootstrap label-default (which didn’t work in dark mode) - rewrites this using different variables, fixes hover contrast ratio issues, uses colormix for hover states - fixes UI, see below
5. Removes from inactive dashlet bg, dashboard.css. Changes to a colormix on dashlet-bg variable, removes two un-used lines,  and fixes cascade issue on inactive header border-radius - fixes+changes UI, see below 
6. Removes bg4 from the search kit table header select all toggle and dropdown. Moves this css to the right file, uses an opacity colormix on text-colour to create a dark-mode friendly equivalent to the old colour. - maintains UI, moves/amends css.
7. Removes bg4 from pagination hover border, also minimise pagination css using ‘:is()’ - maintains UI
8. Removes bg5 from tab emphasis counts, changes to crm-c-secondary - changes UI, most noticeably in Thames & Hackney - where previously the `0` counts were bolder than the non-empty counts, now they're fainter, see below
9. Removes bg5 and Bg4 and two instances of BG3 from Afform, **creates new variables --crm-fb-header-bg and --crm-form-block-header** - maintains UI (slight change to one active state)

Before
----------------------------------------
2. range-sliders
<img width="1564" height="138" alt="image" src="https://github.com/user-attachments/assets/32663180-42d0-48e8-af00-31142c88dbc7" />

4. label-default
(including bad contrast ratio hover states)
<img width="712" height="308" alt="image" src="https://github.com/user-attachments/assets/5b9908bb-1cc3-4f1f-be94-e3c7d519afcd" />

5. inactive dashlet

<img width="777" height="542" alt="image" src="https://github.com/user-attachments/assets/d1d9b181-4c48-4efc-821d-cbc56ce43e44" />

8. Tab counts

<img width="1284" height="109" alt="image" src="https://github.com/user-attachments/assets/d4ef5958-0888-4878-81b1-36bc2c43433f" />
<img width="470" height="388" alt="image" src="https://github.com/user-attachments/assets/b639694d-cca2-4c7e-b380-33dfd2d15f94" />
<img width="399" height="380" alt="image" src="https://github.com/user-attachments/assets/681b80df-8d59-46a7-adc0-6de202b5c53d" />
<img width="453" height="447" alt="image" src="https://github.com/user-attachments/assets/6ef74730-0f22-4728-be35-5043bd5c2bdf" />

After
----------------------------------------
2. range-sliders

Minetta:
<img width="1548" height="142" alt="image" src="https://github.com/user-attachments/assets/3a31df5d-a4ef-44c5-9cef-f03468c00c2f" />

Walbrook:
<img width="1540" height="141" alt="image" src="https://github.com/user-attachments/assets/e7c41773-46f9-48aa-9cd9-de989f509829" />

Thames: 
<img width="1561" height="149" alt="image" src="https://github.com/user-attachments/assets/3a876454-6314-4b1b-96c4-38dfe0b9edf4" />

Hackney:
<img width="1544" height="138" alt="image" src="https://github.com/user-attachments/assets/503a6c79-c1d6-4b5b-82f6-4068da4e8223" />

Hackney DM:
<img width="1544" height="139" alt="image" src="https://github.com/user-attachments/assets/e497a5b8-723c-406b-9226-d4c4a97b0ca5" />

4. label-default

Minetta:
<img width="549" height="72" alt="image" src="https://github.com/user-attachments/assets/c4212a29-1065-446c-be5e-735d197c47a3" />

Walbrook:
<img width="692" height="88" alt="image" src="https://github.com/user-attachments/assets/bd23fc17-835a-4ef8-a761-02774e97d289" />

Thames:
<img width="559" height="74" alt="image" src="https://github.com/user-attachments/assets/8846d11c-c5ec-418b-b8cb-868151aab219" />

5. inactive dashlet

Minetta:
<img width="754" height="175" alt="image" src="https://github.com/user-attachments/assets/da4383d0-9550-41ee-abb0-d3e4931fc792" />

Walbrook:
<img width="801" height="191" alt="image" src="https://github.com/user-attachments/assets/59133a45-a9fe-49d5-9648-ce9eef01046b" />

Thames:
<img width="777" height="126" alt="image" src="https://github.com/user-attachments/assets/a9406e9e-3184-432f-8c61-54fbc6cefb78" />

Hackney:
<img width="741" height="175" alt="image" src="https://github.com/user-attachments/assets/29226dc3-d520-46f1-92e0-6bbdcee9805f" />

8. Tab counts:

Minetta:
<img width="1177" height="103" alt="image" src="https://github.com/user-attachments/assets/a38d7d89-984d-4de8-82f5-4bbaefe9acde" />

Walbrook:
<img width="617" height="488" alt="image" src="https://github.com/user-attachments/assets/0d663f7d-e2f8-4fbf-8b3e-edc0fcc797fe" />

Thames:
<img width="434" height="311" alt="image" src="https://github.com/user-attachments/assets/15911725-d2ae-444d-a614-b65a349038e4" />

Hackney:
<img width="478" height="407" alt="image" src="https://github.com/user-attachments/assets/667891b7-e838-4880-90e6-16dc9554ac4a" />

Technical Details
----------------------------------------
[Color-Mix](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-mix) has had 2 years since adoption by the main browser engines, which equals > 90% of browsers [ref](https://caniuse.com/?search=color-mix).

Sidenote: refactoring RL already?!
----------------------------------------
The reason this mess exists, requiring quite a bit of effort to clean up, is when I first worked to get a proof-of-concept running for RL, I was trying to imitate Greenwich's colour scheme, using the `crm-c-background*` colours like a colour palette (as well as some of the base `crm-c-gray-*` type colours). I needed a grey of a certain shade I'd use one of these defaults. When I then started on Walbrook I began to diverge, adding new variables where these defaults diverged. Same again for Hackney Brook. At no point did I sit and plan for how a customiser would optimally work with RL variables,  as back then I assumed people would customise by spending a day making a new Stream, rather than a few minutes making some colours and fonts match a branding guideline. It meant RL came out quicker - ahead of schedule, technically - but this is some of the tech debt still standing as a result.