### PR TITLE
Add Refund permission and API4 PaymentProcessor.Refund

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3990,7 +3990,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         'weight' => 0,
       ];
     }
-    if ($contributionStatus !== 'Pending') {
+    if ($contributionStatus !== 'Pending' && CRM_Core_Permission::check('refund contributions')) {
       $actionLinks[] = [
         'url' => 'civicrm/payment',
         'title' => ts('Record Refund'),

--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -108,6 +108,10 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     $this->_paymentType = $this->getPaymentType();
 
+    if ($this->isARefund() && !CRM_Core_Permission::check('refund contributions')) {
+      throw new CRM_Core_Exception('You do not have permission to refund contributions.');
+    }
+
     if (!empty($this->_mode) && $this->isARefund()) {
       throw new CRM_Core_Exception(ts('Credit card payment is not for Refund payments use'));
     }

--- a/CRM/Contribute/Info.php
+++ b/CRM/Contribute/Info.php
@@ -62,6 +62,10 @@ class CRM_Contribute_Info extends CRM_Core_Component_Info {
         'label' => ts('edit contributions'),
         'description' => ts('Record and update contributions'),
       ],
+      'refund contributions' => [
+        'label' => ts('Refund contributions'),
+        'description' => ts('Allow refunds to be issued for contributions'),
+      ],
       'make online contributions' => [
         'label' => ts('make online contributions'),
       ],

--- a/CRM/Contribute/Page/ContributionRecurPayments.php
+++ b/CRM/Contribute/Page/ContributionRecurPayments.php
@@ -181,25 +181,32 @@ class CRM_Contribute_Page_ContributionRecurPayments extends CRM_Core_Page {
     }
 
     if (in_array($contribution['contribution_status'], ['Partially paid', 'Pending refund']) || $isPayLater) {
-      $buttonName = ts('Record Payment');
-
       if ($contribution['contribution_status'] == 'Pending refund') {
-        $buttonName = ts('Record Refund');
+        if (CRM_Core_Permission::check('refund contributions')) {
+          $links[CRM_Core_Action::ADD] = [
+            'name' => 'Record Refund',
+            'url' => 'civicrm/payment',
+            'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
+            'title' => ts('Record Refund'),
+          ];
+        }
       }
-      elseif (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
-        $links[CRM_Core_Action::BASIC] = [
-          'name' => ts('Submit Credit Card payment'),
-          'url' => 'civicrm/payment/add',
-          'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution&mode=live',
-          'title' => ts('Submit Credit Card payment'),
+      else {
+        $links[CRM_Core_Action::ADD] = [
+          'name' => 'Record Payment',
+          'url' => 'civicrm/payment',
+          'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
+          'title' => ts('Record Payment'),
         ];
+        if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
+          $links[CRM_Core_Action::BASIC] = [
+            'name' => ts('Submit Credit Card payment'),
+            'url' => 'civicrm/payment/add',
+            'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution&mode=live',
+            'title' => ts('Submit Credit Card payment'),
+          ];
+        }
       }
-      $links[CRM_Core_Action::ADD] = [
-        'name' => $buttonName,
-        'url' => 'civicrm/payment',
-        'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
-        'title' => $buttonName,
-      ];
     }
 
     return $links;

--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -405,26 +405,35 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
       ];
 
       if (in_array($row['contribution_status_name'], ['Partially paid', 'Pending refund']) || $isPayLater) {
-        $buttonName = ts('Record Payment');
         if ($row['contribution_status_name'] === 'Pending refund') {
-          $buttonName = ts('Record Refund');
+          if (CRM_Core_Permission::check('refund contributions')) {
+            $links[CRM_Core_Action::ADD] = [
+              'name' => 'Record Refund',
+              'url' => 'civicrm/payment',
+              'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
+              'title' => ts('Record Refund'),
+              'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
+            ];
+          }
         }
-        elseif (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
-          $links[CRM_Core_Action::BASIC] = [
-            'name' => ts('Submit Credit Card payment'),
-            'url' => 'civicrm/payment/add',
-            'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution&mode=live',
-            'title' => ts('Submit Credit Card payment'),
-            'weight' => 30,
+        else {
+          $links[CRM_Core_Action::ADD] = [
+            'name' => 'Record Payment',
+            'url' => 'civicrm/payment',
+            'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
+            'title' => ts('Record Payment'),
+            'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
           ];
+          if (CRM_Core_Config::isEnabledBackOfficeCreditCardPayments()) {
+            $links[CRM_Core_Action::BASIC] = [
+              'name' => ts('Submit Credit Card payment'),
+              'url' => 'civicrm/payment/add',
+              'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution&mode=live',
+              'title' => ts('Submit Credit Card payment'),
+              'weight' => 30,
+            ];
+          }
         }
-        $links[CRM_Core_Action::ADD] = [
-          'name' => $buttonName,
-          'url' => 'civicrm/payment',
-          'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=contribution',
-          'title' => $buttonName,
-          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::ADD),
-        ];
       }
       $links = $links + CRM_Contribute_Task::getContextualLinks($row);
 

--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -346,7 +346,7 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
 
       if ($statusTypes[$row['participant_status_id']] === 'Partially paid') {
         $links[CRM_Core_Action::ADD] = [
-          'name' => ts('Record Payment'),
+          'name' => 'Record Payment',
           'url' => 'civicrm/payment',
           'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=event',
           'title' => ts('Record Payment'),
@@ -364,13 +364,15 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
       }
 
       if ($statusTypes[$row['participant_status_id']] === 'Pending refund') {
-        $links[CRM_Core_Action::ADD] = [
-          'name' => ts('Record Refund'),
-          'url' => 'civicrm/payment',
-          'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=event',
-          'title' => ts('Record Refund'),
-          'weight' => 60,
-        ];
+        if (CRM_Core_Permission::check('refund contributions')) {
+          $links[CRM_Core_Action::ADD] = [
+            'name' => 'Record Refund',
+            'url' => 'civicrm/payment',
+            'qs' => 'reset=1&id=%%id%%&cid=%%cid%%&action=add&component=event',
+            'title' => ts('Record Refund'),
+            'weight' => 60,
+          ];
+        }
       }
 
       // CRM-20879: Show 'Transfer or Cancel' action only if logged in user

--- a/Civi/Api4/Action/PaymentProcessor/Refund.php
+++ b/Civi/Api4/Action/PaymentProcessor/Refund.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\PaymentProcessor;
+
+/**
+ * PaymentProcessor refund action
+ */
+class Refund extends \Civi\Api4\Generic\AbstractAction {
+
+  /**
+   * The Payment Processor ID
+   *
+   * @var int
+   * @required
+   */
+  protected int $paymentProcessorID;
+
+  /**
+   * The amount to refund
+   *
+   * @var float
+   * @required
+   */
+  protected float $amountToRefund;
+
+  /**
+   * The payment processor transaction ID
+   * Required by most payment processors
+   *
+   * @var string
+   * @required
+   */
+  protected string $transactionID;
+
+  /**
+   * @see \Civi\Api4\Generic\AbstractEntity::permissions()
+   * @return array
+   */
+  public static function permissions() {
+    return [
+      'refund' => ['refund contributions'],
+    ];
+  }
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    /** @var \CRM_Core_Payment $processor */
+    $processor = \Civi\Payment\System::singleton()->getById($this->paymentProcessorID);
+    if (!$processor->supportsRefund()) {
+      throw new \CRM_Core_Exception('Payment Processor does not support refund');
+    }
+    $refundParams['amount'] = $this->amountToRefund;
+    $refundParams['trxn_id'] = $this->transactionID;
+
+    $result->exchangeArray($processor->doRefund($refundParams));
+    return $result;
+  }
+
+}

--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -14,6 +14,7 @@
  *
  * @package CiviCRM_APIv3
  */
+use Civi\API\Exception\UnauthorizedException;
 
 /**
  * Add/Update a PaymentProcessor.
@@ -175,11 +176,14 @@ function _civicrm_api3_payment_processor_pay_spec(&$params) {
  * @throws \Civi\Payment\Exception\PaymentProcessorException
  */
 function civicrm_api3_payment_processor_refund($params) {
+  if (!CRM_Core_Permission::check('refund contributions')) {
+    throw new UnauthorizedException(ts('You do not have permission to issue refunds'));
+  }
   /** @var \CRM_Core_Payment $processor */
   $processor = Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
   $processor->setPaymentProcessor(civicrm_api3('PaymentProcessor', 'getsingle', ['id' => $params['payment_processor_id']]));
   if (!$processor->supportsRefund()) {
-    throw new CRM_Core_Exception('Payment Processor does not support refund');
+    throw new CRM_Core_Exception(ts('Payment Processor does not support refund'));
   }
   $result = $processor->doRefund($params);
   return civicrm_api3_create_success([$result], $params);


### PR DESCRIPTION
Overview
----------------------------------------
- Adds a "Refund contributions" permission to CiviCRM.
- Adds an API4 PaymentProcessor.Refund.
- Makes both API3 PaymentProcessor.Refund and API4 PaymentProcessor.Refund require "Refund contributions" permission.
- Removes "Record Refund" buttons and access to Refund (AdditionalPayment in refund mode) form if user doesn't have permission.

Before
----------------------------------------
No refund permission or API4 PaymentProcessor.Refund

After
----------------------------------------
Refund permission and API4 PaymentProcessor.Refund

Technical Details
----------------------------------------


Comments
----------------------------------------

