### PR TITLE
Redefine isUpgradeMode() to include regular (pre-upgrade) page-views

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -414,7 +414,14 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * @return bool
    */
   public static function isUpgradeMode($path = NULL) {
-    if (defined('CIVICRM_UPGRADE_ACTIVE')) {
+    if (!defined('CIVICRM_UPGRADE_ACTIVE') && !empty(Civi::$statics[CRM_Core_DAO::class]['init'])) {
+      $dbVersion = \CRM_Core_DAO::singleValueQuery('SELECT version FROM civicrm_domain WHERE id = %1', [
+        1 => [\CRM_Core_Config::domainID(), 'Positive'],
+      ]);
+      define('CIVICRM_UPGRADE_ACTIVE', version_compare($dbVersion, \CRM_Utils_System::version(), '<'));
+    }
+
+    if (defined('CIVICRM_UPGRADE_ACTIVE') && CIVICRM_UPGRADE_ACTIVE) {
       return TRUE;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

This changes the definition of `isUpgradeMode()` subtly.  For me, this fixes https://lab.civicrm.org/dev/core/-/issues/6135.

Before
----------------------------------------

`isUpgradeMode()` is a signal that *the current process is handling an upgrade*. It is true under any of these circumstances:

* You're running a CLI command like `cv updb` or  `drush civicrm-upgrade-db`.
* You're browsing the web UI  `civicrm/upgrade` (or some page within its flow).

After
----------------------------------------

`isUpgradeMode()` is a signal that *the upgrade is running __or__ should-be running*. It is true under any of these circumstances:

* (**Same**) You're running a CLI command like `cv updb` or  `drush civicrm-upgrade-db`.
* (**Same**) You're browsing the web UI  `civicrm/upgrade` (or some page within its flow).
* (**New**) You're running any other page, and you started with an old `civicrm_domain.version`.

Technical Details
----------------------------------------

* In theory, this should make the regular web-pages a bit more robust when being loaded during the pre-upgrade period. And... for the scenario of dev/core#6135... it does seem to do that...
* This would have an effect of issuing one extra SQL query on every page-load.
    * I'm of two minds. It doesn't feel great to have an extra query that (on most requests) tells you nothing. OTOH, there's a very good chance that (*in absence of this query*) we wind up doing more work in more bespoke places. Maybe it's better to have one centralized query.
* Historically, I remember an intention that `isUpgradeMode()` would only be used to trigger extra _validations_.
    * Your process may have set `CIVICRM_UPGRADE_ACTIVE` at the start because it was using `cv updb` or whatever... but the database will encounter many different states during the upgrade. This flag only tells that extra diligence is necessary.  (It doesn't directly trigger work, and it doesn't substantively tell you the current state of the system.)
    * However, I have vague sense that this was unenforced and drifted.
* My main reservation is that it's fairly hard to QA potential edge-cases. I would sort of lean toward a narrower for `6.7-stable` (and then let the more aggressive fix go through full master/rc process).