### PR TITLE
Security fix: Add verification of IPN messages received from PayPal

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Api4\Contribution;
+use Civi\Payment\System;
 
 /**
  *
@@ -245,10 +246,16 @@ class CRM_Core_Payment_PayPalIPN {
       $this->getInput($input);
 
       $paymentProcessorID = $this->getPayPalPaymentProcessorID($input, $this->getContributionRecurID());
+      $paymentProcessor = System::singleton()->getById($paymentProcessorID);
 
       Civi::log()->debug('PayPalIPN: Received (ContactID: ' . $this->getContactID() . '; trxn_id: ' . $input['trxn_id'] . ').');
 
       $input['payment_processor_id'] = $paymentProcessorID;
+
+      if (!$paymentProcessor->verifyIPN()) {
+        Civi::log()->warning('PayPalIPN: Verification failed; input {input}', ['input' => $input]);
+        return;
+      }
 
       if ($this->getContributionRecurID()) {
         $this->recur($input);


### PR DESCRIPTION
Overview
----------------------------------------
This PR is a proposed fix for [#6090](https://lab.civicrm.org/dev/core/-/issues/6090), in which it has been discovered that CiviCRM does not implement the verification post-back to PayPal when IPN messages are received, as is required by the IPN architecture to verify that the message received is genuine.

This is a first attempt to get the ball rolling. There are some details on which others may have an opinion and may need to be refined - see Technical Details below.

Before
----------------------------------------
IPN messages are received from PayPal and processed at face value, i.e. without first verifying that they are genuine. This means that in theory any well-formatted message will be accepted and so it is possible to spoof arbitrary transaction data into the CiviCRM database.

After
----------------------------------------
The verification step is now added to the "PayPal Standard" IPN listener process. When an IPN message is received, the data is POST-ed back to PayPal in accordance with [the guidance](https://developer.paypal.com/api/nvp-soap/ipn/). Invalid messages are rejected.

Some examples of this working below, from the `ConfigAndLog` file:

Example of sandbox transaction going through OK, including verification step:

```
2025-09-28 21:58:54+0100  [debug] PayPalIPN: Received (ContactID: 98; trxn_id: 9S241804FP981603R).

2025-09-28 21:58:55+0100  [debug] PayPalIPN: Verification response from PayPal: "VERIFIED".

2025-09-28 21:58:55+0100  [info] Contribution 2317 updated successfully
```

Example of message now rejected as invalid (simulated using [base64.guru](https://base64.guru/tools/http-request-online)):

```
2025-09-30 08:18:19+0100  [debug] PayPalIPN: Received (ContactID: 98; trxn_id: 80L63072DE025184H).

2025-09-30 08:18:21+0100  [debug] PayPalIPN: Verification response from PayPal: "INVALID".

2025-09-30 08:18:21+0100  [debug] PayPalIPN: Verification failed; input {input}
Array
(
    [input] => Array
        (
            [component] => contribute
            [paymentStatus] => Completed
            [invoice] => 332d52dff9148d7fbb7422b7e201f7ac
            [total_amount] => 1.00
            [reasonCode] => 
            [first_name] => Mr A P
            [last_name] => Wood
            [street_address-5] => 
            [city-5] => 
            [state-5] => 
            [postal_code-5] => 
            [country-5] => 
            [is_test] => 
            [fee_amount] => 0.21
            [net_amount] => 
            [trxn_id] => 80L63072DE025184H
            [receive_date] => 20250924183444
            [payment_processor_id] => 2
        )

)
```

Two examples of live transactions going through OK, including verification step. Downstream logic, e.g. duplicate detection, is still working as normal (*note that these were captured before I added the debug message of the actual response from PayPal*):

```
2025-09-25 01:40:53+0100  [debug] PayPalIPN: Received (ContactID: 98; trxn_id: 89E77079J8670352T).

2025-09-25 01:40:57+0100  [info] Contribution 2308 updated successfully


2025-09-25 01:42:57+0100  [debug] PayPalIPN: Received (ContactID: 98; trxn_id: 89E77079J8670352T).

2025-09-25 01:42:58+0100  [debug] PayPalIPN: Returning since contribution has already been handled. (ID: 2308).

...

2025-09-25 08:30:08+0100  [debug] PayPalIPN: Received (ContactID: 3681; trxn_id: 6KU02656LA441290X).

2025-09-25 08:30:12+0100  [info] Contribution 2309 updated successfully


2025-09-25 08:32:08+0100  [debug] PayPalIPN: Received (ContactID: 3681; trxn_id: 6KU02656LA441290X).

2025-09-25 08:32:10+0100  [debug] PayPalIPN: Returning since contribution has already been handled. (ID: 2309).
```


Technical Details
----------------------------------------
The added code is essentially copied from the official sample code published by PayPal at https://github.com/paypal/ipn-code-samples/blob/master/php/PaypalIPN.php.

This has been end-to-end tested on CiviCRM 6.6.1 using both the PayPal sandbox (test-drive version of contribution page) and live environments. Visual inspection of the resulting Contribution data in CiviCRM is nominal - the downstream processing is unaffected.

**Some points to consider:**

1. Currently the new `verifyIPN()` routine is simply bypassed for unit tests. A more elegant / robust approach would be to somehow capture the data being passed back to PayPal and verify it in the test case. The PayPal implementation relies on cURL functions directly (i.e. not a framework with a mock adaptor etc) so would require some bespoke arrangement to pass the data back, e.g. in an environment variable?
2. So far I have only added this to the "PayPal Standard" workflow, but in time this should be added to the others i.e. Express and Pro, handled by `CRM_Core_Payment_PayPalProIPN`. I have no immediate means of testing these workflows.
3. This PR includes a commit to upload the `cacert.pem` local certificate bundle into the same folder as `PayPalImpl`, which is provided in case the server somehow doesn't have an up-to-date CA cert. Is this the right place for it, should it go somewhere else or should we just leave it out entirely?

I can tidy up commits once the final details are agreed.

Comments
----------------------------------------
The PayPal IPN documentation now bears deprecation notices, so there may be a longer-term action to migrate to a more modern approach in CiviCRM. However, I believe there is an immediate need to plug the security gap in the existing implementation.
