### PR TITLE
Allow writing to `tags` field

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/TagFieldSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/TagFieldSpecProvider.php
@@ -74,6 +74,7 @@ class TagFieldSpecProvider extends \Civi\Core\Service\AutoService implements Spe
       ->setDescription(ts('Tags applied to this record'))
       ->setType('Extra')
       ->setInputType('Select')
+      ->setInputAttrs(['multiple' => TRUE])
       ->setOperators(['IN', 'NOT IN'])
       ->addSqlFilter([__CLASS__, 'getTagFilterSql'])
       ->setSqlRenderer([__CLASS__, 'getTagSelectSql'])


### PR DESCRIPTION
Overview
----------------------------------------
Currently this virtual field is only available on `get` actions, for filtering.

This aims to allow writing to the field (similar to how the `roles` field works on User entity in Standalone)

Before
----------------------------------------
- `tags` virtual field on taggable entities is read only


After
----------------------------------------
- `tags` virtual field on taggable entities is read-write


Technical Details
----------------------------------------
It doesn't seem to work in the case of Contact create, because the create params aren't passed through to `hook_civicrm_post` by the Contact create? I think it works for everything else.

I think technically this doesn't stop you saving a tag that isn't "used_for" the entity you are saving to, which would be good to guard against. I think it could be done with `getTagList` but I can't quite parse it.
