### PR TITLE
(dev/core#6076) Address - Fix rendering of state_province_name

### DIFF
--- a/CRM/Utils/Address.php
+++ b/CRM/Utils/Address.php
@@ -188,7 +188,7 @@ class CRM_Utils_Address {
     $legacyFieldConversions = [
       'address_name' => 'name',
       'state' => 'state_province_id:label',
-      'state_province_name' => 'state_province_id:abbr',
+      'state_province_name' => 'state_province_id:label',
       'state_province' => 'state_province_id:abbr',
       'county' => 'county_id:label',
       'country' => 'country_id:label',


### PR DESCRIPTION
Overview
----------------------------------------

Fix a bug displaying the full-name of a state in the "View Contact (Summary)" screen.

Regression circa 6.4 (#32744). See also: https://lab.civicrm.org/dev/core/-/issues/6076

Steps to Reproduce
----------------------------------------

* Configure "Administer > Localization > Address Settings". 
    * In the "Address Display Format", change `{contact.state_province}` to `{contact.state_province_name}`.
* Find a contact which has an address.
* View the contact record

Before
----------------------------------------

In this sample address, the state name "North Carolina" is missing:

<img width="633" height="102" alt="Screenshot 2025-09-23 at 5 18 37 PM" src="https://github.com/user-attachments/assets/7792a812-82cd-473e-9595-5226b386c6c5" />

After
----------------------------------------

In this sample address, the state name "North Carolina" is included:

<img width="632" height="101" alt="Screenshot 2025-09-23 at 5 18 51 PM" src="https://github.com/user-attachments/assets/190affe4-6784-4928-8ff3-6cfcbd6da9e3" />

