### PR TITLE
dev/core#6137 Add `cms` flushing to `Civi::rebuild()`

### DIFF
--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -79,6 +79,7 @@ class Rebuilder {
       'cases' => TRUE,
       'triggers' => TRUE,
       'entities' => TRUE,
+      'cms' => TRUE,
     ];
     if (!empty($targets['*'])) {
       $targets = array_merge($all, $targets);
@@ -200,6 +201,9 @@ class Rebuilder {
     }
     if (!empty($targets['entities'])) {
       CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    }
+    if (!empty($targets['cms'])) {
+      \CRM_Utils_System::flush();
     }
   }
 

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -85,6 +85,13 @@ class Rebuilder {
       $targets = array_merge($all, $targets);
       unset($targets['*']);
     }
+    // if resetting system it is highly advisable to reset
+    // the cms cache to remove hanging references to old CiviCRM
+    // paths (particular if asset codes change)
+    // TODO: move asset paths out of `system` target?
+    if (!empty($targets['system']) && !isset($targets['cms'])) {
+      $targets['cms'] = TRUE;
+    }
 
     $config = CRM_Core_Config::singleton();
 

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -79,6 +79,7 @@ class Rebuilder {
       'cases' => TRUE,
       'triggers' => TRUE,
       'entities' => TRUE,
+      'cms' => TRUE,
     ];
     if (!empty($targets['*'])) {
       $targets = array_merge($all, $targets);
@@ -215,6 +216,9 @@ class Rebuilder {
     }
     if (!empty($targets['entities'])) {
       CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    }
+    if (!empty($targets['cms'])) {
+      \CRM_Utils_System::flush();
     }
   }
 

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -85,6 +85,13 @@ class Rebuilder {
       $targets = array_merge($all, $targets);
       unset($targets['*']);
     }
+    // if resetting system it is highly advisable to reset
+    // the cms cache to remove hanging references to old CiviCRM
+    // paths (particular if asset codes change)
+    // TODO: move asset paths out of `system` target?
+    if (!empty($targets['system']) && !isset($targets['cms'])) {
+      $targets['cms'] = TRUE;
+    }
 
     if (isset($targets['menu'])) {
       \CRM_Core_Error::deprecatedWarning("In Civi::rebuild(), the 'menu' option is deprecated. For CiviCRM 6.9+, please specify combination of 'router', 'navigation', and/or 'system'.");


### PR DESCRIPTION
Overview
----------------------------------------
Add call to the user framework flush when flushing Civi's caches. Fixes https://lab.civicrm.org/dev/core/-/issues/6137

Before
----------------------------------------
- Flushing CiviCRM's cache can easily invalidate things in the CMS's cache. This can leave site in a broken state.

After
----------------------------------------
- Allow calling the CMS flush when flushing CiviCRM's cache
- Include this in a blanket "flush everything" flush

Technical Details
----------------------------------------
The only disadvantage I can see is that this may be overkill if the site has lots of non-CiviCRM content. It would be good to implement more targeted flushing in the CMS caches where possible (see e.g. https://github.com/civicrm/civicrm-drupal-8/pull/113)

I would guess a lot of people have scripts which do `cv flush && drush cr`. This could make the second call a bit redundant (unless we implement more targeted CMS flush, and the script wants to flush the _whole_ Drupal cache). But I _think_ the CMS flushes are more strictly flushes (rather than flush+rebuild), so not costly.

I'm not sure about https://github.com/civicrm/civicrm-core/commit/430fa540a74b2d15a5587a98907927dc929479e1 - I could take it or leave it. In the general case using `*` it doesn't make a difference. @totten do you have a general view on whether to include implications like this in Rebuilder?

