### PR TITLE
Utils - Ensure consistent return values from `getRgb()`

### DIFF
--- a/CRM/Utils/Color.php
+++ b/CRM/Utils/Color.php
@@ -55,7 +55,7 @@ class CRM_Utils_Color {
     $color = str_replace(' ', '', $color);
     $color = self::nameToHex($color) ?? $color;
     if (str_starts_with($color, 'rgb(')) {
-      return explode(',', substr($color, 4, strpos($color, ')') - 4));
+      return array_map('intval', explode(',', substr($color, 4, strpos($color, ')') - 4)));
     }
     $color = ltrim($color, '#');
     if (strlen($color) === 3) {

--- a/tests/phpunit/CRM/Utils/ColorTest.php
+++ b/tests/phpunit/CRM/Utils/ColorTest.php
@@ -36,8 +36,8 @@ class CRM_Utils_ColorTest extends CiviUnitTestCase {
    */
   public function testGetRgb($color, $expectedRGB, $expectedHex) {
     $rgb = CRM_Utils_Color::getRgb($color);
-    $this->assertEquals($expectedRGB, $rgb);
-    $this->assertEquals($expectedHex, CRM_Utils_Color::rgbToHex($rgb));
+    $this->assertSame($expectedRGB, $rgb);
+    $this->assertSame($expectedHex, CRM_Utils_Color::rgbToHex($rgb));
   }
 
   public static function rgbExamples() {


### PR DESCRIPTION
Overview
----------------------------------------
Minor improvement to CRM_Utils_Color.


Technical Details
----------------------------------------
Tightens up the test to make sure the array always contains integers, never numeric strings.