### PR TITLE
AJAX - Standardize json response

### DIFF
--- a/CRM/Core/Page/AJAX/Attachment.php
+++ b/CRM/Core/Page/AJAX/Attachment.php
@@ -118,17 +118,8 @@ class CRM_Core_Page_AJAX_Attachment {
       $isError = $isError || $item['is_error'];
     }
 
-    if ($isError) {
-      $sapi_type = php_sapi_name();
-      if (substr($sapi_type, 0, 3) == 'cgi') {
-        CRM_Utils_System::setHttpHeader("Status", "500 Internal Server Error");
-      }
-      else {
-        header("HTTP/1.1 500 Internal Server Error");
-      }
-    }
-
-    CRM_Utils_JSON::output(array_merge($result));
+    $responseCode = $isError ? 500 : 200;
+    CRM_Utils_System::sendJSONResponse(array_merge($result), $responseCode);
   }
 
   /**

--- a/CRM/Utils/JSON.php
+++ b/CRM/Utils/JSON.php
@@ -35,6 +35,7 @@ class CRM_Utils_JSON {
   /**
    * Output json to the client.
    * @param mixed $input
+   * @deprecated - use CRM_Utils_System::sendJSONResponse
    */
   public static function output($input) {
     if (CIVICRM_UF === 'UnitTests') {

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1952,7 +1952,7 @@ class CRM_Utils_System {
    *
    * @return void
    */
-  public static function sendJSONResponse(array $response, int $httpResponseCode): void {
+  public static function sendJSONResponse(array $response, int $httpResponseCode = 200): void {
     CRM_Core_Config::singleton()->userSystem->sendJSONResponse($response, $httpResponseCode);
   }
 

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -218,4 +218,11 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
     return '127.0.0.1';
   }
 
+  /**
+   * Simulate JSON response to the client
+   */
+  public static function sendJSONResponse(array $response, int $httpResponseCode): void {
+    throw new CRM_Core_Exception_PrematureExitException('sendJSONResponse', $response, $httpResponseCode);
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1323,7 +1323,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
    * @return void
    */
   public static function sendJSONResponse(array $response, int $httpResponseCode): void {
-    wp_send_json($response, $httpResponseCode);
+    wp_send_json($response, $httpResponseCode, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
   }
 
   /**

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -98,12 +98,6 @@
           }
           return crmApi4('Afform', 'prefill', params)
             .then((result) => {
-              // In some cases (noticed on Wordpress) the response header incorrectly outputs success when there's an error.
-              if (result.error_message) {
-                disableForm(result.error_message);
-                $element.unblock();
-                return;
-              }
               result.forEach((item) => {
                 // Use _.each() because item.values could be cast as an object if array keys are not sequential
                 _.each(item.values, (values, index) => {


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #33792 with additional cleanup.


Technical Details
----------------------------------------
- Removes workaround from Afform.
- Uses our currently-agreed-upon settings for `json_encode` in wordpress.
- Adds an ajax endpoint for unit tests.
- As there are now two competing functions, this deprecates the old one as the new one correctly sets response codes.