### PR TITLE
Piping option ids to numeric to prevent weird !! issues

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -53,7 +53,7 @@
         // Ensure boolean options are truly boolean
         if (this.defn.data_type === 'Boolean') {
           if (fieldOptions) {
-            fieldOptions.forEach((option) => option.id = !!option.id);
+            fieldOptions.forEach((option) => option.id = !!Numeric(option.id));
           } else {
             fieldOptions = [{id: true, label: ts('Yes')}, {id: false, label: ts('No')}];
           }


### PR DESCRIPTION
Overview
----------------------------------------
While testing out the new `Toggle` and changing the values I noticed that the labels were not appearing. The reason being is that the Angular was complaining about duplicate id entries. I narrowed this down to the `fieldOptions` calculation.

Technical Details
----------------------------------------
Essentially, what is happening is that we could have something like this:

```html
<af-field name="do_not_email" defn="{help_pre: 'I do not wish to receive e-bulletins or bulk emails', input_type: 'Toggle', options: [{id: '1', label: 'Enabled'}, {id: '0', label: 'Disabled'}], required: false, name: 'do_not_email', data_type: 'Boolean', fk_entity: null, label: 'Do Not Email', input_attrs: {label: 'Do Not Email'}, help_post: null, search_range: false}" class="ng-isolate-scope af-field-type-toggle"><!-- ngIf: :: $ctrl.defn.label && !($ctrl.defn.input_type == 'CheckBox' && $ctrl.defn.data_type == 'Boolean') --><label class="crm-af-field-label ng-binding ng-scope" ng-if=":: $ctrl.defn.label &amp;&amp; !($ctrl.defn.input_type == 'CheckBox' &amp;&amp; $ctrl.defn.data_type == 'Boolean')" for="do-not-email-0">.
..
</af-field>
```

The field options are ```options: [{id: '1', label: 'Enabled'}, {id: '0', label: 'Disabled'}],```

When run through JS with the old code

```!!"1"``` => true and ```!!"0"``` => true probably because of some weird casting of the string. So I convert and all is well.

Comments
----------------------------------------
I don't think this would have affects in other areas, but I never tested all scenarios