### PR TITLE
followup for issue 6078: correct URL tpl for edit-user page

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -76,7 +76,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     if (CRM_Core_Permission::check('cms:administer users')) {
       $uid = (int) CRM_Core_BAO_UFMatch::getUFId($contactID);
       if ($uid) {
-        return (string) Civi::url("backend://civicrm/admin/user#User=[uid]")->addVars(compact('uid'));
+        return (string) Civi::url("backend://civicrm/admin/user/#?User1=[uid]")->addVars(compact('uid'));
       }
     }
     return NULL;


### PR DESCRIPTION
Refs:

- https://lab.civicrm.org/dev/core/-/issues/6078
- https://github.com/civicrm/civicrm-core/pull/33520
- https://github.com/civicrm/civicrm-core/pull/33524

The fix above does not appear to be working on smaster! See subtle wrongness of the URL pattern.  I think the URL must have gotten mangled in when I updated the PR from the old URL generating function to the newer Civi::url() way.

I've tested the change included here and it works for me. But please somebody verify!

I've made this against 6.7 since it is a correction to a backport there. (Can do for 6.6 if wanted)