### PR TITLE
(REF) Addresses - Rename `$microformat` to `$useMarkup`

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -787,13 +787,15 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
    * @param array $defaults
    *   (reference ) an assoc array to hold the name / value pairs.
    *                        in a hierarchical manner
-   * @param bool $microformat
-   *   Deprecated value
+   * @param bool $useAddressMarkup
+   *   (DEPRECATED) If TRUE, the contact's primary address will be
+   *   returned with a formatted (HTML) blob.
    *
    * @return CRM_Contact_BAO_Contact
+   *
    */
-  public static function &retrieve(&$params, &$defaults = [], $microformat = FALSE) {
-    if ($microformat) {
+  public static function &retrieve(&$params, &$defaults = [], $useAddressMarkup = FALSE) {
+    if ($useAddressMarkup) {
       CRM_Core_Error::deprecatedWarning('microformat is deprecated in CRM_Contact_BAO_Contact::retrieve');
     }
     if (array_key_exists('contact_id', $params)) {
@@ -811,7 +813,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     $contact->email = $defaults['email'] = CRM_Core_BAO_Email::getValues(['contact_id' => $params['contact_id']]);
     $contact->openid = $defaults['openid'] = CRM_Core_BAO_OpenID::getValues(['contact_id' => $params['contact_id']]);
     $contact->phone = $defaults['phone'] = CRM_Core_BAO_Phone::getValues(['contact_id' => $params['contact_id']]);
-    $contact->address = $defaults['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $params['contact_id']], $microformat);
+    $contact->address = $defaults['address'] = CRM_Core_BAO_Address::getValues(['contact_id' => $params['contact_id']], $useAddressMarkup);
     $contact->website = CRM_Core_BAO_Website::getValues($params, $defaults);
 
     if (!isset($params['noNotes'])) {

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -350,14 +350,16 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
    *
    * @param array $entityBlock
    *   Associated array of fields.
-   * @param bool $microformat
-   *   If microformat output is required.
+   * @param bool $useMarkup
+   *   If TRUE, then `$this->display` will be filled with an address summary -- using markup.
+   *   If FALSE, then `$this->display` will be filled with an address summary -- using plain-text.
+   *   NOTE: Regardless of the flag, `$this->display_text` will have an address summary -- using plain-text.
    * @param int|string $fieldName conditional field name
    *
    * @return array
    *   array with address fields
    */
-  public static function &getValues($entityBlock, $microformat = FALSE, $fieldName = 'contact_id') {
+  public static function &getValues($entityBlock, $useMarkup = FALSE, $fieldName = 'contact_id') {
     if (empty($entityBlock)) {
       return NULL;
     }
@@ -423,7 +425,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
         $values['world_region'] = CRM_Core_PseudoConstant::worldregion($regionId);
       }
 
-      $address->addDisplay($microformat);
+      $address->addDisplay($useMarkup);
 
       $values['display'] = $address->display;
       $values['display_text'] = $address->display_text;
@@ -453,10 +455,12 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
   /**
    * Add the formatted address to $this-> display.
    *
-   * @param bool $microformat
-   *   Unexplained parameter that I've always wondered about.
+   * @param bool $useMarkup
+   *   If TRUE, then `$this->display` will be filled with an address summary -- using markup.
+   *   If FALSE, then `$this->display` will be filled with an address summary -- using plain-text.
+   *   NOTE: Regardless of the flag, `$this->display_text` will have an address summary -- using plain-text.
    */
-  public function addDisplay($microformat = FALSE) {
+  public function addDisplay($useMarkup = FALSE) {
     $fields = [
       // added this for CRM 1200
       'address_id' => $this->id,
@@ -481,7 +485,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
     else {
       $fields['county'] = NULL;
     }
-    if ($microformat) {
+    if ($useMarkup) {
       $this->display = CRM_Utils_Address::formatVCard($fields);
       $this->display_text = CRM_Utils_Address::format($fields);
     }

--- a/CRM/Core/BAO/Location.php
+++ b/CRM/Core/BAO/Location.php
@@ -201,13 +201,15 @@ WHERE e.id = %1";
    * Get array of location block BAOs.
    *
    * @param array $entityBlock
-   * @param bool $microformat
-   *
+   * @param bool $useMarkup
+   *   If TRUE, then `address[display]` will be filled with an address summary -- using markup.
+   *   If FALSE, then `address[display]` will be filled with an address summary -- using plain-text.
+   *   NOTE: Regardless of the flag, `address['display_text']` will have an address summary -- using plain-text.
    * @return CRM_Core_BAO_Location[]|null
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getValues($entityBlock, $microformat = FALSE): ?array {
+  public static function getValues($entityBlock, $useMarkup = FALSE): ?array {
     if (empty($entityBlock)) {
       // Can't imagine this is reachable.
       CRM_Core_Error::deprecatedWarning('calling function pointlessly is deprecated');
@@ -218,7 +220,7 @@ WHERE e.id = %1";
       'email' => CRM_Core_BAO_Email::getValues($entityBlock),
       'openid' => CRM_Core_BAO_OpenID::getValues($entityBlock),
       'phone' => CRM_Core_BAO_Phone::getValues($entityBlock),
-      'address' => CRM_Core_BAO_Address::getValues($entityBlock, $microformat),
+      'address' => CRM_Core_BAO_Address::getValues($entityBlock, $useMarkup),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Rename a confusing variable.

There are various functions which can fetch an `Address`. All of these functions pass around an option (`$microformat`), but none of them explain what `$microformat` means. Which microformat? What's the full format? 🤔 

Well, difference is in this behavior: these functions produce a printable address string (e.g. `$addressDao->display`), and the flag changes the format of the property from _plain-text_ to _HTML-markup_.

Before
----------------------------------------

Fewer docs.

After
----------------------------------------

More docs. 

