### PR TITLE
Add API4 ContributionRecur.updateAmountOnRecur

### DIFF
--- a/Civi/Api4/Action/ContributionRecur/UpdateAmountOnRecur.php
+++ b/Civi/Api4/Action/ContributionRecur/UpdateAmountOnRecur.php
@@ -1,0 +1,81 @@
+<?php
+namespace Civi\Api4\Action\ContributionRecur;
+
+use Civi\Api4\Contribution;
+use Brick\Money\Money;
+use Civi\Api4\ContributionRecur;
+use Civi\Api4\Generic\BasicBatchAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ * This API Action updates the contributionRecur and related entities (templatecontribution/lineitems)
+ *   when a subscription is changed.
+ */
+class UpdateAmountOnRecur extends BasicBatchAction {
+
+  /**
+   * The amount to update
+   *
+   * @var float
+   * @required
+   */
+  protected float $amount;
+
+  /**
+   * @inheritDoc
+   */
+  public function _run(Result $result) {
+    if ($this->amount <= 0) {
+      throw new \CRM_Core_Exception(ts('Amount must be greater than 0.0'));
+    }
+
+    parent::_run($result);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function doTask($item) {
+    $newAmount = Money::of($this->amount, $item['currency']);
+
+    // Check if amount is the same
+    if (Money::of($item['amount'], $item['currency'])->compareTo($newAmount) === 0) {
+      \Civi::log()->debug('Nothing to do. Amount is already the same');
+      return $item;
+    }
+
+    // Get the template contribution
+    // Calling ensureTemplateContributionExists will *always* return a template contribution
+    //   Either it will have created one or will return the one that already exists.
+    $templateContributionID = \CRM_Contribute_BAO_ContributionRecur::ensureTemplateContributionExists($item['id']);
+
+    // Now we update the template contribution with the new details
+    // This will automatically update the Contribution LineItems as well.
+    Contribution::update(FALSE)
+      ->addValue('total_amount', $newAmount->getAmount()->toFloat())
+      ->addWhere('id', '=', $templateContributionID)
+      ->execute();
+
+    // Update the recur
+    // If we update a template contribution the recur will automatically be updated
+    // (see CRM_Contribute_BAO_Contribution::self_hook_civicrm_post)
+    // We need to make sure we updated the template contribution first because
+    //   CRM_Contribute_BAO_ContributionRecur::self_hook_civicrm_post will also try to update it.
+    return ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $item['id'])
+      ->execute()
+      ->first();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected function getSelect() {
+    return [
+      'id',
+      'amount',
+      'currency',
+    ];
+  }
+
+}

--- a/ext/civi_contribute/Civi/Api4/ContributionRecur.php
+++ b/ext/civi_contribute/Civi/Api4/ContributionRecur.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\Api4;
 
+use Civi\Api4\Action\ContributionRecur\UpdateAmountOnRecur;
+
 /**
  * ContributionRecur entity.
  *
@@ -18,5 +20,14 @@ namespace Civi\Api4;
  * @package Civi\Api4
  */
 class ContributionRecur extends Generic\DAOEntity {
+
+  /**
+   * @param bool $checkPermissions
+   * @return \Civi\Api4\Action\ContributionRecur\UpdateAmountOnRecur
+   */
+  public static function updateAmountOnRecur($checkPermissions = TRUE) {
+    return (new UpdateAmountOnRecur(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
 
 }

--- a/tests/phpunit/api/v4/Action/ContributionRecurUpdateAmountTest.php
+++ b/tests/phpunit/api/v4/Action/ContributionRecurUpdateAmountTest.php
@@ -1,0 +1,288 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use Civi\Api4\FinancialType;
+use Civi\Api4\OptionValue;
+use Civi\Api4\Order;
+use Civi\Api4\Payment;
+use Civi\Api4\Contribution;
+use Civi\Api4\ContributionRecur;
+
+/**
+ * Test API4 ContributionRecur::updateAmountOnRecur
+ *
+ * @group headless
+ */
+class ContributionRecurUpdateAmountTest extends \CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->createFixture();
+    $this->createOrder();
+  }
+
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    $this->contactDelete($this->ids['Contact']['EmberRecur']);
+    parent::tearDown();
+  }
+
+  /**
+   * @var array
+   * contactID => recurID
+   */
+  protected array $recurs;
+
+  /**
+   * Populates properties: $this->recurs.
+   */
+  protected function createFixture(): void {
+    $this->individualCreate(['first_name' => 'Ember', 'last_name' => 'Recur'], 'EmberRecur');
+
+    $recur = [
+      'currency' => 'USD',
+      'contribution_status_id:name' => 'In Progress',
+      'financial_type_id:name' => 'Donation',
+      'contact_id' => $this->ids['Contact']['EmberRecur'],
+      'amount' => 2,
+    ];
+    $this->recurs = ContributionRecur::save(FALSE)
+      ->addRecord($recur)
+      ->execute()
+      ->indexBy('contact_id')
+      ->column('id');
+  }
+
+  private function createOrder() {
+    $financialTypeID = FinancialType::get(FALSE)
+      ->addWhere('name', '=', 'Donation')
+      ->execute()
+      ->first()['id'];
+    $paymentInstrumentID = OptionValue::get(FALSE)
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->execute()
+      ->first()['value'];
+
+    foreach ($this->recurs as $contactID => $recurID) {
+      $recur = ContributionRecur::get(FALSE)
+        ->addWhere('id', '=', $recurID)
+        ->execute()
+        ->first();
+
+      $orderBAO = new \CRM_Financial_BAO_Order();
+
+      $orderAPI = Order::create(FALSE)
+        ->setContributionValues([
+          'receive_date' => date('YmdHis'),
+          // trxn_date is necessary for membership date calcs.
+          'trxn_date' => date('YmdHis'),
+          'trxn_id' => 'testtrxnid' . $recur['id'],
+          'total_amount' => $recur['amount'],
+          'contact_id' => $contactID,
+          'payment_instrument_id' => $paymentInstrumentID,
+          'currency' => 'USD',
+          'financial_type_id' => $financialTypeID,
+          'is_email_receipt' => FALSE,
+          'is_test' => FALSE,
+          'contribution_recur_id' => $recurID,
+          'contribution_status_id' => 'Pending',
+          'contribution_source' => 'my test description',
+        ]);
+
+      $lineItem = [
+        'line_total' => $recur['amount'],
+        'unit_price' => $recur['amount'],
+        'price_field_id' => $orderBAO->getDefaultPriceFieldID(),
+        'price_field_value_id' => $orderBAO->getDefaultPriceFieldValueID(),
+        'financial_type_id' => $financialTypeID,
+        'qty' => 1,
+      ];
+
+      $orderAPI->addLineItem($lineItem);
+      $contributionID = $orderAPI->execute()->single()['id'];
+
+      Payment::create(FALSE)
+        ->addValue('contribution_id', $contributionID)
+        ->addValue('total_amount', $recur['amount'])
+        ->addValue('is_send_contribution_notification', FALSE)
+        ->addValue('trxn_date', date('YmdHis'))
+        ->execute();
+    }
+  }
+
+  /**
+   * Test that calling updateAmountOnRecur with an unchanged amount
+   * has no effect.
+   */
+  public function testNoChangeAmount(): void {
+    // We should not have a template contribution yet
+    $preTemplateContribution = Contribution::get(FALSE)
+      ->addSelect('*', 'line_item.*')
+      ->addJoin('LineItem AS line_item', 'LEFT')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->addWhere('is_template', '=', TRUE)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $this->assertEmpty($preTemplateContribution);
+
+    $preContributionRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContributionRecur);
+
+    // But we should have a completed contribution
+    $preContribution = Contribution::get(FALSE)
+      ->addWhere('contribution_status_id:name', '=', 'Completed')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContribution);
+    $this->assertEquals($preContributionRecur['amount'], $preContribution['total_amount']);
+
+    // Call updateAmountOnRecur with the same amount.
+    $newAmount = 2.0;
+    ContributionRecur::updateAmountOnRecur(FALSE)
+      ->setAmount($newAmount)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $updatedRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $templateContribution = Contribution::get(FALSE)
+      ->addSelect('*', 'line_item.*')
+      ->addJoin('LineItem AS line_item', 'LEFT')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->addWhere('is_template', '=', TRUE)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $this->assertEmpty($templateContribution);
+    $this->assertEquals($newAmount, $updatedRecur['amount']);
+  }
+
+  /**
+   * Test that we can increase an amount on a recurring contribution
+   */
+  public function testIncreaseAmount(): void {
+    // We should not have a template contribution yet
+    $preTemplateContribution = Contribution::get(FALSE)
+      ->addSelect('*', 'line_item.*')
+      ->addJoin('LineItem AS line_item', 'LEFT')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->addWhere('is_template', '=', TRUE)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $this->assertEmpty($preTemplateContribution);
+
+    $preContributionRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContributionRecur);
+
+    // But we should have a completed contribution
+    $preContribution = Contribution::get(FALSE)
+      ->addWhere('contribution_status_id:name', '=', 'Completed')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContribution);
+    $this->assertEquals($preContributionRecur['amount'], $preContribution['total_amount']);
+
+    $newAmount = 3.0;
+    ContributionRecur::updateAmountOnRecur(FALSE)
+      ->setAmount($newAmount)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $updatedRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $templateContribution = Contribution::get(FALSE)
+      ->addSelect('*', 'line_item.*')
+      ->addJoin('LineItem AS line_item', 'LEFT')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->addWhere('is_template', '=', TRUE)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $paramsToAssertEqual = [
+      [$newAmount, $updatedRecur['amount']],
+      [$newAmount, $templateContribution['total_amount']],
+      [$newAmount, $templateContribution['line_item.line_total']],
+      [0.0, $templateContribution['fee_amount']],
+    ];
+    foreach ($paramsToAssertEqual as [$expected, $actual]) {
+      $this->assertEquals($expected, $actual);
+    }
+  }
+
+  /**
+   * Test that we can't set a recurring contribution to 0.0
+   */
+  public function testNewAmountZero(): void {
+    // We should not have a template contribution yet
+    $preTemplateContribution = Contribution::get(FALSE)
+      ->addSelect('*', 'line_item.*')
+      ->addJoin('LineItem AS line_item', 'LEFT')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->addWhere('is_template', '=', TRUE)
+      ->addOrderBy('id', 'DESC')
+      ->execute()
+      ->first();
+    $this->assertEmpty($preTemplateContribution);
+
+    $preContributionRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContributionRecur);
+
+    // But we should have a completed contribution
+    $preContribution = Contribution::get(FALSE)
+      ->addWhere('contribution_status_id:name', '=', 'Completed')
+      ->addWhere('contribution_recur_id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContribution);
+    $this->assertEquals($preContributionRecur['amount'], $preContribution['total_amount']);
+
+    $newAmount = 0.0;
+    $message = '';
+    try {
+      ContributionRecur::updateAmountOnRecur(FALSE)
+        ->setAmount($newAmount)
+        ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+        ->execute()
+        ->first();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $message = $e->getMessage();
+    }
+    $this->assertEquals('Amount must be greater than 0.0', $message);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Accepts `amount` parameter.

Accepts standard `where` clause to select recurring contributions.
You can update multiple recurring contributions at the same time
if multiple are returned by the `where` clause.

This updates a recurring contribution, associated contribution and lineitems with a new amount.
Should be called eg. after calling changeSubscriptionAmount on a paymentprocessor to
reflect the changes in CiviCRM.

Logic:
- Find or create a template contribution for the recur.
- Update the template contribution with the new amount.
- CiviCRM core automatically updates LineItems and Recur amounts.

Notes:
Will fail if (template) contribution has more than one LineItem.

Before
----------------------------------------
No supported way to update everything necessary to ensure trouble-free subscription updates.

After
----------------------------------------
API that handles the internals for you.

Technical Details
----------------------------------------
To ensure that subscriptions/membership renewals/amounts/contributions get recorded correctly in CiviCRM (especially when working with external processors and IPN/webhook notifications) we need to ensure that an change to the ContributionRecur amount is recorded correctly across the ContributionRecur, Template Contribution and LineItems. Additionally those changes must be made in a specific order to work correctly (and not trigger post-hook things which make additional changes).

As documented in the code in this PR you have to:

1. Get the template contribution: Calling ensureTemplateContributionExists will *always* return a template contribution. Either it will have created one or will return the one that already exists.

2. Now we update the template contribution with the new details. This will automatically update the Contribution LineItems as well.

3. Update the recur: If we update a template contribution the recur will automatically be updated (see CRM_Contribute_BAO_Contribution::self_hook_civicrm_post). We need to make sure we updated the template contribution first because CRM_Contribute_BAO_ContributionRecur::self_hook_civicrm_post will also try to update it.

Comments
----------------------------------------
We've shipped ContributionRecur.updateAmountOnRecurMJW in the paymentshared/mjwshared library for a few years now. It's currently in use by various extensions including stripeimport, upgraderecur (MJW branch, @artfulrobot wrote some earlier code that lead to me creating the API call, intention is to use core API once available), variablerecurpayments etc.
