### PR TITLE
Afform - Add range slider input element

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -18,14 +18,14 @@
     <input id="{{:: $ctrl.getFieldName() }}-maxlength" type="number" min="1" step="1" class="form-control" ng-model="getSet('input_attrs.maxlength')" ng-model-options="{getterSetter: true}">
   </form>
 </li>
-<li ng-if="$ctrl.fieldDefn.input_type === 'Number'">
+<li ng-if="($ctrl.fieldDefn.input_type === 'Number' || $ctrl.fieldDefn.input_type === 'Range') && !hasOptions()">
   <div ng-click="$event.stopPropagation()" class="form-inline">
-    <input type="number" class="form-control four" ng-model="getSet('input_attrs.min')" ng-model-options="{getterSetter: true}" title="{{:: ts('Minimum value') }}" placeholder="{{:: ts('Min') }}">
+    <input type="number" class="form-control four" ng-model="$ctrl.node.defn.input_attrs.min" ng-change="$ctrl.onChangeMin()" title="{{:: ts('Minimum value') }}" placeholder="{{:: ts('Min') }}">
     -
-    <input type="number" class="form-control four" ng-model="getSet('input_attrs.max')" ng-model-options="{getterSetter: true}" title="{{:: ts('Maximum value') }}" placeholder="{{:: ts('Max') }}">
+    <input type="number" class="form-control four" ng-model="$ctrl.node.defn.input_attrs.max" ng-change="$ctrl.onChangeMax()" title="{{:: ts('Maximum value') }}" placeholder="{{:: ts('Max') }}">
   </div>
 </li>
-<li ng-if="$ctrl.fieldDefn.input_type === 'Number' && $ctrl.fieldDefn.data_type === 'Float'">
+<li ng-if="($ctrl.fieldDefn.input_type === 'Number' || $ctrl.fieldDefn.input_type === 'Range') && $ctrl.fieldDefn.data_type === 'Float' && !hasOptions()">
   <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Decimal places:') }}</label>
     <select class="form-control" ng-model="getSet('input_attrs.step')" ng-model-options="{getterSetter: true}" title="{{:: ts('Decimal places') }}">

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Range.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Range.html
@@ -1,0 +1,11 @@
+<div class="crm-af-field">
+  <label>
+    <input id="{{:: fieldId }}" type="range" min="{{getRangeProp('min')}}" max="{{getRangeProp('max')}}" step="{{getRangeProp('step')}}" list="{{:: fieldId }}-list" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}">
+    <span ng-repeat="opt in $ctrl.getOptions()" ng-if="getSet('afform_default')() == opt.id">
+      {{:: opt.label }}
+    </span>
+  </label>
+  <datalist id="{{:: fieldId }}-list">
+    <option ng-repeat="opt in $ctrl.getOptions() track by opt.id" value="{{ opt.id }}">
+  </datalist>
+</div>

--- a/ext/afform/core/ang/af/fields/Range.html
+++ b/ext/afform/core/ang/af/fields/Range.html
@@ -1,0 +1,10 @@
+<label class="crm-af-field-label" >
+  <input type="range" id="{{:: fieldId }}" step="{{:: $ctrl.defn.input_attrs.step || 1 }}" min="{{:: $ctrl.defn.input_attrs.min || '' }}" max="{{:: $ctrl.defn.input_attrs.max || '' }}" list="{{:: fieldId }}-list" ng-model="getSetValue" ng-model-options="{getterSetter: true}" />
+  <span ng-repeat="opt in getOptions() track by opt.id" ng-if="opt.id == getSetValue()">
+    {{:: opt.label }}
+  </span>
+  <span ng-if="!getOptions()">{{ getSetValue() }}</span>
+</label>
+<datalist id="{{:: fieldId }}-list">
+  <option ng-repeat="opt in getOptions() track by opt.id" value="{{ opt.id }}">
+</datalist>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new form input widget.

The "range" slider is a standard html element, now available to Afform for all fields that have either numeric input, or numeric option values.

<img width="950" height="550" alt="image" src="https://github.com/user-attachments/assets/8b69edcb-c996-4b9f-878e-ba732f043c9d" />
