### PR TITLE
RiverLea: tidies disabled row for scheduled jobs

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -299,7 +299,7 @@ dl dl {
 .crm-container #extensions-main table tr.disabled td {
   font-style: italic;
 }
-.crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column,.crm-extensions-label) {
+.crm-container tr.disabled td:first-of-type:not(.crm-search-ctrl-column,.crm-extensions-label,.crm-job-name) {
   display: inline-flex;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
The inline disabled icon on disabled table rows strikes again: schedule jobs listing. This PR resets it there.

Before
----------------------------------------
<img width="2824" height="438" alt="image" src="https://github.com/user-attachments/assets/9cf94377-004f-4ac1-bcca-2d1d9ea8f2e0" />

After
----------------------------------------
<img width="2812" height="628" alt="image" src="https://github.com/user-attachments/assets/0c4fc016-92ba-4371-8385-5ea145bbd665" />
