### PR TITLE
Settings - Add validate_callback to maxFileSize + test fix

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -75,13 +75,11 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
     $errors = [];
 
     // validate max file size
-    $iniBytes = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'));
-    $inputBytes = ((int) $fields['maxFileSize']) * 1024 * 1024;
-
-    if ($inputBytes > $iniBytes) {
-      $errors['maxFileSize'] = ts("Maximum file size cannot exceed limit defined in \"php.ini\" (\"upload_max_filesize=%1\").", [
-        1 => ini_get('upload_max_filesize'),
-      ]);
+    try {
+      CRM_Core_BAO_Setting::validateMaxFileSize($fields['maxFileSize']);
+    }
+    catch (CRM_Core_Exception $e) {
+      $errors['maxFileSize'] = $e->getMessage();
     }
 
     // validate recent items stack size

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -316,6 +316,25 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     return TRUE;
   }
 
+  public static function validateMaxFileSize($value): bool {
+    if (!$value) {
+      // Value is not required
+      return TRUE;
+    }
+    if (!CRM_Utils_Rule::positiveInteger($value)) {
+      throw new CRM_Core_Exception(ts('Maximum file size must be a positive integer'));
+    }
+    $iniBytes = CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize'));
+    $inputBytes = ((int) $value) * 1024 * 1024;
+
+    if ($inputBytes > $iniBytes) {
+      throw new CRM_Core_Exception(ts('Maximum file size cannot exceed limit defined in "php.ini" ("upload_max_filesize=%1").', [
+        1 => ini_get('upload_max_filesize'),
+      ]));
+    }
+    return TRUE;
+  }
+
   /**
    * This provides information about the setting - similar to the fields concept for DAO information.
    * As the setting is serialized code creating validation setting input needs to know the data type

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -164,7 +164,7 @@ function civicrm_api3_setting_revert($params) {
   });
   $domains = _civicrm_api3_setting_getDomainArray($params);
   $result = [];
-  $isError = FALSE;
+  $errors = [];
   foreach ($domains as $domainID) {
     $valuesToRevert = array_intersect_key($defaults['values'][$domainID], $revertable);
     if (!empty($valuesToRevert)) {
@@ -173,13 +173,13 @@ function civicrm_api3_setting_revert($params) {
       // note that I haven't looked at how the result would appear with multiple domains in play
       $result = array_merge($result, civicrm_api('Setting', 'create', $valuesToRevert));
       if ($result['is_error'] ?? FALSE) {
-        $isError = TRUE;
+        $errors[] = $result['error_message'];
       }
     }
   }
 
-  if ($isError) {
-    return civicrm_api3_create_error('Error reverting settings');
+  if ($errors) {
+    return civicrm_api3_create_error(implode(', ', $errors));
   }
 
   return civicrm_api3_create_success($result, $params, 'Setting', 'revert');

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -463,7 +463,8 @@ return [
       'size' => 2,
       'maxlength' => 8,
     ],
-    'default' => 3,
+    // Set default to match php.ini 'upload_max_filesize'
+    'default' => ini_get('upload_max_filesize') ? intval(ini_parse_quantity(ini_get('upload_max_filesize')) / (1024 * 1024)) : 3,
     'validate_callback' => 'CRM_Core_BAO_Setting::validateMaxFileSize',
     'add' => '4.3',
     'title' => ts('Maximum File Size (in MB)'),

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -464,6 +464,7 @@ return [
       'maxlength' => 8,
     ],
     'default' => 3,
+    'validate_callback' => 'CRM_Core_BAO_Setting::validateMaxFileSize',
     'add' => '4.3',
     'title' => ts('Maximum File Size (in MB)'),
     'is_domain' => 1,


### PR DESCRIPTION
Comments
----------------------------------------
I'm in the process of [moving setting validation](https://github.com/civicrm/civicrm-core/pull/33745) from the form layer to the setting metadata, and `maxFileSize` presents a strange problem so I made it into its own PR:

The default value of `3` [causes a test failure](https://test.civicrm.org/job/CiviCRM-Test/108998/testReport/(root)/api_v3_SettingTest/testRevertAll/) on standard `buildkit` installs due to their low `php.ini:upload_max_filesize=2M` setting. Validation fails because 3 is greater than  2.

Incidentally, this was already a problem: a standard buildkit install won't allow you to submit the "Miscellaneous" settings form as-is due to the same validation. But moving the validation to metadata makes it more apparent.

I can think of 3 possible solutions

1. Quick Fix: Lower the default to 2.
2. Dynamic fix: calculate the default based on `ini_get('upload_max_filesize')`.
3. BK Fix: Increase `php.ini:upload_max_filesize` on buildkit.