### PR TITLE
Add created/modified date columns to Participant

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -45,88 +45,11 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
   ];
 
   /**
-   * Takes an associative array and creates a participant object.
-   *
-   * the function extract all the params it needs to initialize the create a
-   * participant object. the params array could contain additional unused name/value
-   * pairs
-   *
-   * @param array $params
-   *   (reference ) an assoc array of name/value pairs.
-   *
+   * @deprecated
    * @return CRM_Event_BAO_Participant
    */
-  public static function &add(&$params) {
-
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::pre('edit', 'Participant', $params['id'], $params);
-    }
-    else {
-      CRM_Utils_Hook::pre('create', 'Participant', NULL, $params);
-    }
-
-    // converting dates to mysql format
-    if (!empty($params['register_date'])) {
-      $params['register_date'] = CRM_Utils_Date::isoToMysql($params['register_date']);
-    }
-
-    if (!empty($params['participant_fee_amount'])) {
-      $params['participant_fee_amount'] = CRM_Utils_Rule::cleanMoney($params['participant_fee_amount']);
-    }
-
-    // ensure that role ids are encoded as a string
-    if (isset($params['role_id']) && is_array($params['role_id'])) {
-      if (in_array(key($params['role_id']), CRM_Core_DAO::acceptedSQLOperators(), TRUE)) {
-        $op = key($params['role_id']);
-        $params['role_id'] = $params['role_id'][$op];
-      }
-      else {
-        $params['role_id'] = implode(CRM_Core_DAO::VALUE_SEPARATOR, $params['role_id']);
-      }
-    }
-
-    $participantBAO = new CRM_Event_BAO_Participant();
-    if (!empty($params['id'])) {
-      $participantBAO->id = $params['id'] ?? NULL;
-      $participantBAO->find(TRUE);
-      $participantBAO->register_date = CRM_Utils_Date::isoToMysql($participantBAO->register_date);
-    }
-
-    $participantBAO->copyValues($params);
-
-    //CRM-6910
-    //1. If currency present, it should be valid one.
-    //2. We should have currency when amount is not null.
-    $currency = $participantBAO->fee_currency;
-    if ($currency ||
-      !CRM_Utils_System::isNull($participantBAO->fee_amount)
-    ) {
-      if (!CRM_Utils_Rule::currencyCode($currency)) {
-        $config = CRM_Core_Config::singleton();
-        $currency = $config->defaultCurrency;
-      }
-    }
-    $participantBAO->fee_currency = $currency;
-
-    $participantBAO->save();
-
-    // add custom field values
-    if (!empty($params['custom']) &&
-      is_array($params['custom'])
-    ) {
-      CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_participant', $participantBAO->id);
-    }
-
-    CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
-
-    if (!empty($params['id'])) {
-      CRM_Utils_Hook::post('edit', 'Participant', $participantBAO->id, $participantBAO);
-    }
-    else {
-      CRM_Utils_Hook::post('create', 'Participant', $participantBAO->id, $participantBAO);
-    }
-
-    return $participantBAO;
+  public static function add($params) {
+    return self::writeRecord($params);
   }
 
   /**
@@ -176,6 +99,7 @@ class CRM_Event_BAO_Participant extends CRM_Event_DAO_Participant implements \Ci
     }
 
     $participant = self::add($params);
+    $participant->find(TRUE);
 
     // Log activity when creating new participant or changing status
     if (empty($params['id']) ||
@@ -1871,41 +1795,71 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
    * @throws CRM_Core_Exception
    */
   public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $event) {
-    // Set the default role ID on create.
-    if ($event->entity === 'Participant' && $event->action === 'create' && empty($event->params['role_id'])) {
-      if (!empty($event->params['event_id'])) {
-        $event->params['role_id'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $event->params['event_id'], 'default_role_id');
-      }
-      else {
-        $params['role_id'] = CRM_Core_DAO::singleValueQuery('SELECT default_role_id FROM civicrm_event WHERE id = %1', [
-          1 => [$event->params['event_id'], 'Integer'],
-        ]);
-      }
+    $params = &$event->params;
+
+    // Is this still necessary?
+    if (!empty($params['participant_fee_amount'])) {
+      $params['participant_fee_amount'] = CRM_Utils_Rule::cleanMoney($params['participant_fee_amount']);
     }
-    if ($event->entity === 'Participant' && $event->action === 'create' && empty($event->params['created_id'])) {
-      // Set the "created_id" field if not already set.
-      // The created_id should always be the person that actually did the registration.
-      // That might be the first participant, but it might be someone registering someone without registering themselves.
-      // 1. Prefer logged in contact id
-      // 2. Fall back to 'registered_by_id' param.
-      // 3. Fall back to participant contact_id (for anonymous person registering themselves)
-      $event->params['created_id'] = CRM_Core_Session::getLoggedInContactID();
-      if (empty($event->params['created_id'])) {
-        if (!empty($event->params['registered_by_id'])) {
-          // No logged in contact but participant was registered by someone else.
-          // Look up the contact ID of that participant and record
-          $participant = \Civi\Api4\Participant::get(FALSE)
-            ->addSelect('contact_id')
-            ->addWhere('id', '=', $event->params['registered_by_id'])
-            ->execute()
-            ->first();
-          $event->params['created_id'] = $participant['contact_id'];
+
+    if ($event->action === 'create') {
+      //CRM-6910
+      //1. If currency present, it should be valid one.
+      //2. We should have currency when amount is not null.
+      $currency = $params['fee_currency'] ?? NULL;
+      if ($currency || !empty($params['fee_amount'])) {
+        if (!CRM_Utils_Rule::currencyCode($currency)) {
+          $config = CRM_Core_Config::singleton();
+          $currency = $config->defaultCurrency;
+        }
+        $params['fee_currency'] = $currency;
+      }
+
+      // Set the default role ID on create.
+      if (empty($params['role_id'])) {
+        if (!empty($params['event_id'])) {
+          $params['role_id'] = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Event', $params['event_id'], 'default_role_id');
         }
         else {
-          $event->params['created_id'] = $event->params['contact_id'];
+          $params['role_id'] = CRM_Core_DAO::singleValueQuery('SELECT default_role_id FROM civicrm_event WHERE id = %1', [
+            1 => [$params['event_id'], 'Integer'],
+          ]);
+        }
+      }
+      if (empty($params['created_id'])) {
+        // Set the "created_id" field if not already set.
+        // The created_id should always be the person that actually did the registration.
+        // That might be the first participant, but it might be someone registering someone without registering themselves.
+        // 1. Prefer logged in contact id
+        // 2. Fall back to 'registered_by_id' param.
+        // 3. Fall back to participant contact_id (for anonymous person registering themselves)
+        $params['created_id'] = CRM_Core_Session::getLoggedInContactID();
+        if (empty($params['created_id'])) {
+          if (!empty($params['registered_by_id'])) {
+            // No logged in contact but participant was registered by someone else.
+            // Look up the contact ID of that participant and record
+            $participant = \Civi\Api4\Participant::get(FALSE)
+              ->addSelect('contact_id')
+              ->addWhere('id', '=', $params['registered_by_id'])
+              ->execute()
+              ->first();
+            $params['created_id'] = $participant['contact_id'];
+          }
+          else {
+            $params['created_id'] = $params['contact_id'];
+          }
         }
       }
     }
+  }
+
+  /**
+   * Callback for hook_civicrm_post().
+   * @param \Civi\Core\Event\PostEvent $event
+   * @throws CRM_Core_Exception
+   */
+  public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixNine.php
+++ b/CRM/Upgrade/Incremental/php/SixNine.php
@@ -62,6 +62,40 @@ class CRM_Upgrade_Incremental_php_SixNine extends CRM_Upgrade_Incremental_Base {
       ],
     ]);
 
+    $this->addTask('Add column "Participant.created_date"', 'alterSchemaField', 'Participant', 'created_date', [
+      'title' => ts('Created Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the participant record was created.'),
+      'unique_name' => 'participant_created_date',
+      'default' => 'CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
+        'label' => ts('Created Date'),
+      ],
+    ]);
+
+    $this->addTask('Add column "Participant.modified_date"', 'alterSchemaField', 'Participant', 'modified_date', [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the participant record created or modified or deleted.'),
+      'unique_name' => 'participant_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
+        'label' => ts('Modified Date'),
+      ],
+    ]);
+
     // dev/core#2290 - Remove id from cache tables
     $tables = ['civicrm_cache', 'civicrm_acl_cache', 'civicrm_acl_contact_cache', 'civicrm_group_contact_cache'];
     foreach ($tables as $table) {

--- a/schema/Event/Participant.entityType.php
+++ b/schema/Event/Participant.entityType.php
@@ -368,5 +368,39 @@ return [
         'on_delete' => 'SET NULL',
       ],
     ],
