### PR TITLE
dev/core#6135  - dont crash if `civicrm_translation_source` isnt available

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -810,11 +810,17 @@ class CRM_Core_I18n {
     // temporary to avoid collision with word replacements
     $translationReplacement = 'tr-' . $replacementsLocale;
     if ((!isset(Civi::$statics[__CLASS__]) || !array_key_exists($translationReplacement, Civi::$statics[__CLASS__]))) {
+      Civi::$statics[__CLASS__][$translationReplacement] = [];
+
       if (defined('CIVICRM_DSN') && !CRM_Core_Config::isUpgradeMode()) {
-        Civi::$statics[__CLASS__][$translationReplacement] = CRM_Core_BAO_TranslationSource::getTranslationSources($replacementsLocale);
-      }
-      else {
-        Civi::$statics[__CLASS__][$translationReplacement] = [];
+        try {
+          Civi::$statics[__CLASS__][$translationReplacement] = CRM_Core_BAO_TranslationSource::getTranslationSources($replacementsLocale);
+        }
+        catch (\CRM_Core_Exception $e) {
+          // dont crash everything if we can't get translation source
+          // for example - if this is called before the upgrade step that add `civicrm_translation_source`
+          // TODO: define this exception more narrowly?
+        }
       }
     }
     return Civi::$statics[__CLASS__][$translationReplacement];


### PR DESCRIPTION
Overview
----------------------------------------
Quick fix for https://lab.civicrm.org/dev/core/-/issues/6135

Comments
----------------------------------------
A more explicit check might be better in the long run.