### PR TITLE
dev/core#6125: Ensure there is an FK from import batch table to entity

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -87,7 +87,7 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
     $importEntities = Civi\BAO\Import::getImportTables();
     $jobTypes = array_column(\CRM_Core_BAO_UserJob::getTypes(), 'entity', 'id');
     foreach ($importEntities as $importEntity) {
-      $fkEntity = $jobTypes[$importEntity['job_type']] ?? NULL;
+      $fkEntity = $importEntity['entity'] ?? $jobTypes[$importEntity['job_type']] ?? NULL;
       $fkTable = $fkEntity ? CoreUtil::getTableName($fkEntity) : NULL;
       if ($fkEntity && $fkTable) {
         $table = $schema->getTableByName($importEntity['table_name']);

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -86,22 +86,24 @@ function _civiimport_civicrm_get_import_tables(): array {
   }
   // We need to avoid the api here as it is called early & could cause loops.
   $tables = CRM_Core_DAO::executeQuery('
-     SELECT `user_job`.`id` AS id, `metadata`, `name`, `job_type`, `user_job`.`created_id`, `created_id`.`display_name`, `user_job`.`created_date`, `user_job`.`expires_date`
-     FROM civicrm_user_job user_job
-     LEFT JOIN civicrm_contact created_id ON created_id.id = created_id
-       -- As of writing expires date is probably not being managed
-       -- it is intended to be used to actually purge the record in
-       -- a cleanup job so it might not be relevant here & perhaps this will
-       -- be removed later
-       WHERE (expires_date IS NULL OR expires_date > NOW())
-       -- this is a short-cut for looking up if they are imports
-       -- it is a new convention, at best, to require anything
-       -- specific in the job_type, but it saves any onerous lookups
-       -- in a function which needs to avoid loops
-       AND job_type LIKE "%import%"
-         -- also more of a feature than a specification - but we need a table
-         -- to do this pseudo-api
-       AND metadata LIKE "%table_name%"');
+    SELECT `user_job`.`id` AS id, `metadata`, `user_job`.`name`, `job_type`, `user_job`.`created_id`, `created_id`.`display_name`, `user_job`.`created_date`, `user_job`.`expires_date`, `ss`.`api_entity` as entity
+    FROM civicrm_user_job user_job
+    LEFT JOIN civicrm_contact created_id ON created_id.id = user_job.created_id
+    LEFT JOIN civicrm_search_display sd ON sd.id = user_job.search_display_id
+    LEFT JOIN civicrm_saved_search ss ON ss.id = sd.saved_search_id
+      -- As of writing expires date is probably not being managed
+      -- it is intended to be used to actually purge the record in
+      -- a cleanup job so it might not be relevant here & perhaps this will
+      -- be removed later
+      WHERE (user_job.expires_date IS NULL OR user_job.expires_date > NOW())
+      -- this is a short-cut for looking up if they are imports
+      -- it is a new convention, at best, to require anything
+      -- specific in the job_type, but it saves any onerous lookups
+      -- in a function which needs to avoid loops
+      AND job_type LIKE "%import%"
+      -- also more of a feature than a specification - but we need a table
+      -- to do this pseudo-api
+      AND metadata LIKE "%table_name%"');
   $importEntities = [];
   while ($tables->fetch()) {
     $tableName = json_decode($tables->metadata, TRUE)['DataSource']['table_name'];
@@ -119,6 +121,7 @@ function _civiimport_civicrm_get_import_tables(): array {
       'expires_date' => $tables->expires_date,
       'title' => E::ts('Import Job %1', [1 => $tables->id]),
       'description' => $tables->created_date . $createdBy,
+      'entity' => $tables->entity,
     ];
   }
   Civi::$statics['civiimport_tables'] = $importEntities;


### PR DESCRIPTION
Overview
----------------------------------------
If this FK doesn't exist, the entity id that has been imported is not a link to the entity in the SearchDisplay for the User Job.

To reproduce:
- Create a data entry SearchDisplay
- Import a row with it
- Check the user job by clicking the number of rows imported
- Note the entity id for whatever you just imported is not a link before and is a link after