### PR TITLE
dev/core#6111 - don't double-format numeric case custom fields

### DIFF
--- a/CRM/Case/Form/CustomData.php
+++ b/CRM/Case/Form/CustomData.php
@@ -204,8 +204,9 @@ class CRM_Case_Form_CustomData extends CRM_Core_Form implements CRM_Case_Form_Ca
   private function formatDisplayValue(mixed $value, int $customFieldId, string $customFieldDataType): string {
     switch ($customFieldDataType) {
       case 'Money':
-        // Money is special for non-US locales because at this point it's in human format so we don't try
-        // want to try to convert it.
+      case 'Float':
+        // Money and Float are special for non-US locales because at this point
+        // it's in human format so we don't want to try to convert it.
         return $value;
 
       case 'File':


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6111

Before
----------------------------------------
1. Create a custom field of type numeric for cases. (This is specific to cases.)
2. Set your locale to one that formats numbers different from en_US, e.g. fr_FR.
3. Change the localization settings for separators to match, e.g. a space for thousands and comma for decimals.
4. Create a case.
5. Edit the custom field on the case and change it to something.
6. Crash.

After
----------------------------------------


Technical Details
----------------------------------------
See lab ticket.

Comments
----------------------------------------
While there was a recent change in the related code I think this would predate it by a while because even before it would have tried to call getdisplayvalue on the already formatted value. So putting against master.

See also https://chat.civicrm.org/civicrm/pl/aa5pmmnjatg9pr9fuibgne8c4h
