### PR TITLE
afForm - let others know when submit fails

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -405,6 +405,12 @@
           status.reject();
           $element.unblock();
           CRM.alert(error.error_message || '', ts('Form Error'));
+          $element.trigger('crmFormError', {
+            afform: ctrl.getFormMeta(),
+            data: data,
+            submissionResponse: submissionResponse,
+            error: error
+          });
         });
       };
 


### PR DESCRIPTION
Before
----------------------------------------
- `crmFormSuccess` event lets people know afForm submit has succeeded
- No way for anything else to know if afForm submit fails

After
----------------------------------------
- `crmFormSuccess` event lets people know afForm submit has succeeded
- `crmFormError` event lets people know afForm submit has failed
 
Comments
----------------------------------------
Improves afform_payments experience
