### PR TITLE
Api4 - Allow GET params in ajax requests

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -62,13 +62,34 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       // Received single-call format
       $entity = $this->urlPath[3];
       $action = $this->urlPath[4];
-      $params = CRM_Utils_Request::retrieve('params', 'String');
-      $params = $params ? json_decode($params, TRUE) : [];
+      $params = $this->getParamsFromRequest($entity, $action);
       $index = CRM_Utils_Request::retrieve('index', 'String');
       $response = $this->execute($entity, $action, $params, $index);
     }
 
     CRM_Utils_System::sendJSONResponse($response, $this->httpResponseCode);
+  }
+
+  private function getParamsFromRequest(string $entity, string $action): array {
+    $config = CRM_Core_Config::singleton();
+    $params = CRM_Utils_Request::retrieve('params', 'String');
+    $params = $params ? json_decode($params, TRUE) : [];
+
+    // Add query params if they are not in the params json and if they are allowed by the api action
+    $queryParams = array_diff_key($_GET, $params);
+    unset($queryParams['params'], $queryParams['index'], $queryParams[$config->userFrameworkURLVar]);
+    if (count($queryParams) > 0) {
+      $allowedParams = civicrm_api4($entity, 'getActions', [
+        'checkPermissions' => FALSE,
+        'where' => [['name', '=', $action]],
+      ], ['params'])->single();
+      foreach ($queryParams as $key => $value) {
+        if (array_key_exists($key, $allowedParams)) {
+          $params[$key] = $value;
+        }
+      }
+    }
+    return $params;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Allows e.g. `https://example.org/civicrm/ajax/api4/Participant/get?offset=100&limit=200` which can make rest requests a bit easier to write.
