### PR TITLE
SearchKit: Add new EmailReport action for the SearchDisplay entity.

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/EmailReport.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/EmailReport.php
@@ -1,0 +1,161 @@
+<?php
+namespace Civi\Api4\Action\SearchDisplay;
+
+use Civi\Token\TokenProcessor;
+
+/**
+ * Leverages the saveFile action to save the SearchDisplay to a file,
+ * and then emails one or more contacts with the saved file as an attachment.
+ *
+ * @package Civi\Api4\Action\SearchDisplay
+ */
+class EmailReport extends SaveFile {
+
+  /**
+   * A single Contact ID or multiple Contact ID's separated by comma.
+   * @var string
+   * @required
+   */
+  protected $contactID;
+
+  /**
+   * The subject of the email.
+   *
+   * @var string
+   * @required
+   */
+  protected $subject;
+
+  /**
+   * The ID of the message template to be used for the email.
+   *
+   * @var int
+   * @required
+   */
+  protected $templateID;
+
+  /**
+   * Send copy to email address (cc)
+   *
+   * @var string
+   */
+  protected $cc;
+
+  /**
+   * Send blind copy to email address (bcc)
+   *
+   * @var string
+   */
+  protected $bcc;
+
+  /**
+   * @param \Civi\Api4\Result\SearchDisplayRunResult $result
+   *
+   * @return void
+   */
+  protected function processResult(\Civi\Api4\Result\SearchDisplayRunResult $result) {
+    parent::processResult($result);
+
+    if (!empty($result['file']) && !empty($result['file']->uri)) {
+      $attachment = [
+        'fullPath' => $result['file']->uri,
+        'mime_type' => $result['file']->mime_type,
+        'cleanName' => $result['file']->description
+      ];
+
+
+      if (!\CRM_Utils_Type::validate($this->contactID, 'CommaSeparatedIntegers')) {
+        throw new \API_Exception('Parameter contact_id must be a unique id or a list of ids separated by comma');
+      }
+
+      $contactIDs = explode(',', $this->contactID);
+
+      $messageTemplates = new \CRM_Core_DAO_MessageTemplate();
+      $messageTemplates->id = $this->templateID;
+
+      if (!$messageTemplates->find(TRUE)) {
+        throw new \API_Exception('Could not find template with ID: ' . $this->templateID);
+      }
+
+      [$defaultFromName, $defaultFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail();
+      $from = "\"$defaultFromName\" <$defaultFromEmail>";
+
+      $returnValues = [];
+      for ($i = 0; $i < count($contactIDs); $i++) {
+        $contactId = $contactIDs[$i];
+        $contact = \Civi\Api4\Contact::get(TRUE)
+          ->addSelect('*', 'email_primary.email', 'email_primary.on_hold')
+          ->addWhere('id', '=', $contactId)
+          ->setLimit(1)
+          ->execute()->first();
+        if (!$contact || $contact['do_not_email'] || empty($contact['email_primary.email']) || \CRM_Utils_Array::value('is_deceased', $contact) || $contact['email_primary.on_hold'] || $contact['is_deleted']) {
+          /*
+           * Contact is deceased or has opted out from mailings so do not send the email
+           */
+          continue;
+        }
+        else {
+          $toName = $contact['display_name'];
+          $toEmail = $contact['email_primary.email'];
+        }
+
+        $schema['contactId'] = 'contactId';
+        $context['contactId'] = $contactId;
+
+        // Whether to enable Smarty evaluation.
+        $useSmarty = (defined('CIVICRM_MAIL_SMARTY') && CIVICRM_MAIL_SMARTY) ?? FALSE;
+
+        $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+          'controller' => __CLASS__,
+          'schema' => $schema,
+          'smarty' => $useSmarty,
+        ]);
+
+        // Populate the token processor.
+        $tokenProcessor->addMessage('messageSubject', ($this->subject ?? $messageTemplates->msg_subject), 'text/plain');
+        $tokenProcessor->addMessage('html', $messageTemplates->msg_html, 'text/html');
+        $tokenProcessor->addMessage('text', ($messageTemplates->msg_text ?? \CRM_Utils_String::htmlToText($messageTemplates->msg_html)), 'text/plain');
+        $row = $tokenProcessor->addRow($context);
+        // Evaluate and render.
+        $tokenProcessor->evaluate();
+        $messageSubject = $row->render('messageSubject');
+        $html = $row->render('html');
+        $text = $row->render('text');
+
+        // set up the parameters for CRM_Utils_Mail::send
+        $mailParams = [
+          'groupName' => 'Email from API',
+          'from' => $from,
+          'toName' => $toName,
+          'toEmail' => $toEmail,
+          'subject' => $messageSubject,
+          'messageTemplateID' => $messageTemplates->id,
+          'contactId' => $contactId,
+          'attachments' => [$attachment],
+        ];
+
+        // render the &amp; entities in text mode, so that the links work
+        $mailParams['text'] = str_replace('&amp;', '&', $text);
+        $mailParams['html'] = $html;
+        if (!empty($this->cc)) {
+          $mailParams['cc'] = $this->cc;
+        }
+        if (!empty($this->bcc)) {
+          $mailParams['bcc'] = $this->bcc;
+        }
+
+        // Try to send the email.
+        $emailResult = \CRM_Utils_Mail::send($mailParams);
+        if (!$emailResult) {
+          throw new \API_Exception('Error sending email to ' . $contact['display_name'] . ' <' . $toEmail . '> ');
+        }
+
+        $result[$contactId] = [
+          'contact_id' => $contactId,
+          'send' => 1,
+          'status_msg' => "Successfully sent email to {$toEmail}",
+        ];
+      }
+    }
+  }
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/EmailReport.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/EmailReport.php
@@ -60,9 +60,8 @@ class EmailReport extends SaveFile {
       $attachment = [
         'fullPath' => $result['file']->uri,
         'mime_type' => $result['file']->mime_type,
-        'cleanName' => $result['file']->description
+        'cleanName' => $result['file']->description,
       ];
-
 
       if (!\CRM_Utils_Type::validate($this->contactID, 'CommaSeparatedIntegers')) {
         throw new \API_Exception('Parameter contact_id must be a unique id or a list of ids separated by comma');
@@ -158,4 +157,5 @@ class EmailReport extends SaveFile {
       }
     }
   }
