### PR TITLE
Civi::rebuild() - Reduce duplicative work

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -466,10 +466,7 @@ ORDER BY weight";
     if (!$contactID) {
       // In theory, the name "resetNavigation" could mean _merely_ flushing the navigation tree(s).
       // In practice, it evolved into an entry-point for diverse parties to signal that anything nav-adjacent should reset.
-      static::resetContactNavigation(NULL);
-      Civi::cache('navigation')->flush();
-      // reset ACL and System caches
-      Civi::rebuild(['system' => TRUE])->execute();
+      Civi::rebuild(['system' => TRUE, 'navigation' => TRUE])->execute();
     }
     else {
       static::resetContactNavigation($contactID);

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -460,18 +460,37 @@ ORDER BY weight";
    *
    * @param int $contactID
    *   Reset only entries belonging to that contact ID.
-   *
-   * @return string
+   * @return void
    */
-  public static function resetNavigation($contactID = NULL) {
+  public static function resetNavigation($contactID = NULL): void {
+    if (!$contactID) {
+      // In theory, the name "resetNavigation" could mean _merely_ flushing the navigation tree(s).
+      // In practice, it evolved into an entry-point for diverse parties to signal that anything nav-adjacent should reset.
+      static::resetContactNavigation(NULL);
+      Civi::cache('navigation')->flush();
+      // reset ACL and System caches
+      Civi::rebuild(['system' => TRUE])->execute();
+    }
+    else {
+      static::resetContactNavigation($contactID);
+    }
+  }
+
+  /**
+   * Mark the current "navigation" data as invalid for one or all contacts.
+   *
+   * @param int|null $contactID
+   *   NULL for all contacts.
+   * @return string
+   * @throws \Civi\Core\Exception\DBQueryException
+   * @internal
+   */
+  public static function resetContactNavigation(?int $contactID): string {
     $newKey = CRM_Utils_String::createRandom(self::CACHE_KEY_STRLEN, CRM_Utils_String::ALPHANUMERIC);
     if (!$contactID) {
       $ser = serialize($newKey);
       $query = "UPDATE civicrm_setting SET value = '$ser' WHERE name='navigation' AND contact_id IS NOT NULL";
       CRM_Core_DAO::executeQuery($query);
-      Civi::cache('navigation')->flush();
-      // reset ACL and System caches
-      Civi::rebuild(['system' => TRUE])->execute();
     }
     else {
       // before inserting check if contact id exists in db
@@ -850,7 +869,7 @@ ORDER BY weight";
       ->getBagByContact(NULL, $cid)
       ->get('navigation');
     if (strlen($key ?? '') !== self::CACHE_KEY_STRLEN) {
-      $key = self::resetNavigation($cid);
+      $key = self::resetContactNavigation($cid);
     }
     return $key;
   }

--- a/Civi.php
+++ b/Civi.php
@@ -195,7 +195,7 @@ class Civi {
    * Ex: Rebuild the temp SQL data and the system-caches (and nothing else))
    *   Civi::rebuild(['tables' => TRUE, 'system' => TRUE])->execute();
    * Ex: Rebuild everything except the menu
-   *   Civi::rebuild(['*' => TRUE, 'menu' => FALSE])->execute();
+   *   Civi::rebuild(['*' => TRUE, 'router' => FALSE])->execute();
    *
    * @param string|array{ext:bool,files:bool,tables:bool,sessions:bool,metadata:bool,system:bool,userjob:bool,menu:bool,perms:bool,strings:bool,settings:bool,cases:bool,triggers:bool,entities:bool}|null $targets
    *   The special key '*' indicates that all flags should start as TRUE (but you may opt-out of specific ones).
@@ -207,8 +207,10 @@ class Civi {
    *     - metadata: Rebuild metadata about the available entities and fields
    *     - system: Reset any cache-services defined by the system.
    *     - userjob: Delete any expired UserJob records.
-   *     - menu: Rebuild the routing-table and nav-bars.
+   *     - menu: (DEPRECATED 6.9+) Equivalent to 'router' + 'navigation' + 'system'.
+   *     - navigation: (ADDED 6.9) Reset navigation indices for all users.
    *     - perms: Republish the list of available permissions. (Some CMS's need to be notified.)
+   *     - router: (ADDED 6.9) Rebuild list of available HTTP routes.
    *     - strings: Reset caches involving visible strings (WordReplacements, JS ts()).
    *     - settings: Rebuild the index of available settings and their values.
    *     - cases: Somethingsomething.

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -72,8 +72,9 @@ class Rebuilder {
       'metadata' => TRUE,
       'system' => TRUE,
       'userjob' => TRUE,
-      'menu' => TRUE,
+      'navigation' => TRUE,
       'perms' => TRUE,
+      'router' => TRUE,
       'strings' => TRUE,
       'settings' => TRUE,
       'cases' => TRUE,
@@ -83,6 +84,14 @@ class Rebuilder {
     if (!empty($targets['*'])) {
       $targets = array_merge($all, $targets);
       unset($targets['*']);
+    }
+
+    if (isset($targets['menu'])) {
+      \CRM_Core_Error::deprecatedWarning("In Civi::rebuild(), the 'menu' option is deprecated. For CiviCRM 6.9+, please specify combination of 'router', 'navigation', and/or 'system'.");
+      $targets['router'] = $targets['router'] || $targets['menu'];
+      $targets['navigation'] = $targets['navigation'] || $targets['menu'];
+      $targets['system'] = $targets['system'] || $targets['menu'];
+      unset($targets['menu']);
     }
 
     $config = CRM_Core_Config::singleton();
@@ -170,9 +179,12 @@ class Rebuilder {
       $session = CRM_Core_Session::singleton();
       $session->reset(2);
     }
-    if (!empty($targets['menu'])) {
+    if (!empty($targets['router'])) {
       CRM_Core_Menu::store();
-      CRM_Core_BAO_Navigation::resetNavigation();
+    }
+    if (!empty($targets['navigation'])) {
+      CRM_Core_BAO_Navigation::resetContactNavigation(NULL);
+      Civi::cache('navigation')->flush();
     }
     if (!empty($targets['perms'])) {
       $config->cleanupPermissions();

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -97,6 +97,7 @@ class Rebuilder {
     $config = CRM_Core_Config::singleton();
 
     if (!empty($targets['ext'])) {
+      // N.B. clearModuleList() includes call to CRM_Extension_System::singleton()->getCache()->flush();
       $config->clearModuleList();
 
       // dev/core#3660 - Activate any new classloaders/mixins/etc before re-hydrating any data-structures.
@@ -140,7 +141,11 @@ class Rebuilder {
         Civi::cache('contactTypes')->clear();
         Civi::cache('metadata')->clear(); /* Again? Huh. */
         ClassScanner::cache('index')->flush();
-        CRM_Extension_System::singleton()->getCache()->flush();
+
+        // If ext=>TRUE, then we've already flushed ext system (10ms ago).
+        if (empty($targets['ext'])) {
+          CRM_Extension_System::singleton()->getCache()->flush();
+        }
       }
 
       // also reset the various static memory caches


### PR DESCRIPTION
Overview
----------------------------------------

While testing #33680, I noticed that the extension-related caches weren't performing as well as expected. During the course of `cv flush`, it would make sense to rebuild those extension-caches.... one time. But _three times_? That's weird. It suggests a qualitative issue (*hard to read/trace/predict the flush process*) and a quantitative issue (*the small cost of rescanning exts*).

Steps to Reproduce
----------------------------------------

My procedure is to alternately call two commands:

```bash
cv ev 'return 123;' ; time cv flush
```

The first command hydrates the system. The second flushes it... and checks the timing.

<details>

<summary><b>Bonus: Watching flush operations</b></summary>

While this patch alongside #33680, I also printed some debug notices. This helped to count the number of flushes/builds.

```
diff --git a/CRM/Extension/MixinScanner.php b/CRM/Extension/MixinScanner.php
index 43fbdee729..1949ee65d5 100644
--- a/CRM/Extension/MixinScanner.php
+++ b/CRM/Extension/MixinScanner.php
@@ -79,6 +79,7 @@ class CRM_Extension_MixinScanner {
    * @return array{0: funcFiles, 1: mixInfos}
    */
   public function build() {
+    fprintf(STDERR, "Building Mixin Scanner...\n");
     $this->scan();
     return $this->compile();
   }
diff --git a/CRM/Utils/Cache/SqlGroup.php b/CRM/Utils/Cache/SqlGroup.php
index ffc81bc843..5b0e7f4edc 100644
--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -225,6 +225,10 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
   }

   public function flush() {
+    if (str_starts_with($this->group, '-ext')) {
+      fprintf(STDERR, "Flush ext cache\n");
+    }
+
     if ($this->group == CRM_Utils_Cache::cleanKey('CiviCRM Search PrevNextCache') &&
       Civi::service('prevnext') instanceof CRM_Core_PrevNextCache_Sql) {
       Civi::service('prevnext')->cleanup();
```

</details>

Before
----------------------------------------

Redundant flushes. After a sample of 4x runs of `cv flush` on Apple M4, I see a baseline runtime of 0.9502s.

After
----------------------------------------

(Fewer) Redundant flushes. After a sample of 4x runs of `cv flush` on Apple M4, I see a runtime of .9060 -- so roughly 45ms better. 

Performance change isn't huge (but is better). Probably more noticeable on slower hardware. 

Comments
----------------------------------------

There should be some decent coverage of alternately toggling extensions and running features within the suite. We'll see what Jenkins thinks...

I would be tempted to wait for 33680 to be merged to 6.7+master before merging this (since the use-case was overlapping). But I think they also work independently.