### PR TITLE
Afform - Prevent double-validation messages

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -380,7 +380,7 @@
           CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
           return;
         }
-        status = CRM.status({});
+        status = CRM.status({error: ts('Not saved')});
         $element.block();
         if (cancelDraftWatcher) {
           cancelDraftWatcher();


### PR DESCRIPTION


Overview
----------------------------------------
Prevent extra popups when Afform validation fails.

Technical Details
----------------------------------------
The validation messages should already be visible, so let's prevent the default popup from CRM.status and just show a small message instead.