### PR TITLE
Additional settings help text cleanup

### DIFF
--- a/ext/iframe/settings/iframe.setting.php
+++ b/ext/iframe/settings/iframe.setting.php
@@ -22,7 +22,7 @@ return [
     ],
     'default' => ['public', 'ajax'],
     'title' => ts('Allow pages (Common)'),
-    'description' => ts('List of pages and use-cases which may be accessed via embedded IFRAME.'),
+    'help_text' => ts('List of pages and use-cases which may be accessed via embedded IFRAME.'),
     'pseudoconstant' => [
       'callback' => 'CRM_Iframe_Utils::getAllowOptions',
     ],
@@ -33,8 +33,7 @@ return [
     'html_type' => 'textarea',
     'default' => "",
     'title' => ts('Allow pages (Other)'),
-    'description' => E::ts('List of other pages that may be embedded. One line per item. May use wildcards. Example: "<code>civicrm/ajax/*</code>"'),
-    'help_text' => NULL,
+    'help_markup' => '<p>' . E::ts('List of other pages that may be embedded. One line per item. May use wildcards. Example: "<code>civicrm/ajax/*</code>"') . '</p>',
   ],
   'iframe_theme' => $basic + [
     'name' => 'iframe_theme',
@@ -49,8 +48,7 @@ return [
     ],
     'default' => 'default',
     'title' => E::ts('Theme'),
-    'description' => E::ts('Apply styling to elements inside the IFRAME. In "Automatic" mode, inherit styling from the CiviCRM frontend.'),
-    'help_text' => NULL,
+    'help_text' => E::ts('Apply styling to elements inside the IFRAME. In "Automatic" mode, inherit styling from the CiviCRM frontend.'),
   ],
   'iframe_layout' => $basic + [
     'name' => 'iframe_layout',
@@ -62,8 +60,7 @@ return [
     ],
     'default' => 'auto',
     'title' => E::ts('Layout'),
-    'description' => E::ts('Apply wrapping to the page layout.'),
-    'help_text' => NULL,
+    'help_text' => E::ts('Apply wrapping to the page layout.'),
     'pseudoconstant' => [
       'callback' => 'CRM_Iframe_Utils::getLayoutOptions',
     ],

--- a/ext/legacycustomsearches/settings/LegacyCustomSearch.setting.php
+++ b/ext/legacycustomsearches/settings/LegacyCustomSearch.setting.php
@@ -11,12 +11,11 @@ return [
     'title' => ts('InnoDB Full Text Search'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('Enable InnoDB full-text search optimizations. (Requires MySQL 5.6+)'),
-    'help_text' => NULL,
+    'help_text' => ts('Enable InnoDB full-text search optimizations. (Requires MySQL 5.6+)'),
     'on_change' => [
       ['CRM_Core_InnoDBIndexer', 'onToggleFts'],
     ],
-    'settings_pages' => ['search' => ['weight' => 100]],
+    'settings_pages' => ['search' => ['section' => 'legacy', 'weight' => 100]],
   ],
   'fts_query_mode' => [
     'group_name' => 'Search Preferences',


### PR DESCRIPTION
Overview
----------------------------------------
Another followup to #33786. This should fix the last instance of escaped markup appearing in help text.