### PR TITLE
Make sure FormBuilder GUI Editor field settings button is clickable

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -275,6 +275,7 @@
 #afGuiEditor .af-gui-node-title {
   position: absolute;
   top: 1px;
+  margin-right: 18px;
 }
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-bar,
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container-title span:empty {


### PR DESCRIPTION
Before
----------------------------------------
Create a FormBuilder with a filter with a long title (that breaks onto two lines). The editable title span partially covers the little gear icon button, making it unclickable.

<img width="318" height="63" alt="image" src="https://github.com/user-attachments/assets/0401512c-2860-443c-952b-b0eae7edd37e" />

After
----------------------------------------
Now the gear icon button is no longer covered by the label and so is clickable.

<img width="306" height="90" alt="image" src="https://github.com/user-attachments/assets/9bfba72d-43ce-4c4e-8f94-50d0bbc8bf0c" />