### PR TITLE
Store configuration of a more advanced Afform behavior

### DIFF
--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -331,9 +331,6 @@ class CRM_Afform_ArrayHtml {
         return $mixedAttrValue;
 
       case 'js':
-        if (is_string($mixedAttrValue)) {
-          $mixedAttrValue = json_decode($mixedAttrValue, TRUE);
-        }
         $v = CRM_Utils_JS::writeObject($mixedAttrValue, TRUE);
         return $v;
 

--- a/ext/afform/core/CRM/Afform/ArrayHtml.php
+++ b/ext/afform/core/CRM/Afform/ArrayHtml.php
@@ -32,6 +32,7 @@ class CRM_Afform_ArrayHtml {
       'type' => 'text',
       'security' => 'text',
       'actions' => 'js',
+      'behavior' => 'js',
     ],
     'af-field' => [
       '#selfClose' => TRUE,
@@ -330,6 +331,9 @@ class CRM_Afform_ArrayHtml {
         return $mixedAttrValue;
 
       case 'js':
+        if (is_string($mixedAttrValue)) {
+          $mixedAttrValue = json_decode($mixedAttrValue, TRUE);
+        }
         $v = CRM_Utils_JS::writeObject($mixedAttrValue, TRUE);
         return $v;
 


### PR DESCRIPTION
Overview
----------------------------------------

I am working on the integration of the form processor and form builder. I have added a behavior to the form processor for retrieving the default values. This behavior has some advanced configuration and is stored on the `<af-entity>` tag. 

Ideally I want to store this at an attribute called `form-processor-retrieval-of-defaults`. (Or any other attribute). 

This is how the tag looks like:

```html
  <af-entity type="FormProcessor_test_form_builder" name="FormProcessor_test_form_builder1" label="Test Form Builder 1" actions="{create: true, update: true}" security="RBAC" form-processor-retrieval-of-defaults="{'default-data-inputs': '{id: routeParams.id}'}" />

```

This is how the behavior configuration looks like on the screen

<img width="699" height="377" alt="2025-09-24_16-13" src="https://github.com/user-attachments/assets/edcc1e02-f506-4eea-9c7e-8d442e7663b9" />



Before
----------------------------------------

Storing it at the `form-processor-retrieval-of-defaults` attribute returns in a fatal error. 

This is the fatal error: PHP Fatal error:  Uncaught TypeError: htmlentities(): Argument #1 ($string) must be of type string, array given in /var/www/html/standalone/web/core/ext/afform/core/CRM/Afform/ArrayHtml.php:122


After
----------------------------------------

There is a generic attribute `behavior` for storing advanced behavior configurations.  And no fatal errors anymore.


Comments
----------------------------------------

@colemanw suggested I create this pr.  However, I am happy to work on a more robust method. One idea I think which might work is to implement an event for altering the `$protoSchema`. The form processor extension can list to that event and add the right attribute. 
