### PR TITLE
fix grant field labels

### DIFF
--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -166,7 +166,7 @@ return [
       ],
     ],
     'amount_total' => [
-      'title' => E::ts('Total Amount'),
+      'title' => E::ts('Total Amount Requested'),
       'sql_type' => 'decimal(20,2)',
       'input_type' => 'Text',
       'required' => TRUE,
@@ -179,7 +179,7 @@ return [
       ],
     ],
     'amount_requested' => [
-      'title' => E::ts('Amount Requested'),
+      'title' => E::ts('Amount Requested in Original Currency'),
       'sql_type' => 'decimal(20,2)',
       'input_type' => 'Text',
       'description' => E::ts('Requested grant amount, in original currency (optional).'),


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/4631

Before
----------------------------------------
Labels in FormBuilder don't match labels in Quickform (or in the CiviGrant "View Grants" SearchKit).

After
----------------------------------------
Labels match

Comments
----------------------------------------
The "Amount Requested in Original Currency" field seems like a client-specific hack that somehow made it into core.