### PR TITLE
Load line items in stricter, more consistent way

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2770,13 +2770,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['trxnParams']['fee_amount'] = $params['prevContribution']->fee_amount;
         $params['trxnParams']['net_amount'] = $params['prevContribution']->net_amount;
         $params['trxnParams']['status_id'] = $params['prevContribution']->contribution_status_id;
-        $previousContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['prevContribution']->contribution_status_id);
-        if (!(($previousContributionStatus === 'Pending' || $previousContributionStatus === 'In Progress')
-          && $contributionStatus === 'Completed')
-        ) {
-          $params['trxnParams']['payment_instrument_id'] = $params['prevContribution']->payment_instrument_id;
-          $params['trxnParams']['check_number'] = $params['prevContribution']->check_number;
-        }
 
         //if financial account is changed
         if ($financialProcessor->isFinancialAccountChanged()) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2809,12 +2809,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $updated = TRUE;
         }
 
-        // change Payment Instrument for a Completed contribution
-        // first handle special case when contribution is changed from Pending to Completed status when initial payment
-        // instrument is null and now new payment instrument is added along with the payment
-        $params['trxnParams']['payment_instrument_id'] = $params['contribution']->payment_instrument_id;
-        $params['trxnParams']['check_number'] = $params['check_number'] ?? NULL;
-
         if ($financialProcessor->isPaymentInstrumentChange($params)) {
           $updated = $financialProcessor->updateFinancialAccountsOnPaymentInstrumentChange($params);
         }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2779,17 +2779,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           if (isset($params['fee_amount'])) {
             $params['trxnParams']['fee_amount'] = 0 - $params['fee_amount'];
           }
-          if ($financialProcessor->isAccountsReceivableTransaction()) {
-            $accountRelationship = $contribution->revenue_recognition_date ? 'Deferred Revenue Account is' : 'Income Account is';
-            $params['trxnParams']['to_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
-              $params['prevContribution']->financial_type_id, $accountRelationship);
-          }
-          else {
-            $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($params['prevContribution']->id, 'DESC');
-            if (!empty($lastFinancialTrxnId['financialTrxnId'])) {
-              $params['trxnParams']['to_financial_account_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialTrxn', $lastFinancialTrxnId['financialTrxnId'], 'to_financial_account_id');
-            }
-          }
           $financialProcessor->updateFinancialAccounts($params, 'changeFinancialType');
           $params['skipLineItem'] = FALSE;
           CRM_Core_BAO_FinancialTrxn::createDeferredTrxn($params['line_item'] ?? NULL, $params['contribution'], TRUE, 'changeFinancialType');

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2769,13 +2769,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $params['prevContribution']->total_amount;
         $params['trxnParams']['fee_amount'] = $params['prevContribution']->fee_amount;
         $params['trxnParams']['net_amount'] = $params['prevContribution']->net_amount;
-        if (!isset($params['trxnParams']['trxn_id'])) {
-          // Actually I have no idea why we are overwriting any values from the previous contribution.
-          // (filling makes sense to me). However, only protecting this value as I really really know we
-          // don't want this one overwritten.
-          // CRM-17751.
-          $params['trxnParams']['trxn_id'] = $params['prevContribution']->trxn_id;
-        }
         $params['trxnParams']['status_id'] = $params['prevContribution']->contribution_status_id;
         $previousContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['prevContribution']->contribution_status_id);
         if (!(($previousContributionStatus === 'Pending' || $previousContributionStatus === 'In Progress')

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2805,13 +2805,11 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
               $params['trxnParams']['to_financial_account_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialTrxn', $lastFinancialTrxnId['financialTrxnId'], 'to_financial_account_id');
             }
           }
