### PR TITLE
Allow expired user jobs to exist until they have been deleted

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -91,16 +91,11 @@ function _civiimport_civicrm_get_import_tables(): array {
     LEFT JOIN civicrm_contact created_id ON created_id.id = user_job.created_id
     LEFT JOIN civicrm_search_display sd ON sd.id = user_job.search_display_id
     LEFT JOIN civicrm_saved_search ss ON ss.id = sd.saved_search_id
-      -- As of writing expires date is probably not being managed
-      -- it is intended to be used to actually purge the record in
-      -- a cleanup job so it might not be relevant here & perhaps this will
-      -- be removed later
-      WHERE (user_job.expires_date IS NULL OR user_job.expires_date > NOW())
       -- this is a short-cut for looking up if they are imports
       -- it is a new convention, at best, to require anything
       -- specific in the job_type, but it saves any onerous lookups
       -- in a function which needs to avoid loops
-      AND job_type LIKE "%import%"
+      WHERE job_type LIKE "%import%"
       -- also more of a feature than a specification - but we need a table
       -- to do this pseudo-api
       AND metadata LIKE "%table_name%"');


### PR DESCRIPTION
If a user job has expired, but has not been deleted (it has a expiry date in the past, but a cache clear hasn't happened yet), then the cached list of entities will contain the import_NN entity, but CiviImport will believe it no longer exists as a table. The result is that if you try to access the API Explorer in this state, you get an error because it tries to getFields for the entity core thinks exists, but CiviImport does not agree exists. I've seen and had reports of this error in other places, but API Explorer is the only way I've been able to replicate.

In any case, there's no harm in allowing the user job entity to exist until the cache has been cleared, which will make sure the cached entity list and CiviImport are on the same page.

@eileenmcnaughton said this line "might be removed later" — turns out later is now.