### PR TITLE
RiverLea: removes extension version number from Civi 6.10

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -4,8 +4,6 @@
 ****************************/
 
 :root {
-  --crm-release: '1.4.10-6.8';
-  --crm-version: 'v' var(--crm-release);
 /* Fonts */
   --crm-system-fonts: unset;
   --crm-font: unset;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -425,11 +425,6 @@ table.advmultiselect {
   text-align: center;
   font-size: var(--crm-m2);
 }
-/* Outputs stream + version number
-#civicrm-footer::after {
-  content: var(--crm-version);
-  float: right;
-}*/
 .crm-container #civicrm-footer .status {
   border-radius: var(--crm-roundness);
   padding: var(--crm-btn-small-padding);

--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.10-[civicrm.version]</version>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>

--- a/ext/riverlea/managed/RiverleaStream_Minetta.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Minetta.mgd.php
@@ -19,9 +19,6 @@ return [
         'file_prefix' => 'streams/minetta/',
         'css_file' => '_main.css',
         'css_file_dark' => '_dark.css',
-        'vars' => [
-          '--crm-version' => "'Minetta, v' var(--crm-release)",
-        ],
       ],
       'match' => ['name'],
     ],

--- a/ext/riverlea/streams/empty/_variables.css
+++ b/ext/riverlea/streams/empty/_variables.css
@@ -1,7 +1,6 @@
 /*
     Name: Empty stream;
     Description: duplicate this to create a new stream;
-    Riverlea version: 1.4.8;
     Some pointers:
       - Use this stream to replace the variables in '/core/css/_variables.css'.
         That's the file to study to understand how RL variables work.
@@ -41,7 +40,6 @@
 */
 
 :root {
-  --crm-version: 'Empty, v' var(--crm-release);
 /* Fonts '--crm-font-' */
 /* Colour names, e.g. green, red, blue '--crm-c-' */
 /* Practical colours, e.g. text, link '--crm-c-' */

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -1,11 +1,9 @@
 /*
     Name: HackneyBrook;
     Description: named after the Hackney Brook, a tributary of the River Lea that ran through Finsbury Park;
-    Riverlea version: 1.3.8;
 */
 
 :root {
-  --crm-version: 'Hackney, v' var(--crm-release);
   /* Fonts */
   --crm-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   /* Colour names */

--- a/ext/riverlea/streams/minetta/_main.css
+++ b/ext/riverlea/streams/minetta/_main.css
@@ -1,7 +1,6 @@
 /*
     Name: Minetta;
     Description: Generic CiviCRM UI, somewhat familiar to users of CiviCRM since 2014. Named after Minetta Creek, which runs under Greenwich, New York. NB - variables appear here when they run diverge from a pattern that supports broader customisation;
-    Riverlea version: 1.3.8;
 */
 
 :root {

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -1,7 +1,6 @@
 /*
     Name: Thames;
     Description: Aaaaah;
-    Riverlea version: 1.3.8;
 
     I have added 'thames' to lines I changed.
     This means I can track changes to the core variables with diff.
@@ -12,7 +11,6 @@
 */
 
 :root {
-  --crm-version: 'Thames, v' var(--crm-release);
 /* FONTS */
 /* --crm-system-fonts:; */
   --crm-font: Lato, sans-serif;

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -1,11 +1,9 @@
 /*
     Name: Walbrook;
     Description: Based on Shoreditch theme. Named after after River Walbrook, which runs under Shoreditch, London;
-    Riverlea version: 1.3.8;
 */
 
 :root {
-  --crm-version: 'Walbrook, v' var(--crm-release);
 /* Fonts */
   --crm-system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   --crm-font: "Inter", "Open Sans", var(--crm-system-fonts);


### PR DESCRIPTION
Overview
----------------------------------------
To help with development RiverLea has had it's own version number updating in parallel with CiviCRM's version number - this appeared in the info.xml and as a variable that could be exposed on screen to help with debugging. This is no longer helpful - and is something that needs updating each month. 

Also removes some commented out css for displaying this version number, and a variable for this in `managed/RiverleaStream_Minetta.mgd.php`

Before
----------------------------------------
Version numbers in Streams and info.xml

After
----------------------------------------
No more
