### PR TITLE
dev/core#6182 RecurringEntity: clarify the error message when the repeat does not align with the start date

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -301,6 +301,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity implemen
       }
 
       if (CRM_Core_Config::singleton()->userFramework == 'UnitTests') {
+        // dev/core#6182 The Start Date will probably not align with a weekly repetition
         $this->recursion->RFC5545_COMPLIANT = When::IGNORE;
       }
       $count = 1;
@@ -1207,8 +1208,12 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity implemen
     try {
       return $this->recursion->getNextOccurrence($occurDate, $strictly_after);
     }
+    catch (\When\InvalidStartDate $exception) {
+      // dev/core#6182 Provide a more clear and translatable error
+      CRM_Core_Session::setStatus(ts('The repetition schedule does not match with the start date.') . ' ' . ts('For example, if the first occurrence is on a Monday, a weekly repetition should repeat on Monday.'), ts('Error'), 'error');
+    }
     catch (Exception $exception) {
-      CRM_Core_Session::setStatus(_ts($exception->getMessage()));
+      CRM_Core_Session::setStatus(_ts($exception->getMessage()), ts('Error'), 'error');
     }
     return FALSE;
   }


### PR DESCRIPTION
Overview
----------------------------------------

https://lab.civicrm.org/dev/core/-/issues/6182

To reproduce on smaster:

- Go to en Event > Settings > Repeat
- Select to repeat weekly, for 5 times, on Tuesday. The Tuesday should not match the same Day of Week as the first occurrence.
- Click preview.

Before
----------------------------------------

<img width="3184" height="1506" alt="image" src="https://github.com/user-attachments/assets/ebab4e8d-4855-425d-8627-997ab75e3551" />


Preview:

<img width="3316" height="1462" alt="image" src="https://github.com/user-attachments/assets/59f3b3f1-4c21-4109-9ae4-8c1c88c782aa" />

If we save, there are no recurrences.

After
----------------------------------------

- A bit more clear error message
- Displayed as an error, not a warning

<img width="3346" height="1550" alt="2025-10-31_07-39" src="https://github.com/user-attachments/assets/e788e75d-52da-468c-b3b3-c4feb1cc08e5" />

Comments
----------------------------------------

It would have been better to display the error in the popup itself, or not show the preview popup, but this would be more work, and the error is mostly seen by testers like me who do not pay attention to the dates/days, just clicking around the interface.

h/t @demeritcowboy @Edzelopez for the responses.