### PR TITLE
Manage Extensions: tune down and harmonize the danger messages

### DIFF
--- a/templates/CRM/Admin/Form/Extensions.tpl
+++ b/templates/CRM/Admin/Form/Extensions.tpl
@@ -12,31 +12,31 @@
 <h3>{$title|smarty:nodefaults}</h3>
 <div class="crm-block crm-form-block crm-admin-optionvalue-form-block">
    {if $action eq 2}
-     <div class="messages status no-popup">
+     <div class="messages status alert-warning no-popup">
         {icon icon="fa-info-circle"}{/icon}
         {ts}Downloading this extension will provide you with new functionality. Please make sure that the extension you're installing or upgrading comes from a trusted source.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 1}
-     <div class="messages status no-popup">
+     <div class="messages status alert-warning no-popup">
         {icon icon="fa-info-circle"}{/icon}
         {ts}Installing this extension will provide you with new functionality.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 8}
-      <div class="messages status no-popup">
+      <div class="messages status alert-warning no-popup">
         {icon icon="fa-info-circle"}{/icon}
         {ts}WARNING: Uninstalling this extension might result in the loss of all records which use the extension.{/ts} {ts}This may mean the loss of a substantial amount of data, and the action cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 32}
-      <div class="messages status no-popup">
+      <div class="messages status alert-warning no-popup">
         {icon icon="fa-info-circle"}{/icon}
         {ts}Enabling this extension will restore the functionality that it provides.{/ts} {ts}Any records which use this extension will be become available again.{/ts} {ts}Do you want to continue?{/ts}
       </div>
    {/if}
    {if $action eq 64}
-      <div class="messages status no-popup">
+      <div class="messages status alert-warning no-popup">
         {icon icon="fa-info-circle"}{/icon}
         {ts}Disabling this extension will remove the functionality that it provides.{/ts} {ts}Any records which use this extension will be retained, but will only become available when it is enabled again.{/ts} {ts}Do you want to continue?{/ts}
       </div>

--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -17,6 +17,9 @@
         {ts}Version{/ts}</td><td>{$extension.version|escape}
       </td>
     </tr>
+    <tr>
+      <td class="label">{ts}Released on{/ts}</td><td>{$extension.releaseDate|escape}</td>
+    </tr>
     {if $extension.develStage}
     <tr>
       <td class="label">{ts}Stability{/ts}</td>
@@ -25,8 +28,7 @@
           {icon icon="fa-trophy crm-extensions-stage"}{ts}This extension has been reviewed by the community.{/ts}{/icon}
           {ts}This extension has been reviewed by the community.{/ts}
         {elseif $extension.develStage == 'stable' && $extension.ready == 'not_ready'}
-          <div class="crm-error alert alert-danger">
-            {icon icon="fa-warning crm-extensions-stage"}{ts}This extension has not been reviewed by the community.{/ts} {ts}Please proceed with caution.{/ts}{/icon}
+          <div class="crm-error alert alert-warning">
             {ts}Please proceed with caution.{/ts} {ts}This extension has not been reviewed by the community and therefore may conflict with your configuration.{/ts} {ts}Consider evaluating the stated version compatibility, the total number of active installations and the date of the latest release of the extension as these may be good indicators of the extension's stability. If a support link is listed, please consult their issue queue to review any known issues.{/ts} {docURL page="dev/extensions/lifecycle"}</div>
         {else}
           {$extension.develStage_formatted|escape}
@@ -34,9 +36,6 @@
       </td>
     </tr>
     {/if}
-    <tr>
-      <td class="label">{ts}Released on{/ts}</td><td>{$extension.releaseDate|escape}</td>
-    </tr>
     <tr>
       <td class="label">{ts}Active Installs{/ts}</td><td>{$extension.usage}</td>
     </tr>

--- a/templates/CRM/Admin/Page/Extensions/AddNew.tpl
+++ b/templates/CRM/Admin/Page/Extensions/AddNew.tpl
@@ -32,8 +32,6 @@ Depends: CRM/common/enableDisableApi.tpl and CRM/common/jsortable.tpl
           <td class="crm-extensions-version right">{$row.version|escape}
             {if $row.ready == 'ready'}
               {icon icon="fa-trophy crm-extensions-stage"}{ts}This extension has been reviewed by the community.{/ts}{/icon}
-            {else}
-              {icon icon="fa-warning crm-extensions-stage"}{ts}This extension has not been reviewed by the community. Proceed with caution.{/ts}{/icon}
             {/if}
           </td>
           <td>{$row.action|smarty:nodefaults|replace:'xx':$row.id}</td>


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #33856, minor tweaks to the warnings displayed on screen:

- For non-recommended/reviewed extensions, show a yellow warning instead of a red danger message
- Use the same color/level for the warning about installing extensions (green = OK/success, so it felt contradictory)
- Remove the warning icon, because it's kind of silly/clutter-ish. It only takes a glance to understand that there are recommended extensions (green trophy) and those that are not.

Before
----------------------------------------

<img width="1531" height="391" alt="image" src="https://github.com/user-attachments/assets/f1cc0e21-1b68-4b34-a1a2-049b63e3598b" />

<img width="1524" height="1062" alt="image" src="https://github.com/user-attachments/assets/0162e000-938e-4047-93f0-eb180589c74b" />

After
----------------------------------------

<img width="1518" height="367" alt="image" src="https://github.com/user-attachments/assets/ca8f93b8-879e-4ba1-899f-8ca0b94151e4" />

<img width="1533" height="1077" alt="image" src="https://github.com/user-attachments/assets/f20ac6db-bc33-4562-841c-24dc35a2b78d" />

Comments
----------------------------------------

Based on a NL code sprint discussion with @artfulrobot 