### PR TITLE
Add link to 'View My Contact' to CiviCRM user menu

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -918,6 +918,15 @@ ORDER BY weight";
         ];
         $item['child'][] = [
           'attributes' => [
+            'label' => ts('View My Contact'),
+            'name' => 'CiviCRM Dashboard',
+            'url' => 'civicrm/contact/view?cid=' . CRM_Core_Session::getLoggedInContactID() . '&reset=1',
+            'icon' => 'crm-i fa-user',
+            'weight' => 1,
+          ],
+        ];
+        $item['child'][] = [
+          'attributes' => [
             'label' => ts('Hide Menu'),
             'name' => 'Hide Menu',
             'url' => '#hidemenu',


### PR DESCRIPTION
Overview
----------------------------------------
If you want to view your own contact record you have to know your own name (or email) and be able to search for it. Let's make it a bit easier...

Before
----------------------------------------
Really hard to view your own contact record...

After
----------------------------------------
New menu item to "View My Contact":

<img width="303" height="340" alt="image" src="https://github.com/user-attachments/assets/2df27102-9f3d-4c36-9bc7-fa353c3039a8" />

Technical Details
----------------------------------------
Uses `cid=0` to map to current logged in contact ID for civicrm/contact/view. This means that you can easily create links to "View My Contact" without having to look up / have access to the contact ID first.

Comments
----------------------------------------
cid=0 seemed the simplest way without unintended consequences. For example we could just map empty contactID = current contact ID but that might cause broken/malformed links etc. to map to view current contact which is not ideal behaviour.
