### PR TITLE
CustomField - Add field type Toggle

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -720,6 +720,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       'Select',
       'CheckBox',
       'Radio',
+      'Toggle',
     ])) {
       $options = $field->getOptions($search ? 'search' : 'create');
 
@@ -825,6 +826,13 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
           }
           $qf->addRadio($elementName, $label, $options, $fieldAttributes, $separator, $useRequired);
         }
+        break;
+
+      case 'Toggle':
+        $fieldAttributes = array_merge($fieldAttributes, $customFieldAttributes);
+        $fieldAttributes['off'] = $options[0];
+        $fieldAttributes['on'] = $options[1];
+        $qf->addToggle($elementName, $label, $fieldAttributes, $useRequired && !$search);
         break;
 
       // For all select elements
@@ -1123,6 +1131,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       case 'Autocomplete-Select':
       case 'Radio':
       case 'CheckBox':
+      case 'Toggle':
         if ($field['data_type'] == 'ContactReference' && (is_array($value) || is_numeric($value))) {
           // Issue #2939 - guard against passing empty values to CRM_Core_DAO::getFieldValue(), which would throw an exception
           if (empty($value)) {
@@ -1682,7 +1691,9 @@ SELECT $columnName
     $customFormatted[$customFieldId][$index] = [
       'id' => $customValueId > 0 ? $customValueId : NULL,
       'value' => $value,
+      // 'type' is the data type, 'html_type' is the input type.
       'type' => $customFields[$customFieldId]['data_type'],
+      'html_type' => $customFields[$customFieldId]['html_type'],
       'custom_field_id' => $customFieldId,
       'custom_group_id' => $groupID,
       'table_name' => $tableName,

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -148,8 +148,13 @@ class CRM_Core_BAO_CustomValueTable {
               break;
 
             case 'Boolean':
-              //fix for CRM-3290
-              $value = CRM_Utils_String::strtoboolstr($value);
+              if ($field['html_type'] === 'Toggle') {
+                $value = (int) $value;
+              }
+              else {
+                // fix for CRM-3290
+                $value = CRM_Utils_String::strtoboolstr($value);
+              }
               if ($value === FALSE) {
                 $type = 'Timestamp';
               }
@@ -319,6 +324,7 @@ class CRM_Core_BAO_CustomValueTable {
           'entity_id' => $entityID,
           'value' => $customValue['value'],
           'type' => $customValue['type'],
+          'html_type' => $customValue['html_type'],
           'custom_field_id' => $customValue['custom_field_id'],
           'custom_group_id' => $customValue['custom_group_id'],
           'table_name' => $customValue['table_name'],
@@ -578,6 +584,7 @@ class CRM_Core_BAO_CustomValueTable {
           'entity_id' => $params['entityID'],
           'value' => $fieldValue['value'],
           'type' => $dataType,
+          'html_type' => $fieldInfo['html_type'],
           'custom_field_id' => $fieldInfo['id'],
           'custom_group_id' => $fieldInfo['custom_group']['id'],
           'table_name' => $fieldInfo['custom_group']['table_name'],

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -207,6 +207,11 @@ class CRM_Core_SelectValues {
         'label' => ts('Drop-down (select list)'),
       ],
       [
+        'id' => 'Toggle',
+        'name' => 'Toggle',
+        'label' => ts('Toggle Switch'),
+      ],
+      [
         'id' => 'Radio',
         'name' => 'Radio buttons',
         'label' => ts('Radio buttons'),

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -64,7 +64,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     'Money' => ['Text', 'Select', 'Radio', 'Hidden'],
     'Memo' => ['TextArea', 'RichTextEditor'],
     'Date' => ['Select Date'],
-    'Boolean' => ['Radio'],
+    'Boolean' => ['Toggle', 'Radio'],
     'StateProvince' => ['Select'],
     'Country' => ['Select'],
     'File' => ['File'],

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -346,6 +346,7 @@ class BasicGetFieldsAction extends BasicGetAction {
           'Select' => ts('Select'),
           'Text' => ts('Single-Line Text'),
           'TextArea' => ts('Multi-Line Text'),
+          'Toggle' => ts('Toggle Switch'),
           'Url' => ts('URL'),
         ],
       ],

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -588,6 +588,7 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
         -1 => [
           'value' => 'Test custom value',
           'type' => 'String',
+          'html_type' => 'Text',
           'custom_field_id' => $customField['id'],
           'custom_group_id' => $customGroup['id'],
           'table_name' => $customGroupTableName,

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionTest.php
@@ -128,6 +128,7 @@ class CRM_Contribute_BAO_ContributionTest extends CiviUnitTestCase {
         -1 => [
           'value' => 'Test custom value',
           'type' => 'String',
+          'html_type' => 'Text',
           'custom_field_id' => $customFieldID,
           'custom_group_id' => $customGroupID,
           'table_name' => $customGroup['table_name'],

--- a/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomValueTableTest.php
@@ -27,7 +27,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
     $fields = [
       'custom_group_id' => $customGroup['id'],
       'data_type' => 'Country',
-      'html_type' => 'Select Country',
+      'html_type' => 'Select',
       'default_value' => '',
     ];
 
@@ -37,6 +37,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       $customField['id'] => [
         'value' => 1228,
         'type' => 'Country',
+        'html_type' => 'Select',
         'custom_field_id' => $customField['id'],
         'custom_group_id' => $customGroup['id'],
         'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
@@ -68,6 +69,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       $customField['id'] => [
         'value' => 'i/contact_house.png',
         'type' => 'File',
+        'html_type' => 'File',
         'custom_field_id' => $customField['id'],
         'custom_group_id' => $customGroup['id'],
         'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
@@ -98,6 +100,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       $customField['id'] => [
         'value' => 1029,
         'type' => 'StateProvince',
+        'html_type' => 'Select',
         'custom_field_id' => $customField['id'],
         'custom_group_id' => $customGroup['id'],
         'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
@@ -129,6 +132,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       $customField['id'] => [
         'value' => '20080608000000',
         'type' => 'Date',
+        'html_type' => 'Select Date',
         'custom_field_id' => $customField['id'],
         'custom_group_id' => $customGroup['id'],
         'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
@@ -159,6 +163,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       $customField['id'] => [
         'value' => '<p><strong>This is a <u>test</u></p>',
         'type' => 'Memo',
+        'html_type' => 'RichTextEditor',
         'custom_field_id' => $customField['id'],
         'custom_group_id' => $customGroup['id'],
         'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
@@ -196,6 +201,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
         $customField['id'] => [
           'value' => CRM_Core_DAO::VALUE_SEPARATOR . '1' . CRM_Core_DAO::VALUE_SEPARATOR . '2' . CRM_Core_DAO::VALUE_SEPARATOR,
           'type' => 'Int',
+          'html_type' => 'Select',
           'custom_field_id' => $customField['id'],
           'custom_group_id' => $customGroup['id'],
           'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],
@@ -233,6 +239,7 @@ class CRM_Core_BAO_CustomValueTableTest extends CiviUnitTestCase {
       $customField['id'] => [
         'value' => '<p><strong>This is a <u>test</u></p>',
         'type' => 'Memo',
+        'html_type' => 'RichTextEditor',
         'custom_field_id' => $customField['id'],
         'custom_group_id' => $customGroup['id'],
         'table_name' => $customGroup['values'][$customGroup['id']]['table_name'],


### PR DESCRIPTION
Overview
----------------------------------------
Makes the new Toggle input available as a custom field type.

Before
--------
Yes/No (boolean) custom fields must be radio buttons.

After
------
Boolean custom fields can be radio buttons or a toggle.

Comments
-------
This makes a nice-looking toggle switch for boolean custom fields. Functionally, it's slightly different from the radio button widget, because radios are trinary (the field can be set to TRUE, FALSE, or NULL). A toggle switch is true binary (only TRUE or FALSE).