### PR TITLE
AbstractProcessor: use stricter regex for replacing tokens

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -822,7 +822,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   public function replaceTokens(string $text): string {
     $matches = [];
-    preg_match_all('/\[[a-zA-Z0-9]{1,}\.[0-9]{1,}\.[^.]{1,}\]/', $text, $matches);
+    preg_match_all('/\[[a-zA-Z0-9]{1,}\.[0-9]{1,}\.[^.\]]{1,}\]/', $text, $matches);
 
     foreach ($matches[0] as $match) {
       // strip [ ] and split on .


### PR DESCRIPTION
Overview
----------------------------------------
The regex used by AbstractProcessor for replacing tokens may overmatch on certain inputs.

Before
----------------------------------------
For the input `[foo.0.id][bar]`, the regex would recognise `[foo.0.id][bar]` as a token.

After
----------------------------------------
For the same input, the regex would recognise `[foo.0.id]` as a token.

Comments
----------------------------------------
I apologise for the length of the diff.