### PR TITLE
Remove 'every minute' repetition option from scheduled reminder form

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -157,9 +157,11 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->addField('repetition_frequency_unit', ['placeholder' => FALSE])->setAttribute('class', 'crm-form-select');
     $this->addField('end_frequency_unit', ['placeholder' => FALSE])->setAttribute('class', 'crm-form-select');
     // Data for js pluralization
+    // Don't want to include 'minute' option as not supported by RecipientBuilder::parseRepetitionInterval()
+    $excludeFrequencyOptions = ['minute' => NULL];
     $this->assign('recurringFrequencyOptions', [
-      'plural' => CRM_Utils_Array::makeNonAssociative(CRM_Core_SelectValues::getRecurringFrequencyUnits(2)),
-      'single' => CRM_Utils_Array::makeNonAssociative(CRM_Core_SelectValues::getRecurringFrequencyUnits()),
+      'plural' => CRM_Utils_Array::makeNonAssociative(array_diff_key(CRM_Core_SelectValues::getRecurringFrequencyUnits(2), $excludeFrequencyOptions)),
+      'single' => CRM_Utils_Array::makeNonAssociative(array_diff_key(CRM_Core_SelectValues::getRecurringFrequencyUnits(), $excludeFrequencyOptions)),
     ]);
 
     $this->addField('title', [], TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Residual lower-priority issue/action from #31600.

The scheduled reminder form (`CRM_Admin_Form_ScheduleReminders`) has an option to repeat every X `minute`s, but this is not supported by the code that processes the reminders (`RecipientBuilder::parseRepetitionInterval()`).

Discussion on the other PR suggests that we just don't need / want the option.

Before
----------------------------------------
`minute` option **is** present on scheduled reminder repetition frequency dropdown:

<img width="787" height="464" alt="Screenshot 2025-09-27 113702" src="https://github.com/user-attachments/assets/14c60ac7-6645-4856-9d40-86fa85e325bc" />

After
----------------------------------------
`minute` option **not** present on scheduled reminder repetition frequency dropdown:

<img width="706" height="391" alt="Screenshot 2025-09-27 113722" src="https://github.com/user-attachments/assets/a734c98e-f436-4854-aff5-c0d2ce41373c" />

Technical Details
----------------------------------------
Any reminders already set up with the `minute` option are not affected because this defaults to being interpreted as every `hour` anyway, per the implementation of `RecipientBuilder::parseRepetitionInterval()`.

Comments
----------------------------------------
Tested on CiviCRM 6.6.1.
