### PR TITLE
dev/core#6104: Add label to import title when present & make import title consistent

### DIFF
--- a/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
+++ b/ext/civiimport/Civi/Api4/Event/Subscriber/ImportSubscriber.php
@@ -62,9 +62,9 @@ class ImportSubscriber extends AutoService implements EventSubscriberInterface {
       /** @noinspection PhpUndefinedFieldInspection */
       $event->entities['Import_' . $userJobID] = [
         'name' => 'Import_' . $userJobID,
-        'title' => ts('Import Data') . ' ' . $userJobID . (empty($table['created_by']) ? '' : '(' . $table['created_by'] . ')'),
-        'title_plural' => ts('Import Data') . ' ' . $userJobID,
-        'description' => ts('Import Job temporary data'),
+        'title' => $table['title'],
+        'title_plural' => $table['title'],
+        'description' => $table['description'],
         'primary_key' => ['_id'],
         'type' => ['Import'],
         'table_name' => $table['table_name'],

--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -18,7 +18,6 @@ foreach ($importEntities as $importEntity) {
     'target' => '_blank',
     'join' => '_entity_id',
   ];
-  $createdBy = empty($importEntity['created_by']) ? '' : ' (' . E::ts('Created by %1', [$importEntity['created_by'], 'String']) . ')';
   $managedEntities[] = [
     'name' => 'SavedSearch_Import' . $importEntity['user_job_id'],
     'entity' => 'SavedSearch',
@@ -72,7 +71,7 @@ foreach ($importEntities as $importEntity) {
       'version' => 4,
       'values' => [
         'name' => 'Import' . '_' . $importEntity['user_job_id'],
-        'label' => E::ts('Import') . ' ' . $importEntity['user_job_id'] . $createdBy,
+        'label' => $importEntity['title'] . ' ' . $importEntity['description'],
         'saved_search_id.name' => 'Import' . '_' . $importEntity['user_job_id'],
         'type' => 'table',
         'settings' => [

--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -86,7 +86,7 @@ function _civiimport_civicrm_get_import_tables(): array {
   }
   // We need to avoid the api here as it is called early & could cause loops.
   $tables = CRM_Core_DAO::executeQuery('
-    SELECT `user_job`.`id` AS id, `metadata`, `user_job`.`name`, `job_type`, `user_job`.`created_id`, `created_id`.`display_name`, `user_job`.`created_date`, `user_job`.`expires_date`, `ss`.`api_entity` as entity
+    SELECT `user_job`.`id` AS id, `metadata`, `user_job`.`name`, `user_job`.`label`, `job_type`, `user_job`.`created_id`, `created_id`.`display_name`, `user_job`.`created_date`, `user_job`.`expires_date`, `ss`.`api_entity` as entity
     FROM civicrm_user_job user_job
     LEFT JOIN civicrm_contact created_id ON created_id.id = user_job.created_id
     LEFT JOIN civicrm_search_display sd ON sd.id = user_job.search_display_id
@@ -119,7 +119,7 @@ function _civiimport_civicrm_get_import_tables(): array {
       'user_job_id' => (int) $tables->id,
       'created_date' => $tables->created_date,
       'expires_date' => $tables->expires_date,
-      'title' => E::ts('Import Job %1', [1 => $tables->id]),
+      'title' => $tables->label ? E::ts('Import: %1', [1 => $tables->label]) : E::ts('Import Job %1', [1 => $tables->id]),
       'description' => $tables->created_date . $createdBy,
       'entity' => $tables->entity,
     ];
@@ -220,5 +220,6 @@ function civiimport_civicrm_buildForm(string $formName, $form) {
     $form->assign('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=ERROR', FALSE));
     $form->assign('allRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID(), FALSE));
     $form->assign('importedRowsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $form->getUserJobID() . '/Import_' . $form->getUserJobID() . '?_status=IMPORTED', FALSE));
+    $form->setTitle(ts('My Custom Title'));
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Continuing work on [#6104](https://lab.civicrm.org/dev/core/-/issues/6104).

If the user job has a label, its title will be ```Import: Label```, if not it will continue to be called ```Import Job NN```.

Instead of the Saved Search's title including the import title and description (which is created date and created by) and the SearchDisplay containing the same minus the created date, now both just have the same full title with created date and created by. This seems simpler and cleaner rather than concatenating different strings for each.

The API Entity has the same title as the user job as above, instead of the former ```Import Data NN```, which was inconsistent with the title of the entity in other contexts where it is called a job. I changed the API Entity ```title``` to be the same as the title for the SK and SD as above, but I'm not sure if this even appears in the UI anywhere.