### PR TITLE
Refactor: tokens for contact + case with createToken event

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -5,6 +5,7 @@ use Civi\Afform\AbstractBehavior;
 use Civi\Afform\Event\AfformEntitySortEvent;
 use Civi\Afform\Event\AfformPrefillEvent;
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Token\TokenRow;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use CRM_Afform_ExtensionUtil as E;
 
@@ -21,6 +22,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
     return [
       'civi.afform.sort.prefill' => 'onAfformSortPrefill',
       'civi.afform.prefill' => ['onAfformPrefill', 99],
+      '&civi.afform.createToken' => ['onCreateToken', 99],
     ];
   }
 
@@ -146,6 +148,12 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
           $apiRequest->loadEntity($entity, $relatedIds);
         }
       }
+    }
+  }
+
+  public function onCreateToken(TokenRow $row, array &$afformArgs) {
+    if (!empty($row->context['contactId'])) {
+      $afformArgs['contact_id'] = $row->context['contactId'];
     }
   }
 

--- a/ext/afform/core/Civi/Afform/Tokens.php
+++ b/ext/afform/core/Civi/Afform/Tokens.php
@@ -225,21 +225,14 @@ class Tokens extends AutoService implements EventSubscriberInterface {
   /**
    * Get Additional args from the row context.
    *
-   * This supports args for the contact being viewed and for the case being viewed.
-   * It also dispatches event 'civi.afform.createToken' so other entity types can
-   * fill in their tokens.
+   * Dispatches event 'civi.afform.createToken' so entity types can
+   * fill in their tokens (usually in Civi/Afform/Behavior/).
    *
    * @param \Civi\Token\TokenRow $row
    * @return array
    */
   private static function getAfformArgsFromTokenContext(TokenRow $row): array {
     $afformArgs = [];
-    if (!empty($row->context['contactId'])) {
-      $afformArgs['contact_id'] = $row->context['contactId'];
-    }
-    if (!empty($row->context['caseId'])) {
-      $afformArgs['case_id'] = $row->context['caseId'];
-    }
     $event = GenericHookEvent::create(['row' => $row, 'afformArgs' => &$afformArgs]);
     \Civi::dispatcher()->dispatch('civi.afform.createToken', $event);
     return $afformArgs;

--- a/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
+++ b/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
@@ -3,6 +3,7 @@ namespace Civi\Afform\Behavior;
 
 use Civi\Afform\AbstractBehavior;
 use Civi\Afform\Event\AfformPrefillEvent;
+use Civi\Token\TokenRow;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use CRM_Case_ExtensionUtil as E;
 
@@ -18,6 +19,7 @@ class CaseAutofill extends AbstractBehavior implements EventSubscriberInterface 
   public static function getSubscribedEvents() {
     return [
       'civi.afform.prefill' => ['onAfformPrefill', 99],
+      '&civi.afform.createToken' => ['onCreateToken', 99],
     ];
   }
 
@@ -60,6 +62,12 @@ class CaseAutofill extends AbstractBehavior implements EventSubscriberInterface 
           $apiRequest->loadEntity($entity, [['id' => $id]]);
         }
       }
+    }
+  }
+
+  public function onCreateToken(TokenRow $row, array &$afformArgs) {
+    if (!empty($row->context['caseId'])) {
+      $afformArgs['case_id'] = $row->context['caseId'];
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
#33764 introduced a new event 'civi.afform.createToken' to fill tokens.
It implemented this event only for activity.
This change drops the extra handling of contact and case and moves the token fill to the according Behavior classes.

Before
----------------------------------------
Hard coded handling of contact_id and case_id in Civi\Afform\Token (old code).

After
----------------------------------------
Better code: unified handling via event.

Comments
----------------------------------------
No change in behavior.