### PR TITLE
Riverlea - remove some double defs of vars

### DIFF
--- a/ext/riverlea/streams/hackneybrook/_variables.css
+++ b/ext/riverlea/streams/hackneybrook/_variables.css
@@ -62,7 +62,6 @@
   --crm-alert-info-text: var(--crm-c-blue-darker);
   --crm-alert-danger-text: var(--crm-c-text);
   /* Form */
-  --crm-input-color: var(--crm-c-text);
   --crm-input-border-color: var(--crm-c-gray-300);
   --crm-input-box-shadow: 0;
   --crm-input-label-weight: normal;

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -64,7 +64,6 @@
   --crm-table-row-alternate-bg: #fff;
   --crm-panel-border-col: var(--crm-c-gray-200);
   --crm-input-border-color: var(--crm-c-gray-200);
-  --crm-c-inactive: var(--crm-c-gray-400);
   --crm-input-color: var(--crm-c-text);
   --crm-input-description: var(--crm-c-gray-300);
   --crm-input-radio-color: #38c4b4;

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -4,7 +4,6 @@
   --crm-c-dkblue-03: #1a292f;
   --crm-c-dkblue-04: #1e323b;
   --crm-c-dkblue-08: #2ea4ff;
-  --crm-c-container-bg: var(--crm-c-dkblue-02);
   --crm-dash-tabs-bg: var(--crm-c-dkblue-03);
   --crm-dash-tab-count-bg: var(--crm-c-blue-darker);
   --crm-c-code-bg: var(--crm-c-dkblue-04);
@@ -12,8 +11,8 @@
   --crm-c-layer0-bg: var(--crm-c-dkblue-01);
   --crm-c-page-bg: var(--crm-c-dkblue-01);
   --crm-c-container-bg: var(--crm-c-dkblue-02);
-  --crm-c-layer1-bg: var(--crm-c-dkblue-03);
-  --crm-c-layer2-bg: var(--crm-c-dkblue-04);
+  --crm-c-layer1-bg: var(--crm-c-dkblue-02);
+  --crm-c-layer2-bg: var(--crm-c-dkblue-02);
   --crm-c-green: #335417;
   --crm-c-link: var(--crm-c-dkblue-08);
   --crm-c-link-hover: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
@@ -43,8 +42,6 @@
   --crm-table-row-bg: var(--crm-c-dkblue-02);
   --crm-table-row-hover: var(--crm-c-dkblue-03);
   --crm-table-row-alternate-bg: #fff;
-  --crm-c-layer1-bg: var(--crm-c-dkblue-02);
-  --crm-c-layer2-bg: var(--crm-c-dkblue-02);
   --crm-panel-bg: var(--crm-c-dkblue-02);
   --crm-form-block-bg: var(--crm-c-dkblue-02);
   --crm-notify-bg: var(--crm-c-dkblue-02);

--- a/ext/riverlea/streams/thames/_variables.css
+++ b/ext/riverlea/streams/thames/_variables.css
@@ -226,7 +226,6 @@
   --crm-expand2-header-bg: transparent;
   --crm-expand2-header-bg-active: var(--crm-c-layer2-bg);
   --crm-expand2-header-weight: normal;
-  --crm-expand2-header-color: var(--crm-c-text);
   --crm-expand2-header-border: unset;
   --crm-expand2-header-border-width: unset;
   --crm-expand2-header-padding: .6rem 1.6rem 0.6rem 2.8rem; /*var(--crm-s) var(--crm-m); */ /* thames */
@@ -244,7 +243,6 @@
   --crm-alert-success-bg: var(--crm-c-blue-light); /* thames */
   --crm-alert-success-border: unset; /* thames */
   --crm-alert-success-text: unset; /* thames */
-  --crm-alert-warning-text: var(--crm-c-text);
   --crm-alert-warning-border: var(--crm-c-yellow);
   --crm-alert-info-bg: var(--crm-c-blue-light);
   --crm-alert-info-border: var(--crm-c-blue);
@@ -259,7 +257,6 @@
   --crm-form-block-padding: var(--crm-m);
   --crm-form-block-border-radius: var(--crm-roundness);
   --crm-input-bg-image: linear-gradient(top, #eee 1%, #fff 15%);
-  --crm-input-color: var(--crm-c-text);
   --crm-input-border-color: #0000001a; /* thames */
   --crm-input-border-radius: 3px;
   --crm-input-active-ani: border-color .15s ease-in-out 0s;
@@ -291,7 +288,6 @@
   --crm-tab-bg-active: var(--crm-c-layer0-bg);
   --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* lip to extend tab flush with active region - set to 0 for no lip */ /* thames todo check */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
-  --crm-tab-col: var(--crm-c-text);
   --crm-tab-weight: normal;
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
@@ -394,7 +390,6 @@
   --crm-dropdown-width: 23ch; /* thames */
   --crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns */
   --crm-dropdown-2-bg: var(--crm-c-secondary);
-  --crm-dropdown-2-col: var(--crm-c-text);
   --crm-dropdown-2-padding: var(--crm-padding-small);
 }
 :root {

--- a/ext/riverlea/streams/walbrook/_variables.css
+++ b/ext/riverlea/streams/walbrook/_variables.css
@@ -122,7 +122,6 @@
   --crm-form-block-border-radius: 0;
   --crm-input-bg: var(--crm-c-container-bg);
   --crm-input-bg-image: none;
-  --crm-input-color: var(--crm-c-text);
   --crm-input-border-color: #c2cfd8;
   --crm-input-border-radius: var(--crm-roundness);
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);


### PR DESCRIPTION
Overview
----------------------------------------
- `--crm-c-inactive` is defined twice in Minetta dark vars. This later one is overriding the intended one above.
- a few vars are defined twice in Thames dark vars. I've removed the earlier ones to preserve the current behaviour.