### PR TITLE
Riverlea: fix for settings menu not shown in standalone

### DIFF
--- a/ext/riverlea/managed/navigationmenu.mgd.php
+++ b/ext/riverlea/managed/navigationmenu.mgd.php
@@ -14,7 +14,7 @@ return [
           'label' => E::ts('Riverlea Settings'),
           'name' => 'riverlea_settings',
           'url' => 'civicrm/admin/setting/riverlea',
-          'permission' => 'administer Riverlea',
+          'permission' => 'administer riverlea',
           'permission_operator' => 'OR',
           'parent_id.name' => 'Customize Data and Screens',
           'is_active' => TRUE,


### PR DESCRIPTION
Before
----------------------------------------
In CiviCRM `standalone`, the Riverlea settings menu isn't shown in the navigation menu at `Administer > Customize Data and Screens`. It is, however, possible to call the settings page via its URL `/civicrm/admin/setting/riverlea`.

After
----------------------------------------
The Riverlea settings menu is shown correctly in the navigation in `standalone` and `wp-demo`.

Technical Details
----------------------------------------
The navigation menu requested the permission `administer Riverlea` to be shown. However, the permission is called `administer riverlea` (no caps), so the menu isn't visible.
