### PR TITLE
BAO - Consistently call hook_civicrm_post with $params

### DIFF
--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -396,7 +396,7 @@ class CRM_Activity_Page_AJAX {
 
     $params['mainActivityId'] = $mainActivityId;
     CRM_Activity_BAO_Activity::copyExtendedActivityData($params);
-    CRM_Utils_Hook::post('create', 'CaseActivity', $caseActivity->id, $caseActivity);
+    CRM_Utils_Hook::post('create', 'CaseActivity', $caseActivity->id, $caseActivity, $params);
 
     return (['error_msg' => $error_msg, 'newId' => $mainActivity->id]);
   }

--- a/CRM/Campaign/Form/Task/Interview.php
+++ b/CRM/Campaign/Form/Task/Interview.php
@@ -536,7 +536,7 @@ WHERE {$clause}
     $activity->save();
     //really this should use Activity BAO& not be here but refactoring will have to be later
     //actually the whole ajax call could be done as an api ajax call & post hook would be sorted
-    CRM_Utils_Hook::post('edit', 'Activity', $activity->id, $activity);
+    CRM_Utils_Hook::post('edit', 'Activity', $activity->id, $activity, $params);
 
     return $activityId;
   }

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -142,10 +142,10 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
     }
 
     if (!empty($params['id'])) {
-      CRM_Utils_Hook::post('edit', 'Case', $case->id, $case);
+      CRM_Utils_Hook::post('edit', 'Case', $case->id, $case, $params);
     }
     else {
-      CRM_Utils_Hook::post('create', 'Case', $case->id, $case);
+      CRM_Utils_Hook::post('create', 'Case', $case->id, $case, $params);
     }
     $transaction->commit();
 

--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -419,7 +419,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
 
     $transaction->commit();
 
-    CRM_Utils_Hook::post($action, 'CaseType', $caseType->id, $case);
+    CRM_Utils_Hook::post($action, 'CaseType', $caseType->id, $case, $params);
 
     return $caseType;
   }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -402,12 +402,7 @@ class CRM_Contact_BAO_Contact extends CRM_Contact_DAO_Contact implements Civi\Co
     CRM_Contact_BAO_Contact_Utils::clearContactCaches();
 
     if ($invokeHooks) {
-      if ($isEdit) {
-        CRM_Utils_Hook::post('edit', $params['contact_type'], $contact->id, $contact);
-      }
-      else {
-        CRM_Utils_Hook::post('create', $params['contact_type'], $contact->id, $contact);
-      }
+      CRM_Utils_Hook::post($isEdit ? 'edit' : 'create', $params['contact_type'], $contact->id, $contact, $params);
     }
 
     // In order to prevent a series of expensive queries in intensive batch processing
@@ -771,7 +766,7 @@ WHERE     civicrm_contact.id = " . CRM_Utils_Type::escape($id, 'Integer');
     }
     CRM_Core_BAO_Log::register($contact->id, 'civicrm_contact', $contact->id);
 
-    CRM_Utils_Hook::post('edit', $contact->contact_type, $contact->id, $contact);
+    CRM_Utils_Hook::post('edit', $contact->contact_type, $contact->id, $contact, $updateParams);
 
     return TRUE;
   }

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -99,7 +99,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
 
     $transaction->commit();
 
