### PR TITLE
If Sweetalert is available use it instead of browser alert

### DIFF
--- a/js/Common.js
+++ b/js/Common.js
@@ -1498,11 +1498,20 @@ if (!CRM.vars) CRM.vars = {};
       return $('#crm-notification-container').notify('create', params, options);
     }
     else {
-      if (title.length) {
-        text = title + "\n" + text;
+      if (typeof Swal === 'function') {
+        Swal.fire({
+          icon: type,
+          text: text || '',
+          title: title || '',
+        });
       }
-      // strip html tags as they are not parsed in standard alerts
-      alert($("<div/>").html(text).text());
+      else {
+        if (title.length) {
+          text = title + "\n" + text;
+        }
+        // strip html tags as they are not parsed in standard alerts
+        alert($("<div/>").html(text).text());
+      }
       return null;
     }
   };


### PR DESCRIPTION
Overview
----------------------------------------
Use Sweetalert for CRM.alert on frontend if available instead of browser "alert".

Before
----------------------------------------
Ugly browser-based "alert":

<img width="509" height="222" alt="image" src="https://github.com/user-attachments/assets/4b0954a5-bdad-4abb-b254-3f46e74da446" />

After
----------------------------------------
Nicer, sweetalert "alert":

<img width="534" height="344" alt="image" src="https://github.com/user-attachments/assets/77b9287f-65a4-4946-b6f8-17bee51ba825" />

<img width="546" height="351" alt="image" src="https://github.com/user-attachments/assets/5b68db64-314d-4dfd-8e70-ab9f7cb0d4a6" />


Technical Details
----------------------------------------
This just checks for existence of "Swal" function and uses it if available. So no extra dependencies but if you install sweetalert extension it will use Sweetalert for all "CRM.alert" notifications on the frontend (on the backend they are handled by the standard CiviCRM notification boxes that appear in the top right.

Comments
----------------------------------------
Might be nice to put Sweetalert into core at some point.