### PR TITLE
SearchKit - Only show columns with labels in "Pick Columns" selector

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -130,25 +130,6 @@
         return cssClass;
       };
 
-      this.getColumnToggleLabel = (col) => {
-        if (col.label) {
-          return col.label;
-        }
-        if (col.key) {
-          return `[${col.key}]`;
-        }
-        if (col.type === 'menu') {
-          return ts('Menu');
-        }
-        if (col.type === 'buttons') {
-          return ts('Buttons');
-        }
-        if (col.type === 'links') {
-          return ts('Links');
-        }
-        return ts('Column %1', {1: col.index});
-      };
-
       /**
        * Update the settings for which columns to include.
        *
@@ -161,9 +142,7 @@
       };
 
       this.resetColumnToggles = () => {
-        this.columns.forEach((col, index) => {
-          this.columns[index].enabled = true;
-        });
+        this.columns.forEach((col) => col.enabled = true);
         this.toggleColumns();
       };
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -8,15 +8,14 @@
     <details ng-if="$ctrl.settings.toggleColumns">
       <summary>{{:: ts('Pick Columns') }}</summary>
       <div class="crm-accordion-body">
-        <!-- TODO: select2 might be nicer here? -->
-        <label ng-repeat="(index, col) in $ctrl.columns">
+        <label ng-repeat="(index, col) in $ctrl.columns" ng-if="col.label">
           <input type="checkbox"
             ng-model="$ctrl.columns[index].enabled"
             ng-change="$ctrl.toggleColumns()"
             >
-            {{:: $ctrl.getColumnToggleLabel(col) }}
+            {{:: col.label }}
         </label>
-        <button type="button" class="btn btn-secondary" ng-click="$ctrl.resetColumnToggles()">
+        <button type="button" class="btn btn-sm btn-secondary" ng-click="$ctrl.resetColumnToggles()">
           {{:: ts('Select All') }}
         </button>
       </div>


### PR DESCRIPTION
Overview
----------------------------------------
Minor tweak to the feature added in https://github.com/civicrm/civicrm-core/pull/33807

Before
----------------------------------------
All columns shown in "Pick Columns" checkboxes.

After
----------------------------------------
Only columns with a label shown.

Comments
---------------
IDK if there's one perfect way to do this, but it strikes me as unnecessary clutter to allow e.g. links or menu columns to be "picked." A report-like interface would always keep columns containing UI & the only picking needed is columns containing data.

Technical Details
----------------------------------------
A few minor optimizations as well.