### PR TITLE
Prevent error when exporting with household relationship types disabled

### DIFF
--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -568,10 +568,7 @@ class CRM_Export_BAO_ExportProcessor {
     if (!$this->isMergeSameHousehold()) {
       return [];
     }
-    return [
-      CRM_Utils_Array::key('Household Member of', $this->getRelationshipTypes()),
-      CRM_Utils_Array::key('Head of Household for', $this->getRelationshipTypes()),
-    ];
+    return array_keys(array_intersect($this->getRelationshipTypes(), ['Household Member of', 'Head of Household for']));
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
If you disable household relationship types, exporting contacts will fail if you try to merge contacts with the same address.

After
----------------------------------------
Works.

Technical Details
----------------------------------------
The code was returning ```[[0] => [1] => ]``` which was [later producing](https://github.com/civicrm/civicrm-core/blob/9c53c818830b9e0c0772b4423d83a674287c300f/CRM/Export/BAO/Export.php#L393) borked SQL because there was no ```$id```.

You might ask why ```$isMergeSameHousehold``` is true when we are merging by shared address and not household? Apparently, [same address implies household as well.](https://github.com/civicrm/civicrm-core/pull/16369)