### PR TITLE
Api4 Explorer - Fix cli formatting

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1068,16 +1068,11 @@
     // Format string to be cli-input-safe
     function cliFormat(str) {
       str = str.replace(/\b(true|false)\b/g, match => match === "true" ? '1' : '0');
-      if (!_.includes(str, ' ') && !_.includes(str, '"') && !_.includes(str, "'")) {
+      const safeCliPattern = /^[a-zA-Z0-9_\-\.\/]+$/;
+      if (safeCliPattern.test(str)) {
         return str;
       }
-      if (!_.includes(str, "'")) {
-        return "'" + str + "'";
-      }
-      if (!_.includes(str, '"')) {
-        return '"' + str + '"';
-      }
-      return "'" + str.replace(/'/g, "\\'") + "'";
+      return "'" + str.replace(/'/g, "'\\''") + "'";
     }
 
     function fetchMeta() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes Api4 Explorer output in the CLI tab.

Technical Details
----------------------------------------
Single quotes need to be escaped in cli with concatenation. Double-quotes aren't safe to surround a string.
