### PR TITLE
RiverLea: make FormBuilder checkbox list full-width in admin/front & without border/bg in front

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -134,3 +134,16 @@ fieldset.af-container.af-layout-inline {
   display: flex;
   padding-block: 0.25rem;
 }
+.af-container ul.crm-checkbox-list {
+  width: 100%;
+  max-height: 100%;
+  overflow: auto;
+  height: auto;
+}
+.crm-public .af-container ul.crm-checkbox-list {
+  border: 0;
+  background-color: inherit;
+}
+.crm-public .af-container ul.crm-checkbox-list li {
+  background-color: inherit;
+}

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -702,3 +702,11 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   background: linear-gradient(to bottom, #f2f2f2 0 var(--crm-l), transparent var(--crm-l) 100%) no-repeat;
   border-radius: var(--crm-roundness);
 }
+/* Check boxes */
+
+.af-container ul.crm-checkbox-list {
+  width: 100%;
+  max-height: 100%;
+  overflow: auto;
+  height: auto;
+}


### PR DESCRIPTION
This is intended as a replacement for @GuillaumeSorel's PR https://github.com/civicrm/civicrm-core/pull/33858 - it is the same but puts one selector into a second location to load back-end
(I'm not git-skilled enough yet to make a commit onto someone else's PR). 

Am copying the text from that PR

Before
----------------------------------------
300px width, border, scroll and stripes in the background

FB Editor:

<img width="1682" height="496" alt="image" src="https://github.com/user-attachments/assets/c0fa8e66-ec12-4fa5-ab08-b28c490ee0b1" />

FB Display:

<img width="568" height="158" alt="image" src="https://github.com/user-attachments/assets/65bbf281-3c81-4426-8cc1-296ecc80579a" />

After
----------------------------------------
100% width and no scroll-bars in the front and back-end;
no border or background stripes in the front-end (same as other Profile/custom field checkbox displays)
inherit background color

FB Editor:

<img width="1694" height="500" alt="image" src="https://github.com/user-attachments/assets/0beb7684-aeb9-42dc-91d3-9f492f9dfc2e" />

FB Display:

<img width="643" height="137" alt="image" src="https://github.com/user-attachments/assets/21fe7ad1-8c17-4448-a1d8-8b7c8c87f88c" />

Comments
----------------------------------------
For testing you need to check that:
 - back-end form-builder checkbox lists are now full-width and still have striped background, border and internal scroll.
 - front-end form-builder checkbox lists are also full width but don't have striped bg, scroll or border anymore.