### PR TITLE
RiverLea 6.7 metadata - updates version number / points changelog at gitlab

### DIFF
--- a/ext/riverlea/CHANGELOG.md
+++ b/ext/riverlea/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.4.9-6.7 - Changelog moved to - https://lab.civicrm.org/extensions/riverlea/-/blob/main/CHANGELOG.md
+
 1.4.8-6.6
  - ADDED - 9 new flexbox utility classes for use by extension devs/etc, e.g. '.crm-flex-align-start' (https://github.com/civicrm/civicrm-core/pull/33118)
  - CHANGED - Empty stream to include all new variables / patterns (https://github.com/civicrm/civicrm-core/pull/33126)

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -4,7 +4,7 @@
 ****************************/
 
 :root {
-  --crm-release: '1.4.8-6.6';
+  --crm-release: '1.4.9-6.7';
   --crm-version: 'v' var(--crm-release);
 /* Fonts */
   --crm-system-fonts: unset;

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.8-[civicrm.version]</version>
+  <version>1.4.9-[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
Before
----------------------------------------
6.6-1.4.8

After
----------------------------------------
6.7-1.4.9
And changelog has a notice pointing to https://lab.civicrm.org/extensions/riverlea/-/blob/main/CHANGELOG.md
(not currently updated, but will be before 6.7 release).

Comments
----------------------------------------
Including the changelog inside the extension seems no longer necessary - moving it to gitlab makes it easier to update and view. If there's no objections, in 6.8-1.4.10 the changelog will be removed from this extension directory.