### PR TITLE
Enable user to pick columns when viewing/downloading table search displays

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -30,6 +30,12 @@ trait SavedSearchInspectorTrait {
   protected $savedSearch;
 
   /**
+   * Toggle columns to include in the result
+   * @var array
+   */
+  protected array $toggleColumns = [];
+
+  /**
    * @var array{select: array, where: array, having: array, orderBy: array, limit: int, offset: int, checkPermissions: bool, debug: bool}
    */
   protected $_apiParams;
@@ -112,6 +118,12 @@ trait SavedSearchInspectorTrait {
         'id' => NULL,
         'name' => NULL,
       ];
+    }
+    if (
+      $this->toggleColumns
+      && (count($this->toggleColumns) < count($this->display['settings']['columns']))
+      ) {
+      $this->display['settings']['columns'] = array_values(array_map(fn ($i) => $this->display['settings']['columns'][$i], $this->toggleColumns));
     }
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -61,10 +61,10 @@
         <search-admin-tasks-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-tasks-config>
       </div>
       <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
-      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Allow user to toggle columns on and off') }}">
+      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Allow user to pick which columns to include when viewing/download results') }}">
         <label for="crm-search-admin-display-table-column-toggle">
           <input type="checkbox" class="form-control crm-flex-1" id="crm-search-admin-display-table-column-toggle" ng-model="$ctrl.display.settings.toggleColumns">
-          {{:: ts('Enable Toggling Columns') }}
+          {{:: ts('Enable Column Picker') }}
         </label>
       </div>
       <div class="form-inline" ng-repeat="style in $ctrl.parent.tableClasses">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -61,6 +61,18 @@
         <search-admin-tasks-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-tasks-config>
       </div>
       <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>
+      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Allow user to toggle columns on and off') }}">
+        <label for="crm-search-admin-display-table-column-toggle">
+          <input type="checkbox" class="form-control crm-flex-1" id="crm-search-admin-display-table-column-toggle" ng-model="$ctrl.display.settings.toggleColumns">
+          {{:: ts('Enable Toggling Columns') }}
+        </label>
+      </div>
+      <div class="form-inline" ng-repeat="style in $ctrl.parent.tableClasses">
+        <label>
+          <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.parent.toggle($ctrl.display.settings.classes, style.name)">
+          <span>{{:: style.label }}</span>
+        </label>
+      </div>
     </div>
   </details>
 

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -332,6 +332,10 @@
         ctrl.settings = ctrl.display.settings;
       }
 
