### PR TITLE
Extend events to disable confirmation screen for paid events

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -442,7 +442,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
         $errorMsg['registration_link_text'] = ts('Please enter Registration Link Text');
       }
       // Check if the confirm text is set if we have enabled the confirmation page or page is monetary which forces the confirm page.
-      if (($values['confirm_title'] ?? '') === '' && (!empty($values['is_confirm_enabled']) || CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_id, 'is_monetary'))) {
+      if (($values['confirm_title'] ?? '') === '' && (!empty($values['is_confirm_enabled']))) {
         $errorMsg['confirm_title'] = ts('Please enter a Title for the registration Confirmation Page');
       }
       if (($values['thankyou_title'] ?? '') === '') {

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -378,12 +378,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    */
   public function buildConfirmationBlock(&$form) {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
-    // CRM-11182 - Optional confirmation page for free events
-    $is_monetary = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $form->_id, 'is_monetary');
-    $form->assign('is_monetary', $is_monetary);
-    if ($is_monetary == "0") {
-      $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
-    }
+    $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen?'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
     $form->add('text', 'confirm_title', ts('Title'), $attributes['confirm_title']);
     $form->add('wysiwyg', 'confirm_text', ts('Introductory Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
     $form->add('wysiwyg', 'confirm_footer_text', ts('Footer Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -196,9 +196,7 @@
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
         <td scope="row" class="label" width="20%">{$form.is_confirm_enabled.label}</td>
-        <td>{$form.is_confirm_enabled.html}
-          <div class="description">{ts}The confirmation screen is optional for events.{/ts}</div>
-        </td>
+        <td>{$form.is_confirm_enabled.html}</td>
       </tr>
     </table>
     <table class="form-layout-compressed" id="confirm_screen_settings">
@@ -302,7 +300,6 @@ target_element_type ="block"
 field_type          ="radio"
 invert              = 0
 }
-{if !$is_monetary}
 {include file="CRM/common/showHideByFieldValue.tpl"
 trigger_field_id    ="is_confirm_enabled"
 trigger_value       =""
@@ -311,7 +308,6 @@ target_element_type ="block"
 field_type          ="radio"
 invert              = 0
 }
-{/if}
 {include file="CRM/common/showHideByFieldValue.tpl"
 trigger_field_id    ="is_email_confirm"
 trigger_value       =""

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -193,16 +193,14 @@
 <details id="confirm" {if !$defaultsEmpty}open{/if}>
   <summary class="collapsible-title">{ts}Confirmation Screen{/ts}</summary>
   <div class="crm-accordion-body">
-    {if !$is_monetary}
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
         <td scope="row" class="label" width="20%">{$form.is_confirm_enabled.label}</td>
         <td>{$form.is_confirm_enabled.html}
-          <div class="description">{ts}The confirmation screen is optional for free events.{/ts}</div>
+          <div class="description">{ts}The confirmation screen is optional for events.{/ts}</div>
         </td>
       </tr>
     </table>
-    {/if}
     <table class="form-layout-compressed" id="confirm_screen_settings">
       <tr class="crm-event-manage-registration-form-block-confirm_title">
         <td scope="row" class="label" width="20%">{$form.confirm_title.label} <span

--- a/templates/CRM/Event/Form/Registration/Register.tpl
+++ b/templates/CRM/Event/Form/Registration/Register.tpl
@@ -178,7 +178,7 @@
 
     function toggleAdditionalParticipants() {
       var submit_button = $("#crm-submit-buttons > button").html();
-      {/literal}{if $event.is_monetary || $event.is_confirm_enabled}{literal}
+      {/literal}{if $event.is_confirm_enabled}{literal}
         var next_translated = '{/literal}{ts escape="js"}Review{/ts}{literal}';
       {/literal}{else}{literal}
         var next_translated = '{/literal}{ts escape="js"}Register{/ts}{literal}';


### PR DESCRIPTION
Overview
----------------------------------------
Re-submission of https://github.com/civicrm/civicrm-core/pull/21392

Extend event to disable confirmation screen for paid events

Before
----------------------------------------
Disable confirmation screen was only available for free events.

After
----------------------------------------
The confirmation screen can be disabled for paid events too.

![image](https://user-images.githubusercontent.com/5929648/132349060-f32c71d0-819b-4c77-b22b-7608928651e7.png)

For additional participants, the confirmation screen is still forced during registration.

Comments
----------------------------------------
Gitlab - https://lab.civicrm.org/dev/core/-/issues/2382

I think we need to test this with Paypal, stripe and other processors to ensure correct navigation of pages. I've tested it with dummy and pay later payments.