### PR TITLE
(NFC) System::addHTMLHead() - Reframe as internal. Offer consistent alternatives.

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -30,7 +30,6 @@ use GuzzleHttp\Psr7\Response;
  * @method static mixed updateCategories() Clear CMS caches related to the user registration/profile forms.
  * @method static void appendBreadCrumb(array $breadCrumbs) Append an additional breadcrumb link to the existing breadcrumbs.
  * @method static void resetBreadCrumb() Reset an additional breadcrumb tag to the existing breadcrumb.
- * @method static void addHTMLHead(string $head) Append a string to the head of the HTML file. Note: this is only used in Drupal7/Backdrop/Joomla and is deprecated in Drupal8+/Wordpress/Standalone
  * @method static string postURL(int $action) Determine the post URL for a form.
  * @method static string|null getUFLocale() Get the locale of the CMS.
  * @method static bool setUFLocale(string $civicrm_language) Set the locale of the CMS.

--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -185,6 +185,7 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
 
   /**
    * @inheritDoc
+   * @internal
    */
   public function addHTMLHead($header) {
     static $count = 0;

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -108,9 +108,15 @@ abstract class CRM_Utils_System_Base {
    *
    * @param string $head
    *   The new string to be appended.
+   * @internal
+   *   Historically, this was a public method.
+   *   In practice, today, it's mostly used as internal plumbing for some UF-integrations.
+   *   For writing application logic, you should be looking at one of these:
+   *     - To add JS+CSS resources, see Civi::resources().
+   *     - To add novel markup, see CRM_Core_Region::instance('html-header').
    */
   public function addHTMLHead($head) {
-    \CRM_Core_Error::deprecatedFunctionWarning("addHTMLHead is deprecated in " . self::class);
+    \CRM_Core_Error::deprecatedFunctionWarning('Civi::resources() or CRM_Core_Region::instance("html-header")');
   }
 
   /**

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -199,6 +199,7 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
 
   /**
    * @inheritDoc
+   * @internal
    */
   public function addHTMLHead($header) {
     static $count = 0;

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -215,7 +215,7 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @deprecated
    */
   public function addHTMLHead($header) {
-    \CRM_Core_Error::deprecatedFunctionWarning('Civi::resources()->addStyleFile() or addScriptFile() etc');
+    \CRM_Core_Error::deprecatedFunctionWarning('Civi::resources() or CRM_Core_Region::instance("html-header")');
     \Drupal::service('civicrm.page_state')->addHtmlHeader($header);
   }
 

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -270,6 +270,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
 
   /**
    * @inheritDoc
+   * @internal
    */
   public function addHTMLHead($string = NULL) {
     if ($string) {

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -272,9 +272,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
 
   /**
    * @inheritDoc
+   * @internal
+   * @deprecated
    */
   public function addHTMLHead($head) {
-    \CRM_Core_Error::deprecatedFunctionWarning("addHTMLHead is deprecated in WordPress and will be removed in a future version");
+    \CRM_Core_Error::deprecatedFunctionWarning('Civi::resources() or CRM_Core_Region::instance("html-header")');
     static $registered = FALSE;
     if (!$registered) {
       // front-end view


### PR DESCRIPTION
Overview
----------------------------------------

Updates the deprecation message to `addHTMLHead()`

(Follow-up to #33727, #32831, #32254. Alternative to #33821. Speaks to the [last question from 32831](https://github.com/civicrm/civicrm-core/pull/32831#issuecomment-3325142619).)

Comments
----------------------------------------

* Use consistent deprecation message (in all contexts where `addHTMLHead()` is live-but-deprecated).
* The deprecation message should include the realistic replacement:
    * `Civi::resources()->addStyleFile()` and `addScriptFile()` are loosely head-related, and they're perfectly good functions -- prettier -- more prominent. Everyone learns about those first.
    * But if you're looking at `addHTMLHead()`, then `addStyleFile()` probably won't work as a replacement.
    * `addHTMLHead()` is more obscure. The only way you wind up here is if (a) you need special markup or (b) you're working on the plumbing of the UF.
        * For someone who needs to add special markup, they should see `CRM_Core_Region::instance('html-header`)`.
        * For someone working on plumbing, they should be able to rework the plumbing.