### PR TITLE
redis acl based authorisation fixes

### DIFF
--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -197,7 +197,7 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     elseif ($id === NULL && $cacheKey === NULL) {
       // Delete everything.
       $keys = $this->redis->keys($this->prefix . '*');
-      if ( $keys !== false ){
+      if ($keys !== FALSE) {
         $this->redis->del($keys);
       }
     }

--- a/CRM/Core/PrevNextCache/Redis.php
+++ b/CRM/Core/PrevNextCache/Redis.php
@@ -197,7 +197,9 @@ class CRM_Core_PrevNextCache_Redis implements CRM_Core_PrevNextCache_Interface {
     elseif ($id === NULL && $cacheKey === NULL) {
       // Delete everything.
       $keys = $this->redis->keys($this->prefix . '*');
-      $this->redis->del($keys);
+      if ( $keys !== false ){
+        $this->redis->del($keys);
+      }
     }
     elseif ($id !== NULL && $cacheKey !== NULL) {
       // Delete a specific contact, within a specific cache.

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -62,6 +62,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     $port = $config['port'] ?? self::DEFAULT_PORT;
     // Ugh.
     $pass = CRM_Utils_Constant::value('CIVICRM_DB_CACHE_PASSWORD');
+    $user = CRM_Utils_Constant::value('CIVICRM_DB_CACHE_USERNAME');
     $id = implode(':', ['connect', $host, $port /* $pass is constant */]);
     if (!isset(Civi::$statics[__CLASS__][$id])) {
       // Ideally, we'd track the connection in the service-container, but the
@@ -72,7 +73,9 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
         echo 'Could not connect to redisd server';
         CRM_Utils_System::civiExit();
       }
-      if ($pass) {
+      if ( $user && $pass ) {
+        $redis->auth([$user, $pass]);
+      }else if ($pass) {
         $redis->auth($pass);
       }
       Civi::$statics[__CLASS__][$id] = $redis;
@@ -96,7 +99,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
       $this->_prefix = $config['prefix'];
     }
     if (defined('CIVICRM_DEPLOY_ID')) {
-      $this->_prefix = CIVICRM_DEPLOY_ID . '_' . $this->_prefix;
+      $this->_prefix .= '_' . CIVICRM_DEPLOY_ID;
     }
 
     $this->_cache = self::connect($config);
@@ -161,7 +164,9 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     // more general rethink of cache expiration/TTL.
 
     $keys = $this->_cache->keys($this->_prefix . '*');
-    $this->_cache->del($keys);
+    if ( $keys !== false ) {
+      $this->_cache->del($keys);
+    }
     return TRUE;
   }
 

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -73,9 +73,10 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
         echo 'Could not connect to redisd server';
         CRM_Utils_System::civiExit();
       }
-      if ( $user && $pass ) {
+      if ($user && $pass) {
         $redis->auth([$user, $pass]);
-      }else if ($pass) {
+      }
+      elseif ($pass) {
         $redis->auth($pass);
       }
       Civi::$statics[__CLASS__][$id] = $redis;
@@ -164,7 +165,7 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
     // more general rethink of cache expiration/TTL.
 
     $keys = $this->_cache->keys($this->_prefix . '*');
-    if ( $keys !== false ) {
+    if ($keys !== FALSE) {
       $this->_cache->del($keys);
     }
     return TRUE;

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -466,6 +466,14 @@ if (!defined('CIVICRM_DB_CACHE_PASSWORD')) {
 }
 
 /**
+ * Change this if your cache server requires a username (currently only works
+ * with Redis - if you are ACLs)
+ */
+if (!defined('CIVICRM_DB_CACHE_USERNAME')) {
+  define('CIVICRM_DB_CACHE_USERNAME', '');
+}
+
+/**
  * Items in cache will expire after the number of seconds specified here.
  * Default value is 3600 (i.e., after an hour)
  */


### PR DESCRIPTION
Overview
----------------------------------------
We are setting up a civicrm with redis caching and want to use redis caching. Currently there's no way of using Redis ACL's (https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/).

Before
----------------------------------------
Redis cache did not support ACL authentication
Prefix based authentication would fail

After
----------------------------------------
CIVICRM_DB_CACHE_USERNAME can be used as the ACL based authentication username

Technical Details
----------------------------------------
This PR changes the redis prefix. Previously the prefix was 

{CIVICRM_DEPLOY_ID}_{prefix}
and the PrevNextCache uses {prefix}/prevnext/

so if you want to set the ACL authentication to use the {prefix} as follows then the prefix is not actually respected in the Redis cache and will fail.

ACL SETUSER {user} on >{password} ~{prefix}* +get +set +setex +del +expire'


Comments
----------------------------------------
ACL based redis access is the only safe multi-tenant way to use shared infrastructure between installations, thus is an important feature to support
