### PR TITLE
dev/core#6087 Queue up recording of Tracked Opens and Click throughs …

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventOpened.php
+++ b/CRM/Mailing/Event/BAO/MailingEventOpened.php
@@ -24,7 +24,7 @@ class CRM_Mailing_Event_BAO_MailingEventOpened extends CRM_Mailing_Event_DAO_Mai
    *
    * @return bool
    */
-  public static function open($queue_id) {
+  public static function open($queue_id): bool {
     // First make sure there's a matching queue event.
     $q = new CRM_Mailing_Event_BAO_MailingEventQueue();
     $q->id = $queue_id;
@@ -293,6 +293,10 @@ class CRM_Mailing_Event_BAO_MailingEventOpened extends CRM_Mailing_Event_DAO_Mai
       ];
     }
     return $results;
+  }
+
+  public static function queuedOpen(\CRM_Queue_TaskContext $ctx, $queue_id): bool {
+    return self::open($queue_id);
   }
 
 }

--- a/CRM/Mailing/Event/BAO/MailingEventTrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/MailingEventTrackableURLOpen.php
@@ -36,28 +36,26 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
     $eq = CRM_Utils_Type::escape(CRM_Mailing_Event_BAO_MailingEventQueue::getTableName(), 'MysqlColumnNameOrAlias');
     $turl = CRM_Utils_Type::escape(CRM_Mailing_BAO_MailingTrackableURL::getTableName(), 'MysqlColumnNameOrAlias');
 
