### PR TITLE
JWT - Add support for signing/verifying with EdDSA

### DIFF
--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -53,6 +53,9 @@ class CryptoJwt extends AutoService {
         $privateKey = base64_encode(sodium_crypto_sign_secretkey($key['key']));
         return JWT::encode($payload, $privateKey, 'EdDSA', $key['id']);
 
+      case 'jwt-eddsa-public':
+        throw new CryptoException("Cannot use public-key to sign JWT.");
+
       // Symmetric keys...
       default:
         $alg = $this->suiteToAlg($key['suite']);
@@ -71,6 +74,9 @@ class CryptoJwt extends AutoService {
    */
   public function decode($token, $keyTag = 'SIGN') {
     $keyRows = $this->getRegistry()->findKeysByTag($keyTag);
+    if (empty($keyRows)) {
+      throw new CryptoException("Unknown key/tag ($keyTag)");
+    }
 
     $jwtKeys = [];
     foreach ($keyRows as $key) {
@@ -79,6 +85,10 @@ class CryptoJwt extends AutoService {
         case 'jwt-eddsa-keypair':
           $publicKey = base64_encode(sodium_crypto_sign_publickey($key['key']));
           $jwtKeys[$key['id']] = new Key($publicKey, 'EdDSA');
+          break;
+
+        case 'jwt-eddsa-public':
+          $jwtKeys[$key['id']] = new Key(base64_encode($key['key']), 'EdDSA');
           break;
 
         // Symmetric keys...

--- a/Civi/Crypto/CryptoJwt.php
+++ b/Civi/Crypto/CryptoJwt.php
@@ -47,9 +47,17 @@ class CryptoJwt extends AutoService {
    */
   public function encode($payload, $keyIdOrTag = 'SIGN') {
     $key = $this->getRegistry()->findKey($keyIdOrTag);
-    $alg = $this->suiteToAlg($key['suite']);
-    // Currently, registry only has symmetric keys in $key['key']. For public key-pairs, might need to change.
-    return JWT::encode($payload, $key['key'], $alg, $key['id']);
+    switch ($key['suite']) {
+      // Asymmetric key-pairs...
+      case 'jwt-eddsa-keypair':
+        $privateKey = base64_encode(sodium_crypto_sign_secretkey($key['key']));
+        return JWT::encode($payload, $privateKey, 'EdDSA', $key['id']);
+
+      // Symmetric keys...
+      default:
+        $alg = $this->suiteToAlg($key['suite']);
+        return JWT::encode($payload, $key['key'], $alg, $key['id']);
+    }
   }
 
   /**
@@ -66,9 +74,18 @@ class CryptoJwt extends AutoService {
 
     $jwtKeys = [];
     foreach ($keyRows as $key) {
-      if ($alg = $this->suiteToAlg($key['suite'])) {
-        // Currently, registry only has symmetric keys in $key['key']. For public key-pairs, might need to change.
-        $jwtKeys[$key['id']] = new Key($key['key'], $alg);
+      switch ($key['suite']) {
+        // Asymmetric key-pairs...
+        case 'jwt-eddsa-keypair':
+          $publicKey = base64_encode(sodium_crypto_sign_publickey($key['key']));
+          $jwtKeys[$key['id']] = new Key($publicKey, 'EdDSA');
+          break;
+
+        // Symmetric keys...
+        default:
+          $alg = $this->suiteToAlg($key['suite']);
+          $jwtKeys[$key['id']] = new Key($key['key'], $alg);
+          break;
       }
     }
 

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -196,7 +196,12 @@ class CryptoRegistry extends AutoService {
     }
 
     if (!isset($options['id'])) {
-      $options['id'] = \CRM_Utils_String::base64UrlEncode(sha1($options['suite'] . chr(0) . $options['key'], TRUE));
+      $identifyingPart = match($options['suite']) {
+        'jwt-eddsa-keypair' => 'jwt-eddsa-*' . chr(0) . sodium_crypto_sign_publickey($options['key']),
+        'jwt-eddsa-public' => 'jwt-eddsa-*' . chr(0) . $options['key'],
+        default => $options['suite'] . chr(0) . $options['key'],
+      };
+      $options['id'] = \CRM_Utils_String::base64UrlEncode(sha1($identifyingPart, TRUE));
     }
     // Manual key IDs should be validated.
     elseif (!$this->isValidKeyId($options['id'])) {

--- a/Civi/Crypto/CryptoRegistry.php
+++ b/Civi/Crypto/CryptoRegistry.php
@@ -167,6 +167,29 @@ class CryptoRegistry extends AutoService {
       'weight' => 0,
     ];
     $options = array_merge($defaults, $options);
+    return $this->addKey($options);
+  }
+
+  /**
+   * @param string|array $options
+   *   Additional options:
+   *     - key: string, a representation of the key as binary
+   *     - suite: string, ex: 'aes-cbc' or ''jwt-eddsa-keypair''
+   *     - tags: string[]
+   *     - weight: int, default 0
+   *     - id: string, a unique identifier for this key. (default: fingerprint the key+suite)
+   *
+   * @return array
+   *   The full key record. (Same format as $options)
+   * @throws \Civi\Crypto\Exception\CryptoException
+   */
+  public function addKey($options) {
+    if (empty($options['suite'])) {
+      throw new CryptoException("addKey(): Must specify a suite");
+    }
+
+    $defaults = ['weight' => 0];
+    $options = array_merge($defaults, $options);
 
     if (!isset($options['key'])) {
       throw new CryptoException("Missing crypto key");
@@ -182,6 +205,10 @@ class CryptoRegistry extends AutoService {
 
     $this->keys[$options['id']] = $options;
     return $options;
+  }
+
+  public function removeKey(string $id): void {
+    unset($this->keys[$id]);
   }
 
   /**

--- a/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
@@ -58,6 +58,7 @@ class CryptoJwtTest extends \CiviUnitTestCase {
   public function getMixKeyExamples() {
     return [
       ['SIGN-TEST', 'SIGN-TEST', TRUE],
+      ['SIGN-TEST-EDDSA', 'SIGN-TEST-EDDSA', TRUE],
       ['sign-key-0', 'SIGN-TEST', TRUE],
       ['sign-key-1', 'SIGN-TEST', TRUE],
       ['sign-key-alt', 'SIGN-TEST', FALSE],

--- a/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoJwtTest.php
@@ -17,6 +17,9 @@ use Firebase\JWT\JWT;
 
 /**
  * Test major use-cases of the 'crypto.token' service.
+ *
+ * @group headless
+ * @group crypto
  */
 class CryptoJwtTest extends \CiviUnitTestCase {
 

--- a/tests/phpunit/Civi/Crypto/CryptoRegistryTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoRegistryTest.php
@@ -15,6 +15,9 @@ use Civi\Crypto\Exception\CryptoException;
 
 /**
  * Test major use-cases of the 'crypto.registry' service.
+ *
+ * @group headless
+ * @group crypto
  */
 class CryptoRegistryTest extends \CiviUnitTestCase {
 

--- a/tests/phpunit/Civi/Crypto/CryptoTestTrait.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTestTrait.php
@@ -22,6 +22,8 @@ trait CryptoTestTrait {
       'jwt-hs256::abcd1234abcd1234',
       'jwt-hs384:b64:8h5wNGnJbdVHpXms2RwcVx+jxCNdYEsYCdNlPpVgNLRMg9Q2xKYnxSfuihS6YCRi',
       'jwt-hs256::fdsafdsafdsa',
+      'jwt-eddsa-keypair:b64:1mLWxLLESEJphn4V8RHZfkk5UtoxBHXzrWFjdf7swNdQvgc+K4gd/xnwjFaInkfnHiFFjRRckbfZZXrYVLeRgFC+Bz4riB3/GfCMVoieR+ceIUWNFFyRt9llethUt5GA',
+      // Example EdDSA keypair generated with `base64_encode(sodium_crypto_sign_keypair())`
     ];
   }
 
@@ -78,8 +80,14 @@ trait CryptoTestTrait {
     ]);
     $this->assertEquals(0, $key['weight']);
 
-    $this->assertEquals(7, count($examples));
-    $this->assertEquals(7 + $origCount, count($registry->getKeys()));
+    $key = $registry->addKey($registry->parseKey($examples[7]) + [
+      'tags' => ['SIGN-TEST-EDDSA'],
+      'id' => 'sign-key-eddsa',
+    ]);
+    $this->assertEquals(0, $key['weight']);
+
+    $this->assertEquals(8, count($examples));
+    $this->assertEquals(8 + $origCount, count($registry->getKeys()));
   }
 
 }

--- a/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
+++ b/tests/phpunit/Civi/Crypto/CryptoTokenTest.php
@@ -15,6 +15,9 @@ use Civi\Crypto\Exception\CryptoException;
 
 /**
  * Test major use-cases of the 'crypto.token' service.
+ *
+ * @group headless
+ * @group crypto
  */
 class CryptoTokenTest extends \CiviUnitTestCase {
 

--- a/tests/phpunit/api/v4/Entity/SystemRotateKeyTest.php
+++ b/tests/phpunit/api/v4/Entity/SystemRotateKeyTest.php
@@ -26,6 +26,7 @@ use Psr\Log\LoggerInterface;
 
 /**
  * @group headless
+ * @group crypto
  */
 class SystemRotateKeyTest extends Api4TestBase implements TransactionalInterface {
 


### PR DESCRIPTION
Overview
----------------------------------------

The `crypto.jwt` service can be used to generate JSON Web Tokens (JWT). It currently supports symmetric signatures (*using HMAC-SHA256 with a private-key*). This adds support for asymmetric signatures (*using EdDSA with public/private key-pair*).

This is a product of work on introducing an OAuth2 bridge with self-registration. In a current draft protocol, the site would authenticate to the bridge using JWT PKI. __For that purpose, the main thing is that the unit-tests are passing.__

However, as a side-effect, this PR also allows CiviCRM to use EdDSA for its general-purpose signing key (*logins, secret links, etc*).

Technical Details
----------------------------------------

If you wanted to use EdDSA for the general-purpose signing-key, then the steps would be:

1. Generate a new keypair.

    ```bash
    $ php -r 'echo "jwt-eddsa-keypair:b64:".base64_encode(sodium_crypto_sign_keypair())."\n";'

    jwt-eddsa-keypair:b64:Um9nb7rFLhVwPmVQCKU1IFEBjoFA8O8c3ezIuRo9uUYVOhoGaR3OFKWHhx7LU5s6UOhn8djqAxAGscZx8fD3DhU6GgZpHc4UpYeHHstTmzpQ6Gfx2OoDEAaxxnHx8PcO
    ```

2. Update `civicrm.settings.php`.
    * Find the `CIVICRM_SIGN_KEYS` -- which is a space-separated list of valid signing keys.
    * Add this new key to the start of the list. (The first one is the primary/default.)

Additionally, if you wanted to trust an external agent that issues JWTs, then you could. However, that's a more advanced topic. (I'll leave some notes in case some future reader wants the info -- but it's not important to the current PR/goals.)

<details>
<summary><strong>In Depth: Trusting a third-party's public key</strong></summary>

> A basic formula for trusting a public-key would be:

> 1. Identify the public-key of the third-party. This should be an EdDSA key encoded as a Base64-string.
>     * Example: `FToaBmkdzhSlh4cey1ObOlDoZ/HY6gMQBrHGcfHw9w4=`
> 2. Construct the string `jwt-eddsa-public:b64:FToaBmkdzhSlh4cey1ObOlDoZ/HY6gMQBrHGcfHw9w4=`.
> 3. Update `civicrm.settings.php`. Find the `CIVICRM_SIGN_KEYS`. Add this new item at the end of the list.

> However, there is a problem: each public key should have a _key-identifier_ (`kid`). By default, CiviCRM computes its own `kid`s. But you would need the `kid` to match the external system. So that requires extra work -- like one of the following:

> * Configure the external system to match the default`kid` in CiviCRM. You can find this by inspecting the registry:
>
>    ```bash
>    cv ev 'print_r(Civi::service("crypto.registry"));' | less
>    ```
>
> * Configure CiviCRM to use the external `kid`. To include the `kid` as part of the `CIVICRM_SIGN_KEYS` declaration, you would need to patch `CryptoRegistry::parseKey()`.
> * Configure CiviCRM to use the external `kid`. Instead of `CIVICRM_SIGN_KEYS`, use `hook_civicrm_crypto()`. Pseudocode:

>    ```php
>     function hook_civicrm_crypto($registry) {
>       $registry->addKey([
>         'suite' => 'jwt-eddsa-public',
>         'key' => base64_decode('...the public key...')
>         'id' => '...the key ID, as specified by third-party...'
>         'tags' => ['SIGN'],
>       ]);
>     }
>    ```

</details>