### PR TITLE
add index to civicrm_translation_source on upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixEight.php
+++ b/CRM/Upgrade/Incremental/php/SixEight.php
@@ -37,4 +37,14 @@ class CRM_Upgrade_Incremental_php_SixEight extends CRM_Upgrade_Incremental_Base 
     ], 'name');
   }
 
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_6_8_beta1($rev): void {
+    $this->addTask('Add index to civicrm_translation_source', 'addIndex', 'civicrm_translation_source', 'source_key');
+  }
+
 }

--- a/CRM/Upgrade/Incremental/schema/6.7.alpha1.TranslationSource.entityType.php
+++ b/CRM/Upgrade/Incremental/schema/6.7.alpha1.TranslationSource.entityType.php
@@ -11,6 +11,14 @@ return [
     'log' => TRUE,
     'add' => '6.7.alpha1',
   ],
+  'getIndices' => fn() => [
+    'index_source_key' => [
+      'fields' => [
+        'source_key' => TRUE,
+      ],
+      'add' => '6.7.alpha1',
+    ],
+  ],
   'getFields' => fn() => [
     'id' => [
       'title' => ts('Source ID'),


### PR DESCRIPTION
Overview
----------------------------------------
If you upgrade to Civi 6.7, you don't get the civicrm_translation_source index on `source_key`.  This adds it.

Before
----------------------------------------
Missing index.

After
----------------------------------------
Index.

Comments
----------------------------------------
I know the "check for missing indexes" check was removed from core Civi a while back, but I still run it, because bugs like these are still relatively common.
