### PR TITLE
Riverlea - fix stream override load order

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -118,10 +118,12 @@ class StyleLoader implements \Symfony\Component\EventDispatcher\EventSubscriberI
     }
 
     if ($bundle->name === 'coreStyles') {
-      // queue all core files in order (weights starting at -100, so long as we dont
-      // have 100 then all less than 0)
+      // queue all core files in order
+      // between crm-i at -101
+      // and civicrm.css at -99
+      $j = count(self::CORE_FILES);
       foreach (self::CORE_FILES as $i => $file) {
-        $bundle->addStyleFile('riverlea', "core/css/{$file}", ['weight' => -100 + $i]);
+        $bundle->addStyleFile('riverlea', "core/css/{$file}", ['weight' => -100 + ($i / $j)]);
       }
       // get the URL for dynamic css asset (aka "the river")
       $riverUrl = \Civi::service('asset_builder')->getUrl(


### PR DESCRIPTION
Overview
----------------------------------------
Prior to https://github.com/civicrm/civicrm-core/pull/33395 when streams overrided `civicrm.css`, the rules would load _after_ the core css files.

Since https://github.com/civicrm/civicrm-core/pull/33395 overrides in `civicrm.css` load _before_ core css files.

This reinstates the old order.
