### PR TITLE
dev/core#6131: Respect pager setting on SearchKitBatch

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.component.js
@@ -32,14 +32,13 @@
         this.display.settings.pager = this.display.settings.pager ? false : getDefaultSettings();
         if (this.display.settings.pager && !this.display.settings.limit) {
           this.toggleLimit();
+        } else if (!this.display.settings.pager && this.noLimit) {
+          delete this.display.settings.limit;
         }
       };
 
       this.toggleLimit = function() {
-        if (ctrl.noLimit) {
-          delete ctrl.display.settings.limit;
-        }
-        else if (ctrl.display.settings.limit) {
+        if (ctrl.display.settings.limit) {
           ctrl.display.settings.limit = 0;
         } else {
           ctrl.display.settings.limit = CRM.crmSearchAdmin.defaultPagerSize;


### PR DESCRIPTION
Before
----------------------------------------
Disabling the pager removes the pager UI, but only shows rows up to the previous limit.

After
----------------------------------------
Disabling the pager shows all rows.