### PR TITLE
Clear the asset cache after translation

### DIFF
--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -157,6 +157,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookI
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event): void {
     unset(Civi::$statics[__CLASS__]);
+    \Civi::service('asset_builder')->clear(FALSE);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Clear the asset cache after any change in the translation to ensure that it is reflected in the afform for immediate verification.

Before
----------------------------------------
With asset caching enabled, if we translate, the translation is not visible in the afform unless the cache is manually cleared (or automatically cleared from other process)

After
----------------------------------------
New translation are immediately available.
