### PR TITLE
WIP: Afform + Riverlea: put title inside the title-bar div so it wraps: dev/core/#6162

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.html
@@ -1,4 +1,8 @@
 <div class="af-gui-bar {{ block ? 'af-gui-block-bar' : '' }}" ng-if="$ctrl.node['#tag'] && $ctrl.node['#tag'] !== 'af-tab'" ng-click="selectEntity()" >
+  <div class="crm-sortable-grab"></div>
+  <label class="af-gui-node-title af-gui-container-title af-gui-text-h3" ng-if="$ctrl.node['#tag'] && $ctrl.node['#tag'] !== 'af-tab' && !block" title="{{:: ts('Container title') }}">
+    <i class="crm-i {{ $ctrl.getCollapsibleIcon() }}" role="img" aria-hidden="true"></i><span placeholder="{{:: ts('No title') }}" crm-ui-editable ng-model="$ctrl.getSetTitle" ng-model-options="{getterSetter: true}"></span>
+  </label>
   <div ng-if="!$ctrl.loading" class="form-inline" title="{{ $ctrl.getToolTip() }}">
     <span ng-if="block">{{ $ctrl.join ? ts($ctrl.join) + ':' : ts('Block:') }}</span>
     <select ng-if="block" ng-model="block.directive" ng-change="selectBlockDirective()" title="{{:: ts('Select block') }}">
@@ -18,10 +22,6 @@
   </div>
   <div ng-if="$ctrl.loading"><i class="crm-i fa-spin fa-spinner" role="img" aria-hidden="true"></i></div>
 </div>
-<label class="af-gui-node-title af-gui-container-title af-gui-text-h3" ng-if="$ctrl.node['#tag'] && $ctrl.node['#tag'] !== 'af-tab' && !block" title="{{:: ts('Container title') }}">
-  <i class="crm-i {{ $ctrl.getCollapsibleIcon() }}" role="img" aria-hidden="true"></i>
-  <span placeholder="{{:: ts('No title') }}" crm-ui-editable ng-model="$ctrl.getSetTitle" ng-model-options="{getterSetter: true}"></span>
-</label>
 <div ng-if="!$ctrl.loading" ui-sortable="$ctrl.sortableOptions" ui-sortable-update="$ctrl.editor.onDrop" ng-model="getSetChildren" ng-model-options="{getterSetter: true}" class="af-gui-layout {{ getLayout() }}">
   <div ng-repeat="item in getSetChildren()" >
     <div ng-switch="$ctrl.getNodeType(item)">

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -251,15 +251,16 @@
   cursor: move;
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: stretch;
 }
-#afGuiEditor [ui-sortable] .af-gui-bar:before,
 #afGuiEditor .af-gui-entity-palette-select-list [ui-sortable] > div:not(.disabled):hover:before,
-#afGuiEditor af-gui-edit-options.af-gui-content-editing-area [ui-sortable] li:before {
+#afGuiEditor af-gui-edit-options.af-gui-content-editing-area [ui-sortable] li:before,
+.crm-sortable-grab {
   background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1IiBoZWlnaHQ9IjUiPgo8cmVjdCB3aWR0aD0iMSIgaGVpZ2h0PSIxIiBmaWxsPSIjODg4Ij48L3JlY3Q+Cjwvc3ZnPg==");
   width: var(--crm-m);
   height: calc(100% - var(--crm-m));
   content: ' ';
+  height: auto;
   width: 10px;
 }
 #afGuiEditor-canvas .af-gui-bar .form-inline {
@@ -272,10 +273,11 @@
   display: flex;
   margin-right: var(--crm-m);
 }
-#afGuiEditor .af-gui-node-title {
-  position: absolute;
-  top: 1px;
-  margin-right: 18px;
+#afGuiEditor-canvas af-gui-container .af-gui-bar {
+  height: auto;
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
 }
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-bar,
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container-title span:empty {
@@ -319,6 +321,7 @@ af-gui-container > .af-gui-bar,
 /* Canvas layout */
 #afGuiEditor .af-gui-layout {
   min-height: 2rem;
+  padding: var(--crm-m);
 }
 #afGuiEditor .af-gui-layout.af-layout-cols,
 #afGuiEditor .af-gui-layout.af-layout-inline {


### PR DESCRIPTION
Follows this issue - https://lab.civicrm.org/dev/core/-/issues/6162. Titles of Form Builder elements have a fixed height and the text floats on top..

Todo:
 - [ ] Apply to the [other Form Builder components](https://github.com/search?q=repo%3Acivicrm%2Fcivicrm-core%20af-gui-bar&type=code).
 - [ ] Backport to Greenwich

Before
----------------------------------------
<img width="574" height="144" alt="image" src="https://github.com/user-attachments/assets/988daf4b-b5a8-4209-b2b3-642b42d42625" />

After
----------------------------------------
<img width="531" height="173" alt="image" src="https://github.com/user-attachments/assets/037b902e-4eba-47e0-90c4-72c645a4c3e2" />

Comments
----------------------------------------
Adjusts the markup and the CSS to match, so needs to be backported to Greenwich, and re-applied to the other similar AF elements (e.g. second item above).