### PR TITLE
Afform - add async Validate action

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -26,7 +26,7 @@ class Submit extends AbstractProcessor {
    */
   protected $values;
 
-  protected function processForm() {
+  protected function validate(): array {
     // preprocess submitted values
     $this->_entityValues = $this->preprocessSubmittedValues($this->values);
 
@@ -48,7 +48,11 @@ class Submit extends AbstractProcessor {
     // Call validation handlers
     $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this);
     \Civi::dispatcher()->dispatch('civi.afform.validate', $event);
-    $errors = $event->getErrors();
+    return $event->getErrors();
+  }
+
+  protected function processForm() {
+    $errors = $this->validate();
     if ($errors) {
       \Civi::log('afform')->error('Afform Validation errors: ' . print_r($errors, TRUE));
       throw new \CRM_Core_Exception(implode("\n", $errors), 0, ['show_detailed_error' => TRUE]);

--- a/ext/afform/core/Civi/Api4/Action/Afform/Validate.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Validate.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Civi\Api4\Action\Afform;
+
+/**
+ * Class Validate
+ * @package Civi\Api4\Action\Afform
+ */
+class Validate extends Submit {
+
+  protected function processForm() {
+    $errors = $this->validate();
+    if ($errors) {
+      $this->setResponseItem('errors', $errors);
+      $this->setResponseItem('is_error', TRUE);
+    }
+
+    return [$this->_response];
+  }
+
+}

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -403,6 +403,20 @@
         }
       };
 
+      this.validate = () => {
+        if (!ctrl.ngForm.$valid || !validateFileFields()) {
+          return new Promise((resolve) => resolve({
+            is_error: true,
+            message: ts('Please fill all required fields.'),
+          }));
+        }
+        return crmApi4('Afform', 'validate', {
+          name: this.getFormMeta().name,
+          args: args,
+          values: data,
+        });
+      };
+
       this.submit = function () {
         // validate required fields on the form
         if (!ctrl.ngForm.$valid || !validateFileFields()) {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformValidateUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformValidateUsageTest.php
@@ -200,4 +200,52 @@ EOHTML;
       ->execute();
   }
 
+  public function testValidateAction(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{contact_type: 'Individual'}" type="Contact" name="Individual1" label="Individual 1" actions="{create: true, update: true}" url-autofill="1" security="RBAC"  />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" defn="{required: true}" />
+    <af-field name="last_name" defn="{required: true}" />
+    <af-field name="middle_name" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Validate with empty first and last names. Should return 2 validation errors.
+    $submission = [
+      ['fields' => ['middle_name' => 'Person']],
+    ];
+    $result = Afform::validate()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $response = $result->first();
+    $this->assertTrue($response['is_error'] ?? FALSE);
+    $this->assertCount(2, $response['errors']);
+    $this->assertStringContainsString('First Name is a required field', implode("\n", $response['errors']));
+    $this->assertStringContainsString('Last Name is a required field', implode("\n", $response['errors']));
+
+    // Validate with valid values. Should return no errors.
+    $validSubmission = [
+      ['fields' => ['first_name' => 'John', 'last_name' => 'Doe']],
+    ];
+    $validResult = Afform::validate()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $validSubmission])
+      ->execute();
+
+    $this->assertCount(1, $validResult);
+    $validResponse = $validResult->first();
+    $this->assertEmpty($validResponse);
+  }
+
 }


### PR DESCRIPTION
Before
----------------------------------------
- server side Afform validation only runs during a Submit

After
----------------------------------------
- server side Afform validation can be run asynchronously without submitting
- this is useful for Afform Payments as you can check things are valid and preview the line items without submitting
- there may be other contexts where this is useful -- on a long form you might want to check your results *before* you finally submit (maybe crossover with save draft, I'm not too sure how that works)

Technical Details
----------------------------------------
The Validate action class currently extends Submit. Maybe it should be the other way round? But the AfformValidateEvent currently expects a Submit action to be passed as the API request, which might take some unwinding. What do you think @colemanw ?