### PR TITLE
dev/core#6143 Enforce translation_source source_key unicity

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -91,6 +91,16 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'collate' => $bin_collation,
       'required' => TRUE,
     ]);
+    $this->addTask('Replace TranslationSource "index_source_key" with "UI_source_key"', 'replaceTranslationSourceIndex');
+  }
+
+  /**
+   * @see https://lab.civicrm.org/dev/core/-/issues/6143
+   */
+  public static function replaceTranslationSourceIndex() {
+    \CRM_Core_BAO_SchemaHandler::createMissingIndices(CRM_Core_BAO_SchemaHandler::getMissingIndices(FALSE, ['civicrm_translation_source']));
+    \CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_translation_source', 'index_source_key');
+    return TRUE;
   }
 
 }

--- a/schema/Core/TranslationSource.entityType.php
+++ b/schema/Core/TranslationSource.entityType.php
@@ -12,11 +12,12 @@ return [
     'add' => '6.7.alpha1',
   ],
   'getIndices' => fn() => [
-    'index_source_key' => [
+    'UI_source_key' => [
       'fields' => [
         'source_key' => TRUE,
       ],
-      'add' => '6.7.alpha1',
+      'unique' => TRUE,
+      'add' => '6.14.alpha1',
     ],
   ],
   'getFields' => fn() => [


### PR DESCRIPTION
Overview
----------------------------------------
Issue on installing CiviCRM on MySQL8.4 because a foreign key is pointing to a non unique field (source_key).

After
----------------------------------------
Enforcing `civicrm_translation_source` column `source_key` to be UNIQUE in the database.

