### PR TITLE
Cleanup getMaxFileSize function & add test

### DIFF
--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -1197,20 +1197,17 @@ HTACCESS;
   /**
    * Get the maximum file size permitted for upload.
    *
-   * This function contains logic to check the server setting if none
-   * is configured. It is unclear if this is still relevant but perhaps it is no
-   * harm-no-foul.
+   * This is mostly redundant with what settings.get already does.
    *
    * @return int
-   *   Size in mega-bytes.
+   *   Size in megabytes.
    */
   public static function getMaxFileSize(): int {
-    $maxFileSizeMegaBytes = \Civi::settings()->get('maxFileSize');
-    //Fetch maxFileSizeMegaBytes from php_ini when $config->maxFileSize is set to "no limit".
-    if (empty($maxFileSizeMegaBytes)) {
-      $maxFileSizeMegaBytes = round((CRM_Utils_Number::formatUnitSize(ini_get('upload_max_filesize')) / (1024 * 1024)), 2);
-    }
-    return $maxFileSizeMegaBytes;
+    $maxFileSize = (int) Civi::settings()->get('maxFileSize');
+    // The default value for this setting is based on php.ini:upload_max_filesize
+    // Normally the default would be returned if the setting isn't set;
+    // this is only an issue if the setting was explicitly set to 0.
+    return $maxFileSize ?: (int) Civi::settings()->getDefault('maxFileSize');
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/SettingTest.php
+++ b/tests/phpunit/api/v4/Entity/SettingTest.php
@@ -131,4 +131,24 @@ class SettingTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue(is_array($setting['default']));
   }
 
+  public function testMaxFileSize(): void {
+    $settingMeta = civicrm_api4('Setting', 'getFields', ['where' => [['name', '=', 'maxFileSize']]], 0);
+    $phpUploadMax = intval(ini_parse_quantity(ini_get('upload_max_filesize')) / (1024 * 1024));
+    $this->assertSame($phpUploadMax, $settingMeta['default']);
+    try {
+      // Non-numeric values aren't allowed
+      Setting::set()->addValue('maxFileSize', '1G')->execute();
+      $this->fail();
+    }
+    catch (\CRM_Core_Exception $e) {
+    }
+    try {
+      // Values higher than the php setting aren't allowed
+      Setting::set()->addValue('maxFileSize', $phpUploadMax + 1)->execute();
+      $this->fail();
+    }
+    catch (\CRM_Core_Exception $e) {
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #33755 removes a usage of the deprecated `CRM_Utils_Number::formatUnitSize` 

Technical Details
----------------------------------------
I was going to add more test but there are [still quirks](https://github.com/civicrm/civicrm-core/pull/33763) in the saving and validation of this setting (and settings in general) but this much works at least.