### PR TITLE
Settings - Add support for metadata callbacks

### DIFF
--- a/CRM/Admin/Form/Setting/Miscellaneous.php
+++ b/CRM/Admin/Form/Setting/Miscellaneous.php
@@ -41,20 +41,6 @@ class CRM_Admin_Form_Setting_Miscellaneous extends CRM_Admin_Form_Setting {
 
     parent::buildQuickForm();
 
-    $settingMetaData = $this->getSettingsMetaData();
-
-    // Disable logging field if system does not meet requirements
-    if (CRM_Core_I18n::isMultilingual()) {
-      $settingMetaData['logging']['description'] = ts('Logging is not supported in multilingual environments.');
-      $this->freeze('logging');
-    }
-    elseif (!CRM_Core_DAO::checkTriggerViewPermission(FALSE)) {
-      $settingMetaData['logging']['description'] = ts("In order to use this functionality, the installation's database user must have privileges to create triggers (in MySQL 5.0 – and in MySQL 5.1 if binary logging is enabled – this means the SUPER privilege). This install either does not seem to have the required privilege enabled.");
-      $this->freeze('logging');
-    }
-
-    $this->assign('settings_fields', $settingMetaData);
-
     $this->addRule('checksum_timeout', ts('Value should be a positive number'), 'positiveInteger');
   }
 

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -67,7 +67,7 @@ trait CRM_Admin_Form_SettingTrait {
    */
   protected function getSettingsMetaData(): array {
     if (empty($this->settingsMetadata)) {
-      $this->settingsMetadata = \Civi\Core\SettingsMetadata::getMetadata(['name' => array_keys($this->_settings)], NULL, TRUE);
+      $this->settingsMetadata = \Civi\Core\SettingsMetadata::getMetadata(['name' => array_keys($this->_settings)], NULL, TRUE, FALSE, TRUE);
       // This array_merge re-orders to the key order of $this->_settings.
       $this->settingsMetadata = array_merge($this->_settings, $this->settingsMetadata);
     }

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -336,35 +336,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
   }
 
   /**
-   * This provides information about the setting - similar to the fields concept for DAO information.
-   * As the setting is serialized code creating validation setting input needs to know the data type
-   * This also helps move information out of the form layer into the data layer where people can interact with
-   * it via the API or other mechanisms. In order to keep this consistent it is important the form layer
-   * also leverages it.
-   *
-   * Note that this function should never be called when using the runtime getvalue function. Caching works
-   * around the expectation it will be called during setting administration
-   *
-   * Function is intended for configuration rather than runtime access to settings
-   *
-   * The following params will filter the result. If none are passed all settings will be returns
-   *
-   * @param int $componentID
-   *   Id of relevant component.
-   * @param array $filters
-   * @param int $domainID
-   * @param null $profile
-   *
-   * @return array
-   *   the following information as appropriate for each setting
-   *   - name
-   *   - type
-   *   - default
-   *   - add (CiviCRM version added)
-   *   - is_domain
-   *   - is_contact
-   *   - description
-   *   - help_text
+   * @deprecated in 6.9 will be removed around 6.21
    */
   public static function getSettingSpecification(
     $componentID = NULL,
@@ -372,6 +344,7 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     $domainID = NULL,
     $profile = NULL
   ) {
+    CRM_Core_Error::deprecatedFunctionWarning('Civi\Core\SettingsMetadata::getMetadata');
     return \Civi\Core\SettingsMetadata::getMetadata($filters, $domainID);
   }
 

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -543,4 +543,16 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
     }
   }
 
+  public static function loggingMetadataCallback(array &$setting): void {
+    // Disable field on setting form if system does not meet requirements
+    if (\CRM_Core_I18n::isMultilingual()) {
+      $setting['description'] = ts('Logging is not supported in multilingual environments.');
+      $setting['html_attributes']['disabled'] = 'disabled';
+    }
+    elseif (!\CRM_Core_DAO::checkTriggerViewPermission(FALSE)) {
+      $setting['description'] = ts("In order to use this functionality, the installation's database user must have privileges to create triggers (in MySQL 5.0 – and in MySQL 5.1 if binary logging is enabled – this means the SUPER privilege). This install either does not seem to have the required privilege enabled.");
+      $setting['html_attributes']['disabled'] = 'disabled';
+    }
+  }
+
 }

