### PR TITLE
RL: select-list close icon position

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -417,7 +417,7 @@ input.crm-form-checkbox) + label {
   top: auto;
 }
 .crm-container .select2-container .select2-choice > .select2-chosen {
-  margin-right: var(--crm-m2);
+  margin-right: var(--crm-r2);
 }
 .crm-container .select2-container-multi .select2-choices::before,
 .crm-container .select2-container .select2-choice .select2-arrow::before {


### PR DESCRIPTION
Overview
----------------------------------------
Increases the right padding on 'selected' select list items so the unselect/'x' icon doesn't overlap the text. Noticeable on SearchKit builder.

Before
----------------------------------------
Minetta…
<img width="559" height="104" alt="image" src="https://github.com/user-attachments/assets/5e2540fc-1052-4b23-a5dc-1612c8043154" />

Thames…
<img width="479" height="100" alt="image" src="https://github.com/user-attachments/assets/57b2735f-988e-4a32-8ab0-d1e8212e74df" />

After
----------------------------------------
Minetta…
<img width="613" height="168" alt="image" src="https://github.com/user-attachments/assets/b53baa0e-d197-43f0-a6d9-bf4dd6ed760d" />

Thames…
<img width="621" height="117" alt="image" src="https://github.com/user-attachments/assets/d4c82d4e-1838-4ba2-933a-4c2af9ae8b1d" />