### PR TITLE
Show detailed error message for anonymous users when Afform validation fails

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -56,7 +56,7 @@ class Submit extends AbstractProcessor {
     $errors = $event->getErrors();
     if ($errors) {
       \Civi::log('afform')->error('Afform Validation errors: ' . print_r($errors, TRUE));
-      throw new \CRM_Core_Exception(implode("\n", $errors));
+      throw new \CRM_Core_Exception(implode("\n", $errors), 0, ['show_detailed_error' => TRUE]);
     }
 
     // Save submission record


### PR DESCRIPTION
Overview
----------------------------------------
When you implement `civi.afform.validate` or any Afform validation code runs it can call `setError('my nice validation error')`. If any errors are set the form fails validation and the error messages are shown to the user.

Except that if you don't have "view debug output" (eg. anonymous user) you don't see the nice error and instead see an unhelpful error - eg. 

> Form Error
> Sorry an error occurred and your request was not completed. (Error ID: Cyg3-Vj20-QpId)

With this patch you see the message set by the validation (eg. with FormProtection extension):

> Form Error
> There was a timeout while processing your request. Please wait a few seconds and try again.

The intention of `show_detailed_error` default to FALSE is to prevent error messages from being seen by unprivileged users (eg. an error contains an SQL query with a password).
But in this case it is expected that error messages from form validation *should* be shown to the end user.

Before
----------------------------------------
Unhelpful, meaningless error message shown to end user.

After
----------------------------------------
Helpful, meaningful error message shown to end user.

Technical Details
----------------------------------------
Adds `show_detailed_error` when the validate error is thrown.

Comments
----------------------------------------
