### PR TITLE
dev/core#6160 - fix bug for contactTypes variable properties

### DIFF
--- a/ext/civiimport/CRM/CiviImport/Form/MapField.php
+++ b/ext/civiimport/CRM/CiviImport/Form/MapField.php
@@ -37,7 +37,7 @@ class CRM_CiviImport_Form_MapField extends CRM_Import_Form_MapField {
    * @throws \CRM_Core_Exception
    */
   private function assignCiviimportVariables(): void {
-    $contactTypes = CRM_Utils_Array::formatForSelect2(CRM_Contact_BAO_ContactType::basicTypeInfo(), 'name', 'label');
+    $contactTypes = CRM_Utils_Array::formatForSelect2(CRM_Contact_BAO_ContactType::basicTypeInfo(), 'label', 'name');
     $parser = $this->getParser();
     $this->isQuickFormMode = FALSE;
     Civi::resources()->addVars('crmImportUi', [


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug where the properties of Contact Types are incorrectly assigning the values to the wrong keys. The id field was referencing the label / text and the text field was referencing the id. I have given an explanation in answer to my own question on [civicrm.stackexchange](https://civicrm.stackexchange.com/questions/49907/why-is-angularjs-code-displaying-on-the-contributions-import-page/)

Before
----------------------------------------
It was causing the import contribution process to be unusable, when a user has previously changed a Contact Type's name / label from the default value. It was trying to access an undefined variable casuing major issues with the page. This can be replicated on the dmaster demo by changing one of the built in contact type names and trying to import contributions.

After
----------------------------------------
The import contribution process now works, when a user has changed a Contact Type's name / label.

Comments
----------------------------------------
This is my first PR any feedback welcome.
