### PR TITLE
When processing an Afform set status to Pending on create and then Processed when it has actually been processed

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -60,19 +60,14 @@ class Submit extends AbstractProcessor {
     }
 
     // Save submission record
-    $status = 'Processed';
     if (!empty($this->_afform['create_submission']) && empty($this->args['sid'])) {
-      if (!empty($this->_afform['manual_processing'])) {
-        $status = 'Pending';
-      }
-
       $userId = \CRM_Core_Session::getLoggedInContactID();
 
       $submissionRecord = [
         'contact_id' => $userId,
         'afform_name' => $this->name,
         'data' => $this->getValues(),
-        'status_id:name' => $status,
+        'status_id:name' => 'Pending',
       ];
       // Update draft if it exists
       if ($userId) {
@@ -112,7 +107,7 @@ class Submit extends AbstractProcessor {
         AfformSubmission::update(FALSE)
           ->addWhere('id', '=', $submissionId)
           ->addValue('data', $submissionData)
-          ->addValue('status_id:name', $status)
+          ->addValue('status_id:name', 'Processed')
           ->execute();
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
When an Afform is submitted and it is configured to create an `AfformSubmission` record it first creates an AfformSubmission record and then updates it when the form has actually been processed.

Two scenarios:
1. If "verify submission" is enabled the AfformSubmission is set to "Pending" on create and changes to "Processed" once manually verified.
2. If "verify submission" is not enabled, ie. submit will process form the AfformSubmission is set to "Processed" on create and changes to "Processed" once the processing of the form has actually completed.

1 - is sensible.
2 - seems wrong. a) If for any reason the form processing fails (eg. crashes) it will show "Processed" when it has not actually been processed. b) If you want to perform an action once form processing has completed (ie. after ALL entities have been saved/updated etc.) then you need to be able to identify that case (ie. transition from create->update). We don't currently have a reason/mechanism for updating an `AfformSubmission` once it has been updated the first time but that could happen in the future.

Specifically I developed this change to make this CiviRules PR work better: You can trigger on a form "update" and use the status changed condition to check if it changed from Pending to Processed. If you trigger on a form "create" you won't have access to created entities. If you trigger on update without the condition you risk triggering in the future if AfformSubmission record is updated for some reason.


Before
----------------------------------------
Processed -> Processed

After
----------------------------------------
Pending -> Processed

Technical Details
----------------------------------------


Comments
----------------------------------------

