### PR TITLE
crm-angular-js - support multiple modules space separated

### DIFF
--- a/js/crm-angularjs-loader.js
+++ b/js/crm-angularjs-loader.js
@@ -4,7 +4,7 @@
 
   $(document).on('crmLoad', function(e) {
     $('crm-angular-js', e.target).not('.ng-scope').each(function() {
-      angular.bootstrap(this, $(this).attr('modules').split(' '));
+      angular.bootstrap(this, $(this).attr('modules').trim().split(/\s+/));
     });
   });
 

--- a/js/crm-angularjs-loader.js
+++ b/js/crm-angularjs-loader.js
@@ -4,7 +4,7 @@
 
   $(document).on('crmLoad', function(e) {
     $('crm-angular-js', e.target).not('.ng-scope').each(function() {
-      angular.bootstrap(this, $(this).attr('modules').split());
+      angular.bootstrap(this, $(this).attr('modules').split(' '));
     });
   });
 


### PR DESCRIPTION
Before
----------------------------------------
- "modules" attribute is "split" but with no separator it always splits to a single item, so it doesnt really allow for passing multiple modules
- if you want to use multiple modules on a page you have to bootstrap them all separately

After
----------------------------------------
- multiple modules can be bootstrapped using `<crm-angular-js>` by passing their names space separated to modules attribute

Technical Details
----------------------------------------
Previously including a space would treat the whole attribute including the space as one module name, which would then be invalid and fail. As such I don't think this could cause problems to existing code.

