### PR TITLE
Afform - Ensure drafts don't count toward submit limit

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -113,6 +113,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       $afformSubmissions = \Civi\Api4\AfformSubmission::get(FALSE)
         ->addSelect('afform_name', 'COUNT(id) AS count', 'MAX(submission_date) AS date')
         ->addWhere('afform_name', 'IN', array_keys($afforms))
+        ->addWhere('status_id:name', '!=', 'Draft')
         ->addGroupBy('afform_name')
         ->execute()->indexBy('afform_name');
       foreach ($afforms as $name => $record) {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -613,13 +613,19 @@ EOHTML;
       ->setValues(['me' => $submitValues])
       ->execute();
 
+    // Submit draft - won't count toward the limit
+    Afform::submitDraft()
+      ->setName($this->formName)
+      ->setValues(['me' => []])
+      ->execute();
+
     // Autofilling form works because limit hasn't been reached
     Afform::prefill()
       ->setName($this->formName)
       ->setFillMode('form')
       ->execute();
 
-    // Last time
+    // Submit again (this will overwrite the draft)
     Afform::submit()
       ->setName($this->formName)
       ->setValues(['me' => $submitValues])


### PR DESCRIPTION
Overview
----------------------------------------
Fix afform's counting of draft submissions toward the submission limit.

Before
----------------------------------------
Submitting a draft will count toward the limit, and then you won't be able to edit your draft if it thinks the limit has been reached.

After
----------------------------------------
Works as expected. Test added.

Comments
----------------------------------------
Not a regression per-se but worth fixing right away.