### PR TITLE
dev/core#6179 fix issue with tasks on a front end searh kit

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -200,6 +200,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
               'path' => "'{$task['url']}'",
               'query' => "{reset: 1}",
               'data' => "{cids: ids.join(','), qfKey: '$key'}",
+              'mode' => $task['mode'] ?? 'back',
             ],
           ];
         }

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -56,9 +56,10 @@
         };
         // If task uses a crmPopup form
         if (task.crmPopup) {
+          const mode = task.crmPopup.mode && task.crmPopup.mode == 'front'  ? 'front' : 'back';
           const path = $rootScope.$eval(task.crmPopup.path, data),
             query = task.crmPopup.query && $rootScope.$eval(task.crmPopup.query, data);
-          CRM.loadForm(CRM.url(path, query, 'back'), {post: task.crmPopup.data && $rootScope.$eval(task.crmPopup.data, data)})
+          CRM.loadForm(CRM.url(path, query, mode), {post: task.crmPopup.data && $rootScope.$eval(task.crmPopup.data, data)})
             .on('crmFormSuccess', (e) => {
                 // refreshAfterTask emits its own
                 // crmPopupFormSuccess event
@@ -67,9 +68,10 @@
             });
         }
         else if (task.redirect) {
+          const mode = task.redirect.mode && task.crmPopup.mode == 'front'  ? 'front' : 'back';
           const redirectPath = $rootScope.$eval(task.redirect.path, data),
             redirectQuery = task.redirect.query && $rootScope.$eval(task.redirect.query, data) && $rootScope.$eval(task.redirect.data, data);
-          $window.open(CRM.url(redirectPath, redirectQuery, 'back'), '_blank');
+          $window.open(CRM.url(redirectPath, redirectQuery, mode), '_blank');
         }
         // If task uses dialogService
         else {

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -56,7 +56,7 @@
         };
         // If task uses a crmPopup form
         if (task.crmPopup) {
-          const mode = task.crmPopup.mode && task.crmPopup.mode == 'front'  ? 'front' : 'back';
+          const mode = ('mode' in task.crmPopup) ? task.crmPopup.mode : 'back';
           const path = $rootScope.$eval(task.crmPopup.path, data),
             query = task.crmPopup.query && $rootScope.$eval(task.crmPopup.query, data);
           CRM.loadForm(CRM.url(path, query, mode), {post: task.crmPopup.data && $rootScope.$eval(task.crmPopup.data, data)})


### PR DESCRIPTION
The search action designer extension provides custom actions for searches and integrates neatly with Search Kit. However when search kit is run on the frontend with by pass permission the action won't load because the user has no access to the front end page.

**Steps to reproduce**

1. Install search action designer and create an action with this search action designer
2. Add a new user which only has front end permissions (make sure the permision for access CiviCRM backend and API is NOT SET)
3. Create a search kit on a front end page and set access by pass on the search kit. Also create the form for the search kit
4. Login as the newly created user
5. Lookup the search
6. You will see results and check some records and the select action
7. select the action created with the search action designer

**Expected result**

The screen with fields from the search action designer will show up

**Actual result**

Access Denies error

**Cause**

In the search kit the popup and url redirects will go to a backend page and this requires the `access CiviCRM Backend and API` permission. Setting this to the front end page will fix this. This was a fix in https://github.com/civicrm/civicrm-core/pull/30247

**Proposed solution**

Make sure the tasks can provide a mode for frontend or backend. See here for an example implementation: https://lab.civicrm.org/extensions/searchactiondesigner/-/merge_requests/17/diffs#05bc1b8751b31504898426c9f92ec18f98e3cbaa_50_50