### PR TITLE
Replace fa-pulse with fa-spin (animation tweak)

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -261,7 +261,7 @@
                 <i class="fa fa-fw fa-check-circle" ng-switch-when="success" role="img" aria-hidden="true"></i>
                 <i class="fa fa-fw fa-check-circle" ng-switch-when="warning" role="img" aria-hidden="true"></i>
                 <i class="fa fa-fw fa-minus-circle" ng-switch-when="danger" role="img" aria-hidden="true"></i>
-                <i class="fa fa-fw fa-spinner fa-pulse" ng-switch-when="info" role="img" aria-hidden="true"></i>
+                <i class="fa fa-fw fa-spinner fa-spin" ng-switch-when="info" role="img" aria-hidden="true"></i>
               </span>
               <span>{{:: ts('Result') }}</span>
             </a>

--- a/ang/exportui/exportSaveMapping.html
+++ b/ang/exportui/exportSaveMapping.html
@@ -19,7 +19,7 @@
   <div class="ui-dialog-buttonpane ui-widget-content">
     <div class="ui-dialog-buttonset">
       <button type="button" class="crm-button" ng-click="model.saveMapping()" ng-disabled="!model.new_name || model.saving || !model.nameIsUnique()">
-        <i class="crm-i" ng-class="{'fa-check': !model.saving, 'fa-spinner fa-pulse': model.saving}" role="img" aria-hidden="true"></i>
+        <i class="crm-i" ng-class="{'fa-check': !model.saving, 'fa-spinner fa-spin': model.saving}" role="img" aria-hidden="true"></i>
         {{ model.ts('Save Fields') }}
       </button>
     </div>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.html
@@ -4,7 +4,7 @@
     {{:: ts('Search configuration copied from the "Export" action can be pasted here.') }}
   </div>
   <div class="alert alert-info" ng-if="$ctrl.checking || $ctrl.running">
-    <i class="crm-i fa-spinner fa-pulse" role="img" aria-hidden="true"></i>
+    <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i>
     {{ $ctrl.checking ? ts('Checking input...') : ts('Importing Saved Search...') }}
   </div>
   <div class="alert alert-danger" ng-if="$ctrl.error">

--- a/js/Common.js
+++ b/js/Common.js
@@ -1181,7 +1181,7 @@ if (!CRM.vars) CRM.vars = {};
         }
       }
       var $icon = $(submitButton).siblings('.crm-i').add('.crm-i, .ui-icon', submitButton);
-      $icon.data('origClass', $icon.attr('class')).removeClass().addClass('crm-i crm-submit-icon fa-spinner fa-pulse');
+      $icon.data('origClass', $icon.attr('class')).removeClass().addClass('crm-i crm-submit-icon fa-spinner fa-spin');
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Seems we have two animations for spinning things. A clunky old one and a smoother new one. 
This PR moves us to the newer one across the project.

And fixes a related problem specific to Thames stream.

Before
----------------------------------------

`fa-pulse` used in 4 files.

e.g. 
deleting an activity

Hackney Brooke: 

![hackney-pulse](https://github.com/user-attachments/assets/90a02668-8172-4c59-9137-1fc492a5de3b)



Thames:


![thames-old](https://github.com/user-attachments/assets/d8cadd6a-3b2a-46e3-a371-83d89d47f0d2)

In this context (activity deletion) the classes on the `<i>` are changed from
`ui-button-icon ui-icon crm-i fa-check` to `crm-i crm-submit-icon fa-spinner fa-pulse`


After
----------------------------------------

Hackney Brooke: 

![hackney-new](https://github.com/user-attachments/assets/dc753e77-2b6f-49e5-bbb3-4b9752175739)


Thames:

![thames-new](https://github.com/user-attachments/assets/6d23748a-3061-4a43-83c5-d1ea90efbb6b)

In this context (activity deletion) the classes on the `<i>` are changed from
`ui-button-icon ui-icon crm-i fa-check` to `crm-i crm-submit-icon fa-spinner fa-spin`


notes
---------

- fa-pulse was only used in 4 places; fa-spin in around two dozen, lots in searchkit. Seemed fa-spin was the more recent one.

- thames implements its own version of the spinner and overrides the animation. This includes a fix for that. too
