### PR TITLE
AdminUI: add Mailing Click-Through report

### DIFF
--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -120,11 +120,10 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
     }
     $this->assign('backUrl', $backUrl);
     $this->assign('backUrlTitle', $backUrlTitle);
-
+    // We use this variable to alter the Mailing Report layout
+    $this->assign('is_adminui_enabled', FALSE);
     $this->assign('report', $report);
-    CRM_Utils_System::setTitle(ts('CiviMail Report: %1',
-      [1 => $report['mailing']['name']]
-    ));
+    CRM_Utils_System::setTitle(ts('CiviMail Report: %1', [1 => $report['mailing']['name']]));
     $this->assign('public_url', CRM_Mailing_BAO_Mailing::getPublicViewUrl($this->_mailing_id));
 
     return CRM_Core_Page::run();

--- a/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.html
@@ -1,0 +1,3 @@
+<div af-fieldset="">
+  <crm-search-display-table search-name="Mailing_Click_throughs_Report" display-name="Mailing_Click_throughs_Results" filters="{'Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01.id': routeParams.uid, 'Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01.mailing_id': routeParams.mid}"></crm-search-display-table>
+</div>

--- a/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.json
+++ b/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.json
@@ -1,0 +1,13 @@
+{
+    "type": "search",
+    "title": "Mailing Click-throughs",
+    "placement": [],
+    "placement_filters": [],
+    "icon": "fa-list-alt",
+    "server_route": "civicrm/mailing/report/urltrack",
+    "permission": [
+        "access CiviMail"
+    ],
+    "permission_operator": "AND",
+    "confirmation_type": "redirect_to_url",
+}

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.php
@@ -13,6 +13,24 @@ function civicrm_admin_ui_civicrm_config(&$config) {
 }
 
 /**
+ * Implements hook_civicrm_pageRun().
+ */
+function civicrm_admin_ui_civicrm_pageRun(&$page) {
+  $pageName = get_class($page);
+  if ($pageName == 'CRM_Mailing_Page_Report') {
+    $smarty = CRM_Core_Smarty::singleton();
+    $report = $smarty->getTemplateVars()['report'];
+    foreach ($report['click_through'] as $key => &$val) {
+      if (preg_match('/mid=(\d+).*uid=(\d+)/', $val['link'], $matches)) {
+        $val['link_unique'] = CRM_Utils_System::url('civicrm/mailing/report/urltrack#/?mid=' . $matches[1] . '&uid=' . $matches[2]);
+      }
+    }
+    $smarty->assign('report', $report);
+    $smarty->assign('is_adminui_enabled', TRUE);
+  }
+}
+
+/**
  * Implements hook_civicrm_postProcess().
  */
 function civicrm_admin_ui_civicrm_postProcess($className, $form) {

--- a/ext/civicrm_admin_ui/info.xml
+++ b/ext/civicrm_admin_ui/info.xml
@@ -36,7 +36,7 @@
   <civix>
     <namespace>CRM/CivicrmAdminUi</namespace>
     <angularModule>crmCivicrmAdminUi</angularModule>
-    <format>25.01.1</format>
+    <format>25.10.1</format>
   </civix>
   <mixins>
     <mixin>mgd-php@1.0.0</mixin>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Click_throughs_Report.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Click_throughs_Report.mgd.php
@@ -1,0 +1,132 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Mailing_Click_throughs_Report',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Mailing_Click_throughs_Report',
+        'label' => E::ts('Mailing Click-throughs'),
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'display_name',
+            'GROUP_CONCAT(DISTINCT Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01.url) AS GROUP_CONCAT_Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01_url',
+            'GROUP_CONCAT(DISTINCT Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01.time_stamp) AS GROUP_CONCAT_Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_time_stamp',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => ['id'],
+          'join' => [
+            [
+              'MailingEventQueue AS Contact_MailingEventQueue_contact_id_01',
+              'INNER',
+              [
+                'id',
+                '=',
+                'Contact_MailingEventQueue_contact_id_01.contact_id',
+              ],
+            ],
+            [
+              'MailingEventTrackableURLOpen AS Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01',
+              'INNER',
+              [
+                'Contact_MailingEventQueue_contact_id_01.id',
+                '=',
+                'Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01.event_queue_id',
+              ],
+            ],
+            [
+              'MailingTrackableURL AS Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01',
+              'INNER',
+              [
+                'Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01.trackable_url_id',
+                '=',
+                'Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01.id',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Mailing_Click_throughs_Report_SearchDisplay_Mailing_Click_throughs_Results',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Mailing_Click_throughs_Results',
+        'label' => E::ts('Mailing Click-throughs'),
+        'saved_search_id.name' => 'Mailing_Click_throughs_Report',
+        'type' => 'table',
+        'settings' => [
+          'description' => '',
+          'sort' => [
+            [
+              'Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01.time_stamp',
+              'DESC',
+            ],
+          ],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'display_name',
+              'label' => E::ts('Display Name'),
+              'sortable' => TRUE,
+              'link' => [
+                'path' => '',
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => '',
+                'target' => '',
+                'task' => '',
+              ],
+              'title' => E::ts('View Contact'),
+            ],
+            [
+              'type' => 'field',
+              'key' => 'GROUP_CONCAT_Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01_url',
+              'label' => E::ts('URL'),
+              'sortable' => TRUE,
+              'link' => [
+                'path' => '[GROUP_CONCAT_Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_MailingEventTrackableURLOpen_MailingTrackableURL_trackable_url_id_01_url]',
+                'entity' => '',
+                'action' => '',
+                'join' => '',
+                'target' => '',
+                'task' => '',
+              ],
+            ],
+            [
+              'type' => 'field',
+              'key' => 'GROUP_CONCAT_Contact_MailingEventQueue_contact_id_01_MailingEventQueue_MailingEventTrackableURLOpen_event_queue_id_01_time_stamp',
+              'label' => E::ts('Date'),
+              'sortable' => TRUE,
+            ],
+          ],
+          'actions' => TRUE,
+          'classes' => ['table', 'table-striped'],
+          'actions_display_mode' => 'menu',
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -123,26 +123,37 @@
 
 {if $report.mailing.url_tracking && $report.click_through|@count > 0}
 <fieldset>
-<legend>{ts}Click-through Summary{/ts}</legend>
-{strip}
-<table class="crm-info-panel">
-<tr>
-<th><a href="{$report.event_totals.links.clicks}">{ts}Clicks{/ts}</a></th>
-<th><a href="{$report.event_totals.links.clicks_unique}">{ts}Unique Clicks{/ts}</a></th>
-<th>{ts}Success Rate{/ts}</th>
-<th>{ts}URL{/ts}</th>
-<th>{ts}Report{/ts}</th></tr>
-{foreach from=$report.click_through item=row}
-<tr class="{cycle values="odd-row,even-row"}">
-<td>{if $row.clicks > 0}<a href="{$row.link}">{$row.clicks}</a>{else}{$row.clicks}{/if}</td>
-<td>{if $row.unique > 0}<a href="{$row.link_unique}">{$row.unique}</a>{else}{$row.unique}{/if}</td>
-<td>{$row.rate|string_format:"%0.2f"}%</td>
-<td><a href="{$row.url}">{$row.url}</a></td>
-<td><a href="{$row.report}">{ts}Report{/ts}</a></td>
-</tr>
-{/foreach}
-</table>
-{/strip}
+  <legend>{ts}Click-through Summary{/ts}</legend>
+  <table class="crm-info-panel">
+    <tr>
+      {if $is_adminui_enabled}
+        <th><a href="{$report.event_totals.links.clicks}">{ts}Clicks{/ts}</a></th>
+        <th>{ts}Success Rate{/ts}</th>
+        <th>{ts}URL{/ts}</th>
+      {else}
+        <th><a href="{$report.event_totals.links.clicks}">{ts}Clicks{/ts}</a></th>
+        <th><a href="{$report.event_totals.links.clicks_unique}">{ts}Unique Clicks{/ts}</a></th>
+        <th>{ts}Success Rate{/ts}</th>
+        <th>{ts}URL{/ts}</th>
+        <th>{ts}Report{/ts}</th>
+      {/if}
+    </tr>
+    {foreach from=$report.click_through item=row}
+      <tr class="{cycle values="odd-row,even-row"}">
+        {if $is_adminui_enabled}
+          <td>{if $row.unique > 0}<a href="{$row.link_unique}">{$row.unique}</a>{else}{$row.unique}{/if}</td>
+          <td>{$row.rate|string_format:"%0.2f"}%</td>
+          <td><a href="{$row.url}">{$row.url|truncate:100:'....':true:true}</a></td>
+        {else}
+          <td>{if $row.clicks > 0}<a href="{$row.link}">{$row.clicks}</a>{else}{$row.clicks}{/if}</td>
+          <td>{if $row.unique > 0}<a href="{$row.link_unique}">{$row.unique}</a>{else}{$row.unique}{/if}</td>
+          <td>{$row.rate|string_format:"%0.2f"}%</td>
+          <td><a href="{$row.url}">{$row.url|truncate:100:'....':true:true}</a></td>
+          <td><a href="{$row.report}">{ts}Report{/ts}</a></td>
+        {/if}
+      </tr>
+    {/foreach}
+  </table>
 </fieldset>
 {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------

Provides a SearchKit/FormBuilder alternative to the Mailing Click-Through report that is accessible from the Mailing Report.

Ex: when we click on the mailing report, then scroll to the list of clicked URLs, we can then click to see exactly who clicked on a specific link.

However, we cannot create a smart-group or otherwise do any actions on those contacts. This PR replaces that report with SearchKit.

Click-Through Report
----------------------------------------

**Before**

Old limited report.

<img width="3288" height="478" alt="2025-10-15_12-21" src="https://github.com/user-attachments/assets/d49771da-00af-4601-9828-da1c09166b98" />

**After**

Report is uses SearchKit, so it can do all sorts of fancy things.

<img width="3386" height="790" alt="2025-10-15_12-22" src="https://github.com/user-attachments/assets/1a00a59d-c3ea-4493-8d1b-a2adec3b9960" />

Mailing Report
-------------------------

I simplified: the click-through section had 3 links to 2 different reports. Now it has only one.

**Before**

<img width="3220" height="308" alt="2025-10-15_14-56" src="https://github.com/user-attachments/assets/9f327c0f-2205-4143-9639-c97e4cf01b8a" />

**After**

<img width="3252" height="294" alt="2025-10-15_14-54" src="https://github.com/user-attachments/assets/f8ae9503-bf3d-4db1-b680-6442d7c06f15" />


I also truncated the URLs, because I stumbled on a client report where they had really long URLs and it looked silly.

Note that the "Clicks" is what was previously "Unique Clicks". If a person clicks many times, then it looks like this:

<img width="3288" height="552" alt="2025-10-15_16-49" src="https://github.com/user-attachments/assets/3fbf0cde-6b66-4f36-938a-b4a9afc180ca" />

(admittedly, that's a bit weird) :shrug: 

Comment
-----------------

I'm sure some people will be angry about the loss of functionality. Hear me out:

- The "Report" that linked to CiviReport is redundant to the other two links for unique/total click-through, except that it's CiviReport, and it's kind of ugly.
- Yes I removed "non-unique click-throughs", because nobody cares about that. I compromised by keeping the list of dates on which people clicked links.

Even if it seems obvious to to most regular users of CiviCRM, having to think  about what "Clicks" and "Unique Clicks" means, to most normal people, makes them feel stupid. And they're not stupid. Nobody cares about non-unique clicks :upside_down_face: 

Eventually I hope to also do this for opens/bounces/etc, and do a similar cleanup there.