### PR TITLE
Make copy button optional in af-repeat

### DIFF
--- a/ext/afform/core/ang/af/afRepeat.directive.js
+++ b/ext/afform/core/ang/af/afRepeat.directive.js
@@ -18,6 +18,7 @@
         link: function($scope, $el, $attr, ctrls) {
           $scope.afFieldset = ctrls[0];
           $scope.afJoin = ctrls[1];
+          $scope.element = $el;
         },
         controller: function($scope) {
           this.getItems = $scope.getItems = function() {

--- a/ext/afform/core/ang/af/afRepeat.html
+++ b/ext/afform/core/ang/af/afRepeat.html
@@ -3,4 +3,4 @@
   <button crm-icon="fa-ban" class="btn btn-xs af-repeat-remove-btn" ng-if="canRemove()" ng-click="removeItem($index)"></button>
 </div>
 <button crm-icon="{{ addIcon || 'fa-plus' }}" class="btn btn-sm af-repeat-add-btn" ng-if="canAdd()" ng-click="addItem()">{{ addLabel }}</button>
-<button crm-icon="{{ copyIcon || 'fa-copy' }}" class="btn btn-sm af-repeat-copy-btn" ng-if="canAdd()" ng-click="copyItem()">{{ copyLabel }}</button>
+<button crm-icon="{{ copyIcon || 'fa-copy' }}" class="btn btn-sm af-repeat-copy-btn" ng-if="canAdd() && element.attr('af-copy')" ng-click="copyItem()">{{ copyLabel }}</button>


### PR DESCRIPTION
Before
----------------------------------------
If you remove the af-copy attribute, your repeat still shows a copy button.

After
----------------------------------------
No af-copy attribute, no button.