### PR TITLE
Afform - Pre-check permissions for ang admin screens

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -14,6 +14,10 @@ class AfformAdminMeta {
    * @return array
    */
   public static function getAdminSettings(): array {
+    // Check minimum permission needed to reach this
+    if (!\CRM_Core_Permission::check('manage own afform')) {
+      return [];
+    }
     $afformPlacement = \CRM_Utils_Array::formatForSelect2(PlacementUtils::getPlacements(), 'label', 'value');
     $afformTags = \CRM_Utils_Array::formatForSelect2((array) \Civi\Api4\Utils\AfformTags::getTagOptions());
     $afformTypes = (array) \Civi\Api4\OptionValue::get(FALSE)

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -33,6 +33,10 @@ class Admin {
    * @throws \CRM_Core_Exception
    */
   public static function getAdminSettings():array {
+    // Check minimum permission needed to reach this
+    if (!\CRM_Core_Permission::check('manage own search_kit')) {
+      return [];
+    }
     $schema = self::getSchema();
     $data = [
       'schema' => self::addImplicitFKFields($schema),


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6110](https://lab.civicrm.org/dev/core/-/issues/6110)

Before
----------------------------------------
Not-very-nice error messages when a non-admin attempts to access SearchKit and FormBuilder.

After
----------------------------------------
Nicer

Technical Details
----------------------------------------
Either way, unprivileged users won't have access to these screens, but this prevents them from seeing confusing error messages.

Comments
----------------------------------------
Credit to @sdoijad for the original patch in https://github.com/civicrm/civicrm-core/pull/33661.
