### PR TITLE
Improve UI for scheduled jobs log

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -388,6 +388,9 @@ dl dl {
   border: var(--crm-code-border-color);
   border-radius: var(--crm-l-radius);
 }
+.crm-container pre {
+  white-space: pre-wrap;
+}
 .crm-container pre code {
   display: block;
   padding: 0;
@@ -397,8 +400,8 @@ dl dl {
   border-radius: 0;
 }
 .crm-container pre.prettyprint {
-  background: var(--crm-text-light-color); /* method to force light bg on prettyprint code as inverting is too complex */
-  white-space: pre;
+  background: var(--crm-c-text-light); /* method to force light bg on prettyprint code as inverting is too complex */
+  white-space: pre-wrap;
   text-wrap: auto;
 }
 .crm-container pre.linenums {
@@ -448,6 +451,11 @@ dl dl {
   min-height: 100vh;
   padding: var(--crm-page-padding);
 }
+
+.crm-container .vertical-align-baseline {
+  vertical-align: baseline;
+}
+
 .crm-container .crm-flex-box {
   display: flex;
   flex-wrap: wrap;

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -26,6 +26,9 @@
   border-bottom: var(--crm-table-row-border);
   background-color: var(--crm-table-row-bg-color);
 }
+.crm-container table.vertical-align-baseline tr {
+  vertical-align: baseline;
+}
 .crm-container td,
 .crm-container table.dataTable thead td {
   padding: var(--crm-table-padding);

--- a/templates/CRM/Admin/Page/JobLog.tpl
+++ b/templates/CRM/Admin/Page/JobLog.tpl
@@ -14,7 +14,7 @@
 <div class="crm-content-block crm-block">
 
 {if $jobId}
-    <h3>{ts}List of log entries for:{/ts} {$jobName}</h3>
+    <h2>{ts}List of log entries for:{/ts} {$jobName}</h2>
 {/if}
 
   <div class="action-link">
@@ -29,20 +29,50 @@
         {strip}
         {* handle enable/disable actions*}
    {include file="CRM/common/enableDisableApi.tpl"}
-        <table class="selector row-highlight">
+        <table class="selector row-highlight vertical-align-baseline">
         <tr class="columnheader">
             <th >{ts}Date{/ts}</th>
-            <th >{ts}Job Name{/ts}</th>
+            {if !$jobId}<th >{ts}Job Name{/ts}</th>{/if}
             <th >{ts}Command{/ts}/{ts}Job Status{/ts}/{ts}Additional Information{/ts}</th>
         </tr>
         {foreach from=$rows item=row}
         <tr id="job-{$row.id}" class="crm-entity {cycle values="odd-row,even-row"}{if !empty($row.class)} {$row.class}{/if}">
             <td class="crm-joblog-run_datetime">{$row.run_time}</td>
-            <td class="crm-joblog-name">{$row.name}</td>
+            {if !$jobId}<td class="crm-joblog-name">{$row.name}</td>{/if}
             <td class="crm-joblog-details">
-                <div class="crm-joblog-command">{$row.command}</div>
-                {if $row.description}<div class="crm-joblog-description"><span class="bold">{ts}Summary{/ts}</span><br/>{$row.description}</div>{/if}
-                {if $row.data}<div class="crm-joblog-data" style="border-top:1px solid #ccc; margin-top: 10px;"><span class="bold">{ts}Details{/ts}</span><br/><pre>{$row.data}</pre></div>{/if}
+                {if $row.description}
+                  <!-- TODO:
+                    It would be nice to apply some CSS based on the messageType (success|error|info)
+                    We also have $row.logLevel (debug|info|error|...)
+                  -->
+                  <p class="crm-joblog-description {$row.statusClass}">
+                    <strong>{$row.description}</strong>
+                  </p>
+                  {if $row.resultValues}
+                    {if $row.resultIsMultiline}
+                    <details class="crm-joblog-data crm-accordion-light">
+                      <summary>{ts}Result{/ts}</summary>
+                      <div class="crm-accordion-body">
+                        <pre>
+                          {$row.resultValues|escape}
+                        </pre>
+                      </div>
+                    </details>
+                    {else}
+                      <p>{ts}Result:{/ts} <code>{$row.resultValues|escape}</code></p>
+                    {/if}
+                  {/if}
+                {/if}
+                {if $row.command}
+                <details class="crm-joblog-data crm-accordion-light">
+                  <summary class="crm-joblog-command">{ts}Api call details for{/ts} <code>{$row.command}</code></summary>
+                  <div class="crm-accordion-body">
+                    {if $row.data}
+                      <pre>{$row.data|trim}</pre>
+                    {/if}
+                  </div>
+                </details>
+                {/if}
             </td>
         </tr>
         {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------

The Scheduled Job log screen is awful. This seeks to improve it in the following ways:

- Reduce repeated text.
   - if you're viewing the logs for a particular job, you don't need a whole column dedicated to repeating the name of that job.
   - remove duplication of job name in job messages; we already have this data in other fields.
   - move the very verbose calling parameters into an accordion.
- Improve readability
  - Humans can't read PHP's serialize() output! Moved to JSON with JSON_PRETTY_PRINT.
  - Structure the data array, *allow* some special structure for the 'description'/message field. This means we can have a nice "Successfully completed" message separate from the possibly detailed results JSON.
  - Show results in an accordion, if they require multiple lines
  - add `white-space: pre-line` to JSON output, so long lines do not cause the table to overflow the browser width making everything really hard to read.
- Move `ts()` calls to presentation layer - previously was a mix of un/translated text in the strings.
- Note: The exsting code that generates log messages uses different log levels but this data was ignored. I have stored it in the `data` field, but it is not yet used in presentations.
- Api4 support. Currently Api4 Job actions return Civi\Api4\Generic\Result objects, not arrays, and so the scheduled job log reports "empty values!" even when there are values.
- a11y heading use: h1 > h3



Before
----------------------------------------

screenshot below shows

➊ confusing technical details. "Entity: Job Action: process_participant" - what's a "Job Action" (already a code comment from Tim about this!); only technical people need technical details, and for them, `Job.process_participant` is much clearer.

➋ long serialize() output forces messages to be truncated, you have to scroll sideways to read this and other lines:

<img width="600" height="632" alt="image" src="https://github.com/user-attachments/assets/b209b236-fcfd-4189-9bae-cb58a194036e" />

Screenshot below shows an api4 job. Look, no results (there should be)

<img width="964" height="350" alt="image" src="https://github.com/user-attachments/assets/b8b56873-f99f-4eb0-9c5e-a278fcde8cbb" />


After
----------------------------------------

The screenshot below shows:

- Reduced duplication of the job name "Update Inlays" as that's the log page we're looking at. Previously this name was repeated in a table column, and in the "starting..." and "finishing..." texts as well!
- clean layout thanks to accordions.

<img width="982" height="641" alt="image" src="https://github.com/user-attachments/assets/82a0cdfa-6ac3-4618-b4c6-b839e092386d" />


The video below shows:

- Clear summary messages, easy to scan by eye.
- long results hidden in accordions
- handling legacy code which outputs HTML (hello CiviEvent) in its api call result.
- handling long array data output
- wrapping of long lines to avoid sideways scrolling.
- structured Api call details.

https://github.com/user-attachments/assets/bca5360f-b322-48bc-af4e-7966bab84291


The screenshot below shows how legacy logs are displayed. It's still nasty - I did not try to write a parser to fish out the serialize()-ed message and prettify it - but it at least doesn't overflow.

<img width="964" height="164" alt="image" src="https://github.com/user-attachments/assets/934b33e9-9577-409a-b73c-83b7a64bca68" />


The screenshot below shows:

- how Api4 results are handled. The result here *is* an empty set, which is fine, but the screenshot shows that we see that result nevertheless. Before ALL api4 jobs returned the message about "empty values!". The third log entry shows the how legacy-created results would look.
- demonstrates the green colour applied to success messages (created other screenshots before adding this feature).
- shows that when the result is not multi-line, it's not hidden in an accordion.

<img width="964" height="442" alt="image" src="https://github.com/user-attachments/assets/ae8e8844-e8fc-4e7f-8459-6f491f4afab3" />


Status
----------

I've done this as a DRAFT because I wanted to log the work I'd done and the reasons for it. But I intend to run it myself for a while to polish it up a bit.


