### PR TITLE
fix missing Fields button on event reg 'additional' profiles

### DIFF
--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -134,6 +134,7 @@
               class='crm-event-manage-registration-form-block-custom_post_multiple'>
             <td class="label">{$form.custom_post_id_multiple.$profilePostNum.label}</td>
             <td class="html-adjust">{$form.custom_post_id_multiple.$profilePostNum.html}
+              <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
               <span class='profile_bottom_link_remove'>
                 <a href="#" class="crm-hover-button crm-button-rem-profile">
                   <i class="crm-i fa-trash" role="img" aria-hidden="true"></i> {ts}remove profile{/ts}


### PR DESCRIPTION
Overview
----------------------------------------
The removal of BackboneJS means we've replaced the editor with a "Fields" button.  If you have multiple "Bottom Profile Fields" in use, the Fields button appears on first use, but does not when the page is loaded.

To replicate:
* Edit the "Online Registration" tab of an event.
* Add an additional bottom profile.  The "Fields" button appears.
* Save the page and reload it.  The "Fields" button is missing.

Before
----------------------------------------
<img width="750" height="237" alt="Selection_2646" src="https://github.com/user-attachments/assets/0269e296-0317-4f0e-9af9-2a6257e6e37b" />

After
----------------------------------------
<img width="814" height="198" alt="Selection_2645" src="https://github.com/user-attachments/assets/26866f37-2fa3-442d-bcc8-591a0e7941b2" />

Comments
----------------------------------------
The additional profile templating is rough. Hopefully we can put it behind us one day.
