### PR TITLE
trxn_date should be passed into completeOrder as receive_date

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -175,7 +175,7 @@ class CRM_Financial_BAO_Payment {
         }
         CRM_Contribute_BAO_Contribution::completeOrder([
           'is_email_receipt' => $params['is_send_contribution_notification'],
-          'trxn_date' => $params['trxn_date'],
+          'receive_date' => $params['trxn_date'],
           'payment_instrument_id' => $paymentTrxnParams['payment_instrument_id'],
           'payment_processor_id' => $paymentTrxnParams['payment_processor_id'] ?? '',
         ], $contributionBAO->contribution_recur_id, $contribution['id'], TRUE, $disableActionsOnCompleteOrder);


### PR DESCRIPTION
Overview
----------------------------------------
Found via https://github.com/civicrm/civicrm-core/pull/33003

Before
----------------------------------------
trxn_date parameter ignored when using API4 Payment::create with completeOrder

After
----------------------------------------
trxn_date parameter used when using API4 Payment::create with completeOrder

Technical Details
----------------------------------------


Comments
----------------------------------------
