### PR TITLE
FormBuilder - Take guesswork out of multiselect vs single select

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiFieldValue.directive.js
@@ -45,16 +45,13 @@
 
           getDataType();
 
-          // Decide whether the input should be multivalued
+          // Decide whether the input should be multivalued:
+          // On a search form, it's based on the search operator
           if (ctrl.op) {
             multi = ['IN', 'NOT IN'].includes(ctrl.op);
-          } else if (inputType && dataType !== 'Boolean') {
-            multi = (inputType === 'CheckBox' || (field.input_attrs && field.input_attrs.multiple));
-            // Hidden fields are multi-select if the original input type is.
-            if (inputType === 'Hidden' || inputType === 'DisplayOnly') {
-              multi = _.contains(['CheckBox', 'Radio', 'Select'], field.original_input_type);
-            }
-          } else {
+          }
+          // On an input form, it's based on the field's data type
+          else {
             multi = field.serialize || dataType === 'Array';
           }
           $el.crmAutocomplete('destroy').crmDatepicker('destroy');

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -102,7 +102,7 @@
 </li>
 <li ng-if="$ctrl.hasDefaultValueInput()">
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
-    <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" >
+    <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" op="$ctrl.isSearch() ? (getSetOperator() || 'IN') : null">
   </form>
 </li>
 <li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -93,10 +93,15 @@
         ));
       };
 
-      this.canBeMultiple = function() {
-        return this.isSearch() &&
-          !_.includes(['Date', 'Timestamp'], ctrl.getDefn().data_type) &&
-          _.includes(['Select', 'EntityRef', 'ChainSelect'], $scope.getProp('input_type'));
+      this.canBeMultiple = () => {
+        if (!this.isSearch() ||
+          ['Date', 'Timestamp'].includes(ctrl.getDefn().data_type) ||
+          !(['Select', 'EntityRef', 'ChainSelect'].includes($scope.getProp('input_type')))
+        ) {
+          return false;
+        }
+        const op = $scope.getSetOperator();
+        return (!op || ['_EXPOSE_', 'IN', 'NOT IN'].includes(op));
       };
 
       this.getRangeElements = function(type) {
@@ -432,6 +437,10 @@
             getSet('search_operator', _.keys(ctrl.searchOperators)[0]);
           } else {
             getSet('search_operator', val);
+          }
+          // Ensure multiselect is only used when compatible with operator
+          if (['_EXPOSE_', 'IN', 'NOT IN'].includes(val) != getSet('input_attrs.multiple')) {
+            $scope.toggleMultiple();
           }
           return val;
         }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [a bug with backend formBuilder select inputs](https://lab.civicrm.org/dev/core/-/issues/6190).

Before
----------------------------------------
Inputs, e.g. "Default Value" would sometimes be multiselect when they should be single.

After
----------------------------------------
The input is always rendered appropriately based on the search operator or field data type.

Technical Details
----------------------------------------

There's been a lot of back-n-forth on this one, e.g.

- https://github.com/civicrm/civicrm-core/pull/30943 by @MegaphoneJon 
- https://github.com/civicrm/civicrm-core/pull/32699 by me

That push/pull has been due to `afGuiFieldValue` using guesswork. This replaces that guesswork with context awareness.