### PR TITLE
dev/core#6120 - alternate to 33679 - Fix broken names for mailing labels with merged addresses

### DIFF
--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -1085,7 +1085,14 @@ SELECT is_primary,
         }
         else {
           // collapse the tree to summarize
-          $family = trim(implode(" & ", array_keys($first_names)) . " " . $last_name);
+          // "first_names" is a leftover misnomer from before it was converted
+          // to tokens - it's now the whole display name, so remove last name
+          // and just add it only at the end.
+          $remove_last_names = str_replace($last_name, '', array_keys($first_names));
+          $remove_last_names = array_map(function($v) {
+            return trim($v);
+          }, $remove_last_names);
+          $family = trim(implode(" & ", $remove_last_names) . " " . $last_name);
         }
         if ($count) {
           $processedNames .= "\n" . $family;


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6120

I don't like this one as much as #33679 because the output is different from before, notably the contact suffix if present now appears if using the default display_name config. But codewise it's simpler.

Before
----------------------------------------
1. Create a contact Jerry Smith.
2. Create a contact Beth Smith.
3. Give them both the same address.
4. Do a contact search and select both and choose Mailing Labels - Print from the actions dropdown.
5. Check the box to merge with same address.
6. Note the output says `Jerry Smith & Beth Smith Smith`.
7. It's supposed to say `Jerry & Beth Smith`.

After
----------------------------------------
Compromise because doing exactly like before when the display_name pref is highly customized is difficult, but should work in most cases.

Technical Details
----------------------------------------
See lab ticket.

Comments
----------------------------------------
Broke in 6.1.
