### PR TITLE
Fix API4 Payment.Get contribution_id field not found when passing in contribution ID and use where clause for more flexibility/standardisation

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -546,13 +546,19 @@ trait Api3TestTrait {
     // Build where clause for 'getcount', 'getsingle', 'getvalue', 'get' & 'replace'
     if ($v4Action == 'get' || $v3Action == 'replace') {
       foreach ($v3Params as $key => $val) {
-        $op = '=';
-        if (is_array($val) && count($val) == 1 && array_intersect_key($val, array_flip(\CRM_Core_DAO::acceptedSQLOperators()))) {
-          foreach ($val as $op => $newVal) {
-            $val = $newVal;
-          }
+        if ($key === 'orderBy') {
+          $v4Params[$key] = $val;
+          $indexBy = NULL;
         }
-        $v4Params['where'][] = [$key, $op, $val];
+        else {
+          $op = '=';
+          if (is_array($val) && count($val) == 1 && array_intersect_key($val, array_flip(\CRM_Core_DAO::acceptedSQLOperators()))) {
+            foreach ($val as $op => $newVal) {
+              $val = $newVal;
+            }
+          }
+          $v4Params['where'][] = [$key, $op, $val];
+        }
       }
     }
 

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -219,7 +219,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals(9, $contribution['total_amount']);
 
     $payment = Payment::get()
-      ->setContributionID($contribution['id'])
+      ->addWhere('contribution_id', '=', $contribution['id'])
       ->execute()->single();
     $this->assertEquals(567, $payment['pan_truncation']);
     $this->assertEquals(9, $payment['total_amount']);

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -105,12 +105,27 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $this->assertEquals(1, $contribution['contribution_status_id']);
 
     //Get Payment using options
-    $getParams = [
-      'sequential' => 1,
-      'contribution_id' => $contributionID,
-      'is_payment' => 1,
-      'options' => ['limit' => 0, 'sort' => 'total_amount DESC'],
-    ];
+    switch ($apiVersion) {
+      case 3:
+        $getParams = [
+          'sequential' => 1,
+          'contribution_id' => $contributionID,
+          'is_payment' => 1,
+          'options' => ['limit' => 0, 'sort' => 'total_amount DESC'],
+        ];
+        break;
+
+      case 4:
+        $getParams = [
+          'where' => [
+            ['contribution_id', '=', $contributionID],
+          ],
+          'orderBy' => [
+            'total_amount' => 'DESC',
+          ],
+        ];
+    }
+
     $payments = $this->callAPISuccess('Payment', 'get', $getParams);
     $this->assertEquals(3, $payments['count']);
     foreach ([50, 30, 20] as $key => $total_amount) {
@@ -210,7 +225,19 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'trxn_id' => 111111,
       'total_amount' => 10,
     ]);
-    $paymentParams = ['contribution_id' => $contributionID1];
+
+    switch ($apiVersion) {
+      case 3:
+        $paymentParams = ['contribution_id' => $contributionID1];
+        break;
+
+      case 4:
+        $paymentParams = [
+          'where' => [
+            ['contribution_id', '=', $contributionID1],
+          ],
+        ];
+    }
     $this->callAPISuccess('Payment', 'create', ['total_amount' => '-10', 'contribution_id' => $contributionID1]);
     $this->callAPISuccess('payment', 'get', $paymentParams);
     $this->callAPISuccess('Payment', 'create', ['total_amount' => '-10', 'contribution_id' => $contributionID1]);


### PR DESCRIPTION
Overview
----------------------------------------
If you pass a contribution ID into API4 `Payment.Get` it crashes with "unknown field contribution_id".

I'm also not sure why we implemented contribution ID as a parameter instead of part of the where clause - @seamuslee001 ? so I've deprecated that and switched it to support the where clause.

From memory, at the Hamburg Sprint in 2024, I think I said that was my main issue with API3 Payment.Get that you couldn't pass in a Contribution ID so we added it for API4.

Before
----------------------------------------
Crash when passing in contribution ID.

After
----------------------------------------
No crash, where clause contribution_id supported.

Technical Details
----------------------------------------
Deprecate the parameter.
Remove contribution_id from where clause once we've looked it up using EntityFinancialTrxn since API4 will crash otherwise as it's not a valid field for FinancialTrxn.
Support passing contribution_id via where clause (means we can do eg '=', 'IN' etc.)

Comments
----------------------------------------
@seamuslee001 @eileenmcnaughton 
