### PR TITLE
Replace participant_status smarty var with label

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1604,6 +1604,7 @@ class CRM_Utils_Token {
           '$paidBy' => 'contribution.payment_instrument_id:label',
           '$title' => 'event.title',
           '$lineItem' => '$lineItems',
+          '$participant_status' => '{participant.status_id:label}',
         ],
         'participant_transferred' => [
           '$location' => 'event.location',

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -28,7 +28,7 @@
         <p>{event.confirm_email_text}</p>
       {else}
         <p>{ts}Thank you for your registration.{/ts}
-            {if $participant_status}{ts 1=$participant_status}This is a confirmation that your registration has been received and your status has been updated to <strong>%1</strong>.{/ts}
+            {if '{participant.status_id:label}'}{ts 1='{participant.status_id:label}'}This is a confirmation that your registration has been received and your status has been updated to <strong>%1</strong>.{/ts}
             {else}
               {if $isOnWaitlist}{ts}This is a confirmation that your registration has been received and your status has been updated to <strong>waitlisted</strong>.{/ts}
               {else}{ts}This is a confirmation that your registration has been received and your status has been updated to <strong>registered<strong>.{/ts}


### PR DESCRIPTION

Overview
----------------------------------------
Replace participant_status smarty var with label

Before
----------------------------------------
`$participant_status` still used in the template

After
----------------------------------------
Switch to the token in line with other variables

Technical Details
----------------------------------------
This does have specific test cover

Comments
----------------------------------------
