### PR TITLE
[REF] move getAfformValues logic to afFieldset, remove lodash

### DIFF
--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -68,6 +68,19 @@
             }, true);
           }
         };
+        /**
+         * Get fieldset values to use for afform filters
+         * @returns Object
+         */
+        this.getFilterValues = () => {
+          const data = this.getFieldData();
+          // filter out unset values
+          // intended to be equivalent to previous lodash implementation
+          // (typeof val !== 'undefined' && val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length));
+          return Object.fromEntries(Object.entries(data).filter(([key, value]) =>
+            (['boolean', 'number', 'object'].includes(typeof value) && value !== null) || (value && value.length)
+          ));
+        };
       }
     };
   });

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -187,9 +187,7 @@
       },
 
       getAfformFilters: function() {
-        return _.pick(this.afFieldset ? this.afFieldset.getFieldData() : {}, function(val) {
-          return typeof val !== 'undefined' && val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length);
-        });
+        return this.afFieldset ? this.afFieldset.getFilterValues() : {};
       },
 
       // WARNING: Only to be used with trusted/sanitized markup.


### PR DESCRIPTION
Overview
----------------------------------------
This method belongs on `afFieldset`. Pulled out from https://github.com/civicrm/civicrm-core/pull/33801 as an easy pre-merge.

