### PR TITLE
Open files in new tab

### DIFF
--- a/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
+++ b/ext/legacycustomsearches/templates/CRM/Contact/Form/Search/Custom/FullText.tpl
@@ -387,11 +387,11 @@
     <tbody>
       {foreach from=$summary.File item=row}
         <tr class="{cycle values="odd-row,even-row"}">
-          <td><a href="{$row.file_url}">{$row.file_name}</a></td>
+          <td><a href="{$row.file_url}" target="_blank">{$row.file_name}</a></td>
           <td>{$row.file_mime_type}</td>
           <td>{crmCrudLink action=VIEW table=$row.file_entity_table id=$row.file_entity_id}</td>
           <td>
-            <a href="{$row.file_url}">{ts}View{/ts}</a>
+            <a href="{$row.file_url}" target="_blank">{ts}View{/ts}</a>
           </td>
         </tr>
       {/foreach}

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -52,7 +52,7 @@
             {if !empty($attachment)}
             {foreach from=$attachment key=attKey item=attVal}
             <div class="crm-attachment-wrapper crm-entity" id="file_{$attVal.fileID}">
-              <strong><a class="crm-attachment" href="{$attVal.url}">{$attVal.cleanName}</a></strong>
+              <strong><a class="crm-attachment" href="{$attVal.url}" target="_blank">{$attVal.cleanName}</a></strong>
               {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
               {if $attVal.deleteURLArgs}
                 <a href="#" class="crm-hover-button delete-attachment" data-mimetype="{$attVal.mime_type}" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts escape='htmlattribute'}Delete File{/ts}"><span class="icon delete-icon"></span></a>

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -56,7 +56,7 @@
                        width="{$element.element_value.imageThumbWidth}">
                 </a>
               {else}
-                <a class="crm-attachment" href="{$element.element_value.fileURL}">{$element.element_value.fileName}</a>
+                <a class="crm-attachment" href="{$element.element_value.fileURL}" target="_blank">{$element.element_value.fileName}</a>
               {/if}
               {if $element.element_value.deleteURL}
                 <a href="#" class="crm-hover-button delete-attachment"

--- a/templates/CRM/Form/attachment.tpl
+++ b/templates/CRM/Form/attachment.tpl
@@ -15,7 +15,7 @@
           {foreach from=$currentAttachmentInfo key=attKey item=attVal}
                 <div id="attachStatusMesg" class="status hiddenElement"></div>
                 <div id="attachFileRecord_{$attVal.fileID}">
-                  <strong><a href="{$attVal.url}"><i class="crm-i {$attVal.icon}" role="img" aria-hidden="true"></i> {$attVal.cleanName}</a></strong>
+                  <strong><a href="{$attVal.url}" target="_blank"><i class="crm-i {$attVal.icon}" role="img" aria-hidden="true"></i> {$attVal.cleanName}</a></strong>
                   {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
                   {if $attVal.tag}
                     <br />
@@ -87,7 +87,7 @@
             <td class="view-value">
           {foreach from=$currentAttachmentInfo key=attKey item=attVal}
                 <div class="crm-attachment-wrapper crm-entity" id="file_{$attVal.fileID}">
-                  <strong><a class="crm-attachment" href="{$attVal.url}">{$attVal.cleanName}</a></strong>
+                  <strong><a class="crm-attachment" href="{$attVal.url}" target="_blank">{$attVal.cleanName}</a></strong>
                   {if $attVal.description}&nbsp;-&nbsp;{$attVal.description}{/if}
                   {if $attVal.deleteURLArgs}
                    <a href="#" class="crm-hover-button delete-attachment" data-filename="{$attVal.cleanName}" data-args="{$attVal.deleteURLArgs}" title="{ts escape='htmlattribute'}Delete File{/ts}"><span class="icon delete-icon"></span></a>


### PR DESCRIPTION
Overview
----------------------------------------
This change adds `target="_blank"` to file links. This allows to intercept runs of `\CRM_Core_Page_File` and to display files in the browser using additional services instead of downloading without CiviCRM being replaced. (The AngularJS templates already have `target="_blank"` set for file links.)

When file downloads (`Content-Disposition: attachment`) are opened in a new tab, browsers will close the new tab immediately. So the behavior is actually as before.

Before
----------------------------------------
File links to download files on classic pages (i.e. not AngularJS) where loaded in the same tab.

After
----------------------------------------
File links to download files on classic pages are loaded in a new tab (as on AngularJS pages). The default behavior is as before as explained above.