### PR TITLE
Api4 - Fix php error when joining on tables with no primary key

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -68,7 +68,7 @@ class Api4SelectQuery extends Api4Query {
     parent::__construct($api);
 
     // Always select ID of main table unless grouping by something else
-    $keys = CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
+    $keys = (array) CoreUtil::getInfoItem($this->getEntity(), 'primary_key');
     $this->forceSelectId = !$this->isAggregateQuery() || array_intersect($this->getGroupBy(), $keys);
 
     // Build field lists


### PR DESCRIPTION
Overview
----------------------------------------
Fixes error when joining on log tables with Group By.

Technical Details
----------------------------------------
Fixes `PHP Fatal error: array_intersect(): Argument #2 must be of type array, null given`
