### PR TITLE
Throw exception if the contact ID in an import is deleted

### DIFF
--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -588,7 +588,7 @@ abstract class ImportParser extends \CRM_Import_Parser {
         $contactID = $result['id'];
       }
       else {
-        throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact {contact_id}', ['contact_id', $contactID]));
+        throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact %1', [1 => $contactID]));
       }
     }
     return $contactID;

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -587,6 +587,9 @@ abstract class ImportParser extends \CRM_Import_Parser {
       if ($result) {
         $contactID = $result['id'];
       }
+      else {
+        throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact {contact_id}', ['contact_id', $contactID]));
+      }
     }
     return $contactID;
   }


### PR DESCRIPTION

Overview
----------------------------------------
Throw exception if the contact ID in an import is deleted

We should error rather than add a contribution etc. to a deleted contact


Before
----------------------------------------
If the contact ID for a deleted contact is passed in an activity, contribution etc will be imported to it (if the attempt to find out who it was merged to fails

After
----------------------------------------
An exception is thrown once we have checked that
1) this is not an attempt to undelete (ie contactParams['is_deleted'] is not set and 
2) we can't find the contact it was merged to


Technical Details
----------------------------------------

Comments
----------------------------------------
