### PR TITLE
Mixins - Add mgd-php@2. Use tighter search to ignore nested submodules.

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -771,6 +771,7 @@ abstract class CRM_Utils_Hook {
    *     - 'always' (default): always delete orphaned records
    *     - 'never': never delete orphaned records
    *     - 'unused': only delete orphaned records if there are no other references to it in the DB. (This is determined by calling the API's "getrefcount" action.)
+   *   + 'source' (optional): string, the file which defined this entity
    * @param array|NULL $modules
    *   (Added circa v5.50) If given, only report entities related to $modules. NULL is a wildcard ("all modules").
    *

--- a/mixin/mgd-php@2/example/CRM/Shimmy/crm-group.mgd.php
+++ b/mixin/mgd-php@2/example/CRM/Shimmy/crm-group.mgd.php
@@ -1,0 +1,11 @@
+<?php
+return [
+  [
+    'name' => 'the_managed_group_crm',
+    'entity' => 'OptionGroup',
+    'params' => [
+      'name' => 'shimmy_group_crm',
+      'title' => 'Shimmy Group (CRM/Shimmy/)',
+    ],
+  ],
+];

--- a/mixin/mgd-php@2/example/api/v3/api-group.mgd.php
+++ b/mixin/mgd-php@2/example/api/v3/api-group.mgd.php
@@ -1,0 +1,11 @@
+<?php
+return [
+  [
+    'name' => 'the_managed_group_api',
+    'entity' => 'OptionGroup',
+    'params' => [
+      'name' => 'shimmy_group_api',
+      'title' => 'Shimmy Group (api/v3/)',
+    ],
+  ],
+];

--- a/mixin/mgd-php@2/example/managed/managed-group.mgd.php
+++ b/mixin/mgd-php@2/example/managed/managed-group.mgd.php
@@ -1,0 +1,11 @@
+<?php
+return [
+  [
+    'name' => 'the_managed_group_managed',
+    'entity' => 'OptionGroup',
+    'params' => [
+      'name' => 'shimmy_group_managed',
+      'title' => 'Shimmy Group (managed/)',
+    ],
+  ],
+];

--- a/mixin/mgd-php@2/example/other/other-group.mgd.php
+++ b/mixin/mgd-php@2/example/other/other-group.mgd.php
@@ -1,0 +1,11 @@
+<?php
+return [
+  [
+    'name' => 'the_managed_group_other',
+    'entity' => 'OptionGroup',
+    'params' => [
+      'name' => 'shimmy_group_other',
+      'title' => 'Should Not Be Loaded (other/)',
+    ],
+  ],
+];

--- a/mixin/mgd-php@2/example/root-group.mgd.php
+++ b/mixin/mgd-php@2/example/root-group.mgd.php
@@ -1,0 +1,11 @@
+<?php
+return [
+  [
+    'name' => 'the_managed_group_root',
+    'entity' => 'OptionGroup',
+    'params' => [
+      'name' => 'shimmy_group_root',
+      'title' => 'Shimmy Group (./)',
+    ],
+  ],
+];

--- a/mixin/mgd-php@2/example/tests/mixin/ManagedV2Test.php
+++ b/mixin/mgd-php@2/example/tests/mixin/ManagedV2Test.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Civi\Shimmy\Mixins;
+
+/**
+ * Assert that the managed-entity mixin is working properly.
+ *
+ * This class defines the assertions to run when installing or uninstalling the extension.
+ * It use called as part of E2E_Shimmy_LifecycleTest.
+ *
+ * @see E2E_Shimmy_LifecycleTest
+ */
+class ManagedV2Test extends \PHPUnit\Framework\Assert {
+
+  private $expectTitles = [
+    // Sort by name, ascending.
+    'Shimmy Group (api/v3/)',
+    'Shimmy Group (CRM/Shimmy/)',
+    'Shimmy Group (managed/)',
+    'Shimmy Group (./)',
+    // NOTE: 'other/other-group.mgd.php' is specifically excluded.
+  ];
+
+  public function testPreConditions($cv): void {
+    $this->assertFileExists(static::getPath('/root-group.mgd.php'), 'The shimmy extension must have example MGD file.');
+    $this->assertFileExists(static::getPath('/api/v3/api-group.mgd.php'), 'The shimmy extension must have example MGD file.');
+    $this->assertFileExists(static::getPath('/CRM/Shimmy/crm-group.mgd.php'), 'The shimmy extension must have example MGD file.');
+    $this->assertFileExists(static::getPath('/managed/managed-group.mgd.php'), 'The shimmy extension must have example MGD file.');
+    $this->assertFileExists(static::getPath('/other/other-group.mgd.php'), 'The shimmy extension must have example MGD file.');
+  }
+
+  private function getMyGroups($cv): array {
+    return $cv->api4('OptionGroup', 'get', [
+      'where' => [['name', 'LIKE', 'shimmy_group_%']],
+      'orderBy' => ['name' => 'ASC'],
+    ]);
+  }
+
+  public function testInstalled($cv): void {
+    $items = $this->getMyGroups($cv);
+    foreach ($this->expectTitles as $n => $title) {
+      $this->assertEquals($title, $items[$n]['title'], "Active item ($n) should have title ($title).");
+      $this->assertEquals(TRUE, $items[$n]['is_active'], "Item ($n) should be active.");
+    }
+    $this->assertEquals(count($this->expectTitles), count($items), 'Number of groups should match number of supported folders');
+  }
+
+  public function testDisabled($cv): void {
+    $items = $this->getMyGroups($cv);
+    foreach ($this->expectTitles as $n => $title) {
+      $this->assertEquals($title, $items[$n]['title'], "Disabled item ($n) should have title ($title).");
+      $this->assertEquals(FALSE, $items[$n]['is_active'], "Item ($n) should be active.");
+    }
+    $this->assertEquals(count($this->expectTitles), count($items), 'Number of groups should match number of supported folders');
+  }
+
+  public function testUninstalled($cv): void {
+    $items = $this->getMyGroups($cv);
+    $this->assertEmpty($items);
+  }
+
+  protected static function getPath($suffix = ''): string {
+    return dirname(__DIR__, 2) . $suffix;
+  }
+
+}

--- a/mixin/mgd-php@2/mixin.php
+++ b/mixin/mgd-php@2/mixin.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Auto-register "**.mgd.php" files.
+ *
+ * The older (mgd-php@1) and newer (mgd-php@2) are similar in that both load `*.mgd.php` files.
+ * However, they differ in how the search:
+ *
+ * - v1.x does a broad search over the entire extension source-tree.
+ * - v2.x does a narrower search in folders which commonly have mgds.
+ *   Within 2.x, future increments may add other paths (after vetting `universe` for impacts).
+ *
+ * @mixinName mgd-php
+ * @mixinVersion 2.0.0
+ * @since 6.9
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::managed()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_managed', function ($event) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    // Optimization: if managed entities were requested for specific module(s),
+    // check name and return early if not applicable.
+    if ($event->modules && !in_array($mixInfo->longName, $event->modules, TRUE)) {
+      return;
+    }
+
+    $path = $mixInfo->getPath();
+    $mgdFiles = array_merge(
+      (array) glob("$path/*.mgd.php"),
+      CRM_Utils_File::findFiles("$path/managed", '*.mgd.php'),
+      CRM_Utils_File::findFiles("$path/api", '*.mgd.php'),
+      CRM_Utils_File::findFiles("$path/CRM", '*.mgd.php'),
+      CRM_Utils_File::findFiles("$path/Civi", '*.mgd.php'),
+    );
+
+    sort($mgdFiles);
+    foreach ($mgdFiles as $file) {
+      $es = include $file;
+      foreach ($es as $e) {
+        if (empty($e['module'])) {
+          $e['module'] = $mixInfo->longName;
+        }
+        if (empty($e['params']['version'])) {
+          $e['params']['version'] = '3';
+        }
+        if (empty($e['source'])) {
+          $e['source'] = $file;
+        }
+        $event->entities[] = $e;
+      }
+    }
+  });
+
+};

