### PR TITLE
pick correct contact type when updating contact sub types

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1935,7 +1935,15 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
       else {
         $profileType = $gId ? CRM_Core_BAO_UFField::getProfileType($gId) : NULL;
         if ($profileType == 'Contact') {
-          $profileType = 'Individual';
+          if ($contactId) {
+            $profileType = \Civi\Api4\Contact::get(FALSE)
+              ->addWhere('id', '=', $contactId)
+              ->addSelect('contact_type')
+              ->execute()->first()['contact_type'];
+          }
+          else {
+            $profileType = 'Individual';
+          }
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------

When using the workflow:

 * Search for records
 * Pick action "Update Multiple Contacts"
 * Pick profile

It doesn't work if you are updating the sub contact type field for an organization.

Before
----------------------------------------

To replicate:

 * Create an organization sub type
 * Create a contact profile that only includes the contact sub type field
 * Search for regular organizations in the database
 * Select one or two and choose the option to "Update multiple contacts'
 * Select the contact profile you created 

The contact sub types you can change this contact to will not include the organization sub type you just created. It will only include sub types appropriate for Individual contacts.

After
----------------------------------------

The contact sub types will include the organization sub type you just created.

Technical Details
----------------------------------------

Before we simply defaulted to the Individual sub contact types, but since we have access to the contact id, there is no reason not to get the correct one.

Also, I know this work flow is somewhat obsolete thanks to search kit.