### PR TITLE
Add / update forms for quick edit contacts from autocomplete

### DIFF
--- a/ang/afform/afformQuickEditHousehold.aff.html
+++ b/ang/afform/afformQuickEditHousehold.aff.html
@@ -1,11 +1,9 @@
 <af-form ctrl="afform">
-  <af-entity type="Individual" name="Individual1" actions="{create: false, update: true}" security="RBAC" url-autofill="1" />
-  <fieldset af-fieldset="Individual1" class="af-container">
+  <af-entity type="Household" name="Household1" actions="{create: false, update: true}" security="RBAC" url-autofill="1" />
+  <fieldset af-fieldset="Household1" class="af-container">
     <div class="af-container">
       <div class="af-container af-layout-inline">
-        <af-field name="first_name" />
-        <af-field name="middle_name" />
-        <af-field name="last_name" />
+        <af-field name="household_name" />
       </div>
       <div af-join="Email" actions="{update: true, delete: true}" af-repeat="Add Email" min="0" >
         <afblock-contact-email actions="{update: true, delete: true}"></afblock-contact-email>

--- a/ang/afform/afformQuickEditHousehold.aff.php
+++ b/ang/afform/afformQuickEditHousehold.aff.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'type' => 'form',
+  'title' => ts('Edit Household'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/quick-edit/Household',
+  'permission' => [
+    'access CiviCRM',
+  ],
+  'permission_operator' => 'AND',
+  'submit_enabled' => TRUE,
+  'create_submission' => FALSE,
+];

--- a/ang/afform/afformQuickEditOrganization.aff.html
+++ b/ang/afform/afformQuickEditOrganization.aff.html
@@ -1,11 +1,9 @@
 <af-form ctrl="afform">
-  <af-entity type="Individual" name="Individual1" actions="{create: false, update: true}" security="RBAC" url-autofill="1" />
-  <fieldset af-fieldset="Individual1" class="af-container">
+  <af-entity type="Organization" name="Organization1" actions="{create: false, update: true}" security="RBAC" url-autofill="1" />
+  <fieldset af-fieldset="Organization1" class="af-container">
     <div class="af-container">
       <div class="af-container af-layout-inline">
-        <af-field name="first_name" />
-        <af-field name="middle_name" />
-        <af-field name="last_name" />
+        <af-field name="organization_name" />
       </div>
       <div af-join="Email" actions="{update: true, delete: true}" af-repeat="Add Email" min="0" >
         <afblock-contact-email actions="{update: true, delete: true}"></afblock-contact-email>

--- a/ang/afform/afformQuickEditOrganization.aff.php
+++ b/ang/afform/afformQuickEditOrganization.aff.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+  'type' => 'form',
+  'title' => ts('Edit Organization'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/quick-edit/Organization',
+  'permission' => [
+    'access CiviCRM',
+  ],
+  'permission_operator' => 'AND',
+  'submit_enabled' => TRUE,
+  'create_submission' => FALSE,
+];


### PR DESCRIPTION
Overview
----------------------------------------
The new quick edit for autocomplete added in #33705 adds a basic Individual form. This adds forms for Organizations and Households and expands the Individual form to include the email and address blocks.

<img width="1673" height="488" alt="image" src="https://github.com/user-attachments/assets/2e79e1c1-44fb-4a83-a99b-be8300b40694" />

These could certainly use some style improvements, but that's out of scope here.
