### PR TITLE
Add 'No Results' text to SearchKit grid display

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
@@ -13,6 +13,10 @@
       </select>
       <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
     </div>
+    <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if there are no results.') }}">
+      <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+      <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+    </div>
     <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
     <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
     <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -9,5 +9,10 @@
     class="crm-search-display-grid-container crm-search-display-grid-layout-{{$ctrl.settings.colno}}"
     ng-include="'~/crmSearchDisplayGrid/crmSearchDisplayGrid' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'"
   ></div>
+  <div ng-if="$ctrl.rowCount === 0" class="crm-search-display-grid-no-results">
+    <p class="alert alert-info text-center">
+      {{ $ctrl.settings.noResultsText || ts('None found.') }}
+    </p>
+  </div>
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Allow to configure "No Results" text on grid display. Already available on table, list etc.

Before
----------------------------------------
Cannot add no results text.

After
----------------------------------------
Can add no results text.

Technical Details
----------------------------------------


Comments
----------------------------------------

