### PR TITLE
For Individual searchkit tasks make sure we remove 'Contact' actions added by hooks

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -11,6 +11,7 @@
 
 namespace Civi\Api4\Event\Subscriber;
 
+use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -48,9 +49,15 @@ class SearchDisplayTasksSubscriber extends \Civi\Core\Service\AutoService implem
     $entityName = $event->search['api_entity'] ?? NULL;
     // Hack to support relationships
     $entityName = ($entityName === 'RelationshipCache') ? 'Relationship' : $entityName;
-    if ($entityName && is_array($enabledActions)) {
-      $event->tasks[$entityName] = array_intersect_key($event->tasks[$entityName], array_flip($enabledActions));
+    if (is_array($enabledActions)) {
+      if ($entityName) {
+        $event->tasks[$entityName] = array_intersect_key($event->tasks[$entityName], array_flip($enabledActions));
+      }
+      if (CoreUtil::isContact($entityName)) {
+        $event->tasks['Contact'] = array_intersect_key($event->tasks['Contact'], array_flip($enabledActions));
+      }
     }
+
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Contact search tasks added by hooks appear when search is of type Individual etc.

Before
----------------------------------------
Extra "Send/Schedule via CiviMail" sneaked in via MailTasksProvider::addMailTasks:

<img width="478" height="541" alt="image" src="https://github.com/user-attachments/assets/462936a7-1ee3-4a78-9c06-016dddb15fee" />


After
----------------------------------------
"Extra" Contact tasks filtered out:

<img width="478" height="541" alt="image" src="https://github.com/user-attachments/assets/849c5641-08b6-4d44-a08d-8fe95b6f51ce" />

Technical Details
----------------------------------------
Filters on Contact as well as Individual like in other places.

Comments
----------------------------------------
