### PR TITLE
bin/csv/export.php: support PHP 8

### DIFF
--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -351,7 +351,6 @@ class civicrm_cli_csv_exporter extends civicrm_cli {
     }
 
     $out = fopen("php://output", 'w');
-    fputcsv($out, $this->columns, $this->separator, '"');
 
     $this->row = 1;
     $result = civicrm_api($this->_entity, 'Get', $this->_params);
@@ -366,7 +365,7 @@ class civicrm_cli_csv_exporter extends civicrm_cli {
       foreach ($row as &$field) {
         if (is_array($field)) {
           //convert to string
-          $field = implode($field, CRM_Core_DAO::VALUE_SEPARATOR) . CRM_Core_DAO::VALUE_SEPARATOR;
+          $field = implode(CRM_Core_DAO::VALUE_SEPARATOR, $field) . CRM_Core_DAO::VALUE_SEPARATOR;
         }
       }
       fputcsv($out, $row, $this->separator, '"');


### PR DESCRIPTION
Overview
----------------------------------------
Scripts in bin/csv/ have been solid for a long time, even though very lightly maintained. They're still quite useful for cli-driven import/export operations.  This PR fixes two small dealbreakers under PHP 8:
- Invalid attempt to write column headers using an undefined (presumably array) variable.
- Legacy signature for `implode()` (deprecated as of PHP 7.4.0, removed as of PHP 8.0.0):

Before
----------------------------------------
Fatal errors when running bin/csv/export.php:

```
$ php export.php -e Contact
PHP Warning:  Undefined property: civicrm_cli_csv_exporter::$columns in /opt/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/bin/cli.class.php on line 354
PHP Fatal error:  Uncaught TypeError: fputcsv(): Argument #2 ($fields) must be of type array, null given in /opt/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/bin/cli.class.php:354
```

```
$ php export.php -e Contact
contact_id,contact_type,contact_sub_type,sort_name,display_name,external_identifier,organization_name,first_name,middle_name,last_name,do_not_email,do_not_phone,do_not_mail,do_not_sms,do_not_trade,is_opt_out,legal_identifier,nick_name,legal_name,image_URL,preferred_communication_method,preferred_language,contact_source,prefix_id,suffix_id,formal_title,communication_style_id,job_title,gender_id,birth_date,is_deceased,deceased_date,household_name,sic_code,contact_is_deleted,current_employer,address_id,street_address,supplemental_address_1,supplemental_address_2,supplemental_address_3,city,postal_code_suffix,postal_code,geo_code_1,geo_code_2,state_province_id,country_id,phone_id,phone_type_id,phone,email_id,email,on_hold,im_id,provider_id,im,worldregion_id,world_region,languages,individual_prefix,individual_suffix,communication_style,gender,state_province_name,state_province,country,id
1,Organization,,"Default Organization","Default Organization",,"Default Organization",,,,0,0,0,0,0,0,,,"Default Organization",,,,,,,,,,,,0,,,,0,,185,"123 Some St",,,,Hereville,,94100,,,1004,1228,,,,1,fixme.domainemail@example.org,0,,,,2,"America South, Central, North and Caribbean",,,,,,California,CA,"United States",1
PHP Fatal error:  Uncaught TypeError: implode(): Argument #2 ($array) must be of type ?array, string given in /opt/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/bin/cli.class.php:369
Stack trace:
#0 /opt/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/bin/cli.class.php(369): implode()
#1 /opt/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/bin/csv/export.php(26): civicrm_cli_csv_exporter->run()
#2 {main}
  thrown in /opt/buildkit/build/wpmaster/web/wp-content/plugins/civicrm/civicrm/bin/cli.class.php on line 369
```


After
----------------------------------------
No more fatal errors on such operations, and proper CSV output:

```
$ php export.php -e Contact
contact_id,contact_type,contact_sub_type,sort_name,display_name,external_identifier,organization_name,first_name,middle_name,last_name,do_not_email,do_not_phone,do_not_mail,do_not_sms,do_not_trade,is_opt_out,legal_identifier,nick_name,legal_name,image_URL,preferred_communication_method,preferred_language,contact_source,prefix_id,suffix_id,formal_title,communication_style_id,job_title,gender_id,birth_date,is_deceased,deceased_date,household_name,sic_code,contact_is_deleted,current_employer,address_id,street_address,supplemental_address_1,supplemental_address_2,supplemental_address_3,city,postal_code_suffix,postal_code,geo_code_1,geo_code_2,state_province_id,country_id,phone_id,phone_type_id,phone,email_id,email,on_hold,im_id,provider_id,im,worldregion_id,world_region,languages,individual_prefix,individual_suffix,communication_style,gender,state_province_name,state_province,country,id
1,Organization,,"Default Organization","Default Organization",,"Default Organization",,,,0,0,0,0,0,0,,,"Default Organization",,,,,,,,,,,,0,,,,0,,185,"123 Some St",,,,Hereville,,94100,,,1004,1228,,,,1,fixme.domainemail@example.org,0,,,,2,"America South, Central, North and Caribbean",,,,,,California,CA,"United States",1
...
```

Technical Details
----------------------------------------
- The removed line `fputcsv($out, $this->columns, $this->separator, '"');` appears to have been intended to print column headers, so removing that line seemed questionable; but headers are still printed, nonetheless.

Comments
----------------------------------------
These scripts, though lightly maintained, are still quite useful. It seems that they're low enough in the archtecture that they're not easily affected by most feature changes in the larger project, which is why we're (fortnately) getting away with such light maintenance. I personally hope that these will always remain a supported part of the core project.
