### PR TITLE
better wording for FormBuilder is_public control 

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -68,7 +68,7 @@
     <div class="form-group" ng-if="!!editor.afform.server_route">
       <label>
         <input type="checkbox" ng-model="editor.afform.is_public">
-        {{:: ts('Accessible on front-end of website') }}
+        {{:: ts('Use front-end page styles and URL') }}
       </label>
     </div>
 


### PR DESCRIPTION
Overview
----------------------------------------
The current control is unhelpful - "Accessible" suggests this is about who can access the page. But that is controlled by the permissions setting. The main thing this checkbox affects is whether a page uses frontend styles. On WP (and maybe Joomla?) it also affects the URL format.

Before
----------------------------------------
- "Accessible on front-end of website"

After
----------------------------------------
- "Use front-end page styles and URL"

