### PR TITLE
Don't allow changing name of built-in contact types

### DIFF
--- a/CRM/Admin/Form/ContactType.php
+++ b/CRM/Admin/Form/ContactType.php
@@ -42,7 +42,7 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
       return;
     }
     $this->applyFilter('__ALL__', 'trim');
-    $this->add('text', 'label', ts('Name'),
+    $name = $this->add('text', 'label', ts('Name'),
       CRM_Core_DAO::getAttribute('CRM_Contact_DAO_ContactType', 'label'),
       TRUE
     );
@@ -61,6 +61,10 @@ class CRM_Admin_Form_ContactType extends CRM_Admin_Form {
       // dev/core#4470 except Household which can be disabled
       if (is_null($this->parentId) && $contactTypeName != 'Household') {
         $enabled->freeze();
+      }
+      // Freeze name field for built-in contact types
+      if (is_null($this->parentId)) {
+        $name->freeze();
       }
     }
     // TODO: Remove when dropping image_URL column


### PR DESCRIPTION
Overview
----------------------------------------
There is a whole lot of code in CiviCRM that presumes that you have contact types named "Individual, "Organization", and "Household".  CiviImport breaks, for instance, if you rename a built-in contact type, and I suspect other things do as well.

Before
----------------------------------------

<img width="466" height="341" alt="Selection_2616" src="https://github.com/user-attachments/assets/d0ac1fe9-cdb0-4452-bf02-dcbc06957452" />

After
----------------------------------------

<img width="658" height="372" alt="Selection_2615" src="https://github.com/user-attachments/assets/29d71f96-30c0-4502-b97a-f88c84b3811f" />


Comments
----------------------------------------
I'm a bit concerned about how this affects folks who might have already changed the contact type names, but I'm open to suggestions.  One possibility: A check on upgrade. Another possibility: Instructions on how to fix this via API.  Feedback welcomed.