### PR TITLE
Fix cannot delete group due to missing saved search form values

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -405,7 +405,7 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     foreach ($groups as $group) {
       // Filter out arrays in Form Values which are group searchs.
       $groupSearches = array_filter(
-        $group['saved_search_id.form_values'],
+        $group['saved_search_id.form_values'] ?: [],
         function($v) {
           return ($v[0] == 'group');
         }

--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -60,6 +60,11 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
     if ($fv) {
       // make sure u CRM_Utils_String::unserialize - since it's stored in serialized form
       $result = CRM_Utils_String::unserialize($fv);
+      if ($result === FALSE) {
+        // See https://github.com/civicrm/civicrm-core/pull/33638
+        Civi::log()->error("Invalid saved_search.form_values for search ID $id. Failed to unserialize. Risk of unexpected search results.");
+        return [];
+      }
     }
 
     $specialFields = ['contact_type', 'group', 'contact_tags', 'member_membership_type_id', 'member_status_id'];

--- a/CRM/Contact/Form/Search/Advanced.php
+++ b/CRM/Contact/Form/Search/Advanced.php
@@ -382,7 +382,7 @@ class CRM_Contact_Form_Search_Advanced extends CRM_Contact_Form_Search {
   public function normalizeDefaultValues($defaults) {
     $this->loadDefaultCountryBasedOnState($defaults);
     if ($this->_ssID && empty($_POST)) {
-      $defaults = array_merge($defaults, CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID));
+      $defaults = array_merge($defaults, (CRM_Contact_BAO_SavedSearch::getFormValues($this->_ssID) ?: []));
     }
 
     /*


### PR DESCRIPTION
Overview
----------------------------------------

A client on 6.5.0 got a crash when deleting a group via the Manage Groups screen.

This appeared to be because "form values" saved on the saved search can be FALSE, but there's a PHP type hint requirement that it is Array.

I haven't figured out if it's *every group* or just some that cause the crash.

Before
----------------------------------------

Fatal error deleting a group; user just gets "network error" and http 500.

> PHP Fatal error:  Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array.



After
----------------------------------------

User is able to delete the group as normal.

