### PR TITLE
OAuthClient - Add `$ttl` and `$responseMode` to AuthorizationCode flow

### DIFF
--- a/ext/oauth-client/CRM/OAuth/Page/Return.php
+++ b/ext/oauth-client/CRM/OAuth/Page/Return.php
@@ -3,7 +3,7 @@ use CRM_OAuth_ExtensionUtil as E;
 
 class CRM_OAuth_Page_Return extends CRM_Core_Page {
 
-  const TTL = 3600;
+  const LEGACY_TTL = 3600;
 
   public function run() {
     $json = function ($d) {
@@ -79,7 +79,8 @@ class CRM_OAuth_Page_Return extends CRM_Core_Page {
     if (PHP_SAPI === 'cli') {
       // CLI doesn't have a real session, so we can't defend as deeply. However,
       // it's also quite uncommon to run authorizationCode in CLI.
-      \Civi::cache('session')->set('OAuthStates_' . $stateId, $stateData, self::TTL);
+      $ttl = $stateData['ttl'] ?? self::LEGACY_TTL;
+      \Civi::cache('session')->set('OAuthStates_' . $stateId, $stateData, $ttl);
       return 'c_' . $stateId;
     }
     else {
@@ -113,7 +114,8 @@ class CRM_OAuth_Page_Return extends CRM_Core_Page {
         throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
     }
 
-    if (!isset($state['time']) || $state['time'] + self::TTL < CRM_Utils_Time::getTimeRaw()) {
+    $ttl = $state['ttl'] ?? self::LEGACY_TTL;
+    if (!isset($state['time']) || $state['time'] + $ttl < CRM_Utils_Time::time()) {
       throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
     }
 

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
@@ -56,6 +56,10 @@ abstract class AbstractGrantAction extends \Civi\Api4\Generic\AbstractBatchActio
     }
   }
 
+  protected function getSelect() {
+    return ['*'];
+  }
+
   /**
    * Look up the definition for the desired client.
    *

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
@@ -27,6 +27,8 @@ use Civi\OAuth\OAuthException;
  * @method string getLandingUrl()
  * @method $this setPrompt(string $prompt)
  * @method string getPrompt()
+ * @method $this setTtl(int $ttl)
+ * @method int getTtl()
  *
  * @link https://tools.ietf.org/html/rfc6749#section-4.1
  */
@@ -52,6 +54,14 @@ class AuthorizationCode extends AbstractGrantAction {
   protected $prompt = NULL;
 
   /**
+   * How long we will wait for the user return. After this time, the stored "state" is lost.
+   *
+   * @var int
+   *  Duration, in seconds
+   */
+  protected $ttl = 3600;
+
+  /**
    * Tee-up the authorization request.
    *
    * @param \Civi\Api4\Generic\Result $result
@@ -68,7 +78,8 @@ class AuthorizationCode extends AbstractGrantAction {
     $scopes = $this->getScopes() ?: $this->callProtected($provider, 'getDefaultScopes');
 
     $stateId = \CRM_OAuth_Page_Return::storeState([
-      'time' => \CRM_Utils_Time::getTimeRaw(),
+      'time' => \CRM_Utils_Time::time(),
+      'ttl' => $this->getTtl(),
       'clientId' => $this->getClientDef()['id'],
       'landingUrl' => $this->getLandingUrl(),
       'storage' => $this->getStorage(),

--- a/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
+++ b/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
@@ -21,6 +21,8 @@ use League\OAuth2\Client\Token\AccessToken;
  */
 class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider {
 
+  use ResponseModeTrait;
+
   /**
    * @var string
    */

--- a/ext/oauth-client/Civi/OAuth/ResponseModeTrait.php
+++ b/ext/oauth-client/Civi/OAuth/ResponseModeTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Civi\OAuth;
+
+trait ResponseModeTrait {
+
+  /**
+   * List of supported response-modes.
+   *
+   * @var array|string[]
+   *
+   *   Some mix of values. At time of writing, Civi supports:
+   *
+   *   - 'query': Values returned to the `$redirectUri` as query params. (Standard OAuth 2.0 behavior.)
+   *   - 'web_message': Values returned via JS API: `window.opener.postMessage(params, civicrmInstanceUrl)`
+   *     Requires the calling page to have a listener corresponding listener for `window.addEventListener` (where e.origin==findOrigin(urlAuthorize))
+   *
+   * @link https://www.ietf.org/archive/id/draft-meyerzuselha-oauth-web-message-response-mode-00.html
+   */
+  protected array $responseModes = ['query'];
+
+  public function getResponseModes(): array {
+    return $this->responseModes;
+  }
+
+  public function setResponseModes(array $responseModes): void {
+    $this->responseModes = $responseModes;
+  }
+
+}

--- a/ext/oauth-client/providers/test_example_3.test.json
+++ b/ext/oauth-client/providers/test_example_3.test.json
@@ -1,0 +1,10 @@
+{
+  "title": "Third Test Example",
+  "options": {
+    "urlAuthorize": "https://example.com/three/auth",
+    "urlAccessToken": "https://example.com/three/token",
+    "urlResourceOwnerDetails": "https://example.com/three/owner",
+    "scopes": ["scope-3-foo", "scope-3-bar"],
+    "responseModes": ["query", "web_message"]
+  }
+}

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -37,12 +37,13 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
     };
 
     $usePerms(['manage OAuth client']);
-    $client = $this->createClient();
+    $client = $this->createClient('test_example_1');
 
     $usePerms(['manage OAuth client']);
     $result = Civi\Api4\OAuthClient::authorizationCode()->addWhere('id', '=', $client['id'])->execute();
     $this->assertEquals(1, $result->count());
     foreach ($result as $ac) {
+      $this->assertEquals('query', $ac['response_mode']);
       $url = parse_url($ac['url']);
       $this->assertEquals('example.com', $url['host']);
       $this->assertEquals('/one/auth', $url['path']);
@@ -52,13 +53,61 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
       $this->assertEquals('scope-1-foo,scope-1-bar', $actualQuery['scope']);
       // ? // $this->assertEquals('auto', $actualQuery['approval_prompt']);
       $this->assertEquals('example-id', $actualQuery['client_id']);
+      $this->assertTrue(empty($actualQuery['response_mode']), 'response_mode should be empty');
       $this->assertMatchesRegularExpression(';civicrm/oauth-client/return;', $actualQuery['redirect_uri']);
+    }
+
+    try {
+      Civi\Api4\OAuthClient::authorizationCode()
+        ->addWhere('id', '=', $client['id'])
+        ->setResponseMode('web_message')
+        ->execute();
+      $this->fail('test_example_1 should not support response_mode=web_message');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertMatchesRegularExpression(';Unsupported response mode: web_message;', $e->getMessage());
     }
   }
 
-  private function createClient(): array {
+  /**
+   * Generate the URL to request an authorization code from a provider.
+   */
+  public function testAuthorizationCode_webMessage(): void {
+    $usePerms = function($ps) {
+      $base = ['access CiviCRM'];
+      \CRM_Core_Config::singleton()->userPermissionClass->permissions = array_merge($base, $ps);
+    };
+
+    $usePerms(['manage OAuth client']);
+    $client = $this->createClient('test_example_3');
+
+    $usePerms(['manage OAuth client']);
+    $result = Civi\Api4\OAuthClient::authorizationCode()
+      ->addWhere('id', '=', $client['id'])
+      ->setResponseMode('web_message')
+      ->execute();
+    $this->assertEquals(1, $result->count());
+    foreach ($result as $ac) {
+      $this->assertEquals('web_message', $ac['response_mode']);
+
+      $url = parse_url($ac['url']);
+      $this->assertEquals('example.com', $url['host']);
+      $this->assertEquals('/three/auth', $url['path']);
+      \parse_str($url['query'], $actualQuery);
+      $this->assertEquals('code', $actualQuery['response_type']);
+      $this->assertMatchesRegularExpression(';^[cs]_[a-zA-Z0-9]+$;', $actualQuery['state']);
+      $this->assertEquals('scope-3-foo,scope-3-bar', $actualQuery['scope']);
+      // ? // $this->assertEquals('auto', $actualQuery['approval_prompt']);
+      $this->assertEquals('example-id', $actualQuery['client_id']);
+      $this->assertEquals('web_message', $actualQuery['response_mode']);
+      $this->assertMatchesRegularExpression(';civicrm/oauth-client/return;', $actualQuery['redirect_uri']);
+      $this->assertEquals($actualQuery['redirect_uri'], $ac['continue_url']);
+    }
+  }
+
+  private function createClient(string $provider): array {
     $create = Civi\Api4\OAuthClient::create()->setValues([
-      'provider' => 'test_example_1',
+      'provider' => $provider,
       'guid' => "example-id",
       'secret' => "example-secret",
     ])->execute();

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
@@ -35,12 +35,20 @@ class api_v4_OAuthProviderTest extends \PHPUnit\Framework\TestCase implements He
       ->addWhere('name', 'LIKE', 'test_example%')
       ->addOrderBy('name', 'DESC')
       ->execute();
-    $this->assertEquals(2, $examples->count());
+    $this->assertEquals(3, $examples->count());
 
-    $this->assertEquals('Civi\OAuth\CiviGenericProvider', $examples->last()['class']);
-    $this->assertEquals('My\Example2', $examples->first()['class']);
-    $this->assertEquals('https://example.com/one/auth', $examples->last()['options']['urlAuthorize']);
-    $this->assertEquals('https://example.com/two', $examples->first()['options']['urlAuthorize']);
+    $this->assertEquals('test_example_3', $examples[0]['name']);
+    $this->assertEquals('Civi\OAuth\CiviGenericProvider', $examples[0]['class']);
+    $this->assertEquals('https://example.com/three/auth', $examples[0]['options']['urlAuthorize']);
+
+    $this->assertEquals('test_example_2', $examples[1]['name']);
+    $this->assertEquals('My\Example2', $examples[1]['class']);
+    $this->assertEquals('https://example.com/two', $examples[1]['options']['urlAuthorize']);
+
+    $this->assertEquals('test_example_1', $examples[2]['name']);
+    $this->assertEquals('Civi\OAuth\CiviGenericProvider', $examples[2]['class']);
+    $this->assertEquals('https://example.com/one/auth', $examples[2]['options']['urlAuthorize']);
+
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

OAuth's "Authorization Code" defines a pageflow where a client site (e.g. Civi) requests credentials from an external site. This PR adds two more options for that flow: "time to live" (`$ttl`) and "response mode" (`$responseMode`).

(Extracted from #33707.)

Technical Details
----------------------------------------

Recall how the "Authorization Code" process works:

<img width="782" height="684" alt="image" src="https://github.com/user-attachments/assets/48e111e7-04d3-4b36-8c23-dd09069b10a4" />

When rendering the start page (1) and its outbound links (2), we generate the links with `\Civi\Api4\OAuthClient::authorizationCode()`. 

```php
$result = \Civi\Api4\OAuthClient::authorizationCode()
  ->addWhere('provider', '=', 'foobar')
  ->setPrompt('select_account')
  ->setTtl(2 * 60 * 60)
  ->setResponseMode('web_message')
  ->execute()
  ->single();
// Note $result includes a URL that we should display to the user.
```

By passing more options into this API (e.g. `setTtl()`, `setResponseMode()`), we can influence the links and the flow. The PR specifically adds two options:

* __Time to live (`$ttl`)__: How long do we expect the user to stay on the other site ("Microkookle")? That depends a lot on how the other site works.
    * __Comments__: The current limit (60 min) is perfectly generous for (say) the Google/Microsoft flows -- where you already have an account. However, for new use-cases involving PayPal/Stripe, you might not have an account yet. To setup an account, you might talk to your colleagues or pull out your business docs (to find your organization's EIN) -- in other words, it may take some time. So you might send a longer TTL (say, 90min).
    * __Before__: Civi has a hard-coded timeout at 60 minutes. 
    * __After__: Civi can set a different TTL each time it initiates the flow.
* __Response mode__: At step (4), the browser will return a credential. This corresponds to an HTTP request. What exactly is in that request?
    * __Comments__: Originally, OAuth 2.0 specified a response using URL query parameters. (`https://example.org/civicrm/oauth-client/return?state=ABCD&code=1234`). However, over time, [other options](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html) have been developed, such as URL `fragment`, [form_post](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html), and [web_message](https://www.ietf.org/archive/id/draft-meyerzuselha-oauth-web-message-response-mode-00.html)
    * __Before__: Civi's implementation only supports the original `query` responses.
    * __After__: You can declare the supported `response_mode`s (for each provider) and request a specific `response_mode` (at runtime). The PR includes partial support for the `web_message` draft RFC. 
     
    This isn't a full implementation of all response-modes. It's building block. Further work (e.g. on web-message style response-mode) is evolving under #33707.

