### PR TITLE
Cleanup - remove extra require_once statements

### DIFF
--- a/CRM/Admin/Page/ExtensionsUpgrade.php
+++ b/CRM/Admin/Page/ExtensionsUpgrade.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'CRM/Core/Page.php';
-
 /**
  * Display a page which displays a progress bar while executing
  * upgrade tasks.

--- a/CRM/Core/Smarty/plugins/block.crmRegion.php
+++ b/CRM/Core/Smarty/plugins/block.crmRegion.php
@@ -20,7 +20,6 @@ function smarty_block_crmRegion($params, $content, &$smarty, &$repeat) {
   if ($repeat) {
     return NULL;
   }
-  require_once 'CRM/Core/Region.php';
   $region = CRM_Core_Region::instance($params['name'], FALSE);
   if ($region) {
     $result = $region->render($content, $params['allowCmsOverride'] ?? TRUE);

--- a/CRM/Queue/Page/Runner.php
+++ b/CRM/Queue/Page/Runner.php
@@ -9,9 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-
-require_once 'CRM/Core/Page.php';
-
 /**
  * The queue-runner page provides an interactive, web-based system
  * running the tasks in a queue and monitoring its progression.

--- a/CRM/UF/Page/ProfileEditor.php
+++ b/CRM/UF/Page/ProfileEditor.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once 'CRM/Core/Page.php';
-
 /**
  * This class is not a real page -- it contains helpers for rendering the profile-selector and profile-editor
  * widgets


### PR DESCRIPTION
Overview
----------------------------------------
Pretty sure these are all leftover from the bad ol days when we didn't have class loading.