### PR TITLE
I18n - Add escape=html mode

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -52,8 +52,11 @@ class CRM_Core_I18n {
       case 'js':
         return substr(json_encode($text, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT), 1, -1);
 
+      case 'html':
       case 'htmlattribute':
-        return htmlspecialchars($text, ENT_QUOTES);
+        // Note: the default flags in htmlspecialchars changed from PHP 8.0 to PHP 8.1
+        // Setting them explicitly prevents any PHP-version-specific surprises.
+        return htmlspecialchars($text, ENT_QUOTES | ENT_HTML401);
     }
     throw new Exception('Invalid escape mode: ' . $mode);
   }

--- a/tests/phpunit/CRM/Core/I18n/EscapeTest.php
+++ b/tests/phpunit/CRM/Core/I18n/EscapeTest.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Test\Invasive;
+
+/**
+ * @group headless
+ * @group locale
+ */
+class CRM_Core_I18n_EscapeTest extends CiviUnitTestCase {
+
+  /**
+   * Data provider for testEscape
+   *
+   * @return array
+   */
+  public function escapeDataProvider(): array {
+    return [
+      'no escape mode' => [
+        'Hello & World',
+        '',
+        'Hello & World',
+      ],
+      'html escape special chars' => [
+        'Hello & <World>',
+        'html',
+        'Hello &amp; &lt;World&gt;',
+      ],
+      'htmlattribute escape special chars' => [
+        'Hello & "World"',
+        'htmlattribute',
+        'Hello &amp; &quot;World&quot;',
+      ],
+      'js escape special chars' => [
+        "Hello 'World' & <script>",
+        'js',
+        "Hello \u0027World\u0027 \u0026 \u003Cscript\u003E",
+      ],
+      'invalid mode throws exception' => [
+        'test',
+        'invalid',
+        'Invalid escape mode: invalid',
+        TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * @dataProvider escapeDataProvider
+   * @param string $input Text to escape
+   * @param string $mode Escape mode
+   * @param string $expected Expected result
+   * @param bool $expectException Whether to expect an exception
+   */
+  public function testEscape(
+    string $input,
+    string $mode,
+    string $expected,
+    bool $expectException = FALSE,
+  ): void {
+    if ($expectException) {
+      $this->expectException(Exception::class);
+      $this->expectExceptionMessage($expected);
+    }
+
+    $result = Invasive::call(['CRM_Core_I18n', 'escape'], [$input, $mode]);
+
+    if (!$expectException) {
+      $this->assertEquals($expected, $result);
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds new escaping mode for translated strings in Smarty.

Technical Details
----------------------------------------
Followup to d1d7d2ade, this adds a 'html' escape mode, which is really no different from 'htmlattribute'.
The only time escaping a html attribute would need extra handling would be if someone forgot to put quotes around it, like `<a title={ts}Whoops!{/ts}>`, but, well, we don't support that.

Also let's prevent any PHP-version-specific surprises by setting the flags in `htmlspecialchars`. `ENT_HTML401` is the implicit default so let's just add it explicitly.