### PR TITLE
Afform - Fix editing button text & icon

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton-menu.html
@@ -1,7 +1,15 @@
 <li>
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+    <label for="af-gui-button-text">{{:: ts('Text:') }}</label>
+    <input id="af-gui-button-text" type="text" class="form-control" ng-model="$ctrl.node['#children'][0]['#text']">
+  </div>
+  <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
+    <label for="af-gui-button-icon">{{:: ts('Icon:') }}</label>
+    <input id="af-gui-button-icon" crm-ui-icon-picker class="form-control" ng-model="$ctrl.node['crm-icon']">
+  </div>
   <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline" >
-    <label>{{:: ts('Color:') }}</label>
-    <select class="form-control {{ getSetStyle().replace('btn', 'text') }}" ng-model="getSetStyle" ng-model-options="{getterSetter: true}" title="{{:: ts('Button color scheme') }}">
+    <label for="af-gui-button-color">{{:: ts('Color:') }}</label>
+    <select id="af-gui-button-color" class="form-control {{ getSetStyle().replace('btn', 'text') }}" ng-model="getSetStyle" ng-model-options="{getterSetter: true}" title="{{:: ts('Button color scheme') }}">
       <option ng-repeat="(style, label) in styles" class="{{ style.replace('btn', 'bg') }}" value="{{ style }}">{{ label }}</option>
     </select>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiButton.html
@@ -8,7 +8,7 @@
     </div>
   </div>
 </div>
-<button type="button" class="btn {{ getSetStyle() }}" disabled>
+<button type="button" class="btn {{ getSetStyle() }}" >
   <span class="crm-editable-enabled" ng-click="pickIcon()" >
     <i class="crm-i {{ $ctrl.node['crm-icon'] }}" role="img" aria-hidden="true"></i>
   </span>


### PR DESCRIPTION
Overview
----------------------------------------
Fix FormBuilder bug preventing buttons from being edited.

See https://lab.civicrm.org/dev/core/-/issues/6145

Before
----------------------------------------
Clicking on the button to edit title & icon doesn't work. No way to edit these from the popup menu either.

<img width="1312" height="402" alt="image" src="https://github.com/user-attachments/assets/01f8bdfd-973b-4560-b6b1-33c744bf811f" />


After
----------------------------------------
<img width="1336" height="490" alt="image" src="https://github.com/user-attachments/assets/63f00cfb-63f0-4adb-be95-2db1522f1693" />

Technical Details
----------------------------------------
The button text & icon are supposed to be editable but this was thwarted by css that disables pointer events on disabled buttons.

Fixed by removing the `disabled` attribute which wasn't needed.

Also added these 2 options to the popup menu to make them more obvious.