### PR TITLE
Improve the docURL function, add icon

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1438,18 +1438,22 @@ class CRM_Utils_System {
    * @return null|string
    *   URL or link to documentation page, based on provided parameters.
    */
-  public static function docURL($params) {
+  public static function docURL(array $params): ?string {
+    $link = $params['url'] ?? NULL;
 
-    if (!isset($params['page'])) {
-      return NULL;
+    if (!$link && isset($params['page'])) {
+      if (($params['resource'] ?? NULL) == 'wiki') {
+        $docBaseURL = self::getWikiBaseURL();
+      }
+      else {
+        $docBaseURL = self::getDocBaseURL();
+        $params['page'] = self::formatDocUrl($params['page']);
+      }
+      $link = $docBaseURL . str_replace(' ', '+', $params['page']);
     }
 
-    if (($params['resource'] ?? NULL) == 'wiki') {
-      $docBaseURL = self::getWikiBaseURL();
-    }
-    else {
-      $docBaseURL = self::getDocBaseURL();
-      $params['page'] = self::formatDocUrl($params['page']);
+    if (!empty($params['URLonly']) || is_null($link)) {
+      return $link;
     }
 
     if (!isset($params['title'])) {
@@ -1460,7 +1464,7 @@ class CRM_Utils_System {
     }
 
     if (!isset($params['text'])) {
-      $params['text'] = ts('(Learn more...)');
+      $params['text'] = ts('Learn more...');
     }
 
     if (!isset($params['style'])) {
@@ -1470,16 +1474,9 @@ class CRM_Utils_System {
       $style = "style=\"{$params['style']}\"";
     }
 
-    $link = $docBaseURL . str_replace(' ', '+', $params['page']);
-
-    if (!empty($params['URLonly'])) {
-      return $link;
-    }
-    else {
-      $params['text'] = htmlspecialchars($params['text']);
-      $params['title'] = htmlspecialchars($params['title']);
-      return "<a href=\"{$link}\" $style target=\"_blank\" class=\"crm-doc-link no-popup\" title=\"{$params['title']}\">{$params['text']}</a>";
-    }
+    $params['text'] = htmlspecialchars($params['text']);
+    $params['title'] = htmlspecialchars($params['title']);
+    return "<a href=\"{$link}\" $style target=\"_blank\" class=\"crm-doc-link no-popup\" title=\"{$params['title']}\">{$params['text']} <i class=\"crm-i fa-external-link\" role=\"img\" aria-hidden=\"true\"></i></a>";
   }
 
   /**

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -1,4 +1,4 @@
-.crm-container .messages .crm-i {
+.crm-container .messages > .crm-i {
   padding: 0 var(--crm-m) var(--crm-s) 0;
   float: left;
 }


### PR DESCRIPTION
Overview
----------------------------------------
The doc urls were looking a little dated with their ascii-art-esque brackets instead of an icon.

A small piece of the #33745 epic.


Before
----------------------------------------
<img width="2166" height="190" alt="image" src="https://github.com/user-attachments/assets/a3c9e1d3-1854-43d9-aa9d-f09890d1a96d" />


After
----------------------------------------
<img width="2168" height="192" alt="image" src="https://github.com/user-attachments/assets/3489d163-b5dc-489d-9cc0-e0eb3ac5d849" />


Technical Details
----------------------------------------

This improves the function to allow an arbitrary url to be supplied to `{docURL}`, and formats prettier output with an icon.