--- a/Civi/Api4/Action/Setting/GetFields.php
+++ b/Civi/Api4/Action/Setting/GetFields.php
@@ -30,7 +30,7 @@ class GetFields extends \Civi\Api4\Generic\BasicGetFieldsAction {
   protected function getRecords() {
     $names = $this->_itemsToGet('name');
     $filter = $names ? ['name' => $names] : [];
-    $settings = \Civi\Core\SettingsMetadata::getMetadata($filter, $this->domainId, $this->loadOptions);
+    $settings = \Civi\Core\SettingsMetadata::getMetadata($filter, $this->domainId, $this->loadOptions, FALSE, TRUE);
 
     // FIXME: This is a workaround for a workaround for settingsBag::setDb() which means [] is returned
     // for non-existent settings if passed in name filter

--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -42,10 +42,11 @@ class SettingsMetadata {
    * @param array $filters
    * @param int $domainID
    * @param bool|array $loadOptions
+   * @param bool $bootOnly
+   *   Optionally restricts to only boot-time settings
+   * @param bool $resolveCallbacks
+   *   Perform callback logic - this should only be done when the system is fully bootstrapped
    *
-   * The final param optionally restricts to only boot-time settings
-   *
-   * @param bool $bootOnly - only
    *
    * @return array
    *   the following information as appropriate for each setting
@@ -63,13 +64,14 @@ class SettingsMetadata {
    *   - is_env_loadable (whether this setting should be read from corresponding environment variable)
    *   - is_constant (whether a PHP constant should be defined for this setting)
    */
-  public static function getMetadata($filters = [], $domainID = NULL, $loadOptions = FALSE, $bootOnly = FALSE) {
+  public static function getMetadata($filters = [], $domainID = NULL, $loadOptions = FALSE, $bootOnly = FALSE, $resolveCallbacks = FALSE) {
     $settingsMetadata = $bootOnly ? self::getBootMetadata() : self::getFullMetadata($domainID);
 
     self::_filterSettingsSpecification($filters, $settingsMetadata);
     if ($loadOptions) {
       self::fillOptions($settingsMetadata, $loadOptions);
     }
+    self::handleCallbacks($settingsMetadata, $resolveCallbacks);
 
     return $settingsMetadata;
   }
@@ -231,6 +233,16 @@ class SettingsMetadata {
       else {
         $spec['options'] = $options;
       }
+    }
+  }
+
+  private static function handleCallbacks(array &$settingsMetadata, bool $resolveCallbacks): void {
+    foreach ($settingsMetadata as &$setting) {
+      if ($resolveCallbacks && isset($setting['metadata_callback'])) {
+        \Civi\Core\Resolver::singleton()->call($setting['metadata_callback'], [&$setting]);
+      }
+      // Treat this as internal and don't return it
+      unset($setting['metadata_callback']);
     }
   }
 

--- a/api/v3/Setting.php
+++ b/api/v3/Setting.php
@@ -48,11 +48,9 @@ function civicrm_api3_setting_getfields($params) {
   if ($domainID === 'current_domain') {
     $domainID = NULL;
   }
-  $result = CRM_Core_BAO_Setting::getSettingSpecification(
-    $params['component_id'] ?? NULL,
+  $result = \Civi\Core\SettingsMetadata::getMetadata(
     $params['filters'] ?? [],
     $domainID,
-    $params['profile'] ?? NULL
   );
   // find any supplemental information
   if (!empty($params['action'])) {

--- a/settings/Core.setting.php
+++ b/settings/Core.setting.php
@@ -883,6 +883,7 @@ return [
     'title' => ts('Logging'),
     'description' => ts('If enabled, all actions will be logged with a complete record of changes.'),
     'validate_callback' => 'CRM_Logging_Schema::checkLoggingSupport',
+    'metadata_callback' => ['CRM_Core_BAO_Setting', 'loggingMetadataCallback'],
     'on_change' => [
       'CRM_Logging_Schema::onToggle',
     ],


### PR DESCRIPTION
Overview
----------------------------------------
Allows setting metadata to be dynamic.

Part of the #33745 epic.

Technical Details
----------------------------------------
Sometimes a setting has conditional logic (e.g. whether it should be shown, hidden, or disabled, depending on env). This adds a new `metadata_callback` to allow settings to modify their own metadata at runtime.

Example usage added, moving a piece of form-layer logic into the callback.

Note: Callbacks can't be anonymous closures because settings get serialized and cached.