### PR TITLE
Setup - Install FormBuilder by default

### DIFF
--- a/setup/plugins/init/DefaultExtensions.civi-setup.php
+++ b/setup/plugins/init/DefaultExtensions.civi-setup.php
@@ -19,6 +19,7 @@ if (!defined('CIVI_SETUP')) {
 
     $e->getModel()->extensions[] = 'org.civicrm.search_kit';
     $e->getModel()->extensions[] = 'org.civicrm.afform';
+    $e->getModel()->extensions[] = 'org.civicrm.afform_admin';
     $e->getModel()->extensions[] = 'authx';
     $e->getModel()->extensions[] = 'civiimport';
     $e->getModel()->extensions[] = 'message_admin';


### PR DESCRIPTION
Overview
----------------------------------------
On demo sites and new installs, people often get confused by the missing FormBuilder extension. This adds it.