### PR TITLE
API3 - json_decode: Remove incorrect backslash before double quotation marks

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -314,12 +314,13 @@ class CRM_Utils_REST {
     ];
 
     if (array_key_exists('json', $requestParams) && $requestParams['json'][0] == "{") {
+      $requestParams['json'] = str_replace('\\"', '"', $requestParams['json']);
       $params = json_decode($requestParams['json'], TRUE);
       if ($params === NULL) {
         CRM_Utils_JSON::output([
           'is_error' => 1,
           0 => 'error_message',
-          1 => 'Unable to decode supplied JSON.',
+          1 => 'Unable to decode supplied JSON: ' . json_last_error_msg(),
         ]);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When using the api3 with a direct web request, the api-parameters are put in the (url-encoded) parameter json. Then the `json_decode()` in `CRM/Utils/REST.php` fails with a syntax error.

Before
----------------------------------------
Create an API3 request with the api explorer (for example Contact->get).
When executing the curl example this results in an error. You don't get the details - but it is a syntax error.

After
----------------------------------------
The curl example from the api explorer works as expected.

Technical Details
----------------------------------------
The call of `json_decode()` fails caused by a syntax error - which I added to the error message.

Comments
----------------------------------------
I am not shure if this is the correct solution - it is more like a workaround.. any better ideas?
