### PR TITLE
AssetBuilder - Use buckets. Gracefully invalidate after string translation.

### DIFF
--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -157,6 +157,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookI
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event): void {
     unset(Civi::$statics[__CLASS__]);
+    Civi::service('asset_builder')->invalidate();
   }
 
   /**

--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -338,7 +338,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
   public function getCacheCode() {
     // Ex: AngularJS json partials are language-specific because they ship with the strings
     // for the current language.
-    return $this->cacheCode . CRM_Core_I18n::getLocale();
+    // Note: AssetBuilder::getBuckets() includes a pattern-match against this convention.
+    return $this->cacheCode . '-' . CRM_Core_I18n::getLocale();
   }
 
   /**

--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -649,6 +649,10 @@ function civicrm_api3_job_cleanup($params) {
     CRM_Core_BAO_Cache::cleanup($session, $tempTable, $prevNext, $expired);
   }
 
+  if ($expired) {
+    Civi::service('asset_builder')->prune();
+  }
+
   if ($jobLog) {
     CRM_Core_BAO_Job::cleanup();
   }

--- a/tests/phpunit/CRM/Core/ResourcesTest.php
+++ b/tests/phpunit/CRM/Core/ResourcesTest.php
@@ -133,8 +133,8 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmRegion name="testAddScriptFile"}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<script type=\"text/javascript\" src=\"http://core-app/foo%20bar.js?r=resTesten_US\">\n</script>\n"
-      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTesten_US\">\n</script>\n";
+      . "<script type=\"text/javascript\" src=\"http://core-app/foo%20bar.js?r=resTest-en_US\">\n</script>\n"
+      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTest-en_US\">\n</script>\n";
     $this->assertEquals($expected, $actual);
   }
 
@@ -267,7 +267,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmRegion name="testCrmJS"}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTesten_US\">\n</script>\n"
+      . "<script type=\"text/javascript\" src=\"http://ext-dir/com.example.ext/foo%20bar.js?r=resTest-en_US\">\n</script>\n"
       . "<script type=\"text/javascript\" src=\"/whiz/foo%20bar.js\">\n</script>\n";
     $this->assertEquals($expected, $actual);
   }
@@ -282,8 +282,8 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmRegion name="testAddStyleFile"}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<link href=\"http://core-app/foo%20bar.css?r=resTesten_US\" rel=\"stylesheet\" type=\"text/css\"/>\n"
-      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTesten_US\" rel=\"stylesheet\" type=\"text/css\"/>\n";
+      . "<link href=\"http://core-app/foo%20bar.css?r=resTest-en_US\" rel=\"stylesheet\" type=\"text/css\"/>\n"
+      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTest-en_US\" rel=\"stylesheet\" type=\"text/css\"/>\n";
     $this->assertEquals($expected, $actual);
   }
 
@@ -324,7 +324,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmRegion name="testCrmCSS"}{/crmRegion}');
     // stable ordering: alphabetical by (snippet.weight,snippet.name)
     $expected = ""
-      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTesten_US\" rel=\"stylesheet\" type=\"text/css\"/>\n"
+      . "<link href=\"http://ext-dir/com.example.ext/foo%20bar.css?r=resTest-en_US\" rel=\"stylesheet\" type=\"text/css\"/>\n"
       . "<link href=\"/whiz/foo%20bar.css\" rel=\"stylesheet\" type=\"text/css\"/>\n";
     $this->assertEquals($expected, $actual);
   }
@@ -353,7 +353,7 @@ class CRM_Core_ResourcesTest extends CiviUnitTestCase {
     $this->assertEquals('http://ext-dir/com.example.ext/foo%20bar.png', $actual);
 
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmResURL ext="com.example.ext" file="foo%20bar.png" addCacheCode=1}');
-    $this->assertEquals('http://ext-dir/com.example.ext/foo%20bar.png?r=resTesten_US', $actual);
+    $this->assertEquals('http://ext-dir/com.example.ext/foo%20bar.png?r=resTest-en_US', $actual);
 
     $actual = CRM_Utils_String::parseOneOffStringThroughSmarty('{crmResURL ext="com.example.ext"}');
     $this->assertEquals('http://ext-dir/com.example.ext/', $actual);

--- a/tests/phpunit/E2E/Core/AssetBuilderTest.php
+++ b/tests/phpunit/E2E/Core/AssetBuilderTest.php
@@ -136,7 +136,7 @@ class AssetBuilderTest extends \CiviEndToEndTestCase {
     \Civi::service('asset_builder')->setCacheEnabled(TRUE);
     $url = \Civi::service('asset_builder')->getUrl($asset, $params);
     $this->assertEquals(1, $this->fired['hook_civicrm_buildAsset']);
-    $this->assertMatchesRegularExpression(';^https?:.*dyn/square.[0-9a-f]+.(txt|js)$;', $url);
+    $this->assertMatchesRegularExpression(';^https?:.*dyn/\d+-[a-zA-Z0-9]+-[a-z]{2}_[A-Z]{2}/square.[0-9a-f]+.(txt|js)$;', $url);
     $response = $this->createGuzzle()->get($url);
     // Note: This actually relies on httpd to determine MIME type.
     // That could be ambiguous for javascript.


### PR DESCRIPTION
Overview
----------------------------------------

After editing translated strings in-app, the cache-files may retain old copies of the old translation. We need to stop using the old strings.

@samuelsov's #33883 introduced the idea of clearing the asset-cache after every edit to a translation. This adjusts that idea and addresses race-conditions. (If another user is browsing the site while someone is translating, then they may be in the middle of work which relies on fetching those old files.) In this variant, the cache-files are preserved for a grace period (90 minutes).

Before
----------------------------------------

After editing a translated string, the system will still use the old cache-files -- which may contain the old strings.

After
----------------------------------------

After editing a translated string, the old cache-files are marked as stale. Going forward, they won't be used in new page-views. (However, if you have an active page-view, then you can still read the files.)

Technical Details
----------------------------------------

Compare:

* `$assetBuilder->clear()` deletes all files. Any active browsers may find the files have disappeared before they get loaded. This is used (e.g.) when `cv flush` performs an aggressive cleanup.
* `$assetBuilder->invalidate()` marks caches as old, and then a subsequent call to `$assetBuilder->prune()` can remove them. (`prune()` runs as part of the scheduled `Job.cleanup`.)

Comments
----------------------------------------

Ideally... if someone edits an `fr_FR` string, then you invalidate `fr_FR` assets and preserve `de_DE` assets. This PR gets about half-way -- at least, it puts the cache files for each locale into separate folders (which can be invalidated separately). However, more work is required to take advantage of that. See [this comment](https://github.com/civicrm/civicrm-core/pull/33883#issuecomment-3459340611) and expand the section "In Depth: Issues with targeted invalidation...".

In the mean time, this gets closer and should be safe...