### PR TITLE
Fix E-notice passing null to explode.

### DIFF
--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -1010,7 +1010,7 @@ GROUP BY civicrm_activity_id $having {$this->_orderBy}";
       if (array_key_exists('civicrm_contact_contact_assignee', $row)) {
         $assigneeNames = explode(';', $row['civicrm_contact_contact_assignee']);
         if ($value = $row['civicrm_contact_contact_assignee_id']) {
-          $assigneeContactIds = explode(';', $value);
+          $assigneeContactIds = explode(';', (string) $value);
           $link = [];
           if ($viewLinks) {
             foreach ($assigneeContactIds as $id => $value) {


### PR DESCRIPTION
Details activity report on sample data shows the problem. 

Overview
----------------------------------------
Null is being passed to explode as parameter 2.

explode(): Passing null to parameter #2 ($string) of type string is deprecated [8192]
/srv/buildkit/build/smaster/web/core/CRM/Report/Form/Activity.php line 1011

Before
----------------------------------------
https://smaster.demo.civicrm.org/civicrm/report/instance/3 is filled with warnings.

After
----------------------------------------
https://smaster.demo.civicrm.org/civicrm/report/instance/3 should not be filled with warnings.

Comments
----------------------------------------
This is a fix from @jitendrapurohit for a client that I've figured out how to replicate and include here.