### PR TITLE
rename View My Contact menu item; remove on Standalone

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -918,7 +918,7 @@ ORDER BY weight";
         $item['child'][] = [
           'attributes' => [
             'label' => ts('View My Contact'),
-            'name' => 'CiviCRM Dashboard',
+            'name' => 'View My Contact',
             'url' => 'civicrm/contact/view?cid=' . CRM_Core_Session::getLoggedInContactID() . '&reset=1',
             'icon' => 'crm-i fa-user',
             'weight' => 1,

--- a/ext/standaloneusers/Civi/Standalone/Utils.php
+++ b/ext/standaloneusers/Civi/Standalone/Utils.php
@@ -17,8 +17,8 @@ class Utils {
         }
       }
 
-      // remove hide menu
-      $item['child'] = array_filter($item['child'], fn ($subitem) => ($subitem['attributes']['name'] !== 'Hide Menu'));
+      // remove Hide Menu and View My Contact
+      $item['child'] = array_filter($item['child'], fn ($subitem) => !in_array($subitem['attributes']['name'], ['Hide Menu', 'View My Contact']));
 
       // Add My Account.
       $item['child'][] = [


### PR DESCRIPTION
Overview
----------------------------------------
This new User menu item is basically a dupe on Standalone, so remove it.

Before
----------------------------------------
- on CMSes, View my Contact
- on Standalone, View My Contact **and** My Account (which then links to Contact record) 
<img width="516" height="267" alt="image" src="https://github.com/user-attachments/assets/4fe8fff6-299d-4942-8f2b-dc78c5831fa4" />


After
----------------------------------------
- on CMSes, View my Contact
- on Standalone, just My Account (which then links to Contact record) 


Technical Details
----------------------------------------
Updated the name for the View My Contact menu item to match label and purpose.
