### PR TITLE
Manage Extensions: minor ext detail cleanup, support URL label translations

### DIFF
--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -15,11 +15,6 @@
     <tr>
       <td class="label">
         {ts}Version{/ts}</td><td>{$extension.version|escape}
-        {if $extension.ready == 'ready'}
-          {icon icon="fa-trophy crm-extensions-stage"}{ts}This extension has been reviewed by the community.{/ts}{/icon}
-        {elseif $extension.develStage == 'stable' && $extension.ready == 'not_ready'}
-          {icon icon="fa-warning crm-extensions-stage"}{ts}This extension has not been reviewed by the community.{/ts} {ts}Please proceed with caution.{/ts}{/icon}
-        {/if}
       </td>
     </tr>
     {if $extension.develStage}
@@ -27,9 +22,12 @@
       <td class="label">{ts}Stability{/ts}</td>
       <td>
         {if $extension.ready == 'ready'}
+          {icon icon="fa-trophy crm-extensions-stage"}{ts}This extension has been reviewed by the community.{/ts}{/icon}
           {ts}This extension has been reviewed by the community.{/ts}
         {elseif $extension.develStage == 'stable' && $extension.ready == 'not_ready'}
-          <div class="crm-error alert alert-danger">{ts}Please proceed with caution.{/ts} {ts}This extension has not been reviewed by the community and therefore may conflict with your configuration.{/ts} {ts}Consider evaluating the stated version compatibility, the total number of active installations and the date of the latest release of the extension as these may be good indicators of the extension's stability. If a support link is listed, please consult their issue queue to review any known issues.{/ts} {docURL page="dev/extensions/lifecycle"}</div>
+          <div class="crm-error alert alert-danger">
+            {icon icon="fa-warning crm-extensions-stage"}{ts}This extension has not been reviewed by the community.{/ts} {ts}Please proceed with caution.{/ts}{/icon}
+            {ts}Please proceed with caution.{/ts} {ts}This extension has not been reviewed by the community and therefore may conflict with your configuration.{/ts} {ts}Consider evaluating the stated version compatibility, the total number of active installations and the date of the latest release of the extension as these may be good indicators of the extension's stability. If a support link is listed, please consult their issue queue to review any known issues.{/ts} {docURL page="dev/extensions/lifecycle"}</div>
         {else}
           {$extension.develStage_formatted|escape}
         {/if}
@@ -94,7 +92,7 @@
     </td>
   </tr>
     <tr>
-      <td class="label">{ts}License{/ts}</td><td>{$extension.license|escape}</td>
+      <td class="label">{ts}License{/ts}</td><td><a href="{$extension.urls['Licensing']}" target="_blank">{$extension.license|escape}</a></td>
     </tr>
     {if !empty($extension.path)}
       <tr>
@@ -102,8 +100,23 @@
       </tr>
     {/if}
     {if $extension.urls}
-        {foreach from=$extension.urls key=label item=url}
-            <tr><td class="label">{$label|escape}</td><td><a href="{$url|escape}">{$url|escape}</a></td></tr>
+        {foreach from=$extension.urls key=name item=url}
+          <tr>
+            {* This is required to support translation of the main URL types *}
+            {if $name == "Documentation"}
+              <td class="label">{ts}Documentation{/ts}</td>
+            {elseif $name == "Licensing"}
+              {* already linked above, do nothing *}
+            {elseif $name == "Main Extension Page"}
+              <td class="label">{ts}Main Extension Page{/ts}</td>
+            {elseif $name == "Support"}
+              <td class="label">{ts}Support{/ts}</td>
+            {else}
+              <td class="label">{$name|escape}</td>
+            {/if}
+            {if $name != "Licensing"}
+              <td><a href="{$url|escape}" target="_blank">{$url|escape}</a></td></tr>
+            {/if}
         {/foreach}
     {/if}
     {if $extension.downloadUrl}

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -22,9 +22,11 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
         <tr id="addnew-row_{$row.file}" class="crm-extension-row crm-extensions crm-extensions_{$row.file} {cycle values="odd-row,even-row"}">
           <td class="crm-extensions-label">
             <details class="crm-accordion-light">
