### PR TITLE
dev/core#3891 Fixing Show Calendar Links to appear if an event is active

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -157,7 +157,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
 
     $this->add('textarea', 'summary', ts('Event Summary'), $attributes['summary']);
     $this->add('wysiwyg', 'description', ts('Complete Description'), $attributes['event_description'] + ['preset' => 'civievent']);
-    $this->addToggle('is_public', ts('Display the event in public listings'));
+    $this->addToggle('is_public', ts('Include in Upcoming Events'));
     $this->addToggle('is_share', ts('Social media sharing links'));
     $this->addToggle('is_show_calendar_links', ts('Calendar links'));
 

--- a/CRM/Event/ICalendar.php
+++ b/CRM/Event/ICalendar.php
@@ -44,8 +44,7 @@ class CRM_Event_ICalendar {
     $rss = CRM_Utils_Request::retrieveValue('rss', 'Positive', 0);
     $gCalendar = CRM_Utils_Request::retrieveValue('gCalendar', 'Positive', 0);
 
-    $info = CRM_Event_BAO_Event::getCompleteInfo($start, $type, $id, $end);
-
+    $info = CRM_Event_BAO_Event::getCompleteInfo($start, $type, $id, $end, ($id == NULL));
     if ($gCalendar && count($info) === 1) {
       return self::gCalRedirect($info);
     }

--- a/templates/CRM/Event/Form/Registration/ThankYou.tpl
+++ b/templates/CRM/Event/Form/Registration/ThankYou.tpl
@@ -179,7 +179,7 @@
         <a href="{crmURL p='civicrm/event/info' q="reset=1&id=`$event.id`"}"><i class="crm-i fa-chevron-left" role="img" aria-hidden="true"></i> {ts 1=$event.event_title}Back to "%1" event information{/ts}</a>
     </div>
 
-    {if $event.is_public and $event.is_show_calendar_links}
+    {if $event.is_show_calendar_links}
       <div class="action-link section iCal_links-section">
         {include file="CRM/Event/Page/iCalLinks.tpl"}
       </div>

--- a/templates/CRM/Event/Page/EventInfo.tpl
+++ b/templates/CRM/Event/Page/EventInfo.tpl
@@ -234,7 +234,7 @@
         {/if}
       {/crmRegion}
     </div>
-    {if $event.is_public and $event.is_show_calendar_links}
+    {if $event.is_show_calendar_links}
         <div class="action-link section iCal_links-section">
           {include file="CRM/Event/Page/iCalLinks.tpl"}
         </div>

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -28,7 +28,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
    * Initial test of submit function.
    */
   public function testSubmit(): void {
-    $this->submitPaidEvent();
+    $this->submitPaidEvent(['is_show_calendar_links' => TRUE]);
     $this->assertMailSentContainingStrings([
       'Dear Kim,',
       'Thank you for your registration.',

--- a/tests/phpunit/CRM/Utils/ICalendarTest.php
+++ b/tests/phpunit/CRM/Utils/ICalendarTest.php
@@ -148,6 +148,35 @@ class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
     $this->assertEquals($expected['Cache-Control'], $headers['Cache-Control']);
   }
 
+  public function testICalPermissions() {
+    // Ensure that the ICal permissions are functioning based on public/private events
+    // Check against public listing
+    $eventParameters = [
+      'start_date' => 'tomorrow 19:00',
+      'end_date' => 'tomorrow 20:00',
+      'is_public' => TRUE,
+    ];
+    $this->eventCreateUnpaid($eventParameters);
+
+    // Check against the full feed of events not an individual one
+    $info = CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, NULL, NULL, TRUE);
+    $this->assertCount(1, $info);
+
+    // Update Event to be private and test again
+    \Civi\Api4\Event::update(FALSE)
+      ->addWhere('id', '=', $this->getEventId())
+      ->addValue('is_public', FALSE)
+      ->execute();
+
+    // Check against the full feed of events not an individual one
+    $info = CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, NULL, NULL, TRUE);
+    $this->assertCount(0, $info);
+
+    // Check against an individual private event (used to generate ICal cards)
+    $info = CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, $this->getEventId(), NULL, ($this->getEventId() == NULL));
+    $this->assertCount(1, $info);
+  }
+
   public function testIcalTimezones() {
     // The default timezone is UTC which makes it hard to test timezone
     // accuracy, so we set to an arbitrary different timezone.
@@ -162,11 +191,12 @@ class CRM_Utils_ICalendarTest extends CiviUnitTestCase {
     $eventParameters = [
       'start_date' => 'tomorrow 19:00',
       'end_date' => 'tomorrow 20:00',
+      'is_public' => FALSE,
     ];
     $this->eventCreateUnpaid($eventParameters);
 
     $expectedDate = date('Ymd', strtotime('tomorrow'));
-    $info = CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, $this->getEventId());
+    $info = CRM_Event_BAO_Event::getCompleteInfo(NULL, NULL, $this->getEventId(), NULL, FALSE);
     $calendar = explode("\n", CRM_Utils_ICalendar::createCalendarFile($info));
     $expectedLines = [
       "TZID:America/Los_Angeles" => FALSE,

--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -121,7 +121,7 @@
        {/if}
      {/if}
 
-     {if {event.is_public|boolean} and {event.is_show_calendar_links|boolean}}
+     {if {event.is_show_calendar_links|boolean}}
       <tr>
        <td colspan="2" {$valueStyle}>
         {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -130,7 +130,7 @@
           {/if}
         {/if}
 
-        {if {event.is_public|boolean} and {event.is_show_calendar_links|boolean}}
+        {if {event.is_show_calendar_links|boolean}}
           <tr>
             <td colspan="2" {$valueStyle}>
               {capture assign=icalFeed}{crmURL p='civicrm/event/ical' q="reset=1&id={event.id}" h=0 a=1 fe=1}{/capture}


### PR DESCRIPTION
Overview
----------------------------------------
As per https://lab.civicrm.org/dev/core/-/issues/3891 this issue (3 years old eek) allows for the iCal and Google Calendar links to appear _regardless_ if the Event is public or not.

Before
----------------------------------------
Calendar links were not appearing in emails, confirmation pages, and event info pages when an event is active but not public.

After
----------------------------------------
Calendar links appear afterwards. It was also suggested that we change the wording to be clearer.

