### PR TITLE
Stop assigning deprecated mail variables to online contribution receipt

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -350,16 +350,6 @@ class CRM_Contribute_Form_AdditionalInfo {
       $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
     }
     else {
-      //offline contribution
-      // assigned various dates to the templates
-      $form->assign('receipt_date', CRM_Utils_Date::processDate($params['receipt_date']));
-
-      if (!empty($params['cancel_date'])) {
-        $form->assign('cancel_date', CRM_Utils_Date::processDate($params['cancel_date']));
-      }
-      if (!empty($params['thankyou_date'])) {
-        $form->assign('thankyou_date', CRM_Utils_Date::processDate($params['thankyou_date']));
-      }
       if ($form->_action & CRM_Core_Action::UPDATE) {
         $form->assign('lineItem', empty($form->_lineItems) ? FALSE : $form->_lineItems);
       }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1559,6 +1559,7 @@ class CRM_Utils_Token {
           '$receive_date' => 'contribution.receive_date',
           '$thankyou_date' => 'contribution.thankyou_date',
           '$receipt_date' => 'contribution.receipt_date',
+          '$cancel_date' => 'contribution.cancel_date',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),


### PR DESCRIPTION
Overview
----------------------------------------
Stop assigning deprecated mail variables to online contribution receipt

Before
----------------------------------------
Deprecated values assigned

After
----------------------------------------
no longer

Technical Details
----------------------------------------

Comments
----------------------------------------
