### PR TITLE
Extensions - Add support for hidden submodules

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -159,7 +159,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     $localExtensionRows = [];
     $keys = array_keys($manager->getStatuses());
     sort($keys);
-    $hiddenExtensions = $mapper->getKeysByTag('mgmt:hidden');
+    $hiddenExtensions = array_unique(array_merge($mapper->getKeysByTag('mgmt:hidden'), $mapper->getKeysByTag('mgmt:submodule')));
     $requiredExtensions = $mapper->getKeysByTag('mgmt:required');
     foreach ($keys as $key) {
       if (in_array($key, $hiddenExtensions)) {

--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -208,6 +208,15 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
       if (!is_array($this->relPaths)) {
         $this->relPaths = [];
         $infoPaths = CRM_Utils_File::findFiles($this->baseDir, 'info.xml', FALSE, $this->maxDepth);
+
+        // If an extension has its own `./ext` subfolder, then look for submodules.
+        // These may exceed declared $maxDepth, but the positioning must be exact.
+        foreach ($infoPaths as $infoPath) {
+          $submodules = (array) glob(dirname($infoPath) . '/ext/*/info.xml');
+          $infoPaths = array_unique(array_merge($infoPaths, $submodules));
+        }
+
+        // Check each info.xml
         foreach ($infoPaths as $infoPath) {
           $relPath = CRM_Utils_File::relativize(dirname($infoPath), $this->baseDir);
           try {

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -396,6 +396,16 @@ class CRM_Extension_Info {
     }
   }
 
+  public function isInstallable(): bool {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    foreach ($this->requires as $require) {
+      if (!$manager->isEnabled($require)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
   /**
    * Filter out invalid requirements, e.g. extensions that have been moved to core.
    *

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -61,6 +61,16 @@ class CRM_Extension_Info {
   public $requires = [];
 
   /**
+   * (Optional) The parent of a submodule.
+   *
+   * If the parent is installed, then the submodule becomes eligible for auto-installation.
+   * If the parent is uninstalled, then the submodule must be uninstalled.
+   *
+   * @var string|null
+   */
+  public $parent = NULL;
+
+  /**
    * @var array
    *   List of expected mixins.
    *   Ex: ['civix@2.0.0']
@@ -361,6 +371,15 @@ class CRM_Extension_Info {
       }
       else {
         $this->$attr = $eval(CRM_Utils_XML::xmlObjToArray($val));
+      }
+    }
+
+    if (in_array('mgmt:submodule', $this->tags)) {
+      if ($this->parent) {
+        $this->requires[] = $this->parent;
+      }
+      else {
+        \Civi::log()->warning("Extension ($info->key) is a submodule, but no parent is declared.");
       }
     }
   }

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -274,7 +274,7 @@ class CRM_Extension_Manager {
     foreach ($keys as $key) {
       /** @var CRM_Extension_Info $info */
       /** @var CRM_Extension_Manager_Base $typeManager */
-      list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+      [$info, $typeManager] = $this->_getInfoTypeHandler($key);
 
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
@@ -334,7 +334,7 @@ class CRM_Extension_Manager {
     }
     foreach ($keys as $key) {
       // throws Exception
-      list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+      [$info, $typeManager] = $this->_getInfoTypeHandler($key);
 
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
@@ -410,7 +410,7 @@ class CRM_Extension_Manager {
           case self::STATUS_INSTALLED:
             $this->addProcess([$key], 'disabling');
             // throws Exception
-            list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+            [$info, $typeManager] = $this->_getInfoTypeHandler($key);
             $typeManager->onPreDisable($info);
             $this->_setExtensionActive($info, 0);
             $typeManager->onPostDisable($info);
@@ -419,7 +419,7 @@ class CRM_Extension_Manager {
 
           case self::STATUS_INSTALLED_MISSING:
             // throws Exception
-            list ($info, $typeManager) = $this->_getMissingInfoTypeHandler($key);
+            [$info, $typeManager] = $this->_getMissingInfoTypeHandler($key);
             $typeManager->onPreDisable($info);
             $this->_setExtensionActive($info, 0);
             $typeManager->onPostDisable($info);
@@ -483,7 +483,7 @@ class CRM_Extension_Manager {
         case self::STATUS_DISABLED:
           $this->addProcess([$key], 'uninstalling');
           // throws Exception
-          list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+          [$info, $typeManager] = $this->_getInfoTypeHandler($key);
           $typeManager->onPreUninstall($info);
           $this->_removeExtensionEntry($info);
           $typeManager->onPostUninstall($info);
@@ -491,7 +491,7 @@ class CRM_Extension_Manager {
 
         case self::STATUS_DISABLED_MISSING:
           // throws Exception
-          list ($info, $typeManager) = $this->_getMissingInfoTypeHandler($key);
+          [$info, $typeManager] = $this->_getMissingInfoTypeHandler($key);
           $typeManager->onPreUninstall($info);
           $this->_removeExtensionEntry($info);
           $typeManager->onPostUninstall($info);

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -118,9 +118,9 @@ class CRM_Extension_QueueTasks {
   }
 
   /**
-   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   * Enable the listed extensions.
    */
-  public static function enable(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+  public static function enable(CRM_Queue_TaskContext $ctx, ?string $stagingPath, array $keys): bool {
     CRM_Extension_System::singleton()->getManager()->enable($keys);
     return TRUE;
   }

--- a/tests/extensions/test.extension.parenttest/ext/childtest/childtest.php
+++ b/tests/extensions/test.extension.parenttest/ext/childtest/childtest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Implements civicrm_install
+ */
+function childtest_civicrm_install() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_uninstall
+ */
+function childtest_civicrm_uninstall() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_enable
+ */
+function childtest_civicrm_enable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_disable
+ */
+function childtest_civicrm_disable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}

--- a/tests/extensions/test.extension.parenttest/ext/childtest/info.xml
+++ b/tests/extensions/test.extension.parenttest/ext/childtest/info.xml
@@ -1,0 +1,11 @@
+<extension key='test.extension.childtest' type='module'>
+  <file>childtest</file>
+  <name>test_extension_childtest</name>
+  <tags>
+    <tag>mgmt:submodule</tag>
+  </tags>
+  <parent>test.extension.parenttest</parent>
+  <requires>
+    <ext>test.extension.uncletest</ext>
+  </requires>
+</extension>

--- a/tests/extensions/test.extension.parenttest/info.xml
+++ b/tests/extensions/test.extension.parenttest/info.xml
@@ -1,0 +1,4 @@
+<extension key='test.extension.parenttest' type='module'>
+  <file>parenttest</file>
+  <name>test_extension_parenttest</name>
+</extension>

--- a/tests/extensions/test.extension.parenttest/parenttest.php
+++ b/tests/extensions/test.extension.parenttest/parenttest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Implements civicrm_install
+ */
+function parenttest_civicrm_install() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_uninstall
+ */
+function parenttest_civicrm_uninstall() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_enable
+ */
+function parenttest_civicrm_enable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_disable
+ */
+function parenttest_civicrm_disable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}

--- a/tests/extensions/test.extension.uncletest/info.xml
+++ b/tests/extensions/test.extension.uncletest/info.xml
@@ -1,0 +1,4 @@
+<extension key='test.extension.uncletest' type='module'>
+  <file>uncletest</file>
+  <name>test_extension_uncletest</name>
+</extension>

--- a/tests/extensions/test.extension.uncletest/uncletest.php
+++ b/tests/extensions/test.extension.uncletest/uncletest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Implements civicrm_install
+ */
+function uncletest_civicrm_install() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_uninstall
+ */
+function uncletest_civicrm_uninstall() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_enable
+ */
+function uncletest_civicrm_enable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_disable
+ */
+function uncletest_civicrm_disable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -83,6 +83,14 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
     $this->assertEquals(['org.civicrm.a', 'org.civicrm.b'], $info->requires);
   }
 
+  public function testSubmodule(): void {
+    $info = CRM_Extension_Info::loadFromFile(Civi::paths()->getPath('[civicrm.root]/tests/extensions/test.extension.parenttest/ext/childtest/info.xml'));
+    $this->assertTrue(in_array('mgmt:submodule', $info->tags), 'childtest is marked as submodule');
+    // For submodules, <parent>X</parent> implies <requires><ext>X</ext></requires>.
+    $this->assertEquals('test.extension.parenttest', $info->parent);
+    $this->assertTrue(in_array('test.extension.parenttest', $info->requires));
+  }
+
   public static function getExampleAuthors() {
     $authorAliceXml = '<author><name>Alice</name><email>alice@example.org</email><role>Maintainer</role></author>';
     $authorAliceArr = ['name' => 'Alice', 'email' => 'alice@example.org', 'role' => 'Maintainer'];

--- a/tests/phpunit/CRM/Extension/Manager/SubmoduleTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/SubmoduleTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Class CRM_Extension_Manager_SubmoduleTest
+ *
+ * The test scenarios here involve multiple actions (install/disable/uninstall) and targets (parent/uncle/child).
+ * It takes a lot of words to describe each sequence. For naming the test-functions, we follow a convention:
+ *
+ * - Actions: [I]nstall, [D]isable, [U]ninstall
+ * - Targets: [P]arent, [C]hild, [U]ncle
+ *
+ * Ex: [I]nstall [P]arent + [I]nstall [U]ncle + [D]isable [P]arent = IP_IU_DU
+ *
+ * @group headless
+ */
+class CRM_Extension_Manager_SubmoduleTest extends CiviUnitTestCase {
+
+  /**
+   * @var string
+   */
+  protected $basedir;
+
+  /**
+   * @var \CRM_Extension_System
+   */
+  protected $system;
+
+  public function setUp():void {
+    parent::setUp();
+    // $query = "INSERT INTO civicrm_domain ( name, version ) VALUES ( 'domain', 3 )";
+    // $result = CRM_Core_DAO::executeQuery($query);
+    global $_test_extension_manager_submodule_log;
+    $_test_extension_manager_submodule_log = [];
+    $this->basedir = $this->createTempDir('ext-');
+    $this->system = new CRM_Extension_System([
+      'extensionsDir' => $this->basedir,
+      'extensionsURL' => 'http://testbase/',
+    ]);
+    $this->setExtensionSystem($this->system);
+  }
+
+  public function tearDown(): void {
+    parent::tearDown();
+    $this->system = NULL;
+  }
+
+  public function testIP_IU_DU_UU_DP_UP(): void {
+    $manager = $this->system->getManager();
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+
+    $manager->install(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['parenttest_civicrm_install', 'parenttest_civicrm_enable']);
+
+    $manager->install(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'installed', 'uncletest' => 'installed']);
+    $this->assertHookLog(['uncletest_civicrm_install', 'uncletest_civicrm_enable', 'childtest_civicrm_install', 'childtest_civicrm_enable']);
+
+    $manager->disable(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'disabled', 'uncletest' => 'disabled']);
+    $this->assertHookLog(['childtest_civicrm_disable', 'uncletest_civicrm_disable']);
+
+    $manager->uninstall(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'disabled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['uncletest_civicrm_uninstall']);
+
+    $manager->disable(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'disabled', 'childtest' => 'disabled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['parenttest_civicrm_disable']);
+
+    $manager->uninstall(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['childtest_civicrm_uninstall', 'parenttest_civicrm_uninstall']);
+  }
+
+  public function testIU_IP_DP_UP(): void {
+    $manager = $this->system->getManager();
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+
+    $manager->install(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'installed']);
+    $this->assertHookLog(['uncletest_civicrm_install', 'uncletest_civicrm_enable']);
+
+    $manager->install(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'installed', 'uncletest' => 'installed']);
+    $this->assertHookLog(['parenttest_civicrm_install', 'parenttest_civicrm_enable', 'childtest_civicrm_install', 'childtest_civicrm_enable']);
+
+    $manager->disable(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'disabled', 'childtest' => 'disabled', 'uncletest' => 'installed']);
+    $this->assertHookLog(['childtest_civicrm_disable', 'parenttest_civicrm_disable']);
+
+    $manager->uninstall(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'installed']);
+    $this->assertHookLog(['childtest_civicrm_uninstall', 'parenttest_civicrm_uninstall']);
+  }
+
+  public function assertHookLog(array $expected): void {
+    global $_test_extension_manager_submodule_log;
+    $this->assertEquals($expected, $_test_extension_manager_submodule_log);
+    $_test_extension_manager_submodule_log = [];
+  }
+
+  public function assertModules(array $expected): void {
+    $manager = $this->system->getManager();
+    foreach ($expected as $module => $expectStatus) {
+      $key = "test.extension.{$module}";
+      $this->assertEquals($expectStatus, $manager->getStatus($key), "Module $module should have status {$expectStatus}.");
+    }
+  }
+
+  /**
+   * @param string $name
+   */
+  public static function logHook(string $name) {
+    global $_test_extension_manager_submodule_log;
+    $_test_extension_manager_submodule_log[] = $name;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Define a new concept, "_submodule_", which acts an optional addendum to an existing module. It allows you to fill-in extra functionality. To convert a traditional module to a submodule, the `info.xml` must specify the following:

```xml
<tags><tag>mgmt:submodule</tag></tags>
<parent>org.example.myparent</parent>
<requires>...</requires>
```


The submodule is automatically enabled if its requirements are satisfied.

_Inspired by conversations with @mattwire and @jaapjansma._

Motivation
----------------------------------------

As we develop larger portions of CiviCRM's functionality in extensions, we get exposed to the problem of _integrations between extensions_. For example:

* When adding OAuth support to Stripe, you have an integration between two extensions (`oauth-client`, `stripe`).
* Similarly, the `emailapi` extension defines an APIv3 action -- but it also integrates that action with CiviRules and ActionProvider.

In each case, you have a piece of integration-code (such as the Stripe-OAuth connector or the EmailApi-CiviRules connector). Where should this go?

* You could embed the integration-code into one extension (e.g. `stripe` includes its own OAuth integration; `emailapi` includes its own CiviRules integration). However, as you start to include more artifacts (like scanned-classes, managed-entities, and settings), then you need to sprinkle-in various conditionals and overrides.
* You could put this in an entirely new project (`stripe_oauth.git`, `emailapi_civirules.git`, etc), but this becomes annoying for the site administrator (*more things to download, more things to enable, more things to disable*) and developers (*more git repos to manage*). 
* You could put this integration into a _submodule_ (e.g. `stripe.git/ext/stripe-oauth` or `emailapi.git/ext/emailapi-rules`).
    * For the site administrator, this means you don't need any extra downloads.
    * For the developer, this means you don't need any extra repos or releases.
    * But it still provides separation-of-concerns -- the integration code lives in a distinct folder.
    * And it still provides a full API -- the subfolder can include any mix of PHP classes, services, managed entities, settings, mixins, JS files, CSS files, etc.

Example: Setup
----------------------------------------

For the moment, we setup an example using `civix generate:module`. (If this PR is merged, then we can also implement a simpler `civix generate:submodule`.) Steps:

```bash
## Create a primary/parent module
civix generate:module myparent
mkdir myparent/ext

## Create a submodule
cd myparent/ext
civix generate:module mychild

## Update the child's metadata
nano mychild/info.xml
```

In the `info.xml`, set a few flags:

```diff
   <name>mychild</name>
+  <!-- Flag this as a submodule. Helps with browsing/indexing. -->
+  <tags>
+    <tag>mgmt:submodule</tag>
+  </tags>

+  <!-- Specify the parent's name. Helps with install/uninstall. -->
+  <parent>myparent</parent>

+  <!-- Specify the list of required extensions. -->
+  <requires>
+    <ext>myparent</ext>
+    <ext>myuncle</ext>
+  </requires>
```

Example: Patched behavior
----------------------------------------

If the system is running this patch, then:

* The "Manage Extensions" screen will not display `mychild`.
* `mychild` is auto-enabled whenever BOTH `myparent` AND `myuncle` are enabled.
* `mychild` is auto-disabled whenever EITHER `myparent` OR `myuncle` is disabled.
* `mychild` is auto-uninstalled whenever `myparent` is uninstalled.

For an administrator, the submodule is out-of-sight/out-of-mind. But for the developer, the submodule retains the coding-conventions of a regular module.

(Note that `myparent` and `myuncle` are similar -- you need both to run `mychild`. But the parent is *slightly* more significant -- uninstalling the parent will also uninstall the child.)

Example: Transitional/legacy behavior
----------------------------------------

During a transitional period, you can install `myparent` and `mychild` on older sites which don't have this patch; it just isn't as automatic.

* The "Manage Extensions" will display `mychild`.
* You can enable, disable, and uninstall `mychild` as you would with any other extension.

