### PR TITLE
"Edit Payment Processor" - Fix help. Replace redundant code with loop.

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -108,6 +108,10 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
 
     $this->assign('is_recur', $this->_paymentProcessorDAO->is_recur);
 
+    // The list here is loosely redundant with $this->_fields, except that several parts of $this->_fields are conditioned on extant data.
+    $this->assign('liveFieldNames', ['user_name', 'password', 'signature', 'subject', 'url_site', 'url_api', 'url_recur', 'url_button']);
+    $this->assign('testFieldNames', array_map(fn($f) => "test_$f", $this->getTemplateVars('liveFieldNames')));
+
     $this->_fields = [
       [
         'name' => 'user_name',

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -55,97 +55,16 @@
   </table>
 <fieldset>
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>
-    <table class="form-layout-compressed">
-{if !empty($form.user_name)}
-        <tr class="crm-paymentProcessor-form-block-user_name">
-            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="{$ppTypeName}_live_user_name" title=$form.user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.password)}
-        <tr class="crm-paymentProcessor-form-block-password">
-            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="{$ppTypeName}_live_password" title=$form.password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.signature)}
-        <tr class="crm-paymentProcessor-form-block-signature">
-            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id="{$ppTypeName}_live_signature" title=$form.signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.subject)}
-        <tr class="crm-paymentProcessor-form-block-subject">
-            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id="{$ppTypeName}_live_subject" title=$form.subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.url_site)}
-        <tr class="crm-paymentProcessor-form-block-url_site">
-            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_site" title=$form.url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.url_api)}
-        <tr class="crm-paymentProcessor-form-block-url_api">
-            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_api" title=$form.url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.url_recur)}
-        <tr class="crm-paymentProcessor-form-block-url_recur">
-            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_recur" title=$form.url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.url_button)}
-        <tr class="crm-paymentProcessor-form-block-url_button">
-            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_button" title=$form.url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-    </table>
+  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames helpSet="_live_"}
 </fieldset>
 
 <fieldset>
 <legend>{ts}Processor Details for Test Payments{/ts}</legend>
-    <table class="form-layout-compressed">
-{if !empty($form.test_user_name)}
-        <tr class="crm-paymentProcessor-form-block-test_user_name">
-            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="{$ppTypeName}_test_user_name" title=$form.test_user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
+  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$testFieldNames helpSet="_"}
+</fieldset>
 {/if}
-{if !empty($form.test_password)}
-        <tr class="crm-paymentProcessor-form-block-test_password">
-            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="{$ppTypeName}_test_password" title=$form.test_password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.test_signature)}
-        <tr class="crm-paymentProcessor-form-block-test_signature">
-            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id="{$ppTypeName}_test_signature" title=$form.test_signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.test_subject)}
-        <tr class="crm-paymentProcessor-form-block-test_subject">
-            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id="{$ppTypeName}_test_subject" title=$form.test_subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.test_url_site)}
-        <tr class="crm-paymentProcessor-form-block-test_url_site">
-            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_site" title=$form.test_url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.test_url_api)}
-        <tr class="crm-paymentProcessor-form-block-test_url_api">
-            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_api" title=$form.test_url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.test_url_recur)}
-        <tr class="crm-paymentProcessor-form-block-test_url_recur">
-            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_recur" title=$form.test_url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{if !empty($form.test_url_button)}
-        <tr class="crm-paymentProcessor-form-block-test_url_button">
-            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_button" title=$form.test_url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
-        </tr>
-{/if}
-{/if}
-</table>
-       <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
-  </fieldset>
+
+  <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
 
 {if $action eq 1  or $action eq 2}

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -57,41 +57,41 @@
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-user_name">
-            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="$ppTypeName-live-user-name" title=$form.user_name.label}</td>
+            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="$ppTypeName-live-user-name" title=$form.user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {if !empty($form.password)}
         <tr class="crm-paymentProcessor-form-block-password">
-            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="$ppTypeName-live-password" title=$form.password.label}</td>
+            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="$ppTypeName-live-password" title=$form.password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.signature)}
         <tr class="crm-paymentProcessor-form-block-signature">
-            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id="$ppTypeName-live-signature" title=$form.signature.label}</td>
+            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id="$ppTypeName-live-signature" title=$form.signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.subject)}
         <tr class="crm-paymentProcessor-form-block-subject">
-            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id="$ppTypeName-live-subject" title=$form.subject.label}</td>
+            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id="$ppTypeName-live-subject" title=$form.subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_site)}
         <tr class="crm-paymentProcessor-form-block-url_site">
-            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id="$ppTypeName-live-url-site" title=$form.url_site.label}</td>
+            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id="$ppTypeName-live-url-site" title=$form.url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_api)}
         <tr class="crm-paymentProcessor-form-block-url_api">
-            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id="$ppTypeName-live-url-api" title=$form.url_api.label}</td>
+            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id="$ppTypeName-live-url-api" title=$form.url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_recur)}
         <tr class="crm-paymentProcessor-form-block-url_recur">
-            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id="$ppTypeName-live-url-recur" title=$form.url_recur.label}</td>
+            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id="$ppTypeName-live-url-recur" title=$form.url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_button)}
         <tr class="crm-paymentProcessor-form-block-url_button">
-            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id="$ppTypeName-live-url-button" title=$form.url_button.label}</td>
+            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id="$ppTypeName-live-url-button" title=$form.url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
     </table>
