### PR TITLE
Filter out unrecognised entity types when doing Managed Entity reconciliation

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -259,7 +259,7 @@ class CRM_Core_ManagedEntities {
     }
     // APIv3
     else {
-      $result = civicrm_api($item['entity_type'], 'create', $params);
+      $result = civicrm_api3($item['entity_type'], 'create', $params);
       if (!empty($result['is_error'])) {
         $this->onApiError($item['module'], $item['name'], 'create', $result['error_message']);
         return;

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -76,6 +76,8 @@ class CRM_Core_ManagedEntities {
   public function reconcile($modules = NULL) {
     $modules = $modules ? (array) $modules : NULL;
     $declarations = $this->getDeclarations($modules);
+    // remove declarations for entities we dont recognise
+    $declarations = $this->filterUnrecognisedEntities($declarations);
     $plan = $this->createPlan($declarations, $modules);
     if (!CRM_Core_Config::isUpgradeMode()) {
       $plan = $this->optimizePlan($plan);
@@ -173,6 +175,19 @@ class CRM_Core_ManagedEntities {
    */
   private function filterPlanByAction(array $plan, string $action): array {
     return CRM_Utils_Array::findAll($plan, ['managed_action' => $action]);
+  }
+
+  /**
+   * Filter out declarations for entities we dont recognise
+   *
+   * This is useful during upgrade mode, when extension entities are not available.
+   *
+   * @param array[] $declarations
+   *
+   * @return array
+   */
+  private function filterUnrecognisedEntities(array $declarations): array {
+    return array_filter($declarations, fn ($declaration) => CoreUtil::entityExists($declaration['entity']));
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
- Managed Entity complains a lot about SearchDisplays during upgrade mode, because core provides various managed records for SearchDisplays, but the SearchDisplay entity isn't available (because extensions including `search_kit` are turned down by the display policy)

After
----------------------------------------
- unrecognised entities are filtered out. less reliance on try/catch

Technical Details
----------------------------------------
Possibly should be restricted based on the version param in the Managed Record?