### PR TITLE
OAuthClient - Fire a hook whenever a token is received

### DIFF
--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -1,0 +1,27 @@
+<?php
+
+use Civi\Core\Event\GenericHookEvent;
+
+class CRM_OAuth_Hook {
+
+  /**
+   * Fires a hook whenever we receive an updated OAuth token.
+   *
+   * @param string $flow
+   *   Ex: 'init' or 'refresh'
+   * @param string $type
+   *   Ex: 'OAuthSysToken', 'OAuthContactToken', 'OAuthSessionToken'
+   * @param array $token
+   *   Ex: ['tag' => 'foo', 'client_id' => 123]
+   * @return void
+   */
+  public static function hook_civicrm_oauthToken(string $flow, string $type, array &$token) {
+    $event = GenericHookEvent::create([
+      'flow' => $flow,
+      'type' => $type,
+      'token' => &$token,
+    ]);
+    \Civi::dispatcher()->dispatch('hook_civicrm_oauthToken', $event);
+  }
+
+}

--- a/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
@@ -38,7 +38,7 @@ class Refresh extends BasicBatchAction {
 
   private $syncFields = ['access_token', 'refresh_token', 'expires', 'token_type'];
   private $writeFields = ['access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
-  private $selectFields = ['id', 'client_id', 'access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
+  private $selectFields = ['id', 'client_id', 'tag', 'access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
   private $providers = [];
 
   protected function getSelect() {
@@ -62,6 +62,8 @@ class Refresh extends BasicBatchAction {
         $row[$field] = $raw[$field];
       }
     }
+
+    \CRM_OAuth_Hook::hook_civicrm_oauthToken('refresh', $this->getEntityName(), $row);
 
     civicrm_api4($this->getEntityName(), 'update', [
       // You may have permission to refresh even if you can't inspect/update secrets directly.

--- a/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
@@ -76,6 +76,8 @@ class OAuthTokenFacade {
       \Civi::log()->warning("Failed to resolve resource_owner");
     }
 
+    \CRM_OAuth_Hook::hook_civicrm_oauthToken('init', $options['storage'], $tokenRecord);
+
     return civicrm_api4($options['storage'], 'create', [
       'checkPermissions' => FALSE,
       'values' => $tokenRecord,


### PR DESCRIPTION
Overview
----------------------------------------

Defines a new hook, `hook_civicrm_oauthToken`, which fires whenever we receive a token via OAuth. This can be used to used to update related records. (*Ex: I've been using it in #33707 to update the `civicrm_payment_processor.password` for Stripe Connect.*)

(Extracted from #33707.)

Before + After
----------------------------------------

See diff, red + green.

Technical Details
----------------------------------------

I originally played with using entity-data hooks. However, that path is more precarious -- there are multiple storage-backends (`OAuthSysToken`, `OAuthContactToken`) -- and some don't a have SQL/DAO lifecycle(`OAuthSessionToken`). This gives a more general way to monitor token lifecycle.