### PR TITLE
HtmlPurifier - Allow 'open' attr of `<summary>` element

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -680,7 +680,9 @@ class CRM_Utils_String {
         $def->addElement('figcaption', 'Block', 'Flow', 'Common');
         $def->addElement('figure', 'Block', 'Optional: (figcaption, Flow) | (Flow, figcaption) | Flow', 'Common');
         // Allow `<summary>` and `<details>`
-        $def->addElement('details', 'Block', 'Flow', 'Common');
+        $def->addElement('details', 'Block', 'Flow', 'Common', [
+          'open' => new \HTMLPurifier_AttrDef_HTML_Bool('open'),
+        ]);
         $def->addElement('summary', 'Inline', 'Inline', 'Common');
       }
       $_filter = new HTMLPurifier($config);

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -373,8 +373,19 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
         '<p>To view your dashboard, <a href="https://mysite.org/civicrm/?civiwp=CiviCRM&amp;q=civicrm/user&reset=1&id={contact.contact_id}&{contact.checksum}">click here.</a></p>',
         '<p>To view your dashboard, <a href="https://mysite.org/civicrm/?civiwp=CiviCRM&amp;q=civicrm/user&amp;reset=1&amp;id={contact.contact_id}&amp;{contact.checksum}">click here.</a></p>',
       ],
-      'hover' => ['<span onmouseover=alert(0)>HOVER</span>', '<span>HOVER</span>'],
-      'target' => ['<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>', '<a href="https://civicrm.org" target="_blank" class="button-purple" rel="noreferrer noopener">hello</a>'],
+      'hover' => [
+        '<span onmouseover=alert(0)>HOVER</span>',
+        '<span>HOVER</span>',
+      ],
+      'target' => [
+        '<a href="https://civicrm.org" target="_blank" class="button-purple">hello</a>',
+        '<a href="https://civicrm.org" target="_blank" class="button-purple" rel="noreferrer noopener">hello</a>',
+      ],
+      'details' => [
+        '<details class="foo" open><summary>hello</summary>world</details>',
+        // Meh, close enough. May need to be updated if HTMLPurifier gets prettier handing of booleans like `open`.
+        '<details class="foo" open="open"><summary>hello</summary>world</details>',
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
- Followup to #33589

- To fully support the disclosure element we need to whitelist its `open` property.