### PR TITLE
Prevent errors when creating tables that already exist

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -81,7 +81,7 @@ class CRM_Core_BAO_SchemaHandler {
    * @return string
    */
   public static function buildTableSQL($params): string {
-    $sql = "CREATE TABLE {$params['name']} (";
+    $sql = "CREATE TABLE IF NOT EXISTS {$params['name']} (";
     if (isset($params['fields']) &&
       is_array($params['fields'])
     ) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a potential error with SearchKit table displays.

Technical Details
----------------------------------------
It's been reported that sometimes a managed search display of type entity:table can cause this error.