### PR TITLE
dev/core#6170 form builder token handling improvement

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -27,7 +27,15 @@
 
       this.getTokens = function() {
         var tokens = _.transform(ctrl.editor.getEntities(), function(tokens, entity) {
-          tokens.push({id: entity.name + '.0.id', text: entity.label + ' ' + ts('ID')});
+          const entityMeta = ctrl.editor.meta.entities[entity.type];
+          if (entityMeta.submissionTokens) {
+            _.each(entityMeta.submissionTokens, function(submissionToken) {
+              const description = submissionToken.description ? submissionToken.description : '';
+              tokens.push({id: entity.name + '.0.' + submissionToken.token, text: entity.label + ' ' + submissionToken.label, description: description});  
+            });
+          } else {
+            tokens.push({id: entity.name + '.0.id', text: entity.label + ' ' + ts('ID')});
+          }
         }, []);
         tokens.push({id: 'token', text: ts('Submission JWT')});
         return {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -29,7 +29,7 @@
         var tokens = _.transform(ctrl.editor.getEntities(), function(tokens, entity) {
           const entityMeta = ctrl.editor.meta.entities[entity.type];
           if (entityMeta.submissionTokens) {
-            _.each(entityMeta.submissionTokens, function(submissionToken) {
+            entityMeta.submissionTokens.forEach((submissionToken) => {
               const description = submissionToken.description ? submissionToken.description : '';
               tokens.push({id: entity.name + '.0.' + submissionToken.token, text: entity.label + ' ' + submissionToken.label, description: description});  
             });

--- a/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
@@ -29,6 +29,8 @@ class AfformSubmitEvent extends AfformBaseEvent {
    */
   public $records;
 
+  public $saved = [];
+
   /**
    * AfformSubmitEvent constructor.
    *
@@ -62,6 +64,29 @@ class AfformSubmitEvent extends AfformBaseEvent {
    */
   public function setRecords(array $records) {
     $this->records = $records;
+    return $this;
+  }
+
+  /**
+   * Returns the array with the saved values.
+   *
+   * @return array
+   */
+  public function getSaved(): array {
+    return $this->saved;
+  }
+
+  /**
+   * Set the saved values
+   *
+   * @param int $index
+   *   Index of the record for which the saved values are set.
+   * @param array $savedValues
+   *   The saved values. (Probably the return values from the API4 Save action)
+   * @return $this
+   */
+  public function setSaved(int $index, array $savedValues) {
+    $this->saved[$index] = $savedValues;
     return $this;
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -873,7 +873,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   public function replaceTokens(string $text): string {
     $matches = [];
-    preg_match_all('/[[a-zA-Z0-9_]{1,}\.[0-9]{1,}\..*]/', $text, $matches);
+    preg_match_all('/[[a-zA-Z0-9_]{1,}\.[0-9]{1,}\.[^]]+]/', $text, $matches);
 
     foreach ($matches[0] as $match) {
       // strip [ ] and split on .

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -76,6 +76,14 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   protected $_entityValues = [];
 
   /**
+   * Values for the submission tokens.
+   * Eg. $entityValues['FormProcessor_MyFormProcessor'][0]['input.first_name' => 'john', 'action.create_contact.id' => 2]
+   *
+   * @var array
+   */
+  protected $_submissionTokenValues = [];
+
+  /**
    * Get the (submitted) values from all the entities on the form
    *
    * @return array
@@ -192,6 +200,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   public function unloadEntity(array $entity) {
     unset($this->_entityIds[$entity['name']]);
     unset($this->_entityValues[$entity['name']]);
+    unset($this->_submissionTokenValues[$entity['name']]);
   }
 
   /**
@@ -816,6 +825,27 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
+   * Set the submission token values for a given entity and index.
+   *
+   * @param string $entityName
+   *   The entity
+   * @param int $index
+   *   The index of the entity (0 for single value entitie; otherwise the index of the multi value entity)
+   * @param array $tokenValues
+   *   An array containing the token name as the key and the token value as the value.
+   */
+  public function setSubmissionTokenValues(string $entityName, int $index, array $tokenValues) {
+    $this->_submissionTokenValues[$entityName][$index] = $tokenValues;
+  }
+
+  /**
+   * Rerturn the current set submission token values.
+   */
+  public function getSubmissionTokenValues(): array {
+    return $this->_submissionTokenValues;
+  }
+
+  /**
    * Function to get allowed action of a join entity
    *
    * @param array $mainEntity
@@ -843,13 +873,16 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   public function replaceTokens(string $text): string {
     $matches = [];
-    preg_match_all('/\[[a-zA-Z0-9]{1,}\.[0-9]{1,}\.[^.\]]{1,}\]/', $text, $matches);
+    preg_match_all('/[[a-zA-Z0-9_]{1,}\.[0-9]{1,}\..*]/', $text, $matches);
 
     foreach ($matches[0] as $match) {
       // strip [ ] and split on .
-      [$entityName, $index, $field] = explode('.', substr($match, 1, -1));
+      [$entityName, $index, $field] = explode('.', substr($match, 1, -1), 3);
       if ($field === 'id') {
         $value = $this->_entityIds[$entityName][$index]['id'];
+      }
+      elseif (isset($this->_submissionTokenValues[$entityName][$index][$field])) {
+        $value = $this->_submissionTokenValues[$entityName][$index][$field];
       }
       else {
         $value = $this->_entityValues[$entityName][$index]['fields'][$field];

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -457,6 +457,7 @@ class Submit extends AbstractProcessor {
         $idField = CoreUtil::getIdFieldName($event->getEntityType());
         $saved = $api4($event->getEntityType(), 'save', ['records' => [$record['fields']]])->first();
         $event->setEntityId($index, $saved[$idField]);
+        $event->setSaved($index, $saved);
         self::saveJoins($event, $index, $saved[$idField], $record['joins'] ?? []);
       }
       catch (\CRM_Core_Exception $e) {


### PR DESCRIPTION
This issue is about integrating Form Builder and Form Processor.

**Use case**

1. Create a form processor 
2. Create a form builder based on this form processor
3. Now try to redirect the user based on a return value from the form processor

**Expected behavior**

The admin can select a token in the redirect url at the form builder and select an output from the form processor

**Current behavior**

Only Form Processor ID tokens are possible.

**Remarks**

1. A Form processor **does not** have a return **ID**
2. A form processor has different return values than input values. (e.g. input could be first_name output is an array containing the `input.first_name` as well `action.action_name.output_from_action`

**Technical improvements**

1.  When listening to the `civi.afform_admin.metadata` event one can add `submissionTokens`. Which is an array with for each token the following format `['token' => 'my_token', 'label' => 'My Token Label', 'description' => 'Optional a description']`  Those tokens are shown in the Token drop down in the Form Builder admin screen
2. When listening to the `civi.afform.submit' event when can read the saved values and set tokens on the `request` of the submit event with the function `setSubmissionTokenValues
3. There is a change in the `replaceTokens` function. So it supports a token like `[FormProcessor_test_form_builder1.0.action.test_action.value]` (There is an underscore in the entity name. And there are dots in the field names. )

See https://lab.civicrm.org/extensions/form-processor/-/merge_requests/120 for an implementation at the form processor 