### PR TITLE
Fix page title on report template list

### DIFF
--- a/CRM/Report/Page/InstanceList.php
+++ b/CRM/Report/Page/InstanceList.php
@@ -160,7 +160,7 @@ class CRM_Report_Page_InstanceList extends CRM_Core_Page {
       }
       if (trim($dao->title ?? '')) {
         if ($this->ovID) {
-          $this->title = ts("Report(s) created from the template: %1", [1 => $dao->label]);
+          $this->assign('pageTitle', ts("Report(s) created from the template: %1", [1 => $dao->label]));
         }
 
         $report_grouping = $dao->compName;


### PR DESCRIPTION
Overview
----------------------------------------
Fix page title on report template list.

Before
----------------------------------------
When viewing the existing reports for a template:
<img width="1381" height="501" alt="Screenshot 2025-10-26 at 12 12 12" src="https://github.com/user-attachments/assets/77fad7ba-e1e0-4eb8-bbe7-8bd4f69097a8" />

(e.g. https://smaster.demo.civicrm.org/civicrm/report/list?reset=1&ovid=275)

After
----------------------------------------
<img width="1369" height="455" alt="Screenshot 2025-10-26 at 12 13 02" src="https://github.com/user-attachments/assets/1c0c810d-1bfc-493c-81cc-79b34d3299b3" />

