### PR TITLE
(dev/core#4073) Navigation - Use cache instead of settings

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -476,29 +476,14 @@ ORDER BY weight";
   /**
    * Mark the current "navigation" data as invalid for one or all contacts.
    *
-   * @param int|null $contactID
-   *   NULL for all contacts.
+   * @param int $contactID
    * @return string
    * @throws \Civi\Core\Exception\DBQueryException
    * @internal
    */
-  public static function resetContactNavigation(?int $contactID): string {
+  public static function resetContactNavigation(int $contactID): string {
     $newKey = CRM_Utils_String::createRandom(self::CACHE_KEY_STRLEN, CRM_Utils_String::ALPHANUMERIC);
-    if (!$contactID) {
-      $ser = serialize($newKey);
-      $query = "UPDATE civicrm_setting SET value = '$ser' WHERE name='navigation' AND contact_id IS NOT NULL";
-      CRM_Core_DAO::executeQuery($query);
-    }
-    else {
-      // before inserting check if contact id exists in db
-      // this is to handle weird case when contact id is in session but not in db
-      $contact = new CRM_Contact_DAO_Contact();
-      $contact->id = $contactID;
-      if ($contact->find(TRUE)) {
-        Civi::contactSettings($contactID)->set('navigation', $newKey);
-      }
-    }
-
+    Civi::cache('navigation')->set("contact_$contactID", $newKey);
     return $newKey;
   }
 
@@ -862,9 +847,7 @@ ORDER BY weight";
    * @return object|string
    */
   public static function getCacheKey($cid) {
-    $key = Civi::service('settings_manager')
-      ->getBagByContact(NULL, $cid)
-      ->get('navigation');
+    $key = Civi::cache('navigation')->get("contact_{$cid}");
     if (strlen($key ?? '') !== self::CACHE_KEY_STRLEN) {
       $key = self::resetContactNavigation($cid);
     }

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -17,7 +17,6 @@ use CRM_ACL_BAO_Cache;
 use CRM_Case_XMLRepository;
 use CRM_Contact_BAO_Contact;
 use CRM_Contribute_BAO_Contribution;
-use CRM_Core_BAO_Navigation;
 use CRM_Core_BAO_WordReplacement;
 use CRM_Core_Config;
 use CRM_Core_DAO;
@@ -188,7 +187,6 @@ class Rebuilder {
       CRM_Core_Menu::store();
     }
     if (!empty($targets['navigation'])) {
-      CRM_Core_BAO_Navigation::resetContactNavigation(NULL);
       Civi::cache('navigation')->flush();
     }
     if (!empty($targets['perms'])) {

--- a/settings/Navigation.setting.php
+++ b/settings/Navigation.setting.php
@@ -56,15 +56,4 @@ return [
     'validate_callback' => 'CRM_Utils_Color::normalize',
     'settings_pages' => ['display' => ['weight' => 820]],
   ],
-  'navigation' => [
-    'group' => 'navigation',
-    'group_Name' => 'Navigation settings',
-    'name' => 'navigation',
-    'type' => 'String',
-    'title' => ts('Contact Navigation Menu Cache Key'),
-    'is_contact' => 1,
-    'is_domain' => 0,
-    // NOTE: key was used without meta in previous versions
-    'add' => '6.4',
-  ],
 ];

--- a/tests/phpunit/Civi/Core/SettingsStyleTest.php
+++ b/tests/phpunit/Civi/Core/SettingsStyleTest.php
@@ -15,7 +15,6 @@ class SettingsStyleTest extends \CiviUnitTestCase {
   const NEW_SETTINGS_WITH_OLD_NAMES = [
     'domain',
     'userFrameworkBaseURL',
-    'navigation',
   ];
 
   protected function setUp(): void {


### PR DESCRIPTION
Overview
----------------------------------------

To allow resetting the navigation-menu, CiviCRM tracks a random navigational ID which identifies the user's current menu-build. As long as this ID remains the same, the user can use their locally-cached menu. But when it changes, the browser will fetch+store a new copy of the menu.

In https://lab.civicrm.org/dev/core/-/issues/4073, @JKingsnorth identified a problem with the mechanics -- the random IDs are stored as a `Setting` (`civicrm_setting`), which means that every iteration of the random ID is _logged for posterity_. However, there's no value in storing this forever -- and (for large databases) it can create a lot of spurious data. Instead, we can storing it in a cache.

Before
----------------------------------------

Each navigational nonce is stored in `civicrm_setting` (with `name=navigation`,`contact_id=123`).

After
----------------------------------------

Each navigational nonce is stored in `civicrm_cache` (with `group=navigation`,`path=contact_123`) -- or an equivalent spot in Redis/Memcache.

Comments
----------------------------------------

* I have ___not___ done proportionate testing. In particular, to get past review, someone should try some use-cases where you have multiple users/multiple browsers -- with on-going edits that cause the navigation to change for each user.

* I believe there is also subtle change in how the random ID works. I mention this for disclosure, but it doesn't seem bad to me.
    * __Before__: When doing bulk-reset for all users, they will all get the exact same nav-ID. (But new users who arrive organically will get their own random IDs.)
    * __After__: When doing a bulk-reset, all users will briefly lose their nav-ID. But as users return to view more pages, they will be organically assigned their own random IDs.
    * __Analysis__: You might think it's useful to have all the users share the same nav-ID. Maybe then you can take advantage of more caching? Except that every user really should have a different menu (different roles, permissions, etc). The caching is already setup to ensure that users do _not_ share the same nav-data. We already assign new/random IDs (based on organic usage patterns). So this seems fine to me...