### PR TITLE
dev/core#4516 Increase default quickform session timeout to 120 minutes

### DIFF
--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -962,7 +962,7 @@ return [
       'size' => 2,
       'maxlength' => 8,
     ],
-    'default' => 20,
+    'default' => 120,
     'add' => '4.7',
     'title' => ts('Secure Cache Timeout'),
     'is_domain' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/4516 . Basically means that you don't get "your session has expired" after 20 minutes, but 2 hours instead.

Before
----------------------------------------
Timeout set at 20 minutes

After
----------------------------------------
Timeout set at 2 hours

Technical Details
----------------------------------------
Change default value of setting

Comments
----------------------------------------

