### PR TITLE
AJAX error, API Request Authorization failed - simpler, clearer log messages

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -149,7 +149,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       $status = $statusMap[get_class($e)] ?? 500;
 
       $errorId = rtrim(chunk_split(CRM_Utils_String::createRandom(12, CRM_Utils_String::ALPHANUMERIC), 4, '-'), '-');
-      $logMessage = 'AJAX Error ({error_id}): failed with exception';
+      $logMessage = "AJAX Error ({$errorId}): {$e->getMessage()}";
       $logContext = ['error_id' => $errorId, 'exception' => $e];
       if ($status === 500) {
         \Civi::log()->error($logMessage, $logContext);

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -145,7 +145,13 @@ class Kernel {
       }
       catch (\Civi\API\Exception\UnauthorizedException $e) {
         // We catch and re-throw to log for visibility
-        \CRM_Core_Error::backtrace('API Request Authorization failed', TRUE);
+        if ($apiRequest instanceof \Civi\Api4\Generic\AbstractAction) {
+          $context = (method_exists($apiRequest, 'getWhere') ? ['apiRequest[where]' => $apiRequest->getWhere()] : []);
+          \Civi::log()->error('API4 Request Authorization failed: ' . $apiRequest->getEntityName() . '::' . $apiRequest->getActionName(), $context);
+        }
+        else {
+          \CRM_Core_Error::backtrace('API3 Request Authorization failed', TRUE);
+        }
         throw $e;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
When using SearchKit/FormBuilder as a non-admin user there are two log messages that get recorded a lot:

#### AJAX Error ({error_id}): failed with exception
This adds detail of the error via context.

But the initial error message is too generic and not helpful. So we change this to add the actual error into the initial message.

#### API Request Authorization failed
This triggers a backtrace which generates a lot of log data.

The backtrace is usually not very helpful, generates a large amount of data and does not usually give any useful information except for the name of the API call that failed.

So we change this to just extract the name of the API call and the "where clause" from the API request (which might help with identifying where it was called from).

Before
----------------------------------------
"AJAX Error ({error_id}): failed with exception" adds more information via context.
"API Request Authorization failed" generates backtrace.

After
----------------------------------------
"AJAX Error ({$errorId}): {$e->getMessage()}" - shows clearly the error ID (though not necessarily that useful unless you have a screenshot from the user when it happened) and the actual error message. 

Eg. "AJAX Error (qaYN-C0ei-f03f): Authorization failed: CiviCRM APIv4 (Contact::getFields)"

"API Request Authorization failed: Email::getActions" shows clearly the API that was not authorised and context provides info about the where clause that was passed in.

Technical Details
----------------------------------------

Comments
----------------------------------------
Helps with debugging, keeps log files a bit smaller..