### PR TITLE
fix 'update' on importing memberships/participants

### DIFF
--- a/ext/civiimport/Civi/Import/MembershipParser.php
+++ b/ext/civiimport/Civi/Import/MembershipParser.php
@@ -71,10 +71,11 @@ class MembershipParser extends ImportParser {
         'supports_multiple' => FALSE,
         'is_required' => TRUE,
         // For now we stick with the action selected on the DataSource page.
-        'actions' => $this->isUpdateExisting() ?
-          [['id' => 'update', 'text' => ts('Update existing'), 'description' => ts('Skip if no match found')]] :
-          [['id' => 'create', 'text' => ts('Create'), 'description' => ts('Skip if already exists')]],
-        'default_action' => $this->isUpdateExisting() ? 'update' : 'create',
+        'actions' => [
+          ['id' => 'update', 'text' => ts('Update existing'), 'description' => ts('Skip if no match found')],
+          ['id' => 'create', 'text' => ts('Create'), 'description' => ts('Skip if already exists')],
+        ],
+        'default_action' => 'create',
         'entity_name' => 'Membership',
         'entity_title' => ts('Membership'),
         'selected' => ['action' => $this->isUpdateExisting() ? 'update' : 'create'],

--- a/ext/civiimport/Civi/Import/ParticipantParser.php
+++ b/ext/civiimport/Civi/Import/ParticipantParser.php
@@ -72,10 +72,11 @@ class ParticipantParser extends ImportParser {
         'supports_multiple' => FALSE,
         'is_required' => TRUE,
         // For now we stick with the action selected on the DataSource page.
-        'actions' => $this->isUpdateExisting() ?
-          [['id' => 'update', 'text' => ts('Update existing'), 'description' => ts('Skip if no match found')]] :
-          [['id' => 'create', 'text' => ts('Create'), 'description' => ts('Skip if already exists')]],
-        'default_action' => $this->isUpdateExisting() ? 'update' : 'create',
+        'actions' => [
+          ['id' => 'update', 'text' => ts('Update existing'), 'description' => ts('Skip if no match found')],
+          ['id' => 'create', 'text' => ts('Create'), 'description' => ts('Skip if already exists')],
+        ],
+        'default_action' => 'create',
         'entity_name' => 'Participant',
         'entity_title' => ts('Participant'),
         'selected' => ['action' => $this->isUpdateExisting() ? 'update' : 'create'],


### PR DESCRIPTION
Overview
----------------------------------------
[_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._](https://lab.civicrm.org/dev/core/-/issues/6163)

Before
----------------------------------------
Can't select "update" on the "Import Memberships" or "Import Participants" screen.

After
----------------------------------------
Can.


Comments
----------------------------------------
See also https://github.com/civicrm/civicrm-core/pull/33136.
