### PR TITLE
Fix failure to clear cache when editing mailing components

### DIFF
--- a/CRM/Mailing/BAO/MailingComponent.php
+++ b/CRM/Mailing/BAO/MailingComponent.php
@@ -9,12 +9,16 @@
  +--------------------------------------------------------------------+
  */
 
+
+use Civi\Core\Event\PreEvent;
+use Civi\Core\Event\PostEvent;
+
 /**
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Mailing_BAO_MailingComponent extends CRM_Mailing_DAO_MailingComponent {
+class CRM_Mailing_BAO_MailingComponent extends CRM_Mailing_DAO_MailingComponent implements Civi\Core\HookInterface {
 
   /**
    * @deprecated
@@ -43,40 +47,51 @@ class CRM_Mailing_BAO_MailingComponent extends CRM_Mailing_DAO_MailingComponent 
    *
    * @param array $params
    *
+   * @deprecated since 6.8 will be removed around 6.24
+   *
    * @return CRM_Mailing_BAO_MailingComponent
    */
   public static function add(array $params) {
-    $id = $params['id'] ?? NULL;
-    $component = new CRM_Mailing_BAO_MailingComponent();
-    if ($id) {
-      $component->id = $id;
-      $component->find(TRUE);
-    }
+    return self::writeRecord($params);
+  }
 
-    $component->copyValues($params);
-    if (empty($id) && empty($params['body_text'])) {
-      $component->body_text = CRM_Utils_String::htmlToText($params['body_html'] ?? '');
-    }
+  /**
+   * Clear cached options when altering mailing components
+   *
+   * @param \Civi\Core\Event\PostEvent $event
+   */
+  public static function self_hook_civicrm_post(PostEvent $event): void {
+    \Civi::cache('metadata')->clear();
+  }
 
-    if ($component->is_default) {
-      if (!empty($id)) {
-        $sql = 'UPDATE civicrm_mailing_component SET is_default = 0 WHERE component_type = %1 AND id <> %2';
-        $sqlParams = [
-          1 => [$component->component_type, 'String'],
-          2 => [$id, 'Positive'],
-        ];
+  /**
+   * Event fired when creating a contribution
+   *
+   * @param \Civi\Core\Event\PreEvent $event
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function self_hook_civicrm_pre(PreEvent $event): void {
+    if ($event->action === 'create') {
+      if (empty($event->params['body_text'])) {
+        $event->params['body_text'] = CRM_Utils_String::htmlToText($event->params['body_html'] ?? '');
       }
-      else {
-        $sql = 'UPDATE civicrm_mailing_component SET is_default = 0 WHERE component_type = %1';
-        $sqlParams = [
-          1 => [$component->component_type, 'String'],
-        ];
+      if (!empty($event->params['is_default'])) {
+        CRM_Core_DAO::executeQuery('UPDATE civicrm_mailing_component SET is_default = 0 WHERE component_type = %1', [
+          1 => [$event->params['component_type'], 'String'],
+        ]);
       }
-      CRM_Core_DAO::executeQuery($sql, $sqlParams);
+    }
+    elseif (!empty($event->params['is_default'])) {
+      if (empty($event->params['component_type'])) {
+        $event->params['component_type'] = CRM_Core_DAO::singleValueQuery('SELECT component_type FROM civicrm_mailing_component WHERE id = %1', [1 => [$event->params['id'], 'Positive']]);
+      }
+      CRM_Core_DAO::executeQuery('UPDATE civicrm_mailing_component SET is_default = 0 WHERE component_type = %1 AND id <> %2', [
+        1 => [$event->params['component_type'], 'String'],
+        2 => [$event->params['id'], 'Positive'],
+      ]);
     }
 
-    $component->save();
-    return $component;
   }
 
 }

--- a/tests/phpunit/CRM/Mailing/BAO/ConfirmTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/ConfirmTest.php
@@ -57,6 +57,7 @@ class CRM_Mailing_BAO_ConfirmTest extends CiviUnitTestCase {
 
     $mailingComponentID = $this->callAPISuccess('MailingComponent', 'get', ['component_type' => 'Welcome'])['id'];
     $this->callAPISuccess('MailingComponent', 'create', [
+      'is_default' => 1,
       // Swap {welcome.group} to {group.frontend_title} which is the standardised token.
       // The intent is to make this version the default, but need to ensure it is required.
       'body_html' => 'Welcome. Your subscription to the {group.frontend_title} mailing list has been activated.',

--- a/tests/phpunit/Civi/Entity/MailingComponentTest.php
+++ b/tests/phpunit/Civi/Entity/MailingComponentTest.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace phpunit\Civi\Entity;
+
+use Civi\Api4\Mailing;
+use Civi\Core\HookInterface;
+use Civi\Test\EntityTrait;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the core Entity->getOptions functionality
+ * @group headless
+ */
+class MailingComponentTest extends TestCase implements HeadlessInterface, HookInterface {
+
+  use EntityTrait;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->apply();
+  }
+
+  public function testCacheClear(): void {
+    $this->createTestEntity('MailingComponent', [
+      'component_type' => 'Footer',
+      'name' => 'another',
+      'subject' => 'blah',
+      'body_html' => '<p>blah</p>',
+    ]);
+    $mailing = Mailing::getFields()
+      ->setLoadOptions(TRUE)
+      ->addWhere('name', '=', 'footer_id')
+      ->execute()->first();
+    $this->assertTrue(in_array('another', $mailing['options']));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to clear cache when editing mailing components

Before
----------------------------------------
- Add a new mailing footer at https://dmaster.localhost:32353/civicrm/admin/component?reset=1
- go to new mailing & attempt to use it - on save an error occurs as the new footer_id is not yet loaded

After
----------------------------------------
Cache cleared - loads

Technical Details
----------------------------------------

Comments
