### PR TITLE
Riverlea adds input:disabled support

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -862,12 +862,6 @@ input.crm-form-checkbox) + label {
   margin-top: 10px;
   margin-bottom: 10px;
 }
-#bootstrap-theme .radio.disabled label,
-#bootstrap-theme fieldset[disabled].radio label,
-#bootstrap-theme .checkbox.disabled label,
-#bootstrap-theme fieldset[disabled] .checkbox label {
-  cursor: not-allowed;
-}
 #bootstrap-theme .radio label,
 #bootstrap-theme .checkbox label {
   min-height: 20px;
@@ -889,14 +883,23 @@ input.crm-form-checkbox) + label {
   vertical-align: middle;
   cursor: var(--crm-hover-clickable);
 }
-#bootstrap-theme .radio-inline.disabled,
-fieldset[disabled] #bootstrap-theme .radio-inline,
-#bootstrap-theme .checkbox-inline.disabled,
-fieldset[disabled] #bootstrap-theme .checkbox-inline {
-  cursor: not-allowed;
-}
 #bootstrap-theme .radio-inline + .radio-inline,
 #bootstrap-theme .checkbox-inline + .checkbox-inline {
   margin-top: 0;
   margin-left: var(--crm-m);
+}
+
+/* Disabled styles */
+
+.crm-container :is(input,textarea,option):disabled,
+.crm-container fieldset[disabled] input,
+#bootstrap-theme .disabled:is(.radio,.checkbox) label,
+#bootstrap-theme fieldset[disabled] :is(.radio,.checkbox) label,
+#bootstrap-theme .disabled:is(.radio-inline,.checkbox-inline),
+#bootstrap-theme fieldset[disabled] :is(.radio-inline,.checkbox-inline) {
+  cursor: not-allowed;
+  color: var(--crm-c-inactive);
+}
+.crm-container :is(input,textarea,option):disabled {
+  background-color: color-mix(in srgb, var(--crm-input-background) 90%, var(--crm-c-text) 10%);
 }


### PR DESCRIPTION
Adds support `input:disabled` ie, `<input disabled />`, as discussed [here](https://chat.civicrm.org/civicrm/pl/f49p345ifbfrjqtrq3nenwbrmc). Until now it needed a class `disabled` to change the colour, or change the cursor.

Before
----------------------------------------
`<input disabled />` and `fieldset[disabled]` doesn't have any special styling.

After
----------------------------------------

### When input background is white (e.g. Minetta):

<img width="1014" height="413" alt="image" src="https://github.com/user-attachments/assets/c3d20136-ce31-4a57-93a9-7355ee274f0d" />

### Darkmode version:

<img width="1014" height="417" alt="image" src="https://github.com/user-attachments/assets/f0e3e816-e413-4a95-b4d1-9f4b6c5c2142" />

### When input background is another colour (e.g. yellow)

<img width="1026" height="414" alt="image" src="https://github.com/user-attachments/assets/70910f87-3867-4769-b27c-20c4d8af0535" />

Technical details
----------------------------------------
This PR groups changes with similar Bootstrap3 syntax in form.css.

I'm doing the css colour mix on the text colour as this has the advantage of flipping inverse with light/dark mode. But if someone had a Stream with non greyscale text (e.g. green) and pink input backgrounds (say) then it could behave oddly. But as that's not the case with the four streams not worrying about…