### PR TITLE
SearchKit - Combine logic for "Pick Columns" fix

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1943,4 +1943,31 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     return $data;
   }
 
+  /**
+   * Checks columns for display and permissions.
+   *
+   * @param array $settings The settings from search display.
+   *
+   * @return void
+   */
+  protected function checkColumns(array &$settings): void {
+    // Respect if user has disabled any columns, otherwise show all
+    $this->toggleColumns = $this->toggleColumns ?: array_keys($settings['columns']);
+
+    // Checking permissions for menu, link or button columns is costly, so remove them early
+    foreach ($settings['columns'] as $index => $col) {
+      // Remove buttons/menus and other column types that cannot be rendered in a spreadsheet
+      if (in_array($index, $this->toggleColumns) && empty($col['key'])) {
+        unset($this->toggleColumns[array_search($index, $this->toggleColumns)]);
+      }
+      // Avoid wasting time processing links, editable and other non-printable items from spreadsheet
+      else {
+        \CRM_Utils_Array::remove($settings['columns'][$index], 'link', 'editable', 'icons', 'cssClass');
+      }
+    }
+
+    // Reset indexes as some items may have been removed
+    $settings['columns'] = array_values($settings['columns']);
+  }
+
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1950,7 +1950,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    *
    * @return void
    */
-  protected function checkColumns(array &$settings): void {
+  protected function filterPrintableColumns(array &$settings): void {
     // Respect if user has disabled any columns, otherwise show all
     $this->toggleColumns = $this->toggleColumns ?: array_keys($settings['columns']);
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -25,7 +25,7 @@ class Download extends AbstractRunAction {
     $settings =& $this->display['settings'];
     $fileName = '';
 
-    $this->checkColumns($settings);
+    $this->filterPrintableColumns($settings);
 
     // Displays are only exportable if they have actions enabled
     if (empty($settings['actions'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -25,20 +25,7 @@ class Download extends AbstractRunAction {
     $settings =& $this->display['settings'];
     $fileName = '';
 
-    // Respect if user has disabled any columns, otherwise show all
-    $this->toggleColumns = $this->toggleColumns ?: array_keys($settings['columns']);
-
-    // Checking permissions for menu, link or button columns is costly, so remove them early
-    foreach ($settings['columns'] as $index => $col) {
-      // Remove buttons/menus and other column types that cannot be rendered in a spreadsheet
-      if (in_array($index, $this->toggleColumns) && empty($col['key'])) {
-        unset($this->toggleColumns[array_search($index, $this->toggleColumns)]);
-      }
-      // Avoid wasting time processing links, editable and other non-printable items from spreadsheet
-      else {
-        \CRM_Utils_Array::remove($settings['columns'][$index], 'link', 'editable', 'icons', 'cssClass');
-      }
-    }
+    $this->checkColumns($settings);
 
     // Displays are only exportable if they have actions enabled
     if (empty($settings['actions'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SaveFile.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SaveFile.php
@@ -58,19 +58,7 @@ class SaveFile extends AbstractRunAction {
     $settings =& $this->display['settings'];
     $fileName = '';
 
-    // Checking permissions for menu, link or button columns is costly, so remove them early
-    foreach ($settings['columns'] as $index => $col) {
-      // Remove buttons/menus and other column types that cannot be rendered in a spreadsheet
-      if (empty($col['key'])) {
-        unset($settings['columns'][$index]);
-      }
-      // Avoid wasting time processing links, editable and other non-printable items from spreadsheet
-      else {
-        \CRM_Utils_Array::remove($settings['columns'][$index], 'link', 'editable', 'icons', 'cssClass');
-      }
-    }
-    // Reset indexes as some items may have been removed
-    $settings['columns'] = array_values($settings['columns']);
+    $this->checkColumns($settings);
 
     // Displays are only exportable if they have actions enabled
     if (empty($settings['actions'])) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SaveFile.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SaveFile.php
@@ -58,7 +58,7 @@ class SaveFile extends AbstractRunAction {
     $settings =& $this->display['settings'];
     $fileName = '';
 
-    $this->checkColumns($settings);
+    $this->filterPrintableColumns($settings);
 
     // Displays are only exportable if they have actions enabled
     if (empty($settings['actions'])) {


### PR DESCRIPTION
Overview
---------------------------------------
In #33948, some logic was introduced to fix a bug but wasn't carried over to the SaveFile action.

Technical Details
----------------------------------------
This moves the column checking logic out of the individual Actions and int the `AbstractRunAction` as a new function. This way the logic doesn't need to be repeated and can be used by additional Actions in the future.