### PR TITLE
SchemaStructure - Fix new warning on EFv1 extensions

### DIFF
--- a/CRM/Core/I18n/SchemaStructure.php
+++ b/CRM/Core/I18n/SchemaStructure.php
@@ -28,7 +28,7 @@ class CRM_Core_I18n_SchemaStructure {
       global $civicrm_root;
       $sqlGenerator = require "$civicrm_root/mixin/lib/civimix-schema@5/src/SqlGenerator.php";
       foreach (\Civi\Schema\EntityRepository::getEntities() as $entity) {
-        if ($entity['module'] !== 'civicrm') {
+        if (($entity['module'] ?? NULL) !== 'civicrm') {
           continue;
         }
         if (empty($entity['getFields'])) {


### PR DESCRIPTION
Overview
----------------------------------------

@seamuslee001, this fixes a new warning that arises after 09800b550e9.

The warning does not affect EFv2 extensions, because they use `entity-types-php@2` which sets the `$entity['module']` property. However, other extensions have different wiring for `hook_civicrm_entityTypes`, and they don't guarantee that `'module'` will be set.

A few random examples: `sepa`, `aip`, `areas`, `civigeometry`, `apirestlog`,`pricesetfrequency`, `belgischeogm`, `bigbluebutton`.  More specifically, they have snippets like this -- where `module` is not defined:

```php
## FILE: bigbluebutton/bigbluebutton.php
function bigbluebutton_civicrm_entityTypes(&$entityTypes) {
  $entityTypes = array_merge($entityTypes, [
    'CRM_Bigbluebutton_DAO_BbbEventLog' =>   [
      'name' => 'BbbEventLog',
      'class' => 'CRM_Bigbluebutton_DAO_BbbEventLog',
      'table' => 'civicrm_bbb_event_log',
    ],
  ]);
}
```

(*There's more, but I don't have an exact count.*)

(*There seems to be some additional variable in whether the warning is actually printed. I haven't precisely tracked that down. But I stumbled across the warning organically -- and saw it in both web UI and CLI.*)