### PR TITLE
SearchKit admin - accordions, use Civi accordion pattern/class and body wrapper

### DIFF
--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -13,6 +13,9 @@
   border-radius: var(--crm-expand-radius);
   padding: var(--crm-expand-header-padding);
 }
+.crm-container details .crm-accordion-body {
+  padding: var(--crm-expand-body-padding);
+}
 .crm-container details[open] > summary { /* open version of that */
   border-radius: var(--crm-expand-radius) var(--crm-expand-radius) 0 0;
 }

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -203,33 +203,21 @@
   padding: 0;
   border: 0 solid transparent;
 }
-.crm-search-admin-edit-columns fieldset.crm-draggable:has(> details) { /* targetted to cetaild because SK Tokens extension shares classname */
+.crm-search-admin-edit-columns fieldset.crm-draggable:has(> details) { /* targetted to details because other layouts share classnmae */
   display: grid;
-  grid-template-columns: 2ch auto;
-  align-items: center;
-}
-.crm-search-admin-edit-columns fieldset.crm-draggable:has(details[open]) {
-  align-items: start;
+  grid-template-columns: 2.5ch auto;
 }
 #bootstrap-theme .crm-search-admin-edit-columns fieldset.crm-draggable .btn.btn-xs.pull-right {
-  line-height: 1.45rem;
-  display: block;
   z-index: 1;
   position: absolute;
-  right: calc(4 * var(--crm-padding-small)); /* aligns button relative to stream padding */
+  right: 0;
+  top: var(--crm-xs1);
+  margin: var(--crm-expand-header-padding);
 }
-i.crm-i.crm-search-move-icon {
+#bootstrap-theme .crm-search-admin-edit-columns i.crm-i.crm-search-move-icon {
   opacity: .5;
-}
-.crm-draggable details > *,
-.crm-draggable details > .form-inline {
-  padding-inline: var(--crm-expand-body-padding);
-}
-.crm-draggable details > div:first-of-type {
-  padding-top: var(--crm-expand-body-padding);
-}
-.crm-draggable details > div:last-of-type {
-  padding-bottom: var(--crm-expand-body-padding);
+  padding: var(--crm-expand-header-padding);
+  justify-self: center;
 }
 #bootstrap-theme .crm-search-admin-edit-columns .input-group-btn {
   display: flex;
@@ -254,11 +242,6 @@ i.crm-i.crm-search-move-icon {
   position: relative;
   display: block;
 }
-.crm-search .crm-search-admin-relative details > summary {
-  background: var(--crm-expand-header2-bg);
-  color: var(--crm-expand-header2-color);
-  padding: var(--crm-padding-small) var(--crm-padding-reg);
-}
 .crm-search crm-search-admin-link-group {
   background: var(--crm-c-background2);
 }
@@ -271,17 +254,10 @@ i.crm-i.crm-search-move-icon {
   padding: 0;
   border: 0 solid transparent;
 }