+      // this is used to filter toggled columns in the table
+      // search display - here its trivial
+      this.getRowColumns = (row) => row.columns;
+
       // @return {Promise}
       this.loadAfforms = function() {
         if (!ctrl.afformEnabled && !afformLoad) {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -24,8 +24,16 @@
       this.$onInit = function() {
         let tallyParams;
 
-        this._allColumns = ctrl.settings.columns;
-        this.resetColumnToggles();
+        this._allColumns = ctrl.settings.columns.map((col, index) => {
+          // store the canonical index on the array items
+          // useful when we want to refer to this index
+          // after filtering, e.g. in getApiParams
+          col.index = index;
+          col.toggled = true;
+          return col;
+        });
+
+        ctrl.onPreRun.push(() => this.trackFetchedColumns());
 
         // Copy API params from the run and adapt them in a secondary `tally` call for the "Totals" row
         if (ctrl.settings.tally) {
@@ -46,6 +54,7 @@
         }
 
         this.initializeDisplay($scope, $element);
+
 
         if (ctrl.settings.draggable) {
           ctrl.draggableOptions = {
@@ -133,18 +142,15 @@
       };
 
       /**
-       * Filter row columns to the toggled ones (on the clientside)
+       * Get the columns to display from a result row
        *
-       * TODO: sometimes we may want to pass column selections to the server
-       * to lighten the query (and for actions like spreadsheet export)
-       *
-       * We *dont* want to keep refetching from the server  when toggling
-       * columns on/off on the same page - so this approach works well for now
+       * The columns in the result row will correspond to those most recently fetched
+       * - so we need to find those first and then use those indices to filter by
+       * toggled status
        */
-      this.getRowColumns = (row) => row.columns.filter((col, index) => this._allColumns[index].toggled);
-
-      this.toggleColumns = () => {
-        this.settings.columns = this._allColumns.filter((col) => col.toggled);
+      this.getRowColumns = (row) => {
+        const resultColumns = this._allColumns.filter((col) => col.fetched);
+        return row.columns.filter((col, index) => resultColumns[index].toggled);
       };
 
       this.getColumnToggleLabel = (col) => {
@@ -164,15 +170,48 @@
           return ts('Links');
         }
         return ts('Column %1', {1: col.index});
-      }
+      };
+
+      /**
+       * Update the settings for which columns to include.
+       *
+       * If including columns that we haven't fetched, trigger a refetch
+       */
+      this.toggleColumns = () => {
+        this.settings.columns = this._allColumns.filter((col) => col.toggled);
+        if (this._allColumns.find((col) => col.toggled && !col.fetched)) {
+          this.getResultsPronto();
+        }
+      };
+
       this.resetColumnToggles = () => {
         this._allColumns.forEach((col, index) => {
           this._allColumns[index].toggled = true;
-          this._allColumns[index].index = index;
         });
         this.toggleColumns();
       };
 
+      /**
+       * Keep track of which columns we have fetched each
+       * time we fetch results. This allows us to only
+       * refetch if we need columns we don't have (we can
+       * hide columns without refetching)
+       */
+      this.trackFetchedColumns = () => {
+        this._allColumns.forEach((col, index) => {
+          this._allColumns[index].fetched = col.toggled;
+        });
+      };
+
+      // Override base method: add userJobId
+      const _getApiParams = this.getApiParams;
+      this.getApiParams = function(mode) {
+        const apiParams = _getApiParams.call(this, mode);
+        apiParams.toggleColumns = this._allColumns
+          .filter((col) => col.toggled)
+          .map((col) => col.index);
+        return apiParams;
+      };
     }
   });
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -19,8 +19,13 @@
         // Mix in copies of traits to this controller
         ctrl = angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), _.cloneDeep(searchDisplayTasksTrait), _.cloneDeep(searchDisplaySortableTrait), _.cloneDeep(searchDisplayEditableTrait));
 
+      this._allColumns = null;
+
       this.$onInit = function() {
         let tallyParams;
+
+        this._allColumns = ctrl.settings.columns;
+        this.resetColumnToggles();
 
         // Copy API params from the run and adapt them in a secondary `tally` call for the "Totals" row
         if (ctrl.settings.tally) {
@@ -125,6 +130,47 @@
           }
         }
         return cssClass;
+      };
+
+      /**
+       * Filter row columns to the toggled ones (on the clientside)
+       *
+       * TODO: sometimes we may want to pass column selections to the server
+       * to lighten the query (and for actions like spreadsheet export)
+       *
+       * We *dont* want to keep refetching from the server  when toggling
+       * columns on/off on the same page - so this approach works well for now
+       */
+      this.getRowColumns = (row) => row.columns.filter((col, index) => this._allColumns[index].toggled);
+
+      this.toggleColumns = () => {
+        this.settings.columns = this._allColumns.filter((col) => col.toggled);
+      };
+
+      this.getColumnToggleLabel = (col) => {
+        if (col.label) {
+          return col.label;
+        }
+        if (col.key) {
+          return `[${col.key}]`;
+        }
+        if (col.type === 'menu') {
+          return ts('Menu');
+        }
+        if (col.type === 'buttons') {
+          return ts('Buttons');
+        }
+        if (col.type === 'links') {
+          return ts('Links');
+        }
+        return ts('Column %1', {1: col.index});
+      }
+      this.resetColumnToggles = () => {
+        this._allColumns.forEach((col, index) => {
+          this._allColumns[index].toggled = true;
+          this._allColumns[index].index = index;
+        });
+        this.toggleColumns();
       };
 
     }

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -6,7 +6,7 @@
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
     <div class="form-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
     <details ng-if="$ctrl.settings.toggleColumns">
