### PR TITLE
Replace assertApproxEquals with assertEqualsWithDelta in tests

### DIFF
--- a/Civi/Test/GenericAssertionsTrait.php
+++ b/Civi/Test/GenericAssertionsTrait.php
@@ -46,29 +46,6 @@ trait GenericAssertionsTrait {
   }
 
   /**
-   * Assert that two numbers are approximately equal,
-   * give or take some $tolerance.
-   *
-   * @param int|float $expected
-   * @param int|float $actual
-   * @param int|float $tolerance
-   *   Any differences <$tolerance are considered irrelevant.
-   *   Differences >=$tolerance are considered relevant.
-   * @param string $message
-   */
-  public function assertApproxEquals($expected, $actual, $tolerance, $message = NULL) {
-    if ($tolerance == 1 && is_int($expected) && is_int($actual)) {
-      //           ^^ loose equality is on purpose
-      throw new \CRM_Core_Exception('assertApproxEquals is a fractions-first thinking function and compares integers with a tolerance of 1 as if they are identical. You want a bigger number, such as 2, or 5.');
-    }
-    $diff = abs($actual - $expected);
-    if ($message === NULL) {
-      $message = sprintf("approx-equals: expected=[%.3f] actual=[%.3f] diff=[%.3f] tolerance=[%.3f]", $expected, $actual, $diff, $tolerance);
-    }
-    $this->assertTrue($diff < $tolerance, $message);
-  }
-
-  /**
    * Assert attributes are equal.
    *
    * @param array $expectedValues

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -2137,19 +2137,19 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
 
     // Assert the timestamp as of when the emails of respective three reminders as configured
     // 2 weeks before, on and 1 day after MED, are sent
-    $this->assertApproxEquals(
+    $this->assertEqualsWithDelta(
       strtotime('2012-06-01 01:00:00'),
       strtotime(CRM_Core_DAO::getFieldValue('CRM_Core_DAO_ActionLog', $actionScheduleBefore->id, 'action_date_time', 'action_schedule_id', TRUE)),
       // Variation in test execution time.
       3
     );
-    $this->assertApproxEquals(
+    $this->assertEqualsWithDelta(
       strtotime('2012-06-15 00:00:00'),
       strtotime(CRM_Core_DAO::getFieldValue('CRM_Core_DAO_ActionLog', $actionScheduleOn->id, 'action_date_time', 'action_schedule_id', TRUE)),
       // Variation in test execution time.
       3
     );
-    $this->assertApproxEquals(
+    $this->assertEqualsWithDelta(
       strtotime('2012-06-16 01:00:00'),
       strtotime(CRM_Core_DAO::getFieldValue('CRM_Core_DAO_ActionLog', $actionScheduleAfter->id, 'action_date_time', 'action_schedule_id', TRUE)),
       // Variation in test execution time.

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -684,7 +684,7 @@ emo
     $returned_parts = explode('_', substr($messageContent['subject'], $checksum_position));
     $expected_parts = explode('_', substr($fixedExpected, $checksum_position));
     $this->assertEquals($expected_parts[0], $returned_parts[0]);
-    $this->assertApproxEquals($expected_parts[1], $returned_parts[1], 2);
+    $this->assertEqualsWithDelta($expected_parts[1], $returned_parts[1], 2);
     $this->assertEquals($expected_parts[2], $returned_parts[2]);
   }
 

--- a/tests/phpunit/CRM/Core/CommunityMessagesTest.php
+++ b/tests/phpunit/CRM/Core/CommunityMessagesTest.php
@@ -180,7 +180,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     );
     $doc1 = $communityMessages->getDocument();
     $this->assertEquals('<h1>First valid response</h1>', $doc1['messages'][0]['markup']);
-    $this->assertApproxEquals(strtotime('2013-03-01 10:10:00'), $doc1['expires'], self::APPROX_TIME_EQUALITY);
+    $this->assertEqualsWithDelta(strtotime('2013-03-01 10:10:00'), $doc1['expires'], self::APPROX_TIME_EQUALITY);
 
     // second try, $doc1 hasn't expired yet, so still use it
     CRM_Utils_Time::setTime('2013-03-01 10:09:00');
@@ -190,7 +190,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     );
     $doc2 = $communityMessages->getDocument();
     $this->assertEquals('<h1>First valid response</h1>', $doc2['messages'][0]['markup']);
-    $this->assertApproxEquals(strtotime('2013-03-01 10:10:00'), $doc2['expires'], self::APPROX_TIME_EQUALITY);
+    $this->assertEqualsWithDelta(strtotime('2013-03-01 10:10:00'), $doc2['expires'], self::APPROX_TIME_EQUALITY);
 
     // third try, $doc1 expired, update it
     // more than 2 hours later (DEFAULT_RETRY)
@@ -201,7 +201,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     );
     $doc3 = $communityMessages->getDocument();
     $this->assertEquals('<h1>Second valid response</h1>', $doc3['messages'][0]['markup']);
-    $this->assertApproxEquals(strtotime('2013-03-01 12:10:02'), $doc3['expires'], self::APPROX_TIME_EQUALITY);
+    $this->assertEqualsWithDelta(strtotime('2013-03-01 12:10:02'), $doc3['expires'], self::APPROX_TIME_EQUALITY);
   }
 
   /**
@@ -269,7 +269,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     );
     $doc1 = $communityMessages->getDocument();
     $this->assertEquals('<h1>First valid response</h1>', $doc1['messages'][0]['markup']);
-    $this->assertApproxEquals(strtotime('2013-03-01 10:10:00'), $doc1['expires'], self::APPROX_TIME_EQUALITY);
+    $this->assertEqualsWithDelta(strtotime('2013-03-01 10:10:00'), $doc1['expires'], self::APPROX_TIME_EQUALITY);
 
     // second try, $doc1 has expired; bad response; keep old data
     // more than 2 hours later (DEFAULT_RETRY)
@@ -300,7 +300,7 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     );
     $doc4 = $communityMessages->getDocument();
     $this->assertEquals('<h1>Second valid response</h1>', $doc4['messages'][0]['markup']);
-    $this->assertApproxEquals(strtotime('2013-03-01 12:20:05'), $doc4['expires'], self::APPROX_TIME_EQUALITY);
+    $this->assertEqualsWithDelta(strtotime('2013-03-01 12:20:05'), $doc4['expires'], self::APPROX_TIME_EQUALITY);
   }
 
   /**
@@ -325,8 +325,8 @@ class CRM_Core_CommunityMessagesTest extends CiviUnitTestCase {
     }
 
     // assert the probabilities
-    $this->assertApproxEquals(0.5, $freq['<h1>One</h1>'] / $trials, 0.3);
-    $this->assertApproxEquals(0.5, $freq['<h1>Two</h1>'] / $trials, 0.3);
+    $this->assertEqualsWithDelta(0.5, $freq['<h1>One</h1>'] / $trials, 0.3);
+    $this->assertEqualsWithDelta(0.5, $freq['<h1>Two</h1>'] / $trials, 0.3);
     $this->assertEquals($trials, $freq['<h1>One</h1>'] + $freq['<h1>Two</h1>']);
   }
 

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -410,7 +410,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $log = $this->callAPISuccessGetSingle('MembershipLog', ['membership_id' => $membership['id'], 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
     $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-01'), $log['start_date']);
     $this->assertEquals(CRM_Utils_Time::date($nextYear . '-01-31'), $log['end_date']);
-    $this->assertApproxEquals(CRM_Utils_Time::time(), strtotime($log['modified_date']), 20);
+    $this->assertEqualsWithDelta(CRM_Utils_Time::time(), strtotime($log['modified_date']), 20);
 
     $contributionRecur = $this->callAPISuccessGetSingle('ContributionRecur', ['contact_id' => $this->_individualId]);
     $this->assertEquals($contributionRecur['id'], $membership['contribution_recur_id']);
@@ -864,7 +864,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
     $log = $this->callAPISuccessGetSingle('MembershipLog', ['membership_id' => $renewedMembership['id'], 'options' => ['limit' => 1, 'sort' => 'id DESC']]);
     $this->assertEquals(CRM_Utils_Time::date('Y-01-01'), $log['start_date']);
     $this->assertEquals(CRM_Utils_Time::date('Y-12-31'), $log['end_date']);
-    $this->assertApproxEquals(CRM_Utils_Time::time(), strtotime($log['modified_date']), 20);
+    $this->assertEqualsWithDelta(CRM_Utils_Time::time(), strtotime($log['modified_date']), 20);
     $this->assertEquals(CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Current'), $log['status_id']);
   }
 

--- a/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
+++ b/tests/phpunit/Civi/ActionSchedule/AbstractMappingTestCase.php
@@ -314,7 +314,7 @@ abstract class AbstractMappingTestCase extends \CiviUnitTestCase {
     usort($actualMessages, [__CLASS__, 'compareSimpleMsgs']);
     foreach ($expectMessages as $offset => $expectMessage) {
       $actualMessage = $actualMessages[$offset];
-      $this->assertApproxEquals(strtotime($expectMessage['time']), strtotime($actualMessage['time']), $this->dateTolerance, $errorText);
+      $this->assertEqualsWithDelta(strtotime($expectMessage['time']), strtotime($actualMessage['time']), $this->dateTolerance, $errorText);
       if (isset($expectMessage['to'])) {
         sort($expectMessage['to']);
         $this->assertEquals($expectMessage['to'], $actualMessage['to'], $errorText);

--- a/tests/phpunit/E2E/Cache/TieredTest.php
+++ b/tests/phpunit/E2E/Cache/TieredTest.php
@@ -97,18 +97,18 @@ class E2E_Cache_TieredTest extends E2E_Cache_CacheTestCase {
     $this->cache = $this->createSimpleCache([100, 1000]);
 
     $this->cache->set('foo', 'bar');
-    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
 
     // Simulate expiration & repopulation in nearest tier.
 
     $this->a->clear();
-    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
 
     $this->assertEquals('bar', $this->cache->get('foo'));
-    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
   }
 
   public function testTieredTimeout_explicitLow(): void {
@@ -116,18 +116,18 @@ class E2E_Cache_TieredTest extends E2E_Cache_CacheTestCase {
     $this->cache = $this->createSimpleCache([100, 1000]);
 
     $this->cache->set('foo', 'bar', 50);
-    $this->assertApproxEquals($start + 50, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 50, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
 
     // Simulate expiration & repopulation in nearest tier.
 
     $this->a->clear();
-    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
 
     $this->assertEquals('bar', $this->cache->get('foo'));
-    $this->assertApproxEquals($start + 50, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 50, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 50, $this->b->getExpires('foo'), self::TOLERANCE);
   }
 
   public function testTieredTimeout_explicitMedium(): void {
@@ -135,18 +135,18 @@ class E2E_Cache_TieredTest extends E2E_Cache_CacheTestCase {
     $this->cache = $this->createSimpleCache([100, 1000]);
 
     $this->cache->set('foo', 'bar', 500);
-    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
 
     // Simulate expiration & repopulation in nearest tier.
 
     $this->a->clear();
-    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
 
     $this->assertEquals('bar', $this->cache->get('foo'));
-    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 500, $this->b->getExpires('foo'), self::TOLERANCE);
   }
 
   public function testTieredTimeout_explicitHigh_lateReoad(): void {
@@ -154,35 +154,20 @@ class E2E_Cache_TieredTest extends E2E_Cache_CacheTestCase {
     $this->cache = $this->createSimpleCache([100, 1000]);
 
     $this->cache->set('foo', 'bar', 5000);
-    $this->assertApproxEquals($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 100, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
 
     // Simulate expiration & repopulation in nearest tier.
 
     $this->a->clear();
-    $this->assertApproxEquals(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta(NULL, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
 
     sleep(self::TOLERANCE);
 
     $this->assertEquals('bar', $this->cache->get('foo'));
-    $this->assertApproxEquals($start + 100 + self::TOLERANCE, $this->a->getExpires('foo'), self::TOLERANCE);
-    $this->assertApproxEquals($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
-  }
-
-  /**
-   * Assert that two numbers are approximately equal.
-   *
-   * @param int|float $expected
-   * @param int|float $actual
-   * @param int|float $tolerance
-   * @param string $message
-   */
-  public function assertApproxEquals($expected, $actual, $tolerance, $message = NULL) {
-    if ($message === NULL) {
-      $message = sprintf("approx-equals: expected=[%.3f] actual=[%.3f] tolerance=[%.3f]", $expected, $actual, $tolerance);
-    }
-    $this->assertTrue(abs($actual - $expected) < $tolerance, $message);
+    $this->assertEqualsWithDelta($start + 100 + self::TOLERANCE, $this->a->getExpires('foo'), self::TOLERANCE);
+    $this->assertEqualsWithDelta($start + 1000, $this->b->getExpires('foo'), self::TOLERANCE);
   }
 
 }

