### PR TITLE
Add created/modified date columns to Contribution

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixNine.php
+++ b/CRM/Upgrade/Incremental/php/SixNine.php
@@ -29,6 +29,38 @@ class CRM_Upgrade_Incremental_php_SixNine extends CRM_Upgrade_Incremental_Base {
    */
   public function upgrade_6_9_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+
+    $this->addTask('Add column "Contribution.created_date"', 'alterSchemaField', 'Contribution', 'created_date', [
+      'title' => ts('Created Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the contribution created.'),
+      'unique_name' => 'contribution_created_date',
+      'default' => 'CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Created Date'),
+      ],
+    ]);
+
+    $this->addTask('Add column "Contribution.modified_date"', 'alterSchemaField', 'Contribution', 'modified_date', [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the contribution created or modified or deleted.'),
+      'unique_name' => 'contribution_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Modified Date'),
+      ],
+    ]);
   }
 
 }

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -589,5 +589,37 @@ return [
         'duplicate_matching',
       ],
     ],
+    'created_date' => [
+      'title' => ts('Created Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the contribution created.'),
+      'add' => '6.9',
+      'unique_name' => 'contribution_created_date',
+      'default' => 'CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Created Date'),
+      ],
+    ],
+    'modified_date' => [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the contribution created or modified or deleted.'),
+      'add' => '6.9',
+      'unique_name' => 'contribution_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Modified Date'),
+      ],
+    ],
   ],
 ];

--- a/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
+++ b/tests/phpunit/CRM/Contribute/ActionMapping/ByTypeTest.php
@@ -478,6 +478,8 @@ class CRM_Contribute_ActionMapping_ByTypeTest extends AbstractMappingTestCase {
         'address_id.name' => 'Billing Address Name',
         'address_id.display' => 'Billing Address',
         'header' => 'Message Header',
+        'created_date' => 'Created Date',
+        'modified_date' => 'Modified Date',
       ], $comparison);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add columns `created_date` and `modified_date` to the contributions table.

Before
----------------------------------------
The contributions table does not have the columns `created_date` and `modified_date`.

After
----------------------------------------
The contributions table now has the columns `created_date` and `modified_date`.

Technical Details
----------------------------------------

Comments
----------------------------------------
The purpose of these changes is to increase conformity with other entities that already have these columns and to facilitate the detection of recent updates to contributions.