### PR TITLE
core#6188 Support API4 style suffixes in afform data objects

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -96,7 +96,10 @@ class AfformAdminMeta {
   public static function getFields($entityName, $params = []) {
     $params += [
       'checkPermissions' => FALSE,
-      'loadOptions' => ['id', 'label'],
+      'loadOptions' => [
+        'id',
+        ...array_keys(\CRM_Core_SelectValues::optionAttributes()),
+      ],
       'action' => 'create',
       'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
       'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -25,6 +25,57 @@
         return ctrl.entity.type;
       };
 
+      $scope.getUnsuffixedName = function(fieldName) {
+        const parts = fieldName.split(':');
+        const baseName = parts[0];
+        return baseName;
+      };
+
+      $scope.getFieldMeta = function(fieldName) {
+        return $scope.getMeta().fields[
+          $scope.getUnsuffixedName(fieldName)
+        ];
+      };
+
+      /**
+       * The UI always deals with IDs;
+       * this function translates to and from suffixed values,
+       * if the suffixed name is being used in the data object
+       */
+      $scope.entityDataGetterSetter = function(fieldName) {
+        const parts = fieldName.split(':');
+        const baseName = parts[0];
+        const suffix = parts.length > 1 ? parts.slice(1).join(':') : null;
+        const fieldMeta = $scope.getMeta().fields[baseName];
+
+        return function(value) {
+          if (arguments.length) {
+            // Setter
+            if (suffix) {
+              const options = fieldMeta.options || [];
+              const matchedOption = options.find(opt => {
+                return opt.id == value;
+              });
+              value = matchedOption ? matchedOption[suffix] : value;
+            }
+            ctrl.entity.data[fieldName] = value;
+            return ctrl.entity.data[fieldName];
+          } else {
+            // Getter
+            const dataValue = ctrl.entity.data[fieldName];
+            if (suffix) {
+              const options = fieldMeta.options || [];
+              const matchedOption = options.find(opt => {
+                return opt[suffix] == dataValue;
+              });
+              return matchedOption ? matchedOption.id : dataValue;
+            }
+
+            return dataValue;
+          }
+        };
+      };
+
       $scope.getMeta = () => {
         return afGui.meta.entities[ctrl.getEntityType()];
       };
@@ -154,8 +205,11 @@
       // Checks if a field is on the form or set as a value
       $scope.fieldInUse = (fieldName, joinEntity) => {
         const data = ctrl.entity.data || {};
+        const unsuffixedDataKeys = Object.keys(data).map(key => {
+          return $scope.getUnsuffixedName(key);
+        });
         if (!joinEntity) {
-          return (fieldName in data) || check(ctrl.editor.layout['#children'], {'#tag': 'af-field', name: fieldName});
+          return (unsuffixedDataKeys.includes(fieldName)) || check(ctrl.editor.layout['#children'], {'#tag': 'af-field', name: fieldName});
         }
         // Joins might support multiple instances per entity; first fetch them all
         const afJoinContainers = afGui.getFormElements(ctrl.editor.layout['#children'], {'af-join': joinEntity}, (item) => {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -1,8 +1,8 @@
 <form class="af-gui-columns crm-flex-box" ng-if="!$ctrl.entity.loading">
   <fieldset class="af-gui-entity-values" ng-if="$ctrl.editor.getAfform().type !== 'block'">
     <legend>{{:: ts('Values:') }}</legend>
-    <div ng-if="getMeta().fields[fieldName]" ng-repeat="(fieldName, value) in $ctrl.entity.data">
-      <label class="af-gui-block-label" for="{{ $ctrl.getFieldId(fieldName) }}">{{:: getMeta().fields[fieldName].label }}:</label>
+    <div ng-if="getFieldMeta(fieldName)" ng-repeat="(fieldName, value) in $ctrl.entity.data">
+      <label class="af-gui-block-label" for="{{ $ctrl.getFieldId(fieldName) }}">{{:: getFieldMeta(fieldName).label }}:</label>
       <label class="af-gui-block-label" ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] === 'Date'">
         <input type="radio" name="{{:: fieldName + 'now' }}" ng-click="$ctrl.entity.data[fieldName] = 'now'" ng-checked="$ctrl.entity.data[fieldName] === 'now'">
         {{:: ts('Current Date') }}
@@ -17,8 +17,9 @@
                ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] !== 'Date' || $ctrl.entity.data[fieldName] !== 'now'"
                id="{{ $ctrl.getFieldId(fieldName) }}"
                class="form-control"
-               af-gui-field-value="getField($ctrl.getEntityType(), fieldName)"
-               ng-model="$ctrl.entity.data[fieldName]" />
+               af-gui-field-value="getField($ctrl.getEntityType(), getUnsuffixedName(fieldName))"
+               ng-model-options="{ getterSetter: true }"
+               ng-model="entityDataGetterSetter(fieldName)" />
         <a href ng-click="removeValue($ctrl.entity, fieldName)">
           <i class="crm-i fa-times" role="img" aria-hidden="true"></i>
         </a>

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSuffixSubmitUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSuffixSubmitUsageTest.php
@@ -1,0 +1,73 @@
+<?php
+namespace Civi\ext\afform\mock\tests\phpunit\api\v4\Afform;
+
+use api\v4\Afform\AfformUsageTestCase;
+use Civi\Api4\Afform;
+
+/**
+ * Test case for Afform with API4 style suffixes.
+ *
+ * @group headless
+ */
+class AfformSuffixSubmitUsageTest extends AfformUsageTestCase {
+
+  public function testSubmitWithPrefixIdNameSuffix(): void {
+
+    // Ensure the entity we are testing with exists
+    $prefixValue = \Civi\Api4\OptionValue::save(FALSE)
+      ->addRecord([
+        'name' => 'Mr.',
+        'option_group_id:name' => 'individual_prefix',
+      ])
+      ->setMatch([
+        'option_group_id',
+        'name',
+      ])
+      ->setReload([
+        'value',
+      ])
+      ->execute()
+      ->first()['value'];
+
+    // Specify prefix_id with :name suffix
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'prefix', 'prefix_id:name': 'Mr.'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="last_name" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Submit without the default value (prefix_id:name) and then check it was correctly written on submit
+    $submission = [
+      [
+        'fields' => [
+          'first_name' => 'Joe',
+          'last_name' => 'Bloggs',
+        ],
+      ],
+    ];
+    $result = Afform::submit(FALSE)
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $resultId = $result[0]['Individual1'][0]['id'];
+    $resultPrefix = \Civi\Api4\Individual::get(FALSE)
+      ->addSelect('prefix_id')
+      ->addWhere('id', '=', $resultId)
+      ->execute()
+      ->first()['prefix_id'];
+
+    $this->assertSame((string) $prefixValue, (string) $resultPrefix);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Resolves https://lab.civicrm.org/dev/core/-/issues/6188 (Support API4 style suffixes in afform data objects)

Before
----------------------------------------
FormBuilder forms are designed to be portable. However, when adding a default (fixed) value, the ID is used in the resulting `.aff.html` file. For example in this screenshot `1` or `2` would be used, rather than `formal`, `familiar`:

<img width="275" height="265" alt="Screenshot 2025-11-08 at 14 01 28" src="https://github.com/user-attachments/assets/d431c29b-3004-46a3-89ba-a9d9b5656d8d" />

That's not great, as the ID is not designed to be consistent across environments (this is especially true of option groups designed to be edited).

I have hit problems when trying to share afforms between sites (via extensions) in the past, due to this issue.

After
----------------------------------------
The `.aff.html` file can use the API4 style prefixes like so:
```
data="{'communication_style_id:name': 'formal'}"
```

All the API4 prefixes are supported (name, label, etc).

The afform GUI has been updated to support this - the above "formal" could be changed to "familar", but will still be stored as `'communication_style_id:name'` in the template file.

Comments
----------------------------------------
For now the UI still defaults to adding the unpreffixed field name - to make use of this new functionality, the `.aff.html` needs to be manually updated to reference a prefix. A sensible follow-up task will be to default to using `:name` if that is a supported prefix for the field.
