### PR TITLE
[REF] fix signature on isAuthorized call

### DIFF
--- a/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/PermissionCheckSubscriber.php
@@ -46,7 +46,7 @@ class PermissionCheckSubscriber extends \Civi\Core\Service\AutoService implement
         !$apiRequest->getCheckPermissions() ||
         // This action checks permissions internally
         $apiRequest->getActionName() === 'getLinks' ||
-        $apiRequest->isAuthorized(\CRM_Core_Session::singleton()->getLoggedInContactID())
+        $apiRequest->isAuthorized()
       ) {
         $event->authorize();
         $event->stopPropagation();


### PR DESCRIPTION
Overview
----------------------------------------
Back in 2021, [this commit](https://github.com/civicrm/civicrm-core/commit/70da392777d9c663ea79755b43cfec2e347b5f04) changed the signature on `isAuthorized()` calls.  But apparently this one instance was missed.  It was a red herring in an issue I saw yesterday so I'm submitting this.


Comments
----------------------------------------
A quick grep of `isAuthorized` should satisfy someone that nowhere does `isAuthorized()` take an argument.
