### PR TITLE
dev/core#6173 Fix fatal error due to case-sensitive referencing of CRM_Mailing_Form_Optout

### DIFF
--- a/CRM/Mailing/Page/OptOut.php
+++ b/CRM/Mailing/Page/OptOut.php
@@ -32,7 +32,7 @@ class CRM_Mailing_Page_OptOut extends CRM_Core_Page {
     }
 
     $wrapper = new CRM_Utils_Wrapper();
-    return $wrapper->run('CRM_Mailing_Form_OptOut', $this->_title);
+    return $wrapper->run('CRM_Mailing_Form_Optout', $this->_title);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fatal error when attempting to access civicrm/mailing/optout.

Before
----------------------------------------
In CRM/Mailing/Page/OptOut.php, incorrectly attempts to run the class CRM_Mailing_Form_OptOut. This is actually CRM_Mailing_Form_Optout.

After
----------------------------------------
Fixed the class name.

Comments
----------------------------------------
dev/core#6173
Agileware Ref : SUP-75055