### PR TITLE
RiverLea: Walbrook link colour, make more visible / closer to The Island extensions/riverlea/#157

### DIFF
--- a/ext/riverlea/streams/walbrook/_variables.css
+++ b/ext/riverlea/streams/walbrook/_variables.css
@@ -33,8 +33,8 @@
   --crm-c-teal: #399389;
 /* Practical colours */
   --crm-c-text: #34303b;
-  --crm-c-link: var(--crm-c-blue-darker);
-  --crm-c-link-hover: #004370;
+  --crm-c-link: var(--crm-c-blue-dark);
+  --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-page-bg: #e8eef0;
   --crm-c-container-bg: var(--crm-c-layer0-bg);
   --crm-c-drag-bg: var(--crm-c-gray-200); /* background for drag/drop regions, select2 highlight */


### PR DESCRIPTION
Links in the Search Kit search results are not clearly differentiated from normal text: https://lab.civicrm.org/extensions/riverlea/-/issues/157

Before
----------------------------------------
<img width="859" height="149" alt="image" src="https://github.com/user-attachments/assets/b992465a-b939-480c-8c87-58078323a62a" />

After
----------------------------------------
<img width="841" height="135" alt="image" src="https://github.com/user-attachments/assets/9375bc44-2ff5-4709-9118-806266857888" />

Technical Details
----------------------------------------
Change only impacts Walbrook light mode. Dark mode has its own variables for links that's not impacted.