### PR TITLE
RiverLea: fixes wrapping long item count regression in some builds 

### DIFF
--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -87,6 +87,7 @@
 .crm-container #mainTabContainer ul.ui-tabs-nav a em {
   background: var(--crm-dash-tab-count-bg);
   color: var(--crm-dash-tab-count-col);
+  word-break: keep-all;
 }
 .crm-container li.crm-count-0 a.ui-tabs-anchor,
 .crm-container li.crm-count-0 a.ui-tabs-anchor em {


### PR DESCRIPTION
Regression from https://github.com/civicrm/civicrm-core/pull/33530 identified by @Upperholme here - https://lab.civicrm.org/extensions/riverlea/-/issues/152.

Before
----------------------------------------
Longer item counts in horizontal contact layout tabs wrap…

<img width="860" height="646" alt="image" src="https://github.com/user-attachments/assets/866aea7f-524b-4929-9006-0c327fe56085" />

After
----------------------------------------
They don't…

Technical Details
----------------------------------------
I can't recreate the regression on Chromekit/Standlone/Drupal - but it makes sense. If this patch fixes Graham's issue I'd suggest it's worth it tho as it makes sense.