### PR TITLE
[NFC] deprecate `CRM_Utils_System::addHTMLHead` in Drupal8+

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -30,7 +30,7 @@ use GuzzleHttp\Psr7\Response;
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.
  * @method static void appendBreadCrumb(array $breadCrumbs) Append an additional breadcrumb link to the existing breadcrumbs.
  * @method static void resetBreadCrumb() Reset an additional breadcrumb tag to the existing breadcrumb.
- * @method static void addHTMLHead(string $head) Append a string to the head of the HTML file. Note: this is only used in Drupal/Backdrop/Joomla and is deprecated in Wordpress/Standalone
+ * @method static void addHTMLHead(string $head) Append a string to the head of the HTML file. Note: this is only used in Drupal7/Backdrop/Joomla and is deprecated in Drupal8+/Wordpress/Standalone
  * @method static string postURL(int $action) Determine the post URL for a form.
  * @method static string|null getUFLocale() Get the locale of the CMS.
  * @method static bool setUFLocale(string $civicrm_language) Set the locale of the CMS.

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -215,6 +215,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @deprecated
    */
   public function addHTMLHead($header) {
+    \CRM_Core_Error::deprecatedFunctionWarning('Civi::resources()->addStyleFile() or addScriptFile() etc');
     \Drupal::service('civicrm.page_state')->addHtmlHeader($header);
   }
 

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -212,6 +212,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
   /**
    * @inheritDoc
+   * @deprecated
    */
   public function addHTMLHead($header) {
     \Drupal::service('civicrm.page_state')->addHtmlHeader($header);


### PR DESCRIPTION
Overview
----------------------------------------
This system function has been deprecated in WP/Standalone.

In general it is "a bad idea" to add blobs of HTML to the header directly - much better to use more structured things like `addStyle`, `addScript` etc. It causes havoc for asset caching etc.

Currently this function is used on every page request though! Should not be merged until  https://github.com/civicrm/civicrm-drupal-8/pull/112 is merged!

