### PR TITLE
dev/core#6128 Fix filter on relationship tab

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -314,6 +314,8 @@ trait SavedSearchInspectorTrait {
         $field = $this->getField($fieldName);
         $operators = array_values($field['operators'] ?? []) ?: CoreUtil::getOperators();
         $options = $field['options'] ?? NULL;
+        // Fallback in case getQuery wasn't available
+        $dataType ??= $field['data_type'] ?? NULL;
       }
       elseif (is_a($expr, SqlFunction::class)) {
         $options = $expr->getOptions();

--- a/Civi/Api4/RelationshipCache.php
+++ b/Civi/Api4/RelationshipCache.php
@@ -56,6 +56,8 @@ class RelationshipCache extends Generic\AbstractEntity {
   public static function getInfo() {
     $info = parent::getInfo();
     $info['bridge_title'] = ts('Relationship');
+    // This entity uses DAOGetAction so counts as a DAOEntity
+    $info['type'][0] = 'DAOEntity';
     $info['bridge'] = [
       'near_contact_id' => [
         'to' => 'far_contact_id',

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -56,7 +56,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
         'title' => $display['label'],
         'title_plural' => $display['label'],
         'description' => $display['settings']['description'] ?? NULL,
-        'type' => ['SavedSearch'],
+        'type' => ['DAOEntity', 'SavedSearch'],
         'table_name' => $display['tableName'],
         'class_args' => [$display['name']],
         'label_field' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6128](https://lab.civicrm.org/dev/core/-/issues/6128)

Before
----------------------------------------
On the contact summary page, inactive relationship table shows all relationships.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
This regressed with commit 739d2e31; the problem was that the RelationshipCache entity wasn't declared as a DAOEntity and therefore `SavedSearchInspectorTrait::getQuery` failed to load a query object for it.

I've fixed the metadata for that entity and a couple others, and also added a fallback in `SavedSearchInspectorTrait::applyFilter` so it's not so heavily dependent on the query.