### PR TITLE
Remove reference to undefined property _fieldset and remove deprecate…

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -158,6 +158,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
 
   protected $_currentUserID = NULL;
   protected $_session = NULL;
+  protected $_maxRecordLimit = NULL;
 
   /**
    * Check for any duplicates.
@@ -339,7 +340,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
       }
     }
 
-    $gids = explode(',', (CRM_Utils_Request::retrieve('gid', 'String', CRM_Core_DAO::$_nullObject, FALSE, 0) ?? ''));
+    $gids = explode(',', (CRM_Utils_Request::retrieve('gid', 'String', NULL, FALSE, 0) ?? ''));
 
     if ((count($gids) > 1) && !$this->_profileIds && empty($this->_profileIds)) {
       if (!empty($gids)) {
@@ -802,7 +803,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     $this->assign('isHideFieldSet', ($this->_mode === self::MODE_CREATE || $this->_mode === self::MODE_EDIT));
     $this->assign('action', $this->_action);
     $this->assign('fields', $this->_fields);
-    $this->assign('fieldset', (isset($this->_fieldset)) ? $this->_fieldset : "");
+    $this->assign('fieldset', '');
 
     // should we restrict what we display
     $admin = TRUE;
@@ -969,7 +970,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
    *   The input form values.
    * @param array $files
    *   The uploaded files if any.
-   * @param CRM_Core_Form $form
+   * @param CRM_Profile_Form $form
    *   The form object.
    *
    * @return bool|array


### PR DESCRIPTION
…d nullObject reference and define maxRecordLimit class variable

Overview
----------------------------------------
This updates the CRM_Profile_Form class to define one class variable, remove refernce to one that doesn't seem to be set at all and remove reference to the _nullObject and make a clarification in the doc block of the validate function

@colemanw @demeritcowboy 