### PR TITLE
(dev/core#6096) Error in "Grant Report (Statistics)"

### DIFF
--- a/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
+++ b/ext/civigrant/CRM/Report/Form/Grant/Statistics.php
@@ -300,6 +300,7 @@ WHERE {$this->_aliases['civicrm_grant']}.amount_total IS NOT NULL
 
   public function preProcess() {
     \Civi::resources()->addBundle('visual');
+    parent::preProcess();
   }
 
   public function postProcess() {


### PR DESCRIPTION
Backport @monishdeb's  #33621 from 6.7-rc to 6.6-stable.

In my local `r-run`, this did resolve some errors with using "Grant Statistics".