### PR TITLE
Fixes red on red button in Formbuilder Admin UI in Thames stream.

### DIFF
--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -1040,10 +1040,6 @@ html.crm-standalone  nav.breadcrumb>ol {
   --crm-c-page-bg: transparent;
 }
 
-/* Override _dropdowns.css */
-#afGuiEditor .af-gui-bar .dropdown-menu {
-  --crm-c-danger-text: var(--crm-c-red-dark);
-}
 /* Override contactSummary.css */
 #crm-contact-actions-list a.delete {
   --crm-c-danger-text: var(--crm-c-red-dark);


### PR DESCRIPTION
Overview
----------------------------------------
This override of _dropdowns.css is no longer required as it is clashing with other more recent commits to update the colours in the Riverlea theme, resulting in red text on top of a red button. This is appears on the "Remove Field" button within the Formbuilder Admin UI, but nowhere else.

Before
----------------------------------------
Formbuilder UI shows an unreadable red on red button for "Remove Field" when using the Thames stream of Riverlea.

<img width="1139" height="435" alt="Screenshot from 2025-10-23 10-47-54" src="https://github.com/user-attachments/assets/003652e1-f580-4002-b1c2-0e3a099ecf60" />

Same in the dark mode:
<img width="479" height="479" alt="Screenshot from 2025-10-27 10-24-14" src="https://github.com/user-attachments/assets/ec4a6c42-a567-46bb-bb0d-39d87b8d0236" />



Issue reported here: https://lab.civicrm.org/extensions/riverlea/-/issues/159


After
----------------------------------------
Removing this override returns the text to white on red danger background.

<img width="479" height="479" alt="Screenshot from 2025-10-27 10-44-44" src="https://github.com/user-attachments/assets/1f050568-75df-4dd8-baf9-74b243a78bb7" />
<img width="479" height="479" alt="Screenshot from 2025-10-27 10-44-18" src="https://github.com/user-attachments/assets/15063227-93ab-4212-a7df-e33dda20b93c" />



Technical Details
----------------------------------------
Nothing else.

Comments
----------------------------------------
Nothing else.
