### PR TITLE
Afform - Keep resources loaded via popup

### DIFF
--- a/CRM/Core/Region.php
+++ b/CRM/Core/Region.php
@@ -30,6 +30,11 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
   public $_name;
 
   /**
+   * @var bool
+   */
+  private bool $rendered = FALSE;
+
+  /**
    * @param string $name
    */
   public function __construct($name) {
@@ -69,10 +74,6 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
       // https://lab.civicrm.org/dev/core/-/issues/5712
       $allowCmsOverride = FALSE;
     }
-
-    Civi::dispatcher()->dispatch('civi.region.render', \Civi\Core\Event\GenericHookEvent::create(['region' => $this]));
-
-    $this->sort();
 
     $cms = CRM_Core_Config::singleton()->userSystem;
     $smarty = CRM_Core_Smarty::singleton();
@@ -161,12 +162,24 @@ class CRM_Core_Region implements CRM_Core_Resources_CollectionInterface, CRM_Cor
       }
     };
 
-    foreach ($this->snippets as $snippet) {
+    foreach ($this->getFinalItems() as $snippet) {
       if (empty($snippet['disabled'])) {
         $renderSnippet($snippet);
       }
     }
     return $html;
+  }
+
+  /**
+   * Returns the final sorted content after dispatching `civi.region.render`
+   */
+  public function getFinalItems(): iterable {
+    // Dispatch `civi.region.render` event, but only once
+    if (!$this->rendered) {
+      $this->rendered = TRUE;
+      Civi::dispatcher()->dispatch('civi.region.render', \Civi\Core\Event\GenericHookEvent::create(['region' => $this]));
+    }
+    return $this->getAll();
   }
 
 }

--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -323,6 +323,23 @@
           that._onError(data);
           return;
         }
+        if (data.settings) {
+          $.extend(true, CRM, data.settings);
+        }
+        if (data.scriptUrls) {
+          data.scriptUrls.forEach(function(scriptUrl) {
+            if ($('script[src="' + scriptUrl + '"]').length === 0) {
+              $('<script type="text/javascript" src="' + scriptUrl + '"></script>').appendTo('head');
+            }
+          });
+        }
+        if (data.styleUrls) {
+          data.styleUrls.forEach(function(styleUrl) {
+            if ($('link[href="' + styleUrl + '"]').length === 0) {
+              $('<link rel="stylesheet" href="' + styleUrl + '">').appendTo('head');
+            }
+          });
+        }
         data.url = url;
         that.element.trigger('crmUnload').trigger('crmBeforeLoad', data);
         that._beforeRemovingContent();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6187](https://lab.civicrm.org/dev/core/-/issues/6187)

Before
----------------------------------------
Resources like js or css are loaded into a popup container, then destroyed when the popup is closed.

After
----------------------------------------
Header css/js/settings are loaded into the document `<head>`, so they persist after the popup is closed.

Resources added to other page regions (e.g. `page-footer`) are not affected by this PR.


Technical Details
----------------------------------------
Css/js/settings are now sent to client as structured data during ajax requests so they can be properly added to the header.

This is needed because we [track which ang modules are already loaded](https://github.com/civicrm/civicrm-core/commit/a45465497a5dc0d55495b0c616f4c53a882de0b5) and don't load them again. Angular js & css is added to the `html-header` and is expected to persist, so this PR gets popups to conform to that expectation.

Comments
------
The big functional change here is that any scripts or styles added to the `html-header` region are going to persist. Before, they were added to the markup of the popup. Now they're added to the document `<head>`.

I think this will have minimal unintended consequences because the default for `addStyleFile` and `addScriptFile` functions is the `page-footer` region, so it won't make any difference (that region doesn't change with this PR), so before&after, `page-footer` resources will stay in the markup of the popup.