### PR TITLE
RiverLea / FormBuilder UI - removes last of the wobbly mouseover…

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -286,9 +286,6 @@
   opacity: 1;
   transition: opacity .2s;
 }
-#afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover :is(.af-gui-container:not(.af-gui-container-type-fieldset),.af-gui-element,.af-gui-markup) {
-  border: 2px solid var(--crm-c-layout1-bg);
-}
 /* Dragging related */
 #afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar,
 #afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-container-title span:empty {
@@ -349,11 +346,7 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-element:hover,
 #afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-markup:hover,
 #afGuiEditor .crm-editable-enabled:hover:not(:focus) {
-  outline: 2px dashed var(--crm-c-gray-700);
-}
-#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container .af-gui-element:hover,
-#afGuiEditor-canvas:not(.af-gui-menu-open) .af-gui-container .af-gui-markup:hover {
-  border-width: 1px;
+  outline: 2px dashed var(--crm-c-inverse-bg);
 }
 #afGuiEditor-canvas .af-entity-selected {
   outline: 2px dashed var(--crm-c-blue-dark);


### PR DESCRIPTION
Overview
----------------------------------------
@artfulrobot removed most of the wobbly mouse in https://github.com/civicrm/civicrm-core/pull/33869 - this removes the last bits, and some CSS in the process…

Before
----------------------------------------
https://github.com/user-attachments/assets/d2b16b6d-870e-4017-b30b-071c6aeb2999

After
----------------------------------------
https://github.com/user-attachments/assets/9a0347f6-51f2-4681-b6ec-3342d8996e82

Technical Details
----------------------------------------
PR also swaps `var(--crm-c-gray-700)` for `var(--crm-c-inverse-bg)` – which is gray-700 in all Streams, so no visual change.