### PR TITLE
OAuthClient - Add docblocs for state. Suggest `code_verifier` and `grant_type`.

### DIFF
--- a/ext/oauth-client/CRM/OAuth/Page/Return.php
+++ b/ext/oauth-client/CRM/OAuth/Page/Return.php
@@ -39,7 +39,7 @@ class CRM_OAuth_Page_Return extends CRM_Core_Page {
         'scope' => $state['scopes'],
         'tag' => $state['tag'],
         'storage' => $state['storage'],
-        'grant_type' => 'authorization_code',
+        'grant_type' => $state['grant_type'] ?? 'authorization_code',
         'cred' => array_merge(
           ['code' => $authCode],
           empty($state['code_verifier']) ? [] : ['code_verifier' => $state['code_verifier']],

--- a/ext/oauth-client/CRM/OAuth/Page/Return.php
+++ b/ext/oauth-client/CRM/OAuth/Page/Return.php
@@ -40,7 +40,10 @@ class CRM_OAuth_Page_Return extends CRM_Core_Page {
         'tag' => $state['tag'],
         'storage' => $state['storage'],
         'grant_type' => 'authorization_code',
-        'cred' => ['code' => $authCode],
+        'cred' => array_merge(
+          ['code' => $authCode],
+          empty($state['code_verifier']) ? [] : ['code_verifier' => $state['code_verifier']],
+        ),
       ]);
 
       $nextUrl = $state['landingUrl'] ?? NULL;

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
@@ -94,6 +94,7 @@ class AuthorizationCode extends AbstractGrantAction {
       'time' => \CRM_Utils_Time::time(),
       'ttl' => $this->getTtl(),
       'clientId' => $this->getClientDef()['id'],
+      'grant_type' => 'authorization_code',
       'landingUrl' => $this->getLandingUrl(),
       'storage' => $this->getStorage(),
       'scopes' => $scopes,

--- a/ext/oauth-client/Civi/OAuth/OAuthState.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthState.php
@@ -46,6 +46,7 @@ class OAuthState extends AutoService {
    *   - scopes (array), List of scopes being requested
    *   - tag (string, optional), The symbolic tag to apply to the new token
    *   - code_verifier (string, optional), An extra string that we will send to the token-endpoint to prove that we initiated the flow
+   *   - grant_type (string, optional), The kind of flow that we are pursuing. Default: authorization_code
    * @return string
    *   State token / identifier
    */

--- a/ext/oauth-client/Civi/OAuth/OAuthState.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthState.php
@@ -40,6 +40,12 @@ class OAuthState extends AutoService {
    *   - session (string), automatically defined
    *   - time (int), creation time; seconds since epoch. Default: NOW
    *   - ttl (int), the number of seconds for which this record is valid. Default: LEGACY_TTL
+   *   - clientId (int), the OAuthClient.id which initiated this flow
+   *   - landingUrl (string, optional), If we want to ultimately redirect back to another part of our web UI
+   *   - storage (string), Where to store the resulting token. Ex: OAuthSysToken or OAuthContactToken
+   *   - scopes (array), List of scopes being requested
+   *   - tag (string, optional), The symbolic tag to apply to the new token
+   *   - code_verifier (string, optional), An extra string that we will send to the token-endpoint to prove that we initiated the flow
    * @return string
    *   State token / identifier
    */

--- a/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
@@ -21,7 +21,7 @@ class OAuthTokenFacade {
    *   - grant_type: string, ex "authorization_code", "client_credentials",
    *   "password"
    *   - cred: array, extra credentialing options to pass to the "token" URL
-   *   (via getAccessToken($tokenOptions)), eg "username", "password", "code"
+   *   (via getAccessToken($tokenOptions)), eg "username", "password", "code", "code_verifier"
    *
    * @return array
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------

Updates for the internals of how OAuthClient handles the "state". Recall that the `state` is created at the beginning of the pageflow, and it is used later to resume the page-flow.

Adding more fields for the `state` means you have more information available when resuming. This prepares for the special authorization flow used by PayPal PPCP. (Extracted from #33707.) cc @seamuslee001 

Before
----------------------------------------

* Fewer docblocks about `state` properties
* It is _implied_ that all `state`s are part of the `grant_type=authorization_code` flow
* It is unclear how to carry-forward a [`code_verifier`](https://www.oauth.com/oauth2-servers/pkce/authorization-code-exchange/) (*generated at the start of the flow; used again at the end of the flow*)

After
----------------------------------------

* More docblocks about `state` properties
* You can optionally override the `grant_type` (but the implied default is still  `grant_type=authorization_code`).
* There is a clear place to track the `code_verifier`.

