### PR TITLE
CRM_Utils_Url - Add helper to determine origin of an absolute URL

### DIFF
--- a/CRM/Utils/Url.php
+++ b/CRM/Utils/Url.php
@@ -78,6 +78,22 @@ class CRM_Utils_Url {
   }
 
   /**
+   * @param string $url
+   *   Ex: 'http://local.example.com:8080/foo/bar/whiz'
+   * @return string
+   *   Ex: 'http://local.example.com:8080'
+   */
+  public static function toOrigin(string $url): string {
+    return \CRM_Utils_Url::unparseUrl(
+      \CRM_Utils_Url::parseUrl($url)
+        ->withUserInfo('')
+        ->withPath('')
+        ->withQuery('')
+        ->withFragment('')
+    );
+  }
+
+  /**
    * Parse an internal URL. Extract the CiviCRM route.
    *
    * @param string $pageUrl

--- a/tests/phpunit/CRM/Utils/UrlTest.php
+++ b/tests/phpunit/CRM/Utils/UrlTest.php
@@ -197,4 +197,10 @@ class CRM_Utils_UrlTest extends CiviUnitTestCase {
     }
   }
 
+  public function testOriginUrl() {
+    $this->assertEquals('https://example.com', CRM_Utils_Url::toOrigin('https://example.com/'));
+    $this->assertEquals('https://example.com', CRM_Utils_Url::toOrigin('https://user:pass@example.com/foo/bar/whiz?whiz=1#bang'));
+    $this->assertEquals('http://local.example.com:8080', CRM_Utils_Url::toOrigin('http://local.example.com:8080/foo/bar/whiz'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Small helper to determine the "origin" of a URL (as understood by web-browsers; basically, two pages are considered to be in the same origin if they're on the same server).
