### PR TITLE
Add getEntityValues() to Afform AbstractProcessor so that we have access to all form values when processing a specific entity

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -67,7 +67,22 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   protected $_entityIds = [];
 
+  /**
+   * Values of each entity that is submitted on the form.
+   * Eg. $entityValues['Contribution1'][0]['fields']['field1' => 1, 'field2' => 2]
+   *
+   * @var array
+   */
   protected $_entityValues = [];
+
+  /**
+   * Get the (submitted) values from all the entities on the form
+   *
+   * @return array
+   */
+  public function getEntityValues() {
+    return $this->_entityValues;
+  }
 
   protected array $_response = [];
 


### PR DESCRIPTION
Overview
----------------------------------------
Example:

ShoppingCart checkout submission form has an entity `Cart1` and an entity `Contribution1`.
Submission handler (`civi.afform.submit`) for `Cart1` needs custom field values from `Contribution1` so they can be submitted together with the `Cart::submit()` -> `Order::create()` API call.

Before
----------------------------------------
Cannot access values of other entities because they are stored in a protected variable.

After
----------------------------------------
Get function to access values of other entities on the form.

Technical Details
----------------------------------------
This exposes the entityValues without any further processing in a format like `Contribution1`[0]['fields']['fieldX'] => value`

Comments
----------------------------------------
@colemanw / @ufundo thoughts?
