### PR TITLE
AbstractAction: Execute options callback only if container is booted

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -305,7 +305,10 @@ abstract class AbstractAction implements \ArrayAccess {
             $docs['type'] = array_diff($docs['type'], ['null']);
           }
           if (!empty($docs['optionsCallback'])) {
-            $docs['options'] = $this->{$docs['optionsCallback']}();
+            // Allow to create actions in PHPUnit tests without booted CiviCRM environment.
+            if (\Civi\Core\Container::isContainerBooted()) {
+              $docs['options'] = $this->{$docs['optionsCallback']}();
+            }
             unset($docs['optionsCallback']);
           }
           $this->_paramInfo[$name] = $docs;


### PR DESCRIPTION
Overview
----------------------------------------
With this change the execution of the options callback in `\Civi\Api4\Generic\AbstractAction::getParamInfo` is only performed if a container is booted. This makes it possible to create action objects without booted CiviCRM environment in PHPUnit tests.

Before
----------------------------------------
The execution of phpunit is interrupted with the message "You need to define CIVICRM_DSN in civicrm.settings.php", if a test without booted CiviCRM environment that sets a parameter on an action object shall be executed.

After
----------------------------------------
It's possible to set parameters on action objects without booted CiviCRM environment.