+    'created_date' => [
+      'title' => ts('Created Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the participant record was created.'),
+      'add' => '6.9',
+      'unique_name' => 'participant_created_date',
+      'default' => 'CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
+        'label' => ts('Created Date'),
+      ],
+    ],
+    'modified_date' => [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the participant record created or modified or deleted.'),
+      'add' => '6.9',
+      'unique_name' => 'participant_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'format_type' => 'activityDateTime',
+        'label' => ts('Modified Date'),
+      ],
+    ],
   ],
 ];

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -111,6 +111,8 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'must_wait' => NULL,
       'transferred_to_contact_id' => NULL,
       'created_id' => $this->ids['Contact']['individual_0'],
+      'created_date' => date('Y-m-d H:i:s'),
+      'modified_date' => date('Y-m-d H:i:s'),
     ];
 
     foreach ($compareValues as $key => $value) {

--- a/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantTest.php
@@ -90,7 +90,6 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
     $compareValues = $fetchParticipant[$participantID];
 
     $params = [
-      'send_receipt' => 1,
       'is_test' => 0,
       'is_pay_later' => 0,
       'event_id' => $this->getEventID(),
@@ -107,18 +106,22 @@ class CRM_Event_BAO_ParticipantTest extends CiviUnitTestCase {
       'discount_id' => NULL,
       'fee_currency' => NULL,
       'discount_amount' => NULL,
-      'cart_id' => NULL,
       'must_wait' => NULL,
       'transferred_to_contact_id' => NULL,
       'created_id' => $this->ids['Contact']['individual_0'],
-      'created_date' => date('Y-m-d H:i:s'),
-      'modified_date' => date('Y-m-d H:i:s'),
     ];
 
-    foreach ($compareValues as $key => $value) {
-      if ($key[0] !== '_' && $key !== 'N') {
-        $this->assertEquals($compareValues->$key, $params[$key], 'Check for ' . $key . ' for given participant');
-      }
+    $dateParams = [
+      'created_date',
+      'modified_date',
+    ];
+
+    foreach ($dateParams as $key) {
+      $this->assertEqualsWithDelta(time(), strtotime($compareValues->$key), 2, 'Check for ' . $key . ' for given participant');
+    }
+
+    foreach ($params as $key => $value) {
+      $this->assertEquals($compareValues->$key, $value, 'Check for ' . $key . ' for given participant');
     }
   }
 

--- a/tests/phpunit/api/v4/Entity/ParticipantTest.php
+++ b/tests/phpunit/api/v4/Entity/ParticipantTest.php
@@ -88,7 +88,7 @@ class ParticipantTest extends Api4TestBase {
         'source' => $dummy['sources'][$i % 3],
       ];
     }
-    $this->saveTestRecords('Participant', [
+    $pid = $this->saveTestRecords('Participant', [
       'records' => $records,
       'defaults' => [
         'status_id' => 2,
@@ -96,7 +96,7 @@ class ParticipantTest extends Api4TestBase {
         'register_date' => 20070219,
         'event_level' => 'Payment',
       ],
-    ]);
+    ])->column('id');
     $sqlCount = $this->getRowCount('civicrm_participant');
     $this->assertEquals($participantCount, $sqlCount, "Unexpected count");
 
@@ -213,9 +213,9 @@ class ParticipantTest extends Api4TestBase {
       ->addWhere('event_id', '=', $secondEventId)
       ->setCheckPermissions(FALSE)
       ->execute();
-    $expectedDeletes = [2, 7, 12, 17];
+    $expectedDeletes = [$pid[1], $pid[6], $pid[11], $pid[16]];
     $this->assertEquals($expectedDeletes, array_column((array) $deleteResult, 'id'),
-      "didn't delete every second record as expected");
+      "didn't delete every 5th record as expected");
 
     $sqlCount = $this->getRowCount('civicrm_participant');
     $this->assertEquals(


### PR DESCRIPTION
Overview
----------------------------------------
Add columns created_date and modified_date to the participants table.

Before
----------------------------------------
The participant table does not have created or modified dates.  

After
----------------------------------------
Participant table has created and modified dates.  This will allow better tracking of when the records have changed.

Technical Details
----------------------------------------
These changes will facilitate the detection of recent updates to participants. 

Comments
----------------------------------------

