### PR TITLE
EFv1 - Add 'module' if missing

### DIFF
--- a/mixin/entity-types-php@1/mixin.php
+++ b/mixin/entity-types-php@1/mixin.php
@@ -4,7 +4,7 @@
  * Auto-register entity declarations from `xml/schema/...*.entityType.php`.
  *
  * @mixinName entity-types-php
- * @mixinVersion 1.0.0
+ * @mixinVersion 1.0.1
  * @since 5.57
  *
  * @param CRM_Extension_MixInfo $mixInfo

--- a/mixin/entity-types-php@1/mixin.php
+++ b/mixin/entity-types-php@1/mixin.php
@@ -28,6 +28,7 @@ return function ($mixInfo, $bootCache) {
     foreach ($files as $file) {
       $entities = include $file;
       foreach ($entities as $entity) {
+        $entity += ['module' => $mixInfo->longName];
         $e->entityTypes[$entity['class']] = $entity;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/33999 to partially address the missing 'module' key.


Technical Details
----------------------------------------
This doesn't fix every instance of a missing 'module' key because it doesn't help with extensions that implement `hook_civicrm_entityTypes` directly, but it solves some of the cases addressed by https://github.com/civicrm/civicrm-core/pull/33999