### PR TITLE
dev/core#5041 Making additional Font Awesome icons more accessible

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2330,7 +2330,7 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
         $activity['DT_RowAttr']['data-entity'] = 'activity';
         $activity['DT_RowAttr']['data-id'] = $activityId;
 
-        $activity['activity_type'] = (!empty($activityIcons[$values['activity_type_id']]) ? '<span class="crm-i ' . $activityIcons[$values['activity_type_id']] . '" aria-hidden="true"></span> ' : '') . htmlentities($values['activity_type']);
+        $activity['activity_type'] = (!empty($activityIcons[$values['activity_type_id']]) ? '<span class="crm-i ' . $activityIcons[$values['activity_type_id']] . '" role="img" aria-hidden="true"></span> ' : '') . htmlentities($values['activity_type']);
         $activity['subject'] = $values['subject'];
 
         if ($params['contact_id'] == $values['source_contact_id']) {

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -1134,7 +1134,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
       $caseActivities[$caseActivityId]['subject'] = $dao->subject;
 
       //Activity Type
-      $caseActivities[$caseActivityId]['type'] = (!empty($activityTypes[$dao->type]['icon']) ? '<span class="crm-i ' . $activityTypes[$dao->type]['icon'] . '"></span> ' : '')
+      $caseActivities[$caseActivityId]['type'] = (!empty($activityTypes[$dao->type]['icon']) ? '<span class="crm-i ' . $activityTypes[$dao->type]['icon'] . '" role="img" aria-hidden="true"></span> ' : '')
         . $activityTypes[$dao->type]['label'];
 
       // Activity Target (With Contact) (There can be more than one)

--- a/ang/crmDashboard/Dashlet.html
+++ b/ang/crmDashboard/Dashlet.html
@@ -1,8 +1,16 @@
 <div class="crm-dashlet-header" ng-if="!$ctrl.isFullscreen">
-  <a href class="crm-i fa-times" title="{{:: ts('Remove from dashboard') }}" aria-hidden="true" ng-click="$ctrl.remove()"></a>
-  <a href class="crm-i fa-expand" title="{{:: ts('View fullscreen') }}" aria-hidden="true" ng-click="$ctrl.fullscreen()"></a>
-  <a href class="crm-i fa-refresh" title="{{:: ts('Refresh') }}" aria-hidden="true" ng-click="$ctrl.forceRefresh()"></a>
-  <a href class="crm-dashlet-collapse crm-i fa-caret-{{ $ctrl.collapsed ? 'right' : 'down' }}" title="{{ $ctrl.collapsed ? ts('Expand') : ts('Collapse') }}" aria-hidden="true" ng-click="$ctrl.toggleCollapse()"></a>
+  <a href title="{{:: ts('Remove from dashboard') }}" ng-click="$ctrl.remove()" role="button" aria-label="{{:: ts('Remove from dashboard') }}">
+    <i class="crm-i fa-times" role="img" aria-hidden="true"></i>
+  </a>
+  <a href title="{{:: ts('View fullscreen') }}" ng-click="$ctrl.fullscreen()" role="button" aria-label="{{:: ts('View fullscreen') }}">
+    <i class="crm-i fa-expand" role="img" aria-hidden="true"></i>
+  </a>
+  <a href title="{{:: ts('Refresh') }}" ng-click="$ctrl.forceRefresh()" role="button" aria-label="{{:: ts('Refresh') }}">
+    <i class="crm-i fa-refresh" role="img" aria-hidden="true"></i>
+  </a>
+  <a href class="crm-dashlet-collapse" title="{{ $ctrl.collapsed ? ts('Expand') : ts('Collapse') }}" ng-click="$ctrl.toggleCollapse()" role="button" aria-label="{{ $ctrl.collapsed ? ts('Expand') : ts('Collapse') }}">
+    <i class="crm-i fa-caret-{{ $ctrl.collapsed ? 'right' : 'down' }}" role="img" aria-hidden="true"></i>
+  </a>
   <h3>{{:: $ctrl.dashlet.label }}</h3>
 </div>
 <div class="crm-dashlet-content" ng-show="!$ctrl.collapsed">

--- a/ang/crmDashboard/InactiveDashlet.html
+++ b/ang/crmDashboard/InactiveDashlet.html
@@ -1,4 +1,6 @@
-<div class="crm-dashlet-header" title="{{:: $ctrl.dashlet.label }}">
-  <a href class="crm-i fa-trash" title="{{:: ts('Permanently Delete %1', {1: $ctrl.dashlet.label}) }}" aria-hidden="true" crm-confirm="$ctrl.confirmParams" on-yes="$ctrl.delete()" ng-if="$ctrl.isAdmin && !$ctrl.dashlet.is_reserved"></a>
+<div class="crm-dashlet-header">
+  <a href title="{{:: ts('Permanently delete %1', {1: $ctrl.dashlet.label}) }}" crm-confirm="$ctrl.confirmParams" on-yes="$ctrl.delete()" ng-if="$ctrl.isAdmin && !$ctrl.dashlet.is_reserved" role="button" aria-label="{{:: ts('Permanently delete %1 dashlet', {1: $ctrl.dashlet.label}) }}">
+    <i class="crm-i fa-trash" role="img" aria-hidden="true"></i>
+  </a>
   <h3>{{:: $ctrl.dashlet.label }}</h3>
 </div>

--- a/ang/exportui/exportField.html
+++ b/ang/exportui/exportField.html
@@ -1,5 +1,5 @@
 <div>
-  <span class="crm-export-row-handle crm-i fa-arrows" aria-hidden="true"></span>
+  <span class="crm-export-row-handle crm-i fa-arrows" role="img" aria-hidden="true"></span>
   <input class="big" crm-ui-select="{data: getFields, allowClear: true, placeholder: 'clear'}" ng-model="field.select" />
 </div>
 <div ng-if="fields[field.select].relationship_type_id">

--- a/ext/civi_case/ang/crmCaseType/edit.html
+++ b/ext/civi_case/ang/crmCaseType/edit.html
@@ -26,7 +26,9 @@ Required vars: caseType
         </a>
         <span class="crm-i fa-trash" title="{{:: ts('Remove') }}"
           ng-hide="activitySet.name == 'standard_timeline'"
-          ng-click="removeItem(caseType.definition.activitySets, activitySet)"></span>
+          ng-click="removeItem(caseType.definition.activitySets, activitySet)"
+          role="img" aria-hidden="true">
+        </span>
         <!-- Weird spacing:
         <a class="crm-hover-button" ng-click="removeItem(caseType.definition.activitySets, activitySet)">
           <span class="crm-i fa-trash" title="Remove">Remove</span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -6,7 +6,7 @@
 <span ng-if=":: $ctrl.isArray(colData.val)">
   <span ng-repeat="val in colData.val track by $index">
     <i ng-if=":: colData.icons.left[$index]" class="crm-i {{:: colData.icons.left[$index] }}" role="img" aria-hidden="true"></i>
-      <span class="crm-search-field-value">{{:: val }}</span><i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}"> </i><span ng-if="!$last">,
+      <span class="crm-search-field-value">{{:: val }}</span><i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i><span ng-if="!$last">,
     </span>
   </span>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/link.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/link.html
