### PR TITLE
dev/core#6181 Participant Import: avoid JS error if Households are disabled

### DIFF
--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -275,6 +275,10 @@
               let optGroup = dedupeRules.find(group => group.contact_type === rule.contact_type);
               if (!optGroup) {
                 const contactType = $scope.data.contactTypes.find(type => type.id === rule.contact_type);
+                // The contactType might be disabled, ex: Households
+                if (!contactType) {
+                  return;
+                }
                 optGroup = {contact_type: rule.contact_type, text: contactType.text, icon: contactType.icon, children: []};
                 dedupeRules.push(optGroup);
               }


### PR DESCRIPTION
Overview
----------------------------------------

Copied from: https://lab.civicrm.org/dev/core/-/issues/6181

Steps to reproduce:

- Under Administer > Customize > Contact Types, disable Households
- Go to Event > Import Participants
- Upload a CSV file, go to mapping.

Result:

<img width="3218" height="1464" alt="image" src="https://github.com/user-attachments/assets/334bde54-2924-4eea-b4f0-9a9bf1636e74" />


While digging in the AngularJS code, I see it get stuck in 

```
$scope.getDedupeRules = function (selectedEntity) {
  const dedupeRules = [
    {contact_type: null, text: ts('Universal'), icon: 'fa-star', children: []},
  ];
  _.each($scope.data.dedupeRules, function (rule) {
    if (!selectedEntity || !rule.contact_type || rule.contact_type === selectedEntity) {
      let optGroup = dedupeRules.find(group => group.contact_type === rule.contact_type);
        if (!optGroup) {
          const contactType = $scope.data.contactTypes.find(type => type.id === rule.contact_type);
          // HERE because contactType.text is undefined
          optGroup = {contact_type: rule.contact_type, text: contactType.text, icon: contactType.icon, children: []};
        dedupeRules.push(optGroup);
      }
      optGroup.children.push({id: rule.name, text: rule.title, is_default: rule.used === 'Unsupervised'});
    }
  });
```

Before
----------------------------------------

JS bug

After
----------------------------------------

Fixed

Comments
------------------

Bug found by a CiviCRM user, reported by lcarter of BackOffice Thinking.


cc @eileenmcnaughton 