### PR TITLE
Add Search to Manage Extensions

### DIFF
--- a/templates/CRM/Admin/Page/Extensions.tpl
+++ b/templates/CRM/Admin/Page/Extensions.tpl
@@ -27,6 +27,9 @@
     {include file="CRM/common/enableDisableApi.tpl"}
     {include file="CRM/common/jsortable.tpl"}
 
+    <div class="ui-widget ui-widget-content ui-corner-all" style="padding: 4px;">
+      <input type="search" id="search_extension" class="ui-widget-content ui-corner-all" placeholder="🔍 {ts escape='htmlattribute'}Search extensions{/ts}" oninput="filterExtensions()" style="padding: 8px;">
+    </div>
     <div id="mainTabContainer" class="ui-tabs ui-widget ui-widget-content ui-corner-all">
         <ul class="crm-extensions-tabs-list" role="tablist">
             <li id="tab_summary" role="tab" class="crm-tab-button">
@@ -87,6 +90,31 @@
         return false;
       }); // .click
     }); // onload
+
+    // Keyword search
+    function filterExtensions() {
+      const searchTerm = document.getElementById('search_extension').value.toLowerCase().trim();
+      const coreTab = document.getElementById('extensions-main');
+      const addNewTab = document.getElementById('extensions-addnew');
+      // Filter Core Extensions
+      if (coreTab) {
+        const coreRows = coreTab.querySelectorAll('.crm-extension-row');
+        coreRows.forEach(extensionRow => {
+          const title = extensionRow.querySelector('summary').textContent.toLowerCase();
+          const isVisible = title.includes(searchTerm);
+          extensionRow.style.display = isVisible ? 'table-row' : 'none';
+        });
+      }
+      // Filter Add New Extensions
+      if (addNewTab) {
+        const addNewRows = addNewTab.querySelectorAll('.crm-extension-row');
+        addNewRows.forEach(extensionRow => {
+          const title = extensionRow.querySelector('summary').textContent.toLowerCase();
+          const isVisible = title.includes(searchTerm);
+          extensionRow.style.display = isVisible ? 'table-row' : 'none';
+        });
+      }
+    }
     </script>
     {/literal}
 {/if}

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -19,7 +19,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         {if array_key_exists($extKey, $localExtensionRows)}
           {continue}
         {/if}
-        <tr id="addnew-row_{$row.file}" class="crm-extensions crm-extensions_{$row.file} {cycle values="odd-row,even-row"}">
+        <tr id="addnew-row_{$row.file}" class="crm-extension-row crm-extensions crm-extensions_{$row.file} {cycle values="odd-row,even-row"}">
           <td class="crm-extensions-label">
             <details class="crm-accordion-light">
               <summary><strong>{$row.label|escape}</strong>

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -17,7 +17,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
       </thead>
       <tbody>
         {foreach from=$localExtensionRows key=extKey item=row}
-        <tr id="extension-{$row.file|escape}" class="crm-entity crm-extension-{$row.file|escape}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.status eq 'installed'} extension-installed{/if}">
+        <tr id="extension-{$row.file|escape}" class="crm-extension-row crm-entity crm-extension-{$row.file|escape}{if $row.status eq 'disabled'} disabled{/if}{if $row.status eq 'installed-missing' or $row.status eq 'disabled-missing'} extension-missing{/if}{if $row.status eq 'installed'} extension-installed{/if}">
           <td class="crm-extensions-label">
             <details class="crm-accordion-light">
               <summary>


### PR DESCRIPTION
Overview
----------------------------------------

Alternative to PR #33347 - only adds the search feature.

To test: go to Administer > System Settings  > Extensions

Before
----------------------------------------

No search bar.

After
----------------------------------------

Search bar :beers: 

<img width="1536" height="886" alt="image" src="https://github.com/user-attachments/assets/e9aa5baa-64c7-4dfc-ba25-5c4855c8fe51" />

Comments
----------------------------------------

The idea is to focus on a UX quickfix to something often requested (search) but without adding new patterns that would make this difficult to migrate to SearchKit/FormBuilder.

cc @sunilpawar 