### PR TITLE
Support tree display/hierarchical entity for Activities

### DIFF
--- a/Civi/Api4/Activity.php
+++ b/Civi/Api4/Activity.php
@@ -25,8 +25,10 @@ namespace Civi\Api4;
  * @searchable primary
  * @since 5.19
  * @iconField activity_type_id:icon
+ * @parentField parent_id
  * @package Civi\Api4
  */
 class Activity extends Generic\DAOEntity {
+  use Generic\Traits\HierarchicalEntity;
 
 }

--- a/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
+++ b/tests/phpunit/CRM/Activity/Form/Task/PDFTest.php
@@ -94,6 +94,8 @@ class CRM_Activity_Form_Task_PDFTest extends CiviUnitTestCase {
       '{activity.source_contact_id}' => 'Source Contact',
       '{activity.target_contact_id}' => 'Target Contacts',
       '{activity.assignee_contact_id}' => 'Assignee Contacts',
+      '{activity._depth}' => 'Depth',
+      '{activity._descendents}' => 'Descendents',
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Activities have a `parent_id` for follow-up activities. So we can display using a tree view in that case. It allows us to do things like "threaded email reply displays" like this:

<img width="1316" height="401" alt="image" src="https://github.com/user-attachments/assets/3d5943c3-da4a-465e-a61d-a93b85e8395f" />

This PR adds support for hierarchical displays to Activity entity.

Before
----------------------------------------
Not supported

After
----------------------------------------
Supported

Technical Details
----------------------------------------
Adds trait to API4 entity

Comments
----------------------------------------
Aside, it would be nice to be able to add a condition to the buttons so you can say "only add to the last record".