-          $params['trxnParams']['total_amount'] = $params['trxnParams']['net_amount'] = ($params['total_amount'] - $params['prevContribution']->total_amount);
           $financialProcessor->updateFinancialAccounts($params, 'changeFinancialType');
           $params['skipLineItem'] = FALSE;
           CRM_Core_BAO_FinancialTrxn::createDeferredTrxn($params['line_item'] ?? NULL, $params['contribution'], TRUE, 'changeFinancialType');
           /* $params['trxnParams']['to_financial_account_id'] = $trxnParams['to_financial_account_id']; */
           $params['financial_account_id'] = $financialProcessor->getUpdatedFinancialAccount();
-          $params['total_amount'] = $params['trxnParams']['total_amount'] = $params['trxnParams']['net_amount'] = $trxnParams['total_amount'];
           // Set the transaction fee amount back to the original value for creating the new positive financial trxn.
           if (isset($params['fee_amount'])) {
             $params['trxnParams']['fee_amount'] = $params['fee_amount'];

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2808,11 +2808,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           $params['trxnParams']['total_amount'] = $params['trxnParams']['net_amount'] = ($params['total_amount'] - $params['prevContribution']->total_amount);
           $financialProcessor->updateFinancialAccounts($params, 'changeFinancialType');
           $params['skipLineItem'] = FALSE;
-          foreach ($params['line_item'] as &$lineItems) {
-            foreach ($lineItems as &$line) {
-              $line['financial_type_id'] = $params['financial_type_id'];
-            }
-          }
           CRM_Core_BAO_FinancialTrxn::createDeferredTrxn($params['line_item'] ?? NULL, $params['contribution'], TRUE, 'changeFinancialType');
           /* $params['trxnParams']['to_financial_account_id'] = $trxnParams['to_financial_account_id']; */
           $params['financial_account_id'] = $financialProcessor->getUpdatedFinancialAccount();
@@ -2864,7 +2859,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $totalAmount = $contribution->total_amount ?? 0;
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $totalAmount;
         $params['trxnParams']['trxn_id'] = $params['contribution']->trxn_id;
-        if ($financialProcessor->isContributionTotalChanged()) {
+        if ($financialProcessor->isContributionTotalChanged() && !$financialProcessor->isFinancialAccountChanged()) {
           //Update Financial Records
           $params['trxnParams']['from_financial_account_id'] = NULL;
           $params['trxnParams']['total_amount'] = $params['trxnParams']['net_amount'] = ($params['total_amount'] - $params['prevContribution']->total_amount);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2761,11 +2761,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $skipRecords = TRUE;
 
       //build financial transaction params
-      $trxnParams = $financialProcessor->getTrxnParams($params);
-
-      $params['trxnParams'] = $trxnParams;
 
       if ($isUpdate) {
+        $trxnParams = $financialProcessor->getTrxnParams($params);
+        $params['trxnParams'] = $trxnParams;
         $updated = FALSE;
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $params['prevContribution']->total_amount;
         $params['trxnParams']['fee_amount'] = $params['prevContribution']->fee_amount;
@@ -2889,14 +2888,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
 
       else {
-        $trxnParams['total_amount'] = $contribution->total_amount;
-        $trxnParams['fee_amount'] = $contribution->fee_amount;
-        $trxnParams['net_amount'] = $contribution->net_amount;
-        // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
-        // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
-        // this should really default to completed (after discussion). But after moving this
-        // to the only place it is actually used - maybe it makes more sense?
-        $trxnParams['status_id'] = $contribution->contribution_status_id;;
+        $trxnParams = $financialProcessor->getTrxnParams($params);
         // records finanical trxn and entity financial trxn
         // also make it available as return value
         $financialProcessor->recordAlwaysAccountsReceivable($trxnParams, $params);

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -163,7 +163,16 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
     // Get Line Items if we don't have them already.
     if (empty($params['line_item'])) {
-      CRM_Price_BAO_LineItem::getLineItemArray($params, $contributionID ? [$contributionID] : NULL);
+      if ($contributionID) {
+        $order = new CRM_Financial_BAO_Order();
+        $order->setExistingContributionID($contributionID);
+        $order->setOverrideTotalAmount($params['total_amount'] ?? NULL);
+        $order->setOverrideFinancialTypeID($params['financial_type_id'] ?? NULL);
+        $params['line_item'] = [$order->getLineItems()];
+      }
+      else {
+        CRM_Price_BAO_LineItem::getLineItemArray($params);
+      }
     }
 
     // We should really ALWAYS calculate tax amount off the line items.

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2797,12 +2797,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
         //Update contribution status
         $params['trxnParams']['status_id'] = $params['contribution']->contribution_status_id;
-        if (!isset($params['refund_trxn_id'])) {
-          // CRM-17751 This has previously been deliberately set. No explanation as to why one variant
-          // gets preference over another so I am only 'protecting' a very specific tested flow
-          // and letting natural justice take care of the rest.
-          $params['trxnParams']['trxn_id'] = $params['contribution']->trxn_id;
-        }
         if (!empty($params['contribution_status_id']) &&
           $params['prevContribution']->contribution_status_id != $params['contribution']->contribution_status_id
         ) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2818,7 +2818,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['trxnParams']['net_amount'] = $params['net_amount'] ?? NULL;
         $totalAmount = $contribution->total_amount ?? 0;
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $totalAmount;
-        $params['trxnParams']['trxn_id'] = $params['contribution']->trxn_id;
         if ($financialProcessor->isContributionTotalChanged() && !$financialProcessor->isFinancialAccountChanged()) {
           //Update Financial Records
           $params['trxnParams']['from_financial_account_id'] = NULL;

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -376,6 +376,18 @@ class CRM_Contribute_BAO_FinancialProcessor {
         $trxnParams['payment_instrument_id'] = $params['prevContribution']->payment_instrument_id;
         $trxnParams['check_number'] = $params['prevContribution']->check_number;
       }
+      // It's unclear why we only set these on update.
+      if ($this->isAccountsReceivableTransaction()) {
+        $accountRelationship = $this->getUpdatedContribution()->revenue_recognition_date ? 'Deferred Revenue Account is' : 'Income Account is';
+        $trxnParams['to_financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+          $this->getOriginalContribution()->financial_type_id, $accountRelationship);
+      }
+      else {
+        $lastFinancialTrxnId = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($this->getUpdatedContribution()->id, 'DESC');
+        if (!empty($lastFinancialTrxnId['financialTrxnId'])) {
+          $trxnParams['to_financial_account_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialTrxn', $lastFinancialTrxnId['financialTrxnId'], 'to_financial_account_id');
+        }
+      }
     }
     return $trxnParams;
   }

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -297,7 +297,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
       return $lineTotal;
     }
     elseif ($context === 'changeFinancialType') {
-      return -$lineItemDetails['line_total'];
+      return -$previousLineItemTotal;
     }
     elseif ($context === 'changedStatus') {
       $cancelledTaxAmount = 0;

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -369,6 +369,14 @@ class CRM_Contribute_BAO_FinancialProcessor {
       // to the only place it is actually used - maybe it makes more sense?
       $trxnParams['status_id'] = $this->updatedContribution->contribution_status_id;
     }
+    else {
+      if (!(($this->getOriginalContributionStatus() === 'Pending' || $this->getOriginalContributionStatus() === 'In Progress')
+        && $this->getUpdatedContributionStatus() === 'Completed')
+      ) {
+        $trxnParams['payment_instrument_id'] = $params['prevContribution']->payment_instrument_id;
+        $trxnParams['check_number'] = $params['prevContribution']->check_number;
+      }
+    }
     return $trxnParams;
   }
 

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -330,7 +330,8 @@ class CRM_Contribute_BAO_FinancialProcessor {
       // of Payment.create handling of trxn_date will tighten up.
       'trxn_date' => $this->getInputValue('receive_date') ?: date('YmdHis'),
       'currency' => $this->getUpdatedContribution()->currency,
-      'trxn_id' => $this->getUpdatedContribution()->trxn_id,
+      // CRM-17751
+      'trxn_id' => $this->getInputValue('trxn_id') ?: $this->getUpdatedContribution()->trxn_id ?: $this->getOriginalContributionValue('trxn_id'),
       'payment_instrument_id' => $this->getInputValue('payment_instrument_id') ?: $this->getUpdatedContribution()->payment_instrument_id,
       'check_number' => $this->getInputValue('check_number'),
       'pan_truncation' => $this->getInputValue('pan_truncation'),

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -331,7 +331,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
       'trxn_date' => $this->getInputValue('receive_date') ?: date('YmdHis'),
       'currency' => $this->getUpdatedContribution()->currency,
       // CRM-17751
-      'trxn_id' => $this->getInputValue('trxn_id') ?: $this->getUpdatedContribution()->trxn_id ?: $this->getOriginalContributionValue('trxn_id'),
+      'trxn_id' => $this->getUpdatedContribution()->trxn_id ?: $this->getOriginalContributionValue('trxn_id'),
       'payment_instrument_id' => $this->getInputValue('payment_instrument_id') ?: $this->getUpdatedContribution()->payment_instrument_id,
       'check_number' => $this->getInputValue('check_number'),
       'pan_truncation' => $this->getInputValue('pan_truncation'),

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1045,7 +1045,11 @@ class CRM_Financial_BAO_Order {
       if ($this->getOverrideTotalAmount() !== FALSE) {
         $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
       }
-      elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount') {
+      elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount'
+        // If we are loading an existing contribution then this switcheroo to treat the amount set
+        // as being the inclusive amount has already been done, so skip.
+        && !$this->getExistingContributionID() && !$this->getTemplateContributionID()
+      ) {
         // Other amount is a front end user entered form. It is reasonable to think it would be tax inclusive.
         $lineItem['line_total_inclusive'] = $lineItem['line_total'];
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] ? $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100)) : 0;

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -452,6 +452,7 @@ WHERE li.contribution_id = %1";
       }
     }
     else {
+      CRM_Core_Error::deprecatedWarning('use the api to load line items for existing entities');
       $setID = NULL;
       $totalEntityId = count($entityId);
       if ($entityTable == 'contribution') {

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -384,11 +384,30 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
       ->addWhere('entity_table', '=', 'civicrm_line_item')
       ->addSelect('amount', 'financial_account_id:name', 'description')
       ->execute();
-    $amount = 0;
-    foreach ($financialItems as $financialItem) {
-      $amount += $financialItem['amount'];
-    }
-    $this->assertEquals('300.00', $amount);
+
+    // The first 2 financial items are the Original 100 line item
+    // and the $20 sales tax on that line.
+    $this->assertEquals([
+      'id' => $financialItems[0]['id'],
+      'amount' => 100,
+      'description' => 'Contribution Amount',
+      'financial_account_id:name' => 'type_with_tax',
+    ], $financialItems[0]);
+    $this->assertEquals([
+      'id' => $financialItems[1]['id'],
+      'amount' => 20,
+      'description' => 'Sales Tax',
+      'financial_account_id:name' => 'vat full tax rate account',
+    ], $financialItems[1]);
+
+    // Next these lines are reversed...
+    $this->assertEquals([
+      'id' => $financialItems[1]['id'],
+      'amount' => -100,
+      'description' => 'Sales Tax',
+      'financial_account_id:name' => 'Sales Tax',
+    ], $financialItems[2]);
+
   }
 
   /**

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -388,7 +388,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
     foreach ($financialItems as $financialItem) {
       $amount += $financialItem['amount'];
     }
-    $this->assertEquals('320.00', $amount);
+    $this->assertEquals('300.00', $amount);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Load line items in stricter, more consistent way

Before
----------------------------------------
Most places load line items for existing contributions using the `BAO_Order->getLineItems()` method but this place does not - we can see it also results in sloppier typing per https://github.com/civicrm/civicrm-core/pull/33928

After
----------------------------------------
Same method as elsewhere

Technical Details
----------------------------------------
We can get away without keying on price set this deep down cos that extra key is used in the form layer

I want to remove the second part of the else too & use the same method in both places - will look to that shortly

Comments
----------------------------------------