-      <summary>{{:: ts('Toggle Columns') }}</summary>
+      <summary>{{:: ts('Pick Columns') }}</summary>
       <div class="crm-accordion-body">
         <!-- TODO: select2 might be nicer here? -->
         <label ng-repeat="(index, col) in $ctrl._allColumns">

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -17,7 +17,7 @@
             {{:: $ctrl.getColumnToggleLabel(col) }}
         </label>
         <button type="button" class="btn btn-secondary" ng-click="$ctrl.resetColumnToggles()">
-          Reset
+          {{:: ts('Select All') }}
         </button>
       </div>
     </details>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -5,6 +5,22 @@
     <crm-search-tasks-menu ng-if="$ctrl.settings.actions && $ctrl.taskManager" ids="$ctrl.selectedRows" task-manager="$ctrl.taskManager" display-mode="$ctrl.settings.actions_display_mode || 'menu'"></crm-search-tasks-menu>
     <span ng-if="$ctrl.settings.headerCount" ng-include="'~/crmSearchDisplay/ResultCount.html'"></span>
     <div class="form-group pull-right" ng-include="'~/crmSearchDisplay/toolbar.html'" ng-if="$ctrl.toolbar"></div>
+    <details ng-if="$ctrl.settings.toggleColumns">
+      <summary>{{:: ts('Toggle Columns') }}</summary>
+      <div class="crm-accordion-body">
+        <!-- TODO: select2 might be nicer here? -->
+        <label ng-repeat="(index, col) in $ctrl._allColumns">
+          <input type="checkbox"
+            ng-model="$ctrl._allColumns[index].toggled"
+            ng-change="$ctrl.toggleColumns()"
+            >
+            {{:: $ctrl.getColumnToggleLabel(col) }}
+        </label>
+        <button type="button" class="btn btn-secondary" ng-click="$ctrl.resetColumnToggles()">
+          Reset
+        </button>
+      </div>
+    </details>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
     <thead>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -16,7 +16,7 @@
       </button>
     </div>
   </td>
-  <td ng-repeat="(colIndex, colData) in row.columns" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
+  <td ng-repeat="(colIndex, colData) in $ctrl.getRowColumns(row)" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">


### PR DESCRIPTION
Overview
----------------------------------------
Adds a setting to enable clientside column toggling on table search displays:

The setting itself is this innocuous toggle in the SearchKit editor (OUT OF SCOPE TODO: how do we make these settings a bit more discoverable)
<img width="1392" height="733" alt="image" src="https://github.com/user-attachments/assets/bdf0a7d1-550e-4b6f-a07c-8ce2fc5558e0" />

If enabled, the search kit header has a "Toggle Columns" widget:


https://github.com/user-attachments/assets/2d8d2f1b-0221-438b-9a5b-cc804f425167




Technical Details
----------------------------------------
If columns don't have a label, we have to make one up for the UI selector. It would be good in general if table columns were *required* to have labels - this is good practice accessibilitywise too AFAIK.

~Toggling is currently done clientside. This makes sense when you are toggling on one page. It would be nice if you could start fetching only the columns you need on subsequent pages, but that's going to be trickier.~

Toggling is mixed between clientside and serverside:
- if you are on a single page and you remove a column, it just hides without refetching
- if you readd the column, it unhides
- if you go to the next page, it will only fetch the columns you are currently viewing
- if you add a column that you haven't fetched for the current page, it will refetch
- if you Download as CSV, it will only download the columns you are currently viewing

The implementation is a little tricky because the search display controller currently uses a lot of arrays directly (`$ctrl.settings.columns`, `rows.columns`), relying on the array indices lining up. I think it would be nice to try to go through a `getColumns` getter and use a more semantic key rather than just index for each column. But one for another day.


Comments
----------------------------------------
I tested compatibility with tallies and seems fine.

~I would like to pass the column selection through to the download spreadsheet action, but was thinking that could be a follow up.~