-    CRM_Utils_Hook::post('delete', 'Group', $id, $group);
+    CRM_Utils_Hook::post('delete', 'Group', $id, $group, $params);
   }
 
   /**

--- a/CRM/Contact/BAO/GroupNesting.php
+++ b/CRM/Contact/BAO/GroupNesting.php
@@ -34,7 +34,7 @@ class CRM_Contact_BAO_GroupNesting extends CRM_Contact_DAO_GroupNesting {
       $dao->find(TRUE);
     }
     $dao->save();
-    CRM_Utils_Hook::post($hook, 'GroupNesting', $dao->id, $dao);
+    CRM_Utils_Hook::post($hook, 'GroupNesting', $dao->id, $dao, $params);
     return $dao;
   }
 

--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -254,7 +254,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship implemen
       CRM_Core_BAO_CustomValueTable::store($params['custom'], 'civicrm_relationship', $relationship->id);
     }
 
-    CRM_Utils_Hook::post($hook, 'Relationship', $relationship->id, $relationship);
+    CRM_Utils_Hook::post($hook, 'Relationship', $relationship->id, $relationship, $params);
 
     return $relationship;
   }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -253,7 +253,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
 
-    CRM_Utils_Hook::post($action, 'Contribution', $contribution->id, $contribution);
+    CRM_Utils_Hook::post($action, 'Contribution', $contribution->id, $contribution, $params);
     return $result;
   }
 
@@ -1221,7 +1221,7 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
     $dao->id = $id;
     $results = $dao->delete();
     $transaction->commit();
-    CRM_Utils_Hook::post('delete', 'Contribution', $dao->id, $dao);
+    CRM_Utils_Hook::post('delete', 'Contribution', $dao->id, $dao, $params);
 
     return $results;
   }

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -41,7 +41,7 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
       $contributionSoft->currency = $config->defaultCurrency;
     }
     $result = $contributionSoft->save();
-    CRM_Utils_Hook::post($hook, 'ContributionSoft', $contributionSoft->id, $contributionSoft);
+    CRM_Utils_Hook::post($hook, 'ContributionSoft', $contributionSoft->id, $contributionSoft, $params);
     return $result;
   }
 

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -169,7 +169,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       CRM_Core_DAO::singleValueQuery(self::getAlterSerializeSQL($customField));
     }
 
-    CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField);
+    CRM_Utils_Hook::post(($op === 'add' ? 'create' : 'edit'), 'CustomField', $customField->id, $customField, $params);
 
     Civi::rebuild(['system' => TRUE])->execute();
 
@@ -260,7 +260,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       if (!empty($records[$index]['custom']) && is_array($records[$index]['custom'])) {
         CRM_Core_BAO_CustomValueTable::store($records[$index]['custom'], static::getTableName(), $customField->id, $op);
       }
-      CRM_Utils_Hook::post($op, 'CustomField', $customField->id, $customField);
+      CRM_Utils_Hook::post($op, 'CustomField', $customField->id, $customField, $records[$index]);
     }
     return $customFields;
   }

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -33,7 +33,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $hook = empty($params['id']) ? 'create' : 'edit';
     CRM_Utils_Hook::pre($hook, 'Dashboard', $params['id'] ?? NULL, $params);
     $dao = self::addDashlet($params);
-    CRM_Utils_Hook::post($hook, 'Dashboard', $dao->id, $dao);
+    CRM_Utils_Hook::post($hook, 'Dashboard', $dao->id, $dao, $params);
     return $dao;
   }
 

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -173,7 +173,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File implements \Civi\Core\HookInte
     }
 
     // lets call the post hook here so attachments code can do the right stuff
-    CRM_Utils_Hook::post($op, 'File', $fileDAO->id, $fileDAO);
+    CRM_Utils_Hook::post($op, 'File', $fileDAO->id, $fileDAO, $params);
   }
 
   /**

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -143,7 +143,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
       );
     }
 
-    CRM_Utils_Hook::post($hook, 'MessageTemplate', $messageTemplates->id, $messageTemplates);
+    CRM_Utils_Hook::post($hook, 'MessageTemplate', $messageTemplates->id, $messageTemplates, $params);
     return $messageTemplates;
   }
 

--- a/CRM/Core/BAO/OptionValue.php
+++ b/CRM/Core/BAO/OptionValue.php
@@ -179,7 +179,7 @@ class CRM_Core_BAO_OptionValue extends CRM_Core_DAO_OptionValue implements \Civi
     Civi::cache('metadata')->clear();
     CRM_Core_PseudoConstant::flush();
 
-    CRM_Utils_Hook::post($op, 'OptionValue', $id, $optionValue);
+    CRM_Utils_Hook::post($op, 'OptionValue', $id, $optionValue, $params);
 
     // Create relationship for payment instrument options
     if (!empty($params['financial_account_id'])) {

--- a/CRM/Core/BAO/StatusPreference.php
+++ b/CRM/Core/BAO/StatusPreference.php
@@ -64,7 +64,7 @@ class CRM_Core_BAO_StatusPreference extends CRM_Core_DAO_StatusPreference {
     $statusPreference->copyValues($params);
     $statusPreference->save();
 
-    CRM_Utils_Hook::post($op, 'StatusPreference', $statusPreference->id, $statusPreference);
+    CRM_Utils_Hook::post($op, 'StatusPreference', $statusPreference->id, $statusPreference, $params);
 
     // Clear the static cache of the CRM_Utils_Check so that the newly created message is available.
     unset(\Civi::$statics['CRM_Utils_Check']);

--- a/CRM/Core/BAO/UFField.php
+++ b/CRM/Core/BAO/UFField.php
@@ -101,7 +101,7 @@ class CRM_Core_BAO_UFField extends CRM_Core_DAO_UFField implements \Civi\Core\Ho
     $fieldsType = CRM_Core_BAO_UFGroup::calculateGroupType($ufField->uf_group_id, TRUE);
     CRM_Core_BAO_UFGroup::updateGroupTypes($ufField->uf_group_id, $fieldsType);
 
-    CRM_Utils_Hook::post($op, 'UFField', $ufField->id, $ufField);
+    CRM_Utils_Hook::post($op, 'UFField', $ufField->id, $ufField, $params);
 
     civicrm_api3('profile', 'getfields', ['cache_clear' => TRUE]);
     return $ufField;

--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -39,7 +39,7 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
     if (!$dao->find(TRUE)) {
       $dao->save();
       Civi::$statics[__CLASS__][$params['domain_id']][(int) $dao->contact_id] = (int) $dao->uf_id;
-      CRM_Utils_Hook::post($hook, 'UFMatch', $dao->id, $dao);
+      CRM_Utils_Hook::post($hook, 'UFMatch', $dao->id, $dao, $params);
     }
     return $dao;
   }

--- a/CRM/Dedupe/BAO/DedupeException.php
+++ b/CRM/Dedupe/BAO/DedupeException.php
@@ -50,9 +50,9 @@ class CRM_Dedupe_BAO_DedupeException extends CRM_Dedupe_DAO_DedupeException {
       }
     }
     $dao->save();
-    CRM_Utils_Hook::post($hook, 'DedupeException', $dao->id, $dao);
+    CRM_Utils_Hook::post($hook, 'DedupeException', $dao->id, $dao, $params);
     // Also call hook with deprecated entity name
-    CRM_Utils_Hook::post($hook, 'Exception', $dao->id, $dao);
+    CRM_Utils_Hook::post($hook, 'Exception', $dao->id, $dao, $params);
     return $dao;
   }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -66,10 +66,10 @@ class CRM_Event_BAO_Event extends CRM_Event_DAO_Event implements \Civi\Core\Hook
     $result = $event->save();
 
     if (!empty($params['id'])) {
-      CRM_Utils_Hook::post('edit', 'Event', $event->id, $event);
+      CRM_Utils_Hook::post('edit', 'Event', $event->id, $event, $params);
     }
     else {
-      CRM_Utils_Hook::post('create', 'Event', $event->id, $event);
+      CRM_Utils_Hook::post('create', 'Event', $event->id, $event, $params);
     }
     if ($financialTypeId && !empty($params['financial_type_id']) && $financialTypeId != $params['financial_type_id']) {
       CRM_Price_BAO_PriceFieldValue::updateFinancialType($params['id'], 'civicrm_event', $params['financial_type_id']);

--- a/CRM/Event/BAO/ParticipantPayment.php
+++ b/CRM/Event/BAO/ParticipantPayment.php
@@ -53,10 +53,10 @@ class CRM_Event_BAO_ParticipantPayment extends CRM_Event_DAO_ParticipantPayment 
       $participantPayment->find(TRUE);
     }
     if ($id) {
-      CRM_Utils_Hook::post('edit', 'ParticipantPayment', $participantPayment->id, $participantPayment);
+      CRM_Utils_Hook::post('edit', 'ParticipantPayment', $participantPayment->id, $participantPayment, $params);
     }
     else {
-      CRM_Utils_Hook::post('create', 'ParticipantPayment', $participantPayment->id, $participantPayment);
+      CRM_Utils_Hook::post('create', 'ParticipantPayment', $participantPayment->id, $participantPayment, $params);
     }
 
     //generally if people are creating participant_payments via the api they won't be setting the line item correctly - we can't help them if they are doing complex transactions

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -142,10 +142,10 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
       }
     }
     if (!empty($ids['id'])) {
-      CRM_Utils_Hook::post('edit', 'FinancialItem', $financialItem->id, $financialItem);
+      CRM_Utils_Hook::post('edit', 'FinancialItem', $financialItem->id, $financialItem, $params);
     }
     else {
-      CRM_Utils_Hook::post('create', 'FinancialItem', $financialItem->id, $financialItem);
+      CRM_Utils_Hook::post('create', 'FinancialItem', $financialItem->id, $financialItem, $params);
     }
     return $financialItem;
   }

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -148,11 +148,11 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
         }
       }
 
-      CRM_Utils_Hook::post('edit', 'Membership', $membership->id, $membership);
+      CRM_Utils_Hook::post('edit', 'Membership', $membership->id, $membership, $params);
     }
     else {
       CRM_Activity_BAO_Activity::addActivity($membership, 'Membership Signup', $targetContactID, $activityParams);
-      CRM_Utils_Hook::post('create', 'Membership', $membership->id, $membership);
+      CRM_Utils_Hook::post('create', 'Membership', $membership->id, $membership, $params);
     }
 
     return $membership;

--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -44,7 +44,7 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
     if (!$dao->find(TRUE)) {
       $dao->save();
     }
-    CRM_Utils_Hook::post($hook, 'MembershipPayment', $dao->id, $dao);
+    CRM_Utils_Hook::post($hook, 'MembershipPayment', $dao->id, $dao, $params);
     // CRM-14197 we are in the process on phasing out membershipPayment in favour of storing both contribution_id & entity_id (membership_id) on the line items
     // table. However, at this stage we have both - there is still quite a bit of refactoring to do to set the line_iten entity_id right the first time
     // however, we can assume at this stage that any contribution id will have only one line item with that membership type in the line item table

--- a/CRM/Pledge/BAO/Pledge.php
+++ b/CRM/Pledge/BAO/Pledge.php
@@ -63,7 +63,7 @@ class CRM_Pledge_BAO_Pledge extends CRM_Pledge_DAO_Pledge {
 
     $result = $pledge->save();
 
-    CRM_Utils_Hook::post($hook, 'Pledge', $pledge->id, $pledge);
+    CRM_Utils_Hook::post($hook, 'Pledge', $pledge->id, $pledge, $params);
 
     return $result;
   }

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -78,10 +78,10 @@ class CRM_Price_BAO_LineItem extends CRM_Price_DAO_LineItem {
       // CRM-21281: Restore entity reference in case the post hook needs it
       $lineItemBAO->entity_id = $entity_id;
       $lineItemBAO->entity_table = $entity_table;
-      CRM_Utils_Hook::post('edit', 'LineItem', $id, $lineItemBAO);
+      CRM_Utils_Hook::post('edit', 'LineItem', $id, $lineItemBAO, $params);
     }
     else {
-      CRM_Utils_Hook::post('create', 'LineItem', $lineItemBAO->id, $lineItemBAO);
+      CRM_Utils_Hook::post('create', 'LineItem', $lineItemBAO->id, $lineItemBAO, $params);
     }
 
     return $return;

--- a/CRM/SMS/BAO/SmsProvider.php
+++ b/CRM/SMS/BAO/SmsProvider.php
@@ -93,10 +93,10 @@ class CRM_SMS_BAO_SmsProvider extends CRM_SMS_DAO_SmsProvider {
     $provider->copyValues($params);
     $result = $provider->save();
     if ($id) {
-      CRM_Utils_Hook::post('edit', 'SmsProvider', $provider->id, $provider);
+      CRM_Utils_Hook::post('edit', 'SmsProvider', $provider->id, $provider, $params);
     }
     else {
-      CRM_Utils_Hook::post('create', 'SmsProvider', NULL, $provider);
+      CRM_Utils_Hook::post('create', 'SmsProvider', NULL, $provider, $params);
     }
     return $result;
   }

--- a/api/v3/Generic/Setvalue.php
+++ b/api/v3/Generic/Setvalue.php
@@ -129,7 +129,7 @@ function civicrm_api3_generic_setValue($apiRequest) {
   elseif (CRM_Core_DAO::setFieldValue($dao_name, $id, $field, $params[$field])) {
     $entityDAO = new $dao_name();
     $entityDAO->copyValues($params);
-    CRM_Utils_Hook::post('edit', $entity, $entityDAO->id, $entityDAO);
+    CRM_Utils_Hook::post('edit', $entity, $entityDAO->id, $entityDAO, $params);
   }
   else {
     return civicrm_api3_create_error("error assigning $field=$value for $entity (id=$id)");

--- a/ext/civiimport/Civi/BAO/Import.php
+++ b/ext/civiimport/Civi/BAO/Import.php
@@ -135,7 +135,7 @@ class Import extends CRM_Core_DAO {
       CRM_Core_BAO_CustomValueTable::store($record['custom'], $tableName, $instance->_id, $op);
     }
 
-    CRM_Utils_Hook::post($op, $entityName, $instance->_id, $instance);
+    CRM_Utils_Hook::post($op, $entityName, $instance->_id, $instance, $record);
 
     return $instance;
   }


### PR DESCRIPTION
Overview
----------------------------------------
More consistent hook params.

Technical Details
----------------------------------------
In df3b37993 $params was added to hook_civicrm_post but it wasn't consistently passed in by all BAOs. This fixes the majority of them.

Note: these BAO create functions are all being phased out in favor of the generic writeRecords function, which already does pass $params