### PR TITLE
FormBuilder - Prevent "Error: missing field" on overridden field types

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -2,7 +2,7 @@
   <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Type:') }}</label>
     <select class="form-control" ng-model="getSet('input_type')" ng-model-options="{getterSetter: true}" title="{{:: ts('Field type') }}">
-      <option ng-repeat="type in $ctrl.inputTypes" value="{{ type.name }}">{{ type.label }}</option>
+      <option ng-repeat="type in $ctrl.inputTypes" value="{{ type.name }}" ng-if="type.enabled || type.name === $ctrl.fieldDefn.input_type">{{ type.label }}</option>
     </select>
   </div>
 </li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -33,22 +33,21 @@
         ctrl.hasDefaultValue = !!getSet('afform_default');
         setFieldDefn();
         ctrl.inputTypes = _.transform(_.cloneDeep(afGui.meta.inputTypes), function(inputTypes, type) {
-          if (inputTypeCanBe(type.name)) {
-            // Change labels for EntityRef fields
-            if (ctrl.getDefn().input_type === 'EntityRef') {
-              const entity = ctrl.getFkEntity();
-              if (entity && type.name === 'EntityRef') {
-                type.label = ts('Autocomplete %1', {1: entity.label});
-              }
-              if (entity && type.name === 'Number') {
-                type.label = ts('%1 ID', {1: entity.label});
-              }
-              if (entity && type.name === 'Select') {
-                type.label = ts('Select Form %1', {1: entity.label});
-              }
+          type.enabled = inputTypeCanBe(type.name);
+          // Change labels for EntityRef fields
+          if (ctrl.getDefn().input_type === 'EntityRef') {
+            const entity = ctrl.getFkEntity();
+            if (entity && type.name === 'EntityRef') {
+              type.label = ts('Autocomplete %1', {1: entity.label});
             }
-            inputTypes.push(type);
+            if (entity && type.name === 'Number') {
+              type.label = ts('%1 ID', {1: entity.label});
+            }
+            if (entity && type.name === 'Select') {
+              type.label = ts('Select Form %1', {1: entity.label});
+            }
           }
+          inputTypes.push(type);
         });
         // Quick-add links for autocompletes
         this.quickAddLinks = [];


### PR DESCRIPTION
Overview
----------------------------------------
While FormBuilder constrains what fields support what input_types, it's possiblt to override input_type in the markup. This makes FormBuilder less breaky when you do.

Technical Details
----------------------------------------
Instead of completely removing non-supported input_types from the list, this hides them from the dropdown but still handles them correctly if overridden.