### PR TITLE
Edit Payment Processor - Prohibit changes to the "Type"

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -184,7 +184,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       CRM_Financial_BAO_PaymentProcessor::buildOptions('payment_processor_type_id'),
       TRUE
     );
-    if ($this->_action !== 1) {
+    if ($this->_action !== CRM_Core_Action::ADD) {
       $this->freeze('payment_processor_type_id');
     }
 

--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -184,6 +184,9 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
       CRM_Financial_BAO_PaymentProcessor::buildOptions('payment_processor_type_id'),
       TRUE
     );
+    if ($this->_action !== 1) {
+      $this->freeze('payment_processor_type_id');
+    }
 
     // Financial Account of account type asset CRM-11515
     $accountType = CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name = 'Asset' ");


### PR DESCRIPTION
Overview
----------------------------------------

The _payment processor type_ determines how API requests are fired to make new payments, setup recurring payments, cancel or refund payments, etc. 

For basic operations on an empty system, you could imagine that it's easy to change the "Type" of a payment processor. You'll simply use the new API for new payments.

However, in practice, the stored-data (*transaction IDs; payment-tokens; recurring schedules; etc*) are all entwined with the type of payment-processor. Payment tokens in Stripe cannot be ported to PayPal, and vice-versa. If you switch the type, then the deeper interactions (*recurring; refunds; etc*) will likely break.

Before
----------------------------------------

If you edit a `PaymentProcessor`, you are allowed to change its "Type".

<img width="935" height="367" alt="Screenshot 2025-11-11 at 1 23 23 PM" src="https://github.com/user-attachments/assets/675c7b19-08b4-4aaa-9e17-16878b468afa" />


After
----------------------------------------

If you edit a `PaymentProcessor`, you are not allowed to change its "Type".

<img width="934" height="367" alt="Screenshot 2025-11-11 at 1 22 51 PM" src="https://github.com/user-attachments/assets/c32e9ce5-71a2-4e37-93fb-58989556ac36" />

Comments
----------------------------------------

I briefly considered an alternative approach to make this data-driven:

* __Alternate Policy__: _If you have data from this payment processor_, then you prohibit changing its type. But if it's a recent creation with _no data_, then you allow edits. 
* __Comments__: But I don't think it's worth the effort. It's not as easy as checking `empty($refCount)` -- because some kind of references would be blocking (e.g. recurring contributions), but other references would be non-blocking (e.g. ContributionPages and Financial Types). You'd have to maintain a list of which relations are blocking/non-blocking. But it's such a niche scenario... we'd be unlikely to keep the list up-to-date. It seems simpler to do a straight-up prohibition on changes.