### PR TITLE
[WIP] In the case of an empty data type set it to string.

### DIFF
--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -103,6 +103,9 @@ class FieldSpec {
   public function __construct($name, $entity, $dataType = 'String') {
     $this->entity = $entity;
     $this->name = $name;
+    if (empty($dataType)) {
+	    $dataType = 'String';
+    }
     $this->setDataType($dataType);
   }
 


### PR DESCRIPTION
Data type should not be empty. However it appears that you can create a searchkit entity such that it is.

Overview
----------------------------------------
In some cases it would appear that a searchkit db table can set a datatype to be the empty string. This is not ideal as it then breaks that entity. Perhaps it should break the entity? But it also breaks any entity discovery for example API4 explorer page will not load.

Before
----------------------------------------
You can have an empty string for a datatype but you'll get an error up the line.

After
----------------------------------------
Your empty string datatype will magically become a string.

Technical Details
----------------------------------------
Why should we have to error detect this far into the internals? Probably better this is caught further up the chain.

Comments
----------------------------------------
Not ready to merge.
