### PR TITLE
Setting - Add test to demonstrate inconsistent default handling

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -466,6 +466,7 @@ class SettingsBag {
 
     if (!is_array($value) && \CRM_Utils_System::isNull($value)) {
       $dao->value = 'null';
+      $value = NULL;
     }
     else {
       $dao->value = serialize($value);

--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Civi\Core;
 
+use Civi\Api4\Setting;
+
 class SettingsBagTest extends \CiviUnitTestCase {
 
   protected $origSetting;
@@ -30,6 +32,32 @@ class SettingsBagTest extends \CiviUnitTestCase {
 
     $settingsBag->set("enable_innodb_fts", "0");
     $this->assertEquals(0, $settingsBag->get('enable_innodb_fts'));
+  }
+
+  public function testMaxFileSizeDefault(): void {
+    $settingsBag = \Civi::settings();
+    $defaultValue = $settingsBag->getDefault('maxFileSize');
+
+    // Question: how is an empty value '' treated when retrieving a seting?
+    Setting::set()->addValue('maxFileSize', '')->execute();
+
+    // Get the value from settingsBag
+    $value = $settingsBag->get('maxFileSize');
+
+    // Get the value from cv
+    $cvVal = exec('cv setting:get maxFileSize --out json');
+    $cvVal = json_decode($cvVal, TRUE)[0]['value'];
+
+    // Get the value from the api
+    $api3Value = civicrm_api3('Setting', 'getsingle')['maxFileSize'];
+    $api4Value = Setting::get()->addSelect('maxFileSize')->execute()->single()['value'];
+
+    // They should all be the same, right?
+    $this->assertSame($defaultValue, $cvVal);
+    $this->assertSame($defaultValue, $value);
+    $this->assertSame($defaultValue, $api3Value);
+    $this->assertSame($defaultValue, $api4Value);
+
   }
 
 }

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -820,7 +820,7 @@ class api_v3_ContactTest extends CiviUnitTestCase {
       'contact_type' => 'Individual',
     ]);
     $result = $this->callAPISuccessGetSingle('Contact', ['last_name' => 'Dog']);
-    $this->assertEquals(NULL, $result['preferred_language']);
+    $this->assertSame('en_US', $result['preferred_language']);
   }
 
   /**


### PR DESCRIPTION
Question: how is an empty value `''` treated when retrieving a seting?

It turns out, that depends on how it's retrieved!

`cv setting:get` will fill in the default if the value is explicitly `''`.

But `Civi::settings()` and the API will return `''`.

This is especially confusing because cv [appears to be using the same SettingsBag](https://github.com/civicrm/cv/blob/69a41dd9791703a026da750120c226b25e4ea95e/src/Command/SettingGetCommand.php#L89) as `Civi::settings()`.