### PR TITLE
Fix for dev/core#6161: Bad urls generated via shortcodes on WordPress…

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -331,6 +331,11 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       global $post;
       if ($post) {
         $frontend_url = get_permalink($post->ID);
+        if ($frontend_url == CRM_Utils_System::baseURL()) {
+          // Frontend URL is the bare WP homepage. Append civicrm basepage path so that
+          // URLs will resolve to a workable civicrm page/form.
+          $frontend_url = $this->getBasePageUrl();
+        }
         if (civi_wp()->basepage->is_match($post->ID)) {
           $basepage = TRUE;
         }


### PR DESCRIPTION
… "Homepage" / "Front Page"

Overview
----------------------------------------
As in original issue: https://lab.civicrm.org/dev/core/-/issues/6161: 
When using civicrm shortcodes on WordPress homepage ("Front Page"), CiviCRM generates URLs that don't point to working CiviCRM content.

Before
----------------------------------------
Bad links (e.g. http://wpmaster.local.civi.bid/?civiwp=CiviCRM&q=civicrm%2Fcontribute%2Ftransact&cid=0&reset=1&id=1 ) are generated.

After
----------------------------------------
Useful links (e.g. http://wpmaster.local.civi.bid/civicrm?civiwp=CiviCRM&q=civicrm%2Fcontribute%2Ftransact&cid=0&reset=1&id=1 ) are generated.

Technical Details
----------------------------------------
Worth acknowledging: 
- Admittedly, this PR changes a method that already seems quite complex. However, I believe the change is narrowly scoped. 
- Also: it's conceivable that content on 'homepage' `/` and `civicrm/` will be displayed in different contexts, which may create varying display differences on some sites. Regardless of this, a functional URL seems much preferable to a non-functional one.

Comments
----------------------------------------
None.
