### PR TITLE
trxn_date should be passed into completeOrder as receive_date

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3440,7 +3440,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     if ($contributionParams['contribution_status_id'] === $completedContributionStatusID && !$disableActionsOnCompleteOrder) {
       $orderCompleteEventParams = [
-        'effective_date' => $input['trxn_date'] ?? date('YmdHis'),
+        'effective_date' => $input['receive_date'] ?? date('YmdHis'),
       ];
       \Civi::dispatcher()->dispatch('civi.order.complete', new OrderCompleteEvent($contributionID, $orderCompleteEventParams));
     }

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -175,7 +175,7 @@ class CRM_Financial_BAO_Payment {
         }
         CRM_Contribute_BAO_Contribution::completeOrder([
           'is_email_receipt' => $params['is_send_contribution_notification'],
-          'trxn_date' => $params['trxn_date'],
+          'receive_date' => $contribution['receive_date'],
           'payment_instrument_id' => $paymentTrxnParams['payment_instrument_id'],
           'payment_processor_id' => $paymentTrxnParams['payment_processor_id'] ?? '',
         ], $contributionBAO->contribution_recur_id, $contribution['id'], TRUE, $disableActionsOnCompleteOrder);

--- a/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalProIPNTest.php
@@ -102,6 +102,16 @@ class CRM_Core_Payment_PayPalProIPNTest extends CiviUnitTestCase {
   public function testIPNPaymentMembershipRecurSuccess(): void {
     $durationUnit = 'year';
     $this->setupMembershipRecurringPaymentProcessorTransaction(['duration_unit' => $durationUnit, 'frequency_unit' => $durationUnit]);
+    // I can't see where the membership is created? But the dates need to start within the range of contributions received by the IPN
+    //   or we'll get issues with "fixMembershipStatusBeforeRenew()" throwing an exception and membership not being renewed.
+    // Since the IPN dates are 2013 we set initial membership to start at the beginning of that year.
+    \Civi\Api4\Membership::update(FALSE)
+      ->addValue('join_date', '20130101000000')
+      ->addValue('start_date', '20130101000000')
+      ->addValue('end_date', '20140101000000')
+      ->addWhere('id', '=', $this->ids['membership'])
+      ->execute();
+
     $this->callAPISuccessGetSingle('membership_payment', []);
     $paypalIPN = new CRM_Core_Payment_PayPalProIPN($this->getPaypalProRecurTransaction());
     $paypalIPN->main();


### PR DESCRIPTION
Overview
----------------------------------------

- `trxn_date` is the date that the payment was received.
- `receive_date` is the date that the contribution was expected to be made. The "effective date". Usually it will be the date the contribution was created.

In general, CiviCRM expects that the "effective date" is the date the contribution was created and not when the payment was received, since the payment received date (trxn_date) can be from a few seconds later to a few days later depending on the payment processor and method used.

This area of the code has been refactored recently via https://github.com/civicrm/civicrm-core/pull/30085. When using contribution.repeattransaction API the "effective date" was basically being ignored in favour of the contribution receive date. However, when you use Payment.create the "effective date" is respected so we need to pass in the right date.

That exposed a problem with PayPalProIPN and related tests. Since that relied on some slightly obscure behaviour of contribution.repeattransaction with status=Completed (which is no longer supported). So this PR also switches PayPalProIPN to contribution.repeattransaction + payment.create and fixes the tests to work properly in that case. 

Before
----------------------------------------
Payment date was being passed in as effective date.

After
----------------------------------------
Contribution receive date is being passed in as effective date.

Technical Details
----------------------------------------


Comments
----------------------------------------
This gets us closer to being able to merge https://github.com/civicrm/civicrm-core/pull/30776