### PR TITLE
Use labels for pseudoconstants in import SearchDisplays

### DIFF
--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -50,12 +50,16 @@ foreach ($importEntities as $importEntity) {
       ],
     ],
   ];
-
+  $pseudoconstants = civicrm_api4($fields['_entity_id']['fk_entity'], 'getFields', [
+    'where' => [['options', 'IS NOT EMPTY']],
+    'select' => ['name'],
+    'checkPermissions' => FALSE,
+  ])->column('name');
   $columns = [];
   foreach ($fields as $field) {
     $columns[] = [
       'type' => 'field',
-      'key' => $field['name'],
+      'key' => in_array($field['name'], $pseudoconstants) ? $field['name'] . ':label' : $field['name'],
       'dataType' => $field['data_type'] ?? 'String',
       'label' => $field['title'] ?? $field['label'],
       'sortable' => TRUE,


### PR DESCRIPTION
Before
----------------------------------------
Pseudoconstants, like contribution_status_id or payment_method_id are only shown as their id in import SearchDisplays, making it harder to verify your work.

After
----------------------------------------
Pseudoconstants show their label, but only when they are fields on the entity imported, not on joined entities.

Comments
----------------------------------------
It would be nice to also be able to show labels for pseudoconstants from joins, e.g. the soft credit type, but the names are like ```Contribution_ContributionSoft_contribution081389190c7d84c0``` which makes things more difficult. But if anyone has a brilliant idea to make this possible, it would be much appreciated.