### PR TITLE
RiverLea removes duplicate CSS Custom Properties from Thames

### DIFF
--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -14,78 +14,41 @@
 :root {
   --crm-version: 'Thames, v' var(--crm-release);
 /* FONTS */
-/* --crm-system-fonts:; */
   --crm-font: Lato, sans-serif;
 }
 :root {
 /* COLOUR NAMES */
-  --crm-c-darkest: #0a0a0a;
-  --crm-c-gray-900: #2f2f2e;
-  --crm-c-gray-800: #3e3e3e;
-  --crm-c-gray-700: #696969;
-  --crm-c-gray-600: #828388;
-  --crm-c-gray-500: #919297;
-  --crm-c-gray-400: #adaeb3;
-  --crm-c-gray-300: #c2c0c0;
-  --crm-c-gray-200: #d5d5d5;
-  --crm-c-gray-100: #e2e1e1;
-  --crm-c-gray-050: #f8f8f8;
-  --crm-c-gray-025: #fcfbfb;
   --crm-c-blue-overlay2: #edf4f7; /* thames only */
   --crm-c-blue-overlay: #dce9ef; /* thames only */
-  --crm-c-blue-light: #d8edfe; /* thames */
-  --crm-c-blue: #c5e4fc; /* thames */
+  --crm-c-blue-light: #d8edfe;
+  --crm-c-blue: #c5e4fc;
   --crm-c-blue-dark: #0d5790; /* thames. nb #127aca not AAA on #f8f8f8  */
-  --crm-c-blue-darker: #033b67; /* thames */
-  --crm-c-purple: #4d4d69;
-  --crm-c-purple-dark: #3e3e54;
-  --crm-c-green: #d6e9c6;
-  --crm-c-green-light: #dff0d8;
+  --crm-c-blue-darker: #033b67;
   --crm-c-green-dark: #468847;
-  --crm-c-red: #eed3d7;
   --crm-c-red-light: #f2dede;
-  --crm-c-red-dark: #740f0f; /* thames */
+  --crm-c-red-dark: #740f0f;
   --crm-c-red-bright: #bd0404; /* thames only */
   --crm-c-amber: #eeb153;
   --crm-c-amber-light: #ffebc5;
-  --crm-c-yellow: #fcfc5a; /* thames todo change this horrible yellow! */
+  --crm-c-yellow: #fcfc5a; /* todo change this horrible yellow! */
   --crm-c-yellow-light: #f2deb9;
-  --crm-c-yellow-less-light: #fffdb2;
-  --crm-c-teal: #63c4b9;
-  --crm-c-dark-teal: #3e8079;
 /* PRACTICAL COLOURS */
-  --crm-c-text-light: #fff;
-  --crm-c-text-dark: #000000dd; /* thames */
-  --crm-c-link: var(--crm-c-blue-dark);
-  --crm-c-link-hover: var(--crm-c-blue-darker);
-  --crm-c-divider: 1px solid var(--crm-c-blue-overlay); /* thames */
-  --crm-c-layer0-bg: #fff;
-  --crm-c-inverse-bg: var(--crm-c-gray-700);
+  --crm-c-text-dark: #000000dd;
+  --crm-c-divider: 1px solid var(--crm-c-blue-overlay);
   --crm-c-page-bg: #f3f2ed;
   --crm-c-container-bg: #f8f8f8;
-  --crm-c-layer1-bg: var(--crm-c-gray-050);
   --crm-c-layer2-bg: color-mix(in srgb,var(--crm-c-layer1-bg) 90%,#000 10%);
   --crm-c-drag-bg: var(--crm-c-blue-overlay2); /* background for drag/drop regions, select2 highlight */
   --crm-c-code-bg: var(--crm-c-blue-overlay2); /* background for code regions */
-  --crm-c-focus: var(--crm-c-blue-dark);
   /* Emphasis colours */
-  --crm-c-primary: var(--crm-c-blue-dark); /* primary button bgs */ /* thames */
-  --crm-c-primary-hover: var(--crm-c-blue-darker); /* thames */
-  --crm-c-primary-text: var(--crm-c-text-light);
-  --crm-c-primary-hover-text: var(--crm-c-text-light); /* thames */
-  --crm-c-secondary: #c9e1f1; /* buttons */ /* thames */
-  --crm-c-secondary-hover: #a1cef3; /* thames */
-  --crm-c-secondary-text: var(--crm-c-blue-darker); /* thames */
+  --crm-c-primary: var(--crm-c-blue-dark); /* primary button bgs */
+  --crm-c-primary-hover: var(--crm-c-blue-darker);
+  --crm-c-secondary: #c9e1f1; /* buttons */
+  --crm-c-secondary-hover: #a1cef3;
+  --crm-c-secondary-text: var(--crm-c-blue-darker);
   --crm-c-secondary-hover-text: var(--crm-c-text-light); /* thames todo */
   --crm-c-secondary-on-page-bg: var(--crm-c-blue-darker);
-  --crm-c-success: var(--crm-c-green-dark);
-  --crm-c-success-text: var(--crm-c-text-light);
-  --crm-c-danger: var(--crm-c-red-dark); /* thames */
-  --crm-c-danger-text: var(--crm-c-text-light);
-  --crm-c-warning: var(--crm-c-amber); /* bg on .btn-warning, .label-warming but border on notification .alert */
   --crm-c-warning-text: var(--crm-c-text-dark);
-  --crm-c-info: var(--crm-c-blue-dark);
-  --crm-c-info-text: var(--crm-c-text-light);
 }
 :root {
 /* thames only radii */
@@ -94,154 +57,74 @@
   --crm-r-2: 0.25em;
   --crm-r-1: 3px;
 /* SHADOWS */
-  --crm-block-shadow: unset;
-  --crm-popup-shadow: 3px 3px 18px 0 rgba(0, 0, 0,.25); /* thames */
-  --crm-bottom-shadow: unset;  /* thames */
-  --crm-body-inset: unset;
+  --crm-popup-shadow: 3px 3px 18px 0 rgba(0, 0, 0,.25);
+  --crm-bottom-shadow: unset;
 /* SIZES - temporary */
   --crm-roundness: 0; /* thames - this gets applied in too many places; so setting to 0 and positively re-applying, rather than using this and negatively unapplying. */
-  --crm-xs: 0.1rem;
-  --crm-xs1: 0.125rem;
-  --crm-xs2: 0.15rem;
-  --crm-s: 0.25rem;
-  --crm-s1: 0.275rem;
-  --crm-s2: 0.325rem;
-  --crm-s3: 0.375rem;
-  --crm-m: 0.5rem;
-  --crm-m1: 0.625rem;
-  --crm-m2: 0.75rem;
-  --crm-m3: 0.875rem;
-  --crm-r: 1rem;
-  --crm-r1: 1.125rem;
-  --crm-r2: 1.25rem;
-  --crm-r3: 1.375rem;
-  --crm-r4: 1.5rem;
-  --crm-l: 2rem;
-  --crm-xl: 3rem;
-  --crm-xxl: 4rem;
-  --crm-big-input: 15em;
-  --crm-huge-input: 25em;
-  --crm-padding-reg: var(--crm-r);
-  --crm-padding-small: var(--crm-s);
-  --crm-padding-inset: var(--crm-m);
 /* thames: on standalone the following is overridden in cms.css */
-  --crm-page-padding: clamp(0.5rem 2vw 4rem); /* Margin left/right */ /* thames */
-  --crm-page-width: 100%; /* Default that CMS can overwrite */
+  --crm-page-padding: clamp(0.5rem 2vw 4rem); /* Margin left/right */
 /* Type */
-  --crm-font-size: var(--crm-r);
-  --crm-small-font-size: var(--crm-m2);
-  --crm-type-line-height: 1.5;
-  --crm-link-decoration: none;
-  --crm-link-decoration-hover: underline;
-  --crm-heading-bg: unset; /*var(--crm-c-blue-light);*/ /* thames */
+  --crm-heading-bg: unset;
   --crm-heading-col: var(--crm-c-text-dark);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1); /* thames unset this? todo */
-  --crm-heading-margin: var(--crm-m) 0;
-  --crm-heading-radius: var(--crm-roundness);
-/* Mouse events */
-  --crm-hover-clickable: pointer;
 }
 :root {
 /* Buttons */
-  --crm-btn-box-shadow: none;
-  --crm-btn-border: 0 solid transparent;
-  --crm-btn-txt-transform: inherit;
-  --crm-btn-radius: 3px;
-  --crm-btn-padding-block: var(--crm-s); /* padding for top and bottom, one value */ /* thames */
-  --crm-btn-padding-inline: var(--crm-m2); /* padding for left and right, one value */ /* thames */
-  --crm-btn-small-padding: var(--crm-xs) var(--crm-s);
-  --crm-btn-large-padding: var(--crm-m) var(--crm-r);
-  --crm-btn-align: center;
-  --crm-btn-height: 1.825rem; /* thames */
-  --crm-btn-icon-spacing: var(--crm-xs2); /* thames */
-  --crm-btn-icon-size: auto;
+  --crm-btn-padding-block: var(--crm-s);
+  --crm-btn-padding-inline: var(--crm-m2);
+  --crm-btn-height: 1.825rem;
+  --crm-btn-icon-spacing: var(--crm-xs2);
   --crm-btn-cancel-bg: var(--crm-c-red-light);
   --crm-btn-cancel-text: var(--crm-c-red-dark);
-  --crm-btn-info-bg: var(--crm-c-secondary); /* thames */
-  --crm-btn-info-text: var(--crm-c-secondary-text); /* thames */
-  --crm-btn-warning-bg: var(--crm-c-warning);
-  --crm-btn-warning-text: var(--crm-c-warning-text);
-  --crm-btn-success-bg: var(--crm-c-info); /* thames */
-  --crm-btn-success-text: #fff; /* thames */
+  --crm-btn-info-bg: var(--crm-c-secondary);
+  --crm-btn-info-text: var(--crm-c-secondary-text);
+  --crm-btn-success-bg: var(--crm-c-info);
+  --crm-btn-success-text: #fff;
   --crm-btn-danger-bg: var(--crm-c-red);
   --crm-btn-danger-text: var(--crm-c-red-dark);
-  --crm-btn-icon-bg: unset;
-  --crm-btn-icon-border: unset;
   --crm-btn-margin: var(--crm-m) 0;
 }
 :root {
 /* Tables */
   --crm-table-outside-border: 1px solid var(--crm-c-layer2-bg);
   --crm-table-bg: var(--crm-c-page-bg);
-  --crm-table-row-border: var(--crm-c-divider);
-  --crm-table-column-border: 0 solid transparent;
-  --crm-table-font-size: var(--crm-font-size);
-  --crm-table-padding: var(--crm-m);
-  --crm-table-header-border: 1px solid transparent;
-  --crm-table-header-bottom: 2px solid var(--crm-c-gray-300);
   --crm-table-header-bg: var(--crm-c-page-bg);
-  --crm-table-header-txt: inherit;
   --crm-table-row-bg: var(--crm-c-gray-025);
   --crm-table-row-hover: var(--crm-c-blue-overlay);
-  --crm-table-sort-col: var(--crm-c-gray-300);
-  --crm-table-sort-float: left; /* 'left', 'right' or 'none' */
-  --crm-table-sort-active-col: var(--crm-c-link);
-  --crm-table-compressed-width: auto;
-  --crm-table-nested-padding: var(--crm-r) var(--crm-m);
-  --crm-table-nested-head-border: 0 solid transparent;
-  --crm-table-nested-border: var(--crm-c-divider);
-  --crm-table-inset-bg: var(--crm-c-layer2-bg);
 }
 :root {
 /* Panels */
-  --crm-panel-shadow: var(--crm-block-shadow);
-  --crm-panel-border: var(--crm-c-divider);
-  --crm-panel-head-margin: 0px;
   --crm-panel-head-height: 42px;
 }
 :root {
 /* Accordions */
-  --crm-expand-icon: "\f0da"; /* unicode value for FontAwesome icon */
-  --crm-expand-icon-color: var(--crm-c-text);
-  --crm-expand-icon-spacing: var(--crm-m);
-  --crm-expand-transform: rotate(90deg);
-  --crm-expand-transition: transform .3s;
-  --crm-expand-radius: 4px; /* thames */
-  --crm-expand-gap: var(--crm-xs2) 0 0; /* space between multiple accordions */
+  --crm-expand-radius: 4px;
 /* .crm-accordion-bold */
-  --crm-expand-header-bg: var(--crm-c-blue-overlay); /* thames */
-  --crm-expand-header-bg-active: var(--crm-c-blue-overlay); /* thames */
-  --crm-expand-header-color: var(--crm-c-blue-darker); /* thames */
-  --crm-expand-header-padding: 0.6rem 1.6rem 0.6rem 2.8rem; /* thames */
-  --crm-expand-header-weight: bold;
-  --crm-expand-header-border: unset;/*var(--crm-c-divider);*/ /* thames */
-  --crm-expand-header-border-width: unset; /*0 0 1px 0*/; /* thames */
-  --crm-expand-border: unset; /* thames */
-  --crm-expand-border-width: unset; /* thames */
-  --crm-expand-body-bg: var(--crm-c-blue-overlay); /* thames  todo check*/
-  --crm-expand-body-box-shadow: unset;
-  --crm-expand-body-padding: 0.25rem 2.8rem; /* thames */
+  --crm-expand-header-bg: var(--crm-c-blue-overlay);
+  --crm-expand-header-bg-active: var(--crm-c-blue-overlay);
+  --crm-expand-header-color: var(--crm-c-blue-darker);
+  --crm-expand-header-padding: 0.6rem 1.6rem 0.6rem 2.8rem;
+  --crm-expand-header-border: unset;
+  --crm-expand-header-border-width: unset;
+  --crm-expand-border: unset;
+  --crm-expand-border-width: unset;
+  --crm-expand-body-bg: var(--crm-c-blue-overlay); /* thames - todo check*/
+  --crm-expand-body-padding: 0.25rem 2.8rem;
 /* .crm-accordion-light */
   --crm-expand2-header-bg: transparent;
   --crm-expand2-header-bg-active: var(--crm-c-layer2-bg);
-  --crm-expand2-header-weight: normal;
-  --crm-expand2-header-border: unset;
-  --crm-expand2-header-border-width: unset;
-  --crm-expand2-header-padding: .6rem 1.6rem 0.6rem 2.8rem; /*var(--crm-s) var(--crm-m); */ /* thames */
-  --crm-expand2-border: unset;
-  --crm-expand2-border-width: unset;
+  --crm-expand2-header-padding: .6rem 1.6rem 0.6rem 2.8rem;
   --crm-expand2-body-bg: transparent;
-  --crm-expand2-body-padding: 0.25rem 2.8rem; /* thames */
+  --crm-expand2-body-padding: 0.25rem 2.8rem;
 }
 :root {
 /* Alerts */
-  --crm-alert-padding: var(--crm-r); /* thames */
-  --crm-alert-margin: 0 0 var(--crm-m);
-  --crm-alert-border-width: 0; /* thames */
+  --crm-alert-padding: var(--crm-r);
+  --crm-alert-border-width: 0;
 /* Note 'help' suffix here is for the 'success' boxes. */
-  --crm-alert-success-bg: var(--crm-c-blue-light); /* thames */
-  --crm-alert-success-border: unset; /* thames */
-  --crm-alert-success-text: unset; /* thames */
+  --crm-alert-success-bg: var(--crm-c-blue-light);
+  --crm-alert-success-border: unset;
+  --crm-alert-success-text: unset;
   --crm-alert-warning-border: var(--crm-c-yellow);
   --crm-alert-info-bg: var(--crm-c-blue-light);
   --crm-alert-info-border: var(--crm-c-blue);
@@ -252,152 +135,89 @@
 }
 :root {
 /* Form */
-  --crm-form-block-box-shadow: var(--crm-block-shadow);
-  --crm-form-block-padding: var(--crm-m);
-  --crm-form-block-border-radius: var(--crm-roundness);
-  --crm-input-bg-image: linear-gradient(top, #eee 1%, #fff 15%);
-  --crm-input-border-color: #0000001a; /* thames */
-  --crm-input-border-radius: 3px;
-  --crm-input-active-ani: border-color .15s ease-in-out 0s;
-  --crm-input-box-shadow: none; /* thames */
-  --crm-input-padding: var(--crm-xs1) var(--crm-s2);
-  --crm-input-padding-large: var(--crm-s) var(--crm-m1);
-  --crm-input-height: var(--crm-l);
-  --crm-input-font-size: var(--crm-m3);
-  --crm-input-label-weight: bold;
-  --crm-input-label-font: var(--crm-font);
-  --crm-input-label-size: var(--crm-font-size);
+  --crm-input-border-color: #0000001a;
+  --crm-input-box-shadow: none;
   --crm-input-label-width: 16ch; /* thames todo - where is this used? */
-  --crm-input-label-align: right;
-  --crm-input-description: #000000e8; /* darker for legibility */ /* thames */
-  --crm-input-dropdown-icon: "\f107";
-  --crm-input-radio-color: var(--crm-c-focus);
-  --crm-inline-edit-border: 0 solid transparent;
-  --crm-fieldset-border-color: var(--crm-c-gray-400);
-  --crm-fieldset-border: 1px 0 0 0;
-  --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
+  --crm-input-description: #000000e8; /* darker for legibility */
 }
 :root {
 /* Tabs */
   --crm-tabs-bg: var(--crm-c-blue-overlay2);
   --crm-tabs-padding: 0;
   --crm-tabs-border: 4px solid var(--crm-c-blue-overlay2);
-  --crm-tabs-gap: var(--crm-s);
   --crm-tab-bg-hover: var(--crm-c-blue-overlay);
   --crm-tab-bg-active: var(--crm-c-layer0-bg);
-  --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* lip to extend tab flush with active region - set to 0 for no lip */ /* thames todo check */
+  --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* thames todo check */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
-  --crm-tab-weight: normal;
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
   --crm-tab-roundness: var(--crm-r-3) var(--crm-r-3) 0 0;
   --crm-tab-border: none;
-  --crm-tab-border-width: 0;
-  --crm-tab-border-active: 0 solid transparent;
   --crm-tabs-2-border: var(--crm-tabs-border);
 }
 :root {
 /* Contact dashboard/summary */
-  --crm-dash-border: 0 solid transparent; /* thames */
-  --crm-dash-roundness: var(--crm-r-5); /* thames */
-  --crm-dash-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */ /* thames */
-  --crm-side-tabs-width: 220px; /* thames */
-  --crm-dash-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */ /* thames */
-  --crm-dash-tabs-gap: 0; /* thames */
-  --crm-dash-tabs-bg: var(--crm-c-blue-overlay); /* thames */
-  --crm-dash-tabs-padding: unset; /* thames */
+  --crm-dash-border: 0 solid transparent;
+  --crm-dash-roundness: var(--crm-r-5);
+  --crm-dash-direction: grid;
+  --crm-side-tabs-width: 220px;
+  --crm-dash-tabs-flow: column;
+  --crm-dash-tabs-gap: 0;
+  --crm-dash-tabs-bg: var(--crm-c-blue-overlay);
+  --crm-dash-tabs-padding: unset;
   --crm-dash-tab-bg: transparent;
   --crm-dash-tabs-roundness: var(--crm-dash-roundness) 0 0 var(--crm-dash-roundness);
-  --crm-dash-tab-bg-hover: var(--crm-c-layer0-bg); /* thames */
-  --crm-dash-tab-padding: var(--crm-m2) var(--crm-r1); /* thames */
-  --crm-dash-tab-border: var(--crm-dash-border); /* thames */
-  --crm-dash-tab-border-hover: 0 solid transparent;
-  --crm-dash-tab-border-width: 0; /* to remove border on one side for hanging tabs */
-  --crm-dash-tab-col: unset; /* thames */
-  --crm-dash-tab-count-bg: var(--crm-c-primary); /* thames */
-  --crm-dash-tab-count-col: var(--crm-c-text-light); /* thames */
-  --crm-dash-tab-width: 100%;
-  --crm-dash-tab-align: none;
-  --crm-dash-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */ /* thames */
-  --crm-dash-tab-radius: 0; /* thames */
-  --crm-dash-icon-size: var(--crm-r); /* thames */
-  --crm-dash-box-shadow: 0; /* thames */
+  --crm-dash-tab-bg-hover: var(--crm-c-layer0-bg);
+  --crm-dash-tab-padding: var(--crm-m2) var(--crm-r1);
+  --crm-dash-tab-border: var(--crm-dash-border);
+  --crm-dash-tab-col: unset;
+  --crm-dash-tab-count-bg: var(--crm-c-primary);
+  --crm-dash-tab-count-col: var(--crm-c-text-light);
+  --crm-dash-tab-hang: 0 0 -1px 0;
+  --crm-dash-tab-radius: 0;
   --crm-dash-heading-inset: unset;
-  --crm-dash-panel-padding: var(--crm-r2); /* thames */
-  --crm-dash-panel-bg: var(--crm-c-layer0-bg); /* thames */
-  --crm-dash-panel-border: 0;
+  --crm-dash-panel-padding: var(--crm-r2);
+  --crm-dash-panel-bg: var(--crm-c-layer0-bg);
   --crm-dash-panel-radius: 0 var(--crm-dash-roundness) var(--crm-dash-roundness) 0;
-  --crm-dash-edit-border: 1px solid var(--crm-c-blue-dark); /* thames */
-  --crm-dash-block-padding: var(--crm-m2); /* thames */
-  --crm-dash-block-bg: var(--crm-c-container-bg); /* thames */
-  --crm-dash-block-radius: var(--crm-roundness);
-  --crm-dash-label-bg: var(--crm-c-container-bg); /* thames */
-  --crm-dash-header-bg: unset; /* thames */
-  --crm-dash-header-bg2: unset; /* thames */
-  --crm-dash-header-col: var(--crm-c-blue-darker); /* thames */
-  --crm-dash-header-size: var(--crm-r3);
-  --crm-dash-header-padding: unset; /* thames */
-  --crm-dash-image-right: 20px; /* distance from right of dashboard */
+  --crm-dash-edit-border: 1px solid var(--crm-c-blue-dark);
+  --crm-dash-block-padding: var(--crm-m2);
+  --crm-dash-block-bg: var(--crm-c-container-bg);
+  --crm-dash-label-bg: var(--crm-c-container-bg);
+  --crm-dash-header-bg: unset;
+  --crm-dash-header-bg2: unset;
+  --crm-dash-header-col: var(--crm-c-blue-darker);
+  --crm-dash-header-padding: unset;
+  --crm-dash-image-right: 20px;
 }
 :root {
 /* Dialog */
   --crm-dialog-bg: var(--crm-c-page-bg);
-  --crm-dialog-padding: 0; /* thames */
-  --crm-dialog-radius: var(--crm-roundness);
-  --crm-dialog-line: unset;
-  --crm-dialog-inner-shadow: var(--crm-bottom-shadow);
-  --crm-dialog-header-bg: var(--crm-c-blue-overlay); /* thames */
-  --crm-dialog-header-col: var(--crm-c-blue-darker); /* thames */
-  --crm-dialog-header-size: var(--crm-r1);
-  --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
-  --crm-dialog-header-radius: var(--crm-dialog-radius);
-  --crm-dialog-header-border-col: transparent; /* thames */
-  --crm-dialog-body-padding: var(--crm-m);
+  --crm-dialog-padding: 0;
+  --crm-dialog-header-bg: var(--crm-c-blue-overlay);
+  --crm-dialog-header-col: var(--crm-c-blue-darker);
+  --crm-dialog-header-border-col: transparent;
 }
 :root {
 /* Dashlet */
-  --crm-dashlet-border: unset;
-  --crm-dashlet-padding: var(--crm-s2);
   --crm-dashlet-box-shadow: none;
-  --crm-dashlet-header-bg: var(--crm-c-layer0-bg); /* Thames */
-  --crm-dashlet-header-col: var(--crm-expand-header-color);
-  --crm-dashlet-header-border: unset;
-  --crm-dashlet-header-border-width: unset;
-  --crm-dashlet-header-font-size: var(--crm-font-size);
-  --crm-dashlet-header-padding: var(--crm-s);
-  --crm-dashlet-content-padding: var(--crm-dashlet-padding) 0;
+  --crm-dashlet-header-bg: var(--crm-c-layer0-bg);
   --crm-dashlet-tabs-bg: var(--crm-tabs-bg);
-  --crm-dashlet-tabs-border: 0;
-  --crm-dashlet-tab-bg: transparent;
-  --crm-dashlet-tab-border: unset;
-  --crm-dashlet-tab-color: unset;
-  --crm-dashlet-tab-active: var(--crm-tab-bg-active);
-  --crm-dashlet-tab-border-active: var(--crm-tab-border-active);
-  --crm-dashlet-tab-body-border: 0;
-  --crm-dashlet-tab-body-padding: var(--crm-m);
   --crm-dashlet-radius: var(--crm-r-3);
 }
 :root {
 /* Button dropdowns */
-  --crm-dropdown-padding: var(--crm-s);
-  --crm-dropdown-radius: var(--crm-roundness);
-  --crm-dropdown-bg: var(--crm-c-layer0-bg); /* thames */
-  --crm-dropdown-col: var(--crm-c-blue-darker); /* thames */
-  --crm-dropdown-hover: var(--crm-c-blue-dark); /* thames */
-  --crm-dropdown-hover-bg: var(--crm-c-blue-light); /* thames */
-  --crm-dropdown-border: 0;
-  --crm-dropdown-width: 23ch; /* thames */
-  --crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns */
-  --crm-dropdown-2-bg: var(--crm-c-secondary);
-  --crm-dropdown-2-padding: var(--crm-padding-small);
+  --crm-dropdown-bg: var(--crm-c-layer0-bg);
+  --crm-dropdown-col: var(--crm-c-blue-darker);
+  --crm-dropdown-hover: var(--crm-c-blue-dark);
+  --crm-dropdown-hover-bg: var(--crm-c-blue-light);
+  --crm-dropdown-width: 23ch;
 }
 :root {
 /* Notifications */
-  --crm-notify-bg: var(--crm-c-layer0-bg); /* thames */
-  --crm-notify-padding: var(--crm-m2);
-  --crm-notify-col: var(--crm-c-text); /* thames */
-  --crm-notify-accent-border: 0.875rem 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */ /* thames */
-  --crm-notify-radius: 4px; /* thames */
+  --crm-notify-bg: var(--crm-c-layer0-bg);
+  --crm-notify-col: var(--crm-c-text);
+  --crm-notify-accent-border: 0.875rem 0 0 0;
+  --crm-notify-radius: 4px;
   --crm-notify-danger: var(--crm-c-danger);
   --crm-notify-warning: var(--crm-c-warning);
   --crm-notify-success: var(--crm-c-success);
@@ -406,12 +226,6 @@
 :root {
 /* Icons */
   --crm-icon-danger: "\f06a";
-  --crm-icon-success: "\f058";
-  --crm-icon-info: "\f05a";
-  --crm-icon-close: "\f00d";
-  --crm-icon-sort: "\f0dc";
-  --crm-icon-sort-desc: "\f0dd";
-  --crm-icon-sort-asc: "\f0de";
   --crm-icon-danger-color: inherit;
   --crm-icon-success-color: inherit;
   --crm-icon-warning-color: inherit;
@@ -419,49 +233,26 @@
 }
 :root {
 /* Wizard */
-  --crm-wizard-width: fit-content;
-  --crm-wizard-margin: 0.5rem auto;
-  --crm-wizard-height: 30px;
-  --crm-wizard-radius: var(--crm-l);
-  --crm-wizard-angle: 0px;
-  --crm-wizard-active-col: var(--crm-c-text-light);
-  --crm-wizard-active-bg: var(--crm-c-link);
-  --crm-wizard-border: var(--crm-c-divider);
   --crm-wizard-bg: var(--crm-c-page-bg);
 }
 :root {
 /* Alpha filter */
   --crm-filter-bg: var(--crm-c-blue-overlay);
-  --crm-filter-padding: var(--crm-m);
   --crm-filter-item-bg: transparent;
   --crm-filter-item-shadow: none;
-  --crm-filter-spacing: space-between;
 }
 :root {
 /* Frontend */
   --crm-f-form-width: 700px;
-  --crm-f-box-shadow: var(--crm-block-shadow);
   --crm-f-fieldset-bg: var(--crm-c-container-bg);
   --crm-f-fieldset-padding: var(--crm-r);
-  --crm-f-fieldset-margin: 0 0 var(--crm-padding-reg) 0;
-  --crm-f-fieldset-border: 0;
   --crm-f-legend-align: center;
-  --crm-f-legend-size: var(--crm-r3);
-  --crm-f-form-padding: var(--crm-padding-reg);
-  --crm-f-form-layout: block; /* 'grid' = inline, 'block' = stacked */
   --crm-f-label-position: unset;
   --crm-f-label-align: left;
-  --crm-f-label-weight: bold;
-  --crm-f-label-margin: var(--crm-s);
   --crm-f-label-width: unset;
-  --crm-f-input-radius: var(--crm-roundness);
-  --crm-f-input-padding: var(--crm-r2) var(--crm-m2);
-  --crm-f-input-font-size: var(--crm-r1);
-  --crm-f-input-width: 100%; /* thames */
+  --crm-f-input-width: 100%;
   --crm-f-form-focus-bg: var(--crm-c-green);
   --crm-f-form-error-bg: var(--crm-c-red);
-  --crm-f-logo-height: 40px;
-  --crm-f-logo-align: center; /* left, right or center */
 }
 
 /* Only affect body colour in standalone */


### PR DESCRIPTION
Overview
----------------------------------------
Thames currently loads an old copy of RL core's Variables including both those changed (mostly commented with `/* thames */`) and those unchanged (mostly not commented). This was for development and following discussion with @artfulrobot seems no longer needed. 

Removing this duplication as its grown out of sync and it's unclear how much of that is intentional or accidental as the commenting isn't consistent so (un/)changed variables aren't always obvious. This means a changed core variable might not get changed in Thames when it would want that.

I've done this as two commits - the first is the removed duplicated variables which I created by manually comparing `/css/_variables.css` and `thames/_main.css` side-by-side. (as it was a human process I obvs can't guarantee I didn't miss something!)

The second commit removes `/* thames */` next to the names, plus other comments that duplicate core comments. But that makes the diff harder to compare, so Rich - if you want to double check I've not removed anything that first commit has a clearer diff.

I also spotted two bugs in `/css/_variables.css` as I went which I fixed…

Before
----------------------------------------
Thames duplicates many of the variables from `/css/_variables.css`

After
----------------------------------------
It doesn't.

Notes
----------------------------------------
This PR shouldn't change the appearance of anything. I'm doing it ahead of the variable rename/cleanup planned [here](https://lab.civicrm.org/extensions/riverlea/-/issues/161).