### PR TITLE
allow option to not create civicrm.settings.php on install

### DIFF
--- a/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
@@ -86,7 +86,7 @@ if (!defined('CIVI_SETUP')) {
     );
     $str = \Civi\Setup\SettingsUtil::evaluate($tplPath, $params);
 
-    if (!$m->getField('doNotCreateSettingsFile', 'value')) {
+    if (!$m->doNotCreateSettingsFile) {
       file_put_contents($m->settingsPath, $str);
     }
 

--- a/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallSettingsFile.civi-setup.php
@@ -85,6 +85,9 @@ if (!defined('CIVI_SETUP')) {
       [$m->srcPath, 'templates', 'CRM', 'common', 'civicrm.settings.php.template']
     );
     $str = \Civi\Setup\SettingsUtil::evaluate($tplPath, $params);
-    file_put_contents($m->settingsPath, $str);
+
+    if (!$m->getField('doNotCreateSettingsFile', 'value')) {
+      file_put_contents($m->settingsPath, $str);
+    }
 
   }, \Civi\Setup::PRIORITY_LATE);

--- a/setup/src/Setup.php
+++ b/setup/src/Setup.php
@@ -197,25 +197,16 @@ class Setup {
   /**
    * Create the settings file.
    *
-   * @param bool $create
-   *   Flag to create civicrm.settings.php
-   *
    * @return \Civi\Setup\Event\InstallFilesEvent
    */
-  public function installFiles($create = TRUE) {
+  public function installFiles() {
     if ($this->pendingAction !== NULL) {
       throw new InitException(sprintf("Cannot begin action %s. Already executing %s.", __FUNCTION__, $this->pendingAction));
     }
     $this->pendingAction = __FUNCTION__;
 
     try {
-      $model = $this->getModel();
-      $model->addField([
-        'name' => 'doNotCreateSettingsFile',
-        'type' => 'bool',
-        'value' => !$create,
-      ]);
-      $event = new InstallFilesEvent($model);
+      $event = new InstallFilesEvent($this->getModel());
       return $this->getDispatcher()->dispatch('civi.setup.installFiles', $event);
     }
     finally {

--- a/setup/src/Setup.php
+++ b/setup/src/Setup.php
@@ -197,16 +197,25 @@ class Setup {
   /**
    * Create the settings file.
    *
+   * @param bool $create
+   *   Flag to create civicrm.settings.php
+   *
    * @return \Civi\Setup\Event\InstallFilesEvent
    */
-  public function installFiles() {
+  public function installFiles($create = TRUE) {
     if ($this->pendingAction !== NULL) {
       throw new InitException(sprintf("Cannot begin action %s. Already executing %s.", __FUNCTION__, $this->pendingAction));
     }
     $this->pendingAction = __FUNCTION__;
 
     try {
-      $event = new InstallFilesEvent($this->getModel());
+      $model = $this->getModel();
+      $model->addField([
+        'name' => 'doNotCreateSettingsFile',
+        'type' => 'bool',
+        'value' => !$create,
+      ]);
+      $event = new InstallFilesEvent($model);
       return $this->getDispatcher()->dispatch('civi.setup.installFiles', $event);
     }
     finally {

--- a/setup/src/Setup/Model.php
+++ b/setup/src/Setup/Model.php
@@ -69,6 +69,10 @@ namespace Civi\Setup;
  *   Open-ended list translations files which should be downloaded. Each entry is a url of an mo-file.
  *   Provide each entry with en_US langugae code. That code will be replaced with the actual language.
  *   The default is: ['https://download.civicrm.org/civicrm-l10n-core/mo/en_US/civicrm.mo']
+ * @property bool $doNotCreateSettingsFile
+ *   Flag to skip creation of civicrm.settings.php on install.
+ *   Set to TRUE if you want to NOT create civicrm.settings.php on install.
+ *   The default is FALSE, create settings file on install.
  */
 class Model {
 
@@ -192,6 +196,12 @@ class Model {
         'civicrm.mo' => 'https://download.civicrm.org/civicrm-l10n-core/mo/[locale]/civicrm.mo',
       ),
     ));
+    $this->addField([
+      'description' => 'Option for installation process to skip creation of civicrm.settings.php',
+      'name' => 'doNotCreateSettingsFile',
+      'type' => 'bool',
+      'value' => FALSE,
+    ]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
To install CiviCRM into Drupal 10+ the civicrm.settings.php file must not be present. It throws an exception and breaks the site if you install CiviCRM and the civicrm.settings.php is present

To include a civicrm.settings.php in a repository used for automating site creation, sometime we want to use a civicrm.settings.php.


Before
----------------------------------------
 It throws an exception and breaks the site if you install CiviCRM and the civicrm.settings.php is present


After
----------------------------------------
CiviCRM is installed and uses the civicrm.settings.php that is there.

Developed in conjunction with https://github.com/civicrm/civicrm-drupal-8/pull/115
