### PR TITLE
Use civicrm/home rather than civicrm/dashboard for home nav url

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -910,7 +910,7 @@ ORDER BY weight";
           'attributes' => [
             'label' => ts('CiviCRM Home'),
             'name' => 'CiviCRM Home',
-            'url' => 'civicrm/dashboard?reset=1',
+            'url' => 'civicrm/home?reset=1',
             'icon' => 'crm-i fa-house-user',
             'weight' => 1,
           ],

--- a/ext/standaloneusers/Civi/Standalone/Utils.php
+++ b/ext/standaloneusers/Civi/Standalone/Utils.php
@@ -10,13 +10,6 @@ class Utils {
         continue;
       }
 
-      // use /civicrm/home rather than /civicrm/dashboard
-      foreach ($item['child'] as &$subitem) {
-        if ($subitem['attributes']['name'] === 'CiviCRM Home') {
-          $subitem['attributes']['url'] = 'civicrm/home?reset=1';
-        }
-      }
-
       // remove Hide Menu and View My Contact
       $item['child'] = array_filter($item['child'], fn ($subitem) => !in_array($subitem['attributes']['name'], ['Hide Menu', 'View My Contact']));
 


### PR DESCRIPTION
Overview
----------------------------------------
Use `civicrm/home` rather than `civicrm/dashboard` for the CiviCRM Home link. This is currently behaviour on Standalone, and makes it easier to provide a custom home page with FormBuilder.

In general it makes more sense to call this "the home page!" anyway - because there are many many Dashboards in CiviCRM. It is confusing to have "the dashboard" as well as "the contact/user/event/contribution/mailing/etc dashboard" .

Before
----------------------------------------
- you can add a custom home page at `civicrm/dashboard` using Form Builder, but you lost access to the default dashboard page

After
----------------------------------------
- if you dont create a custom home page, you still get the default dashboard at `civicrm/home` => no difference for users
- you can add a custom home page at `civicrm/home` using Form Builder, and it will be used here
- if you add a custom page, you can still access the old dashboard at `civicrm/dashboard`

Technical Details
----------------------------------------
An issue could arise if custom hooks are firing based on strictly matching `civicrm/dashboard` url. But they are already likely to be problematic, because you can access the old dashboard at just `/civicrm/` route


Comments
-------------------------------------
There are lots of places in the codebase that redirect to `civicrm/dashboard`. If there's general support for this direction I could follow up going through them.