--- a/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.template.php
+++ b/tests/extensions/shimmy/tests/phpunit/E2E/Shimmy/LifecycleTest.template.php
@@ -26,13 +26,21 @@ class E2E_Shimmy_LifecycleTest extends \Civi\Test\MixinTestCase {
     return $mixinTests;
   }
 
+  public static function getTestId(): array {
+    // We don't really want to use a data provider, but we don't to ensure that each
+    // invocation of this suite can produce distinct results-files.
+    return ['%%TEST_ID%%' => ['%%TEST_ID%%']];
+  }
+
   /**
    * Install and uninstall the extension. Ensure that various mixins+artifacts work correctly.
    *
    * This interacts with Civi by running many subprocesses (`cv api3` and `cv api4` commands).
    * This style of interaction is a better representation of how day-to-day sysadmin works.
+   *
+   * @dataProvider getTestId
    */
-  public function testLifecycleWithSubprocesses(): void {
+  public function testLifecycleWithSubprocesses(string $id): void {
     $this->runLifecycle($this->createCvWithSubprocesses());
   }
 
@@ -42,8 +50,10 @@ class E2E_Shimmy_LifecycleTest extends \Civi\Test\MixinTestCase {
    * This interacts with Civi by calling local PHP functions (`civicrm_api3(` and `civicrm_api4()`).
    * This style of interaction reveals whether the install/uninstall mechanics have data-leaks that
    * may cause subtle/buggy interactions during the transitions.
+   *
+   * @dataProvider getTestId
    */
-  public function testLifecycleWithLocalFunctions(): void {
+  public function testLifecycleWithLocalFunctions(string $id): void {
     $this->runLifecycle($this->createCvWithLocalFunctions());
   }
 

--- a/tools/mixin/bin/mixer
+++ b/tools/mixin/bin/mixer
@@ -33,7 +33,7 @@ function task_create(array $options, string $targetDir, ...$mixinNames) {
     }
   }
 
-  $mixinNames = resolve_mixin_names($mixinNames);
+  $mixinNames = resolve_mixin_names($mixinNames, $options['exclude'] ?? []);
   fprintf(STDOUT, "Create %s for %s\n", $targetDir, implode(',', $mixinNames));
 
   $srcDirs = [];
@@ -71,6 +71,16 @@ function task_create(array $options, string $targetDir, ...$mixinNames) {
     }
   });
 