@@ -1,6 +1,8 @@
 <span ng-repeat="link in colData.links">
   <a target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}" title="{{:: link.title }}" class="{{:: link.style }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
     <i ng-if="colData.icons.left[$index]" class="crm-i {{:: colData.icons.left[$index] }}" role="img" aria-hidden="true"></i>
-    {{:: link.text }}<i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}"> </i></a><span ng-if="!$last">,
-  </span>
+    {{:: link.text }}
+    <i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"> </i>
+  </a>
+  <span ng-if="!$last">,</span>
 </span>

--- a/templates/CRM/Contact/Page/Inline/Address.tpl
+++ b/templates/CRM/Contact/Page/Inline/Address.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{if $add}{ts escape='htmlattribute'}Edit address{/ts}{else}{ts escape='htmlattribute'}Add address{/ts}{/if}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {if $add}{ts}Edit address{/ts}{else}{ts}Add address{/ts}{/if}
+        <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {if $add}{ts}Edit address{/ts}{else}{ts}Add address{/ts}{/if}
       </div>
     {/if}
     {if !$add}

--- a/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
+++ b/templates/CRM/Contact/Page/Inline/CommunicationPreferences.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content"{if $permission EQ 'edit'} title="{ts escape='htmlattribute'}Edit communication preferences{/ts}"{/if}>
     {if $permission EQ 'edit'}
     <div class="crm-edit-help">
