### PR TITLE
dev/core#6127 event locblocks

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1707,9 +1707,7 @@ WHERE  id = $cfID
           $address .= ($address ? ' :: ' : '') . $event[$field];
         }
       }
-      if ($address) {
-        $events[$event['loc_block_id']] = $address;
-      }
+      $events[$event['loc_block_id']] = $address ?: ts("(Location %1)", [1 => $event['loc_block_id']]);
     }
 
     return CRM_Utils_Array::asort($events);

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -77,7 +77,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
       ];
       // Get all the existing email addresses, The array historically starts
       // with 1 not 0 so we do something nasty to continue that.
-      $this->_values['email'] = array_merge([0 => 1], (array) $this->getExistingEmails());
+      $this->_values['email'] = array_merge([0 => 1], (array) $this->getExistingEmails(TRUE));
       unset($this->existingEmails[0]);
 
       //get event values.


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/6127

Before:

- Event creator's emails become defaults in a blank locblock for a new event, which get persisted on event save. The user is typically unaware this happened, so this exposes data they did not intend to expose.
- A locBlock without an address is not listed in the `<select2>` so the UX is broken for these cases.

After:

- Event creator's emails are not pre-populated in blank form. So no accidental exposure (and no creation of unnecessary locblocks)
- Locblocks without addresses are listed with "(Location 123)" as their labels. Better than nothing.