### PR TITLE
SearchKit - Support date-only input widgets for editable fields

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1009,7 +1009,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return array{entity: string, action: string, input_type: string, data_type: string, options: bool, serialize: bool, nullable: bool, fk_entity: string, value_key: string, record: array, value_path: string}|null
    */
   protected function formatEditableColumn($column, $data) {
-    $editable = $this->getEditableInfo($column['key']);
+    $editable = $this->getEditableInfo($column);
     $editable['record'] = [];
     // Generate params to edit existing record
     if (!empty($data[$editable['id_path']])) {
@@ -1113,30 +1113,34 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
-   * @param $key
+   * @param array $column
+   *   Column definition
+   * @param null|string $key
+   *   Internal use only
    * @return array{entity: string, input_type: string, data_type: string, options: bool, serialize: bool, nullable: bool, fk_entity: string, value_key: string, value_path: string, id_key: string, id_path: string, explicit_join: string, grouping_fields: array}|null
    */
-  protected function getEditableInfo($key) {
-    // Strip pseudoconstant suffix
-    [$key] = explode(':', $key);
+  protected function getEditableInfo(array $column, ?string $key = NULL) {
+    $key ??= $column['key'];
     if (array_key_exists($key, $this->editableInfo)) {
       return $this->editableInfo[$key];
     }
+    // Strip pseudoconstant suffix
+    [$baseKey] = explode(':', $key);
     $getModeField = $this->getField($key);
     $fieldName = $getModeField['name'] ?? NULL;
     // If field is an implicit join to another entity, use the original fk field
     // UNLESS it's a custom field (which the api treats the same as core fields) or a virtual join like `address_primary.city`
     if (!empty($getModeField['implicit_join']) && empty($getModeField['custom_field_id'])) {
-      $baseFieldName = substr($key, 0, -1 - strlen($getModeField['name']));
+      $baseFieldName = substr($baseKey, 0, -1 - strlen($getModeField['name']));
       $baseField = $this->getField($baseFieldName);
-      $baseInfo = $this->getEditableInfo($baseFieldName);
+      $baseInfo = $this->getEditableInfo($column, $baseFieldName);
       // Implicit join to real field
       if ($baseField && !empty($baseField['fk_entity']) && $baseField['type'] === 'Field') {
         return $baseInfo;
       }
       elseif ($getModeField) {
         $getModeField['entity'] = $baseField['entity'];
-        $getModeField['name'] = $key;
+        $getModeField['name'] = $baseKey;
       }
     }
     $result = NULL;
@@ -1159,6 +1163,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $field['entity'] = 'Relationship';
         $idPath = $path . 'relationship_id';
       }
+      // Allow date/time elements to be represented as date-only
+      if ($field['data_type'] === 'Timestamp' && ($column['format'] ?? '') === 'dateformatFull') {
+        $field['data_type'] = 'Date';
+      }
       $result = [
         'entity' => $field['entity'],
         'input_type' => $field['input_type'],
@@ -1169,7 +1177,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         'nullable' => !empty($field['nullable']),
         'fk_entity' => $field['fk_entity'],
         'value_key' => $field['name'],
-        'value_path' => $key,
+        'value_path' => $baseKey,
         'id_key' => $idKey,
         'id_path' => $idPath,
         'explicit_join' => $field['explicit_join'],
@@ -1436,7 +1444,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       // Select id, value & grouping for in-place editing
       if (!empty($column['editable'])) {
         $isEditable = TRUE;
-        $editable = $this->getEditableInfo($column['key']);
+        $editable = $this->getEditableInfo($column);
         if ($editable) {
           foreach (array_merge($editable['grouping_fields'], [$editable['value_path'], $editable['id_path']]) as $addition) {
             $this->addSelectExpression($addition);

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
@@ -151,7 +151,7 @@ class InlineEdit extends Run {
     $columns = $this->display['settings']['columns'];
     foreach ($columns as $column) {
       if (array_key_exists($column['key'], $this->values)) {
-        $editableInfo = $this->getEditableInfo($column['key']);
+        $editableInfo = $this->getEditableInfo($column);
         if (!$editableInfo) {
           throw new \CRM_Core_Exception('Cannot edit column ' . $column['key']);
         }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -213,7 +213,7 @@ class Run extends AbstractRunAction {
   private function addEditableInfo(SearchDisplayRunResult $result): void {
     foreach ($this->display['settings']['columns'] as $column) {
       if (!empty($column['editable'])) {
-        $result->editable[$column['key']] = $this->getEditableInfo($column['key']);
+        $result->editable[$column['key']] = $this->getEditableInfo($column);
       }
     }
   }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/RunBatch.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/RunBatch.php
@@ -71,7 +71,7 @@ class RunBatch extends Run {
     foreach ($this->display['settings']['columns'] as $column) {
       if (!empty($column['key'])) {
         $key = $column['key'];
-        $result->editable[$key] = $this->getEditableInfo($key);
+        $result->editable[$key] = $this->getEditableInfo($column);
         // Set `required` field status based on search display settings
         $result->editable[$key]['required'] = !empty($column['required']);
         // Instead of using nullable from field defn, defer to `required` display setting

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.html
@@ -60,6 +60,13 @@
           {{:: ts('Required') }}
         </label>
       </div>
+      <div class="form-inline" ng-if="$ctrl.getField(col.key).data_type === 'Timestamp'">
+        <label for="crm-search-admin-edit-date-format-{{ $index }}">{{:: ts('Input Format') }}</label>
+        <select id="crm-search-admin-edit-date-format-{{ $index }}" class="form-control" ng-model="col.format" title="{{:: ts('Input Format') }}">
+          <option value="">{{:: ts('Date and Time') }}</option>
+          <option value="dateformatFull">{{:: ts('Date Only') }}</option>
+        </select>
+      </div>
       <div class="form-inline" ng-if="col.type === 'field'">
         <label>
           <input type="checkbox" ng-click="$ctrl.toggleDefault(col)" ng-checked="$ctrl.hasDefault(col)" >


### PR DESCRIPTION
Overview
----------------------------------------
In inline-edit and in batch-data entry displays, choosing the "Date Only" format type will omit the time part of the input.

<img width="1752" height="1076" alt="image" src="https://github.com/user-attachments/assets/a8c68649-9bd3-4ff1-bd4a-cc2840d33847" />

Technical Details
------------
Most of this was just refactoring so the necessary `$column` variable gets passed into the `getEditableInfo` function.