### PR TITLE
RiverLea: Form table label column - change width to minimum to avoid inconsistent squishing

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -28,7 +28,7 @@
 .crm-container .form-layout-compressed td.label,
 .crm-container .selector td.label,
 .crm-container .form-layout-compressed th.label {
-  width: var(--crm-input-label-width);
+  min-width: var(--crm-input-label-width);
   text-align: var(--crm-input-label-align);
   margin: var(--crm-m) var(--crm-m2) 0 0;
   font-family: var(--crm-input-label-font);


### PR DESCRIPTION
Overview
----------------------------------------
As raised by @GuillaumeSorel - Older Civi form layouts using table for layout with label and input in separate columns don't give a consistent width for the label column. But they should! Using the custom property `--crm-input-label-width`.

But that's only working in some contexts because it's a width, not a min-width.

Before
----------------------------------------
`--crm-input-label-width` is set to table label width
<img width="1073" height="328" alt="image" src="https://github.com/user-attachments/assets/049095c7-fdd6-4312-ba80-7b6ec312df47" />

After
----------------------------------------
`--crm-input-label-width` is set to table label min-width
<img width="1088" height="371" alt="image" src="https://github.com/user-attachments/assets/85b7ebe4-fb9a-4dc3-8355-e62b331f7336" />