### PR TITLE
Set Contribution status to 'Partially Paid' when a partial refund is issued

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3189,11 +3189,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $checkStatus = [
       'Cancelled' => ['Completed', 'Refunded'],
-      'Completed' => ['Cancelled', 'Refunded', 'Chargeback'],
+      'Completed' => ['Cancelled', 'Refunded', 'Chargeback', 'Partially paid'],
       'Pending' => ['Cancelled', 'Completed', 'Failed', 'Partially paid'],
       'In Progress' => ['Cancelled', 'Completed', 'Failed'],
       'Refunded' => ['Cancelled', 'Completed'],
-      'Partially paid' => ['Completed'],
+      'Partially paid' => ['Completed', 'Refunded'],
       'Pending refund' => ['Completed', 'Refunded'],
       'Failed' => ['Pending'],
     ];

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -130,7 +130,7 @@ class CRM_Financial_BAO_Payment {
     }
     else {
       // Link the payment with the relevant financial items, by creating EntityFinancialItems.
-      // We also ensure the status of the Item is set to Paid or Partially Paid as appropriate.
+      // We also ensure the status of the Item is set to Paid or Partially paid as appropriate.
       foreach ($payableItems as $payableItem) {
         if ($payableItem['allocation'] === 0.0) {
           continue;
@@ -186,7 +186,7 @@ class CRM_Financial_BAO_Payment {
       }
     }
     elseif ($contributionStatus === 'Pending' && $params['total_amount'] > 0) {
-      self::updateContributionStatus($contribution['id'], 'Partially Paid');
+      self::updateContributionStatus($contribution['id'], 'Partially paid');
       $participantPayments = civicrm_api3('ParticipantPayment', 'get', [
         'contribution_id' => $contribution['id'],
         'participant_id.status_id' => ['IN' => ['Pending from pay later', 'Pending from incomplete transaction']],
@@ -197,10 +197,22 @@ class CRM_Financial_BAO_Payment {
     }
     // Note that we reload the payments rather than use $contribution['paid_amount']
     // here as we are interested in the paid_amount AFTER this payment has been made.
-    elseif ($contributionStatus === 'Completed' && ((float) CRM_Core_BAO_FinancialTrxn::getTotalPayments($contribution['id'], TRUE) === 0.0)) {
-      // If the contribution has previously been completed (fully paid) and now has total payments adding up to 0
-      //  change status to 'refunded'.
-      self::updateContributionStatus($contribution['id'], 'Refunded');
+    elseif ($contributionStatus === 'Completed') {
+      $contributionPaidAmount = Contribution::get(FALSE)
+        ->addSelect('paid_amount')
+        ->addWhere('id', '=', $contribution['id'])
+        ->execute()
+        ->first()['paid_amount'];
+      if ($contributionPaidAmount === 0.0) {
+        // If the contribution has previously been Completed (fully paid) and now has total payments adding up to 0
+        //  change status to 'refunded'.
+        // Note: If refunds add up to more than total amount it'll get set to "Partially paid" - see below.
+        self::updateContributionStatus($contribution['id'], 'Refunded');
+      }
+      elseif ($contributionPaidAmount < $contribution['total_amount']) {
+        // Amount paid is less than contribution amount. Set to "Partially paid".
+        self::updateContributionStatus($contribution['id'], 'Partially paid');
+      }
     }
     CRM_Contribute_BAO_Contribution::recordPaymentActivity($params['contribution_id'], $params['participant_id'] ?? NULL, $params['total_amount'], $trxn->currency, $trxn->trxn_date);
     return $trxn;

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -197,7 +197,7 @@ class CRM_Financial_BAO_Payment {
     }
     // Note that we reload the payments rather than use $contribution['paid_amount']
     // here as we are interested in the paid_amount AFTER this payment has been made.
-    elseif ($contributionStatus === 'Completed') {
+    elseif (in_array($contributionStatus, ['Partially paid', 'Completed'])) {
       $contributionPaidAmount = Contribution::get(FALSE)
         ->addSelect('paid_amount')
         ->addWhere('id', '=', $contribution['id'])

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -589,8 +589,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       'return' => ['contribution_status_id'],
       'id' => $contributionID,
     ]);
-    //Still we've a status of Completed after refunding a partial amount.
-    $this->assertEquals('Completed', $contribution['contribution_status']);
+    // We should now have a status of "Partially paid" after refunding a partial amount.
+    $this->assertEquals('Partially paid', $contribution['contribution_status']);
 
     //Refund the complete amount.
     $this->callAPISuccess('Payment', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/financial/-/issues/87 and https://lab.civicrm.org/dev/financial/-/issues/103

Before
----------------------------------------
Partially refunding a contribution leaves it as "Completed".

After
----------------------------------------
Partially refunding a contribution sets it to "Partially Paid".

Technical Details
----------------------------------------


Comments
----------------------------------------
