### PR TITLE
dev/core#6104: Add name field to batch entry page

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
@@ -51,6 +51,13 @@ class CreateBatch extends AbstractAction {
   protected $targets = [];
 
   /**
+   * Label for the batch
+   *
+   * @var string
+   */
+  protected $label;
+
+  /**
    * @inheritDoc
    */
   public function _run(Result $result) {
@@ -64,6 +71,7 @@ class CreateBatch extends AbstractAction {
     \CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS `$tableName`");
 
     $userJob = [
+      'label' => $this->label,
       'job_type' => 'search_batch_import',
       'status_id:name' => 'draft',
       'is_template' => FALSE,

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -116,6 +116,7 @@
           display: this.display,
           rowCount: this.newBatch.rowCount,
           targets: this.newBatch.targets,
+          label: this.newBatch.label,
         }, 0).then(function(userJob) {
           $location.search('batch', userJob.id);
           // Re-init display to switch modes from creating batch to editing batch

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.html
@@ -3,6 +3,10 @@
     <li class="list-group-item">
       <fieldset>
         <legend>{{:: ts('New Batch') }}</legend>
+        <div class="form-inline" title="{{:: ts('Name of new batch') }}">
+          <label for="crm-create-new-batch-name">{{:: ts('Name') }}</label>
+          <input type="text" class="form-control" id="crm-create-new-batch-label" ng-model="$ctrl.newBatch.label" >
+        </div>
         <div class="form-inline" title="{{:: ts('Initial row count for new batch') }}">
           <label for="crm-create-new-batch-row-count">{{:: ts('Rows') }}</label>
           <input type="number" min="1" step="1" class="form-control" required id="crm-create-new-batch-row-count" ng-model="$ctrl.newBatch.rowCount" >


### PR DESCRIPTION
Overview
----------------------------------------
Users can enter a name for their batch (really a label) when they create a new batch

<img width="409" height="521" alt="image" src="https://github.com/user-attachments/assets/ba4ee2dd-d24c-46e2-bc9e-1e1982b24b13" />
