### PR TITLE
CustomFields - Deprecate 'min_multiple'

### DIFF
--- a/Civi/Api4/Event/Subscriber/CustomValueAccessSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/CustomValueAccessSubscriber.php
@@ -76,9 +76,6 @@ class CustomValueAccessSubscriber extends \Civi\Core\Service\AutoService impleme
     if (!$group) {
       return;
     }
-    if ($group['min_multiple']) {
-      // TODO: prevent delete
-    }
     if ($group['max_multiple']) {
       $currentCount = civicrm_api4($apiRequest->getEntityName(), 'get', [
         'select' => ['row_count'],

--- a/schema/Core/CustomGroup.entityType.php
+++ b/schema/Core/CustomGroup.entityType.php
@@ -205,8 +205,9 @@ return [
       'title' => ts('Minimum Multiple Records'),
       'sql_type' => 'int unsigned',
       'input_type' => 'Number',
-      'description' => ts('minimum number of multiple records (typically 0?)'),
+      'description' => ts('Unused deprecated column.'),
       'add' => '2.2',
+      'deprecated' => TRUE,
     ],
     'max_multiple' => [
       'title' => ts('Maximum Multiple Records'),


### PR DESCRIPTION
Overview
----------------------------------------
Marks unused field as deprecated.

Technical Details
----------------------------------------
This column was added in 2.2 but never supported. It's not on the admin form, so there's no way to set it in the UI. Logic for actually enforcing a minimum was never added.