### PR TITLE
Allow searchkit admin to user with Admininstrator civicrm permissions

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -33,6 +33,10 @@ class Admin {
    * @throws \CRM_Core_Exception
    */
   public static function getAdminSettings():array {
+    if (!\CRM_Core_Permission::check('administer CiviCRM')) {
+      return [];
+    }
+
     $schema = self::getSchema();
     $data = [
       'schema' => self::addImplicitFKFields($schema),


### PR DESCRIPTION
Overview
----------------------------------------
When anonymous user try to access the saved searchkit page like : https://my-site/civicrm/admin/search#/edit/237 it should show access denied error like other Civi admin page. Instead it shows white screen of error and in the log it recorded error as : _Uncaught PHP Exception Civi\API\Exception\UnauthorizedException: "Authorization failed: CiviCRM APIv4 (Entity::get)" at /vendor/civicrm/civicrm-core/Civi/API/Kernel.php line 234_

Before
----------------------------------------
Click on Search -> SearchKit.
      Copy edit link of any existing Saved searches which looks like : "/[civicrm/admin/search#/edit/237](https://my-site/civicrm/admin/search#/edit/237)"        
      Copy this link and open for anonymous user or incognito mode without login to site.       
      This will throws error like 'The website encountered an unexpected error.'      
      In the Civi logs the error is : _Uncaught PHP Exception Civi\API\Exception\UnauthorizedException: "Authorization failed: CiviCRM APIv4 (Entity::get)" at /vendor/civicrm/civicrm-core/Civi/API/Kernel.php line 234_

After
----------------------------------------
It now throws the 'Access denied' for anonymous users like other Civi admin pages of seachkit

Technical Details
----------------------------------------
Ticket is already created here : https://lab.civicrm.org/dev/core/-/issues/6110
