### PR TITLE
dev/core#3807 - Download invoice button on contribution fails to attach it to activity on windows

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -102,6 +102,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File implements \Civi\Core\HookInte
 
     $config = CRM_Core_Config::singleton();
 
+    $data = str_replace(DIRECTORY_SEPARATOR, '/', $data);
     $path = explode('/', $data);
     $filename = $path[count($path) - 1];
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/3807

Before
----------------------------------------
1. Try to download an invoice on windows. It works, but the created activity doesn't have the pdf.

Alt:
1. Turn on the setting to always attach pdf to receipts.
2. Crash when doing stuff that does that.

After
----------------------------------------


Technical Details
----------------------------------------
See ticket.

Comments
----------------------------------------
I've been running this for a year or so for a set of sites where they have the setting to always attach pdfs, since locally when dev'ing it kept coming up. Obviously on unix this change is a no-op.