-      <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit communication preferences{/ts}
+      <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {ts}Edit communication preferences{/ts}
     </div>
     {/if}
     <div class="crm-summary-row">

--- a/templates/CRM/Contact/Page/Inline/ContactInfo.tpl
+++ b/templates/CRM/Contact/Page/Inline/ContactInfo.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Edit info{/ts}"{/if}>
     {if $permission EQ 'edit'}
     <div class="crm-edit-help">
-      <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit info{/ts}
+      <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {ts}Edit info{/ts}
     </div>
     {/if}
 

--- a/templates/CRM/Contact/Page/Inline/ContactName.tpl
+++ b/templates/CRM/Contact/Page/Inline/ContactName.tpl
@@ -12,7 +12,7 @@
     <div class="crm-inline-block-content"{if $permission EQ 'edit'} title="{ts escape='htmlattribute'}Edit Contact Name{/ts}"{/if}>
       {if $permission EQ 'edit'}
         <div class="crm-edit-help">
-          <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit name{/ts}
+          <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {ts}Edit name{/ts}
         </div>
       {/if}
 

--- a/templates/CRM/Contact/Page/Inline/Demographics.tpl
+++ b/templates/CRM/Contact/Page/Inline/Demographics.tpl
@@ -11,7 +11,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Edit demographics{/ts}"{/if}>
     {if $permission EQ 'edit'}
     <div class="crm-edit-help">
-      <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit demographics{/ts}
+      <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {ts}Edit demographics{/ts}
     </div>
     {/if}
     <div class="crm-summary-row">

--- a/templates/CRM/Contact/Page/Inline/Email.tpl
+++ b/templates/CRM/Contact/Page/Inline/Email.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit email{/ts}"{/if}>
   {if $permission EQ 'edit'}
     <div class="crm-edit-help">
-      <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($email)}{ts}Add email{/ts}{else}{ts}Add or edit email{/ts}{/if}
+      <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {if empty($email)}{ts}Add email{/ts}{else}{ts}Add or edit email{/ts}{/if}
     </div>
   {/if}
   {if empty($email)}

--- a/templates/CRM/Contact/Page/Inline/IM.tpl
+++ b/templates/CRM/Contact/Page/Inline/IM.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit IM{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($im)}{ts}Add IM{/ts}{else}{ts}Add or edit IM{/ts}{/if}
+        <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {if empty($im)}{ts}Add IM{/ts}{else}{ts}Add or edit IM{/ts}{/if}
       </div>
     {/if}
     {if empty($im)}

--- a/templates/CRM/Contact/Page/Inline/OpenID.tpl
+++ b/templates/CRM/Contact/Page/Inline/OpenID.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit OpenID{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($openid)}{ts}Add OpenID{/ts}{else}{ts}Add or edit OpenID{/ts}{/if}
+        <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {if empty($openid)}{ts}Add OpenID{/ts}{else}{ts}Add or edit OpenID{/ts}{/if}
       </div>
     {/if}
     {if empty($openid)}

--- a/templates/CRM/Contact/Page/Inline/Phone.tpl
+++ b/templates/CRM/Contact/Page/Inline/Phone.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit phone{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($phone)}{ts}Add phone{/ts}{else}{ts}Add or edit phone{/ts}{/if}
+        <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {if empty($phone)}{ts}Add phone{/ts}{else}{ts}Add or edit phone{/ts}{/if}
       </div>
     {/if}
     {if empty($phone)}

