### PR TITLE
Generate Base Page URL for front-end Afform "MessageTokens"

### DIFF
--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -101,7 +101,17 @@ class Tokens extends AutoService implements EventSubscriberInterface {
             if (empty($row->context['contactId'])) {
               continue;
             }
+            if (function_exists('civi_wp')) {
+              // For WordPress: add modifying callbacks prior to multi-lingual compat.
+              add_filter('civicrm/basepage/match', [civi_wp()->basepage, 'ensure_match'], 9);
+              add_filter('civicrm/core/url/base', [civi_wp()->basepage, 'ensure_url'], 9, 2);
+            }
             $url = self::createUrl($afform, $row->context['contactId'], self::getAfformArgsFromTokenContext($row));
+            if (function_exists('civi_wp')) {
+              // For WordPress: remove callbacks.
+              remove_filter('civicrm/basepage/match', [civi_wp()->basepage, 'ensure_match'], 9);
+              remove_filter('civicrm/core/url/base', [civi_wp()->basepage, 'ensure_url'], 9);
+            }
             $row->format('text/plain')->tokens(static::$prefix, $afform['name'] . 'Url', $url);
             $row->format('text/html')->tokens(static::$prefix, $afform['name'] . 'Link', sprintf('<a href="%s">%s</a>', htmlentities($url), htmlentities($afform['title'] ?? $afform['name'])));
           }


### PR DESCRIPTION
Overview
----------------------------------------
Addresses the issue raised in #31801 in a way that respects multi-lingual WordPress.

@mattwire This PR is for you to test the approach I suggested on your draft PR.

Before
----------------------------------------
Untested: URLs should be generated incorrectly depending on context.

After
----------------------------------------
Untested: URLs should be generated correctly.

Technical Details
----------------------------------------
Uses appropriate CiviCRM-WordPress filters to respect URL-modification by WPML and Polylang.