### PR TITLE
[PHP8.5] Use canonical type casts

### DIFF
--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -525,9 +525,9 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
       // then we add 1 day first in case it's the end of the month, then subtract afterwards
       // eg. 2018-02-28 should renew to 2018-03-31, if we just added 1 month we'd get 2018-03-28
       $logStartDate = date('Y-m-d', mktime(0, 0, 0,
-        (double) $date[1],
-        (double) ($date[2] + 1),
-        (double) $date[0]
+        (float) $date[1],
+        (float) ($date[2] + 1),
+        (float) $date[0]
       ));
 
       switch ($membershipTypeDetails['duration_unit']) {

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -99,7 +99,7 @@ class CRM_Utils_Chart {
     foreach ($params['multiValues'] as $i => $dataSet) {
       $output['values'][$i] = [];
       foreach ($dataSet as $k => $v) {
-        $output['values'][$i][] = ['label' => $k, 'value' => (double) $v];
+        $output['values'][$i][] = ['label' => $k, 'value' => (float) $v];
       }
     }
     if (!$output['values']) {

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -98,7 +98,7 @@ function civicrm_api3_generic_setValue($apiRequest) {
         $value = '';
       }
       else {
-        $value = (boolean) $value;
+        $value = (bool) $value;
       }
       break;
 


### PR DESCRIPTION
In PHP 8.5 (out in around a month), non-canonical scalar type casts (boolean|double|integer|binary) deprecated: https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated.

This PR updates the few instances where CiviCRM is impacted to use the canonical casts.