### PR TITLE
Standalone - don't create table if it already exists

### DIFF
--- a/ext/standaloneusers/sql/upgrade_5691.sql
+++ b/ext/standaloneusers/sql/upgrade_5691.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `civicrm_session` (
+CREATE TABLE IF NOT EXISTS `civicrm_session` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT 'Unique Session ID',
   `session_id` char(64) NOT NULL COMMENT 'Hexadecimal Session Identifier',
   `data` longtext COMMENT 'Session Data',


### PR DESCRIPTION
Overview
----------------------------------------
After migrating a site to Standalone using Standalone Migrate, I hit an issue with the database upgrader. The standaloneusers extension wasn't enabled on the source site so the database migrations are pending after the database is migrated to the target site. The migration attempts to create a table which already exists so fails.

Before
----------------------------------------
Database upgrade fails if table already exists.

After
----------------------------------------
No problem!

Comments
----------------------------------------
See [chat thread](https://chat.civicrm.org/civicrm/pl/m9qfnq4akidnbdape6o79jq6jr) for background.
