### PR TITLE
Autocomplete - Add entity id if available

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2156,7 +2156,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       'select' => [],
     ];
     $props['api'] += [
-      'formName' => 'qf:' . get_class($this),
+      'formName' => 'qf:' . get_class($this) . ':' . ($this->_id ?? $this->_contactId ?? ''),
     ];
     // If fieldName is missing and no default entity is set for the form, this will throw an excption.
     // In that case, you should explicitly supply api.fieldName in the format `EntityName.field_name`


### PR DESCRIPTION
Overview
----------------------------------------
This makes the entity id being edited known to autocomplete subscribers

Todo: add this to Afforms as well

Usage
-----------
An autocomplete subscriber (listening to the `Civi\API\Event\PrepareEvent` event) can now get the entity id as well as the name of the form like:

```php
[$formType, $formName, $entityId] = array_pad(explode(':', (string) $apiRequest->getFormName()), 3, '');
```