### PR TITLE
SearchKit - Remove redundant table classes from "Header" section

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -67,12 +67,6 @@
           {{:: ts('Enable Column Picker') }}
         </label>
       </div>
-      <div class="form-inline" ng-repeat="style in $ctrl.parent.tableClasses">
-        <label>
-          <input type="checkbox" ng-checked="$ctrl.includes($ctrl.display.settings.classes, style.name)" ng-click="$ctrl.parent.toggle($ctrl.display.settings.classes, style.name)">
-          <span>{{:: style.label }}</span>
-        </label>
-      </div>
     </div>
   </details>
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes double-checkboxes added from #33807. "Row Borders" etc. were appearing twice.

Before
----------------------------------------
<img width="1522" height="1178" alt="image" src="https://github.com/user-attachments/assets/c77f82ea-20f9-4e8e-a0ac-2b0a1bf0d33e" />


After
----------------------------------------
<img width="1516" height="902" alt="image" src="https://github.com/user-attachments/assets/2e2e4513-8576-4c32-915c-c455a7bc71a0" />


Comments
----------------------------------------
@ufundo 