### PR TITLE
riverlea - fix loading fonts with relative urls

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -20,6 +20,7 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
 
   public const CORE_FILES = [
     '_variables.css',
+    '_fonts.css',
     '_base.css',
     '_cms.css',
     'components/_accordion.css',

--- a/ext/riverlea/core/css/_fonts.css
+++ b/ext/riverlea/core/css/_fonts.css
@@ -1,0 +1,62 @@
+/* fonts that are packaged in Riverlea and can be used in streams
+   NOTE: browsers shouldn't load these unless they are used by the stream */
+
+/* Inter */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+  src: local('Inter-Regular'), local('Inter Regular'), local('Inter'), url('../../fonts/inter-v18-latin-regular.woff2') format("woff2");
+}
+@font-face {
+  font-family: 'Inter';
+  font-style: italic;
+  font-weight: normal;
+  font-display: swap;
+  src: local('Inter-Italic'), local('Inter Italic'), url('../../fonts/inter-v18-latin-italic.woff2') format("woff2");
+}
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: bold;
+  font-display: swap;
+  src: local('Inter-Bold'), local('Inter Bold'), url('../../fonts/inter-v18-latin-600.woff2') format("woff2");
+}
+@font-face {
+  font-family: 'Inter';
+  font-style: italic;
+  font-weight: bold;
+  font-display: swap;
+  src: local('Inter-BoldItalic'), local('Inter BoldItalic'), url('../../fonts/inter-v18-latin-600.woff2') format("woff2");
+}
+
+/* Lato */
+@font-face {
+  font-family: 'Lato';
+  font-display: swap;
+  font-style: normal;
+  font-weight: 400;
+  src: local('Lato-Regular'), local('Lato Regular'), local('Lato'), url('../../fonts/lato-v24-latin-regular.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Lato';
+  font-display: swap;
+  font-style: italic;
+  font-weight: 400;
+  src: local('Lato-Italic'), local('Lato Italic'), url('../../fonts/lato-v24-latin-italic.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Lato';
+  font-display: swap;
+  font-style: normal;
+  font-weight: 700;
+  src: local('Lato-Bold'), local('Lato Bold'), url('../../fonts/lato-v24-latin-700.woff2') format('woff2');
+}
+@font-face {
+  font-family: 'Lato';
+  font-display: swap;
+  font-style: italic;
+  font-weight: 700;
+  src: local('Lato-BoldItalic'), local('Lato BoldItalic'), url('../../fonts/lato-v24-latin-700italic.woff2') format('woff2');
+}

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -11,42 +11,6 @@
 
 */
 
-/* Font */
-@font-face {
-  font-display: swap;
-  font-family: 'Lato';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Lato-Regular') local('Lato Regular') local('Lato') url('../../../fonts/lato-v24-latin-regular.woff2') format('woff2');
-}
-
-/* lato-italic - latin */
-@font-face {
-  font-display: swap;
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 400;
-  src: local('Lato-Italic') local('Lato Italic') url('../../../fonts/lato-v24-latin-italic.woff2') format('woff2');
-}
-
-/* lato-700 - latin */
-@font-face {
-  font-display: swap;
-  font-family: 'Lato';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Lato-Bold') local('Lato Bold') url('../../../fonts/lato-v24-latin-700.woff2') format('woff2');
-}
-
-/* lato-700italic - latin */
-@font-face {
-  font-display: swap;
-  font-family: 'Lato';
-  font-style: italic;
-  font-weight: 700;
-  src: local('Lato-BoldItalic') local('Lato BoldItalic') url('../../../fonts/lato-v24-latin-700italic.woff2') format('woff2');
-}
-
 :root {
   --crm-version: 'Thames, v' var(--crm-release);
 /* FONTS */

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -4,36 +4,6 @@
     Riverlea version: 1.3.8;
 */
 
-/* Font */
-@font-face {
-  font-family: Inter;
-  font-style: normal;
-  font-weight: normal;
-  font-display: swap;
-  src: local('Inter-Regular') local('Inter Regular') local('Inter') url('../../../fonts/inter-v18-latin-regular.woff2') format("woff2");
-}
-@font-face {
-  font-family: Inter;
-  font-style: italic;
-  font-weight: normal;
-  font-display: swap;
-  src: local('Inter-Italic') local('Inter Italic') url('../../../fonts/inter-v18-latin-italic.woff2') format("woff2");
-}
-@font-face {
-  font-family: Inter;
-  font-style: normal;
-  font-weight: bold;
-  font-display: swap;
-  src: local('Inter-Bold') local('Inter Bold') url('../../../fonts/inter-v18-latin-600.woff2') format("woff2");
-}
-@font-face {
-  font-family: Inter;
-  font-style: italic;
-  font-weight: bold;
-  font-display: swap;
-  src: local('Inter-BoldItalic') ('Inter BoldItalic') url('../../../fonts/inter-v18-latin-600.woff2') format("woff2");
-}
-
 :root {
   --crm-version: 'Walbrook, v' var(--crm-release);
 /* Fonts */


### PR DESCRIPTION
Overview
----------------------------------------
Moving the @font-face definitions in the Thames and Walbrook into their dynamic css has broken them. Move them into Riverlea core instead.

Before
----------------------------------------
- stream font-face definitions are defined in Stream `_main.css`
- relative urls are broken because the stream css is compiled and loaded at a different url
- loading from non local fonts are broken because the `src` definitions are missing commas

After 
----------------------------------------
- stream font-face definitions are in a core `_fonts.css` with consistent relative path to Riverlea's font folder
- loading from non local fonts is fixed
- the actual fonts are only loaded by the browser if used on the page -- ie. if the stream references them

Technical Details
----------------------------------------
An alternative could be to move the font definitions back to per stream `_civicrm.css` files. But it seems neater to me to keep all the stream css in a single file.
