### PR TITLE
Update database defaults when custom field option values are saved.

### DIFF
--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -439,7 +439,7 @@ SELECT count(*)
             = CRM_Core_DAO::VALUE_SEPARATOR .
             implode(CRM_Core_DAO::VALUE_SEPARATOR, $defVal) .
             CRM_Core_DAO::VALUE_SEPARATOR;
-          $customField->save();
+          CRM_Core_BAO_CustomField::createField($customField, 'modify');
         }
       }
       elseif (in_array($customOption->value, $defVal)) {
@@ -454,7 +454,7 @@ SELECT count(*)
           = CRM_Core_DAO::VALUE_SEPARATOR .
           implode(CRM_Core_DAO::VALUE_SEPARATOR, $tempVal) .
           CRM_Core_DAO::VALUE_SEPARATOR;
-        $customField->save();
+        CRM_Core_BAO_CustomField::createField($customField, 'modify');
       }
     }
     else {
@@ -474,12 +474,12 @@ SELECT count(*)
 
       if (!empty($params['default_value'])) {
         $customField->default_value = $customOption->value;
-        $customField->save();
+        CRM_Core_BAO_CustomField::createField($customField, 'modify');
       }
       elseif ($customField->find(TRUE) && $customField->default_value == $customOption->value) {
         // this is the case where this option is the current default value and we have been reset
         $customField->default_value = 'null';
-        $customField->save();
+        CRM_Core_BAO_CustomField::createField($customField, 'modify');
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Since #33377 made sure we are adding custom field default values when creating via APIv4, we found that some defaults on fields in the database did not match the option value set to the default in the UI. It turns out the default value for custom fields with option values wasn't being set in the database.

Before
----------------------------------------
To reproduce:
1. Edit an option value for a custom field, checking default and saving.
2. Check your database and note that the default for the field has not been updated.

After
----------------------------------------
Saving the custom field when updating the option value now follows the same code path as updating the custom field directly, so the database field default is updated.