-    if (!$queue_id) {
-      $search = CRM_Core_DAO::executeQuery(
-        "SELECT url
-           FROM $turl
-          WHERE $turl.id = %1",
-        [
-          1 => [$url_id, 'Integer'],
-        ]
-      );
-
-      if (!$search->fetch()) {
-        return CRM_Utils_System::baseURL();
-      }
-
-      return $search->url;
+    $urlSearch = CRM_Core_DAO::executeQuery(
+      "SELECT url
+        FROM $turl
+        WHERE $turl.id = %1",
+      [
+        1 => [$url_id, 'Integer'],
+      ]
+    );
+    if (!$urlSearch->fetch()) {
+      return CRM_Utils_System::baseURL();
     }
 
-    $search = CRM_Core_DAO::executeQuery(
+    if (!$queue_id) {
+      return $urlSearch->url;
+    }
+
+    $queueSearch = CRM_Core_DAO::executeQuery(
       "SELECT $turl.url as url
          FROM $turl
-        INNER JOIN $job ON $turl.mailing_id = $job.mailing_id
-        INNER JOIN $eq ON $job.id = $eq.job_id
+        INNER JOIN $eq ON $turl.mailing_id = $eq.mailing_id
         WHERE $eq.id = %1 AND $turl.id = %2",
       [
         1 => [$queue_id, 'Integer'],
@@ -65,32 +63,15 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
       ]
     );
 
-    if (!$search->fetch()) {
-      // Can't find either the URL or the queue. If we can find the URL then
-      // return the URL without tracking.  Otherwise return the base URL.
-      $search = CRM_Core_DAO::executeQuery(
-        "SELECT $turl.url as url
-           FROM $turl
-          WHERE $turl.id = %1",
-        [
-          1 => [$url_id, 'Integer'],
-        ]
-      );
-
-      if (!$search->fetch()) {
-        return CRM_Utils_System::baseURL();
-      }
-
-      return $search->url;
+    if (!$queueSearch->fetch()) {
+      // Can't find the queue.
+      // return the URL without tracking.
+      return $urlSearch->url;
     }
 
-    self::writeRecord([
-      'event_queue_id' => $queue_id,
-      'trackable_url_id' => $url_id,
-      'time_stamp' => date('YmdHis'),
-    ]);
+    self::recordUrlClick($queue_id, $url_id);
 
-    return $search->url;
+    return $urlSearch->url;
   }
 
   /**
@@ -358,6 +339,27 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
       ];
     }
     return $results;
+  }
+
+  public static function queuedTrack(\CRM_Queue_TaskContext $ctx, $queue_id, $url_id) {
+    $queueCheck = CRM_Core_DAO::singleValueQuery("SELECT u.url as url
+      FROM civicrm_mailing_trackable_url u
+      INNER JOIN civicrm_mailing_event_queue q ON u.mailing_id = q.mailing_id
+      WHERE q.id = %1 AND u.id = %2", [
+        1 => [$queue_id, 'Positive'],
+        2 => [$url_id, 'Positive'],
+      ]);
+    if ($queueCheck) {
+      self::recordUrlClick($queue_id, $url_id);
+    }
+  }
+
+  private static function recordUrlClick($queue_id, $url_id) {
+    self::writeRecord([
+      'event_queue_id' => $queue_id,
+      'trackable_url_id' => $url_id,
+      'time_stamp' => date('YmdHis'),
+    ]);
   }
 
 }

--- a/CRM/Mailing/Page/Open.php
+++ b/CRM/Mailing/Page/Open.php
@@ -39,7 +39,16 @@ class CRM_Mailing_Page_Open extends CRM_Core_Page {
       CRM_Utils_System::sendInvalidRequestResponse(ts("Missing input parameters"));
     }
 
-    CRM_Mailing_Event_BAO_MailingEventOpened::open($queue_id);
+    $queue = Civi::queue('civicrm.mailing.event.queue', [
+      'type' => 'Sql',
+      'reset' => FALSE,
+      'error' => 'abort',
+    ]);
+    $queue->createItem(new CRM_Queue_Task(
+      ['CRM_Mailing_Event_BAO_MailingEventOpened', 'queuedOpen'],
+      [$queue_id],
+      'Processing tracked open for queue (#' . $queue_id . ')'
+    ));
 
     $filename = Civi::paths()->getPath('[civicrm.root]/i/tracker.gif');
 

--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -35,7 +35,17 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
     if (!$url_id) {
       CRM_Utils_System::sendInvalidRequestResponse(ts("Missing input parameters"));
     }
-    $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($queue_id, $url_id));
+    $queue = Civi::queue('civicrm.mailing.event.queue', [
+      'type' => 'Sql',
+      'reset' => FALSE,
+      'error' => 'abort',
+    ]);
+    $queue->createItem(new CRM_Queue_Task(
+      ['CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen', 'queuedTrack'],
+      [$queue_id, $url_id],
+      'Processing tracked url open for queue (#' . $queue_id . '), url (#' . $url_id . ')'
+    ));
+    $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track(NULL, $url_id));
     $query_string = $this->extractPassthroughParameters();
 
     if (strlen($query_string) > 0) {

--- a/ext/civi_mail/Civi/Api4/Action/Mailing/ProcessQueue.php
+++ b/ext/civi_mail/Civi/Api4/Action/Mailing/ProcessQueue.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Mailing;
+
+use Civi\Api4\Generic\AbstractAction;
+
+class ProcessQueue extends AbstractAction {
+
+  /**
+   * @var bool
+   */
+  protected $runInNonProductionEnvironment = TRUE;
+
+  /**
+   * @var null
+   */
+  protected $language = NULL;
+
+  public function _run(\Civi\Api4\Generic\Result $result) {
+    $queue = \Civi::queue('civicrm.mailing.event.queue', [
+      'type' => 'Sql',
+      'reset' => FALSE,
+      'error' => 'abort',
+    ]);
+    $runner = new \CRM_Queue_Runner([
+      'title' => ts('CiviCRM Mailing Events Queue'),
+      'queue' => $queue,
+      'errorMode' => \CRM_Queue_Runner::ERROR_CONTINUE,
+    ]);
+    // stop executing next item after 5 minutes
+    $maxRunTime = time() + 600;
+    $continue = TRUE;
+    while (time() < $maxRunTime && $continue) {
+      $result = $runner->runNext();
+      if (!$result['is_continue']) {
+        // all items in the queue are processed
+        $continue = FALSE;
+      }
+      $result[] = $result;
+    }
+  }
+
+}

--- a/ext/civi_mail/Civi/Api4/Mailing.php
+++ b/ext/civi_mail/Civi/Api4/Mailing.php
@@ -10,6 +10,7 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Action\Mailing\ProcessQueue;
 use Civi\Api4\Action\Mailing\UpdateAction;
 use Civi\Api4\Action\Mailing\CreateAction;
 use Civi\Api4\Action\Mailing\SaveAction;
@@ -50,6 +51,11 @@ class Mailing extends Generic\DAOEntity {
    */
   public static function save($checkPermissions = TRUE): SaveAction {
     return (new SaveAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  public static function runQueue($checkPermissions = TRUE): ProcessQueue {
+    return (new ProcessQueue(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 


### PR DESCRIPTION
…to avoid congestion on the mailing_event_queue table

Overview
----------------------------------------
This aims to add a queuing mechansim to process tracked opens and click throughs to avoid potential congestion issues on the civicrm_mailing_event_queue table

Before
----------------------------------------
No queue

After
----------------------------------------
Queue

I wasn't sure if I should just add a job directly into civicrm_job or not to call the new API but maybe?