### PR TITLE
allow using TEXT for serialized custom fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2802,9 +2802,12 @@ WHERE      f.id IN ($ids)";
       }
     }
     if ($field->serialize) {
-      // Ensure length is at least 255, but allow it to go higher.
-      $text_length = intval($field->text_length) < 255 ? 255 : $field->text_length;
-      $params['type'] = 'varchar(' . $text_length . ')';
+      // Serialized fields must be able to hold long strings. TEXT is acceptable,
+      // otherwise force using a VARCHAR of at least 255, but allow it to go higher.
+      if ($params['type'] !== 'text') {
+        $text_length = intval($field->text_length) < 255 ? 255 : $field->text_length;
+        $params['type'] = 'varchar(' . $text_length . ')';
+      }
     }
     if (isset($field->default_value)) {
       $params['default'] = "'{$field->default_value}'";

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2777,7 +2777,8 @@ WHERE      f.id IN ($ids)";
       'name' => $field->column_name,
       'type' => CRM_Core_BAO_CustomValueTable::fieldToSQLType(
         $field->data_type,
-        $field->text_length
+        $field->text_length,
+        $field->serialize
       ),
       'required' => $field->is_required,
       'searchable' => $field->is_searchable && $field->is_active,
@@ -2799,14 +2800,6 @@ WHERE      f.id IN ($ids)";
         $params['fk_table_name'] = $fkFields[$field->data_type];
         $params['fk_field_name'] = 'id';
         $params['fk_attributes'] = 'ON DELETE SET NULL';
-      }
-    }
-    if ($field->serialize) {
-      // Serialized fields must be able to hold long strings. TEXT is acceptable,
-      // otherwise force using a VARCHAR of at least 255, but allow it to go higher.
-      if ($params['type'] !== 'text') {
-        $text_length = intval($field->text_length) < 255 ? 255 : $field->text_length;
-        $params['type'] = 'varchar(' . $text_length . ')';
       }
     }
     if (isset($field->default_value)) {

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -229,11 +229,28 @@ class CRM_Core_BAO_CustomValueTable {
    *
    * @param string $type
    * @param int|null $maxLength
+   * @param bool $isSerialized (serialized fields must always have a textual mysql field)
    *
    * @return string
    *   the mysql data store placeholder
    */
-  public static function fieldToSQLType(string $type, $maxLength = NULL) {
+  public static function fieldToSQLType(string $type, $maxLength = NULL, bool $isSerialized = FALSE) {
+    if ($isSerialized) {
+      switch ($type) {
+        case 'Text':
+          return 'text';
+
+        case 'String':
+        default:
+          // ensure minimum varchar of 255
+          // TODO: this can still be insufficient if you try to serialize
+          // long text values. in this case a `text` field would be better
+          // but how to know? we could switch to only using varchar for serialized
+          // ints and text otherwise?
+          $maxLength = max(255, $maxLength ?: 255);
+          return "varchar($maxLength)";
+      }
+    }
     switch ($type) {
       case 'String':
         $maxLength = $maxLength ?: 255;

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -220,7 +220,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
         $fieldName = $customGroup['name'] . '.' . $customField['name'];
         $field = [
           'title' => $customField['label'],
-          'sql_type' => \CRM_Core_BAO_CustomValueTable::fieldToSQLType($customField['data_type'], $customField['text_length'], $customField['serialize'] ?: FALSE),
+          'sql_type' => \CRM_Core_BAO_CustomValueTable::fieldToSQLType($customField['data_type'], $customField['text_length'], !empty($customField['serialize'])),
           'data_type' => \CRM_Core_BAO_CustomField::getDataTypeString($customField),
           'input_type' => $inputTypeMap[$customField['html_type']] ?? $customField['html_type'],
           'input_attrs' => [

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -220,7 +220,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
         $fieldName = $customGroup['name'] . '.' . $customField['name'];
         $field = [
           'title' => $customField['label'],
-          'sql_type' => \CRM_Core_BAO_CustomValueTable::fieldToSQLType($customField['data_type'], $customField['text_length']),
+          'sql_type' => \CRM_Core_BAO_CustomValueTable::fieldToSQLType($customField['data_type'], $customField['text_length'], $customField['serialize'] ?: FALSE),
           'data_type' => \CRM_Core_BAO_CustomField::getDataTypeString($customField),
           'input_type' => $inputTypeMap[$customField['html_type']] ?? $customField['html_type'],
           'input_attrs' => [


### PR DESCRIPTION
Overview
----------------------------------------
The Custom Field BAO forces serialized fields to use VARCHAR. This makes sense if you are storing Integers (you can't serialize them into an numeric sql field. But it doesn't make sense to overwrite TEXT data type.

Before
----------------------------------------
- serialized custom fields are always created as VARCHAR

After
----------------------------------------
- serialized custom fields are normally created as VARCHAR
- if you use Api4 to specify data_type = TEXT, then the serialized field will be created as TEXT


Comments
----------------------------------------
There's no way to do this through the standard Custom Field UI, so only comes into play when using the api.

Example of a CustomField.create :

<img width="1141" height="735" alt="image" src="https://github.com/user-attachments/assets/fa1d8a4d-b43c-4b5d-8362-751ac0913637" />

SQL columns created before/after this patch:
<img width="951" height="126" alt="image" src="https://github.com/user-attachments/assets/0c97bbe9-a06b-4bde-bff3-2a9259509904" />

I see two potential uses for this:
- you have lots of Custom Fields in the same group, and run up against SQL row size limits - see e.g. https://civicrm.stackexchange.com/questions/40097/custom-data-set-field-limit
- if you want a multiselect with long text values, and dont want to worry about them hitting the varchar limit when serialised

