### PR TITLE
Allow id attribute in ckeditor (HTMLPurifier)

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -672,7 +672,8 @@ class CRM_Utils_String {
       $config->set('HTML.DefinitionRev', 1);
       $config->set('HTML.MaxImgLength', NULL);
       $config->set('CSS.MaxImgLength', NULL);
-      $config->set('Attr.EnableID', true);
+      // Prevent id atrributes from being stripped (useful for e.g. anchors)
+      $config->set('Attr.EnableID', TRUE);
       $def = $config->maybeGetRawHTMLDefinition();
       $uri = $config->getDefinition('URI');
       $uri->addFilter(new CRM_Utils_HTMLPurifier_URIFilter(), $config);

--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -672,6 +672,7 @@ class CRM_Utils_String {
       $config->set('HTML.DefinitionRev', 1);
       $config->set('HTML.MaxImgLength', NULL);
       $config->set('CSS.MaxImgLength', NULL);
+      $config->set('Attr.EnableID', true);
       $def = $config->maybeGetRawHTMLDefinition();
       $uri = $config->getDefinition('URI');
       $uri->addFilter(new CRM_Utils_HTMLPurifier_URIFilter(), $config);


### PR DESCRIPTION
Overview
----------------------------------------
Small change to the HTML Purifier configuration to allow the id attribute in the ckeditor.

Before
----------------------------------------
The id attribute gets stripped from the html code by the HTML Purifier. I am pretty sure this wasn't the case in the past, and that it is due to a newer version of HTMLPurifier.

After
----------------------------------------
The id attribute is kept in e.g. event descriptions. Useful if you use anchors.

Technical Details
----------------------------------------
Only 1 line of code was added to CRM_Utils_String::purifyHTML()

Comments
----------------------------------------
This was briefly discussed with @DaveD here: https://lab.civicrm.org/dev/core/-/issues/5591 
