### PR TITLE
Deprecate old `$lineItem` template assignment

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -349,11 +349,6 @@ class CRM_Contribute_Form_AdditionalInfo {
       $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($params);
       $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
     }
-    else {
-      if ($form->_action & CRM_Core_Action::UPDATE) {
-        $form->assign('lineItem', empty($form->_lineItems) ? FALSE : $form->_lineItems);
-      }
-    }
 
     //handle custom data
     if (!empty($params['hidden_custom'])) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1513,6 +1513,7 @@ class CRM_Utils_Token {
           '$domain_postal_code' => 'domain.postal_code',
           '$domain_state' => 'domain.state_province_id:abbr',
           '$domain_country' => 'domain.country_id:abbr',
+          '$lineItem' => '$lineItems',
         ],
         'contribution_online_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
@@ -1520,6 +1521,7 @@ class CRM_Utils_Token {
           '$last_name' => 'contact.last_name',
           '$displayName' => 'contact.display_name',
           '$dataArray' => ts('see default template for how to show this'),
+          '$lineItem' => '$lineItems',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1540,6 +1542,7 @@ class CRM_Utils_Token {
           '$module' => 'unknown',
           '$currency' => 'contribution.currency',
           '$paidBy' => 'contribution.payment_instrument_id:label',
+          '$lineItem' => '$lineItems',
         ],
         'membership_online_receipt' => [
           '$dataArray' => ts('see default template for how to show this'),
@@ -1551,6 +1554,7 @@ class CRM_Utils_Token {
           '$mem_status' => 'membership.membership_status_id:name',
           '$receive_date' => 'contribution.receive_date',
           '$currency' => 'contribution.currency',
+          '$lineItem' => '$lineItems',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',
@@ -1560,6 +1564,7 @@ class CRM_Utils_Token {
           '$thankyou_date' => 'contribution.thankyou_date',
           '$receipt_date' => 'contribution.receipt_date',
           '$cancel_date' => 'contribution.cancel_date',
+          '$lineItem' => '$lineItems',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
@@ -1585,6 +1590,7 @@ class CRM_Utils_Token {
           '$trxn_id' => 'contribution.trxn_id',
           '$participant_status_id' => 'participant.status_id',
           '$participant.role' => 'participant.role_id:label',
+          '$lineItem' => '$lineItems',
         ],
         'event_online_receipt' => [
           '`$participant.id`' => 'participant.id',
@@ -1597,6 +1603,7 @@ class CRM_Utils_Token {
           '$event.participant_role' => 'participant.role_id:label',
           '$paidBy' => 'contribution.payment_instrument_id:label',
           '$title' => 'event.title',
+          '$lineItem' => '$lineItems',
         ],
         'participant_transferred' => [
           '$location' => 'event.location',


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate old `$lineItem` template assignment

Before
----------------------------------------
We swapped out `$lineItem` for `$lineItems` some time ago. The latter has less nesting and is in all the shipped templates. We haven't been putting out messages because `$lineItem` is only deprecated if not nested in `$lineItems`

After
----------------------------------------
This starts the process of deprecating `$lineItem`  by adding it to the status check and removing it from one, more obscure, template assignment - ie offline contribution 

Technical Details
----------------------------------------
After this has been out for a bit we can remove the assignment from more places 

Comments
----------------------------------------
