### PR TITLE
Misc ts usage fixes

### DIFF
--- a/CRM/Admin/Page/PaymentProcessor.php
+++ b/CRM/Admin/Page/PaymentProcessor.php
@@ -103,7 +103,7 @@ class CRM_Admin_Page_PaymentProcessor extends CRM_Core_Page_Basic {
         $paymentProcessors[$paymentProcessorID]['test_id'] = CRM_Financial_BAO_PaymentProcessor::getTestProcessorId($paymentProcessorID);
       }
       catch (CRM_Core_Exception $e) {
-        CRM_Core_Session::setStatus(ts('No test processor entry exists for %1. Not having a test entry for each processor could cause problems', [$paymentProcessor['name']]));
+        CRM_Core_Session::setStatus(ts('No test processor entry exists for %1. Not having a test entry for each processor could cause problems', [1 => $paymentProcessor['name']]));
       }
     }
 

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -344,7 +344,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
     }
     $buttonName = $this->controller->getButtonName();
     if ($buttonName == $this->getButtonName('upload', 'new')) {
-      CRM_Core_Session::setStatus(ts(' You can add another Campaign.'), '', 'info');
+      CRM_Core_Session::setStatus(ts('You can add another Campaign.'), '', 'info');
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/campaign/add', 'reset=1&action=add'));
     }
     else {

--- a/CRM/Campaign/Form/Petition.php
+++ b/CRM/Campaign/Form/Petition.php
@@ -326,7 +326,7 @@ WHERE  $whereClause
 
       if ($this->_action & CRM_Core_Action::DELETE) {
         CRM_Campaign_BAO_Survey::deleteRecord(['id' => $this->_surveyId]);
-        CRM_Core_Session::setStatus(ts(' Petition has been deleted.'), ts('Record Deleted'), 'success');
+        CRM_Core_Session::setStatus(ts('Petition has been deleted.'), ts('Record Deleted'), 'success');
         $session->replaceUserContext(CRM_Utils_System::url('civicrm/campaign', 'reset=1&subPage=petition'));
         return;
       }
@@ -374,7 +374,7 @@ WHERE  $whereClause
 
     $buttonName = $this->controller->getButtonName();
     if ($buttonName == $this->getButtonName('next', 'new')) {
-      CRM_Core_Session::setStatus(ts(' You can add another Petition.'), '', 'info');
+      CRM_Core_Session::setStatus(ts('You can add another Petition.'), '', 'info');
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/petition/add', 'reset=1&action=add'));
     }
     else {

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -556,7 +556,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form implements CRM_Case_Form_Case
   public static function activityForm($form) {
     $caseRelationships = CRM_Case_BAO_Case::getCaseRoles($form->_contactID, $form->_caseID);
     //build reporter select
-    $reporters = ["" => ts(' - any reporter - ')];
+    $reporters = ["" => ts('- any reporter -')];
     foreach ($caseRelationships as $key => & $value) {
       $reporters[$value['cid']] = $value['sort_name'] . " ( {$value['relation']} )";
     }
@@ -581,7 +581,7 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form implements CRM_Case_Form_Case
     $form->add('select', 'activity_type_filter_id', ts('Activity Type'), ['' => ts('- select activity type -')] + $aTypesFilter, FALSE, ['id' => 'activity_type_filter_id_' . $form->_caseID]);
 
     $activityStatus = CRM_Core_PseudoConstant::activityStatus();
-    $form->add('select', 'status_id', ts('Status'), ["" => ts(' - any status - ')] + $activityStatus, FALSE, ['id' => 'status_id_' . $form->_caseID]);
+    $form->add('select', 'status_id', ts('Status'), ["" => ts('- any status -')] + $activityStatus, FALSE, ['id' => 'status_id_' . $form->_caseID]);
 
     // activity date search filters
     $form->add('datepicker', 'activity_date_low_' . $form->_caseID, ts('Activity Dates - From'), [], FALSE, ['time' => FALSE]);

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -7222,14 +7222,14 @@ AND   displayRelType.is_active = 1
    */
   protected function getQillForRelativeDateRange($from, $to, string $fieldTitle, string $relativeRange): string {
     if (!$from) {
-      return ts('%1 is ', [$fieldTitle]) . $relativeRange . ' (' . ts('to %1', [CRM_Utils_Date::customFormat($to)]) . ')';
+      return ts('%1 is ', [1 => $fieldTitle]) . $relativeRange . ' (' . ts('to %1', [1 => CRM_Utils_Date::customFormat($to)]) . ')';
     }
     if (!$to) {
-      return ts('%1 is ', [$fieldTitle]) . $relativeRange . ' (' . ts('from %1', [CRM_Utils_Date::customFormat($from)]) . ')';
+      return ts('%1 is ', [1 => $fieldTitle]) . $relativeRange . ' (' . ts('from %1', [1 => CRM_Utils_Date::customFormat($from)]) . ')';
     }
-    return ts('%1 is ', [$fieldTitle]) . $relativeRange . ' (' . ts('between %1 and %2', [
-      CRM_Utils_Date::customFormat($from),
-      CRM_Utils_Date::customFormat($to),
+    return ts('%1 is ', [1 => $fieldTitle]) . $relativeRange . ' (' . ts('between %1 and %2', [
+      1 => CRM_Utils_Date::customFormat($from),
+      2 => CRM_Utils_Date::customFormat($to),
     ]) . ')';
   }
 

--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -518,7 +518,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
         // Add user-friendly placeholder
         foreach (['a', 'b'] as $x) {
           $type = !empty($jsData[$id]["contact_sub_type_$x"]) ? $jsData[$id]["contact_sub_type_$x"] : ($jsData[$id]["contact_type_$x"] ?? NULL);
-          $jsData[$id]["placeholder_$x"] = $type ? ts('- select %1 -', [strtolower($contactTypes[$type]['label'])]) : ts('- select contact -');
+          $jsData[$id]["placeholder_$x"] = $type ? ts('- select %1 -', [1 => strtolower($contactTypes[$type]['label'])]) : ts('- select contact -');
         }
       }
     }

--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -654,7 +654,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {
       if (str_contains($fields['html_message'], $token)) {
-        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
+        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [1 => $token, 2 => $replacement]);
       }
     }
     return empty($tokenErrors) ? TRUE : ['html_message' => implode('<br>', $tokenErrors)];

--- a/CRM/Contact/Form/Task/PDFTrait.php
+++ b/CRM/Contact/Form/Task/PDFTrait.php
@@ -188,7 +188,7 @@ trait CRM_Contact_Form_Task_PDFTrait {
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {
       if (str_contains($fields['html_message'], $token)) {
-        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
+        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [1 => $token, 2 => $replacement]);
       }
     }
     if (!empty($tokenErrors)) {

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -62,7 +62,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
 
     $tag = CRM_Core_DAO_EntityTag::buildOptions('tag_id', 'get');
     if (!empty($tag)) {
-      $this->addElement('select', 'tag', ts(' Tag imported records'), $tag, [
+      $this->addElement('select', 'tag', ts('Tag imported records'), $tag, [
         'multiple' => 'multiple',
         'class' => 'crm-select2',
       ]);

--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -446,7 +446,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
         ),
         ($params['payment_processor'] ?? NULL)
       )) {
-        CRM_Core_Session::setStatus(ts(' Please note that the Authorize.net payment processor only allows recurring contributions and auto-renew memberships with payment intervals from 7-365 days or 1-12 months (i.e. not greater than 1 year).'), '', 'alert');
+        CRM_Core_Session::setStatus(ts('Please note that the Authorize.net payment processor only allows recurring contributions and auto-renew memberships with payment intervals from 7-365 days or 1-12 months (i.e. not greater than 1 year).'), '', 'alert');
       }
     }
 

--- a/CRM/Core/Form/Task/PDFLetterCommon.php
+++ b/CRM/Core/Form/Task/PDFLetterCommon.php
@@ -220,7 +220,7 @@ class CRM_Core_Form_Task_PDFLetterCommon {
     $tokenErrors = [];
     foreach ($deprecatedTokens as $token => $replacement) {
       if (str_contains($fields['html_message'], $token)) {
-        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [$token, $replacement]);
+        $tokenErrors[] = ts('Token %1 is no longer supported - use %2 instead', [1 => $token, 2 => $replacement]);
       }
     }
     if (!empty($tokenErrors)) {

--- a/CRM/Core/Form/Task/PickProfile.php
+++ b/CRM/Core/Form/Task/PickProfile.php
@@ -65,7 +65,7 @@ abstract class CRM_Core_Form_Task_PickProfile extends CRM_Core_Form_Task {
     $session = CRM_Core_Session::singleton();
     $this->_userContext = $session->readUserContext();
 
-    $this->setTitle(ts('Update multiple ' . $this::$entityShortname . 's'));
+    $this->setTitle(ts('Update multiple %1s', [1 => $this::$entityShortname]));
 
     // validations
     if (count($this->_entityIds) > $this->_maxEntities) {

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -479,11 +479,11 @@ class CRM_Core_ManagedEntities {
       foreach (['name', 'module', 'entity', 'params'] as $key) {
         if (empty($declare[$key])) {
           $str = print_r($declare, TRUE);
-          throw new CRM_Core_Exception(ts('Managed Entity (%1) is missing field "%2": %3', [$module, $key, $str]));
+          throw new CRM_Core_Exception(ts('Managed Entity (%1) is missing field "%2": %3', [1 => $module, 2 => $key, 3 => $str]));
         }
       }
       if (!$this->isModuleRecognised($declare['module'])) {
-        throw new CRM_Core_Exception(ts('Entity declaration references invalid or inactive module name [%1]', [$declare['module']]));
+        throw new CRM_Core_Exception(ts('Entity declaration references invalid or inactive module name [%1]', [1 => $declare['module']]));
       }
     }
   }

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -332,11 +332,11 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     $errorMsg = [];
 
     if (empty($this->_paymentProcessor['user_name'])) {
-      $errorMsg[] = ts(' Store Name is not set for this payment processor');
+      $errorMsg[] = ts('Store Name is not set for this payment processor');
     }
 
     if (empty($this->_paymentProcessor['url_site'])) {
-      $errorMsg[] = ts(' URL is not set for this payment processor');
+      $errorMsg[] = ts('URL is not set for this payment processor');
     }
 
     if (!empty($errorMsg)) {

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -583,7 +583,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           //if primary participant contributing additional amount
           //append (multiple participants) to its fee level. CRM-4196.
           if (count($params) > 1) {
-            $participantRecord['amount_level'] .= ts(' (multiple participants)') . CRM_Core_DAO::VALUE_SEPARATOR;
+            $participantRecord['amount_level'] .= ' ' . ts('(multiple participants)') . CRM_Core_DAO::VALUE_SEPARATOR;
           }
 
           //passing contribution id is already registered.

--- a/CRM/Financial/Form/FinancialTypeAccount.php
+++ b/CRM/Financial/Form/FinancialTypeAccount.php
@@ -329,7 +329,7 @@ class CRM_Financial_Form_FinancialTypeAccount extends CRM_Core_Form {
     $session = CRM_Core_Session::singleton();
 
     if ($buttonName == $this->getButtonName('next', 'new')) {
-      CRM_Core_Session::setStatus(ts(' You can add another Financial Account Type.'));
+      CRM_Core_Session::setStatus(ts('You can add another Financial Account Type.'));
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin/financial/financialType/accounts',
         "reset=1&action=add&aid={$this->_aid}"));
     }

--- a/CRM/Import/StateMachine.php
+++ b/CRM/Import/StateMachine.php
@@ -55,7 +55,7 @@ class CRM_Import_StateMachine extends CRM_Core_StateMachine {
     elseif ($this->entity) {
       $entityName = CRM_Core_DAO_AllCoreTables::getDAONameForEntity($this->entity);
       if (!$entityName) {
-        throw new CRM_Core_Exception(ts('Invalid import entity %1', [htmlentities($this->entity), 'String']));
+        throw new CRM_Core_Exception(ts('Invalid import entity %1', [1 => htmlentities($this->entity)]));
       }
       $entityPath = explode('_', $entityName);
       $this->classPrefix = $entityPath[0] . '_' . $entityPath[1] . '_Import';

--- a/CRM/PCP/Form/Campaign.php
+++ b/CRM/PCP/Form/Campaign.php
@@ -334,7 +334,7 @@ class CRM_PCP_Form_Campaign extends CRM_Core_Form {
     if (!$this->_pageId) {
       CRM_PCP_BAO_PCP::sendStatusUpdate($pcp->id, $statusId, TRUE, $this->_component);
       if ($approvalMessage && ($params['status_id'] ?? NULL) == 1) {
-        $notifyStatus .= ts(' You will receive a second email as soon as the review process is complete.');
+        $notifyStatus .= ' ' . ts('You will receive a second email as soon as the review process is complete.');
       }
     }
 

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -625,7 +625,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     $buttonName = $this->controller->getButtonName();
     $session = CRM_Core_Session::singleton();
     if ($buttonName == $this->getButtonName('next', 'new')) {
-      CRM_Core_Session::setStatus(ts(' You can add another price set field.'), '', 'info');
+      CRM_Core_Session::setStatus(ts('You can add another price set field.'), '', 'info');
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin/price/field/edit', 'reset=1&action=add&sid=' . $this->_sid));
     }
     else {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -692,9 +692,9 @@ class CRM_Report_Form extends CRM_Core_Form {
         $this->_createNew = TRUE;
         $this->_params = $this->_formValues;
         $this->_params['view_mode'] = 'criteria';
-        $this->_params['title'] = $this->getTitle() . ts(' (copy created by %1 on %2)', [
-          CRM_Core_Session::singleton()->getLoggedInContactDisplayName(),
-          CRM_Utils_Date::customFormat(date('Y-m-d H:i')),
+        $this->_params['title'] = $this->getTitle() . ' ' . ts('(copy created by %1 on %2)', [
+          1 => CRM_Core_Session::singleton()->getLoggedInContactDisplayName(),
+          2 => CRM_Utils_Date::customFormat(date('Y-m-d H:i')),
         ]);
         // Do not pass go. Do not collect another chance to re-run the same query.
         CRM_Report_Form_Instance::postProcess($this);
@@ -1688,7 +1688,7 @@ class CRM_Report_Form extends CRM_Core_Form {
 
     if (!empty($options)) {
       $options = [
-        '-' => ts(' - none - '),
+        '-' => ts('- none -'),
       ] + $options;
       for ($i = 1; $i <= 5; $i++) {
         $this->addElement('select', "order_bys[{$i}][column]", ts('Order by Column'), $options);

--- a/CRM/Upgrade/Incremental/php/SixFive.php
+++ b/CRM/Upgrade/Incremental/php/SixFive.php
@@ -51,7 +51,7 @@ class CRM_Upgrade_Incremental_php_SixFive extends CRM_Upgrade_Incremental_Base {
         . " " . ts("If your extensions or other custom code will not run on Smarty5, you should log an issue with the maintainer. If the maintainer does not respond you should consider uninstalling the extension.")
         . " " . ts("In the short term you can make your site continue to use Smarty2 by editing your civicrm.settings.php file and adding the line %1",
           [1 => sprintf("<pre>  define('CIVICRM_SMARTY_AUTOLOAD_PATH',\n    %s);</pre>", htmlentities(var_export($smarty2Path, 1)))])
-        . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v6.4-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+        . (ts('Upcoming versions will standardize on Smarty v5. CiviCRM <a %1>v6.4-ESR</a> will provide extended support for Smarty v2, v3, & v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
         ])

--- a/CRM/Utils/Check/Component/Security.php
+++ b/CRM/Utils/Check/Component/Security.php
@@ -126,17 +126,12 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
       if ($this->isDirAccessible($privateDir, $heuristicUrl)) {
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
-          ts('Files in the data directory (<a href="%3">%2</a>) should not be downloadable.'
+          ts('Files in the data directory (<a href="%1">%2</a>) should not be downloadable.', [1 => $heuristicUrl, 2 => $privateDir])
             . '<br />'
-            . '<a href="%1">Read more about this warning</a>',
-            [
-              1 => $this->createDocUrl('uploads-should-not-be-accessible'),
-              2 => $privateDir,
-              3 => $heuristicUrl,
-            ]),
-            ts('Private Files Readable'),
-            \Psr\Log\LogLevel::WARNING,
-            'fa-lock'
+            . ts('<a href="%1">Read more about this warning</a>', [1 => $this->createDocUrl('uploads-should-not-be-accessible')]),
+          ts('Private Files Readable'),
+          \Psr\Log\LogLevel::WARNING,
+          'fa-lock'
         );
       }
     }
@@ -201,13 +196,13 @@ class CRM_Utils_Check_Component_Security extends CRM_Utils_Check_Component {
     // Test that $publicDir is not browsable
     foreach ($publicDirs as $publicDir => $publicUrl) {
       if ($this->isBrowsable($publicDir, $publicUrl)) {
-        $msg = 'Directory <a href="%1">%2</a> should not be browseable via the web.'
+        $msg = ts('Directory <a %1>%2</a> should not be browseable via the web.', [1 => "href='$publicDir'", 2 => $publicDir])
           . '<br />' .
-          '<a href="%3">Read more about this warning</a>';
+          '<a href="' . $docs_url . '">' . ts('Read more about this warning') . '</a>';
         $docs_url = $this->createDocUrl('directories-should-not-be-browsable');
         $messages[] = new CRM_Utils_Check_Message(
           __FUNCTION__,
-          ts($msg, [1 => $publicDir, 2 => $publicDir, 3 => $docs_url]),
+          $msg,
           ts('Browseable Directories'),
           \Psr\Log\LogLevel::ERROR,
           'fa-lock'

--- a/CRM/Utils/Check/Component/Smarty.php
+++ b/CRM/Utils/Check/Component/Smarty.php
@@ -37,12 +37,12 @@ class CRM_Utils_Check_Component_Smarty extends CRM_Utils_Check_Component {
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__,
       "
-        <p>" . (ts("CiviCRM recommends Smarty version 5. This site is overriding that default with an older version of Smarty.")) . "</p>
-        <p>" . (ts("CiviCRM will support such overrides until version 6.10. By v6.11, Smarty 5 will be required. You can try out Smarty 5 before then by deleting the line starting with <code>%1</code> from the <code>%2</code> file.", [1 => "define($settingName", 2 => 'civicrm.settings.php'])) . "</p>
-        <p>" . (ts('CiviCRM <a %1>v6.10-ESR</a> provides extended support for Smarty v2 and v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.' . '</p>', [
+        <p>" . ts("CiviCRM recommends Smarty version 5. This site is overriding that default with an older version of Smarty.") . "</p>
+        <p>" . ts("CiviCRM will support such overrides until version 6.10. By v6.11, Smarty 5 will be required. You can try out Smarty 5 before then by deleting the line starting with <code>%1</code> from the <code>%2</code> file.", [1 => "define($settingName", 2 => 'civicrm.settings.php']) . "</p>
+        <p>" . ts('CiviCRM <a %1>v6.10-ESR</a> provides extended support for Smarty v2 and v4. To learn more and discuss, see the <a %2>Smarty transition page</a>.', [
           1 => 'target="_blank" href="' . htmlentities('https://civicrm.org/esr') . '"',
           2 => 'target="_blank" href="' . htmlentities('https://civicrm.org/redirect/smarty-v3') . '"',
-        ])),
+        ]) . '</p>',
         ts('Smarty Version Override'),
         LogLevel::WARNING,
         'fa-lock'

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1928,7 +1928,7 @@ class CRM_Utils_System {
         break;
 
       default:
-        $title = ts(ucfirst($action)) . ' ' . $daoClass::getEntityTitle();
+        $title = ucfirst($action) . ' ' . $daoClass::getEntityTitle();
     }
 
     return [

--- a/Civi/Api4/Service/Autocomplete/ContributionRecurAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContributionRecurAutocompleteProvider.php
@@ -79,7 +79,7 @@ class ContributionRecurAutocompleteProvider extends \Civi\Core\Service\AutoServi
         [
           'type' => 'field',
           'key' => 'frequency_unit:label',
-          'rewrite' => ts('Every %1 %2 since %3', [1 => '[frequency_interval]', 2 => '[frequency_unit:label]', '[start_date]']),
+          'rewrite' => ts('Every %1 %2 since %3', [1 => '[frequency_interval]', 2 => '[frequency_unit:label]', 3 => '[start_date]']),
         ],
       ],
     ];

--- a/Civi/WorkflowMessage/GenericWorkflowMessage.php
+++ b/Civi/WorkflowMessage/GenericWorkflowMessage.php
@@ -93,7 +93,7 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
         'severity' => 'error',
         'fields' => ['contactId', 'contact'],
         'name' => 'missingContact',
-        'message' => ts('Message template requires one of these fields (%1)', ['contactId, contact']),
+        'message' => ts('Message template requires one of these fields (%1)', [1 => 'contactId, contact']),
       ];
     }
     if (!empty($this->contactID) && !empty($this->contact)) {
@@ -101,7 +101,7 @@ class GenericWorkflowMessage implements WorkflowMessageInterface {
         'severity' => 'warning',
         'fields' => ['contactId', 'contact'],
         'name' => 'missingContact',
-        'message' => ts('Passing both (%1) may lead to ambiguous behavior.', ['contactId, contact']),
+        'message' => ts('Passing both (%1) may lead to ambiguous behavior.', [1 => 'contactId, contact']),
       ];
     }
   }

--- a/Civi/WorkflowMessage/Traits/LocalizationTrait.php
+++ b/Civi/WorkflowMessage/Traits/LocalizationTrait.php
@@ -88,7 +88,7 @@ trait LocalizationTrait {
         'severity' => 'error',
         'fields' => ['locale'],
         'name' => 'badLocale',
-        'message' => ts('The given locale is not valid (%1)', [json_encode($this->locale)]),
+        'message' => ts('The given locale is not valid (%1)', [1 => json_encode($this->locale)]),
       ];
     }
   }

--- a/api/v3/Relationship.php
+++ b/api/v3/Relationship.php
@@ -155,28 +155,21 @@ function _civicrm_api3_relationship_getoptions_spec(&$params) {
   $relationshipTypePrefix = ts('(For relationship_type_id only) ');
   $params['contact_id'] = [
     'title' => ts('Contact ID'),
-    'description' => $relationshipTypePrefix . ts('Limits options to those'
-      . ' available to give contact'),
+    'description' => $relationshipTypePrefix . ts('Limits options to those available to give contact'),
     'type' => CRM_Utils_Type::T_INT,
     'FKClassName' => 'CRM_Contact_DAO_Contact',
     'FKApiName' => 'Contact',
   ];
   $params['relationship_direction'] = [
     'title' => ts('Relationship Direction'),
-    'description' => $relationshipTypePrefix . ts('For relationships where the '
-      . 'name is the same for both sides (i.e. "Spouse Of") show the option '
-      . 'from "A" (origin) side or "B" (target) side of the relationship?'),
+    'description' => $relationshipTypePrefix . ts('For relationships where the name is the same for both sides (i.e. "Spouse Of") show the option from "A" (origin) side or "B" (target) side of the relationship?'),
     'type' => CRM_Utils_Type::T_STRING,
     'options' => ['a_b' => 'a_b', 'b_a' => 'b_a'],
     'api.default' => 'a_b',
   ];
   $params['relationship_id'] = [
     'title' => ts('Reference Relationship ID'),
-    'description' => $relationshipTypePrefix . ts('If provided alongside '
-      . 'contact ID it will be used to establish the contact type of the "B" '
-      . 'side of the relationship and limit options based on it. If the '
-      . 'provided contact ID does not match the "A" side of this relationship '
-      . 'then the "A" side of this relationship will be used to limit options'),
+    'description' => $relationshipTypePrefix . ts('If provided alongside contact ID it will be used to establish the contact type of the "B" side of the relationship and limit options based on it. If the provided contact ID does not match the "A" side of this relationship then the "A" side of this relationship will be used to limit options'),
     'type' => CRM_Utils_Type::T_INT,
     'FKClassName' => 'CRM_Contact_DAO_Relationship',
     'FKApiName' => 'Relationship',
@@ -184,16 +177,13 @@ function _civicrm_api3_relationship_getoptions_spec(&$params) {
   $contactTypes = CRM_Contact_BAO_ContactType::contactTypes();
   $params['contact_type'] = [
     'title' => ts('Contact Type'),
-    'description' => $relationshipTypePrefix . ts('Limits options to those '
-    . 'available to this contact type. Overridden by the contact type of '
-    . 'contact ID (if provided)'),
+    'description' => $relationshipTypePrefix . ts('Limits options to those available to this contact type. Overridden by the contact type of contact ID (if provided)'),
     'type' => CRM_Utils_Type::T_STRING,
     'options' => array_combine($contactTypes, $contactTypes),
   ];
   $params['is_form'] = [
     'title' => ts('Is Form?'),
-    'description' => $relationshipTypePrefix . ts('Formats the options for use'
-      . ' in a form if true. The format is &lt;id&gt;_a_b => &lt;label&gt;'),
+    'description' => $relationshipTypePrefix . ts('Formats the options for use in a form if true. The format is &lt;id&gt;_a_b => &lt;label&gt;'),
     'type' => CRM_Utils_Type::T_BOOLEAN,
   ];
 }

--- a/bin/cli.class.php
+++ b/bin/cli.class.php
@@ -314,7 +314,7 @@ class civicrm_cli {
     $out .= "  --output will pretty print the result from the api call\n";
     $out .= "  --json will print the result from the api call as JSON\n";
     $out .= "  PARAMS is one or more --param=value combinations to pass to the api\n";
-    return ts($out);
+    return $out;
   }
 
   /**

--- a/bin/migrate/move.php
+++ b/bin/migrate/move.php
@@ -33,7 +33,7 @@ function run() {
   $moveStatus = CRM_Core_BAO_ConfigSetting::doSiteMove();
 
   echo $moveStatus . '<br />';
-  echo ts("If no errors are displayed above, the site move steps have completed successfully. Please visit <a href=\"{$config->userFrameworkBaseURL}\">your moved site</a> and test the move.");
+  echo "If no errors are displayed above, the site move steps have completed successfully. Please visit <a href=\"{$config->userFrameworkBaseURL}\">your moved site</a> and test the move.";
 }
 
 run();

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -241,7 +241,7 @@ class AfformAdminMeta {
         $name = basename($file, '.html');
         $inputTypes[] = [
           'name' => $name,
-          'label' => $inputTypeLabels[$name] ?? E::ts($name),
+          'label' => $inputTypeLabels[$name] ?? $name,
           'template' => '~/af/fields/' . $name . '.html',
           'admin_template' => '~/afGuiEditor/inputType/' . $name . '.html',
         ];

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -35,7 +35,7 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
           CRM_Utils_System::resetBreadCrumb();
           CRM_Utils_System::appendBreadCrumb([
             ['title' => E::ts('CiviCRM'), 'url' => Civi::url('current://civicrm', 'h')],
-            ['title' => ts($navParent['label']), 'url' => Civi::url('current://' . $navParent['url'], 'h')],
+            ['title' => $navParent['label'], 'url' => Civi::url('current://' . $navParent['url'], 'h')],
           ]);
         }
       }

--- a/ext/civicrm_search_ui/managed/SavedSearch_ActivitySearch.mgd.php
+++ b/ext/civicrm_search_ui/managed/SavedSearch_ActivitySearch.mgd.php
@@ -97,7 +97,7 @@ return [
         'saved_search_id.name' => 'ActivitySearch',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(NULL),
+          'description' => NULL,
           'sort' => [
             [
               'activity_date_time',

--- a/ext/civicrm_search_ui/managed/SavedSearch_CiviCRM_Reports.mgd.php
+++ b/ext/civicrm_search_ui/managed/SavedSearch_CiviCRM_Reports.mgd.php
@@ -39,7 +39,7 @@ return [
         'saved_search_id.name' => 'CiviCRM_Reports',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(NULL),
+          'description' => NULL,
           'sort' => [
             ['title', 'ASC'],
           ],

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -568,10 +568,10 @@ abstract class ImportParser extends \CRM_Import_Parser {
         $contactID = array_key_first($possibleMatches);
       }
       elseif (count($possibleMatches) > 1) {
-        throw new \CRM_Core_Exception(ts('Record duplicates multiple contacts: ') . implode(',', $possibleMatches));
+        throw new \CRM_Core_Exception(ts('Record duplicates multiple contacts:') . ' ' . implode(',', $possibleMatches));
       }
       elseif (!in_array($action, ['create', 'ignore', 'save'], TRUE)) {
-        throw new \CRM_Core_Exception(ts('No matching %1 found', [$entity, 'String']));
+        throw new \CRM_Core_Exception(ts('No matching %1 found', [1 => $entity]));
       }
     }
     if ($contactID && !isset($contactParams['is_deleted']) && $this->getExistingContactValue($contactID, 'is_deleted')) {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ActivitySearch.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/ActivitySearch.php
@@ -96,7 +96,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
     );
 
     // Select box for Activity Type
-    $activityType = ['' => ts(' - select activity - ')] + CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'search');
+    $activityType = ['' => ts('- select activity -')] + CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'search');
 
     $form->add('select', 'activity_type_id', ts('Activity Type'),
       $activityType,
@@ -104,7 +104,7 @@ class CRM_Contact_Form_Search_Custom_ActivitySearch extends CRM_Contact_Form_Sea
     );
 
     // textbox for Activity Status
-    $activityStatus = ['' => ts(' - select status - ')] + CRM_Activity_BAO_Activity::buildOptions('status_id', 'search');
+    $activityStatus = ['' => ts('- select status -')] + CRM_Activity_BAO_Activity::buildOptions('status_id', 'search');
 
     $form->add('select', 'activity_status_id', ts('Activity Status'),
       $activityStatus,

--- a/tests/phpunit/CRM/Core/BAO/NavigationTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NavigationTest.php
@@ -99,7 +99,7 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $url_params = "reset=1";
     $params = [
       'name' => $name,
-      'label' => ts($name),
+      'label' => $name,
       'url' => "{$url}?{$url_params}",
       'parent_id' => NULL,
       'is_active' => TRUE,
@@ -126,7 +126,7 @@ class CRM_Core_BAO_NavigationTest extends CiviUnitTestCase {
     $url_params = "reset=1&output=criteria";
     $params = [
       'name' => $name,
-      'label' => ts($name),
+      'label' => $name,
       'url' => "{$url}?{$url_params}",
       'parent_id' => NULL,
       'is_active' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------

Fixes `ts()` usage - the translation function - so that strings are correctly extracted.

I found a common error: `ts('Hello %1', [$name]);`. While this works for English, `civistrings` outputs an error and cannot parse it.

Another common error, more often is older code, was to concatenate variables in the strings. In some cases, like old CLI tools, I removed `ts()` because it's old legacy code.

Comment
---------------------

We also have warnings such as these:

```
$ civistrings . > /tmp/after.pot 
[warn] second argument of ts() call is not an array. (./CRM/Dedupe/Merger.php:1734)
[warn] second argument of ts() call is not an array. (./CRM/Dedupe/Merger.php:1746)
[warn] second argument of ts() call is not an array. (./CRM/Financial/Form/FinancialType.php:156)
[warn] second argument of ts() call is not an array. (./CRM/Financial/Form/FinancialType.php:159)
[warn] second argument of ts() call is not an array. (./CRM/Upgrade/Incremental/php/FiveNine.php:31)
[warn] second argument of ts() call is not an array. (./CRM/Upgrade/Incremental/php/FiveThree.php:35)
[warn] second argument of ts() call is not an array. (./ext/iframe/Civi/Iframe/ScriptManager.php:64)
[warn] second argument of ts() call is not an array. (./ext/iframe/Civi/Iframe/ScriptManager.php:65)
[warn] second argument of ts() call is not an array. (./ext/search_kit/Civi/Search/Admin.php:281)
[warn] second argument of ts() call is not an array. (./ext/search_kit/Civi/Search/Admin.php:281)
```

but most that I checked, they were arrays, it's just that civistrings could not tell what type the variable was.

If we could fix that - then we could add civistrings to the Jenkins tests, because it does not throw any other warnings.