### PR TITLE
Adding check for abortMailSend in flexmailer, fix for dev/core#6189

### DIFF
--- a/ext/flexmailer/src/Listener/DefaultSender.php
+++ b/ext/flexmailer/src/Listener/DefaultSender.php
@@ -47,7 +47,11 @@ class DefaultSender extends AutoService {
         continue;
       }
 
-      $message = \Civi\FlexMailer\MailParams::convertMailParamsToMime($task->getMailParams());
+      $params = $task->getMailParams();
+      if (isset($params['abortMailSend']) && $params['abortMailSend']) {
+        continue;
+      }
+      $message = \Civi\FlexMailer\MailParams::convertMailParamsToMime($params);
 
       if (empty($message)) {
         // lets keep the message in the queue


### PR DESCRIPTION
Overview
----------------------------------------
Flexmailer not respecting abortMailSend

Before
----------------------------------------
Before implementing flexmailer, bulk emails respected the abortMailSend and would abort a bulk email but now it doesn't

After
----------------------------------------
After flexmailer implementation, even if the abort flag is set still it sends the email to end user.

Technical Details
----------------------------------------
Implementing check and skipping if the abort flag is set
