### PR TITLE
Riverlea: make FormBuilder checkbox list full width in admin/front & without border/bg in front

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -143,6 +143,7 @@ fieldset.af-container.af-layout-inline {
 }
 .crm-public .af-container ul.crm-checkbox-list {
   border: 0;
+  background-color: inherit;
 }
 .crm-public .af-container ul.crm-checkbox-list li {
   background-color: inherit;

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -135,3 +135,15 @@ fieldset.af-container.af-layout-inline {
   display: flex;
   padding-block: 0.25rem;
 }
+.af-container ul.crm-checkbox-list {
+  width: 100%;
+  max-height: 100%;
+  overflow: auto;
+  height: auto;
+}
+.crm-public .af-container ul.crm-checkbox-list {
+  border: 0;
+}
+.crm-public .af-container ul.crm-checkbox-list li {
+  background-color: inherit;
+}


### PR DESCRIPTION
Before
----------------------------------------
300px width, border, scroll and stripes in the background

<img width="568" height="158" alt="image" src="https://github.com/user-attachments/assets/bda81b9a-a4f8-4f41-ad88-19aff9b91248" />


After
----------------------------------------
100% width and no scroll-bars in the front and back-end;
no border or background stripes in the front-end (same as other Profile/custom field checkbox displays)
inherit background color

<img width="643" height="137" alt="image" src="https://github.com/user-attachments/assets/3df9869d-ae23-4938-b5bb-144f12e38b58" />

#team_work_with_Nic