### PR TITLE
SearchKit - Fix db entity views with long column names

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
+++ b/ext/search_kit/Civi/Api4/Action/SKEntity/Refresh.php
@@ -41,8 +41,7 @@ class Refresh extends AbstractAction {
     // and it would change the default ordering over time.)
 
     // Prepare a sketch of the process. Ensure metadata is well-formed.
-    $query = (new SKEntityGenerator())->createQuery($display['saved_search_id.api_entity'], $display['saved_search_id.api_params'], $display['settings']);
-    $sql = $query->getSql();
+    $sql = (new SKEntityGenerator())->createQuery($display['saved_search_id.api_entity'], $display['saved_search_id.api_params'], $display['settings']);
     $finalTable = _getSearchKitDisplayTableName($displayName);
     $columnSpecs = array_column($display['settings']['columns'], 'spec');
     $columns = implode(', ', array_column($columnSpecs, 'name'));

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -129,10 +129,10 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       case 'view':
         $tableName = _getSearchKitDisplayTableName($newName);
         $tempSettings = $event->params['settings'];
-        $query = (new SKEntityGenerator())->createQuery($this->savedSearch['api_entity'], $this->savedSearch['api_params'], $tempSettings);
+        $sql = (new SKEntityGenerator())->createQuery($this->savedSearch['api_entity'], $this->savedSearch['api_params'], $tempSettings);
         $columnSpecs = array_column($tempSettings['columns'], 'spec');
         $columns = implode(', ', array_column($columnSpecs, 'name'));
-        $sql = "CREATE VIEW `$tableName` ($columns) AS " . $query->getSql();
+        $sql = "CREATE VIEW `$tableName` ($columns) AS " . $sql;
 
         // do not i18n-rewrite
         \CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);

--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -22,6 +22,11 @@ use Civi\Api4\Utils\CoreUtil;
 class Meta {
 
   /**
+   * 64 characters is the max for some versions of SQL, minus the length of "index_" = 58.
+   */
+  const MAX_COLUMN_LENGTH = 58;
+
+  /**
    * Get calculated fields used by a saved search
    *
    * @param string $apiEntity
@@ -110,19 +115,18 @@ class Meta {
     // Strip the pseuoconstant suffix
     [$name, $suffix] = array_pad(explode(':', $key), 2, NULL);
     if (!empty($sqlName)) {
-      if (!preg_match(';^[A-Za-z0-9_]+$;', $sqlName) || strlen($sqlName) > 58) {
+      if (!preg_match(';^[A-Za-z0-9_]+$;', $sqlName) || strlen($sqlName) > self::MAX_COLUMN_LENGTH) {
         throw new \CRM_Core_Exception("Malformed column name");
       }
       $name = $sqlName;
     }
-    // Sanitize the name and limit to 58 characters.
-    // 64 characters is the max for some versions of SQL, minus the length of "index_" = 58.
-    if (strlen($name) <= 58) {
+    // Sanitize the name and limit to MAX_COLUMN_LENGTH characters.
+    if (strlen($name) <= self::MAX_COLUMN_LENGTH) {
       $name = \CRM_Utils_String::munge($name, '_', NULL);
     }
     // Append a hash of the full name to trimmed names to keep them unique but predictable
     else {
-      $name = \CRM_Utils_String::munge($name, '_', 42) . substr(md5($name), 0, 16);
+      $name = \CRM_Utils_String::munge($name, '_', self::MAX_COLUMN_LENGTH - 16) . substr(md5($name), 0, 16);
     }
     return [$name, $suffix];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an error when creating MySql Views using the DB Entity display type. 

Technical Details
----------------------------------------
Column names longer than 64 cause errors and must be trimmed.