### PR TITLE
Event Dashboard: always display top buttons, move iCal feed under the list of events

### DIFF
--- a/templates/CRM/Event/Page/DashBoard.tpl
+++ b/templates/CRM/Event/Page/DashBoard.tpl
@@ -10,33 +10,29 @@
 {* CiviEvent DashBoard (launch page) *}
 {capture assign=newEventURL}{crmURL p="civicrm/event/add" q="action=add&reset=1"}{/capture}
 {capture assign=configPagesURL}{crmURL p="civicrm/event/manage" q="reset=1"}{/capture}
-
+<div class="crm-submit-buttons">
+  <a href="{$configPagesURL}" class="button no-popup"><span><i class="crm-i fa-th-list" role="img" aria-hidden="true"></i> {ts}Manage Events{/ts}</span></a>
+  <a href="{$newEventURL}" class="button"><span><i class="crm-i fa-calendar-plus-o" role="img" aria-hidden="true"></i> {ts}New Event{/ts}</span></a>
+</div>
+<div class="clear"></div>
 {if $eventSummary.total_events}
-    <a href="{$configPagesURL}" class="button no-popup"><span><i class="crm-i fa-th-list" role="img" aria-hidden="true"></i> {ts}Manage Events{/ts}</span></a>
-    <a href="{$newEventURL}" class="button"><span><i class="crm-i fa-calendar-plus-o" role="img" aria-hidden="true"></i> {ts}New Event{/ts}</span></a>
-    <div class="clear">&nbsp;</div>
-    <h3 id="crm-event-dashboard-heading">{ts}Event Summary{/ts}
-      {help id="id-event-intro"}
-    </h3>
-    <div class="crm-clearfix">
-      {include file="CRM/Event/Page/iCalLinks.tpl"}
-    </div>
-    {include file="CRM/common/jsortable.tpl"}
-    <table id="options" class="display">
+  <h3 id="crm-event-dashboard-heading">{ts}Event Summary{/ts} {help id="id-event-intro"}</h3>
+  {include file="CRM/common/jsortable.tpl"}
+  <table id="options" class="display">
     <thead>
-    <tr>
-  <th>{ts}Event{/ts}</th>
-  <th>{ts}ID{/ts}</th>
-  <th>{ts}Type{/ts}</th>
-  <th id="nosort">{ts}Public{/ts}</th>
-  <th id="nosort">{ts}Date(s){/ts}</th>
-  <th id="nosort">{ts}Participants{/ts}</th>
+      <tr>
+        <th>{ts}Event{/ts}</th>
+        <th>{ts}ID{/ts}</th>
+        <th>{ts}Type{/ts}</th>
+        <th id="nosort">{ts}Public{/ts}</th>
+        <th id="nosort">{ts}Date(s){/ts}</th>
+        <th id="nosort">{ts}Participants{/ts}</th>
         {if $actionColumn}<th></th>{/if}
-    </tr>
+      </tr>
     </thead>
     <tbody>
     {foreach from=$eventSummary.events item=values key=id}
-    <tr class="crm-event_{$id}">
+      <tr class="crm-event_{$id}">
         <td class="crm-event-eventTitle"><a href="{crmURL p="civicrm/event/info" q="reset=1&id=`$id`"}" title="{ts escape='htmlattribute'}View event info page{/ts}">{$values.eventTitle|smarty:nodefaults|purify}</a>
             {if $values.is_repeating_event}
                 <br/>
@@ -116,14 +112,16 @@
       {/if}
     </tr>
     {/foreach}
-
     </tbody>
     </table>
     {if $eventSummary.total_events GT 10}
      <div><a href="{crmURL p='civicrm/admin/event' q='reset=1'}"><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Browse more events{/ts}...</a></div>
     {/if}
+    <div class="float-right">
+      {include file="CRM/Event/Page/iCalLinks.tpl"}
+    </div>
+    <div class="clear"></div>
 {else}
-    <br />
     <div class="messages status no-popup">
       {icon icon="fa-info-circle"}{/icon}
       {ts}There are no active Events to display.{/ts}


### PR DESCRIPTION
Overview
----------------------------------------

When we go to the Event Dashboard and there are no ongoing/future events, it displays "there are not events, you can create one". I've often seen confused admins, because they have the habit of going to the dashboard during the event, and now it's completely empty.

Empty dashboard
----------------------------------------

Before:

<img width="3292" height="652" alt="2025-09-25_14-10" src="https://github.com/user-attachments/assets/b2d5e3ec-a82f-40ab-93c3-3e17983708a9" />

After:

<img width="3276" height="722" alt="2025-09-25_14-11" src="https://github.com/user-attachments/assets/89c3185b-101f-4172-86f6-c8ac1cf87227" />

iCal and spaces between button

Before:

<img width="3278" height="874" alt="2025-09-25_14-14" src="https://github.com/user-attachments/assets/438bc35b-f3f9-4da7-b5e9-aa0850d750bb" />

After:

<img width="3286" height="870" alt="2025-09-25_14-13" src="https://github.com/user-attachments/assets/77193c8d-e9a5-4c0e-a4eb-12d865081ebe" />


Technical Details
----------------------------------------

I cheated a bit on the CSS class to fix the spaces, but that's what the New Contact form looks like too.

Comments
---------------------------

I think we should always show the ongoing OR latest events, but that felt like a bit of a rabbit hole. 