### PR TITLE
Focus on date field or adjacent time field after selecting date in datepicker

### DIFF
--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -73,6 +73,13 @@
           if (!settings.yearRange && settings.minDate !== null && settings.maxDate !== null) {
             settings.yearRange = '' + CRM.utils.formatDate(settings.minDate, 'yy') + ':' + CRM.utils.formatDate(settings.maxDate, 'yy');
           }
+          settings.onSelect = function (dateText, inst) {
+            if (settings.time !== false) {
+              $timeField.focus();
+            } else {
+              $(this).focus();
+            }
+          };
           $dateField.addClass('crm-form-date').datepicker(settings);
         } else {
           $dateField.attr('min', settings.minDate ? CRM.utils.formatDate(settings.minDate, 'yy') : '1000');


### PR DESCRIPTION
Before
----------------------------------------
When selecting a date in crmDatepicker, after clicking the day, focus goes to the first element on the page. If you press tab you don't go to the next field, but to the second element on the page. 

After
----------------------------------------
If there is a time field present, after clicking the day, focus goes to the time field.
If there is no time field, focus goes to the date field.

Comments
----------------------------------------
If folks think different behaviour with and without a time field is bad UX (e.g. if you're expecting to have to tab, so you do and end up skipping the time field), then I'm happy to just make it always focus the date field. But it felt like a nice feature to move the focus straight to the time field.

This change is particularly helpful when you are doing batch data entry, where it is quite annoying to not be able to tab through the fields as expected.