+  $testTemplate = "$targetDir/tests/phpunit/E2E/Shimmy/LifecycleTest.template.php";
+  $mixinNamesConcat = implode(',', $mixinNames);
+  $testName = 'Lifecycle' . md5($mixinNamesConcat) . 'Test';
+  rename(assert_file($testTemplate), "$targetDir/tests/phpunit/E2E/Shimmy/$testName.php");
+  update_file("$targetDir/tests/phpunit/E2E/Shimmy/$testName.php", function (string $content) use ($testName, $mixinNamesConcat) {
+    $content = str_replace('LifecycleTest', $testName, $content);
+    $content = str_replace('%%TEST_ID%%', $mixinNamesConcat, $content);
+    return $content;
+  });
+
   return $targetDir;
 }
 
@@ -95,7 +105,7 @@ function task_test(array $options, string $targetDir, ...$args) {
     $phpunitArgs = explode(' ', '--group e2e --debug --stop-on-failure');
   }
 
-  $mixinNames = resolve_mixin_names($mixinNames);
+  $mixinNames = resolve_mixin_names($mixinNames, $options['exclude'] ?? []);
   $errors = [];
   if (!empty($options['isolate']) && count($mixinNames) > 1) {
     foreach ($mixinNames as $mixinName) {
@@ -122,13 +132,13 @@ function task_test(array $options, string $targetDir, ...$args) {
     return;
   }
   fprintf(STDOUT, "Test %s\n", implode(',', $mixinNames));
-  with_dir($targetDir, function () use ($phpunitArgs) {
-    phpunit($phpunitArgs);
+  with_dir($targetDir, function () use ($phpunitArgs, $mixinNames) {
+    phpunit(implode(',', $mixinNames), $phpunitArgs);
   });
 }
 
 function task_list(array $options, ...$mixinNames) {
-  $mixinNames = resolve_mixin_names($mixinNames);
+  $mixinNames = resolve_mixin_names($mixinNames, $options['exclude'] ?? []);
   fprintf(STDOUT, "%-20s %-8s %-8s %s\n", "NAME", "VERSION", "SINCE", "DESCRIPTION");
   fprintf(STDOUT, "%-20s %-8s %-8s %s\n", "----", "-------", "-----", "-----------");
   foreach ($mixinNames as $mixinName) {
@@ -146,8 +156,8 @@ function task_help(array $options) {
   fprintf(STDERR, "%s - Test utility for extension mixins\n", $cmd);
   fprintf(STDERR, "\n");
   fprintf(STDERR, "Usage:\n");
-  fprintf(STDERR, "  %s create [-f] [--bare] <new-ext-path> [<mixin-name>...]\n", $cmd);
-  fprintf(STDERR, "  %s test [-f] [--bare] [--isolate] <new-ext-path> [<mixin-name>...] -- [<phpunit-args>...]\n", $cmd);
+  fprintf(STDERR, "  %s create [-f] [--bare|--copy] [--exclude=...] <new-ext-path> [<mixin-name>...]\n", $cmd);
+  fprintf(STDERR, "  %s test [-f] [--bare|--copy] [--exclude=...] [--isolate] <new-ext-path> [<mixin-name>...] -- [<phpunit-args>...]\n", $cmd);
   fprintf(STDERR, "  %s list [<mixin-name>...]\n", $cmd);
 }
 
@@ -194,10 +204,26 @@ function deep_copy(array $srcDirs, string $targetDir): void {
   }
 }
 
-function phpunit(array $args = []) {
-  $argString = implode(' ' , array_map('escapeshellarg', $args));
-  $phpunit = getenv('PHPUNIT') ?: 'phpunit9';
-  passthru_ok($phpunit . ' ' . $argString);
+function phpunit(string $id, array $args = []) {
+  $state = 'boring';
+  foreach ($args as &$arg) {
+    if ($state === 'boring' && $arg === '--log-junit') {
+      $state = 'log-junit';
+    }
+    elseif ($state === 'log-junit') {
+      $arg = preg_replace('/\.xml$/', '-' . md5($id) . '.xml', $arg);
+    }
+  }
+
+  // putenv("TEST_ID=$id");
+  // try {
+    $argString = implode(' ' , array_map('escapeshellarg', $args));
+    $phpunit = getenv('PHPUNIT') ?: 'phpunit9';
+    passthru_ok($phpunit . ' ' . $argString);
+  // }
+  // finally {
+    putenv('TEST_ID');
+  // }
 }
 
 function passthru_ok($cmd) {
@@ -207,16 +233,18 @@ function passthru_ok($cmd) {
   }
 }
 
-function resolve_mixin_names(array $mixinNames): array {
+function resolve_mixin_names(array $mixinNames, array $excludeMixinNames = []): array {
   if (empty($mixinNames)) {
-    return mixlib()->getList();
+    $result = mixlib()->getList();
   }
   else {
-    return array_map(
+    $result = array_map(
       function (string $mixinName) {
         return trim($mixinName, '/' . DIRECTORY_SEPARATOR);
       }, $mixinNames);
   }
+
+  return array_diff($result, $excludeMixinNames);
 }
 
 function with_dir(string $dir, callable $callback) {
@@ -246,6 +274,14 @@ function update_xml(string $file, callable $filter): void {
   file_put_contents($file, $xml->saveXML());
 }
 
+function update_file(string $file, callable $filter): void {
+  $oldContent = file_get_contents($file);
+  $newContent = $filter($oldContent);
+  if ($newContent !== $oldContent) {
+    file_put_contents($file, $newContent);
+  }
+}
+
 function main($args) {
   $cmd = array_shift($args);
 
@@ -265,6 +301,12 @@ function main($args) {
     }
     elseif (preg_match(';^--(bare|isolate|force)$;', $arg, $m)) {
       $newOptions[$m[1]] = TRUE;
+    }
+    elseif ($arg === '--copy') {
+      $newOptions['bare'] = FALSE;
+    }
+    elseif (preg_match(';^--(exclude)=(.*)$;', $arg, $m)) {
+      $newOptions[$m[1]] = explode(' ', $m[2]);
     }
     elseif ($task === NULL) {
       $task = 'task_' . preg_replace(';[^\w];', '_', $arg);

--- a/tools/mixin/bin/test-all
+++ b/tools/mixin/bin/test-all
@@ -1,4 +1,5 @@
 #!/bin/bash
+{
 set -e
 # Not really readed, and currently segfaulting on CI: # export XDEBUG_PORT= XDEBUG_MODE=off
 
@@ -21,6 +22,10 @@ JUNIT_DIR="$1"
 ## TODO: Once the managed-entity regression is examined/fixed, remove the MY_MIXINS list. Then it will test all mixins.
 # MY_MIXINS='ang-php@1 case-xml@1 menu-xml@1 setting-php@1 theme-php@1'
 MY_MIXINS=''
+
+## Unit-tests for old-mixins may conflict with unit-tests for new-mixins.
+## Therefore, these are pulled out and tested separately.
+OLD_MIXINS='mgd-php@1 entity-types-php@1 smarty-v2@1'
 
 ###############################################################################
 
@@ -57,6 +62,17 @@ fi
 
 
 set -ex
-mixer_test "mixin-isolate-bare.xml" $MY_MIXINS --isolate --bare
-mixer_test "mixin-combine-bare.xml" $MY_MIXINS --bare
-mixer_test "mixin-combine-copy.xml" $MY_MIXINS
+
+## Test all mixins individually.
+mixer_test "mixin-isolate-bare.xml" --isolate --bare
+
+## Test the latest mixins (together), and test older mixins (together).
+## Load the mixins directly from civicrm-core:mixin/
+mixer_test "mixin-combine-bare-new.xml" --bare --exclude="$OLD_MIXINS"
+mixer_test "mixin-combine-bare-old.xml" --bare $OLD_MIXINS
+
+mixer_test "mixin-combine-copy-new.xml" --copy --exclude="$OLD_MIXINS"
+mixer_test "mixin-combine-copy-old.xml" --copy $OLD_MIXINS
+
+exit
+}


### PR DESCRIPTION
Overview
----------------------------------------

The mixin `mgd-php@1` helps extensions autoload `*.mgd.php` files. The original policy is quite open, allowing these files to be placed anywhere. However, if you have overlapping extensions (e.g. nested extensions or submodules), then this can become actively harmful: the `*.mgd.php` from a child extension can be loaded by its parent extension.

This defines a new iteration (mixin `mgd-php@2`) with a tighter search radius.

Before
----------------------------------------

`mgd-php@1` searches the entire subtree underneath the extension.

After
----------------------------------------

`mgd-php@2` searches specific folders which are commonly used for `*.mgd.php` files:

* __Root Files__ Files in the top-level folder of the extension (`*.mgd.php`)
* __In Situ Files__: Files that are adjacent to relevant code (e.g. `api/**.mgd.php`, `CRM/**.mgd.php`)
* __Managed Folder__: Files in a general managed folder (`managed/**.mgd.php`)

This has a few effects:

* It skips many folders (e.g. `templates/`, `vendor/`, `settings/`, `schema/`) that are commonly included in extensions but which don't have MGDs . Many of these folders are small (e.g. `settings/`), but some can get large (e.g. `vendor/`).
* It skips unknown/unrecognized folders. In observed-practice and in common-sense, the nested-extensions tend to have bespoke folders. You won't find them under `PARENT_EXT/managed/CHILD_EXT/` or `PARENT_EXT/api/v3/CHILD_EXT/`.

Comments
----------------------------------------

You can look at this topic from a few angles:

1. _False-matches_: The impetus for the PR is to fix a problem where some extensions are vulnerable to false-matches, which cause one extension (e.g. `ext/parent/`) to incorrectly load MGDs from another (e.g. `ext/parent/child/`).
2. _Performance_: If you're changing the search, then you can also reduce the search-space - which is good for performance.
3. _Aesthetics_: When writing an extension, you want to put files in a place that feels sensible.
4. _Deployment_: How much work is required to deploy the update?

The impetus for this PR is to solve the false-match problem. But you can imagine different patches which create different trade-offs. For example:

* Scan all folders but _exclude_ nested extensions. If the search encounters a `$subfolder/` with its own `$subfolder/info.xml`, then skip it. _This requires a longer implementation, and there is little prospect for improving performance._
* Scan `./managed/` exclusively. The implementation is fairly simple, and there's more performance benefit. _But this takes more work to deploy (re:conversions), and it prematurely judges the aesthetic situation (re:sensible organization)._

Originally, when drafting this PR, I started with that last notion -- to search only `./managed/`. But then I reviewed `universe` to gauge actual impacts. 

* https://gist.github.com/totten/a63069fbe262a711a54308e7f21b8bec (*This excludes ext's before 2020. The vast majority of ext's are _recent_, i.e. updated in 2024/2025.*)

This led me to the middle-ground (*this PR*). Compare:

* __Deployment__: 
    * If one *only* accepts `./managed/`, then it would require reorganizing 127/210 exts (60%) -- enough that `civix` would need to automatically convert them. That means more detailed testing (and lower tolerance for mistakes).
    * This middle-ground has very high drop-in compatibility. It only requires reorganizing 14/210 exts (6%).  With this smaller number, `civix` doesn't need to do it automatically. (We could just print a notice and leave the oddballs on `mgd-php@1` until the author manually reorganizes.)
* __Aesthetics__:
    * If we had a plan for ___One Good Layout___, then I would be fine with sorting-out migration via `civix` for  60%+ ext's. But what we actually have are ___Multiple Middling Layouts___ (with prevalence of 10%/48%/49%).
    * The layout of `managed/` is centralized, and that's nice with 2-5 MGDs. It works with any kind of entity. But when you get 10+ MGDs, then it's messy.
    * The in-situ layout scales (*more structured*), but it only works with PHP classes and APIv3 files. There is no comparable structure for saved-searches, option-groups, etc.
    * I don't want a conversion with "bouncy" aesthetics -- where we compel half the extensions to reorganize and then (8 months later) compel them to reorganize again.

This middle-ground allows incremental progress (fix false-matches; improve performance; no reorganization) and avoids rushing the aesthetic questions. (When we're ready to work on ___One Good Layout___, then we can give that proper attention.)