### PR TITLE
riverlea frontend - wrap title as well as content

### DIFF
--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -5,6 +5,7 @@
 .crm-container.crm-public {
   --crm-font: inherit;
 }
+.crm-container.crm-public .crm-page-title-wrapper,
 .crm-container.crm-public #crm-main-content-wrapper {
   margin-inline: auto;
   width: clamp(calc(var(--crm-f-form-width) / 2),100%,var(--crm-f-form-width));


### PR DESCRIPTION
Before
----------------------------------------
- Riverlea frontend styles have a narrow fixed width for the body content
- but the header is still fullwidth, so often mismatched on a somewhat wide screen

<img width="2080" height="1173" alt="image" src="https://github.com/user-attachments/assets/2d93e5f8-69b7-46e8-84aa-d386c6d216a4" />



After
----------------------------------------
- consistent fixed width for both

<img width="1628" height="1194" alt="image" src="https://github.com/user-attachments/assets/d43c97a3-7cd6-4f74-a323-8fe65864b32b" />


Technical Details
----------------------------------------
You can remove the fixed with if you wish by changing `--crm-f-form-width`.

I've only `r-run` on Standalone. Is there any reason it would be different on CMS?

@vingle 


