### PR TITLE
dev/core#6142 Further cleanup to `CRM_Utils_System::theme` 

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -217,7 +217,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $exit = TRUE;
     if ($config->initialized) {
       $content = $template->fetch('CRM/common/fatal.tpl');
-      echo CRM_Utils_System::theme($content);
+      CRM_Utils_System::theme($content);
       $exit = CRM_Utils_System::shouldExitAfterFatal();
     }
     else {
@@ -465,7 +465,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // set the response code before starting the request
     http_response_code(500);
 
-    echo CRM_Utils_System::theme($content);
+    CRM_Utils_System::theme($content);
     $exit = CRM_Utils_System::shouldExitAfterFatal();
 
     if ($exit) {

--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -274,7 +274,7 @@ class CRM_Core_Page {
     //its time to call the hook.
     CRM_Utils_Hook::alterContent($content, 'page', $pageTemplateFile, $this);
 
-    echo CRM_Utils_System::theme($content, $this->_print);
+    CRM_Utils_System::theme($content);
   }
 
   /**

--- a/CRM/Core/QuickForm/Action/Display.php
+++ b/CRM/Core/QuickForm/Action/Display.php
@@ -129,7 +129,7 @@ class CRM_Core_QuickForm_Action_Display extends CRM_Core_QuickForm_Action {
       $html = &$content;
     }
     else {
-      $html = CRM_Utils_System::theme($content, $print);
+      $html = CRM_Utils_System::theme($content);
     }
 
     if ($controller->_QFResponseType == 'json') {

--- a/CRM/Core/Selector/Controller.php
+++ b/CRM/Core/Selector/Controller.php
@@ -488,7 +488,7 @@ class CRM_Core_Selector_Controller {
     self::$_template->assign('tplFile', $this->_object->getHookedTemplateFileName());
     $contentTpl = CRM_Utils_System::getContentTemplate($this->_print);
     $content = self::$_template->fetch($contentTpl);
-    echo CRM_Utils_System::theme($content, $this->_print);
+    CRM_Utils_System::theme($content);
   }
 
   /**

--- a/CRM/Queue/Page/Runner.php
+++ b/CRM/Queue/Page/Runner.php
@@ -53,16 +53,7 @@ class CRM_Queue_Page_Runner extends CRM_Core_Page {
     if ($runner->isMinimal) {
       $smarty = CRM_Core_Smarty::singleton();
       $content = $smarty->fetch('CRM/Queue/Page/Runner.tpl');
-      if ($this->_print) {
-        // unexpected - trying to print the output of the upgrader?
-        // @todo remove this case and just ignore $this->_print entirely
-        // for now we use the original call, to maintain preexisting behaviour (however strange that is)
-        \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $print and $maintenance is unexpected and may behave strangely. This codepath will be removed in a future release. If you need it, please comment on https://lab.civicrm.org/dev/core/-/issues/5803');
-        echo CRM_Utils_System::theme($content, $this->_print, TRUE);
-      }
-      else {
-        echo CRM_Utils_System::renderMaintenanceMessage($content);
-      }
+      CRM_Utils_System::renderMaintenanceMessage($content);
     }
     else {
       parent::run();

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -109,16 +109,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
 
     $content = $template->fetch('CRM/common/success.tpl');
 
-    if ($this->_print) {
-      // unexpected - trying to print the output of the upgrader?
-      // @todo remove this case and just ignore $this->_print entirely
-      // for now we use the original call, to maintain preexisting behaviour (however strange that is)
-      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $print and $maintenance is unexpected and may behave strangely. This codepath will be removed in a future release. If you need it, please comment on https://lab.civicrm.org/dev/core/-/issues/5803');
-      echo CRM_Utils_System::theme($content, $this->_print, TRUE);
-    }
-    else {
-      echo CRM_Utils_System::renderMaintenanceMessage($content);
-    }
+    CRM_Utils_System::renderMaintenanceMessage($content);
   }
 
   /**
@@ -192,16 +183,7 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
 
     $content = $template->fetch('CRM/common/success.tpl');
 
-    if ($this->_print) {
-      // unexpected - trying to print the output of the upgrader?
-      // @todo remove this case and just ignore $this->_print entirely
-      // for now we use the original call, to maintain preexisting behaviour (however strange that is)
-      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $print and $maintenance is unexpected and may behave strangely. This codepath will be removed in a future release. If you need it, please comment on https://lab.civicrm.org/dev/core/-/issues/5803');
-      echo CRM_Utils_System::theme($content, $this->_print, TRUE);
-    }
-    else {
-      echo CRM_Utils_System::renderMaintenanceMessage($content);
-    }
+    CRM_Utils_System::renderMaintenanceMessage($content);
   }
 
 }

--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -399,8 +399,8 @@ class CRM_Utils_REST {
       $content = $smarty->fetch('CRM/common/' . strtolower($config->userFramework) . '.tpl');
       CRM_Utils_System::appendTPLFile($tpl, $content);
 
-      return CRM_Utils_System::theme($content);
-
+      CRM_Utils_System::theme($content);
+      return;
     }
     else {
       $content = "<!-- .tpl file embedded: $tpl -->\n";

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -201,26 +201,6 @@ class CRM_Utils_System {
   }
 
   /**
-   * If we are using a theming system, invoke theme, else just print the content.
-   *
-   * @param string $content
-   *   The content that will be themed.
-   * @param bool $print
-   *   (optional) Are we displaying to the screen or bypassing theming?
-   * @param bool $maintenance
-   *   (optional) For maintenance mode.
-   *
-   * @return string
-   */
-  public static function theme(
-    &$content,
-    $print = FALSE,
-    $maintenance = FALSE
-  ) {
-    return CRM_Core_Config::singleton()->userSystem->theme($content, $print, $maintenance);
-  }
-
-  /**
    * Generate a query string if input is an array.
    *
    * @param array|string $query

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1207,33 +1207,14 @@ AND    u.status = 1
   /**
    * @inheritdoc
    */
-  public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
-    if ($maintenance) {
-      \CRM_Core_Error::deprecatedWarning('CRM_Utils_System::theme called with $maintenance = TRUE - please use renderMaintenanceMessage instead');
-    }
-
-    if (!$print) {
-      if ($maintenance) {
-        print $this->renderMaintenanceMessage($content);
-        exit();
-      }
-      return $content;
-    }
-
-    print $content;
-    return NULL;
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function renderMaintenanceMessage(string $content): string {
+  public function renderMaintenanceMessage(string $content): void {
     backdrop_set_breadcrumb('');
     backdrop_maintenance_theme();
     if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
       $this->addHTMLHead($region->render(''));
     }
-    return theme('maintenance_page', ['content' => $content]);
+    print theme('maintenance_page', ['content' => $content]);
+    exit();
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -963,7 +963,7 @@ abstract class CRM_Utils_System_Base {
    * @param string $content
    */
   public function outputError($content) {
-    echo CRM_Utils_System::theme($content);
+    CRM_Utils_System::theme($content);
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -337,40 +337,38 @@ abstract class CRM_Utils_System_Base {
   /**
    * @see https://lab.civicrm.org/dev/core/-/issues/5803
    *
-   * If we are using a theming system, invoke theme, else just print the content.
+   * Print content to screen.
+   *
+   * On WP this adds the admin header on admin screens.
    *
    * @param string $content
-   *   The content that will be themed.
+   *   Content to print
    * @param bool $print
+   *   DEPRECATED - this function will always print
    * @param bool $maintenance
-   *   DEPRECATED - use renderMaintenanceMessage instead,
-   *
-   * @throws Exception
-   * @return string|null
-   *   NULL, If $print is FALSE, and some other criteria match up.
-   *   The themed string, otherwise.
-   *
-   * @todo Remove maintenance param
-   * @todo The return value is inconsistent.
-   * @todo Better to always return, and never print.
+   *   DEPRECATED - use renderMaintenanceMessage directly instead
    */
-  public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+  public function theme($content, $print = FALSE, $maintenance = FALSE): void {
     if ($maintenance) {
       \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_System::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
-      $content = $this->renderMaintenanceMessage($content);
+      $this->renderMaintenanceMessage($content);
+      return;
     }
+
     print $content;
-    return NULL;
   }
 
   /**
-   * Wrap content in maintenance template
+   * Print content to screen, wrapped in maintenance template if possible
+   *
+   * NOTE: on D7 / Backdrop / Standalone this function exits immediately
+   *
+   * @todo make the behaviours consistent?
    *
    * @param string $content
-   * @return string
    */
-  public function renderMaintenanceMessage(string $content): string {
-    return $content;
+  public function renderMaintenanceMessage(string $content): void {
+    print $content;
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -897,33 +897,14 @@ AND    u.status = 1
   /**
    * @inheritdoc
    */
-  public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
-    if ($maintenance) {
-      \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_Base::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
-    }
-
-    if (!$print) {
-      if ($maintenance) {
-        print $this->renderMaintenanceMessage($content);
-        exit();
-      }
-      return $content;
-    }
-
-    print $content;
-    return NULL;
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function renderMaintenanceMessage(string $content): string {
+  public function renderMaintenanceMessage(string $content): void {
     drupal_set_breadcrumb('');
     drupal_maintenance_theme();
     if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
       $this->addHTMLHead($region->render(''));
     }
-    return theme('maintenance_page', ['content' => $content]);
+    print theme('maintenance_page', ['content' => $content]);
+    exit();
   }
 
   /**

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -955,14 +955,6 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
   /**
    * @inheritdoc
-   * @todo use Drupal "maintenance page" template and theme during installation
-   */
-  public function renderMaintenanceMessage(string $content): string {
-    return $content;
-  }
-
-  /**
-   * @inheritdoc
    */
   public function ipAddress():?string {
     // dev/core#4756 fallback if checking before CMS bootstrap

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -342,13 +342,13 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
-  public function renderMaintenanceMessage(string $content): string {
+  public function renderMaintenanceMessage(string $content): void {
     // wrap in a minimal header
     $headerContent = CRM_Core_Region::instance('html-header', FALSE)->render('');
 
     // note - not adding #crm-container is a hacky way to avoid rendering
     // the civicrm menubar. @todo a better way
-    return <<<HTML
+    print <<<HTML
       <!DOCTYPE html >
       <html class="crm-standalone">
         <head>
@@ -361,6 +361,8 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
         </body>
       </html>
     HTML;
+
+    exit();
   }
 
   /**

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1686,51 +1686,28 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   /**
    * @inheritdoc
-   * @todo why are the environment checks here? could they be removed
    */
-  public function theme(&$content, $print = FALSE, $maintenance = FALSE) {
+  public function theme($content, $print = FALSE, $maintenance = FALSE): void {
     if ($maintenance) {
       \CRM_Core_Error::deprecatedWarning('Calling CRM_Utils_Base::theme with $maintenance is deprecated - use renderMaintenanceMessage instead');
-    }
-    if (!$print) {
-      if (!function_exists('is_admin')) {
-        throw new \Exception('Function "is_admin()" is missing, even though WordPress is the user framework.');
-      }
-      if (!defined('ABSPATH')) {
-        throw new \Exception('Constant "ABSPATH" is not defined, even though WordPress is the user framework.');
-      }
-      if (is_admin()) {
-        require_once ABSPATH . 'wp-admin/admin-header.php';
-      }
-      else {
-        // FIXME: we need to figure out to replace civicrm content on the frontend pages
-      }
-    }
-
-    print $content;
-    return NULL;
-  }
-
-  /**
-   * @inheritdoc
-   * @todo environment checks are copied from the original implementation of `theme` above and should probably
-   * be removed
-   */
-  public function renderMaintenanceMessage(string $content): string {
-    if (!function_exists('is_admin')) {
-      throw new \Exception('Function "is_admin()" is missing, even though WordPress is the user framework.');
-    }
-    if (!defined('ABSPATH')) {
-      throw new \Exception('Constant "ABSPATH" is not defined, even though WordPress is the user framework.');
+      $this->renderMaintenanceMessage($content);
+      return;
     }
     if (is_admin()) {
       require_once ABSPATH . 'wp-admin/admin-header.php';
     }
-    else {
-      // FIXME: we need to figure out to replace civicrm content on the frontend pages
-    }
+    print $content;
+  }
 
-    return $content;
+  /**
+   * @inheritdoc
+   * be removed
+   */
+  public function renderMaintenanceMessage(string $content): void {
+    if (is_admin()) {
+      require_once ABSPATH . 'wp-admin/admin-header.php';
+    }
+    print $content;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Further cleanup to `CRM_Utils_System::theme` and associated `CRM_Utils_System::renderMaintenanceMode`. Previously tried to do this slowly, slowly - but that caused a bug https://lab.civicrm.org/dev/core/-/issues/6142

Before
----------------------------------------
- theme and renderMaintenanceMode try to return a themed value
- on D7 / Backdrop the theming gets done again by the CMS

After
----------------------------------------
- theme and renderMaintenanceMode print directly
- on D7 / Backdrop they can exit early, to stop the double wrapping

Technical Details
----------------------------------------
I'm working on the basis that WP and D8+ have never respected the `print` value and always print directly, so hopefully all callers can handle that behaviour in all cases. :crossed_fingers: 