### PR TITLE
Switch transferParticipant to use the v4 ap

### DIFF
--- a/CRM/Event/Form/SelfSvcTransfer.php
+++ b/CRM/Event/Form/SelfSvcTransfer.php
@@ -17,6 +17,7 @@
  */
 
 use Civi\API\EntityLookupTrait;
+use Civi\Api4\LineItem;
 use Civi\Api4\Participant;
 
 /**
@@ -441,40 +442,50 @@ class CRM_Event_Form_SelfSvcTransfer extends CRM_Core_Form {
     $toParticipantValues['contact_id'] = $toContactID;
     $toParticipantValues['register_date'] = date('Y-m-d');
     //first create the new participant row -don't set registered_by yet or email won't be sent
-    $participant = CRM_Event_BAO_Participant::create($toParticipantValues);
+    $participant = Participant::create(FALSE)
+      ->setValues($toParticipantValues)
+      ->execute()->first();
     foreach ($participantPayments as $payment) {
-      civicrm_api3('ParticipantPayment', 'create', ['id' => $payment['id'], 'participant_id' => $participant->id]);
+      civicrm_api3('ParticipantPayment', 'create', ['id' => $payment['id'], 'participant_id' => $participant['id']]);
     }
-    //copy line items to new participant
-    $line_items = CRM_Price_BAO_LineItem::getLineItems($fromParticipantID);
-    foreach ($line_items as $id => $item) {
-      //Remove contribution id from older participant line item.
-      CRM_Core_DAO::singleValueQuery('UPDATE civicrm_line_item SET contribution_id = NULL WHERE id = %1', [1 => [$id, 'Integer']]);
+    // Copy line items to new participant
+    $line_items = LineItem::get(FALSE)
+      ->addWhere('entity_id', '=', $fromParticipantID)
+      ->addWhere('entity_table', '=', 'civicrm_participant')
+      ->execute();
 
-      $item['entity_id'] = $participant->id;
-      $item['id'] = NULL;
-      $item['entity_table'] = 'civicrm_participant';
-      $toLineItem = CRM_Price_BAO_LineItem::create($item);
+    foreach ($line_items as $lineItem) {
+      //Remove contribution id from older participant line item.
+      CRM_Core_DAO::singleValueQuery('UPDATE civicrm_line_item SET contribution_id = NULL WHERE id = %1', [1 => [$lineItem['id'], 'Integer']]);
+
+      $lineItem['entity_id'] = $participant['id'];
+      $lineItemID = $lineItem['id'];
+      unset($lineItem['id']);
+      $lineItem['entity_table'] = 'civicrm_participant';
+      $toLineItem = LineItem::create(FALSE)
+        ->setValues($lineItem)
+        ->execute()->first();
 
       //Update Financial Item for previous line item row.
-      $prevFinancialItem = CRM_Financial_BAO_FinancialItem::getPreviousFinancialItem($id);
+      $prevFinancialItem = CRM_Financial_BAO_FinancialItem::getPreviousFinancialItem($lineItemID);
       $prevFinancialItem['contact_id'] = $toContactID;
-      $prevFinancialItem['entity_id'] = $toLineItem->id;
+      $prevFinancialItem['entity_id'] = $toLineItem['id'];
       CRM_Financial_BAO_FinancialItem::create($prevFinancialItem);
     }
     //send a confirmation email to the new participant
     $this->participantTransfer((array) $participant);
     //now update registered_by_id
-    $query = "UPDATE civicrm_participant cp SET cp.registered_by_id = %1 WHERE  cp.id = ({$participant->id})";
+    $query = "UPDATE civicrm_participant cp SET cp.registered_by_id = %1 WHERE  cp.id = ({$participant['id']})";
     CRM_Core_DAO::executeQuery($query, [1 => [$fromParticipantID, 'Integer']]);
 
-    //now cancel the from participant record, leaving the original line-item(s)
-    $value_from = [];
-    $value_from['id'] = $fromParticipantID;
-    $tansferId = array_search('Transferred', CRM_Event_PseudoConstant::participantStatus(NULL, "class = 'Negative'"), TRUE);
-    $value_from['status_id'] = $tansferId;
-    $value_from['transferred_to_contact_id'] = $toContactID;
-    CRM_Event_BAO_Participant::create($value_from);
+    // Now cancel the from participant record, leaving the original line-item(s)
+    Participant::update(FALSE)
+      ->addWhere('id', '=', $fromParticipantID)
+      ->setValues([
+        'status_id:name' => 'Transferred',
+        'transferred_to_contact_id' => $toContactID,
+      ])
+      ->execute()->first();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Switch transferParticipant to use the v4 ap

Before
----------------------------------------
less use of api

After
----------------------------------------
more use

Technical Details
----------------------------------------
Test cover in `CRM_Event_Form_SelfSvcTransferTest` - the main target here is the `getLineItems()` call which is more confusing than a direct api call

Comments
----------------------------------------