### PR TITLE
dev/core#6117 Allow SQL functions to be nested within CONCAT functions (API4)

### DIFF
--- a/Civi/Api4/Query/SqlFunctionCONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT.php
@@ -25,7 +25,7 @@ class SqlFunctionCONCAT extends SqlFunction {
       [
         'max_expr' => 99,
         'optional' => FALSE,
-        'must_be' => ['SqlField', 'SqlString'],
+        'must_be' => ['SqlField', 'SqlString', 'SqlFunction'],
         'label' => ts('And'),
       ],
     ];

--- a/Civi/Api4/Query/SqlFunctionCONCAT_WS.php
+++ b/Civi/Api4/Query/SqlFunctionCONCAT_WS.php
@@ -31,7 +31,7 @@ class SqlFunctionCONCAT_WS extends SqlFunction {
       [
         'max_expr' => 99,
         'optional' => FALSE,
-        'must_be' => ['SqlField', 'SqlString'],
+        'must_be' => ['SqlField', 'SqlString', 'SqlFunction'],
         'label' => ts('Plus'),
         'can_be_empty' => TRUE,
       ],


### PR DESCRIPTION


Overview
----------------------------------------
Allow SQL functions to be nested within CONCAT functions (API4)

See https://lab.civicrm.org/dev/core/-/issues/6117

Before
----------------------------------------
Running the following in API4:
```
->addSelect('id', 'CONCAT_WS(" ", display_name, MAX(address.city)) AS concatenated')`
```

would result in `Uncaught Exception: Illegal sql expression.`.

After
----------------------------------------
SQL functions are permitted to be nested within group functions.

Technical Details
----------------------------------------
I originally considered just allowing aggregate functions, but @colemanw [suggested on GitLab](https://lab.civicrm.org/dev/core/-/issues/6117#note_188974) that allowing all functions was fine.