### PR TITLE
Tweak Non Riverlea Greenwich to reset the height param on td and tr t…

### DIFF
--- a/ext/greenwich/css/drupal8.css
+++ b/ext/greenwich/css/drupal8.css
@@ -1,0 +1,5 @@
+/* Reset Claro in D10 table rows (td/th) height */
+#block-claro-content .crm-container td,
+#block-claro-content .crm-container th {
+  height: unset;
+}

--- a/ext/greenwich/greenwich.php
+++ b/ext/greenwich/greenwich.php
@@ -40,4 +40,9 @@ function greenwich_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
       ]);
       break;
   }
+  // Add an additional css file for claro overrides if we are on drupal9+ sites
+  $config = CRM_Core_Config::singleton();
+  if ($theme === 'greenwich' && $bundle->name === 'coreResources' && $config->userFramework === 'Drupal8') {
+    $bundle->addStyleFile('greenwich', 'css/drupal8.css');
+  }
 }

--- a/ext/greenwich/scss/_tweaks.scss
+++ b/ext/greenwich/scss/_tweaks.scss
@@ -35,3 +35,9 @@ legend {
   text-transform: inherit;
   float: none;
 }
+
+/* Reset Claro in D10 table rows (td/th) height */
+#block-claro-content .crm-container td,
+#block-claro-content .crm-container th {
+  height: unset;
+}


### PR DESCRIPTION
…hat claro sets to 4rem

Overview
----------------------------------------
This applies a similar thing to what [Riverlea does](https://github.com/civicrm/civicrm-core/blob/master/ext/riverlea/core/css/_base.css#L36) but specifically when your using non Riverlea Greenwich on D10 with Claro

Before
----------------------------------------
Height on Table Rows and Table headers in D10 with Claro is set to 4rem

After
----------------------------------------
Height is back to the initial value which I think might be 1rem?

ping @colemanw @ufundo @vingle 