--- a/templates/CRM/Contact/Page/Inline/Website.tpl
+++ b/templates/CRM/Contact/Page/Inline/Website.tpl
@@ -12,7 +12,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts escape='htmlattribute'}Add or edit website{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {if empty($website)}{ts}Add website{/ts}{else}{ts}Add or edit website{/ts}{/if}
+        <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {if empty($website)}{ts}Add website{/ts}{else}{ts}Add or edit website{/ts}{/if}
       </div>
     {/if}
     {if empty($website)}

--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -11,7 +11,7 @@
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit' && !empty($cd_edit.editable)}title="{ts escape='htmlattribute'}Edit{/ts}"{/if}>
     {if $permission EQ 'edit' && !empty($cd_edit.editable)}
       <div class="crm-edit-help">
-        <span class="crm-i fa-pencil" aria-hidden="true"></span> {ts}Edit{/ts}
+        <span class="crm-i fa-pencil" role="img" aria-hidden="true"></span> {ts}Edit{/ts}
       </div>
     {/if}
 

--- a/templates/CRM/Custom/Page/Option.tpl
+++ b/templates/CRM/Custom/Page/Option.tpl
@@ -86,7 +86,7 @@
                 var cl = $('td:last', nRow).text().split(',')[1];
                 $(nRow).addClass(cl).attr({id: 'OptionValue-' + id});
                 $('td:eq(0)', nRow).wrapInner('<span class="crm-editable crmf-label" />');
-                $('td:eq(0)', nRow).prepend('<span class="crm-i fa-arrows crm-grip" />');
+                $('td:eq(0)', nRow).prepend('<span class="crm-i fa-arrows crm-grip" role="img" aria-hidden="true"/>');
                 $('td:eq(3)', nRow).addClass('crmf-default_value').html(CRM.utils.formatIcon('fa-check', ts('Default'), nRow.cells[3].innerText));
                 return nRow;
               },

--- a/templates/CRM/UF/Page/ProfileTemplates.tpl
+++ b/templates/CRM/UF/Page/ProfileTemplates.tpl
@@ -58,8 +58,12 @@
  *}
 <script type="text/template" id="field_summary_template">
   <span class="crm-designer-buttons">
-    <a class="crm-i fa-pencil crm-designer-action-settings" title="{ts escape='htmlattribute'}Settings{/ts}" aria-hidden="true"></a>
-    <a class="crm-i fa-trash crm-designer-action-remove" title="{ts escape='htmlattribute'}Remove{/ts}" aria-hidden="true"></a>
+    <a class="crm-designer-action-settings" title="{ts escape='htmlattribute'}Settings{/ts}" aria-label="{ts escape='htmlattribute'}Settings{/ts}">
+      <i class="crm-i fa-pencil" role="img" aria-hidden="true"></i>
+    </a>
+    <a class="crm-designer-action-remove" title="{ts escape='htmlattribute'}Remove{/ts}" aria-label="{ts escape='htmlattribute'}Remove{/ts}">
+      <i class="crm-i fa-trash" role="img" aria-hidden="true"></i>
+    </a>
   </span>
   <div class="description"><%= help_pre %></div>
   <div class="crm-designer-row-label">


### PR DESCRIPTION
# Overview

Further addressing [#5041 Make Font Awesome icons more accessible](https://lab.civicrm.org/dev/core/-/issues/5041). There were a few missed instances of icons that were not `<i>` elements but either `<a>` links or `<span>`s

They all now also have the required pattern:
- `role="img"`
- `aria-hidden="true"`

The above helps users with custom stylesheets who, in order to improve readability, overwrite all fonts on websites. As font icons are also fonts, if not properly tagged as an image these users can lose the context the icons provide.

## Comments
**Icon links** needed a bit more adjustment due to the fact that all icons need and an image role which should not be put on a link, therefore the icons needed to be nested inside the link.
The links have also been sufficiently labelled for screen reader users with the further context of their roles defined as buttons as these links are all used to perform actions on the page.
