### PR TITLE
Fix Datasegment issue when Contains clause is used

### DIFF
--- a/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
+++ b/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php
@@ -95,7 +95,7 @@ class SearchSegmentExtraFieldProvider extends AutoService implements Generic\Spe
       foreach ($item['when'] ?? [] as $clause) {
         // Add field prefix
         $clause[0] = $prefix . $clause[0];
-        $conditions[] = $query->composeClause($clause, 'WHERE', 0);
+        $conditions[] = $query->treeWalkClauses($clause, 'WHERE', 0);
       }
       // If no conditions, this is the ELSE clause
       if (!$conditions) {


### PR DESCRIPTION
Overview
----------------------------------------
```
Error: Object of class Civi\Api4\Query\SqlField could not be converted to string in Civi\Api4\Query\Api4Query->composeClause() (line 399 of /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Query/Api4Query.php).

#0 /var/drupal11/vendor/civicrm/civicrm-core/ext/search_kit/Civi/Api4/Service/Spec/Provider/SearchSegmentExtraFieldProvider.php(98): Civi\Api4\Query\Api4Query->composeClause()
#1 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Query/SqlField.php(32): Civi\Api4\Service\Spec\Provider\SearchSegmentExtraFieldProvider::renderSql()
#2 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Query/Api4SelectQuery.php(204): Civi\Api4\Query\SqlField->render()
#3 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Query/Api4Query.php(74): Civi\Api4\Query\Api4SelectQuery->buildSelectClause()
#4 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Query/Api4Query.php(85): Civi\Api4\Query\Api4Query->getSql()
#5 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Query/Api4SelectQuery.php(106): Civi\Api4\Query\Api4Query->getResults()
#6 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Generic/DAOGetAction.php(107): Civi\Api4\Query\Api4SelectQuery->run()
#7 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Generic/DAOGetAction.php(94): Civi\Api4\Generic\DAOGetAction->getObjects()
#8 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Provider/ActionObjectProvider.php(91): Civi\Api4\Generic\DAOGetAction->_run()
#9 /var/drupal11/vendor/civicrm/civicrm-core/Civi/API/Kernel.php(153): Civi\Api4\Provider\ActionObjectProvider->invoke()
#10 /var/drupal11/vendor/civicrm/civicrm-core/Civi/Api4/Generic/AbstractAction.php(251): Civi\API\Kernel->runRequest()
#11 /var/drupal11/vendor/civicrm/civicrm-core/api/api.php(102): Civi\Api4\Generic\AbstractAction->execute()
#12 /var/drupal11/vendor/civicrm/civicrm-core/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php(111): civicrm_api4()
```

Fatal Error when a multi-select custom field is used as a filter with contains clause in datasegment and is included as a column in a Searchkit search