### PR TITLE
Fix group contact import to work

### DIFF
--- a/CRM/Import/StateMachine.php
+++ b/CRM/Import/StateMachine.php
@@ -58,7 +58,9 @@ class CRM_Import_StateMachine extends CRM_Core_StateMachine {
         throw new CRM_Core_Exception(ts('Invalid import entity %1', [1 => htmlentities($this->entity)]));
       }
       $entityPath = explode('_', $entityName);
-      if ($this->entity === 'Event') {
+      if ($this->entity === 'Event'
+        || ($entityPath[1] === 'Contact' && $entity !== 'Contact')
+      ) {
         // If we allow this to be set it finds the participant import...
         $this->classPrefix = '';
       }

--- a/ext/civiimport/Civi/Import/GenericParser.php
+++ b/ext/civiimport/Civi/Import/GenericParser.php
@@ -181,7 +181,7 @@ class GenericParser extends ImportParser {
         ],
       ])->single();
       if (!empty($params['Contact'])) {
-        $params['Contact']['id'] = $this->getContactID($params['Contact'] ?? [], ($existing['contact_id'] ?? NULL), 'Contact', $this->getDedupeRulesForEntity('Contact'));
+        $params['Contact']['id'] = $this->getContactID($params['Contact'] ?? [], ($params['Contact']['id'] ?? $existing['contact_id'] ?? NULL), 'Contact', $this->getDedupeRulesForEntity('Contact'));
         $params[$this->getBaseEntity()]['contact_id'] = $this->saveContact('Contact', $params['Contact'] ?? []) ?: $params['Contact']['id'];
       }
       $entity = civicrm_api4($this->baseEntity, 'save', [

--- a/schema/Contact/GroupContact.entityType.php
+++ b/schema/Contact/GroupContact.entityType.php
@@ -31,6 +31,10 @@ return [
       'add' => '1.1',
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'import',
+        'export',
+      ],
     ],
     'group_id' => [
       'title' => ts('Group ID'),
@@ -52,6 +56,10 @@ return [
         'key' => 'id',
         'on_delete' => 'CASCADE',
       ],
+      'usage' => [
+        'import',
+        'export',
+      ],
     ],
     'contact_id' => [
       'title' => ts('Contact ID'),
@@ -68,6 +76,10 @@ return [
         'key' => 'id',
         'on_delete' => 'CASCADE',
       ],
+      'usage' => [
+        'import',
+        'export',
+      ],
     ],
     'status' => [
       'title' => ts('Group Contact Status'),
@@ -77,6 +89,10 @@ return [
       'add' => '1.1',
       'pseudoconstant' => [
         'callback' => ['CRM_Core_SelectValues', 'groupContactStatus'],
+      ],
+      'usage' => [
+        'import',
+        'export',
       ],
     ],
     'location_id' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fix Group Contact import to work
    
This requires going to the url civicrm/import/group_contact
    
It's a bit confusing that it offers Group Contact ID which
is NOT contact ID - but I'm not too sure how to improve that
in a generic way since it just happens to be a confusing table name

Before
----------------------------------------
Group Contact import doesn't work

After
----------------------------------------
It does

Technical Details
----------------------------------------
Use Contact ID not GroupContact ID 
<img width="702" height="363" alt="image" src="https://github.com/user-attachments/assets/c0f75511-ea6d-4495-87b9-a26eadf3b9fa" />


Comments
----------------------------------------
