### PR TITLE
Make standalone roles (including permissions) a managed entity

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Role.php
+++ b/ext/standaloneusers/Civi/Api4/Role.php
@@ -9,6 +9,7 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class Role extends Generic\DAOEntity {
+  use Generic\Traits\ManagedEntity;
 
   /**
    * Declare permissions needed to access this entity.


### PR DESCRIPTION
Overview
----------------------------------------
The entity "Role" becomes a managed entity. 

Before
----------------------------------------
Is is not possible to export standalone roles and permissions.

After
----------------------------------------
You can use `civix export Role ID` to export standalone roles with their corresponding permissions.

Technical Details
----------------------------------------
This is only possible for standalone.

Comments
----------------------------------------
Probably not very useful for contributed extensions as it is standalone only. But for custom extensions it can be handy for deployments.