### PR TITLE
Fix WordPress frontend always returning http 200

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -28,11 +28,11 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
     if (\CRM_Utils_System::isMaintenanceMode() && ($this->urlPath[3] ?? NULL) !== 'User') {
       if (!CRM_Core_Permission::check([['administer CiviCRM system', 'cms:bypass maintenance mode']])) {
         // HTTP 503 Service Unavailable
-        $this->httpResponseCode = 503;
-        $this->returnJSON([
+        CRM_Utils_System::sendJSONResponse([
           'status_code' => 503,
           'status_message' => 'Temporarily unavailable for maintenance.',
-        ]);
+        ],
+        503);
         return;
       }
     }
@@ -46,7 +46,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
     // First check for problems with the request
     $error = $this->checkRequestMethod();
     if ($error) {
-      $this->returnJSON($error);
+      CRM_Utils_System::sendJSONResponse($error, $this->httpResponseCode);
     }
 
     // Two call formats. Which one was used? Note: CRM_Api4_Permission::check() and CRM_Api4_Page_AJAX::run() should have matching conditionals.
@@ -68,7 +68,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       $response = $this->execute($entity, $action, $params, $index);
     }
 
-    $this->returnJSON($response);
+    CRM_Utils_System::sendJSONResponse($response, $this->httpResponseCode);
   }
 
   /**
@@ -181,19 +181,6 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       $response['status'] = $status;
     }
     return $response;
-  }
-
-  /**
-   * Output JSON response to the client
-   *
-   * @param array $response
-   * @return void
-   */
-  private function returnJSON(array $response): void {
-    http_response_code($this->httpResponseCode);
-    CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
-    echo json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-    CRM_Utils_System::civiExit();
   }
 
 }

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1965,6 +1965,18 @@ class CRM_Utils_System {
     self::sendResponse(new Response(200, [], $message));
   }
 
+  /**
+   * Output JSON response to the client
+   *
+   * @param array $response
+   * @param int $httpResponseCode
+   *
+   * @return void
+   */
+  public static function sendJSONResponse(array $response, int $httpResponseCode): void {
+    CRM_Core_Config::singleton()->userSystem->sendJSONResponse($response, $httpResponseCode);
+  }
+
   public static function isMaintenanceMode(): bool {
     try {
       $civicrmSetting = \Civi::settings()->get('core_maintenance_mode');

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1048,6 +1048,21 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Output JSON response to the client
+   *
+   * @param array $response
+   * @param int $httpResponseCode
+   *
+   * @return void
+   */
+  public static function sendJSONResponse(array $response, int $httpResponseCode): void {
+    http_response_code($httpResponseCode);
+    CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
+    echo json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    CRM_Utils_System::civiExit();
+  }
+
+  /**
    * Start a new session.
    */
   public function sessionStart() {

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1313,6 +1313,18 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
+   * Output JSON response to the client
+   *
+   * @param array $response
+   * @param int $httpResponseCode
+   *
+   * @return void
+   */
+  public static function sendJSONResponse(array $response, int $httpResponseCode): void {
+    wp_send_json($response, $httpResponseCode);
+  }
+
+  /**
    * Start a new session if there's no existing session ID.
    *
    * Checks are needed to prevent sessions being started when not necessary.


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a longstanding ajax bug where http status codes were not returned correctly in Wordpress.

Before
----------------------------------------
HTTP 200 always returned, even on error. You have to check for existence of eg. "error_message" in the response to handle the error.

After
----------------------------------------
The actual HTTP response code is returned. You can rely on standard success/error handlers to trigger!

Technical Details
----------------------------------------
On WordPress frontend CiviCRM API calls always return HTTP status code = 200 even when they fail / should return an http error code. Calling http_response_code() has no effect but you can inspect the result and see that the contents of the response contains error_message, status. You can reproduce this by throwing an exception in any API call that is called from the frontend.

Solution, as suggested by @christianwach is to use a wordpress-native function that sets the status code for us. This adds delegation to CRM_Utils_System to allow for CMS-specific handing of json output.

Note that we worked around this same issue in the Stripe extension back in 2023: https://lab.civicrm.org/extensions/stripe/-/commit/c8510cb219688416ac6e796440d70c728e9d29c9