@@ -101,40 +101,40 @@
 <legend>{ts}Processor Details for Test Payments{/ts}</legend>
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-test_user_name">
-            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="$ppTypeName-test-user-name" title=$form.test_user_name.label}</td></tr>
+            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="$ppTypeName-test-user-name" title=$form.test_user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td></tr>
 {if !empty($form.test_password)}
         <tr class="crm-paymentProcessor-form-block-test_password">
-            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="$ppTypeName-test-password" title=$form.test_password.label}</td>
+            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="$ppTypeName-test-password" title=$form.test_password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_signature)}
         <tr class="crm-paymentProcessor-form-block-test_signature">
-            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id="$ppTypeName-test-signature" title=$form.test_signature.label}</td>
+            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id="$ppTypeName-test-signature" title=$form.test_signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_subject)}
         <tr class="crm-paymentProcessor-form-block-test_subject">
-            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id="$ppTypeName-test-subject" title=$form.test_subject.label}</td>
+            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id="$ppTypeName-test-subject" title=$form.test_subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_site)}
         <tr class="crm-paymentProcessor-form-block-test_url_site">
-            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id="$ppTypeName-test-url-site" title=$form.test_url_site.label}</td>
+            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id="$ppTypeName-test-url-site" title=$form.test_url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_api)}
         <tr class="crm-paymentProcessor-form-block-test_url_api">
-            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id="$ppTypeName-test-url-api" title=$form.test_url_api.label}</td>
+            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id="$ppTypeName-test-url-api" title=$form.test_url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_recur)}
         <tr class="crm-paymentProcessor-form-block-test_url_recur">
-            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id="$ppTypeName-test-url-recur" title=$form.test_url_recur.label}</td>
+            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id="$ppTypeName-test-url-recur" title=$form.test_url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_button)}
         <tr class="crm-paymentProcessor-form-block-test_url_button">
-            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id="$ppTypeName-test-url-button" title=$form.test_url_button.label}</td>
+            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id="$ppTypeName-test-url-button" title=$form.test_url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {/if}

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -56,9 +56,11 @@
 <fieldset>
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>
     <table class="form-layout-compressed">
+{if !empty($form.user_name)}
         <tr class="crm-paymentProcessor-form-block-user_name">
             <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="{$ppTypeName}_live_user_name" title=$form.user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
+{/if}
 {if !empty($form.password)}
         <tr class="crm-paymentProcessor-form-block-password">
             <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="{$ppTypeName}_live_password" title=$form.password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
@@ -100,9 +102,11 @@
 <fieldset>
 <legend>{ts}Processor Details for Test Payments{/ts}</legend>
     <table class="form-layout-compressed">
+{if !empty($form.test_user_name)}
         <tr class="crm-paymentProcessor-form-block-test_user_name">
             <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="{$ppTypeName}_test_user_name" title=$form.test_user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
+{/if}
 {if !empty($form.test_password)}
         <tr class="crm-paymentProcessor-form-block-test_password">
             <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="{$ppTypeName}_test_password" title=$form.test_password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -55,12 +55,12 @@
   </table>
 <fieldset>
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>
-  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames helpSet="_live_"}
+  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames}
 </fieldset>
 
 <fieldset>
 <legend>{ts}Processor Details for Test Payments{/ts}</legend>
-  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$testFieldNames helpSet="_"}
+  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$testFieldNames}
 </fieldset>
 {/if}
 

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -57,41 +57,41 @@
 <legend>{ts}Processor Details for Live Payments{/ts}</legend>
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-user_name">
-            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="$ppTypeName-live-user-name" title=$form.user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.user_name.label}</td><td>{$form.user_name.html} {help id="{$ppTypeName}_live_user_name" title=$form.user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {if !empty($form.password)}
         <tr class="crm-paymentProcessor-form-block-password">
-            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="$ppTypeName-live-password" title=$form.password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.password.label}</td><td>{$form.password.html} {help id="{$ppTypeName}_live_password" title=$form.password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.signature)}
         <tr class="crm-paymentProcessor-form-block-signature">
-            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id="$ppTypeName-live-signature" title=$form.signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.signature.label}</td><td>{$form.signature.html} {help id="{$ppTypeName}_live_signature" title=$form.signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.subject)}
         <tr class="crm-paymentProcessor-form-block-subject">
-            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id="$ppTypeName-live-subject" title=$form.subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.subject.label}</td><td>{$form.subject.html} {help id="{$ppTypeName}_live_subject" title=$form.subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_site)}
         <tr class="crm-paymentProcessor-form-block-url_site">
-            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id="$ppTypeName-live-url-site" title=$form.url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.url_site.label}</td><td>{$form.url_site.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_site" title=$form.url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_api)}
         <tr class="crm-paymentProcessor-form-block-url_api">
-            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id="$ppTypeName-live-url-api" title=$form.url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.url_api.label}</td><td>{$form.url_api.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_api" title=$form.url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_recur)}
         <tr class="crm-paymentProcessor-form-block-url_recur">
-            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id="$ppTypeName-live-url-recur" title=$form.url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.url_recur.label}</td><td>{$form.url_recur.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_recur" title=$form.url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.url_button)}
         <tr class="crm-paymentProcessor-form-block-url_button">
-            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id="$ppTypeName-live-url-button" title=$form.url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.url_button.label}</td><td>{$form.url_button.html|crmAddClass:huge} {help id="{$ppTypeName}_live_url_button" title=$form.url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
     </table>
@@ -101,40 +101,41 @@
 <legend>{ts}Processor Details for Test Payments{/ts}</legend>
     <table class="form-layout-compressed">
         <tr class="crm-paymentProcessor-form-block-test_user_name">
-            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="$ppTypeName-test-user-name" title=$form.test_user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td></tr>
+            <td class="label">{$form.test_user_name.label}</td><td>{$form.test_user_name.html} {help id="{$ppTypeName}_test_user_name" title=$form.test_user_name.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+        </tr>
 {if !empty($form.test_password)}
         <tr class="crm-paymentProcessor-form-block-test_password">
-            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="$ppTypeName-test-password" title=$form.test_password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_password.label}</td><td>{$form.test_password.html} {help id="{$ppTypeName}_test_password" title=$form.test_password.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_signature)}
         <tr class="crm-paymentProcessor-form-block-test_signature">