-              <summary><strong>{$row.label|escape}</strong>
-              <br/>{$row.description|escape}</summary>
-                {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row}
+              <summary>
+                <strong>{$row.label|escape}</strong>
+                <br/>{$row.description|escape}
+              </summary>
+              {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row}
             </details>
           </td>
           <td class="crm-extensions-version right">{$row.version|escape}
@@ -43,7 +45,7 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
   </div>
 {else}
   <div class="messages status no-popup">
-       {icon icon="fa-info-circle"}{/icon}
-      {ts}There are no extensions to display. Please click "Refresh" to update information about available extensions.{/ts}
+    {icon icon="fa-info-circle"}{/icon}
+    {ts}There are no extensions to display. Please click "Refresh" to update information about available extensions.{/ts}
   </div>
 {/if}

--- a/templates/CRM/Admin/Page/Extensions/Main.tpl
+++ b/templates/CRM/Admin/Page/Extensions/Main.tpl
@@ -5,13 +5,12 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
 {if $localExtensionRows}
   <div id="extensions">
     {strip}
-    {* handle enable/disable actions*}
     <table id="extensions" class="display">
       <thead>
         <tr>
           <th>{ts}Extension{/ts}</th>
           <th>{ts}Status{/ts}</th>
-          <th>{ts}Version{/ts}</th>
+          <th id="nosort">{ts}Version{/ts}</th>
           <th></th>
         </tr>
       </thead>
@@ -21,10 +20,11 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <td class="crm-extensions-label">
             <details class="crm-accordion-light">
               <summary>
-              <strong>{$row.label|escape}</strong><br/>{$row.description|escape}
-              {if $extAddNewEnabled && array_key_exists($extKey, $remoteExtensionRows) && $remoteExtensionRows[$extKey].upgradelink|smarty:nodefaults}
-                <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink|smarty:nodefaults}</div>
-              {/if}
+                <strong>{$row.label|escape}</strong>
+                <br/>{$row.description|escape}
+                {if $extAddNewEnabled && array_key_exists($extKey, $remoteExtensionRows) && $remoteExtensionRows[$extKey].upgradelink|smarty:nodefaults}
+                  <div class="crm-extensions-upgrade">{$remoteExtensionRows[$extKey].upgradelink|smarty:nodefaults}</div>
+                {/if}
               </summary>
               {include file="CRM/Admin/Page/ExtensionDetails.tpl" extension=$row localExtensionRows=$localExtensionRows remoteExtensionRows=$remoteExtensionRows}
             </details>


### PR DESCRIPTION
Overview
----------------------------------------

A few tweaks to the information displayed in Administer > Settings > Extensions.

- Adds "nosort" on the version for the Main page (local extensions) to be consistent with the AddNew page
- Translates the Documentation, Main Extension Page and Support URL labels
- Opens links in a new tab
- Hides the redundant Licensing URL, and instead add a hyperlink on the License label (ex: AGPL3)
- Moves the recommended/warning icon next to the related text, so that it's clear what this icon means.
- Moves the recommended/warning sentence below the release date, because the release-date and version go together, but the recommended flag is not version-specific.

Before
----------------------------------------

<img width="1521" height="1007" alt="image" src="https://github.com/user-attachments/assets/d85508e7-8fe1-4c7e-8c16-e2cd28fe9403" />

(this screenshot was taken in English, from smaster, so it does not show the translation bug, which only affects the URL labels)

After
----------------------------------------

<img width="1532" height="823" alt="image" src="https://github.com/user-attachments/assets/5e827c4a-e5ab-4a89-8126-a690946d045b" />

Comments
----------------------------------------

I plan on adding the extension "Category" in a separate PR (with a search dropdown). This will add another row to this screen.