### PR TITLE
APIv4 Explorer - Add refresh button

### DIFF
--- a/ang/api4Explorer/Explorer.html
+++ b/ang/api4Explorer/Explorer.html
@@ -247,6 +247,7 @@
     <div class="panel explorer-result-panel panel-{{ status }}" >
       <div class="panel-heading">
         <div class="form-inline pull-right">
+          <button class="btn" crm-icon="fa-sync" ng-disabled="!entity || !action || loading" ng-click="execute()" title="Refresh"></button>
           <select ng-show="selectedTab.result === 'result'" class="form-control crm-auto-width" ng-model="$ctrl.resultFormat" ng-change="$ctrl.formatResult()">
             <option ng-repeat="fmt in $ctrl.resultFormats" value="{{:: fmt.name }}">
               {{:: fmt.label }}


### PR DESCRIPTION
Overview
----------------------------------------

Add a button to refresh the results in the APIv4 Explorer.

Before
----------------------------------------

There is no refresh button.

<img width="503" height="329" alt="Screenshot 2025-11-13 at 10 45 14 AM" src="https://github.com/user-attachments/assets/ccd868c3-b07f-4f14-8370-24f074c0a360" />

What do you do if you're inspecting or debugging this call? You need to run it repeatedly (after you fiddle with the relevant code or configuration or data). Steps to run again:

1. Scroll up to the top
2. Click "Execute"
3. Scroll down to the bottom
4. View the "Results"

Repeat steps 1-4 until it actually works... which may mean a lot of scrolling...

After
----------------------------------------

There is a refresh button. It even has a textual `title` and an icon!

<img width="517" height="355" alt="Screenshot 2025-11-13 at 10 44 57 AM" src="https://github.com/user-attachments/assets/00270265-2d9e-4f96-ad2c-86cd9310f64b" />

Less scrolling.

