### PR TITLE
Fix product image upload URL, bigger thumbnail

### DIFF
--- a/templates/CRM/Contribute/Form/ManagePremiums.tpl
+++ b/templates/CRM/Contribute/Form/ManagePremiums.tpl
@@ -41,11 +41,16 @@
      <tr class="crm-contribution-form-block-imageOption">
       <td class="label">{$form.imageOption.label}</td>
       <td>
-        {if $imageURL}
-          <img src="{$imageURL}" alt="{ts escape="htmlattribute"}Current Image{/ts}"/>
-        {/if}
+        <div id="currentImage">
+          {if $imageURL}
+            <img src="{$imageURL}" alt="{ts escape="htmlattribute"}Current Image{/ts}"/>
+          {/if}
+        </div>
+        <div class="hiddenElement" id="defaultImage">
+          <img src="{$defaultImageURL}" alt="{ts escape="htmlattribute"}Default product image with the words "No image available".{/ts}">
+        </div>
         <div class="description">
-          <p>{ts}You can give this premium a picture that will be displayed on the contribution page. The image displayed will be resized to a maximum of 200x200 pixels. Images must be in GIF, JPEG, or PNG format.{/ts}</p>
+          <p>{ts 1="400x400"}You can give this premium a picture that will be displayed on the contribution page. The image displayed will be resized to a maximum of %1 pixels. Images must be in GIF, JPEG, or PNG format.{/ts}</p>
         </div>
   <table class="form-layout-compressed">
     <tr class="crm-contribution-form-block-imageOption">
@@ -60,6 +65,9 @@
     </tr>
     <tr id="imageURL"{if $action neq 2} class="hiddenElement"{/if}>
       <td class="label">{$form.imageUrl.label}</td><td>{$form.imageUrl.html|crmAddClass:huge}</td>
+    </tr>
+    <tr id="thumbnailURL"{if $action neq 2} class="hiddenElement"{/if}>
+      <td class="label">{$form.thumbnailUrl.label}</td><td>{$form.thumbnailUrl.html|crmAddClass:huge}</td>
     </tr>
     <tr>
       <td colspan="2">{$form.imageOption.default_image.html}</td>
@@ -153,17 +161,29 @@
 
 <script type="text/javascript">
 {literal}
-function add_upload_file_block(parms) {
-  if (parms == 'thumbnail') {
-    document.getElementById("imageURL").style.display = "table-row";
-    document.getElementById("uploadFileRow").style.display = "none";
-  }
-  else if (parms == 'image') {
-    document.getElementById("uploadFileRow").style.display = "table-row";
-    document.getElementById("imageURL").style.display = "none";
+function add_upload_file_block(option) {
+  if (option == 'thumbnail') {
+    document.getElementById("imageURL").classList.remove('hiddenElement');
+    document.getElementById("thumbnailURL").classList.remove('hiddenElement');
   }
   else {
-    document.getElementById("imageURL").style.display = "none";
+    document.getElementById("imageURL").classList.add('hiddenElement');
+    document.getElementById("thumbnailURL").classList.add('hiddenElement');
+  }
+
+  if (option == 'image') {
+    document.getElementById("uploadFileRow").classList.remove('hiddenElement');
+  }
+  else {
+    document.getElementById("uploadFileRow").classList.add('hiddenElement');
+  }
+
+  if (option == 'default_image') {
+    document.getElementById("defaultImage").classList.remove('hiddenElement');
+    document.getElementById("currentImage").classList.add('hiddenElement');
+  }
+  else {
+    document.getElementById("defaultImage").classList.add('hiddenElement');
   }
 }
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------

When product images are uploaded using AdminUI, the image URL and thumbnail are not correctly saved.

To reproduce:

- Go to Contribution > Premiums (ex: https://smaster.demo.civicrm.org/civicrm/admin/contribute/managePremiums?reset=1)
- Edit a product
- Upload new image from your computer
- Save

Then click on "edit", and notice that the image URL is empty. It shows as if no image was uploaded.

Here is an example image for testing: 
<img width="225" height="161" alt="tshirt_75173d9103ffeb1bcbd0e0d5264e731c" src="https://github.com/user-attachments/assets/d7498ac4-f148-425b-a36e-a2c2082e7f7f" />

Before
----------------------------------------

- image url missing.
- thumbnail is 200x200
- thumbnail is suffixed "_full"

After
----------------------------------------

- fixed image
- thumbnail is 400x400
- thumbnail filename is suffixed "_thumb"

Also, it now displays the "default image" as a preview image, if selected:

<img width="2088" height="594" alt="2025-10-09_12-03" src="https://github.com/user-attachments/assets/f31e057e-87f8-4a70-b358-74a8876c1a25" />

Not that I can imagine anyone really using this not-very-aesthetic option, but at least it lets people see what they selected.

The conditions for hiding/showing things was a bit murky. I poked around a bit, but decided not to go too far down the rabbit hole. For example, we show a preview image if editing a product, but if we change the URL, there is not a live preview of the image. Same for when we upload a new image.

Technical Details
----------------------------------------

Is there a better way to get the URL to `imageUploadURL`?  I looked at : https://docs.civicrm.org/dev/en/latest/framework/filesystem/ but it was not clear (I'll be happy to add that to the docs)

Comments
----------------------------------------

Somewhat related to #33747