### PR TITLE
standalone: Remember me MFA bypass

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/Login.php
@@ -24,8 +24,11 @@ class CRM_Standaloneusers_Page_Login extends CRM_Core_Page {
     $this->assign('pageTitle', '');
     // Remove breadcrumb for login page.
     $this->assign('breadcrumb', NULL);
+    Civi::resources()->addVars('standalone', [
+      'mfa_remember' => (\Civi::settings()->get('standalone_mfa_remember') ?? 0),
+    ]);
 
-    // Add the jQuery notify library because this library is only loaded whne the user is logged in. And we need this for CRM.alert
+    // Add the jQuery notify library because this library is only loaded when the user is logged in. And we need this for CRM.alert
     CRM_Core_Resources::singleton()->addScriptFile('civicrm.packages', "jquery/plugins/jquery.notify.min.js", ['region' => 'html-header']);
 
     \Civi::service('angularjs.loader')->addModules('crmLogin');

--- a/ext/standaloneusers/ang/crmLogin/crmLogin.html
+++ b/ext/standaloneusers/ang/crmLogin/crmLogin.html
@@ -16,6 +16,18 @@
       <label for="passwordInput" class="form-label">{{:: ts('Password') }}</label>
       <input type="password" class="form-control crm-form-text" id="passwordInput" ng-model="$ctrl.password" required />
     </div>
+    <div class="input-wrapper" ng-if="$ctrl.mfa_remember > 0" style="padding-left: 1.5rem;">
+      <input style="margin: 0.2rem 0 0 -1.5rem;position:absolute;"
+             type="checkbox"
+             class="form-control crm-form-checkbox"
+             id="rememberInput"
+             ng-model="$ctrl.rememberMe"
+             ng-change="$ctrl.rememberMeChanged()" />
+      <div>
+        <label for="rememberInput" class="form-label">{{:: ts('Remember this device') }}</label>
+        <div class="description">{{:: ts('Only use on a private device. Allows skipping multi-factor authentication on this device for %1 days.', {1: $ctrl.mfa_remember})}}</div>
+      </div>
+    </div>
     <div class="login-or-forgot">
       <a href="{{:: $ctrl.forgottenPasswordUrl }}">{{:: ts('Forgotten password?') }}</a>
       <button type="submit" class="btn btn-primary crm-button">{{:: ts('Log In') }}</button>

--- a/ext/standaloneusers/ang/crmLogin/crmLogin.js
+++ b/ext/standaloneusers/ang/crmLogin/crmLogin.js
@@ -12,10 +12,13 @@
       this.loading = true;
       this.loggedInAs = null;
 
+      let rememberJWT = localStorage.getItem('rememberJWT');
+      this.rememberMe = !!rememberJWT;
+      this.mfa_remember = CRM.vars.standalone.mfa_remember;
+
       this.forgottenPasswordUrl = CRM.url('civicrm/login/password');
 
       this.logoutUrl = CRM.url('civicrm/logout');
-
       this.$onInit = () => {
         if (CRM.config.cid) {
           return crmApi4('Contact', 'get', {
@@ -33,6 +36,12 @@
       this.canSubmit = () => {
         return this.identifier && this.password && !this.loading;
       };
+      this.rememberMeChanged = () => {
+        if (!this.rememberMe) {
+          // Immediately remove the JWT if user de-selects.
+          localStorage.removeItem('rememberJWT');
+        }
+      };
 
       this.attemptLogin = () => {
         if (!this.canSubmit()) {
@@ -48,13 +57,22 @@
 
         let publicError = ts('Unexpected error');
 
+        if (!this.rememberMe) {
+          // They have chosen not to remember, so clear any existing thing now.
+          localStorage.removeItem('rememberJWT');
+          rememberJWT = null;
+        }
+
         crmApi4('User', 'login', {
           identifier: this.identifier,
           password: this.password,
-          originalUrl
+          originalUrl,
+          rememberMe: this.rememberMe,
+          rememberJWT
         })
         .then((response) => {
           if (response.url) {
+            // Success.
             $window.location = response.url;
             return;
           }

--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -46,7 +46,8 @@ div.crm-container .standalone-auth-form label {
   margin-bottom: 0.25rem;
 }
 /* the div.crm-container is to beat the specificity of civicrm.css under Greenwich */
-div.crm-container .standalone-auth-form input {
+div.crm-container .standalone-auth-form input[type=password],
+div.crm-container .standalone-auth-form input[type=text] {
   box-sizing: border-box;
   width: 100%;
   height: 2rem;

--- a/ext/standaloneusers/settings/standaloneusers.setting.php
+++ b/ext/standaloneusers/settings/standaloneusers.setting.php
@@ -31,4 +31,19 @@ return [
     ],
     'pseudoconstant' => ['callback' => '\\Civi\\Standalone\\MFA\\Base::getMFAclasses'],
   ],
+  'standalone_mfa_remember' => [
+    'name' => 'standalone_mfa_remember',
+    'group' => 'standaloneusers',
+    'type' => 'Integer',
+    'title' => E::ts('Remember this device expiry (days)'),
+    'description' => E::ts('How many days should ‘remember this device’ allow a user to bypass MFA? Use zero to disable this feature.'),
+    'default' => '',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'html_type' => 'number',
+    'html_attributes' => [
+      'min' => 0,
+      'max' => 31,
+    ],
+  ],
 ];

--- a/ext/standaloneusers/templates/CRM/Standaloneusers/Page/TOTP.tpl
+++ b/ext/standaloneusers/templates/CRM/Standaloneusers/Page/TOTP.tpl
@@ -6,10 +6,11 @@
 
       <div class="input-wrapper">
         <label for="totpcode" name=totp class="form-label">{ts}Enter the code from your authenticator app{/ts}</label>
-        <input type="text" class="form-control" id="totpcode" maxlength=6>
+        <input type="text" class="form-control" id="totpcode" maxlength=6 autocomplete="off" >
       </div>
       <div>
-        <button id="submit" type="submit" class="btn crm-button">{ts}Submit{/ts}</button>
+        <button id="submit" type="submit" class="btn crm-button"><i id="submit-icon" class="crm-i fa-check" role="img" aria-hidden="true" ></i>
+        {ts}Submit{/ts}</button>
       </div>
     </form>
   </div>
@@ -23,14 +24,32 @@
       totpcodeInput = document.getElementById('totpcode');
 
     async function submit(e) {
+      const iconClasses = document.getElementById('submit-icon').classList;
+      const submitButton = document.getElementById('submit');
+
+      submitButton.disabled = true;
+      iconClasses.replace('fa-check', 'fa-spinner');
+      iconClasses.add('fa-spin');
       e.preventDefault();
       let errorMsg = 'Unexpected error';
       try {
         const response = await CRM.api4('User', 'login', { mfaClass: 'TOTP', mfaData: totpcodeInput.value });
         if (response.url) {
+          // Successful login. If we started the login with rememberMe then we
+          // will receive a JWT on successful login. We store this on
+          // localStorage to skip MFA in future.
+          if (response.rememberJWT) {
+            localStorage.setItem('rememberJWT', response.rememberJWT);
+          }
+          else {
+            localStorage.removeItem('rememberJWT');
+          }
           window.location = response.url;
           return;
         }
+        submitButton.disabled = false;
+        iconClasses.replace('fa-spinner', 'fa-check');
+        iconClasses.remove('fa-spin');
         errorMsg = response.publicError || "Unexpected error";
       }
       catch (e) {


### PR DESCRIPTION
It's annoying to have to keep entering MFA info (TOTP) into standalone. This implements a "remember me" functionality, which means that after a successful login including MFA, next time logins from that browser will not require MFA for a longer period.

The flow is:

- login screen includes checkbox "remember me"
  - this is pre-checked if the user has used this before (based on a JWT in localstorage)
- on login submit (username, password), the value of the checkbox is passed and the JWT if present. (If the checkbox is NOT checked, then the JWT is removed from localstorage).
- user, password checked as normal. Assuming ok...
- if the JWT was sent and is valid, the user is logged straight in.
- otherwise, the remember me checkbox value is stored in the temporary "pendingLogin" session array, then the user is sent to the OTP page.
- on completion of OTP, the login request checks the "remember me" value from the pendingLogin array, if set it returns a new JWT, which the browser puts on localStorage before redirecting the user to civicrm/home.


@ufundo 

To-do list

- [x] the jwt should include a short hash of the user's hashed password. This means a user can revoke any JWTs on other devices by updating their password. 
- [x] the timeout for the remember me should be a config setting.
- [x] the jwt's "iat" timestamp should be checked against the config setting, so that if an admin shortens the time, older JWTs with longer timeouts will be invalidated.