-            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id="$ppTypeName-test-signature" title=$form.test_signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_signature.label}</td><td>{$form.test_signature.html} {help id="{$ppTypeName}_test_signature" title=$form.test_signature.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_subject)}
         <tr class="crm-paymentProcessor-form-block-test_subject">
-            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id="$ppTypeName-test-subject" title=$form.test_subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_subject.label}</td><td>{$form.test_subject.html} {help id="{$ppTypeName}_test_subject" title=$form.test_subject.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_site)}
         <tr class="crm-paymentProcessor-form-block-test_url_site">
-            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id="$ppTypeName-test-url-site" title=$form.test_url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_url_site.label}</td><td>{$form.test_url_site.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_site" title=$form.test_url_site.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_api)}
         <tr class="crm-paymentProcessor-form-block-test_url_api">
-            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id="$ppTypeName-test-url-api" title=$form.test_url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_url_api.label}</td><td>{$form.test_url_api.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_api" title=$form.test_url_api.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_recur)}
         <tr class="crm-paymentProcessor-form-block-test_url_recur">
-            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id="$ppTypeName-test-url-recur" title=$form.test_url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_url_recur.label}</td><td>{$form.test_url_recur.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_recur" title=$form.test_url_recur.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {if !empty($form.test_url_button)}
         <tr class="crm-paymentProcessor-form-block-test_url_button">
-            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id="$ppTypeName-test-url-button" title=$form.test_url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
+            <td class="label">{$form.test_url_button.label}</td><td>{$form.test_url_button.html|crmAddClass:huge} {help id="{$ppTypeName}_test_url_button" title=$form.test_url_button.label file="CRM/Admin/Page/PaymentProcessor.hlp"}</td>
         </tr>
 {/if}
 {/if}

--- a/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
@@ -1,15 +1,17 @@
 {*
- @param string[] $fieldNames
- @param string $ppTypeName
+ @param string[] $fieldNames Ex: ["user_name", "url_recur"] or ["test_user_name", "test_url_recur"]
+ @param string $ppTypeName Ex: "AuthNet" or "PayPal_Express"
  *}
 <table class="form-layout-compressed">
   {foreach from=$fieldNames item=fieldName}
     {if !empty($form.$fieldName)}
       <tr class="crm-paymentProcessor-form-block-{$fieldName}">
-        <td class="label">{$form.$fieldName.label}</td>
+        <td class="label">
+          {$form.$fieldName.label}
+          {help id="`$ppTypeName`_`$fieldName`" title=$form.$fieldName.textLabel file="CRM/Admin/Page/PaymentProcessor.hlp"}
+        </td>
         <td>
           {$form.$fieldName.html}
-          {help id="`$ppTypeName`_`$fieldName`" title=$form.$fieldName.textLabel file="CRM/Admin/Page/PaymentProcessor.hlp"}
         </td>
       </tr>
     {/if}

--- a/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
@@ -1,6 +1,6 @@
 {*
  @param string[] $fieldNames
- @param string $helpSet
+ @param string $ppTypeName
  *}
 <table class="form-layout-compressed">
   {foreach from=$fieldNames item=fieldName}
@@ -9,7 +9,7 @@
         <td class="label">{$form.$fieldName.label}</td>
         <td>
           {$form.$fieldName.html}
-          {help id="`$ppTypeName``$helpSet``$fieldName`" title=$form.$fieldName.label file="CRM/Admin/Page/PaymentProcessor.hlp"}
+          {help id="`$ppTypeName`_`$fieldName`" title=$form.$fieldName.label file="CRM/Admin/Page/PaymentProcessor.hlp"}
         </td>
       </tr>
     {/if}

--- a/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
@@ -9,7 +9,7 @@
         <td class="label">{$form.$fieldName.label}</td>
         <td>
           {$form.$fieldName.html}
-          {help id="`$ppTypeName`_`$fieldName`" title=$form.$fieldName.label file="CRM/Admin/Page/PaymentProcessor.hlp"}
+          {help id="`$ppTypeName`_`$fieldName`" title=$form.$fieldName.textLabel file="CRM/Admin/Page/PaymentProcessor.hlp"}
         </td>
       </tr>
     {/if}

--- a/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor/Details.tpl
@@ -1,0 +1,17 @@
+{*
+ @param string[] $fieldNames
+ @param string $helpSet
+ *}
+<table class="form-layout-compressed">
+  {foreach from=$fieldNames item=fieldName}
+    {if !empty($form.$fieldName)}
+      <tr class="crm-paymentProcessor-form-block-{$fieldName}">
+        <td class="label">{$form.$fieldName.label}</td>
+        <td>
+          {$form.$fieldName.html}
+          {help id="`$ppTypeName``$helpSet``$fieldName`" title=$form.$fieldName.label file="CRM/Admin/Page/PaymentProcessor.hlp"}
+        </td>
+      </tr>
+    {/if}
+  {/foreach}
+</table>

--- a/templates/CRM/Admin/Page/PaymentProcessor.hlp
+++ b/templates/CRM/Admin/Page/PaymentProcessor.hlp
@@ -19,19 +19,19 @@
 <p>{ts 1="https://civicrm.org/extensions?field_extension_civi_use_target_id=125"}If your desired processor is not in the list, check the <a href="%1">Extensions Directory</a> for more payment processors you can download. If you still can't find it, consider partnering with a developer and contributing a new extension.{/ts}</p>
 {/htxt}
 
-{htxt id='AuthNet_live_user_name'}
+{htxt id='AuthNet_user_name'}
 {ts}Generate your API Login and Transaction Key by logging in to your Merchant Account and navigating to <strong>Settings &raquo; General Security Settings</strong>.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet_live_password'}
+{htxt id='AuthNet_password'}
 {ts}Generate your API Login and Transaction Key by logging in to your Merchant Account and navigating to <strong>Settings &raquo; General Security Settings</strong>.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet_live_signature'}
+{htxt id='AuthNet_signature'}
 {ts}You may also optionally set an MD5 Hash Key to verify that responses come directly from Authorize.Net. Login to your merchant account and navigate to <strong>Account Settings</strong>. Select MD5-Hash and enter a new hash value. This can be just about any string of characters or words. Then enter the exact same value here.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet_live_url_site'}
+{htxt id='AuthNet_url_site'}
 {ts}The URL for Authorize.net's LIVE Payment server. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
-{htxt id='AuthNet_live_url_recur'}
+{htxt id='AuthNet_url_recur'}
 {ts}The URL for recurring payments. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
 {htxt id='AuthNet_test_user_name'}
@@ -50,22 +50,22 @@
 {ts}The URL for recurring payments. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
 
-{htxt id='PayPal_live_user_name'}
+{htxt id='PayPal_user_name'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Username</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_live_password'}
+{htxt id='PayPal_password'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Password</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_live_signature'}
+{htxt id='PayPal_signature'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Signature</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_live_url_site'}
+{htxt id='PayPal_url_site'}
 {ts}The URL for PayPal's LIVE Payment server. Use the default value (unless otherwise advised by PayPal):{/ts}<br /> https://www.paypal.com/
 {/htxt}
-{htxt id='PayPal_live_url_api'}
+{htxt id='PayPal_url_api'}
 {ts}The URL for PayPal's LIVE API gateway server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://api-3t.paypal.com/
 {/htxt}
-{htxt id='PayPal_live_url_button'}
+{htxt id='PayPal_url_button'}
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
 {htxt id='PayPal_test_user_name'}
@@ -87,22 +87,22 @@
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
 
-{htxt id='PayPal_Express_live_user_name'}
+{htxt id='PayPal_Express_user_name'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Username</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express_live_password'}
+{htxt id='PayPal_Express_password'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Password</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express_live_signature'}
+{htxt id='PayPal_Express_signature'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Signature</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express_live_url_site'}
+{htxt id='PayPal_Express_url_site'}
 {ts}The URL for PayPal's LIVE Payment server. Use the default value (unless otherwise advised by PayPal):{/ts}<br /> https://www.paypal.com/
 {/htxt}
-{htxt id='PayPal_Express_live_url_api'}
+{htxt id='PayPal_Express_url_api'}
 {ts}The URL for PayPal's LIVE API gateway server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://api-3t.paypal.com/
 {/htxt}
-{htxt id='PayPal_Express_live_url_button'}
+{htxt id='PayPal_Express_url_button'}
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
 {htxt id='PayPal_Express_test_user_name'}
@@ -124,13 +124,13 @@
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
 
-{htxt id='PayPal_Standard_live_user_name'}
-{ts}Enter the Merchant Account Email Address linked to your LIVE PayPal Merchant Account.{/ts}</p>
+{htxt id='PayPal_Standard_user_name'}
+{ts}ZOOP Enter the Merchant Account Email Address linked to your LIVE PayPal Merchant Account.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Standard_live_url_site'}
+{htxt id='PayPal_Standard_url_site'}
 {ts}The URL for PayPal's LIVE Payment server. Use the default value unless otherwise indicated by PayPal.{/ts}
 {/htxt}
-{htxt id='PayPal_Standard_live_url_recur'}
+{htxt id='PayPal_Standard_url_recur'}
 {ts}The URL for PayPal Standard recurring payments. Use the default value unless otherwise indicated by PayPal.{/ts}
 {/htxt}
 {htxt id='PayPal_Standard_test_user_name'}
@@ -156,23 +156,23 @@
 <p>{ts}The Recurring Payments URL is not currently used.{/ts}</p>
 {/htxt}
 
-{htxt id='PayJunction_live_user_name'}
+{htxt id='PayJunction_user_name'}
 <p>{ts}Enter the User Name associated with your LIVE merchant account.{/ts}</p>
 {/htxt}
-{htxt id='PayJunction_live_password'}
+{htxt id='PayJunction_password'}
 <p>{ts}Enter the Password associated with your LIVE merchant account.{/ts}</p>
 {/htxt}
-{htxt id='PayJunction_live_url_site'}
+{htxt id='PayJunction_url_site'}
 {ts}The URL for PayJunction's Payment server. This is the same for TEST and LIVE transactions. Use the default value unless otherwise advised by PayJunction.{/ts}
 {/htxt}
-{htxt id='PayJunction_live_url_recur'}
+{htxt id='PayJunction_url_recur'}
 <p>{ts}The Recurring Payments URL is not currently used.{/ts}</p>
 {/htxt}
 
-{htxt id='Dummy_live_user_name'}
+{htxt id='Dummy_user_name'}
 {ts}Set up a 'Dummy' Processor if you want to test Online Contribution pages or Event Registration pages prior to selecting and configuring a real payment processor. You can enter any values for User Name and Site URL.{/ts}</p>
 {/htxt}
-{htxt id='Dummy_live_url_site'}
+{htxt id='Dummy_url_site'}
 {ts}Set up a 'Dummy' Processor if you want to test Online Contribution pages or Event Registration pages prior to selecting and configuring a real payment processor. You can enter any values for User Name and Site URL.{/ts}</p>
 {/htxt}
 {htxt id='Dummy_test_user_name'}
@@ -193,24 +193,24 @@
 <br />{ts 1='<strong>https://www.eway.com.au/gateway_cvn/xmltest/testpage.asp</strong>'}Use %1 unless otherwise advised by eWAY.{/ts}
 {/htxt}
 
-{htxt id='eWAY_live_user_name'}
+{htxt id='eWAY_user_name'}
 <p>{ts}This is the LIVE <strong>eWAYCustomerID</strong> associated with your eWAY account.{/ts}</p>
 {/htxt}
-{htxt id='eWAY_live_url_site'}
+{htxt id='eWAY_url_site'}
 {ts}The <strong>URL</strong> for eWAY's LIVE Gateway.{/ts}
 <br />{ts 1='<strong>https://www.eway.com.au/gateway_cvn/xmlpayment.asp</strong>'}Use %1 unless otherwise advised by eWAY.{/ts}
 {/htxt}
 
-{htxt id='Elavon_live_user_name'}
+{htxt id='Elavon_user_name'}
 <p>{ts}This is the LIVE <strong>Elavon Merchant ID</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon_live_password'}
+{htxt id='Elavon_password'}
 <p>{ts}This is the LIVE <strong>Elavon User ID</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon_live_signature'}
+{htxt id='Elavon_signature'}
 <p>{ts}This is the LIVE <strong>Elavon SSL PIN</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon_live_url_site'}
+{htxt id='Elavon_url_site'}
 <p>{ts}Use 'https://www.myvirtualmerchant.com/VirtualMerchant/processxml.do' unless otherwise advised by Elavon..{/ts}</p>
 {/htxt}
 
@@ -227,13 +227,13 @@
 <p>{ts}Use 'https://www.myvirtualmerchant.com/VirtualMerchant/processxml.do' unless otherwise advised by Elavon.{/ts}</p>
 {/htxt}
 
-{htxt id='FirstData_live_user_name'}
+{htxt id='FirstData_user_name'}
 <p>{ts}This is the LIVE <strong>First Data Store Name</strong> associated with your First Data account (This is Certificate file number without the extension).{/ts}</p>
 {/htxt}
-{htxt id='FirstData_live_password'}
+{htxt id='FirstData_password'}
 <p>{ts}This is the LIVE <strong>Certificate Path</strong> associated with your First Data account.{/ts}</p>
 {/htxt}
-{htxt id='FirstData_live_url_site'}
+{htxt id='FirstData_url_site'}
 <p>{ts}The URL for First Data's Live Payment server. Use the default value (unless otherwise advised by First Data):{/ts}<br />https://secure.linkpt.net</p>
 {/htxt}
 {htxt id='FirstData_test_user_name'}

--- a/templates/CRM/Admin/Page/PaymentProcessor.hlp
+++ b/templates/CRM/Admin/Page/PaymentProcessor.hlp
@@ -19,229 +19,229 @@
 <p>{ts 1="https://civicrm.org/extensions?field_extension_civi_use_target_id=125"}If your desired processor is not in the list, check the <a href="%1">Extensions Directory</a> for more payment processors you can download. If you still can't find it, consider partnering with a developer and contributing a new extension.{/ts}</p>
 {/htxt}
 
-{htxt id='AuthNet-live-user-name'}
+{htxt id='AuthNet_live_user_name'}
 {ts}Generate your API Login and Transaction Key by logging in to your Merchant Account and navigating to <strong>Settings &raquo; General Security Settings</strong>.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet-live-password'}
+{htxt id='AuthNet_live_password'}
 {ts}Generate your API Login and Transaction Key by logging in to your Merchant Account and navigating to <strong>Settings &raquo; General Security Settings</strong>.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet-live-signature'}
+{htxt id='AuthNet_live_signature'}
 {ts}You may also optionally set an MD5 Hash Key to verify that responses come directly from Authorize.Net. Login to your merchant account and navigate to <strong>Account Settings</strong>. Select MD5-Hash and enter a new hash value. This can be just about any string of characters or words. Then enter the exact same value here.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet-live-url-site'}
+{htxt id='AuthNet_live_url_site'}
 {ts}The URL for Authorize.net's LIVE Payment server. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
-{htxt id='AuthNet-live-url-recur'}
+{htxt id='AuthNet_live_url_recur'}
 {ts}The URL for recurring payments. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
-{htxt id='AuthNet-test-user-name'}
+{htxt id='AuthNet_test_user_name'}
 {ts}Generate your API Login and Transaction Key by logging in to your Merchant Account and navigating to <strong>Settings &raquo; General Security Settings</strong>.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet-test-password'}
+{htxt id='AuthNet_test_password'}
 {ts}Generate your API Login and Transaction Key by logging in to your Merchant Account and navigating to <strong>Settings &raquo; General Security Settings</strong>.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet-test-signature'}
+{htxt id='AuthNet_test_signature'}
 {ts}You may also optionally set an MD5 Hash Key to verify that responses come directly from Authorize.Net. Login to your merchant account and navigate to <strong>Account Settings</strong>. Select MD5-Hash and enter a new hash value. This can be just about any string of characters or words. Then enter the exact same value here.{/ts}</p>
 {/htxt}
-{htxt id='AuthNet-test-url-site'}
+{htxt id='AuthNet_test_url_site'}
 {ts}The URL for Authorize.net's TEST Payment server. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
-{htxt id='AuthNet-test-url-recur'}
+{htxt id='AuthNet_test_url_recur'}
 {ts}The URL for recurring payments. Use the default value unless otherwise advised by the processor.{/ts}
 {/htxt}
 
-{htxt id='PayPal-live-user-name'}
+{htxt id='PayPal_live_user_name'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Username</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal-live-password'}
+{htxt id='PayPal_live_password'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Password</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal-live-signature'}
+{htxt id='PayPal_live_signature'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Signature</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal-live-url-site'}
+{htxt id='PayPal_live_url_site'}
 {ts}The URL for PayPal's LIVE Payment server. Use the default value (unless otherwise advised by PayPal):{/ts}<br /> https://www.paypal.com/
 {/htxt}
-{htxt id='PayPal-live-url-api'}
+{htxt id='PayPal_live_url_api'}
 {ts}The URL for PayPal's LIVE API gateway server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://api-3t.paypal.com/
 {/htxt}
-{htxt id='PayPal-live-url-button'}
+{htxt id='PayPal_live_url_button'}
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
-{htxt id='PayPal-test-user-name'}
+{htxt id='PayPal_test_user_name'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Username</strong> as displayed in your TEST (sandbox) account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal-test-password'}
+{htxt id='PayPal_test_password'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Password</strong> as displayed in your TEST (sandbox) account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal-test-signature'}
+{htxt id='PayPal_test_signature'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Signature</strong> as displayed in your TEST (sandbox) account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal-test-url-site'}
+{htxt id='PayPal_test_url_site'}
 {ts}The URL for PayPal's TEST Payment server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://www.sandbox.paypal.com/
 {/htxt}
-{htxt id='PayPal-test-url-api'}
+{htxt id='PayPal_test_url_api'}
 {ts}The URL for PayPal's TEST API gateway server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://api-3t.sandbox.paypal.com/
 {/htxt}
-{htxt id='PayPal-test-url-button'}
+{htxt id='PayPal_test_url_button'}
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
 
-{htxt id='PayPal_Express-live-user-name'}
+{htxt id='PayPal_Express_live_user_name'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Username</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express-live-password'}
+{htxt id='PayPal_Express_live_password'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Password</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express-live-signature'}
+{htxt id='PayPal_Express_live_signature'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Signature</strong> as displayed in your LIVE account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express-live-url-site'}
+{htxt id='PayPal_Express_live_url_site'}
 {ts}The URL for PayPal's LIVE Payment server. Use the default value (unless otherwise advised by PayPal):{/ts}<br /> https://www.paypal.com/
 {/htxt}
-{htxt id='PayPal_Express-live-url-api'}
+{htxt id='PayPal_Express_live_url_api'}
 {ts}The URL for PayPal's LIVE API gateway server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://api-3t.paypal.com/
 {/htxt}
-{htxt id='PayPal_Express-live-url-button'}
+{htxt id='PayPal_Express_live_url_button'}
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
-{htxt id='PayPal_Express-test-user-name'}
+{htxt id='PayPal_Express_test_user_name'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Username</strong> as displayed in your TEST (sandbox) account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express-test-password'}
+{htxt id='PayPal_Express_test_password'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Password</strong> as displayed in your TEST (sandbox) account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express-test-signature'}
+{htxt id='PayPal_Express_test_signature'}
 {ts}CiviCRM requires that you use the <strong>Signature-based API Credentials</strong> for PayPal Pro and Express. Enter your <strong>API Signature</strong> as displayed in your TEST (sandbox) account's <strong>Profile - View API Signature</strong> screen.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Express-test-url-site'}
+{htxt id='PayPal_Express_test_url_site'}
 {ts}The URL for PayPal's TEST Payment server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://www.sandbox.paypal.com/
 {/htxt}
-{htxt id='PayPal_Express-test-url-api'}
+{htxt id='PayPal_Express_test_url_api'}
 {ts}The URL for PayPal's TEST API gateway server. Use the default value (unless otherwise advised by PayPal):{/ts}<br />https://api-3t.sandbox.paypal.com/
 {/htxt}
-{htxt id='PayPal_Express-test-url-button'}
+{htxt id='PayPal_Express_test_url_button'}
 {ts}The URL for displaying PayPal's 'Pay with PayPal' payment button image. Use the default value unless otherwise advised by PayPal.{/ts}
 {/htxt}
 
-{htxt id='PayPal_Standard-live-user-name'}
+{htxt id='PayPal_Standard_live_user_name'}
 {ts}Enter the Merchant Account Email Address linked to your LIVE PayPal Merchant Account.{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Standard-live-url-site'}
+{htxt id='PayPal_Standard_live_url_site'}
 {ts}The URL for PayPal's LIVE Payment server. Use the default value unless otherwise indicated by PayPal.{/ts}
 {/htxt}
-{htxt id='PayPal_Standard-live-url-recur'}
+{htxt id='PayPal_Standard_live_url_recur'}
 {ts}The URL for PayPal Standard recurring payments. Use the default value unless otherwise indicated by PayPal.{/ts}
 {/htxt}
-{htxt id='PayPal_Standard-test-user-name'}
+{htxt id='PayPal_Standard_test_user_name'}
 {ts}Enter the Merchant Account Email Address linked to your PayPal Sandbox merchant account (NOT your Developer Central login - unless it's the same).{/ts}</p>
 {/htxt}
-{htxt id='PayPal_Standard-test-url-site'}
+{htxt id='PayPal_Standard_test_url_site'}
 {ts}The URL for PayPal's TEST Payment server. Use the default value unless otherwise indicated by PayPal.{/ts}
 {/htxt}
-{htxt id='PayPal_Standard-test-url-recur'}
+{htxt id='PayPal_Standard_test_url_recur'}
 {ts}The URL for PayPal Standard recurring payments. Use the default value unless otherwise indicated by PayPal.{/ts}
 {/htxt}
 
-{htxt id='PayJunction-test-user-name'}
+{htxt id='PayJunction_test_user_name'}
 <p>{ts}Enter <strong>pj-ql-01</strong>. This is the User Name associated with the shared PayJunction test account.{/ts}</p>
 {/htxt}
-{htxt id='PayJunction-test-password'}
+{htxt id='PayJunction_test_password'}
 <p>{ts}Enter <strong>pj-ql-01p</strong>. This is the Password associated with the shared PayJunction test account.{/ts}</p>
 {/htxt}
-{htxt id='PayJunction-test-url-site'}
+{htxt id='PayJunction_test_url_site'}
 {ts}The URL for PayJunction's Payment server. This is the same for TEST and LIVE transactions. Use the default value unless otherwise advised by PayJunction.{/ts}
 {/htxt}
-{htxt id='PayJunction-test-url-recur'}
+{htxt id='PayJunction_test_url_recur'}
 <p>{ts}The Recurring Payments URL is not currently used.{/ts}</p>
 {/htxt}
 
-{htxt id='PayJunction-live-user-name'}
+{htxt id='PayJunction_live_user_name'}
 <p>{ts}Enter the User Name associated with your LIVE merchant account.{/ts}</p>
 {/htxt}
-{htxt id='PayJunction-live-password'}
+{htxt id='PayJunction_live_password'}
 <p>{ts}Enter the Password associated with your LIVE merchant account.{/ts}</p>
 {/htxt}
-{htxt id='PayJunction-live-url-site'}
+{htxt id='PayJunction_live_url_site'}
 {ts}The URL for PayJunction's Payment server. This is the same for TEST and LIVE transactions. Use the default value unless otherwise advised by PayJunction.{/ts}
 {/htxt}
-{htxt id='PayJunction-live-url-recur'}
+{htxt id='PayJunction_live_url_recur'}
 <p>{ts}The Recurring Payments URL is not currently used.{/ts}</p>
 {/htxt}
 
-{htxt id='Dummy-live-user-name'}
+{htxt id='Dummy_live_user_name'}
 {ts}Set up a 'Dummy' Processor if you want to test Online Contribution pages or Event Registration pages prior to selecting and configuring a real payment processor. You can enter any values for User Name and Site URL.{/ts}</p>
 {/htxt}
-{htxt id='Dummy-live-url-site'}
+{htxt id='Dummy_live_url_site'}
 {ts}Set up a 'Dummy' Processor if you want to test Online Contribution pages or Event Registration pages prior to selecting and configuring a real payment processor. You can enter any values for User Name and Site URL.{/ts}</p>
 {/htxt}
-{htxt id='Dummy-test-user-name'}
+{htxt id='Dummy_test_user_name'}
 {ts}Set up a 'Dummy' Processor if you want to test Online Contribution pages or Event Registration pages prior to selecting and configuring a real payment processor. You can enter any values for User Name and Site URL.{/ts}</p>
 {/htxt}
-{htxt id='Dummy-test-url-site'}
+{htxt id='Dummy_test_url_site'}
 {ts}Set up a 'Dummy' Processor if you want to test Online Contribution pages or Event Registration pages prior to selecting and configuring a real payment processor. You can enter any values for User Name and Site URL.{/ts}</p>
 {/htxt}
 
-{htxt id='eWAY-test-user-name'}
+{htxt id='eWAY_test_user_name'}
 <p>{ts 1='<strong>eWAYCustomerID</strong>'}This is the TEST %1 used solely for testing.{/ts}
 <br />{ts 1='<strong>87654321</strong>'}Use %1 unless otherwise advised by eWAY.{/ts}
 <br />{ts 1='<strong>4444333322221111</strong>'}The test Credit Card number is %1 - this is the only credit card number that will work on the test gateway.{/ts}
 <br />{ts 1='00' 2='08'}The test Total Amount should end in <strong>%1</strong> or <strong>%2</strong> to get a successful response (e.g. $10.%1 or $10.%2) - all other amounts will return a failed response.{/ts}</p>
 {/htxt}
-{htxt id='eWAY-test-url-site'}
+{htxt id='eWAY_test_url_site'}
 {ts}The <strong>URL</strong> for eWAY's TEST Gateway.{/ts}
 <br />{ts 1='<strong>https://www.eway.com.au/gateway_cvn/xmltest/testpage.asp</strong>'}Use %1 unless otherwise advised by eWAY.{/ts}
 {/htxt}
 
-{htxt id='eWAY-live-user-name'}
+{htxt id='eWAY_live_user_name'}
 <p>{ts}This is the LIVE <strong>eWAYCustomerID</strong> associated with your eWAY account.{/ts}</p>
 {/htxt}
-{htxt id='eWAY-live-url-site'}
+{htxt id='eWAY_live_url_site'}
 {ts}The <strong>URL</strong> for eWAY's LIVE Gateway.{/ts}
 <br />{ts 1='<strong>https://www.eway.com.au/gateway_cvn/xmlpayment.asp</strong>'}Use %1 unless otherwise advised by eWAY.{/ts}
 {/htxt}
 
-{htxt id='Elavon-live-user-name'}
+{htxt id='Elavon_live_user_name'}
 <p>{ts}This is the LIVE <strong>Elavon Merchant ID</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon-live-password'}
+{htxt id='Elavon_live_password'}
 <p>{ts}This is the LIVE <strong>Elavon User ID</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon-live-signature'}
+{htxt id='Elavon_live_signature'}
 <p>{ts}This is the LIVE <strong>Elavon SSL PIN</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon-live-url-site'}
+{htxt id='Elavon_live_url_site'}
 <p>{ts}Use 'https://www.myvirtualmerchant.com/VirtualMerchant/processxml.do' unless otherwise advised by Elavon..{/ts}</p>
 {/htxt}
 
-{htxt id='Elavon-test-user-name'}
+{htxt id='Elavon_test_user_name'}
 <p>{ts}This is the TEST <strong>Elavon Merchant ID</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon-test-password'}
+{htxt id='Elavon_test_password'}
 <p>{ts}This is the TEST <strong>Elavon User ID</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon-test-signature'}
+{htxt id='Elavon_test_signature'}
 <p>{ts}This is the TEST <strong>Elavon SSL PIN</strong> associated with your Elavon account.{/ts}</p>
 {/htxt}
-{htxt id='Elavon-test-url-site'}
+{htxt id='Elavon_test_url_site'}
 <p>{ts}Use 'https://www.myvirtualmerchant.com/VirtualMerchant/processxml.do' unless otherwise advised by Elavon.{/ts}</p>
 {/htxt}
 
-{htxt id='FirstData-live-user-name'}
+{htxt id='FirstData_live_user_name'}
 <p>{ts}This is the LIVE <strong>First Data Store Name</strong> associated with your First Data account (This is Certificate file number without the extension).{/ts}</p>
 {/htxt}
-{htxt id='FirstData-live-password'}
+{htxt id='FirstData_live_password'}
 <p>{ts}This is the LIVE <strong>Certificate Path</strong> associated with your First Data account.{/ts}</p>
 {/htxt}
-{htxt id='FirstData-live-url-site'}
+{htxt id='FirstData_live_url_site'}
 <p>{ts}The URL for First Data's Live Payment server. Use the default value (unless otherwise advised by First Data):{/ts}<br />https://secure.linkpt.net</p>
 {/htxt}
-{htxt id='FirstData-test-user-name'}
+{htxt id='FirstData_test_user_name'}
 <p>{ts}This is the TEST <strong>First Data Store Name</strong> associated with your First Data account (This is Certificate file number without the extension).{/ts}</p>
 {/htxt}
-{htxt id='FirstData-test-password'}
+{htxt id='FirstData_test_password'}
 <p>{ts}This is the TEST <strong>Certificate Path</strong> associated with your First Data account.{/ts}</p>
 {/htxt}
-{htxt id='FirstData-test-url-site'}
+{htxt id='FirstData_test_url_site'}
 <p>{ts}The URL for First Data's TEST Payment server. Use the default value (unless otherwise advised by First Data):{/ts}<br />https://staging.linkpt.net</p>
 {/htxt}


### PR DESCRIPTION
Overview
----------------------------------------

In "Administer => System => Payment Processors", the "Edit" screen includes sections for "Processor Details" (in "Live" and "Test" variants). This is a fix+cleanup.

Contributes toward RevShare epic (#33707 et al).


Before
----------------------------------------

* Help buttons don't actually show content from the help file. (Presumably, the relevant bits were moved/refactored at some point, and nobody noticed that the filenames got mismatched.)

    <img width="970" height="357" alt="Screenshot 2025-11-08 at 2 16 30 PM" src="https://github.com/user-attachments/assets/7ed763a1-6dbb-4c2f-a628-6cbbc6a2b18f" />

* There are large, redundant blocks of TPL. This makes it hard to move/reorganize the content of the file.

After
----------------------------------------

* Help buttons work:

    <img width="970" height="480" alt="Screenshot 2025-11-08 at 2 14 40 PM" src="https://github.com/user-attachments/assets/8fabd4f9-48cd-401e-8822-4b08a4ab2a8b" />

* Less redundant code

Comments
----------------------------------------

To make it easier to loop through the fields, this also incidentally renames the help blurbs -- so that field-names and help-ids match more closely.

I kind of think it's crazy that there is separate help for the "live" vs "test" fields (ie `user_name` vs `test_user_name`). Maybe we'll land somewhere else on that. But for the moment, this PR is a straight cleanup/refactor.

`r-run`: I tried this in both Smarty v2 and Smarty v5.