### PR TITLE
CiviMail - Use native html range elements instead of jQuery sliders

### DIFF
--- a/ext/civi_mail/ang/crmMailingAB.css
+++ b/ext/civi_mail/ang/crmMailingAB.css
@@ -1,9 +1,13 @@
-.crm-mailing-ab-slider .slider-test .ui-slider-range {
-  background: #5050b0;
+.crm-mailing-ab-slider input[type="range"] {
+  width: 100%;
 }
 
-.crm-mailing-ab-slider .slider-win .ui-slider-range {
-  background: #50b050;
+.crm-mailing-ab-slider .slider-test input {
+  accent-color: #5050b0;
+}
+
+.crm-mailing-ab-slider .slider-win input {
+  accent-color: #259a25;
 }
 
 .crm-mailing-ab-stats .series {

--- a/ext/civi_mail/ang/crmMailingAB/Slider.html
+++ b/ext/civi_mail/ang/crmMailingAB/Slider.html
@@ -3,14 +3,18 @@
   <tr>
     <td style="width: 10em;">{{:: ts('Test Mailing A') }}</td>
     <td>
-      <div class="slider-test slider-a"></div>
+      <div class="slider-test slider-a">
+        <input type="range" min=0 max=100 step=1 ng-model="testValue" />
+      </div>
     </td>
     <td style="width: 5em;">({{testValue}}%)</td>
   </tr>
   <tr>
     <td>{{:: ts('Test Mailing B') }}</td>
     <td>
-      <div class="slider-test slider-b"></div>
+      <div class="slider-test slider-b">
+        <input type="range" min=0 max=100 step=1 ng-model="testValue" />
+      </div>
     </td>
     <td>({{testValue}}%)</td>
   </tr>
@@ -18,7 +22,9 @@
   <tr>
     <td>{{:: ts('Final Mailing') }}</td>
     <td>
-      <div class="slider-win slider-b"></div>
+      <div class="slider-win slider-b">
+        <input type="range" min=0 max=100 step=2 ng-model="winValue" ng-change="onChangeWinValue()"/>
+      </div>
     </td>
     <td>({{winValue}}%)</td>
   </tr>

--- a/ext/civi_mail/ang/crmMailingAB/Slider.js
+++ b/ext/civi_mail/ang/crmMailingAB/Slider.js
@@ -3,56 +3,34 @@
   // example: <div crm-mailing-ab-slider ng-model="abtest.ab.group_percentage"></div>
   angular.module('crmMailingAB').directive('crmMailingAbSlider', function() {
     return {
-      require: '?ngModel',
-      scope: {},
+      scope: {
+        testValue: '=ngModel',
+      },
       templateUrl: '~/crmMailingAB/Slider.html',
-      link: function(scope, element, attrs, ngModel) {
-        var TEST_MIN = 1, TEST_MAX = 50;
-        var sliders = $('.slider-test,.slider-win', element);
-        var sliderTests = $('.slider-test', element);
-        var sliderWin = $('.slider-win', element);
-
+      link: function(scope, element, attrs) {
+        const TEST_MIN = 1, TEST_MAX = 50;
         scope.ts = CRM.ts('civi_mail');
-        scope.testValue = 0;
-        scope.winValue = 100;
+
+        scope.testValue = Number(scope.testValue) || 10;
+        scope.winValue = 100 - (2 * scope.testValue);
 
         // set the base value (following a GUI event)
-        function setValue(value) {
-          value = Math.min(TEST_MAX, Math.max(TEST_MIN, value));
-          scope.$apply(function() {
-            ngModel.$setViewValue(value);
-            scope.testValue = value;
-            scope.winValue = 100 - (2 * scope.testValue);
-            sliderTests.slider('value', scope.testValue);
-            sliderWin.slider('value', scope.winValue);
-          });
-        }
-
-        sliders.slider({
-          min: 0,
-          max: 100,
-          range: 'min',
-          step: 1
-        });
-        sliderTests.slider({
-          slide: function slideTest(event, ui) {
-            event.preventDefault();
-            setValue(ui.value);
-          }
-        });
-        sliderWin.slider({
-          slide: function slideWinner(event, ui) {
-            event.preventDefault();
-            setValue(Math.round((100 - ui.value) / 2));
-          }
-        });
-
-        ngModel.$render = function() {
-          scope.testValue = ngModel.$viewValue;
-          scope.winValue = 100 - (2 * scope.testValue);
-          sliderTests.slider('value', scope.testValue);
-          sliderWin.slider('value', scope.winValue);
+        scope.onChangeWinValue = () => {
+          scope.testValue = (100 - scope.winValue) / 2;
         };
+
+        // Watch external changes as well as user interaction with the test sliders
+        scope.$watch('testValue', (newValue, oldValue) => {
+          if (newValue !== oldValue) {
+            if (newValue > TEST_MAX) {
+              scope.testValue = TEST_MAX;
+            }
+            if (newValue < TEST_MIN) {
+              scope.testValue = TEST_MIN;
+            }
+            scope.winValue = 100 - (2 * scope.testValue);
+          }
+        });
       }
     };
   });

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -358,25 +358,17 @@ input.crm-form-checkbox) + label {
 .crm-container .crm-multiple-checkbox-radio-options.crm-options-per-line .crm-option-label-pair {
   flex: 0 0 calc((100% - (var(--crm-opts-per-line) - 1) * var(--crm-gap)) / var(--crm-opts-per-line));
 }
-/* Slider */
-.crm-container .ui-slider {
-  background: var(--crm-input-bg);
-  border: 1px solid var(--crm-input-border-color);
-}
-.crm-container .ui-slider .ui-slider-handle {
-  border: var(--crm-btn-border);
-  background: var(--crm-c-secondary);
-}
-.crm-container .ui-slider .ui-slider-range {
-  border: 0;
-  border-radius: 0;
-}
 
 /* Input types */
 
 .crm-container input[type="file"] {
   height: auto;
   padding: var(--crm-s);
+}
+.crm-container input[type="range"] {
+  accent-color: var(--crm-c-focus);
+  height: auto;
+  box-shadow: none;
 }
 
 /* Contact dashboard form */


### PR DESCRIPTION
Overview
----------------------------------------
This replaces jQuery sliders with native html range inputs. Includes a commit from @vingle to update the theming.

Before
----------------------------------------
<img width="1632" height="370" alt="image" src="https://github.com/user-attachments/assets/3863cbcd-feaf-4b1a-9bf4-4332a70d4177" />


After
----------------------------------------
<img width="1616" height="390" alt="image" src="https://github.com/user-attachments/assets/6a71bae6-6cc1-4abf-bd4c-c1c6d1eaa3eb" />
