### PR TITLE
update remaining uses of Invoice ID label to Invoice Reference for consistency

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -103,7 +103,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     $action = $contributionID ? 'edit' : 'create';
     $duplicates = [];
     if (self::checkDuplicate($params, $duplicates, $contributionID)) {
-      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice ID. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicates)]);
+      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicates)]);
       throw new CRM_Core_Exception($message);
     }
 

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -105,7 +105,7 @@ class CRM_Contribute_Form_AdditionalInfo {
       $feeAmount->freeze();
     }
 
-    $element = &$form->add('text', 'invoice_id', ts('Invoice ID'),
+    $element = &$form->add('text', 'invoice_id', ts('Invoice Reference'),
       $attributes['invoice_id']
     );
     if ($form->_online) {
@@ -113,7 +113,7 @@ class CRM_Contribute_Form_AdditionalInfo {
     }
     else {
       $form->addRule('invoice_id',
-        ts('This Invoice ID already exists in the database.'),
+        ts('This Invoice Reference already exists in the database.'),
         'objectExists',
         ['CRM_Contribute_DAO_Contribution', $form->_id, 'invoice_id']
       );

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1892,7 +1892,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $feeAmount->freeze();
     }
 
-    $element = &$form->add('text', 'invoice_id', ts('Invoice ID'),
+    $element = &$form->add('text', 'invoice_id', ts('Invoice Reference'),
       $attributes['invoice_id']
     );
     if ($form->_online) {
@@ -1900,7 +1900,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
     else {
       $form->addRule('invoice_id',
-        ts('This Invoice ID already exists in the database.'),
+        ts('This Invoice Reference already exists in the database.'),
         'objectExists',
         ['CRM_Contribute_DAO_Contribution', $form->_id, 'invoice_id']
       );

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -452,7 +452,7 @@ class ContributionParser extends ImportParser {
    */
   private function lookupContribution(array $params): array {
     $where = [];
-    foreach (['id' => 'Contribution ID', 'trxn_id' => 'Transaction ID', 'invoice_id' => 'Invoice ID'] as $field => $label) {
+    foreach (['id' => 'Contribution ID', 'trxn_id' => 'Transaction ID', 'invoice_id' => 'Invoice Reference'] as $field => $label) {
       if (!empty($params[$field])) {
         $where[] = [$field, '=', $params[$field]];
       }


### PR DESCRIPTION
Overview
----------------------------------------

Update some labels still showing the old Invoice ID label. See: https://lab.civicrm.org/dev/core/-/issues/6092

Before
----------------------------------------

In a handful of places, we still show "Invoice ID" instead of "Invoice Reference". Here is an example on the new contribution form:

<img width="836" height="485" alt="image" src="https://github.com/user-attachments/assets/037e09f7-12c9-414c-ac83-bcea5527bfb0" />


After
----------------------------------------

These places now show Invoice Reference.

<img width="815" height="447" alt="image" src="https://github.com/user-attachments/assets/41d1fee5-d2df-4919-a51e-21c4569fbd3f" />
