### PR TITLE
Geocoder: Don't set lat/lon to 0,0 on error

### DIFF
--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -59,7 +59,7 @@ class CRM_Utils_Address_BatchUpdate {
       if (CRM_Utils_String::strtobool($this->geocoding) === TRUE) {
         $this->returnMessages[] = ts('Error: You need to set a mapping provider under Administer > System Settings > Mapping and Geocoding');
         $this->returnError = 1;
-        $this->returnResult();
+        return $this->returnResult();
       }
     }
     else {
@@ -71,13 +71,7 @@ class CRM_Utils_Address_BatchUpdate {
     }
 
     // do check for parse street address.
-    $parseAddress = FALSE;
-    $parseAddress = CRM_Utils_Array::value('street_address_parsing',
-      CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
-        'address_options'
-      ),
-      FALSE
-    );
+    $parseAddress = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'address_options')['street_address_parsing'] ?? FALSE;
     $parseStreetAddress = FALSE;
     if (!$parseAddress) {
       if (CRM_Utils_String::strtobool($this->parse) === TRUE) {
@@ -195,10 +189,7 @@ class CRM_Utils_Address_BatchUpdate {
 
           // see if we got a geocode error, in this case we'll trigger a fatal
           // CRM-13760
-          if (
-            isset($params['geo_code_error']) &&
-            $params['geo_code_error'] == 'OVER_QUERY_LIMIT'
-          ) {
+          if (isset($params['geo_code_error']) && $params['geo_code_error'] == 'OVER_QUERY_LIMIT') {
             throw new CRM_Core_Exception('Aborting batch geocoding. Hit the over query limit on geocoder.');
           }
 

--- a/CRM/Utils/Address/BatchUpdate.php
+++ b/CRM/Utils/Address/BatchUpdate.php
@@ -207,7 +207,7 @@ class CRM_Utils_Address_BatchUpdate {
         else {
           // If an address has failed in the geocoding scheduled job i.e. no lat/long is fetched, we will update the manual_geocode field to 1.
           $addressParams['manual_geo_code'] = TRUE;
-          $addressParams['geo_code_1'] = $addressParams['geo_code_2'] = 0;
+          $addressParams['geo_code_1'] = $addressParams['geo_code_2'] = NULL;
         }
       }
 
@@ -238,10 +238,10 @@ class CRM_Utils_Address_BatchUpdate {
 
       // finally update address object.
       if (!empty($addressParams)) {
-        $address = new CRM_Core_DAO_Address();
-        $address->id = $dao->address_id;
-        $address->copyValues($addressParams);
-        $address->save();
+        \Civi\Api4\Address::update(FALSE)
+          ->setValues($addressParams)
+          ->addWhere('id', '=', $dao->address_id)
+          ->execute();
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
If core geocode job fails (because of eg. REQUEST_DENIED response from google) then it sets manual_geo_code=1 and also sets lat/lon to 0,0. That is problematic since 0,0 is a valid lat/lon... We should set them to NULL.

Before
----------------------------------------
If geocoder fails we get 0,0 as lat/lon

After
----------------------------------------
If geocoder fails we get NULL,NULL as lat/lon

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/27977 for last change to this.

Comments
----------------------------------------
First commit is cleanup/refactor only
