### PR TITLE
fix locale selector hide on monolingual

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -8,7 +8,7 @@
     <input ng-model="editor.afform.title" class="form-control" id="af_config_form_title" required title="{{:: ts('Required') }}" ng-model-options="editor.debounceMode" >
   </div>
 
-  <div class="form-group" ng-if="editor.meta.locales" ng-if="editor.meta.locales.length">
+  <div class="form-group" ng-if="editor.meta.locales && editor.meta.locales.length">
     <label for="afform_locale">
       {{:: ts('Locale') }} <span class="crm-marker">*</span>
     </label>


### PR DESCRIPTION
Before
----------------------------------------
- locale field is shown as required but with no options
<img width="992" height="596" alt="image" src="https://github.com/user-attachments/assets/e8ceed2a-d48c-4026-8b58-7d3969edd563" />

After
----------------------------------------
- locale field is hidden if no options

