### PR TITLE
smarty/php warning on relationship types screen

### DIFF
--- a/CRM/Core/Page/Basic.php
+++ b/CRM/Core/Page/Basic.php
@@ -414,6 +414,7 @@ abstract class CRM_Core_Page_Basic extends CRM_Core_Page {
           CRM_Core_DAO::storeValues($object, $values[$object->id]);
 
           if (is_a($object, 'CRM_Contact_DAO_RelationshipType')) {
+            $values[$object->id]['contact_type_a_display'] = $values[$object->id]['contact_type_b_display'] = '';
             if (isset($values[$object->id]['contact_type_a'])) {
               $values[$object->id]['contact_type_a_display'] = $contactTypes[$values[$object->id]['contact_type_a']];
             }


### PR DESCRIPTION
Overview
----------------------------------------
followup to https://github.com/civicrm/civicrm-core/pull/33725. The problem was there before but it's more obvious now since now there's a stock type with All Contacts.

Before
----------------------------------------
If you have any relationship types that are for All Contacts, then the screen at civicrm/admin/reltype?reset=1 has a bunch of warnings about contact_type_a_display etc.

After
----------------------------------------


Technical Details
----------------------------------------
All Contacts is internally stored as null, so it was skipping over setting a display value.

Comments
----------------------------------------

