### PR TITLE
SearchKit - Fix bugs in new "Pick Columns" feature

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -30,12 +30,6 @@ trait SavedSearchInspectorTrait {
   protected $savedSearch;
 
   /**
-   * Toggle columns to include in the result
-   * @var array
-   */
-  protected array $toggleColumns = [];
-
-  /**
    * @var array{select: array, where: array, having: array, orderBy: array, limit: int, offset: int, checkPermissions: bool, debug: bool}
    */
   protected $_apiParams;
@@ -118,12 +112,6 @@ trait SavedSearchInspectorTrait {
         'id' => NULL,
         'name' => NULL,
       ];
-    }
-    if (
-      $this->toggleColumns
-      && (count($this->toggleColumns) < count($this->display['settings']['columns']))
-      ) {
-      $this->display['settings']['columns'] = array_values(array_map(fn ($i) => $this->display['settings']['columns'][$i], $this->toggleColumns));
     }
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -49,6 +49,9 @@ trait ResultDataTrait {
     $data_columns = [];
     $result = [];
     foreach ($columns as $index => $col) {
+      if (!$this->isColumnEnabled($index)) {
+        continue;
+      }
       $col += ['type' => NULL, 'label' => '', 'rewrite' => FALSE];
       $data_columns[$index] = $col;
       // Convert html to plain text

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -39,10 +39,6 @@
         $scope.$watch('$ctrl.search.api_params', buildSettings, true);
       };
 
-      // this is used to filter toggled columns in the table
-      // search display - here its trivial
-      this.getRowColumns = (row) => row.columns;
-
       // Add callbacks for pre & post run
       this.onPreRun.push(function(apiCalls) {
         // So the raw SQL can be shown in the "Query Info" tab

--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.html
@@ -9,8 +9,8 @@
       <tr ng-model="$ctrl.search.api_params.select" ui-sortable="sortableColumnOptions">
         <th class="crm-search-result-select" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.settings.actions">
         </th>
-        <th ng-repeat="item in $ctrl.search.api_params.select" ng-click="$ctrl.setSort($ctrl.settings.columns[$index], $event)" title="{{$index || !$ctrl.crmSearchAdmin.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
-          <i ng-if=":: $ctrl.isSortable($ctrl.settings.columns[$index])" class="crm-i {{ $ctrl.getSort($ctrl.settings.columns[$index]) }}" role="img" aria-hidden="true"></i>
+        <th ng-repeat="item in $ctrl.search.api_params.select" ng-click="$ctrl.setSort($ctrl.columns[$index], $event)" title="{{$index || !$ctrl.crmSearchAdmin.groupExists ? ts('Drag to reorder columns, click to sort results (shift-click to sort by multiple).') : ts('Column reserved for smart group.')}}">
+          <i ng-if=":: $ctrl.isSortable($ctrl.columns[$index])" class="crm-i {{ $ctrl.getSort($ctrl.columns[$index]) }}" role="img" aria-hidden="true"></i>
           <span ng-class="{'crm-draggable': $index || !$ctrl.crmSearchAdmin.groupExists}">{{ getColumnLabel($index) }}</span>
           <span ng-switch="$index || !$ctrl.crmSearchAdmin.groupExists ? 'sortable' : 'locked'">
             <i ng-switch-when="locked" class="crm-i fa-lock" role="img" aria-hidden="true"></i>

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -332,10 +332,6 @@
         ctrl.settings = ctrl.display.settings;
       }
 
-      // this is used to filter toggled columns in the table
-      // search display - here its trivial
-      this.getRowColumns = (row) => row.columns;
-
       // @return {Promise}
       this.loadAfforms = function() {
         if (!ctrl.afformEnabled && !afformLoad) {

--- a/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/buttons.html
@@ -1,5 +1,5 @@
 <span ng-repeat="link in colData.links">
-  <a class="btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: link.style }}" target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
+  <a class="btn {{:: $ctrl.columns[colIndex].size }} btn-{{:: link.style }}" target="{{:: link.target }}" ng-attr-href="{{ link.url || '' }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
     <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}" role="img" aria-hidden="true"></i>
     {{:: link.text }}
   </a>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/editable.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/editable.html
@@ -2,7 +2,7 @@
   row="row"
   display="$ctrl"
   is-full-row-mode="$ctrl.settings.editableRow.full"
-  col-key="$ctrl.settings.columns[colIndex].key"
+  col-key="$ctrl.columns[colIndex].key"
   col-data="colData"
   ng-if="!colData.loading && $ctrl.editing === row.key && colData.editing"
 ></crm-search-display-editable>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/menu.html
@@ -1,10 +1,10 @@
 <div class="btn-group" role="group" ng-if="colData.links.length">
-  <button type="button" class="dropdown-toggle btn {{:: $ctrl.settings.columns[colIndex].size }} btn-{{:: $ctrl.settings.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
-    <i ng-if=":: $ctrl.settings.columns[colIndex].icon" class="crm-i {{:: $ctrl.settings.columns[colIndex].icon }}" role="img" aria-hidden="true"></i>
+  <button type="button" class="dropdown-toggle btn {{:: $ctrl.columns[colIndex].size }} btn-{{:: $ctrl.columns[colIndex].style }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" ng-click="colData.open = true">
+    <i ng-if=":: $ctrl.columns[colIndex].icon" class="crm-i {{:: $ctrl.columns[colIndex].icon }}" role="img" aria-hidden="true"></i>
     {{:: colData.text }}
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu {{ $ctrl.settings.columns[colIndex].alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: colData.open">
+  <ul class="dropdown-menu {{ $ctrl.columns[colIndex].alignment === 'text-right' ? 'dropdown-menu-right' : '' }}" ng-if=":: colData.open">
     <li ng-repeat="link in colData.links" class="bg-{{:: link.style }}">
       <a ng-attr-href="{{ link.url || '' }}" target="{{:: link.target }}" title="{{:: link.title }}" ng-click="$ctrl.onClickLink(link, row.key, $event)">
         <i ng-if=":: link.icon" class="crm-i {{:: link.icon }}" role="img" aria-hidden="true"></i>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -30,6 +30,14 @@
         for (let p=0; p < placeholderCount; ++p) {
           this.placeholders.push({});
         }
+        this.columns = this.settings.columns.map((column) => {
+          // Break reference so original settings are preserved
+          const col = _.cloneDeep(column);
+          // Used by crmSearchDisplayTable.toggleColumns
+          col.enabled = true;
+          col.fetched = true;
+          return col;
+        });
         _.each(ctrl.onInitialize, function(callback) {
           callback.call(ctrl, $scope, $element);
         });
@@ -198,7 +206,7 @@
 
       // Generate params for the SearchDisplay.run api
       getApiParams: function(mode) {
-        return {
+        const apiParams = {
           return: arguments.length ? mode : 'page:' + this.page,
           savedSearch: this.search,
           display: this.display,
@@ -208,6 +216,17 @@
           filters: this.getFilters(),
           afform: this.afFieldset ? this.afFieldset.getFormName() : null
         };
+        // Add toggleColumns if any columns are disabled
+        const toggleColumns = this.columns.reduce((indices, col, index) => {
+          if (col.enabled) {
+            indices.push(index);
+          }
+          return indices;
+        }, []);
+        if (toggleColumns.length < this.columns.length) {
+          apiParams.toggleColumns = toggleColumns;
+        }
+        return apiParams;
       },
 
       onClickSearchButton: function() {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -9,9 +9,9 @@
       <summary>{{:: ts('Pick Columns') }}</summary>
       <div class="crm-accordion-body">
         <!-- TODO: select2 might be nicer here? -->
-        <label ng-repeat="(index, col) in $ctrl._allColumns">
+        <label ng-repeat="(index, col) in $ctrl.columns">
           <input type="checkbox"
-            ng-model="$ctrl._allColumns[index].toggled"
+            ng-model="$ctrl.columns[index].enabled"
             ng-change="$ctrl.toggleColumns()"
             >
             {{:: $ctrl.getColumnToggleLabel(col) }}
@@ -28,7 +28,7 @@
         <th ng-class="{'crm-search-result-select': $ctrl.settings.actions}" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.hasExtraFirstColumn()">
           <span class="sr-only">{{:: ts('Bulk row actions')}}</span>
         </th>
-        <th ng-repeat="col in $ctrl.settings.columns" ng-click="$ctrl.setSort(col, $event)" class="{{:: $ctrl.getHeaderClass(col) }}" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
+        <th ng-repeat="col in $ctrl.columns" ng-if="col.enabled" ng-click="$ctrl.setSort(col, $event)" class="{{:: $ctrl.getHeaderClass(col) }}" title="{{:: $ctrl.isSortable(col) ? ts('Click to sort results (shift-click to sort by multiple).') : '' }}">
           <i ng-if=":: $ctrl.isSortable(col)" class="crm-i crm-search-table-column-sort-icon {{ $ctrl.getSort(col) }}" role="img" aria-hidden="true"></i>
           <span class="crm-search-display-table-column-label">{{:: col.label }}</span>
         </th>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -16,11 +16,11 @@
       </button>
     </div>
   </td>
-  <td ng-repeat="(colIndex, colData) in $ctrl.getRowColumns(row)" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.settings.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.settings.columns[colIndex].key }}">
+  <td ng-repeat="(colIndex, colData) in row.columns track by $index" ng-if="$ctrl.columns[colIndex].enabled" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.columns[colIndex].key }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">
-  <td colspan="{{ $ctrl.settings.columns.length + 2 }}">
+  <td colspan="{{ $ctrl.columns.length + 2 }}">
     <p class="alert alert-info text-center">
       {{ $ctrl.settings.noResultsText || ts('None found.') }}
     </p>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableCreateNew.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableCreateNew.html
@@ -17,7 +17,7 @@
       </button>
     </div>
   </td>
-  <td ng-repeat="(colIndex, colInfo) in $ctrl.settings.columns" title="{{:: colData.title }}" class="crm-search-col-type-{{:: colInfo.type }}" data-field-name="{{:: colInfo.key }}">
+  <td ng-repeat="(colIndex, colInfo) in $ctrl.columns" ng-if="colInfo.enabled" title="{{:: colData.title }}" class="crm-search-col-type-{{:: colInfo.type }}" data-field-name="{{:: colInfo.key }}">
     <crm-search-display-editable display="$ctrl" is-full-row-mode="true" col-key="colInfo.key" ng-if="colInfo.editable && $ctrl.editing === -1"></crm-search-display-editable>
   </td>
 </tr>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableLoading.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableLoading.html
@@ -3,7 +3,7 @@
   <td ng-if=":: $ctrl.hasExtraFirstColumn()">
     <input ng-if=":: $ctrl.settings.actions" type="checkbox" disabled>
   </td>
-  <td ng-repeat="col in $ctrl.settings.columns">
+  <td ng-repeat="col in $ctrl.columns" ng-if="col.enabled">
     <div class="crm-search-loading-placeholder"></div>
   </td>
 </tr>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTally.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTally.html
@@ -3,7 +3,7 @@
   <td ng-if=":: $ctrl.hasExtraFirstColumn()">
     {{:: $ctrl.settings.tally.label }}
   </td>
-  <td ng-repeat="col in $ctrl.settings.columns">
+  <td ng-repeat="col in $ctrl.columns" ng-if="col.enabled">
     <div ng-if="!$ctrl.tally" class="crm-search-loading-placeholder"></div>
     <div ng-if="$ctrl.tally">
       {{:: col.tally.label }}


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a few bugs observed after https://github.com/civicrm/civicrm-core/pull/33807 was merged.

Technical Details
----------------------------------------
- Breaks reference so preview screen doesn't inadvertently delete columns
- Keeps indices stable; `run` action will return `null` for disabled columns
- Moves common functionality into the searchDisplayBaseTrait
- Removes reliance on `getRowColumns` function in the template
