### PR TITLE
SearchKit - Add 'module' key to entities

### DIFF
--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -95,6 +95,7 @@ function search_kit_civicrm_entityTypes(array &$entityTypes): void {
       'name' => $display['entityName'],
       'class' => \Civi\BAO\SK_Entity::class,
       'table' => $display['tableName'],
+      'module' => E::LONG_NAME,
       'metaProvider' => \Civi\Schema\SkEntityMetaProvider::class,
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/33999

Comments
----------------------------------------
This 'module' key might or might not ever be required, but we might as well add it when we can to improve consistency.