### PR TITLE
Remove double error alert on searchkit batch runner. Make runMsg/successMsg/errorMsg optional

### DIFF
--- a/ext/civi_case/ang/civiCaseTasks/civiCaseTaskCaseRole.html
+++ b/ext/civi_case/ang/civiCaseTasks/civiCaseTaskCaseRole.html
@@ -28,7 +28,7 @@
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Adding roles...') }}</h5>
-      <crm-search-batch-runner entity="'CaseContact'" action="get" params="$ctrl.run" ids="$ctrl.ids" id-field="case_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'CaseContact'" action="get" params="$ctrl.run" ids="$ctrl.ids" id-field="case_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)" ></crm-search-batch-runner>
     </div>
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
     <crm-dialog-button text="ts('Save')" icons="{primary: 'fa-user-plus'}" on-click="$ctrl.submit()" disabled="$ctrl.run || $ctrl.existingCount === null || !civiCaseTaskCaseRoleForm.$valid" />

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -97,8 +97,7 @@
               runBatch();
             }
           }, function(error) {
-            CRM.alert(error.error_message, ts('Error'), 'error');
-            ctrl.error();
+            ctrl.error({error: error});
           });
         // Move the bar every second to simulate progress between batches
         incrementer = $interval(function(i) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -39,13 +39,15 @@
       if (result.action === 'inlineEdit') {
         CRM.status(ts('Saved'));
       } else {
-        CRM.alert(ts(ctrl.apiBatch.successMsg, {1: result.batchCount, 2: entityTitle}), ts('%1 Complete', {1: ctrl.task.title}), 'success');
+        if (ctrl.apiBatch.successMsg) {
+          CRM.alert(ts(ctrl.apiBatch.successMsg, { 1: result.batchCount, 2: entityTitle }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
+        }
       }
       this.close(result);
     };
 
-    this.onError = function() {
-      CRM.alert(ts(ctrl.apiBatch.errorMsg, {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Error'), 'error');
+    this.onError = function(error) {
+      CRM.alert(ts(ctrl.apiBatch.errorMsg || error.error_message || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Error'), 'error');
       this.cancel();
     };
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.html
@@ -6,8 +6,8 @@
     </div>
     <hr />
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
-      <h5>{{:: ts(apiBatch.runMsg, {1: $ctrl.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="$ctrl.entity" action="{{:: apiBatch.action }}" params="$ctrl.run" ids="$ctrl.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}" display-ctrl="$ctrl.displayCtrl" is-link="$ctrl.isLink"></crm-search-batch-runner>
+      <h5 ng-if="apiBatch.runMsg">{{:: ts(apiBatch.runMsg, {1: $ctrl.ids.length, 2: $ctrl.entityTitle}) }}</h5>
+      <crm-search-batch-runner entity="$ctrl.entity" action="{{:: apiBatch.action }}" params="$ctrl.run" ids="$ctrl.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}" display-ctrl="$ctrl.displayCtrl" is-link="$ctrl.isLink"></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.ctrl.js
@@ -67,7 +67,7 @@
       window.location = CRM.url('civicrm/a#/mailing/' + mailingId);
     };
 
-    this.onError = function() {
+    this.onError = function(error) {
       CRM.alert(ts('An error occurred while attempting to create mailing.'), ts('Error'), 'error');
       this.cancel();
     };

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskMailing.html
@@ -30,11 +30,11 @@
     </div>
     <div ng-if="$ctrl.run && !$ctrl.addContacts" class="crm-search-task-progress">
       <h5>{{:: ts('Creating mailing...') }}</h5>
-      <crm-search-batch-runner entity="'Group'" action="create" params="$ctrl.run" success="$ctrl.afterGroupCreate(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'Group'" action="create" params="$ctrl.run" success="$ctrl.afterGroupCreate(result)" error="$ctrl.onError(error)" ></crm-search-batch-runner>
     </div>
     <div ng-if="$ctrl.addContacts" class="crm-search-task-progress">
       <h5>{{:: ts('Adding contacts...') }}</h5>
-      <crm-search-batch-runner entity="'GroupContact'" action="save" params="$ctrl.addContacts" ids="$ctrl.ids" id-field="contact_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'GroupContact'" action="save" params="$ctrl.addContacts" ids="$ctrl.ids" id-field="contact_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)" ></crm-search-batch-runner>
     </div>
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
     <crm-dialog-button text="ts('Create Mailing')" icons="{primary: 'fa-paper-plane'}" on-click="$ctrl.submit()" disabled="!$ctrl.recipientCount || $ctrl.run || !crmSearchTaskMailingForm.$valid" />

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.html
@@ -13,7 +13,7 @@
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Adding relationships...') }}</h5>
-      <crm-search-batch-runner entity="'Relationship'" action="save" params="$ctrl.run" ids="$ctrl.ids" id-field="{{:: $ctrl.idField }}" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'Relationship'" action="save" params="$ctrl.run" ids="$ctrl.ids" id-field="{{:: $ctrl.idField }}" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)" ></crm-search-batch-runner>
     </div>
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run || !$ctrl.relationshipFields" />
     <crm-dialog-button text="ts('Save')" icons="{primary: 'fa-user-plus'}" on-click="$ctrl.submit()" disabled="$ctrl.run || !crmSearchTaskRelationshipForm.$valid" />

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
@@ -103,7 +103,7 @@
       this.close();
     };
 
-    this.onError = function() {
+    this.onError = function(error) {
       CRM.alert(ts('An error occurred while updating tags.'), ts('Error'), 'error');
       this.cancel();
     };

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.html
@@ -40,7 +40,7 @@
     </fieldset>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: $ctrl.action === 'save' ? ts('Adding tags...') : ts('Removing tags...') }}</h5>
-      <crm-search-batch-runner entity="'EntityTag'" action="{{ $ctrl.action }}" id-field="entity_id" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+      <crm-search-batch-runner entity="'EntityTag'" action="{{ $ctrl.action }}" id-field="entity_id" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)" ></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.ctrl.js
@@ -80,7 +80,7 @@
       this.close();
     };
 
-    this.onError = function() {
+    this.onError = function(error) {
       CRM.alert(ts('An error occurred while attempting to update %1 %2.', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Error'), 'error');
       this.cancel();
     };

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskUpdate.html
@@ -10,7 +10,7 @@
     </div>
     <div ng-if="$ctrl.run" class="crm-search-task-progress">
       <h5>{{:: ts('Updating %1 %2...', {1: model.ids.length, 2: $ctrl.entityTitle}) }}</h5>
-      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess()" error="$ctrl.onError()" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}"></crm-search-batch-runner>
+      <crm-search-batch-runner entity="model.entity" action="update" params="$ctrl.run" ids="model.ids" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)" id-field="{{:: $ctrl.entityInfo.primary_key[0] }}"></crm-search-batch-runner>
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" ></crm-dialog-button>


### PR DESCRIPTION
Overview
----------------------------------------
For a SearchKit searchtask we have `onSuccess` and `onError` handlers. For onSuccess the result (of the API call) was being passed through and could be used. For the onError the result (error message etc.) was not being passed through so we could not use it (eg. to display a custom error message containing the actual error..).

For the batch task a CRM.alert was being displayed twice. Once with the actual error and again with the configured "errorMsg" in the task. Now it is displayed only once, with the configured "errorMsg" or the API error message.

We make `successMsg`, `runMsg` and `errorMsg` optional in the task configuration:
- successMsg: If not set, a CRM.alert will not be displayed and the batch dialog will just close.
- runMsg: If not set, no message will be displayed above the progress bar on the batch dialog.
- errorMsg: If not set, the API error message will be displayed if available, otherwise just "Error".
 

Before
----------------------------------------
Unfriendly and limited config on the batch task UI.

After
----------------------------------------
More friendly and more configurable.

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw as we discussed on the call this attempts to make the batch runner a bit more friendly and configurable.
