### PR TITLE
dev/core#6196 permission for Event.get api is too strict

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1311,7 +1311,6 @@ class CRM_Core_Permission {
         'delete in CiviEvent',
       ],
       'get' => [
-        'access CiviCRM',
         'access CiviEvent',
         'view event info',
       ],


### PR DESCRIPTION
Overview
----------------------------------------

The permission for the Event.get API is too strict.

Before
----------------------------------------

When having an Event autocomplete on a frontend page it is not possible to load the list of events. It worked when the frontend user also got access to CiviCRM Backend and API permission,

After
----------------------------------------

The Event.get permission is less strict (only depends on access CiviEvent and View Event Info).

Comments
----------------------------------------

See https://lab.civicrm.org/dev/core/-/issues/6196 for steps on how to reproduce.
