### PR TITLE
OAuthProvider - Allow tags on providers (e.g. "CiviConnect")

### DIFF
--- a/ext/oauth-client/Civi/Api4/OAuthProvider.php
+++ b/ext/oauth-client/Civi/Api4/OAuthProvider.php
@@ -60,6 +60,10 @@ class OAuthProvider extends Generic\AbstractEntity {
           'name' => 'options',
         ],
         [
+          'name' => 'tags',
+          'data_type' => 'Array',
+        ],
+        [
           'name' => 'contactTemplate',
         ],
         [

--- a/ext/oauth-client/providers/test_example_2.test.json
+++ b/ext/oauth-client/providers/test_example_2.test.json
@@ -2,6 +2,7 @@
   "name": "test_example_2",
   "title": "Second Test Example",
   "class": "My\\Example2",
+  "tags": ["LaundryInstructions", "MSRP", "MattressMaterials"],
   "options": {
     "urlAuthorize": "https://example.com/two",
     "scopes": ["scope-2-foo", "scope-2-bar"]

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthProviderTest.php
@@ -51,4 +51,20 @@ class api_v4_OAuthProviderTest extends \PHPUnit\Framework\TestCase implements He
 
   }
 
+  /**
+   * Create, read, and destroy token - with full access to secrets.
+   */
+  public function testGetByTag(): void {
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = ['access CiviCRM'];
+
+    $examples = Civi\Api4\OAuthProvider::get()
+      ->addWhere('tags', 'CONTAINS', 'LaundryInstructions')
+      ->addOrderBy('name', 'DESC')
+      ->execute();
+    $this->assertEquals(1, $examples->count());
+
+    $this->assertEquals('My\Example2', $examples->single()['class']);
+    $this->assertEquals('https://example.com/two', $examples->single()['options']['urlAuthorize']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Add an extra field on the `OAuthProvider` record called `tags`. Tags can be used as a basic flag for the purpose/behavior of each OAuth integration.

(cc @pfigel ) 

Comments
-----------------------------------------

* This is extracted from #33707. In that case, the idea is to tag an OAuthProvider as `CiviConnect` (which enables certain types of auto-registration).
* Another way to use this would be to filter providers by their general purpose (e.g. `InboundEmail` vs `Login` vs `PaymentProcessor`).