### PR TITLE
SearchKit - Prevent api error when batch import display is deleted

### DIFF
--- a/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
+++ b/ext/civiimport/Civi/Api4/Import/ImportSpecProvider.php
@@ -91,11 +91,17 @@ class ImportSpecProvider extends AutoService implements SpecProviderInterface {
       $field->setDescription(ts('Data being imported into the field.'));
       $field->setColumnName($column['name']);
       if ($column['name'] === '_entity_id') {
-        $field->setFkEntity($parser->getBaseEntity());
-        $field->setInputType('EntityRef');
-        $field->setInputAttrs([
-          'label' => CoreUtil::getInfoItem($parser->getBaseEntity(), 'title'),
-        ]);
+        try {
+          $baseEntity = $parser->getBaseEntity();
+          $field->setFkEntity($baseEntity);
+          $field->setInputType('EntityRef');
+          $field->setInputAttrs([
+            'label' => CoreUtil::getInfoItem($baseEntity, 'title'),
+          ]);
+        }
+        catch (\CRM_Core_Exception $e) {
+          // Search display may have been deleted
+        }
       }
       $spec->addFieldSpec($field);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a crash on the Api4 Explorer page after a batch import search display has been deleted.

- Fixes regression from #32541

Technical Details
----------------------------------------
The code added in c33b77821 would throw an uncaught exception if the search display has been deleted. This causes the Api4 Explorer page to crash.