-.crm-search-admin-edit-columns details,
-.crm-search .crm-search-admin-relative details {
+.crm-search-admin-edit-columns details {
   background-color: var(--crm-c-page-background);
-  border-radius: var(--crm-roundness);
+  margin: 0;
   border: 0;
-}
-.crm-search-admin-edit-columns details > summary {
-  background: var(--crm-expand-header2-bg);
-  color: var(--crm-expand-header2-color);
-  padding: var(--crm-padding-reg);
-  font-size: inherit;
 }
 /* Various */
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.html
@@ -8,29 +8,33 @@
   </div>
 </fieldset>
 
-<details>
+<details class="crm-accordion-bold">
   <summary>{{:: ts('Style') }}</summary>
-  <div class="form-inline">
-    <label>{{:: ts('Table Style') }}</label>
-    <div class="checkbox-inline form-control" ng-repeat="style in $ctrl.parent.tableClasses">
-      <label>
-        <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.parent.toggle($ctrl.display.settings.classes, style.name)">
-        <span>{{:: style.label }}</span>
-      </label>
+  <div class="crm-accordion-body">
+    <div class="form-inline">
+      <label>{{:: ts('Table Style') }}</label>
+      <div class="checkbox-inline form-control" ng-repeat="style in $ctrl.parent.tableClasses">
+        <label>
+          <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.parent.toggle($ctrl.display.settings.classes, style.name)">
+          <span>{{:: style.label }}</span>
+        </label>
+      </div>
     </div>
   </div>
 </details>
 
 
-<details>
+<details class="crm-accordion-bold">
   <summary>{{:: ts('Footer') }}</summary>
-  <search-admin-pager-config display="$ctrl.display" no-limit="true"></search-admin-pager-config>
-  <div class="form-inline">
-    <div class="checkbox-inline form-control" title="{{:: ts('Shows grand totals or other statistics, configured per-column.') }}">
-      <label>
-        <input type="checkbox" ng-click="$ctrl.toggleTally()" ng-checked="!!$ctrl.display.settings.tally">
-        <span>{{:: ts('Show Totals in Footer') }}</span>
-      </label>
+  <div class="crm-accordion-body">
+    <search-admin-pager-config display="$ctrl.display" no-limit="true"></search-admin-pager-config>
+    <div class="form-inline">
+      <div class="checkbox-inline form-control" title="{{:: ts('Shows grand totals or other statistics, configured per-column.') }}">
+        <label>
+          <input type="checkbox" ng-click="$ctrl.toggleTally()" ng-checked="!!$ctrl.display.settings.tally">
+          <span>{{:: ts('Show Totals in Footer') }}</span>
+        </label>
+      </div>
     </div>
   </div>
 </details>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
@@ -1,26 +1,28 @@
 <div ng-include="'~/crmSearchAdmin/crmSearchAdminDisplayHeader.html'"></div>
-<details>
+<details class="crm-accordion-bold">
   <summary>{{:: ts('Settings') }}</summary>
-  <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
-  <fieldset>
-    <div class="form-inline">
-      <label for="crm-search-admin-display-colno">{{:: ts('Layout') }}</label>
-      <select id="crm-search-admin-display-colno" class="form-control" ng-model="$ctrl.display.settings.colno">
-        <option value="2">{{:: ts('2 x 2') }}</option>
-        <option value="3">{{:: ts('3 x 3') }}</option>
-        <option value="4">{{:: ts('4 x 4') }}</option>
-        <option value="5">{{:: ts('5 x 5') }}</option>
-      </select>
-      <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
-    </div>
-    <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if there are no results.') }}">
-      <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-      <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-    </div>
-    <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
-    <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
-    <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
-  </fieldset>
+  <div class="crm-accordion-body">
+    <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
+    <fieldset>
+      <div class="form-inline">
+        <label for="crm-search-admin-display-colno">{{:: ts('Layout') }}</label>
+        <select id="crm-search-admin-display-colno" class="form-control" ng-model="$ctrl.display.settings.colno">
+          <option value="2">{{:: ts('2 x 2') }}</option>
+          <option value="3">{{:: ts('3 x 3') }}</option>
+          <option value="4">{{:: ts('4 x 4') }}</option>
+          <option value="5">{{:: ts('5 x 5') }}</option>
+        </select>
+        <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+      </div>
+      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if there are no results.') }}">
+        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+      </div>
+      <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+      <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
+      <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
+    </fieldset>
+  </div>
 </details>
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>
@@ -35,32 +37,34 @@
       </button>
       <details>
         <summary> {{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline">
-          <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
-            <input type="checkbox" ng-model="col.break">
-            {{:: ts('New Line') }}
-          </label>
-          &nbsp;
-          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
-            <input type="checkbox" ng-model="col.nowrap" >
-            {{:: ts('Prevent Wrapping') }}
-          </label>
-        </div>
-        <div class="form-inline crm-search-admin-flex-row">
-          <label>
-            <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getColLabel(col)" >
-            {{:: ts('Label') }}
-          </label>
-          <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
-          <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
-        </div>
-        <div class="form-inline" ng-if="col.label">
-          <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->
-          <div class="checkbox">
-            <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
+        <div class="crm-accordion-body">
+          <div class="form-inline">
+            <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
+              <input type="checkbox" ng-model="col.break">
+              {{:: ts('New Line') }}
+            </label>
+            &nbsp;
+            <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+              <input type="checkbox" ng-model="col.nowrap" >
+              {{:: ts('Prevent Wrapping') }}
+            </label>
           </div>
+          <div class="form-inline crm-search-admin-flex-row">
+            <label>
+              <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getColLabel(col)" >
+              {{:: ts('Label') }}
+            </label>
+            <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
+            <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
+          </div>
+          <div class="form-inline" ng-if="col.label">
+            <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->
+            <div class="checkbox">
+              <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
+            </div>
+          </div>
+          <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
         </div>
-        <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
       </details>
     </fieldset>
   </fieldset>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -1,36 +1,38 @@
 <div ng-include="'~/crmSearchAdmin/crmSearchAdminDisplayHeader.html'"></div>
-<details>
+<details class="crm-accordion-bold">
   <summary>{{:: ts('Settings') }}</summary>
-  <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
-  <fieldset>
-    <div class="form-inline">
-      <label for="crm-search-admin-display-style">{{:: ts('Style') }}</label>
-      <select id="crm-search-admin-display-style" class="form-control" ng-model="$ctrl.display.settings.style" ng-change="$ctrl.display.settings.symbol = ''">
-        <option value="ul">{{:: ts('Bullets') }}</option>
-        <option value="ol">{{:: ts('Numbers') }}</option>
-      </select>
-      <label for="crm-search-admin-display-symbol">{{:: ts('Symbol') }}</label>
-      <select id="crm-search-admin-display-symbol" class="form-control" ng-model="$ctrl.display.settings.symbol">
-        <option ng-repeat="symbol in $ctrl.symbols[$ctrl.display.settings.style]" value="{{ symbol.char }}">
-          {{ symbol.label }}
-        </option>
-      </select>
-    </div>
-  </fieldset>
-  <fieldset>
-    <div class="form-inline crm-search-admin-flex-row" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
-    <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if no results.') }}">
-      <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-      <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-    </div>
-  </fieldset>
-  <fieldset>
-    <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
-    <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
-  </fieldset>
-  <fieldset>
-    <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
-  </fieldset>
+  <div class="crm-accordion-body">
+    <fieldset ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
+    <fieldset>
+      <div class="form-inline">
+        <label for="crm-search-admin-display-style">{{:: ts('Style') }}</label>
+        <select id="crm-search-admin-display-style" class="form-control" ng-model="$ctrl.display.settings.style" ng-change="$ctrl.display.settings.symbol = ''">
+          <option value="ul">{{:: ts('Bullets') }}</option>
+          <option value="ol">{{:: ts('Numbers') }}</option>
+        </select>
+        <label for="crm-search-admin-display-symbol">{{:: ts('Symbol') }}</label>
+        <select id="crm-search-admin-display-symbol" class="form-control" ng-model="$ctrl.display.settings.symbol">
+          <option ng-repeat="symbol in $ctrl.symbols[$ctrl.display.settings.style]" value="{{ symbol.char }}">
+            {{ symbol.label }}
+          </option>
+        </select>
+      </div>
+    </fieldset>
+    <fieldset>
+      <div class="form-inline crm-search-admin-flex-row" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if no results.') }}">
+        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+      </div>
+    </fieldset>
+    <fieldset>
+      <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+      <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
+    </fieldset>
+    <fieldset>
+      <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
+    </fieldset>
+  </div>
 </details>
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>
@@ -45,32 +47,34 @@
       </button>
       <details>
         <summary>{{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline">
-          <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
-            <input type="checkbox" ng-model="col.break">
-            {{:: ts('New Line') }}
-          </label>
-          &nbsp;
-          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
-            <input type="checkbox" ng-model="col.nowrap" >
-            {{:: ts('Prevent Wrapping') }}
-          </label>
-        </div>
-        <div class="form-inline crm-search-admin-flex-row">
-          <label>
-            <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getColLabel(col)" >
-            {{:: ts('Label') }}
-          </label>
-          <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
-          <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
-        </div>
-        <div class="form-inline" ng-if="col.label">
-          <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->
-          <div class="checkbox">
-            <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
+        <div class="crm-accordion-body">
+          <div class="form-inline">
+            <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
+              <input type="checkbox" ng-model="col.break">
+              {{:: ts('New Line') }}
+            </label>
+            &nbsp;
+            <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+              <input type="checkbox" ng-model="col.nowrap" >
+              {{:: ts('Prevent Wrapping') }}
+            </label>
           </div>
+          <div class="form-inline crm-search-admin-flex-row">
+            <label>
+              <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getColLabel(col)" >
+              {{:: ts('Label') }}
+            </label>
+            <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
+            <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
+          </div>
+          <div class="form-inline" ng-if="col.label">
+            <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->
+            <div class="checkbox">
+              <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
+            </div>
+          </div>
+          <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
         </div>
-        <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
       </details>
     </fieldset>
   </fieldset>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -2,103 +2,113 @@
 <fieldset>
   <legend>{{:: ts('Display Settings') }}</legend>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Sorting') }}</summary>
-    <div ng-if="$ctrl.sortableEntity" class="form-inline">
-      <div class="checkbox-inline form-control">
-        <label>
-          <input type="checkbox" ng-checked="!!$ctrl.display.settings.draggable" ng-click="$ctrl.parent.toggleDraggable()">
-          <span>{{:: ts('Drag and drop sorting') }}</span>
-        </label>
+    <div class="crm-accordion-body">
+      <div ng-if="$ctrl.sortableEntity" class="form-inline">
+        <div class="checkbox-inline form-control">
+          <label>
+            <input type="checkbox" ng-checked="!!$ctrl.display.settings.draggable" ng-click="$ctrl.parent.toggleDraggable()">
+            <span>{{:: ts('Drag and drop sorting') }}</span>
+          </label>
+        </div>
       </div>
-    </div>
-    <fieldset ng-if="!$ctrl.display.settings.draggable" ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
-    <div ng-if="$ctrl.hierarchicalEntity" class="form-inline">
-      <div class="checkbox-inline form-control">
-        <label>
-          <input type="checkbox" ng-model="$ctrl.display.settings.hierarchical">
-          <span>{{:: ts('Show nested hierarchy') }}</span>
-        </label>
+      <fieldset ng-if="!$ctrl.display.settings.draggable" ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
+      <div ng-if="$ctrl.hierarchicalEntity" class="form-inline">
+        <div class="checkbox-inline form-control">
+          <label>
+            <input type="checkbox" ng-model="$ctrl.display.settings.hierarchical">
+            <span>{{:: ts('Show nested hierarchy') }}</span>
+          </label>
+        </div>
+        <select class="form-control" ng-if="$ctrl.display.settings.hierarchical" ng-model="$ctrl.display.settings.collapsible" title="{{:: ts('Should hierarchical tree be collapsible') }}">
+          <option value="">{{:: ts('Not collapsible') }}</option>
+          <option value="open">{{:: ts('Collapsible - Open') }}</option>
+          <option value="closed">{{:: ts('Collapsible - Closed') }}</option>
+        </select>
       </div>
-      <select class="form-control" ng-if="$ctrl.display.settings.hierarchical" ng-model="$ctrl.display.settings.collapsible" title="{{:: ts('Should hierarchical tree be collapsible') }}">
-        <option value="">{{:: ts('Not collapsible') }}</option>
-        <option value="open">{{:: ts('Collapsible - Open') }}</option>
-        <option value="closed">{{:: ts('Collapsible - Closed') }}</option>
-      </select>
     </div>
   </details>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Style') }}</summary>
-    <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
-    <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the table is empty.') }}">
-      <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-      <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-    </div>
-    <div class="form-inline">
-      <label>{{:: ts('Table Style') }}</label>
-      <div class="checkbox-inline form-control" ng-repeat="style in $ctrl.parent.tableClasses">
-        <label>
-          <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.parent.toggle($ctrl.display.settings.classes, style.name)">
-          <span>{{:: style.label }}</span>
-        </label>
+    <div class="crm-accordion-body">
+      <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
+      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the table is empty.') }}">
+        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
       </div>
+      <div class="form-inline">
+        <label>{{:: ts('Table Style') }}</label>
+        <div class="checkbox-inline form-control" ng-repeat="style in $ctrl.parent.tableClasses">
+          <label>
+            <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.parent.toggle($ctrl.display.settings.classes, style.name)">
+            <span>{{:: style.label }}</span>
+          </label>
+        </div>
+      </div>
+      <search-admin-css-rules label="{{:: ts('Row Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
     </div>
-    <search-admin-css-rules label="{{:: ts('Row Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
   </details>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Header') }}</summary>
-    <div class="form-inline">
-      <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+    <div class="crm-accordion-body">
+      <div class="form-inline">
+        <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+      </div>
+      <div class="form-inline">
+        <search-admin-tasks-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-tasks-config>
+      </div>
+      <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
     </div>
-    <div class="form-inline">
-      <search-admin-tasks-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-tasks-config>
-    </div>
-    <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
   </details>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Footer') }}</summary>
-    <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
-    <div class="form-inline">
-      <div class="checkbox-inline form-control" title="{{:: ts('Shows grand totals or other statistics, configured per-column.') }}">
-        <label>
-          <input type="checkbox" ng-click="$ctrl.toggleTally()" ng-checked="!!$ctrl.display.settings.tally">
-          <span>{{:: ts('Show Totals in Footer') }}</span>
-        </label>
-      </div>
-      <div class="form-group" ng-if="$ctrl.display.settings.tally">
-        <label for="crm-search-admin-table-tally-title">{{:: ts('Label') }}</label>
-        <input id="crm-search-admin-table-tally-title" ng-model="$ctrl.display.settings.tally.label" class="form-control">
+    <div class="crm-accordion-body">
+      <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
+      <div class="form-inline">
+        <div class="checkbox-inline form-control" title="{{:: ts('Shows grand totals or other statistics, configured per-column.') }}">
+          <label>
+            <input type="checkbox" ng-click="$ctrl.toggleTally()" ng-checked="!!$ctrl.display.settings.tally">
+            <span>{{:: ts('Show Totals in Footer') }}</span>
+          </label>
+        </div>
+        <div class="form-group" ng-if="$ctrl.display.settings.tally">
+          <label for="crm-search-admin-table-tally-title">{{:: ts('Label') }}</label>
+          <input id="crm-search-admin-table-tally-title" ng-model="$ctrl.display.settings.tally.label" class="form-control">
+        </div>
       </div>
     </div>
   </details>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('In-Place Edit') }}</summary>
-    <div class="form-inline">
-      <label class="radio-inline">
-        <input type="radio" ng-click="$ctrl.toggleEditableRowMode('full', false)" ng-checked="!$ctrl.display.settings.editableRow.full && !$ctrl.display.settings.editableRow.disable">
-        {{:: ts('Single Field') }}
-      </label>
-      <label class="radio-inline">
-        <input type="radio" ng-click="$ctrl.toggleEditableRowMode('full', true)" ng-checked="!!$ctrl.display.settings.editableRow.full">
-        {{:: ts('Entire Row') }}
-      </label>
-      <label class="radio-inline" ng-class="{disabled: !$ctrl.display.settings.editableRow.create}">
-        <input type="radio" ng-click="$ctrl.toggleEditableRowMode('disable', true)" ng-checked="!!$ctrl.display.settings.editableRow.disable">
-        {{:: ts('Disabled (create only)') }}
-      </label>
-    </div>
-    <div class="form-inline">
-      <div class="checkbox-inline form-control" title="{{:: ts('Create a new record using in-place edit.') }}">
-        <label>
-          <input type="checkbox" ng-click="$ctrl.toggleEditableRowMode('create')" ng-checked="!!$ctrl.display.settings.editableRow.create">
-          <span>{{:: ts('Add New Button') }}</span>
+    <div class="crm-accordion-body">
+      <div class="form-inline">
+        <label class="radio-inline">
+          <input type="radio" ng-click="$ctrl.toggleEditableRowMode('full', false)" ng-checked="!$ctrl.display.settings.editableRow.full && !$ctrl.display.settings.editableRow.disable">
+          {{:: ts('Single Field') }}
+        </label>
+        <label class="radio-inline">
+          <input type="radio" ng-click="$ctrl.toggleEditableRowMode('full', true)" ng-checked="!!$ctrl.display.settings.editableRow.full">
+          {{:: ts('Entire Row') }}
+        </label>
+        <label class="radio-inline" ng-class="{disabled: !$ctrl.display.settings.editableRow.create}">
+          <input type="radio" ng-click="$ctrl.toggleEditableRowMode('disable', true)" ng-checked="!!$ctrl.display.settings.editableRow.disable">
+          {{:: ts('Disabled (create only)') }}
         </label>
       </div>
-      <input ng-if="$ctrl.display.settings.editableRow.create" class="form-control" placeholder="{{:: ts('(no label)') }}" ng-model="$ctrl.display.settings.editableRow.createLabel">
+      <div class="form-inline">
+        <div class="checkbox-inline form-control" title="{{:: ts('Create a new record using in-place edit.') }}">
+          <label>
+            <input type="checkbox" ng-click="$ctrl.toggleEditableRowMode('create')" ng-checked="!!$ctrl.display.settings.editableRow.create">
+            <span>{{:: ts('Add New Button') }}</span>
+          </label>
+        </div>
+        <input ng-if="$ctrl.display.settings.editableRow.create" class="form-control" placeholder="{{:: ts('(no label)') }}" ng-model="$ctrl.display.settings.editableRow.createLabel">
+      </div>
     </div>
   </details>
 </fieldset>
@@ -116,43 +126,45 @@
       </button>
       <details>
         <summary>{{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline crm-search-admin-flex-row">
-          <label for="crm-search-admin-edit-header-{{ $index }}">{{:: ts('Header') }}</label>
-          <input id="crm-search-admin-edit-header-{{ $index }}" class="form-control crm-flex-1" type="text" ng-model="col.label" >
-        </div>
-        <div class="form-inline">
-          <label>
-            {{:: ts('Alignment') }}
-            <select ng-model="col.alignment" class="form-control crm-auto-width">
-              <option value="">{{:: ts('Left') }}</option>
-              <option value="text-center">{{:: ts('Center') }}</option>
-              <option value="text-right">{{:: ts('Right') }}</option>
-            </select>
-          </label>
-          &nbsp;
-          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
-            <input type="checkbox" ng-model="col.nowrap" >
-            {{:: ts('Prevent Wrapping') }}
-          </label>
-        </div>
-        <div class="form-inline" ng-if="$ctrl.parent.canBeSortable(col)">
-          <label title="{{:: ts('Allow user to click on header to sort table by this column') }}">
-            <input type="checkbox" ng-checked="col.sortable !== false" ng-click="col.sortable = col.sortable === false" >
-            {{:: ts('Sortable Header') }}
-          </label>
-        </div>
-        <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
-        <div class="form-inline" ng-if="col.type === 'field' && $ctrl.display.settings.tally">
-          <label for="crm-search-admin-edit-footer-label-{{:: $index }}">{{:: ts('Footer') }}</label>
-          <input class="form-control" id="crm-search-admin-edit-footer-label-{{:: $index }}" ng-model="col.tally.label" placeholder="{{:: ts('No label') }}" title="{{:: ts('Footer label') }}">
-          <label for="crm-search-admin-edit-footer-agg-{{:: $index }}">{{:: ts('Aggregate') }}</label>
-          <input id="crm-search-admin-edit-footer-agg-{{:: $index }}" class="form-control" ng-model="col.tally.fn" crm-ui-select="{data: $ctrl.getTallyFunctions, placeholder: ts('None'), allowClear: true}" title="{{:: ts('Footer aggregate function') }}">
-          <label>
-            <input type="checkbox" ng-click="$ctrl.toggleTallyRewrite(col)" ng-checked="!!col.tally.rewrite">
-            {{:: ts('Footer Rewrite') }}
-          </label>
-          <input class="form-control" ng-if="col.tally.rewrite" ng-model="col.tally.rewrite" placeholder="{{:: ts('None') }}" title="{{:: ts('Footer rewrite with tokens') }}" ng-model-options="{updateOn: 'blur'}">
-          <crm-search-admin-token-select ng-if="col.tally.rewrite" model="col.tally" field="rewrite" only-select="true"></crm-search-admin-token-select>
+        <div class="crm-accordion-body">
+          <div class="form-inline crm-search-admin-flex-row">
+            <label for="crm-search-admin-edit-header-{{ $index }}">{{:: ts('Header') }}</label>
+            <input id="crm-search-admin-edit-header-{{ $index }}" class="form-control crm-flex-1" type="text" ng-model="col.label" >
+          </div>
+          <div class="form-inline">
+            <label>
+              {{:: ts('Alignment') }}
+              <select ng-model="col.alignment" class="form-control crm-auto-width">
+                <option value="">{{:: ts('Left') }}</option>
+                <option value="text-center">{{:: ts('Center') }}</option>
+                <option value="text-right">{{:: ts('Right') }}</option>
+              </select>
+            </label>
+            &nbsp;
+            <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+              <input type="checkbox" ng-model="col.nowrap" >
+              {{:: ts('Prevent Wrapping') }}
+            </label>
+          </div>
+          <div class="form-inline" ng-if="$ctrl.parent.canBeSortable(col)">
+            <label title="{{:: ts('Allow user to click on header to sort table by this column') }}">
+              <input type="checkbox" ng-checked="col.sortable !== false" ng-click="col.sortable = col.sortable === false" >
+              {{:: ts('Sortable Header') }}
+            </label>
+          </div>
+          <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
+          <div class="form-inline" ng-if="col.type === 'field' && $ctrl.display.settings.tally">
+            <label for="crm-search-admin-edit-footer-label-{{:: $index }}">{{:: ts('Footer') }}</label>
+            <input class="form-control" id="crm-search-admin-edit-footer-label-{{:: $index }}" ng-model="col.tally.label" placeholder="{{:: ts('No label') }}" title="{{:: ts('Footer label') }}">
+            <label for="crm-search-admin-edit-footer-agg-{{:: $index }}">{{:: ts('Aggregate') }}</label>
+            <input id="crm-search-admin-edit-footer-agg-{{:: $index }}" class="form-control" ng-model="col.tally.fn" crm-ui-select="{data: $ctrl.getTallyFunctions, placeholder: ts('None'), allowClear: true}" title="{{:: ts('Footer aggregate function') }}">
+            <label>
+              <input type="checkbox" ng-click="$ctrl.toggleTallyRewrite(col)" ng-checked="!!col.tally.rewrite">
+              {{:: ts('Footer Rewrite') }}
+            </label>
+            <input class="form-control" ng-if="col.tally.rewrite" ng-model="col.tally.rewrite" placeholder="{{:: ts('None') }}" title="{{:: ts('Footer rewrite with tokens') }}" ng-model-options="{updateOn: 'blur'}">
+            <crm-search-admin-token-select ng-if="col.tally.rewrite" model="col.tally" field="rewrite" only-select="true"></crm-search-admin-token-select>
+          </div>
         </div>
       </details>
     </fieldset>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.html
@@ -6,42 +6,48 @@
 <fieldset>
   <legend>{{:: ts('Display Settings') }}</legend>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Sorting') }}</summary>
-    <div ng-if="$ctrl.sortableEntity" class="form-inline">
-      <div class="checkbox-inline form-control">
-        <label>
-          <input type="checkbox" ng-checked="!!$ctrl.display.settings.draggable" ng-click="$ctrl.parent.toggleDraggable()">
-          <span>{{:: ts('Drag and drop sorting') }}</span>
-        </label>
+    <div class="crm-accordion-body">
+      <div ng-if="$ctrl.sortableEntity" class="form-inline">
+        <div class="checkbox-inline form-control">
+          <label>
+            <input type="checkbox" ng-checked="!!$ctrl.display.settings.draggable" ng-click="$ctrl.parent.toggleDraggable()">
+            <span>{{:: ts('Drag and drop sorting') }}</span>
+          </label>
+        </div>
+      </div>
+      <fieldset ng-if="!$ctrl.display.settings.draggable" ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
+      <div ng-if="$ctrl.hierarchicalEntity" class="form-inline">
+        <select class="form-control" ng-model="$ctrl.display.settings.collapsible" title="{{:: ts('Should hierarchical tree be collapsible') }}">
+          <option value="">{{:: ts('Not collapsible') }}</option>
+          <option value="open">{{:: ts('Collapsible - Open') }}</option>
+          <option value="closed">{{:: ts('Collapsible - Closed') }}</option>
+        </select>
       </div>
     </div>
-    <fieldset ng-if="!$ctrl.display.settings.draggable" ng-include="'~/crmSearchAdmin/crmSearchAdminDisplaySort.html'"></fieldset>
-    <div ng-if="$ctrl.hierarchicalEntity" class="form-inline">
-      <select class="form-control" ng-model="$ctrl.display.settings.collapsible" title="{{:: ts('Should hierarchical tree be collapsible') }}">
-        <option value="">{{:: ts('Not collapsible') }}</option>
-        <option value="open">{{:: ts('Collapsible - Open') }}</option>
-        <option value="closed">{{:: ts('Collapsible - Closed') }}</option>
-      </select>
-    </div>
   </details>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Style') }}</summary>
-    <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
-    <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the tree is empty.') }}">
-      <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-      <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+    <div class="crm-accordion-body">
+      <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
+      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the tree is empty.') }}">
+        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
+        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
+      </div>
+      <search-admin-css-rules label="{{:: ts('Item Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
     </div>
-    <search-admin-css-rules label="{{:: ts('Item Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
   </details>
 
-  <details>
+  <details class="crm-accordion-bold">
     <summary>{{:: ts('Header') }}</summary>
-    <div class="form-inline">
-      <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+    <div class="crm-accordion-body">
+      <div class="form-inline">
+        <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
+      </div>
+      <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
     </div>
-    <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
   </details>
 </fieldset>
 
@@ -58,32 +64,34 @@
       </button>
       <details>
         <summary> {{ $ctrl.parent.getColLabel(col) }}</summary>
-        <div class="form-inline">
-          <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
-            <input type="checkbox" ng-model="col.break">
-            {{:: ts('New Line') }}
-          </label>
-          &nbsp;
-          <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
-            <input type="checkbox" ng-model="col.nowrap" >
-            {{:: ts('Prevent Wrapping') }}
-          </label>
-        </div>
-        <div class="form-inline crm-search-admin-flex-row">
-          <label>
-            <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getColLabel(col)" >
-            {{:: ts('Label') }}
-          </label>
-          <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
-          <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
-        </div>
-        <div class="form-inline" ng-if="col.label">
-          <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->
-          <div class="checkbox">
-            <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
+        <div class="crm-accordion-body">
+          <div class="form-inline">
+            <label title="{{:: ts('Should this item display on its own line or inline with other items?') }}">
+              <input type="checkbox" ng-model="col.break">
+              {{:: ts('New Line') }}
+            </label>
+            &nbsp;
+            <label title="{{:: ts('Disable line breaks to keep contents inline') }}">
+              <input type="checkbox" ng-model="col.nowrap" >
+              {{:: ts('Prevent Wrapping') }}
+            </label>
           </div>
+          <div class="form-inline crm-search-admin-flex-row">
+            <label>
+              <input type="checkbox" ng-checked="col.label" ng-click="col.label = col.label ? null : $ctrl.parent.getColLabel(col)" >
+              {{:: ts('Label') }}
+            </label>
+            <input ng-if="col.label" class="form-control crm-flex-1" type="text" ng-model="col.label" ng-model-options="{updateOn: 'blur'}">
+            <crm-search-admin-token-select ng-if="col.label" model="col" field="label" suffix=":label"></crm-search-admin-token-select>
+          </div>
+          <div class="form-inline" ng-if="col.label">
+            <label style="visibility: hidden"><input type="checkbox" disabled></label><!--To indent by 1 checkbox-width-->
+            <div class="checkbox">
+              <label><input type="checkbox" ng-model="col.forceLabel"> {{:: ts('Show label even when field is blank') }}</label>
+            </div>
+          </div>
+          <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
         </div>
-        <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
       </details>
     </fieldset>
   </fieldset>

--- a/ext/search_kit/css/crmSearchAdmin.css
+++ b/ext/search_kit/css/crmSearchAdmin.css
@@ -325,5 +325,5 @@ crm-search-admin-import {
 }
 
 #bootstrap-theme .crm-search-admin-outer details summary ~ * {
-  margin-left: 1rem;
+  padding: 0.75rem 1rem;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Civi accordions were updated and harmonised across a lot of CiviCRM in autumn 2023 - spring 2024, but the accordions in SearchKit builder didn't adopt [the new pattern](https://docs.civicrm.org/dev/en/latest/framework/ui/#html-accordion) of wrapping contents in `crm-accordion-body`. This adds the 'bold-accordion' style to the SearchKit settings expand regions, and the wrapper for the body to provide padding consistently. This markup change allows for a reduction of css. It also solves a few other issues, like the right-floated delete icon jumping around in position during expand/collapse, and positions it a bit more consistently across streams with different button and summary heights.

| Before | After | 
| ------------- | ------------- |
| Minetta - Table display
<img width="2326" height="1202" alt="image" src="https://github.com/user-attachments/assets/2154ee78-34ae-4498-988d-d5c52fcee973" /> | <img width="2332" height="1176" alt="image" src="https://github.com/user-attachments/assets/02bd83c7-f066-4463-b835-822d2065e66c" /> |
| Minetta - Grid display
<img width="1427" height="447" alt="image" src="https://github.com/user-attachments/assets/7324b152-db92-4763-ba75-efa4a959664d" /> | <img width="1433" height="573" alt="image" src="https://github.com/user-attachments/assets/6ccc8b21-0422-440a-8bf7-bbf985c3da68" /> |
| Minetta - Tree display
<img width="2316" height="590" alt="image" src="https://github.com/user-attachments/assets/e21a5dca-0460-4346-83f4-5ac3dd7f4219" /> |  <img width="1421" height="305" alt="image" src="https://github.com/user-attachments/assets/b307f392-07f2-4d77-9f3d-756fc52d6472" /> |
| Minetta - Search display
<img width="1420" height="369" alt="image" src="https://github.com/user-attachments/assets/323636b7-9b78-4cc7-9464-54e823041d6a" /> | <img width="1429" height="208" alt="image" src="https://github.com/user-attachments/assets/86dde71b-524c-49aa-bc66-f98101046ebf" /> |
| Walbrook - table
<img width="1429" height="592" alt="image" src="https://github.com/user-attachments/assets/630855eb-1557-4ccb-a908-5fa1c3f1f274" /> | <img width="2320" height="1006" alt="image" src="https://github.com/user-attachments/assets/a06c3e78-d77a-4574-91e7-67982a43ea87" /> |
| Hackney - table
<img width="1425" height="498" alt="image" src="https://github.com/user-attachments/assets/5d540f3e-89f7-48e2-bbb3-1241df64b2f6" /> | <img width="2322" height="1132" alt="image" src="https://github.com/user-attachments/assets/99fc1df5-5565-46f9-9487-28ae7a07bbae" /> |
| Thames - table
<img width="2352" height="1218" alt="image" src="https://github.com/user-attachments/assets/ebd8a9aa-214f-4358-b58a-8c6aa6ea97b0" /> | <img width="2322" height="1464" alt="image" src="https://github.com/user-attachments/assets/8369f568-27c9-41aa-b29b-6a495fde1779" /> |
| Greenwich - table
<img width="2078" height="1518" alt="image" src="https://github.com/user-attachments/assets/9128aa1c-20b2-41af-b606-57897c0c21e8" /> | <img width="2046" height="1502" alt="image" src="https://github.com/user-attachments/assets/fd78f85e-4664-4a3a-908f-4f187422b49a" /> |

Technical Details
----------------------------------------
This PR impacts the Grid, List, Table and Tree Search Displays. It doesn't impact the other displays. 

This changes smarty markup in a way that will impact other themes than RiverLea - a one-line change is made to core/Greenwich civicrm.css to remove this change, which should resolve any impact on Shoreditch / The Island.

Comments
----------------------------------------
@colemanw - I realise this changes the appearance a bit, tho more in keeping with other bits of Civi. If it's too bold a change, we could use `crm-accordion-light` instead of `crm-accordion-bold`.