### PR TITLE
Fix edit link in Administer Custom Field Options SK

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Field_Options.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Custom_Field_Options.mgd.php
@@ -19,12 +19,33 @@ return [
             'label',
             'value',
             'description',
-            'option_group_id:label',
+            'id',
+            'OptionValue_OptionGroup_option_group_id_01_OptionGroup_CustomField_option_group_id_01.id',
+            'OptionValue_OptionGroup_option_group_id_01.id',
           ],
           'orderBy' => [],
           'where' => [],
           'groupBy' => [],
-          'join' => [],
+          'join' => [
+            [
+              'OptionGroup AS OptionValue_OptionGroup_option_group_id_01',
+              'INNER',
+              [
+                'option_group_id',
+                '=',
+                'OptionValue_OptionGroup_option_group_id_01.id',
+              ],
+            ],
+            [
+              'CustomField AS OptionValue_OptionGroup_option_group_id_01_OptionGroup_CustomField_option_group_id_01',
+              'INNER',
+              [
+                'OptionValue_OptionGroup_option_group_id_01.id',
+                '=',
+                'OptionValue_OptionGroup_option_group_id_01_OptionGroup_CustomField_option_group_id_01.option_group_id',
+              ],
+            ],
+          ],
           'having' => [],
         ],
       ],
@@ -90,14 +111,14 @@ return [
               'icon' => 'fa-bars',
               'links' => [
                 [
-                  'entity' => 'OptionValue',
-                  'action' => 'update',
+                  'entity' => '',
+                  'action' => '',
                   'join' => '',
                   'target' => 'crm-popup',
                   'icon' => 'fa-pencil',
                   'text' => E::ts('Edit'),
                   'style' => 'default',
-                  'path' => '',
+                  'path' => 'civicrm/admin/custom/group/field/option?reset=1&action=update&id=[id]&fid=[OptionValue_OptionGroup_option_group_id_01_OptionGroup_CustomField_option_group_id_01.id]&gid=[OptionValue_OptionGroup_option_group_id_01.id]',
                   'condition' => [],
                 ],
                 [


### PR DESCRIPTION
Before
----------------------------------------
Link goes to update option value form, where you cannot change if this field is default.

After
----------------------------------------
Link goes to update custom field option value form, where you can change if the field is default.

Comments
----------------------------------------
Unfortunately, we can't add default as a column to this SK as the default available is the option group default, not the custom field default. Would be nice if this had parity to the old form.