### PR TITLE
OAuthClient - Ensure that `state`s will eventually be cleaned up

### DIFF
--- a/CRM/Core/BAO/Cache.php
+++ b/CRM/Core/BAO/Cache.php
@@ -201,6 +201,7 @@ class CRM_Core_BAO_Cache extends CRM_Core_DAO_Cache {
 
     if ($expired) {
       \Civi::cache('long')->garbageCollection();
+      \Civi::cache('session')->garbageCollection();
     }
   }
 

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
@@ -90,7 +90,7 @@ class AuthorizationCode extends AbstractGrantAction {
     // effective list.
     $scopes = $this->getScopes() ?: $this->callProtected($provider, 'getDefaultScopes');
 
-    $stateId = \CRM_OAuth_Page_Return::storeState([
+    $stateId = \Civi::service('oauth2.state')->store([
       'time' => \CRM_Utils_Time::time(),
       'ttl' => $this->getTtl(),
       'clientId' => $this->getClientDef()['id'],

--- a/ext/oauth-client/Civi/OAuth/OAuthState.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthState.php
@@ -12,6 +12,23 @@ class OAuthState extends AutoService {
   const LEGACY_TTL = 3600;
 
   /**
+   * Session IDs are cookie values, so... "Any US-ASCII character excluding control characters
+   * (ASCII characters 0 up to 31 and ASCII character 127), Whitespace, double quotes, commas,
+   * semicolons, and backslashes."
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#attributes
+   */
+  const SESSION_ID_REGEX = '/^([\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]+)$/';
+
+  /**
+   * When beginning OAuth flow from CLI, set the state with `session=>SESSION_WILDCARD`
+   * to allow the pageflow to continue in a browser with an unknown session ID.
+   *
+   * Ideal value is (1) serializable and (2) invalid as cookie-content and (3) recognizable.
+   */
+  const SESSION_WILDCARD = ',;"wildcard';
+
+  /**
    * @var \CRM_Utils_Cache_Interface
    * @inject cache.session
    */
@@ -56,7 +73,7 @@ class OAuthState extends AutoService {
     if (!$state) {
       throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
     }
-    if (!($state['session'] === '*' || hash_equals($state['session'], $this->getSessionId()))) {
+    if (!($state['session'] === static::SESSION_WILDCARD || hash_equals($state['session'], $this->getSessionId()))) {
       throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
     }
     $ttl = $state['ttl'] ?? self::LEGACY_TTL;
@@ -70,11 +87,19 @@ class OAuthState extends AutoService {
   protected function getSessionId(): string {
     if (PHP_SAPI === 'cli') {
       // CLI doesn't have a session. If we generate OAuthState on CLI, then allow it to be used in any browser session.
-      return '*';
+      return static::SESSION_WILDCARD;
     }
 
     // In general, we want `state`s to only be valid within a particular session.
-    return session_id();
+    $id = session_id();
+    if (!preg_match(static::SESSION_ID_REGEX, $id)) {
+      // We double-check that ID is well-formed (n.b. not WILDCARD). This would
+      // be true in any sensible session-management design. However, we have a mix
+      // of HTTPDs, PHP versions, and PHP frameworks (and a box of magical $_COOKIEs),
+      // so... we do an extra guard against unusual/non-conformant cases.
+      throw new OAuthException("OAuth: Invalid session ID");
+    }
+    return $id;
   }
 
 }

--- a/ext/oauth-client/Civi/OAuth/OAuthState.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthState.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Civi\OAuth;
+
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service oauth2.state
+ */
+class OAuthState extends AutoService {
+
+  const LEGACY_TTL = 3600;
+
+  /**
+   * @var \CRM_Utils_Cache_Interface
+   * @inject cache.session
+   */
+  protected $cache;
+
+  /**
+   * @param array $state
+   *   Flexible data. Standard keys:
+   *   - session (string), automatically defined
+   *   - time (int), creation time; seconds since epoch. Default: NOW
+   *   - ttl (int), the number of seconds for which this record is valid. Default: LEGACY_TTL
+   * @return string
+   *   State token / identifier
+   */
+  public function store($state): string {
+    $stateId = 'CC_' . \CRM_Utils_String::createRandom(29, \CRM_Utils_String::ALPHANUMERIC);
+
+    $state['session'] = $this->getSessionId();
+    $state['time'] = \CRM_Utils_Time::time();
+    $ttl = $state['ttl'] ?? self::LEGACY_TTL;
+
+    // We store this in cache layer to ensure that stale records will be cleaned up automatically.
+    $this->cache->set($stateId, $state, $ttl);
+
+    return $stateId;
+  }
+
+  /**
+   * Restore from the $stateId.
+   *
+   * @param string $stateId
+   * @return mixed
+   * @throws \Civi\OAuth\OAuthException
+   */
+  public function load($stateId) {
+    [$type, $id] = explode('_', $stateId);
+    $state = match($type) {
+      'CC' => $this->cache->get($stateId),
+      default => NULL,
+    };
+
+    if (!$state) {
+      throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
+    }
+    if (!($state['session'] === '*' || hash_equals($state['session'], $this->getSessionId()))) {
+      throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
+    }
+    $ttl = $state['ttl'] ?? self::LEGACY_TTL;
+    if (!isset($state['time']) || $state['time'] + $ttl < \CRM_Utils_Time::time()) {
+      throw new \Civi\OAuth\OAuthException("OAuth: Received invalid or expired state");
+    }
+
+    return $state;
+  }
+
+  protected function getSessionId(): string {
+    if (PHP_SAPI === 'cli') {
+      // CLI doesn't have a session. If we generate OAuthState on CLI, then allow it to be used in any browser session.
+      return '*';
+    }
+
+    // In general, we want `state`s to only be valid within a particular session.
+    return session_id();
+  }
+
+}

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -49,7 +49,7 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
       $this->assertEquals('/one/auth', $url['path']);
       \parse_str($url['query'], $actualQuery);
       $this->assertEquals('code', $actualQuery['response_type']);
-      $this->assertMatchesRegularExpression(';^[cs]_[a-zA-Z0-9]+$;', $actualQuery['state']);
+      $this->assertMatchesRegularExpression(';^CC_[a-zA-Z0-9]+$;', $actualQuery['state']);
       $this->assertEquals('scope-1-foo,scope-1-bar', $actualQuery['scope']);
       // ? // $this->assertEquals('auto', $actualQuery['approval_prompt']);
       $this->assertEquals('example-id', $actualQuery['client_id']);
@@ -95,7 +95,7 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
       $this->assertEquals('/three/auth', $url['path']);
       \parse_str($url['query'], $actualQuery);
       $this->assertEquals('code', $actualQuery['response_type']);
-      $this->assertMatchesRegularExpression(';^[cs]_[a-zA-Z0-9]+$;', $actualQuery['state']);
+      $this->assertMatchesRegularExpression(';^CC_[a-zA-Z0-9]+$;', $actualQuery['state']);
       $this->assertEquals('scope-3-foo,scope-3-bar', $actualQuery['scope']);
       // ? // $this->assertEquals('auto', $actualQuery['approval_prompt']);
       $this->assertEquals('example-id', $actualQuery['client_id']);


### PR DESCRIPTION
Overview
----------------------------------------

When using OAuth2's "Authorization Grant" flow, the Civi site must create a `state` identifier. The `state` is passed around steps (2) - (4) in the diagram.

<img src="https://docs.civicrm.org/sysadmin/en/latest/img/OAuthBasic-Annotated.png">

For each `state` ID, we store some data in the user's session. In step 4, we can read the `state` and resume our interaction with the user.  (e.g. "Thank you for setting up SuperMail -- now let's fine-tune your IMAP polling options" or "Thank you for setting up PayWhiz -- now let's fine-tune your payment-processor options.")

Over time, you may accumulate several `state` records in the user's session. This PR ensures that old `state`s will eventually be deleted.

Before
----------------------------------------

* Old `state` values retained indefinitely.
* State values may be stored in two different ways -- either in the `$session` object or the `Civi::cache('session')` (depending on whether the OAuth flow began in a web-browser or CLI).
* In typical usage (browser based), all past `state`s will be loaded on every page-view.

After
----------------------------------------

* Old `state` values will eventually be deleted.
* State values are always stored the same way -- in the session-cache. (This cache has garbage-collection to ensure that old records are eventually deleted.)
* States are only loaded if they are actually relevant to the page-view.

Technical Details
----------------------------------------

`r-run`: I have tested this with `beeceptor.com` using OAuth-flows with both web- and CLI-based-initiation.

(The mechanics of state-storage are the same on all the existing providers, so testing one should be sufficient.)

Comments
----------------------------------------

This came up while working on OAuth for PayPal, and it arises from this question: "How often do we create new `state`s?" Answers:

* (*Rarely/On-Demand*) You only create a `state` if a user actively chooses to run an OAuth flow. There might be 0-3 states in the life of a session. (Cleanup is "nice-to-have" / "unimportant".)
* (*Frequently/Speculatively*) You create a `state` whenever you render a button that a user _might_ click to activate an OAuth flow. There might be 10-50 `state`s. (You don't want to load them into the `$session` object for every page-request, and you want them to be deleted eventually.)

When doing earlier integrations with Google+Microsoft+Stripe, the answer was _Rarely/On-Demand_. So cleanup didn't matter much. 

But PayPal has a different initiation process. Roughly speaking, they want to own the `onclick` handler for the `button` that begins the flow -- which makes it awkward to initialize things on-demand. This drives you toward _frequent/speculative_ initialization. So that's a bigger liability.