### PR TITLE
AfformMetadataInjector - fallback to text input if field doesn't have…

### DIFF
--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -116,7 +116,7 @@ class AfformMetadataInjector {
     // Get field defn from afform markup
     $fieldDefn = $existingFieldDefn ? \CRM_Utils_JS::getRawProps($existingFieldDefn) : [];
     // Uses input type set on the form if specified (else falls back to the input type in the field spec)
-    $inputType = !empty($fieldDefn['input_type']) ? \CRM_Utils_JS::decode($fieldDefn['input_type']) : $fieldInfo['input_type'];
+    $inputType = !empty($fieldDefn['input_type']) ? \CRM_Utils_JS::decode($fieldDefn['input_type']) : ($fieldInfo['input_type'] ?? 'Text');
     // On a search form, search_range will present a pair of fields (or possibly 3 fields for date select + range)
     $isSearchRange = !empty($fieldDefn['search_range']) && \CRM_Utils_JS::decode($fieldDefn['search_range']);
 


### PR DESCRIPTION
… an input type

Before
----------------------------------------
- sometime fields come through here without an input type (I think the issue is with calculated fields which dont have the full spec definition
- this causes a crash at L124 when it tries to fetch the template

After
----------------------------------------
- sometime fields come through here without an input type (I think the issue is with calculated fields which dont have the full spec definition
- dont crash, fallback to a Text input

Comments
----------------------------------------
Reproduction steps:
- start with the Bookkeeping Transactions report from Search Kit Reports Starter Pack, 
- create an Afform from that search
- add the field `Contribution_EntityFinancialTrxn_FinancialTrxn_01.amount`
