### PR TITLE
Stop passing contribution_mode from v3 order, participant form

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1026,10 +1026,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
         $contributionParams['currency'] = $this->getCurrency();
         $contributionParams['contact_id'] = $this->_contactID;
 
-        if ($this->_id) {
-          $contributionParams['contribution_mode'] = 'participant';
-          $contributionParams['participant_id'] = $this->_id;
-        }
         // Set is_pay_later flag for back-office offline Pending status contributions
         if ($contributionParams['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Pending')) {
           $contributionParams['is_pay_later'] = 1;

--- a/api/v3/Order.php
+++ b/api/v3/Order.php
@@ -138,10 +138,6 @@ function civicrm_api3_order_create(array $params): array {
       $entityParams['status_id'] = $entityParams['participant_status_id'];
       $entityParams['skipLineItem'] = TRUE;
       $entityResult = civicrm_api3('Participant', 'create', $entityParams);
-      // @todo - once membership is cleaned up & financial validation tests are extended
-      // we can look at removing this - some weird handling in removeFinancialAccounts
-      $params['contribution_mode'] = 'participant';
-      $params['participant_id'] = $entityResult['id'];
       foreach ($entityParams['line_references'] as $lineIndex) {
         $order->setLineItemValue('entity_id', $entityResult['id'], $lineIndex);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing contribution_mode from v3 order, participant form

Before
----------------------------------------
`$contributionParams['contribute_mode']` set along with `participant_id`

After
----------------------------------------
Not set

Technical Details
----------------------------------------
I've done some digging & here is what it does

1) if the contribution is being updated from Pending to Completed it creates a discount fee transaction. That is not relevant on order and on Participant form it is not possible to update the contribution if it exists (the ability to edit through the contribution form is there)

2) it recalculates the line items to add in line items for extra participants. This is not relevant on these forms as the order path generates it's own line items while the backoffice participant form does not support creating multiple participants. You can create the multiple participant transaction online but then `record_contribution` is not presented and this path is not available. If you delete the contribution & try again `record_contribution` becomes available - but then it never works (with or without this patch) to put the participant values in the line items in the `BAO_Contribution` (and in fact the form records it's own line items anyway so the calculated values are discarded)


Comments
----------------------------------------
