### PR TITLE
Don't validate page size in SearchKit

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -22,7 +22,7 @@
       <label for="{{ 'crm-search-results-page-size-' + $ctrl.uniqueId }}" >
         {{:: ts('Page Size') }}
       </label>
-      <input class="form-control four" id="{{ 'crm-search-results-page-size-' + $ctrl.uniqueId }}" type="number" ng-model="$ctrl.limit" min="10" step="10">
+      <input class="form-control four" id="{{ 'crm-search-results-page-size-' + $ctrl.uniqueId }}" type="number" ng-model="$ctrl.limit" min="1">
     </div>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
SearchDisplays have an input for the number of rows on the page. The step and min of this are set to 10, which makes sense for those using the little up and down arrows in the input. I don't see why we don't just let users enter any number of rows they want. Maybe 25 is convenient. Maybe they want 63.

Before
----------------------------------------
In a normal SearchDisplay, you get a validation error if you enter a number that is not a multiple of 10 and the default number of rows are shown.
In a SKBatch, the same, plus the row numbers all change to NaN.

After
----------------------------------------
Works as expected, the number of rows you enter is the number of rows you are shown.

Comments
----------------------------------------
If you do something silly like entering 0 or -1, you'll get a validation error, but the pager will still be broken until you put in a positive number. That seems OK.