### PR TITLE
Fix float precision edge case (server dependent)

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2878,9 +2878,13 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $statusId = $params['contribution']->contribution_status_id;
-
+    // Checking $params['is_pay_later'] means we only pick this up if
+    // is_pay_later has been passed in - this feels like a mistake but it
+    // is an entrenched mistake (the previous code did the same although
+    // less obviously as it checked a partially populated contribution object.
+    $isPayLater = !empty($params['is_pay_later']);
     if ($contributionStatus !== 'Failed' &&
-      !($contributionStatus === 'Pending' && !$params['contribution']->is_pay_later)
+      !($contributionStatus === 'Pending' && !$isPayLater)
     ) {
       $skipRecords = TRUE;
       $pendingStatus = [

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -202,6 +202,15 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     }
 
     $result = $contribution->save();
+    // Re-load the contribution, first removing all money values.
+    // We need to have some contribution details later on - ie
+    // if for record financial accounts and for adding activities.
+    // Under some circumstances (server dependent) the php values
+    // might be unrounded floats that save to rounded floats so
+    // doing the reload once here when we can unset them
+    // is better than possibly unreliable re-loads in other places.
+    unset($contribution->total_amount, $contribution->net_amount, $contribution->fee_amount, $contribution->non_deductible_amount, $contribution->tax_amount);
+    $contribution->find(TRUE);
     // Save invoice number if appropriate. Note we used to try to
     // avoid a second save but check https://lab.civicrm.org/dev/core/-/issues/5004
     // to see how that worked out....
@@ -520,10 +529,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
     $transaction->commit();
 
-    if (empty($contribution->contact_id)) {
-      $contribution->find(TRUE);
-    }
-
     $isCompleted = ('Completed' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id));
     if (!empty($params['on_behalf'])
       ||  $isCompleted
@@ -570,23 +575,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
       $url = CRM_Utils_System::url('civicrm/contact/view/contribution',
         "action=view&reset=1&id={$contribution->id}&cid={$contribution->contact_id}&context=home"
       );
-      // in some update cases we need to get extra fields - ie an update that doesn't pass in all these params
-      $titleFields = [
-        'contact_id',
-        'total_amount',
-        'currency',
-        'financial_type_id',
-      ];
-      $retrieveRequired = 0;
-      foreach ($titleFields as $titleField) {
-        if (!isset($contribution->$titleField)) {
-          $retrieveRequired = 1;
-          break;
-        }
-      }
-      if ($retrieveRequired == 1) {
-        $contribution->find(TRUE);
-      }
+
       $financialType = CRM_Contribute_PseudoConstant::financialType($contribution->financial_type_id);
       $title = CRM_Contact_BAO_Contact::displayName($contribution->contact_id) . ' - (' . CRM_Utils_Money::format($contribution->total_amount, $contribution->currency) . ' ' . ' - ' . $financialType . ')';
 
@@ -2928,9 +2917,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       if (!isset($totalAmount) && !empty($params['prevContribution'])) {
         $totalAmount = $params['total_amount'] = $params['prevContribution']->total_amount;
       }
-      if (empty($contribution->currency)) {
-        $contribution->find(TRUE);
-      }
+
       //build financial transaction params
       $trxnParams = [
         'contribution_id' => $contribution->id,


### PR DESCRIPTION

Overview
----------------------------------------
Fix float precision edge case (server dependent)

In some cases the value php holds when it goes to save the Contribution is different to the value that is actually saved due to precision rounding This relates to the serialize_precision ini variable but appears to also have some other factors impacting it.

We have 3 places where we conditionally try to load a contribution once saved so it is useful to know that it is always retrieved and seems worth any trade off. On the other side if we retrieve it right after save we can unset the values that might cause inaccuracies


Before
----------------------------------------
In some circumstances we can wind up with a contribution with an amount field that is being rounded when saved in the contribution BAO due to floats being weird. In this case the `$contribution->find()` may not retrieve it causing failure when the activity is to be sent

After
----------------------------------------
Contribution is re-loaded straight after save in all cases. Amount fields are removed to prevent rounding mismatches

Technical Details
----------------------------------------
I was unable to replicate this with a pure float locally but could with a string. However, on our server it appears to be happening with a string...

Comments
----------------------------------------
