### PR TITLE
Don't break word in Contact summary tab count

### DIFF
--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -145,6 +145,8 @@
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li {
   background: var(--crm-dash-tab-bg);
   margin: var(--crm-dash-tab-hang);
+}
+.crm-contact-page #mainTabContainer .crm-contact-tabs-list li span {
   word-break: break-word;
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li .ui-tabs-anchor {


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #33530 to target the word breaking to the title of the tab only, so the tab count doesn't break.

Before
----------------------------------------
<img width="332" height="132" alt="image" src="https://github.com/user-attachments/assets/354cbc1a-7235-428c-ad42-9806f2b4d6cc" />


After
----------------------------------------
<img width="298" height="122" alt="image" src="https://github.com/user-attachments/assets/1456df71-1cd0-44af-9aac-7f521d7654fb" />

Still breaks the title
<img width="536" height="1196" alt="image" src="https://github.com/user-attachments/assets/a41ac85b-ef3b-42fb-b518-02a4916183fd" />
