### PR TITLE
Generate human-readable table and column names for custom groups

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -332,8 +332,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
     $group->save();
     if (!isset($params['id'])) {
       if (!isset($params['table_name'])) {
-        $munged_title = strtolower(CRM_Utils_String::munge($group->title, '_', 13));
-        $tableName = "civicrm_value_{$munged_title}_{$group->id}";
+        $munged_title = strtolower(CRM_Utils_String::munge($group->title, '_', 45));
+        $tableName = "civicrm_value_{$munged_title}";
+        // only add custom group ID if table name is not unique at this point
+        if (CRM_Core_DAO::checkTableExists($tableName)) {
+          $tableName .= "_{$group->id}";
+        }
       }
       $group->table_name = $tableName;
       CRM_Core_DAO::setFieldValue('CRM_Core_DAO_CustomGroup',

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -26,6 +26,11 @@ class CRM_Report_Form extends CRM_Core_Form {
   public $expectedSmartyVariables = ['pager', 'skip', 'sections', 'grandStat', 'chartEnabled', 'uniqueId', 'rows', 'group_bys_freq'];
 
   /**
+   * 64 characters is the max for some versions of SQL
+   */
+  const MAX_COLUMN_NAME_LENGTH = 64;
+
+  /**
    * Deprecated constant, Reports should be updated to use the getRowCount function.
    */
   const ROW_COUNT_LIMIT = 50;
@@ -5351,6 +5356,7 @@ LEFT JOIN civicrm_contact {$field['alias']} ON {$field['alias']}.id = {$this->_a
    * @return array
    */
   protected function addBasicFieldToSelect($tableName, $fieldName, $field, $select) {
+    $tableName = substr($tableName, 0, self::MAX_COLUMN_NAME_LENGTH - strlen("_{$fieldName}"));
     $alias = "{$tableName}_{$fieldName}";
     $select[] = "{$field['dbAlias']} as $alias";
     $this->_columnHeaders["{$tableName}_{$fieldName}"]['title'] = $field['title'] ?? NULL;

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -44,7 +44,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
 
     $dbFieldName = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customFieldID, 'name', 'id', 'Database check for edited CustomField.');
     $dbColumnName = $this->assertDBNotNull('CRM_Core_DAO_CustomField', $customFieldID, 'column_name', 'id', 'Database check for edited CustomField.');
-    $this->assertEquals(strtolower("{$dbFieldName}_{$customFieldID}"), $dbColumnName,
+    $this->assertEquals(strtolower("{$dbFieldName}"), $dbColumnName,
       "Column name ends in ID");
 
     $this->assertSame('new_custom_group.testFld', CRM_Core_BAO_CustomField::getLongNameFromShortName("custom_{$customFieldID}_123"));
@@ -105,6 +105,33 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
       "Column name set as specified");
 
     $this->customGroupDelete($customGroup['id']);
+  }
+
+  /**
+   * Test custom field creation when the inferred column name already exists
+   */
+  public function testCreateInferredColumnNameConflict() {
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+
+    $customField_1 = CRM_Core_BAO_CustomField::create([
+      'label' => 'Custom Field A',
+      'name' => 'custom_field_1',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+      'custom_group_id' => $customGroup['id'],
+    ]);
+
+    $this->assertEquals('custom_field_a', $customField_1->column_name, "The column name should not be suffixed with '_ID'.");
+
+    $customField_2 = CRM_Core_BAO_CustomField::create([
+      'label' => 'Custom_Field_A',
+      'name' => 'custom_field_2',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+      'custom_group_id' => $customGroup['id'],
+    ]);
+
+    $this->assertEquals("custom_field_a_{$customField_2->id}", $customField_2->column_name, "The column name should be suffixed with '_ID'.");
   }
 
   /**
@@ -509,9 +536,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('country'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('country'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('country'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -548,9 +575,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('multi_country'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('multi_country'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('multi_country'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 1,
@@ -587,9 +614,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
-        'column_name' => 'my_file_' . $this->getCustomFieldID('file'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.my_file_' . $this->getCustomFieldID('file'),
+        'table_name' => 'civicrm_value_custom_group',
+        'column_name' => 'my_file',
+        'where' => 'civicrm_value_custom_group.my_file',
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -620,9 +647,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
-        'column_name' => 'enter_text_here_' . $this->getCustomFieldID('text'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.enter_text_here_' . $this->getCustomFieldID('text'),
+        'table_name' => 'civicrm_value_custom_group',
+        'column_name' => 'enter_text_here',
+        'where' => 'civicrm_value_custom_group.enter_text_here',
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'maxlength' => 300,
@@ -654,9 +681,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
-        'column_name' => 'pick_color_' . $this->getCustomFieldID('select_string'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.pick_color_' . $this->getCustomFieldID('select_string'),
+        'table_name' => 'civicrm_value_custom_group',
+        'column_name' => 'pick_color',
+        'where' => 'civicrm_value_custom_group.pick_color',
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -691,9 +718,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'is_multiple' => '0',
         'option_group_id' => NULL,
         'is_required' => '0',
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
-        'column_name' => 'test_date_' . $this->getCustomFieldID('select_date'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.test_date_' . $this->getCustomFieldID('select_date'),
+        'table_name' => 'civicrm_value_custom_group',
+        'column_name' => 'test_date',
+        'where' => 'civicrm_value_custom_group.test_date',
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -724,9 +751,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
-        'column_name' => 'test_link_' . $this->getCustomFieldID('link'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.test_link_' . $this->getCustomFieldID('link'),
+        'table_name' => 'civicrm_value_custom_group',
+        'column_name' => 'test_link',
+        'where' => 'civicrm_value_custom_group.test_link',
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -757,9 +784,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('int'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('int'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('int'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -790,9 +817,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('contact_reference'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('contact_reference'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('contact_reference'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -816,9 +843,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('state'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('state'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('state'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 0,
@@ -853,9 +880,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('multi_state'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('multi_state'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('multi_state'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'serialize' => 1,
@@ -891,9 +918,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('boolean'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('boolean'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('boolean'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'import' => 1,
@@ -925,9 +952,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
         'date_format' => NULL,
         'time_format' => NULL,
         'is_required' => 0,
-        'table_name' => 'civicrm_value_custom_group_' . $customGroupID,
+        'table_name' => 'civicrm_value_custom_group',
         'column_name' => $this->getCustomFieldColumnName('checkbox'),
-        'where' => 'civicrm_value_custom_group_' . $customGroupID . '.' . $this->getCustomFieldColumnName('checkbox'),
+        'where' => 'civicrm_value_custom_group.' . $this->getCustomFieldColumnName('checkbox'),
         'extends_table' => 'civicrm_contact',
         'search_table' => 'contact_a',
         'import' => 1,
@@ -981,9 +1008,9 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $dao = CRM_Core_DAO::executeQuery(('SHOW CREATE TABLE ' . $customGroup['values'][$customGroup['id']]['table_name']));
     $dao->fetch();
     $collation = \CRM_Core_BAO_SchemaHandler::getInUseCollation();
-    $this->assertStringContainsString('`test_link_2` varchar(2047) COLLATE ' . $collation . ' DEFAULT NULL', $dao->Create_Table);
+    $this->assertStringContainsString('`test_link` varchar(2047) COLLATE ' . $collation . ' DEFAULT NULL', $dao->Create_Table);
     $this->assertStringContainsString('KEY `index_my_text` (`my_text`)', $dao->Create_Table);
-    $this->assertStringContainsString('KEY `index_test_link_2` (`test_link_2`(512))', $dao->Create_Table);
+    $this->assertStringContainsString('KEY `index_test_link` (`test_link`(512))', $dao->Create_Table);
     $characterSet = stripos($collation, 'utf8mb4') !== FALSE ? 'utf8mb4' : 'utf8';
     $this->assertStringContainsString("ENGINE=InnoDB DEFAULT CHARSET={$characterSet} COLLATE={$collation}", $dao->Create_Table);
   }

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -49,7 +49,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $params = CRM_Contact_BAO_Query::convertFormValues($formValues);
     $queryObj = new CRM_Contact_BAO_Query($params);
     $this->assertEquals(
-      "civicrm_value_testsearchcus_1.date_field_2 BETWEEN '" . date('Y') . "0101000000' AND '" . date('Y') . "1231235959'",
+      "civicrm_value_testsearchcustomdatadaterelative.date_field BETWEEN '" . date('Y') . "0101000000' AND '" . date('Y') . "1231235959'",
       $queryObj->_where[0][0]
     );
     $this->assertEquals('date field is This calendar year (between January 1st, ' . date('Y') . " 12:00 AM and December 31st, " . date('Y') . " 11:59 PM)", $queryObj->_qill[0][0]);
@@ -61,8 +61,8 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       'data_type' => 'Date',
       'html_type' => 'Select Date',
       'is_search_range' => '0',
-      'column_name' => 'date_field_' . $dateCustomField['id'],
-      'table_name' => 'civicrm_value_testsearchcus_' . $ids['custom_group_id'],
+      'column_name' => 'date_field',
+      'table_name' => 'civicrm_value_testsearchcustomdatadaterelative',
       'option_group_id' => NULL,
       'groupTitle' => 'testSearchCustomDataDateRelative',
       'default_value' => NULL,
@@ -83,7 +83,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       'custom_field_id' => $dateCustomField['id'],
       'name' => 'custom_' . $dateCustomField['id'],
       'type' => 4,
-      'where' => 'civicrm_value_testsearchcus_' . $ids['custom_group_id'] . '.date_field_' . $dateCustomField['id'],
+      'where' => 'civicrm_value_testsearchcustomdatadaterelative.date_field',
       'import' => 1,
       'serialize' => 0,
     ], $queryObj->getFieldSpec('custom_' . $dateCustomField['id']));
@@ -114,8 +114,8 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $queryObject = new CRM_Contact_BAO_Query($params);
     $queryObject->query();
     $this->assertEquals(
-      '( civicrm_value_group_with_fi_1.' . $this->getCustomFieldColumnName('date') . ' >= \'20140606000000\' ) AND
-( civicrm_value_group_with_fi_1.' . $this->getCustomFieldColumnName('date') . ' <= \'20150606235959\' )',
+      '( civicrm_value_group_with_field_date.' . $this->getCustomFieldColumnName('date') . ' >= \'20140606000000\' ) AND
+( civicrm_value_group_with_field_date.' . $this->getCustomFieldColumnName('date') . ' <= \'20150606235959\' )',
       trim($queryObject->_where[0][0])
     );
     $this->assertEquals('Test Date - greater than or equal to "June 6th, 2014 12:00 AM" AND less than or equal to "June 6th, 2015 11:59 PM"', $queryObject->_qill[0][0]);
@@ -148,7 +148,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $queryObject = new CRM_Contact_BAO_Query($params);
     $queryObject->query();
     $this->assertEquals(
-      'civicrm_value_group_with_fi_1.' . $this->getCustomFieldColumnName('date') . ' >= \'20140606000000\'',
+      'civicrm_value_group_with_field_date.' . $this->getCustomFieldColumnName('date') . ' >= \'20140606000000\'',
       trim($queryObject->_where[0][0])
     );
     $this->assertEquals(
@@ -186,7 +186,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $queryObj = new CRM_Contact_BAO_Query($params);
     $queryObj->query();
     $this->assertEquals(
-      'civicrm_value_testsearchcus_1.date_field_2 BETWEEN "20140606000000" AND "20150606235959"',
+      'civicrm_value_testsearchcustomdatadatefromto.date_field BETWEEN "20140606000000" AND "20150606235959"',
       $queryObj->_where[0][0]
     );
     $this->assertEquals($queryObj->_qill[0][0], "date field BETWEEN 'June 6th, 2014 12:00 AM AND June 6th, 2015 11:59 PM'");
@@ -233,7 +233,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       $queryObj = new CRM_Contact_BAO_Query($params);
       $queryObj->query();
       $this->assertEquals(
-        'civicrm_value_testsearchcus_1.' . strtolower($type) . "_field_{$customField['id']} BETWEEN \"$from\" AND \"$to\"",
+        'civicrm_value_testsearchcustomdatafromto.' . strtolower($type) . "_field BETWEEN \"$from\" AND \"$to\"",
         $queryObj->_where[0][0]
       );
       $this->assertEquals($queryObj->_qill[0][0], "$type field BETWEEN $from, $to");
@@ -284,7 +284,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       $queryObj = new CRM_Contact_BAO_Query($params);
       $queryObj->query();
       $this->assertEquals(
-        'civicrm_value_testlocalized_1.' . strtolower($type) . "_{$i}_field_{$customField['id']} BETWEEN \"$from\" AND \"$to\"",
+        'civicrm_value_testlocalizedsearchcustomdatafromto.' . strtolower($type) . "_{$i}_field BETWEEN \"$from\" AND \"$to\"",
         $queryObj->_where[0][0]
       );
       $this->assertEquals($queryObj->_qill[0][0], "$type $i field BETWEEN $formatted_from, $formatted_to");
@@ -341,7 +341,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       $queryObj->query();
 
       $this->assertEquals(
-        'civicrm_value_testsearchcus_1.' . strtolower($type) . "_field_{$customField['id']} <= $expectedValue",
+        'civicrm_value_testsearchcustomdatafromandto.' . strtolower($type) . "_field <= $expectedValue",
         $queryObj->_where[0][0]
       );
       $this->assertEquals($queryObj->_qill[0][0],
@@ -359,7 +359,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
 
       $expectedValue = ($isDate) ? '"20150606000000"' : $expectedValue;
       $this->assertEquals(
-        'civicrm_value_testsearchcus_1.' . strtolower($type) . "_field_{$customField['id']} >= $expectedValue",
+        'civicrm_value_testsearchcustomdatafromandto.' . strtolower($type) . "_field >= $expectedValue",
         $queryObj->_where[0][0]
       );
       $this->assertEquals(
@@ -421,7 +421,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
       $queryObj->query();
 
       $this->assertEquals(
-        'civicrm_value_testlocalized_1.' . strtolower($type) . "_{$i}_field_{$customField['id']} <= $expectedValue",
+        'civicrm_value_testlocalizedsearchcustomdatafromandto.' . strtolower($type) . "_{$i}_field <= $expectedValue",
         $queryObj->_where[0][0]
       );
       $this->assertEquals($queryObj->_qill[0][0],
@@ -439,7 +439,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
 
       $expectedValue = ($isDate) ? '"20150606000000"' : $expectedValue;
       $this->assertEquals(
-        'civicrm_value_testlocalized_1.' . strtolower($type) . "_{$i}_field_{$customField['id']} >= $expectedValue",
+        'civicrm_value_testlocalizedsearchcustomdatafromandto.' . strtolower($type) . "_{$i}_field >= $expectedValue",
         $queryObj->_where[0][0]
       );
       $this->assertEquals(
@@ -476,7 +476,7 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
     $queryObj->query();
 
     $this->assertEquals(
-      "civicrm_value_testsearchcus_1.date_field_2 = '2015-06-06'",
+      "civicrm_value_testsearchcustomdatadateequals.date_field = '2015-06-06'",
       $queryObj->_where[0][0]
     );
     $this->assertEquals($queryObj->_qill[0][0], "date field = 'June 6th, 2015'");

--- a/tests/phpunit/CRM/Custom/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Custom/Page/AJAXTest.php
@@ -62,7 +62,7 @@ class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
 
     //check sorting
     foreach ($customFields as $fieldId) {
-      $columnName = "field_{$fieldId}{$ids['custom_group_id']}_{$fieldId}";
+      $columnName = "field_{$fieldId}{$ids['custom_group_id']}";
       $_GET['columns'][] = [
         'data' => $columnName,
       ];
@@ -84,7 +84,7 @@ class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
     $this->assertEquals(3, $sortedRecords['recordsTotal']);
     $this->assertEquals(3, $multiRecordFields['recordsTotal']);
     foreach ($customFields as $fieldId) {
-      $columnName = "field_{$fieldId}{$ids['custom_group_id']}_{$fieldId}";
+      $columnName = "field_{$fieldId}{$ids['custom_group_id']}";
       $this->assertEquals("test value {$fieldId} one", $multiRecordFields['data'][0][$columnName]['data']);
       $this->assertEquals("test value {$fieldId} two", $multiRecordFields['data'][1][$columnName]['data']);
       $this->assertEquals("test value {$fieldId} three", $multiRecordFields['data'][2][$columnName]['data']);

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1631,7 +1631,7 @@ class CRM_Dedupe_MergerTest extends CiviUnitTestCase {
       'civicrm_user_job' => [
         0 => 'created_id',
       ],
-      'civicrm_value_testgetcidref_1' => [
+      'civicrm_value_testgetcidrefs' => [
         0 => 'entity_id',
       ],
       'civicrm_website' => [

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Activity-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Activity-text.xml
@@ -10,7 +10,7 @@
       <collapse_display>0</collapse_display>
       <weight>1</weight>
       <is_active>1</is_active>
-      <table_name>civicrm_value_example_1</table_name>
+      <table_name>civicrm_value_example</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
       <is_reserved>0</is_reserved>
@@ -30,7 +30,7 @@
       <weight>1</weight>
       <is_active>1</is_active>
       <is_view>0</is_view>
-      <column_name>name1_1</column_name>
+      <column_name>name1</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
       <fk_entity_on_delete>set_null</fk_entity_on_delete>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/ActivityMeeting-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/ActivityMeeting-text.xml
@@ -12,7 +12,7 @@
       <collapse_display>0</collapse_display>
       <weight>1</weight>
       <is_active>1</is_active>
-      <table_name>civicrm_value_example_1</table_name>
+      <table_name>civicrm_value_example</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
       <is_reserved>0</is_reserved>
@@ -32,7 +32,7 @@
       <weight>1</weight>
       <is_active>1</is_active>
       <is_view>0</is_view>
-      <column_name>name1_1</column_name>
+      <column_name>name1</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
       <fk_entity_on_delete>set_null</fk_entity_on_delete>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Contact-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Contact-text.xml
@@ -10,7 +10,7 @@
       <collapse_display>0</collapse_display>
       <weight>1</weight>
       <is_active>1</is_active>
-      <table_name>civicrm_value_example_1</table_name>
+      <table_name>civicrm_value_example</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
       <is_reserved>0</is_reserved>
@@ -30,7 +30,7 @@
       <weight>1</weight>
       <is_active>1</is_active>
       <is_view>0</is_view>
-      <column_name>name1_1</column_name>
+      <column_name>name1</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
       <fk_entity_on_delete>set_null</fk_entity_on_delete>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/Individual-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/Individual-text.xml
@@ -10,7 +10,7 @@
       <collapse_display>0</collapse_display>
       <weight>1</weight>
       <is_active>1</is_active>
-      <table_name>civicrm_value_example_1</table_name>
+      <table_name>civicrm_value_example</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
       <is_reserved>0</is_reserved>
@@ -30,7 +30,7 @@
       <weight>1</weight>
       <is_active>1</is_active>
       <is_view>0</is_view>
-      <column_name>name1_1</column_name>
+      <column_name>name1</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
       <fk_entity_on_delete>set_null</fk_entity_on_delete>

--- a/tests/phpunit/CRM/Utils/Migrate/fixtures/IndividualStudent-text.xml
+++ b/tests/phpunit/CRM/Utils/Migrate/fixtures/IndividualStudent-text.xml
@@ -12,7 +12,7 @@
       <collapse_display>0</collapse_display>
       <weight>1</weight>
       <is_active>1</is_active>
-      <table_name>civicrm_value_example_1</table_name>
+      <table_name>civicrm_value_example</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
       <is_reserved>0</is_reserved>
@@ -32,7 +32,7 @@
       <weight>1</weight>
       <is_active>1</is_active>
       <is_view>0</is_view>
-      <column_name>name1_1</column_name>
+      <column_name>name1</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
       <fk_entity_on_delete>set_null</fk_entity_on_delete>


### PR DESCRIPTION
Overview
----------------------------------------
When CustomGroups/Fields are created and no explicit `table_name`/`column_name` is provided these names are inferred from the `label` parameter. This change tries to improve the readability of these generated table/column names.

Before
----------------------------------------
- Column names are generated by replacing all spaces in the label with `_`, converting it to lowercase, and truncating the label at 30 characters. The custom field ID is *always* appended.
- Table names are generated by replacing all spaces in the label with `_`, converting it to lowercase, truncating the label at 13 characters, and then prefixing it with `civicrm_value_`. The custom group ID is *always* appended.

After
----------------------------------------
- Column names are generated by replacing all spaces in the label with `_`, converting it to lowercase, and truncating the label at 58 characters. The custom field ID is appended *only* if the resulting column name is not unique within the custom group.
- Table names are generated by replacing all spaces in the label with `_`, converting it to lowercase, truncating the label at 45 characters, and then prefixing it with `civicrm_value_`. The custom group ID is added *only* if the resulting table name already exists.

Technical Details
----------------------------------------

Comments
----------------------------------------
