### PR TITLE
Riverlea: add settings item to set the font size for all streams

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -195,7 +195,7 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
    * point number (CSS font size in rem)
    */
   public static function validateFontSize($value):bool {
-    $fontSize = floatval($value);
+    $fontSize = \CRM_Utils_Type::validate($value, 'Float', FALSE);
     if ($fontSize < 0.5 || $fontSize > 2) {
       return FALSE;
     }

--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -189,29 +189,40 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
 
     $e->content = $render['content'] ?? '';
   }
-  
-  /** Get font size from setting and add a variable for it
+
+  /**
+   * Validate the font size setting: it should be a floating
+   * point number (CSS font size in rem)
+   */
+  public static function validateFontSize($value):bool {
+    $fontSize = floatval($value);
+    if ($fontSize < 0.5 || $fontSize > 2) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Get font size setting and add a variable for it
    * to the CSS properties of every stream
    */
   public static function onChangeFontsize($oldValue, $newValue, $metadata) {
     if ($oldValue != $newValue) {
-      // Make sure a floating point number was input
       $fontSize = floatval($newValue);
-      if ($fontSize > 0.3 && $fontSize < 5) {
-        // Get current CSS properties for every stream
-        $riverleaStreams = \Civi\Api4\RiverleaStream::get(TRUE)
+      // Get current CSS properties for every stream
+      $riverleaStreams = \Civi\Api4\RiverleaStream::get(TRUE)
         ->addSelect('vars')
         ->execute();
-        // Add new font size to each stream as a CSS property
-        foreach ($riverleaStreams as $riverleaStream) {
-          $riverleaStream['vars']['--crm-font-size'] = $fontSize . "rem";
-          // Write the new value to the CSS vars of each stream
-          $results = \Civi\Api4\RiverleaStream::update(TRUE)
+      // Add new font size to each stream as a CSS property
+      foreach ($riverleaStreams as $riverleaStream) {
+        $riverleaStream['vars']['--crm-font-size'] = $fontSize . "rem";
+        // Write the new value to the CSS vars of each stream
+        $results = \Civi\Api4\RiverleaStream::update(TRUE)
           ->addValue('vars', $riverleaStream['vars'])
           ->addWhere('id', '=', $riverleaStream['id'])
           ->execute();
-        }
       }
     }
   }
+
 }

--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -189,5 +189,29 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
 
     $e->content = $render['content'] ?? '';
   }
-
+  
+  /** Get font size from setting and add a variable for it
+   * to the CSS properties of every stream
+   */
+  public static function onChangeFontsize($oldValue, $newValue, $metadata) {
+    if ($oldValue != $newValue) {
+      // Make sure a floating point number was input
+      $fontSize = floatval($newValue);
+      if ($fontSize > 0.3 && $fontSize < 5) {
+        // Get current CSS properties for every stream
+        $riverleaStreams = \Civi\Api4\RiverleaStream::get(TRUE)
+        ->addSelect('vars')
+        ->execute();
+        // Add new font size to each stream as a CSS property
+        foreach ($riverleaStreams as $riverleaStream) {
+          $riverleaStream['vars']['--crm-font-size'] = $fontSize . "rem";
+          // Write the new value to the CSS vars of each stream
+          $results = \Civi\Api4\RiverleaStream::update(TRUE)
+          ->addValue('vars', $riverleaStream['vars'])
+          ->addWhere('id', '=', $riverleaStream['id'])
+          ->execute();
+        }
+      }
+    }
+  }
 }

--- a/ext/riverlea/settings/riverlea.setting.php
+++ b/ext/riverlea/settings/riverlea.setting.php
@@ -47,4 +47,28 @@ return [
       'display' => ['section' => 'theme', 'weight' => 40],
     ],
   ],
+  'riverlea_font_size' => [
+    'name' => 'riverlea_font_size',
+    'group' => 'riverlea',
+    'default' => '1',
+    'html_type' => 'select',
+    'add' => 1.0,
+    'options' => [
+      '0.75' => E::ts('Smallest'),
+      '0.875' => E::ts('Small'),
+      '1' => E::ts('Default'),
+      '1.125' => E::ts('Big'),
+      '1.5' => E::ts('Bigger'),
+    ],
+    'on_change' => [
+      '\\Civi\\Riverlea\\StyleLoader::onChangeFontsize',
+    ],
+    'title' => E::ts('Font size'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('The font size (Smallest 12px, Small 14px, Default 16px, Big 18px, Bigger 24px)'),
+    'settings_pages' => [
+      'riverlea' => ['weight' => 500],
+    ],
+  ],
 ];

--- a/ext/riverlea/settings/riverlea.setting.php
+++ b/ext/riverlea/settings/riverlea.setting.php
@@ -68,7 +68,7 @@ return [
     'title' => E::ts('Font size'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => E::ts('The font size (Smallest 12px, Small 14px, Default 16px, Big 18px, Bigger 24px)'),
+    'help_text' => E::ts('For systems where 1rem = 16px (which is the default in RiverLea and all browsers) these sizes represent: Smallest 12px, Small 14px, Default 16px, Big 18px, Bigger 24px.'),
     'settings_pages' => [
       'riverlea' => ['weight' => 500],
     ],

--- a/ext/riverlea/settings/riverlea.setting.php
+++ b/ext/riverlea/settings/riverlea.setting.php
@@ -51,6 +51,7 @@ return [
     'name' => 'riverlea_font_size',
     'group' => 'riverlea',
     'default' => '1',
+    'type' => 'String',
     'html_type' => 'select',
     'add' => 1.0,
     'options' => [
@@ -63,6 +64,7 @@ return [
     'on_change' => [
       '\\Civi\\Riverlea\\StyleLoader::onChangeFontsize',
     ],
+    'validate_callback' => '\\Civi\\Riverlea\\StyleLoader::validateFontsize',
     'title' => E::ts('Font size'),
     'is_domain' => 1,
     'is_contact' => 0,


### PR DESCRIPTION
Overview
----------------------------------------
Adds a setting to the Riverlea settings screen to set the font size.

Before
----------------------------------------
No setting existed to set the font size.

After
----------------------------------------
There is a font size setting on the Riverlea settings screen:

<img width="1181" height="490" alt="RIverlea-Font-size-setting" src="https://github.com/user-attachments/assets/7934430c-c98f-418c-86ac-3a5b09aceaa2" />

Technical Details
----------------------------------------
After the font size is changed, the CSS property `--crm-font-size` is written into the "vars" attribute of all Riverlea streams.

Comments
----------------------------------------
As discussed at Civi Sprint with Nick and Ben. The setting is only validated when setting the font size, it would be nice to have a validator set for the setting before it gets saved.
