### PR TITLE
Allow cache rebuild as anonymous user for afformAdmin metadata

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -221,7 +221,7 @@ class AfformAdminMeta {
       ];
 
       // Explicitly load Contact and Custom entities because they do not have afformEntity files
-      $contactAndCustom = Entity::get(TRUE)
+      $contactAndCustom = Entity::get(FALSE)
         ->addClause('OR', ['name', '=', 'Contact'], ['type', 'CONTAINS', 'CustomValue'])
         ->execute()->indexBy('name');
       foreach ($contactAndCustom as $name => $entity) {
@@ -229,7 +229,7 @@ class AfformAdminMeta {
       }
 
       // Call getFields on getFields to get input type labels
-      $inputTypeLabels = \Civi\Api4\Contact::getFields()
+      $inputTypeLabels = \Civi\Api4\Contact::getFields(FALSE)
         ->setLoadOptions(TRUE)
         ->setAction('getFields')
         ->addWhere('name', '=', 'input_type')
@@ -348,7 +348,7 @@ class AfformAdminMeta {
         'danger' => E::ts('Danger'),
       ];
 
-      $perms = \Civi\Api4\Permission::get()
+      $perms = \Civi\Api4\Permission::get(FALSE)
         ->addWhere('group', 'IN', ['afformGeneric', 'const', 'civicrm', 'cms'])
         ->addWhere('is_active', '=', 1)
         ->setOrderBy(['title' => 'ASC'])


### PR DESCRIPTION
Overview
----------------------------------------
`\Civi\Afform\FormDataModel::getInputTypeTemplate()` is called when loading a form. If that form can be accessed when not logged in it will crash with `UnauthorizedException` if the `afform_admin.metadata` cache is stale.

This affects 6.6, didn't see it on 6.4. Tested on WordPress.

Before
----------------------------------------
Intermittent `UnauthorizedException` and 500 error on site if `afform_admin.metadata` cache is stale and anonymous user tries to load a afform.

After
----------------------------------------
Cache can be rebuilt as anonymous user. No crash.

Technical Details
----------------------------------------
@colemanw I don't think we need to be checking permissions here to rebuild the cache? But also, it seems a bit wierd having a core Afform function requiring access to a function on afform admin.

Comments
----------------------------------------
Because a client site had a newsletter signup on every public page (in the footer) this effectively caused a complete site outage until an admin logged in as every page load triggered a 500 error / unauthorizedexception.
