### PR TITLE
Encourage `scan-classes` for extensions providing Api4 entities

### DIFF
--- a/Civi/Api4/Service/LegacyEntityScanner.php
+++ b/Civi/Api4/Service/LegacyEntityScanner.php
@@ -123,12 +123,12 @@ class LegacyEntityScanner extends AutoSubscriber {
 
     if ($legacyEntities) {
       $intro = ts('Some of your extensions are providing entities through the Legacy Entity Scanner. These should be updated to use <code>scan-classes</code> mixin for better performance and future proofing.');
-      $entityList = implode('', array_map(fn ($info) => "<li><code>{$info['name']}</code></li>", $legacyEntities));
+      $entityList = implode('', array_map(fn ($info) => sprintf("<li><code>%s</code></li>", $info['name']), $legacyEntities));
       $message = "<p>{$intro}</p><ul>{$entityList}</ul>";
       $e->messages[] = new \CRM_Utils_Check_Message(
         'api4_legacy_entity_scan',
         $message,
-        ts('Api4 Entities using Legacy Entity Scanner'),
+        ts('APIv4 Entities using Legacy Entity Scanner'),
         \Psr\Log\LogLevel::INFO,
         'fa-box'
       );

--- a/Civi/Api4/Service/LegacyEntityScanner.php
+++ b/Civi/Api4/Service/LegacyEntityScanner.php
@@ -129,7 +129,7 @@ class LegacyEntityScanner extends AutoSubscriber {
         'api4_legacy_entity_scan',
         $message,
         ts('Api4 Entities using Legacy Entity Scanner'),
-        \Psr\Log\LogLevel::WARNING,
+        \Psr\Log\LogLevel::INFO,
         'fa-box'
       );
 

--- a/Civi/Api4/Service/LegacyEntityScanner.php
+++ b/Civi/Api4/Service/LegacyEntityScanner.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Service;
 
+use Civi\Core\ClassScanner;
 use Civi\Core\Service\AutoSubscriber;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Api4\Generic\EntityInterface;
@@ -102,6 +103,7 @@ class LegacyEntityScanner extends AutoSubscriber {
 
     foreach ($active as $ext) {
       $info = $infos[$ext['fullName']];
+      // Optimization: Avoid duplicate scans for exts with 'scan-classes@'.
       if (!self::hasScanClasses($info)) {
         $locations[] = $ext['filePath'];
       }
@@ -119,11 +121,14 @@ class LegacyEntityScanner extends AutoSubscriber {
   }
 
   public function check(GenericHookEvent $e): void {
+    // Prefer entities be discoverable via class-scanner. Any entities that aren't should generate warnings.
+    $scannedEntities = array_map(fn($c) => $c::getEntityName(), ClassScanner::get(['interface' => EntityInterface::class]));
     $legacyEntities = self::getEntitiesFromClasses();
+    $unscannedEntities = array_filter($legacyEntities, fn($e) => !in_array($e['name'], $scannedEntities));
 
-    if ($legacyEntities) {
+    if ($unscannedEntities) {
       $intro = ts('Some of your extensions are providing entities through the Legacy Entity Scanner. These should be updated to use <code>scan-classes</code> mixin for better performance and future proofing.');
-      $entityList = implode('', array_map(fn ($info) => sprintf("<li><code>%s</code></li>", $info['name']), $legacyEntities));
+      $entityList = implode('', array_map(fn ($info) => sprintf("<li><code>%s</code></li>", $info['name']), $unscannedEntities));
       $message = "<p>{$intro}</p><ul>{$entityList}</ul>";
       $e->messages[] = new \CRM_Utils_Check_Message(
         'api4_legacy_entity_scan',

--- a/Civi/Api4/Service/LegacyEntityScanner.php
+++ b/Civi/Api4/Service/LegacyEntityScanner.php
@@ -21,6 +21,7 @@ class LegacyEntityScanner extends AutoSubscriber {
   public static function getSubscribedEvents(): array {
     return [
       'civi.api4.entityTypes' => 'addEntities',
+      'hook_civicrm_check' => 'check',
     ];
   }
 
@@ -115,6 +116,24 @@ class LegacyEntityScanner extends AutoSubscriber {
       }
     }
     return FALSE;
+  }
+
+  public function check(GenericHookEvent $e): void {
+    $legacyEntities = self::getEntitiesFromClasses();
+
+    if ($legacyEntities) {
+      $intro = ts('Some of your extensions are providing entities through the Legacy Entity Scanner. These should be updated to use <code>scan-classes</code> mixin for better performance and future proofing.');
+      $entityList = implode('', array_map(fn ($info) => "<li><code>{$info['name']}</code></li>", $legacyEntities));
+      $message = "<p>{$intro}</p><ul>{$entityList}</ul>";
+      $e->messages[] = new \CRM_Utils_Check_Message(
+        'api4_legacy_entity_scan',
+        $message,
+        ts('Api4 Entities using Legacy Entity Scanner'),
+        \Psr\Log\LogLevel::WARNING,
+        'fa-box'
+      );
+
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
- reinstate the status check on `master` (i.e. for 6.9, release in 2 months)
- reduce severity from WARNING to INFO