--- a/tests/phpunit/api/v3/CaseTest.php
+++ b/tests/phpunit/api/v3/CaseTest.php
@@ -893,7 +893,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     ]);
     $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_1['created_date']);
     $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $case_1['modified_date']);
-    $this->assertApproxEquals(strtotime($case_1['created_date']), strtotime($case_1['modified_date']), 2);
+    $this->assertEqualsWithDelta(strtotime($case_1['created_date']), strtotime($case_1['modified_date']), 2);
 
     $activity_1 = $this->callAPISuccess('activity', 'getsingle', [
       'case_id' => $case_created['id'],
@@ -903,7 +903,7 @@ class api_v3_CaseTest extends CiviCaseTestCase {
     ]);
     $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_1['created_date']);
     $this->assertMatchesRegularExpression(';^\d\d\d\d-\d\d-\d\d \d\d:\d\d;', $activity_1['modified_date']);
-    $this->assertApproxEquals(strtotime($activity_1['created_date']), strtotime($activity_1['modified_date']), 2);
+    $this->assertEqualsWithDelta(strtotime($activity_1['created_date']), strtotime($activity_1['modified_date']), 2);
 
     usleep(1.5 * 1000000);
     $this->callAPISuccess('activity', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
Replaces a homemade function with the one provided by PhpUnit. Happily, the inputs and outputs are all the same so it's a drop-in replacement.

Notes
-----------
`assertEqualsWithDelta` is [available since PhpUnit 7.5](https://github.com/sebastianbergmann/phpunit/blob/7.5.0/ChangeLog-7.5.md).