### PR TITLE
FormBuilder - Ensure input type name is translated

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -242,7 +242,7 @@ class AfformAdminMeta {
         $name = basename($file, '.html');
         $inputTypes[] = [
           'name' => $name,
-          'label' => $inputTypeLabels[$name] ?? $name,
+          'label' => $inputTypeLabels[$name] ?? _ts($name),
           'template' => '~/af/fields/' . $name . '.html',
           'admin_template' => '~/afGuiEditor/inputType/' . $name . '.html',
         ];


### PR DESCRIPTION
Overview
----------------------------------------
If an input type isn't one of the standard ones recognized by Api4, the string should still be translated.