### PR TITLE
Fix dev/core#5800: profile frontend_title printed twice in contrib confirmation page

### DIFF
--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -46,9 +46,6 @@ af-form > fieldset > legend {
   font-size: var(--crm-r1);
   border-radius: var(--crm-roundness);
 }
-.crm-contribution-confirm-form-block fieldset legend:has(~ .header-dark) {
-  display: none; /* fix for duplication on confirmation screen of legend text with Header Dark text */
-}
 .crm-container.crm-public .crm-section:not(.alert) {
   padding: 0;
 }

--- a/templates/CRM/UF/Form/Block.tpl
+++ b/templates/CRM/UF/Form/Block.tpl
@@ -29,11 +29,13 @@
     {/if}
 
     {if !$hideFieldset}
-      <fieldset class="crm-profile crm-profile-id-{$group_id} crm-profile-name-{$groupName}"><legend>{$groupDisplayTitle}</legend>
+      <fieldset class="crm-profile crm-profile-id-{$group_id} crm-profile-name-{$groupName}">
     {/if}
 
     {if ($form.formName eq 'Confirm' OR $form.formName eq 'ThankYou') AND $prefix neq 'honor'}
       <div class="header-dark">{$groupDisplayTitle} </div>
+    {elseif !$hideFieldset}
+      <legend>{$groupDisplayTitle}</legend>
     {/if}
     {include file="CRM/UF/Form/Fields.tpl"}
 


### PR DESCRIPTION
Original issue: https://lab.civicrm.org/dev/core/-/issues/5800

Overview
----------------------------------------
Double-printing of public profile title in contribution Confirmation page. 

Interestingly, RiverLea actually has a CSS rule to solve this by hiding one of these double-printed titles:
```css
.crm-contribution-confirm-form-block fieldset legend:has(~ .header-dark) {
    display: none;
}
```
But it's clearly in the HTML where it should not be, and without RiverLea to hide it (e.g. current smaster "Powered by CiviCRM 6.8.alpha1") , it appears.

Before
----------------------------------------
<img width="910" height="742" alt="5800-before" src="https://github.com/user-attachments/assets/f8236599-6926-4eac-a754-587a567e035e" />

After
----------------------------------------
<img width="792" height="722" alt="5800-after" src="https://github.com/user-attachments/assets/1d6484dd-c2e2-45a4-8e2c-8f91c8b84f41" />


Technical Details
----------------------------------------
This `{elseif}` logic aims to preserve support for existing complexity around when to show/omit profile headers.

Comments
----------------------------------------
Thanks to [masetto](https://lab.civicrm.org/Samuele.Masetto) / @masetto for filing the original issue and suggesting this fix.
