### PR TITLE
dev/core#6098 - Fix delete file links in CRM/Profile form

### DIFF
--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -625,7 +625,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
               $fileId = $url['file_id'];
               $fileHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileId);
               $deleteURL = CRM_Utils_System::url('civicrm/file',
-                "reset=1&id={$fileId}&eid=$entityId&fid={$key}&action=delete&fcs={$fileHash}"
+                "reset=1&id={$fileId}&fid={$key}&action=delete&fcs={$fileHash}"
               );
               $text = ts("Delete Attached File");
               $customFiles[$field['name']]['deleteURL'] = "<a href=\"{$deleteURL}\" onclick = \"if (confirm( ' $deleteExtra ' )) this.href+='&amp;confirmed=1'; else return false;\">$text</a>";
@@ -667,7 +667,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
               $fileId = $url['file_id'];
               $fileHash = CRM_Core_BAO_File::generateFileHash(NULL, $fileId);
               $deleteURL = CRM_Utils_System::url('civicrm/file',
-                "reset=1&id={$fileId}&eid=$entityId&fid={$customFieldID}&action=delete&fcs={$fileHash}"
+                "reset=1&id={$fileId}&fid={$customFieldID}&action=delete&fcs={$fileHash}"
               );
               $text = ts("Delete Attached File");
               $customFiles[$field['name']]['deleteURL'] = "<a href=\"{$deleteURL}\" onclick = \"if (confirm( ' $deleteExtra ' )) this.href+='&amp;confirmed=1'; else return false;\">$text</a>";


### PR DESCRIPTION
This change fixes an error that occurs when you try to delete a file upload from a custom field from
this form. (Issue dev/core#6098)

In PR #32319 the way that the EntityFile table is used was changed for these fields, and an entity_id should no longer be passed to this endpoint.