### PR TITLE
Fix cannot delete group due to missing saved search form values

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -405,7 +405,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     foreach ($groups as $group) {
       // Filter out arrays in Form Values which are group searchs.
       $groupSearches = array_filter(
-        $group['saved_search_id.form_values'],
+        $group['saved_search_id.form_values'] ?: [],
         function($v) {
           return ($v[0] == 'group');
         }

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -382,7 +382,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
   public function normalizeDefaultValues($defaults) {
     $this->loadDefaultCountryBasedOnState($defaults);
     if ($this->_ssID && empty($_POST)) {
-      $defaults = array_merge($defaults, CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID));
+      $defaults = array_merge($defaults, (CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID) ?: []));
     }
 
     /*


### PR DESCRIPTION
Overview
----------------------------------------
6.6. port of https://github.com/civicrm/civicrm-core/pull/33638

Before
----------------------------------------

Fatal error deleting a group; user just gets "network error" and http 500.

> `PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array.`



After
----------------------------------------

User is able to delete the group as normal.

