### PR TITLE
dev/core#6115 - CRM/Member - Set is_pay_later consistently in back end

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1058,11 +1058,11 @@ DESC limit 1");
       $params['contribution_source'] = $this->getContributionSource();
 
       $completedContributionStatusId = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
-      if (empty($params['is_override']) &&
-        ($params['contribution_status_id'] ?? NULL) != $completedContributionStatusId
-      ) {
-        $params['status_id'] = $pendingMembershipStatusId;
-        $params['skipStatusCal'] = TRUE;
+      if (($params['contribution_status_id'] ?? NULL) != $completedContributionStatusId) {
+        if (empty($params['is_override'])) {
+          $params['status_id'] = $pendingMembershipStatusId;
+          $params['skipStatusCal'] = TRUE;
+        }
         $params['is_pay_later'] = 1;
         $this->assign('is_pay_later', 1);
       }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1013,6 +1013,79 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
     // Check if Membership is set to Pending.
     $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending'), $membership['status_id']);
+
+    // Check if Contribution is_pay_later flag is set.
+    $this->assertEquals(1, $contribution['is_pay_later']);
+  }
+
+  /**
+   * Test the submit function of the membership form for pay later with membership status override.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSubmitPayLaterWithBillingStatusOverride(): void {
+    $params = [
+      'contact_id' => $this->ids['Contact']['individual_0'],
+      'join_date' => date('Y-m-d'),
+      'start_date' => '',
+      'end_date' => '',
+      // This format reflects the first number being the organisation & the second being the type.
+      'membership_type_id' => [$this->ids['Contact']['organization'], $this->ids['MembershipType']['AnnualFixed']],
+      'auto_renew' => '0',
+      'max_related' => '',
+      'num_terms' => '2',
+      'source' => '',
+      'is_override' => TRUE,
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending'),
+      'total_amount' => '50.00',
+      //Member dues, see data.xml
+      'financial_type_id' => '2',
+      'soft_credit_type_id' => '',
+      'soft_credit_contact_id' => '',
+      'payment_instrument_id' => 4,
+      'from_email_address' => '"Demonstrators Anonymous" <info@example.org>',
+      'receipt_text_signup' => 'Thank you text',
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'record_contribution' => TRUE,
+      'trxn_id' => 777,
+      'contribution_status_id' => 2,
+      'billing_first_name' => 'Test',
+      'billing_middle_name' => 'Last',
+      'billing_street_address-5' => '10 Test St',
+      'billing_city-5' => 'Test',
+      'billing_state_province_id-5' => '1003',
+      'billing_postal_code-5' => '90210',
+      'billing_country_id-5' => '1228',
+    ];
+    $form = $this->getForm($params);
+    $this->createLoggedInUser();
+
+    $form->_contactID = $this->ids['Contact']['individual_0'];
+
+    $form->testSubmit($params);
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0']]);
+    $contribution = $this->callAPISuccessGetSingle('Contribution', [
+      'contact_id' => $this->ids['Contact']['individual_0'],
+      'contribution_status_id' => 2,
+    ]);
+    $this->assertEquals($contribution['trxn_id'], 777);
+
+    $this->callAPISuccessGetCount('LineItem', [
+      'entity_id' => $membership['id'],
+      'entity_table' => 'civicrm_membership',
+      'contribution_id' => $contribution['id'],
+    ], 1);
+    $this->callAPISuccessGetSingle('address', [
+      'contact_id' => $this->ids['Contact']['individual_0'],
+      'street_address' => '10 Test St',
+      'postal_code' => 90210,
+    ]);
+
+    // Check if Membership is set to Pending.
+    $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Pending'), $membership['status_id']);
+
+    // Check if Contribution is_pay_later flag is set.
+    $this->assertEquals(1, $contribution['is_pay_later']);
   }
 
   /**


### PR DESCRIPTION
For back end membership creation with pending contribution, set the is_pay_later flag on the contribution regardless of whether the membership has the is_override flag set.

Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/6115 for overview and steps to replicate.

For back end membership creation with pending contribution and membership is_override flag set...

Before
----------------------------------------
Fails to set the is_pay_later flag on the contribution, giving contribution status: Pending (Incomplete Transaction).

After
----------------------------------------
Sets the is_pay_later flag on the contribution, giving contribution status: Pending (Pay Later).

Technical Details
----------------------------------------
Unit tests: adds an assertion to `testSubmitPayLaterWithBilling()` and adds test `testSubmitPayLaterWithBillingStatusOverride()`.