### PR TITLE
Browse Mailings: respect global search setting

### DIFF
--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -643,6 +643,10 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
   }
 
   public function pagerAtoZ() {
+    if (!Civi::settings()->get('includeAlphabeticalPager')) {
+      $this->_parent->assign('aToZ', NULL);
+      return;
+    }
 
     $params = [];
     $whereClause = $this->whereClause($params, FALSE);


### PR DESCRIPTION
Overview
----------------------------------------

If the search setting "Include Alphabetical Pager" is disabled, then do not display the alphabetic pager on the Browse Mailings screen.

To reproduce:

- Disable the "Admin UI" extension (the new UI does not have an alpha pager)
- Change the setting, go to Administer > Customize Data and Screens > Search Settings, and find "Include Alphabetical Pager". Set it to "no". It should be off by default.
- Then go to Mailings > Sent mailings.

Before
----------------------------------------

<img width="3388" height="1636" alt="2025-10-10_16-08" src="https://github.com/user-attachments/assets/dcd74f2b-5b6f-451d-90f5-9660604a91b6" />

After
----------------------------------------

Gone, as per setting:

<img width="3392" height="1630" alt="2025-10-10_16-08_1" src="https://github.com/user-attachments/assets/edc44b5d-1b81-4fe4-8cef-775e3313126b" />