+
 }

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -55,6 +55,15 @@ class SearchDisplay extends Generic\DAOEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return Action\SearchDisplay\EmailReport
+   */
+  public static function emailReport($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\EmailReport(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Action\SearchDisplay\InlineEdit
    */
   public static function inlineEdit($checkPermissions = TRUE) {


### PR DESCRIPTION
Overview
----------------------------------------
_Adds the ability to Email a SearchDisplay to one or more contacts.._

Technical Details
----------------------------------------
_This leverages the newer SaveFile action to save the SearchDisplay output to a file. It then will email one or more contacts the file from the SaveFile action as an attachment. It will use a Message Template as the basis for the email body and you can set the subject of the email in the API params._

This new action builds upon other SearchDisplay actions. First, this is extending the `SaveFile` action. The `SaveFile` action is similar to the `Download` action in that it creates a file from the SavedSearch/SearchDisplay. The `SaveFile` will save the file to the CiviCRM uploads directory with the file name specified. Then this action creates a new email with the saved file as an attachment, and send the email using the supplied MessageTemplate. It will send to one or more contacts and you can CC/BCC other contacts as well, although the CC/BCC are comma delimited email(s).

Screenshot of the API UI.
<img width="985" height="1020" alt="Screenshot 2025-10-28 at 12 37 06 PM" src="https://github.com/user-attachments/assets/326aec78-3e4b-4d3a-b0cd-6cd92bed7c5b" />
