### PR TITLE
Manage Extensions: fix License PHP warning

### DIFF
--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -91,7 +91,14 @@
     </td>
   </tr>
     <tr>
-      <td class="label">{ts}License{/ts}</td><td><a href="{$extension.urls['Licensing']}" target="_blank">{$extension.license|escape}</a></td>
+      <td class="label">{ts}License{/ts}</td>
+      <td>
+        {if !empty($extension.urls['Licensing']) }
+          <a href="{$extension.urls['Licensing']}" target="_blank">{$extension.license|escape}</a>
+        {else}
+          {$extension.license|escape}
+        {/if}
+      </td>
     </tr>
     {if !empty($extension.path)}
       <tr>


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a regression caused by #33856

Before
----------------------------------------

PHP warnings when an extension does not have a License URL.

After
----------------------------------------

Fixed

