### PR TITLE
Hook - Remove unused deprecated hook code

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -625,17 +625,6 @@ abstract class CRM_Utils_Hook {
    */
   public static function aclGroup($type, $contactID, $tableName, &$allGroups, &$currentGroups) {
     $null = NULL;
-    // Legacy support for hooks that still expect 'civicrm_group' to be 'civicrm_saved_search'
-    // This was changed in 5.64
-    if ($tableName === 'civicrm_group') {
-      $initialValue = $currentGroups;
-      $legacyTableName = 'civicrm_saved_search';
-      self::singleton()
-        ->invoke(['type', 'contactID', 'tableName', 'allGroups', 'currentGroups'], $type, $contactID, $legacyTableName, $allGroups, $currentGroups, $null, 'civicrm_aclGroup');
-      if ($initialValue != $currentGroups) {
-        CRM_Core_Error::deprecatedWarning('Since 5.64 hook_civicrm_aclGroup passes "civicrm_group" instead of "civicrm_saved_search" for the $tableName when referring to Groups. Hook listeners should be updated.');
-      }
-    }
     return self::singleton()
       ->invoke(['type', 'contactID', 'tableName', 'allGroups', 'currentGroups'], $type, $contactID, $tableName, $allGroups, $currentGroups, $null, 'civicrm_aclGroup');
   }


### PR DESCRIPTION
Overview
----------------------------------------
Removes unused legacy support for deprecated hook signature.

Compat adapter has been in place since 5.64, but there are no remaining instances in `universe` where it's used.