### PR TITLE
importer: recognize urls for eck entities

### DIFF
--- a/CRM/Import/Controller.php
+++ b/CRM/Import/Controller.php
@@ -43,7 +43,12 @@ class CRM_Import_Controller extends CRM_Core_Controller {
     else {
       $pathArguments = explode('/', (CRM_Utils_System::currentPath() ?: ''));
       unset($pathArguments[0], $pathArguments[1]);
-      $this->entity = CRM_Utils_String::convertStringToCamel(implode('_', $pathArguments));
+      $snakeCaseEntity = implode('_', $pathArguments);
+      $camelCaseEntity = CRM_Utils_String::convertStringToCamel($snakeCaseEntity);
+      if (str_starts_with(strtolower($snakeCaseEntity), 'eck_')) {
+        $camelCaseEntity = 'Eck_' . substr($camelCaseEntity, 3);
+      }
+      $this->entity = $camelCaseEntity;
     }
     $this->_stateMachine = new CRM_Import_StateMachine($this, TRUE, $this->entity, $arguments['class_prefix'] ?? NULL);
     // 1 (or TRUE)  has been the action passed historically - but it is probably meaningless.

--- a/CRM/Import/Controller.php
+++ b/CRM/Import/Controller.php
@@ -42,8 +42,7 @@ class CRM_Import_Controller extends CRM_Core_Controller {
     }
     else {
       $pathArguments = explode('/', (CRM_Utils_System::currentPath() ?: ''));
-      unset($pathArguments[0], $pathArguments[1]);
-      $entity = implode('', $pathArguments);
+      $entity = $pathArguments[2] ?? '';
       // For backwards compatibility, allow snake_case entity name
       if ($entity === (mb_strtolower($entity, "UTF-8"))) {
         $entity = CRM_Utils_String::convertStringToCamel($entity);

--- a/CRM/Import/Controller.php
+++ b/CRM/Import/Controller.php
@@ -43,12 +43,12 @@ class CRM_Import_Controller extends CRM_Core_Controller {
     else {
       $pathArguments = explode('/', (CRM_Utils_System::currentPath() ?: ''));
       unset($pathArguments[0], $pathArguments[1]);
-      $snakeCaseEntity = implode('_', $pathArguments);
-      $camelCaseEntity = CRM_Utils_String::convertStringToCamel($snakeCaseEntity);
-      if (str_starts_with(strtolower($snakeCaseEntity), 'eck_')) {
-        $camelCaseEntity = 'Eck_' . substr($camelCaseEntity, 3);
+      $entity = implode('', $pathArguments);
+      // For backwards compatibility, allow snake_case entity name
+      if ($entity === (mb_strtolower($entity, "UTF-8"))) {
+        $entity = CRM_Utils_String::convertStringToCamel($entity);
       }
-      $this->entity = $camelCaseEntity;
+      $this->entity = $entity;
     }
     $this->_stateMachine = new CRM_Import_StateMachine($this, TRUE, $this->entity, $arguments['class_prefix'] ?? NULL);
     // 1 (or TRUE)  has been the action passed historically - but it is probably meaningless.


### PR DESCRIPTION
In #33273, @eileenmcnaughton gave the importer the ability to process any entity. Just pass the entity name in `snake_case` in the url and it gets converted to `CamelCase` and processed. However, Eck entity names are a hybrid between snake case and camel case, so they need special handling.