### PR TITLE
RiverLea: Fix Joomla sticky header offset

### DIFF
--- a/ext/riverlea/core/css/joomla.css
+++ b/ext/riverlea/core/css/joomla.css
@@ -76,6 +76,7 @@ body.com_civicm.layout-default .table tbody a:not(.badge):not(.btn):not(.dropdow
 body.com_civicm #bootstrap-theme .bg-secondary {
   background-color: var(--crm-c-secondary) !important; /* vs !important bg colour in Atum theme */
 }
-body.com_civicrm.layout-default table .crm-sticky-header {
+body.com_civicrm.layout-default table .crm-sticky-header,
+body.com_civicrm.layout-default table.crm-sticky-header {
   --crm-menubar-bottom: 0;
 }


### PR DESCRIPTION
Sticky table headers have a variable for top offset that varies depending on the CMS. Joomla 4+5 resets this 0, but it doesn't work on `table.crm-sticky-header`. This adds support for that, doesn't change any existing behaviours.

Before
----------------------------------------
<img width="1201" height="260" alt="image" src="https://github.com/user-attachments/assets/7b16d585-6289-495b-8a1f-85970cd109ee" />

After
----------------------------------------
<img width="1232" height="334" alt="image" src="https://github.com/user-attachments/assets/a298d6ae-967c-494a-a68c-c9300bb15a2f" />
