### PR TITLE
APIv4 Explorer - Joins for write actions fixes

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -245,10 +245,11 @@
     function addWriteJoinFields(fieldList) {
       _.eachRight(fieldList, function(field, pos) {
         const fkNameField = field.fk_entity && getField('name', field.fk_entity, $scope.action);
-        if (fkNameField) {
+        if (fkNameField && !field.name.includes(':')) {
           const newField = _.cloneDeep(fkNameField);
           newField.name = field.name + '.' + newField.name;
-          fieldList.splice(pos, 0, newField);
+          // Insert new field after the current one
+          fieldList.splice(pos + 1, 0, newField);
         }
       });
     }


### PR DESCRIPTION
Overview
----------------------------------------
Minor fixes to the Api4 Explorer.

Technical Details
----------------------------------------
Fixes 2 bugs in 8c5bb56dd5

1. The extra join field was being added multiple times if there was also a pseudoconstant.
2. The extra field was being inserted before the normal field. It makes more sense to place it after.