### PR TITLE
(dev/core#5650) Bad "Learn more" link in System Status check

### DIFF
--- a/CRM/Utils/Check/Component/Cms.php
+++ b/CRM/Utils/Check/Component/Cms.php
@@ -206,6 +206,7 @@ class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
    * @return CRM_Utils_Check_Message[]
    */
   public static function checkUfMatchUnique(): array {
+
     $checks = [];
 
     if (CRM_Core_BAO_UFMatch::tryToAddUniqueIndexOnUfId()) {
@@ -216,9 +217,7 @@ class CRM_Utils_Check_Component_Cms extends CRM_Utils_Check_Component {
     // Your DB has multiple uf_match records! Bad
     $checks[] = new CRM_Utils_Check_Message(
       __FUNCTION__,
-      ts('You have multiple records with the same uf_id in civicrm_uf_match. You need to manually fix this in the database so that uf_id is unique') .
-      ' ' .
-      CRM_Utils_System::docURL2('sysadmin/upgrade/todo/#todo'),
+      ts('You have multiple records with the same uf_id in civicrm_uf_match. You need to manually fix this in the database so that uf_id is unique.'),
       ts('Duplicate records in UFMatch'),
       \Psr\Log\LogLevel::ERROR,
       'fa-database'


### PR DESCRIPTION
Bad "Learn more" link in System Status "Duplicate records in UFMatch" check.

Issue: https://lab.civicrm.org/dev/core/-/issues/5650

Overview
----------------------------------------
Status message includes a link to "learn more", but that link is a 404. Per the ticket, nobody seems to know where the docs are or what they should say if they existed, so I'm just removing the link.

Before
----------------------------------------
Users think they can learn more, but only learn that they clicked a dead link.

After
----------------------------------------
No link to click. Now they can see they're on their own even sooner!

Technical Details
----------------------------------------
none.

Comments
----------------------------------------
none.
