### PR TITLE
Fix wobbly mouseover in AfGuiEditor

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.css
+++ b/ext/afform/admin/ang/afGuiEditor.css
@@ -99,7 +99,7 @@
   min-width: 21px;
 }
 #afGuiEditor .crm-editable-enabled:hover:not(:focus) {
-  border: 2px dashed grey !important;
+  outline: 2px dashed grey !important;
 }
 /* Undo Shoreditch add-ons */
 #afGuiEditor .crm-editable-enabled:before,
@@ -198,7 +198,7 @@ body.af-gui-dragging {
 }
 
 #afGuiEditor .af-gui-container {
-  border: 2px dashed transparent;
+  outline: 2px dashed transparent;
   position: relative;
   padding: 22px 3px 3px;
   min-height: 40px;
@@ -237,7 +237,7 @@ body.af-gui-dragging {
 
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container:hover,
 .af-gui-dragging #afGuiEditor .af-gui-container {
-  border: 2px dashed #757575;
+  outline: 2px dashed #757575;
 }
 #afGuiEditor .af-gui-container.af-gui-dragtarget {
   border: 2px solid #0071bd;
@@ -268,7 +268,7 @@ body.af-gui-dragging {
 }
 
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected {
-  border: 2px dashed #0071bd;
+  outline: 2px dashed #0071bd;
 }
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar {
   background-color: #0071bd;
@@ -303,7 +303,7 @@ body.af-gui-dragging {
 #afGuiEditor .ui-sortable-helper .af-gui-palette-item {
   height: 30px;
   width: 300px;
-  border: 2px dashed #0071bd;
+  outline: 2px dashed #0071bd;
 }
 
 #afGuiEditor .af-gui-entity-palette-select-list {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -349,14 +349,14 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-element:hover,
 #afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-markup:hover,
 #afGuiEditor .crm-editable-enabled:hover:not(:focus) {
-  border: 2px dashed var(--crm-c-gray-700);
+  outline: 2px dashed var(--crm-c-gray-700);
 }
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container .af-gui-element:hover,
 #afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container .af-gui-markup:hover {
   border-width: 1px;
 }
 #afGuiEditor-canvas .af-entity-selected {
-  border: 2px dashed var(--crm-c-blue-dark);
+  outline: 2px dashed var(--crm-c-blue-dark);
 }
 #afGuiEditor-canvas .af-entity-selected > .af-gui-bar {
   background-color: var(--crm-c-primary);
@@ -683,7 +683,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 #afGuiEditor .ui-sortable-helper .af-gui-palette-item {
   height: 30px;
   width: 300px;
-  border: 2px dashed var(--crm-c-blue-dark);
+  outline: 2px dashed var(--crm-c-blue-dark);
 }
 .af-gui-conditional-dialog .api4-operator {
   width: 110px;


### PR DESCRIPTION
TL;DR: Switch from `:hover { border: ...}` to `:hover { outline:...}`. "outline" does not affect the CSS box model.

## Before: hover over causes layout shift

This is a bit jumpy and also at certain sizes/themes causes elements to be re positioned significantly, e.g. wrapping, which makes them impossible to interract with.

![af-border](https://github.com/user-attachments/assets/7a16a337-7898-4fe3-a6e9-d09233bcfeed)

## After: hover over does not cause layout shift.

More stable, easier to use.

![af-outline](https://github.com/user-attachments/assets/76047179-53dd-4ea0-a57a-98a2e3539229)


ping @vingle @colemanw 