### PR TITLE
dev/core#6087 Use the Date Time of when the queue item was created as…

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventOpened.php
+++ b/CRM/Mailing/Event/BAO/MailingEventOpened.php
@@ -21,17 +21,19 @@ class CRM_Mailing_Event_BAO_MailingEventOpened extends CRM_Mailing_Event_DAO_Mai
    *
    * @param int $queue_id
    *   The Queue Event ID of the recipient.
+   * @param string|null $dateTime
+   *   When did the Open Event happen
    *
    * @return bool
    */
-  public static function open($queue_id): bool {
+  public static function open($queue_id, $dateTime = NULL): bool {
     // First make sure there's a matching queue event.
     $q = new CRM_Mailing_Event_BAO_MailingEventQueue();
     $q->id = $queue_id;
     if ($q->find(TRUE)) {
       self::writeRecord([
         'event_queue_id' => $queue_id,
-        'time_stamp' => date('YmdHis'),
+        'time_stamp' => $dateTime ?? date('YmdHis'),
       ]);
       return TRUE;
     }
@@ -295,8 +297,8 @@ class CRM_Mailing_Event_BAO_MailingEventOpened extends CRM_Mailing_Event_DAO_Mai
     return $results;
   }
 
-  public static function queuedOpen(\CRM_Queue_TaskContext $ctx, $queue_id): bool {
-    return self::open($queue_id);
+  public static function queuedOpen(\CRM_Queue_TaskContext $ctx, $queue_id, $dateTime): bool {
+    return self::open($queue_id, $dateTime);
   }
 
 }

--- a/CRM/Mailing/Event/BAO/MailingEventTrackableURLOpen.php
+++ b/CRM/Mailing/Event/BAO/MailingEventTrackableURLOpen.php
@@ -69,7 +69,7 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
       return $urlSearch->url;
     }
 
-    self::recordUrlClick($queue_id, $url_id);
+    self::recordUrlClick($queue_id, $url_id, date('YmdHis'));
 
     return $urlSearch->url;
   }
@@ -341,7 +341,7 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
     return $results;
   }
 
-  public static function queuedTrack(\CRM_Queue_TaskContext $ctx, $queue_id, $url_id) {
+  public static function queuedTrack(\CRM_Queue_TaskContext $ctx, $queue_id, $url_id, $dateTime) {
     $queueCheck = CRM_Core_DAO::singleValueQuery("SELECT u.url as url
       FROM civicrm_mailing_trackable_url u
       INNER JOIN civicrm_mailing_event_queue q ON u.mailing_id = q.mailing_id
@@ -350,15 +350,15 @@ class CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen extends CRM_Mailing_Eve
         2 => [$url_id, 'Positive'],
       ]);
     if ($queueCheck) {
-      self::recordUrlClick($queue_id, $url_id);
+      self::recordUrlClick($queue_id, $url_id, $dateTime);
     }
   }
 
-  private static function recordUrlClick($queue_id, $url_id) {
+  private static function recordUrlClick($queue_id, $url_id, $dateTime) {
     self::writeRecord([
       'event_queue_id' => $queue_id,
       'trackable_url_id' => $url_id,
-      'time_stamp' => date('YmdHis'),
+      'time_stamp' => $dateTime,
     ]);
   }
 

--- a/CRM/Mailing/Page/Open.php
+++ b/CRM/Mailing/Page/Open.php
@@ -46,7 +46,7 @@ class CRM_Mailing_Page_Open extends CRM_Core_Page {
     ]);
     $queue->createItem(new CRM_Queue_Task(
       ['CRM_Mailing_Event_BAO_MailingEventOpened', 'queuedOpen'],
-      [$queue_id],
+      [$queue_id, date('YmdHis')],
       'Processing tracked open for queue (#' . $queue_id . ')'
     ));
 

--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -42,7 +42,7 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
     ]);
     $queue->createItem(new CRM_Queue_Task(
       ['CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen', 'queuedTrack'],
-      [$queue_id, $url_id],
+      [$queue_id, $url_id, date('YmdHis')],
       'Processing tracked url open for queue (#' . $queue_id . '), url (#' . $url_id . ')'
     ));
     $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track(NULL, $url_id));


### PR DESCRIPTION
… the date time for the timestamp of the event record

Overview
----------------------------------------
This passes in the datetime of when the queue event is created as an argument to be used as part of the recording of time_stamp when the tracked open or the tracked click is recorded

@colemanw @stesi561 
