### PR TITLE
DAO: Custom fields: Allow explicit null to override default

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -297,11 +297,12 @@ trait DAOActionTrait {
     $customGroups = \CRM_Core_BAO_CustomGroup::getAll($fieldFilters);
 
     foreach ($customGroups as $customGroup) {
+      // look for a field whose value is unspecified and whose default is non-null
       foreach ($customGroup['fields'] as $field) {
         $fieldName = "{$customGroup['name']}.{$field['name']}";
-        if (isset($field['default_value']) && !isset($record[$fieldName])) {
+        if (isset($field['default_value']) && !array_key_exists($fieldName, $record)) {
           $record[$fieldName] = $field['default_value'];
-          // Setting the value for one field in the group will ensure that all get written
+          // Setting the non-null value for one field in the group will ensure that all get written
           break;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Amendment to #33377 — if a field has a non-null default value, but a null value is explicitly specified in the DAO create action, write null.

Before
----------------------------------------
Default value was used if no value is specified, *or* null was specified.

After
----------------------------------------
Default is only used if no value is specified.

Comments
----------------------------------------
Relevant to #33497.