### PR TITLE
dev/core#6180 dont crash formbuilder on non-multilingual sites

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -403,7 +403,7 @@ class AfformAdminMeta {
   }
 
   private static function getLocales(): array {
-    $options = NULL;
+    $options = [];
     if (\CRM_Core_I18n::isMultiLingual()) {
       $languages = \CRM_Core_I18n::languages();
       $locales = \CRM_Core_I18n::getMultilingual();

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -8,7 +8,7 @@
     <input ng-model="editor.afform.title" class="form-control" id="af_config_form_title" required title="{{:: ts('Required') }}" ng-model-options="editor.debounceMode" >
   </div>
 
-  <div class="form-group" ng-if="editor.meta.locales">
+  <div class="form-group" ng-if="editor.meta.locales" ng-if="editor.meta.locales.length">
     <label for="afform_locale">
       {{:: ts('Locale') }} <span class="crm-marker">*</span>
     </label>


### PR DESCRIPTION
Before
----------------------------------------
- Type error when accessing FormBuilder if multilingual is disabled

After
----------------------------------------
- No type error
- Still a slightly odd required box with no options in the FormBuilder UI
<img width="599" height="367" alt="image" src="https://github.com/user-attachments/assets/2cd94083-4879-4c77-bbb4-11beb188b92c" />



Comments
----------------------------------------
I'm very supportive of encouraging more multilingualism but I'm not sure we're ready to require it!