### PR TITLE
FormBuilder - dont add middle name by default when adding new Individual

### DIFF
--- a/ext/afform/admin/afformEntities/Individual.php
+++ b/ext/afform/admin/afformEntities/Individual.php
@@ -8,6 +8,7 @@ return [
   }",
   'icon' => 'fa-user',
   'boilerplate' => [
-    ['#tag' => 'afblock-name-individual'],
+    ['#tag' => 'af-field', 'name' => 'first_name'],
+    ['#tag' => 'af-field', 'name' => 'last_name'],
   ],
 ];


### PR DESCRIPTION
Before
----------------------------------------
- the default boilerplate for Individual entity is a block which contains first/middle/last names
- every time I create a new form, I remove the middle name
- almost every time I create a new form, I move the first/last name inputs out of the block container in order to make the styles neater

After
----------------------------------------
- when adding a new individual, you just get first and last name fields


Comments
----------------------------------------
I would have removed the middle name from the `afblock-name-individual` block, but that would affect existing forms.

I think adding email could be good default too, but that is a bit more contentious.
