### PR TITLE
RiverLea: big variable rename (#161) - appends '-color' to colors, renames -dash and -expand, renames sizes, adds ink+paper vars, other tidying

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4120,5 +4120,5 @@ html.crm-standalone body {
   margin: 0;
   padding: 0;
   font-family: var(--crm-font, sans-serif);
-  background-color: var(--crm-c-page-background, #f8f8f8);
+  background-color: var(--crm-page-bg-color, #f8f8f8);
 }

--- a/css/crm-menubar.css
+++ b/css/crm-menubar.css
@@ -2,11 +2,11 @@
 
 :root {
   --crm-menubar-height: $menubarHeight;
-  --crm-c-menubar-bg: $menubarColor;
-  --crm-c-menubar-item: $menuItemColor;
-  --crm-c-menubar-text: $textColor;
-  --crm-c-menubar-highlight: $highlightColor;
-  --crm-c-menubar-highlight-text: $highlightTextColor;
+  --crm-menubar-color: $menubarColor;
+  --crm-menubar-item-color: $menuItemColor;
+  --crm-menubar-text-color: $textColor;
+  --crm-menubar-highlight-color: $highlightColor;
+  --crm-menubar-highlight-text-color: $highlightTextColor;
 }
 #civicrm-menu-nav {
   line-height: 0;
@@ -14,7 +14,7 @@
   font-size: 13px;
 }
 #civicrm-menu {
-  background-color: var(--crm-c-menubar-bg);
+  background-color: var(--crm-menubar-color);
   width: 100%;
   z-index: 500;
   height: auto;
@@ -47,8 +47,8 @@
 #civicrm-menu li a:hover,
 #civicrm-menu li a.highlighted {
   text-decoration: none;
-  background-color: var(--crm-c-menubar-highlight);
-  color: var(--crm-c-menubar-highlight-text);
+  background-color: var(--crm-menubar-highlight-color);
+  color: var(--crm-menubar-highlight-text-color);
 }
 #civicrm-menu li li .sub-arrow:before {
   content: "\f0da";
@@ -185,7 +185,7 @@ ul.crm-quickSearch-results.ui-state-disabled {
 }
 #civicrm-menu #crm-menubar-toggle-position a i {
   margin: 0;
-  border-top: 2px solid var(--crm-c-menubar-text);
+  border-top: 2px solid var(--crm-menubar-text-color);
   font-size: 11px;
   opacity: .8;
 }
@@ -264,8 +264,8 @@ body.crm-menubar-over-cms-menu #crm-menubar-toggle-position a i {
   }
 
   #civicrm-menu li a {
-    background-color: var(--crm-c-menubar-item);
-    color: var(--crm-c-menubar-text);
+    background-color: var(--crm-menubar-item-color);
+    color: var(--crm-menubar-text-color);
   }
 
   #civicrm-menu > li > a {

--- a/ext/chart_kit/ang/crmChartKitAdmin.css
+++ b/ext/chart_kit/ang/crmChartKitAdmin.css
@@ -23,7 +23,7 @@
 }
 .crm-chart-kit-admin .select2-container {
   /* fix select2 collapsing boxes in RiverLea */
-  width: var(--crm-big-input)!important;
+  width: var(--crm-input-width)!important;
 }
 
 .crm-chart-kit-admin input[type='color'] {

--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -5,9 +5,9 @@
   opacity: .85;
   display: flex;
   justify-content: space-between;
-  gap: var(--crm-r);
+  gap: var(--crm-s-reg);
   align-items: center;
-  padding: var(--crm-padding-small) var(--crm-padding-small) var(--crm-padding-small) var(--crm-r);
+  padding: var(--crm-padding-small) var(--crm-padding-small) var(--crm-padding-small) var(--crm-s-reg);
 }
 #crm-status-list h3:hover,
 #crm-status-list h3.menuopen {
@@ -38,12 +38,12 @@
   color: var(--crm-success-text-color);
 }
 #crm-status-list .crm-status-message-body {
-  margin: var(--crm-r) 0;
+  margin: var(--crm-s-reg) 0;
 }
 #crm-status-list .hidden-until {
   font-weight: normal;
   font-size: var(--crm-font-small-size);
-  margin-right: var(--crm-r);
+  margin-right: var(--crm-s-reg);
 }
 #crm-status-list .hush-menu {
   margin-left: auto;

--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -42,7 +42,7 @@
 }
 #crm-status-list .hidden-until {
   font-weight: normal;
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
   margin-right: var(--crm-r);
 }
 #crm-status-list .hush-menu {
@@ -69,7 +69,7 @@
   padding: var(--crm-dropdown-padding);
   border-radius: var(--crm-dropdown-radius);
   font-size: var(--crm-font-size);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
 }
 #crm-status-list .hush-menu li {
   padding: var(--crm-dropdown-padding);
@@ -84,5 +84,5 @@
   color: var(--crm-dropdown-hover);
 }
 .status-debug-information {
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
 }

--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -5,9 +5,9 @@
   opacity: .85;
   display: flex;
   justify-content: space-between;
-  gap: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
   align-items: center;
-  padding: var(--crm-padding-small) var(--crm-padding-small) var(--crm-padding-small) var(--crm-s-reg);
+  padding: var(--crm-padding-small) var(--crm-padding-small) var(--crm-padding-small) var(--crm-l-reg);
 }
 #crm-status-list h3:hover,
 #crm-status-list h3.menuopen {
@@ -38,12 +38,12 @@
   color: var(--crm-success-text-color);
 }
 #crm-status-list .crm-status-message-body {
-  margin: var(--crm-s-reg) 0;
+  margin: var(--crm-l-reg) 0;
 }
 #crm-status-list .hidden-until {
   font-weight: normal;
   font-size: var(--crm-font-small-size);
-  margin-right: var(--crm-s-reg);
+  margin-right: var(--crm-l-reg);
 }
 #crm-status-list .hush-menu {
   margin-left: auto;
@@ -81,7 +81,7 @@
 #crm-status-list .hush-menu li:hover,
 #crm-status-list .hush-menu li:focus {
   background-color: var(--crm-dropdown-hover-bg-color);
-  color: var(--crm-dropdown-hover);
+  color: var(--crm-dropdown-hover-text-color);
 }
 .status-debug-information {
   font-size: var(--crm-font-small-size);

--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -18,24 +18,24 @@
 #crm-status-list .crm-severity-alert,
 #crm-status-list .crm-severity-critical,
 #crm-status-list .crm-severity-error {
-  background-color: var(--crm-c-danger);
-  color: var(--crm-c-danger-text);
+  background-color: var(--crm-danger-color);
+  color: var(--crm-danger-text-color);
 }
 /* Warning Severity */
 #crm-status-list .crm-severity-warning {
-  background-color: var(--crm-c-warning);
-  color: var(--crm-c-warning-text);
+  background-color: var(--crm-warning-color);
+  color: var(--crm-warning-text-color);
 }
 /* Not Okay - Not Warning */
 #crm-status-list .crm-severity-notice {
-  background-color: var(--crm-c-info);
-  color: var(--crm-c-info-text);
+  background-color: var(--crm-info-color);
+  color: var(--crm-info-text-color);
 }
 /* All OK Severity */
 #crm-status-list .crm-severity-info,
 #crm-status-list .crm-severity-debug {
-  background-color: var(--crm-c-success);
-  color: var(--crm-c-success-text);
+  background-color: var(--crm-success-color);
+  color: var(--crm-success-text-color);
 }
 #crm-status-list .crm-status-message-body {
   margin: var(--crm-r) 0;
@@ -53,7 +53,7 @@
 }
 #crm-status-list .hush-menu button {
   background-color: rgba(256,256,256,0.6);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-size: initial;
   border-color: transparent;
 }
@@ -65,7 +65,7 @@
   margin: 0;
   padding: 0;
   z-index: 99;
-  background: var(--crm-dropdown-bg);
+  background: var(--crm-dropdown-bg-color);
   padding: var(--crm-dropdown-padding);
   border-radius: var(--crm-dropdown-radius);
   font-size: var(--crm-font-size);
@@ -73,14 +73,14 @@
 }
 #crm-status-list .hush-menu li {
   padding: var(--crm-dropdown-padding);
-  color: var(--crm-dropdown-col);
-  background-color: var(--crm-dropdown-bg);
+  color: var(--crm-dropdown-color);
+  background-color: var(--crm-dropdown-bg-color);
   font-weight: normal;
   border-radius: var(--crm-dropdown-radius);
 }
 #crm-status-list .hush-menu li:hover,
 #crm-status-list .hush-menu li:focus {
-  background-color: var(--crm-dropdown-hover-bg);
+  background-color: var(--crm-dropdown-hover-bg-color);
   color: var(--crm-dropdown-hover);
 }
 .status-debug-information {

--- a/ext/riverlea/core/ang/crmUI.css
+++ b/ext/riverlea/core/ang/crmUI.css
@@ -10,7 +10,7 @@
   border: 2px dashed #d1d1d1;
   cursor: pointer;
   background-color: white !important;
-  color: var(--crm-c-text-dark);
+  color: var(--crm-text-dark-color);
 }
 .crm-container span[crm-ui-editable] {
   display: inline-block !important;

--- a/ext/riverlea/core/civi_mail-ang/crmMailing.css
+++ b/ext/riverlea/core/civi_mail-ang/crmMailing.css
@@ -34,12 +34,12 @@
 }
 .crmMailing .preview-popup,
 .crmMailing .preview-contact {
-  border-right: var(--crm-c-divider);
+  border-right: var(--crm-border);
 }
 .crmMailing .preview-popup,
 .crmMailing .preview-contact {
   text-align: center;
-  border-right: var(--crm-c-divider);
+  border-right: var(--crm-border);
 }
 .crmMailing .crmMailing-schedule-inner {
   width: var(--crm-huge-input);

--- a/ext/riverlea/core/civi_mail-ang/crmMailing.css
+++ b/ext/riverlea/core/civi_mail-ang/crmMailing.css
@@ -9,14 +9,14 @@
   background: var(--crm-c-yellow-light);
   font-size: var(--crm-font-small-size);
   padding: var(--crm-padding-small);
-  margin: 0 0 0 var(--crm-m);
-  width: var(--crm-big-input);
+  margin: 0 0 0 var(--crm-s-medium);
+  width: var(--crm-input-width);
   text-align: center;
 }
 .crmMailing input.crm-form-date,
 .crmMailing input[name=preview_test_email],
 .crmMailing-preview select[name=preview_test_group] {
-  width: var(--crm-big-input);
+  width: var(--crm-input-width);
 }
 .crmMailing .crmMailing-preview {
   display: grid;
@@ -29,7 +29,7 @@
   flex-direction: column;
   height: auto;
   align-items: center;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   width: 100%;
 }
 .crmMailing .preview-popup,
@@ -42,7 +42,7 @@
   border-right: var(--crm-border);
 }
 .crmMailing .crmMailing-schedule-inner {
-  width: var(--crm-huge-input);
+  width: var(--crm-input-large-width);
   margin: auto;
 }
 input[name=preview_test_email]::placeholder {
@@ -52,8 +52,8 @@ input[name=preview_test_email]::placeholder {
   text-decoration: line-through;
 }
 .crm-container #crm-main-content-wrapper a.crmMailing-submit-button {
-  margin-top: var(--crm-r);
-  font-size: var(--crm-r1);
+  margin-top: var(--crm-s-reg);
+  font-size: var(--crm-s-reg-1);
 }
 .crm-container a.crmMailing-submit-button.disabled,
 .crm-container a.crmMailing-submit-button.blocking {

--- a/ext/riverlea/core/civi_mail-ang/crmMailing.css
+++ b/ext/riverlea/core/civi_mail-ang/crmMailing.css
@@ -9,7 +9,7 @@
   background: var(--crm-c-yellow-light);
   font-size: var(--crm-font-small-size);
   padding: var(--crm-padding-small);
-  margin: 0 0 0 var(--crm-s-medium);
+  margin: 0 0 0 var(--crm-l-medium);
   width: var(--crm-input-width);
   text-align: center;
 }
@@ -29,7 +29,7 @@
   flex-direction: column;
   height: auto;
   align-items: center;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   width: 100%;
 }
 .crmMailing .preview-popup,
@@ -52,8 +52,8 @@ input[name=preview_test_email]::placeholder {
   text-decoration: line-through;
 }
 .crm-container #crm-main-content-wrapper a.crmMailing-submit-button {
-  margin-top: var(--crm-s-reg);
-  font-size: var(--crm-s-reg-1);
+  margin-top: var(--crm-l-reg);
+  font-size: var(--crm-l-reg-1);
 }
 .crm-container a.crmMailing-submit-button.disabled,
 .crm-container a.crmMailing-submit-button.blocking {

--- a/ext/riverlea/core/civi_mail-ang/crmMailing.css
+++ b/ext/riverlea/core/civi_mail-ang/crmMailing.css
@@ -7,7 +7,7 @@
 }
 .crmMailing-recip-est {
   background: var(--crm-c-yellow-light);
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
   padding: var(--crm-padding-small);
   margin: 0 0 0 var(--crm-m);
   width: var(--crm-big-input);

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -386,7 +386,7 @@ dl dl {
   color: var(--crm-c-text);
   background-color: var(--crm-c-code-bg);
   border: var(--crm-c-code-border);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container pre code {
   display: block;

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -158,8 +158,8 @@ body {
   font-family: var(--crm-font);
   font-size: var(--crm-font-size);
   line-height: 1.4;
-  color: var(--crm-c-text);
-  background: var(--crm-c-page-bg);
+  color: var(--crm-text-color);
+  background: var(--crm-page-bg-color);
 }
 .crm-container table,
 .crm-container tr,
@@ -168,7 +168,7 @@ body {
 .crm-container ul {
   font-size: var(--crm-font-size);
   line-height: var(--crm-font-line-height);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 
 /* iFrame */
@@ -209,10 +209,10 @@ body.civicrm-iframe-page {
 }
 .crm-container h3,
 #bootstrap-theme h3 {
-  background-color: var(--crm-heading-bg);
+  background-color: var(--crm-heading-bg-color);
   font-size: var(--crm-r1);
   font-weight: bold;
-  color: var(--crm-heading-col);
+  color: var(--crm-heading-color);
   padding: var(--crm-heading-padding);
   border-radius: var(--crm-heading-radius);
   margin: var(--crm-heading-margin);
@@ -251,8 +251,8 @@ dl dl {
 #bootstrap-theme .has-error.checkbox label,
 #bootstrap-theme .has-error.radio-inline label,
 #bootstrap-theme .has-error.checkbox-inline label {
-  color: var(--crm-c-danger-on-page-bg);
-  --crm-c-text: var(--crm-c-danger-on-page-bg);
+  color: var(--crm-danger-ink-color);
+  --crm-text-color: var(--crm-danger-ink-color);
 }
 .crm-container td.tasklist a:visited,
 #bootstrap-theme .has-success .help-block,
@@ -265,7 +265,7 @@ dl dl {
 #bootstrap-theme .has-success.checkbox label,
 #bootstrap-theme .has-success.radio-inline label,
 #bootstrap-theme .has-success.checkbox-inline label {
-  color: var(--crm-c-success-on-page-bg);
+  color: var(--crm-success-ink-color);
 }
 #bootstrap-theme .has-warning .help-block,
 #bootstrap-theme .has-warning .control-label,
@@ -277,7 +277,7 @@ dl dl {
 #bootstrap-theme .has-warning.checkbox label,
 #bootstrap-theme .has-warning.radio-inline label,
 #bootstrap-theme .has-warning.checkbox-inline label {
-  color: var(--crm-c-warning-on-page-bg);
+  color: var(--crm-warning-ink-color);
 }
 .crm-container .disabled,
 .crm-container .crm-disabled,
@@ -285,14 +285,14 @@ dl dl {
 .crm-container .cancelled,
 .crm-container .cancelled td,
 .crm-container li.disabled a.ui-tabs-anchor {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
   opacity: 1;
 }
 .crm-container tr.disabled,
 .crm-container tr:has(td.disabled),
 .crm-container .table-striped > tbody > tr:has(td.disabled) {
-  --crm-striped-bg: var(--crm-c-page-bg) /* for striped rows */;
-  background-color: var(--crm-striped-bg) !important /* vs jquery */;
+  --crm-striped-bg-color: var(--crm-page-bg-color) /* for striped rows */;
+  background-color: var(--crm-striped-bg-color) !important /* vs jquery */;
 }
 .crm-container tr.disabled td *:not(.btn,button,i,a),
 .crm-container td.disabled,
@@ -333,45 +333,45 @@ dl dl {
 }
 .crm-container .text-muted,
 .crm-container .diasbled {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
 }
 .crm-container .text-primary {
-  color: var(--crm-c-primary);
+  color: var(--crm-primary-color);
 }
 .crm-container a.text-primary:hover,
 .crm-container a.text-primary:focus {
-  color: var(--crm-c-primary-hover);
+  color: var(--crm-primary-hover-color);
 }
 .crm-container .text-success {
-  color: var(--crm-c-success-on-page-bg);
+  color: var(--crm-success-ink-color);
 }
 .crm-container .text-info {
-  color: var(--crm-c-info-on-page-bg);
+  color: var(--crm-info-ink-color);
 }
 .crm-container .text-warning {
-  color: var(--crm-c-warning-on-page-bg);
+  color: var(--crm-warning-ink-color);
 }
 .crm-container .text-danger {
-  color: var(--crm-c-danger-on-page-bg);
+  color: var(--crm-danger-ink-color);
 }
 .crm-container .text-primary {
-  color: var(--crm-c-primary-on-page-bg);
+  color: var(--crm-primary-ink-color);
 }
 .crm-container .text-secondary {
-  color: var(--crm-c-secondary-on-page-bg);
+  color: var(--crm-secondary-ink-color);
 }
 .crm-container h1,
 .crm-container h2,
 .crm-container h4,
 .crm-container h5,
 .crm-container h6 {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 .crm-container code {
   display: inline;
-  background-color: var(--crm-c-code-bg);
+  background-color: var(--crm-code-bg-color);
   border: var(--crm-code-border-color);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   border-radius: 2px;
   padding: 2px;
 }
@@ -383,8 +383,8 @@ dl dl {
   margin: 0 0 var(--crm-padding-small);
   font-size: var(--crm-font-size) !important /* vs inline css on api3 */;
   line-height: 1.4  !important /* vs inline css on api3 */;
-  color: var(--crm-c-text);
-  background-color: var(--crm-c-code-bg);
+  color: var(--crm-text-color);
+  background-color: var(--crm-code-bg-color);
   border: var(--crm-code-border-color);
   border-radius: var(--crm-s-radius);
 }
@@ -397,13 +397,13 @@ dl dl {
   border-radius: 0;
 }
 .crm-container pre.prettyprint {
-  background: var(--crm-c-text-light); /* method to force light bg on prettyprint code as inverting is too complex */
+  background: var(--crm-text-light-color); /* method to force light bg on prettyprint code as inverting is too complex */
   white-space: pre;
   text-wrap: auto;
 }
 .crm-container pre.linenums {
-  background: var(--crm-c-text-light);
-  color: var(--crm-c-text-dark);
+  background: var(--crm-text-light-color);
+  color: var(--crm-text-dark-color);
 }
 .crm-container ol.linenums {
   list-style-type: decimal;
@@ -426,12 +426,12 @@ dl dl {
 *******************/
 
 .crm-container a {
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
   text-decoration: var(--crm-link-decoration);
 }
 .crm-container a:hover,
 .crm-container a:focus {
-  color: var(--crm-c-link-hover);
+  color: var(--crm-link-hover-color);
   text-decoration: var(--crm-link-decoration-hover);
 }
 .crm-container a:focus {

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -167,7 +167,7 @@ body {
 .crm-container p,
 .crm-container ul {
   font-size: var(--crm-font-size);
-  line-height: var(--crm-type-line-height);
+  line-height: var(--crm-font-line-height);
   color: var(--crm-c-text);
 }
 

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -210,7 +210,7 @@ body.civicrm-iframe-page {
 .crm-container h3,
 #bootstrap-theme h3 {
   background-color: var(--crm-heading-bg-color);
-  font-size: var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
   font-weight: bold;
   color: var(--crm-heading-color);
   padding: var(--crm-heading-padding);
@@ -222,8 +222,8 @@ body.civicrm-iframe-page {
 
 dl dd,
 dl dl {
-  margin-block-end: var(--crm-m1);
-  margin-inline-start: var(--crm-r1);
+  margin-block-end: var(--crm-s-medium-1);
+  margin-inline-start: var(--crm-s-reg-1);
 }
 
 /* Practical colors */

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -370,7 +370,7 @@ dl dl {
 .crm-container code {
   display: inline;
   background-color: var(--crm-c-code-bg);
-  border: var(--crm-c-code-border);
+  border: var(--crm-code-border-color);
   color: var(--crm-c-text);
   border-radius: 2px;
   padding: 2px;
@@ -385,7 +385,7 @@ dl dl {
   line-height: 1.4  !important /* vs inline css on api3 */;
   color: var(--crm-c-text);
   background-color: var(--crm-c-code-bg);
-  border: var(--crm-c-code-border);
+  border: var(--crm-code-border-color);
   border-radius: var(--crm-s-radius);
 }
 .crm-container pre code {

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -210,7 +210,7 @@ body.civicrm-iframe-page {
 .crm-container h3,
 #bootstrap-theme h3 {
   background-color: var(--crm-heading-bg-color);
-  font-size: var(--crm-s-reg-1);
+  font-size: var(--crm-l-reg-1);
   font-weight: bold;
   color: var(--crm-heading-color);
   padding: var(--crm-heading-padding);
@@ -222,8 +222,8 @@ body.civicrm-iframe-page {
 
 dl dd,
 dl dl {
-  margin-block-end: var(--crm-s-medium-1);
-  margin-inline-start: var(--crm-s-reg-1);
+  margin-block-end: var(--crm-l-medium-1);
+  margin-inline-start: var(--crm-l-reg-1);
 }
 
 /* Practical colors */
@@ -386,7 +386,7 @@ dl dl {
   color: var(--crm-text-color);
   background-color: var(--crm-code-bg-color);
   border: var(--crm-code-border-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container pre code {
   display: block;

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -1714,7 +1714,7 @@ fieldset[disabled] #bootstrap-theme .form-control {
 #bootstrap-theme input[type="reset"],
 #bootstrap-theme input[type="submit"] {
   -webkit-appearance: button;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 #bootstrap-theme button[disabled],
 #bootstrap-theme html input[disabled] {
@@ -1726,7 +1726,7 @@ fieldset[disabled] #bootstrap-theme .form-control {
   padding: 0;
 }
 #bootstrap-theme [role="button"] {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 #bootstrap-theme .input-group-btn {
   position: relative;
@@ -2979,13 +2979,13 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme .close:focus {
   color: black;
   text-decoration: none;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   filter: alpha(opacity=50);
   opacity: .5;
 }
 #bootstrap-theme button.close {
   padding: 0;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   background: transparent;
   border: 0;
   height: auto;
@@ -3396,7 +3396,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme a.label:hover,
 #bootstrap-theme a.label:focus {
   text-decoration: none;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 #bootstrap-theme .label-default {
   background: var(--crm-c-darkest);

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -228,7 +228,7 @@
   padding: 4px;
   line-height: 1.428571429;
   background-color: white;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-radius: var(--crm-s-radius);
   transition: all .2s ease-in-out;
   display: inline-block;
@@ -436,7 +436,7 @@
   margin-top: 20px;
   margin-bottom: 20px;
   border: 0;
-  border-top: var(--crm-c-divider);
+  border-top: var(--crm-border);
 }
 #bootstrap-theme address {
   margin-bottom: 20px;
@@ -2946,7 +2946,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   padding: 19px;
   margin-bottom: 20px;
   background-color: var(--crm-c-container-bg);
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-radius: var(--crm-s-radius);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
 }

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -229,7 +229,7 @@
   line-height: 1.428571429;
   background-color: white;
   border: var(--crm-c-divider);
-  border-radius: var(--crm-c-roundness);
+  border-radius: var(--crm-s-radius);
   transition: all .2s ease-in-out;
   display: inline-block;
   max-width: 100%;
@@ -1794,7 +1794,7 @@ fieldset[disabled] #bootstrap-theme .btn-link:focus {
   text-align: left;
   background-color: var(--crm-input-bg);
   /* width: 100%; */
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 #bootstrap-theme .has-success .form-control,
 #bootstrap-theme .has-success .form-control:focus {
@@ -2593,7 +2593,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   margin-bottom: 20px;
   overflow: hidden;
   background-color: whitesmoke;
-  border-radius: var(--crm-c-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, .1);
 }
 #bootstrap-theme .progress-bar {
@@ -2947,7 +2947,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   margin-bottom: 20px;
   background-color: var(--crm-c-container-bg);
   border: var(--crm-c-divider);
-  border-radius: var(--crm-c-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
 }
 #bootstrap-theme .well blockquote {
@@ -3384,7 +3384,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 #bootstrap-theme .label:empty {
   display: none;

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -68,7 +68,7 @@
 }
 #bootstrap-theme .help-block {
   display: block;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-style: italic;
   margin: var(--crm-s) 0 var(--crm-m);
   font-size: var(--crm-font-small-size);
@@ -82,7 +82,7 @@
   margin-top: var(--crm-m1);
   margin-bottom: var(--crm-m1);
   font-weight: bold;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   line-height: 1.2;
 }
 #bootstrap-theme h1,
@@ -126,7 +126,7 @@
 #bootstrap-theme mark,
 #bootstrap-theme .mark {
   background: var(--crm-c-yellow);
-  color: var(--crm-c-text-dark);
+  color: var(--crm-text-dark-color);
   padding: .2rem;
 }
 @media (min-width: 768px) {
@@ -256,28 +256,28 @@
   margin-top: 5px;
 }
 #bootstrap-theme .alert-success hr {
-  border-top-color: var(--crm-alert-success-border);
+  border-top-color: var(--crm-alert-success-border-color);
 }
 #bootstrap-theme .alert-success .alert-link {
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 #bootstrap-theme .alert-info hr {
-  border-top-color: var(--crm-alert-info-border);
+  border-top-color: var(--crm-alert-info-border-color);
 }
 #bootstrap-theme .alert-info .alert-link {
-  color: var(--crm-alert-info-text);
+  color: var(--crm-alert-info-text-color);
 }
 #bootstrap-theme .alert-warning hr {
-  border-top-color: var(--crm-alert-warning-border);
+  border-top-color: var(--crm-alert-warning-border-color);
 }
 #bootstrap-theme .alert-warning .alert-link {
-  color: var(--crm-alert-warning-text);
+  color: var(--crm-alert-warning-text-color);
 }
 #bootstrap-theme .alert-danger hr {
-  border-top-color: var(--crm-alert-danger-border);
+  border-top-color: var(--crm-alert-danger-border-color);
 }
 #bootstrap-theme .alert-danger .alert-link {
-  color: var(--crm-alert-danger-text);
+  color: var(--crm-alert-danger-text-color);
 }
 
 /* Screen reader */
@@ -1290,7 +1290,7 @@
 #bootstrap-theme .form-control[disabled],
 #bootstrap-theme .form-control[readonly],
 fieldset[disabled] #bootstrap-theme .form-control {
-  background-color: var(--crm-c-layer1-bg);
+  background-color: var(--crm-layer1-bg-color);
   opacity: 1;
 }
 #bootstrap-theme .form-control[disabled],
@@ -1755,7 +1755,7 @@ fieldset[disabled] #bootstrap-theme .form-control {
 }
 #bootstrap-theme .btn-link {
   font-weight: 400;
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
   border-radius: 0;
 }
 #bootstrap-theme .btn-link,
@@ -1774,7 +1774,7 @@ fieldset[disabled] #bootstrap-theme .btn-link {
 }
 #bootstrap-theme .btn-link:hover,
 #bootstrap-theme .btn-link:focus {
-  color: var(--crm-c-link-hover);
+  color: var(--crm-link-hover-color);
   text-decoration: var(--crm-link-decoration);
   background-color: transparent;
 }
@@ -1782,7 +1782,7 @@ fieldset[disabled] #bootstrap-theme .btn-link {
 #bootstrap-theme .btn-link[disabled]:focus,
 fieldset[disabled] #bootstrap-theme .btn-link:hover,
 fieldset[disabled] #bootstrap-theme .btn-link:focus {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
   text-decoration: none;
 }
 #bootstrap-theme .input-group-addon {
@@ -1792,50 +1792,50 @@ fieldset[disabled] #bootstrap-theme .btn-link:focus {
   line-height: inherit;
   color: var(--crm-input-color);
   text-align: left;
-  background-color: var(--crm-input-bg);
+  background-color: var(--crm-input-bg-color);
   /* width: 100%; */
   border-radius: var(--crm-s-radius);
 }
 #bootstrap-theme .has-success .form-control,
 #bootstrap-theme .has-success .form-control:focus {
-  border-color: var(--crm-alert-success-border);
+  border-color: var(--crm-alert-success-border-color);
 }
 #bootstrap-theme .has-success .input-group-addon {
-  color: var(--crm-alert-success-text);
-  background-color: var(--crm-alert-sucess-bg);
-  border-color: var(--crm-alert-success-border);
+  color: var(--crm-alert-success-text-color);
+  background-color: var(--crm-alert-sucess-bg-color);
+  border-color: var(--crm-alert-success-border-color);
 }
 #bootstrap-theme .has-success .form-control-feedback {
-  color: var(--crm-c-success-on-page-bg);
+  color: var(--crm-success-ink-color);
 }
 #bootstrap-theme .has-warning .form-control {
-  border-color: var(--crm-c-warning);
+  border-color: var(--crm-warning-color);
 }
 #bootstrap-theme .has-warning .form-control:focus {
-  border-color: var(--crm-c-warning);
+  border-color: var(--crm-warning-color);
 }
 #bootstrap-theme .has-warning .input-group-addon {
-  color: var(--crm-alert-warning-text);
-  background-color: var(--crm-alert-warning-bg);
-  border-color: var(--crm-alert-warning-border);
+  color: var(--crm-alert-warning-text-color);
+  background-color: var(--crm-alert-warning-bg-color);
+  border-color: var(--crm-alert-warning-border-color);
 }
 #bootstrap-theme .has-warning .form-control-feedback {
-  color: var(--crm-c-warning);
+  color: var(--crm-warning-color);
 }
 #bootstrap-theme .has-error .form-control,
 #bootstrap-theme .has-error .form-control a.select2-default {
-  border-color: var(--crm-c-danger);
+  border-color: var(--crm-danger-color);
 }
 #bootstrap-theme .has-error .form-control:focus {
-  border-color: var(--crm-c-danger);
+  border-color: var(--crm-danger-color);
 }
 #bootstrap-theme .has-error .input-group-addon {
-  color: var(--crm-alert-danger-text);
-  background-color: var(--crm-alert-danger-bg);
-  border-color: var(--crm-alert-danger-border);
+  color: var(--crm-alert-danger-text-color);
+  background-color: var(--crm-alert-danger-bg-color);
+  border-color: var(--crm-alert-danger-border-color);
 }
 #bootstrap-theme .has-error .form-control-feedback {
-  color: var(--crm-c-danger);
+  color: var(--crm-danger-color);
 }
 
 /* Nav */
@@ -1843,7 +1843,7 @@ fieldset[disabled] #bootstrap-theme .btn-link:focus {
 #bootstrap-theme .navbar-default {
   background-color: var(--crm-c-darkest);
   border-color: var(--crm-c-darkest);
-  color: var(--crm-c-text-light);
+  color: var(--crm-text-light-color);
 }
 #bootstrap-theme .nav-justified,
 #bootstrap-theme .nav-tabs.nav-justified {
@@ -2539,7 +2539,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   padding-bottom: 30px;
   margin-bottom: 30px;
   color: inherit;
-  background-color: var(--crm-c-container-bg);
+  background-color: var(--crm-container-bg-color);
 }
 #bootstrap-theme .jumbotron h1,
 #bootstrap-theme .jumbotron .h1 {
@@ -2618,25 +2618,25 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   animation: progress-bar-stripes 2s linear infinite;
 }
 #bootstrap-theme .progress-bar-success {
-  background-color: var(--crm-c-success);
+  background-color: var(--crm-success-color);
 }
 .progress-striped #bootstrap-theme .progress-bar-success {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
 #bootstrap-theme .progress-bar-info {
-  background-color: var(--crm-c-info);
+  background-color: var(--crm-info-color);
 }
 .progress-striped #bootstrap-theme .progress-bar-info {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
 #bootstrap-theme .progress-bar-warning {
-  background-color: var(--crm-c-warning);
+  background-color: var(--crm-warning-color);
 }
 .progress-striped #bootstrap-theme .progress-bar-warning {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
 #bootstrap-theme .progress-bar-danger {
-  background-color: var(--crm-c-danger);
+  background-color: var(--crm-danger-color);
 }
 .progress-striped #bootstrap-theme .progress-bar-danger {
   background-image: linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
@@ -2782,7 +2782,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme button.list-group-item:focus {
   color: #555;
   text-decoration: none;
-  background-color: var(--crm-c-container-bg);
+  background-color: var(--crm-container-bg-color);
 }
 #bootstrap-theme button.list-group-item {
   width: 100%;
@@ -2790,7 +2790,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme a.list-group-item-success,
 #bootstrap-theme button.list-group-item-success {
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 #bootstrap-theme a.list-group-item-success .list-group-item-heading,
 #bootstrap-theme button.list-group-item-success .list-group-item-heading {
@@ -2801,8 +2801,8 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme a.list-group-item-success:focus,
 #bootstrap-theme button.list-group-item-success:hover,
 #bootstrap-theme button.list-group-item-success:focus {
-  color: var(--crm-alert-success-text);
-  background-color: var(--crm-alert-success-bg);
+  color: var(--crm-alert-success-text-color);
+  background-color: var(--crm-alert-success-bg-color);
 }
 #bootstrap-theme a.list-group-item-success.active,
 #bootstrap-theme a.list-group-item-success.active:hover,
@@ -2810,17 +2810,17 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme button.list-group-item-success.active,
 #bootstrap-theme button.list-group-item-success.active:hover,
 #bootstrap-theme button.list-group-item-success.active:focus {
-  color: var(--crm-alert-success-text);
-  background-color: var(--crm-alert-success-bg);
-  border-color: var(--crm-alert-success-border);
+  color: var(--crm-alert-success-text-color);
+  background-color: var(--crm-alert-success-bg-color);
+  border-color: var(--crm-alert-success-border-color);
 }
 #bootstrap-theme .list-group-item-info {
-  color: var(--crm-alert-info-text);
-  background-color: var(--crm-alert-info-bg);
+  color: var(--crm-alert-info-text-color);
+  background-color: var(--crm-alert-info-bg-color);
 }
 #bootstrap-theme a.list-group-item-info,
 #bootstrap-theme button.list-group-item-info {
-  color: var(--crm-alert-info-text);
+  color: var(--crm-alert-info-text-color);
 }
 #bootstrap-theme a.list-group-item-info .list-group-item-heading,
 #bootstrap-theme button.list-group-item-info .list-group-item-heading {
@@ -2830,8 +2830,8 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme a.list-group-item-info:focus,
 #bootstrap-theme button.list-group-item-info:hover,
 #bootstrap-theme button.list-group-item-info:focus {
-  color: var(--crm-alert-info-text);
-  background-color: var(--crm-alert-info-bg);
+  color: var(--crm-alert-info-text-color);
+  background-color: var(--crm-alert-info-bg-color);
 }
 #bootstrap-theme a.list-group-item-info.active,
 #bootstrap-theme a.list-group-item-info.active:hover,
@@ -2839,17 +2839,17 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme button.list-group-item-info.active,
 #bootstrap-theme button.list-group-item-info.active:hover,
 #bootstrap-theme button.list-group-item-info.active:focus {
-  color: var(--crm-alert-info-text);
-  background-color: var(--crm-alert-info-bg);
-  border-color: var(--crm-alert-info-border);
+  color: var(--crm-alert-info-text-color);
+  background-color: var(--crm-alert-info-bg-color);
+  border-color: var(--crm-alert-info-border-color);
 }
 #bootstrap-theme .list-group-item-warning {
-  color: var(--crm-alert-warning-text);
-  background-color: var(--crm-alert-warning-bg);
+  color: var(--crm-alert-warning-text-color);
+  background-color: var(--crm-alert-warning-bg-color);
 }
 #bootstrap-theme a.list-group-item-warning,
 #bootstrap-theme button.list-group-item-warning {
-  color: var(--crm-alert-warning-text);
+  color: var(--crm-alert-warning-text-color);
 }
 #bootstrap-theme a.list-group-item-warning .list-group-item-heading,
 #bootstrap-theme button.list-group-item-warning .list-group-item-heading {
@@ -2859,8 +2859,8 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme a.list-group-item-warning:focus,
 #bootstrap-theme button.list-group-item-warning:hover,
 #bootstrap-theme button.list-group-item-warning:focus {
-  color: var(--crm-alert-warning-text);
-  background-color: var(--crm-alert-warning-bg);
+  color: var(--crm-alert-warning-text-color);
+  background-color: var(--crm-alert-warning-bg-color);
 }
 #bootstrap-theme a.list-group-item-warning.active,
 #bootstrap-theme a.list-group-item-warning.active:hover,
@@ -2868,17 +2868,17 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme button.list-group-item-warning.active,
 #bootstrap-theme button.list-group-item-warning.active:hover,
 #bootstrap-theme button.list-group-item-warning.active:focus {
-  color: var(--crm-alert-warning-text);
-  background-color: var(--crm-alert-warning-bg);
-  border-color: var(--crm-alert-warning-border);
+  color: var(--crm-alert-warning-text-color);
+  background-color: var(--crm-alert-warning-bg-color);
+  border-color: var(--crm-alert-warning-border-color);
 }
 #bootstrap-theme .list-group-item-danger {
-  color: var(--crm-alert-danger-text);
-  background-color: var(--crm-alert-danger-bg);
+  color: var(--crm-alert-danger-text-color);
+  background-color: var(--crm-alert-danger-bg-color);
 }
 #bootstrap-theme a.list-group-item-danger,
 #bootstrap-theme button.list-group-item-danger {
-  color: var(--crm-alert-danger-text);
+  color: var(--crm-alert-danger-text-color);
 }
 #bootstrap-theme a.list-group-item-danger .list-group-item-heading,
 #bootstrap-theme button.list-group-item-danger .list-group-item-heading {
@@ -2888,8 +2888,8 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme a.list-group-item-danger:focus,
 #bootstrap-theme button.list-group-item-danger:hover,
 #bootstrap-theme button.list-group-item-danger:focus {
-  color: var(--crm-alert-danger-text);
-  background-color: var(--crm-alert-danger-bg);
+  color: var(--crm-alert-danger-text-color);
+  background-color: var(--crm-alert-danger-bg-color);
 }
 #bootstrap-theme a.list-group-item-danger.active,
 #bootstrap-theme a.list-group-item-danger.active:hover,
@@ -2897,9 +2897,9 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme button.list-group-item-danger.active,
 #bootstrap-theme button.list-group-item-danger.active:hover,
 #bootstrap-theme button.list-group-item-danger.active:focus {
-  color: var(--crm-alert-danger-text);
-  background-color: var(--crm-alert-danger-bg);
-  border-color: var(--crm-alert-danger-border);
+  color: var(--crm-alert-danger-text-color);
+  background-color: var(--crm-alert-danger-bg-color);
+  border-color: var(--crm-alert-danger-border-color);
 }
 #bootstrap-theme .list-group-item-heading {
   margin-top: 0;
@@ -2945,7 +2945,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   min-height: 20px;
   padding: 19px;
   margin-bottom: 20px;
-  background-color: var(--crm-c-container-bg);
+  background-color: var(--crm-container-bg-color);
   border: var(--crm-border);
   border-radius: var(--crm-s-radius);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
@@ -3380,7 +3380,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   display: inline;
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
   font-weight: normal;
-  color: var(--crm-c-text-light);
+  color: var(--crm-text-light-color);
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
@@ -3400,51 +3400,51 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 }
 #bootstrap-theme .label-default {
   background: var(--crm-c-darkest);
-  color: var(--crm-c-text-light);
+  color: var(--crm-text-light-color);
 }
 #bootstrap-theme .label-default[href]:hover,
 #bootstrap-theme .label-default[href]:focus {
   background: color-mix(in srgb, var(--crm-c-darkest) 87.5%, #fff 12.5%);
 }
 #bootstrap-theme .label-primary {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 #bootstrap-theme .label-primary[href]:hover,
 #bootstrap-theme .label-primary[href]:focus {
-  background: var(--crm-c-primary-hover);
+  background: var(--crm-primary-hover-color);
 }
 #bootstrap-theme .label-success {
-  background: var(--crm-c-success);
-  color: var(--crm-c-success-text);
+  background: var(--crm-success-color);
+  color: var(--crm-success-text-color);
 }
 #bootstrap-theme .label-success[href]:hover,
 #bootstrap-theme .label-success[href]:focus {
-  background: color-mix(in srgb, var(--crm-c-success) 87.5%, #000 12.5%);
+  background: color-mix(in srgb, var(--crm-success-color) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label-info {
-  background: var(--crm-c-info);
-  color: var(--crm-c-info-text);
+  background: var(--crm-info-color);
+  color: var(--crm-info-text-color);
 }
 #bootstrap-theme .label-info[href]:hover,
 #bootstrap-theme .label-info[href]:focus {
-  background: color-mix(in srgb, var(--crm-c-info) 87.5%, #000 12.5%);
+  background: color-mix(in srgb, var(--crm-info-color) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label-warning {
-  background: var(--crm-c-warning);
-  color: var(--crm-c-warning-text);
+  background: var(--crm-warning-color);
+  color: var(--crm-warning-text-color);
 }
 #bootstrap-theme .label-warning[href]:hover,
 #bootstrap-theme .label-warning[href]:focus {
-  background: color-mix(in srgb, var(--crm-c-warning) 87.5%, #000 12.5%);
+  background: color-mix(in srgb, var(--crm-warning-color) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label-danger {
-  background: var(--crm-c-danger);
-  color: var(--crm-c-danger-text);
+  background: var(--crm-danger-color);
+  color: var(--crm-danger-text-color);
 }
 #bootstrap-theme .label-danger[href]:hover,
 #bootstrap-theme .label-danger[href]:focus {
-  background: color-mix(in srgb, var(--crm-c-danger) 87.5%, #000 12.5%);
+  background: color-mix(in srgb, var(--crm-danger-color) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label i.crm-i {
   color: inherit; /* resets icons inside labels to use the label text colour */

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -70,7 +70,7 @@
   display: block;
   color: var(--crm-text-color);
   font-style: italic;
-  margin: var(--crm-s) 0 var(--crm-m);
+  margin: var(--crm-s-small) 0 var(--crm-s-medium);
   font-size: var(--crm-font-small-size);
 }
 #bootstrap-theme h4,
@@ -79,8 +79,8 @@
 #bootstrap-theme .h5,
 #bootstrap-theme h6,
 #bootstrap-theme .h6 {
-  margin-top: var(--crm-m1);
-  margin-bottom: var(--crm-m1);
+  margin-top: var(--crm-s-medium-1);
+  margin-bottom: var(--crm-s-medium-1);
   font-weight: bold;
   color: var(--crm-text-color);
   line-height: 1.2;

--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -70,7 +70,7 @@
   display: block;
   color: var(--crm-text-color);
   font-style: italic;
-  margin: var(--crm-s-small) 0 var(--crm-s-medium);
+  margin: var(--crm-l-small) 0 var(--crm-l-medium);
   font-size: var(--crm-font-small-size);
 }
 #bootstrap-theme h4,
@@ -79,8 +79,8 @@
 #bootstrap-theme .h5,
 #bootstrap-theme h6,
 #bootstrap-theme .h6 {
-  margin-top: var(--crm-s-medium-1);
-  margin-bottom: var(--crm-s-medium-1);
+  margin-top: var(--crm-l-medium-1);
+  margin-bottom: var(--crm-l-medium-1);
   font-weight: bold;
   color: var(--crm-text-color);
   line-height: 1.2;
@@ -229,7 +229,7 @@
   line-height: 1.428571429;
   background-color: white;
   border: var(--crm-border);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   transition: all .2s ease-in-out;
   display: inline-block;
   max-width: 100%;
@@ -1794,7 +1794,7 @@ fieldset[disabled] #bootstrap-theme .btn-link:focus {
   text-align: left;
   background-color: var(--crm-input-bg-color);
   /* width: 100%; */
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 #bootstrap-theme .has-success .form-control,
 #bootstrap-theme .has-success .form-control:focus {
@@ -2593,7 +2593,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   margin-bottom: 20px;
   overflow: hidden;
   background-color: whitesmoke;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, .1);
 }
 #bootstrap-theme .progress-bar {
@@ -2947,7 +2947,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   margin-bottom: 20px;
   background-color: var(--crm-container-bg-color);
   border: var(--crm-border);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, .05);
 }
 #bootstrap-theme .well blockquote {
@@ -3384,7 +3384,7 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 #bootstrap-theme .label:empty {
   display: none;

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -182,11 +182,11 @@ body.wp-admin.wp-core-ui.toplevel_page_CiviCRM select:hover {
 body.wp-admin .crm-container input[type="checkbox"],
 body.wp-admin .crm-container input[type="radio"] {
   appearance: none;
-  border-radius: var(--crm-s-small);
+  border-radius: var(--crm-l-small);
   border-color: #8c8f94 /* reset to WP default border col */;
   background: #fff;
-  height: var(--crm-s-reg);
-  width: var(--crm-s-reg);
+  height: var(--crm-l-reg);
+  width: var(--crm-l-reg);
 }
 body.wp-admin .crm-container input[type="radio"] {
   border-radius: 50%;

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -7,7 +7,7 @@
 /* Backdrop - html.admin-bar */
 
 html.admin-bar body {
-  background-color: var(--crm-c-page-bg);
+  background-color: var(--crm-page-bg-color);
 }
 html.admin-bar .crm-container {
   --crm-page-padding: 0;
@@ -38,20 +38,20 @@ body.page-civicrm .crm-container div.status {
 /* D8+ */
 body.page-civicrm header.content-header {
   margin-bottom: 0;
-  background-color: var(--crm-c-container-bg);
+  background-color: var(--crm-container-bg-color);
 }
 body.page-civicrm main.page-content {
   margin-top: 0;
 }
 body.page-civicrm header + div.layout-container {
-  background-color: var(--crm-c-page-bg) !important;
+  background-color: var(--crm-page-bg-color) !important;
   margin: 0 !important; /* use of important vs some themes */
 }
 body.page-civicrm .button {
   -webkit-font-smoothing: initial;
 }
 body.page-civicrm .page-title {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 
 /* D7 Garland */
@@ -59,7 +59,7 @@ body.page-civicrm #squeeze #crm-container,
 .region-sidebar-first .block-civicrm {
   padding: 0;
   --crm-page-padding: 0;
-  --crm-c-page-bg: transparent;
+  --crm-page-bg-color: transparent;
   --crm-input-label-width: 12em;
 }
 body.page-civicrm #squeeze .crm-container ul li:not(.ui-tab) {
@@ -69,7 +69,7 @@ body.page-civicrm #squeeze .crm-container ul li:not(.ui-tab) {
 
 /* D7 Seven */
 body.page-civicrm > #branding {
-  background-color: var(--crm-c-page-bg);
+  background-color: var(--crm-page-bg-color);
 }
 body.page-civicrm > #branding + #page {
   --crm-page-padding: 0.5rem 1.25rem;
@@ -81,7 +81,7 @@ body.page-civicrm {
 }
 body.page-civicrm .breadcrumb__item,
 body.page-civicrm .breadcrumb__link {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 #block-claro-content {
   --crm-page-padding: 3rem;
@@ -130,7 +130,7 @@ body.page-civicrm .page-content:has(#block-claro-content) {
 /* Bootstrap 4 */
 body.page-civicrm main > .container:has(#block-bootstrap4-content) {
   max-width: 100%;
-  background: var(--crm-c-page-bg);
+  background: var(--crm-page-bg-color);
 }
 
 /******************
@@ -138,7 +138,7 @@ body.page-civicrm main > .container:has(#block-bootstrap4-content) {
 *******************/
 
 body.toplevel_page_CiviCRM.wp-admin {
-  background: var(--crm-c-page-bg);
+  background: var(--crm-page-bg-color);
 }
 body.toplevel_page_CiviCRM #wpcontent {
   padding-left: 0; /* resets WP padding */
@@ -208,8 +208,8 @@ html.crm-standalone body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif; /* Adds fallback for base font */
 }
 html.crm-standalone #crm-container:has(.standalone-auth-form) {
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
 }
 html.crm-standalone .standalone-auth-box {
-  background: var(--crm-c-page-bg);
+  background: var(--crm-page-bg-color);
 }

--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -182,11 +182,11 @@ body.wp-admin.wp-core-ui.toplevel_page_CiviCRM select:hover {
 body.wp-admin .crm-container input[type="checkbox"],
 body.wp-admin .crm-container input[type="radio"] {
   appearance: none;
-  border-radius: var(--crm-s);
+  border-radius: var(--crm-s-small);
   border-color: #8c8f94 /* reset to WP default border col */;
   background: #fff;
-  height: var(--crm-r);
-  width: var(--crm-r);
+  height: var(--crm-s-reg);
+  width: var(--crm-s-reg);
 }
 body.wp-admin .crm-container input[type="radio"] {
   border-radius: 50%;

--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -15,7 +15,7 @@
   --crm-c-danger-on-page-bg: var(--crm-c-danger-light);
   --crm-c-info-on-page-bg: var(--crm-c-info-light);
 /* Shadows */
-  --crm-popup-shadow: 0 3px 18px 0 rgb(0,0,0);
+  --crm-shadow-popup: 0 3px 18px 0 rgb(0,0,0);
 /* Sizes */
 /* Type */
   --crm-heading-col: var(--crm-c-text-light);

--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -24,8 +24,8 @@
 /* Tables '--crm-table-' */
   --crm-table-row-alternate-bg: #fff;
 /* Panels '--crm-panel-' */
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
-  --crm-expand-body-bg: var(--crm-c-layer1-bg);
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
+  --crm-accordion-body-bg: var(--crm-c-layer1-bg);
 /* Alerts '--crm-alert' */
   --crm-alert-danger-bg: var(--crm-c-danger);
   --crm-alert-danger-text: var(--crm-c-danger-text);
@@ -42,8 +42,8 @@
   --crm-input-description: var(--crm-c-gray-300);
 /* Tabs '--crm-tabs' */
   --crm-tabs-bg: var(--crm-c-layer2-bg);
-/* Contact layout '--crm-dash-' */
-  --crm-dash-label-bg: transparent;
+/* Contact layout '--crm-contact-' */
+  --crm-contact-label-bg: transparent;
 /* Dialog '--crm-dialog-' */
   --crm-dialog-header-border-col: transparent;
 /* Dashlet for main dashboard '--crm-dashlet-' */

--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -2,7 +2,7 @@
 /* Colour names */
 /* Practical colours, e.g. text, link '--crm-c-' */
   --crm-c-text: var(--crm-c-text-light);
-  --crm-c-divider: 1px solid var(--crm-c-gray-500);
+  --crm-border-color: var(--crm-c-gray-500);
 /* Backgrounds, '--crm-c-X-bg' */
   --crm-c-code-bg: var(--crm-c-layer1-bg);
   --crm-c-layer1-bg: var(--crm-c-gray-800);

--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -3,6 +3,8 @@
 /* Practical colours, e.g. text, link '--crm-c-' */
   --crm-c-text: var(--crm-c-text-light);
   --crm-border-color: var(--crm-c-gray-500);
+  --crm-paper: var(--crm-c-gray-900); /* The darkest bg in dark mode */
+  --crm-ink: var(--crm-c-text-light); /* The lightest foreground in dark mode */
 /* Backgrounds, '--crm-c-X-bg' */
   --crm-c-code-bg: var(--crm-c-layer1-bg);
   --crm-c-layer1-bg: var(--crm-c-gray-800);

--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -1,53 +1,53 @@
 :root {
 /* Colour names */
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-text: var(--crm-c-text-light);
+  --crm-text-color: var(--crm-text-light-color);
   --crm-border-color: var(--crm-c-gray-500);
   --crm-paper: var(--crm-c-gray-900); /* The darkest bg in dark mode */
-  --crm-ink: var(--crm-c-text-light); /* The lightest foreground in dark mode */
+  --crm-ink: var(--crm-text-light-color); /* The lightest foreground in dark mode */
 /* Backgrounds, '--crm-c-X-bg' */
-  --crm-c-code-bg: var(--crm-c-layer1-bg);
-  --crm-c-layer1-bg: var(--crm-c-gray-800);
-  --crm-c-layer2-bg: var(--crm-c-gray-700);
+  --crm-code-bg-color: var(--crm-layer1-bg-color);
+  --crm-layer1-bg-color: var(--crm-c-gray-800);
+  --crm-layer2-bg-color: var(--crm-c-gray-700);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
-  --crm-c-primary-on-page-bg: var(--crm-c-gray-300);
-  --crm-c-secondary-on-page-bg: #cdcdcd;
-  --crm-c-success-on-page-bg: var(--crm-c-success-light);
-  --crm-c-warning-on-page-bg: var(--crm-c-warning-light);
-  --crm-c-danger-on-page-bg: var(--crm-c-danger-light);
-  --crm-c-info-on-page-bg: var(--crm-c-info-light);
+  --crm-primary-ink-color: var(--crm-c-gray-300);
+  --crm-secondary-ink-color: #cdcdcd;
+  --crm-success-ink-color: var(--crm-success-light-color);
+  --crm-warning-ink-color: var(--crm-warning-light-color);
+  --crm-danger-ink-color: var(--crm-danger-light-color);
+  --crm-info-ink-color: var(--crm-info-light-color);
 /* Shadows */
   --crm-shadow-popup: 0 3px 18px 0 rgb(0,0,0);
 /* Sizes */
 /* Type */
-  --crm-heading-col: var(--crm-c-text-light);
+  --crm-heading-color: var(--crm-text-light-color);
 /* Mouse events */
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
-  --crm-table-row-alternate-bg: #fff;
+  --crm-table-row-alternate-bg-color: #fff;
 /* Panels '--crm-panel-' */
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
-  --crm-accordion-body-bg: var(--crm-c-layer1-bg);
+  --crm-accordion-body-bg-color: var(--crm-layer1-bg-color);
 /* Alerts '--crm-alert' */
-  --crm-alert-danger-bg: var(--crm-c-danger);
-  --crm-alert-danger-text: var(--crm-c-danger-text);
-  --crm-alert-danger-border: color-mix(in srgb, var(--crm-alert-danger-bg) 90%,#fff 10%);
-  --crm-alert-info-bg: var(--crm-c-info);
-  --crm-alert-info-border: color-mix(in srgb, var(--crm-alert-info-bg) 90%,#fff 10%);
-  --crm-alert-info-text: var(--crm-c-success-text);
-  --crm-alert-success-bg: var(--crm-c-success);
-  --crm-alert-success-border: color-mix(in srgb, var(--crm-alert-success-bg) 90%,#fff 10%);
-  --crm-alert-success-text: var(--crm-c-success-text);
-  --crm-alert-warning-bg: var(--crm-c-warning);
-  --crm-alert-warning-border: color-mix(in srgb, var(--crm-alert-warning-bg) 90%,#fff 10%);
+  --crm-alert-danger-bg-color: var(--crm-danger-color);
+  --crm-alert-danger-text-color: var(--crm-danger-text-color);
+  --crm-alert-danger-border-color: color-mix(in srgb, var(--crm-alert-danger-bg-color) 90%,#fff 10%);
+  --crm-alert-info-bg-color: var(--crm-info-color);
+  --crm-alert-info-border-color: color-mix(in srgb, var(--crm-alert-info-bg-color) 90%,#fff 10%);
+  --crm-alert-info-text-color: var(--crm-success-text-color);
+  --crm-alert-success-bg-color: var(--crm-success-color);
+  --crm-alert-success-border-color: color-mix(in srgb, var(--crm-alert-success-bg-color) 90%,#fff 10%);
+  --crm-alert-success-text-color: var(--crm-success-text-color);
+  --crm-alert-warning-bg-color: var(--crm-warning-color);
+  --crm-alert-warning-border-color: color-mix(in srgb, var(--crm-alert-warning-bg-color) 90%,#fff 10%);
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
   --crm-input-description: var(--crm-c-gray-300);
 /* Tabs '--crm-tabs' */
-  --crm-tabs-bg: var(--crm-c-layer2-bg);
+  --crm-tabs-bg-color: var(--crm-layer2-bg-color);
 /* Contact layout '--crm-contact-' */
-  --crm-contact-label-bg: transparent;
+  --crm-contact-label-bg-color: transparent;
 /* Dialog '--crm-dialog-' */
-  --crm-dialog-header-border-col: transparent;
+  --crm-dialog-header-border-color: transparent;
 /* Dashlet for main dashboard '--crm-dashlet-' */
 /* Button dropdowns '--crm-dropdown-' */
 /* Notifications '--crm-notify-' */

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -26,7 +26,7 @@
 }
 .accordion.ui-accordion.ui-widget.ui-helper-reset {
   border: 0 solid transparent;
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
 }
 
 /* Expand/collapse icons */
@@ -54,7 +54,7 @@ details.af-collapsible > .af-title::before,
   display: inline-block;
   transform-origin: center center;
   content: var(--crm-accordion-icon);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .crm-container .collapsed .crm-accordion-header::before,
 .crm-accordion-wrapper.collapsed .crm-master-accordion-header:before,
@@ -102,7 +102,7 @@ a.crm-expand-row:focus {
 .crm-container .crm-collapsible .collapsible-title,
 .af-collapsible > summary.af-title,
 .crm-container span.collapsed:not(.show-children) {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   padding: var(--crm-accordion-header-padding);
   border-radius: var(--crm-accordion-radius) var(--crm-accordion-radius) 0 0;
   background-color: var(--crm-accordion-header-bg);
@@ -193,7 +193,7 @@ a.crm-expand-row:focus {
   white-space: nowrap;
   vertical-align: middle;
   touch-action: manipulation;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   background-image: none;
   border: var(--crm-btn-border);
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
@@ -298,13 +298,13 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .btn-group-xs > a.button,
 .crm-container .btn-group-xs > input[type="button"] {
   padding: var(--crm-btn-small-padding);
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
   border-radius: var(--crm-s-radius);
   height: auto;
 }
 .crm-container .btn-group-xs button {
   padding: var(--crm-xs) var(--crm-s);
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
 }
 /* select all 'checkbox' on table th */
 .crm-container button.btn:has(.fa-square-o),
@@ -390,7 +390,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   display: none;
 }
 #crm-status-list {
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
 }
 
 /******************
@@ -428,7 +428,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   position: relative;
   background: var(--crm-c-container-bg);
   border: 0 solid transparent;
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
   font-family: var(--crm-font);
   border-radius: var(--crm-s-radius);
@@ -465,7 +465,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 /* CiviContribute dashboard */
 .crm-container #ContributionCharts #mainTabContainer {
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
 }
 .crm-container #ContributionCharts .ui-tabs-nav {
   gap: 1px; /* to handle white space in markup */
@@ -627,7 +627,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   display: grid;
   background: var(--crm-c-container-bg);
   border: 0 solid transparent;
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
   gap: var(--crm-m);
   margin-bottom: var(--crm-r);

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -49,11 +49,11 @@ details.af-collapsible > .af-title::before,
   text-rendering: auto;
   text-indent: inherit;
   font-family: FontAwesome;
-  color: var(--crm-expand-icon-color);
-  margin-right: var(--crm-expand-icon-spacing);
+  color: var(--crm-accordion-icon-color);
+  margin-right: var(--crm-accordion-icon-spacing);
   display: inline-block;
   transform-origin: center center;
-  content: var(--crm-expand-icon);
+  content: var(--crm-accordion-icon);
   cursor: var(--crm-hover-clickable);
 }
 .crm-container .collapsed .crm-accordion-header::before,
@@ -67,7 +67,7 @@ details.af-collapsible.af-collapsed > .af-title::before,
 .crm-container .ui-tabs-collapsible > ul.ui-tabs-nav::before {
   transform: none;
   transform-origin: center center;
-  transition: var(--crm-expand-transition);
+  transition: var(--crm-accordion-transition);
 }
 .crm-container .crm-accordion-header::before,
 details.af-collapsible[open] > .af-title::before,
@@ -80,10 +80,10 @@ details.af-collapsible[open] > .af-title::before,
 .crm-container .civicrm-community-messages .crm-collapsible .collapsible-title::before,
 .crm-container .show-children.expanded::before,
 .crm-container .ui-tabs-collapsible > ul.ui-tabs-nav:has(li.ui-tabs-active)::before {
-  content: var(--crm-expand-icon);
-  transform: var(--crm-expand-transform);
+  content: var(--crm-accordion-icon);
+  transform: var(--crm-accordion-transform);
   transform-origin: center center;
-  transition: var(--crm-expand-transition);
+  transition: var(--crm-accordion-transition);
   float: left;
 }
 .crm-container a.crm-expand-row:not(.expanded)::before,
@@ -103,15 +103,15 @@ a.crm-expand-row:focus {
 .af-collapsible > summary.af-title,
 .crm-container span.collapsed:not(.show-children) {
   cursor: var(--crm-hover-clickable);
-  padding: var(--crm-expand-header-padding);
-  border-radius: var(--crm-expand-radius) var(--crm-expand-radius) 0 0;
-  background-color: var(--crm-expand-header-bg);
-  font-weight: var(--crm-expand-header-weight);
-  color: var(--crm-expand-header-color);
+  padding: var(--crm-accordion-header-padding);
+  border-radius: var(--crm-accordion-radius) var(--crm-accordion-radius) 0 0;
+  background-color: var(--crm-accordion-header-bg);
+  font-weight: var(--crm-accordion-header-weight);
+  color: var(--crm-accordion-header-color);
 }
 .crm-container .crm-accordion-wrapper.collapsed .crm-accordion-header,
 .crm-container .crm-collapsible.collapsed .collapsible-title {
-  border-radius: var(--crm-expand-radius);
+  border-radius: var(--crm-accordion-radius);
 }
 .crm-container .widget-content .crm-accordion-header,
 .crm-container .crm-accordion-inner .crm-accordion-header,
@@ -125,40 +125,40 @@ a.crm-expand-row:focus {
 .crm-accordion-wrapper .crm-accordion-wrapper.collapsed:focus,
 .crm-accordion-wrapper .crm-accordion-header:hover,
 .crm-accordion-wrapper .crm-accordion-header.active:hover {
-  background-color: var(--crm-expand-header-bg-active);
+  background-color: var(--crm-accordion-header-bg-active);
 }
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header {
-  font-weight: var(--crm-expand2-header-weight);
-  background-color: var(--crm-expand2-header-bg);
-  color: var(--crm-expand2-header-color);
-  border: var(--crm-expand2-header-border);
-  border-width: var(--crm-expand2-header-border-width);
-  padding: var(--crm-expand2-header-padding);
+  font-weight: var(--crm-accordion2-header-weight);
+  background-color: var(--crm-accordion2-header-bg);
+  color: var(--crm-accordion2-header-color);
+  border: var(--crm-accordion2-header-border);
+  border-width: var(--crm-accordion2-header-border-width);
+  padding: var(--crm-accordion2-header-padding);
 }
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header:hover,
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header:focus {
-  background-color: var(--crm-expand2-header-bg-active);
+  background-color: var(--crm-accordion2-header-bg-active);
 }
 /* Body */
 
 .crm-container .crm-accordion-wrapper .crm-accordion-body {
-  border-radius: 0 0 var(--crm-expand-radius) var(--crm-expand-radius);
-  border: var(--crm-expand-border);
-  padding: var(--crm-expand-body-padding);
-  background-color: var(--crm-expand-body-bg);
-  box-shadow: var(--crm-expand-body-box-shadow);
+  border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
+  border: var(--crm-accordion-border);
+  padding: var(--crm-accordion-body-padding);
+  background-color: var(--crm-accordion-body-bg);
+  box-shadow: var(--crm-accordion-body-box-shadow);
   color: var(--crm-c-text); /* specified for Drupal Claro Darkmode */
 }
 .crm-container .widget-content .crm-accordion-body,
 .crm-container .crm-collapsible .crm-summary-block {
-  padding: var(--crm-expand-body-padding);
+  padding: var(--crm-accordion-body-padding);
 }
 .crm-container .crm-master-accordion-header + .crm-accordion-body {
-  padding: var(--crm-expand2-body-padding);
-  background: var(--crm-expand2-body-bg);
-  border: var(--crm-expand2-border);
-  border-width: var(--crm-expand2-border-width);
-  border-radius: 0 0 var(--crm-expand-radius) var(--crm-expand-radius);
+  padding: var(--crm-accordion2-body-padding);
+  background: var(--crm-accordion2-body-bg);
+  border: var(--crm-accordion2-border);
+  border-width: var(--crm-accordion2-border-width);
+  border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
 }
 .crm-container summary label {
   color: inherit !important; /* all vs .crm-container .form-item label */
@@ -299,7 +299,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .btn-group-xs > input[type="button"] {
   padding: var(--crm-btn-small-padding);
   font-size: var(--crm-small-font-size);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   height: auto;
 }
 .crm-container .btn-group-xs button {
@@ -352,7 +352,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   margin-right: var(--crm-m);
 }
 .crm-container .afadmin-list .nav.nav-tabs { /* Fix for AForm tabs border */
-  border-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
+  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   margin-bottom: 0;
 }
 .crm-container .panel-heading:has(.nav-tabs) {
@@ -367,7 +367,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-search:has(.crm-search-nav-tabs) .crm-search-display.crm-search-display-table {
   border: var(--crm-tabs-border);
   box-shadow: none;
-  border-radius: 0 0 var(--crm-roundness) var(--crm-roundness);
+  border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
   background: var(--crm-tab-bg-active);
 }
 .crm-container .afadmin-list >  .form-inline,
@@ -402,8 +402,8 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .CRM_Contact_Form_Contact > .crm-form-block > details,
 .CRM_Contact_Form_Contact > .crm-form-block > div > details {
   margin-inline: calc(-1 * var(--crm-form-block-padding));
-  padding-inline: var(--crm-expand2-body-padding);
-  margin-bottom: var(--crm-expand2-body-padding);
+  padding-inline: var(--crm-accordion2-body-padding);
+  margin-bottom: var(--crm-accordion2-body-padding);
 }
 .crm-container .crm-add-address-wrapper {
   height: auto;
@@ -431,7 +431,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   box-shadow: var(--crm-block-shadow);
   padding: var(--crm-padding-reg);
   font-family: var(--crm-font);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   top: 0;;
 }
 .crm-container .tag-tree-wrapper div.tag-info .tdl {
@@ -475,7 +475,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 #ContributionCharts ul.ui-tabs-nav li.crm-tab-button {
   padding: var(--crm-tab-padding);
-  border-radius: var(--crm-tab-roundness);
+  border-radius: var(--crm-tab-radius);
 }
 #ContributionCharts ul.ui-tabs-nav li.crm-tab-button a {
   padding: 0;
@@ -830,7 +830,7 @@ details + .crm-content-block:has(.dataTables_wrapper) {
   border-top: 0;
   padding: var(--crm-tab-padding);
   background-color: var(--crm-tab-bg-active);
-  border-radius: 0 0 var(--crm-tab-roundness) var(--crm-tab-roundness);
+  border-radius: 0 0 var(--crm-tab-radius) var(--crm-tab-radius);
 }
 .select2-drop.select2-drop-active.crm-container {
   max-width: var(--crm-huge-input); /* Mosaico fix - https://lab.civicrm.org/extensions/riverlea/-/issues/23 */
@@ -846,7 +846,7 @@ details + .crm-content-block:has(.dataTables_wrapper) {
 .crm-mosaico-wizard .crm-mosaico-template-item.thumbnail {
   background: var(--crm-c-layer1-bg) !important /* vs _template-item.scss */;
   border: var(--crm-c-divider) !important /* vs _template-item.scss */;
-  border-radius: var(--crm-roundness) !important /* vs _template-item.scss */;
+  border-radius: var(--crm-s-radius) !important /* vs _template-item.scss */;
 }
 .crm-mosaico-wizard .crm_wizard__title .nav-pills li.disabled a {
   color: var(--crm-c-inactive) !important /* vs _template-item.scss */;

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -299,11 +299,11 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .btn-group-xs > input[type="button"] {
   padding: var(--crm-btn-small-padding);
   font-size: var(--crm-font-small-size);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   height: auto;
 }
 .crm-container .btn-group-xs button {
-  padding: var(--crm-s-xsmall) var(--crm-s-small);
+  padding: var(--crm-l-xsmall) var(--crm-l-small);
   font-size: var(--crm-font-small-size);
 }
 /* select all 'checkbox' on table th */
@@ -349,10 +349,10 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   background-color: var(--crm-tabs-bg-color);
 }
 .crm-container .panel-heading:has(.nav-tabs) .pull-right {
-  margin-right: var(--crm-s-medium);
+  margin-right: var(--crm-l-medium);
 }
 .crm-container .afadmin-list .nav.nav-tabs { /* Fix for AForm tabs border */
-  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
+  border-radius: var(--crm-l-radius) var(--crm-l-radius) 0 0;
   margin-bottom: 0;
 }
 .crm-container .panel-heading:has(.nav-tabs) {
@@ -367,7 +367,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-search:has(.crm-search-nav-tabs) .crm-search-display.crm-search-display-table {
   border: var(--crm-tabs-border);
   box-shadow: none;
-  border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
+  border-radius: 0 0 var(--crm-l-radius) var(--crm-l-radius);
   background: var(--crm-tab-bg-active);
 }
 .crm-container .afadmin-list >  .form-inline,
@@ -383,7 +383,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 .afadmin-list .nav-tabs + .form-inline,
 .crm-search-nav-tabs ~ .ng-scope > .form-inline {
-  padding: var(--crm-s-reg);
+  padding: var(--crm-l-reg);
   background: var(--crm-tab-bg-active);
 }
 .crm-container .ui-tabs ul.crm-extensions-tabs-list a em {
@@ -418,7 +418,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .tag-tree-wrapper {
   display: grid;
   grid-template-columns: 2fr 1fr;
-  margin: var(--crm-s-medium) 0;
+  margin: var(--crm-l-medium) 0;
 }
 .crm-container .tag-tree-wrapper div.tag-tree {
   width: auto;
@@ -431,7 +431,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
   font-family: var(--crm-font);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   top: 0;;
 }
 .crm-container .tag-tree-wrapper div.tag-info .tdl {
@@ -439,7 +439,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   color: var(--crm-text-color);
 }
 .crm-container .tag-tree-wrapper div.tag-info .crm-submit-buttons {
-  margin: var(--crm-s-medium) 0 0;
+  margin: var(--crm-l-medium) 0 0;
   padding: 0;
 }
 .crm-container .tag-tree-wrapper .tag-tree a.crm-tag-item {
@@ -457,7 +457,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 /* Dedupe change usage */
 .crm-container label:has(.dedupe-rules-dialog-desc) input {
   float: left;
-  margin: var(--crm-s-small) var(--crm-s-medium) 0 0;
+  margin: var(--crm-l-small) var(--crm-l-medium) 0 0;
 }
 .crm-container .dedupe-rules-dialog-desc {
   font-weight: normal;
@@ -471,7 +471,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   gap: 1px; /* to handle white space in markup */
 }
 .crm-container #ContributionCharts .ui-tabs-nav .float-right td {
-  padding: 0 var(--crm-s-small);
+  padding: 0 var(--crm-l-small);
 }
 #ContributionCharts ul.ui-tabs-nav li.crm-tab-button {
   padding: var(--crm-tab-padding);
@@ -485,8 +485,8 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 #ContributionCharts ul.ui-tabs-nav .float-right {
   position: absolute;
-  right: var(--crm-s-small);
-  top: var(--crm-s-small);
+  right: var(--crm-l-small);
+  top: var(--crm-l-small);
 }
 #ContributionCharts ul.ui-tabs-nav .float-right table,
 #ContributionCharts ul.ui-tabs-nav .float-right table tr {
@@ -507,13 +507,13 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 /* Event dashboard */
 .CRM_Event_Form_Search .button {
   float: left;
-  margin-right: var(--crm-s-medium);
+  margin-right: var(--crm-l-medium);
 }
 #crm-event-dashboard-heading + div a,
 .CRM_Event_Form_SearchEvent .crm-content-block .float-right a {
   display: flex;
-  padding: 0 0 var(--crm-s-medium) 0;
-  gap: var(--crm-s-medium);
+  padding: 0 0 var(--crm-l-medium) 0;
+  gap: var(--crm-l-medium);
   align-items: center;
 }
 /* Dedupe page */
@@ -523,7 +523,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   float: none !important; /* overwrites inline 'float' that breaks page wrapper */
   display: flex;
   justify-content: flex-end;
-  padding: 0 0 var(--crm-s-large) 0;
+  padding: 0 0 var(--crm-l-large) 0;
 }
 
 /* CiviCase  */
@@ -585,7 +585,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 }
 .crm-container .form-layout td:has(#_qf_Advanced_refresh-bottom) {
   display: flex;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   align-items: center;
 }
 .crm-container .adv-search-top-submit .crm-submit-buttons,
@@ -606,7 +606,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   display: none !important;
 }
 .crm-case_search-accordion .crm-accordion-body .form-layout > tbody:first-child > tr #s2id_case_status_id {
-  margin-bottom: var(--crm-s-reg-1);
+  margin-bottom: var(--crm-l-reg-1);
 }
 .crm-case_search-accordion .crm-accordion-body .form-layout > tbody:first-child > tr:nth-of-type(1) > td:nth-of-type(1) label {
   display: block;
@@ -616,7 +616,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 }
 /* Member */
 .page-civicrm-member-search .CRM_Member_Form_Search .crm-accordion-body tr:last-child td {
-  padding-top: var(--crm-s-reg);
+  padding-top: var(--crm-l-reg);
 }
 /* Find Participants */
 .crm-container div#searchForm table.form-layout td {
@@ -629,8 +629,8 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   border: 0 solid transparent;
   box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
-  gap: var(--crm-s-medium);
-  margin-bottom: var(--crm-s-reg);
+  gap: var(--crm-l-medium);
+  margin-bottom: var(--crm-l-reg);
 }
 .crm-container > #crm-main-content-wrapper > fieldset > * {
   margin: 0;
@@ -643,7 +643,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 /* General */
 .crm-container .crm-form-block .crm-form-block {
   padding: var(--crm-form-block-padding);
-  margin-bottom: var(--crm-s-reg);
+  margin-bottom: var(--crm-l-reg);
 }
 /* Save as template text on new email form */
 .crm-container #editMessageDetails {
@@ -654,7 +654,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   padding: 0;
 }
 #mainTabContainer .form-group.pull-right  > .btn-group {
-  margin-bottom: var(--crm-s-medium-2);
+  margin-bottom: var(--crm-l-medium-2);
 }
 /* Contact dashboard page */
 .crm-actions-ribbon .crm-next-action,
@@ -662,7 +662,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   margin-left: auto;
 }
 .crm-container .view-contact-groups .description {
-  margin: var(--crm-s-reg) 0;
+  margin: var(--crm-l-reg) 0;
 }
 /* Contacts - new */
 .CRM_Contact_Form_Contact > .crm-form-block .crm-submit-buttons:first-of-type {
@@ -691,14 +691,14 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   margin-bottom: 0;
 }
 .crm-search-form .crm-submit-buttons {
-  padding: 0 0 var(--crm-s-medium);
+  padding: 0 0 var(--crm-l-medium);
 }
 .crm-search-form .crm-search-form-block {
-  margin-bottom: var(--crm-s-reg);
+  margin-bottom: var(--crm-l-reg);
 }
 /* Dedupe exceptions */
 details + .crm-content-block:has(.dataTables_wrapper) {
-  margin-top: var(--crm-s-reg);
+  margin-top: var(--crm-l-reg);
 }
 /* Contribution page edit/create */
 .crm-container .crm-premium-settings-accordion {
@@ -846,7 +846,7 @@ details + .crm-content-block:has(.dataTables_wrapper) {
 .crm-mosaico-wizard .crm-mosaico-template-item.thumbnail {
   background: var(--crm-layer1-bg-color) !important /* vs _template-item.scss */;
   border: var(--crm-border) !important /* vs _template-item.scss */;
-  border-radius: var(--crm-s-radius) !important /* vs _template-item.scss */;
+  border-radius: var(--crm-l-radius) !important /* vs _template-item.scss */;
 }
 .crm-mosaico-wizard .crm_wizard__title .nav-pills li.disabled a {
   color: var(--crm-inactive-color) !important /* vs _template-item.scss */;
@@ -864,5 +864,5 @@ details + .crm-content-block:has(.dataTables_wrapper) {
 *******************/
 
 .af-container.af-layout-cols { /* vs afCore */
-  column-gap: var(--crm-s-medium);
+  column-gap: var(--crm-l-medium);
 }

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -845,7 +845,7 @@ details + .crm-content-block:has(.dataTables_wrapper) {
 }
 .crm-mosaico-wizard .crm-mosaico-template-item.thumbnail {
   background: var(--crm-c-layer1-bg) !important /* vs _template-item.scss */;
-  border: var(--crm-c-divider) !important /* vs _template-item.scss */;
+  border: var(--crm-border) !important /* vs _template-item.scss */;
   border-radius: var(--crm-s-radius) !important /* vs _template-item.scss */;
 }
 .crm-mosaico-wizard .crm_wizard__title .nav-pills li.disabled a {

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -105,7 +105,7 @@ a.crm-expand-row:focus {
   cursor: var(--crm-link-hover-cursor);
   padding: var(--crm-accordion-header-padding);
   border-radius: var(--crm-accordion-radius) var(--crm-accordion-radius) 0 0;
-  background-color: var(--crm-accordion-header-bg);
+  background-color: var(--crm-accordion-header-bg-color);
   font-weight: var(--crm-accordion-header-weight);
   color: var(--crm-accordion-header-color);
 }
@@ -117,7 +117,7 @@ a.crm-expand-row:focus {
 .crm-container .crm-accordion-inner .crm-accordion-header,
 .crm-container .crm-collapsible .collapsible-title {
   background-color: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-size: var(--crm-font-size);
 }
 .crm-accordion-wrapper .crm-accordion-header.active,
@@ -125,11 +125,11 @@ a.crm-expand-row:focus {
 .crm-accordion-wrapper .crm-accordion-wrapper.collapsed:focus,
 .crm-accordion-wrapper .crm-accordion-header:hover,
 .crm-accordion-wrapper .crm-accordion-header.active:hover {
-  background-color: var(--crm-accordion-header-bg-active);
+  background-color: var(--crm-accordion-header-bg-active-color);
 }
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header {
   font-weight: var(--crm-accordion2-header-weight);
-  background-color: var(--crm-accordion2-header-bg);
+  background-color: var(--crm-accordion2-header-bg-color);
   color: var(--crm-accordion2-header-color);
   border: var(--crm-accordion2-header-border);
   border-width: var(--crm-accordion2-header-border-width);
@@ -137,7 +137,7 @@ a.crm-expand-row:focus {
 }
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header:hover,
 .crm-container .crm-accordion-wrapper .crm-master-accordion-header:focus {
-  background-color: var(--crm-accordion2-header-bg-active);
+  background-color: var(--crm-accordion2-header-bg-active-color);
 }
 /* Body */
 
@@ -145,9 +145,9 @@ a.crm-expand-row:focus {
   border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
   border: var(--crm-accordion-border);
   padding: var(--crm-accordion-body-padding);
-  background-color: var(--crm-accordion-body-bg);
+  background-color: var(--crm-accordion-body-bg-color);
   box-shadow: var(--crm-accordion-body-box-shadow);
-  color: var(--crm-c-text); /* specified for Drupal Claro Darkmode */
+  color: var(--crm-text-color); /* specified for Drupal Claro Darkmode */
 }
 .crm-container .widget-content .crm-accordion-body,
 .crm-container .crm-collapsible .crm-summary-block {
@@ -155,7 +155,7 @@ a.crm-expand-row:focus {
 }
 .crm-container .crm-master-accordion-header + .crm-accordion-body {
   padding: var(--crm-accordion2-body-padding);
-  background: var(--crm-accordion2-body-bg);
+  background: var(--crm-accordion2-body-bg-color);
   border: var(--crm-accordion2-border);
   border-width: var(--crm-accordion2-border-width);
   border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
@@ -177,11 +177,11 @@ a.crm-expand-row:focus {
 .crm-container .ui-icons_deleted,
 .crm-container .font-red,
 .crm-contact-deceased {
-  color: var(--crm-c-danger-on-page-bg);
+  color: var(--crm-danger-ink-color);
 }
 .crm-container .alert.alert-info.font-red { /* for when an info alert wants to be a danger alert! */
-  background-color: var(--crm-alert-danger-bg);
-  border-color: var(--crm-alert-danger-border);
+  background-color: var(--crm-alert-danger-bg-color);
+  border-color: var(--crm-alert-danger-border-color);
 }
 
 /******************
@@ -201,8 +201,8 @@ a.crm-expand-row:focus {
   border-radius: var(--crm-btn-radius);
   user-select: none;
   margin: var(--crm-btn-margin);
-  background-color: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background-color: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
   line-height: 1.5;
   display: flex;
   height: var(--crm-btn-height);
@@ -211,8 +211,8 @@ a.crm-expand-row:focus {
 }
 .crm-container .ui-button:hover,
 .crm-container .ui-button:focus {
-  background: var(--crm-c-primary-hover);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-hover-color);
+  color: var(--crm-primary-text-color);
   text-decoration: none;
 }
 .crm-button > input[type="button"],
@@ -226,8 +226,8 @@ a.crm-expand-row:focus {
 .crm-container a.button,
 .crm-container a.button:link,
 .crm-container a.button:visited {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color);
   border: var(--crm-btn-border);
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
   font-weight: normal;
@@ -249,13 +249,13 @@ a.crm-expand-row:focus {
 }
 .crm-container a.button:hover,
 .crm-container a.button:focus {
-  background: var(--crm-c-secondary-hover);
-  color: var(--crm-c-secondary-hover-text);
+  background: var(--crm-secondary-hover-color);
+  color: var(--crm-secondary-hover-text-color);
 }
 .crm-actions-ribbon a.button,
 .crm-container .action-link a.button {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
   font-weight: normal;
   text-decoration: none;
 }
@@ -268,7 +268,7 @@ a.crm-expand-row:focus {
 .crm-container .crm-actions-ribbon a.button:not(.delete):focus,
 .crm-container .action-link a.button:hover,
 .crm-container .action-link a.button:focus {
-  background: var(--crm-c-primary-hover);
+  background: var(--crm-primary-hover-color);
   text-decoration: none;
 }
 .crm-config-backend-form-block > div { /* makes cleanup cache buttons flow inline */
@@ -346,7 +346,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 /* Bootstrap tabs */
 
 .crm-container .panel-default > .panel-heading:has(.nav-tabs) { /* Fix for default panel heading bg */
-  background-color: var(--crm-tabs-bg);
+  background-color: var(--crm-tabs-bg-color);
 }
 .crm-container .panel-heading:has(.nav-tabs) .pull-right {
   margin-right: var(--crm-m);
@@ -358,7 +358,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .panel-heading:has(.nav-tabs) {
   padding: 0;
   border-bottom: 0;
-  background-color: var(--crm-tabs-bg);
+  background-color: var(--crm-tabs-bg-color);
 }
 .crm-container .panel-heading .nav.nav-tabs {
   background-color: transparent;
@@ -426,7 +426,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .tag-tree-wrapper div.tag-info {
   width: auto;
   position: relative;
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
   border: 0 solid transparent;
   box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
@@ -436,7 +436,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 .crm-container .tag-tree-wrapper div.tag-info .tdl {
   font-weight: bold;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 .crm-container .tag-tree-wrapper div.tag-info .crm-submit-buttons {
   margin: var(--crm-m) 0 0;
@@ -625,7 +625,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 /* Custom searches */
 .crm-container > #crm-main-content-wrapper > fieldset {
   display: grid;
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
   border: 0 solid transparent;
   box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
@@ -771,8 +771,8 @@ details + .crm-content-block:has(.dataTables_wrapper) {
   grid-template-columns: min-content min-content min-content auto min-content min-content;
 }
 .crm-container .crm-contact-summary-edit-layout a.crm-hover-button {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text) !important;
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color) !important;
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
   border: var(--crm-btn-border);
 }
@@ -781,8 +781,8 @@ details + .crm-content-block:has(.dataTables_wrapper) {
 }
 .crm-container .crm-contact-summary-edit-layout a.crm-hover-button:hover,
 .crm-container .crm-contact-summary-edit-layout a.crm-hover-button:focus {
-  background: var(--crm-c-primary-hover);
-  color: var(--crm-c-primary-text) !important;
+  background: var(--crm-primary-hover-color);
+  color: var(--crm-primary-text-color) !important;
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline) var(--crm-btn-padding-block) 0;
 }
 .crm-previous-action {
@@ -844,12 +844,12 @@ details + .crm-content-block:has(.dataTables_wrapper) {
   gap: var(--crm-flex-gap);
 }
 .crm-mosaico-wizard .crm-mosaico-template-item.thumbnail {
-  background: var(--crm-c-layer1-bg) !important /* vs _template-item.scss */;
+  background: var(--crm-layer1-bg-color) !important /* vs _template-item.scss */;
   border: var(--crm-border) !important /* vs _template-item.scss */;
   border-radius: var(--crm-s-radius) !important /* vs _template-item.scss */;
 }
 .crm-mosaico-wizard .crm_wizard__title .nav-pills li.disabled a {
-  color: var(--crm-c-inactive) !important /* vs _template-item.scss */;
+  color: var(--crm-inactive-color) !important /* vs _template-item.scss */;
 }
 #bootstrap-theme .crm-mosaico-template-item .crm-mosaico-template-actions {
   display: flex !important /* vs _template-item.scss */;

--- a/ext/riverlea/core/css/_fixes.css
+++ b/ext/riverlea/core/css/_fixes.css
@@ -303,7 +303,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   height: auto;
 }
 .crm-container .btn-group-xs button {
-  padding: var(--crm-xs) var(--crm-s);
+  padding: var(--crm-s-xsmall) var(--crm-s-small);
   font-size: var(--crm-font-small-size);
 }
 /* select all 'checkbox' on table th */
@@ -349,7 +349,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   background-color: var(--crm-tabs-bg-color);
 }
 .crm-container .panel-heading:has(.nav-tabs) .pull-right {
-  margin-right: var(--crm-m);
+  margin-right: var(--crm-s-medium);
 }
 .crm-container .afadmin-list .nav.nav-tabs { /* Fix for AForm tabs border */
   border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
@@ -383,7 +383,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 .afadmin-list .nav-tabs + .form-inline,
 .crm-search-nav-tabs ~ .ng-scope > .form-inline {
-  padding: var(--crm-r);
+  padding: var(--crm-s-reg);
   background: var(--crm-tab-bg-active);
 }
 .crm-container .ui-tabs ul.crm-extensions-tabs-list a em {
@@ -418,7 +418,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 .crm-container .tag-tree-wrapper {
   display: grid;
   grid-template-columns: 2fr 1fr;
-  margin: var(--crm-m) 0;
+  margin: var(--crm-s-medium) 0;
 }
 .crm-container .tag-tree-wrapper div.tag-tree {
   width: auto;
@@ -439,7 +439,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   color: var(--crm-text-color);
 }
 .crm-container .tag-tree-wrapper div.tag-info .crm-submit-buttons {
-  margin: var(--crm-m) 0 0;
+  margin: var(--crm-s-medium) 0 0;
   padding: 0;
 }
 .crm-container .tag-tree-wrapper .tag-tree a.crm-tag-item {
@@ -457,7 +457,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 /* Dedupe change usage */
 .crm-container label:has(.dedupe-rules-dialog-desc) input {
   float: left;
-  margin: var(--crm-s) var(--crm-m) 0 0;
+  margin: var(--crm-s-small) var(--crm-s-medium) 0 0;
 }
 .crm-container .dedupe-rules-dialog-desc {
   font-weight: normal;
@@ -471,7 +471,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   gap: 1px; /* to handle white space in markup */
 }
 .crm-container #ContributionCharts .ui-tabs-nav .float-right td {
-  padding: 0 var(--crm-s);
+  padding: 0 var(--crm-s-small);
 }
 #ContributionCharts ul.ui-tabs-nav li.crm-tab-button {
   padding: var(--crm-tab-padding);
@@ -485,8 +485,8 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 }
 #ContributionCharts ul.ui-tabs-nav .float-right {
   position: absolute;
-  right: var(--crm-s);
-  top: var(--crm-s);
+  right: var(--crm-s-small);
+  top: var(--crm-s-small);
 }
 #ContributionCharts ul.ui-tabs-nav .float-right table,
 #ContributionCharts ul.ui-tabs-nav .float-right table tr {
@@ -507,13 +507,13 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
 /* Event dashboard */
 .CRM_Event_Form_Search .button {
   float: left;
-  margin-right: var(--crm-m);
+  margin-right: var(--crm-s-medium);
 }
 #crm-event-dashboard-heading + div a,
 .CRM_Event_Form_SearchEvent .crm-content-block .float-right a {
   display: flex;
-  padding: 0 0 var(--crm-m) 0;
-  gap: var(--crm-m);
+  padding: 0 0 var(--crm-s-medium) 0;
+  gap: var(--crm-s-medium);
   align-items: center;
 }
 /* Dedupe page */
@@ -523,7 +523,7 @@ body[class*="page-civicrm-report-"] #report-tab-order-by-elements #optionFieldLi
   float: none !important; /* overwrites inline 'float' that breaks page wrapper */
   display: flex;
   justify-content: flex-end;
-  padding: 0 0 var(--crm-l) 0;
+  padding: 0 0 var(--crm-s-large) 0;
 }
 
 /* CiviCase  */
@@ -585,7 +585,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 }
 .crm-container .form-layout td:has(#_qf_Advanced_refresh-bottom) {
   display: flex;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   align-items: center;
 }
 .crm-container .adv-search-top-submit .crm-submit-buttons,
@@ -606,7 +606,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   display: none !important;
 }
 .crm-case_search-accordion .crm-accordion-body .form-layout > tbody:first-child > tr #s2id_case_status_id {
-  margin-bottom: var(--crm-r1);
+  margin-bottom: var(--crm-s-reg-1);
 }
 .crm-case_search-accordion .crm-accordion-body .form-layout > tbody:first-child > tr:nth-of-type(1) > td:nth-of-type(1) label {
   display: block;
@@ -616,7 +616,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 }
 /* Member */
 .page-civicrm-member-search .CRM_Member_Form_Search .crm-accordion-body tr:last-child td {
-  padding-top: var(--crm-r);
+  padding-top: var(--crm-s-reg);
 }
 /* Find Participants */
 .crm-container div#searchForm table.form-layout td {
@@ -629,8 +629,8 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   border: 0 solid transparent;
   box-shadow: var(--crm-shadow-block);
   padding: var(--crm-padding-reg);
-  gap: var(--crm-m);
-  margin-bottom: var(--crm-r);
+  gap: var(--crm-s-medium);
+  margin-bottom: var(--crm-s-reg);
 }
 .crm-container > #crm-main-content-wrapper > fieldset > * {
   margin: 0;
@@ -643,7 +643,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
 /* General */
 .crm-container .crm-form-block .crm-form-block {
   padding: var(--crm-form-block-padding);
-  margin-bottom: var(--crm-r);
+  margin-bottom: var(--crm-s-reg);
 }
 /* Save as template text on new email form */
 .crm-container #editMessageDetails {
@@ -654,7 +654,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   padding: 0;
 }
 #mainTabContainer .form-group.pull-right  > .btn-group {
-  margin-bottom: var(--crm-m2);
+  margin-bottom: var(--crm-s-medium-2);
 }
 /* Contact dashboard page */
 .crm-actions-ribbon .crm-next-action,
@@ -662,7 +662,7 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   margin-left: auto;
 }
 .crm-container .view-contact-groups .description {
-  margin: var(--crm-r) 0;
+  margin: var(--crm-s-reg) 0;
 }
 /* Contacts - new */
 .CRM_Contact_Form_Contact > .crm-form-block .crm-submit-buttons:first-of-type {
@@ -691,14 +691,14 @@ tr.crm-preferences-display-form-block-contact_edit_options td table {
   margin-bottom: 0;
 }
 .crm-search-form .crm-submit-buttons {
-  padding: 0 0 var(--crm-m);
+  padding: 0 0 var(--crm-s-medium);
 }
 .crm-search-form .crm-search-form-block {
-  margin-bottom: var(--crm-r);
+  margin-bottom: var(--crm-s-reg);
 }
 /* Dedupe exceptions */
 details + .crm-content-block:has(.dataTables_wrapper) {
-  margin-top: var(--crm-r);
+  margin-top: var(--crm-s-reg);
 }
 /* Contribution page edit/create */
 .crm-container .crm-premium-settings-accordion {
@@ -808,7 +808,7 @@ details + .crm-content-block:has(.dataTables_wrapper) {
   height: auto;
 }
 .crm-mosaico-page .select2-container {
-  min-width: var(--crm-big-input);
+  min-width: var(--crm-input-width);
 }
 .mosaico-templates-wrapper {
   margin: 0 !important;
@@ -833,7 +833,7 @@ details + .crm-content-block:has(.dataTables_wrapper) {
   border-radius: 0 0 var(--crm-tab-radius) var(--crm-tab-radius);
 }
 .select2-drop.select2-drop-active.crm-container {
-  max-width: var(--crm-huge-input); /* Mosaico fix - https://lab.civicrm.org/extensions/riverlea/-/issues/23 */
+  max-width: var(--crm-input-large-width); /* Mosaico fix - https://lab.civicrm.org/extensions/riverlea/-/issues/23 */
 }
 .crmb-wizard-button-right {
   display: flex;
@@ -864,5 +864,5 @@ details + .crm-content-block:has(.dataTables_wrapper) {
 *******************/
 
 .af-container.af-layout-cols { /* vs afCore */
-  column-gap: var(--crm-m);
+  column-gap: var(--crm-s-medium);
 }

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -4,9 +4,6 @@
 ****************************/
 
 :root {
-/* Fonts */
-  --crm-system-fonts: unset;
-  --crm-font: unset;
 /* Colour names */
   --crm-c-gray-900: #2f2f2e;
   --crm-c-gray-800: #3e3e3e;
@@ -86,10 +83,9 @@
   --crm-c-info-light: hsl(from var(--crm-c-info) h s calc(l + 67));
   --crm-c-info-on-page-bg: var(--crm-c-info);
 /* Shadows */
-  --crm-block-shadow: unset;
-  --crm-popup-shadow: 0 3px 18px 0 rgba(48,40,40,.25);
-  --crm-bottom-shadow: 0 0 16px 1px rgba(0,0,0,.1);
-  --crm-body-inset: unset;
+  --crm-shadow-block: unset;
+  --crm-shadow-popup: 0 3px 18px 0 rgba(48,40,40,.25);
+  --crm-shadow-bottom: 0 0 16px 1px rgba(0,0,0,.1);
 /* Sizes */
   --crm-s-radius: 0.25rem;
   --crm-xs: 0.1rem;
@@ -120,18 +116,19 @@
   --crm-page-width: 100%; /* Default that CMS can overwrite */
   --crm-flex-gap: 0.5rem;
 /* Type */
+  --crm-font-system: unset;
+  --crm-font: unset;
   --crm-font-size: var(--crm-r);
-  --crm-small-font-size: var(--crm-m2);
-  --crm-type-line-height: 1.5;
+  --crm-font-small-size: var(--crm-m2);
+  --crm-font-line-height: 1.5;
   --crm-link-decoration: none;
   --crm-link-decoration-hover: underline;
+  --crm-link-hover-cursor: pointer;
   --crm-heading-bg: var(--crm-c-info-light);
   --crm-heading-col: var(--crm-c-info-on-dark);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1);
   --crm-heading-margin: var(--crm-m) 0;
   --crm-heading-radius: var(--crm-s-radius);
-/* Mouse events */
-  --crm-hover-clickable: pointer;
 /* Buttons */
   --crm-btn-box-shadow: none;
   --crm-btn-border: 0 solid transparent;
@@ -186,7 +183,7 @@
   --crm-table-nested-border: var(--crm-c-divider);
   --crm-table-inset-bg: var(--crm-c-layer2-bg);
 /* Panels */
-  --crm-panel-shadow: var(--crm-block-shadow);
+  --crm-panel-shadow: var(--crm-shadow-block);
   --crm-panel-bg: var(--crm-c-layer0-bg);
   --crm-panel-border: var(--crm-c-divider);
   --crm-panel-head-margin: 0px;
@@ -241,7 +238,7 @@
   --crm-alert-danger-border: color-mix(in srgb, var(--crm-alert-danger-bg) 90%,#000 10%);
   --crm-alert-danger-text: var(--crm-c-danger);
 /* Form */
-  --crm-form-block-box-shadow: var(--crm-block-shadow);
+  --crm-form-block-box-shadow: var(--crm-shadow-block);
   --crm-form-block-bg: var(--crm-c-container-bg);
   --crm-form-block-padding: var(--crm-m);
   --crm-form-block-border-radius: var(--crm-s-radius);
@@ -348,7 +345,7 @@
   --crm-dialog-padding: var(--crm-s);
   --crm-dialog-radius: var(--crm-s-radius);
   --crm-dialog-line: unset;
-  --crm-dialog-inner-shadow: var(--crm-bottom-shadow);
+  --crm-dialog-inner-shadow: var(--crm-shadow-bottom);
   --crm-dialog-header-bg: var(--crm-c-secondary);
   --crm-dialog-header-col: var(--crm-c-secondary-text);
   --crm-dialog-header-size: var(--crm-r1);
@@ -362,7 +359,7 @@
   --crm-dashlet-border: unset;
   --crm-dashlet-bg: var(--crm-c-layer0-bg);
   --crm-dashlet-padding: var(--crm-s2);
-  --crm-dashlet-box-shadow: var(--crm-popup-shadow);
+  --crm-dashlet-box-shadow: var(--crm-shadow-popup);
   --crm-dashlet-dashlets-bg: var(--crm-c-container-bg);
   --crm-dashlet-header-bg: var(--crm-accordion-header-bg);
   --crm-dashlet-header-col: var(--crm-accordion-header-color);
@@ -431,7 +428,7 @@
   --crm-filter-spacing: space-between; /* choose 'space-between' to spread out evenly, 'start' for left align, or 'end' for right. */
 /* Frontend */
   --crm-f-form-width: 800px;
-  --crm-f-box-shadow: var(--crm-block-shadow);
+  --crm-f-box-shadow: var(--crm-shadow-block);
   --crm-f-fieldset-bg: var(--crm-c-page-bg);
   --crm-f-fieldset-padding: var(--crm-r) 0;
   --crm-f-fieldset-margin: 0 0 var(--crm-padding-reg) 0;

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -89,47 +89,45 @@
   --crm-shadow-popup: 0 3px 18px 0 rgba(48,40,40,.25);
   --crm-shadow-bottom: 0 0 16px 1px rgba(0,0,0,.1);
 /* Sizes */
+  --crm-s-xsmall: 0.1rem; /* default extra-small */
+  --crm-s-xsmall-1: 0.125rem;
+  --crm-s-xsmall-2: 0.15rem;
+  --crm-s-small: 0.25rem; /* default small */
+  --crm-s-small-1: 0.275rem;
+  --crm-s-small-2: 0.325rem;
+  --crm-s-small-3: 0.375rem;
+  --crm-s-medium: 0.5rem; /* default medium */
+  --crm-s-medium-1: 0.625rem;
+  --crm-s-medium-2: 0.75rem;
+  --crm-s-medium-3: 0.875rem;
+  --crm-s-reg: 1rem;  /* default size */
+  --crm-s-reg-1: 1.125rem;
+  --crm-s-reg-2: 1.25rem;
+  --crm-s-reg-3: 1.375rem;
+  --crm-s-reg-4: 1.5rem;
+  --crm-s-large: 2rem;  /* default large */
+  --crm-s-large-1: 3rem;
+  --crm-s-large-2: 4rem;
   --crm-s-radius: 0.25rem;
-  --crm-xs: 0.1rem;
-  --crm-xs1: 0.125rem;
-  --crm-xs2: 0.15rem;
-  --crm-s: 0.25rem;
-  --crm-s1: 0.275rem;
-  --crm-s2: 0.325rem;
-  --crm-s3: 0.375rem;
-  --crm-m: 0.5rem;
-  --crm-m1: 0.625rem;
-  --crm-m2: 0.75rem;
-  --crm-m3: 0.875rem;
-  --crm-r: 1rem;
-  --crm-r1: 1.125rem;
-  --crm-r2: 1.25rem;
-  --crm-r3: 1.375rem;
-  --crm-r4: 1.5rem;
-  --crm-l: 2rem;
-  --crm-xl: 3rem;
-  --crm-xxl: 4rem;
-  --crm-big-input: 15em;
-  --crm-huge-input: 25em;
-  --crm-padding-reg: var(--crm-r);
-  --crm-padding-small: var(--crm-s);
-  --crm-padding-inset: var(--crm-m);
-  --crm-page-padding: var(--crm-xl); /* Margin left/right */
+  --crm-padding-reg: var(--crm-s-reg);
+  --crm-padding-small: var(--crm-s-small);
+  --crm-padding-inset: var(--crm-s-medium);
+  --crm-page-padding: var(--crm-s-large-1); /* Margin left/right */
   --crm-page-width: 100%; /* Default that CMS can overwrite */
-  --crm-flex-gap: 0.5rem;
+  --crm-flex-gap: var(--crm-s-medium);
 /* Type */
   --crm-font-system: unset;
   --crm-font: unset;
-  --crm-font-size: var(--crm-r);
-  --crm-font-small-size: var(--crm-m2);
+  --crm-font-size: var(--crm-s-reg);
+  --crm-font-small-size: var(--crm-s-medium-2);
   --crm-font-line-height: 1.5;
   --crm-link-decoration: none;
   --crm-link-decoration-hover: underline;
   --crm-link-hover-cursor: pointer;
   --crm-heading-bg-color: var(--crm-info-light-color);
   --crm-heading-color: var(--crm-info-color-on-dark);
-  --crm-heading-padding: var(--crm-s1) var(--crm-m1);
-  --crm-heading-margin: var(--crm-m) 0;
+  --crm-heading-padding: var(--crm-s-small-1) var(--crm-s-medium-1);
+  --crm-heading-margin: var(--crm-s-medium) 0;
   --crm-heading-radius: var(--crm-s-radius);
 /* Buttons */
   --crm-btn-box-shadow: none;
@@ -138,13 +136,13 @@
   --crm-btn-weight: inherit;
   --crm-btn-font: inherit;
   --crm-btn-radius: 3px;
-  --crm-btn-padding-block: var(--crm-xs1); /* padding for top and bottom, one value */
-  --crm-btn-padding-inline: var(--crm-m1); /* padding for left and right, one value */
-  --crm-btn-small-padding: var(--crm-xs) var(--crm-s);
-  --crm-btn-large-padding: var(--crm-m) var(--crm-r);
+  --crm-btn-padding-block: var(--crm-s-xsmall-1); /* padding for top and bottom, one value */
+  --crm-btn-padding-inline: var(--crm-s-medium-1); /* padding for left and right, one value */
+  --crm-btn-small-padding: var(--crm-s-xsmall) var(--crm-s-small);
+  --crm-btn-large-padding: var(--crm-s-medium) var(--crm-s-reg);
   --crm-btn-align: center;
   --crm-btn-height: 28px;
-  --crm-btn-icon-spacing: var(--crm-s);
+  --crm-btn-icon-spacing: var(--crm-s-small);
   --crm-btn-icon-size: auto;
   --crm-btn-cancel-bg-color: var(--crm-danger-color);
   --crm-btn-cancel-text-color: var(--crm-danger-text-color);
@@ -166,7 +164,7 @@
   --crm-table-row-border: var(--crm-border);
   --crm-table-column-border: 0 solid transparent;
   --crm-table-font-size: var(--crm-font-size);
-  --crm-table-padding: var(--crm-m);
+  --crm-table-padding: var(--crm-s-medium);
   --crm-table-header-border: 1px solid transparent;
   --crm-table-header-border-bottom: 2px solid var(--crm-border-color);
   --crm-table-header-bg-color: var(--crm-paper);
@@ -180,7 +178,7 @@
   --crm-table-sort-float: left; /* 'left', 'right' or 'none' */
   --crm-table-sort-active-color: var(--crm-link-color);
   --crm-table-compressed-width: auto;
-  --crm-table-nested-padding: var(--crm-r) var(--crm-m);
+  --crm-table-nested-padding: var(--crm-s-reg) var(--crm-s-medium);
   --crm-table-nested-head-border: 0 solid transparent;
   --crm-table-nested-border: var(--crm-border);
   --crm-table-inset-bg-color: var(--crm-layer2-bg-color);
@@ -193,16 +191,16 @@
 /* Accordions */
   --crm-accordion-icon: "\f0da"; /* unicode value for FontAwesome icon */
   --crm-accordion-icon-color: var(--crm-text-color);
-  --crm-accordion-icon-spacing: var(--crm-m);
+  --crm-accordion-icon-spacing: var(--crm-s-medium);
   --crm-accordion-transform: rotate(90deg);
   --crm-accordion-transition: transform .3s;
   --crm-accordion-radius: var(--crm-s-radius);
-  --crm-accordion-gap: var(--crm-xs2) 0 0; /* space between multiple accordions */
+  --crm-accordion-gap: var(--crm-s-xsmall-2) 0 0; /* space between multiple accordions */
 /* .crm-accordion-bold */
   --crm-accordion-header-bg-color: var(--crm-secondary-color);
   --crm-accordion-header-bg-active-color: var(--crm-c-gray-900);
   --crm-accordion-header-color: var(--crm-secondary-text-color);
-  --crm-accordion-header-padding: var(--crm-s) var(--crm-m);
+  --crm-accordion-header-padding: var(--crm-s-small) var(--crm-s-medium);
   --crm-accordion-header-weight: bold;
   --crm-accordion-header-border: var(--crm-border);
   --crm-accordion-header-border-width: 0 0 1px 0;
@@ -218,14 +216,14 @@
   --crm-accordion2-header-color: var(--crm-text-color);
   --crm-accordion2-header-border: unset;
   --crm-accordion2-header-border-width: unset;
-  --crm-accordion2-header-padding: var(--crm-s) var(--crm-m);
+  --crm-accordion2-header-padding: var(--crm-s-small) var(--crm-s-medium);
   --crm-accordion2-border: unset;
   --crm-accordion2-border-width: unset;
   --crm-accordion2-body-bg-color: unset;
-  --crm-accordion2-body-padding: var(--crm-s);
+  --crm-accordion2-body-padding: var(--crm-s-small);
 /* Alerts */
-  --crm-alert-padding: var(--crm-m) var(--crm-m2);
-  --crm-alert-margin: 0 0 var(--crm-m);
+  --crm-alert-padding: var(--crm-s-medium) var(--crm-s-medium-2);
+  --crm-alert-margin: 0 0 var(--crm-s-medium);
   --crm-alert-border-width: 1px;
   --crm-alert-success-bg-color: var(--crm-success-light-color);
   --crm-alert-success-border-color: color-mix(in srgb, var(--crm-alert-success-bg-color) 90%,#000 10%);
@@ -242,7 +240,7 @@
 /* Form */
   --crm-form-block-box-shadow: var(--crm-shadow-block);
   --crm-form-block-bg-color: var(--crm-container-bg-color);
-  --crm-form-block-padding: var(--crm-m);
+  --crm-form-block-padding: var(--crm-s-medium);
   --crm-form-block-border-radius: var(--crm-s-radius);
   --crm-form-block-header-color: var(--crm-inverse-bg-color);
   --crm-form-fieldset-border-color: var(--crm-c-gray-400);
@@ -256,14 +254,16 @@
   --crm-input-border-radius: 3px;
   --crm-input-active-transition: border-color .15s ease-in-out 0s;
   --crm-input-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,.1);
-  --crm-input-padding: var(--crm-xs1) var(--crm-s2);
-  --crm-input-padding-large: var(--crm-s) var(--crm-m1);
-  --crm-input-height: var(--crm-l);
-  --crm-input-font-size: var(--crm-m3);
+  --crm-input-padding: var(--crm-s-xsmall-1) var(--crm-s-small-2);
+  --crm-input-padding-large: var(--crm-s-small) var(--crm-s-medium-1);
+  --crm-input-height: var(--crm-s-large);
+  --crm-input-width: 15em;
+  --crm-input-large-width: 25em;
+  --crm-input-font-size: var(--crm-s-medium-3);
   --crm-input-label-weight: bold;
   --crm-input-label-font: var(--crm-font);
   --crm-input-label-size: var(--crm-font-size);
-  --crm-input-label-width: var(--crm-big-input);
+  --crm-input-label-width: var(--crm-input-width);
   --crm-input-label-align: right;
   --crm-input-label-color: var(--crm-text-color);
   --crm-input-description: var(--crm-inactive-color);
@@ -283,15 +283,15 @@
   --crm-input-toggle-button-bg: var(--crm-paper);
 /* Tabs */
   --crm-tabs-bg-color: var(--crm-c-gray-200);
-  --crm-tabs-padding: var(--crm-s);
+  --crm-tabs-padding: var(--crm-s-small);
   --crm-tabs-border: var(--crm-contact-border);
   --crm-tabs-radius: var(--crm-s-radius);
-  --crm-tabs-gap: var(--crm-s);
+  --crm-tabs-gap: var(--crm-s-small);
   --crm-tab-bg-color: var(--crm-layer1-bg-color);
   --crm-tab-hover-bg-color: color-mix(in srgb,var(--crm-layer1-bg-color) 75%,#000 25%);
   --crm-tab-bg-active: var(--crm-container-bg-color);
   --crm-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-tab-padding: var(--crm-s3) var(--crm-m) var(--crm-s) var(--crm-m);
+  --crm-tab-padding: var(--crm-s-small-3) var(--crm-s-medium) var(--crm-s-small) var(--crm-s-medium);
   --crm-tab-color: var(--crm-text-color);
   --crm-tab-weight: normal;
   --crm-tab-count-bg-color: var(--crm-info-text-color);
@@ -312,7 +312,7 @@
   --crm-contact-tabs-radius: var(--crm-contact-radius) var(--crm-contact-radius) 0 0;
   --crm-contact-tab-bg-color: var(--crm-tab-bg-color);
   --crm-contact-tab-hover-bg-color: var(--crm-tab-hover-bg-color);
-  --crm-contact-tab-padding: var(--crm-s3) var(--crm-m2);
+  --crm-contact-tab-padding: var(--crm-s-small-3) var(--crm-s-medium-2);
   --crm-contact-tab-border: 0 solid transparent;
   --crm-contact-tab-border-hover: 0 solid transparent;
   --crm-contact-tab-border-width: 0; /* to remove border on one side for hanging tabs */
@@ -322,11 +322,11 @@
   --crm-contact-tab-align: none;
   --crm-contact-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-contact-tab-radius: var(--crm-contact-radius);
-  --crm-contact-icon-size: var(--crm-r);
+  --crm-contact-icon-size: var(--crm-s-reg);
   --crm-contact-summary-row-bg-color: var(--crm-container-bg-color);
   --crm-contact-heading-inset: 0;
   --crm-contact-box-shadow: 0;
-  --crm-contact-panel-padding: var(--crm-m);
+  --crm-contact-panel-padding: var(--crm-s-medium);
   --crm-contact-panel-bg-color: var(--crm-paper);
   --crm-contact-panel-border: 0;
   --crm-contact-panel-radius: 0 0 var(--crm-contact-radius) var(--crm-contact-radius);
@@ -338,8 +338,8 @@
   --crm-contact-header-bg-color: var(--crm-paper);
   --crm-contact-header2-bg-color: transparent;
   --crm-contact-header-color: var(--crm-text-color);
-  --crm-contact-header-size: var(--crm-r3);
-  --crm-contact-header-padding: 0 0 var(--crm-r) 0;
+  --crm-contact-header-size: var(--crm-s-reg-3);
+  --crm-contact-header-padding: 0 0 var(--crm-s-reg) 0;
   --crm-contact-image-size: 100px;
   --crm-contact-image-radius: 0;
   --crm-contact-image-right: var(--crm-contact-panel-padding); /* distance from right of dashboard */
@@ -347,23 +347,23 @@
   --crm-contact-image-border: 0;
 /* Dialog */
   --crm-dialog-bg-color: var(--crm-paper);
-  --crm-dialog-padding: var(--crm-s);
+  --crm-dialog-padding: var(--crm-s-small);
   --crm-dialog-radius: var(--crm-s-radius);
   --crm-dialog-line: unset;
   --crm-dialog-inner-shadow: var(--crm-shadow-bottom);
   --crm-dialog-header-bg-color: var(--crm-secondary-color);
   --crm-dialog-header-color: var(--crm-secondary-text-color);
-  --crm-dialog-header-size: var(--crm-r1);
-  --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
+  --crm-dialog-header-size: var(--crm-s-reg-1);
+  --crm-dialog-header-padding: var(--crm-s-medium-1) var(--crm-s-reg);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
   --crm-dialog-header-border-color: transparent transparent var(--crm-border-color) transparent; /* set a border color for each side of the header */
   --crm-dialog-body-bg-color: var(--crm-container-bg-color);
-  --crm-dialog-body-padding: var(--crm-m);
+  --crm-dialog-body-padding: var(--crm-s-medium);
 /* Dashlet */
   --crm-dashlet-columns: 2fr 3fr;
   --crm-dashlet-border: unset;
   --crm-dashlet-bg-color: var(--crm-paper);
-  --crm-dashlet-padding: var(--crm-s2);
+  --crm-dashlet-padding: var(--crm-s-small-2);
   --crm-dashlet-box-shadow: var(--crm-shadow-popup);
   --crm-dashlet-dashlets-bg-color: var(--crm-container-bg-color);
   --crm-dashlet-header-bg-color: var(--crm-accordion-header-bg-color);
@@ -371,12 +371,12 @@
   --crm-dashlet-header-border: unset;
   --crm-dashlet-header-border-width: unset;
   --crm-dashlet-header-font-size: var(--crm-font-size);
-  --crm-dashlet-header-padding: var(--crm-s);
+  --crm-dashlet-header-padding: var(--crm-s-small);
   --crm-dashlet-content-padding: var(--crm-dashlet-padding) 0;
   --crm-dashlet-tabs-border: 0;
   --crm-dashlet-radius: var(--crm-s-radius);
 /* Button dropdowns */
-  --crm-dropdown-padding: var(--crm-s);
+  --crm-dropdown-padding: var(--crm-s-small);
   --crm-dropdown-radius: var(--crm-s-radius);
   --crm-dropdown-bg-color: var(--crm-secondary-hover-color);
   --crm-dropdown-color: var(--crm-text-light-color);
@@ -390,7 +390,7 @@
   --crm-dropdown-2-padding: var(--crm-padding-small);
 /* Notifications */
   --crm-notify-bg-color: rgba(0,0,0,0.85);
-  --crm-notify-padding: var(--crm-m2);
+  --crm-notify-padding: var(--crm-s-medium-2);
   --crm-notify-color: var(--crm-text-light-color);
   --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: var(--crm-s-radius);
@@ -417,7 +417,7 @@
   --crm-wizard-width: fit-content;
   --crm-wizard-margin: 0.5rem auto;
   --crm-wizard-height: 30px;
-  --crm-wizard-radius: var(--crm-l);
+  --crm-wizard-radius: var(--crm-s-large);
   --crm-wizard-angle: 0px;
   --crm-wizard-arrow-thickness: 1px;
   --crm-wizard-active-color: var(--crm-text-light-color);
@@ -427,7 +427,7 @@
   --crm-wizard-box-shadow: unset;
 /* Alpha filter */
   --crm-filter-bg-color: var(--crm-info-light-color);
-  --crm-filter-padding: var(--crm-m);
+  --crm-filter-padding: var(--crm-s-medium);
   --crm-filter-item-bg-color: var( --crm-layer1-bg-color);
   --crm-filter-item-shadow: 0px 0px 3px rgba(0,0,0,0.1);
   --crm-filter-spacing: space-between; /* choose 'space-between' to spread out evenly, 'start' for left align, or 'end' for right. */
@@ -435,26 +435,26 @@
   --crm-f-form-width: 800px;
   --crm-f-box-shadow: var(--crm-shadow-block);
   --crm-f-fieldset-bg-color: var(--crm-page-bg-color);
-  --crm-f-fieldset-padding: var(--crm-r) 0;
+  --crm-f-fieldset-padding: var(--crm-s-reg) 0;
   --crm-f-fieldset-margin: 0 0 var(--crm-padding-reg) 0;
   --crm-f-fieldset-border: 0;
   --crm-f-fieldset-box-shadow: var(--crm-f-box-shadow);
   --crm-f-legend-position: left; /* chose 'left', 'right' or 'inherit' for browser-default of mid fieldset border */
   --crm-f-legend-align: left;
-  --crm-f-legend-size: var(--crm-r3);
+  --crm-f-legend-size: var(--crm-s-reg-3);
   --crm-f-legend-padding: 0;
   --crm-f-form-padding: var(--crm-padding-reg);
   --crm-f-form-layout: block; /* 'grid' = inline, 'block' = stacked */
   --crm-f-label-position: left; /* 'unset' = stacked, 'left' = left align, in combination with width/margin below */
   --crm-f-label-align: right;
   --crm-f-label-width: 200px;
-  --crm-f-label-gap: var(--crm-m); /* applies for inline label + input */
-  --crm-f-label-margin: var(--crm-s);
+  --crm-f-label-gap: var(--crm-s-medium); /* applies for inline label + input */
+  --crm-f-label-margin: var(--crm-s-small);
   --crm-f-label-weight: bold;
   --crm-f-label-color: inherit;
   --crm-f-input-radius: var(--crm-s-radius);
-  --crm-f-input-padding: var(--crm-r2) var(--crm-m2);
-  --crm-f-input-font-size: var(--crm-r1);
+  --crm-f-input-padding: var(--crm-s-reg-2) var(--crm-s-medium-2);
+  --crm-f-input-font-size: var(--crm-s-reg-1);
   --crm-f-input-width: 300px;
   --crm-f-form-focus-bg-color: var(--crm-c-green-light);
   --crm-f-form-error-bg-color: var(--crm-c-gray-200);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -37,53 +37,53 @@
   --crm-c-dark-teal: #3e8079;
   --crm-c-darkest: #0a0a0a;
 /* Practical colours */
-  --crm-c-text-light: #fff;
-  --crm-c-text-dark: #464354;
-  --crm-c-text: var(--crm-c-text-dark);
-  --crm-c-link: var(--crm-c-blue-dark);
-  --crm-c-link-hover: var(--crm-c-blue-darker);
-  --crm-c-focus: var(--crm-c-blue-dark);
-  --crm-paper: var(--crm-c-text-light); /* The lightest bg in light mode */
+  --crm-text-light-color: #fff;
+  --crm-text-dark-color: #464354;
+  --crm-text-color: var(--crm-text-dark-color);
+  --crm-link-color: var(--crm-c-blue-dark);
+  --crm-link-hover-color: var(--crm-c-blue-darker);
+  --crm-focus-color: var(--crm-c-blue-dark);
+  --crm-paper: var(--crm-text-light-color); /* The lightest bg in light mode */
   --crm-ink: var(--crm-c-darkest); /* The darkest foreground in light mode */
-  --crm-c-inactive: color-mix(in srgb,var(--crm-c-text) 95%,var(--crm-paper) 5%);
+  --crm-inactive-color: color-mix(in srgb,var(--crm-text-color) 95%,var(--crm-paper) 5%);
 /* Backgrounds */
-  --crm-c-page-bg: var(--crm-paper);
-  --crm-c-container-bg: #f4f4ed;
-  --crm-c-layer1-bg: var(--crm-c-gray-050);
-  --crm-c-layer2-bg: color-mix(in srgb,var(--crm-c-layer1-bg) 95%,#000 5%);
-  --crm-c-inverse-bg: var(--crm-c-gray-700); /* bg to light text */
-  --crm-c-drag-bg: var(--crm-c-layer2-bg);
+  --crm-page-bg-color: var(--crm-paper);
+  --crm-container-bg-color: #f4f4ed;
+  --crm-layer1-bg-color: var(--crm-c-gray-050);
+  --crm-layer2-bg-color: color-mix(in srgb,var(--crm-layer1-bg-color) 95%,#000 5%);
+  --crm-inverse-bg-color: var(--crm-c-gray-700); /* bg to light text */
+  --crm-drag-bg-color: var(--crm-layer2-bg-color);
   --crm-border-color: var(--crm-c-gray-300);
   --crm-border: 1px solid var(--crm-border-color);
-  --crm-c-code-bg: var(--crm-c-layer1-bg);
-  --crm-code-border-color: color-mix(in srgb,var(--crm-c-code-bg) 75%,#000 25%);
+  --crm-code-bg-color: var(--crm-layer1-bg-color);
+  --crm-code-border-color: color-mix(in srgb,var(--crm-code-bg-color) 75%,#000 25%);
 /* Emphasis colours */
-  --crm-c-primary: var(--crm-c-inverse-bg);
-  --crm-c-primary-hover: color-mix(in srgb,var(--crm-c-primary) 75%,#000 25%);
-  --crm-c-primary-text: var(--crm-c-text-light);
-  --crm-c-primary-hover-text: var(--crm-c-text-light);
-  --crm-c-primary-on-page-bg: var(--crm-c-primary-hover);
-  --crm-c-secondary: #5d677b;
-  --crm-c-secondary-hover: color-mix(in srgb,var(--crm-c-secondary) 75%,#000 25%);
-  --crm-c-secondary-text: var(--crm-c-text-light);
-  --crm-c-secondary-hover-text: var(--crm-c-text-light);
-  --crm-c-secondary-on-page-bg: var(--crm-c-secondary-hover);
-  --crm-c-success: var(--crm-c-green-dark); /* Main colour for emphasis */
-  --crm-c-success-text: var(--crm-c-text-light); /* Text colour on top */
-  --crm-c-success-light: hsl(from var(--crm-c-success) h s calc(l + 65));
-  --crm-c-success-on-page-bg: var(--crm-c-success);
-  --crm-c-warning: var(--crm-c-amber);
-  --crm-c-warning-text: var(--crm-c-text-light);
-  --crm-c-warning-light: hsl(from var(--crm-c-warning) h s calc(l + 65));
-  --crm-c-warning-on-page-bg: var(--crm-c-warning);
-  --crm-c-danger: var(--crm-c-red-dark);
-  --crm-c-danger-text: var(--crm-c-text-light);
-  --crm-c-danger-light: hsl(from var(--crm-c-danger) h s calc(l + 60));
-  --crm-c-danger-on-page-bg: var(--crm-c-danger);
-  --crm-c-info: var(--crm-c-blue-dark);
-  --crm-c-info-text: var(--crm-c-text-light);
-  --crm-c-info-light: hsl(from var(--crm-c-info) h s calc(l + 67));
-  --crm-c-info-on-page-bg: var(--crm-c-info);
+  --crm-primary-color: var(--crm-inverse-bg-color);
+  --crm-primary-hover-color: color-mix(in srgb,var(--crm-primary-color) 75%,#000 25%);
+  --crm-primary-text-color: var(--crm-text-light-color);
+  --crm-primary-hover-text-color: var(--crm-text-light-color);
+  --crm-primary-ink-color: var(--crm-primary-hover-color); /* color on page bg */
+  --crm-secondary-color: #5d677b;
+  --crm-secondary-hover-color: color-mix(in srgb,var(--crm-secondary-color) 75%,#000 25%);
+  --crm-secondary-text-color: var(--crm-text-light-color);
+  --crm-secondary-hover-text-color: var(--crm-text-light-color);
+  --crm-secondary-ink-color: var(--crm-secondary-hover-color);
+  --crm-success-color: var(--crm-c-green-dark); /* Main colour for emphasis */
+  --crm-success-text-color: var(--crm-text-light-color); /* Text colour on top */
+  --crm-success-light-color: hsl(from var(--crm-success-color) h s calc(l + 65));
+  --crm-success-ink-color: var(--crm-success-color);
+  --crm-warning-color: var(--crm-c-amber);
+  --crm-warning-text-color: var(--crm-text-light-color);
+  --crm-warning-light-color: hsl(from var(--crm-warning-color) h s calc(l + 65));
+  --crm-warning-ink-color: var(--crm-warning-color);
+  --crm-danger-color: var(--crm-c-red-dark);
+  --crm-danger-text-color: var(--crm-text-light-color);
+  --crm-danger-light-color: hsl(from var(--crm-danger-color) h s calc(l + 60));
+  --crm-danger-ink-color: var(--crm-danger-color);
+  --crm-info-color: var(--crm-c-blue-dark);
+  --crm-info-text-color: var(--crm-text-light-color);
+  --crm-info-light-color: hsl(from var(--crm-info-color) h s calc(l + 67));
+  --crm-info-ink-color: var(--crm-info-color);
 /* Shadows */
   --crm-shadow-block: unset;
   --crm-shadow-popup: 0 3px 18px 0 rgba(48,40,40,.25);
@@ -126,8 +126,8 @@
   --crm-link-decoration: none;
   --crm-link-decoration-hover: underline;
   --crm-link-hover-cursor: pointer;
-  --crm-heading-bg: var(--crm-c-info-light);
-  --crm-heading-col: var(--crm-c-info-on-dark);
+  --crm-heading-bg-color: var(--crm-info-light-color);
+  --crm-heading-color: var(--crm-info-color-on-dark);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1);
   --crm-heading-margin: var(--crm-m) 0;
   --crm-heading-radius: var(--crm-s-radius);
@@ -146,111 +146,115 @@
   --crm-btn-height: 28px;
   --crm-btn-icon-spacing: var(--crm-s);
   --crm-btn-icon-size: auto;
-  --crm-btn-cancel-bg: var(--crm-c-danger);
-  --crm-btn-cancel-text: var(--crm-c-danger-text);
-  --crm-btn-info-bg: var(--crm-c-info);
-  --crm-btn-info-text: var(--crm-c-info-text);
-  --crm-btn-warning-bg: var(--crm-c-warning);
-  --crm-btn-warning-text: var(--crm-c-warning-text);
-  --crm-btn-success-bg: var(--crm-c-success);
-  --crm-btn-success-text: var(--crm-c-success-text);
-  --crm-btn-danger-bg: var(--crm-c-danger);
-  --crm-btn-danger-text: var(--crm-c-danger-text);
-  --crm-btn-icon-bg: unset; /* btn-icon-* supports distinct border/bg for icons. If applied, set btn-icon-padding to 0px to make the icon bg stretch to the button */
+  --crm-btn-cancel-bg-color: var(--crm-danger-color);
+  --crm-btn-cancel-text-color: var(--crm-danger-text-color);
+  --crm-btn-info-bg-color: var(--crm-info-color);
+  --crm-btn-info-text-color: var(--crm-info-text-color);
+  --crm-btn-warning-bg-color: var(--crm-warning-color);
+  --crm-btn-warning-text-color: var(--crm-warning-text-color);
+  --crm-btn-success-bg-color: var(--crm-success-color);
+  --crm-btn-success-text-color: var(--crm-success-text-color);
+  --crm-btn-danger-bg-color: var(--crm-danger-color);
+  --crm-btn-danger-text-color: var(--crm-danger-text-color);
+  --crm-btn-icon-bg-color: unset; /* btn-icon-* supports distinct border/bg for icons. If applied, set btn-icon-padding to 0px to make the icon bg stretch to the button */
   --crm-btn-icon-border: unset;
   --crm-btn-icon-padding: var(--crm-btn-padding-block);
   --crm-btn-margin: 0; /* used to add padding block between multiple stacked buttons */
 /* Tables */
   --crm-table-outside-border: var(--crm-border);
-  --crm-table-bg: var(--crm-paper);
+  --crm-table-bg-color: var(--crm-paper);
   --crm-table-row-border: var(--crm-border);
   --crm-table-column-border: 0 solid transparent;
   --crm-table-font-size: var(--crm-font-size);
   --crm-table-padding: var(--crm-m);
   --crm-table-header-border: 1px solid transparent;
-  --crm-table-header-bottom: 2px solid var(--crm-border-color);
-  --crm-table-header-bg: var(--crm-paper);
-  --crm-table-header-col: var(--crm-c-text);
+  --crm-table-header-border-bottom: 2px solid var(--crm-border-color);
+  --crm-table-header-bg-color: var(--crm-paper);
+  --crm-table-header-color: var(--crm-text-color);
   --crm-table-header-txt: inherit;
-  --crm-table-row-bg: var(--crm-table-bg); /* don't make transparent */
-  --crm-table-row-alternate-bg: #000; /* color for alternate row mixer */
+  --crm-table-row-bg-color: var(--crm-table-bg-color); /* don't make transparent */
+  --crm-table-row-alternate-bg-color: #000; /* color for alternate row mixer */
   --crm-table-row-alternate-mix: 7%; /* 0% for no row col, 100% for all of it */
-  --crm-table-row-hover: var(--crm-c-yellow-light);
-  --crm-table-sort-col: var(--crm-c-gray-300);
+  --crm-table-row-hover-color: var(--crm-c-yellow-light);
+  --crm-table-sort-color: var(--crm-c-gray-300);
   --crm-table-sort-float: left; /* 'left', 'right' or 'none' */
-  --crm-table-sort-active-col: var(--crm-c-link);
+  --crm-table-sort-active-color: var(--crm-link-color);
   --crm-table-compressed-width: auto;
   --crm-table-nested-padding: var(--crm-r) var(--crm-m);
   --crm-table-nested-head-border: 0 solid transparent;
   --crm-table-nested-border: var(--crm-border);
-  --crm-table-inset-bg: var(--crm-c-layer2-bg);
+  --crm-table-inset-bg-color: var(--crm-layer2-bg-color);
 /* Panels */
   --crm-panel-shadow: var(--crm-shadow-block);
-  --crm-panel-bg: var(--crm-paper);
+  --crm-panel-bg-color: var(--crm-paper);
   --crm-panel-border: var(--crm-border);
   --crm-panel-head-margin: 0px;
   --crm-panel-head-height: 37px;
 /* Accordions */
   --crm-accordion-icon: "\f0da"; /* unicode value for FontAwesome icon */
-  --crm-accordion-icon-color: var(--crm-c-text);
+  --crm-accordion-icon-color: var(--crm-text-color);
   --crm-accordion-icon-spacing: var(--crm-m);
   --crm-accordion-transform: rotate(90deg);
   --crm-accordion-transition: transform .3s;
   --crm-accordion-radius: var(--crm-s-radius);
   --crm-accordion-gap: var(--crm-xs2) 0 0; /* space between multiple accordions */
 /* .crm-accordion-bold */
-  --crm-accordion-header-bg: var(--crm-c-secondary);
-  --crm-accordion-header-bg-active: var(--crm-c-gray-900);
-  --crm-accordion-header-color: var(--crm-c-secondary-text);
+  --crm-accordion-header-bg-color: var(--crm-secondary-color);
+  --crm-accordion-header-bg-active-color: var(--crm-c-gray-900);
+  --crm-accordion-header-color: var(--crm-secondary-text-color);
   --crm-accordion-header-padding: var(--crm-s) var(--crm-m);
   --crm-accordion-header-weight: bold;
   --crm-accordion-header-border: var(--crm-border);
   --crm-accordion-header-border-width: 0 0 1px 0;
   --crm-accordion-border: var(--crm-border);
   --crm-accordion-border-width: 0 1px 1px 1px;
-  --crm-accordion-body-bg: unset;
+  --crm-accordion-body-bg-color: unset;
   --crm-accordion-body-box-shadow: unset;
   --crm-accordion-body-padding: var(--crm-padding-reg);
 /* .crm-accordion-light */
-  --crm-accordion2-header-bg: unset;
-  --crm-accordion2-header-bg-active: unset;
+  --crm-accordion2-header-bg-color: unset;
+  --crm-accordion2-header-bg-active-color: unset;
   --crm-accordion2-header-weight: normal;
-  --crm-accordion2-header-color: var(--crm-c-text);
+  --crm-accordion2-header-color: var(--crm-text-color);
   --crm-accordion2-header-border: unset;
   --crm-accordion2-header-border-width: unset;
   --crm-accordion2-header-padding: var(--crm-s) var(--crm-m);
   --crm-accordion2-border: unset;
   --crm-accordion2-border-width: unset;
-  --crm-accordion2-body-bg: unset;
+  --crm-accordion2-body-bg-color: unset;
   --crm-accordion2-body-padding: var(--crm-s);
 /* Alerts */
   --crm-alert-padding: var(--crm-m) var(--crm-m2);
   --crm-alert-margin: 0 0 var(--crm-m);
   --crm-alert-border-width: 1px;
-  --crm-alert-success-bg: var(--crm-c-success-light);
-  --crm-alert-success-border: color-mix(in srgb, var(--crm-alert-success-bg) 90%,#000 10%);
-  --crm-alert-success-text: var(--crm-c-success);
-  --crm-alert-warning-bg: var(--crm-c-warning-light);
-  --crm-alert-warning-border: color-mix(in srgb, var(--crm-alert-warning-bg) 90%,#000 10%);
-  --crm-alert-warning-text: var(--crm-c-text);
-  --crm-alert-info-bg: var(--crm-c-info-light);
-  --crm-alert-info-border: color-mix(in srgb, var(--crm-alert-info-bg) 90%,#000 10%);
-  --crm-alert-info-text: var(--crm-c-info);
-  --crm-alert-danger-bg: var(--crm-c-danger-light);
-  --crm-alert-danger-border: color-mix(in srgb, var(--crm-alert-danger-bg) 90%,#000 10%);
-  --crm-alert-danger-text: var(--crm-c-danger);
+  --crm-alert-success-bg-color: var(--crm-success-light-color);
+  --crm-alert-success-border-color: color-mix(in srgb, var(--crm-alert-success-bg-color) 90%,#000 10%);
+  --crm-alert-success-text-color: var(--crm-success-color);
+  --crm-alert-warning-bg-color: var(--crm-warning-light-color);
+  --crm-alert-warning-border-color: color-mix(in srgb, var(--crm-alert-warning-bg-color) 90%,#000 10%);
+  --crm-alert-warning-text-color: var(--crm-text-color);
+  --crm-alert-info-bg-color: var(--crm-info-light-color);
+  --crm-alert-info-border-color: color-mix(in srgb, var(--crm-alert-info-bg-color) 90%,#000 10%);
+  --crm-alert-info-text-color: var(--crm-info-color);
+  --crm-alert-danger-bg-color: var(--crm-danger-light-color);
+  --crm-alert-danger-border-color: color-mix(in srgb, var(--crm-alert-danger-bg-color) 90%,#000 10%);
+  --crm-alert-danger-text-color: var(--crm-danger-color);
 /* Form */
   --crm-form-block-box-shadow: var(--crm-shadow-block);
-  --crm-form-block-bg: var(--crm-c-container-bg);
+  --crm-form-block-bg-color: var(--crm-container-bg-color);
   --crm-form-block-padding: var(--crm-m);
   --crm-form-block-border-radius: var(--crm-s-radius);
-  --crm-form-block-header: var(--crm-c-inverse-bg);
-  --crm-input-bg: var(--crm-paper);
+  --crm-form-block-header-color: var(--crm-inverse-bg-color);
+  --crm-form-fieldset-border-color: var(--crm-c-gray-400);
+  --crm-form-fieldset-border: 1px 0 0 0;
+  --crm-form-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
+  --crm-form-checkbox-list-bg-color: var(--crm-table-row-hover-color);
+  --crm-input-bg-color: var(--crm-paper);
   --crm-input-bg-image: linear-gradient(top, #eee 1%, #fff 15%);
-  --crm-input-color: var(--crm-c-text);
+  --crm-input-color: var(--crm-text-color);
   --crm-input-border-color: var(--crm-c-gray-400);
   --crm-input-border-radius: 3px;
-  --crm-input-active-ani: border-color .15s ease-in-out 0s;
+  --crm-input-active-transition: border-color .15s ease-in-out 0s;
   --crm-input-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,.1);
   --crm-input-padding: var(--crm-xs1) var(--crm-s2);
   --crm-input-padding-large: var(--crm-s) var(--crm-m1);
@@ -261,37 +265,37 @@
   --crm-input-label-size: var(--crm-font-size);
   --crm-input-label-width: var(--crm-big-input);
   --crm-input-label-align: right;
-  --crm-input-label-color: var(--crm-c-text);
-  --crm-input-description: var(--crm-c-inactive);
+  --crm-input-label-color: var(--crm-text-color);
+  --crm-input-description: var(--crm-inactive-color);
   --crm-input-dropdown-icon: "\f107";
-  --crm-input-radio-color: var(--crm-c-focus);
-  --crm-form-select-bg: var(--crm-c-layer1-bg);
-  --crm-inline-edit-border: 0 solid transparent;
-  --crm-inline-edit-bg: var(--crm-c-container-bg);
+  --crm-input-radio-color: var(--crm-focus-color);
+  --crm-input-select-bg-color: var(--crm-layer1-bg-color);
+  --crm-input-inline-edit-border: 0 solid transparent;
+  --crm-input-inline-edit-bg-color: var(--crm-container-bg-color);
   --crm-fieldset-border-color: var(--crm-c-gray-400);
   --crm-fieldset-border: 1px 0 0 0;
   --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
   --crm-checkbox-list-bg: var(--crm-table-row-hover);
   --crm-input-toggle-width: 2.75rem;
   --crm-input-toggle-height: 1.5rem;
-  --crm-input-toggle-disabled-bg: var(--crm-c-inverse-bg);
+  --crm-input-toggle-disabled-bg: var(--crm-inverse-bg-color);
   --crm-input-toggle-enabled-bg: var(--crm-c-focus);
-  --crm-input-toggle-button-bg: var(--crm-c-layer0-bg);
+  --crm-input-toggle-button-bg: var(--crm-paper);
 /* Tabs */
-  --crm-tabs-bg: var(--crm-c-gray-200);
+  --crm-tabs-bg-color: var(--crm-c-gray-200);
   --crm-tabs-padding: var(--crm-s);
   --crm-tabs-border: var(--crm-contact-border);
   --crm-tabs-radius: var(--crm-s-radius);
   --crm-tabs-gap: var(--crm-s);
-  --crm-tab-bg: var(--crm-c-layer1-bg);
-  --crm-tab-bg-hover: color-mix(in srgb,var(--crm-c-layer1-bg) 75%,#000 25%);
-  --crm-tab-bg-active: var(--crm-c-container-bg);
+  --crm-tab-bg-color: var(--crm-layer1-bg-color);
+  --crm-tab-hover-bg-color: color-mix(in srgb,var(--crm-layer1-bg-color) 75%,#000 25%);
+  --crm-tab-bg-active: var(--crm-container-bg-color);
   --crm-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-tab-padding: var(--crm-s3) var(--crm-m) var(--crm-s) var(--crm-m);
-  --crm-tab-col: var(--crm-c-text);
+  --crm-tab-color: var(--crm-text-color);
   --crm-tab-weight: normal;
-  --crm-tab-count-bg: var(--crm-c-info-text);
-  --crm-tab-count-col: var(--crm-c-info);
+  --crm-tab-count-bg-color: var(--crm-info-text-color);
+  --crm-tab-count-color: var(--crm-info-color);
   --crm-tab-radius: var(--crm-s-radius);
   --crm-tab-border: var(--crm-border);
   --crm-tab-border-width: 0;
@@ -303,38 +307,37 @@
   --crm-side-tabs-width: unset;
   --crm-contact-tabs-flow: row; /* choose 'row' for tabs at top, or 'column' for tabs at side */
   --crm-contact-tabs-gap: var(--crm-tabs-gap);
-  --crm-contact-tabs-bg: var(--crm-tabs-bg);
+  --crm-contact-tabs-bg-color: var(--crm-tabs-bg-color);
   --crm-contact-tabs-padding: var(--crm-tabs-padding);
   --crm-contact-tabs-radius: var(--crm-contact-radius) var(--crm-contact-radius) 0 0;
-  --crm-contact-tab-bg: var(--crm-tab-bg);
-  --crm-contact-tab-bg-hover: var(--crm-tab-bg-hover);
+  --crm-contact-tab-bg-color: var(--crm-tab-bg-color);
+  --crm-contact-tab-hover-bg-color: var(--crm-tab-hover-bg-color);
   --crm-contact-tab-padding: var(--crm-s3) var(--crm-m2);
   --crm-contact-tab-border: 0 solid transparent;
   --crm-contact-tab-border-hover: 0 solid transparent;
   --crm-contact-tab-border-width: 0; /* to remove border on one side for hanging tabs */
-  --crm-contact-tab-col: var(--crm-tab-col);
-  --crm-contact-tab-count-bg: rgba(0,0,0,0.1);
-  --crm-contact-tab-count-col: var(--crm-c-text);
+  --crm-contact-tab-count-bg-color: rgba(0,0,0,0.1);
+  --crm-contact-tab-count-color: var(--crm-text-color);
   --crm-contact-tab-width: 100%;
   --crm-contact-tab-align: none;
   --crm-contact-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-contact-tab-radius: var(--crm-contact-radius);
   --crm-contact-icon-size: var(--crm-r);
-  --crm-contact-summary-row-bg: var(--crm-c-container-bg);
+  --crm-contact-summary-row-bg-color: var(--crm-container-bg-color);
   --crm-contact-heading-inset: 0;
   --crm-contact-box-shadow: 0;
   --crm-contact-panel-padding: var(--crm-m);
-  --crm-contact-panel-bg: #fff;
+  --crm-contact-panel-bg-color: var(--crm-paper);
   --crm-contact-panel-border: 0;
   --crm-contact-panel-radius: 0 0 var(--crm-contact-radius) var(--crm-contact-radius);
   --crm-contact-edit-border: 1px dashed var(--crm-border-color);
   --crm-contact-block-padding: 0;
-  --crm-contact-block-bg: unset;
+  --crm-contact-block-bg-color: unset;
   --crm-contact-block-radius: var(--crm-s-radius);
-  --crm-contact-label-bg: var(--crm-c-layer1-bg);
-  --crm-contact-header-bg: var(--crm-paper);
-  --crm-contact-header-bg2: transparent;
-  --crm-contact-header-col: var(--crm-c-text);
+  --crm-contact-label-bg-color: var(--crm-layer1-bg-color);
+  --crm-contact-header-bg-color: var(--crm-paper);
+  --crm-contact-header2-bg-color: transparent;
+  --crm-contact-header-color: var(--crm-text-color);
   --crm-contact-header-size: var(--crm-r3);
   --crm-contact-header-padding: 0 0 var(--crm-r) 0;
   --crm-contact-image-size: 100px;
@@ -343,28 +346,28 @@
   --crm-contact-image-top: unset; /* distance from top of dashboard */
   --crm-contact-image-border: 0;
 /* Dialog */
-  --crm-dialog-bg: var(--crm-paper);
+  --crm-dialog-bg-color: var(--crm-paper);
   --crm-dialog-padding: var(--crm-s);
   --crm-dialog-radius: var(--crm-s-radius);
   --crm-dialog-line: unset;
   --crm-dialog-inner-shadow: var(--crm-shadow-bottom);
-  --crm-dialog-header-bg: var(--crm-c-secondary);
-  --crm-dialog-header-col: var(--crm-c-secondary-text);
+  --crm-dialog-header-bg-color: var(--crm-secondary-color);
+  --crm-dialog-header-color: var(--crm-secondary-text-color);
   --crm-dialog-header-size: var(--crm-r1);
   --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
-  --crm-dialog-header-border-col: transparent transparent var(--crm-border-color) transparent; /* set a border color for each side of the header */
-  --crm-dialog-body-bg: var(--crm-c-container-bg);
+  --crm-dialog-header-border-color: transparent transparent var(--crm-border-color) transparent; /* set a border color for each side of the header */
+  --crm-dialog-body-bg-color: var(--crm-container-bg-color);
   --crm-dialog-body-padding: var(--crm-m);
 /* Dashlet */
   --crm-dashlet-columns: 2fr 3fr;
   --crm-dashlet-border: unset;
-  --crm-dashlet-bg: var(--crm-paper);
+  --crm-dashlet-bg-color: var(--crm-paper);
   --crm-dashlet-padding: var(--crm-s2);
   --crm-dashlet-box-shadow: var(--crm-shadow-popup);
-  --crm-dashlet-dashlets-bg: var(--crm-c-container-bg);
-  --crm-dashlet-header-bg: var(--crm-accordion-header-bg);
-  --crm-dashlet-header-col: var(--crm-accordion-header-color);
+  --crm-dashlet-dashlets-bg-color: var(--crm-container-bg-color);
+  --crm-dashlet-header-bg-color: var(--crm-accordion-header-bg-color);
+  --crm-dashlet-header-color: var(--crm-accordion-header-color);
   --crm-dashlet-header-border: unset;
   --crm-dashlet-header-border-width: unset;
   --crm-dashlet-header-font-size: var(--crm-font-size);
@@ -375,26 +378,26 @@
 /* Button dropdowns */
   --crm-dropdown-padding: var(--crm-s);
   --crm-dropdown-radius: var(--crm-s-radius);
-  --crm-dropdown-bg: var(--crm-c-secondary-hover);
-  --crm-dropdown-col: var(--crm-c-text-light);
-  --crm-dropdown-hover: var(--crm-c-text);
-  --crm-dropdown-hover-bg: var(--crm-paper);
+  --crm-dropdown-bg-color: var(--crm-secondary-hover-color);
+  --crm-dropdown-color: var(--crm-text-light-color);
+  --crm-dropdown-hover: var(--crm-text-color);
+  --crm-dropdown-hover-bg-color: var(--crm-paper);
   --crm-dropdown-border: 0;
   --crm-dropdown-width: 180px;
-  --crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns */
-  --crm-dropdown-2-bg: var(--crm-c-secondary);
-  --crm-dropdown-2-col: var(--crm-c-text);
+  --crm-dropdown-danger-bg-color: var(--crm-danger-color); /* for delete links in dropdowns */
+  --crm-dropdown-2-bg-color: var(--crm-secondary-color);
+  --crm-dropdown-2-color: var(--crm-text-color);
   --crm-dropdown-2-padding: var(--crm-padding-small);
 /* Notifications */
-  --crm-notify-bg: rgba(0,0,0,0.85);
+  --crm-notify-bg-color: rgba(0,0,0,0.85);
   --crm-notify-padding: var(--crm-m2);
-  --crm-notify-col: var(--crm-c-text-light);
+  --crm-notify-color: var(--crm-text-light-color);
   --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: var(--crm-s-radius);
-  --crm-notify-danger: hsl(from var(--crm-c-danger) h s calc(l + 20));
-  --crm-notify-warning: hsl(from var(--crm-c-warning) h s calc(l + 20));
-  --crm-notify-success: hsl(from var(--crm-c-success) h s calc(l + 30));
-  --crm-notify-info: hsl(from var(--crm-c-info) h s calc(l + 30));
+  --crm-notify-danger-color: hsl(from var(--crm-danger-color) h s calc(l + 20));
+  --crm-notify-warning-color: hsl(from var(--crm-warning-color) h s calc(l + 20));
+  --crm-notify-success-color: hsl(from var(--crm-success-color) h s calc(l + 30));
+  --crm-notify-info-color: hsl(from var(--crm-info-color) h s calc(l + 30));
 /* Icons */
   --crm-icon-danger: "\f071";
   --crm-icon-success: "\f058";
@@ -409,7 +412,7 @@
   --crm-icon-info-color: inherit;
   --crm-loading-spinner-size: 48px;
 /* Form Builder UI */
-  --crm-fb-header-bg: var(--crm-c-layer2-bg);
+  --crm-fb-header-bg-color: var(--crm-layer2-bg-color);
 /* Wizard */
   --crm-wizard-width: fit-content;
   --crm-wizard-margin: 0.5rem auto;
@@ -417,21 +420,21 @@
   --crm-wizard-radius: var(--crm-l);
   --crm-wizard-angle: 0px;
   --crm-wizard-arrow-thickness: 1px;
-  --crm-wizard-active-col: var(--crm-c-text-light);
-  --crm-wizard-active-bg: var(--crm-c-link);
+  --crm-wizard-active-color: var(--crm-text-light-color);
+  --crm-wizard-active-bg-color: var(--crm-link-color);
   --crm-wizard-border: var(--crm-border);
-  --crm-wizard-bg: var(--crm-paper);
+  --crm-wizard-bg-color: var(--crm-paper);
   --crm-wizard-box-shadow: unset;
 /* Alpha filter */
-  --crm-filter-bg: var(--crm-c-info-light);
+  --crm-filter-bg-color: var(--crm-info-light-color);
   --crm-filter-padding: var(--crm-m);
-  --crm-filter-item-bg: var( --crm-c-layer1-bg);
+  --crm-filter-item-bg-color: var( --crm-layer1-bg-color);
   --crm-filter-item-shadow: 0px 0px 3px rgba(0,0,0,0.1);
   --crm-filter-spacing: space-between; /* choose 'space-between' to spread out evenly, 'start' for left align, or 'end' for right. */
 /* Frontend */
   --crm-f-form-width: 800px;
   --crm-f-box-shadow: var(--crm-shadow-block);
-  --crm-f-fieldset-bg: var(--crm-c-page-bg);
+  --crm-f-fieldset-bg-color: var(--crm-page-bg-color);
   --crm-f-fieldset-padding: var(--crm-r) 0;
   --crm-f-fieldset-margin: 0 0 var(--crm-padding-reg) 0;
   --crm-f-fieldset-border: 0;
@@ -453,8 +456,8 @@
   --crm-f-input-padding: var(--crm-r2) var(--crm-m2);
   --crm-f-input-font-size: var(--crm-r1);
   --crm-f-input-width: 300px;
-  --crm-f-form-focus-bg: var(--crm-c-green-light);
-  --crm-f-form-error-bg: var(--crm-c-gray-200);
+  --crm-f-form-focus-bg-color: var(--crm-c-green-light);
+  --crm-f-form-error-bg-color: var(--crm-c-gray-200);
   --crm-f-logo-height: 40px;
   --crm-f-logo-align: center; /* left, right or center */
 }

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -189,7 +189,7 @@
   --crm-panel-head-height: 37px;
 /* Accordions */
   --crm-accordion-icon: "\f0da"; /* unicode value for FontAwesome icon */
-  --crm-accordion-icon-color: var(--crm-text-color);
+  --crm-accordion-icon-color: inherit;
   --crm-accordion-icon-spacing: var(--crm-l-medium);
   --crm-accordion-transform: rotate(90deg);
   --crm-accordion-transition: transform .3s;
@@ -276,9 +276,9 @@
   --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
   --crm-checkbox-list-bg: var(--crm-table-row-hover);
   --crm-input-toggle-width: 2.75rem;
-  --crm-input-toggle-height: 1.5rem;
+  --crm-input-toggle-height: var(--crm-l-reg-4);
   --crm-input-toggle-disabled-bg: var(--crm-inverse-bg-color);
-  --crm-input-toggle-enabled-bg: var(--crm-c-focus);
+  --crm-input-toggle-enabled-bg: var(--crm-focus-color);
   --crm-input-toggle-button-bg: var(--crm-paper);
 /* Tabs */
   --crm-tabs-bg-color: var(--crm-c-gray-200);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -35,18 +35,19 @@
   --crm-c-yellow-less-light: #fffdb2;
   --crm-c-teal: #63c4b9;
   --crm-c-dark-teal: #3e8079;
-/* Practical colours */
   --crm-c-darkest: #0a0a0a;
+/* Practical colours */
   --crm-c-text-light: #fff;
   --crm-c-text-dark: #464354;
   --crm-c-text: var(--crm-c-text-dark);
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-focus: var(--crm-c-blue-dark);
-  --crm-c-inactive: color-mix(in srgb,var(--crm-c-text) 95%,#fff 5%);
+  --crm-paper: var(--crm-c-text-light); /* The lightest bg in light mode */
+  --crm-ink: var(--crm-c-darkest); /* The darkest foreground in light mode */
+  --crm-c-inactive: color-mix(in srgb,var(--crm-c-text) 95%,var(--crm-paper) 5%);
 /* Backgrounds */
-  --crm-c-layer0-bg: #fff; /* The lightest bg in light mode */
-  --crm-c-page-bg: var(--crm-c-layer0-bg);
+  --crm-c-page-bg: var(--crm-paper);
   --crm-c-container-bg: #f4f4ed;
   --crm-c-layer1-bg: var(--crm-c-gray-050);
   --crm-c-layer2-bg: color-mix(in srgb,var(--crm-c-layer1-bg) 95%,#000 5%);
@@ -161,14 +162,14 @@
   --crm-btn-margin: 0; /* used to add padding block between multiple stacked buttons */
 /* Tables */
   --crm-table-outside-border: var(--crm-border);
-  --crm-table-bg: var(--crm-c-layer0-bg);
+  --crm-table-bg: var(--crm-paper);
   --crm-table-row-border: var(--crm-border);
   --crm-table-column-border: 0 solid transparent;
   --crm-table-font-size: var(--crm-font-size);
   --crm-table-padding: var(--crm-m);
   --crm-table-header-border: 1px solid transparent;
   --crm-table-header-bottom: 2px solid var(--crm-border-color);
-  --crm-table-header-bg: var(--crm-c-layer0-bg);
+  --crm-table-header-bg: var(--crm-paper);
   --crm-table-header-col: var(--crm-c-text);
   --crm-table-header-txt: inherit;
   --crm-table-row-bg: var(--crm-table-bg); /* don't make transparent */
@@ -185,7 +186,7 @@
   --crm-table-inset-bg: var(--crm-c-layer2-bg);
 /* Panels */
   --crm-panel-shadow: var(--crm-shadow-block);
-  --crm-panel-bg: var(--crm-c-layer0-bg);
+  --crm-panel-bg: var(--crm-paper);
   --crm-panel-border: var(--crm-border);
   --crm-panel-head-margin: 0px;
   --crm-panel-head-height: 37px;
@@ -244,7 +245,7 @@
   --crm-form-block-padding: var(--crm-m);
   --crm-form-block-border-radius: var(--crm-s-radius);
   --crm-form-block-header: var(--crm-c-inverse-bg);
-  --crm-input-bg: var(--crm-c-layer0-bg);
+  --crm-input-bg: var(--crm-paper);
   --crm-input-bg-image: linear-gradient(top, #eee 1%, #fff 15%);
   --crm-input-color: var(--crm-c-text);
   --crm-input-border-color: var(--crm-c-gray-400);
@@ -331,7 +332,7 @@
   --crm-contact-block-bg: unset;
   --crm-contact-block-radius: var(--crm-s-radius);
   --crm-contact-label-bg: var(--crm-c-layer1-bg);
-  --crm-contact-header-bg: var(--crm-c-layer0-bg);
+  --crm-contact-header-bg: var(--crm-paper);
   --crm-contact-header-bg2: transparent;
   --crm-contact-header-col: var(--crm-c-text);
   --crm-contact-header-size: var(--crm-r3);
@@ -342,7 +343,7 @@
   --crm-contact-image-top: unset; /* distance from top of dashboard */
   --crm-contact-image-border: 0;
 /* Dialog */
-  --crm-dialog-bg: var(--crm-c-layer0-bg);
+  --crm-dialog-bg: var(--crm-paper);
   --crm-dialog-padding: var(--crm-s);
   --crm-dialog-radius: var(--crm-s-radius);
   --crm-dialog-line: unset;
@@ -358,7 +359,7 @@
 /* Dashlet */
   --crm-dashlet-columns: 2fr 3fr;
   --crm-dashlet-border: unset;
-  --crm-dashlet-bg: var(--crm-c-layer0-bg);
+  --crm-dashlet-bg: var(--crm-paper);
   --crm-dashlet-padding: var(--crm-s2);
   --crm-dashlet-box-shadow: var(--crm-shadow-popup);
   --crm-dashlet-dashlets-bg: var(--crm-c-container-bg);
@@ -377,7 +378,7 @@
   --crm-dropdown-bg: var(--crm-c-secondary-hover);
   --crm-dropdown-col: var(--crm-c-text-light);
   --crm-dropdown-hover: var(--crm-c-text);
-  --crm-dropdown-hover-bg: var(--crm-c-layer0-bg);
+  --crm-dropdown-hover-bg: var(--crm-paper);
   --crm-dropdown-border: 0;
   --crm-dropdown-width: 180px;
   --crm-dropdown-danger-bg: var(--crm-c-danger); /* for delete links in dropdowns */
@@ -419,7 +420,7 @@
   --crm-wizard-active-col: var(--crm-c-text-light);
   --crm-wizard-active-bg: var(--crm-c-link);
   --crm-wizard-border: var(--crm-border);
-  --crm-wizard-bg: var(--crm-c-layer0-bg);
+  --crm-wizard-bg: var(--crm-paper);
   --crm-wizard-box-shadow: unset;
 /* Alpha filter */
   --crm-filter-bg: var(--crm-c-info-light);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -32,9 +32,8 @@
   --crm-c-amber-light: #fbf0e2;
   --crm-c-yellow: #fcfc5a;
   --crm-c-yellow-light: #ffffcc;
-  --crm-c-yellow-less-light: #fffdb2;
   --crm-c-teal: #63c4b9;
-  --crm-c-dark-teal: #3e8079;
+  --crm-c-teal-dark: #3e8079;
   --crm-c-darkest: #0a0a0a;
 /* Practical colours */
   --crm-text-light-color: #fff;
@@ -88,47 +87,47 @@
   --crm-shadow-block: unset;
   --crm-shadow-popup: 0 3px 18px 0 rgba(48,40,40,.25);
   --crm-shadow-bottom: 0 0 16px 1px rgba(0,0,0,.1);
-/* Sizes */
-  --crm-s-xsmall: 0.1rem; /* default extra-small */
-  --crm-s-xsmall-1: 0.125rem;
-  --crm-s-xsmall-2: 0.15rem;
-  --crm-s-small: 0.25rem; /* default small */
-  --crm-s-small-1: 0.275rem;
-  --crm-s-small-2: 0.325rem;
-  --crm-s-small-3: 0.375rem;
-  --crm-s-medium: 0.5rem; /* default medium */
-  --crm-s-medium-1: 0.625rem;
-  --crm-s-medium-2: 0.75rem;
-  --crm-s-medium-3: 0.875rem;
-  --crm-s-reg: 1rem;  /* default size */
-  --crm-s-reg-1: 1.125rem;
-  --crm-s-reg-2: 1.25rem;
-  --crm-s-reg-3: 1.375rem;
-  --crm-s-reg-4: 1.5rem;
-  --crm-s-large: 2rem;  /* default large */
-  --crm-s-large-1: 3rem;
-  --crm-s-large-2: 4rem;
-  --crm-s-radius: 0.25rem;
-  --crm-padding-reg: var(--crm-s-reg);
-  --crm-padding-small: var(--crm-s-small);
-  --crm-padding-inset: var(--crm-s-medium);
-  --crm-page-padding: var(--crm-s-large-1); /* Margin left/right */
+/* Lengths */
+  --crm-l-xsmall: 0.1rem; /* default extra-small */
+  --crm-l-xsmall-1: 0.125rem;
+  --crm-l-xsmall-2: 0.15rem;
+  --crm-l-small: 0.25rem; /* default small */
+  --crm-l-small-1: 0.275rem;
+  --crm-l-small-2: 0.325rem;
+  --crm-l-small-3: 0.375rem;
+  --crm-l-medium: 0.5rem; /* default medium */
+  --crm-l-medium-1: 0.625rem;
+  --crm-l-medium-2: 0.75rem;
+  --crm-l-medium-3: 0.875rem;
+  --crm-l-reg: 1rem;  /* default size */
+  --crm-l-reg-1: 1.125rem;
+  --crm-l-reg-2: 1.25rem;
+  --crm-l-reg-3: 1.375rem;
+  --crm-l-reg-4: 1.5rem;
+  --crm-l-large: 2rem;  /* default large */
+  --crm-l-large-1: 3rem;
+  --crm-l-large-2: 4rem;
+  --crm-l-radius: 0.25rem;
+  --crm-padding-reg: var(--crm-l-reg);
+  --crm-padding-small: var(--crm-l-small);
+  --crm-padding-inset: var(--crm-l-medium);
+  --crm-page-padding: var(--crm-l-large-1); /* Margin left/right */
   --crm-page-width: 100%; /* Default that CMS can overwrite */
-  --crm-flex-gap: var(--crm-s-medium);
+  --crm-flex-gap: var(--crm-l-medium);
 /* Type */
   --crm-font-system: unset;
   --crm-font: unset;
-  --crm-font-size: var(--crm-s-reg);
-  --crm-font-small-size: var(--crm-s-medium-2);
+  --crm-font-size: var(--crm-l-reg);
+  --crm-font-small-size: var(--crm-l-medium-2);
   --crm-font-line-height: 1.5;
   --crm-link-decoration: none;
   --crm-link-decoration-hover: underline;
   --crm-link-hover-cursor: pointer;
   --crm-heading-bg-color: var(--crm-info-light-color);
   --crm-heading-color: var(--crm-info-color-on-dark);
-  --crm-heading-padding: var(--crm-s-small-1) var(--crm-s-medium-1);
-  --crm-heading-margin: var(--crm-s-medium) 0;
-  --crm-heading-radius: var(--crm-s-radius);
+  --crm-heading-padding: var(--crm-l-small-1) var(--crm-l-medium-1);
+  --crm-heading-margin: var(--crm-l-medium) 0;
+  --crm-heading-radius: var(--crm-l-radius);
 /* Buttons */
   --crm-btn-box-shadow: none;
   --crm-btn-border: 0 solid transparent;
@@ -136,13 +135,13 @@
   --crm-btn-weight: inherit;
   --crm-btn-font: inherit;
   --crm-btn-radius: 3px;
-  --crm-btn-padding-block: var(--crm-s-xsmall-1); /* padding for top and bottom, one value */
-  --crm-btn-padding-inline: var(--crm-s-medium-1); /* padding for left and right, one value */
-  --crm-btn-small-padding: var(--crm-s-xsmall) var(--crm-s-small);
-  --crm-btn-large-padding: var(--crm-s-medium) var(--crm-s-reg);
+  --crm-btn-padding-block: var(--crm-l-xsmall-1); /* padding for top and bottom, one value */
+  --crm-btn-padding-inline: var(--crm-l-medium-1); /* padding for left and right, one value */
+  --crm-btn-small-padding: var(--crm-l-xsmall) var(--crm-l-small);
+  --crm-btn-large-padding: var(--crm-l-medium) var(--crm-l-reg);
   --crm-btn-align: center;
   --crm-btn-height: 28px;
-  --crm-btn-icon-spacing: var(--crm-s-small);
+  --crm-btn-icon-spacing: var(--crm-l-small);
   --crm-btn-icon-size: auto;
   --crm-btn-cancel-bg-color: var(--crm-danger-color);
   --crm-btn-cancel-text-color: var(--crm-danger-text-color);
@@ -157,14 +156,14 @@
   --crm-btn-icon-bg-color: unset; /* btn-icon-* supports distinct border/bg for icons. If applied, set btn-icon-padding to 0px to make the icon bg stretch to the button */
   --crm-btn-icon-border: unset;
   --crm-btn-icon-padding: var(--crm-btn-padding-block);
-  --crm-btn-margin: 0; /* used to add padding block between multiple stacked buttons */
+  --crm-btn-margin: 0; /* used to add padding between multiple buttons */
 /* Tables */
   --crm-table-outside-border: var(--crm-border);
   --crm-table-bg-color: var(--crm-paper);
   --crm-table-row-border: var(--crm-border);
   --crm-table-column-border: 0 solid transparent;
   --crm-table-font-size: var(--crm-font-size);
-  --crm-table-padding: var(--crm-s-medium);
+  --crm-table-padding: var(--crm-l-medium);
   --crm-table-header-border: 1px solid transparent;
   --crm-table-header-border-bottom: 2px solid var(--crm-border-color);
   --crm-table-header-bg-color: var(--crm-paper);
@@ -178,7 +177,7 @@
   --crm-table-sort-float: left; /* 'left', 'right' or 'none' */
   --crm-table-sort-active-color: var(--crm-link-color);
   --crm-table-compressed-width: auto;
-  --crm-table-nested-padding: var(--crm-s-reg) var(--crm-s-medium);
+  --crm-table-nested-padding: var(--crm-l-reg) var(--crm-l-medium);
   --crm-table-nested-head-border: 0 solid transparent;
   --crm-table-nested-border: var(--crm-border);
   --crm-table-inset-bg-color: var(--crm-layer2-bg-color);
@@ -191,16 +190,16 @@
 /* Accordions */
   --crm-accordion-icon: "\f0da"; /* unicode value for FontAwesome icon */
   --crm-accordion-icon-color: var(--crm-text-color);
-  --crm-accordion-icon-spacing: var(--crm-s-medium);
+  --crm-accordion-icon-spacing: var(--crm-l-medium);
   --crm-accordion-transform: rotate(90deg);
   --crm-accordion-transition: transform .3s;
-  --crm-accordion-radius: var(--crm-s-radius);
-  --crm-accordion-gap: var(--crm-s-xsmall-2) 0 0; /* space between multiple accordions */
+  --crm-accordion-radius: var(--crm-l-radius);
+  --crm-accordion-gap: var(--crm-l-xsmall-2) 0 0; /* space between multiple accordions */
 /* .crm-accordion-bold */
   --crm-accordion-header-bg-color: var(--crm-secondary-color);
   --crm-accordion-header-bg-active-color: var(--crm-c-gray-900);
   --crm-accordion-header-color: var(--crm-secondary-text-color);
-  --crm-accordion-header-padding: var(--crm-s-small) var(--crm-s-medium);
+  --crm-accordion-header-padding: var(--crm-l-small) var(--crm-l-medium);
   --crm-accordion-header-weight: bold;
   --crm-accordion-header-border: var(--crm-border);
   --crm-accordion-header-border-width: 0 0 1px 0;
@@ -216,14 +215,14 @@
   --crm-accordion2-header-color: var(--crm-text-color);
   --crm-accordion2-header-border: unset;
   --crm-accordion2-header-border-width: unset;
-  --crm-accordion2-header-padding: var(--crm-s-small) var(--crm-s-medium);
+  --crm-accordion2-header-padding: var(--crm-l-small) var(--crm-l-medium);
   --crm-accordion2-border: unset;
   --crm-accordion2-border-width: unset;
   --crm-accordion2-body-bg-color: unset;
-  --crm-accordion2-body-padding: var(--crm-s-small);
+  --crm-accordion2-body-padding: var(--crm-l-small);
 /* Alerts */
-  --crm-alert-padding: var(--crm-s-medium) var(--crm-s-medium-2);
-  --crm-alert-margin: 0 0 var(--crm-s-medium);
+  --crm-alert-padding: var(--crm-l-medium) var(--crm-l-medium-2);
+  --crm-alert-margin: 0 0 var(--crm-l-medium);
   --crm-alert-border-width: 1px;
   --crm-alert-success-bg-color: var(--crm-success-light-color);
   --crm-alert-success-border-color: color-mix(in srgb, var(--crm-alert-success-bg-color) 90%,#000 10%);
@@ -240,8 +239,8 @@
 /* Form */
   --crm-form-block-box-shadow: var(--crm-shadow-block);
   --crm-form-block-bg-color: var(--crm-container-bg-color);
-  --crm-form-block-padding: var(--crm-s-medium);
-  --crm-form-block-border-radius: var(--crm-s-radius);
+  --crm-form-block-padding: var(--crm-l-medium);
+  --crm-form-block-border-radius: var(--crm-l-radius);
   --crm-form-block-header-color: var(--crm-inverse-bg-color);
   --crm-form-fieldset-border-color: var(--crm-c-gray-400);
   --crm-form-fieldset-border: 1px 0 0 0;
@@ -254,12 +253,12 @@
   --crm-input-border-radius: 3px;
   --crm-input-active-transition: border-color .15s ease-in-out 0s;
   --crm-input-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,.1);
-  --crm-input-padding: var(--crm-s-xsmall-1) var(--crm-s-small-2);
-  --crm-input-padding-large: var(--crm-s-small) var(--crm-s-medium-1);
-  --crm-input-height: var(--crm-s-large);
+  --crm-input-padding: var(--crm-l-xsmall-1) var(--crm-l-small-2);
+  --crm-input-large-padding: var(--crm-l-small) var(--crm-l-medium-1);
+  --crm-input-height: var(--crm-l-large);
   --crm-input-width: 15em;
   --crm-input-large-width: 25em;
-  --crm-input-font-size: var(--crm-s-medium-3);
+  --crm-input-font-size: var(--crm-l-medium-3);
   --crm-input-label-weight: bold;
   --crm-input-label-font: var(--crm-font);
   --crm-input-label-size: var(--crm-font-size);
@@ -283,26 +282,26 @@
   --crm-input-toggle-button-bg: var(--crm-paper);
 /* Tabs */
   --crm-tabs-bg-color: var(--crm-c-gray-200);
-  --crm-tabs-padding: var(--crm-s-small);
+  --crm-tabs-padding: var(--crm-l-small);
   --crm-tabs-border: var(--crm-contact-border);
-  --crm-tabs-radius: var(--crm-s-radius);
-  --crm-tabs-gap: var(--crm-s-small);
+  --crm-tabs-radius: var(--crm-l-radius);
+  --crm-tabs-gap: var(--crm-l-small);
   --crm-tab-bg-color: var(--crm-layer1-bg-color);
   --crm-tab-hover-bg-color: color-mix(in srgb,var(--crm-layer1-bg-color) 75%,#000 25%);
   --crm-tab-bg-active: var(--crm-container-bg-color);
   --crm-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-tab-padding: var(--crm-s-small-3) var(--crm-s-medium) var(--crm-s-small) var(--crm-s-medium);
+  --crm-tab-padding: var(--crm-l-small-3) var(--crm-l-medium) var(--crm-l-small) var(--crm-l-medium);
   --crm-tab-color: var(--crm-text-color);
   --crm-tab-weight: normal;
   --crm-tab-count-bg-color: var(--crm-info-text-color);
   --crm-tab-count-color: var(--crm-info-color);
-  --crm-tab-radius: var(--crm-s-radius);
+  --crm-tab-radius: var(--crm-l-radius);
   --crm-tab-border: var(--crm-border);
   --crm-tab-border-width: 0;
-  --crm-tab-border-active: 0 solid transparent;
+  --crm-tab-active-border: 0 solid transparent;
 /* Contact dashboard */
   --crm-contact-border: var(--crm-tab-border);
-  --crm-contact-radius: var(--crm-s-radius);
+  --crm-contact-radius: var(--crm-l-radius);
   --crm-contact-direction: flex; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: unset;
   --crm-contact-tabs-flow: row; /* choose 'row' for tabs at top, or 'column' for tabs at side */
@@ -312,9 +311,9 @@
   --crm-contact-tabs-radius: var(--crm-contact-radius) var(--crm-contact-radius) 0 0;
   --crm-contact-tab-bg-color: var(--crm-tab-bg-color);
   --crm-contact-tab-hover-bg-color: var(--crm-tab-hover-bg-color);
-  --crm-contact-tab-padding: var(--crm-s-small-3) var(--crm-s-medium-2);
+  --crm-contact-tab-padding: var(--crm-l-small-3) var(--crm-l-medium-2);
   --crm-contact-tab-border: 0 solid transparent;
-  --crm-contact-tab-border-hover: 0 solid transparent;
+  --crm-contact-tab-hover-border: 0 solid transparent;
   --crm-contact-tab-border-width: 0; /* to remove border on one side for hanging tabs */
   --crm-contact-tab-count-bg-color: rgba(0,0,0,0.1);
   --crm-contact-tab-count-color: var(--crm-text-color);
@@ -322,24 +321,24 @@
   --crm-contact-tab-align: none;
   --crm-contact-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-contact-tab-radius: var(--crm-contact-radius);
-  --crm-contact-icon-size: var(--crm-s-reg);
+  --crm-contact-icon-size: var(--crm-l-reg);
   --crm-contact-summary-row-bg-color: var(--crm-container-bg-color);
   --crm-contact-heading-inset: 0;
   --crm-contact-box-shadow: 0;
-  --crm-contact-panel-padding: var(--crm-s-medium);
+  --crm-contact-panel-padding: var(--crm-l-medium);
   --crm-contact-panel-bg-color: var(--crm-paper);
   --crm-contact-panel-border: 0;
   --crm-contact-panel-radius: 0 0 var(--crm-contact-radius) var(--crm-contact-radius);
   --crm-contact-edit-border: 1px dashed var(--crm-border-color);
   --crm-contact-block-padding: 0;
   --crm-contact-block-bg-color: unset;
-  --crm-contact-block-radius: var(--crm-s-radius);
+  --crm-contact-block-radius: var(--crm-l-radius);
   --crm-contact-label-bg-color: var(--crm-layer1-bg-color);
   --crm-contact-header-bg-color: var(--crm-paper);
   --crm-contact-header2-bg-color: transparent;
   --crm-contact-header-color: var(--crm-text-color);
-  --crm-contact-header-size: var(--crm-s-reg-3);
-  --crm-contact-header-padding: 0 0 var(--crm-s-reg) 0;
+  --crm-contact-header-size: var(--crm-l-reg-3);
+  --crm-contact-header-padding: 0 0 var(--crm-l-reg) 0;
   --crm-contact-image-size: 100px;
   --crm-contact-image-radius: 0;
   --crm-contact-image-right: var(--crm-contact-panel-padding); /* distance from right of dashboard */
@@ -347,23 +346,23 @@
   --crm-contact-image-border: 0;
 /* Dialog */
   --crm-dialog-bg-color: var(--crm-paper);
-  --crm-dialog-padding: var(--crm-s-small);
-  --crm-dialog-radius: var(--crm-s-radius);
-  --crm-dialog-line: unset;
+  --crm-dialog-padding: var(--crm-l-small);
+  --crm-dialog-radius: var(--crm-l-radius);
   --crm-dialog-inner-shadow: var(--crm-shadow-bottom);
   --crm-dialog-header-bg-color: var(--crm-secondary-color);
   --crm-dialog-header-color: var(--crm-secondary-text-color);
-  --crm-dialog-header-size: var(--crm-s-reg-1);
-  --crm-dialog-header-padding: var(--crm-s-medium-1) var(--crm-s-reg);
+  --crm-dialog-header-size: var(--crm-l-reg-1);
+  --crm-dialog-header-padding: var(--crm-l-medium-1) var(--crm-l-reg);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
   --crm-dialog-header-border-color: transparent transparent var(--crm-border-color) transparent; /* set a border color for each side of the header */
   --crm-dialog-body-bg-color: var(--crm-container-bg-color);
-  --crm-dialog-body-padding: var(--crm-s-medium);
+  --crm-dialog-body-padding: var(--crm-l-medium);
+  --crm-dialog-footer-border: unset;
 /* Dashlet */
   --crm-dashlet-columns: 2fr 3fr;
   --crm-dashlet-border: unset;
   --crm-dashlet-bg-color: var(--crm-paper);
-  --crm-dashlet-padding: var(--crm-s-small-2);
+  --crm-dashlet-padding: var(--crm-l-small-2);
   --crm-dashlet-box-shadow: var(--crm-shadow-popup);
   --crm-dashlet-dashlets-bg-color: var(--crm-container-bg-color);
   --crm-dashlet-header-bg-color: var(--crm-accordion-header-bg-color);
@@ -371,29 +370,29 @@
   --crm-dashlet-header-border: unset;
   --crm-dashlet-header-border-width: unset;
   --crm-dashlet-header-font-size: var(--crm-font-size);
-  --crm-dashlet-header-padding: var(--crm-s-small);
+  --crm-dashlet-header-padding: var(--crm-l-small);
   --crm-dashlet-content-padding: var(--crm-dashlet-padding) 0;
   --crm-dashlet-tabs-border: 0;
-  --crm-dashlet-radius: var(--crm-s-radius);
+  --crm-dashlet-radius: var(--crm-l-radius);
 /* Button dropdowns */
-  --crm-dropdown-padding: var(--crm-s-small);
-  --crm-dropdown-radius: var(--crm-s-radius);
+  --crm-dropdown-padding: var(--crm-l-small);
+  --crm-dropdown-radius: var(--crm-l-radius);
   --crm-dropdown-bg-color: var(--crm-secondary-hover-color);
   --crm-dropdown-color: var(--crm-text-light-color);
-  --crm-dropdown-hover: var(--crm-text-color);
+  --crm-dropdown-hover-text-color: var(--crm-text-color);
   --crm-dropdown-hover-bg-color: var(--crm-paper);
   --crm-dropdown-border: 0;
   --crm-dropdown-width: 180px;
   --crm-dropdown-danger-bg-color: var(--crm-danger-color); /* for delete links in dropdowns */
-  --crm-dropdown-2-bg-color: var(--crm-secondary-color);
-  --crm-dropdown-2-color: var(--crm-text-color);
-  --crm-dropdown-2-padding: var(--crm-padding-small);
+  --crm-dropdown2-bg-color: var(--crm-secondary-color);
+  --crm-dropdown2-color: var(--crm-text-color);
+  --crm-dropdown2-padding: var(--crm-padding-small);
 /* Notifications */
   --crm-notify-bg-color: rgba(0,0,0,0.85);
-  --crm-notify-padding: var(--crm-s-medium-2);
+  --crm-notify-padding: var(--crm-l-medium-2);
   --crm-notify-color: var(--crm-text-light-color);
   --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
-  --crm-notify-radius: var(--crm-s-radius);
+  --crm-notify-radius: var(--crm-l-radius);
   --crm-notify-danger-color: hsl(from var(--crm-danger-color) h s calc(l + 20));
   --crm-notify-warning-color: hsl(from var(--crm-warning-color) h s calc(l + 20));
   --crm-notify-success-color: hsl(from var(--crm-success-color) h s calc(l + 30));
@@ -417,7 +416,7 @@
   --crm-wizard-width: fit-content;
   --crm-wizard-margin: 0.5rem auto;
   --crm-wizard-height: 30px;
-  --crm-wizard-radius: var(--crm-s-large);
+  --crm-wizard-radius: var(--crm-l-large);
   --crm-wizard-angle: 0px;
   --crm-wizard-arrow-thickness: 1px;
   --crm-wizard-active-color: var(--crm-text-light-color);
@@ -427,7 +426,7 @@
   --crm-wizard-box-shadow: unset;
 /* Alpha filter */
   --crm-filter-bg-color: var(--crm-info-light-color);
-  --crm-filter-padding: var(--crm-s-medium);
+  --crm-filter-padding: var(--crm-l-medium);
   --crm-filter-item-bg-color: var( --crm-layer1-bg-color);
   --crm-filter-item-shadow: 0px 0px 3px rgba(0,0,0,0.1);
   --crm-filter-spacing: space-between; /* choose 'space-between' to spread out evenly, 'start' for left align, or 'end' for right. */
@@ -435,26 +434,26 @@
   --crm-f-form-width: 800px;
   --crm-f-box-shadow: var(--crm-shadow-block);
   --crm-f-fieldset-bg-color: var(--crm-page-bg-color);
-  --crm-f-fieldset-padding: var(--crm-s-reg) 0;
+  --crm-f-fieldset-padding: var(--crm-l-reg) 0;
   --crm-f-fieldset-margin: 0 0 var(--crm-padding-reg) 0;
   --crm-f-fieldset-border: 0;
   --crm-f-fieldset-box-shadow: var(--crm-f-box-shadow);
   --crm-f-legend-position: left; /* chose 'left', 'right' or 'inherit' for browser-default of mid fieldset border */
   --crm-f-legend-align: left;
-  --crm-f-legend-size: var(--crm-s-reg-3);
+  --crm-f-legend-size: var(--crm-l-reg-3);
   --crm-f-legend-padding: 0;
   --crm-f-form-padding: var(--crm-padding-reg);
   --crm-f-form-layout: block; /* 'grid' = inline, 'block' = stacked */
   --crm-f-label-position: left; /* 'unset' = stacked, 'left' = left align, in combination with width/margin below */
   --crm-f-label-align: right;
   --crm-f-label-width: 200px;
-  --crm-f-label-gap: var(--crm-s-medium); /* applies for inline label + input */
-  --crm-f-label-margin: var(--crm-s-small);
+  --crm-f-label-gap: var(--crm-l-medium); /* applies for inline label + input */
+  --crm-f-label-margin: var(--crm-l-small);
   --crm-f-label-weight: bold;
   --crm-f-label-color: inherit;
-  --crm-f-input-radius: var(--crm-s-radius);
-  --crm-f-input-padding: var(--crm-s-reg-2) var(--crm-s-medium-2);
-  --crm-f-input-font-size: var(--crm-s-reg-1);
+  --crm-f-input-radius: var(--crm-l-radius);
+  --crm-f-input-padding: var(--crm-l-reg-2) var(--crm-l-medium-2);
+  --crm-f-input-font-size: var(--crm-l-reg-1);
   --crm-f-input-width: 300px;
   --crm-f-form-focus-bg-color: var(--crm-c-green-light);
   --crm-f-form-error-bg-color: var(--crm-c-gray-200);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -91,7 +91,7 @@
   --crm-bottom-shadow: 0 0 16px 1px rgba(0,0,0,.1);
   --crm-body-inset: unset;
 /* Sizes */
-  --crm-roundness: 0.25rem;
+  --crm-s-radius: 0.25rem;
   --crm-xs: 0.1rem;
   --crm-xs1: 0.125rem;
   --crm-xs2: 0.15rem;
@@ -129,7 +129,7 @@
   --crm-heading-col: var(--crm-c-info-on-dark);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1);
   --crm-heading-margin: var(--crm-m) 0;
-  --crm-heading-radius: var(--crm-roundness);
+  --crm-heading-radius: var(--crm-s-radius);
 /* Mouse events */
   --crm-hover-clickable: pointer;
 /* Buttons */
@@ -192,38 +192,38 @@
   --crm-panel-head-margin: 0px;
   --crm-panel-head-height: 37px;
 /* Accordions */
-  --crm-expand-icon: "\f0da"; /* unicode value for FontAwesome icon */
-  --crm-expand-icon-color: var(--text);
-  --crm-expand-icon-spacing: var(--crm-m);
-  --crm-expand-transform: rotate(90deg);
-  --crm-expand-transition: transform .3s;
-  --crm-expand-radius: var(--crm-roundness);
-  --crm-expand-gap: var(--crm-xs2) 0 0; /* space between multiple accordions */
+  --crm-accordion-icon: "\f0da"; /* unicode value for FontAwesome icon */
+  --crm-accordion-icon-color: var(--crm-c-text);
+  --crm-accordion-icon-spacing: var(--crm-m);
+  --crm-accordion-transform: rotate(90deg);
+  --crm-accordion-transition: transform .3s;
+  --crm-accordion-radius: var(--crm-s-radius);
+  --crm-accordion-gap: var(--crm-xs2) 0 0; /* space between multiple accordions */
 /* .crm-accordion-bold */
-  --crm-expand-header-bg: var(--crm-c-secondary);
-  --crm-expand-header-bg-active: var(--crm-c-gray-900);
-  --crm-expand-header-color: var(--crm-c-secondary-text);
-  --crm-expand-header-padding: var(--crm-s) var(--crm-m);
-  --crm-expand-header-weight: bold;
-  --crm-expand-header-border: var(--crm-c-divider);
-  --crm-expand-header-border-width: 0 0 1px 0;
-  --crm-expand-border: var(--crm-c-divider);
-  --crm-expand-border-width: 0 1px 1px 1px;
-  --crm-expand-body-bg: unset;
-  --crm-expand-body-box-shadow: unset;
-  --crm-expand-body-padding: var(--crm-padding-reg);
+  --crm-accordion-header-bg: var(--crm-c-secondary);
+  --crm-accordion-header-bg-active: var(--crm-c-gray-900);
+  --crm-accordion-header-color: var(--crm-c-secondary-text);
+  --crm-accordion-header-padding: var(--crm-s) var(--crm-m);
+  --crm-accordion-header-weight: bold;
+  --crm-accordion-header-border: var(--crm-c-divider);
+  --crm-accordion-header-border-width: 0 0 1px 0;
+  --crm-accordion-border: var(--crm-c-divider);
+  --crm-accordion-border-width: 0 1px 1px 1px;
+  --crm-accordion-body-bg: unset;
+  --crm-accordion-body-box-shadow: unset;
+  --crm-accordion-body-padding: var(--crm-padding-reg);
 /* .crm-accordion-light */
-  --crm-expand2-header-bg: unset;
-  --crm-expand2-header-bg-active: unset;
-  --crm-expand2-header-weight: normal;
-  --crm-expand2-header-color: var(--crm-c-text);
-  --crm-expand2-header-border: unset;
-  --crm-expand2-header-border-width: unset;
-  --crm-expand2-header-padding: var(--crm-s) var(--crm-m);
-  --crm-expand2-border: unset;
-  --crm-expand2-border-width: unset;
-  --crm-expand2-body-bg: unset;
-  --crm-expand2-body-padding: var(--crm-s);
+  --crm-accordion2-header-bg: unset;
+  --crm-accordion2-header-bg-active: unset;
+  --crm-accordion2-header-weight: normal;
+  --crm-accordion2-header-color: var(--crm-c-text);
+  --crm-accordion2-header-border: unset;
+  --crm-accordion2-header-border-width: unset;
+  --crm-accordion2-header-padding: var(--crm-s) var(--crm-m);
+  --crm-accordion2-border: unset;
+  --crm-accordion2-border-width: unset;
+  --crm-accordion2-body-bg: unset;
+  --crm-accordion2-body-padding: var(--crm-s);
 /* Alerts */
   --crm-alert-padding: var(--crm-m) var(--crm-m2);
   --crm-alert-margin: 0 0 var(--crm-m);
@@ -244,7 +244,7 @@
   --crm-form-block-box-shadow: var(--crm-block-shadow);
   --crm-form-block-bg: var(--crm-c-container-bg);
   --crm-form-block-padding: var(--crm-m);
-  --crm-form-block-border-radius: var(--crm-roundness);
+  --crm-form-block-border-radius: var(--crm-s-radius);
   --crm-form-block-header: var(--crm-c-inverse-bg);
   --crm-input-bg: var(--crm-c-layer0-bg);
   --crm-input-bg-image: linear-gradient(top, #eee 1%, #fff 15%);
@@ -257,7 +257,7 @@
   --crm-input-padding-large: var(--crm-s) var(--crm-m1);
   --crm-input-height: var(--crm-l);
   --crm-input-font-size: var(--crm-m3);
-  --crm-input-label-weight: 600;
+  --crm-input-label-weight: bold;
   --crm-input-label-font: var(--crm-font);
   --crm-input-label-size: var(--crm-font-size);
   --crm-input-label-width: var(--crm-big-input);
@@ -281,8 +281,8 @@
 /* Tabs */
   --crm-tabs-bg: var(--crm-c-gray-200);
   --crm-tabs-padding: var(--crm-s);
-  --crm-tabs-border: var(--crm-dash-border);
-  --crm-tabs-radius: var(--crm-roundness);
+  --crm-tabs-border: var(--crm-contact-border);
+  --crm-tabs-radius: var(--crm-s-radius);
   --crm-tabs-gap: var(--crm-s);
   --crm-tab-bg: var(--crm-c-layer1-bg);
   --crm-tab-bg-hover: color-mix(in srgb,var(--crm-c-layer1-bg) 75%,#000 25%);
@@ -293,60 +293,60 @@
   --crm-tab-weight: normal;
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
-  --crm-tab-roundness: var(--crm-roundness);
+  --crm-tab-radius: var(--crm-s-radius);
   --crm-tab-border: var(--crm-c-divider);
   --crm-tab-border-width: 0;
   --crm-tab-border-active: 0 solid transparent;
 /* Contact dashboard */
-  --crm-dash-border: var(--crm-tab-border);
-  --crm-dash-roundness: var(--crm-roundness);
-  --crm-dash-direction: flex; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
+  --crm-contact-border: var(--crm-tab-border);
+  --crm-contact-radius: var(--crm-s-radius);
+  --crm-contact-direction: flex; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: unset;
-  --crm-dash-tabs-flow: row; /* choose 'row' for tabs at top, or 'column' for tabs at side */
-  --crm-dash-tabs-gap: var(--crm-tabs-gap);
-  --crm-dash-tabs-bg: var(--crm-tabs-bg);
-  --crm-dash-tabs-padding: var(--crm-tabs-padding);
-  --crm-dash-tabs-roundness: var(--crm-dash-roundness) var(--crm-dash-roundness) 0 0;
-  --crm-dash-tab-bg: var(--crm-tab-bg);
-  --crm-dash-tab-bg-hover: var(--crm-tab-bg-hover);
-  --crm-dash-tab-padding: var(--crm-s3) var(--crm-m2);
-  --crm-dash-tab-border: 0 solid transparent;
-  --crm-dash-tab-border-hover: 0 solid transparent;
-  --crm-dash-tab-border-width: 0; /* to remove border on one side for hanging tabs */
-  --crm-dash-tab-col: var(--crm-tab-col);
-  --crm-dash-tab-count-bg: rgba(0,0,0,0.1);
-  --crm-dash-tab-count-col: var(--crm-c-text);
-  --crm-dash-tab-width: 100%;
-  --crm-dash-tab-align: none;
-  --crm-dash-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-dash-tab-radius: var(--crm-dash-roundness);
-  --crm-dash-icon-size: var(--crm-r);
-  --crm-dash-summary-row-bg: var(--crm-c-container-bg);
-  --crm-dash-heading-inset: 0;
-  --crm-dash-box-shadow: 0;
-  --crm-dash-panel-padding: var(--crm-m);
-  --crm-dash-panel-bg: #fff;
-  --crm-dash-panel-border: 0;
-  --crm-dash-panel-radius: 0 0 var(--crm-dash-roundness) var(--crm-dash-roundness);
-  --crm-dash-edit-border: 1px dashed var(--crm-c-gray-300);
-  --crm-dash-block-padding: 0;
-  --crm-dash-block-bg: unset;
-  --crm-dash-block-radius: var(--crm-roundness);
-  --crm-dash-label-bg: var(--crm-c-layer1-bg);
-  --crm-dash-header-bg: var(--crm-c-layer0-bg);
-  --crm-dash-header-bg2: transparent;
-  --crm-dash-header-col: var(--crm-c-text);
-  --crm-dash-header-size: var(--crm-r3);
-  --crm-dash-header-padding: 0 0 var(--crm-r) 0;
-  --crm-dash-image-size: 100px;
-  --crm-dash-image-radius: 0;
-  --crm-dash-image-right: var(--crm-dash-panel-padding); /* distance from right of dashboard */
-  --crm-dash-image-top: unset; /* distance from top of dashboard */
-  --crm-dash-image-border: 0;
+  --crm-contact-tabs-flow: row; /* choose 'row' for tabs at top, or 'column' for tabs at side */
+  --crm-contact-tabs-gap: var(--crm-tabs-gap);
+  --crm-contact-tabs-bg: var(--crm-tabs-bg);
+  --crm-contact-tabs-padding: var(--crm-tabs-padding);
+  --crm-contact-tabs-radius: var(--crm-contact-radius) var(--crm-contact-radius) 0 0;
+  --crm-contact-tab-bg: var(--crm-tab-bg);
+  --crm-contact-tab-bg-hover: var(--crm-tab-bg-hover);
+  --crm-contact-tab-padding: var(--crm-s3) var(--crm-m2);
+  --crm-contact-tab-border: 0 solid transparent;
+  --crm-contact-tab-border-hover: 0 solid transparent;
+  --crm-contact-tab-border-width: 0; /* to remove border on one side for hanging tabs */
+  --crm-contact-tab-col: var(--crm-tab-col);
+  --crm-contact-tab-count-bg: rgba(0,0,0,0.1);
+  --crm-contact-tab-count-col: var(--crm-c-text);
+  --crm-contact-tab-width: 100%;
+  --crm-contact-tab-align: none;
+  --crm-contact-tab-hang: 0; /* lip to extend tab flush with active region - set to 0 for no lip */
+  --crm-contact-tab-radius: var(--crm-contact-radius);
+  --crm-contact-icon-size: var(--crm-r);
+  --crm-contact-summary-row-bg: var(--crm-c-container-bg);
+  --crm-contact-heading-inset: 0;
+  --crm-contact-box-shadow: 0;
+  --crm-contact-panel-padding: var(--crm-m);
+  --crm-contact-panel-bg: #fff;
+  --crm-contact-panel-border: 0;
+  --crm-contact-panel-radius: 0 0 var(--crm-contact-radius) var(--crm-contact-radius);
+  --crm-contact-edit-border: 1px dashed var(--crm-c-gray-300);
+  --crm-contact-block-padding: 0;
+  --crm-contact-block-bg: unset;
+  --crm-contact-block-radius: var(--crm-s-radius);
+  --crm-contact-label-bg: var(--crm-c-layer1-bg);
+  --crm-contact-header-bg: var(--crm-c-layer0-bg);
+  --crm-contact-header-bg2: transparent;
+  --crm-contact-header-col: var(--crm-c-text);
+  --crm-contact-header-size: var(--crm-r3);
+  --crm-contact-header-padding: 0 0 var(--crm-r) 0;
+  --crm-contact-image-size: 100px;
+  --crm-contact-image-radius: 0;
+  --crm-contact-image-right: var(--crm-contact-panel-padding); /* distance from right of dashboard */
+  --crm-contact-image-top: unset; /* distance from top of dashboard */
+  --crm-contact-image-border: 0;
 /* Dialog */
   --crm-dialog-bg: var(--crm-c-layer0-bg);
   --crm-dialog-padding: var(--crm-s);
-  --crm-dialog-radius: var(--crm-roundness);
+  --crm-dialog-radius: var(--crm-s-radius);
   --crm-dialog-line: unset;
   --crm-dialog-inner-shadow: var(--crm-bottom-shadow);
   --crm-dialog-header-bg: var(--crm-c-secondary);
@@ -364,18 +364,18 @@
   --crm-dashlet-padding: var(--crm-s2);
   --crm-dashlet-box-shadow: var(--crm-popup-shadow);
   --crm-dashlet-dashlets-bg: var(--crm-c-container-bg);
-  --crm-dashlet-header-bg: var(--crm-expand-header-bg);
-  --crm-dashlet-header-col: var(--crm-expand-header-color);
+  --crm-dashlet-header-bg: var(--crm-accordion-header-bg);
+  --crm-dashlet-header-col: var(--crm-accordion-header-color);
   --crm-dashlet-header-border: unset;
   --crm-dashlet-header-border-width: unset;
   --crm-dashlet-header-font-size: var(--crm-font-size);
   --crm-dashlet-header-padding: var(--crm-s);
   --crm-dashlet-content-padding: var(--crm-dashlet-padding) 0;
   --crm-dashlet-tabs-border: 0;
-  --crm-dashlet-radius: var(--crm-roundness);
+  --crm-dashlet-radius: var(--crm-s-radius);
 /* Button dropdowns */
   --crm-dropdown-padding: var(--crm-s);
-  --crm-dropdown-radius: var(--crm-roundness);
+  --crm-dropdown-radius: var(--crm-s-radius);
   --crm-dropdown-bg: var(--crm-c-secondary-hover);
   --crm-dropdown-col: var(--crm-c-text-light);
   --crm-dropdown-hover: var(--crm-c-text);
@@ -391,7 +391,7 @@
   --crm-notify-padding: var(--crm-m2);
   --crm-notify-col: var(--crm-c-text-light);
   --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
-  --crm-notify-radius: var(--crm-roundness);
+  --crm-notify-radius: var(--crm-s-radius);
   --crm-notify-danger: hsl(from var(--crm-c-danger) h s calc(l + 20));
   --crm-notify-warning: hsl(from var(--crm-c-warning) h s calc(l + 20));
   --crm-notify-success: hsl(from var(--crm-c-success) h s calc(l + 30));
@@ -450,7 +450,7 @@
   --crm-f-label-margin: var(--crm-s);
   --crm-f-label-weight: bold;
   --crm-f-label-color: inherit;
-  --crm-f-input-radius: var(--crm-roundness);
+  --crm-f-input-radius: var(--crm-s-radius);
   --crm-f-input-padding: var(--crm-r2) var(--crm-m2);
   --crm-f-input-font-size: var(--crm-r1);
   --crm-f-input-width: 300px;

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -44,7 +44,6 @@
   --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-focus: var(--crm-c-blue-dark);
   --crm-c-inactive: color-mix(in srgb,var(--crm-c-text) 95%,#fff 5%);
-  --crm-c-divider: 1px solid var(--crm-c-gray-300);
 /* Backgrounds */
   --crm-c-layer0-bg: #fff; /* The lightest bg in light mode */
   --crm-c-page-bg: var(--crm-c-layer0-bg);
@@ -53,8 +52,10 @@
   --crm-c-layer2-bg: color-mix(in srgb,var(--crm-c-layer1-bg) 95%,#000 5%);
   --crm-c-inverse-bg: var(--crm-c-gray-700); /* bg to light text */
   --crm-c-drag-bg: var(--crm-c-layer2-bg);
+  --crm-border-color: var(--crm-c-gray-300);
+  --crm-border: 1px solid var(--crm-border-color);
   --crm-c-code-bg: var(--crm-c-layer1-bg);
-  --crm-c-code-border: color-mix(in srgb,var(--crm-c-code-bg) 75%,#000 25%);
+  --crm-code-border-color: color-mix(in srgb,var(--crm-c-code-bg) 75%,#000 25%);
 /* Emphasis colours */
   --crm-c-primary: var(--crm-c-inverse-bg);
   --crm-c-primary-hover: color-mix(in srgb,var(--crm-c-primary) 75%,#000 25%);
@@ -159,14 +160,14 @@
   --crm-btn-icon-padding: var(--crm-btn-padding-block);
   --crm-btn-margin: 0; /* used to add padding block between multiple stacked buttons */
 /* Tables */
-  --crm-table-outside-border: var(--crm-c-divider);
+  --crm-table-outside-border: var(--crm-border);
   --crm-table-bg: var(--crm-c-layer0-bg);
-  --crm-table-row-border: var(--crm-c-divider);
+  --crm-table-row-border: var(--crm-border);
   --crm-table-column-border: 0 solid transparent;
   --crm-table-font-size: var(--crm-font-size);
   --crm-table-padding: var(--crm-m);
   --crm-table-header-border: 1px solid transparent;
-  --crm-table-header-bottom: 2px solid var(--crm-c-gray-300);
+  --crm-table-header-bottom: 2px solid var(--crm-border-color);
   --crm-table-header-bg: var(--crm-c-layer0-bg);
   --crm-table-header-col: var(--crm-c-text);
   --crm-table-header-txt: inherit;
@@ -180,12 +181,12 @@
   --crm-table-compressed-width: auto;
   --crm-table-nested-padding: var(--crm-r) var(--crm-m);
   --crm-table-nested-head-border: 0 solid transparent;
-  --crm-table-nested-border: var(--crm-c-divider);
+  --crm-table-nested-border: var(--crm-border);
   --crm-table-inset-bg: var(--crm-c-layer2-bg);
 /* Panels */
   --crm-panel-shadow: var(--crm-shadow-block);
   --crm-panel-bg: var(--crm-c-layer0-bg);
-  --crm-panel-border: var(--crm-c-divider);
+  --crm-panel-border: var(--crm-border);
   --crm-panel-head-margin: 0px;
   --crm-panel-head-height: 37px;
 /* Accordions */
@@ -202,9 +203,9 @@
   --crm-accordion-header-color: var(--crm-c-secondary-text);
   --crm-accordion-header-padding: var(--crm-s) var(--crm-m);
   --crm-accordion-header-weight: bold;
-  --crm-accordion-header-border: var(--crm-c-divider);
+  --crm-accordion-header-border: var(--crm-border);
   --crm-accordion-header-border-width: 0 0 1px 0;
-  --crm-accordion-border: var(--crm-c-divider);
+  --crm-accordion-border: var(--crm-border);
   --crm-accordion-border-width: 0 1px 1px 1px;
   --crm-accordion-body-bg: unset;
   --crm-accordion-body-box-shadow: unset;
@@ -291,7 +292,7 @@
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
   --crm-tab-radius: var(--crm-s-radius);
-  --crm-tab-border: var(--crm-c-divider);
+  --crm-tab-border: var(--crm-border);
   --crm-tab-border-width: 0;
   --crm-tab-border-active: 0 solid transparent;
 /* Contact dashboard */
@@ -325,7 +326,7 @@
   --crm-contact-panel-bg: #fff;
   --crm-contact-panel-border: 0;
   --crm-contact-panel-radius: 0 0 var(--crm-contact-radius) var(--crm-contact-radius);
-  --crm-contact-edit-border: 1px dashed var(--crm-c-gray-300);
+  --crm-contact-edit-border: 1px dashed var(--crm-border-color);
   --crm-contact-block-padding: 0;
   --crm-contact-block-bg: unset;
   --crm-contact-block-radius: var(--crm-s-radius);
@@ -351,7 +352,7 @@
   --crm-dialog-header-size: var(--crm-r1);
   --crm-dialog-header-padding: var(--crm-m1) var(--crm-r);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
-  --crm-dialog-header-border-col: transparent transparent var(--crm-c-gray-300) transparent; /* set a border color for each side of the header */
+  --crm-dialog-header-border-col: transparent transparent var(--crm-border-color) transparent; /* set a border color for each side of the header */
   --crm-dialog-body-bg: var(--crm-c-container-bg);
   --crm-dialog-body-padding: var(--crm-m);
 /* Dashlet */
@@ -417,7 +418,7 @@
   --crm-wizard-arrow-thickness: 1px;
   --crm-wizard-active-col: var(--crm-c-text-light);
   --crm-wizard-active-bg: var(--crm-c-link);
-  --crm-wizard-border: var(--crm-c-divider);
+  --crm-wizard-border: var(--crm-border);
   --crm-wizard-bg: var(--crm-c-layer0-bg);
   --crm-wizard-box-shadow: unset;
 /* Alpha filter */

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -22,7 +22,7 @@
 
 /* Extension management */
 .crm-container #mainTabContainer:has(.crm-extensions-tabs-list) {
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   margin-top: var(--crm-padding-reg);
 }
 .crm-container #extensions-main,

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -55,7 +55,7 @@
 }
 .crm-container #extensions table.dataTable a.crm-hover-button,
 .crm-container #extensions-addnew table.dataTable a.crm-hover-button {
-  padding: 0 var(--crm-s-medium-1);
+  padding: 0 var(--crm-l-medium-1);
 }
 .crm-container .disabled .crm-hover-button:hover,
 .crm-container .disabled .crm-hover-button:focus {
@@ -68,14 +68,14 @@
   background: var(--crm-alert-warning-bg-color);
   border: 1px solid var(--crm-alert-warning-border-color);
   padding: var(--crm-padding-small);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   color: var(--crm-alert-warning-text-color);
 }
 .crm-container .crm-extensions-version {
   white-space: nowrap;
 }
 .crm-container .crm-extensions-stage {
-  margin-left: var(--crm-s-small);
+  margin-left: var(--crm-l-small);
 }
 .crm-container .crm-extensions-stage.fa-flask,
 .crm-container .crm-extensions-stage.fa-warning {

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -68,7 +68,7 @@
   background: var(--crm-alert-warning-bg);
   border: 1px solid var(--crm-alert-warning-border);
   padding: var(--crm-padding-small);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   color: var(--crm-alert-warning-text);
 }
 .crm-container .crm-extensions-version {

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -11,13 +11,13 @@
   width: 20%;
 }
 .crm-container td.tasklist a:visited {
-  color: var(--crm-c-success);
+  color: var(--crm-success-color);
 }
 
 /* Class for successful upgrade */
 .crm-container .upgrade-success {
-  background-color: var(--crm-alert-success-bg);
-  color: var(--crm-alert-success-text);
+  background-color: var(--crm-alert-success-bg-color);
+  color: var(--crm-alert-success-text-color);
 }
 
 /* Extension management */
@@ -45,13 +45,13 @@
 .crm-container #extensions-addnew table.dataTable summary {
   padding: 0;
   background-color: unset;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-weight: unset;
   font-family: var(--crm-font);
 }
 .crm-container #extensions table.dataTable summary a,
 .crm-container #extensions-addnew table.dataTable summary a {
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
 }
 .crm-container #extensions table.dataTable a.crm-hover-button,
 .crm-container #extensions-addnew table.dataTable a.crm-hover-button {
@@ -59,17 +59,17 @@
 }
 .crm-container .disabled .crm-hover-button:hover,
 .crm-container .disabled .crm-hover-button:focus {
-  color: var(--crm-c-secondary-text);
+  color: var(--crm-secondary-text-color);
 }
 .crm-container .extension-missing {
-  color: var(--crm-c-warning);
+  color: var(--crm-warning-color);
 }
 .crm-container .crm-extensions-upgrade {
-  background: var(--crm-alert-warning-bg);
-  border: 1px solid var(--crm-alert-warning-border);
+  background: var(--crm-alert-warning-bg-color);
+  border: 1px solid var(--crm-alert-warning-border-color);
   padding: var(--crm-padding-small);
   border-radius: var(--crm-s-radius);
-  color: var(--crm-alert-warning-text);
+  color: var(--crm-alert-warning-text-color);
 }
 .crm-container .crm-extensions-version {
   white-space: nowrap;
@@ -79,43 +79,43 @@
 }
 .crm-container .crm-extensions-stage.fa-flask,
 .crm-container .crm-extensions-stage.fa-warning {
-  color: var(--crm-notify-warning);
+  color: var(--crm-notify-warning-color);
 }
 .crm-container .crm-extensions-stage.fa-check-circle,
 .crm-container .crm-extensions-stage.fa-trophy {
-  color: var(--crm-notify-success);
+  color: var(--crm-notify-success-color);
 }
 .crm-container .extension-installed {
-  background: var(--crm-alert-success-bg);
-  color: var(--crm-alert-success-text);
+  background: var(--crm-alert-success-bg-color);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-container .extension-installed summary {
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-container table.dataTable.display tbody {
-  --crm-striped-bg: var(--crm-table-row-bg);
+  --crm-striped-bg-color: var(--crm-table-row-bg-color);
 }
 .crm-container table.dataTable.display tbody tr:not(.disabled) {
-  background-color: var(--crm-striped-bg) !important;
+  background-color: var(--crm-striped-bg-color) !important;
 }
 .crm-container table.dataTable.display tbody tr.even:not(.disabled) {
-  --crm-striped-bg: color-mix(in srgb, var(--crm-table-row-bg) 100%, var(--crm-table-row-alternate-bg) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 100%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.display tbody tr.extension-installed {
-  --crm-striped-bg: var(--crm-alert-success-bg);
+  --crm-striped-bg-color: var(--crm-alert-success-bg-color);
 }
 .crm-container table.dataTable.display tbody tr.extension-installed.even {
-  --crm-striped-bg: color-mix(in srgb, var(--crm-alert-success-bg) 100%, var(--crm-table-row-alternate-bg) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-alert-success-bg-color) 100%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.display tbody tr:hover {
-  --crm-striped-bg: var(--crm-table-row-hover);
+  --crm-striped-bg-color: var(--crm-table-row-hover-color);
 }
 .crm-container table.dataTable.display tbody tr.even:hover {
-  --crm-striped-bg: color-mix(in srgb, var(--crm-table-row-hover) 100%, var(--crm-table-row-alternate-bg) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-hover-color) 100%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.display tbody tr > .sorting_1,
 .crm-container table.dataTable.order-column.stripe tbody tr > .sorting_1 {
-  background-color: color-mix(in srgb, var(--crm-striped-bg) 100%, var(--crm-table-row-alternate-bg)  6%) !important;
+  background-color: color-mix(in srgb, var(--crm-striped-bg-color) 100%, var(--crm-table-row-alternate-bg-color)  6%) !important;
 }
 
 /* Navigation Menu Editor */

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -55,7 +55,7 @@
 }
 .crm-container #extensions table.dataTable a.crm-hover-button,
 .crm-container #extensions-addnew table.dataTable a.crm-hover-button {
-  padding: 0 var(--crm-m1);
+  padding: 0 var(--crm-s-medium-1);
 }
 .crm-container .disabled .crm-hover-button:hover,
 .crm-container .disabled .crm-hover-button:focus {
@@ -75,7 +75,7 @@
   white-space: nowrap;
 }
 .crm-container .crm-extensions-stage {
-  margin-left: var(--crm-s);
+  margin-left: var(--crm-s-small);
 }
 .crm-container .crm-extensions-stage.fa-flask,
 .crm-container .crm-extensions-stage.fa-warning {

--- a/ext/riverlea/core/css/api4-explorer.css
+++ b/ext/riverlea/core/css/api4-explorer.css
@@ -18,7 +18,7 @@
 .api4-explorer-page .panel-heading {
   display: flex;
   align-items: center;
-  padding: var(--crm-m);
+  padding: var(--crm-s-medium);
 }
 #bootstrap-theme .api4-explorer-row .panel-heading h3 {
   background-color: transparent;
@@ -32,7 +32,7 @@
   padding: 0;
   display: flex;
   align-items: center;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   flex-wrap: wrap;
 }
 .api4-explorer-row .panel-heading .form-inline .pull-right {
@@ -70,7 +70,7 @@
 .api4-explorer-page .explorer-code-panel pre {
   word-break: break-all;
   white-space: pre-wrap;
-  min-height: var(--crm-xxl);
+  min-height: var(--crm-s-large-2);
 }
 .api4-explorer-page .explorer-code-panel .panel-heading > .nav li a {
   text-transform: uppercase;
@@ -160,7 +160,7 @@
   background-color: rgba(186, 225, 251, 0.94);
 }
 .api4-explorer-page .api4-add-where-group-menu a {
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
 }
 /* Responsive (move to own file at some point) */
 

--- a/ext/riverlea/core/css/api4-explorer.css
+++ b/ext/riverlea/core/css/api4-explorer.css
@@ -13,7 +13,7 @@
 }
 .api4-explorer-row > .panel {
   margin: 0;
-  background: var(--crm-panel-bg);
+  background: var(--crm-panel-bg-color);
 }
 .api4-explorer-page .panel-heading {
   display: flex;
@@ -22,7 +22,7 @@
 }
 #bootstrap-theme .api4-explorer-row .panel-heading h3 {
   background-color: transparent;
-  color: var(--crm-alert-info-text);
+  color: var(--crm-alert-info-text-color);
   background: transparent;
   margin: 0 !important /* vs bootstrap3 */;
   padding: 0 !important /* vs bootstrap3 */;

--- a/ext/riverlea/core/css/api4-explorer.css
+++ b/ext/riverlea/core/css/api4-explorer.css
@@ -18,7 +18,7 @@
 .api4-explorer-page .panel-heading {
   display: flex;
   align-items: center;
-  padding: var(--crm-s-medium);
+  padding: var(--crm-l-medium);
 }
 #bootstrap-theme .api4-explorer-row .panel-heading h3 {
   background-color: transparent;
@@ -32,7 +32,7 @@
   padding: 0;
   display: flex;
   align-items: center;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   flex-wrap: wrap;
 }
 .api4-explorer-row .panel-heading .form-inline .pull-right {
@@ -70,7 +70,7 @@
 .api4-explorer-page .explorer-code-panel pre {
   word-break: break-all;
   white-space: pre-wrap;
-  min-height: var(--crm-s-large-2);
+  min-height: var(--crm-l-large-2);
 }
 .api4-explorer-page .explorer-code-panel .panel-heading > .nav li a {
   text-transform: uppercase;
@@ -160,7 +160,7 @@
   background-color: rgba(186, 225, 251, 0.94);
 }
 .api4-explorer-page .api4-add-where-group-menu a {
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
 }
 /* Responsive (move to own file at some point) */
 

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -148,7 +148,7 @@
   margin-bottom: 0;
 }
 #contact-summary summary {
-  padding: var(--crm-s-medium) !important;
+  padding: var(--crm-l-medium) !important;
 }
 #contact-summary details .crm-accordion-body {
   box-shadow: none;

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -9,7 +9,7 @@
   cursor: var(--crm-link-hover-cursor);
   font-size: var(--crm-font-size);
   font-weight: var(--crm-accordion-header-weight);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   border-radius: var(--crm-accordion-radius);
   padding: var(--crm-accordion-header-padding);
 }
@@ -30,9 +30,9 @@
 }
 .crm-container details:has(input.crm-inline-error) summary,
 .crm-container details:has(input.crm-inline-error) summary.active {
-  background-color: var(--crm-alert-danger-bg);
-  color: var(--crm-alert-danger-text);
-  border-color: var(--crm-alert-danger-border);
+  background-color: var(--crm-alert-danger-bg-color);
+  color: var(--crm-alert-danger-text-color);
+  border-color: var(--crm-alert-danger-border-color);
 }
 
 /* Expand/collapse icons */
@@ -57,10 +57,10 @@
 
 /* Style 1 'bold' */
 .crm-container .crm-accordion-bold {
-  background-color: var(--crm-accordion-body-bg);
+  background-color: var(--crm-accordion-body-bg-color);
 }
 .crm-container .crm-accordion-bold > summary {
-  background-color: var(--crm-accordion-header-bg);
+  background-color: var(--crm-accordion-header-bg-color);
   color: var(--crm-accordion-header-color);
   border: var(--crm-accordion-header-border);
   border-width: var(--crm-accordion-header-border-width);
@@ -72,7 +72,7 @@
 .crm-container .crm-accordion-bold > summary.active,
 .crm-container .crm-accordion-bold > summary:hover,
 .crm-container .crm-accordion-bold > summary:focus { /* hover version of that */
-  background-color: var(--crm-accordion-header-bg-active);
+  background-color: var(--crm-accordion-header-bg-active-color);
 }
 .crm-container .crm-accordion-bold > .crm-accordion-body {
   padding: var(--crm-accordion-body-padding);
@@ -88,11 +88,11 @@
 
 /* Style 2 'light' */
 .crm-container .crm-accordion-light {
-  background-color: var(--crm-accordion2-body-bg);
+  background-color: var(--crm-accordion2-body-bg-color);
 }
 .crm-container .crm-accordion-light > summary {
   font-weight: var(--crm-accordion2-header-weight);
-  background-color: var(--crm-accordion2-header-bg);
+  background-color: var(--crm-accordion2-header-bg-color);
   color: var(--crm-accordion2-header-color);
   border: var(--crm-accordion2-header-border);
   border-width: var(--crm-accordion2-header-border-width);
@@ -101,14 +101,14 @@
 .crm-container .crm-accordion-light > summary.active,
 .crm-container .crm-accordion-light > summary:hover,
 .crm-container .crm-accordion-light > summary:focus { /* hover version of that */
-  background-color: var(--crm-accordion2-header-bg-active);
+  background-color: var(--crm-accordion2-header-bg-active-color);
 }
 .crm-container .crm-accordion-light > summary a {
   color: var(--crm-accordion2-header-color);
 }
 .crm-container .crm-accordion-light > .crm-accordion-body {
   padding: var(--crm-accordion2-body-padding);
-  background: var(--crm-accordion2-body-bg);
+  background: var(--crm-accordion2-body-bg-color);
   border: var(--crm-accordion2-border);
   border-width: var(--crm-accordion2-border-width);
   border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
@@ -141,7 +141,7 @@
   box-shadow: none;
   border: 0 solid transparent;
   background-color: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 #contact-summary details .crm-summary-block {
   box-shadow: var(--crm-shadow-block);

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -1,23 +1,23 @@
 .crm-container details {
   background-color: unset;
-  border-radius: var(--crm-expand-radius);
-  margin: var(--crm-expand-gap);
+  border-radius: var(--crm-accordion-radius);
+  margin: var(--crm-accordion-gap);
 }
 .crm-container summary {
   display: list-item;
   list-style: none;
   cursor: var(--crm-hover-clickable);
   font-size: var(--crm-font-size);
-  font-weight: var(--crm-expand-header-weight);
+  font-weight: var(--crm-accordion-header-weight);
   color: var(--crm-c-text);
-  border-radius: var(--crm-expand-radius);
-  padding: var(--crm-expand-header-padding);
+  border-radius: var(--crm-accordion-radius);
+  padding: var(--crm-accordion-header-padding);
 }
 .crm-container details .crm-accordion-body {
-  padding: var(--crm-expand-body-padding);
+  padding: var(--crm-accordion-body-padding);
 }
 .crm-container details[open] > summary { /* open version of that */
-  border-radius: var(--crm-expand-radius) var(--crm-expand-radius) 0 0;
+  border-radius: var(--crm-accordion-radius) var(--crm-accordion-radius) 0 0;
 }
 .crm-container table summary { /* Makes summary match the size of the rest of the table it's in */
   font-size: inherit;
@@ -26,7 +26,7 @@
   display: none;
 }
 .crm-container details ~ details {
-  margin: var(--crm-expand-gap);
+  margin: var(--crm-accordion-gap);
 }
 .crm-container details:has(input.crm-inline-error) summary,
 .crm-container details:has(input.crm-inline-error) summary.active {
@@ -38,80 +38,80 @@
 /* Expand/collapse icons */
 .crm-container details > summary::before {
   font-size: var(--crm-font-size);
-  content: var(--crm-expand-icon);
-  color: var(--crm-expand-icon-color);
+  content: var(--crm-accordion-icon);
+  color: var(--crm-accordion-icon-color);
   font-style: normal;
   line-height: 1.35;
   font-family: FontAwesome;
   text-rendering: auto;
   text-indent: inherit;
-  margin-right: var(--crm-expand-icon-spacing);
+  margin-right: var(--crm-accordion-icon-spacing);
   display: inline-block;
   transform-origin: center center;
-  transition: var(--crm-expand-transition);
+  transition: var(--crm-accordion-transition);
 }
 .crm-container details[open] > summary::before {
-  transform: var(--crm-expand-transform);
-  transition: var(--crm-expand-transition);
+  transform: var(--crm-accordion-transform);
+  transition: var(--crm-accordion-transition);
 }
 
 /* Style 1 'bold' */
 .crm-container .crm-accordion-bold {
-  background-color: var(--crm-expand-body-bg);
+  background-color: var(--crm-accordion-body-bg);
 }
 .crm-container .crm-accordion-bold > summary {
-  background-color: var(--crm-expand-header-bg);
-  color: var(--crm-expand-header-color);
-  border: var(--crm-expand-header-border);
-  border-width: var(--crm-expand-header-border-width);
-  font-weight: var(--crm-expand-header-weight);
+  background-color: var(--crm-accordion-header-bg);
+  color: var(--crm-accordion-header-color);
+  border: var(--crm-accordion-header-border);
+  border-width: var(--crm-accordion-header-border-width);
+  font-weight: var(--crm-accordion-header-weight);
 }
 .crm-container .crm-accordion-bold > summary a {
-  color: var(--crm-expand-header-color);
+  color: var(--crm-accordion-header-color);
 }
 .crm-container .crm-accordion-bold > summary.active,
 .crm-container .crm-accordion-bold > summary:hover,
 .crm-container .crm-accordion-bold > summary:focus { /* hover version of that */
-  background-color: var(--crm-expand-header-bg-active);
+  background-color: var(--crm-accordion-header-bg-active);
 }
 .crm-container .crm-accordion-bold > .crm-accordion-body {
-  padding: var(--crm-expand-body-padding);
-  border: var(--crm-expand-border);
-  border-width: var(--crm-expand-border-width);
-  border-radius: 0 0 var(--crm-expand-radius) var(--crm-expand-radius);
-  box-shadow: var(--crm-expand-body-box-shadow);
+  padding: var(--crm-accordion-body-padding);
+  border: var(--crm-accordion-border);
+  border-width: var(--crm-accordion-border-width);
+  border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
+  box-shadow: var(--crm-accordion-body-box-shadow);
 }
 .crm-container details.crm-accordion-bold:not( > summary) {
-  border: var(--crm-expand-border);
-  padding: var(--crm-expand-body-padding);
+  border: var(--crm-accordion-border);
+  padding: var(--crm-accordion-body-padding);
 }
 
 /* Style 2 'light' */
 .crm-container .crm-accordion-light {
-  background-color: var(--crm-expand2-body-bg);
+  background-color: var(--crm-accordion2-body-bg);
 }
 .crm-container .crm-accordion-light > summary {
-  font-weight: var(--crm-expand2-header-weight);
-  background-color: var(--crm-expand2-header-bg);
-  color: var(--crm-expand2-header-color);
-  border: var(--crm-expand2-header-border);
-  border-width: var(--crm-expand2-header-border-width);
-  padding: var(--crm-expand2-header-padding);
+  font-weight: var(--crm-accordion2-header-weight);
+  background-color: var(--crm-accordion2-header-bg);
+  color: var(--crm-accordion2-header-color);
+  border: var(--crm-accordion2-header-border);
+  border-width: var(--crm-accordion2-header-border-width);
+  padding: var(--crm-accordion2-header-padding);
 }
 .crm-container .crm-accordion-light > summary.active,
 .crm-container .crm-accordion-light > summary:hover,
 .crm-container .crm-accordion-light > summary:focus { /* hover version of that */
-  background-color: var(--crm-expand2-header-bg-active);
+  background-color: var(--crm-accordion2-header-bg-active);
 }
 .crm-container .crm-accordion-light > summary a {
-  color: var(--crm-expand2-header-color);
+  color: var(--crm-accordion2-header-color);
 }
 .crm-container .crm-accordion-light > .crm-accordion-body {
-  padding: var(--crm-expand2-body-padding);
-  background: var(--crm-expand2-body-bg);
-  border: var(--crm-expand2-border);
-  border-width: var(--crm-expand2-border-width);
-  border-radius: 0 0 var(--crm-expand-radius) var(--crm-expand-radius);
+  padding: var(--crm-accordion2-body-padding);
+  background: var(--crm-accordion2-body-bg);
+  border: var(--crm-accordion2-border);
+  border-width: var(--crm-accordion2-border-width);
+  border-radius: 0 0 var(--crm-accordion-radius) var(--crm-accordion-radius);
 }
 .crm-container details.crm-accordion-light:not( > summary) {
   border: 0;
@@ -126,7 +126,7 @@
   content: '\f013';
 }
 .crm-container details.crm-accordion-settings > .crm-accordion-body {
-  padding: var(--crm-expand2-header-padding);
+  padding: var(--crm-accordion2-header-padding);
 }
 
 /* Contact dashboard */

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -148,7 +148,7 @@
   margin-bottom: 0;
 }
 #contact-summary summary {
-  padding: var(--crm-m) !important;
+  padding: var(--crm-s-medium) !important;
 }
 #contact-summary details .crm-accordion-body {
   box-shadow: none;

--- a/ext/riverlea/core/css/components/_accordion.css
+++ b/ext/riverlea/core/css/components/_accordion.css
@@ -6,7 +6,7 @@
 .crm-container summary {
   display: list-item;
   list-style: none;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   font-size: var(--crm-font-size);
   font-weight: var(--crm-accordion-header-weight);
   color: var(--crm-c-text);
@@ -144,7 +144,7 @@
   color: var(--crm-c-text);
 }
 #contact-summary details .crm-summary-block {
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   margin-bottom: 0;
 }
 #contact-summary summary {

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -83,7 +83,7 @@
   float: right;
   padding: 0;
   border: 0;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   background: transparent;
   appearance: none;
   font-size: var(--crm-r1);

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -86,7 +86,7 @@
   cursor: var(--crm-link-hover-cursor);
   background: transparent;
   appearance: none;
-  font-size: var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
   line-height: 1;
   color: var(--crm-c-darkest) !important;
   text-shadow: 0 1px 0 #fff;

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -11,7 +11,7 @@
   color: var(--crm-alert-success-text);
   margin: var(--crm-alert-margin);
   padding: var(--crm-alert-padding);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container .help > *:first-child {
   margin-top: 0;

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -11,7 +11,7 @@
   color: var(--crm-alert-success-text-color);
   margin: var(--crm-alert-margin);
   padding: var(--crm-alert-padding);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container .help > *:first-child {
   margin-top: 0;
@@ -86,7 +86,7 @@
   cursor: var(--crm-link-hover-cursor);
   background: transparent;
   appearance: none;
-  font-size: var(--crm-s-reg-1);
+  font-size: var(--crm-l-reg-1);
   line-height: 1;
   color: var(--crm-c-darkest) !important;
   text-shadow: 0 1px 0 #fff;

--- a/ext/riverlea/core/css/components/_alerts.css
+++ b/ext/riverlea/core/css/components/_alerts.css
@@ -6,9 +6,9 @@
 .crm-container .alert-success,
 .crm-container .status.crm-ok,
 .crm-container .status.crm-ok.alert {
-  background-color: var(--crm-alert-success-bg);
-  border: var(--crm-alert-border-width) solid var(--crm-alert-success-border);
-  color: var(--crm-alert-success-text);
+  background-color: var(--crm-alert-success-bg-color);
+  border: var(--crm-alert-border-width) solid var(--crm-alert-success-border-color);
+  color: var(--crm-alert-success-text-color);
   margin: var(--crm-alert-margin);
   padding: var(--crm-alert-padding);
   border-radius: var(--crm-s-radius);
@@ -20,43 +20,43 @@
 .crm-container .status p,
 .crm-container .messages p,
 .crm-container .alert p {
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-container .alert-warning p {
-  color: var(--crm-alert-warning-text);
+  color: var(--crm-alert-warning-text-color);
 }
 .crm-container .help li,
 .crm-container .status li,
 .crm-container .messages li {
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-container .status.alert,
 .crm-container .alert-warning,
 .crm-container .messages.warning {
-  background-color: var(--crm-alert-warning-bg);
-  border-color: var(--crm-alert-warning-border);
-  color: var(--crm-alert-warning-text);
+  background-color: var(--crm-alert-warning-bg-color);
+  border-color: var(--crm-alert-warning-border-color);
+  color: var(--crm-alert-warning-text-color);
 }
 .crm-container .status.error {
-  background-color: var(--crm-alert-danger-bg);
-  border-color: var(--crm-alert-danger-border);
-  color: var(--crm-alert-danger-text);
+  background-color: var(--crm-alert-danger-bg-color);
+  border-color: var(--crm-alert-danger-border-color);
+  color: var(--crm-alert-danger-text-color);
 }
 .crm-container .status.alert li,
 .crm-container .alert-warning li,
 .crm-container .messages.warning li {
-  color: var(--crm-alert-warning-text);
+  color: var(--crm-alert-warning-text-color);
 }
 .crm-container .alert-info,
 .crm-container .messages.crm-empty-table {
-  background-color: var(--crm-alert-info-bg);
-  border-color: var(--crm-alert-info-border);
-  color: var(--crm-alert-info-text);
+  background-color: var(--crm-alert-info-bg-color);
+  border-color: var(--crm-alert-info-border-color);
+  color: var(--crm-alert-info-text-color);
 }
 .crm-container .alert-danger {
-  background-color: var(--crm-alert-danger-bg);
-  border-color: var(--crm-alert-danger-border);
-  color: var(--crm-alert-danger-text);
+  background-color: var(--crm-alert-danger-bg-color);
+  border-color: var(--crm-alert-danger-border-color);
+  color: var(--crm-alert-danger-text-color);
 }
 .crm-container .help a:not(.btn),
 .crm-container .messages a:not(.btn),

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -8,7 +8,7 @@
 .crm-container .nav.nav-pills li.navitem a {
   white-space: nowrap;
   touch-action: manipulation;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   background-image: none;
   border: var(--crm-btn-border);
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
@@ -209,7 +209,7 @@
 .crm-container a.crm-hover-button {
   border-radius: var(--crm-btn-radius);
   color: var(--crm-c-link);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
   background-color: var(--crm-c-primary);
   color: var(--crm-c-primary-text);
@@ -221,7 +221,7 @@
   color: var(--crm-c-text);
   padding: var(--crm-btn-small-padding);
   margin: 0;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   border-radius: var(--crm-btn-radius);
   display: inline;
   line-height: 1.5;
@@ -256,7 +256,7 @@
 /* Action links */
 
 .crm-container .ui-widget-content .action-link .button {
-  box-shadow: var(--crm-block-shadow) !important;
+  box-shadow: var(--crm-shadow-block) !important;
   margin: var(--crm-m) 0;
 }
 
@@ -408,7 +408,7 @@
   padding-left: 12px;
 }
 #bootstrap-theme .btn-group.open .dropdown-toggle {
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
 }
 #bootstrap-theme .btn-group.open .dropdown-toggle.btn-link {
   box-shadow: none;

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -16,8 +16,8 @@
   border-radius: var(--crm-btn-radius);
   user-select: none;
   margin: var(--crm-btn-margin);
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
   text-transform: var(--crm-btn-txt-transform);
   height: var(--crm-btn-height);
   display: inline-flex;
@@ -40,19 +40,19 @@
 [type="button"]:focus,
 [type="reset"]:focus,
 [type="submit"]:focus {
-  background: var(--crm-c-primary-hover);
-  color: var(--crm-c-primary-hover-text);
+  background: var(--crm-primary-hover-color);
+  color: var(--crm-primary-hover-text-color);
   text-decoration: none;
 }
 .crm-container .nav.nav-pills li.navitem:not(.active) a {
   background-color: transparent;
   border-color: transparent;
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
 }
 .crm-container .nav.nav-pills li.navitem:not(.active) a:hover,
 .crm-container .nav.nav-pills li.navitem:not(.active) a:focus {
   background-color: transparent;
-  color: var(--crm-c-link-hover);
+  color: var(--crm-link-hover-color);
 }
 .crm-button:focus,
 .crm-container .btn:focus,
@@ -82,26 +82,26 @@
   box-shadow: none;
 }
 .crm-container button.disabled * {
-  color: var(--crm-c-primary-text);
+  color: var(--crm-primary-text-color);
 }
 .crm-container .crm-button-type-cancel,
 .crm-form-submit .cancel.crm-button,
 .crm-container button.ui-button:has(.fa-times),
 #bootstrap-theme button.btn-secondary-outline {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color);
 }
 .crm-container a.button.delete-button,
 .crm-container a.button.delete-button:link,
 .crm-container a.button.delete,
 .crm-container a.button.delete:link {
-  background: var(--crm-btn-cancel-bg);
-  color: var(--crm-btn-cancel-text);
+  background: var(--crm-btn-cancel-bg-color);
+  color: var(--crm-btn-cancel-text-color);
 }
 .crm-container a.button.delete-button:hover,
 .crm-container a.button.delete-button:focus,
 .crm-container a.button.delete:hover {
-  background: color-mix(in srgb, var(--crm-btn-cancel-bg) 87.5%, #000 12.5%);
+  background: color-mix(in srgb, var(--crm-btn-cancel-bg-color) 87.5%, #000 12.5%);
 }
 .crm-container .crm-button-type-cancel:hover,
 .crm-container .crm-button-type-cancel:focus,
@@ -109,56 +109,56 @@
 .crm-container button.ui-button:has(.fa-times):focus,
 #bootstrap-theme button.btn-secondary-outline:hover,
 #bootstrap-theme button.btn-secondary-outline:focus {
-  background: var(--crm-c-secondary-hover);
-  color: var(--crm-c-secondary-hover-text);
+  background: var(--crm-secondary-hover-color);
+  color: var(--crm-secondary-hover-text-color);
 }
 
 /* BS3 colour options */
 
 #bootstrap-theme .btn-secondary {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color);
 }
 #bootstrap-theme .btn.btn-secondary:hover,
 #bootstrap-theme .btn.btn-secondary:focus {
-  background: var(--crm-c-secondary-hover);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-hover-color);
+  color: var(--crm-secondary-text-color);
 }
 #bootstrap-theme .btn-info {
-  background: var(--crm-btn-info-bg);
-  color: var(--crm-btn-info-text);
+  background: var(--crm-btn-info-bg-color);
+  color: var(--crm-btn-info-text-color);
 }
 #bootstrap-theme .btn.btn-info:hover,
 #bootstrap-theme .btn.btn-info:focus {
-  background: color-mix(in srgb, var(--crm-btn-info-bg) 87.5%, #000 12.5%);
-  color: var(--crm-btn-info-text);
+  background: color-mix(in srgb, var(--crm-btn-info-bg-color) 87.5%, #000 12.5%);
+  color: var(--crm-btn-info-text-color);
 }
 #bootstrap-theme .btn-warning {
-  background: var(--crm-btn-warning-bg);
-  color: var(--crm-btn-warning-text);
+  background: var(--crm-btn-warning-bg-color);
+  color: var(--crm-btn-warning-text-color);
 }
 #bootstrap-theme .btn.btn-warning:hover,
 #bootstrap-theme .btn.btn-warning:focus {
-  background: color-mix(in srgb, var(--crm-btn-warning-bg) 87.5%, #000 12.5%);
-  color: var(--crm-btn-warning-text);
+  background: color-mix(in srgb, var(--crm-btn-warning-bg-color) 87.5%, #000 12.5%);
+  color: var(--crm-btn-warning-text-color);
 }
 #bootstrap-theme .btn-success {
-  background: var(--crm-btn-success-bg);
-  color: var(--crm-btn-success-text);
+  background: var(--crm-btn-success-bg-color);
+  color: var(--crm-btn-success-text-color);
 }
 #bootstrap-theme .btn.btn-success:hover,
 #bootstrap-theme .btn.btn-success:focus {
-  background: color-mix(in srgb, var(--crm-btn-success-bg) 87.5%, #000 12.5%);
-  color: var(--crm-btn-success-text);
+  background: color-mix(in srgb, var(--crm-btn-success-bg-color) 87.5%, #000 12.5%);
+  color: var(--crm-btn-success-text-color);
 }
 #bootstrap-theme .btn-danger {
-  background: var(--crm-btn-danger-bg);
-  color: var(--crm-btn-danger-text);
+  background: var(--crm-btn-danger-bg-color);
+  color: var(--crm-btn-danger-text-color);
 }
 #bootstrap-theme .btn.btn-danger:hover,
 #bootstrap-theme .btn.btn-danger:focus {
-  background: color-mix(in srgb, var(--crm-btn-danger-bg) 87.5%, #000 12.5%);
-  color: var(--crm-btn-danger-text);
+  background: color-mix(in srgb, var(--crm-btn-danger-bg-color) 87.5%, #000 12.5%);
+  color: var(--crm-btn-danger-text-color);
 }
 
 /* BS3 size options */
@@ -208,17 +208,17 @@
 /* Hover buttons (plain text, button shows on hover) */
 .crm-container a.crm-hover-button {
   border-radius: var(--crm-btn-radius);
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
   cursor: var(--crm-link-hover-cursor);
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
-  background-color: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background-color: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 .crm-container a.crm-hover-button.action-item,
 .crm-container .crm-hover-button.btn-slide,
 .crm-container .crm-submit-buttons .crm-hover-button {
   background-color: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   padding: var(--crm-btn-small-padding);
   margin: 0;
   cursor: var(--crm-link-hover-cursor);
@@ -238,7 +238,7 @@
 }
 .crm-container .crm-hover-button.crm-clear-link,
 .crm-container .crm-hover-button.crm-close-accordion {
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
   padding: 0;
   background: unset;
 }
@@ -248,8 +248,8 @@
 .crm-container a.crm-hover-button:active,
 .crm-container .crm-submit-buttons .crm-hover-button:hover,
 .crm-container .crm-submit-buttons .crm-hover-button:focus {
-  background: var(--crm-c-secondary-hover);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-hover-color);
+  color: var(--crm-secondary-text-color);
   text-decoration: none;
 }
 
@@ -263,31 +263,31 @@
 /* Modal buttons */
 
 .crm-container.ui-dialog .ui-dialog-buttonset button {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 .crm-container.ui-dialog .ui-dialog-buttonset button:hover,
 .crm-container.ui-dialog .ui-dialog-buttonset button:focus {
-  background: var(--crm-c-primary-hover);
+  background: var(--crm-primary-hover-color);
 }
 
 /* BS3 button dropdowns */
 
 #bootstrap-theme .btn-primary.dropdown-toggle {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 #bootstrap-theme .btn-primary.dropdown-toggle:hover,
 #bootstrap-theme .btn-primary.dropdown-toggle:focus {
-  background: var(--crm-c-primary-hover);
+  background: var(--crm-primary-hover-color);
 }
 #bootstrap-theme .btn-secondary.dropdown-toggle {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color);
 }
 #bootstrap-theme .btn-secondary.dropdown-toggle:hover,
 #bootstrap-theme .btn-secondary.dropdown-toggle:focus {
-  background: var(--crm-c-secondary-hover);
+  background: var(--crm-secondary-hover-color);
 }
 
 /* BS3 Button groups and dropdowns  */
@@ -494,7 +494,7 @@
   left: auto;
 }
 #bootstrap-theme .btn-group .btn + .btn.dropdown-toggle {
-  border-left: 1px solid var(--crm-table-bg);
+  border-left: 1px solid var(--crm-table-bg-color);
 }
 
 /* Icons (for ease, include .button & .ui-button icons) */
@@ -510,7 +510,7 @@
 .crm-container .ui-dialog-buttonset .ui-button .ui-icon,
 .crm-container .btn i.crm-i,
 #bootstrap-theme .btn i.crm-i {
-  background-color: var(--crm-btn-icon-bg);
+  background-color: var(--crm-btn-icon-bg-color);
   border-radius: var(--crm-btn-radius) 0 0 var(--crm-btn-radius);
   border-right: var(--crm-btn-icon-border);
   line-height: inherit;

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -165,23 +165,23 @@
 
 #bootstrap-theme .btn-lg,
 #bootstrap-theme .btn-group-lg > .btn {
-  padding: var(--crm-m3) var(--crm-r);
-  font-size: var(--crm-r1);
+  padding: var(--crm-s-medium-3) var(--crm-s-reg);
+  font-size: var(--crm-s-reg-1);
   line-height: 1.3;
   border-radius: calc(var(--crm-btn-radius) * 2);
 }
 #bootstrap-theme.btn-sm,
 #bootstrap-theme .btn-group-sm > .btn {
-  padding: var(--crm-s2) var(--crm-m1);
-  font-size: var(--crm-m2);
+  padding: var(--crm-s-small-2) var(--crm-s-medium-1);
+  font-size: var(--crm-s-medium-2);
   line-height: 1.5;
   border-radius: var(--crm-btn-radius);
   height: auto;
 }
 #bootstrap-theme .btn-xs,
 #bootstrap-theme .btn-group-xs > .btn {
-  padding: var(--crm-xs) var(--crm-s2);
-  font-size: var(--crm-m2);
+  padding: var(--crm-s-xsmall) var(--crm-s-small-2);
+  font-size: var(--crm-s-medium-2);
   border-radius: var(--crm-btn-radius);
   height: auto;
 }
@@ -199,7 +199,7 @@
   width: 100%;
 }
 .crm-submit-buttons {
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
   display: inline-flex;
   align-items: center;
   gap: var(--crm-flex-gap);
@@ -228,10 +228,10 @@
   white-space: nowrap;
 }
 .crm-container td a.crm-hover-button + .crm-hover-button:not(:last-of-type) {
-  margin-inline: var(--crm-m);
+  margin-inline: var(--crm-s-medium);
 }
 .crm-container td:has(.btn-slide) a.crm-hover-button + .crm-hover-button {
-  margin-inline: var(--crm-m);
+  margin-inline: var(--crm-s-medium);
 }
 .crm-container .crm-submit-buttons .crm-hover-button {
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
@@ -257,7 +257,7 @@
 
 .crm-container .ui-widget-content .action-link .button {
   box-shadow: var(--crm-shadow-block) !important;
-  margin: var(--crm-m) 0;
+  margin: var(--crm-s-medium) 0;
 }
 
 /* Modal buttons */
@@ -295,7 +295,7 @@
 #bootstrap-theme td.text-right:has(.btn + .btn),
 .crm-container .crm-buttons {
   display: flex;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
   flex-wrap: wrap;
 }
 #bootstrap-theme td.text-right:has(.btn + .btn) {
@@ -575,22 +575,22 @@
 /* Small buttons with icons */
 #bootstrap-theme .btn-sm:has(i.crm-i),
 #bootstrap-theme .btn-group-sm > .btn:has(i.crm-i) {
-  padding: 0 var(--crm-m1) 0 0;
+  padding: 0 var(--crm-s-medium-1) 0 0;
 }
 #bootstrap-theme .btn-sm i.crm-i,
 #bootstrap-theme .btn-group-sm > .btn i.crm-i {
   min-width: fit-content;
   height: auto;
-  padding: var(--crm-s2) var(--crm-btn-icon-spacing) var(--crm-s2) var(--crm-m1);
+  padding: var(--crm-s-small-2) var(--crm-btn-icon-spacing) var(--crm-s-small-2) var(--crm-s-medium-1);
 }
 #bootstrap-theme .btn-group-xs button:has(i.crm-i) {
-  padding: 0 var(--crm-s2) 0 0;
+  padding: 0 var(--crm-s-small-2) 0 0;
 }
 #bootstrap-theme .btn-xs:has(i.crm-i),
 #bootstrap-theme .btn-group > .btn-xs + .dropdown-toggle:has(i.crm-i),
 #bootstrap-theme .btn-group-xs > .btn + .dropdown-toggle:has(i.crm-i),
 .crm-container button.dropdown-toggle.btn-xs:has(i.crm-i) {
-  padding: var(--crm-btn-icon-padding) var(--crm-m) var(--crm-btn-icon-padding) 0
+  padding: var(--crm-btn-icon-padding) var(--crm-s-medium) var(--crm-btn-icon-padding) 0
 }
 #bootstrap-theme .btn-xs i.crm-i,
 #bootstrap-theme .btn-group-xs > .btn i.crm-i {

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -165,23 +165,23 @@
 
 #bootstrap-theme .btn-lg,
 #bootstrap-theme .btn-group-lg > .btn {
-  padding: var(--crm-s-medium-3) var(--crm-s-reg);
-  font-size: var(--crm-s-reg-1);
+  padding: var(--crm-l-medium-3) var(--crm-l-reg);
+  font-size: var(--crm-l-reg-1);
   line-height: 1.3;
   border-radius: calc(var(--crm-btn-radius) * 2);
 }
 #bootstrap-theme.btn-sm,
 #bootstrap-theme .btn-group-sm > .btn {
-  padding: var(--crm-s-small-2) var(--crm-s-medium-1);
-  font-size: var(--crm-s-medium-2);
+  padding: var(--crm-l-small-2) var(--crm-l-medium-1);
+  font-size: var(--crm-l-medium-2);
   line-height: 1.5;
   border-radius: var(--crm-btn-radius);
   height: auto;
 }
 #bootstrap-theme .btn-xs,
 #bootstrap-theme .btn-group-xs > .btn {
-  padding: var(--crm-s-xsmall) var(--crm-s-small-2);
-  font-size: var(--crm-s-medium-2);
+  padding: var(--crm-l-xsmall) var(--crm-l-small-2);
+  font-size: var(--crm-l-medium-2);
   border-radius: var(--crm-btn-radius);
   height: auto;
 }
@@ -199,7 +199,7 @@
   width: 100%;
 }
 .crm-submit-buttons {
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
   display: inline-flex;
   align-items: center;
   gap: var(--crm-flex-gap);
@@ -228,10 +228,10 @@
   white-space: nowrap;
 }
 .crm-container td a.crm-hover-button + .crm-hover-button:not(:last-of-type) {
-  margin-inline: var(--crm-s-medium);
+  margin-inline: var(--crm-l-medium);
 }
 .crm-container td:has(.btn-slide) a.crm-hover-button + .crm-hover-button {
-  margin-inline: var(--crm-s-medium);
+  margin-inline: var(--crm-l-medium);
 }
 .crm-container .crm-submit-buttons .crm-hover-button {
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
@@ -257,7 +257,7 @@
 
 .crm-container .ui-widget-content .action-link .button {
   box-shadow: var(--crm-shadow-block) !important;
-  margin: var(--crm-s-medium) 0;
+  margin: var(--crm-l-medium) 0;
 }
 
 /* Modal buttons */
@@ -295,7 +295,7 @@
 #bootstrap-theme td.text-right:has(.btn + .btn),
 .crm-container .crm-buttons {
   display: flex;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
   flex-wrap: wrap;
 }
 #bootstrap-theme td.text-right:has(.btn + .btn) {
@@ -575,22 +575,22 @@
 /* Small buttons with icons */
 #bootstrap-theme .btn-sm:has(i.crm-i),
 #bootstrap-theme .btn-group-sm > .btn:has(i.crm-i) {
-  padding: 0 var(--crm-s-medium-1) 0 0;
+  padding: 0 var(--crm-l-medium-1) 0 0;
 }
 #bootstrap-theme .btn-sm i.crm-i,
 #bootstrap-theme .btn-group-sm > .btn i.crm-i {
   min-width: fit-content;
   height: auto;
-  padding: var(--crm-s-small-2) var(--crm-btn-icon-spacing) var(--crm-s-small-2) var(--crm-s-medium-1);
+  padding: var(--crm-l-small-2) var(--crm-btn-icon-spacing) var(--crm-l-small-2) var(--crm-l-medium-1);
 }
 #bootstrap-theme .btn-group-xs button:has(i.crm-i) {
-  padding: 0 var(--crm-s-small-2) 0 0;
+  padding: 0 var(--crm-l-small-2) 0 0;
 }
 #bootstrap-theme .btn-xs:has(i.crm-i),
 #bootstrap-theme .btn-group > .btn-xs + .dropdown-toggle:has(i.crm-i),
 #bootstrap-theme .btn-group-xs > .btn + .dropdown-toggle:has(i.crm-i),
 .crm-container button.dropdown-toggle.btn-xs:has(i.crm-i) {
-  padding: var(--crm-btn-icon-padding) var(--crm-s-medium) var(--crm-btn-icon-padding) 0
+  padding: var(--crm-btn-icon-padding) var(--crm-l-medium) var(--crm-btn-icon-padding) 0
 }
 #bootstrap-theme .btn-xs i.crm-i,
 #bootstrap-theme .btn-group-xs > .btn i.crm-i {

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -4,7 +4,7 @@
 .crm-container .listing-box-tall,
 .crm-container ul.crm-checkbox-list {
   width: auto;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   max-width: 30rem;
   height: 7.25rem;
   overflow: auto;
@@ -203,13 +203,13 @@ table.advmultiselect {
 .crm-container .panel {
   box-shadow: var(--crm-panel-shadow);
   border: var(--crm-panel-border);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   margin-bottom: calc(var(--crm-r) + var(--crm-panel-head-margin));
   background: transparent;
 }
 .crm-container .panel-heading {
   padding: var(--crm-m2) var(--crm-padding-reg);
-  border-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
+  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   border-bottom: var(--crm-panel-border);
 }
 .crm-container .panel-heading > .dropdown .dropdown-toggle {
@@ -219,7 +219,7 @@ table.advmultiselect {
   padding: var(--crm-padding-reg);
   background: var(--crm-panel-bg);
   box-shadow: none;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container .panel-body:before, #bootstrap-theme .panel-body:after {
   display: table;
@@ -241,7 +241,7 @@ table.advmultiselect {
   padding: var(--crm-padding-reg);
   background: var(--crm-panel-bg);
   border-top: var(--crm-panel-border);
-  border-radius: 0 0 var(--crm-roundness) var(--crm-roundness);
+  border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
   box-shadow: var(--crm-panel-shadow);
 }
 .crm-container .panel-default > .panel-heading {
@@ -365,7 +365,7 @@ table.advmultiselect {
   font-size: var(--crm-m2);
 }
 .crm-container #civicrm-footer .status {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   padding: var(--crm-btn-small-padding);
   border-color: transparent;
 }
@@ -430,7 +430,7 @@ p.crm-upgrade-large-text:first-of-type {
   background: var(--crm-c-layer1-bg);
   padding: var(--crm-padding-reg);
   margin-block: var(--crm-r);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   display: inline-flex;
   flex-direction: row-reverse;
   justify-content: space-between;
@@ -586,7 +586,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 #CKEditorConfig .cke_ltr.cke_button.cke_toolgroup {
   width: 30px;
   height: 30px;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   background: var(--crm-c-container-bg);
 }
 #CKEditorConfig .move {
@@ -615,7 +615,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-input-bg);
   list-style-type: none;
   position: relative;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 #crm-recently-viewed .crm-recentview-wrapper a {
   opacity: 0.6;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -343,7 +343,7 @@ table.advmultiselect {
 .crm-container a.badge:focus {
   color: white;
   text-decoration: none;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 
 /* Footer */

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -8,7 +8,7 @@
   max-width: 30rem;
   height: 7.25rem;
   overflow: auto;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 .crm-container ul.crm-checkbox-list {
   list-style: none;
@@ -255,7 +255,7 @@ table.advmultiselect {
   margin: 0;
 }
 .crm-container .panel-default {
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 .crm-container .panel-default > .panel-heading .badge {
   color: var(--crm-c-secondary-text);
@@ -611,7 +611,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 #crm-recently-viewed li.crm-recently-viewed {
   margin-block: var(--crm-xs);
   padding: var(--crm-s);
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   background-color: var(--crm-input-bg);
   list-style-type: none;
   position: relative;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -245,7 +245,7 @@ table.advmultiselect {
 }
 .crm-container .panel-default > .panel-heading {
   color: var(--crm-text-color);
-  background-color: var(--crm-c-layout1-bg-color);
+  background-color: var(--crm-layer1-bg-color);
   border-bottom: var(--crm-panel-border);
 }
 .crm-container .panel-title {

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -24,10 +24,10 @@
 .crm-container ul.crm-checkbox-list li {
   margin: 0;
   display: grid;
-  grid-template-columns: var(--crm-r) 100%;
-  gap: var(--crm-xs);
+  grid-template-columns: var(--crm-s-reg) 100%;
+  gap: var(--crm-s-xsmall);
   background-color: var(--crm-input-bg-color);
-  padding-inline: var(--crm-s) var(--crm-m2);
+  padding-inline: var(--crm-s-small) var(--crm-s-medium-2);
   word-break: break-all;
   align-items: center;
 }
@@ -43,7 +43,7 @@
   --crm-input-bg-color: var(--crm-form-checkbox-list-bg-color);
 }
 .listing-box input.crm-form-checkbox {
-  margin: 0 0 0 var(--crm-s);
+  margin: 0 0 0 var(--crm-s-small);
 }
 
 /* Action Links */
@@ -52,7 +52,7 @@
   line-height: 1;
   background: unset;
   display: flex;
-  column-gap: var(--crm-m);
+  column-gap: var(--crm-s-medium);
   padding: var(--crm-padding-reg) 0;
   flex-wrap: wrap;
 }
@@ -73,7 +73,7 @@
 }
 .crm-container table.advmultiselect td:nth-of-type(2n) {
   display: flex;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   border: 0;
   align-items: center;
   height: 125px;
@@ -108,11 +108,11 @@ table.advmultiselect {
   gap: initial; /* resets .nav.nav-pills gap */
 }
 .crm-container ul.crm-wizard-nav {
-  margin-bottom: var(--crm-r);
+  margin-bottom: var(--crm-s-reg);
   box-shadow: var(--crm-wizard-box-shadow);
 }
 .crm-wizard-step .ui-tabs {
-  margin-bottom: var(--crm-m);
+  margin-bottom: var(--crm-s-medium);
 }
 .crm-container ul.wizard-bar li,
 .crm_wizard__title ul > li {
@@ -126,12 +126,12 @@ table.advmultiselect {
   display: inline-block;
   font-weight: bold;
   line-height: var(--crm-wizard-height);
-  padding: 0 var(--crm-l) 0 var(--crm-xl);
+  padding: 0 var(--crm-s-large) 0 var(--crm-s-large-1);
   position: relative;
 }
 .crm-container ul.wizard-bar > li:first-child,
 .crm_wizard__title ul > li:first-child {
-  padding-left: var(--crm-l);
+  padding-left: var(--crm-s-large);
 }
 .crm-container ul.wizard-bar > li::after,
 .crm_wizard__title ul > li::after {
@@ -185,7 +185,7 @@ table.advmultiselect {
 }
 .crm-container ul.wizard-bar > li:not(:first-child),
 .crm_wizard__title ul > li:not(:first-child) {
-  padding-left: calc(var(--crm-l) + var(--crm-wizard-angle)) !important;
+  padding-left: calc(var(--crm-s-large) + var(--crm-wizard-angle)) !important;
 }
 .crm-wizard-buttons {
   margin-top: var(--crm-padding-reg);
@@ -203,11 +203,11 @@ table.advmultiselect {
   box-shadow: var(--crm-panel-shadow);
   border: var(--crm-panel-border);
   border-radius: var(--crm-s-radius);
-  margin-bottom: calc(var(--crm-r) + var(--crm-panel-head-margin));
+  margin-bottom: calc(var(--crm-s-reg) + var(--crm-panel-head-margin));
   background: transparent;
 }
 .crm-container .panel-heading {
-  padding: var(--crm-m2) var(--crm-padding-reg);
+  padding: var(--crm-s-medium-2) var(--crm-padding-reg);
   border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   border-bottom: var(--crm-panel-border);
 }
@@ -308,19 +308,19 @@ table.advmultiselect {
 .crm-container .badge {
   display: inline-block;
   min-width: 10px;
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
   line-height: 1;
   color: var(--crm-primary-text-color);
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
   background-color: var(--crm-primary-color);
-  border-radius: var(--crm-m2);
+  border-radius: var(--crm-s-medium-2);
   position: relative;
   top: -1px;
 }
 .crm-container .btn-group .badge {
-  margin-inline: var(--crm-xs);
+  margin-inline: var(--crm-s-xsmall);
 }
 .crm-container .badge:empty {
   display: none;
@@ -351,17 +351,17 @@ table.advmultiselect {
   text-align: right;
 }
 #crm-record-log {
-  font-size: var(--crm-m3);
-  padding: var(--crm-m3) 0;
+  font-size: var(--crm-s-medium-3);
+  padding: var(--crm-s-medium-3) 0;
 }
 #crm-record-log .col1 {
   float: left;
 }
 #civicrm-footer {
-  margin-top: var(--crm-l);
-  padding: var(--crm-m2);
+  margin-top: var(--crm-s-large);
+  padding: var(--crm-s-medium-2);
   text-align: center;
-  font-size: var(--crm-m2);
+  font-size: var(--crm-s-medium-2);
 }
 .crm-container #civicrm-footer .status {
   border-radius: var(--crm-s-radius);
@@ -405,14 +405,14 @@ p.crm-upgrade-large-text {
   color: var(--link) !important  /* vs inline */;
 }
 p.crm-upgrade-large-text:first-of-type {
-  font-size: var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
   color: var(--crm-alert-success-text-color);
   font-weight: bold;
 }
 .crm-success-flex {
   display: unset;
   padding: 0 2rem 0 0 !important /* vs inline */;
-  font-size: var(--crm-l);
+  font-size: var(--crm-s-large);
   line-height: 1.35;
   color: var(--crm-alert-success-text-color);
   grid-column: 1;
@@ -428,7 +428,7 @@ p.crm-upgrade-large-text:first-of-type {
 #crm-queue-runner-desc {
   background: var(--crm-layer1-bg-color);
   padding: var(--crm-padding-reg);
-  margin-block: var(--crm-r);
+  margin-block: var(--crm-s-reg);
   border-radius: var(--crm-s-radius);
   display: inline-flex;
   flex-direction: row-reverse;
@@ -441,7 +441,7 @@ p.crm-upgrade-large-text:first-of-type {
 #crm-queue-runner-buttonset button {
   background: transparent;
   height: inherit;
-  padding: 0 0 0 var(--crm-r);
+  padding: 0 0 0 var(--crm-s-reg);
   color: var(--crm-text-color);
 }
 #crm-queue-runner-buttonset button:hover,
@@ -477,7 +477,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   animation: progress-bar-stripes 1s linear infinite;
 }
 .crm-status-box-outer .crm-status-box-inner {
-  padding: var(--crm-s) var(--crm-r);
+  padding: var(--crm-s-small) var(--crm-s-reg);
   font-size: var(--crm-font-size);
   color: var(--crm-text-light-color);
   font-weight: bold;
@@ -608,8 +608,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   font-size: 0.9rem;
 }
 #crm-recently-viewed li.crm-recently-viewed {
-  margin-block: var(--crm-xs);
-  padding: var(--crm-s);
+  margin-block: var(--crm-s-xsmall);
+  padding: var(--crm-s-small);
   border: var(--crm-border);
   background-color: var(--crm-input-bg-color);
   list-style-type: none;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -14,7 +14,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  background-color: var(--crm-input-bg);
+  background-color: var(--crm-input-bg-color);
   width: 300px;
   max-width: 100%;
   max-height: 300px;
@@ -26,7 +26,7 @@
   display: grid;
   grid-template-columns: var(--crm-r) 100%;
   gap: var(--crm-xs);
-  background-color: var(--crm-input-bg);
+  background-color: var(--crm-input-bg-color);
   padding-inline: var(--crm-s) var(--crm-m2);
   word-break: break-all;
   align-items: center;
@@ -36,18 +36,17 @@
 }
 .crm-container :is(.listing-box,.listing-box-tall) .even-row,
 .crm-container ul.crm-checkbox-list li:nth-child(2n) {
-  background-color: color-mix(in srgb, var(--crm-input-bg) 100%, var(--crm-table-row-alternate-bg) var(--crm-table-row-alternate-mix));
+  background-color: color-mix(in srgb, var(--crm-input-bg-color) 100%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container :is(.listing-box,.listing-box-tall) > div:has(input:checked),
 .crm-container ul.crm-checkbox-list li:has(input:checked) {
-  --crm-input-bg: var(--crm-checkbox-list-bg);
+  --crm-input-bg-color: var(--crm-form-checkbox-list-bg-color);
 }
 .listing-box input.crm-form-checkbox {
   margin: 0 0 0 var(--crm-s);
 }
 
 /* Action Links */
-
 .crm-container .action-link,
 .crm-container .action-link:hover {
   line-height: 1;
@@ -93,7 +92,7 @@ table.advmultiselect {
   list-style: none;
   margin: 0 0 20px;
   line-height: normal;
-  background-color: var(--crm-c-container-bg);
+  background-color: var(--crm-container-bg-color);
   border: var(--crm-wizard-border);
   border-radius: var(--crm-wizard-radius);
   overflow: hidden;
@@ -120,10 +119,10 @@ table.advmultiselect {
   margin: -2px;
   text-decoration: none;
   background-image: none;
-  background-color: var(--crm-wizard-bg);
+  background-color: var(--crm-wizard-bg-color);
   border: 0;
   border-radius: 0;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   display: inline-block;
   font-weight: bold;
   line-height: var(--crm-wizard-height);
@@ -137,7 +136,7 @@ table.advmultiselect {
 .crm-container ul.wizard-bar > li::after,
 .crm_wizard__title ul > li::after {
   border-bottom: var(--crm-wizard-height) solid rgba(0,0,0,0);
-  border-left: calc(1px + var(--crm-wizard-angle)) solid var(--crm-wizard-active-bg);
+  border-left: calc(1px + var(--crm-wizard-angle)) solid var(--crm-wizard-active-bg-color);
   border-top: var(--crm-wizard-height) solid rgba(0,0,0,0);
   content: "";
   height: 0;
@@ -149,12 +148,12 @@ table.advmultiselect {
 }
 .crm-container ul.crm-wizard-nav > li::after,
 .crm_wizard__title ul > li::after {
-  border-left: calc(1.25 * var(--crm-wizard-angle)) solid var(--crm-wizard-active-bg);
+  border-left: calc(1.25 * var(--crm-wizard-angle)) solid var(--crm-wizard-active-bg-color);
 }
 .crm-container ul.wizard-bar > li::before,
 .crm_wizard__title ul > li::before {
   border-bottom: var(--crm-wizard-height) solid rgba(0,0,0,0);
-  border-left: var(--crm-wizard-angle) solid var(--crm-wizard-bg);
+  border-left: var(--crm-wizard-angle) solid var(--crm-wizard-bg-color);
   border-top: var(--crm-wizard-height) solid rgba(0,0,0,0);
   content: "";
   height: 0;
@@ -166,23 +165,23 @@ table.advmultiselect {
 }
 .crm-container ul.crm-wizard-nav > li::before,
 .crm_wizard__title ul > li::before {
-  border-left: calc(1.25 * var(--crm-wizard-angle)) solid var(--crm-wizard-bg);
+  border-left: calc(1.25 * var(--crm-wizard-angle)) solid var(--crm-wizard-bg-color);
 }
 .crm-container ul.wizard-bar > li.current-step,
 .crm_wizard__title ul > li.active,
 .crm_wizard__title ul > li.active a {
-  background-color: var(--crm-wizard-active-bg);
-  color: var(--crm-wizard-active-col);
+  background-color: var(--crm-wizard-active-bg-color);
+  color: var(--crm-wizard-active-color);
 }
 .crm_wizard__title .nav-pills > li.active > a:hover,
 .crm_wizard__title .nav-pills > li.active > a:focus {
-  background-color: var(--crm-wizard-active-bg);
-  color: var(--crm-wizard-active-col);
+  background-color: var(--crm-wizard-active-bg-color);
+  color: var(--crm-wizard-active-color);
 }
 
 .crm-container ul.wizard-bar > li.current-step::before,
 .crm_wizard__title ul > li.active::before {
-  border-left-color: var(--crm-wizard-active-bg);
+  border-left-color: var(--crm-wizard-active-bg-color);
 }
 .crm-container ul.wizard-bar > li:not(:first-child),
 .crm_wizard__title ul > li:not(:first-child) {
@@ -217,7 +216,7 @@ table.advmultiselect {
 }
 .crm-container .panel-body {
   padding: var(--crm-padding-reg);
-  background: var(--crm-panel-bg);
+  background: var(--crm-panel-bg-color);
   box-shadow: none;
   border-radius: var(--crm-s-radius);
 }
@@ -239,14 +238,14 @@ table.advmultiselect {
 }
 .crm-container .panel-footer {
   padding: var(--crm-padding-reg);
-  background: var(--crm-panel-bg);
+  background: var(--crm-panel-bg-color);
   border-top: var(--crm-panel-border);
   border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
   box-shadow: var(--crm-panel-shadow);
 }
 .crm-container .panel-default > .panel-heading {
-  color: var(--crm-c-text);
-  background-color: var(--crm-c-layout1-bg);
+  color: var(--crm-text-color);
+  background-color: var(--crm-c-layout1-bg-color);
   border-bottom: var(--crm-panel-border);
 }
 .crm-container .panel-title {
@@ -258,43 +257,43 @@ table.advmultiselect {
   border: var(--crm-border);
 }
 .crm-container .panel-default > .panel-heading .badge {
-  color: var(--crm-c-secondary-text);
-  background-color: var(--crm-c-secondary);
+  color: var(--crm-secondary-text-color);
+  background-color: var(--crm-secondary-color);
 }
 .crm-container .panel-primary > .panel-heading {
-  color: var(--crm-c-primary-text);
-  background-color: var(--crm-c-primary);
+  color: var(--crm-primary-text-color);
+  background-color: var(--crm-primary-color);
 }
 .crm-container .panel-primary > .panel-heading :is(.badge,a) {
-  color: var(--crm-c-primary-text);
+  color: var(--crm-primary-text-color);
 }
 .crm-container .panel-success > .panel-heading {
-  color: var(--crm-alert-success-text);
-  background-color: var(--crm-alert-success-bg);
+  color: var(--crm-alert-success-text-color);
+  background-color: var(--crm-alert-success-bg-color);
 }
 .crm-container .panel-success > .panel-heading :is(.badge,a) {
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-container .panel-info > .panel-heading {
-  color: var(--crm-alert-info-text);
-  background-color: var(--crm-alert-info-bg);
+  color: var(--crm-alert-info-text-color);
+  background-color: var(--crm-alert-info-bg-color);
 }
 .crm-container .panel-info > .panel-heading :is(.badge,a) {
-  color: var(--crm-alert-info-text);
+  color: var(--crm-alert-info-text-color);
 }
 .crm-container .panel-warning > .panel-heading {
-  color: var(--crm-c-warning-text);
-  background-color: var(--crm-c-warning);
+  color: var(--crm-warning-text-color);
+  background-color: var(--crm-warning-color);
 }
 .crm-container .panel-warning > .panel-heading :is(.badge,a) {
-  color: var(--crm-c-warning-text);
+  color: var(--crm-warning-text-color);
 }
 .crm-container .panel-danger > .panel-heading {
-  color: var(--crm-c-danger-on-page-bg);
-  background-color: var(--crm-c-danger);
+  color: var(--crm-danger-ink-color);
+  background-color: var(--crm-danger-color);
 }
 .crm-container .panel-danger > .panel-heading :is(.badge,a) {
-  color: var(--crm-c-danger);
+  color: var(--crm-danger-color);
 }
 .crm-container .panel:has(.nav.nav-tabs) {
   border: var(--crm-tabs-border);
@@ -311,11 +310,11 @@ table.advmultiselect {
   min-width: 10px;
   padding: var(--crm-s) var(--crm-m);
   line-height: 1;
-  color: var(--crm-c-primary-text);
+  color: var(--crm-primary-text-color);
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
-  background-color: var(--crm-c-primary);
+  background-color: var(--crm-primary-color);
   border-radius: var(--crm-m2);
   position: relative;
   top: -1px;
@@ -333,8 +332,8 @@ table.advmultiselect {
 }
 .list-group-item.active > .badge,
 .nav-pills > .active > a > .badge {
-  color: var(--crm-c-link);
-  background-color: var(--crm-c-layer1-bg);
+  color: var(--crm-link-color);
+  background-color: var(--crm-layer1-bg-color);
 }
 .nav-pills > li > a > .badge {
   margin-left: 3px;
@@ -370,14 +369,14 @@ table.advmultiselect {
   border-color: transparent;
 }
 .crm-container #civicrm-footer .status.crm-error {
-  background-color: var(--crm-c-danger);
+  background-color: var(--crm-danger-color);
   color: var(--danger-text);
 }
 #civicrm-footer .status a {
   color: inherit;
 }
 .crm-container #civicrm-footer .status.crm-error a {
-  color: var(--crm-c-danger-text);
+  color: var(--crm-danger-text-color);
 }
 
 /* Upgrade screen (overwrites inline css) */
@@ -388,8 +387,8 @@ table.advmultiselect {
 }
 .crm-upgrade-box-outer.crm-upgrade-success {
   margin: var(--crm-page-padding);
-  background: var(--crm-alert-success-bg) !important; /* vs inline css */
-  border: var(--crm-alert-border-width) solid var(--crm-alert-success-border) !important; /* vs inline css */
+  background: var(--crm-alert-success-bg-color) !important; /* vs inline css */
+  border: var(--crm-alert-border-width) solid var(--crm-alert-success-border-color) !important; /* vs inline css */
 }
 .crm-upgrade-box-inner {
   padding: 1rem;
@@ -400,14 +399,14 @@ table.advmultiselect {
 }
 p.crm-upgrade-large-text {
   grid-column: 2;
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-upgrade-box-inner a {
   color: var(--link) !important  /* vs inline */;
 }
 p.crm-upgrade-large-text:first-of-type {
   font-size: var(--crm-r1);
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
   font-weight: bold;
 }
 .crm-success-flex {
@@ -415,7 +414,7 @@ p.crm-upgrade-large-text:first-of-type {
   padding: 0 2rem 0 0 !important /* vs inline */;
   font-size: var(--crm-l);
   line-height: 1.35;
-  color: var(--crm-alert-success-text);
+  color: var(--crm-alert-success-text-color);
   grid-column: 1;
   grid-row: 1 / span 3;
 }
@@ -424,10 +423,10 @@ p.crm-upgrade-large-text:first-of-type {
 
 #crm-queue-runner-progress {
   width: 100%;
-  background: var(--crm-c-layer2-bg);
+  background: var(--crm-layer2-bg-color);
 }
 #crm-queue-runner-desc {
-  background: var(--crm-c-layer1-bg);
+  background: var(--crm-layer1-bg-color);
   padding: var(--crm-padding-reg);
   margin-block: var(--crm-r);
   border-radius: var(--crm-s-radius);
@@ -443,23 +442,23 @@ p.crm-upgrade-large-text:first-of-type {
   background: transparent;
   height: inherit;
   padding: 0 0 0 var(--crm-r);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 #crm-queue-runner-buttonset button:hover,
 #crm-queue-runner-buttonset button:focus {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 
 /* Community message */
 
 div.civicrm-community-messages {
-  border: 2px solid var(--crm-alert-success-border);
-  background: var(--crm-alert-success-bg);
+  border: 2px solid var(--crm-alert-success-border-color);
+  background: var(--crm-alert-success-bg-color);
   padding: var(--crm-padding-inset);
 }
 div.civicrm-community-messages .crm-collapsible .collapsible-title,
 div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
-  color: var(--crm-alert-success-text) !important /* vs inline */;
+  color: var(--crm-alert-success-text-color) !important /* vs inline */;
 }
 
 /* Status box (for mailsending) */
@@ -480,105 +479,105 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 .crm-status-box-outer .crm-status-box-inner {
   padding: var(--crm-s) var(--crm-r);
   font-size: var(--crm-font-size);
-  color: var(--crm-c-text-light);
+  color: var(--crm-text-light-color);
   font-weight: bold;
   text-align: center;
-  background: var(--crm-c-layer1-bg);
+  background: var(--crm-layer1-bg-color);
 }
 .crm-status-box-outer.status-success .crm-status-box-inner {
-  background: var(--crm-c-success);
+  background: var(--crm-success-color);
 }
 .crm-status-box-outer.status-error .crm-status-box-inner {
-  background: var(--crm-c-danger);
+  background: var(--crm-danger-color);
 }
 
 /* Background regions */
 
 #bootstrap-theme .bg-primary {
-  background-color: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background-color: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 #bootstrap-theme .bg-primary a {
-  color: var(--crm-c-primary-text);
+  color: var(--crm-primary-text-color);
 }
 #bootstrap-theme a.bg-primary:hover,
 #bootstrap-theme a.bg-primary:focus {
-  background-color: var(--crm-c-primary-hover);
+  background-color: var(--crm-primary-hover-color);
 }
 #bootstrap-theme .bg-secondary {
-  background-color: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text);
+  background-color: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color);
 }
 #bootstrap-theme .bg-secondary a {
-  color: var(--crm-c-secondary-text);
+  color: var(--crm-secondary-text-color);
 }
 #bootstrap-theme a.bg-secondary:hover,
 #bootstrap-theme a.bg-secondary:focus {
-  background-color: var(--crm-c-secondary-hover);
+  background-color: var(--crm-secondary-hover-color);
 }
 #bootstrap-theme .dropdown-menu .bg-success a,
 #bootstrap-theme .dropdown-menu a.bg-success,
 #bootstrap-theme .bg-success {
-  background-color: var(--crm-c-success);
-  color: var(--crm-c-success-text);
+  background-color: var(--crm-success-color);
+  color: var(--crm-success-text-color);
 }
 #bootstrap-theme a.bg-success:hover,
 #bootstrap-theme a.bg-success:focus,
 #bootstrap-theme .dropdown-menu a.bg-success:hover,
 #bootstrap-theme .dropdown-menu .bg-success a:hover {
-  background: color-mix(in srgb, var(--crm-c-success) 87.5%, #000 12.5%);
-  color: var(--crm-c-success-text);
+  background: color-mix(in srgb, var(--crm-success-color) 87.5%, #000 12.5%);
+  color: var(--crm-success-text-color);
 }
 #bootstrap-theme .dropdown-menu .bg-info a,
 #bootstrap-theme .dropdown-menu a.bg-info,
 #bootstrap-theme .bg-info {
-  background-color: var(--crm-c-info);
-  color: var(--crm-c-info-text);
+  background-color: var(--crm-info-color);
+  color: var(--crm-info-text-color);
 }
 #bootstrap-theme a.bg-info:hover,
 #bootstrap-theme a.bg-info:focus,
 #bootstrap-theme .dropdown-menu .bg-info a:hover,
 #bootstrap-theme .dropdown-menu a.bg-info:hover {
-  background: color-mix(in srgb, var(--crm-c-info) 87.5%, #000 12.5%);
-  color: var(--crm-c-info-text);
+  background: color-mix(in srgb, var(--crm-info-color) 87.5%, #000 12.5%);
+  color: var(--crm-info-text-color);
 }
 #bootstrap-theme .bg-warning,
 #bootstrap-theme .dropdown-menu .bg-warning a,
 #bootstrap-theme .dropdown-menu a.bg-warning {
-  background-color: var(--crm-c-warning);
-  color: var(--crm-c-warning-text) !important /* FormBuilder vs .disabled */;
+  background-color: var(--crm-warning-color);
+  color: var(--crm-warning-text-color) !important /* FormBuilder vs .disabled */;
 }
 #bootstrap-theme a.bg-warning:hover,
 #bootstrap-theme a.bg-warning:focus,
 #bootstrap-theme .dropdown-menu .bg-warning a:hover,
 #bootstrap-theme .dropdown-menu a.bg-warning:hover {
-  background: color-mix(in srgb, var(--crm-c-warning) 87.5%, #000 12.5%);
-  color: var(--crm-c-warning-text);
+  background: color-mix(in srgb, var(--crm-warning-color) 87.5%, #000 12.5%);
+  color: var(--crm-warning-text-color);
 }
 #bootstrap-theme .bg-danger,
 #bootstrap-theme .dropdown-menu .bg-danger a,
 #bootstrap-theme .dropdown-menu a.bg-danger {
-  background-color: var(--crm-c-danger);
-  color: var(--crm-c-danger-text);
+  background-color: var(--crm-danger-color);
+  color: var(--crm-danger-text-color);
 }
 #bootstrap-theme a.bg-danger:hover,
 #bootstrap-theme a.bg-danger:focus,
 #bootstrap-theme .dropdown-menu .bg-danger a:hover,
 #bootstrap-theme .dropdown-menu a.bg-danger:hover {
-  background: color-mix(in srgb, var(--crm-c-danger) 87.5%, #000 12.5%);
-  color: var(--crm-c-danger-text);
+  background: color-mix(in srgb, var(--crm-danger-color) 87.5%, #000 12.5%);
+  color: var(--crm-danger-text-color);
 }
 #bootstrap-theme .dropdown-menu .bg-danger .crm-i::before {
-  color: var(--crm-c-danger-text);
+  color: var(--crm-danger-text-color);
 }
 #bootstrap-theme .dropdown-menu .bg-warning .crm-i::before {
-  color: var(--crm-c-warning-text);
+  color: var(--crm-warning-text-color);
 }
 #bootstrap-theme .dropdown-menu .bg-success .crm-i::before {
-  color: var(--crm-c-success-text);
+  color: var(--crm-success-text-color);
 }
 #bootstrap-theme .dropdown-menu .bg-info .crm-i::before {
-  color: var(--crm-c-info-text);
+  color: var(--crm-info-text-color);
 }
 
 /* CKEditor Config */
@@ -587,17 +586,17 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   width: 30px;
   height: 30px;
   border-radius: var(--crm-s-radius);
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
 }
 #CKEditorConfig .move {
-  background-color: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background-color: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
   border: 0;
   margin-block: 1px;
 }
 #CKEditorConfig .move:focus,
 #CKEditorConfig .move:hover {
-  background-color: var(--crm-c-primary-hover);
+  background-color: var(--crm-primary-hover-color);
   border: 0;
 }
 /* Blocks (D7/Joomla) */
@@ -612,7 +611,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   margin-block: var(--crm-xs);
   padding: var(--crm-s);
   border: var(--crm-border);
-  background-color: var(--crm-input-bg);
+  background-color: var(--crm-input-bg-color);
   list-style-type: none;
   position: relative;
   border-radius: var(--crm-s-radius);
@@ -632,7 +631,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 
 .dc-chart .dc-legend text,
 .dc-chart .axis text {
-  fill: var(--crm-c-text);
+  fill: var(--crm-text-color);
 }
 .crm-container .dc-chart .axis line,
 .dc-chart .axis path {
@@ -649,7 +648,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   --crm-svg-logo: url('data:image/svg+xml,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 355 355" style="enable-background:new 0 0 355 355;" xml:space="preserve"><style type="text/css">.st0{fill:%23086287;}.st1{fill:%2381C459;}</style><g transform="matrix(1, 0, 0, 1, -198, -120)"><g><path class="st0" d="M342.05,470.43C342.05,470.43,342.05,470.43,342.05,470.43c-20.72-0.4-28.62-24.34-29.45-27.07l-70.69-231.67c-4.16-13.61-3.21-24.56,2.83-32.55c3.9-5.16,11.67-11.25,26.56-10.96c5.45,0.1,9.72,1.07,10.19,1.17l235.37,54.83c15.13,3.52,24.43,10.66,27.64,21.21c5.09,16.72-9.08,32.57-10.72,34.32L369.09,456.41C360.25,465.89,351.15,470.61,342.05,470.43z M270.14,192.48c-4.21-0.08-5.58,1.07-5.84,1.44c-1.19,1.68-1.45,2.43,1.05,10.62l70.69,231.66c1.58,4.95,4.2,9.55,6.48,9.72l0,0c0.03,0,2.84-0.02,8.64-6.23l164.69-176.68c3.04-3.34,5.84-8.78,5.2-10.46c-0.46-1.19-2.35-2.75-9.76-4.48l-235.37-54.84l0,0C275.92,193.23,272.97,192.54,270.14,192.48z"/></g><g><path class="st1" d="M315.61,451.6c-7.61,2.82-15.56,3.37-21.8,1.34c0,0,0,0,0,0c-19.66-6.41-20.24-31.58-20.24-34.42l0.02-225.56l23.16,5.19L296.84,419c0.06,5.18,1.4,10.13,4.56,10.68l0,0c0.02,0.01,1.64,0.52,6.35-1.63L315.61,451.6z M329.71,415.68l190.44-110.19c3.87-2.3,8.39-5.74,8.01-8.48c-0.06-0.41-0.96-2.89-5.08-5.75l15.97-18.15c9.02,6.88,13.59,14.89,13.59,23.91c0,17.44-18.16,28.45-20.23,29.65L337.06,438.9L329.71,415.68z M500.93,278.76L313.77,169.87c0,0-4.67-2.98-7.36-3.86c-4-1.3-5.96,0.02-6.33,0.27c-1.12,0.75-1.48,1.34-1.95,6.84l-24.11-4.49c1.31-10.03,5.23-17.46,11.68-22.15c5.22-3.79,14.42-7.34,28.55-2.73c5.17,1.69,8.97,3.85,9.38,4.09l194.69,112.31L500.93,278.76z"/></g></g></svg>') no-repeat;
 }
 .crm-container .blockUI.blockOverlay {
-  background: var(--crm-c-page-bg) !important;
+  background: var(--crm-page-bg-color) !important;
 }
 .crm-container .blockUI.blockOverlay::before {
   content: "";
@@ -666,8 +665,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 .crm-loading-spinner {
   width: var(--crm-loading-spinner-size);
   height: var(--crm-loading-spinner-size);
-  border: 5px solid var(--crm-c-info-text);
-  border-bottom-color: var(--crm-c-info);
+  border: 5px solid var(--crm-info-text-color);
+  border-bottom-color: var(--crm-info-color);
   border-radius: 50%;
   display: inline-block;
   box-sizing: border-box;

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -4,7 +4,7 @@
 .crm-container .listing-box-tall,
 .crm-container ul.crm-checkbox-list {
   width: auto;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   max-width: 30rem;
   height: 7.25rem;
   overflow: auto;
@@ -24,10 +24,10 @@
 .crm-container ul.crm-checkbox-list li {
   margin: 0;
   display: grid;
-  grid-template-columns: var(--crm-s-reg) 100%;
-  gap: var(--crm-s-xsmall);
+  grid-template-columns: var(--crm-l-reg) 100%;
+  gap: var(--crm-l-xsmall);
   background-color: var(--crm-input-bg-color);
-  padding-inline: var(--crm-s-small) var(--crm-s-medium-2);
+  padding-inline: var(--crm-l-small) var(--crm-l-medium-2);
   word-break: break-all;
   align-items: center;
 }
@@ -43,7 +43,7 @@
   --crm-input-bg-color: var(--crm-form-checkbox-list-bg-color);
 }
 .listing-box input.crm-form-checkbox {
-  margin: 0 0 0 var(--crm-s-small);
+  margin: 0 0 0 var(--crm-l-small);
 }
 
 /* Action Links */
@@ -52,7 +52,7 @@
   line-height: 1;
   background: unset;
   display: flex;
-  column-gap: var(--crm-s-medium);
+  column-gap: var(--crm-l-medium);
   padding: var(--crm-padding-reg) 0;
   flex-wrap: wrap;
 }
@@ -73,7 +73,7 @@
 }
 .crm-container table.advmultiselect td:nth-of-type(2n) {
   display: flex;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   border: 0;
   align-items: center;
   height: 125px;
@@ -108,11 +108,11 @@ table.advmultiselect {
   gap: initial; /* resets .nav.nav-pills gap */
 }
 .crm-container ul.crm-wizard-nav {
-  margin-bottom: var(--crm-s-reg);
+  margin-bottom: var(--crm-l-reg);
   box-shadow: var(--crm-wizard-box-shadow);
 }
 .crm-wizard-step .ui-tabs {
-  margin-bottom: var(--crm-s-medium);
+  margin-bottom: var(--crm-l-medium);
 }
 .crm-container ul.wizard-bar li,
 .crm_wizard__title ul > li {
@@ -126,12 +126,12 @@ table.advmultiselect {
   display: inline-block;
   font-weight: bold;
   line-height: var(--crm-wizard-height);
-  padding: 0 var(--crm-s-large) 0 var(--crm-s-large-1);
+  padding: 0 var(--crm-l-large) 0 var(--crm-l-large-1);
   position: relative;
 }
 .crm-container ul.wizard-bar > li:first-child,
 .crm_wizard__title ul > li:first-child {
-  padding-left: var(--crm-s-large);
+  padding-left: var(--crm-l-large);
 }
 .crm-container ul.wizard-bar > li::after,
 .crm_wizard__title ul > li::after {
@@ -185,7 +185,7 @@ table.advmultiselect {
 }
 .crm-container ul.wizard-bar > li:not(:first-child),
 .crm_wizard__title ul > li:not(:first-child) {
-  padding-left: calc(var(--crm-s-large) + var(--crm-wizard-angle)) !important;
+  padding-left: calc(var(--crm-l-large) + var(--crm-wizard-angle)) !important;
 }
 .crm-wizard-buttons {
   margin-top: var(--crm-padding-reg);
@@ -202,13 +202,13 @@ table.advmultiselect {
 .crm-container .panel {
   box-shadow: var(--crm-panel-shadow);
   border: var(--crm-panel-border);
-  border-radius: var(--crm-s-radius);
-  margin-bottom: calc(var(--crm-s-reg) + var(--crm-panel-head-margin));
+  border-radius: var(--crm-l-radius);
+  margin-bottom: calc(var(--crm-l-reg) + var(--crm-panel-head-margin));
   background: transparent;
 }
 .crm-container .panel-heading {
-  padding: var(--crm-s-medium-2) var(--crm-padding-reg);
-  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
+  padding: var(--crm-l-medium-2) var(--crm-padding-reg);
+  border-radius: var(--crm-l-radius) var(--crm-l-radius) 0 0;
   border-bottom: var(--crm-panel-border);
 }
 .crm-container .panel-heading > .dropdown .dropdown-toggle {
@@ -218,7 +218,7 @@ table.advmultiselect {
   padding: var(--crm-padding-reg);
   background: var(--crm-panel-bg-color);
   box-shadow: none;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container .panel-body:before, #bootstrap-theme .panel-body:after {
   display: table;
@@ -240,7 +240,7 @@ table.advmultiselect {
   padding: var(--crm-padding-reg);
   background: var(--crm-panel-bg-color);
   border-top: var(--crm-panel-border);
-  border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
+  border-radius: 0 0 var(--crm-l-radius) var(--crm-l-radius);
   box-shadow: var(--crm-panel-shadow);
 }
 .crm-container .panel-default > .panel-heading {
@@ -308,19 +308,19 @@ table.advmultiselect {
 .crm-container .badge {
   display: inline-block;
   min-width: 10px;
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
   line-height: 1;
   color: var(--crm-primary-text-color);
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
   background-color: var(--crm-primary-color);
-  border-radius: var(--crm-s-medium-2);
+  border-radius: var(--crm-l-medium-2);
   position: relative;
   top: -1px;
 }
 .crm-container .btn-group .badge {
-  margin-inline: var(--crm-s-xsmall);
+  margin-inline: var(--crm-l-xsmall);
 }
 .crm-container .badge:empty {
   display: none;
@@ -351,20 +351,20 @@ table.advmultiselect {
   text-align: right;
 }
 #crm-record-log {
-  font-size: var(--crm-s-medium-3);
-  padding: var(--crm-s-medium-3) 0;
+  font-size: var(--crm-l-medium-3);
+  padding: var(--crm-l-medium-3) 0;
 }
 #crm-record-log .col1 {
   float: left;
 }
 #civicrm-footer {
-  margin-top: var(--crm-s-large);
-  padding: var(--crm-s-medium-2);
+  margin-top: var(--crm-l-large);
+  padding: var(--crm-l-medium-2);
   text-align: center;
-  font-size: var(--crm-s-medium-2);
+  font-size: var(--crm-l-medium-2);
 }
 .crm-container #civicrm-footer .status {
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   padding: var(--crm-btn-small-padding);
   border-color: transparent;
 }
@@ -405,14 +405,14 @@ p.crm-upgrade-large-text {
   color: var(--link) !important  /* vs inline */;
 }
 p.crm-upgrade-large-text:first-of-type {
-  font-size: var(--crm-s-reg-1);
+  font-size: var(--crm-l-reg-1);
   color: var(--crm-alert-success-text-color);
   font-weight: bold;
 }
 .crm-success-flex {
   display: unset;
   padding: 0 2rem 0 0 !important /* vs inline */;
-  font-size: var(--crm-s-large);
+  font-size: var(--crm-l-large);
   line-height: 1.35;
   color: var(--crm-alert-success-text-color);
   grid-column: 1;
@@ -428,8 +428,8 @@ p.crm-upgrade-large-text:first-of-type {
 #crm-queue-runner-desc {
   background: var(--crm-layer1-bg-color);
   padding: var(--crm-padding-reg);
-  margin-block: var(--crm-s-reg);
-  border-radius: var(--crm-s-radius);
+  margin-block: var(--crm-l-reg);
+  border-radius: var(--crm-l-radius);
   display: inline-flex;
   flex-direction: row-reverse;
   justify-content: space-between;
@@ -441,7 +441,7 @@ p.crm-upgrade-large-text:first-of-type {
 #crm-queue-runner-buttonset button {
   background: transparent;
   height: inherit;
-  padding: 0 0 0 var(--crm-s-reg);
+  padding: 0 0 0 var(--crm-l-reg);
   color: var(--crm-text-color);
 }
 #crm-queue-runner-buttonset button:hover,
@@ -477,7 +477,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   animation: progress-bar-stripes 1s linear infinite;
 }
 .crm-status-box-outer .crm-status-box-inner {
-  padding: var(--crm-s-small) var(--crm-s-reg);
+  padding: var(--crm-l-small) var(--crm-l-reg);
   font-size: var(--crm-font-size);
   color: var(--crm-text-light-color);
   font-weight: bold;
@@ -585,7 +585,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 #CKEditorConfig .cke_ltr.cke_button.cke_toolgroup {
   width: 30px;
   height: 30px;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   background: var(--crm-container-bg-color);
 }
 #CKEditorConfig .move {
@@ -608,13 +608,13 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   font-size: 0.9rem;
 }
 #crm-recently-viewed li.crm-recently-viewed {
-  margin-block: var(--crm-s-xsmall);
-  padding: var(--crm-s-small);
+  margin-block: var(--crm-l-xsmall);
+  padding: var(--crm-l-small);
   border: var(--crm-border);
   background-color: var(--crm-input-bg-color);
   list-style-type: none;
   position: relative;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 #crm-recently-viewed .crm-recentview-wrapper a {
   opacity: 0.6;

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -27,7 +27,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: var(--crm-m3);
+  gap: var(--crm-s-medium-3);
 }
 .crm-container.ui-dialog .ui-dialog-header .ui-dialog-title,
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-dialog-title {
@@ -89,7 +89,7 @@
   padding: var(--crm-dialog-body-padding);
 }
 .crm-container.ui-dialog:has(.ui-dialog-buttonpane) .ui-dialog-content {
-  margin-bottom: calc(var(--crm-btn-height) + var(--crm-m) + var(--crm-m));
+  margin-bottom: calc(var(--crm-btn-height) + var(--crm-s-medium) + var(--crm-s-medium));
 }
 .crm-container.ui-dialog .ui-dialog-content .crm-container {
   background: var(--crm-dialog-bg-color);
@@ -136,8 +136,8 @@
 .crm-container.ui-dialog .ui-dialog-buttonset {
   width: 100%;
   display: flex;
-  gap: var(--crm-m);
-  padding: var(--crm-m);
+  gap: var(--crm-s-medium);
+  padding: var(--crm-s-medium);
   justify-content: flex-end;
   flex-wrap: wrap;
 }
@@ -155,7 +155,7 @@
   width: 350px;
   position: fixed;
   top: 64px;
-  right: var(--crm-r2);
+  right: var(--crm-s-reg-2);
   /* one less than #civicrm-menu */
   z-index: 99998;
 }
@@ -165,7 +165,7 @@
   color: var(--crm-notify-color);
   border-radius: var(--crm-notify-radius);
   padding: var(--crm-notify-padding);
-  margin-bottom: var(--crm-r);
+  margin-bottom: var(--crm-s-reg);
   max-height: 600px;
   overflow: auto;
   border-width: var(--crm-notify-accent-border);
@@ -207,8 +207,8 @@
   color: var(--crm-notify-color);
 }
 #crm-notification-container div.ui-notify-message .notify-content :is(ul,ol) {
-  padding-left: var(--crm-r2);
-  margin-block: var(--crm-m);
+  padding-left: var(--crm-s-reg-2);
+  margin-block: var(--crm-s-medium);
 }
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:hover,

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -1,11 +1,11 @@
 /* Main modal */
 /* Header */
 .crm-container.ui-dialog {
-  background: var(--crm-dialog-bg);
+  background: var(--crm-dialog-bg-color);
   border: 0;
   border-radius: var(--crm-dialog-radius);
   box-shadow: var(--crm-shadow-popup);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   max-height: 90%;
   padding: var(--crm-dialog-padding);
 }
@@ -15,10 +15,10 @@
 .crm-container .ui-dialog .ui-dialog-titlebar {
   border: 0;
   border: 1px solid transparent;
-  border-color: var(--crm-dialog-header-border-col);
+  border-color: var(--crm-dialog-header-border-color);
   box-shadow: var(--crm-dialog-inner-shadow);
-  color: var(--crm-dialog-header-col);
-  background: var(--crm-dialog-header-bg);
+  color: var(--crm-dialog-header-color);
+  background: var(--crm-dialog-header-bg-color);
   font-size: var(--crm-dialog-header-size);
   border-radius: var(--crm-dialog-header-radius);
   padding: var(--crm-dialog-header-padding);
@@ -41,7 +41,7 @@
 .crm-container.ui-dialog .ui-dialog-header .ui-button,
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-button {
   background: transparent;
-  color: var(--crm-dialog-header-col);
+  color: var(--crm-dialog-header-color);
   display: block;
   font-size: var(--crm-dialog-header-size);
   padding: 0;
@@ -63,25 +63,25 @@
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-button-icon.ui-icon[class*=" fa-"] {
   font-size: var(--crm-dialog-header-size);
   height: 2ch;
-  color: var(--crm-dialog-header-col);
+  color: var(--crm-dialog-header-color);
   opacity: 0.8;
   width: auto;
 }
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-button-icon.ui-icon[class*=" fa-"]:hover,
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-button-icon.ui-icon[class*=" fa-"]:focus {
-  color: var(--crm-dialog-header-col);
+  color: var(--crm-dialog-header-color);
   opacity: 1;
 }
 
 /* Body */
 .crm-container.ui-dialog .ui-dialog-content[id*="crm-ajax-dialog"] {
-  background: var(--crm-dialog-body-bg);
+  background: var(--crm-dialog-body-bg-color);
 }
 .crm-container.ui-dialog .ui-dialog-content {
   max-height: calc(100vh - 280px) !important;
   border-radius: var(--crm-dialog-radius);
-  background: var(--crm-dialog-body-bg);
-  color: var(--crm-c-text);
+  background: var(--crm-dialog-body-bg-color);
+  color: var(--crm-text-color);
   height: auto !important;
   margin: var(--crm-dialog-padding) 0;
   position: static;
@@ -92,7 +92,7 @@
   margin-bottom: calc(var(--crm-btn-height) + var(--crm-m) + var(--crm-m));
 }
 .crm-container.ui-dialog .ui-dialog-content .crm-container {
-  background: var(--crm-dialog-bg);
+  background: var(--crm-dialog-bg-color);
 }
 .crm-container.ui-dialog .ui-dialog-content .crm-block,
 .crm-container.ui-dialog details table {
@@ -121,7 +121,7 @@
 /* Footer */
 .crm-container.ui-dialog .ui-dialog-buttonpane,
 .crm-container.ui-dialog .modal-dialog .modal-footer {
-  background: var(--crm-dialog-bg);
+  background: var(--crm-dialog-bg-color);
   border-radius: 0 0 var(--crm-dialog-radius) var(--crm-dialog-radius);
   border-top: var(--crm-dialog-line) !important;
   box-shadow: var(--crm-dialog-inner-shadow);
@@ -160,9 +160,9 @@
   z-index: 99998;
 }
 #crm-notification-container div.ui-notify-message-style {
-  background: var(--crm-notify-bg);
+  background: var(--crm-notify-bg-color);
   box-shadow: var(--crm-shadow-popup);
-  color: var(--crm-notify-col);
+  color: var(--crm-notify-color);
   border-radius: var(--crm-notify-radius);
   padding: var(--crm-notify-padding);
   margin-bottom: var(--crm-r);
@@ -173,21 +173,21 @@
   border-color: transparent;
 }
 #crm-notification-container div.ui-notify-message-style a {
-  color: var(--crm-notify-col);
+  color: var(--crm-notify-color);
   text-decoration: underline;
 }
 #crm-notification-container div.ui-notify-message-style.error {
-  border-color: var(--crm-notify-danger);
+  border-color: var(--crm-notify-danger-color);
 }
 #crm-notification-container div.ui-notify-message-style.alert,
 #crm-notification-container div.ui-notify-message-style.warning {
-  border-color: var(--crm-notify-warning);
+  border-color: var(--crm-notify-warning-color);
 }
 #crm-notification-container div.ui-notify-message-style.success {
-  border-color: var(--crm-notify-success);
+  border-color: var(--crm-notify-success-color);
 }
 #crm-notification-container div.ui-notify-message-style.info {
-  border-color: var(--crm-notify-info);
+  border-color: var(--crm-notify-info-color);
 }
 #crm-notification-container div.ui-notify-message:last-child {
   margin-bottom: 0;
@@ -196,7 +196,7 @@
   font-size: var(--crm-font-size);
   font-weight: bold;
   margin: 0 2ch var(--m) 0;
-  color: var(--crm-notify-col);
+  color: var(--crm-notify-color);
 }
 #crm-notification-container div.ui-notify-message h1:empty {
   float: left;
@@ -204,7 +204,7 @@
 }
 #crm-notification-container div.ui-notify-message-style,
 #crm-notification-container div.ui-notify-message .notify-content :is(p,ul,ol) {
-  color: var(--crm-notify-col);
+  color: var(--crm-notify-color);
 }
 #crm-notification-container div.ui-notify-message .notify-content :is(ul,ol) {
   padding-left: var(--crm-r2);
@@ -213,8 +213,8 @@
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:hover,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:focus {
-  background: var(--crm-notify-danger);
-  color: var(--crm-c-danger-text);
+  background: var(--crm-notify-danger-color);
+  color: var(--crm-danger-text-color);
   border: 0;
 }
 

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -4,7 +4,7 @@
   background: var(--crm-dialog-bg);
   border: 0;
   border-radius: var(--crm-dialog-radius);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
   color: var(--crm-c-text);
   max-height: 90%;
   padding: var(--crm-dialog-padding);
@@ -161,7 +161,7 @@
 }
 #crm-notification-container div.ui-notify-message-style {
   background: var(--crm-notify-bg);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
   color: var(--crm-notify-col);
   border-radius: var(--crm-notify-radius);
   padding: var(--crm-notify-padding);

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -27,7 +27,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: var(--crm-s-medium-3);
+  gap: var(--crm-l-medium-3);
 }
 .crm-container.ui-dialog .ui-dialog-header .ui-dialog-title,
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-dialog-title {
@@ -89,7 +89,7 @@
   padding: var(--crm-dialog-body-padding);
 }
 .crm-container.ui-dialog:has(.ui-dialog-buttonpane) .ui-dialog-content {
-  margin-bottom: calc(var(--crm-btn-height) + var(--crm-s-medium) + var(--crm-s-medium));
+  margin-bottom: calc(var(--crm-btn-height) + var(--crm-l-medium) + var(--crm-l-medium));
 }
 .crm-container.ui-dialog .ui-dialog-content .crm-container {
   background: var(--crm-dialog-bg-color);
@@ -123,7 +123,7 @@
 .crm-container.ui-dialog .modal-dialog .modal-footer {
   background: var(--crm-dialog-bg-color);
   border-radius: 0 0 var(--crm-dialog-radius) var(--crm-dialog-radius);
-  border-top: var(--crm-dialog-line) !important;
+  border-top: var(--crm-dialog-footer-border) !important;
   box-shadow: var(--crm-dialog-inner-shadow);
   display: flex;
   padding: 0;
@@ -136,8 +136,8 @@
 .crm-container.ui-dialog .ui-dialog-buttonset {
   width: 100%;
   display: flex;
-  gap: var(--crm-s-medium);
-  padding: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
+  padding: var(--crm-l-medium);
   justify-content: flex-end;
   flex-wrap: wrap;
 }
@@ -155,7 +155,7 @@
   width: 350px;
   position: fixed;
   top: 64px;
-  right: var(--crm-s-reg-2);
+  right: var(--crm-l-reg-2);
   /* one less than #civicrm-menu */
   z-index: 99998;
 }
@@ -165,7 +165,7 @@
   color: var(--crm-notify-color);
   border-radius: var(--crm-notify-radius);
   padding: var(--crm-notify-padding);
-  margin-bottom: var(--crm-s-reg);
+  margin-bottom: var(--crm-l-reg);
   max-height: 600px;
   overflow: auto;
   border-width: var(--crm-notify-accent-border);
@@ -207,8 +207,8 @@
   color: var(--crm-notify-color);
 }
 #crm-notification-container div.ui-notify-message .notify-content :is(ul,ol) {
-  padding-left: var(--crm-s-reg-2);
-  margin-block: var(--crm-s-medium);
+  padding-left: var(--crm-l-reg-2);
+  margin-block: var(--crm-l-medium);
 }
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget,
 #crm-notification-container div.ui-notify-message-style a.ui-button.ui-widget:hover,

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -33,7 +33,7 @@
 .vakata-context {
   background-color: var(--crm-dropdown-2-bg);
   color: var(--crm-dropdown-2-col);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-popup-shadow);
   padding: var(--crm-dropdown-2-padding);
   min-width: var(--crm-dropdown-width);
@@ -75,7 +75,7 @@
 #crm-create-new-list ul a {
   color: var(--crm-c-secondary-text);
   padding: var(--crm-xs2) var(--crm-s);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   display: block;
 }
 #crm-contact-actions-list ul a:is(:hover,:focus),
@@ -107,7 +107,7 @@
   margin: var(--crm-m) 0;
   min-width: var(--crm-dropdown-width);
   background: var(--crm-dropdown-bg);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   border: var(--crm-dropdown-border);
   box-shadow: var(--crm-popup-shadow);
 }
@@ -179,7 +179,7 @@
 .crm-container .crm-tooltip-wrapper .crm-tooltip {
   box-shadow: var(--crm-popup-shadow);
   background: var(--crm-c-container-bg);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container .crm-tooltip-active:not(.crm-tooltip-down) .crm-tooltip-wrapper::after {
   border-top: 10px solid var(--crm-c-container-bg);
@@ -268,7 +268,7 @@
   background-color: var(--crm-dropdown-bg);
   background-clip: padding-box;
   border: var(--crm-dropdown-border);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-popup-shadow);
 }
 .crm-container .crm-search .api4-add-where-group-menu {
@@ -290,14 +290,14 @@
   color: var(--crm-dropdown-col);
 }
 .crm-container .dropdown-menu > li {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container .dropdown-menu > li > a {
   display: block;
   padding: var(--crm-dropdown-padding);
   clear: both;
   color: var(--crm-dropdown-col);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   white-space: nowrap;
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a i.crm-i {
@@ -312,7 +312,7 @@
   color: var(--crm-dropdown-hover) !important; /* vs BS .btn-secondary:hover */
   background-color: var(--crm-dropdown-hover-bg);
   text-decoration: none;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a:hover i.crm-i,
 .crm-container .dropdown-menu > li:not(.disabled) > a:focus i.crm-i {
@@ -398,7 +398,7 @@
   background-clip: padding-box;
   border: 1px solid var(--crm-dropdown-border);
   border: 1px solid rgba(0, 0, 0, .15);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-popup-shadow);
 }
 .crm-container .dropdown-menu.dropdown-menu-right {
@@ -437,7 +437,7 @@
   min-width: var(--crm-dropdown-width);
   background-color: var(--crm-dropdown-bg) !important;
   border: 1px solid var(--crm-dropdown-border) !important;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-popup-shadow) !important;
   padding: var(--crm-dropdown-padding) !important;
 }
@@ -448,7 +448,7 @@
   font-weight: normal !important;
   padding: 0 !important;
   border: 0 !important;
-  border-radius: var(--crm-roundness) !important;
+  border-radius: var(--crm-s-radius) !important;
 }
 .vakata-context li > a:hover,
 .vakata-context .vakata-context-hover > a {

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -74,7 +74,7 @@
 .crm-participant-list-inner ul a,
 #crm-create-new-list ul a {
   color: var(--crm-secondary-text-color);
-  padding: var(--crm-xs2) var(--crm-s);
+  padding: var(--crm-s-xsmall-2) var(--crm-s-small);
   border-radius: var(--crm-s-radius);
   display: block;
 }
@@ -104,7 +104,7 @@
   position: absolute;
   right: 0;
   padding: 0;
-  margin: var(--crm-m) 0;
+  margin: var(--crm-s-medium) 0;
   min-width: var(--crm-dropdown-width);
   background: var(--crm-dropdown-bg-color);
   border-radius: var(--crm-s-radius);
@@ -122,15 +122,15 @@
   border-right: 5px solid transparent;
   border-bottom: 5px solid var(--crm-dropdown-bg-color);
   top: -5px;
-  right: var(--crm-r);
+  right: var(--crm-s-reg);
 }
 .crm-container .btn-group .dropdown-menu::before {
-  left: var(--crm-l);
+  left: var(--crm-s-large);
   right: auto;
 }
 .crm-container .btn-group .dropdown-menu-right::before,
 .crm-container .btn-group.pull-right .dropdown-menu::before {
-  right: var(--crm-r);
+  right: var(--crm-s-reg);
   left: auto;
 }
 .crm-container .btn-slide ul.panel li {
@@ -140,7 +140,7 @@
 }
 .crm-container .btn-slide ul.panel li a {
   text-decoration: none;
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
   display: block;
   cursor: var(--crm-link-hover-cursor);
   color: var(--crm-dropdown-color);
@@ -186,7 +186,7 @@
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);
   content: "";
-  left: var(--crm-m2);
+  left: var(--crm-s-medium-2);
   position: relative;
   bottom: -7px;
 }
@@ -195,7 +195,7 @@
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);
   content: "";
-  left: var(--crm-m2);
+  left: var(--crm-s-medium-2);
   position: relative;
   top: -7px;
 }
@@ -217,22 +217,22 @@
   white-space: normal;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr > td.crm-section {
-  padding: var(--crm-s) 0;
+  padding: var(--crm-s-small) 0;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(1) > td {
   background: var(--crm-layer1-bg-color);
   color: var(--crm-text-color);
-  font-size: var(--crm-r1);
-  padding: var(--crm-m2) var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
+  padding: var(--crm-s-medium-2) var(--crm-s-reg-1);
   font-weight: bold;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(2) > td {
   border-top: var(--crm-border) !important;
   width: 50%;
-  padding: var(--crm-r1) var(--crm-m1) 0;
+  padding: var(--crm-s-reg-1) var(--crm-s-medium-1) 0;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(2) > td:first-child {
-  padding-left: var(--crm-r1);
+  padding-left: var(--crm-s-reg-1);
 }
 
 /* BS3 Dropdowns */
@@ -262,7 +262,7 @@
   display: none;
   min-width: var(--crm-dropdown-width);
   padding: var(--crm-dropdown-padding) !important;
-  margin-top: var(--crm-s);
+  margin-top: var(--crm-s-small);
   text-align: left;
   list-style: none;
   background-color: var(--crm-dropdown-bg-color);
@@ -281,7 +281,7 @@
 }
 .crm-container .dropdown-menu .divider {
   height: 1px;
-  margin: var(--crm-m) 0;
+  margin: var(--crm-s-medium) 0;
   overflow: hidden;
   background-color: var(--crm-c-layout2-bg-color);
 }
@@ -301,7 +301,7 @@
   white-space: nowrap;
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a i.crm-i {
-  padding-right: var(--crm-s);
+  padding-right: var(--crm-s-small);
   color: var(--crm-dropdown-color);
 }
 .crm-container .dropdown-menu > li > a:hover,
@@ -335,7 +335,7 @@
 .crm-container .open .btn.dropdown-toggle + .dropdown-menu {
   display: flex;
   flex-direction: column;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
 }
 .crm-container .open > a {
   outline: 0;
@@ -354,7 +354,7 @@
   white-space: nowrap;
   color: var(--crm-dropdown-color);
   font-weight: bold;
-  padding: var(--crm-m) var(--crm-xs) var(--crm-xs) !important;
+  padding: var(--crm-s-medium) var(--crm-s-xsmall) var(--crm-s-xsmall) !important;
   border-bottom: 1px solid var(--crm-dropdown-color);
   border-radius: 0;
 }

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -31,8 +31,8 @@
 .crm-participant-list-inner,
 .crm-create-new-list-inner ul.ui-widget,
 .vakata-context {
-  background-color: var(--crm-dropdown-2-bg);
-  color: var(--crm-dropdown-2-col);
+  background-color: var(--crm-dropdown-2-bg-color);
+  color: var(--crm-dropdown-2-color);
   border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-shadow-popup);
   padding: var(--crm-dropdown-2-padding);
@@ -47,7 +47,7 @@
   height: 0px;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-bottom: 5px solid var(--crm-dropdown-2-bg);
+  border-bottom: 5px solid var(--crm-dropdown-2-bg-color);
   top: -5px;
   left: 12px;
 }
@@ -73,7 +73,7 @@
 .crm-event-links-list-inner ul a,
 .crm-participant-list-inner ul a,
 #crm-create-new-list ul a {
-  color: var(--crm-c-secondary-text);
+  color: var(--crm-secondary-text-color);
   padding: var(--crm-xs2) var(--crm-s);
   border-radius: var(--crm-s-radius);
   display: block;
@@ -84,8 +84,8 @@
 .crm-participant-list-inner ul a:is(:hover,:focus),
 #crm-create-new-list ul a:is(:hover,:focus), {
   text-decoration: none;
-  color: var(--crm-c-text);
-  background-color: var(--crm-c-container-bg);
+  color: var(--crm-text-color);
+  background-color: var(--crm-container-bg-color);
 }
 
 /* In-table dropdown */
@@ -106,7 +106,7 @@
   padding: 0;
   margin: var(--crm-m) 0;
   min-width: var(--crm-dropdown-width);
-  background: var(--crm-dropdown-bg);
+  background: var(--crm-dropdown-bg-color);
   border-radius: var(--crm-s-radius);
   border: var(--crm-dropdown-border);
   box-shadow: var(--crm-shadow-popup);
@@ -120,7 +120,7 @@
   height: 0px;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-bottom: 5px solid var(--crm-dropdown-bg);
+  border-bottom: 5px solid var(--crm-dropdown-bg-color);
   top: -5px;
   right: var(--crm-r);
 }
@@ -143,13 +143,13 @@
   padding: var(--crm-s);
   display: block;
   cursor: var(--crm-link-hover-cursor);
-  color: var(--crm-dropdown-col);
+  color: var(--crm-dropdown-color);
   text-align: left;
 }
 .crm-container .btn-slide ul.panel li a:hover,
 .crm-container .btn-slide ul.panel li a:focus {
   color: var(--crm-dropdown-hover);
-  background-color: var(--crm-dropdown-hover-bg);
+  background-color: var(--crm-dropdown-hover-bg-color);
 }
 
 /* Tooltip - contact dashboard/contact search */
@@ -178,11 +178,11 @@
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip {
   box-shadow: var(--crm-shadow-popup);
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
   border-radius: var(--crm-s-radius);
 }
 .crm-container .crm-tooltip-active:not(.crm-tooltip-down) .crm-tooltip-wrapper::after {
-  border-top: 10px solid var(--crm-c-container-bg);
+  border-top: 10px solid var(--crm-container-bg-color);
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);
   content: "";
@@ -191,7 +191,7 @@
   bottom: -7px;
 }
 .crm-container .crm-tooltip-active.crm-tooltip-down .crm-tooltip-wrapper::before {
-  border-bottom: 10px solid var(--crm-c-layer1-bg);
+  border-bottom: 10px solid var(--crm-layer1-bg-color);
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);
   content: "";
@@ -206,9 +206,9 @@
 .crm-container .crm-tooltip table,
 .crm-container .crm-tooltip table tr,
 .crm-container .crm-tooltip table tr td {
-  background-color: var(--crm-c-container-bg);
+  background-color: var(--crm-container-bg-color);
   border: none;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   word-wrap: break-word;
   width: 100%;
 }
@@ -220,8 +220,8 @@
   padding: var(--crm-s) 0;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(1) > td {
-  background: var(--crm-c-layer1-bg);
-  color: var(--crm-c-text);
+  background: var(--crm-layer1-bg-color);
+  color: var(--crm-text-color);
   font-size: var(--crm-r1);
   padding: var(--crm-m2) var(--crm-r1);
   font-weight: bold;
@@ -265,7 +265,7 @@
   margin-top: var(--crm-s);
   text-align: left;
   list-style: none;
-  background-color: var(--crm-dropdown-bg);
+  background-color: var(--crm-dropdown-bg-color);
   background-clip: padding-box;
   border: var(--crm-dropdown-border);
   border-radius: var(--crm-s-radius);
@@ -273,7 +273,7 @@
 }
 .crm-container .crm-search .api4-add-where-group-menu {
   min-width: 80px;
-  background-color: var(--crm-dropdown-bg) !important;
+  background-color: var(--crm-dropdown-bg-color) !important;
 }
 .crm-container .dropdown-menu.pull-right {
   right: 0;
@@ -283,11 +283,11 @@
   height: 1px;
   margin: var(--crm-m) 0;
   overflow: hidden;
-  background-color: var(--crm-c-layout2-bg);
+  background-color: var(--crm-c-layout2-bg-color);
 }
 #bootstrap-theme .dropdown-menu li .form-inline,
 #bootstrap-theme .dropdown-menu li .form-inline a:not(.select2-choice) {
-  color: var(--crm-dropdown-col);
+  color: var(--crm-dropdown-color);
 }
 .crm-container .dropdown-menu > li {
   border-radius: var(--crm-s-radius);
@@ -296,13 +296,13 @@
   display: block;
   padding: var(--crm-dropdown-padding);
   clear: both;
-  color: var(--crm-dropdown-col);
+  color: var(--crm-dropdown-color);
   border-radius: var(--crm-s-radius);
   white-space: nowrap;
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a i.crm-i {
   padding-right: var(--crm-s);
-  color: var(--crm-dropdown-col);
+  color: var(--crm-dropdown-color);
 }
 .crm-container .dropdown-menu > li > a:hover,
 .crm-container .dropdown-menu > li > a:focus,
@@ -310,7 +310,7 @@
 .crm-container .dropdown-menu > .active > a:hover,
 .crm-container .dropdown-menu > .active > a:focus {
   color: var(--crm-dropdown-hover) !important; /* vs BS .btn-secondary:hover */
-  background-color: var(--crm-dropdown-hover-bg);
+  background-color: var(--crm-dropdown-hover-bg-color);
   text-decoration: none;
   border-radius: var(--crm-s-radius);
 }
@@ -321,7 +321,7 @@
 .crm-container .dropdown-menu > .disabled > a,
 .crm-container .dropdown-menu > .disabled > a:hover,
 .crm-container .dropdown-menu > .disabled > a:focus {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
 }
 .crm-container .dropdown-menu > .disabled > a:hover,
 .crm-container .dropdown-menu > .disabled > a:focus {
@@ -352,10 +352,10 @@
   display: block;
   padding: var(--crm-dropdown-padding);
   white-space: nowrap;
-  color: var(--crm-dropdown-col);
+  color: var(--crm-dropdown-color);
   font-weight: bold;
   padding: var(--crm-m) var(--crm-xs) var(--crm-xs) !important;
-  border-bottom: 1px solid var(--crm-dropdown-col);
+  border-bottom: 1px solid var(--crm-dropdown-color);
   border-radius: 0;
 }
 .crm-container .pull-right > .dropdown-menu {
@@ -394,7 +394,7 @@
   margin: 2px 0 0;
   text-align: left;
   list-style: none;
-  background-color: var(--crm-dropdown-bg);
+  background-color: var(--crm-dropdown-bg-color);
   background-clip: padding-box;
   border: 1px solid var(--crm-dropdown-border);
   border: 1px solid rgba(0, 0, 0, .15);
@@ -424,18 +424,18 @@
 #afGuiEditor .dropdown-menu a:has(.text-danger) {
   display: flex;
   justify-content: center;
-  background: var(--crm-dropdown-danger-bg);
+  background: var(--crm-dropdown-danger-bg-color);
 }
 #afGuiEditor .dropdown-menu .text-danger,
 #afGuiEditor .dropdown-menu .text-danger i.crm-i::before {
-  color: var(--crm-c-danger-text);
+  color: var(--crm-danger-text-color);
 }
 
 /* JsTree Dropdown - all of Vakata Context, from jstree/dist has to be overwritten with !important */
 
 .vakata-context {
   min-width: var(--crm-dropdown-width);
-  background-color: var(--crm-dropdown-bg) !important;
+  background-color: var(--crm-dropdown-bg-color) !important;
   border: 1px solid var(--crm-dropdown-border) !important;
   border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-shadow-popup) !important;
@@ -443,7 +443,7 @@
 }
 .vakata-context li > a {
   line-height: unset !important;
-  color: var(--crm-dropdown-col) !important;
+  color: var(--crm-dropdown-color) !important;
   text-shadow: none !important;
   font-weight: normal !important;
   padding: 0 !important;
@@ -452,7 +452,7 @@
 }
 .vakata-context li > a:hover,
 .vakata-context .vakata-context-hover > a {
-  background-color: var(--crm-dropdown-hover-bg) !important;
+  background-color: var(--crm-dropdown-hover-bg-color) !important;
   box-shadow: none !important;
   color: var(--crm-dropdown-hover) !important;
 }

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -227,7 +227,7 @@
   font-weight: bold;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(2) > td {
-  border-top: var(--crm-c-divider) !important;
+  border-top: var(--crm-border) !important;
   width: 50%;
   padding: var(--crm-r1) var(--crm-m1) 0;
 }

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -283,7 +283,7 @@
   height: 1px;
   margin: var(--crm-l-medium) 0;
   overflow: hidden;
-  background-color: var(--crm-c-layout2-bg-color);
+  background-color: var(--crm-layer2-bg-color);
 }
 #bootstrap-theme .dropdown-menu li .form-inline,
 #bootstrap-theme .dropdown-menu li .form-inline a:not(.select2-choice) {

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -34,7 +34,7 @@
   background-color: var(--crm-dropdown-2-bg);
   color: var(--crm-dropdown-2-col);
   border-radius: var(--crm-s-radius);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
   padding: var(--crm-dropdown-2-padding);
   min-width: var(--crm-dropdown-width);
 }
@@ -109,7 +109,7 @@
   background: var(--crm-dropdown-bg);
   border-radius: var(--crm-s-radius);
   border: var(--crm-dropdown-border);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
 }
 .crm-container .btn-slide ul.panel::before,
 .crm-container .btn-group .dropdown-menu::before {
@@ -142,7 +142,7 @@
   text-decoration: none;
   padding: var(--crm-s);
   display: block;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   color: var(--crm-dropdown-col);
   text-align: left;
 }
@@ -177,7 +177,7 @@
   display: block;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip {
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
   background: var(--crm-c-container-bg);
   border-radius: var(--crm-s-radius);
 }
@@ -269,7 +269,7 @@
   background-clip: padding-box;
   border: var(--crm-dropdown-border);
   border-radius: var(--crm-s-radius);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
 }
 .crm-container .crm-search .api4-add-where-group-menu {
   min-width: 80px;
@@ -399,7 +399,7 @@
   border: 1px solid var(--crm-dropdown-border);
   border: 1px solid rgba(0, 0, 0, .15);
   border-radius: var(--crm-s-radius);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
 }
 .crm-container .dropdown-menu.dropdown-menu-right {
   right: 0;
@@ -438,7 +438,7 @@
   background-color: var(--crm-dropdown-bg) !important;
   border: 1px solid var(--crm-dropdown-border) !important;
   border-radius: var(--crm-s-radius);
-  box-shadow: var(--crm-popup-shadow) !important;
+  box-shadow: var(--crm-shadow-popup) !important;
   padding: var(--crm-dropdown-padding) !important;
 }
 .vakata-context li > a {

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -31,11 +31,11 @@
 .crm-participant-list-inner,
 .crm-create-new-list-inner ul.ui-widget,
 .vakata-context {
-  background-color: var(--crm-dropdown-2-bg-color);
-  color: var(--crm-dropdown-2-color);
-  border-radius: var(--crm-s-radius);
+  background-color: var(--crm-dropdown2-bg-color);
+  color: var(--crm-dropdown2-color);
+  border-radius: var(--crm-l-radius);
   box-shadow: var(--crm-shadow-popup);
-  padding: var(--crm-dropdown-2-padding);
+  padding: var(--crm-dropdown2-padding);
   min-width: var(--crm-dropdown-width);
 }
 .ac_results::before,
@@ -47,7 +47,7 @@
   height: 0px;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-bottom: 5px solid var(--crm-dropdown-2-bg-color);
+  border-bottom: 5px solid var(--crm-dropdown2-bg-color);
   top: -5px;
   left: 12px;
 }
@@ -74,8 +74,8 @@
 .crm-participant-list-inner ul a,
 #crm-create-new-list ul a {
   color: var(--crm-secondary-text-color);
-  padding: var(--crm-s-xsmall-2) var(--crm-s-small);
-  border-radius: var(--crm-s-radius);
+  padding: var(--crm-l-xsmall-2) var(--crm-l-small);
+  border-radius: var(--crm-l-radius);
   display: block;
 }
 #crm-contact-actions-list ul a:is(:hover,:focus),
@@ -104,10 +104,10 @@
   position: absolute;
   right: 0;
   padding: 0;
-  margin: var(--crm-s-medium) 0;
+  margin: var(--crm-l-medium) 0;
   min-width: var(--crm-dropdown-width);
   background: var(--crm-dropdown-bg-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   border: var(--crm-dropdown-border);
   box-shadow: var(--crm-shadow-popup);
 }
@@ -122,15 +122,15 @@
   border-right: 5px solid transparent;
   border-bottom: 5px solid var(--crm-dropdown-bg-color);
   top: -5px;
-  right: var(--crm-s-reg);
+  right: var(--crm-l-reg);
 }
 .crm-container .btn-group .dropdown-menu::before {
-  left: var(--crm-s-large);
+  left: var(--crm-l-large);
   right: auto;
 }
 .crm-container .btn-group .dropdown-menu-right::before,
 .crm-container .btn-group.pull-right .dropdown-menu::before {
-  right: var(--crm-s-reg);
+  right: var(--crm-l-reg);
   left: auto;
 }
 .crm-container .btn-slide ul.panel li {
@@ -140,7 +140,7 @@
 }
 .crm-container .btn-slide ul.panel li a {
   text-decoration: none;
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
   display: block;
   cursor: var(--crm-link-hover-cursor);
   color: var(--crm-dropdown-color);
@@ -148,7 +148,7 @@
 }
 .crm-container .btn-slide ul.panel li a:hover,
 .crm-container .btn-slide ul.panel li a:focus {
-  color: var(--crm-dropdown-hover);
+  color: var(--crm-dropdown-hover-text-color);
   background-color: var(--crm-dropdown-hover-bg-color);
 }
 
@@ -179,14 +179,14 @@
 .crm-container .crm-tooltip-wrapper .crm-tooltip {
   box-shadow: var(--crm-shadow-popup);
   background: var(--crm-container-bg-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container .crm-tooltip-active:not(.crm-tooltip-down) .crm-tooltip-wrapper::after {
   border-top: 10px solid var(--crm-container-bg-color);
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);
   content: "";
-  left: var(--crm-s-medium-2);
+  left: var(--crm-l-medium-2);
   position: relative;
   bottom: -7px;
 }
@@ -195,7 +195,7 @@
   border-left: 10px solid rgba(0,0,0,0);
   border-right: 10px solid rgba(0,0,0,0);
   content: "";
-  left: var(--crm-s-medium-2);
+  left: var(--crm-l-medium-2);
   position: relative;
   top: -7px;
 }
@@ -217,22 +217,22 @@
   white-space: normal;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr > td.crm-section {
-  padding: var(--crm-s-small) 0;
+  padding: var(--crm-l-small) 0;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(1) > td {
   background: var(--crm-layer1-bg-color);
   color: var(--crm-text-color);
-  font-size: var(--crm-s-reg-1);
-  padding: var(--crm-s-medium-2) var(--crm-s-reg-1);
+  font-size: var(--crm-l-reg-1);
+  padding: var(--crm-l-medium-2) var(--crm-l-reg-1);
   font-weight: bold;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(2) > td {
   border-top: var(--crm-border) !important;
   width: 50%;
-  padding: var(--crm-s-reg-1) var(--crm-s-medium-1) 0;
+  padding: var(--crm-l-reg-1) var(--crm-l-medium-1) 0;
 }
 .crm-container .crm-tooltip-wrapper .crm-tooltip .crm-table-group-summary > tbody > tr:nth-child(2) > td:first-child {
-  padding-left: var(--crm-s-reg-1);
+  padding-left: var(--crm-l-reg-1);
 }
 
 /* BS3 Dropdowns */
@@ -262,13 +262,13 @@
   display: none;
   min-width: var(--crm-dropdown-width);
   padding: var(--crm-dropdown-padding) !important;
-  margin-top: var(--crm-s-small);
+  margin-top: var(--crm-l-small);
   text-align: left;
   list-style: none;
   background-color: var(--crm-dropdown-bg-color);
   background-clip: padding-box;
   border: var(--crm-dropdown-border);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: var(--crm-shadow-popup);
 }
 .crm-container .crm-search .api4-add-where-group-menu {
@@ -281,7 +281,7 @@
 }
 .crm-container .dropdown-menu .divider {
   height: 1px;
-  margin: var(--crm-s-medium) 0;
+  margin: var(--crm-l-medium) 0;
   overflow: hidden;
   background-color: var(--crm-c-layout2-bg-color);
 }
@@ -290,18 +290,18 @@
   color: var(--crm-dropdown-color);
 }
 .crm-container .dropdown-menu > li {
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container .dropdown-menu > li > a {
   display: block;
   padding: var(--crm-dropdown-padding);
   clear: both;
   color: var(--crm-dropdown-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   white-space: nowrap;
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a i.crm-i {
-  padding-right: var(--crm-s-small);
+  padding-right: var(--crm-l-small);
   color: var(--crm-dropdown-color);
 }
 .crm-container .dropdown-menu > li > a:hover,
@@ -309,14 +309,14 @@
 .crm-container .dropdown-menu > .active > a,
 .crm-container .dropdown-menu > .active > a:hover,
 .crm-container .dropdown-menu > .active > a:focus {
-  color: var(--crm-dropdown-hover) !important; /* vs BS .btn-secondary:hover */
+  color: var(--crm-dropdown-hover-text-color) !important; /* vs BS .btn-secondary:hover */
   background-color: var(--crm-dropdown-hover-bg-color);
   text-decoration: none;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a:hover i.crm-i,
 .crm-container .dropdown-menu > li:not(.disabled) > a:focus i.crm-i {
-  color: var(--crm-dropdown-hover);
+  color: var(--crm-dropdown-hover-text-color);
 }
 .crm-container .dropdown-menu > .disabled > a,
 .crm-container .dropdown-menu > .disabled > a:hover,
@@ -335,7 +335,7 @@
 .crm-container .open .btn.dropdown-toggle + .dropdown-menu {
   display: flex;
   flex-direction: column;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
 }
 .crm-container .open > a {
   outline: 0;
@@ -354,7 +354,7 @@
   white-space: nowrap;
   color: var(--crm-dropdown-color);
   font-weight: bold;
-  padding: var(--crm-s-medium) var(--crm-s-xsmall) var(--crm-s-xsmall) !important;
+  padding: var(--crm-l-medium) var(--crm-l-xsmall) var(--crm-l-xsmall) !important;
   border-bottom: 1px solid var(--crm-dropdown-color);
   border-radius: 0;
 }
@@ -398,7 +398,7 @@
   background-clip: padding-box;
   border: 1px solid var(--crm-dropdown-border);
   border: 1px solid rgba(0, 0, 0, .15);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: var(--crm-shadow-popup);
 }
 .crm-container .dropdown-menu.dropdown-menu-right {
@@ -437,7 +437,7 @@
   min-width: var(--crm-dropdown-width);
   background-color: var(--crm-dropdown-bg-color) !important;
   border: 1px solid var(--crm-dropdown-border) !important;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: var(--crm-shadow-popup) !important;
   padding: var(--crm-dropdown-padding) !important;
 }
@@ -448,13 +448,13 @@
   font-weight: normal !important;
   padding: 0 !important;
   border: 0 !important;
-  border-radius: var(--crm-s-radius) !important;
+  border-radius: var(--crm-l-radius) !important;
 }
 .vakata-context li > a:hover,
 .vakata-context .vakata-context-hover > a {
   background-color: var(--crm-dropdown-hover-bg-color) !important;
   box-shadow: none !important;
-  color: var(--crm-dropdown-hover) !important;
+  color: var(--crm-dropdown-hover-text-color) !important;
 }
 .vakata-context li > a > i {
   margin: 0 !important;

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -88,7 +88,7 @@
   margin-bottom: var(--crm-flex-gap);
 }
 .crm-container .crm-marker {
-  color: var(--crm-notify-danger);
+  color: var(--crm-notify-danger-color);
 }
 .crm-container .form-inline {
   padding: var(--crm-s) 0;
@@ -104,20 +104,20 @@
 .crm-collapsible,
 .crm-inactive-dashlet-fieldset,
 .crm-search-admin-edit-columns) {
-  padding: var(--crm-fieldset-padding);
+  padding: var(--crm-form-fieldset-padding);
   margin: var(--crm-padding-reg) 0;
-  border: 1px solid var(--crm-fieldset-border-color);
-  border-width: var(--crm-fieldset-border);
+  border: 1px solid var(--crm-form-fieldset-border-color);
+  border-width: var(--crm-form-fieldset-border);
 }
 .crm-container fieldset legend {
   font-weight: bold;
   padding-inline: var(--crm-s);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 
 /* Required Mark */
 .crm-container .required-mark::after {
-  color: var(--crm-c-danger);
+  color: var(--crm-danger-color);
   content: "*";
   margin-left: var(--crm-s);
 }
@@ -136,9 +136,9 @@ select.crm-form-select,
 .crm-container .ui-widget input,
 .crm-container select,
 .ui-datepicker .ui-datepicker-header select {
-  transition: var(--crm-input-active-ani);
+  transition: var(--crm-input-active-transition);
   font-size: var(--crm-input-font-size);
-  background-color: var(--crm-input-bg);
+  background-color: var(--crm-input-bg-color);
   border-radius: var(--crm-input-border-radius);
   box-shadow: var(--crm-input-box-shadow);
   color: var(--crm-input-color);
@@ -162,7 +162,7 @@ select.crm-form-multiselect {
   border: 1px solid var(--crm-c-darkest);
 }
 .crm-container .replace-plain {
-  background-color: var(--crm-input-bg);
+  background-color: var(--crm-input-bg-color);
   min-width: var(--crm-huge-input);
 }
 input.crm-form-text:focus,
@@ -177,18 +177,18 @@ select.crm-form-select:focus,
 .crm-container select[aria-controls]:focus,
 .crm-container .select2-container-active *:focus,
 .crm-container .select2-container-active a.select2-choice {
-  border-color: var(--crm-c-focus);
+  border-color: var(--crm-focus-color);
   outline: 0;
   box-shadow: none;
 }
 .crm-container input.error,
 input.crm-error,
 select.crm-error {
-  border-color: var(--crm-c-danger);
+  border-color: var(--crm-danger-color);
 }
 .crm-container :focus,
 .crm-container .ui-dialog :focus {
-  border-color: var(--crm-c-focus);
+  border-color: var(--crm-focus-color);
   box-shadow: none;
 }
 .crm-container input.crm-placeholder-icon::placeholder {
@@ -284,10 +284,10 @@ select.crm-error {
   padding: var(--crm-padding-small);
 }
 .crm-container .crm-editable-form [type="submit"] {
-  color: var(--crm-c-success) !important;
+  color: var(--crm-success-color) !important;
 }
 .crm-container .crm-editable-form [type="cancel"] {
-  color: var(--crm-c-danger) !important;
+  color: var(--crm-danger-color) !important;
 }
 .crm-container .crm-inline-edit,
 .crm-container .crm-editable-disabled,
@@ -423,7 +423,7 @@ input.crm-form-checkbox) + label {
   padding: var(--crm-s);
 }
 .crm-container input[type="range"] {
-  accent-color: var(--crm-c-focus);
+  accent-color: var(--crm-focus-color);
   height: auto;
   box-shadow: none;
 }
@@ -452,7 +452,7 @@ input.crm-form-checkbox) + label {
 .crm-container select.form-control,
 .crm-container .select2-container-multi .select2-choices,
 .crm-container .select2-container .select2-choice {
-  background: var(--crm-input-bg);
+  background: var(--crm-input-bg-color);
   border: 1px solid var(--crm-input-border-color);
   border-radius: var(--crm-input-border-radius);
   box-shadow: var(--crm-input-box-shadow);
@@ -490,7 +490,7 @@ input.crm-form-checkbox) + label {
   font-family: "Font Awesome 6 Free", "Font Awesome 6 Brands", "FontAwesome";
   font-style: normal;
   text-rendering: auto;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   background: none;
   content: var(--crm-input-dropdown-icon);
 }
@@ -502,7 +502,7 @@ input.crm-form-checkbox) + label {
 .crm-container .select2-dropdown-open .select2-choices {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  border-color: var(--crm-c-focus);
+  border-color: var(--crm-focus-color);
   box-shadow: none;
 }
 .crm-container .select2-container-multi .select2-choices .select2-search-field input {
@@ -518,29 +518,29 @@ input.crm-form-checkbox) + label {
   color: var(--crm-input-color) !important /* vs important in select2.min.css */;
 }
 .crm-container .select2-default .select2-chosen { /* intended to target placeholder text */
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
 }
 .crm-container .select2-container-multi .select2-choices .select2-search-field input.select2-default {
   color: var(--crm-input-color);
 }
 .select2-container-disabled a {
   box-shadow: none;
-  background: var(--crm-c-layer1-bg);
+  background: var(--crm-layer1-bg-color);
 }
 .select2-container-disabled .select2-arrow {
   background: transparent;
 }
 .crm-container .select2-container.select2-container-disabled .select2-choice {
-  background-color: var(--crm-c-container-bg);
-  border: 1px dotted var(--crm-c-inactive);
+  background-color: var(--crm-container-bg-color);
+  border: 1px dotted var(--crm-inactive-color);
   cursor: default;
 }
 .select2-container.select2-container-disabled .select2-choice .select2-arrow {
   border-left: 0;
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
 }
 .select2-results .select2-disabled {
-  background: var(--crm-c-layer1-bg);
+  background: var(--crm-layer1-bg-color);
   cursor: not-allowed;
 }
 .select2-results .select2-disabled > * {
@@ -564,13 +564,13 @@ input.crm-form-checkbox) + label {
   margin: 0;
   position: relative;
   line-height: unset;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   cursor: default;
   border: var(--crm-border);
   border-radius: var(--crm-input-border-radius);
   background-clip: padding-box;
   user-select: none;
-  background-color: var(--crm-form-select-bg);
+  background-color: var(--crm-input-select-bg-color);
   background-image: none;
   box-shadow: none;
 }
@@ -599,11 +599,11 @@ input.crm-form-checkbox) + label {
 
 .select2-drop.select2-drop-active.crm-container {
   min-width: var(--crm-big-input);
-  background: var(--crm-input-bg);
+  background: var(--crm-input-bg-color);
   border-bottom-left-radius: var(--crm-input-border-radius);
   border-bottom-right-radius: var(--crm-input-border-radius);
-  border-color: var(--crm-c-focus);
-  border-top: 1px solid rgb(from var(--crm-c-focus) r g b / 25%);
+  border-color: var(--crm-focus-color);
+  border-top: 1px solid rgb(from var(--crm-focus-color) r g b / 25%);
 }
 .select2-drop.select2-drop-active.crm-container.select2-drop-above {
   border-bottom-left-radius: 0;
@@ -617,7 +617,7 @@ input.crm-form-checkbox) + label {
   font-style: normal;
   text-rendering: auto;
   font-size: .8em;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   content: "";
   font-size: 14px;
   position: relative;
@@ -637,7 +637,7 @@ input.crm-form-checkbox) + label {
   margin: 0;
 }
 .select2-drop.select2-drop-active.crm-container .select2-results li {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   padding: var(--crm-s) var(--crm-m);
   margin: 0;
 }
@@ -648,14 +648,14 @@ input.crm-form-checkbox) + label {
 .select2-results .select2-no-results,
 .select2-results .select2-searching,
 .select2-results .select2-selection-limit {
-  background: var(--crm-input-bg);
+  background: var(--crm-input-bg-color);
 }
 .select2-drop.select2-drop-active.crm-container .select2-results .select2-highlighted {
-  background: var(--crm-form-select-bg);
+  background: var(--crm-input-select-bg-color);
 }
 .select2-drop.select2-drop-active.crm-container .crm-entityref-filters select,
 .select2-drop.select2-drop-active.crm-container .crm-entityref-filters input {
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
   border: 1px solid var(--crm-input-border-color);
   border-radius: var(--crm-input-border-radius);
   box-sizing: border-box;
@@ -681,7 +681,7 @@ input.crm-form-checkbox) + label {
 }
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
-  background: var(--crm-c-layout2-bg);
+  background: var(--crm-c-layout2-bg-color);
   padding: var(--crm-s);
 }
 .crm-container .crm-select2-row-description p {
@@ -758,7 +758,7 @@ input.crm-form-checkbox) + label {
   height: unset;
 }
 #ui-datepicker-div {
-  background: var(--crm-input-bg);
+  background: var(--crm-input-bg-color);
   border-radius: 0;
   box-shadow: var(--crm-shadow-popup);
   min-width: 30ch;
@@ -794,7 +794,7 @@ input.crm-form-checkbox) + label {
   padding: 0;
 }
 #ui-datepicker-div .ui-datepicker-header :is(.ui-datepicker-prev,.ui-datepicker-next):hover::before {
-  color: var(--crm-c-text-dark);
+  color: var(--crm-text-dark-color);
 }
 #ui-datepicker-div .ui-datepicker-prev::before {
   content: "";
@@ -810,7 +810,7 @@ input.crm-form-checkbox) + label {
   width: 9ch;
 }
 #ui-datepicker-div .ui-datepicker-calendar thead th {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-size: var(--crm-font-small-size);
 }
 #ui-datepicker-div .ui-datepicker-calendar tr {
@@ -824,15 +824,15 @@ input.crm-form-checkbox) + label {
 }
 #ui-datepicker-div .ui-state-default,
 #ui-datepicker-div .ui-widget-content .ui-state-default {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   text-align: center;
 }
 #ui-datepicker-div .ui-datepicker-calendar .ui-state-disabled {
   opacity: 0.35;
 }
 #ui-datepicker-div .ui-datepicker-calendar :is(td,.ui-state-disabled) .ui-state-active {
-  background-color: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background-color: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 #ui-datepicker-div .ui-datepicker-calendar :is(td,.ui-state-disabled) a {
   border: 0;
@@ -840,11 +840,11 @@ input.crm-form-checkbox) + label {
   cursor: var(--crm-link-hover-cursor);
   padding: var(--crm-s);
   text-align: center;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 #ui-datepicker-div .ui-datepicker-calendar td.ui-datepicker-today a {
   background: var(--crm-c-gray-100);
-  color: var(--crm-c-text-dark);
+  color: var(--crm-text-dark-color);
 }
 
 /* JQ spinner */
@@ -856,13 +856,13 @@ input.crm-form-checkbox) + label {
   width: var(--crm-r2);
   margin: 1px;
   cursor: var(--crm-link-hover-cursor);
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
   border-radius: 0;
   border-left: 1px solid var(--crm-input-border-color);
 }
 .crm-container .ui-spinner a.ui-spinner-button:hover,
 .crm-container .ui-spinner a.ui-spinner-button:focus {
-  color: var(--crm-c-text-light);
+  color: var(--crm-text-light-color);
 }
 .crm-container .ui-spinner a.ui-spinner-button span::before {
   font-family: "FontAwesome";
@@ -964,7 +964,7 @@ input.crm-form-checkbox) + label {
 #bootstrap-theme .disabled:is(.radio-inline,.checkbox-inline),
 #bootstrap-theme fieldset[disabled] :is(.radio-inline,.checkbox-inline) {
   cursor: not-allowed;
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
 }
 .crm-container :is(input,textarea,option):disabled {
   background-color: color-mix(in srgb, var(--crm-input-background) 90%, var(--crm-ink) 10%);

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -98,7 +98,7 @@
 }
 /* Fieldset */
 .crm-container fieldset {
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 .crm-container fieldset:not(.collapsed,
 .crm-collapsible,
@@ -566,7 +566,7 @@ input.crm-form-checkbox) + label {
   line-height: unset;
   color: var(--crm-c-text);
   cursor: default;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-radius: var(--crm-input-border-radius);
   background-clip: padding-box;
   user-select: none;
@@ -642,7 +642,7 @@ input.crm-form-checkbox) + label {
   margin: 0;
 }
 .select2-drop.select2-drop-active.crm-container .select2-results li:has(.crm-select2-row-description) {
-  border-top: var(--crm-c-divider);
+  border-top: var(--crm-border);
 }
 .select2-results .select2-ajax-error,
 .select2-results .select2-no-results,

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -1,22 +1,22 @@
 /* Form parts */
 .crm-container div.crm-field-wrapper {
-  margin-bottom: var(--crm-s-reg);
+  margin-bottom: var(--crm-l-reg);
 }
 .crm-section {
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
 }
 .crm-container table.form-layout td,
 .crm-container table.form-layout-compressed td,
 .crm-form-block .crm-section {
-  padding: var(--crm-s-medium) var(--crm-s-small-2);
+  padding: var(--crm-l-medium) var(--crm-l-small-2);
   border: none !important /* vs contactSummary.css */;
   height: auto;
   vertical-align: top;
 }
 .crm-container div.form-layout-compressed {
   display: flex;
-  gap: var(--crm-s-small);
-  padding: var(--crm-s-reg) 0;
+  gap: var(--crm-l-small);
+  padding: var(--crm-l-reg) 0;
   align-items: center;
 }
 .crm-container .crm-results-block-empty {
@@ -30,7 +30,7 @@
 .crm-container .form-layout-compressed th.label {
   min-width: var(--crm-input-label-width);
   text-align: var(--crm-input-label-align);
-  margin: var(--crm-s-medium) var(--crm-s-medium-2) 0 0;
+  margin: var(--crm-l-medium) var(--crm-l-medium-2) 0 0;
   font-family: var(--crm-input-label-font);
   font-weight: var(--crm-input-label-weight);
   display: table-cell;
@@ -40,7 +40,7 @@
   text-align: left;
   font-family: var(--crm-input-label-font);
   font-weight: var(--crm-input-label-weight);
-  padding-right: var(--crm-s-medium-2);
+  padding-right: var(--crm-l-medium-2);
 }
 .crm-container .label > label { /* Fix for dble label specification */
   padding-right: 0;
@@ -68,7 +68,7 @@
   font-weight: var(--crm-input-label-weight);
   font-size: var(--crm-input-label-size);
   display: inline-block;
-  margin-bottom: var(--crm-s-small);
+  margin-bottom: var(--crm-l-small);
 }
 .crm-container .form-layout td.label label {
   margin-bottom: 0;
@@ -91,7 +91,7 @@
   color: var(--crm-notify-danger-color);
 }
 .crm-container .form-inline {
-  padding: var(--crm-s-small) 0;
+  padding: var(--crm-l-small) 0;
 }
 .crm-search-display .form-inline {
   padding: var(--crm-padding-reg) 0;
@@ -111,7 +111,7 @@
 }
 .crm-container fieldset legend {
   font-weight: bold;
-  padding-inline: var(--crm-s-small);
+  padding-inline: var(--crm-l-small);
   color: var(--crm-text-color);
 }
 
@@ -119,7 +119,7 @@
 .crm-container .required-mark::after {
   color: var(--crm-danger-color);
   content: "*";
-  margin-left: var(--crm-s-small);
+  margin-left: var(--crm-l-small);
 }
 /* Input */
 
@@ -151,7 +151,7 @@ select.crm-form-select,
 .crm-container .replace-plain,
 .crm-container textarea,
 select.crm-form-multiselect {
-  padding: var(--crm-input-padding-large);
+  padding: var(--crm-input-large-padding);
   height: auto;
   min-height: var(--crm-input-height);
   width: 100%;
@@ -196,7 +196,7 @@ select.crm-error {
   text-align: right;
 }
 .crm-icon-picker-button {
-  margin: 0 0 var(--crm-s-small);
+  margin: 0 0 var(--crm-l-small);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -312,8 +312,8 @@ select.crm-error {
 .crm-container span.crm-editable-disabled,
 .crm-container span.crm-editable-enabled {
   display: inline-block;
-  padding-right: var(--crm-s-small);
-  min-height: var(--crm-s-reg);
+  padding-right: var(--crm-l-small);
+  min-height: var(--crm-l-reg);
 }
 .crm-container .crm-editable-enabled .crm-i,
 .crm-editable-enabled:has(span.crm-search-field-value:empty) {
@@ -363,7 +363,7 @@ input.crm-form-radio + label,
 input.crm-form-checkbox + label,
 .crm-container input[type="checkbox"] + label[for],
 .crm-container input[type="radio"] + label[for] {
-  margin: 0 var(--crm-s-medium) 0 var(--crm-s-small);
+  margin: 0 var(--crm-l-medium) 0 var(--crm-l-small);
   cursor: var(--crm-link-hover-cursor);
   width: unset;
   font-weight: normal;
@@ -420,7 +420,7 @@ input.crm-form-checkbox) + label {
 
 .crm-container input[type="file"] {
   height: auto;
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
 }
 .crm-container input[type="range"] {
   accent-color: var(--crm-focus-color);
@@ -468,7 +468,7 @@ input.crm-form-checkbox) + label {
   background: transparent;
   border-left: 0;
   border-radius: 0 var(--crm-input-border-radius) var(--crm-input-border-radius) 0;
-  width: var(--crm-s-reg-3);
+  width: var(--crm-l-reg-3);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -479,11 +479,11 @@ input.crm-form-checkbox) + label {
 .select2-container.select2-allowclear .select2-choice abbr {
   position: relative;
   margin-left: auto;
-  right: var(--crm-s-reg);
+  right: var(--crm-l-reg);
   top: auto;
 }
 .crm-container .select2-container .select2-choice > .select2-chosen {
-  margin-right: var(--crm-s-reg-2);
+  margin-right: var(--crm-l-reg-2);
 }
 .crm-container .select2-container-multi .select2-choices::before,
 .crm-container .select2-container .select2-choice .select2-arrow::before {
@@ -549,8 +549,8 @@ input.crm-form-checkbox) + label {
 .crm-container .select2-container-multi .select2-choices {
   display: flex;
   flex-flow: wrap;
-  gap: var(--crm-s-small);
-  padding: 2px var(--crm-s-small);
+  gap: var(--crm-l-small);
+  padding: 2px var(--crm-l-small);
   align-items: center;
   font-size: var(--crm-input-font-size);
   min-height: var(--crm-input-height);
@@ -560,7 +560,7 @@ input.crm-form-checkbox) + label {
   max-width: calc(100% - 2rem);
 }
 .select2-container-multi .select2-choices .select2-search-choice {
-  padding: 1px var(--crm-s-medium) 1px var(--crm-s-reg-1);
+  padding: 1px var(--crm-l-medium) 1px var(--crm-l-reg-1);
   margin: 0;
   position: relative;
   line-height: unset;
@@ -587,8 +587,8 @@ input.crm-form-checkbox) + label {
 .select2-container.loading .select2-choice .select2-arrow b {
   content: "\f110";
   position: absolute;
-  right: var(--crm-s-medium);
-  top: var(--crm-s-small);
+  right: var(--crm-l-medium);
+  top: var(--crm-l-small);
   animation-name: fa-spin;
   animation-duration: var(--fa-animation-duration,2s);
   animation-iteration-count: var(--fa-animation-iteration-count,infinite);
@@ -610,7 +610,7 @@ input.crm-form-checkbox) + label {
   border-bottom-right-radius: 0;
 }
 .select2-search {
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
 }
 .select2-search::after {
   font-family: "FontAwesome";
@@ -632,13 +632,13 @@ input.crm-form-checkbox) + label {
   width: 100%;
 }
 .crm-container .select2-results {
-  font-size: var(--crm-s-medium-2);
+  font-size: var(--crm-l-medium-2);
   padding: 0;
   margin: 0;
 }
 .select2-drop.select2-drop-active.crm-container .select2-results li {
   color: var(--crm-text-color);
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
   margin: 0;
 }
 .select2-drop.select2-drop-active.crm-container .select2-results li:has(.crm-select2-row-description) {
@@ -659,19 +659,19 @@ input.crm-form-checkbox) + label {
   border: 1px solid var(--crm-input-border-color);
   border-radius: var(--crm-input-border-radius);
   box-sizing: border-box;
-  height: var(--crm-s-large);
-  margin-top: var(--crm-s-small);
+  height: var(--crm-l-large);
+  margin-top: var(--crm-l-small);
 }
 .select2-drop .crm-entityref-links {
   border-top: 1px solid var(--crm-input-border-color);
-  margin-top: var(--crm-s-medium);
+  margin-top: var(--crm-l-medium);
 }
 .select2-drop .crm-entityref-links a.crm-hover-button {
   white-space: nowrap;
 }
 .crm-container .select2-results .select2-result-label {
   font-size: var(--crm-input-font-size);
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -682,12 +682,12 @@ input.crm-form-checkbox) + label {
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
   background: var(--crm-c-layout2-bg-color);
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
 }
 .crm-container .crm-select2-row-description p {
   font-weight: normal;
   font-family: var(--crm-font);
-  font-size: var(--crm-s-medium-2);
+  font-size: var(--crm-l-medium-2);
   margin: 0;
   padding: 0;
 }
@@ -726,7 +726,7 @@ input.crm-form-checkbox) + label {
 .form-inline:has(.crm-form-date-wrapper) {
   display: flex;
   align-items: center;
-  gap: var(--crm-s-xsmall);
+  gap: var(--crm-l-xsmall);
 }
 .crm-form-date-wrapper {
   display: inline-flex;
@@ -749,7 +749,7 @@ input.crm-form-checkbox) + label {
   align-items: center;
 }
 .crm-container input.crm-placeholder-icon {
-  padding-right: var(--crm-s-medium);
+  padding-right: var(--crm-l-medium);
 }
 #ui-datepicker-div,
 #ui-datepicker-div * {
@@ -762,24 +762,24 @@ input.crm-form-checkbox) + label {
   border-radius: 0;
   box-shadow: var(--crm-shadow-popup);
   min-width: 30ch;
-  padding: var(--crm-s-medium-1);
+  padding: var(--crm-l-medium-1);
   width: auto;
   z-index: 100003; /* vs menubar for datepickers in modals */
 }
 #ui-datepicker-div .ui-datepicker-header {
   border: 0;
-  margin-bottom: var(--crm-s-small);
+  margin-bottom: var(--crm-l-small);
 }
 #ui-datepicker-div :not(b) {
   background: none;
   border: 0 solid transparent;
 }
 #ui-datepicker-div :is(.ui-datepicker-prev,.ui-datepicker-next) {
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: none;
   cursor: var(--crm-link-hover-cursor);
   text-align: center;
-  top: var(--crm-s-small-3);
+  top: var(--crm-l-small-3);
   border: 0 solid transparent;
 }
 #ui-datepicker-div :is(.ui-datepicker-prev,.ui-datepicker-next):hover {
@@ -790,7 +790,7 @@ input.crm-form-checkbox) + label {
   font-family: "FontAwesome";
   color: var(--text);
   font-size: var(--crm-font-small-size);
-  line-height: var(--crm-s-large);
+  line-height: var(--crm-l-large);
   padding: 0;
 }
 #ui-datepicker-div .ui-datepicker-header :is(.ui-datepicker-prev,.ui-datepicker-next):hover::before {
@@ -804,9 +804,9 @@ input.crm-form-checkbox) + label {
 }
 #ui-datepicker-div .ui-datepicker-header select {
   font-family: var(--crm-font);
-  margin: 0 var(--crm-s-medium-1);
+  margin: 0 var(--crm-l-medium-1);
   padding-left: 5px;
-  font-size: var(--crm-s-medium-3);
+  font-size: var(--crm-l-medium-3);
   width: 9ch;
 }
 #ui-datepicker-div .ui-datepicker-calendar thead th {
@@ -820,7 +820,7 @@ input.crm-form-checkbox) + label {
   border: 0;
   font-size: var(--crm-font-small-size);
   opacity: 1;
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
 }
 #ui-datepicker-div .ui-state-default,
 #ui-datepicker-div .ui-widget-content .ui-state-default {
@@ -838,7 +838,7 @@ input.crm-form-checkbox) + label {
   border: 0;
   border-radius: 20px;
   cursor: var(--crm-link-hover-cursor);
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
   text-align: center;
   color: var(--crm-text-color);
 }
@@ -853,7 +853,7 @@ input.crm-form-checkbox) + label {
   width: 8ch;
 }
 .crm-container .ui-spinner a.ui-spinner-button {
-  width: var(--crm-s-reg-2);
+  width: var(--crm-l-reg-2);
   margin: 1px;
   cursor: var(--crm-link-hover-cursor);
   color: var(--crm-link-color);
@@ -868,7 +868,7 @@ input.crm-form-checkbox) + label {
   font-family: "FontAwesome";
   font-style: normal;
   font-weight: normal;
-  font-size: var(--crm-s-medium-3);
+  font-size: var(--crm-l-medium-3);
   text-indent: 0;
   display: block;
 }
@@ -952,7 +952,7 @@ input.crm-form-checkbox) + label {
 #bootstrap-theme .radio-inline + .radio-inline,
 #bootstrap-theme .checkbox-inline + .checkbox-inline {
   margin-top: 0;
-  margin-left: var(--crm-s-medium);
+  margin-left: var(--crm-l-medium);
 }
 
 /* Disabled styles */

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -303,7 +303,7 @@ select.crm-error {
 .crm-container .crm-inline-edit:hover,
 .crm-container .crm-editable-enabled:hover {
   border: var(--crm-contact-edit-border);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .crm-container .crm-editable-enabled.crm-editable-editing:hover {
   border-color: transparent;
@@ -364,7 +364,7 @@ input.crm-form-checkbox + label,
 .crm-container input[type="checkbox"] + label[for],
 .crm-container input[type="radio"] + label[for] {
   margin: 0 var(--crm-m) 0 var(--crm-s);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   width: unset;
   font-weight: normal;
   font-family: var(--crm-font);
@@ -760,7 +760,7 @@ input.crm-form-checkbox) + label {
 #ui-datepicker-div {
   background: var(--crm-input-bg);
   border-radius: 0;
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
   min-width: 30ch;
   padding: var(--crm-m1);
   width: auto;
@@ -777,7 +777,7 @@ input.crm-form-checkbox) + label {
 #ui-datepicker-div :is(.ui-datepicker-prev,.ui-datepicker-next) {
   border-radius: var(--crm-s-radius);
   box-shadow: none;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   text-align: center;
   top: var(--crm-s3);
   border: 0 solid transparent;
@@ -789,7 +789,7 @@ input.crm-form-checkbox) + label {
 #ui-datepicker-div .ui-datepicker-header :is(.ui-datepicker-prev,.ui-datepicker-next)::before {
   font-family: "FontAwesome";
   color: var(--text);
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
   line-height: var(--crm-l);
   padding: 0;
 }
@@ -811,14 +811,14 @@ input.crm-form-checkbox) + label {
 }
 #ui-datepicker-div .ui-datepicker-calendar thead th {
   color: var(--crm-c-text);
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
 }
 #ui-datepicker-div .ui-datepicker-calendar tr {
   border-bottom: none;
 }
 #ui-datepicker-div .ui-datepicker-calendar :is(td,.ui-state-disabled) {
   border: 0;
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
   opacity: 1;
   padding: var(--crm-s);
 }
@@ -837,7 +837,7 @@ input.crm-form-checkbox) + label {
 #ui-datepicker-div .ui-datepicker-calendar :is(td,.ui-state-disabled) a {
   border: 0;
   border-radius: 20px;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   padding: var(--crm-s);
   text-align: center;
   color: var(--crm-c-text);
@@ -855,7 +855,7 @@ input.crm-form-checkbox) + label {
 .crm-container .ui-spinner a.ui-spinner-button {
   width: var(--crm-r2);
   margin: 1px;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   color: var(--crm-c-link);
   border-radius: 0;
   border-left: 1px solid var(--crm-input-border-color);
@@ -934,7 +934,7 @@ input.crm-form-checkbox) + label {
   padding-left: 20px;
   margin-bottom: 0;
   font-weight: 400;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 #bootstrap-theme .radio + .radio,
 #bootstrap-theme .checkbox + .checkbox {
@@ -947,7 +947,7 @@ input.crm-form-checkbox) + label {
   margin-bottom: 0;
   font-weight: 400;
   vertical-align: middle;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 #bootstrap-theme .radio-inline + .radio-inline,
 #bootstrap-theme .checkbox-inline + .checkbox-inline {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -292,7 +292,7 @@ select.crm-error {
 .crm-container .crm-inline-edit,
 .crm-container .crm-editable-disabled,
 .crm-container .crm-editable-enabled {
-  border: var(--crm-dash-edit-border);
+  border: var(--crm-contact-edit-border);
   border-color: transparent;
   background: none;
   position: relative;
@@ -302,7 +302,7 @@ select.crm-error {
 }
 .crm-container .crm-inline-edit:hover,
 .crm-container .crm-editable-enabled:hover {
-  border: var(--crm-dash-edit-border);
+  border: var(--crm-contact-edit-border);
   cursor: var(--crm-hover-clickable);
 }
 .crm-container .crm-editable-enabled.crm-editable-editing:hover {
@@ -701,13 +701,13 @@ input.crm-form-checkbox) + label {
   display: block;
 }
 .select2-drop.collapsible-optgroups-enabled .select2-result-with-children.optgroup-expanded > .select2-result-label:before {
-  transform: var(--crm-expand-transform);
-  transition: var(--crm-expand-transition);
+  transform: var(--crm-accordion-transform);
+  transition: var(--crm-accordion-transition);
 }
 .select2-drop.collapsible-optgroups-enabled .select2-result-with-children > .select2-result-label:before {
   font-size: var(--crm-font-size);
-  content: var(--crm-expand-icon);
-  color: var(--crm-expand-icon-color);
+  content: var(--crm-accordion-icon);
+  color: var(--crm-accordion-icon-color);
   font-style: normal;
   font-family: FontAwesome;
   text-rendering: auto;
@@ -715,7 +715,7 @@ input.crm-form-checkbox) + label {
   margin-right: 0.5rem;
   display: inline-block;
   transform-origin: center center;
-  transition: var(--crm-expand-transition);
+  transition: var(--crm-accordion-transition);
 }
 .select2-drop.select2-drop-active.crm-container li.select2-result-with-children {
   padding: 0;
@@ -775,7 +775,7 @@ input.crm-form-checkbox) + label {
   border: 0 solid transparent;
 }
 #ui-datepicker-div :is(.ui-datepicker-prev,.ui-datepicker-next) {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   box-shadow: none;
   cursor: var(--crm-hover-clickable);
   text-align: center;

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -214,7 +214,7 @@ select.crm-error {
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
-  grid-gap: var(--crm-m2);
+  grid-gap: var(--crm-l-medium-2);
 
   & input[type="checkbox"].crm-form-toggle {
     appearance: none;
@@ -240,7 +240,7 @@ select.crm-error {
     box-sizing: border-box;
     width: 1.25rem;
     height: 1.25rem;
-    margin: 0 var(--crm-xs2);
+    margin: 0 var(--crm-l-xsmall-2);
     border-radius: 50%;
     border: 1px solid var(--crm-input-toggle-button-bg);
     background: var(--crm-input-toggle-button-bg);
@@ -681,7 +681,7 @@ input.crm-form-checkbox) + label {
 }
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
-  background: var(--crm-c-layout2-bg-color);
+  background: var(--crm-layer2-bg-color);
   padding: var(--crm-l-small);
 }
 .crm-container .crm-select2-row-description p {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -1,22 +1,22 @@
 /* Form parts */
 .crm-container div.crm-field-wrapper {
-  margin-bottom: var(--crm-r);
+  margin-bottom: var(--crm-s-reg);
 }
 .crm-section {
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
 }
 .crm-container table.form-layout td,
 .crm-container table.form-layout-compressed td,
 .crm-form-block .crm-section {
-  padding: var(--crm-m) var(--crm-s2);
+  padding: var(--crm-s-medium) var(--crm-s-small-2);
   border: none !important /* vs contactSummary.css */;
   height: auto;
   vertical-align: top;
 }
 .crm-container div.form-layout-compressed {
   display: flex;
-  gap: var(--crm-s);
-  padding: var(--crm-r) 0;
+  gap: var(--crm-s-small);
+  padding: var(--crm-s-reg) 0;
   align-items: center;
 }
 .crm-container .crm-results-block-empty {
@@ -30,7 +30,7 @@
 .crm-container .form-layout-compressed th.label {
   min-width: var(--crm-input-label-width);
   text-align: var(--crm-input-label-align);
-  margin: var(--crm-m) var(--crm-m2) 0 0;
+  margin: var(--crm-s-medium) var(--crm-s-medium-2) 0 0;
   font-family: var(--crm-input-label-font);
   font-weight: var(--crm-input-label-weight);
   display: table-cell;
@@ -40,7 +40,7 @@
   text-align: left;
   font-family: var(--crm-input-label-font);
   font-weight: var(--crm-input-label-weight);
-  padding-right: var(--crm-m2);
+  padding-right: var(--crm-s-medium-2);
 }
 .crm-container .label > label { /* Fix for dble label specification */
   padding-right: 0;
@@ -68,7 +68,7 @@
   font-weight: var(--crm-input-label-weight);
   font-size: var(--crm-input-label-size);
   display: inline-block;
-  margin-bottom: var(--crm-s);
+  margin-bottom: var(--crm-s-small);
 }
 .crm-container .form-layout td.label label {
   margin-bottom: 0;
@@ -91,7 +91,7 @@
   color: var(--crm-notify-danger-color);
 }
 .crm-container .form-inline {
-  padding: var(--crm-s) 0;
+  padding: var(--crm-s-small) 0;
 }
 .crm-search-display .form-inline {
   padding: var(--crm-padding-reg) 0;
@@ -111,7 +111,7 @@
 }
 .crm-container fieldset legend {
   font-weight: bold;
-  padding-inline: var(--crm-s);
+  padding-inline: var(--crm-s-small);
   color: var(--crm-text-color);
 }
 
@@ -119,7 +119,7 @@
 .crm-container .required-mark::after {
   color: var(--crm-danger-color);
   content: "*";
-  margin-left: var(--crm-s);
+  margin-left: var(--crm-s-small);
 }
 /* Input */
 
@@ -145,7 +145,7 @@ select.crm-form-select,
   border: 1px solid var(--crm-input-border-color);
   padding: var(--crm-input-padding);
   height: var(--crm-input-height);
-  width: var(--crm-big-input);
+  width: var(--crm-input-width);
   font-family: inherit; /* for extra JQuery UI protection */
 }
 .crm-container .replace-plain,
@@ -163,7 +163,7 @@ select.crm-form-multiselect {
 }
 .crm-container .replace-plain {
   background-color: var(--crm-input-bg-color);
-  min-width: var(--crm-huge-input);
+  min-width: var(--crm-input-large-width);
 }
 input.crm-form-text:focus,
 input.crm-form-password:focus,
@@ -196,7 +196,7 @@ select.crm-error {
   text-align: right;
 }
 .crm-icon-picker-button {
-  margin: 0 0 var(--crm-s);
+  margin: 0 0 var(--crm-s-small);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -312,8 +312,8 @@ select.crm-error {
 .crm-container span.crm-editable-disabled,
 .crm-container span.crm-editable-enabled {
   display: inline-block;
-  padding-right: var(--crm-s);
-  min-height: var(--crm-r);
+  padding-right: var(--crm-s-small);
+  min-height: var(--crm-s-reg);
 }
 .crm-container .crm-editable-enabled .crm-i,
 .crm-editable-enabled:has(span.crm-search-field-value:empty) {
@@ -363,7 +363,7 @@ input.crm-form-radio + label,
 input.crm-form-checkbox + label,
 .crm-container input[type="checkbox"] + label[for],
 .crm-container input[type="radio"] + label[for] {
-  margin: 0 var(--crm-m) 0 var(--crm-s);
+  margin: 0 var(--crm-s-medium) 0 var(--crm-s-small);
   cursor: var(--crm-link-hover-cursor);
   width: unset;
   font-weight: normal;
@@ -420,7 +420,7 @@ input.crm-form-checkbox) + label {
 
 .crm-container input[type="file"] {
   height: auto;
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
 }
 .crm-container input[type="range"] {
   accent-color: var(--crm-focus-color);
@@ -444,7 +444,7 @@ input.crm-form-checkbox) + label {
 }
 /* Set width using !important to override the inline fixed width given by select2.js */
 .crm-container .select2-container {
-  width: var(--crm-big-input) !important /* vs inline fixed width */;
+  width: var(--crm-input-width) !important /* vs inline fixed width */;
 }
 .crm-container .select2-container-multi {
   min-width: 96px;
@@ -468,7 +468,7 @@ input.crm-form-checkbox) + label {
   background: transparent;
   border-left: 0;
   border-radius: 0 var(--crm-input-border-radius) var(--crm-input-border-radius) 0;
-  width: var(--crm-r3);
+  width: var(--crm-s-reg-3);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -479,11 +479,11 @@ input.crm-form-checkbox) + label {
 .select2-container.select2-allowclear .select2-choice abbr {
   position: relative;
   margin-left: auto;
-  right: var(--crm-r);
+  right: var(--crm-s-reg);
   top: auto;
 }
 .crm-container .select2-container .select2-choice > .select2-chosen {
-  margin-right: var(--crm-r2);
+  margin-right: var(--crm-s-reg-2);
 }
 .crm-container .select2-container-multi .select2-choices::before,
 .crm-container .select2-container .select2-choice .select2-arrow::before {
@@ -549,8 +549,8 @@ input.crm-form-checkbox) + label {
 .crm-container .select2-container-multi .select2-choices {
   display: flex;
   flex-flow: wrap;
-  gap: var(--crm-s);
-  padding: 2px var(--crm-s);
+  gap: var(--crm-s-small);
+  padding: 2px var(--crm-s-small);
   align-items: center;
   font-size: var(--crm-input-font-size);
   min-height: var(--crm-input-height);
@@ -560,7 +560,7 @@ input.crm-form-checkbox) + label {
   max-width: calc(100% - 2rem);
 }
 .select2-container-multi .select2-choices .select2-search-choice {
-  padding: 1px var(--crm-m) 1px var(--crm-r1);
+  padding: 1px var(--crm-s-medium) 1px var(--crm-s-reg-1);
   margin: 0;
   position: relative;
   line-height: unset;
@@ -587,8 +587,8 @@ input.crm-form-checkbox) + label {
 .select2-container.loading .select2-choice .select2-arrow b {
   content: "\f110";
   position: absolute;
-  right: var(--crm-m);
-  top: var(--crm-s);
+  right: var(--crm-s-medium);
+  top: var(--crm-s-small);
   animation-name: fa-spin;
   animation-duration: var(--fa-animation-duration,2s);
   animation-iteration-count: var(--fa-animation-iteration-count,infinite);
@@ -598,7 +598,7 @@ input.crm-form-checkbox) + label {
 /* Select dropdown */
 
 .select2-drop.select2-drop-active.crm-container {
-  min-width: var(--crm-big-input);
+  min-width: var(--crm-input-width);
   background: var(--crm-input-bg-color);
   border-bottom-left-radius: var(--crm-input-border-radius);
   border-bottom-right-radius: var(--crm-input-border-radius);
@@ -610,7 +610,7 @@ input.crm-form-checkbox) + label {
   border-bottom-right-radius: 0;
 }
 .select2-search {
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
 }
 .select2-search::after {
   font-family: "FontAwesome";
@@ -632,13 +632,13 @@ input.crm-form-checkbox) + label {
   width: 100%;
 }
 .crm-container .select2-results {
-  font-size: var(--crm-m2);
+  font-size: var(--crm-s-medium-2);
   padding: 0;
   margin: 0;
 }
 .select2-drop.select2-drop-active.crm-container .select2-results li {
   color: var(--crm-text-color);
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
   margin: 0;
 }
 .select2-drop.select2-drop-active.crm-container .select2-results li:has(.crm-select2-row-description) {
@@ -659,19 +659,19 @@ input.crm-form-checkbox) + label {
   border: 1px solid var(--crm-input-border-color);
   border-radius: var(--crm-input-border-radius);
   box-sizing: border-box;
-  height: var(--crm-l);
-  margin-top: var(--crm-s);
+  height: var(--crm-s-large);
+  margin-top: var(--crm-s-small);
 }
 .select2-drop .crm-entityref-links {
   border-top: 1px solid var(--crm-input-border-color);
-  margin-top: var(--crm-m);
+  margin-top: var(--crm-s-medium);
 }
 .select2-drop .crm-entityref-links a.crm-hover-button {
   white-space: nowrap;
 }
 .crm-container .select2-results .select2-result-label {
   font-size: var(--crm-input-font-size);
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -682,12 +682,12 @@ input.crm-form-checkbox) + label {
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
   background: var(--crm-c-layout2-bg-color);
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
 }
 .crm-container .crm-select2-row-description p {
   font-weight: normal;
   font-family: var(--crm-font);
-  font-size: var(--crm-m2);
+  font-size: var(--crm-s-medium-2);
   margin: 0;
   padding: 0;
 }
@@ -726,7 +726,7 @@ input.crm-form-checkbox) + label {
 .form-inline:has(.crm-form-date-wrapper) {
   display: flex;
   align-items: center;
-  gap: var(--crm-xs);
+  gap: var(--crm-s-xsmall);
 }
 .crm-form-date-wrapper {
   display: inline-flex;
@@ -749,7 +749,7 @@ input.crm-form-checkbox) + label {
   align-items: center;
 }
 .crm-container input.crm-placeholder-icon {
-  padding-right: var(--crm-m);
+  padding-right: var(--crm-s-medium);
 }
 #ui-datepicker-div,
 #ui-datepicker-div * {
@@ -762,13 +762,13 @@ input.crm-form-checkbox) + label {
   border-radius: 0;
   box-shadow: var(--crm-shadow-popup);
   min-width: 30ch;
-  padding: var(--crm-m1);
+  padding: var(--crm-s-medium-1);
   width: auto;
   z-index: 100003; /* vs menubar for datepickers in modals */
 }
 #ui-datepicker-div .ui-datepicker-header {
   border: 0;
-  margin-bottom: var(--crm-s);
+  margin-bottom: var(--crm-s-small);
 }
 #ui-datepicker-div :not(b) {
   background: none;
@@ -779,7 +779,7 @@ input.crm-form-checkbox) + label {
   box-shadow: none;
   cursor: var(--crm-link-hover-cursor);
   text-align: center;
-  top: var(--crm-s3);
+  top: var(--crm-s-small-3);
   border: 0 solid transparent;
 }
 #ui-datepicker-div :is(.ui-datepicker-prev,.ui-datepicker-next):hover {
@@ -790,7 +790,7 @@ input.crm-form-checkbox) + label {
   font-family: "FontAwesome";
   color: var(--text);
   font-size: var(--crm-font-small-size);
-  line-height: var(--crm-l);
+  line-height: var(--crm-s-large);
   padding: 0;
 }
 #ui-datepicker-div .ui-datepicker-header :is(.ui-datepicker-prev,.ui-datepicker-next):hover::before {
@@ -804,9 +804,9 @@ input.crm-form-checkbox) + label {
 }
 #ui-datepicker-div .ui-datepicker-header select {
   font-family: var(--crm-font);
-  margin: 0 var(--crm-m1);
+  margin: 0 var(--crm-s-medium-1);
   padding-left: 5px;
-  font-size: var(--crm-m3);
+  font-size: var(--crm-s-medium-3);
   width: 9ch;
 }
 #ui-datepicker-div .ui-datepicker-calendar thead th {
@@ -820,7 +820,7 @@ input.crm-form-checkbox) + label {
   border: 0;
   font-size: var(--crm-font-small-size);
   opacity: 1;
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
 }
 #ui-datepicker-div .ui-state-default,
 #ui-datepicker-div .ui-widget-content .ui-state-default {
@@ -838,7 +838,7 @@ input.crm-form-checkbox) + label {
   border: 0;
   border-radius: 20px;
   cursor: var(--crm-link-hover-cursor);
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
   text-align: center;
   color: var(--crm-text-color);
 }
@@ -853,7 +853,7 @@ input.crm-form-checkbox) + label {
   width: 8ch;
 }
 .crm-container .ui-spinner a.ui-spinner-button {
-  width: var(--crm-r2);
+  width: var(--crm-s-reg-2);
   margin: 1px;
   cursor: var(--crm-link-hover-cursor);
   color: var(--crm-link-color);
@@ -868,7 +868,7 @@ input.crm-form-checkbox) + label {
   font-family: "FontAwesome";
   font-style: normal;
   font-weight: normal;
-  font-size: var(--crm-m3);
+  font-size: var(--crm-s-medium-3);
   text-indent: 0;
   display: block;
 }
@@ -910,10 +910,10 @@ input.crm-form-checkbox) + label {
   width: 20em !important;
 }
 .crm-container .big {
-  width: var(--crm-big-input) !important;
+  width: var(--crm-input-width) !important;
 }
 .crm-container .huge {
-  width: var(--crm-huge-input) !important;
+  width: var(--crm-input-large-width) !important;
 }
 .crm-container .crm-auto-width {
   width: auto !important;
@@ -952,7 +952,7 @@ input.crm-form-checkbox) + label {
 #bootstrap-theme .radio-inline + .radio-inline,
 #bootstrap-theme .checkbox-inline + .checkbox-inline {
   margin-top: 0;
-  margin-left: var(--crm-m);
+  margin-left: var(--crm-s-medium);
 }
 
 /* Disabled styles */

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -967,5 +967,5 @@ input.crm-form-checkbox) + label {
   color: var(--crm-c-inactive);
 }
 .crm-container :is(input,textarea,option):disabled {
-  background-color: color-mix(in srgb, var(--crm-input-background) 90%, var(--crm-c-text) 10%);
+  background-color: color-mix(in srgb, var(--crm-input-background) 90%, var(--crm-ink) 10%);
 }

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -42,10 +42,10 @@ af-form > fieldset > legend {
 .crm-container.crm-public .header-dark {
   background: var(--crm-secondary-color);
   color: var(--crm-text-light-color);
-  padding: var(--crm-s-medium-1) var(--crm-f-fieldset-padding);
+  padding: var(--crm-l-medium-1) var(--crm-f-fieldset-padding);
   font-weight: bold;
-  font-size: var(--crm-s-reg-1);
-  border-radius: var(--crm-s-radius);
+  font-size: var(--crm-l-reg-1);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container.crm-public .crm-section:not(.alert) {
   padding: 0;
@@ -69,7 +69,7 @@ af-form > fieldset > legend {
   display: table;
 }
 .crm-container.crm-public span#msgbox {
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   padding: var(--crm-padding-small);
 }
 .crm-container.crm-public #civicrm-footer::after {
@@ -138,7 +138,7 @@ af-form > fieldset > legend {
 .crm-container.crm-public .select2-search input,
 .crm-container.crm-public .select2-results select,
 .crm-container.crm-public .select2-results input {
-  padding: var(--crm-s-small) var(--crm-s-reg-1) var(--crm-s-small);
+  padding: var(--crm-l-small) var(--crm-l-reg-1) var(--crm-l-small);
 }
 .crm-container.crm-public .select2-dropdown-open .select2-choice,
 .crm-container.crm-public .select2-dropdown-open .select2-choices {
@@ -168,12 +168,12 @@ af-form > fieldset > legend {
   padding: var(--crm-f-form-padding);
 }
 .crm-container.crm-public #attachments table.form-layout-compressed {
-  margin-block: var(--crm-s-medium) 0;
+  margin-block: var(--crm-l-medium) 0;
 }
 .crm-container.crm-public #attachments table.form-layout-compressed tr {
   display: flex;
   flex-direction: column;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
 }
 .crm-container.crm-public #attachments table.form-layout-compressed td {
   width: 100%;
@@ -182,7 +182,7 @@ af-form > fieldset > legend {
 }
 .crm-container.crm-public .crm-profile-view-title {
   padding-inline: var(--crm-f-form-padding);
-  font-size: var(--crm-s-reg-1);
+  font-size: var(--crm-l-reg-1);
 }
 /* Empowered by logo */
 
@@ -190,7 +190,7 @@ af-form > fieldset > legend {
   display: flex;
   align-items: center;
   justify-content: var(--crm-f-logo-align);
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
   width: var(--crm-f-form-width);
   margin: 0 auto;
 }

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -45,7 +45,7 @@ af-form > fieldset > legend {
   padding: var(--crm-m1) var(--crm-f-fieldset-padding);
   font-weight: bold;
   font-size: var(--crm-r1);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container.crm-public .crm-section:not(.alert) {
   padding: 0;
@@ -69,7 +69,7 @@ af-form > fieldset > legend {
   display: table;
 }
 .crm-container.crm-public span#msgbox {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   padding: var(--crm-padding-small);
 }
 .crm-container.crm-public #civicrm-footer::after {

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -42,9 +42,9 @@ af-form > fieldset > legend {
 .crm-container.crm-public .header-dark {
   background: var(--crm-secondary-color);
   color: var(--crm-text-light-color);
-  padding: var(--crm-m1) var(--crm-f-fieldset-padding);
+  padding: var(--crm-s-medium-1) var(--crm-f-fieldset-padding);
   font-weight: bold;
-  font-size: var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
   border-radius: var(--crm-s-radius);
 }
 .crm-container.crm-public .crm-section:not(.alert) {
@@ -138,7 +138,7 @@ af-form > fieldset > legend {
 .crm-container.crm-public .select2-search input,
 .crm-container.crm-public .select2-results select,
 .crm-container.crm-public .select2-results input {
-  padding: var(--crm-s) var(--crm-r1) var(--crm-s);
+  padding: var(--crm-s-small) var(--crm-s-reg-1) var(--crm-s-small);
 }
 .crm-container.crm-public .select2-dropdown-open .select2-choice,
 .crm-container.crm-public .select2-dropdown-open .select2-choices {
@@ -168,12 +168,12 @@ af-form > fieldset > legend {
   padding: var(--crm-f-form-padding);
 }
 .crm-container.crm-public #attachments table.form-layout-compressed {
-  margin-block: var(--crm-m) 0;
+  margin-block: var(--crm-s-medium) 0;
 }
 .crm-container.crm-public #attachments table.form-layout-compressed tr {
   display: flex;
   flex-direction: column;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
 }
 .crm-container.crm-public #attachments table.form-layout-compressed td {
   width: 100%;
@@ -182,7 +182,7 @@ af-form > fieldset > legend {
 }
 .crm-container.crm-public .crm-profile-view-title {
   padding-inline: var(--crm-f-form-padding);
-  font-size: var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
 }
 /* Empowered by logo */
 
@@ -190,7 +190,7 @@ af-form > fieldset > legend {
   display: flex;
   align-items: center;
   justify-content: var(--crm-f-logo-align);
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
   width: var(--crm-f-form-width);
   margin: 0 auto;
 }

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -17,7 +17,7 @@
 .crm-container.crm-public #crm-profile-block,
 .crm-container.crm-public .crm-container.crm-public .af-container:not(.af-container-style-pane),
 .crm-container.crm-public .email-5-section {
-  background-color: var(--crm-f-fieldset-bg);
+  background-color: var(--crm-f-fieldset-bg-color);
   margin: var(--crm-f-fieldset-margin);
   padding: var(--crm-f-fieldset-padding);
   border: var(--crm-f-fieldset-border);
@@ -40,8 +40,8 @@ af-form > fieldset > legend {
   float: none;
 }
 .crm-container.crm-public .header-dark {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-text-light);
+  background: var(--crm-secondary-color);
+  color: var(--crm-text-light-color);
   padding: var(--crm-m1) var(--crm-f-fieldset-padding);
   font-weight: bold;
   font-size: var(--crm-r1);
@@ -87,7 +87,7 @@ af-form > fieldset > legend {
 .crm-container.crm-public .crm-section:has( > .content input:focus),
 .crm-container.crm-public .crm-section:has( > .content select:focus),
 .crm-container.crm-public .crm-section:has( > .content textarea:focus) {
-  background-color: var(--crm-f-form-focus-bg);
+  background-color: var(--crm-f-form-focus-bg-color);
 }
 .crm-container.crm-public .crm-section:has( > .content input.error),
 .crm-container.crm-public .crm-section:has( > .content textarea.error),
@@ -95,7 +95,7 @@ af-form > fieldset > legend {
 .crm-container.crm-public .crm-section:has( > .content input.crm-inline-error),
 .crm-container.crm-public .crm-section:has( > .content textarea.crm-inline-error),
 .crm-container.crm-public .crm-section:has( > .content select.crm-inline-error) {
-  background-color: var(--crm-f-form-error-bg);
+  background-color: var(--crm-f-form-error-bg-color);
 }
 .crm-container.crm-public input[type="text"],
 .crm-container.crm-public input[type="password"],

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -7,7 +7,7 @@
 .crm-container .crm-hover-button:has(.crm-i):hover,
 .crm-container .crm-hover-button:has(.crm-i):focus {
   background: transparent;
-  color: var(--crm-c-link) !important;
+  color: var(--crm-link-color) !important;
   padding: var(--crm-btn-small-padding);
 }
 .crm-container .select2-container[class*=" fa-"]::before,
@@ -45,22 +45,22 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container #crm-notification-container div.ui-notify-message.error h1::before,
 .crm-container span.batch-invalid::before {
   content: var(--crm-icon-danger);
-  color: var(--crm-notify-danger);
+  color: var(--crm-notify-danger-color);
 }
 .crm-container #crm-notification-container div.ui-notify-message.success h1::before,
 .crm-container span.batch-valid::before {
   content: var(--crm-icon-success);
-  color: var(--crm-notify-success);
+  color: var(--crm-notify-success-color);
 }
 .crm-container #crm-notification-container div.ui-notify-message.info h1::before,
 .crm-container .messages.crm-empty-table::before {
   content: var(--crm-icon-info);
-  color: var(--crm-notify-info);
+  color: var(--crm-notify-info-color);
 }
 .crm-container #crm-notification-container div.ui-notify-message.alert h1::before,
 .crm-container #crm-notification-container div.ui-notify-message.warning h1::before {
   content: var(--crm-icon-danger);
-  color: var(--crm-notify-warning);
+  color: var(--crm-notify-warning-color);
 }
 .crm-container .messages.crm-empty-table > i.crm-i {
   display: none; /* removes double icon when markup uses both */
@@ -102,7 +102,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .ui-icon-circle-close::before {
   content: var(--crm-icon-close);
-  color: var(--crm-notify-col);
+  color: var(--crm-notify-color);
 }
 .crm-container .ui-icon-circle-close:hover,
 .crm-container .ui-icon-circle-close:focus,
@@ -117,7 +117,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   color: var(--crm-icon-danger-color);
 }
 .crm-container .crm-dashlet-header a.fa-times {
-  color: var(--crm-dashlet-header-col);
+  color: var(--crm-dashlet-header-color);
 }
 
 /* Info icon */
@@ -141,7 +141,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container table.dataTable thead th.sorting_asc,
 .crm-container table.dataTable thead th.sorting_desc {
   background-image: none;
-  color: var(--crm-table-header-col);
+  color: var(--crm-table-header-color);
   box-shadow: none;
   line-height: 1;
 }
@@ -162,7 +162,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   /* Bootstrap & SearchKit sort resets */
   position: absolute;
   margin-left: -1.5ch;
-  color: var(--crm-table-sort-col);
+  color: var(--crm-table-sort-color);
   line-height: inherit;
   font-style: normal;
   text-rendering: auto;
@@ -188,7 +188,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   text-rendering: auto;
   font-size: var(--crm-contact-icon-size);
   content: var(--crm-icon-sort);
-  color: var(--crm-table-sort-col);
+  color: var(--crm-table-sort-color);
   cursor: var(--crm-link-hover-cursor);
 }
 .crm-container th.crm-sortable-col i.crm-search-table-column-sort-icon::before,
@@ -203,20 +203,20 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-search-display-table > table.table > thead > tr > th i.crm-search-table-column-sort-icon.fa-sort-asc::before,
 .crm-container table.dataTable thead th.sorting_asc::before {
   content: var(--crm-icon-sort-asc);
-  color: var(--crm-table-sort-active-col);
+  color: var(--crm-table-sort-active-color);
 }
 .crm-container a.sorting_desc::after,
 .crm-container th.crm-sortable-col i.crm-search-table-column-sort-icon.fa-sort-desc::before,
 .crm-search-display-table > table.table > thead > tr > th i.crm-search-table-column-sort-icon.fa-sort-desc::before,
 .crm-container table.dataTable thead th.sorting_desc::before {
   content: var(--crm-icon-sort-desc);
-  color: var(--crm-table-sort-active-col);
+  color: var(--crm-table-sort-active-color);
 }
 
 /* Trash icons */
 .crm-container .delete-icon {
   background-image: none;
-  color: var(--crm-alert-danger-text);
+  color: var(--crm-alert-danger-text-color);
 }
 .crm-container .delete-button > .delete-icon {
   color: inherit;
@@ -265,22 +265,22 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .jstree-default.jstree-checkbox-selection .jstree-clicked > .jstree-checkbox::before,
 .crm-container .jstree-default .jstree-checked > .jstree-checkbox::before {
   content: '\f046';
-  color: var(--crm-c-success-on-page-bg);
+  color: var(--crm-success-ink-color);
 }
 .jstree-default > .jstree-no-dots .jstree-closed > .jstree-ocl::before,
 .jstree .jstree-closed > .jstree-ocl::before {
   display: block;
   content: '\f105';
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 .jstree-default > .jstree-no-dots .jstree-open > .jstree-ocl::before,
 .jstree .jstree-open > .jstree-ocl::before {
   display: block;
   content: '\f107';
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 .crm-container .jstree-default .jstree-search {
-  color: var(--crm-c-danger);
+  color: var(--crm-danger-color);
   font-weight: normal;
 }
 .crm-container #navigation-tree li.jstree-node {
@@ -327,7 +327,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   margin-top: 1rem;
 }
 .crm-container #crmIconPicker a.ui-button {
-  color: var(--crm-c-text) !important;
+  color: var(--crm-text-color) !important;
   background: transparent;
   width: var(--crm-r2);
   height: var(--crm-r2);

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -1,5 +1,5 @@
 .crm-container .messages > .crm-i {
-  padding: 0 var(--crm-m) var(--crm-s) 0;
+  padding: 0 var(--crm-s-medium) var(--crm-s-small) 0;
   float: left;
 }
 .crm-container div:not(.crm-search-display-editable-buttons) > button.btn-xs:has(.fa-times),
@@ -40,7 +40,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   font-weight: normal;
   text-rendering: auto;
   font-size: var(--crm-font-size);
-  margin: 0 var(--crm-m) 0 0;
+  margin: 0 var(--crm-s-medium) 0 0;
 }
 .crm-container #crm-notification-container div.ui-notify-message.error h1::before,
 .crm-container span.batch-invalid::before {
@@ -245,7 +245,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .jstree-wholerow-ul {
   display: flex;
   flex-direction: column;
-  gap: var(--crm-xs);
+  gap: var(--crm-s-xsmall);
 }
 .jstree-default > .jstree-wholerow-ul > li.jstree-node {
   margin-inline: 0;
@@ -256,7 +256,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 .crm-container .jstree-default .jstree-icon {
   background-image: inherit;
-  font-size: var(--crm-r1);
+  font-size: var(--crm-s-reg-1);
   margin-right: var(--btn-icon-spacing);
 }
 .crm-container .jstree-default .jstree-checkbox::before {
@@ -318,19 +318,19 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 .crm-container #crmIconPicker a.ui-button .ui-icon {
   margin-top: 0;
-  font-size: var(--crm-r2);
+  font-size: var(--crm-s-reg-2);
 }
 .crm-container #crmIconPicker .icons {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-m2);
+  gap: var(--crm-s-medium-2);
   margin-top: 1rem;
 }
 .crm-container #crmIconPicker a.ui-button {
   color: var(--crm-text-color) !important;
   background: transparent;
-  width: var(--crm-r2);
-  height: var(--crm-r2);
+  width: var(--crm-s-reg-2);
+  height: var(--crm-s-reg-2);
   border: 0;
   padding: 0;
   display: inline-block;

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -186,7 +186,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   font-family: "Font Awesome 6 Free", "FontAwesome";
   font-style: normal;
   text-rendering: auto;
-  font-size: var(--crm-dash-icon-size);
+  font-size: var(--crm-contact-icon-size);
   content: var(--crm-icon-sort);
   color: var(--crm-table-sort-col);
   cursor: var(--crm-hover-clickable);
@@ -345,7 +345,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   font-family: "Font Awesome 6 Free", "FontAwesome";
   font-style: normal;
   text-rendering: auto;
-  font-size: var(--crm-dash-icon-size);
+  font-size: var(--crm-contact-icon-size);
   display: inline-block;
   content: '\f09d';
   font-size: 2.5rem;

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -169,7 +169,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   font-family: "Font Awesome 6 Free", "FontAwesome";
   font-style: normal;
   font-weight: normal;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   opacity: 1;
 }
 .crm-container .table > thead > tr > th:has(.crm-search-table-column-sort-icon) {
@@ -189,7 +189,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   font-size: var(--crm-contact-icon-size);
   content: var(--crm-icon-sort);
   color: var(--crm-table-sort-col);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .crm-container th.crm-sortable-col i.crm-search-table-column-sort-icon::before,
 .crm-container table.dataTable thead th.sorting::before,

--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -1,5 +1,5 @@
 .crm-container .messages > .crm-i {
-  padding: 0 var(--crm-s-medium) var(--crm-s-small) 0;
+  padding: 0 var(--crm-l-medium) var(--crm-l-small) 0;
   float: left;
 }
 .crm-container div:not(.crm-search-display-editable-buttons) > button.btn-xs:has(.fa-times),
@@ -40,7 +40,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   font-weight: normal;
   text-rendering: auto;
   font-size: var(--crm-font-size);
-  margin: 0 var(--crm-s-medium) 0 0;
+  margin: 0 var(--crm-l-medium) 0 0;
 }
 .crm-container #crm-notification-container div.ui-notify-message.error h1::before,
 .crm-container span.batch-invalid::before {
@@ -245,7 +245,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .jstree-wholerow-ul {
   display: flex;
   flex-direction: column;
-  gap: var(--crm-s-xsmall);
+  gap: var(--crm-l-xsmall);
 }
 .jstree-default > .jstree-wholerow-ul > li.jstree-node {
   margin-inline: 0;
@@ -256,7 +256,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 .crm-container .jstree-default .jstree-icon {
   background-image: inherit;
-  font-size: var(--crm-s-reg-1);
+  font-size: var(--crm-l-reg-1);
   margin-right: var(--btn-icon-spacing);
 }
 .crm-container .jstree-default .jstree-checkbox::before {
@@ -318,19 +318,19 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 }
 .crm-container #crmIconPicker a.ui-button .ui-icon {
   margin-top: 0;
-  font-size: var(--crm-s-reg-2);
+  font-size: var(--crm-l-reg-2);
 }
 .crm-container #crmIconPicker .icons {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-s-medium-2);
+  gap: var(--crm-l-medium-2);
   margin-top: 1rem;
 }
 .crm-container #crmIconPicker a.ui-button {
   color: var(--crm-text-color) !important;
   background: transparent;
-  width: var(--crm-s-reg-2);
-  height: var(--crm-s-reg-2);
+  width: var(--crm-l-reg-2);
+  height: var(--crm-l-reg-2);
   border: 0;
   padding: 0;
   display: inline-block;

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -13,7 +13,7 @@
   display: block;
 }
 .crm-container .nav > li > a {
-  padding: var(--crm-s-medium) var(--crm-s-reg);
+  padding: var(--crm-l-medium) var(--crm-l-reg);
 }
 .crm-container .nav > li > a:is(:hover,:focus) {
   text-decoration: none;
@@ -34,7 +34,7 @@
 }
 .crm-container .nav .nav-divider {
   height: 1px;
-  margin: var(--crm-s-medium) 0;
+  margin: var(--crm-l-medium) 0;
   overflow: hidden;
   background-color: var(--crm-border);
 }

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -17,7 +17,7 @@
 }
 .crm-container .nav > li > a:is(:hover,:focus) {
   text-decoration: none;
-  background-color: var(--crm-c-layout1-bg-color);
+  background-color: var(--crm-layer1-bg-color);
 }
 .crm-container .nav > li.disabled > a {
   color: var(--crm-inactive-color);
@@ -29,7 +29,7 @@
   background-color: transparent;
 }
 .crm-container .nav .open > :is(a,a:hover,a:focus) {
-  background-color: var(--crm-c-layout1-bg-color);
+  background-color: var(--crm-layer1-bg-color);
   border-color: var(--crm-link-color);
 }
 .crm-container .nav .nav-divider {

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -36,7 +36,7 @@
   height: 1px;
   margin: var(--crm-m) 0;
   overflow: hidden;
-  background-color: var(--crm-c-divider);
+  background-color: var(--crm-border);
 }
 .crm-container .nav > li > a > img {
   max-width: none;

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -13,7 +13,7 @@
   display: block;
 }
 .crm-container .nav > li > a {
-  padding: var(--crm-m) var(--crm-r);
+  padding: var(--crm-s-medium) var(--crm-s-reg);
 }
 .crm-container .nav > li > a:is(:hover,:focus) {
   text-decoration: none;
@@ -34,7 +34,7 @@
 }
 .crm-container .nav .nav-divider {
   height: 1px;
-  margin: var(--crm-m) 0;
+  margin: var(--crm-s-medium) 0;
   overflow: hidden;
   background-color: var(--crm-border);
 }

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -6,7 +6,7 @@
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .crm-container .nav > li {
   position: relative;

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -17,20 +17,20 @@
 }
 .crm-container .nav > li > a:is(:hover,:focus) {
   text-decoration: none;
-  background-color: var(--crm-c-layout1-bg);
+  background-color: var(--crm-c-layout1-bg-color);
 }
 .crm-container .nav > li.disabled > a {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
 }
 .crm-container .nav > li.disabled > a:is(:hover,:focus) {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
   text-decoration: none;
   cursor: not-allowed;
   background-color: transparent;
 }
 .crm-container .nav .open > :is(a,a:hover,a:focus) {
-  background-color: var(--crm-c-layout1-bg);
-  border-color: var(--crm-c-link);
+  background-color: var(--crm-c-layout1-bg-color);
+  border-color: var(--crm-link-color);
 }
 .crm-container .nav .nav-divider {
   height: 1px;

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -70,20 +70,20 @@
 .crm-datatable-pager-bottom {
   display: flex;
   justify-content: space-between;
-  font-size: var(--crm-s-medium-3);
-  margin-inline: var(--crm-s-medium);
+  font-size: var(--crm-l-medium-3);
+  margin-inline: var(--crm-l-medium);
 }
 .crm-datatable-pager-top {
-  margin-block: var(--crm-s-reg);
+  margin-block: var(--crm-l-reg);
 }
 .crm-datatable-pager-bottom {
-  margin-top: var(--crm-s-reg);
+  margin-top: var(--crm-l-reg);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button.current {
   background: var(--crm-secondary-color);
   color: var(--crm-secondary-text-color) !important;
   border: 0 solid transparent;
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
   background: var(--crm-secondary-hover-color);
@@ -119,7 +119,7 @@
   display: inline-block;
   padding-left: 0;
   margin: var(--crm-padding-reg) 0;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 .crm-container .pagination > li {
   display: inline;
@@ -127,7 +127,7 @@
 .crm-container .pagination > li > :is(a,span) {
   position: relative;
   float: left;
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
   margin-left: -1px;
   line-height: 1.4;
   color: var(--crm-link-color);
@@ -142,12 +142,12 @@
 }
 .crm-container .pagination > li:first-child > :is(a,span) {
   margin-left: 0;
-  border-top-left-radius: var(--crm-s-radius);
-  border-bottom-left-radius: var(--crm-s-radius);
+  border-top-left-radius: var(--crm-l-radius);
+  border-bottom-left-radius: var(--crm-l-radius);
 }
 .crm-container .pagination > li:last-child > :is(a,span) {
-  border-top-right-radius: var(--crm-s-radius);
-  border-bottom-right-radius: var(--crm-s-radius);
+  border-top-right-radius: var(--crm-l-radius);
+  border-bottom-right-radius: var(--crm-l-radius);
 }
 .crm-container .pagination > .active > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
   z-index: 3;
@@ -163,17 +163,17 @@
   border: var(--crm-border);
 }
 .crm-container .pagination-lg > li > :is(a,span) {
-  padding: var(--crm-s-medium-2) var(--crm-s-reg);
-  font-size: var(--crm-s-reg-1);
+  padding: var(--crm-l-medium-2) var(--crm-l-reg);
+  font-size: var(--crm-l-reg-1);
   line-height: 1.3;
 }
 .crm-container .pagination-lg > li:first-child > :is(a,span) {
-  border-top-left-radius: calc(1.5 * var(--crm-s-radius));
-  border-bottom-left-radius: calc(1.5 * var(--crm-s-radius));
+  border-top-left-radius: calc(1.5 * var(--crm-l-radius));
+  border-bottom-left-radius: calc(1.5 * var(--crm-l-radius));
 }
 .crm-container .pagination-lg > li:last-child > :is(a,span) {
-  border-top-right-radius: calc(1.5 * var(--crm-s-radius));
-  border-bottom-right-radius: calc(1.5 * var(--crm-s-radius));
+  border-top-right-radius: calc(1.5 * var(--crm-l-radius));
+  border-bottom-right-radius: calc(1.5 * var(--crm-l-radius));
 }
 .crm-container .pagination-sm > li > :is(a,span) {
   padding: var(--crm-padding-small);
@@ -181,12 +181,12 @@
   line-height: 1.5;
 }
 .crm-container .pagination-sm > li:first-child > :is(a,span) {
-  border-top-left-radius: calc(0.75 * var(--crm-s-radius));
-  border-bottom-left-radius: calc(0.75 * var(--crm-s-radius));
+  border-top-left-radius: calc(0.75 * var(--crm-l-radius));
+  border-bottom-left-radius: calc(0.75 * var(--crm-l-radius));
 }
 .crm-container .pagination-sm > li:last-child > :is(a,span) {
-  border-top-right-radius: calc(0.75 * var(--crm-s-radius));
-  border-bottom-right-radius: calc(0.75 * var(--crm-s-radius));
+  border-top-right-radius: calc(0.75 * var(--crm-l-radius));
+  border-bottom-right-radius: calc(0.75 * var(--crm-l-radius));
 }
 .crm-search-display-pager {
   padding-inline: var(--crm-padding-reg);

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -4,7 +4,7 @@
 
 .crm-container .crm-form-block { /* darkened page bg style */
   box-shadow: var(--crm-form-block-box-shadow);
-  background-color: var(--crm-form-block-bg);
+  background-color: var(--crm-form-block-bg-color);
   border-radius: var(--crm-form-block-border-radius);
   padding: var(--crm-form-block-padding);
   margin: 0;
@@ -80,13 +80,13 @@
   margin-top: var(--crm-r);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button.current {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text) !important;
+  background: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color) !important;
   border: 0 solid transparent;
   padding: var(--crm-s);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
-  background: var(--crm-c-secondary-hover);
+  background: var(--crm-secondary-hover-color);
 }
 
 /* Pagination quickforms */
@@ -101,13 +101,13 @@
   margin: 0 auto;
 }
 .crm-container .crm-pager-nav a.crm-hover-button {
-  background: var(--crm-c-secondary);
-  color: var(--crm-c-secondary-text);
+  background: var(--crm-secondary-color);
+  color: var(--crm-secondary-text-color);
   padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
 }
 .crm-container .crm-pager-nav a.crm-hover-button:hover,
 .crm-container .crm-pager-nav a.crm-hover-button:focus {
-  background: var(--crm-c-secondary-hover);
+  background: var(--crm-secondary-hover-color);
 }
 .crm-search-results .form-item.float-right {
   margin-bottom: 1rem;
@@ -130,15 +130,15 @@
   padding: var(--crm-s) var(--crm-m);
   margin-left: -1px;
   line-height: 1.4;
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
   text-decoration: none;
-  background-color: var(--crm-c-layer1-bg);
+  background-color: var(--crm-layer1-bg-color);
   border: var(--crm-border);
 }
 .crm-container .pagination > li > :is(a:hover,a:focus,span:hover,span:focus) {
   z-index: 2;
-  color: var(--crm-c-link-hover);
-  background-color: var(--crm-c-layer2-bg);
+  color: var(--crm-link-hover-color);
+  background-color: var(--crm-layer2-bg-color);
 }
 .crm-container .pagination > li:first-child > :is(a,span) {
   margin-left: 0;
@@ -151,13 +151,13 @@
 }
 .crm-container .pagination > .active > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
   z-index: 3;
-  color: var(--crm-c-primary-text);
+  color: var(--crm-primary-text-color);
   cursor: default;
-  background-color: var(--crm-c-primary);
+  background-color: var(--crm-primary-color);
   border: var(--crm-border);
 }
 .crm-container .pagination > .disabled > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
-  color: var(--crm-c-inactive);
+  color: var(--crm-inactive-color);
   cursor: not-allowed;
   background-color: transparent;
   border: var(--crm-border);

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -70,20 +70,20 @@
 .crm-datatable-pager-bottom {
   display: flex;
   justify-content: space-between;
-  font-size: var(--crm-m3);
-  margin-inline: var(--crm-m);
+  font-size: var(--crm-s-medium-3);
+  margin-inline: var(--crm-s-medium);
 }
 .crm-datatable-pager-top {
-  margin-block: var(--crm-r);
+  margin-block: var(--crm-s-reg);
 }
 .crm-datatable-pager-bottom {
-  margin-top: var(--crm-r);
+  margin-top: var(--crm-s-reg);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button.current {
   background: var(--crm-secondary-color);
   color: var(--crm-secondary-text-color) !important;
   border: 0 solid transparent;
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
 }
 .dataTables_wrapper .dataTables_paginate .paginate_button.current:hover {
   background: var(--crm-secondary-hover-color);
@@ -127,7 +127,7 @@
 .crm-container .pagination > li > :is(a,span) {
   position: relative;
   float: left;
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
   margin-left: -1px;
   line-height: 1.4;
   color: var(--crm-link-color);
@@ -163,8 +163,8 @@
   border: var(--crm-border);
 }
 .crm-container .pagination-lg > li > :is(a,span) {
-  padding: var(--crm-m2) var(--crm-r);
-  font-size: var(--crm-r1);
+  padding: var(--crm-s-medium-2) var(--crm-s-reg);
+  font-size: var(--crm-s-reg-1);
   line-height: 1.3;
 }
 .crm-container .pagination-lg > li:first-child > :is(a,span) {

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -133,7 +133,7 @@
   color: var(--crm-c-link);
   text-decoration: none;
   background-color: var(--crm-c-layer1-bg);
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 .crm-container .pagination > li > :is(a:hover,a:focus,span:hover,span:focus) {
   z-index: 2;
@@ -154,13 +154,13 @@
   color: var(--crm-c-primary-text);
   cursor: default;
   background-color: var(--crm-c-primary);
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 .crm-container .pagination > .disabled > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
   color: var(--crm-c-inactive);
   cursor: not-allowed;
   background-color: transparent;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 .crm-container .pagination-lg > li > :is(a,span) {
   padding: var(--crm-m2) var(--crm-r);

--- a/ext/riverlea/core/css/components/_page.css
+++ b/ext/riverlea/core/css/components/_page.css
@@ -119,7 +119,7 @@
   display: inline-block;
   padding-left: 0;
   margin: var(--crm-padding-reg) 0;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 .crm-container .pagination > li {
   display: inline;
@@ -142,12 +142,12 @@
 }
 .crm-container .pagination > li:first-child > :is(a,span) {
   margin-left: 0;
-  border-top-left-radius: var(--crm-roundness);
-  border-bottom-left-radius: var(--crm-roundness);
+  border-top-left-radius: var(--crm-s-radius);
+  border-bottom-left-radius: var(--crm-s-radius);
 }
 .crm-container .pagination > li:last-child > :is(a,span) {
-  border-top-right-radius: var(--crm-roundness);
-  border-bottom-right-radius: var(--crm-roundness);
+  border-top-right-radius: var(--crm-s-radius);
+  border-bottom-right-radius: var(--crm-s-radius);
 }
 .crm-container .pagination > .active > :is(a,a:hover,a:focus,span,span:hover,span:focus) {
   z-index: 3;
@@ -168,12 +168,12 @@
   line-height: 1.3;
 }
 .crm-container .pagination-lg > li:first-child > :is(a,span) {
-  border-top-left-radius: calc(1.5 * var(--crm-roundness));
-  border-bottom-left-radius: calc(1.5 * var(--crm-roundness));
+  border-top-left-radius: calc(1.5 * var(--crm-s-radius));
+  border-bottom-left-radius: calc(1.5 * var(--crm-s-radius));
 }
 .crm-container .pagination-lg > li:last-child > :is(a,span) {
-  border-top-right-radius: calc(1.5 * var(--crm-roundness));
-  border-bottom-right-radius: calc(1.5 * var(--crm-roundness));
+  border-top-right-radius: calc(1.5 * var(--crm-s-radius));
+  border-bottom-right-radius: calc(1.5 * var(--crm-s-radius));
 }
 .crm-container .pagination-sm > li > :is(a,span) {
   padding: var(--crm-padding-small);
@@ -181,12 +181,12 @@
   line-height: 1.5;
 }
 .crm-container .pagination-sm > li:first-child > :is(a,span) {
-  border-top-left-radius: calc(0.75 * var(--crm-roundness));
-  border-bottom-left-radius: calc(0.75 * var(--crm-roundness));
+  border-top-left-radius: calc(0.75 * var(--crm-s-radius));
+  border-bottom-left-radius: calc(0.75 * var(--crm-s-radius));
 }
 .crm-container .pagination-sm > li:last-child > :is(a,span) {
-  border-top-right-radius: calc(0.75 * var(--crm-roundness));
-  border-bottom-right-radius: calc(0.75 * var(--crm-roundness));
+  border-top-right-radius: calc(0.75 * var(--crm-s-radius));
+  border-bottom-right-radius: calc(0.75 * var(--crm-s-radius));
 }
 .crm-search-display-pager {
   padding-inline: var(--crm-padding-reg);

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -3,7 +3,7 @@
   border: var(--crm-table-outside-border);
   background: var(--crm-table-bg-color);
   box-shadow: var(--crm-shadow-block);
-  margin: 0 0 var(--crm-s-reg);
+  margin: 0 0 var(--crm-l-reg);
   border-collapse: collapse;
   width: 100%;
   max-width: 100%;
@@ -76,8 +76,8 @@
   box-shadow: none;
 }
 .crm-selection-reset {
-  padding: var(--crm-s-medium) 0;
-  margin-bottom: var(--crm-s-medium);
+  padding: var(--crm-l-medium) 0;
+  margin-bottom: var(--crm-l-medium);
   display: block;
 }
 
@@ -87,7 +87,7 @@
   background-color: var(--crm-table-header-bg-color);
 }
 .crm-container thead div.sticky-header {
-  height: var(--crm-s-reg);
+  height: var(--crm-l-reg);
 }
 .crm-sticky thead,
 .crm-container thead div.sticky-header {
@@ -147,7 +147,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   border: var(--crm-table-outside-border);
   background: var(--crm-table-bg-color);
   box-shadow: var(--crm-shadow-block);
-  margin: var(--crm-s-medium) 0 var(--crm-s-large);
+  margin: var(--crm-l-medium) 0 var(--crm-l-large);
 }
 .crm-container table.form-layout-compressed th {
   background: transparent;
@@ -168,7 +168,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   width: 100%;
   border: 0;
   padding: var(--crm-padding-reg);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   margin: 0;
 }
 #search-status table.form-layout-compressed tr {
@@ -279,7 +279,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table {
   width: 100%;
   max-width: 100%;
-  margin-bottom: var(--crm-s-reg-1);
+  margin-bottom: var(--crm-l-reg-1);
 }
 .crm-container .table > :is(thead,tbody,tfoot) > tr > :is(th,td) {
   padding: var(--crm-table-padding);
@@ -288,7 +288,7 @@ tbody.scrollContent tr.alternateRow:hover,
   border-top: var(--crm-table-header-border-bottom);
 }
 .crm-container .table-condensed > :is(thead,tbody,tfoot) > tr > :is(th,td) {
-  padding: var(--crm-s-small-1);
+  padding: var(--crm-l-small-1);
 }
 .crm-container .table-bordered {
   border: var(--crm-table-outside-border);
@@ -387,7 +387,7 @@ tbody.scrollContent tr.alternateRow:hover,
   .crm-container .table-responsive,
   .crm-container table {
     width: 100%;
-    margin-bottom: var(--crm-s-reg);
+    margin-bottom: var(--crm-l-reg);
     overflow-y: hidden;
     border: var(--crm-table-outside-border);
     display: contents; /* expirmental addition to provide more responsive behaviour */

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -168,7 +168,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   width: 100%;
   border: 0;
   padding: var(--crm-padding-reg);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   margin: 0;
 }
 #search-status table.form-layout-compressed tr {

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -2,7 +2,7 @@
 .crm-table-group-summary) {
   border: var(--crm-table-outside-border);
   background: var(--crm-table-bg);
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   margin: 0 0 var(--crm-r);
   border-collapse: collapse;
   width: 100%;
@@ -132,7 +132,7 @@ tbody .crm-row-child td {
 }
 tbody .crm-row-child:hover td {
   background: color-mix(in srgb, var(--crm-table-inset-bg) 95%, #000 5%);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 tbody .crm-row-child ~ .crm-row-child td {
   box-shadow: none;
@@ -146,7 +146,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   width: var(--crm-table-compressed-width);
   border: var(--crm-table-outside-border);
   background: var(--crm-table-bg);
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   margin: var(--crm-m) 0 var(--crm-l);
 }
 .crm-container table.form-layout-compressed th {

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -3,7 +3,7 @@
   border: var(--crm-table-outside-border);
   background: var(--crm-table-bg-color);
   box-shadow: var(--crm-shadow-block);
-  margin: 0 0 var(--crm-r);
+  margin: 0 0 var(--crm-s-reg);
   border-collapse: collapse;
   width: 100%;
   max-width: 100%;
@@ -76,8 +76,8 @@
   box-shadow: none;
 }
 .crm-selection-reset {
-  padding: var(--crm-m) 0;
-  margin-bottom: var(--crm-m);
+  padding: var(--crm-s-medium) 0;
+  margin-bottom: var(--crm-s-medium);
   display: block;
 }
 
@@ -87,7 +87,7 @@
   background-color: var(--crm-table-header-bg-color);
 }
 .crm-container thead div.sticky-header {
-  height: var(--crm-r);
+  height: var(--crm-s-reg);
 }
 .crm-sticky thead,
 .crm-container thead div.sticky-header {
@@ -147,7 +147,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   border: var(--crm-table-outside-border);
   background: var(--crm-table-bg-color);
   box-shadow: var(--crm-shadow-block);
-  margin: var(--crm-m) 0 var(--crm-l);
+  margin: var(--crm-s-medium) 0 var(--crm-s-large);
 }
 .crm-container table.form-layout-compressed th {
   background: transparent;
@@ -279,7 +279,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table {
   width: 100%;
   max-width: 100%;
-  margin-bottom: var(--crm-r1);
+  margin-bottom: var(--crm-s-reg-1);
 }
 .crm-container .table > :is(thead,tbody,tfoot) > tr > :is(th,td) {
   padding: var(--crm-table-padding);
@@ -288,7 +288,7 @@ tbody.scrollContent tr.alternateRow:hover,
   border-top: var(--crm-table-header-border-bottom);
 }
 .crm-container .table-condensed > :is(thead,tbody,tfoot) > tr > :is(th,td) {
-  padding: var(--crm-s1);
+  padding: var(--crm-s-small-1);
 }
 .crm-container .table-bordered {
   border: var(--crm-table-outside-border);
@@ -387,7 +387,7 @@ tbody.scrollContent tr.alternateRow:hover,
   .crm-container .table-responsive,
   .crm-container table {
     width: 100%;
-    margin-bottom: var(--crm-r);
+    margin-bottom: var(--crm-s-reg);
     overflow-y: hidden;
     border: var(--crm-table-outside-border);
     display: contents; /* expirmental addition to provide more responsive behaviour */

--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -1,7 +1,7 @@
 .crm-container table:not(.crm-inline-edit-form,
 .crm-table-group-summary) {
   border: var(--crm-table-outside-border);
-  background: var(--crm-table-bg);
+  background: var(--crm-table-bg-color);
   box-shadow: var(--crm-shadow-block);
   margin: 0 0 var(--crm-r);
   border-collapse: collapse;
@@ -9,22 +9,22 @@
   max-width: 100%;
 }
 .crm-container table thead {
-  background-color: var(--crm-table-header-bg);
+  background-color: var(--crm-table-header-bg-color);
 }
 .crm-container th,
 .crm-container table thead.sticky th,
 .crm-container table.dataTable thead th,
 .crm-container tr.columnheader td {
-  background-color: var(--crm-table-header-bg);
-  border-bottom: var(--crm-table-header-bottom);
-  color: var(--crm-table-header-col);
+  background-color: var(--crm-table-header-bg-color);
+  border-bottom: var(--crm-table-header-border-bottom);
+  color: var(--crm-table-header-color);
   font-weight: bold;
   padding: var(--crm-table-padding);
   text-align: left;
 }
 .crm-container table:not(thead) tr {
   border-bottom: var(--crm-table-row-border);
-  background-color: var(--crm-table-row-bg);
+  background-color: var(--crm-table-row-bg-color);
 }
 .crm-container td,
 .crm-container table.dataTable thead td {
@@ -84,7 +84,7 @@
 /* Sticky header */
 .crm-sticky thead > tr > th,
 .crm-container table thead.sticky {
-  background-color: var(--crm-table-header-bg);
+  background-color: var(--crm-table-header-bg-color);
 }
 .crm-container thead div.sticky-header {
   height: var(--crm-r);
@@ -92,7 +92,7 @@
 .crm-sticky thead,
 .crm-container thead div.sticky-header {
   border-bottom: 2px solid #cfcec3;
-  background-color: var(--crm-table-header-bg);
+  background-color: var(--crm-table-header-bg-color);
   z-index: 10;
 }
 .crm-sticky thead {
@@ -104,7 +104,7 @@
 /* Data Tables */
 .crm-container .dataTables_wrapper :is(.dataTables_length,.dataTables_filter,.dataTables_info,.dataTables_processing,.dataTables_paginate),
 .crm-container .dataTables_wrapper .dataTables_paginate :is(.paginate_button.disabled,.paginate_button.disabled:hover,.paginate_button.disabled:active) {
-  color: var(--crm-c-text) !important; /* vs jqueery.dataTables.css */
+  color: var(--crm-text-color) !important; /* vs jqueery.dataTables.css */
 }
 
 /* Nested table */
@@ -121,17 +121,17 @@
 }
 .crm-container tr.crm-child-row > td {
   box-shadow: inset 0 10px 8px -10px rgba(0,0,0,.3), inset 0 -11px 8px -9px rgba(0,0,0,.15);
-  background: var(--crm-table-inset-bg);
+  background: var(--crm-table-inset-bg-color);
 }
 
 /* Nested, inset table - groups page */
 
 tbody .crm-row-child td {
   box-shadow: inset 0 10px 8px -10px rgba(0,0,0,.15);
-  background: var(--crm-table-inset-bg);
+  background: var(--crm-table-inset-bg-color);
 }
 tbody .crm-row-child:hover td {
-  background: color-mix(in srgb, var(--crm-table-inset-bg) 95%, #000 5%);
+  background: color-mix(in srgb, var(--crm-table-inset-bg-color) 95%, #000 5%);
   cursor: var(--crm-link-hover-cursor);
 }
 tbody .crm-row-child ~ .crm-row-child td {
@@ -145,7 +145,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 .crm-container table.form-layout-compressed {
   width: var(--crm-table-compressed-width);
   border: var(--crm-table-outside-border);
-  background: var(--crm-table-bg);
+  background: var(--crm-table-bg-color);
   box-shadow: var(--crm-shadow-block);
   margin: var(--crm-m) 0 var(--crm-l);
 }
@@ -164,7 +164,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 /* Advance search compressed table */
 #search-status table.form-layout-compressed {
   border: 0;
-  background: var(--crm-c-container-bg);
+  background: var(--crm-container-bg-color);
   width: 100%;
   border: 0;
   padding: var(--crm-padding-reg);
@@ -191,8 +191,8 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   background-color: var(--crm-table-alternate-row);
 }
 .crm-container tr.columnheader-dark th {
-  background-color: var(--crm-c-dark-bg);
-  color: var(--crm-c-text-light);
+  background-color: var(--crm-c-dark-bg-color);
+  color: var(--crm-text-light-color);
 }
 
 /* Batch entry table */
@@ -200,7 +200,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   display: table;
   border-collapse: collapse;
   border: var(--crm-table-outside-border);
-  background-color: var(--crm-table-bg);
+  background-color: var(--crm-table-bg-color);
 }
 .crm-container .crm-grid-row,
 .crm-container .crm-grid-header {
@@ -227,7 +227,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 
 .crm-container table#payLater table#payLaterOptions.form-layout {
   border: var(--c-crm-table-nested-border);
-  background: var(--crm-c-table-bg);
+  background: var(--crm-c-table-bg-color);
 }
 
 /* Striped rows */
@@ -236,17 +236,17 @@ tbody.scrollContent:has(.alternateRow),
 .crm-container table:has(.odd-row,.even-row),
 .crm-container table.dataTable tbody,
 .crm-container .table-striped > tbody {
-  --crm-striped-bg: var(--crm-table-row-bg);
+  --crm-striped-bg-color: var(--crm-table-row-bg-color);
 }
 .crm-container table.dataTable:is(.stripe,.display) tbody tr.odd:not(.disabled),
 .crm-container table tbody:has(.odd,.even,.even-row,.odd-row) tr:not(.disabled),
 .crm-container .table-striped > tbody > tr:not(.disabled) {
-  background-color: var(--crm-striped-bg) !important;
+  background-color: var(--crm-striped-bg-color) !important;
 }
 .crm-container table.dataTable:is(.stripe,.display) tbody tr.even:not(.disabled),
 tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):not(.disabled) {
-  --crm-striped-bg: color-mix(in srgb, var(--crm-table-row-bg) 0%, (--crm-table-row-alternate-bg) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, (--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.hover tbody tr.odd:hover,
 .crm-container table.dataTable.display tbody tr.odd:hover,
@@ -255,7 +255,7 @@ tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .odd-row:hover,
 .crm-container .odd:hover,
 .crm-container .table-striped > tbody > tr:hover {
-  --crm-striped-bg: var(--crm-table-row-hover);
+  --crm-striped-bg-color: var(--crm-table-row-hover-color);
 }
 .crm-container table.dataTable.hover tbody tr.even:hover,
 .crm-container table.dataTable.display tbody tr.even:hover,
@@ -267,11 +267,11 @@ tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .even:hover,
 tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):hover {
-  --crm-striped-bg: color-mix(in srgb, var(--crm-table-row-hover) 100%, #000 6%);
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-hover-color) 100%, #000 6%);
 }
 .crm-container table.dataTable.display tbody tr > .sorting_1,
 .crm-container table.dataTable.order-column.stripe tbody tr > .sorting_1 {
-  background-color: color-mix(in srgb, var(--crm-striped-bg) 100%, var(--crm-table-row-alternate-bg) var(--crm-table-row-alternate-mix)) !important;
+  background-color: color-mix(in srgb, var(--crm-striped-bg-color) 100%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix)) !important;
 }
 
 /* Table bg colours */
@@ -285,7 +285,7 @@ tbody.scrollContent tr.alternateRow:hover,
   padding: var(--crm-table-padding);
 }
 .crm-container .table > tbody + tbody {
-  border-top: var(--crm-table-header-bottom);
+  border-top: var(--crm-table-header-border-bottom);
 }
 .crm-container .table-condensed > :is(thead,tbody,tfoot) > tr > :is(th,td) {
   padding: var(--crm-s1);
@@ -301,10 +301,10 @@ tbody.scrollContent tr.alternateRow:hover,
   border-bottom-width: 2px;
 }
 .crm-container .table > :is(thead,tbody,tfoot) > :is(tr > td.active,tr > th.active,tr.active > td,tr.active > th) {
-  background-color: var(--crm-table-row-bg);
+  background-color: var(--crm-table-row-bg-color);
 }*/
 .crm-container .table-hover > tbody > :is(tr > td.active:hover,th.active:hover,tr.active:hover > td,tr:hover > .active,tr.active:hover > th) {
-  background-color: var(--crm-table-row-hover);
+  background-color: var(--crm-table-row-hover-color);
 }
 .crm-container .table td.success,
 .crm-container .table th.success,
@@ -312,8 +312,8 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table tr.success > th,
 .crm-container table tr.crm-row-ok,
 .crm-container table tr.crm-row-ok > td {
-  background-color: var(--crm-alert-success-bg);
-  color: var(--crm-alert-success-text);
+  background-color: var(--crm-alert-success-bg-color);
+  color: var(--crm-alert-success-text-color);
 }
 .crm-container .table-hover > tbody > tr > td.success:hover,
 .crm-container .table-hover > tbody > tr > th.success:hover,
@@ -322,21 +322,21 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-hover > tbody > tr.success:hover > th,
 .crm-container table tr.crm-row-ok:hover > td,
 .crm-container table tr.crm-row-ok > td:hover {
-  background-color: var(--crm-alert-success-border);
+  background-color: var(--crm-alert-success-border-color);
 }
 .crm-container .table td.warning,
 .crm-container .table th.warning,
 .crm-container .table tr.warning > td,
 .crm-container .table tr.warning > th {
-  background-color: var(--crm-alert-warning-bg);
-  color: var(--crm-alert-warning-text);
+  background-color: var(--crm-alert-warning-bg-color);
+  color: var(--crm-alert-warning-text-color);
 }
 .crm-container .table-hover > tbody > tr > td.warning:hover,
 .crm-container .table-hover > tbody > tr > th.warning:hover,
 .crm-container .table-hover > tbody > tr.warning:hover > td,
 .crm-container .table-hover > tbody > tr:hover > .warning,
 .crm-container .table-hover > tbody > tr.warning:hover > th {
-  background-color: var(--crm-alert-warning-border);
+  background-color: var(--crm-alert-warning-border-color);
 }
 .crm-container .table td.danger,
 .crm-container .table th.danger,
@@ -346,8 +346,8 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container table tr.error,
 .crm-container table tr.crm-row-error,
 .crm-container table tr.crm-row-error > td {
-  background-color: var(--crm-alert-danger-bg);
-  color: var(--crm-alert-danger-text);
+  background-color: var(--crm-alert-danger-bg-color);
+  color: var(--crm-alert-danger-text-color);
 }
 .crm-container .table-hover > tbody > tr > td.danger:hover,
 .crm-container .table-hover > tbody > tr > th.danger:hover,
@@ -356,7 +356,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-hover > tbody > tr.danger:hover > th,
 .crm-container table tr.crm-row-error:hover > td,
 .crm-container table tr.crm-row-error > td:hover {
-  background-color: var(--crm-alert-danger-border);
+  background-color: var(--crm-alert-danger-border-color);
 }
 .crm-container .table td.info,
 .crm-container .table th.info,
@@ -364,8 +364,8 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table tr.info > th,
 .crm-container table tr.crm-row-selected,
 .crm-container table tr.crm-row-selected > td {
-  background-color: var(--crm-alert-info-bg);
-  color: var(--crm-alert-info-text);
+  background-color: var(--crm-alert-info-bg-color);
+  color: var(--crm-alert-info-text-color);
 }
 .crm-container .table-hover > tbody > tr > td.info:hover,
 .crm-container .table-hover > tbody > tr > th.info:hover,
@@ -374,7 +374,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-hover > tbody > tr.info:hover > th,
 .crm-container table tr.crm-row-selected:hover > td,
 .crm-container table tr.crm-row-selected > td:hover {
-  background-color: var(--crm-alert-info-border);
+  background-color: var(--crm-alert-info-border-color);
 }
 .crm-container .table-responsive {
   min-height: .01%;

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -4,7 +4,7 @@
 .crm-container .afadmin-list .nav.nav-tabs { /* entire tab region */
   border: var(--crm-tabs-border);
   border-radius: var(--crm-tabs-radius);
-  margin-bottom: var(--crm-r1);
+  margin-bottom: var(--crm-s-reg-1);
 }
 .crm-container .ui-widget-header,
 .crm-container .ui-tabs .ui-tabs-nav,
@@ -60,7 +60,7 @@
   padding: var(--crm-tab-padding);
   font-weight: var(--crm-tab-weight);
   font-size: var(--crm-font-size);
-  line-height: var(--crm-r1);
+  line-height: var(--crm-s-reg-1);
   text-decoration: none;
   border-radius: var(--crm-tab-radius);
   display: block;
@@ -76,11 +76,11 @@
   font-style: inherit;
   background: var(--crm-tab-count-bg-color);
   color: var(--crm-tab-count-color);
-  border-radius: var(--crm-m2);
-  min-width: var(--crm-r2);
+  border-radius: var(--crm-s-medium-2);
+  min-width: var(--crm-s-reg-2);
   display: inline-block;
   text-align: center;
-  font-size: var(--crm-m2);
+  font-size: var(--crm-s-medium-2);
   padding: 0 0.2rem;
 }
 .crm-container #mainTabContainer ul.ui-tabs-nav a em {
@@ -153,7 +153,7 @@
   display: grid;
   grid-template-columns: min-content auto;
   width: var(--crm-contact-tab-width);
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   align-items: center;
   float: var(--crm-contact-tab-align);
   border-radius: var(--crm-contact-tab-radius);

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -10,7 +10,7 @@
 .crm-container .ui-tabs .ui-tabs-nav,
 .crm-container .nav.nav-tabs { /* tab header */
   font-family: var(--crm-font);
-  background: var(--crm-tabs-bg);
+  background: var(--crm-tabs-bg-color);
   border: 0 solid transparent;
   border-radius: var(--crm-tabs-radius) var(--crm-tabs-radius) 0 0;
   border-bottom: var(--crm-tabs-border);
@@ -26,18 +26,18 @@
 .crm-container .ui-button.ui-state-disabled:hover,
 .crm-container .ui-button.ui-state-disabled:active,
 .crm-container .nav-tabs > li { /* individual tab */
-  background: var(--crm-tab-bg);
+  background: var(--crm-tab-bg-color);
   border-radius: var(--crm-tab-radius);
   border: 0 solid transparent;
   font-family: inherit;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   padding: 0;
 }
 .crm-container .ui-tabs .ui-tabs-nav li:hover,
 .crm-container .ui-tabs .ui-tabs-nav li:focus,
 .crm-container .nav-tabs > li:hover,
 .crm-container .nav-tabs > li:focus { /* individual tab hover */
-  background: var(--crm-tab-bg-hover);
+  background: var(--crm-tab-hover-bg-color);
 }
 .crm-container .nav-tabs > li > a:hover,
 .crm-container .nav-tabs > li > a:focus { /* reset from _nav.css */
@@ -56,7 +56,7 @@
 .crm-container .ui-tabs ul.ui-tabs-nav a:not(.button),
 .crm-container .nav-tabs > li > a,
 .crm-container .panel-heading .nav-tabs > li > a {
-  color: var(--crm-tab-col);
+  color: var(--crm-tab-color);
   padding: var(--crm-tab-padding);
   font-weight: var(--crm-tab-weight);
   font-size: var(--crm-font-size);
@@ -67,15 +67,15 @@
 }
 .crm-container .ui-tabs .ui-tabs-nav li.ui-tabs-selected a {
   background: transparent;
-  color: var(--crm-tab-col);
+  color: var(--crm-tab-color);
   padding: var(--crm-tab-padding);
 }
 .crm-container .ui-tabs ul.ui-tabs-nav a em,
 .crm-container .nav-tabs a .badge {
   font-family: inherit;
   font-style: inherit;
-  background: var(--crm-tab-count-bg);
-  color: var(--crm-tab-count-col);
+  background: var(--crm-tab-count-bg-color);
+  color: var(--crm-tab-count-color);
   border-radius: var(--crm-m2);
   min-width: var(--crm-r2);
   display: inline-block;
@@ -84,17 +84,17 @@
   padding: 0 0.2rem;
 }
 .crm-container #mainTabContainer ul.ui-tabs-nav a em {
-  background: var(--crm-contact-tab-count-bg);
-  color: var(--crm-contact-tab-count-col);
+  background: var(--crm-contact-tab-count-bg-color);
+  color: var(--crm-contact-tab-count-color);
 }
 .crm-container li.crm-count-0 a.ui-tabs-anchor,
 .crm-container li.crm-count-0 a.ui-tabs-anchor em {
-  color: var(--crm-tab-col);
+  color: var(--crm-tab-color);
 }
 .crm-container .ui-tabs ul.ui-tabs-nav .crm-count-0 a em,
 .crm-container #mainTabContainer ul.ui-tabs-nav .crm-count-0 a em {
-  background: var(--crm-c-primary);
-  color: var(--crm-c-primary-text);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 .crm-container .ui-tabs ul li em:empty,
 .crm-container .nav-tabs .badge:empty { /* this is to keep the height of tabs with empty badges */
@@ -119,7 +119,7 @@
   flex-direction: column;
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list {
-  background: var(--crm-contact-tabs-bg);
+  background: var(--crm-contact-tabs-bg-color);
   flex-direction: var(--crm-contact-tabs-flow);
   border-radius: var(--crm-contact-tabs-radius);
   gap: var(--crm-contact-tabs-gap);
@@ -143,7 +143,7 @@
   border-radius: var(--crm-contact-panel-radius);
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li {
-  background: var(--crm-contact-tab-bg);
+  background: var(--crm-contact-tab-bg-color);
   margin: var(--crm-contact-tab-hang);
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li span {
@@ -165,8 +165,8 @@
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li.ui-tabs-active a,
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li:hover a,
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li:focus a {
-  color: var(--crm-c-link);
-  background: var(--crm-contact-tab-bg-hover);
+  color: var(--crm-link-color);
+  background: var(--crm-contact-tab-hover-bg-color);
   border: var(--crm-contact-tab-border-hover);
   border-width: var(--crm-contact-tab-border-width);
 }
@@ -174,7 +174,7 @@
   border: 0 solid transparent;
 }
 .crm-container .crm-contact-page .ui-tabs-panel {
-  background: var(--crm-contact-panel-bg);
+  background: var(--crm-contact-panel-bg-color);
 }
 .crm-container .crm-contact-page .ui-tabs-panel .ui-tabs-panel { /* handles tabs inside a tab panel */
   background: var(--crm-tab-bg-active);

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -4,7 +4,7 @@
 .crm-container .afadmin-list .nav.nav-tabs { /* entire tab region */
   border: var(--crm-tabs-border);
   border-radius: var(--crm-tabs-radius);
-  margin-bottom: var(--crm-s-reg-1);
+  margin-bottom: var(--crm-l-reg-1);
 }
 .crm-container .ui-widget-header,
 .crm-container .ui-tabs .ui-tabs-nav,
@@ -49,7 +49,7 @@
 .crm-container .nav-tabs > li.active:hover,
 .crm-container .nav-tabs > li.active:focus { /* individual tab active */
   background: var(--crm-tab-bg-active);
-  border: var(--crm-tab-border-active);
+  border: var(--crm-tab-active-border);
   border-bottom: 0 solid transparent;
   margin: var(--crm-tab-hang);
 }
@@ -60,7 +60,7 @@
   padding: var(--crm-tab-padding);
   font-weight: var(--crm-tab-weight);
   font-size: var(--crm-font-size);
-  line-height: var(--crm-s-reg-1);
+  line-height: var(--crm-l-reg-1);
   text-decoration: none;
   border-radius: var(--crm-tab-radius);
   display: block;
@@ -76,11 +76,11 @@
   font-style: inherit;
   background: var(--crm-tab-count-bg-color);
   color: var(--crm-tab-count-color);
-  border-radius: var(--crm-s-medium-2);
-  min-width: var(--crm-s-reg-2);
+  border-radius: var(--crm-l-medium-2);
+  min-width: var(--crm-l-reg-2);
   display: inline-block;
   text-align: center;
-  font-size: var(--crm-s-medium-2);
+  font-size: var(--crm-l-medium-2);
   padding: 0 0.2rem;
 }
 .crm-container #mainTabContainer ul.ui-tabs-nav a em {
@@ -153,7 +153,7 @@
   display: grid;
   grid-template-columns: min-content auto;
   width: var(--crm-contact-tab-width);
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   align-items: center;
   float: var(--crm-contact-tab-align);
   border-radius: var(--crm-contact-tab-radius);
@@ -167,7 +167,7 @@
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li:focus a {
   color: var(--crm-link-color);
   background: var(--crm-contact-tab-hover-bg-color);
-  border: var(--crm-contact-tab-border-hover);
+  border: var(--crm-contact-tab-hover-border);
   border-width: var(--crm-contact-tab-border-width);
 }
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li.ui-tabs-active {

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -27,7 +27,7 @@
 .crm-container .ui-button.ui-state-disabled:active,
 .crm-container .nav-tabs > li { /* individual tab */
   background: var(--crm-tab-bg);
-  border-radius: var(--crm-tab-roundness);
+  border-radius: var(--crm-tab-radius);
   border: 0 solid transparent;
   font-family: inherit;
   color: var(--crm-c-text);
@@ -62,7 +62,7 @@
   font-size: var(--crm-font-size);
   line-height: var(--crm-r1);
   text-decoration: none;
-  border-radius: var(--crm-tab-roundness);
+  border-radius: var(--crm-tab-radius);
   display: block;
 }
 .crm-container .ui-tabs .ui-tabs-nav li.ui-tabs-selected a {
@@ -84,8 +84,8 @@
   padding: 0 0.2rem;
 }
 .crm-container #mainTabContainer ul.ui-tabs-nav a em {
-  background: var(--crm-dash-tab-count-bg);
-  color: var(--crm-dash-tab-count-col);
+  background: var(--crm-contact-tab-count-bg);
+  color: var(--crm-contact-tab-count-col);
 }
 .crm-container li.crm-count-0 a.ui-tabs-anchor,
 .crm-container li.crm-count-0 a.ui-tabs-anchor em {
@@ -113,38 +113,38 @@
 /* Dashboard */
 
 .crm-contact-page #mainTabContainer.ui-tabs {
-  border: var(--crm-dash-border);
-  display: var(--crm-dash-direction);
+  border: var(--crm-contact-border);
+  display: var(--crm-contact-direction);
   grid-template-columns: var(--crm-side-tabs-width) auto;
   flex-direction: column;
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list {
-  background: var(--crm-dash-tabs-bg);
-  flex-direction: var(--crm-dash-tabs-flow);
-  border-radius: var(--crm-dash-tabs-roundness);
-  gap: var(--crm-dash-tabs-gap);
-  padding: var(--crm-dash-tabs-padding);
+  background: var(--crm-contact-tabs-bg);
+  flex-direction: var(--crm-contact-tabs-flow);
+  border-radius: var(--crm-contact-tabs-radius);
+  gap: var(--crm-contact-tabs-gap);
+  padding: var(--crm-contact-tabs-padding);
   border: 0 solid transparent;
   z-index: 1;
 }
 #mainTabContainer .crm-contact-tabs-list ~ .ui-tabs-panel {
-  box-shadow: var(--crm-dash-box-shadow);
+  box-shadow: var(--crm-contact-box-shadow);
 }
 .crm-contact-page #mainTabContainer .ui-tabs-nav li .ui-tabs-anchor:has(.crm-i) {
   grid-template-columns: min-content auto min-content;
 }
 .crm-contact-page #mainTabContainer .ui-tabs-nav li .ui-tabs-anchor i {
-  font-size: var(--crm-dash-icon-size);
+  font-size: var(--crm-contact-icon-size);
 }
 #mainTabContainer .crm-contact-tabs-list ~ .ui-tabs-panel {
   flex-grow: 1;
-  padding: var(--crm-dash-panel-padding);
-  border: var(--crm-dash-panel-border);
-  border-radius: var(--crm-dash-panel-radius);
+  padding: var(--crm-contact-panel-padding);
+  border: var(--crm-contact-panel-border);
+  border-radius: var(--crm-contact-panel-radius);
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li {
-  background: var(--crm-dash-tab-bg);
-  margin: var(--crm-dash-tab-hang);
+  background: var(--crm-contact-tab-bg);
+  margin: var(--crm-contact-tab-hang);
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li span {
   word-break: break-word;
@@ -152,29 +152,29 @@
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li .ui-tabs-anchor {
   display: grid;
   grid-template-columns: min-content auto;
-  width: var(--crm-dash-tab-width);
+  width: var(--crm-contact-tab-width);
   gap: var(--crm-m);
   align-items: center;
-  float: var(--crm-dash-tab-align);
-  border-radius: var(--crm-dash-tab-radius);
-  padding: var(--crm-dash-tab-padding);
-  border: var(--crm-dash-tab-border);
-  text-align: var(--crm-dash-tab-align);
-  /* border-width: var(--crm-dash-tab-border-width); */
+  float: var(--crm-contact-tab-align);
+  border-radius: var(--crm-contact-tab-radius);
+  padding: var(--crm-contact-tab-padding);
+  border: var(--crm-contact-tab-border);
+  text-align: var(--crm-contact-tab-align);
+  /* border-width: var(--crm-contact-tab-border-width); */
 }
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li.ui-tabs-active a,
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li:hover a,
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li:focus a {
   color: var(--crm-c-link);
-  background: var(--crm-dash-tab-bg-hover);
-  border: var(--crm-dash-tab-border-hover);
-  border-width: var(--crm-dash-tab-border-width);
+  background: var(--crm-contact-tab-bg-hover);
+  border: var(--crm-contact-tab-border-hover);
+  border-width: var(--crm-contact-tab-border-width);
 }
 .crm-contact-page #mainTabContainer .ui-tabs-nav.crm-contact-tabs-list li.ui-tabs-active {
   border: 0 solid transparent;
 }
 .crm-container .crm-contact-page .ui-tabs-panel {
-  background: var(--crm-dash-panel-bg);
+  background: var(--crm-contact-panel-bg);
 }
 .crm-container .crm-contact-page .ui-tabs-panel .ui-tabs-panel { /* handles tabs inside a tab panel */
   background: var(--crm-tab-bg-active);

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -224,7 +224,7 @@ div.crm-inline-edit-form div.crm-clear {
   width: 100%;
 }
 .crm-container div.contact_panel td.grouplabel {
-  border-bottom: var(--crm-c-divider);
+  border-bottom: var(--crm-border);
   border-width: 2px;
 }
 .crm-container .crm-summary-row:after {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -94,7 +94,7 @@
 .crm-contact-page .crm-edit-help .crm-i.fa-pencil {
   float: right;
   color: var(--crm-text-color);
-  margin: var(--crm-xs) 0 0 var(--crm-m);
+  margin: var(--crm-s-xsmall) 0 0 var(--crm-s-medium);
 }
 .crm-container .address.add-new .crm-i.fa-pencil::before {
   content: "\f055";
@@ -136,7 +136,7 @@
 }
 .crm-container .crm-inline-edit.form td {
   background: transparent;
-  padding: var(--crm-m);
+  padding: var(--crm-s-medium);
   border-bottom: 0 solid transparent;
 }
 .crm-container .add-more-inline::after {
@@ -151,7 +151,7 @@
   background-color: var(--crm-input-inline-edit-bg-color);
 }
 div.crm-inline-edit-form div.crm-clear {
-  padding: var(--crm-m) 0 0;
+  padding: var(--crm-s-medium) 0 0;
 }
 #contactname-block,
 #contactname-block .crm-inline-edit,
@@ -177,7 +177,7 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-contact-page .crm-inline-button,
 .crm-contact-page .crm-submit-buttons {
   margin-bottom: 0;
-  padding-bottom: var(--crm-m2);
+  padding-bottom: var(--crm-s-medium-2);
 }
 .CRM_Contact_Form_Inline_ContactName .crm-inline-button {
   margin-left: auto;
@@ -186,7 +186,7 @@ div.crm-inline-edit-form div.crm-clear {
 }
 #crm-contactname-content > .crm-inline-block-content {
   display: flex;
-  gap: var(--crm-r);
+  gap: var(--crm-s-reg);
   align-items: center;
   border: 2px dashed transparent;
 }
@@ -245,7 +245,7 @@ div.crm-inline-edit-form div.crm-clear {
   font-weight: var(--crm-input-label-weight);
   font-family: var(--crm-input-label-font);
   font-size: var(--crm-font-size);
-  padding: var(--crm-m);
+  padding: var(--crm-s-medium);
   min-width: var(--crm-input-label-width);
   text-align: left;
 }
@@ -254,7 +254,7 @@ div.crm-inline-edit-form div.crm-clear {
   width: var(--crm-input-label-width);
 }
 .crm-container .crm-summary-row .crm-content {
-  padding: var(--crm-m);
+  padding: var(--crm-s-medium);
   overflow: auto; /* adds scroll for values wider than container */
 }
 .crm-container #customFields .contact_panel td {
@@ -341,12 +341,12 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-contact-page #tags {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
   align-items: center;
 }
 .crm-contact-page .crm-tag-item {
   border-radius: var(--crm-s-radius);
-  padding: 0 var(--crm-m);
+  padding: 0 var(--crm-s-medium);
   background-color: var(--crm-layer2-bg-color);
 }
 #crm-main-content-wrapper:has(.crm-contact-page) {
@@ -370,7 +370,7 @@ div.crm-inline-edit-form div.crm-clear {
     flex-direction: column;
   }
   .crm-container .crm-summary-row .crm-label {
-    padding-bottom: var(--crm-s);
+    padding-bottom: var(--crm-s-small);
   }
   .crm-container .crm-summary-row .crm-content {
     padding-top: 0;
@@ -395,7 +395,7 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
 .crm-actions-ribbon ul#actions {
   display: grid;
   grid-template-columns: min-content min-content auto min-content min-content;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   margin: 0;
   padding: var(--crm-contact-header-padding);
 }

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -10,10 +10,10 @@
 /* Contact name/header */
 
 .crm-summary-contactname-block {
-  background: var(--crm-dash-header-bg);
-  color: var(--crm-dash-header-col);
-  padding: var(--crm-dash-header-padding);
-  margin-left: var(--crm-dash-heading-inset);
+  background: var(--crm-contact-header-bg);
+  color: var(--crm-contact-header-col);
+  padding: var(--crm-contact-header-padding);
+  margin-left: var(--crm-contact-heading-inset);
 }
 .crm-summary-contactname-block .crm-summary-link {
   color: inherit;
@@ -29,19 +29,19 @@
 }
 .crm-inline-edit-container .crm-contact_image {
   position: absolute;
-  top: var(--crm-dash-image-top);
-  right: var(--crm-dash-image-right);
+  top: var(--crm-contact-image-top);
+  right: var(--crm-contact-image-right);
   z-index: 1;
 }
 .crm-inline-edit-container .crm-image-popup {
-  width: var(--crm-dash-image-size);
-  height: var(--crm-dash-image-size);
+  width: var(--crm-contact-image-size);
+  height: var(--crm-contact-image-size);
   display: block;
   background-size: cover;
-  border-radius: var(--crm-dash-image-radius);
+  border-radius: var(--crm-contact-image-radius);
   box-shadow: var(--crm-bottom-shadow);
   overflow: hidden;
-  border: var(--crm-dash-image-border);
+  border: var(--crm-contact-image-border);
 }
 .crm-container div.contact_panel {
   display: block;
@@ -58,7 +58,7 @@
 .crm-inline-edit.form {
   cursor: default;
   border: 1px solid var(--crm-c-focus);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   background: var(--crm-inline-edit-bg);
   padding: var(--crm-padding-reg);
   z-index: 99;
@@ -88,7 +88,7 @@
   color: var(--crm-c-text);
   display: block;
   opacity: 1;
-  background-color: var(--crm-dash-summary-row-bg);
+  background-color: var(--crm-contact-summary-row-bg);
   z-index: 3;
 }
 .crm-contact-page .crm-edit-help .crm-i.fa-pencil {
@@ -144,7 +144,7 @@
 }
 .CRM_Contact_Form_Inline_ContactName div.crm-inline-edit-form {
   white-space: nowrap;
-  padding: var(--crm-dash-block-padding);
+  padding: var(--crm-contact-block-padding);
   display: flex;
   flex-wrap: wrap;
   color: var(--crm-c-text);
@@ -195,14 +195,14 @@ div.crm-inline-edit-form div.crm-clear {
   border-color: var(--crm-c-gray-200);
 }
 #crm-contactname-content .crm-summary-display_name {
-  padding: var(--crm-dash-header-padding);
-  font-size: var(--crm-dash-header-size);
+  padding: var(--crm-contact-header-padding);
+  font-size: var(--crm-contact-header-size);
   padding-inline: 0;
 }
 .crm-container div.contact_panel {
   display: grid;
-  grid-template-columns: repeat(2, calc(50% - calc(var(--crm-dash-panel-padding) * 0.5)));
-  column-gap: var(--crm-dash-panel-padding);
+  grid-template-columns: repeat(2, calc(50% - calc(var(--crm-contact-panel-padding) * 0.5)));
+  column-gap: var(--crm-contact-panel-padding);
 }
 .crm-container div.contact_panel table {
   margin-bottom: 0;
@@ -235,12 +235,12 @@ div.crm-inline-edit-form div.crm-clear {
   visibility: hidden;
 }
 .crm-container .crm-summary-row {
-  background-color: var(--crm-dash-summary-row-bg);
-  border-top: 1px solid var(--crm-dash-summary-row-bg);
+  background-color: var(--crm-contact-summary-row-bg);
+  border-top: 1px solid var(--crm-contact-summary-row-bg);
   display: flex;
 }
 .crm-container .crm-summary-row .crm-label {
-  background-color: var(--crm-dash-label-bg);
+  background-color: var(--crm-contact-label-bg);
   color: var(--crm-input-label-color);
   font-weight: var(--crm-input-label-weight);
   font-family: var(--crm-input-label-font);
@@ -301,7 +301,7 @@ div.crm-inline-edit-form div.crm-clear {
 #crm-contact-actions-list a.delete {
   background: var(--crm-dropdown-danger-bg);
   color: var(--crm-c-danger-text);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 #crm-contact-actions-list a.delete .crm-i.fa-trash::before {
   color: var(--crm-c-danger-text);
@@ -345,7 +345,7 @@ div.crm-inline-edit-form div.crm-clear {
   align-items: center;
 }
 .crm-contact-page .crm-tag-item {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   padding: 0 var(--crm-m);
   background-color: var(--crm-c-layer2-bg);
 }
@@ -354,10 +354,10 @@ div.crm-inline-edit-form div.crm-clear {
 }
 .crm-contact-page .crm-summary-block {
   display: flow-root; /* to keep block position during edit */
-  background: var(--crm-dash-block-bg);
-  border-radius: var(--crm-roundness);
+  background: var(--crm-contact-block-bg);
+  border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-block-shadow);
-  margin-bottom: var(--crm-dash-panel-padding);
+  margin-bottom: var(--crm-contact-panel-padding);
   container-name: crm-summary-block;
   container-type: inline-size;
 }
@@ -377,7 +377,7 @@ div.crm-inline-edit-form div.crm-clear {
   }
 }
 .crm-contact-page div.crm-clear {
-  padding: var(--crm-dash-block-padding);
+  padding: var(--crm-contact-block-padding);
 }
 #mainTabContainer .crm-summary-block .crm-container-snippet table {
   box-shadow: none;
@@ -386,18 +386,18 @@ div.crm-inline-edit-form div.crm-clear {
   margin: 0;
 }
 div.crm-summary-contactname-block + .crm-actions-ribbon {
-  color: var(--crm-dash-header-col);
-  background-color: var(--crm-dash-header-bg2);
+  color: var(--crm-contact-header-col);
+  background-color: var(--crm-contact-header-bg2);
   margin-bottom: 0;
   clear: both;
-  margin-left: var(--crm-dash-heading-inset);
+  margin-left: var(--crm-contact-heading-inset);
 }
 .crm-actions-ribbon ul#actions {
   display: grid;
   grid-template-columns: min-content min-content auto min-content min-content;
   gap: var(--crm-m);
   margin: 0;
-  padding: var(--crm-dash-header-padding);
+  padding: var(--crm-contact-header-padding);
 }
 .crm-actions-ribbon ul#actions > * {
   width: max-content;
@@ -425,7 +425,7 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
 }
 @media (max-width: 767px) {
   #crm-main-content-wrapper {
-    --crm-dash-heading-inset: 0; /* resets any inset on the title/action links */
+    --crm-contact-heading-inset: 0; /* resets any inset on the title/action links */
     --crm-side-tabs-width: auto; /* resets offset inline edit */
   }
   .crm-container #mainTabContainer {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -58,7 +58,7 @@
 .crm-inline-edit.form {
   cursor: default;
   border: 1px solid var(--crm-focus-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   background: var(--crm-input-inline-edit-bg-color);
   padding: var(--crm-padding-reg);
   z-index: 99;
@@ -94,7 +94,7 @@
 .crm-contact-page .crm-edit-help .crm-i.fa-pencil {
   float: right;
   color: var(--crm-text-color);
-  margin: var(--crm-s-xsmall) 0 0 var(--crm-s-medium);
+  margin: var(--crm-l-xsmall) 0 0 var(--crm-l-medium);
 }
 .crm-container .address.add-new .crm-i.fa-pencil::before {
   content: "\f055";
@@ -136,7 +136,7 @@
 }
 .crm-container .crm-inline-edit.form td {
   background: transparent;
-  padding: var(--crm-s-medium);
+  padding: var(--crm-l-medium);
   border-bottom: 0 solid transparent;
 }
 .crm-container .add-more-inline::after {
@@ -151,7 +151,7 @@
   background-color: var(--crm-input-inline-edit-bg-color);
 }
 div.crm-inline-edit-form div.crm-clear {
-  padding: var(--crm-s-medium) 0 0;
+  padding: var(--crm-l-medium) 0 0;
 }
 #contactname-block,
 #contactname-block .crm-inline-edit,
@@ -177,7 +177,7 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-contact-page .crm-inline-button,
 .crm-contact-page .crm-submit-buttons {
   margin-bottom: 0;
-  padding-bottom: var(--crm-s-medium-2);
+  padding-bottom: var(--crm-l-medium-2);
 }
 .CRM_Contact_Form_Inline_ContactName .crm-inline-button {
   margin-left: auto;
@@ -186,7 +186,7 @@ div.crm-inline-edit-form div.crm-clear {
 }
 #crm-contactname-content > .crm-inline-block-content {
   display: flex;
-  gap: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
   align-items: center;
   border: 2px dashed transparent;
 }
@@ -245,7 +245,7 @@ div.crm-inline-edit-form div.crm-clear {
   font-weight: var(--crm-input-label-weight);
   font-family: var(--crm-input-label-font);
   font-size: var(--crm-font-size);
-  padding: var(--crm-s-medium);
+  padding: var(--crm-l-medium);
   min-width: var(--crm-input-label-width);
   text-align: left;
 }
@@ -254,7 +254,7 @@ div.crm-inline-edit-form div.crm-clear {
   width: var(--crm-input-label-width);
 }
 .crm-container .crm-summary-row .crm-content {
-  padding: var(--crm-s-medium);
+  padding: var(--crm-l-medium);
   overflow: auto; /* adds scroll for values wider than container */
 }
 .crm-container #customFields .contact_panel td {
@@ -301,7 +301,7 @@ div.crm-inline-edit-form div.crm-clear {
 #crm-contact-actions-list a.delete {
   background: var(--crm-dropdown-danger-bg-color);
   color: var(--crm-danger-text-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 #crm-contact-actions-list a.delete .crm-i.fa-trash::before {
   color: var(--crm-danger-text-color);
@@ -341,12 +341,12 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-contact-page #tags {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
   align-items: center;
 }
 .crm-contact-page .crm-tag-item {
-  border-radius: var(--crm-s-radius);
-  padding: 0 var(--crm-s-medium);
+  border-radius: var(--crm-l-radius);
+  padding: 0 var(--crm-l-medium);
   background-color: var(--crm-layer2-bg-color);
 }
 #crm-main-content-wrapper:has(.crm-contact-page) {
@@ -355,7 +355,7 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-contact-page .crm-summary-block {
   display: flow-root; /* to keep block position during edit */
   background: var(--crm-contact-block-bg-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   box-shadow: var(--crm-shadow-block);
   margin-bottom: var(--crm-contact-panel-padding);
   container-name: crm-summary-block;
@@ -370,7 +370,7 @@ div.crm-inline-edit-form div.crm-clear {
     flex-direction: column;
   }
   .crm-container .crm-summary-row .crm-label {
-    padding-bottom: var(--crm-s-small);
+    padding-bottom: var(--crm-l-small);
   }
   .crm-container .crm-summary-row .crm-content {
     padding-top: 0;
@@ -395,7 +395,7 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
 .crm-actions-ribbon ul#actions {
   display: grid;
   grid-template-columns: min-content min-content auto min-content min-content;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   margin: 0;
   padding: var(--crm-contact-header-padding);
 }

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -10,8 +10,8 @@
 /* Contact name/header */
 
 .crm-summary-contactname-block {
-  background: var(--crm-contact-header-bg);
-  color: var(--crm-contact-header-col);
+  background: var(--crm-contact-header-bg-color);
+  color: var(--crm-contact-header-color);
   padding: var(--crm-contact-header-padding);
   margin-left: var(--crm-contact-heading-inset);
 }
@@ -57,9 +57,9 @@
 
 .crm-inline-edit.form {
   cursor: default;
-  border: 1px solid var(--crm-c-focus);
+  border: 1px solid var(--crm-focus-color);
   border-radius: var(--crm-s-radius);
-  background: var(--crm-inline-edit-bg);
+  background: var(--crm-input-inline-edit-bg-color);
   padding: var(--crm-padding-reg);
   z-index: 99;
   width: fit-content;
@@ -85,15 +85,15 @@
 .crm-container #crm-contactname-content .crm-edit-help:hover,
 .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help,
 .crm-container .crm-summary-block .address.add-new .crm-edit-help {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   display: block;
   opacity: 1;
-  background-color: var(--crm-contact-summary-row-bg);
+  background-color: var(--crm-contact-summary-row-bg-color);
   z-index: 3;
 }
 .crm-contact-page .crm-edit-help .crm-i.fa-pencil {
   float: right;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   margin: var(--crm-xs) 0 0 var(--crm-m);
 }
 .crm-container .address.add-new .crm-i.fa-pencil::before {
@@ -147,8 +147,8 @@
   padding: var(--crm-contact-block-padding);
   display: flex;
   flex-wrap: wrap;
-  color: var(--crm-c-text);
-  background-color: var(--crm-inline-edit-bg);
+  color: var(--crm-text-color);
+  background-color: var(--crm-input-inline-edit-bg-color);
 }
 div.crm-inline-edit-form div.crm-clear {
   padding: var(--crm-m) 0 0;
@@ -235,12 +235,12 @@ div.crm-inline-edit-form div.crm-clear {
   visibility: hidden;
 }
 .crm-container .crm-summary-row {
-  background-color: var(--crm-contact-summary-row-bg);
-  border-top: 1px solid var(--crm-contact-summary-row-bg);
+  background-color: var(--crm-contact-summary-row-bg-color);
+  border-top: 1px solid var(--crm-contact-summary-row-bg-color);
   display: flex;
 }
 .crm-container .crm-summary-row .crm-label {
-  background-color: var(--crm-contact-label-bg);
+  background-color: var(--crm-contact-label-bg-color);
   color: var(--crm-input-label-color);
   font-weight: var(--crm-input-label-weight);
   font-family: var(--crm-input-label-font);
@@ -299,17 +299,17 @@ div.crm-inline-edit-form div.crm-clear {
   margin-bottom: .25em;
 }
 #crm-contact-actions-list a.delete {
-  background: var(--crm-dropdown-danger-bg);
-  color: var(--crm-c-danger-text);
+  background: var(--crm-dropdown-danger-bg-color);
+  color: var(--crm-danger-text-color);
   border-radius: var(--crm-s-radius);
 }
 #crm-contact-actions-list a.delete .crm-i.fa-trash::before {
-  color: var(--crm-c-danger-text);
+  color: var(--crm-danger-text-color);
 }
 #crm-contact-actions-list a.delete:hover,
 #crm-contact-actions-list a.delete:focus {
-  color: var(--crm-c-danger-text);
-  background: color-mix(in srgb, var(--crm-btn-cancel-bg) 87.5%, #000 12.5%);
+  color: var(--crm-danger-text-color);
+  background: color-mix(in srgb, var(--crm-btn-cancel-bg-color) 87.5%, #000 12.5%);
 }
 
 /* Tags */
@@ -347,14 +347,14 @@ div.crm-inline-edit-form div.crm-clear {
 .crm-contact-page .crm-tag-item {
   border-radius: var(--crm-s-radius);
   padding: 0 var(--crm-m);
-  background-color: var(--crm-c-layer2-bg);
+  background-color: var(--crm-layer2-bg-color);
 }
 #crm-main-content-wrapper:has(.crm-contact-page) {
   box-shadow: var(--crm-shadow-block);
 }
 .crm-contact-page .crm-summary-block {
   display: flow-root; /* to keep block position during edit */
-  background: var(--crm-contact-block-bg);
+  background: var(--crm-contact-block-bg-color);
   border-radius: var(--crm-s-radius);
   box-shadow: var(--crm-shadow-block);
   margin-bottom: var(--crm-contact-panel-padding);
@@ -386,8 +386,8 @@ div.crm-inline-edit-form div.crm-clear {
   margin: 0;
 }
 div.crm-summary-contactname-block + .crm-actions-ribbon {
-  color: var(--crm-contact-header-col);
-  background-color: var(--crm-contact-header-bg2);
+  color: var(--crm-contact-header-color);
+  background-color: var(--crm-contact-header2-bg-color);
   margin-bottom: 0;
   clear: both;
   margin-left: var(--crm-contact-heading-inset);

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -39,7 +39,7 @@
   display: block;
   background-size: cover;
   border-radius: var(--crm-contact-image-radius);
-  box-shadow: var(--crm-bottom-shadow);
+  box-shadow: var(--crm-shadow-bottom);
   overflow: hidden;
   border: var(--crm-contact-image-border);
 }
@@ -114,7 +114,7 @@
   display: none;
 }
 .crm-container span.crm-custom-greeting {
-  font-size: var(--crm-small-font-size);
+  font-size: var(--crm-font-small-size);
 }
 .crm-container table.crm-inline-edit-form td,
 .crm-container div.crm-inline-edit-form {
@@ -161,7 +161,7 @@ div.crm-inline-edit-form div.crm-clear {
 }
 #contactname-block .crm-inline-edit.form {
   left: 0;
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
 }
 #contactname-block .crm-inline-edit .crm-container {
   overflow: scroll !important; /* vs inline css */
@@ -322,7 +322,7 @@ div.crm-inline-edit-form div.crm-clear {
   margin-top: 5px;
 }
 #tagtree ins.jstree-icon {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   position: relative;
   top: -3px;
 }
@@ -350,13 +350,13 @@ div.crm-inline-edit-form div.crm-clear {
   background-color: var(--crm-c-layer2-bg);
 }
 #crm-main-content-wrapper:has(.crm-contact-page) {
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
 }
 .crm-contact-page .crm-summary-block {
   display: flow-root; /* to keep block position during edit */
   background: var(--crm-contact-block-bg);
   border-radius: var(--crm-s-radius);
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   margin-bottom: var(--crm-contact-panel-padding);
   container-name: crm-summary-block;
   container-type: inline-size;

--- a/ext/riverlea/core/css/crm-i.css
+++ b/ext/riverlea/core/css/crm-i.css
@@ -18,7 +18,7 @@ is loaded before font-awesome.css so that .fa-XXX classes can modify it. */
   -moz-osx-font-smoothing: grayscale;
 }
 .crm-container a.helpicon {
-  margin-inline: var(--crm-s);
+  margin-inline: var(--crm-s-small);
 }
 
 /* Make jQuery UI icons use FA */

--- a/ext/riverlea/core/css/crm-i.css
+++ b/ext/riverlea/core/css/crm-i.css
@@ -18,7 +18,7 @@ is loaded before font-awesome.css so that .fa-XXX classes can modify it. */
   -moz-osx-font-smoothing: grayscale;
 }
 .crm-container a.helpicon {
-  margin-inline: var(--crm-s-small);
+  margin-inline: var(--crm-l-small);
 }
 
 /* Make jQuery UI icons use FA */

--- a/ext/riverlea/core/css/crm-iconPicker.css
+++ b/ext/riverlea/core/css/crm-iconPicker.css
@@ -17,7 +17,7 @@
   margin-top: 2rem;
 }
 #crmIconPicker a.ui-button {
-  color: var(--crm-c-text) !important;
+  color: var(--crm-text-color) !important;
   background: transparent;
   width: var(--crm-r2);
   height: var(--crm-r2);

--- a/ext/riverlea/core/css/crm-iconPicker.css
+++ b/ext/riverlea/core/css/crm-iconPicker.css
@@ -13,14 +13,14 @@
 #crmIconPicker .icons {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
   margin-top: 2rem;
 }
 #crmIconPicker a.ui-button {
   color: var(--crm-text-color) !important;
   background: transparent;
-  width: var(--crm-r2);
-  height: var(--crm-r2);
+  width: var(--crm-s-reg-2);
+  height: var(--crm-s-reg-2);
   border: 0;
   padding: 0;
   display: inline-block;

--- a/ext/riverlea/core/css/crm-iconPicker.css
+++ b/ext/riverlea/core/css/crm-iconPicker.css
@@ -13,14 +13,14 @@
 #crmIconPicker .icons {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
   margin-top: 2rem;
 }
 #crmIconPicker a.ui-button {
   color: var(--crm-text-color) !important;
   background: transparent;
-  width: var(--crm-s-reg-2);
-  height: var(--crm-s-reg-2);
+  width: var(--crm-l-reg-2);
+  height: var(--crm-l-reg-2);
   border: 0;
   padding: 0;
   display: inline-block;

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -68,11 +68,11 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   overflow: auto;
 }
 .crm-container .crm-dashlet-content > .ng-scope { /* for FormBuilder dashlets */
-  padding: var(--crm-dash-block-padding);
+  padding: var(--crm-contact-block-padding);
 }
 .crm-container .crm-dashlet details.crm-accordion-bold > .crm-accordion-body {
   padding: 0;
-  border-bottom: var(--crm-expand-border);
+  border-bottom: var(--crm-accordion-border);
 }
 .crm-container .crm-dashlet .crm-accordion-body table {
   margin: 0;
@@ -80,7 +80,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   box-shadow: var(--crm-input-box-shadow);
 }
 .crm-container .crm-dashlet .crm-accordion-body table tr {
-  padding: var(--crm-dash-block-padding);
+  padding: var(--crm-contact-block-padding);
   display: flex;
   border: 0 solid transparent;
   gap: var(--crm-r);
@@ -89,7 +89,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border-radius: 0;
   box-shadow: none;
   margin: 0;
-  padding: var(--crm-dash-block-padding);
+  padding: var(--crm-contact-block-padding);
   background: var(--crm-dashlet-bg);
 }
 .crm-dashlet table.dataTable {
@@ -99,7 +99,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   width: 99% !important;
 }
 .crm-dashlet #help {
-  margin: var(--crm-dash-block-padding);
+  margin: var(--crm-contact-block-padding);
 }
 .crm-container .crm-inactive-dashlet-fieldset .help {
   width: 100%;
@@ -139,13 +139,13 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 #civicrm-news-feed ul {
   border-bottom: var(--crm-dashlet-tabs-border);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 #civicrm-news-feed .ui-tabs-panel {
   padding: var(--crm-s) 0 0;
 }
 .crm-container #civicrm-news-feed .crm-accordion-body {
-  padding: var(--crm-expand-body-padding);
+  padding: var(--crm-accordion-body-padding);
 }
 
 /* Getting statrted */

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -12,7 +12,7 @@
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);
-  background-color: var(--crm-dashlet-bg);
+  background-color: var(--crm-dashlet-bg-color);
   padding: var(--crm-dashlet-padding);
   box-shadow: var(--crm-dashlet-box-shadow);
   margin-bottom: var(--crm-padding-reg);
@@ -22,7 +22,7 @@
   box-shadow: var(--crm-shadow-block);
 }
 .crm-container .crm-dashlet-header {
-  background-color: var(--crm-dashlet-header-bg);
+  background-color: var(--crm-dashlet-header-bg-color);
   border-radius: var(--crm-dashlet-radius);
   border: var(--crm-dashlet-header-border);
   border-width: var(--crm-dashlet-header-border-width);
@@ -37,15 +37,15 @@
   cursor: move;
   margin: 0 auto 0 0 !important;
   padding: 0;
-  color: var(--crm-dashlet-header-col);
+  color: var(--crm-dashlet-header-color);
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  color: var(--crm-dashlet-header-col);
+  color: var(--crm-dashlet-header-color);
   font-size: var(--crm-dashlet-header-font-size);
 }
 .crm-container .crm-dashlet-header a {
-  color: var(--crm-dashlet-header-col);
+  color: var(--crm-dashlet-header-color);
   padding: var(--crm-xs) var(--crm-s);
   text-decoration: none;
   font-size: var(--crm-font-size);
@@ -63,7 +63,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   height: calc(100% - 1em);
 }
 .crm-container .crm-dashlet-content {
-  background: var(--crm-dashlet-bg);
+  background: var(--crm-dashlet-bg-color);
   padding: var(--crm-dashlet-content-padding);
   overflow: auto;
 }
@@ -90,7 +90,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   box-shadow: none;
   margin: 0;
   padding: var(--crm-contact-block-padding);
-  background: var(--crm-dashlet-bg);
+  background: var(--crm-dashlet-bg-color);
 }
 .crm-dashlet table.dataTable {
   overflow: scroll;
@@ -110,7 +110,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   width: 340px;
   height: var(--crm-xxl);
   box-shadow: var(--crm-shadow-popup);
-  background-color: color-mix(in srgb, var(--crm-dashlet-bg) 90%, #fff 10%);
+  background-color: color-mix(in srgb, var(--crm-dashlet-bg-color) 90%, #fff 10%);
   border-radius: var(--crm-dashlet-radius);
   margin: 0;
 }
@@ -175,7 +175,7 @@ fieldset.crm-inactive-dashlet-fieldset {
   margin-bottom: var(--crm-r);
 }
 fieldset.crm-inactive-dashlet-fieldset > div {
-  background-color: var(--crm-dashlet-dashlets-bg) !important;
+  background-color: var(--crm-dashlet-dashlets-bg-color) !important;
   box-shadow: var(--crm-dashlet-box-shadow);
   border-radius: var(--crm-dashlet-radius);
   display: flex;

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -6,9 +6,9 @@
 #civicrm-dashboard > .crm-flex-box {
   display: grid;
   grid-template-columns: var(--crm-dashlet-columns);
-  gap: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
   /* avoid total collapse else no droppable area if all widgets removed */
-  min-height: var(--crm-s-reg);
+  min-height: var(--crm-l-reg);
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);
@@ -46,7 +46,7 @@
 }
 .crm-container .crm-dashlet-header a {
   color: var(--crm-dashlet-header-color);
-  padding: var(--crm-s-xsmall) var(--crm-s-small);
+  padding: var(--crm-l-xsmall) var(--crm-l-small);
   text-decoration: none;
   font-size: var(--crm-font-size);
   cursor: var(--crm-link-hover-cursor);
@@ -83,7 +83,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   padding: var(--crm-contact-block-padding);
   display: flex;
   border: 0 solid transparent;
-  gap: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
 }
 .crm-dashlet .dataTables_wrapper {
   border-radius: 0;
@@ -108,7 +108,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 .crm-container .crm-inactive-dashlet {
   display: inline-block;
   width: 340px;
-  height: var(--crm-s-large-2);
+  height: var(--crm-l-large-2);
   box-shadow: var(--crm-shadow-popup);
   background-color: color-mix(in srgb, var(--crm-dashlet-bg-color) 90%, #fff 10%);
   border-radius: var(--crm-dashlet-radius);
@@ -119,7 +119,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 .crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {
   font-size: 75%;
-  padding-left: var(--crm-s-small-1);
+  padding-left: var(--crm-l-small-1);
 }
 #civicrm-dashboard .ui-sortable-placeholder {
   border: 2px dashed var(--crm-c-gray-700);
@@ -139,10 +139,10 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 #civicrm-news-feed ul {
   border-bottom: var(--crm-dashlet-tabs-border);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 #civicrm-news-feed .ui-tabs-panel {
-  padding: var(--crm-s-small) 0 0;
+  padding: var(--crm-l-small) 0 0;
 }
 .crm-container #civicrm-news-feed .crm-accordion-body {
   padding: var(--crm-accordion-body-padding);
@@ -172,7 +172,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 fieldset.crm-inactive-dashlet-fieldset {
   padding: 0;
   border: 0;
-  margin-bottom: var(--crm-s-reg);
+  margin-bottom: var(--crm-l-reg);
 }
 fieldset.crm-inactive-dashlet-fieldset > div {
   background-color: var(--crm-dashlet-dashlets-bg-color) !important;
@@ -180,18 +180,18 @@ fieldset.crm-inactive-dashlet-fieldset > div {
   border-radius: var(--crm-dashlet-radius);
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-s-reg);
-  padding: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
+  padding: var(--crm-l-reg);
 }
 fieldset.crm-inactive-dashlet-fieldset legend {
   background-color: transparent;
   display: block;
-  margin-bottom: var(--crm-s-reg);
-  top: var(--crm-s-small);
+  margin-bottom: var(--crm-l-reg);
+  top: var(--crm-l-small);
 }
 fieldset.crm-inactive-dashlet-fieldset legend .crm-hover-button {
   padding: var(--crm-btn-large-padding);
-  margin-right: var(--crm-s-reg);
+  margin-right: var(--crm-l-reg);
 }
 /* Searchkit Dashlets */
 

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -6,9 +6,9 @@
 #civicrm-dashboard > .crm-flex-box {
   display: grid;
   grid-template-columns: var(--crm-dashlet-columns);
-  gap: var(--crm-r);
+  gap: var(--crm-s-reg);
   /* avoid total collapse else no droppable area if all widgets removed */
-  min-height: var(--crm-r);
+  min-height: var(--crm-s-reg);
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);
@@ -46,7 +46,7 @@
 }
 .crm-container .crm-dashlet-header a {
   color: var(--crm-dashlet-header-color);
-  padding: var(--crm-xs) var(--crm-s);
+  padding: var(--crm-s-xsmall) var(--crm-s-small);
   text-decoration: none;
   font-size: var(--crm-font-size);
   cursor: var(--crm-link-hover-cursor);
@@ -83,7 +83,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   padding: var(--crm-contact-block-padding);
   display: flex;
   border: 0 solid transparent;
-  gap: var(--crm-r);
+  gap: var(--crm-s-reg);
 }
 .crm-dashlet .dataTables_wrapper {
   border-radius: 0;
@@ -108,7 +108,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 .crm-container .crm-inactive-dashlet {
   display: inline-block;
   width: 340px;
-  height: var(--crm-xxl);
+  height: var(--crm-s-large-2);
   box-shadow: var(--crm-shadow-popup);
   background-color: color-mix(in srgb, var(--crm-dashlet-bg-color) 90%, #fff 10%);
   border-radius: var(--crm-dashlet-radius);
@@ -119,7 +119,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 .crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {
   font-size: 75%;
-  padding-left: var(--crm-s1);
+  padding-left: var(--crm-s-small-1);
 }
 #civicrm-dashboard .ui-sortable-placeholder {
   border: 2px dashed var(--crm-c-gray-700);
@@ -142,7 +142,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border-radius: var(--crm-s-radius);
 }
 #civicrm-news-feed .ui-tabs-panel {
-  padding: var(--crm-s) 0 0;
+  padding: var(--crm-s-small) 0 0;
 }
 .crm-container #civicrm-news-feed .crm-accordion-body {
   padding: var(--crm-accordion-body-padding);
@@ -172,7 +172,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 fieldset.crm-inactive-dashlet-fieldset {
   padding: 0;
   border: 0;
-  margin-bottom: var(--crm-r);
+  margin-bottom: var(--crm-s-reg);
 }
 fieldset.crm-inactive-dashlet-fieldset > div {
   background-color: var(--crm-dashlet-dashlets-bg-color) !important;
@@ -180,18 +180,18 @@ fieldset.crm-inactive-dashlet-fieldset > div {
   border-radius: var(--crm-dashlet-radius);
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-r);
-  padding: var(--crm-r);
+  gap: var(--crm-s-reg);
+  padding: var(--crm-s-reg);
 }
 fieldset.crm-inactive-dashlet-fieldset legend {
   background-color: transparent;
   display: block;
-  margin-bottom: var(--crm-r);
-  top: var(--crm-s);
+  margin-bottom: var(--crm-s-reg);
+  top: var(--crm-s-small);
 }
 fieldset.crm-inactive-dashlet-fieldset legend .crm-hover-button {
   padding: var(--crm-btn-large-padding);
-  margin-right: var(--crm-r);
+  margin-right: var(--crm-s-reg);
 }
 /* Searchkit Dashlets */
 

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -19,7 +19,7 @@
   border: var(--crm-dashlet-border);
 }
 .crm-container .ui-sortable-helper.crm-dashlet {
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
 }
 .crm-container .crm-dashlet-header {
   background-color: var(--crm-dashlet-header-bg);
@@ -49,7 +49,7 @@
   padding: var(--crm-xs) var(--crm-s);
   text-decoration: none;
   font-size: var(--crm-font-size);
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   opacity: .7;
   float: right;
 }
@@ -109,7 +109,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   display: inline-block;
   width: 340px;
   height: var(--crm-xxl);
-  box-shadow: var(--crm-popup-shadow);
+  box-shadow: var(--crm-shadow-popup);
   background-color: color-mix(in srgb, var(--crm-dashlet-bg) 90%, #fff 10%);
   border-radius: var(--crm-dashlet-radius);
   margin: 0;

--- a/ext/riverlea/core/css/joomla.css
+++ b/ext/riverlea/core/css/joomla.css
@@ -74,7 +74,7 @@ body.com_civicm.layout-default .table tbody a:not(.badge):not(.btn):not(.dropdow
   text-decoration: none; /* Reset theme */
 }
 body.com_civicm #bootstrap-theme .bg-secondary {
-  background-color: var(--crm-c-secondary) !important; /* vs !important bg colour in Atum theme */
+  background-color: var(--crm-secondary-color) !important; /* vs !important bg colour in Atum theme */
 }
 body.com_civicrm.layout-default table .crm-sticky-header,
 body.com_civicrm.layout-default table.crm-sticky-header {

--- a/ext/riverlea/core/css/searchForm.css
+++ b/ext/riverlea/core/css/searchForm.css
@@ -5,7 +5,7 @@
 /* Alpha filter */
 
 .crm-container div#alpha-filter {
-  background-color: var(--crm-filter-bg);
+  background-color: var(--crm-filter-bg-color);
   margin: var(--crm-r) 0;
   padding: var(--crm-filter-padding);
   text-align: left;
@@ -19,11 +19,11 @@
   justify-content: var(--crm-filter-spacing);
 }
 .crm-container #alpha-filter li {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 .crm-container #alpha-filter a {
   font-weight: normal;
-  background: var(--crm-filter-item-bg);
+  background: var(--crm-filter-item-bg-color);
   padding: var(--crm-s) var(--crm-m);
   box-shadow: var(--crm-filter-item-shadow);
 }

--- a/ext/riverlea/core/css/searchForm.css
+++ b/ext/riverlea/core/css/searchForm.css
@@ -9,7 +9,7 @@
   margin: var(--crm-r) 0;
   padding: var(--crm-filter-padding);
   text-align: left;
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
   border-radius: var(--crm-s-radius);
 }
 #crm-container #alpha-filter ul {

--- a/ext/riverlea/core/css/searchForm.css
+++ b/ext/riverlea/core/css/searchForm.css
@@ -6,7 +6,7 @@
 
 .crm-container div#alpha-filter {
   background-color: var(--crm-filter-bg-color);
-  margin: var(--crm-r) 0;
+  margin: var(--crm-s-reg) 0;
   padding: var(--crm-filter-padding);
   text-align: left;
   box-shadow: var(--crm-shadow-block);
@@ -24,7 +24,7 @@
 .crm-container #alpha-filter a {
   font-weight: normal;
   background: var(--crm-filter-item-bg-color);
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
   box-shadow: var(--crm-filter-item-shadow);
 }
 
@@ -35,8 +35,8 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     width: 100%;
-    column-gap: var(--crm-r);
-    row-gap: var(--crm-s);
+    column-gap: var(--crm-s-reg);
+    row-gap: var(--crm-s-small);
   }
 }
 .advanced-search-fields .search-field__span-2 {

--- a/ext/riverlea/core/css/searchForm.css
+++ b/ext/riverlea/core/css/searchForm.css
@@ -6,11 +6,11 @@
 
 .crm-container div#alpha-filter {
   background-color: var(--crm-filter-bg-color);
-  margin: var(--crm-s-reg) 0;
+  margin: var(--crm-l-reg) 0;
   padding: var(--crm-filter-padding);
   text-align: left;
   box-shadow: var(--crm-shadow-block);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
 }
 #crm-container #alpha-filter ul {
   margin: 0;
@@ -24,7 +24,7 @@
 .crm-container #alpha-filter a {
   font-weight: normal;
   background: var(--crm-filter-item-bg-color);
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
   box-shadow: var(--crm-filter-item-shadow);
 }
 
@@ -35,8 +35,8 @@
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     width: 100%;
-    column-gap: var(--crm-s-reg);
-    row-gap: var(--crm-s-small);
+    column-gap: var(--crm-l-reg);
+    row-gap: var(--crm-l-small);
   }
 }
 .advanced-search-fields .search-field__span-2 {

--- a/ext/riverlea/core/css/searchForm.css
+++ b/ext/riverlea/core/css/searchForm.css
@@ -10,7 +10,7 @@
   padding: var(--crm-filter-padding);
   text-align: left;
   box-shadow: var(--crm-block-shadow);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }
 #crm-container #alpha-filter ul {
   margin: 0;

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -52,8 +52,8 @@ af-form {
 
 /* Accordion */
 .crm-container details.af-container {
-  border: var(--crm-expand-border);
-  border-radius: var(--crm-expand-radius);
+  border: var(--crm-accordion-border);
+  border-radius: var(--crm-accordion-radius);
   padding-block: 0;
 }
 details.af-container > *:not(summary) { /* adds padding to Afform internal details */

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -74,7 +74,7 @@ details.af-container.af-layout-inline > *:not(summary) {
 
 /* Card style */
 .af-container-style-pane {
-  background-color: var(--crm-form-block-bg);
+  background-color: var(--crm-form-block-bg-color);
   border-radius: var(--crm-form-block-border-radius);
   box-shadow: var(--crm-form-block-box-shadow);
   position: relative;
@@ -82,8 +82,8 @@ details.af-container.af-layout-inline > *:not(summary) {
   padding-top: 50px !important;
 }
 #bootstrap-theme .af-container-style-pane > .af-title {
-  background-color: var(--crm-form-block-header);
-  color: var(--crm-c-text-light);
+  background-color: var(--crm-form-block-header-color);
+  color: var(--crm-text-light-color);
   border-radius: var(--crm-form-block-border-radius) var(--crm-form-block-border-radius) 0 0;
   position: absolute;
   top: 0;
@@ -104,7 +104,7 @@ details.af-container.af-layout-inline > *:not(summary) {
 }
 #bootstrap-theme .af-admin-edit-form-link > button {
   background: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   border-radius: 2rem;
   height: inherit;
   padding: 0 !important;
@@ -115,7 +115,7 @@ details.af-container.af-layout-inline > *:not(summary) {
 #bootstrap-theme .af-admin-edit-form-link button:hover,
 #bootstrap-theme .af-admin-edit-form-link button:focus {
   background: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   opacity: 1;
   box-shadow: none !important; /* vs dropdown-toggle */
 }

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -7,7 +7,7 @@
   color: var(--crm-c-darkest);
 }
 a.af-api4-action-idle {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .crm-container .af-container.af-layout-cols,
 .af-container.af-layout-inline {

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -57,13 +57,13 @@ af-form {
   padding-block: 0;
 }
 details.af-container > *:not(summary) { /* adds padding to Afform internal details */
-  padding-inline: var(--crm-r);
+  padding-inline: var(--crm-s-reg);
 }
 details.af-container > *:nth-of-type(1):not(summary) {
-  padding-top: var(--crm-m);
+  padding-top: var(--crm-s-medium);
 }
 details.af-container > *:last-of-type {
-  padding-bottom: var(--crm-m);
+  padding-bottom: var(--crm-s-medium);
 }
 details.af-container.af-layout-inline {
   flex-direction: column;
@@ -89,7 +89,7 @@ details.af-container.af-layout-inline > *:not(summary) {
   top: 0;
   left: 0;
   width: 100%;
-  padding: var(--crm-m) var(--crm-r);
+  padding: var(--crm-s-medium) var(--crm-s-reg);
   margin-top: 0;
 }
 

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -57,13 +57,13 @@ af-form {
   padding-block: 0;
 }
 details.af-container > *:not(summary) { /* adds padding to Afform internal details */
-  padding-inline: var(--crm-s-reg);
+  padding-inline: var(--crm-l-reg);
 }
 details.af-container > *:nth-of-type(1):not(summary) {
-  padding-top: var(--crm-s-medium);
+  padding-top: var(--crm-l-medium);
 }
 details.af-container > *:last-of-type {
-  padding-bottom: var(--crm-s-medium);
+  padding-bottom: var(--crm-l-medium);
 }
 details.af-container.af-layout-inline {
   flex-direction: column;
@@ -89,7 +89,7 @@ details.af-container.af-layout-inline > *:not(summary) {
   top: 0;
   left: 0;
   width: 100%;
-  padding: var(--crm-s-medium) var(--crm-s-reg);
+  padding: var(--crm-l-medium) var(--crm-l-reg);
   margin-top: 0;
 }
 

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -4,7 +4,7 @@
 
 /* List page */
 .afadmin-list th[ng-click] {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .afadmin-list th i.fa-sort-desc,
 .afadmin-list th i.fa-sort-asc {
@@ -543,7 +543,7 @@ af-gui-container > .af-gui-bar,
   top: 0;
 }
 .af-gui-conditional-dialog legend[ng-click] {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 i.crm-i.af-gui-conditional-dialog-move-icon {
   opacity: .5;
@@ -609,7 +609,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown label,
 #afGuiEditor .dropdown-menu li > * > label {
   font-weight: normal;
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   color: var(--crm-dropdown-col);
 }
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown > select {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -19,7 +19,7 @@
 /* Editor */
 
 #afGuiEditor {
-  gap: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
 }
 #afGuiEditor-canvas,
 #afGuiEditor-palette,
@@ -30,7 +30,7 @@
 #afGuiEditor .af-gui-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--crm-s-reg);
+  gap: var(--crm-l-reg);
 }
 #afGuiEditor fieldset {
   min-width: 0;
@@ -39,13 +39,13 @@
   border: 0;
 }
 #afGuiEditor fieldset legend {
-  padding: var(--crm-s-small) 0 0 0;
+  padding: var(--crm-l-small) 0 0 0;
   border-bottom: var(--crm-border);
   width: 100%;
-  margin-bottom: var(--crm-s-medium);
+  margin-bottom: var(--crm-l-medium);
 }
 #afGuiEditor hr {
-  margin-block: var(--crm-s-medium);
+  margin-block: var(--crm-l-medium);
 }
 
 /* Icon only buttons */
@@ -63,10 +63,10 @@
 #afGuiEditor .af-gui-remove-entity i.crm-i {
   margin: 0;
   border: 0;
-  padding: var(--crm-s-small-2);
+  padding: var(--crm-l-small-2);
   height: 100%;
   aspect-ratio: 1 / 1;
-  min-width: var(--crm-s-reg-4);
+  min-width: var(--crm-l-reg-4);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -133,7 +133,7 @@
 }
 #afGuiEditor-palette .input-group:has(#af_config_redirect) {
   display: grid;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
   grid-template-columns: 1fr 250px;
 }
 #afGuiEditor-palette .input-group:has(#af_config_redirect) .input-group-addon,
@@ -161,7 +161,7 @@
   color: var(--crm-text-color);
 }
 #afGuiEditor-palette .af-gui-entity-values .form-inline {
-  margin-bottom: var(--crm-s-medium);
+  margin-bottom: var(--crm-l-medium);
   display: flex;
   align-items: center;
   gap: var(--crm-flex-gap);
@@ -169,7 +169,7 @@
 }
 #afGuiEditor-palette .af-gui-entity-values .select2-container {
   width: 100% !important /* vs inline */;
-  margin-bottom: var(--crm-s-small-2);
+  margin-bottom: var(--crm-l-small-2);
 }
 #afGuiEditor-palette .af-gui-entity-values .input-group {
   width: 100%;
@@ -187,12 +187,12 @@
   border-bottom: 0;
 }
 #afGuiEditor-palette .af-gui-entity-palette .input-group {
-  margin-top: var(--crm-s-small);
+  margin-top: var(--crm-l-small);
 }
 #afGuiEditor-palette .af-gui-entity-palette [type="search"] {
   width: 100%;
-  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
-  padding: var(--crm-s-small-2);
+  border-radius: var(--crm-l-radius) var(--crm-l-radius) 0 0;
+  padding: var(--crm-l-small-2);
   font-weight: normal;
   position: relative;
   margin: 0;
@@ -201,14 +201,14 @@
 }
 .af-gui-entity-palette-select-list {
   border: var(--crm-border);
-  border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
-  padding: 0 var(--crm-s-small) var(--crm-s-small);
+  border-radius: 0 0 var(--crm-l-radius) var(--crm-l-radius);
+  padding: 0 var(--crm-l-small) var(--crm-l-small);
   max-height: 400px;
   overflow-y: auto;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div {
   cursor: move;
-  padding: var(--crm-s-xsmall) var(--crm-s-medium) var(--crm-s-xsmall) var(--crm-s-reg);
+  padding: var(--crm-l-xsmall) var(--crm-l-medium) var(--crm-l-xsmall) var(--crm-l-reg);
   position: relative;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div.disabled {
@@ -227,9 +227,9 @@
   margin-bottom: var(--crm-padding-small);
   border: 2px solid transparent;
   display: block;
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   position: relative;
-  padding: var(--crm-s-medium);
+  padding: var(--crm-l-medium);
 }
 #afGuiEditor af-gui-field,
 #afGuiEditor .af-gui-block-label,
@@ -242,12 +242,12 @@
 
 /* Canvas gui bar */
 #afGuiEditor-canvas .af-gui-bar {
-  height: var(--crm-s-large);
+  height: var(--crm-l-large);
   width: 100%;
   border-radius: 0;
   transition: opacity .2s;
   background-color: var(--crm-fb-header-bg-color);
-  padding-inline: var(--crm-s-xsmall);
+  padding-inline: var(--crm-l-xsmall);
   cursor: move;
   display: flex;
   justify-content: space-between;
@@ -257,8 +257,8 @@
 #afGuiEditor .af-gui-entity-palette-select-list [ui-sortable] > div:not(.disabled):hover:before,
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area [ui-sortable] li:before {
   background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1IiBoZWlnaHQ9IjUiPgo8cmVjdCB3aWR0aD0iMSIgaGVpZ2h0PSIxIiBmaWxsPSIjODg4Ij48L3JlY3Q+Cjwvc3ZnPg==");
-  width: var(--crm-s-medium);
-  height: calc(100% - var(--crm-s-medium));
+  width: var(--crm-l-medium);
+  height: calc(100% - var(--crm-l-medium));
   content: ' ';
   width: 10px;
 }
@@ -270,7 +270,7 @@
 }
 #afGuiEditor-canvas af-gui-container-multi-toggle .btn .ng-binding {
   display: flex;
-  margin-right: var(--crm-s-medium);
+  margin-right: var(--crm-l-medium);
 }
 #afGuiEditor .af-gui-node-title {
   position: absolute;
@@ -306,11 +306,11 @@ af-gui-container > .af-gui-bar,
 .af-gui-element > .af-gui-bar,
 .af-gui-container-type-div > .af-gui-bar,
 .af-gui-markup > .af-gui-bar {
-  margin: calc(-1 * var(--crm-s-medium)) calc(-1 * var(--crm-s-medium)) var(--crm-s-medium) calc(-1 * var(--crm-s-medium));
-  width: calc(100% + var(--crm-s-reg)) !important;
+  margin: calc(-1 * var(--crm-l-medium)) calc(-1 * var(--crm-l-medium)) var(--crm-l-medium) calc(-1 * var(--crm-l-medium));
+  width: calc(100% + var(--crm-l-reg)) !important;
 }
 #afGuiEditor-canvas [ui-sortable] .af-gui-bar:has(~ .af-gui-field-input) {
-  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
+  border-radius: var(--crm-l-radius) var(--crm-l-radius) 0 0;
 }
 
 /* Canvas layout */
@@ -320,7 +320,7 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor .af-gui-layout.af-layout-cols,
 #afGuiEditor .af-gui-layout.af-layout-inline {
   display: flex;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
 }
 #afGuiEditor .af-gui-layout.af-layout-inline {
   flex-flow: wrap;
@@ -396,7 +396,7 @@ af-gui-container > .af-gui-bar,
   background-color: var(--crm-c-layout2-bg-color);
   display: flex;
   align-items: center;
-  padding: var(--crm-s-medium);
+  padding: var(--crm-l-medium);
   justify-content: space-between;
 }
 .af-gui-edit-options-bar h4 {
@@ -503,7 +503,7 @@ af-gui-container > .af-gui-bar,
   height: var(--crm-btn-height);
   display: flex;
   align-items: center;
-  padding-inline: var(--crm-s-medium);
+  padding-inline: var(--crm-l-medium);
 }
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area ul[ui-sortable] li:nth-child(even) {
   background-color: color-mix(in srgb, var(--crm-layer1-bg-color) 92%, #000 8%);
@@ -600,7 +600,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   margin: 0;
 }
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown {
-  padding: var(--crm-s-xsmall);
+  padding: var(--crm-l-xsmall);
   margin: 0;
   display: flex;
   align-items: center;
@@ -613,9 +613,9 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   color: var(--crm-dropdown-color);
 }
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown > select {
-  padding-inline: var(--crm-s-medium);
+  padding-inline: var(--crm-l-medium);
   width: 110px;
-  margin-left: var(--crm-s-xsmall-2);
+  margin-left: var(--crm-l-xsmall-2);
   border: 1px solid var(--crm-input-border-color);
   border-radius: 2px;
 }
@@ -625,11 +625,11 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 #afGuiEditor li .af-gui-field-select-in-dropdown input[type="color"] {
   width: 32px;
   padding: 1px;
-  margin-left: var(--crm-s-xsmall-2);
+  margin-left: var(--crm-l-xsmall-2);
 }
 #afGuiEditor li .af-gui-field-select-in-dropdown input[type=number] {
   width: 50px;
-  padding-inline: var(--crm-s-small) 0;
+  padding-inline: var(--crm-l-small) 0;
   height: auto;
 }
 #afGuiEditor .dropdown-menu li .ng-binding:has(> .fa-square-o,
@@ -637,13 +637,13 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   display: flex;
   padding-block: 0;
   align-items: center;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
 }
 #afGuiEditor .af-gui-field-input-type-chainselect .input-group .dropdown-toggle,
 #afGuiEditor .af-gui-field-input-type-select .input-group .dropdown-toggle,
 #bootstrap-theme #afGuiEditor-palette-config .af-gui-entity-palette .input-group .btn,
 #bootstrap-theme #afGuiEditor-canvas-body .af-gui-field-input .input-group .btn {
-  padding: var(--crm-s-small) var(--crm-s-medium-1);
+  padding: var(--crm-l-small) var(--crm-l-medium-1);
 }
 #afGuiEditor .af-gui-field-input-type-select .input-group .dropdown-menu {
   width: 100%;
@@ -655,7 +655,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   display: block;
   background-image: url('data:image/svg+xml,<%3Fxml version="1.0" encoding="UTF-8"%3F><svg fill="none" viewBox="0 0 64 61" xmlns="http://www.w3.org/2000/svg"><mask id="d" fill="white"><rect y="33" width="40" height="28" rx="4"/></mask><rect y="33" width="40" height="28" rx="4" mask="url(%23d)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/><mask id="c" fill="white"><rect x="45" y="33" width="19" height="28" rx="4"/></mask><rect x="45" y="33" width="19" height="28" rx="4" mask="url(%23c)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/><mask id="b" fill="white"><rect width="24" height="28" rx="4"/></mask><rect width="24" height="28" rx="4" mask="url(%23b)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/><mask id="a" fill="white"><rect x="29" width="24" height="28" rx="4"/></mask><rect x="29" width="24" height="28" rx="4" mask="url(%23a)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/></svg>');
   background-repeat: no-repeat;
-  margin: var(--crm-s-medium);
+  margin: var(--crm-l-medium);
   background-size: contain;
 }
 #afGuiEditor .af-gui-layout-icon.af-layout-cols {
@@ -699,6 +699,6 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   display: inline-block;
 }
 #afGuiEditor .af-gui-container.af-container-style-pane {
-  background: linear-gradient(to bottom, #f2f2f2 0 var(--crm-s-large), transparent var(--crm-s-large) 100%) no-repeat;
-  border-radius: var(--crm-s-radius);
+  background: linear-gradient(to bottom, #f2f2f2 0 var(--crm-l-large), transparent var(--crm-l-large) 100%) no-repeat;
+  border-radius: var(--crm-l-radius);
 }

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -8,7 +8,7 @@
 }
 .afadmin-list th i.fa-sort-desc,
 .afadmin-list th i.fa-sort-asc {
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
 }
 .afadmin-list th:not(:hover) i.fa-sort {
   opacity: .5;
@@ -158,7 +158,7 @@
   right: var(--crm-padding-reg);
   padding: 0 !important /* vs buttons.css */;
   background: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 #afGuiEditor-palette .af-gui-entity-values .form-inline {
   margin-bottom: var(--crm-m);
@@ -215,7 +215,7 @@
   cursor: auto;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div:not(.disabled):hover {
-  background-color: var(--crm-c-layout2-bg);
+  background-color: var(--crm-c-layout2-bg-color);
 }
 
 /* Edit canvas (right side) */
@@ -246,7 +246,7 @@
   width: 100%;
   border-radius: 0;
   transition: opacity .2s;
-  background-color: var(--crm-fb-header-bg);
+  background-color: var(--crm-fb-header-bg-color);
   padding-inline: var(--crm-xs);
   cursor: move;
   display: flex;
@@ -289,7 +289,7 @@
 /* Dragging related */
 #afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-bar,
 #afGuiEditor #afGuiEditor-canvas .af-gui-dragtarget > .af-gui-container-title span:empty {
-  background-color: color-mix(in srgb, var(--crm-fb-header-bg) 80%, #000 20%);
+  background-color: color-mix(in srgb, var(--crm-fb-header-bg-color) 80%, #000 20%);
   opacity: 1;
   transition: opacity .1s;
 }
@@ -346,19 +346,19 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-element:hover,
 #afGuiEditor:not(.af-gui-dragging *) #afGuiEditor-canvas:hover .af-gui-markup:hover,
 #afGuiEditor .crm-editable-enabled:hover:not(:focus) {
-  outline: 2px dashed var(--crm-c-inverse-bg);
+  outline: 2px dashed var(--crm-inverse-bg-color);
 }
 #afGuiEditor-canvas .af-entity-selected {
   outline: 2px dashed var(--crm-c-blue-dark);
 }
 #afGuiEditor-canvas .af-entity-selected > .af-gui-bar {
-  background-color: var(--crm-c-primary);
+  background-color: var(--crm-primary-color);
   opacity: 1;
   transition: opacity 0s;
 }
 #afGuiEditor-canvas .af-entity-selected > .af-gui-bar + label,
 #afGuiEditor .af-entity-selected > .af-gui-bar .af-gui-add-element-button span {
-  color: var(--crm-c-primary-text);
+  color: var(--crm-primary-text-color);
 }
 #afGuiEditor .af-gui-container.af-gui-dragtarget {
   border: 2px solid var(--crm-c-blue-dark);
@@ -369,9 +369,9 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor .af-gui-search-display {
   border: var(--crm-border);
   border-style: dotted;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   padding: var(--crm-padding-reg);
-  background-color: var(--crm-c-layout1-bg);
+  background-color: var(--crm-c-layout1-bg-color);
 }
 
 /* Markup area */
@@ -393,7 +393,7 @@ af-gui-container > .af-gui-bar,
 }
 #afGuiEditor .af-gui-content-editing-area .af-gui-edit-options-bar {
   width: 100%;
-  background-color: var(--crm-c-layout2-bg);
+  background-color: var(--crm-c-layout2-bg-color);
   display: flex;
   align-items: center;
   padding: var(--crm-m);
@@ -410,32 +410,32 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button:hover > span,
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button[aria-expanded=true] > span,
 #afGuiEditor #afGuiEditor-canvas .af-entity-selected > .af-gui-bar > .form-inline > .btn-group > .btn-group > button:focus > span {
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
 }
 #afGuiEditor .af-gui-add-element-button span {
   display: inline-block;
   width: 18px;
   height: 18px;
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
 }
 #bootstrap-theme #afGuiEditor .af-gui-button > .btn.disabled .crm-editable-enabled:hover:not(:focus) {
-  border-color: var(--crm-c-layout1-bg) !important;
+  border-color: var(--crm-c-layout1-bg-color) !important;
 }
 #bootstrap-theme #afGuiEditor .af-gui-button > .btn-default.disabled {
-  background-color: var(--crm-c-layer1-bg) !important;
+  background-color: var(--crm-layer1-bg-color) !important;
 }
 #afGuiEditor .af-gui-container-title span:empty {
   font-weight: lighter;
 }
 #afGuiEditor .af-gui-field-required:after {
   content: '*';
-  color: var(--crm-notify-danger);
+  color: var(--crm-notify-danger-color);
   position: relative;
   left: -4px;
 }
 /* For editing field placeholder text */
 #afGuiEditor .af-gui-field-input input[type=text].form-control {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
 }
 #afGuiEditor .af-gui-field-input-type-number input[type=text].form-control {
   background-image: url('../images/number.png');
@@ -487,18 +487,18 @@ af-gui-container > .af-gui-bar,
 }
 #afGuiEditor .af-gui-dropzone {
   background-color: var(--crm-c-dr);
-  border: 2px solid var(--crm-c-info);
+  border: 2px solid var(--crm-info-color);
   min-height: 30px;
 }
 /* Options editor */
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area {
-  border: 2px solid var(--crm-c-info);
+  border: 2px solid var(--crm-info-color);
 }
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area ul[ui-sortable] {
   padding-inline: var(--crm-padding-reg);
 }
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area ul[ui-sortable] li {
-  background-color: var(--crm-c-layer1-bg);
+  background-color: var(--crm-layer1-bg-color);
   cursor: move;
   height: var(--crm-btn-height);
   display: flex;
@@ -506,7 +506,7 @@ af-gui-container > .af-gui-bar,
   padding-inline: var(--crm-m);
 }
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area ul[ui-sortable] li:nth-child(even) {
-  background-color: color-mix(in srgb, var(--crm-c-layer1-bg) 92%, #000 8%);
+  background-color: color-mix(in srgb, var(--crm-layer1-bg-color) 92%, #000 8%);
 }
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area ul[ui-sortable] li > div {
   display: inline-block;
@@ -527,7 +527,7 @@ af-gui-container > .af-gui-bar,
 /* Rules for Conditional dialog */
 .af-gui-conditional-dialog fieldset {
   padding: 6px;
-  border-top: 1px solid var(--crm-c-drag-bg);
+  border-top: 1px solid var(--crm-drag-bg-color);
   margin-top: 10px;
   margin-bottom: 10px;
   position: relative;
@@ -582,7 +582,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   background-color: transparent;
   border: 0;
   box-shadow: none;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   height: auto;
 }
 #afGuiEditor-canvas .dropdown-toggle i.crm-i {
@@ -610,7 +610,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 #afGuiEditor .dropdown-menu li > * > label {
   font-weight: normal;
   cursor: var(--crm-link-hover-cursor);
-  color: var(--crm-dropdown-col);
+  color: var(--crm-dropdown-color);
 }
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown > select {
   padding-inline: var(--crm-m);
@@ -620,7 +620,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   border-radius: 2px;
 }
 #afGuiEditor li.disabled a strong {
-  color: var(--crm-dropdown-col); /* resets inaccessible colour for dropdown headings mislabelled disabled */
+  color: var(--crm-dropdown-color); /* resets inaccessible colour for dropdown headings mislabelled disabled */
 }
 #afGuiEditor li .af-gui-field-select-in-dropdown input[type="color"] {
   width: 32px;
@@ -667,10 +667,10 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 
 /* Misc - aka stuff I can't identify but don't want to risk removing*/
 #bootstrap-theme #afGuiEditor .af-gui-bar .btn.active {
-  background-color: color-mix(in srgb, var(--crm-fb-header-bg) 80%, #000);
+  background-color: color-mix(in srgb, var(--crm-fb-header-bg-color) 80%, #000);
 }
 #afGuiEditor .af-gui-bar > .form-inline > span {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-style: italic;
 }
 #afGuiEditor .ui-sortable-helper .af-gui-palette-item {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -19,7 +19,7 @@
 /* Editor */
 
 #afGuiEditor {
-  gap: var(--crm-r);
+  gap: var(--crm-s-reg);
 }
 #afGuiEditor-canvas,
 #afGuiEditor-palette,
@@ -30,7 +30,7 @@
 #afGuiEditor .af-gui-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--crm-r);
+  gap: var(--crm-s-reg);
 }
 #afGuiEditor fieldset {
   min-width: 0;
@@ -39,13 +39,13 @@
   border: 0;
 }
 #afGuiEditor fieldset legend {
-  padding: var(--crm-s) 0 0 0;
+  padding: var(--crm-s-small) 0 0 0;
   border-bottom: var(--crm-border);
   width: 100%;
-  margin-bottom: var(--crm-m);
+  margin-bottom: var(--crm-s-medium);
 }
 #afGuiEditor hr {
-  margin-block: var(--crm-m);
+  margin-block: var(--crm-s-medium);
 }
 
 /* Icon only buttons */
@@ -63,10 +63,10 @@
 #afGuiEditor .af-gui-remove-entity i.crm-i {
   margin: 0;
   border: 0;
-  padding: var(--crm-s2);
+  padding: var(--crm-s-small-2);
   height: 100%;
   aspect-ratio: 1 / 1;
-  min-width: var(--crm-r4);
+  min-width: var(--crm-s-reg-4);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -133,7 +133,7 @@
 }
 #afGuiEditor-palette .input-group:has(#af_config_redirect) {
   display: grid;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
   grid-template-columns: 1fr 250px;
 }
 #afGuiEditor-palette .input-group:has(#af_config_redirect) .input-group-addon,
@@ -161,7 +161,7 @@
   color: var(--crm-text-color);
 }
 #afGuiEditor-palette .af-gui-entity-values .form-inline {
-  margin-bottom: var(--crm-m);
+  margin-bottom: var(--crm-s-medium);
   display: flex;
   align-items: center;
   gap: var(--crm-flex-gap);
@@ -169,7 +169,7 @@
 }
 #afGuiEditor-palette .af-gui-entity-values .select2-container {
   width: 100% !important /* vs inline */;
-  margin-bottom: var(--crm-s2);
+  margin-bottom: var(--crm-s-small-2);
 }
 #afGuiEditor-palette .af-gui-entity-values .input-group {
   width: 100%;
@@ -187,12 +187,12 @@
   border-bottom: 0;
 }
 #afGuiEditor-palette .af-gui-entity-palette .input-group {
-  margin-top: var(--crm-s);
+  margin-top: var(--crm-s-small);
 }
 #afGuiEditor-palette .af-gui-entity-palette [type="search"] {
   width: 100%;
   border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
-  padding: var(--crm-s2);
+  padding: var(--crm-s-small-2);
   font-weight: normal;
   position: relative;
   margin: 0;
@@ -202,13 +202,13 @@
 .af-gui-entity-palette-select-list {
   border: var(--crm-border);
   border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
-  padding: 0 var(--crm-s) var(--crm-s);
+  padding: 0 var(--crm-s-small) var(--crm-s-small);
   max-height: 400px;
   overflow-y: auto;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div {
   cursor: move;
-  padding: var(--crm-xs) var(--crm-m) var(--crm-xs) var(--crm-r);
+  padding: var(--crm-s-xsmall) var(--crm-s-medium) var(--crm-s-xsmall) var(--crm-s-reg);
   position: relative;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div.disabled {
@@ -229,7 +229,7 @@
   display: block;
   border-radius: var(--crm-s-radius);
   position: relative;
-  padding: var(--crm-m);
+  padding: var(--crm-s-medium);
 }
 #afGuiEditor af-gui-field,
 #afGuiEditor .af-gui-block-label,
@@ -242,12 +242,12 @@
 
 /* Canvas gui bar */
 #afGuiEditor-canvas .af-gui-bar {
-  height: var(--crm-l);
+  height: var(--crm-s-large);
   width: 100%;
   border-radius: 0;
   transition: opacity .2s;
   background-color: var(--crm-fb-header-bg-color);
-  padding-inline: var(--crm-xs);
+  padding-inline: var(--crm-s-xsmall);
   cursor: move;
   display: flex;
   justify-content: space-between;
@@ -257,8 +257,8 @@
 #afGuiEditor .af-gui-entity-palette-select-list [ui-sortable] > div:not(.disabled):hover:before,
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area [ui-sortable] li:before {
   background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1IiBoZWlnaHQ9IjUiPgo8cmVjdCB3aWR0aD0iMSIgaGVpZ2h0PSIxIiBmaWxsPSIjODg4Ij48L3JlY3Q+Cjwvc3ZnPg==");
-  width: var(--crm-m);
-  height: calc(100% - var(--crm-m));
+  width: var(--crm-s-medium);
+  height: calc(100% - var(--crm-s-medium));
   content: ' ';
   width: 10px;
 }
@@ -270,7 +270,7 @@
 }
 #afGuiEditor-canvas af-gui-container-multi-toggle .btn .ng-binding {
   display: flex;
-  margin-right: var(--crm-m);
+  margin-right: var(--crm-s-medium);
 }
 #afGuiEditor .af-gui-node-title {
   position: absolute;
@@ -306,8 +306,8 @@ af-gui-container > .af-gui-bar,
 .af-gui-element > .af-gui-bar,
 .af-gui-container-type-div > .af-gui-bar,
 .af-gui-markup > .af-gui-bar {
-  margin: calc(-1 * var(--crm-m)) calc(-1 * var(--crm-m)) var(--crm-m) calc(-1 * var(--crm-m));
-  width: calc(100% + var(--crm-r)) !important;
+  margin: calc(-1 * var(--crm-s-medium)) calc(-1 * var(--crm-s-medium)) var(--crm-s-medium) calc(-1 * var(--crm-s-medium));
+  width: calc(100% + var(--crm-s-reg)) !important;
 }
 #afGuiEditor-canvas [ui-sortable] .af-gui-bar:has(~ .af-gui-field-input) {
   border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
@@ -320,7 +320,7 @@ af-gui-container > .af-gui-bar,
 #afGuiEditor .af-gui-layout.af-layout-cols,
 #afGuiEditor .af-gui-layout.af-layout-inline {
   display: flex;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
 }
 #afGuiEditor .af-gui-layout.af-layout-inline {
   flex-flow: wrap;
@@ -396,7 +396,7 @@ af-gui-container > .af-gui-bar,
   background-color: var(--crm-c-layout2-bg-color);
   display: flex;
   align-items: center;
-  padding: var(--crm-m);
+  padding: var(--crm-s-medium);
   justify-content: space-between;
 }
 .af-gui-edit-options-bar h4 {
@@ -503,7 +503,7 @@ af-gui-container > .af-gui-bar,
   height: var(--crm-btn-height);
   display: flex;
   align-items: center;
-  padding-inline: var(--crm-m);
+  padding-inline: var(--crm-s-medium);
 }
 #afGuiEditor af-gui-edit-options.af-gui-content-editing-area ul[ui-sortable] li:nth-child(even) {
   background-color: color-mix(in srgb, var(--crm-layer1-bg-color) 92%, #000 8%);
@@ -600,7 +600,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   margin: 0;
 }
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown {
-  padding: var(--crm-xs);
+  padding: var(--crm-s-xsmall);
   margin: 0;
   display: flex;
   align-items: center;
@@ -613,9 +613,9 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   color: var(--crm-dropdown-color);
 }
 #afGuiEditor .dropdown-menu li .af-gui-field-select-in-dropdown > select {
-  padding-inline: var(--crm-m);
+  padding-inline: var(--crm-s-medium);
   width: 110px;
-  margin-left: var(--crm-xs2);
+  margin-left: var(--crm-s-xsmall-2);
   border: 1px solid var(--crm-input-border-color);
   border-radius: 2px;
 }
@@ -625,11 +625,11 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 #afGuiEditor li .af-gui-field-select-in-dropdown input[type="color"] {
   width: 32px;
   padding: 1px;
-  margin-left: var(--crm-xs2);
+  margin-left: var(--crm-s-xsmall-2);
 }
 #afGuiEditor li .af-gui-field-select-in-dropdown input[type=number] {
   width: 50px;
-  padding-inline: var(--crm-s) 0;
+  padding-inline: var(--crm-s-small) 0;
   height: auto;
 }
 #afGuiEditor .dropdown-menu li .ng-binding:has(> .fa-square-o,
@@ -637,13 +637,13 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   display: flex;
   padding-block: 0;
   align-items: center;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
 }
 #afGuiEditor .af-gui-field-input-type-chainselect .input-group .dropdown-toggle,
 #afGuiEditor .af-gui-field-input-type-select .input-group .dropdown-toggle,
 #bootstrap-theme #afGuiEditor-palette-config .af-gui-entity-palette .input-group .btn,
 #bootstrap-theme #afGuiEditor-canvas-body .af-gui-field-input .input-group .btn {
-  padding: var(--crm-s) var(--crm-m1);
+  padding: var(--crm-s-small) var(--crm-s-medium-1);
 }
 #afGuiEditor .af-gui-field-input-type-select .input-group .dropdown-menu {
   width: 100%;
@@ -655,7 +655,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   display: block;
   background-image: url('data:image/svg+xml,<%3Fxml version="1.0" encoding="UTF-8"%3F><svg fill="none" viewBox="0 0 64 61" xmlns="http://www.w3.org/2000/svg"><mask id="d" fill="white"><rect y="33" width="40" height="28" rx="4"/></mask><rect y="33" width="40" height="28" rx="4" mask="url(%23d)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/><mask id="c" fill="white"><rect x="45" y="33" width="19" height="28" rx="4"/></mask><rect x="45" y="33" width="19" height="28" rx="4" mask="url(%23c)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/><mask id="b" fill="white"><rect width="24" height="28" rx="4"/></mask><rect width="24" height="28" rx="4" mask="url(%23b)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/><mask id="a" fill="white"><rect x="29" width="24" height="28" rx="4"/></mask><rect x="29" width="24" height="28" rx="4" mask="url(%23a)" stroke="%23000" stroke-linejoin="round" stroke-width="10"/></svg>');
   background-repeat: no-repeat;
-  margin: var(--crm-m);
+  margin: var(--crm-s-medium);
   background-size: contain;
 }
 #afGuiEditor .af-gui-layout-icon.af-layout-cols {
@@ -699,6 +699,6 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   display: inline-block;
 }
 #afGuiEditor .af-gui-container.af-container-style-pane {
-  background: linear-gradient(to bottom, #f2f2f2 0 var(--crm-l), transparent var(--crm-l) 100%) no-repeat;
+  background: linear-gradient(to bottom, #f2f2f2 0 var(--crm-s-large), transparent var(--crm-s-large) 100%) no-repeat;
   border-radius: var(--crm-s-radius);
 }

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -215,7 +215,7 @@
   cursor: auto;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div:not(.disabled):hover {
-  background-color: var(--crm-c-layout2-bg-color);
+  background-color: var(--crm-layer2-bg-color);
 }
 
 /* Edit canvas (right side) */
@@ -371,7 +371,7 @@ af-gui-container > .af-gui-bar,
   border-style: dotted;
   color: var(--crm-text-color);
   padding: var(--crm-padding-reg);
-  background-color: var(--crm-c-layout1-bg-color);
+  background-color: var(--crm-layer1-bg-color);
 }
 
 /* Markup area */
@@ -393,7 +393,7 @@ af-gui-container > .af-gui-bar,
 }
 #afGuiEditor .af-gui-content-editing-area .af-gui-edit-options-bar {
   width: 100%;
-  background-color: var(--crm-c-layout2-bg-color);
+  background-color: var(--crm-layer2-bg-color);
   display: flex;
   align-items: center;
   padding: var(--crm-l-medium);
@@ -419,7 +419,7 @@ af-gui-container > .af-gui-bar,
   color: var(--crm-link-color);
 }
 #bootstrap-theme #afGuiEditor .af-gui-button > .btn.disabled .crm-editable-enabled:hover:not(:focus) {
-  border-color: var(--crm-c-layout1-bg-color) !important;
+  border-color: var(--crm-layer1-bg-color) !important;
 }
 #bootstrap-theme #afGuiEditor .af-gui-button > .btn-default.disabled {
   background-color: var(--crm-layer1-bg-color) !important;

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -40,7 +40,7 @@
 }
 #afGuiEditor fieldset legend {
   padding: var(--crm-s) 0 0 0;
-  border-bottom: var(--crm-c-divider);
+  border-bottom: var(--crm-border);
   width: 100%;
   margin-bottom: var(--crm-m);
 }
@@ -200,7 +200,7 @@
   font-family: sans-serif,'FontAwesome';
 }
 .af-gui-entity-palette-select-list {
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
   padding: 0 var(--crm-s) var(--crm-s);
   max-height: 400px;
@@ -367,7 +367,7 @@ af-gui-container > .af-gui-bar,
 
 /* Card style */
 #afGuiEditor .af-gui-search-display {
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-style: dotted;
   color: var(--crm-c-text);
   padding: var(--crm-padding-reg);
@@ -534,7 +534,7 @@ af-gui-container > .af-gui-bar,
 }
 .af-gui-conditional-dialog fieldset fieldset {
   padding-top: 0;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-top: 0;
 }
 #bootstrap-theme .af-gui-conditional-dialog af-gui-clause > .btn-group {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -191,7 +191,7 @@
 }
 #afGuiEditor-palette .af-gui-entity-palette [type="search"] {
   width: 100%;
-  border-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
+  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   padding: var(--crm-s2);
   font-weight: normal;
   position: relative;
@@ -201,7 +201,7 @@
 }
 .af-gui-entity-palette-select-list {
   border: var(--crm-c-divider);
-  border-radius: 0 0 var(--crm-roundness) var(--crm-roundness);
+  border-radius: 0 0 var(--crm-s-radius) var(--crm-s-radius);
   padding: 0 var(--crm-s) var(--crm-s);
   max-height: 400px;
   overflow-y: auto;
@@ -227,7 +227,7 @@
   margin-bottom: var(--crm-padding-small);
   border: 2px solid transparent;
   display: block;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   position: relative;
   padding: var(--crm-m);
 }
@@ -310,7 +310,7 @@ af-gui-container > .af-gui-bar,
   width: calc(100% + var(--crm-r)) !important;
 }
 #afGuiEditor-canvas [ui-sortable] .af-gui-bar:has(~ .af-gui-field-input) {
-  border-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
+  border-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
 }
 
 /* Canvas layout */
@@ -700,5 +700,5 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
 }
 #afGuiEditor .af-gui-container.af-container-style-pane {
   background: linear-gradient(to bottom, #f2f2f2 0 var(--crm-l), transparent var(--crm-l) 100%) no-repeat;
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
 }

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -20,8 +20,8 @@
 }
 #bootstrap-theme .crm-search-nav-tabs > div.btn-group {
   position: absolute;
-  right: var(--crm-s);
-  top: var(--crm-s);
+  right: var(--crm-s-small);
+  top: var(--crm-s-small);
 }
 #bootstrap-theme .crm-search-admin-search-listing-buttons {
   display: flex;
@@ -33,12 +33,12 @@
 .crm-search .crm-flex-box.crm-search-admin-outer {
   display: grid;
   grid-template-columns: 280px auto;
-  margin-bottom: var(--crm-r2);
+  margin-bottom: var(--crm-s-reg-2);
 }
 .crm-search .crm-flex-box.crm-search-admin-outer:first-of-type {
   grid-template-columns: 33% auto;
   align-items: center;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
 }
 #crm-saved-search-label {
   width: 100%;
@@ -48,9 +48,9 @@
 /* Tabs */
 .crm-search-admin-main-tabs ul.nav-stacked {
   display: flex;
-  gap: var(--crm-s);
+  gap: var(--crm-s-small);
   position: relative;
-  margin-top: var(--crm-r);
+  margin-top: var(--crm-s-reg);
 }
 .crm-search-admin-main-tabs ul.nav-stacked li {
   cursor: default;
@@ -77,9 +77,9 @@
   box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
 }
 .crm-search ul.nav-stacked li[role=separator] {
-  height: var(--crm-m2);
+  height: var(--crm-s-medium-2);
   border-top: var(--crm-border);
-  margin: var(--crm-m) var(--crm-l) 0 var(--crm-r);
+  margin: var(--crm-s-medium) var(--crm-s-large) 0 var(--crm-s-reg);
 }
 .crm-search ul.nav-stacked li a[disabled] {
   text-decoration: line-through !important;
@@ -100,7 +100,7 @@
 }
 .crm-search-display-control {
   position: absolute;
-  right: var(--crm-s);
+  right: var(--crm-s-small);
   top: 25%;
 }
 .crm-search-display-control+.crm-search-display-control {
@@ -119,7 +119,7 @@
 /* Tab: Filter Conditions */
 
 .crm-search fieldset div.api4-input {
-  margin-bottom: var(--crm-m);
+  margin-bottom: var(--crm-s-medium);
 }
 .crm-search .api4-clause-badge {
   width: 8ch;
@@ -138,9 +138,9 @@
 /* Fieldsets */
 
 .crm-container .crm-search fieldset {
-  padding: var(--crm-s);
+  padding: var(--crm-s-small);
   border-top: var(--crm-border);
-  margin-block: var(--crm-s);
+  margin-block: var(--crm-s-small);
   border-radius: var(--crm-s-radius);
   position: relative;
 }
@@ -160,7 +160,7 @@
 /* Icon only shown while dragging */
 .crm-search .api4-clause-badge .crm-i {
   display: none;
-  padding: 0 var(--crm-s2);
+  padding: 0 var(--crm-s-small-2);
 }
 .crm-search .ui-sortable-helper .api4-clause-badge .badge span {
   display: none;
@@ -169,7 +169,7 @@
   display: inline-block;
 }
 .crm-search .crm-search-admin-relative .api4-clause-group-sortable {
-  margin: var(--crm-r) 0;
+  margin: var(--crm-s-reg) 0;
 }
 /* Tab: Select Fields */
 
@@ -211,7 +211,7 @@
   z-index: 1;
   position: absolute;
   right: 0;
-  top: var(--crm-xs1);
+  top: var(--crm-s-xsmall-1);
   margin: var(--crm-accordion-header-padding);
 }
 #bootstrap-theme .crm-search-admin-edit-columns i.crm-i.crm-search-move-icon {
@@ -230,7 +230,7 @@
   max-width: 125px;
 }
 .crm-search-admin-edit-columns .crm-draggable > td.form-inline {
-  padding-right: var(--crm-s);
+  padding-right: var(--crm-s-small);
 }
 .crm-search-admin-edit-columns .crm-draggable tfoot td.form-inline {
   padding: var(--crm-padding-reg);
@@ -322,7 +322,7 @@
   background-color: rgba(186, 225, 251, 0.94);
 }
 .crm-search .api4-add-where-group-menu a {
-  padding: var(--crm-s) var(--crm-m);
+  padding: var(--crm-s-small) var(--crm-s-medium);
 }
 #bootstrap-theme.crm-search .btn.form-control {
   height: 36px;
@@ -336,7 +336,7 @@
 .crm-search-admin-flex-row {
   display: flex;
   align-items: center;
-  column-gap: var(--crm-s3);
+  column-gap: var(--crm-s-small-3);
 }
 .crm-search-admin-unused-columns fieldset {
   min-height: 60px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -69,7 +69,7 @@
 }
 .crm-search-admin-main-tabs ul.nav-stacked li.active a {
   background-color: var(--crm-tab-bg-active);
-  color: var(--crm-tab-col);
+  color: var(--crm-tab-color);
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
   border: var(--crm-border);
@@ -95,7 +95,7 @@
 }
 #bootstrap-theme .crm-search-admin-main-tabs button.btn-xs {
   background: transparent;
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   font-size: var(--crm-font-size);
 }
 .crm-search-display-control {
@@ -174,7 +174,7 @@
 /* Tab: Select Fields */
 
 .crm-search fieldset.crm-draggable {
-  background-color: var(--crm-c-drag-bg);
+  background-color: var(--crm-drag-bg-color);
   border-radius: var(--crm-s-radius);
   border: 0 solid transparent;
 }
@@ -243,7 +243,7 @@
   display: block;
 }
 .crm-search crm-search-admin-link-group {
-  background: var(--crm-c-layout1-bg);
+  background: var(--crm-c-layout1-bg-color);
 }
 .crm-search crm-search-admin-link-group table {
   margin: var(--crm-padding-reg);
@@ -278,7 +278,7 @@
   cursor: not-allowed;
 }
 .crm-search input.ng-invalid::placeholder {
-  color: var(--crm-c-warning);
+  color: var(--crm-warning-color);
 }
 #bootstrap-theme.crm-search crm-search-clause > .btn-group {
   position: absolute;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -20,8 +20,8 @@
 }
 #bootstrap-theme .crm-search-nav-tabs > div.btn-group {
   position: absolute;
-  right: var(--crm-s-small);
-  top: var(--crm-s-small);
+  right: var(--crm-l-small);
+  top: var(--crm-l-small);
 }
 #bootstrap-theme .crm-search-admin-search-listing-buttons {
   display: flex;
@@ -33,12 +33,12 @@
 .crm-search .crm-flex-box.crm-search-admin-outer {
   display: grid;
   grid-template-columns: 280px auto;
-  margin-bottom: var(--crm-s-reg-2);
+  margin-bottom: var(--crm-l-reg-2);
 }
 .crm-search .crm-flex-box.crm-search-admin-outer:first-of-type {
   grid-template-columns: 33% auto;
   align-items: center;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
 }
 #crm-saved-search-label {
   width: 100%;
@@ -48,9 +48,9 @@
 /* Tabs */
 .crm-search-admin-main-tabs ul.nav-stacked {
   display: flex;
-  gap: var(--crm-s-small);
+  gap: var(--crm-l-small);
   position: relative;
-  margin-top: var(--crm-s-reg);
+  margin-top: var(--crm-l-reg);
 }
 .crm-search-admin-main-tabs ul.nav-stacked li {
   cursor: default;
@@ -61,7 +61,7 @@
   display: inline-block;
   width: 100%;
   border: 1px solid transparent;
-  border-radius: var(--crm-s-radius) 0 0 var(--crm-s-radius);
+  border-radius: var(--crm-l-radius) 0 0 var(--crm-l-radius);
   right: -1px;
 }
 .crm-search-admin-main-tabs ul.nav-stacked li.active {
@@ -77,9 +77,9 @@
   box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
 }
 .crm-search ul.nav-stacked li[role=separator] {
-  height: var(--crm-s-medium-2);
+  height: var(--crm-l-medium-2);
   border-top: var(--crm-border);
-  margin: var(--crm-s-medium) var(--crm-s-large) 0 var(--crm-s-reg);
+  margin: var(--crm-l-medium) var(--crm-l-large) 0 var(--crm-l-reg);
 }
 .crm-search ul.nav-stacked li a[disabled] {
   text-decoration: line-through !important;
@@ -100,7 +100,7 @@
 }
 .crm-search-display-control {
   position: absolute;
-  right: var(--crm-s-small);
+  right: var(--crm-l-small);
   top: 25%;
 }
 .crm-search-display-control+.crm-search-display-control {
@@ -111,7 +111,7 @@
   margin: 0;
 }
 .crm-search .crm-search-admin-outer .crm-flex-4.panel .panel-body {
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   background: var(--crm-tab-bg-active);
   height: 100%;
 }
@@ -119,7 +119,7 @@
 /* Tab: Filter Conditions */
 
 .crm-search fieldset div.api4-input {
-  margin-bottom: var(--crm-s-medium);
+  margin-bottom: var(--crm-l-medium);
 }
 .crm-search .api4-clause-badge {
   width: 8ch;
@@ -138,10 +138,10 @@
 /* Fieldsets */
 
 .crm-container .crm-search fieldset {
-  padding: var(--crm-s-small);
+  padding: var(--crm-l-small);
   border-top: var(--crm-border);
-  margin-block: var(--crm-s-small);
-  border-radius: var(--crm-s-radius);
+  margin-block: var(--crm-l-small);
+  border-radius: var(--crm-l-radius);
   position: relative;
 }
 .crm-search fieldset fieldset {
@@ -160,7 +160,7 @@
 /* Icon only shown while dragging */
 .crm-search .api4-clause-badge .crm-i {
   display: none;
-  padding: 0 var(--crm-s-small-2);
+  padding: 0 var(--crm-l-small-2);
 }
 .crm-search .ui-sortable-helper .api4-clause-badge .badge span {
   display: none;
@@ -169,13 +169,13 @@
   display: inline-block;
 }
 .crm-search .crm-search-admin-relative .api4-clause-group-sortable {
-  margin: var(--crm-s-reg) 0;
+  margin: var(--crm-l-reg) 0;
 }
 /* Tab: Select Fields */
 
 .crm-search fieldset.crm-draggable {
   background-color: var(--crm-drag-bg-color);
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   border: 0 solid transparent;
 }
 
@@ -211,7 +211,7 @@
   z-index: 1;
   position: absolute;
   right: 0;
-  top: var(--crm-s-xsmall-1);
+  top: var(--crm-l-xsmall-1);
   margin: var(--crm-accordion-header-padding);
 }
 #bootstrap-theme .crm-search-admin-edit-columns i.crm-i.crm-search-move-icon {
@@ -230,7 +230,7 @@
   max-width: 125px;
 }
 .crm-search-admin-edit-columns .crm-draggable > td.form-inline {
-  padding-right: var(--crm-s-small);
+  padding-right: var(--crm-l-small);
 }
 .crm-search-admin-edit-columns .crm-draggable tfoot td.form-inline {
   padding: var(--crm-padding-reg);
@@ -255,7 +255,7 @@
   border: 0 solid transparent;
 }
 .crm-search-admin-edit-columns details {
-  border-radius: var(--crm-s-radius);
+  border-radius: var(--crm-l-radius);
   margin: 0;
   border: 0;
 }
@@ -322,7 +322,7 @@
   background-color: rgba(186, 225, 251, 0.94);
 }
 .crm-search .api4-add-where-group-menu a {
-  padding: var(--crm-s-small) var(--crm-s-medium);
+  padding: var(--crm-l-small) var(--crm-l-medium);
 }
 #bootstrap-theme.crm-search .btn.form-control {
   height: 36px;
@@ -336,7 +336,7 @@
 .crm-search-admin-flex-row {
   display: flex;
   align-items: center;
-  column-gap: var(--crm-s-small-3);
+  column-gap: var(--crm-l-small-3);
 }
 .crm-search-admin-unused-columns fieldset {
   min-height: 60px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -61,7 +61,7 @@
   display: inline-block;
   width: 100%;
   border: 1px solid transparent;
-  border-radius: var(--crm-roundness) 0 0 var(--crm-roundness);
+  border-radius: var(--crm-s-radius) 0 0 var(--crm-s-radius);
   right: -1px;
 }
 .crm-search-admin-main-tabs ul.nav-stacked li.active {
@@ -111,7 +111,7 @@
   margin: 0;
 }
 .crm-search .crm-search-admin-outer .crm-flex-4.panel .panel-body {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   background: var(--crm-tab-bg-active);
   height: 100%;
 }
@@ -141,7 +141,7 @@
   padding: var(--crm-s);
   border-top: var(--crm-c-divider);
   margin-block: var(--crm-s);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   position: relative;
 }
 .crm-search fieldset fieldset {
@@ -175,7 +175,7 @@
 
 .crm-search fieldset.crm-draggable {
   background-color: var(--crm-c-drag-bg);
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   border: 0 solid transparent;
 }
 
@@ -212,11 +212,11 @@
   position: absolute;
   right: 0;
   top: var(--crm-xs1);
-  margin: var(--crm-expand-header-padding);
+  margin: var(--crm-accordion-header-padding);
 }
 #bootstrap-theme .crm-search-admin-edit-columns i.crm-i.crm-search-move-icon {
   opacity: .5;
-  padding: var(--crm-expand-header-padding);
+  padding: var(--crm-accordion-header-padding);
   justify-self: center;
 }
 #bootstrap-theme .crm-search-admin-edit-columns .input-group-btn {
@@ -255,7 +255,7 @@
   border: 0 solid transparent;
 }
 .crm-search-admin-edit-columns details {
-  border-radius: var(--crm-roundness);
+  border-radius: var(--crm-s-radius);
   margin: 0;
   border: 0;
 }

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -243,7 +243,7 @@
   display: block;
 }
 .crm-search crm-search-admin-link-group {
-  background: var(--crm-c-layout1-bg-color);
+  background: var(--crm-layer1-bg-color);
 }
 .crm-search crm-search-admin-link-group table {
   margin: var(--crm-padding-reg);

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -301,7 +301,7 @@
 }
 .crm-search .form-control label,
 .crm-search legend[ng-click] {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
 }
 .crm-search .api4-input-group {
   display: inline-block;
@@ -368,7 +368,7 @@ crm-search-admin-tags.btn-group-xs .crm-search-admin-tags-btn-label {
 }
 /* .dropdown-menu li > * > label {
     font-weight: normal;
-    cursor: var(--crm-hover-clickable);
+    cursor: var(--crm-link-hover-cursor);
 } */
 .crm-container .crm-container .dropdown-menu li .form-inline > select {
   max-width: 120px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -72,13 +72,13 @@
   color: var(--crm-tab-col);
   border-bottom-right-radius: 0;
   border-top-right-radius: 0;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-right: 0 none;
   box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
 }
 .crm-search ul.nav-stacked li[role=separator] {
   height: var(--crm-m2);
-  border-top: var(--crm-c-divider);
+  border-top: var(--crm-border);
   margin: var(--crm-m) var(--crm-l) 0 var(--crm-r);
 }
 .crm-search ul.nav-stacked li a[disabled] {
@@ -107,7 +107,7 @@
   right: 28px;
 }
 .crm-search .crm-search-admin-outer .crm-flex-4.panel {
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   margin: 0;
 }
 .crm-search .crm-search-admin-outer .crm-flex-4.panel .panel-body {
@@ -139,14 +139,14 @@
 
 .crm-container .crm-search fieldset {
   padding: var(--crm-s);
-  border-top: var(--crm-c-divider);
+  border-top: var(--crm-border);
   margin-block: var(--crm-s);
   border-radius: var(--crm-s-radius);
   position: relative;
 }
 .crm-search fieldset fieldset {
   padding-top: 0;
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
   border-width: 0 1px 1px 1px;
 }
 #bootstrap-theme.crm-search fieldset legend {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -71,7 +71,7 @@
   float: inherit;
 }
 .crm-contact-page .crm-search-display-pager {
-  padding: 0 var(--crm-s-reg) var(--crm-s-reg) var(--crm-s-reg);
+  padding: 0 var(--crm-l-reg) var(--crm-l-reg) var(--crm-l-reg);
 }
 /* Inline Edit */
 

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -13,7 +13,7 @@
 }
 .crm-search-display th i.fa-sort-desc,
 .crm-search-display th i.fa-sort-asc {
-  color: var(--crm-c-primary);
+  color: var(--crm-primary-color);
 }
 .crm-search-display th:not(:hover) i.fa-sort {
   opacity: .5;
@@ -21,7 +21,7 @@
 .crm-search input.ng-invalid,
 .crm-search-display input.ng-invalid,
 .crm-search-task-dialog input.ng-invalid {
-  border-color: var(--crm-c-warning);
+  border-color: var(--crm-warning-color);
 }
 .crm-search-display button.dropdown-toggle {
   white-space: nowrap;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -4,7 +4,7 @@
 
 /* Sortable headers */
 .crm-search-display th.crm-sortable-col {
-  cursor: var(--crm-hover-clickable);
+  cursor: var(--crm-link-hover-cursor);
   white-space: nowrap;
 }
 .crm-search-display th.crm-sortable-col span {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -71,7 +71,7 @@
   float: inherit;
 }
 .crm-contact-page .crm-search-display-pager {
-  padding: 0 var(--crm-r) var(--crm-r) var(--crm-r);
+  padding: 0 var(--crm-s-reg) var(--crm-s-reg) var(--crm-s-reg);
 }
 /* Inline Edit */
 

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -8,7 +8,7 @@ table.crm-sticky-header > thead > tr {
   z-index: 2;
 }
 .crm-search-display-table > table.table > thead > tr > th.crm-search-result-select {
-  padding-inline: var(--crm-m);
+  padding-inline: var(--crm-s-medium);
   text-transform: none;
   color: initial;
   min-width: 95px; /* Don't allow button to be split on 2 lines */
@@ -22,8 +22,8 @@ table.crm-sticky-header > thead > tr {
 
 /* Afform tables */
 #bootstrap-theme td.crm-search-col-type-buttons {
-  padding: var(--crm-table-padding) calc(var(--crm-table-padding) - var(--crm-s)) calc(var(--crm-table-padding) - var(--crm-s)) var(--crm-table-padding);
-  --crm-btn-margin: 0 var(--crm-s) var(--crm-s) 0;
+  padding: var(--crm-table-padding) calc(var(--crm-table-padding) - var(--crm-s-small)) calc(var(--crm-table-padding) - var(--crm-s-small)) var(--crm-table-padding);
+  --crm-btn-margin: 0 var(--crm-s-small) var(--crm-s-small) 0;
 }
 #bootstrap-theme td:is(.crm-search-col-type-buttons,.crm-search-col-type-menu) {
   width: 1px; /* shrinks cell to width of button/menu */
@@ -31,7 +31,7 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme th.crm-search-result-select button.btn {
   background-color: color-mix(in srgb,var(--crm-text-color) 15%,transparent);
   color: var(--crm-text-color);
-  padding: var(--crm-xs1) var(--crm-m1);
+  padding: var(--crm-s-xsmall-1) var(--crm-s-medium-1);
 }
 #bootstrap-theme th.crm-search-result-select button.btn:hover,
 #bootstrap-theme th.crm-search-result-select button.btn:focus {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -46,7 +46,7 @@ table.crm-sticky-header > thead > tr {
 }
 .crm-search-display-table table {
   border: var(--crm-table-outside-border);
-  box-shadow: var(--crm-block-shadow);
+  box-shadow: var(--crm-shadow-block);
 }
 
 /* Nested styling for hierarchical rows */

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -8,7 +8,7 @@ table.crm-sticky-header > thead > tr {
   z-index: 2;
 }
 .crm-search-display-table > table.table > thead > tr > th.crm-search-result-select {
-  padding-inline: var(--crm-s-medium);
+  padding-inline: var(--crm-l-medium);
   text-transform: none;
   color: initial;
   min-width: 95px; /* Don't allow button to be split on 2 lines */
@@ -22,8 +22,8 @@ table.crm-sticky-header > thead > tr {
 
 /* Afform tables */
 #bootstrap-theme td.crm-search-col-type-buttons {
-  padding: var(--crm-table-padding) calc(var(--crm-table-padding) - var(--crm-s-small)) calc(var(--crm-table-padding) - var(--crm-s-small)) var(--crm-table-padding);
-  --crm-btn-margin: 0 var(--crm-s-small) var(--crm-s-small) 0;
+  padding: var(--crm-table-padding) calc(var(--crm-table-padding) - var(--crm-l-small)) calc(var(--crm-table-padding) - var(--crm-l-small)) var(--crm-table-padding);
+  --crm-btn-margin: 0 var(--crm-l-small) var(--crm-l-small) 0;
 }
 #bootstrap-theme td:is(.crm-search-col-type-buttons,.crm-search-col-type-menu) {
   width: 1px; /* shrinks cell to width of button/menu */
@@ -31,7 +31,7 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme th.crm-search-result-select button.btn {
   background-color: color-mix(in srgb,var(--crm-text-color) 15%,transparent);
   color: var(--crm-text-color);
-  padding: var(--crm-s-xsmall-1) var(--crm-s-medium-1);
+  padding: var(--crm-l-xsmall-1) var(--crm-l-medium-1);
 }
 #bootstrap-theme th.crm-search-result-select button.btn:hover,
 #bootstrap-theme th.crm-search-result-select button.btn:focus {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -29,16 +29,16 @@ table.crm-sticky-header > thead > tr {
   width: 1px; /* shrinks cell to width of button/menu */
 }
 #bootstrap-theme th.crm-search-result-select button.btn {
-  background-color: color-mix(in srgb,var(--crm-c-text) 15%,transparent);
-  color: var(--crm-c-text);
+  background-color: color-mix(in srgb,var(--crm-text-color) 15%,transparent);
+  color: var(--crm-text-color);
   padding: var(--crm-xs1) var(--crm-m1);
 }
 #bootstrap-theme th.crm-search-result-select button.btn:hover,
 #bootstrap-theme th.crm-search-result-select button.btn:focus {
-  background-color: color-mix(in srgb,var(--crm-c-text) 25%,transparent);
+  background-color: color-mix(in srgb,var(--crm-text-color) 25%,transparent);
 }
 #bootstrap-theme th.crm-search-result-select button.btn i.crm-i {
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   min-width: fit-content;
   padding: 0;
   border: 0;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTree.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTree.css
@@ -18,7 +18,7 @@
   display: flex;
   gap: 0.5rem;
   border-bottom: 1px dotted var(--crm-c-gray-200);
-  padding: var(--crm-s) var(--crm-m) !important;
+  padding: var(--crm-s-small) var(--crm-s-medium) !important;
   align-items: center;
   flex-wrap: wrap;
 }
@@ -28,7 +28,7 @@ crm-search-display-tree-branch crm-search-display-tree-branch:has( > ul > li) {
 #bootstrap-theme .crm-search-display-tree-collapse-toggle {
   background: var(--crm-c-gray-200);
   color: var(--crm-text-color);
-  padding: var(--crm-btn-icon-padding) var(--crm-m) var(--crm-btn-icon-padding) 0 !important /* vs crmSearchAdmin */;
+  padding: var(--crm-btn-icon-padding) var(--crm-s-medium) var(--crm-btn-icon-padding) 0 !important /* vs crmSearchAdmin */;
 }
 #bootstrap-theme li.crm-search-display-tree-branch-collapsed {
   /* For collapsed items, add bottom padding to compensate for the hidden subtree */
@@ -72,9 +72,9 @@ crm-search-display-tree-branch crm-search-display-editable form {
 }
 .crm-separator-above {
   border-top: 2px solid var(--crm-c-blue);
-  padding-top: var(--crm-s);
+  padding-top: var(--crm-s-small);
 }
 .crm-separator-below {
   border-bottom: 2px solid var(--crm-c-blue);
-  margin-bottom: var(--crm-s);
+  margin-bottom: var(--crm-s-small);
 }

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTree.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTree.css
@@ -27,7 +27,7 @@ crm-search-display-tree-branch crm-search-display-tree-branch:has( > ul > li) {
 }
 #bootstrap-theme .crm-search-display-tree-collapse-toggle {
   background: var(--crm-c-gray-200);
-  color: var(--crm-c-text);
+  color: var(--crm-text-color);
   padding: var(--crm-btn-icon-padding) var(--crm-m) var(--crm-btn-icon-padding) 0 !important /* vs crmSearchAdmin */;
 }
 #bootstrap-theme li.crm-search-display-tree-branch-collapsed {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTree.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTree.css
@@ -18,7 +18,7 @@
   display: flex;
   gap: 0.5rem;
   border-bottom: 1px dotted var(--crm-c-gray-200);
-  padding: var(--crm-s-small) var(--crm-s-medium) !important;
+  padding: var(--crm-l-small) var(--crm-l-medium) !important;
   align-items: center;
   flex-wrap: wrap;
 }
@@ -28,7 +28,7 @@ crm-search-display-tree-branch crm-search-display-tree-branch:has( > ul > li) {
 #bootstrap-theme .crm-search-display-tree-collapse-toggle {
   background: var(--crm-c-gray-200);
   color: var(--crm-text-color);
-  padding: var(--crm-btn-icon-padding) var(--crm-s-medium) var(--crm-btn-icon-padding) 0 !important /* vs crmSearchAdmin */;
+  padding: var(--crm-btn-icon-padding) var(--crm-l-medium) var(--crm-btn-icon-padding) 0 !important /* vs crmSearchAdmin */;
 }
 #bootstrap-theme li.crm-search-display-tree-branch-collapsed {
   /* For collapsed items, add bottom padding to compensate for the hidden subtree */
@@ -72,9 +72,9 @@ crm-search-display-tree-branch crm-search-display-editable form {
 }
 .crm-separator-above {
   border-top: 2px solid var(--crm-c-blue);
-  padding-top: var(--crm-s-small);
+  padding-top: var(--crm-l-small);
 }
 .crm-separator-below {
   border-bottom: 2px solid var(--crm-c-blue);
-  margin-bottom: var(--crm-s-small);
+  margin-bottom: var(--crm-l-small);
 }

--- a/ext/riverlea/docs/RiverleaStream_MyStream.mgd.php.template
+++ b/ext/riverlea/docs/RiverleaStream_MyStream.mgd.php.template
@@ -22,11 +22,11 @@
 //          # Set stream variables directly here:
 //
 //         'vars' => [
-//            '--crm-c-primary' => 'purple',
+//            '--crm-primary-color' => 'purple',
 //          ],
 //         'vars_dark' => [
 //            # Extra variables for dark mode
-//            '--crm-c-primary' => 'blue',
+//            '--crm-primary-color' => 'blue',
 //          ],
 //
 //          # If you want to add static css files to your stream, then uncomment

--- a/ext/riverlea/streams/empty/_dark.css
+++ b/ext/riverlea/streams/empty/_dark.css
@@ -1,6 +1,6 @@
 /* Minimal dark mode settings
    - delete this file if you don't want dark-mode
-   - it's generally easier to change practical colours (ie '--crm-c-page-bg')
+   - it's generally easier to change practical colours (ie '--crm-page-bg-color')
      than to change the colours themesleves (ie '--crm-c-gray-900').
 */
 
@@ -8,7 +8,7 @@
 /* Fonts '--crm-font-' */
 /* Colour names, e.g. green, red, blue '--crm-c-' */
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-text: var(--crm-c-text-light);
+  --crm-text-color: var(--crm-text-light-color);
 /* Backgrounds, '--crm-c-*-bg' */
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
 /* Shadows */

--- a/ext/riverlea/streams/empty/_dark.css
+++ b/ext/riverlea/streams/empty/_dark.css
@@ -8,9 +8,8 @@
 /* Fonts '--crm-font-' */
 /* Colour names, e.g. green, red, blue '--crm-c-' */
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-text: #fff;
+  --crm-c-text: var(--crm-c-text-light);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-page-bg: var(--crm-c-gray-900);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
 /* Shadows */
 /* Sizes */

--- a/ext/riverlea/streams/empty/_dark.css
+++ b/ext/riverlea/streams/empty/_dark.css
@@ -19,11 +19,11 @@
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
 /* Panels '--crm-panel-' */
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
 /* Tabs '--crm-tabs' */
-/* Contact layout '--crm-dash-' */
+/* Contact layout '--crm-contact-' */
 /* Dialog '--crm-dialog-' */
 /* Dashlet for main dashboard '--crm-dashlet-' */
 /* Button dropdowns '--crm-dropdown-' */

--- a/ext/riverlea/streams/empty/_variables.css
+++ b/ext/riverlea/streams/empty/_variables.css
@@ -28,7 +28,7 @@
         but these two variables text-light/dark stay the same as default.
       - Some colours use 'hsl' processing generate automatically. E.g. 'crm-c-primary-hover' is darker version of any 'crm-c-primary' colour.
         The same with alert-borders. In other words, check core to ensure you need to over-write every colour, if there's an auto colour and it works.
-      - 'crm-roundness' for border-radius is used in dozens of places, most of which (inputs, buttons, fieldsets, accordions, notifications, etc)
+      - 'crm-radius' for border-radius is used in dozens of places, most of which (inputs, buttons, fieldsets, accordions, notifications, etc)
         can be directly over-ridden with specific variables, e.g. '--crm-input-border-radius'
       - While you can add your own CSS here, it can prevent future updates of Civi and RiverLea updating for your theme.
       - Before adding your own CSS in a civicrm.css file a suggested workflow would be:
@@ -56,11 +56,11 @@
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
 /* Panels '--crm-panel-' */
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
 /* Tabs '--crm-tabs'/
-/* Contact layout '--crm-dash-' */
+/* Contact layout '--crm-contact-' */
 /* Dialog '--crm-dialog-' */
 /* Dashlet for main dashboard '--crm-dashlet-' */
 /* Button dropdowns '--crm-dropdown-' */

--- a/ext/riverlea/streams/empty/_variables.css
+++ b/ext/riverlea/streams/empty/_variables.css
@@ -40,7 +40,6 @@
 */
 
 :root {
-/* Fonts '--crm-font-' */
 /* Colour names, e.g. green, red, blue '--crm-c-' */
 /* Practical colours, e.g. text, link '--crm-c-' */
   --crm-c-text-light: #fff;
@@ -51,7 +50,7 @@
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
 /* Shadows */
 /* Sizes */
-/* Type */
+/* Type - fonts, link, heading */
 /* Mouse events */
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */

--- a/ext/riverlea/streams/empty/_variables.css
+++ b/ext/riverlea/streams/empty/_variables.css
@@ -45,7 +45,7 @@
   --crm-c-text-light: #fff;
   --crm-c-text-dark: #302f35;
   --crm-c-text: var(--crm-c-text-dark);
-  --crm-c-page-bg: #fff;
+  --crm-c-page-bg: var(--crm-paper);
 /* Backgrounds, '--crm-c-*-bg' */
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
 /* Shadows */

--- a/ext/riverlea/streams/empty/_variables.css
+++ b/ext/riverlea/streams/empty/_variables.css
@@ -10,23 +10,23 @@
       - Variables often exist in chains, pointing to each other so that you can both
         have one change applied in multiple areas *and* over-ride that in a specific area.
       - These can run three deep, eg a colour variable ('--crm-c-amber'), is applied to a
-        functional colour variable ('--crm-c-warning') that's then used by '--crm-btn-bg-warning'
-        and '--crm-notify-warning'
+        functional colour variable ('--crm-warning-color') that's then used by '--crm-btn-bg-warning'
+        and '--crm-notify-warning-color'
       - All of these are defined in Core Variables, so before replacing in a Stream, decide what your goal is.
       - E.g., if you wanted to change warning colours to pink. you could redefine '--crm-c-amber'
         to point to a pink colour property. But that loses the semantic meaning and maybe there's other
         places that point to amber. It's probably safer to add a variable in your stream '--crm-c-pink'
-        that matches your colour, then set '--crm-c-warning: var(--crm-c-pink)'.
+        that matches your colour, then set '--crm-warning-color: var(--crm-c-pink)'.
       - If you only want warning buttons to change, and not notifications, then you could
         just set '--crm-btn-bg-warning: var(--crm-c-pink)'
       - Good contrast between backgrounds (usually with 'bg' in the variable name) and foreground (usually with 'text') are
-        needed for accessibility. So most functional colours exist in pairs: '--crm-c-warning' and '--crm-c-warning-text'.
+        needed for accessibility. So most functional colours exist in pairs: '--crm-warning-color' and '--crm-warning-text-color'.
       - These can be checked with a tool like https://webaim.org/resources/contrastchecker/ - with
         4.5:1 ratio needed for WCAG AA and 7:1 for WCAG AAA.
-      - '--text' as a foreground colour is normally a black or a white shade, pointing to '--crm-c-text-dark' or '--crm-c-text-light'.
+      - '--text' as a foreground colour is normally a black or a white shade, pointing to '--crm-text-dark-color' or '--crm-text-light-color'.
       - This terminology is key for the inversion with dark-mode, when '-crm-c-text' will change from dark to light
         but these two variables text-light/dark stay the same as default.
-      - Some colours use 'hsl' processing generate automatically. E.g. 'crm-c-primary-hover' is darker version of any 'crm-c-primary' colour.
+      - Some colours use 'hsl' processing generate automatically. E.g. 'crm-primary-color-hover' is darker version of any 'crm-primary-color' colour.
         The same with alert-borders. In other words, check core to ensure you need to over-write every colour, if there's an auto colour and it works.
       - 'crm-radius' for border-radius is used in dozens of places, most of which (inputs, buttons, fieldsets, accordions, notifications, etc)
         can be directly over-ridden with specific variables, e.g. '--crm-input-border-radius'
@@ -42,10 +42,10 @@
 :root {
 /* Colour names, e.g. green, red, blue '--crm-c-' */
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-text-light: #fff;
-  --crm-c-text-dark: #302f35;
-  --crm-c-text: var(--crm-c-text-dark);
-  --crm-c-page-bg: var(--crm-paper);
+  --crm-text-light-color: #fff;
+  --crm-text-dark-color: #302f35;
+  --crm-text-color: var(--crm-text-dark-color);
+  --crm-page-bg-color: var(--crm-paper);
 /* Backgrounds, '--crm-c-*-bg' */
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
 /* Shadows */

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -41,21 +41,21 @@
   --crm-table-row-hover: var(--crm-c-layer2-bg);
 /* Panels '--crm-panel-' */
   --crm-panel-border-col: var(--crm-c-gray-500);
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
-  --crm-expand-header-bg: var(--crm-c-layer2-bg);
-  --crm-expand-header-bg-active: var(--crm-c-gray-600);
-  --crm-expand-body-border: 0;
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
+  --crm-accordion-header-bg: var(--crm-c-layer2-bg);
+  --crm-accordion-header-bg-active: var(--crm-c-gray-600);
+  --crm-accordion-body-border: 0;
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
   --crm-input-border-color: var(--crm-c-gray-500);
   --crm-checkbox-list-bg: #665800;
 /* Tabs '--crm-tabs' */
   --crm-tab-bg-active: var(--crm-c-layer1-bg);
-/* Contact layout '--crm-dash-' */
-  --crm-dash-header-bg: transparent;
-  --crm-dash-tab-bg-hover: var(--crm-c-layer1-bg);
-  --crm-dash-block-bg: var(--crm-c-layer1-bg);
-  --crm-dash-summary-row-bg: var(--crm-c-container-bg);
+/* Contact layout '--crm-contact-' */
+  --crm-contact-header-bg: transparent;
+  --crm-contact-tab-bg-hover: var(--crm-c-layer1-bg);
+  --crm-contact-block-bg: var(--crm-c-layer1-bg);
+  --crm-contact-summary-row-bg: var(--crm-c-container-bg);
 /* Dialog '--crm-dialog-' */
   --crm-dialog-header-bg: var(--crm-c-layer1-bg);
   --crm-dialog-body-bg: var(--crm-c-layer1-bg);

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -63,7 +63,7 @@
   --crm-dashlet-tabs-border: 0;
 /* Button dropdowns '--crm-dropdown-' */
   --crm-dropdown-bg-color: var(--crm-layer1-bg-color);
-  --crm-dropdown-2-bg-color: var(--crm-layer1-bg-color);
+  --crm-dropdown2-bg-color: var(--crm-layer1-bg-color);
 /* Notifications '--crm-notify-' */
   --crm-notify-bg-color: var(--crm-c-darkest);
   --crm-notify-color: var(--crm-text-light-color);

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -15,65 +15,65 @@
   --crm-c-gray-300: #e1dfdf;
   --crm-c-gray-200: #bdbdbd;
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-link: #f5c929;
-  --crm-c-link-hover: #f2d465;
-  --crm-c-focus: #00a3a5;
+  --crm-link-color: #f5c929;
+  --crm-link-hover-color: #f2d465;
+  --crm-focus-color: #00a3a5;
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-container-bg: var(--crm-paper);
+  --crm-container-bg-color: var(--crm-paper);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
-  --crm-c-primary: var(--crm-c-container-bg);
-  --crm-c-primary-text: var(--crm-c-text);
-  --crm-c-secondary: var(--crm-c-layer1-bg);
+  --crm-primary-color: var(--crm-container-bg-color);
+  --crm-primary-text-color: var(--crm-text-color);
+  --crm-secondary-color: var(--crm-layer1-bg-color);
 /* Shadows */
   --crm-shadow-block: 0;
 /* Sizes */
 /* Type */
-  --crm-heading-bg: #354b55;
+  --crm-heading-bg-color: #354b55;
 /* Mouse events */
 /* Buttons '--crm-btn-' */
-  --crm-btn-icon-bg: var(--crm-c-gray-700);
+  --crm-btn-icon-bg-color: var(--crm-c-gray-700);
   --crm-btn-border: 1px solid var(--crm-c-gray-500);
 /* Tables '--crm-table-' */
-  --crm-table-row-bg: var(--crm-c-layer1-bg);
+  --crm-table-row-bg-color: var(--crm-layer1-bg-color);
   --crm-table-row-border: 1px solid var(--crm-c-gray-200);
-  --crm-table-row-hover: var(--crm-c-layer2-bg);
+  --crm-table-row-hover-color: var(--crm-layer2-bg-color);
 /* Panels '--crm-panel-' */
   --crm-panel-border-col: var(--crm-c-gray-500);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
-  --crm-accordion-header-bg: var(--crm-c-layer2-bg);
-  --crm-accordion-header-bg-active: var(--crm-c-gray-600);
+  --crm-accordion-header-bg-color: var(--crm-layer2-bg-color);
+  --crm-accordion-header-bg-active-color: var(--crm-c-gray-600);
   --crm-accordion-body-border: 0;
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
   --crm-input-border-color: var(--crm-c-gray-500);
-  --crm-checkbox-list-bg: #665800;
+  --crm-form-checkbox-list-bg-color: #665800;
 /* Tabs '--crm-tabs' */
-  --crm-tab-bg-active: var(--crm-c-layer1-bg);
+  --crm-tab-bg-active: var(--crm-layer1-bg-color);
 /* Contact layout '--crm-contact-' */
-  --crm-contact-header-bg: transparent;
-  --crm-contact-tab-bg-hover: var(--crm-c-layer1-bg);
-  --crm-contact-block-bg: var(--crm-c-layer1-bg);
-  --crm-contact-summary-row-bg: var(--crm-c-container-bg);
+  --crm-contact-header-bg-color: transparent;
+  --crm-contact-tab-hover-bg-color: var(--crm-layer1-bg-color);
+  --crm-contact-block-bg-color: var(--crm-layer1-bg-color);
+  --crm-contact-summary-row-bg-color: var(--crm-container-bg-color);
 /* Dialog '--crm-dialog-' */
-  --crm-dialog-header-bg: var(--crm-c-layer1-bg);
-  --crm-dialog-body-bg: var(--crm-c-layer1-bg);
+  --crm-dialog-header-bg-color: var(--crm-layer1-bg-color);
+  --crm-dialog-body-bg-color: var(--crm-layer1-bg-color);
 /* Dashlet for main dashboard '--crm-dashlet-' */
-  --crm-dashlet-bg: var(--crm-c-layer1-bg);
-  --crm-dashlet-header-bg: var(--crm-c-layer2-bg);
+  --crm-dashlet-bg-color: var(--crm-layer1-bg-color);
+  --crm-dashlet-header-bg-color: var(--crm-layer2-bg-color);
   --crm-dashlet-tabs-border: 0;
 /* Button dropdowns '--crm-dropdown-' */
-  --crm-dropdown-bg: var(--crm-c-layer1-bg);
-  --crm-dropdown-2-bg: var(--crm-c-layer1-bg);
+  --crm-dropdown-bg-color: var(--crm-layer1-bg-color);
+  --crm-dropdown-2-bg-color: var(--crm-layer1-bg-color);
 /* Notifications '--crm-notify-' */
-  --crm-notify-bg: var(--crm-c-darkest);
-  --crm-notify-col: var(--crm-c-text-light);
+  --crm-notify-bg-color: var(--crm-c-darkest);
+  --crm-notify-color: var(--crm-text-light-color);
 /* Icons '--crm-icon-' */
-  --crm-icon-danger-color: var(--crm-notify-danger);
-  --crm-icon-success-color: var(--crm-notify-success);
-  --crm-icon-warning-color: var(--crm-notify-warning);
+  --crm-icon-danger-color: var(--crm-notify-danger-color);
+  --crm-icon-success-color: var(--crm-notify-success-color);
+  --crm-icon-warning-color: var(--crm-notify-warning-color);
 /* Wizard '--crm-wizard-' */
-  --crm-wizard-active-bg: var(--crm-c-blue-dark);
+  --crm-wizard-active-bg-color: var(--crm-c-blue-dark);
 /* Alpha filter '--crm-filter-' */
-  --crm-filter-item-bg: var(--crm-c-layer1-bg);
+  --crm-filter-item-bg-color: var(--crm-layer1-bg-color);
 /* Frontend '--crm-f- */
 }

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -18,10 +18,8 @@
   --crm-c-link: #f5c929;
   --crm-c-link-hover: #f2d465;
   --crm-c-focus: #00a3a5;
-  --crm-c-inactive: var(--crm-c-gray-400);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-layer0-bg: var(--crm-c-gray-900);
-  --crm-c-container-bg: var(--crm-c-gray-900);
+  --crm-c-container-bg: var(--crm-paper);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
   --crm-c-primary: var(--crm-c-container-bg);
   --crm-c-primary-text: var(--crm-c-text);

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -27,7 +27,7 @@
   --crm-c-primary-text: var(--crm-c-text);
   --crm-c-secondary: var(--crm-c-layer1-bg);
 /* Shadows */
-  --crm-block-shadow: 0;
+  --crm-shadow-block: 0;
 /* Sizes */
 /* Type */
   --crm-heading-bg: #354b55;

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -13,7 +13,7 @@
   --crm-c-teal: #399389;
   /* Practical colours */
   --crm-c-text: #2b2b2b;
-  --crm-c-divider: 1px solid var(--crm-c-gray-200);
+  --crm-border-color: var(--crm-c-gray-200);
   --crm-c-container-bg: var(--crm-c-gray-025);
 /* Emphasis colours */
   --crm-c-primary: var(--crm-c-gray-025);
@@ -65,7 +65,7 @@
   --crm-input-label-width: 10em;
   --crm-fieldset-border: 1px;
   /* Tabs */
-  --crm-tabs-border: var(--crm-c-divider);
+  --crm-tabs-border: var(--crm-border);
   --crm-tab-count-bg: var(--crm-c-blue-dark);
   --crm-tab-count-col: var(--crm-c-text-light);
   --crm-tab-border: 1px solid var(--crm-c-gray-400);
@@ -82,7 +82,7 @@
   --crm-contact-tab-bg-hover: var(--crm-c-container-bg);
   --crm-contact-tab-padding: var(--crm-m2) var(--crm-m1) var(--crm-m2) var(--crm-r);
   --crm-contact-tab-border: 1px solid transparent;
-  --crm-contact-tab-border-hover: var(--crm-c-divider);
+  --crm-contact-tab-border-hover: var(--crm-border);
   --crm-contact-tab-border-width: 1px 0 1px 1px; /* to remove border on one side for hanging tabs */
   --crm-contact-tab-width: auto; /* 100% to fill column width, auto to only cover contents */
   --crm-contact-tab-align: right;
@@ -92,7 +92,7 @@
   --crm-contact-heading-inset: var(--crm-side-tabs-width);
   --crm-contact-panel-padding: var(--crm-r);
   --crm-contact-panel-bg: var(--crm-contact-tab-bg-hover);
-  --crm-contact-panel-border: var(--crm-c-divider);
+  --crm-contact-panel-border: var(--crm-border);
   --crn-dash-panel-radius: var(--crm-contact-radius);
   --crm-contact-image-size: 100px;
   --crm-contact-image-radius: 200px;
@@ -109,7 +109,7 @@
   --crm-dialog-body-bg: var(--crm-c-container-bg);
   --crm-dialog-body-padding: var(--crm-r);
   /* Dashlet */
-  --crm-dashlet-border: var(--crm-c-divider);
+  --crm-dashlet-border: var(--crm-border);
   --crm-dashlet-padding: 0;
   --crm-dashlet-content-padding: var(--crm-m);
   --crm-dashlet-tabs-border: 3px solid #fff;

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -27,12 +27,12 @@
   --crm-info-color: var(--crm-c-blue-darker);
   /* Type */
   --crm-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
-  --crm-heading-padding: var(--crm-s-small-2) var(--crm-s-medium-2);
+  --crm-heading-padding: var(--crm-l-small-2) var(--crm-l-medium-2);
   /* Buttons */
   --crm-btn-border: 1px solid var(--crm-c-gray-300);
   --crm-btn-padding-block: 2px; /* padding for top and bottom, one value */
   --crm-btn-height: 31px;
-  --crm-btn-icon-spacing: var(--crm-s-medium-1);
+  --crm-btn-icon-spacing: var(--crm-l-medium-1);
   --crm-btn-icon-size: var(--crm-btn-height);
   --crm-btn-cancel-bg-color: var(--crm-primary-color);
   --crm-btn-cancel-text-color: var(--crm-primary-text-color);
@@ -54,7 +54,7 @@
   --crm-accordion-header-color: var(--crm-text-color);
   --crm-accordion-header-border: 0 solid transparent;
   /* Alerts */
-  --crm-alert-padding: var(--crm-s-reg);
+  --crm-alert-padding: var(--crm-l-reg);
   --crm-alert-success-text-color: var(--crm-text-color);
   --crm-alert-info-text-color: var(--crm-c-blue-darker);
   --crm-alert-danger-text-color: var(--crm-text-color);
@@ -75,14 +75,14 @@
   --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: 200px;
   --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
-  --crm-contact-tabs-gap: var(--crm-s-medium);
+  --crm-contact-tabs-gap: var(--crm-l-medium);
   --crm-contact-tabs-bg-color: transparent;
-  --crm-contact-tabs-padding: var(--crm-s-reg) 0;
+  --crm-contact-tabs-padding: var(--crm-l-reg) 0;
   --crm-contact-tab-bg-color: transparent;
   --crm-contact-tab-hover-bg-color: var(--crm-container-bg-color);
-  --crm-contact-tab-padding: var(--crm-s-medium-2) var(--crm-s-medium-1) var(--crm-s-medium-2) var(--crm-s-reg);
+  --crm-contact-tab-padding: var(--crm-l-medium-2) var(--crm-l-medium-1) var(--crm-l-medium-2) var(--crm-l-reg);
   --crm-contact-tab-border: 1px solid transparent;
-  --crm-contact-tab-border-hover: var(--crm-border);
+  --crm-contact-tab-hover-border: var(--crm-border);
   --crm-contact-tab-border-width: 1px 0 1px 1px; /* to remove border on one side for hanging tabs */
   --crm-contact-tab-width: auto; /* 100% to fill column width, auto to only cover contents */
   --crm-contact-tab-align: right;
@@ -90,7 +90,7 @@
   --crm-contact-tab-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
   --crm-contact-summary-row-bg-color: var(--crm-layer2-bg-color);
   --crm-contact-heading-inset: var(--crm-side-tabs-width);
-  --crm-contact-panel-padding: var(--crm-s-reg);
+  --crm-contact-panel-padding: var(--crm-l-reg);
   --crm-contact-panel-bg-color: var(--crm-contact-tab-hover-bg-color);
   --crm-contact-panel-border: var(--crm-border);
   --crn-dash-panel-radius: var(--crm-contact-radius);
@@ -103,24 +103,24 @@
   --crm-dialog-header-bg-color: var(--crm-c-gray-200);
   --crm-dialog-header-border-color: transparent;
   --crm-dialog-header-color: var(--crm-text-color);
-  --crm-dialog-header-size: var(--crm-s-reg);
-  --crm-dialog-header-padding: var(--crm-s-small) var(--crm-s-medium-1) var(--crm-s-small) var(--crm-s-medium-2);
+  --crm-dialog-header-size: var(--crm-l-reg);
+  --crm-dialog-header-padding: var(--crm-l-small) var(--crm-l-medium-1) var(--crm-l-small) var(--crm-l-medium-2);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
   --crm-dialog-body-bg-color: var(--crm-container-bg-color);
-  --crm-dialog-body-padding: var(--crm-s-reg);
+  --crm-dialog-body-padding: var(--crm-l-reg);
   /* Dashlet */
   --crm-dashlet-border: var(--crm-border);
   --crm-dashlet-padding: 0;
-  --crm-dashlet-content-padding: var(--crm-s-medium);
+  --crm-dashlet-content-padding: var(--crm-l-medium);
   --crm-dashlet-tabs-border: 3px solid #fff;
-  --crm-dashlet-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
+  --crm-dashlet-radius: var(--crm-l-radius) var(--crm-l-radius) 0 0;
   /* Button dropdowns */
   --crm-dropdown-bg-color: var(--crm-paper);
   --crm-dropdown-color: var(--crm-text-color);
   --crm-dropdown-hover-bg-color: var(--crm-secondary-hover-color);
   --crm-dropdown-border: var(--crm-btn-border);
   --crm-dropdown-width: 180px;
-  --crm-dropdown-2-bg-color: var(--crm-layer2-bg-color);
+  --crm-dropdown2-bg-color: var(--crm-layer2-bg-color);
   /* Notifications */
   --crm-notify-bg-color: rgb(0,0,0);
   --crm-notify-padding: 10px 10px 15px 15px;
@@ -133,11 +133,11 @@
   --crm-icon-info-color: var(--crm-notify-info-color);
   /* Frontend */
   --crm-f-legend-align: unset;
-  --crm-f-legend-size: var(--crm-s-reg-2);
+  --crm-f-legend-size: var(--crm-l-reg-2);
   --crm-f-form-width: 50vw;
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
   --crm-f-label-align: left;
-  --crm-f-label-margin: 0 var(--crm-s-small);
+  --crm-f-label-margin: 0 var(--crm-l-small);
   --crm-f-label-width: unset;
   --crm-f-label-weight: bold;
 }

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -4,8 +4,6 @@
 */
 
 :root {
-  /* Fonts */
-  --crm-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   /* Colour names */
   --crm-c-gray-025: #f9f9f9;
   --crm-c-green-light: #cff0be;
@@ -28,6 +26,7 @@
   --crm-c-secondary-on-page-bg: var(--crm-c-gray-900);
   --crm-c-info: var(--crm-c-blue-darker);
   /* Type */
+  --crm-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   --crm-heading-padding: var(--crm-s2) var(--crm-m2);
   /* Buttons */
   --crm-btn-border: 1px solid var(--crm-c-gray-300);

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -12,19 +12,19 @@
   --crm-c-red: #f9f1f4;
   --crm-c-teal: #399389;
   /* Practical colours */
-  --crm-c-text: #2b2b2b;
+  --crm-text-color: #2b2b2b;
   --crm-border-color: var(--crm-c-gray-200);
-  --crm-c-container-bg: var(--crm-c-gray-025);
+  --crm-container-bg-color: var(--crm-c-gray-025);
 /* Emphasis colours */
-  --crm-c-primary: var(--crm-c-gray-025);
-  --crm-c-primary-text: var(--crm-c-text);
-  --crm-c-primary-hover-text: var(--crm-c-primary-text);
-  --crm-c-primary-on-page-bg: var(--crm-c-gray-800);
-  --crm-c-secondary: var(--crm-c-gray-025);
-  --crm-c-secondary-text: var(--crm-c-text);
-  --crm-c-secondary-hover-text: var(--crm-c-text);
-  --crm-c-secondary-on-page-bg: var(--crm-c-gray-900);
-  --crm-c-info: var(--crm-c-blue-darker);
+  --crm-primary-color: var(--crm-c-gray-025);
+  --crm-primary-text-color: var(--crm-text-color);
+  --crm-primary-hover-text-color: var(--crm-primary-text-color);
+  --crm-primary-ink-color: var(--crm-c-gray-800);
+  --crm-secondary-color: var(--crm-c-gray-025);
+  --crm-secondary-text-color: var(--crm-text-color);
+  --crm-secondary-hover-text-color: var(--crm-text-color);
+  --crm-secondary-ink-color: var(--crm-c-gray-900);
+  --crm-info-color: var(--crm-c-blue-darker);
   /* Type */
   --crm-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   --crm-heading-padding: var(--crm-s2) var(--crm-m2);
@@ -34,52 +34,52 @@
   --crm-btn-height: 31px;
   --crm-btn-icon-spacing: var(--crm-m1);
   --crm-btn-icon-size: var(--crm-btn-height);
-  --crm-btn-cancel-bg: var(--crm-c-primary);
-  --crm-btn-cancel-text: var(--crm-c-primary-text);
-  --crm-btn-info-bg: var(--crm-c-primary);
-  --crm-btn-info-text: var(--crm-c-primary-text);
-  --crm-btn-warning-bg: var(--crm-c-primary);
-  --crm-btn-warning-text: var(--crm-c-primary-text);
-  --crm-btn-success-bg: var(--crm-c-primary);
-  --crm-btn-success-text: var(--crm-c-primary-text);
-  --crm-btn-danger-bg: var(--crm-c-primary);
-  --crm-btn-danger-text: var(--crm-c-primary-text);
-  --crm-btn-icon-bg: rgba(256,256,256,0.25);
+  --crm-btn-cancel-bg-color: var(--crm-primary-color);
+  --crm-btn-cancel-text-color: var(--crm-primary-text-color);
+  --crm-btn-info-bg-color: var(--crm-primary-color);
+  --crm-btn-info-text-color: var(--crm-primary-text-color);
+  --crm-btn-warning-bg-color: var(--crm-primary-color);
+  --crm-btn-warning-text-color: var(--crm-primary-text-color);
+  --crm-btn-success-bg-color: var(--crm-primary-color);
+  --crm-btn-success-text-color: var(--crm-primary-text-color);
+  --crm-btn-danger-bg-color: var(--crm-primary-color);
+  --crm-btn-danger-text-color: var(--crm-primary-text-color);
+  --crm-btn-icon-bg-color: rgba(256,256,256,0.25);
   --crm-btn-icon-border: var(--crm-btn-border);
   --crm-btn-icon-padding: 0px;
   /* Accordions */
   /* .crm-accordion-bold */
-  --crm-accordion-header-bg: var(--crm-c-gray-200);
-  --crm-accordion-header-bg-active: var(--crm-c-gray-300);
-  --crm-accordion-header-color: var(--crm-c-text);
+  --crm-accordion-header-bg-color: var(--crm-c-gray-200);
+  --crm-accordion-header-bg-active-color: var(--crm-c-gray-300);
+  --crm-accordion-header-color: var(--crm-text-color);
   --crm-accordion-header-border: 0 solid transparent;
   /* Alerts */
   --crm-alert-padding: var(--crm-r);
-  --crm-alert-success-text: var(--crm-c-text);
-  --crm-alert-info-text: var(--crm-c-blue-darker);
-  --crm-alert-danger-text: var(--crm-c-text);
+  --crm-alert-success-text-color: var(--crm-text-color);
+  --crm-alert-info-text-color: var(--crm-c-blue-darker);
+  --crm-alert-danger-text-color: var(--crm-text-color);
   /* Form */
   --crm-input-border-color: var(--crm-c-gray-300);
   --crm-input-box-shadow: 0;
   --crm-input-label-weight: normal;
   --crm-input-label-width: 10em;
-  --crm-fieldset-border: 1px;
+  --crm-form-fieldset-border: 1px;
   /* Tabs */
   --crm-tabs-border: var(--crm-border);
-  --crm-tab-count-bg: var(--crm-c-blue-dark);
-  --crm-tab-count-col: var(--crm-c-text-light);
+  --crm-tab-count-bg-color: var(--crm-c-blue-dark);
+  --crm-tab-count-color: var(--crm-text-light-color);
   --crm-tab-border: 1px solid var(--crm-c-gray-400);
-  --crm-tab-bg-active: var(--crm-c-container-bg);
+  --crm-tab-bg-active: var(--crm-container-bg-color);
   /* Contact dashboard */
   --crm-contact-border: 0;
   --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: 200px;
   --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
   --crm-contact-tabs-gap: var(--crm-m);
-  --crm-contact-tabs-bg: transparent;
+  --crm-contact-tabs-bg-color: transparent;
   --crm-contact-tabs-padding: var(--crm-r) 0;
-  --crm-contact-tab-bg: transparent;
-  --crm-contact-tab-bg-hover: var(--crm-c-container-bg);
+  --crm-contact-tab-bg-color: transparent;
+  --crm-contact-tab-hover-bg-color: var(--crm-container-bg-color);
   --crm-contact-tab-padding: var(--crm-m2) var(--crm-m1) var(--crm-m2) var(--crm-r);
   --crm-contact-tab-border: 1px solid transparent;
   --crm-contact-tab-border-hover: var(--crm-border);
@@ -88,10 +88,10 @@
   --crm-contact-tab-align: right;
   --crm-contact-tab-hang: 0 -1px 0 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-contact-tab-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
-  --crm-contact-summary-row-bg: var(--crm-c-layer2-bg);
+  --crm-contact-summary-row-bg-color: var(--crm-layer2-bg-color);
   --crm-contact-heading-inset: var(--crm-side-tabs-width);
   --crm-contact-panel-padding: var(--crm-r);
-  --crm-contact-panel-bg: var(--crm-contact-tab-bg-hover);
+  --crm-contact-panel-bg-color: var(--crm-contact-tab-hover-bg-color);
   --crm-contact-panel-border: var(--crm-border);
   --crn-dash-panel-radius: var(--crm-contact-radius);
   --crm-contact-image-size: 100px;
@@ -100,13 +100,13 @@
   --crm-contact-image-top: -10px; /* distance from top of dashboard */
   --crm-contact-image-border: 0;
   /* Dialog */
-  --crm-dialog-header-bg: var(--crm-c-gray-200);
-  --crm-dialog-header-border-col: transparent;
-  --crm-dialog-header-col: var(--crm-c-text);
+  --crm-dialog-header-bg-color: var(--crm-c-gray-200);
+  --crm-dialog-header-border-color: transparent;
+  --crm-dialog-header-color: var(--crm-text-color);
   --crm-dialog-header-size: var(--crm-r);
   --crm-dialog-header-padding: var(--crm-s) var(--crm-m1) var(--crm-s) var(--crm-m2);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
-  --crm-dialog-body-bg: var(--crm-c-container-bg);
+  --crm-dialog-body-bg-color: var(--crm-container-bg-color);
   --crm-dialog-body-padding: var(--crm-r);
   /* Dashlet */
   --crm-dashlet-border: var(--crm-border);
@@ -115,22 +115,22 @@
   --crm-dashlet-tabs-border: 3px solid #fff;
   --crm-dashlet-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   /* Button dropdowns */
-  --crm-dropdown-bg: var(--crm-paper);
-  --crm-dropdown-col: var(--crm-c-text);
-  --crm-dropdown-hover-bg: var(--crm-c-secondary-hover);
+  --crm-dropdown-bg-color: var(--crm-paper);
+  --crm-dropdown-color: var(--crm-text-color);
+  --crm-dropdown-hover-bg-color: var(--crm-secondary-hover-color);
   --crm-dropdown-border: var(--crm-btn-border);
   --crm-dropdown-width: 180px;
-  --crm-dropdown-2-bg: var(--crm-c-layer2-bg);
+  --crm-dropdown-2-bg-color: var(--crm-layer2-bg-color);
   /* Notifications */
-  --crm-notify-bg: rgb(0,0,0);
+  --crm-notify-bg-color: rgb(0,0,0);
   --crm-notify-padding: 10px 10px 15px 15px;
   --crm-notify-accent-border: 0 0 0 4px; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: 0;
   /* Icons */
-  --crm-icon-danger-color: var(--crm-c-danger);
-  --crm-icon-success-color: var(--crm-c-success);
-  --crm-icon-warning-color: var(--crm-c-warning);
-  --crm-icon-info-color: var(--crm-notify-info);
+  --crm-icon-danger-color: var(--crm-danger-color);
+  --crm-icon-success-color: var(--crm-success-color);
+  --crm-icon-warning-color: var(--crm-warning-color);
+  --crm-icon-info-color: var(--crm-notify-info-color);
   /* Frontend */
   --crm-f-legend-align: unset;
   --crm-f-legend-size: var(--crm-r2);

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -27,12 +27,12 @@
   --crm-info-color: var(--crm-c-blue-darker);
   /* Type */
   --crm-font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
-  --crm-heading-padding: var(--crm-s2) var(--crm-m2);
+  --crm-heading-padding: var(--crm-s-small-2) var(--crm-s-medium-2);
   /* Buttons */
   --crm-btn-border: 1px solid var(--crm-c-gray-300);
   --crm-btn-padding-block: 2px; /* padding for top and bottom, one value */
   --crm-btn-height: 31px;
-  --crm-btn-icon-spacing: var(--crm-m1);
+  --crm-btn-icon-spacing: var(--crm-s-medium-1);
   --crm-btn-icon-size: var(--crm-btn-height);
   --crm-btn-cancel-bg-color: var(--crm-primary-color);
   --crm-btn-cancel-text-color: var(--crm-primary-text-color);
@@ -54,7 +54,7 @@
   --crm-accordion-header-color: var(--crm-text-color);
   --crm-accordion-header-border: 0 solid transparent;
   /* Alerts */
-  --crm-alert-padding: var(--crm-r);
+  --crm-alert-padding: var(--crm-s-reg);
   --crm-alert-success-text-color: var(--crm-text-color);
   --crm-alert-info-text-color: var(--crm-c-blue-darker);
   --crm-alert-danger-text-color: var(--crm-text-color);
@@ -75,12 +75,12 @@
   --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: 200px;
   --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
-  --crm-contact-tabs-gap: var(--crm-m);
+  --crm-contact-tabs-gap: var(--crm-s-medium);
   --crm-contact-tabs-bg-color: transparent;
-  --crm-contact-tabs-padding: var(--crm-r) 0;
+  --crm-contact-tabs-padding: var(--crm-s-reg) 0;
   --crm-contact-tab-bg-color: transparent;
   --crm-contact-tab-hover-bg-color: var(--crm-container-bg-color);
-  --crm-contact-tab-padding: var(--crm-m2) var(--crm-m1) var(--crm-m2) var(--crm-r);
+  --crm-contact-tab-padding: var(--crm-s-medium-2) var(--crm-s-medium-1) var(--crm-s-medium-2) var(--crm-s-reg);
   --crm-contact-tab-border: 1px solid transparent;
   --crm-contact-tab-border-hover: var(--crm-border);
   --crm-contact-tab-border-width: 1px 0 1px 1px; /* to remove border on one side for hanging tabs */
@@ -90,7 +90,7 @@
   --crm-contact-tab-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
   --crm-contact-summary-row-bg-color: var(--crm-layer2-bg-color);
   --crm-contact-heading-inset: var(--crm-side-tabs-width);
-  --crm-contact-panel-padding: var(--crm-r);
+  --crm-contact-panel-padding: var(--crm-s-reg);
   --crm-contact-panel-bg-color: var(--crm-contact-tab-hover-bg-color);
   --crm-contact-panel-border: var(--crm-border);
   --crn-dash-panel-radius: var(--crm-contact-radius);
@@ -103,15 +103,15 @@
   --crm-dialog-header-bg-color: var(--crm-c-gray-200);
   --crm-dialog-header-border-color: transparent;
   --crm-dialog-header-color: var(--crm-text-color);
-  --crm-dialog-header-size: var(--crm-r);
-  --crm-dialog-header-padding: var(--crm-s) var(--crm-m1) var(--crm-s) var(--crm-m2);
+  --crm-dialog-header-size: var(--crm-s-reg);
+  --crm-dialog-header-padding: var(--crm-s-small) var(--crm-s-medium-1) var(--crm-s-small) var(--crm-s-medium-2);
   --crm-dialog-header-radius: var(--crm-dialog-radius);
   --crm-dialog-body-bg-color: var(--crm-container-bg-color);
-  --crm-dialog-body-padding: var(--crm-r);
+  --crm-dialog-body-padding: var(--crm-s-reg);
   /* Dashlet */
   --crm-dashlet-border: var(--crm-border);
   --crm-dashlet-padding: 0;
-  --crm-dashlet-content-padding: var(--crm-m);
+  --crm-dashlet-content-padding: var(--crm-s-medium);
   --crm-dashlet-tabs-border: 3px solid #fff;
   --crm-dashlet-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   /* Button dropdowns */
@@ -133,11 +133,11 @@
   --crm-icon-info-color: var(--crm-notify-info-color);
   /* Frontend */
   --crm-f-legend-align: unset;
-  --crm-f-legend-size: var(--crm-r2);
+  --crm-f-legend-size: var(--crm-s-reg-2);
   --crm-f-form-width: 50vw;
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
   --crm-f-label-align: left;
-  --crm-f-label-margin: 0 var(--crm-s);
+  --crm-f-label-margin: 0 var(--crm-s-small);
   --crm-f-label-width: unset;
   --crm-f-label-weight: bold;
 }

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -115,7 +115,7 @@
   --crm-dashlet-tabs-border: 3px solid #fff;
   --crm-dashlet-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   /* Button dropdowns */
-  --crm-dropdown-bg: var(--crm-c-layer0-bg);
+  --crm-dropdown-bg: var(--crm-paper);
   --crm-dropdown-col: var(--crm-c-text);
   --crm-dropdown-hover-bg: var(--crm-c-secondary-hover);
   --crm-dropdown-border: var(--crm-btn-border);

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -50,10 +50,10 @@
   --crm-btn-icon-padding: 0px;
   /* Accordions */
   /* .crm-accordion-bold */
-  --crm-expand-header-bg: var(--crm-c-gray-200);
-  --crm-expand-header-bg-active: var(--crm-c-gray-300);
-  --crm-expand-header-color: var(--crm-c-text);
-  --crm-expand-header-border: 0 solid transparent;
+  --crm-accordion-header-bg: var(--crm-c-gray-200);
+  --crm-accordion-header-bg-active: var(--crm-c-gray-300);
+  --crm-accordion-header-color: var(--crm-c-text);
+  --crm-accordion-header-border: 0 solid transparent;
   /* Alerts */
   --crm-alert-padding: var(--crm-r);
   --crm-alert-success-text: var(--crm-c-text);
@@ -72,34 +72,34 @@
   --crm-tab-border: 1px solid var(--crm-c-gray-400);
   --crm-tab-bg-active: var(--crm-c-container-bg);
   /* Contact dashboard */
-  --crm-dash-border: 0;
-  --crm-dash-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
+  --crm-contact-border: 0;
+  --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: 200px;
-  --crm-dash-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
-  --crm-dash-tabs-gap: var(--crm-m);
-  --crm-dash-tabs-bg: transparent;
-  --crm-dash-tabs-padding: var(--crm-r) 0;
-  --crm-dash-tab-bg: transparent;
-  --crm-dash-tab-bg-hover: var(--crm-c-container-bg);
-  --crm-dash-tab-padding: var(--crm-m2) var(--crm-m1) var(--crm-m2) var(--crm-r);
-  --crm-dash-tab-border: 1px solid transparent;
-  --crm-dash-tab-border-hover: var(--crm-c-divider);
-  --crm-dash-tab-border-width: 1px 0 1px 1px; /* to remove border on one side for hanging tabs */
-  --crm-dash-tab-width: auto; /* 100% to fill column width, auto to only cover contents */
-  --crm-dash-tab-align: right;
-  --crm-dash-tab-hang: 0 -1px 0 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-dash-tab-radius: var(--crm-dash-roundness) 0 0 var(--crm-dash-roundness);
-  --crm-dash-summary-row-bg: var(--crm-c-layer2-bg);
-  --crm-dash-heading-inset: var(--crm-side-tabs-width);
-  --crm-dash-panel-padding: var(--crm-r);
-  --crm-dash-panel-bg: var(--crm-dash-tab-bg-hover);
-  --crm-dash-panel-border: var(--crm-c-divider);
-  --crn-dash-panel-radius: var(--crm-dash-roundness);
-  --crm-dash-image-size: 100px;
-  --crm-dash-image-radius: 200px;
-  --crm-dash-image-right: 0; /* distance from right of dashboard */
-  --crm-dash-image-top: -10px; /* distance from top of dashboard */
-  --crm-dash-image-border: 0;
+  --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
+  --crm-contact-tabs-gap: var(--crm-m);
+  --crm-contact-tabs-bg: transparent;
+  --crm-contact-tabs-padding: var(--crm-r) 0;
+  --crm-contact-tab-bg: transparent;
+  --crm-contact-tab-bg-hover: var(--crm-c-container-bg);
+  --crm-contact-tab-padding: var(--crm-m2) var(--crm-m1) var(--crm-m2) var(--crm-r);
+  --crm-contact-tab-border: 1px solid transparent;
+  --crm-contact-tab-border-hover: var(--crm-c-divider);
+  --crm-contact-tab-border-width: 1px 0 1px 1px; /* to remove border on one side for hanging tabs */
+  --crm-contact-tab-width: auto; /* 100% to fill column width, auto to only cover contents */
+  --crm-contact-tab-align: right;
+  --crm-contact-tab-hang: 0 -1px 0 0; /* lip to extend tab flush with active region - set to 0 for no lip */
+  --crm-contact-tab-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
+  --crm-contact-summary-row-bg: var(--crm-c-layer2-bg);
+  --crm-contact-heading-inset: var(--crm-side-tabs-width);
+  --crm-contact-panel-padding: var(--crm-r);
+  --crm-contact-panel-bg: var(--crm-contact-tab-bg-hover);
+  --crm-contact-panel-border: var(--crm-c-divider);
+  --crn-dash-panel-radius: var(--crm-contact-radius);
+  --crm-contact-image-size: 100px;
+  --crm-contact-image-radius: 200px;
+  --crm-contact-image-right: 0; /* distance from right of dashboard */
+  --crm-contact-image-top: -10px; /* distance from top of dashboard */
+  --crm-contact-image-border: 0;
   /* Dialog */
   --crm-dialog-header-bg: var(--crm-c-gray-200);
   --crm-dialog-header-border-col: transparent;
@@ -114,7 +114,7 @@
   --crm-dashlet-padding: 0;
   --crm-dashlet-content-padding: var(--crm-m);
   --crm-dashlet-tabs-border: 3px solid #fff;
-  --crm-dashlet-radius: var(--crm-roundness) var(--crm-roundness) 0 0;
+  --crm-dashlet-radius: var(--crm-s-radius) var(--crm-s-radius) 0 0;
   /* Button dropdowns */
   --crm-dropdown-bg: var(--crm-c-layer0-bg);
   --crm-dropdown-col: var(--crm-c-text);

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -13,10 +13,8 @@
   --crm-c-focus: #8cd4cb;
   --crm-c-link: var(--crm-c-teal);
   --crm-c-link-hover: var(--crm-c-yellow);
-  --crm-c-inactive: color-mix(in srgb,var(--crm-c-text) 95%,#000 5%);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-layer0-bg: var(--crm-c-gray-900);
-  --crm-c-page-bg: var(--crm-c-gray-900);
+  --crm-c-page-bg: var(--crm-paper);
   --crm-c-container-bg: var(--crm-c-gray-800);
   --crm-c-inverse-bg: var(--crm-c-gray-300);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -36,19 +36,19 @@
   --crm-table-row-hover: var(--crm-c-amber);
 /* Panels '--crm-panel-' */
   --crm-panel-border-col: var(--crm-c-gray-200);
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
-  --crm-expand-header-bg: var(--crm-c-layer2-bg);
-  --crm-expand-header-bg-active: var(--crm-c-gray-600);
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
+  --crm-accordion-header-bg: var(--crm-c-layer2-bg);
+  --crm-accordion-header-bg-active: var(--crm-c-gray-600);
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
   --crm-form-block-bg: var(--crm-c-layer1-bg);
   --crm-input-border-color: var(--crm-c-gray-200);
   --crm-input-radio-color: #38c4b4;
 /* Tabs '--crm-tabs'/
-/* Contact layout '--crm-dash-' */
-  --crm-dash-header-bg: transparent;
-  --crm-dash-block-bg: var(--crm-c-layer1-bg);
-  --crm-dash-panel-bg: #414141;
+/* Contact layout '--crm-contact-' */
+  --crm-contact-header-bg: transparent;
+  --crm-contact-block-bg: var(--crm-c-layer1-bg);
+  --crm-contact-panel-bg: #414141;
 /* Dialog '--crm-dialog-' */
   --crm-dialog-header-bg: var(--crm-c-layer1-bg);
   --crm-dialog-body-bg: var(--crm-c-layer1-bg);

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -31,7 +31,7 @@
 /* Mouse events */
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
-  --crm-table-outside-border: var(--crm-c-divider);
+  --crm-table-outside-border: var(--crm-border);
   --crm-table-row-border: 1px solid var(--crm-c-gray-200);
   --crm-table-row-hover: var(--crm-c-amber);
 /* Panels '--crm-panel-' */

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -55,12 +55,12 @@
   --crm-dashlet-header-bg-color: var(--crm-layer2-bg-color);
 /* Button dropdowns '--crm-dropdown-' */
   --crm-dropdown-bg-color: var(--crm-layer1-bg-color);
-  --crm-dropdown-2-bg-color: var(--crm-layer1-bg-color);
+  --crm-dropdown2-bg-color: var(--crm-layer1-bg-color);
 /* Notifications '--crm-notify-' */
   --crm-notify-bg-color: var(--crm-c-darkest);
 /* Icons '--crm-icon-' */
 /* Wizard '--crm-wizard-' */
-  --crm-wizard-active-bg-color: var(--crm-c-dark-teal);
+  --crm-wizard-active-bg-color: var(--crm-c-teal-dark);
 /* Alpha filter '--crm-filter-' */
   --crm-filter-item-bg-color: var(--crm-layer1-bg-color);
 /* Frontend '--crm-f- */

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -10,58 +10,58 @@
   --crm-c-gray-300: #e1dfdf;
   --crm-c-gray-200: #bdbdbd;
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-focus: #8cd4cb;
-  --crm-c-link: var(--crm-c-teal);
-  --crm-c-link-hover: var(--crm-c-yellow);
+  --crm-focus-color: #8cd4cb;
+  --crm-link-color: var(--crm-c-teal);
+  --crm-link-hover-color: var(--crm-c-yellow);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-page-bg: var(--crm-paper);
-  --crm-c-container-bg: var(--crm-c-gray-800);
-  --crm-c-inverse-bg: var(--crm-c-gray-300);
+  --crm-page-bg-color: var(--crm-paper);
+  --crm-container-bg-color: var(--crm-c-gray-800);
+  --crm-inverse-bg-color: var(--crm-c-gray-300);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
-  --crm-c-primary: var(--crm-c-gray-500);
-  --crm-c-primary-hover: var(--crm-c-gray-600);
-  --crm-c-primary-text: var(--crm-c-text);
+  --crm-primary-color: var(--crm-c-gray-500);
+  --crm-primary-hover-color: var(--crm-c-gray-600);
+  --crm-primary-text-color: var(--crm-text-color);
 /* Shadows */
   --crm-shadow-block: 0;
 /* Sizes */
 /* Type */
-  --crm-heading-bg: var(--crm-c-blue-dark);
+  --crm-heading-bg-color: var(--crm-c-blue-dark);
 /* Mouse events */
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
   --crm-table-outside-border: var(--crm-border);
   --crm-table-row-border: 1px solid var(--crm-c-gray-200);
-  --crm-table-row-hover: var(--crm-c-amber);
+  --crm-table-row-hover-color: var(--crm-c-amber);
 /* Panels '--crm-panel-' */
   --crm-panel-border-col: var(--crm-c-gray-200);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
-  --crm-accordion-header-bg: var(--crm-c-layer2-bg);
-  --crm-accordion-header-bg-active: var(--crm-c-gray-600);
+  --crm-accordion-header-bg-color: var(--crm-layer2-bg-color);
+  --crm-accordion-header-bg-active-color: var(--crm-c-gray-600);
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
-  --crm-form-block-bg: var(--crm-c-layer1-bg);
+  --crm-form-block-bg-color: var(--crm-layer1-bg-color);
   --crm-input-border-color: var(--crm-c-gray-200);
   --crm-input-radio-color: #38c4b4;
 /* Tabs '--crm-tabs'/
 /* Contact layout '--crm-contact-' */
-  --crm-contact-header-bg: transparent;
-  --crm-contact-block-bg: var(--crm-c-layer1-bg);
-  --crm-contact-panel-bg: #414141;
+  --crm-contact-header-bg-color: transparent;
+  --crm-contact-block-bg-color: var(--crm-layer1-bg-color);
+  --crm-contact-panel-bg-color: #414141;
 /* Dialog '--crm-dialog-' */
-  --crm-dialog-header-bg: var(--crm-c-layer1-bg);
-  --crm-dialog-body-bg: var(--crm-c-layer1-bg);
+  --crm-dialog-header-bg-color: var(--crm-layer1-bg-color);
+  --crm-dialog-body-bg-color: var(--crm-layer1-bg-color);
 /* Dashlet for main dashboard '--crm-dashlet-' */
-  --crm-dashlet-bg: var(--crm-c-layer1-bg);
-  --crm-dashlet-header-bg: var(--crm-c-layer2-bg);
+  --crm-dashlet-bg-color: var(--crm-layer1-bg-color);
+  --crm-dashlet-header-bg-color: var(--crm-layer2-bg-color);
 /* Button dropdowns '--crm-dropdown-' */
-  --crm-dropdown-bg: var(--crm-c-layer1-bg);
-  --crm-dropdown-2-bg: var(--crm-c-layer1-bg);
+  --crm-dropdown-bg-color: var(--crm-layer1-bg-color);
+  --crm-dropdown-2-bg-color: var(--crm-layer1-bg-color);
 /* Notifications '--crm-notify-' */
-  --crm-notify-bg: var(--crm-c-darkest);
+  --crm-notify-bg-color: var(--crm-c-darkest);
 /* Icons '--crm-icon-' */
 /* Wizard '--crm-wizard-' */
-  --crm-wizard-active-bg: var(--crm-c-dark-teal);
+  --crm-wizard-active-bg-color: var(--crm-c-dark-teal);
 /* Alpha filter '--crm-filter-' */
-  --crm-filter-item-bg: var(--crm-c-layer1-bg);
+  --crm-filter-item-bg-color: var(--crm-layer1-bg-color);
 /* Frontend '--crm-f- */
 }

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -24,7 +24,7 @@
   --crm-c-primary-hover: var(--crm-c-gray-600);
   --crm-c-primary-text: var(--crm-c-text);
 /* Shadows */
-  --crm-block-shadow: 0;
+  --crm-shadow-block: 0;
 /* Sizes */
 /* Type */
   --crm-heading-bg: var(--crm-c-blue-dark);

--- a/ext/riverlea/streams/minetta/_main.css
+++ b/ext/riverlea/streams/minetta/_main.css
@@ -15,5 +15,5 @@
 /* Custom CSS */
 
 .contactCardRight:has(#crm-contact-thumbnail) .float-left {
-  width: calc(100% - var(--crm-flex-gap) - var(--crm-dash-image-size));
+  width: calc(100% - var(--crm-flex-gap) - var(--crm-contact-image-size));
 }

--- a/ext/riverlea/streams/minetta/_main.css
+++ b/ext/riverlea/streams/minetta/_main.css
@@ -7,9 +7,9 @@
 /* Tables */
   --crm-table-outside-border: 1px solid var(--crm-c-gray-200);
 /* Alerts */
-  --crm-alert-warning-bg: var(--crm-c-yellow-light);
+  --crm-alert-warning-bg-color: var(--crm-c-yellow-light);
 /* Tabs */
-  --crm-tab-bg-hover: var(--crm-c-container-bg);
+  --crm-tab-hover-bg-color: var(--crm-container-bg-color);
 }
 
 /* Custom CSS */

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -11,7 +11,7 @@
   --crm-c-text: var(--crm-c-blue-overlay2);
   --crm-c-link: var(--crm-c-dkblue-08);
   --crm-c-link-hover: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
-  --crm-c-divider: var(--crm-c-dkblue-04);
+  --crm-border-color: var(--crm-c-dkblue-04);
 /* Backgrounds, '--crm-c-*-bg' */
   --crm-c-layer0-bg: var(--crm-c-dkblue-01);
   --crm-c-page-bg: var(--crm-c-dkblue-01);
@@ -32,7 +32,7 @@
 /* Mouse events */
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
-  --crm-table-outside-border: var(--crm-c-divider);
+  --crm-table-outside-border: var(--crm-border);
   --crm-table-row-bg: var(--crm-c-dkblue-02);
   --crm-table-row-hover: var(--crm-c-dkblue-03);
 /* Panels '--crm-panel-' */

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -37,11 +37,11 @@
   --crm-table-row-hover: var(--crm-c-dkblue-03);
 /* Panels '--crm-panel-' */
   --crm-panel-bg: var(--crm-c-dkblue-02);
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
-  --crm-expand-body-bg: var(--crm-c-dkblue-03);
-  --crm-expand-header-color: var(--crm-c-blue-light);
-  --crm-expand-header-bg: var(--crm-c-dkblue-03);
-  --crm-expand-header-bg-active: var(--crm-c-dkblue-04);
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
+  --crm-accordion-body-bg: var(--crm-c-dkblue-03);
+  --crm-accordion-header-color: var(--crm-c-blue-light);
+  --crm-accordion-header-bg: var(--crm-c-dkblue-03);
+  --crm-accordion-header-bg-active: var(--crm-c-dkblue-04);
 /* Alerts '--crm-alert' */
   --crm-alert-success-bg: var(--crm-c-dkblue-03);
   --crm-alert-warning-bg: #383124;
@@ -61,14 +61,14 @@
   --crm-tab-bg-active: var(--crm-c-dkblue-02);
   --crm-tab-bg-hover: var(--crm-c-dkblue-02);
   --crm-tab-bg: transparent;
-/* Contact layout '--crm-dash-' */
-  --crm-dash-header-col: var(--crm-c-blue-light);
-  --crm-dash-tabs-bg: var(--crm-c-dkblue-03);
-  --crm-dash-tab-count-bg: var(--crm-c-blue-darker);
-  --crm-dash-tab-bg-hover: var(--crm-c-dkblue-02);
-  --crm-dash-panel-bg: var(--crm-c-dkblue-02);
-  --crm-dash-block-bg: var(--crm-c-dkblue-03);
-  --crm-dash-summary-row-bg: transparent;
+/* Contact layout '--crm-contact-' */
+  --crm-contact-header-col: var(--crm-c-blue-light);
+  --crm-contact-tabs-bg: var(--crm-c-dkblue-03);
+  --crm-contact-tab-count-bg: var(--crm-c-blue-darker);
+  --crm-contact-tab-bg-hover: var(--crm-c-dkblue-02);
+  --crm-contact-panel-bg: var(--crm-c-dkblue-02);
+  --crm-contact-block-bg: var(--crm-c-dkblue-03);
+  --crm-contact-summary-row-bg: transparent;
 /* Dialog '--crm-dialog-' */
 /* Dashlet for main dashboard '--crm-dashlet-' */
   --crm-dashlet-bg: var(--crm-c-dkblue-02);
@@ -125,7 +125,7 @@
 }
 .crm-container summary {
   /* background: var(--crm-c-dkblue-03); */
-  color: var(--crm-expand-header-color);
+  color: var(--crm-accordion-header-color);
 }
 .crm-container summary:hover,
 .crm-container summary:focus {

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -8,24 +8,24 @@
   --crm-c-dkblue-08: #2ea4ff;
   --crm-c-green: #335417;
 /* Practical colours, e.g. text, link '--crm-c-' */
-  --crm-c-text: var(--crm-c-blue-overlay2);
-  --crm-c-link: var(--crm-c-dkblue-08);
-  --crm-c-link-hover: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
+  --crm-text-color: var(--crm-c-blue-overlay2);
+  --crm-link-color: var(--crm-c-dkblue-08);
+  --crm-link-hover-color: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
   --crm-border-color: var(--crm-c-dkblue-04);
   --crm-paper: var(--crm-c-dkblue-01);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-page-bg: var(--crm-c-dkblue-01);
-  --crm-c-container-bg: var(--crm-c-dkblue-02);
-  --crm-c-layer1-bg: var(--crm-c-dkblue-02);
-  --crm-c-layer2-bg: var(--crm-c-dkblue-02);
-  --crm-c-code-bg: var(--crm-c-dkblue-04);
-  --crm-c-drag-bg: var(--crm-c-dkblue-04);
+  --crm-page-bg-color: var(--crm-c-dkblue-01);
+  --crm-container-bg-color: var(--crm-c-dkblue-02);
+  --crm-layer1-bg-color: var(--crm-c-dkblue-02);
+  --crm-layer2-bg-color: var(--crm-c-dkblue-02);
+  --crm-code-bg-color: var(--crm-c-dkblue-04);
+  --crm-drag-bg-color: var(--crm-c-dkblue-04);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
-  --crm-c-info-on-page-bg: var(--crm-c-secondary);
-  --crm-c-danger-on-page-bg: var(--crm-btn-danger-bg);
-  --crm-c-primary-on-page-bg: var(--crm-c-secondary);
-  --crm-c-secondary-on-page-bg: var(--crm-c-secondary);
-  --crm-c-warning-text: black;
+  --crm-info-ink-color: var(--crm-secondary-color);
+  --crm-danger-ink-color: var(--crm-btn-danger-bg-color);
+  --crm-primary-ink-color: var(--crm-secondary-color);
+  --crm-secondary-ink-color: var(--crm-secondary-color);
+  --crm-warning-text-color: black;
 /* Shadows */
 /* Sizes */
 /* Type */
@@ -33,53 +33,53 @@
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
   --crm-table-outside-border: var(--crm-border);
-  --crm-table-row-bg: var(--crm-c-dkblue-02);
-  --crm-table-row-hover: var(--crm-c-dkblue-03);
+  --crm-table-row-bg-color: var(--crm-c-dkblue-02);
+  --crm-table-row-hover-color: var(--crm-c-dkblue-03);
 /* Panels '--crm-panel-' */
-  --crm-panel-bg: var(--crm-c-dkblue-02);
+  --crm-panel-bg-color: var(--crm-c-dkblue-02);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
-  --crm-accordion-body-bg: var(--crm-c-dkblue-03);
+  --crm-accordion-body-bg-color: var(--crm-c-dkblue-03);
   --crm-accordion-header-color: var(--crm-c-blue-light);
-  --crm-accordion-header-bg: var(--crm-c-dkblue-03);
-  --crm-accordion-header-bg-active: var(--crm-c-dkblue-04);
+  --crm-accordion-header-bg-color: var(--crm-c-dkblue-03);
+  --crm-accordion-header-bg-active-color: var(--crm-c-dkblue-04);
 /* Alerts '--crm-alert' */
-  --crm-alert-success-bg: var(--crm-c-dkblue-03);
-  --crm-alert-warning-bg: #383124;
-  --crm-alert-info-bg: var(--crm-c-blue-darker);
-  --crm-alert-info-text: var(--crm-c-blue-light);
+  --crm-alert-success-bg-color: var(--crm-c-dkblue-03);
+  --crm-alert-warning-bg-color: #383124;
+  --crm-alert-info-bg-color: var(--crm-c-blue-darker);
+  --crm-alert-info-text-color: var(--crm-c-blue-light);
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
-  --crm-form-block-bg: var(--crm-c-dkblue-02);
-  --crm-input-bg: var(--crm-c-blue-darker);
+  --crm-form-block-bg-color: var(--crm-c-dkblue-02);
+  --crm-input-bg-color: var(--crm-c-blue-darker);
   --crm-input-color: var(--crm-c-blue); /* text */
   --crm-input-description: var(--crm-input-label-color);
   --crm-checkbox-list-col: var(--crm-input-label-color);
-  --crm-checkbox-list-bg: var(--crm-c-dkblue-01);
-  --crm-inline-edit-bg: var(--crm-c-dkblue-01);
+  --crm-form-checkbox-list-bg-color: var(--crm-c-dkblue-01);
+  --crm-input-inline-edit-bg-color: var(--crm-c-dkblue-01);
 /* Tabs '--crm-tabs' */
-  --crm-tabs-bg: var(--crm-dkblue-01);
+  --crm-tabs-bg-color: var(--crm-dkblue-01);
   --crm-tabs-border: var(--crm-dkblue-01);
   --crm-tab-bg-active: var(--crm-c-dkblue-02);
-  --crm-tab-bg-hover: var(--crm-c-dkblue-02);
-  --crm-tab-bg: transparent;
+  --crm-tab-hover-bg-color: var(--crm-c-dkblue-02);
+  --crm-tab-bg-color: transparent;
 /* Contact layout '--crm-contact-' */
-  --crm-contact-header-col: var(--crm-c-blue-light);
-  --crm-contact-tabs-bg: var(--crm-c-dkblue-03);
-  --crm-contact-tab-count-bg: var(--crm-c-blue-darker);
-  --crm-contact-tab-bg-hover: var(--crm-c-dkblue-02);
-  --crm-contact-panel-bg: var(--crm-c-dkblue-02);
-  --crm-contact-block-bg: var(--crm-c-dkblue-03);
-  --crm-contact-summary-row-bg: transparent;
+  --crm-contact-header-color: var(--crm-c-blue-light);
+  --crm-contact-tabs-bg-color: var(--crm-c-dkblue-03);
+  --crm-contact-tab-count-bg-color: var(--crm-c-blue-darker);
+  --crm-contact-tab-hover-bg-color: var(--crm-c-dkblue-02);
+  --crm-contact-panel-bg-color: var(--crm-c-dkblue-02);
+  --crm-contact-block-bg-color: var(--crm-c-dkblue-03);
+  --crm-contact-summary-row-bg-color: transparent;
 /* Dialog '--crm-dialog-' */
 /* Dashlet for main dashboard '--crm-dashlet-' */
-  --crm-dashlet-bg: var(--crm-c-dkblue-02);
+  --crm-dashlet-bg-color: var(--crm-c-dkblue-02);
 /* Button dropdowns '--crm-dropdown-' */
-  --crm-dropdown-col: var(--crm-c-text);
+  --crm-dropdown-color: var(--crm-text-color);
 /* Notifications '--crm-notify-' */
-  --crm-notify-bg: var(--crm-c-dkblue-02);
+  --crm-notify-bg-color: var(--crm-c-dkblue-02);
 /* Icons '--crm-icon-' */
 /* Wizard '--crm-wizard-' */
 /* Alpha filter '--crm-filter-' */
-  --crm-filter-bg: var(--crm-c-dkblue-02);
+  --crm-filter-bg-color: var(--crm-c-dkblue-02);
 /* Frontend '--crm-f- */
 }
 
@@ -155,12 +155,12 @@
 .crm-container .status-past,
 .crm-contact-deceased,
 .crm-container .status-warning {
-  --crm-c-danger: var(--crm-c-red);
+  --crm-danger-color: var(--crm-c-red);
 }
 #civicrm-footer a,
 nav.breadcrumb a {
-  --crm-c-link: var(--crm-c-dkblue-08);
-  --crm-c-link-hover: var(--crm-c-blue);
+  --crm-link-color: var(--crm-c-dkblue-08);
+  --crm-link-hover-color: var(--crm-c-blue);
 }
 
 /* eg. Frontend theme selection */

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -141,7 +141,7 @@
 
 /* override standalone.css */
 #login-form {
-  --crm-big-input: 100%;
+  --crm-input-width: 100%;
 }
 /* Override _fixes.scss */
 .crm-container del,

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -12,8 +12,8 @@
   --crm-c-link: var(--crm-c-dkblue-08);
   --crm-c-link-hover: color-mix(in srgb, white, var(--crm-c-dkblue-08) 70%);
   --crm-border-color: var(--crm-c-dkblue-04);
+  --crm-paper: var(--crm-c-dkblue-01);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-layer0-bg: var(--crm-c-dkblue-01);
   --crm-c-page-bg: var(--crm-c-dkblue-01);
   --crm-c-container-bg: var(--crm-c-dkblue-02);
   --crm-c-layer1-bg: var(--crm-c-dkblue-02);

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -141,7 +141,7 @@
   --crm-tabs-padding: 0;
   --crm-tabs-border: 4px solid var(--crm-c-blue-overlay2);
   --crm-tab-bg-hover: var(--crm-c-blue-overlay);
-  --crm-tab-bg-active: var(--crm-c-layer0-bg);
+  --crm-tab-bg-active: var(--crm-paper);
   --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* thames todo check */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
   --crm-tab-count-bg: var(--crm-c-info-text);
@@ -162,7 +162,7 @@
   --crm-contact-tabs-padding: unset;
   --crm-contact-tab-bg: transparent;
   --crm-contact-tabs-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
-  --crm-contact-tab-bg-hover: var(--crm-c-layer0-bg);
+  --crm-contact-tab-bg-hover: var(--crm-paper);
   --crm-contact-tab-padding: var(--crm-m2) var(--crm-r1);
   --crm-contact-tab-border: var(--crm-contact-border);
   --crm-contact-tab-col: unset;
@@ -172,7 +172,7 @@
   --crm-contact-tab-radius: 0;
   --crm-contact-heading-inset: unset;
   --crm-contact-panel-padding: var(--crm-r2);
-  --crm-contact-panel-bg: var(--crm-c-layer0-bg);
+  --crm-contact-panel-bg: var(--crm-paper);
   --crm-contact-panel-radius: 0 var(--crm-contact-radius) var(--crm-contact-radius) 0;
   --crm-contact-edit-border: 1px solid var(--crm-c-blue-dark);
   --crm-contact-block-padding: var(--crm-m2);
@@ -195,13 +195,13 @@
 :root {
 /* Dashlet */
   --crm-dashlet-box-shadow: none;
-  --crm-dashlet-header-bg: var(--crm-c-layer0-bg);
+  --crm-dashlet-header-bg: var(--crm-paper);
   --crm-dashlet-tabs-bg: var(--crm-tabs-bg);
   --crm-dashlet-radius: var(--crm-r-3);
 }
 :root {
 /* Button dropdowns */
-  --crm-dropdown-bg: var(--crm-c-layer0-bg);
+  --crm-dropdown-bg: var(--crm-paper);
   --crm-dropdown-col: var(--crm-c-blue-darker);
   --crm-dropdown-hover: var(--crm-c-blue-dark);
   --crm-dropdown-hover-bg: var(--crm-c-blue-light);
@@ -209,7 +209,7 @@
 }
 :root {
 /* Notifications */
-  --crm-notify-bg: var(--crm-c-layer0-bg);
+  --crm-notify-bg: var(--crm-paper);
   --crm-notify-col: var(--crm-c-text);
   --crm-notify-accent-border: 0.875rem 0 0 0;
   --crm-notify-radius: 4px;

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -54,21 +54,21 @@
   --crm-shadow-popup: 3px 3px 18px 0 rgba(0, 0, 0,.25);
   --crm-shadow-bottom: unset;
 /* SIZES - temporary */
-  --crm-s-radius: 0; /* thames - this gets applied in too many places; so setting to 0 and positively re-applying, rather than using this and negatively unapplying. */
+  --crm-l-radius: 0; /* thames - this gets applied in too many places; so setting to 0 and positively re-applying, rather than using this and negatively unapplying. */
 /* thames: on standalone the following is overridden in cms.css */
   --crm-page-padding: clamp(0.5rem 2vw 4rem); /* Margin left/right */
 /* Type */
   --crm-font: Lato, sans-serif;
   --crm-heading-bg-color: unset;
   --crm-heading-color: var(--crm-text-dark-color);
-  --crm-heading-padding: var(--crm-s-small-1) var(--crm-s-medium-1); /* thames unset this? todo */
+  --crm-heading-padding: var(--crm-l-small-1) var(--crm-l-medium-1); /* thames unset this? todo */
 }
 :root {
 /* Buttons */
-  --crm-btn-padding-block: var(--crm-s-small);
-  --crm-btn-padding-inline: var(--crm-s-medium-2);
+  --crm-btn-padding-block: var(--crm-l-small);
+  --crm-btn-padding-inline: var(--crm-l-medium-2);
   --crm-btn-height: 1.825rem;
-  --crm-btn-icon-spacing: var(--crm-s-xsmall-2);
+  --crm-btn-icon-spacing: var(--crm-l-xsmall-2);
   --crm-btn-cancel-bg-color: var(--crm-c-red-light);
   --crm-btn-cancel-text-color: var(--crm-c-red-dark);
   --crm-btn-info-bg-color: var(--crm-secondary-color);
@@ -77,7 +77,7 @@
   --crm-btn-success-text-color: #fff;
   --crm-btn-danger-bg-color: var(--crm-c-red);
   --crm-btn-danger-text-color: var(--crm-c-red-dark);
-  --crm-btn-margin: var(--crm-s-medium) 0;
+  --crm-btn-margin: var(--crm-l-medium) 0;
 }
 :root {
 /* Tables */
@@ -114,7 +114,7 @@
 }
 :root {
 /* Alerts */
-  --crm-alert-padding: var(--crm-s-reg);
+  --crm-alert-padding: var(--crm-l-reg);
   --crm-alert-border-width: 0;
 /* Note 'help' suffix here is for the 'success' boxes. */
   --crm-alert-success-bg-color: var(--crm-c-blue-light);
@@ -142,8 +142,8 @@
   --crm-tabs-border: 4px solid var(--crm-c-blue-overlay2);
   --crm-tab-hover-bg-color: var(--crm-c-blue-overlay);
   --crm-tab-bg-active: var(--crm-paper);
-  --crm-tab-hang: 0 0 calc(-1 * var(--crm-s-small)) 0; /* thames todo check */
-  --crm-tab-padding: var(--crm-s-medium-2) var(--crm-s-reg-1) var(--crm-s-medium); /* thames todo check */
+  --crm-tab-hang: 0 0 calc(-1 * var(--crm-l-small)) 0; /* thames todo check */
+  --crm-tab-padding: var(--crm-l-medium-2) var(--crm-l-reg-1) var(--crm-l-medium); /* thames todo check */
   --crm-tab-count-bg-color: var(--crm-info-text-color);
   --crm-tab-count-color: var(--crm-info-color);
   --crm-tab-radius: var(--crm-r-3) var(--crm-r-3) 0 0;
@@ -163,17 +163,17 @@
   --crm-contact-tab-bg-color: transparent;
   --crm-contact-tabs-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
   --crm-contact-tab-hover-bg-color: var(--crm-paper);
-  --crm-contact-tab-padding: var(--crm-s-medium-2) var(--crm-s-reg-1);
+  --crm-contact-tab-padding: var(--crm-l-medium-2) var(--crm-l-reg-1);
   --crm-contact-tab-border: var(--crm-contact-border);
   --crm-contact-tab-count-bg-color: var(--crm-primary-color);
   --crm-contact-tab-count-color: var(--crm-text-light-color);
   --crm-contact-tab-hang: 0 0 -1px 0;
   --crm-contact-tab-radius: 0;
   --crm-contact-heading-inset: unset;
-  --crm-contact-panel-padding: var(--crm-s-reg-2);
+  --crm-contact-panel-padding: var(--crm-l-reg-2);
   --crm-contact-panel-radius: 0 var(--crm-contact-radius) var(--crm-contact-radius) 0;
   --crm-contact-edit-border: 1px solid var(--crm-c-blue-dark);
-  --crm-contact-block-padding: var(--crm-s-medium-2);
+  --crm-contact-block-padding: var(--crm-l-medium-2);
   --crm-contact-block-bg-color: var(--crm-container-bg-color);
   --crm-contact-label-bg-color: var(--crm-container-bg-color);
   --crm-contact-header-bg-color: unset;
@@ -201,7 +201,7 @@
 /* Button dropdowns */
   --crm-dropdown-bg-color: var(--crm-paper);
   --crm-dropdown-color: var(--crm-c-blue-darker);
-  --crm-dropdown-hover: var(--crm-c-blue-dark);
+  --crm-dropdown-hover-text-color: var(--crm-c-blue-dark);
   --crm-dropdown-hover-bg-color: var(--crm-c-blue-light);
   --crm-dropdown-width: 23ch;
 }
@@ -238,7 +238,7 @@
 /* Frontend */
   --crm-f-form-width: 700px;
   --crm-f-fieldset-bg-color: var(--crm-container-bg-color);
-  --crm-f-fieldset-padding: var(--crm-s-reg);
+  --crm-f-fieldset-padding: var(--crm-l-reg);
   --crm-f-legend-align: center;
   --crm-f-label-position: unset;
   --crm-f-label-align: left;
@@ -383,7 +383,7 @@ html.cms-standalone body {
 .crm-container :is(.status,
 .alert-warning,
 .messages.warning) {
-  --crm-s-radius: 0.25rem;
+  --crm-l-radius: 0.25rem;
 }
 
 /* BUTTONS */
@@ -395,7 +395,7 @@ html.cms-standalone body {
 .crm-container [type="reset"],
 .crm-container [type="submit"] {
   Sometimes we have lots of buttons and they wrap to a 2nd line. This puts some vertical space betwixt.
-  margin: var(--crm-s-medium) 0;
+  margin: var(--crm-l-medium) 0;
 }
 
 /* Make it clear when you're hovering delete. */
@@ -517,7 +517,7 @@ html.cms-standalone body {
 
 /* RL has no margin-bottom so the actions ribbon touches the main contact block */
 div.crm-summary-contactname-block+.crm-actions-ribbon {
-  margin-bottom: var(--crm-s-reg-1) !important;
+  margin-bottom: var(--crm-l-reg-1) !important;
 }
 
 /* Use subgrid? No. Not responsive enough. */
@@ -698,11 +698,11 @@ nav.breadcrumb a {
 /* Breadcrumbs */
 html.crm-standalone  nav.breadcrumb>ol {
   display: flex;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
 }
 .breadcrumb ol li:not(:first-child)::before {
   content: " \BB ";
-  margin-inline-end: var(--crm-s-medium);
+  margin-inline-end: var(--crm-l-medium);
   color: var(--crm-c-blue-dark);
 }
 
@@ -726,7 +726,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--crm-s-medium);
+  gap: var(--crm-l-medium);
 }
 
 /* Spinner. Replace the fa icon with something nicer. */

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -28,7 +28,7 @@
   --crm-c-yellow-light: #f2deb9;
 /* PRACTICAL COLOURS */
   --crm-c-text-dark: #000000dd;
-  --crm-c-divider: 1px solid var(--crm-c-blue-overlay);
+  --crm-border-color: var(--crm-c-blue-overlay);
   --crm-c-page-bg: #f3f2ed;
   --crm-c-container-bg: #f8f8f8;
   --crm-c-layer2-bg: color-mix(in srgb,var(--crm-c-layer1-bg) 90%,#000 10%);
@@ -262,7 +262,7 @@ html.cms-standalone body {
 
 .crm-container details {
   /* background-color: var(--crm-accordion-body-bg); Removed for FormBuilder clashes */
-  border: var(--crm-c-divider);
+  border: var(--crm-border);
 }
 
 .crm-container summary {

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -27,22 +27,22 @@
   --crm-c-yellow: #fcfc5a; /* todo change this horrible yellow! */
   --crm-c-yellow-light: #f2deb9;
 /* PRACTICAL COLOURS */
-  --crm-c-text-dark: #000000dd;
+  --crm-text-dark-color: #000000dd;
   --crm-border-color: var(--crm-c-blue-overlay);
-  --crm-c-page-bg: #f3f2ed;
-  --crm-c-container-bg: #f8f8f8;
-  --crm-c-layer2-bg: color-mix(in srgb,var(--crm-c-layer1-bg) 90%,#000 10%);
-  --crm-c-drag-bg: var(--crm-c-blue-overlay2); /* background for drag/drop regions, select2 highlight */
-  --crm-c-code-bg: var(--crm-c-blue-overlay2); /* background for code regions */
+  --crm-page-bg-color: #f3f2ed;
+  --crm-container-bg-color: #f8f8f8;
+  --crm-layer2-bg-color: color-mix(in srgb,var(--crm-layer1-bg-color) 90%,#000 10%);
+  --crm-drag-bg-color: var(--crm-c-blue-overlay2); /* background for drag/drop regions, select2 highlight */
+  --crm-code-bg-color: var(--crm-c-blue-overlay2); /* background for code regions */
   /* Emphasis colours */
-  --crm-c-primary: var(--crm-c-blue-dark); /* primary button bgs */
-  --crm-c-primary-hover: var(--crm-c-blue-darker);
-  --crm-c-secondary: #c9e1f1; /* buttons */
-  --crm-c-secondary-hover: #a1cef3;
-  --crm-c-secondary-text: var(--crm-c-blue-darker);
-  --crm-c-secondary-hover-text: var(--crm-c-text-light); /* thames todo */
-  --crm-c-secondary-on-page-bg: var(--crm-c-blue-darker);
-  --crm-c-warning-text: var(--crm-c-text-dark);
+  --crm-primary-color: var(--crm-c-blue-dark); /* primary button bgs */
+  --crm-primary-hover-color: var(--crm-c-blue-darker);
+  --crm-secondary-color: #c9e1f1; /* buttons */
+  --crm-secondary-hover-color: #a1cef3;
+  --crm-secondary-text-color: var(--crm-c-blue-darker);
+  --crm-secondary-hover-text-color: var(--crm-text-light-color); /* thames todo */
+  --crm-secondary-ink-color: var(--crm-c-blue-darker);
+  --crm-warning-text-color: var(--crm-text-dark-color);
 }
 :root {
 /* thames only radii */
@@ -59,8 +59,8 @@
   --crm-page-padding: clamp(0.5rem 2vw 4rem); /* Margin left/right */
 /* Type */
   --crm-font: Lato, sans-serif;
-  --crm-heading-bg: unset;
-  --crm-heading-col: var(--crm-c-text-dark);
+  --crm-heading-bg-color: unset;
+  --crm-heading-color: var(--crm-text-dark-color);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1); /* thames unset this? todo */
 }
 :root {
@@ -69,23 +69,23 @@
   --crm-btn-padding-inline: var(--crm-m2);
   --crm-btn-height: 1.825rem;
   --crm-btn-icon-spacing: var(--crm-xs2);
-  --crm-btn-cancel-bg: var(--crm-c-red-light);
-  --crm-btn-cancel-text: var(--crm-c-red-dark);
-  --crm-btn-info-bg: var(--crm-c-secondary);
-  --crm-btn-info-text: var(--crm-c-secondary-text);
-  --crm-btn-success-bg: var(--crm-c-info);
-  --crm-btn-success-text: #fff;
-  --crm-btn-danger-bg: var(--crm-c-red);
-  --crm-btn-danger-text: var(--crm-c-red-dark);
+  --crm-btn-cancel-bg-color: var(--crm-c-red-light);
+  --crm-btn-cancel-text-color: var(--crm-c-red-dark);
+  --crm-btn-info-bg-color: var(--crm-secondary-color);
+  --crm-btn-info-text-color: var(--crm-secondary-text-color);
+  --crm-btn-success-bg-color: var(--crm-info-color);
+  --crm-btn-success-text-color: #fff;
+  --crm-btn-danger-bg-color: var(--crm-c-red);
+  --crm-btn-danger-text-color: var(--crm-c-red-dark);
   --crm-btn-margin: var(--crm-m) 0;
 }
 :root {
 /* Tables */
-  --crm-table-outside-border: 1px solid var(--crm-c-layer2-bg);
-  --crm-table-bg: var(--crm-c-page-bg);
-  --crm-table-header-bg: var(--crm-c-page-bg);
-  --crm-table-row-bg: var(--crm-c-gray-025);
-  --crm-table-row-hover: var(--crm-c-blue-overlay);
+  --crm-table-outside-border: 1px solid var(--crm-layer2-bg-color);
+  --crm-table-bg-color: var(--crm-page-bg-color);
+  --crm-table-header-bg-color: var(--crm-page-bg-color);
+  --crm-table-row-bg-color: var(--crm-c-gray-025);
+  --crm-table-row-hover-color: var(--crm-c-blue-overlay);
 }
 :root {
 /* Panels */
@@ -95,21 +95,21 @@
 /* Accordions */
   --crm-accordion-radius: 4px;
 /* .crm-accordion-bold */
-  --crm-accordion-header-bg: var(--crm-c-blue-overlay);
-  --crm-accordion-header-bg-active: var(--crm-c-blue-overlay);
+  --crm-accordion-header-bg-color: var(--crm-c-blue-overlay);
+  --crm-accordion-header-bg-active-color: var(--crm-c-blue-overlay);
   --crm-accordion-header-color: var(--crm-c-blue-darker);
   --crm-accordion-header-padding: 0.6rem 1.6rem 0.6rem 2.8rem;
   --crm-accordion-header-border: unset;
   --crm-accordion-header-border-width: unset;
   --crm-accordion-border: unset;
   --crm-accordion-border-width: unset;
-  --crm-accordion-body-bg: var(--crm-c-blue-overlay); /* thames - todo check*/
+  --crm-accordion-body-bg-color: var(--crm-c-blue-overlay); /* thames - todo check*/
   --crm-accordion-body-padding: 0.25rem 2.8rem;
 /* .crm-accordion-light */
-  --crm-accordion2-header-bg: transparent;
-  --crm-accordion2-header-bg-active: var(--crm-c-layer2-bg);
+  --crm-accordion2-header-bg-color: transparent;
+  --crm-accordion2-header-bg-active-color: var(--crm-layer2-bg-color);
   --crm-accordion2-header-padding: .6rem 1.6rem 0.6rem 2.8rem;
-  --crm-accordion2-body-bg: transparent;
+  --crm-accordion2-body-bg-color: transparent;
   --crm-accordion2-body-padding: 0.25rem 2.8rem;
 }
 :root {
@@ -117,16 +117,16 @@
   --crm-alert-padding: var(--crm-r);
   --crm-alert-border-width: 0;
 /* Note 'help' suffix here is for the 'success' boxes. */
-  --crm-alert-success-bg: var(--crm-c-blue-light);
-  --crm-alert-success-border: unset;
-  --crm-alert-success-text: unset;
-  --crm-alert-warning-border: var(--crm-c-yellow);
-  --crm-alert-info-bg: var(--crm-c-blue-light);
-  --crm-alert-info-border: var(--crm-c-blue);
-  --crm-alert-info-text: var(--crm-c-blue-darker);
-  --crm-alert-danger-bg: var(--crm-c-red-light);
-  --crm-alert-danger-border: var(--crm-c-red);
-  --crm-alert-danger-text: var(--crm-c-red-dark);
+  --crm-alert-success-bg-color: var(--crm-c-blue-light);
+  --crm-alert-success-border-color: unset;
+  --crm-alert-success-text-color: unset;
+  --crm-alert-warning-border-color: var(--crm-c-yellow);
+  --crm-alert-info-bg-color: var(--crm-c-blue-light);
+  --crm-alert-info-border-color: var(--crm-c-blue);
+  --crm-alert-info-text-color: var(--crm-c-blue-darker);
+  --crm-alert-danger-bg-color: var(--crm-c-red-light);
+  --crm-alert-danger-border-color: var(--crm-c-red);
+  --crm-alert-danger-text-color: var(--crm-c-red-dark);
 }
 :root {
 /* Form */
@@ -137,15 +137,15 @@
 }
 :root {
 /* Tabs */
-  --crm-tabs-bg: var(--crm-c-blue-overlay2);
+  --crm-tabs-bg-color: var(--crm-c-blue-overlay2);
   --crm-tabs-padding: 0;
   --crm-tabs-border: 4px solid var(--crm-c-blue-overlay2);
-  --crm-tab-bg-hover: var(--crm-c-blue-overlay);
+  --crm-tab-hover-bg-color: var(--crm-c-blue-overlay);
   --crm-tab-bg-active: var(--crm-paper);
   --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* thames todo check */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
-  --crm-tab-count-bg: var(--crm-c-info-text);
-  --crm-tab-count-col: var(--crm-c-info);
+  --crm-tab-count-bg-color: var(--crm-info-text-color);
+  --crm-tab-count-color: var(--crm-info-color);
   --crm-tab-radius: var(--crm-r-3) var(--crm-r-3) 0 0;
   --crm-tab-border: none;
   --crm-tabs-2-border: var(--crm-tabs-border);
@@ -158,65 +158,63 @@
   --crm-side-tabs-width: 220px;
   --crm-contact-tabs-flow: column;
   --crm-contact-tabs-gap: 0;
-  --crm-contact-tabs-bg: var(--crm-c-blue-overlay);
+  --crm-contact-tabs-bg-color: var(--crm-c-blue-overlay);
   --crm-contact-tabs-padding: unset;
-  --crm-contact-tab-bg: transparent;
+  --crm-contact-tab-bg-color: transparent;
   --crm-contact-tabs-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
-  --crm-contact-tab-bg-hover: var(--crm-paper);
+  --crm-contact-tab-hover-bg-color: var(--crm-paper);
   --crm-contact-tab-padding: var(--crm-m2) var(--crm-r1);
   --crm-contact-tab-border: var(--crm-contact-border);
-  --crm-contact-tab-col: unset;
-  --crm-contact-tab-count-bg: var(--crm-c-primary);
-  --crm-contact-tab-count-col: var(--crm-c-text-light);
+  --crm-contact-tab-count-bg-color: var(--crm-primary-color);
+  --crm-contact-tab-count-color: var(--crm-text-light-color);
   --crm-contact-tab-hang: 0 0 -1px 0;
   --crm-contact-tab-radius: 0;
   --crm-contact-heading-inset: unset;
   --crm-contact-panel-padding: var(--crm-r2);
-  --crm-contact-panel-bg: var(--crm-paper);
   --crm-contact-panel-radius: 0 var(--crm-contact-radius) var(--crm-contact-radius) 0;
   --crm-contact-edit-border: 1px solid var(--crm-c-blue-dark);
   --crm-contact-block-padding: var(--crm-m2);
-  --crm-contact-block-bg: var(--crm-c-container-bg);
-  --crm-contact-label-bg: var(--crm-c-container-bg);
-  --crm-contact-header-bg: unset;
-  --crm-contact-header-bg2: unset;
-  --crm-contact-header-col: var(--crm-c-blue-darker);
+  --crm-contact-block-bg-color: var(--crm-container-bg-color);
+  --crm-contact-label-bg-color: var(--crm-container-bg-color);
+  --crm-contact-header-bg-color: unset;
+  --crm-contact-header2-bg-color: unset;
+  --crm-contact-header-color: var(--crm-c-blue-darker);
   --crm-contact-header-padding: unset;
   --crm-contact-image-right: 20px;
 }
 :root {
 /* Dialog */
-  --crm-dialog-bg: var(--crm-c-page-bg);
+  --crm-dialog-bg-color: var(--crm-page-bg-color);
   --crm-dialog-padding: 0;
-  --crm-dialog-header-bg: var(--crm-c-blue-overlay);
-  --crm-dialog-header-col: var(--crm-c-blue-darker);
-  --crm-dialog-header-border-col: transparent;
+  --crm-dialog-header-bg-color: var(--crm-c-blue-overlay);
+  --crm-dialog-header-color: var(--crm-c-blue-darker);
+  --crm-dialog-header-border-color: transparent;
 }
 :root {
 /* Dashlet */
   --crm-dashlet-box-shadow: none;
-  --crm-dashlet-header-bg: var(--crm-paper);
-  --crm-dashlet-tabs-bg: var(--crm-tabs-bg);
+  --crm-dashlet-header-bg-color: var(--crm-paper);
+  --crm-dashlet-tabs-bg-color: var(--crm-tabs-bg-color);
   --crm-dashlet-radius: var(--crm-r-3);
 }
 :root {
 /* Button dropdowns */
-  --crm-dropdown-bg: var(--crm-paper);
-  --crm-dropdown-col: var(--crm-c-blue-darker);
+  --crm-dropdown-bg-color: var(--crm-paper);
+  --crm-dropdown-color: var(--crm-c-blue-darker);
   --crm-dropdown-hover: var(--crm-c-blue-dark);
-  --crm-dropdown-hover-bg: var(--crm-c-blue-light);
+  --crm-dropdown-hover-bg-color: var(--crm-c-blue-light);
   --crm-dropdown-width: 23ch;
 }
 :root {
 /* Notifications */
-  --crm-notify-bg: var(--crm-paper);
-  --crm-notify-col: var(--crm-c-text);
+  --crm-notify-bg-color: var(--crm-paper);
+  --crm-notify-color: var(--crm-text-color);
   --crm-notify-accent-border: 0.875rem 0 0 0;
   --crm-notify-radius: 4px;
-  --crm-notify-danger: var(--crm-c-danger);
-  --crm-notify-warning: var(--crm-c-warning);
-  --crm-notify-success: var(--crm-c-success);
-  --crm-notify-info: var(--crm-c-info);
+  --crm-notify-danger-color: var(--crm-danger-color);
+  --crm-notify-warning-color: var(--crm-warning-color);
+  --crm-notify-success-color: var(--crm-success-color);
+  --crm-notify-info-color: var(--crm-info-color);
 }
 :root {
 /* Icons */
@@ -228,40 +226,40 @@
 }
 :root {
 /* Wizard */
-  --crm-wizard-bg: var(--crm-c-page-bg);
+  --crm-wizard-bg-color: var(--crm-page-bg-color);
 }
 :root {
 /* Alpha filter */
-  --crm-filter-bg: var(--crm-c-blue-overlay);
-  --crm-filter-item-bg: transparent;
+  --crm-filter-bg-color: var(--crm-c-blue-overlay);
+  --crm-filter-item-bg-color: transparent;
   --crm-filter-item-shadow: none;
 }
 :root {
 /* Frontend */
   --crm-f-form-width: 700px;
-  --crm-f-fieldset-bg: var(--crm-c-container-bg);
+  --crm-f-fieldset-bg-color: var(--crm-container-bg-color);
   --crm-f-fieldset-padding: var(--crm-r);
   --crm-f-legend-align: center;
   --crm-f-label-position: unset;
   --crm-f-label-align: left;
   --crm-f-label-width: unset;
   --crm-f-input-width: 100%;
-  --crm-f-form-focus-bg: var(--crm-c-green);
-  --crm-f-form-error-bg: var(--crm-c-red);
+  --crm-f-form-focus-bg-color: var(--crm-c-green);
+  --crm-f-form-error-bg-color: var(--crm-c-red);
 }
 
 /* Only affect body colour in standalone */
 html.cms-standalone body {
-  background-color: var(--crm-c-page-bg);
+  background-color: var(--crm-page-bg-color);
 }
 
 #crm-container {
   min-height: 100vh;
-  background-color: var(--crm-c-page-bg);
+  background-color: var(--crm-page-bg-color);
 }
 
 .crm-container details {
-  /* background-color: var(--crm-accordion-body-bg); Removed for FormBuilder clashes */
+  /* background-color: var(--crm-accordion-body-bg-color); Removed for FormBuilder clashes */
   border: var(--crm-border);
 }
 
@@ -354,7 +352,7 @@ html.cms-standalone body {
 
 /* Alternate backgrounds */
 /* .crm-container details:not(.crm-accordion-light) details:not(.crm-accordion-light) { */
-/*   --crm-accordion-header-bg: var(--crm-c-blue-overlay2); */
+/*   --crm-accordion-header-bg-color: var(--crm-c-blue-overlay2); */
 /* } */
 
 
@@ -473,7 +471,7 @@ html.cms-standalone body {
 /* OTHER */
 /* 'alpha-filter' is the alphabetical pager you see, for example, on adv search results */
 .crm-container #alpha-filter li {
-  --crm-c-text: #0002; /* referenced in searchForm.css */
+  --crm-text-color: #0002; /* referenced in searchForm.css */
 }
 
 .crm-container .description:not(#help),
@@ -488,7 +486,7 @@ html.cms-standalone body {
     background-color: var(--crm-c-blue-overlay);
 }
   50% {
-    background-color: var(--crm-c-page-bg);
+    background-color: var(--crm-page-bg-color);
 }
   100% {
     background-color: var(--crm-c-blue-overlay);
@@ -665,8 +663,8 @@ div:has(> table .dropdown-toggle[aria-expanded="true"]) {
 /* breadcrumbs - links not accessibile using the nromal blue. */
 #civicrm-footer a,
 nav.breadcrumb a {
-  --crm-c-link: var(--crm-c-blue-darker);
-  --crm-c-link-hover: var(--crm-c-blue-dark);
+  --crm-link-color: var(--crm-c-blue-darker);
+  --crm-link-hover-color: var(--crm-c-blue-dark);
 }
 #crm-contactname-content .crm-edit-help {
   color: var(--crm-c-blue-dark) !important; /* override */
@@ -787,22 +785,22 @@ html.crm-standalone  nav.breadcrumb>ol {
   /*issue https://lab.civicrm.org/extensions/riverlea/-/issues/102 */
   margin-left: 1rem;
   /* crmSearchAdmin applies this var as the bg here and it does not suit us. */
-  --crm-c-page-bg: transparent;
+  --crm-page-bg-color: transparent;
 }
 
 /* Override contactSummary.css */
 #crm-contact-actions-list a.delete {
-  --crm-c-danger-text: var(--crm-c-red-dark);
+  --crm-danger-text-color: var(--crm-c-red-dark);
 }
 #crm-contact-actions-list a.delete:hover,
 #crm-contact-actions-list a.delete:focus {
   /* the hover state gives crm-c-red-dark to the background */
-  --crm-c-danger-text: var(--crm-c-red-light);
+  --crm-danger-text-color: var(--crm-c-red-light);
 }
 
 /* Fix Mosaico wizard */
 .crm_wizard__tille {
-  --crm-panel-bg: transparent;
+  --crm-panel-bg-color: transparent;
 }
 .crmb-wizard-button-right {
   gap: 1rem;
@@ -817,11 +815,11 @@ html.crm-standalone  nav.breadcrumb>ol {
 ul.crm-quickSearch-results a {
   padding: 0.25rem 1rem;
   text-decoration: none;
-  color: var(--crm-c-link);
+  color: var(--crm-link-color);
 }
 ul.crm-quickSearch-results .ui-state-active a /* mouse,keyboard nav */ {
   background: var(--crm-c-blue);
-  color: var(--crm-c-link-hover);
+  color: var(--crm-link-hover-color);
 }
 ul.crm-quickSearch-results a:active {
   background: white;
@@ -845,7 +843,7 @@ ul.crm-quickSearch-results a:active {
   min-width: 8rem;
   max-width: 13rem;
   text-align: left;
-  --crm-c-layer1-bg: transparent;
+  --crm-layer1-bg-color: transparent;
 
   .crm-status-box-msg {
     color: white;

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -58,7 +58,7 @@
   --crm-popup-shadow: 3px 3px 18px 0 rgba(0, 0, 0,.25);
   --crm-bottom-shadow: unset;
 /* SIZES - temporary */
-  --crm-roundness: 0; /* thames - this gets applied in too many places; so setting to 0 and positively re-applying, rather than using this and negatively unapplying. */
+  --crm-s-radius: 0; /* thames - this gets applied in too many places; so setting to 0 and positively re-applying, rather than using this and negatively unapplying. */
 /* thames: on standalone the following is overridden in cms.css */
   --crm-page-padding: clamp(0.5rem 2vw 4rem); /* Margin left/right */
 /* Type */
@@ -96,24 +96,24 @@
 }
 :root {
 /* Accordions */
-  --crm-expand-radius: 4px;
+  --crm-accordion-radius: 4px;
 /* .crm-accordion-bold */
-  --crm-expand-header-bg: var(--crm-c-blue-overlay);
-  --crm-expand-header-bg-active: var(--crm-c-blue-overlay);
-  --crm-expand-header-color: var(--crm-c-blue-darker);
-  --crm-expand-header-padding: 0.6rem 1.6rem 0.6rem 2.8rem;
-  --crm-expand-header-border: unset;
-  --crm-expand-header-border-width: unset;
-  --crm-expand-border: unset;
-  --crm-expand-border-width: unset;
-  --crm-expand-body-bg: var(--crm-c-blue-overlay); /* thames - todo check*/
-  --crm-expand-body-padding: 0.25rem 2.8rem;
+  --crm-accordion-header-bg: var(--crm-c-blue-overlay);
+  --crm-accordion-header-bg-active: var(--crm-c-blue-overlay);
+  --crm-accordion-header-color: var(--crm-c-blue-darker);
+  --crm-accordion-header-padding: 0.6rem 1.6rem 0.6rem 2.8rem;
+  --crm-accordion-header-border: unset;
+  --crm-accordion-header-border-width: unset;
+  --crm-accordion-border: unset;
+  --crm-accordion-border-width: unset;
+  --crm-accordion-body-bg: var(--crm-c-blue-overlay); /* thames - todo check*/
+  --crm-accordion-body-padding: 0.25rem 2.8rem;
 /* .crm-accordion-light */
-  --crm-expand2-header-bg: transparent;
-  --crm-expand2-header-bg-active: var(--crm-c-layer2-bg);
-  --crm-expand2-header-padding: .6rem 1.6rem 0.6rem 2.8rem;
-  --crm-expand2-body-bg: transparent;
-  --crm-expand2-body-padding: 0.25rem 2.8rem;
+  --crm-accordion2-header-bg: transparent;
+  --crm-accordion2-header-bg-active: var(--crm-c-layer2-bg);
+  --crm-accordion2-header-padding: .6rem 1.6rem 0.6rem 2.8rem;
+  --crm-accordion2-body-bg: transparent;
+  --crm-accordion2-body-padding: 0.25rem 2.8rem;
 }
 :root {
 /* Alerts */
@@ -149,43 +149,43 @@
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
   --crm-tab-count-bg: var(--crm-c-info-text);
   --crm-tab-count-col: var(--crm-c-info);
-  --crm-tab-roundness: var(--crm-r-3) var(--crm-r-3) 0 0;
+  --crm-tab-radius: var(--crm-r-3) var(--crm-r-3) 0 0;
   --crm-tab-border: none;
   --crm-tabs-2-border: var(--crm-tabs-border);
 }
 :root {
 /* Contact dashboard/summary */
-  --crm-dash-border: 0 solid transparent;
-  --crm-dash-roundness: var(--crm-r-5);
-  --crm-dash-direction: grid;
+  --crm-contact-border: 0 solid transparent;
+  --crm-contact-radius: var(--crm-r-5);
+  --crm-contact-direction: grid;
   --crm-side-tabs-width: 220px;
-  --crm-dash-tabs-flow: column;
-  --crm-dash-tabs-gap: 0;
-  --crm-dash-tabs-bg: var(--crm-c-blue-overlay);
-  --crm-dash-tabs-padding: unset;
-  --crm-dash-tab-bg: transparent;
-  --crm-dash-tabs-roundness: var(--crm-dash-roundness) 0 0 var(--crm-dash-roundness);
-  --crm-dash-tab-bg-hover: var(--crm-c-layer0-bg);
-  --crm-dash-tab-padding: var(--crm-m2) var(--crm-r1);
-  --crm-dash-tab-border: var(--crm-dash-border);
-  --crm-dash-tab-col: unset;
-  --crm-dash-tab-count-bg: var(--crm-c-primary);
-  --crm-dash-tab-count-col: var(--crm-c-text-light);
-  --crm-dash-tab-hang: 0 0 -1px 0;
-  --crm-dash-tab-radius: 0;
-  --crm-dash-heading-inset: unset;
-  --crm-dash-panel-padding: var(--crm-r2);
-  --crm-dash-panel-bg: var(--crm-c-layer0-bg);
-  --crm-dash-panel-radius: 0 var(--crm-dash-roundness) var(--crm-dash-roundness) 0;
-  --crm-dash-edit-border: 1px solid var(--crm-c-blue-dark);
-  --crm-dash-block-padding: var(--crm-m2);
-  --crm-dash-block-bg: var(--crm-c-container-bg);
-  --crm-dash-label-bg: var(--crm-c-container-bg);
-  --crm-dash-header-bg: unset;
-  --crm-dash-header-bg2: unset;
-  --crm-dash-header-col: var(--crm-c-blue-darker);
-  --crm-dash-header-padding: unset;
-  --crm-dash-image-right: 20px;
+  --crm-contact-tabs-flow: column;
+  --crm-contact-tabs-gap: 0;
+  --crm-contact-tabs-bg: var(--crm-c-blue-overlay);
+  --crm-contact-tabs-padding: unset;
+  --crm-contact-tab-bg: transparent;
+  --crm-contact-tabs-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
+  --crm-contact-tab-bg-hover: var(--crm-c-layer0-bg);
+  --crm-contact-tab-padding: var(--crm-m2) var(--crm-r1);
+  --crm-contact-tab-border: var(--crm-contact-border);
+  --crm-contact-tab-col: unset;
+  --crm-contact-tab-count-bg: var(--crm-c-primary);
+  --crm-contact-tab-count-col: var(--crm-c-text-light);
+  --crm-contact-tab-hang: 0 0 -1px 0;
+  --crm-contact-tab-radius: 0;
+  --crm-contact-heading-inset: unset;
+  --crm-contact-panel-padding: var(--crm-r2);
+  --crm-contact-panel-bg: var(--crm-c-layer0-bg);
+  --crm-contact-panel-radius: 0 var(--crm-contact-radius) var(--crm-contact-radius) 0;
+  --crm-contact-edit-border: 1px solid var(--crm-c-blue-dark);
+  --crm-contact-block-padding: var(--crm-m2);
+  --crm-contact-block-bg: var(--crm-c-container-bg);
+  --crm-contact-label-bg: var(--crm-c-container-bg);
+  --crm-contact-header-bg: unset;
+  --crm-contact-header-bg2: unset;
+  --crm-contact-header-col: var(--crm-c-blue-darker);
+  --crm-contact-header-padding: unset;
+  --crm-contact-image-right: 20px;
 }
 :root {
 /* Dialog */
@@ -264,7 +264,7 @@ html.cms-standalone body {
 }
 
 .crm-container details {
-  /* background-color: var(--crm-expand-body-bg); Removed for FormBuilder clashes */
+  /* background-color: var(--crm-accordion-body-bg); Removed for FormBuilder clashes */
   border: var(--crm-c-divider);
 }
 
@@ -285,9 +285,9 @@ html.cms-standalone body {
 .crm-container details>summary::before /* accordion8 (recommended) */,
 .crm-container .crm-accordion-header::before, /* accordion1, accordion2, accordion6 */
 .crm-container .crm-collapsible .collapsible-title::before /* accordion3 */ {
-  --crm-expand-icon: '';
+  --crm-accordion-icon: '';
   border: .4rem solid transparent;
-  border-left-color: var(--crm-expand-icon-color);
+  border-left-color: var(--crm-accordion-icon-color);
   position: absolute;
   margin-left: -1.5rem;
   margin-top: 0.2rem;
@@ -344,7 +344,7 @@ html.cms-standalone body {
 }
 .crm-container :is(details,
 .crm-accordion-wrapper)>.crm-accordion-body {
-  padding: var(--crm-expand-body-padding);
+  padding: var(--crm-accordion-body-padding);
   animation: crm-details-show 240ms ease-in-out;
 }
 /* We don't want a different colour header bg on 'active' (open) but we do on hover
@@ -357,7 +357,7 @@ html.cms-standalone body {
 
 /* Alternate backgrounds */
 /* .crm-container details:not(.crm-accordion-light) details:not(.crm-accordion-light) { */
-/*   --crm-expand-header-bg: var(--crm-c-blue-overlay2); */
+/*   --crm-accordion-header-bg: var(--crm-c-blue-overlay2); */
 /* } */
 
 
@@ -388,7 +388,7 @@ html.cms-standalone body {
 .crm-container :is(.status,
 .alert-warning,
 .messages.warning) {
-  --crm-roundness: 0.25rem;
+  --crm-s-radius: 0.25rem;
 }
 
 /* BUTTONS */
@@ -504,11 +504,11 @@ html.cms-standalone body {
 /* CONTACT SUMMARY */
 /* Ensure the Summary tab's top left corner matches the radius of the container */
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list>li:first-child a {
-  border-radius: var(--crm-dash-roundness) 0 0 0;
+  border-radius: var(--crm-contact-radius) 0 0 0;
 }
 
 .crm-contact-page #mainTabContainer .ui-tabs-nav li .ui-tabs-anchor:has(.crm-i) {
-  grid-template-columns: var(--crm-dash-icon-size) 1fr auto;
+  grid-template-columns: var(--crm-contact-icon-size) 1fr auto;
   gap: 1ch;
 }
 
@@ -813,7 +813,7 @@ html.crm-standalone  nav.breadcrumb>ol {
 
 /* Support contact dashboard image float */
 .contactCardRight:has(#crm-contact-thumbnail) .float-left {
-  width: calc(100% - var(--crm-flex-gap) - var(--crm-dash-image-size));
+  width: calc(100% - var(--crm-flex-gap) - var(--crm-contact-image-size));
 }
 
 /* Quicksearch */

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -11,10 +11,6 @@
 */
 
 :root {
-/* FONTS */
-  --crm-font: Lato, sans-serif;
-}
-:root {
 /* COLOUR NAMES */
   --crm-c-blue-overlay2: #edf4f7; /* thames only */
   --crm-c-blue-overlay: #dce9ef; /* thames only */
@@ -55,13 +51,14 @@
   --crm-r-2: 0.25em;
   --crm-r-1: 3px;
 /* SHADOWS */
-  --crm-popup-shadow: 3px 3px 18px 0 rgba(0, 0, 0,.25);
-  --crm-bottom-shadow: unset;
+  --crm-shadow-popup: 3px 3px 18px 0 rgba(0, 0, 0,.25);
+  --crm-shadow-bottom: unset;
 /* SIZES - temporary */
   --crm-s-radius: 0; /* thames - this gets applied in too many places; so setting to 0 and positively re-applying, rather than using this and negatively unapplying. */
 /* thames: on standalone the following is overridden in cms.css */
   --crm-page-padding: clamp(0.5rem 2vw 4rem); /* Margin left/right */
 /* Type */
+  --crm-font: Lato, sans-serif;
   --crm-heading-bg: unset;
   --crm-heading-col: var(--crm-c-text-dark);
   --crm-heading-padding: var(--crm-s1) var(--crm-m1); /* thames unset this? todo */

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -61,14 +61,14 @@
   --crm-font: Lato, sans-serif;
   --crm-heading-bg-color: unset;
   --crm-heading-color: var(--crm-text-dark-color);
-  --crm-heading-padding: var(--crm-s1) var(--crm-m1); /* thames unset this? todo */
+  --crm-heading-padding: var(--crm-s-small-1) var(--crm-s-medium-1); /* thames unset this? todo */
 }
 :root {
 /* Buttons */
-  --crm-btn-padding-block: var(--crm-s);
-  --crm-btn-padding-inline: var(--crm-m2);
+  --crm-btn-padding-block: var(--crm-s-small);
+  --crm-btn-padding-inline: var(--crm-s-medium-2);
   --crm-btn-height: 1.825rem;
-  --crm-btn-icon-spacing: var(--crm-xs2);
+  --crm-btn-icon-spacing: var(--crm-s-xsmall-2);
   --crm-btn-cancel-bg-color: var(--crm-c-red-light);
   --crm-btn-cancel-text-color: var(--crm-c-red-dark);
   --crm-btn-info-bg-color: var(--crm-secondary-color);
@@ -77,7 +77,7 @@
   --crm-btn-success-text-color: #fff;
   --crm-btn-danger-bg-color: var(--crm-c-red);
   --crm-btn-danger-text-color: var(--crm-c-red-dark);
-  --crm-btn-margin: var(--crm-m) 0;
+  --crm-btn-margin: var(--crm-s-medium) 0;
 }
 :root {
 /* Tables */
@@ -114,7 +114,7 @@
 }
 :root {
 /* Alerts */
-  --crm-alert-padding: var(--crm-r);
+  --crm-alert-padding: var(--crm-s-reg);
   --crm-alert-border-width: 0;
 /* Note 'help' suffix here is for the 'success' boxes. */
   --crm-alert-success-bg-color: var(--crm-c-blue-light);
@@ -142,8 +142,8 @@
   --crm-tabs-border: 4px solid var(--crm-c-blue-overlay2);
   --crm-tab-hover-bg-color: var(--crm-c-blue-overlay);
   --crm-tab-bg-active: var(--crm-paper);
-  --crm-tab-hang: 0 0 calc(-1 * var(--crm-s)) 0; /* thames todo check */
-  --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m); /* thames todo check */
+  --crm-tab-hang: 0 0 calc(-1 * var(--crm-s-small)) 0; /* thames todo check */
+  --crm-tab-padding: var(--crm-s-medium-2) var(--crm-s-reg-1) var(--crm-s-medium); /* thames todo check */
   --crm-tab-count-bg-color: var(--crm-info-text-color);
   --crm-tab-count-color: var(--crm-info-color);
   --crm-tab-radius: var(--crm-r-3) var(--crm-r-3) 0 0;
@@ -163,17 +163,17 @@
   --crm-contact-tab-bg-color: transparent;
   --crm-contact-tabs-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
   --crm-contact-tab-hover-bg-color: var(--crm-paper);
-  --crm-contact-tab-padding: var(--crm-m2) var(--crm-r1);
+  --crm-contact-tab-padding: var(--crm-s-medium-2) var(--crm-s-reg-1);
   --crm-contact-tab-border: var(--crm-contact-border);
   --crm-contact-tab-count-bg-color: var(--crm-primary-color);
   --crm-contact-tab-count-color: var(--crm-text-light-color);
   --crm-contact-tab-hang: 0 0 -1px 0;
   --crm-contact-tab-radius: 0;
   --crm-contact-heading-inset: unset;
-  --crm-contact-panel-padding: var(--crm-r2);
+  --crm-contact-panel-padding: var(--crm-s-reg-2);
   --crm-contact-panel-radius: 0 var(--crm-contact-radius) var(--crm-contact-radius) 0;
   --crm-contact-edit-border: 1px solid var(--crm-c-blue-dark);
-  --crm-contact-block-padding: var(--crm-m2);
+  --crm-contact-block-padding: var(--crm-s-medium-2);
   --crm-contact-block-bg-color: var(--crm-container-bg-color);
   --crm-contact-label-bg-color: var(--crm-container-bg-color);
   --crm-contact-header-bg-color: unset;
@@ -238,7 +238,7 @@
 /* Frontend */
   --crm-f-form-width: 700px;
   --crm-f-fieldset-bg-color: var(--crm-container-bg-color);
-  --crm-f-fieldset-padding: var(--crm-r);
+  --crm-f-fieldset-padding: var(--crm-s-reg);
   --crm-f-legend-align: center;
   --crm-f-label-position: unset;
   --crm-f-label-align: left;
@@ -395,7 +395,7 @@ html.cms-standalone body {
 .crm-container [type="reset"],
 .crm-container [type="submit"] {
   Sometimes we have lots of buttons and they wrap to a 2nd line. This puts some vertical space betwixt.
-  margin: var(--crm-m) 0;
+  margin: var(--crm-s-medium) 0;
 }
 
 /* Make it clear when you're hovering delete. */
@@ -517,7 +517,7 @@ html.cms-standalone body {
 
 /* RL has no margin-bottom so the actions ribbon touches the main contact block */
 div.crm-summary-contactname-block+.crm-actions-ribbon {
-  margin-bottom: var(--crm-r1) !important;
+  margin-bottom: var(--crm-s-reg-1) !important;
 }
 
 /* Use subgrid? No. Not responsive enough. */
@@ -698,11 +698,11 @@ nav.breadcrumb a {
 /* Breadcrumbs */
 html.crm-standalone  nav.breadcrumb>ol {
   display: flex;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
 }
 .breadcrumb ol li:not(:first-child)::before {
   content: " \BB ";
-  margin-inline-end: var(--crm-m);
+  margin-inline-end: var(--crm-s-medium);
   color: var(--crm-c-blue-dark);
 }
 
@@ -726,7 +726,7 @@ html.crm-standalone  nav.breadcrumb>ol {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: var(--crm-m);
+  gap: var(--crm-s-medium);
 }
 
 /* Spinner. Replace the fa icon with something nicer. */

--- a/ext/riverlea/streams/walbrook/_dark.css
+++ b/ext/riverlea/streams/walbrook/_dark.css
@@ -58,7 +58,7 @@
   --crm-dashlet-header-bg-color: var(--crm-layer1-bg-color);
 /* Button dropdowns '--crm-dropdown-' */
   --crm-dropdown-bg-color: var(--crm-container-bg-color);
-  --crm-dropdown-2-bg-color: var(--crm-container-bg-color);
+  --crm-dropdown2-bg-color: var(--crm-container-bg-color);
 /* Notifications '--crm-notify-' */
   --crm-notify-bg-color: var(--crm-container-bg-color);
 /* Icons '--crm-icon-' */

--- a/ext/riverlea/streams/walbrook/_dark.css
+++ b/ext/riverlea/streams/walbrook/_dark.css
@@ -7,66 +7,66 @@
   --crm-c-gray-600: #67676a;
   --crm-c-gray-500: #b3b3b3;
 /* Practical colours, e.g. background, text, link '--crm-c-' */
-  --crm-c-text-light: #fff;
-  --crm-c-text-dark: #302f35;
-  --crm-c-link: var(--crm-c-amber);
-  --crm-c-link-hover: var(--crm-c-amber-light);
-  --crm-c-focus: var(--crm-c-link);
-  --crm-c-inactive: var(--crm-c-gray-400);
+  --crm-text-light-color: #fff;
+  --crm-text-dark-color: #302f35;
+  --crm-link-color: var(--crm-c-amber);
+  --crm-link-hover-color: var(--crm-c-amber-light);
+  --crm-focus-color: var(--crm-link-color);
+  --crm-inactive-color: var(--crm-c-gray-400);
+  --crm-paper: var(--crm-c-darkest);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-c-page-bg: var(--crm-c-darkest);
-  --crm-c-layer0-bg: var(--crm-c-darkest);
-  --crm-c-container-bg: var(--crm-c-gray-900);
-  --crm-c-drag-bg: var(--crm-c-layer2-bg);
+  --crm-page-bg-color: var(--crm-c-darkest);
+  --crm-container-bg-color: var(--crm-c-gray-900);
+  --crm-drag-bg-color: var(--crm-layer2-bg-color);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */
-  --crm-c-success: var(--crm-c-green-dark);
-  --crm-c-warning-text: var(--crm-c-text-dark);
-  --crm-alert-warning-text: var(--crm-c-text-dark);
-  --crm-c-info: var(--crm-c-blue-dark);
+  --crm-success-color: var(--crm-c-green-dark);
+  --crm-warning-text-color: var(--crm-text-dark-color);
+  --crm-alert-warning-text-color: var(--crm-text-dark-color);
+  --crm-info-color: var(--crm-c-blue-dark);
 /* Shadows */
   --crm-shadow-block: 0 3px 18px 0 rgb(0,0,0);
 /* Sizes */
 /* Type */
-  --crm-heading-bg: var(--crm-c-secondary);
+  --crm-heading-bg-color: var(--crm-secondary-color);
 /* Mouse events */
 /* Buttons '--crm-btn-' */
 /* Tables '--crm-table-' */
-  --crm-table-row-hover: var(--crm-alert-info-border);
+  --crm-table-row-hover-color: var(--crm-alert-info-border-color);
 /* Panels '--crm-panel-' */
   --crm-panel-border-col: var(--crm-c-gray-500);
   --crm-panel-border: 1px;
-  --crm-panel-bg: var(--crm-c-container-bg);
+  --crm-panel-bg-color: var(--crm-container-bg-color);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
-  --crm-accordion-header-bg-active: var(--crm-c-secondary-hover);
-  --crm-accordion2-header-bg-active: var(--crm-c-secondary-hover);
+  --crm-accordion-header-bg-active-color: var(--crm-secondary-hover-color);
+  --crm-accordion2-header-bg-active-color: var(--crm-secondary-hover-color);
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
-  --crm-form-block-bg: var(--crm-c-container-bg);
+  --crm-form-block-bg-color: var(--crm-container-bg-color);
   --crm-input-border-color: var(--crm-c-gray-500);
 /* Tabs '--crm-tabs'/
 /* Contact layout '--crm-contact-' */
-  --crm-contact-header-bg: var(--crm-c-layer2-bg);
-  --crm-contact-block-bg: var(--crm-c-container-bg);
-  --crm-contact-tabs-bg: var(--crm-c-layer1-bg);
-  --crm-contact-panel-bg: var(--crm-c-container-bg);
-  --crm-contact-tab-bg-hover: var(--crm-c-layer2-bg);
+  --crm-contact-header-bg-color: var(--crm-layer2-bg-color);
+  --crm-contact-block-bg-color: var(--crm-container-bg-color);
+  --crm-contact-tabs-bg-color: var(--crm-layer1-bg-color);
+  --crm-contact-panel-bg-color: var(--crm-container-bg-color);
+  --crm-contact-tab-hover-bg-color: var(--crm-layer2-bg-color);
   --crm-contact-box-shadow: inset 0 5px 18px -5px rgba(0, 0, 0, 0.75);
-  --crm-contact-edit-border: 1px solid var(--crm-c-link-hover);
+  --crm-contact-edit-border: 1px solid var(--crm-link-hover-color);
 /* Dialog '--crm-dialog-' */
-  --crm-dialog-body-bg: var(--crm-c-container-bg);
+  --crm-dialog-body-bg-color: var(--crm-container-bg-color);
 /* Dashlet for main dashboard '--crm-dashlet-' */
-  --crm-dashlet-header-bg: var(--crm-c-layer1-bg);
+  --crm-dashlet-header-bg-color: var(--crm-layer1-bg-color);
 /* Button dropdowns '--crm-dropdown-' */
-  --crm-dropdown-bg: var(--crm-c-container-bg);
-  --crm-dropdown-2-bg: var(--crm-c-container-bg);
+  --crm-dropdown-bg-color: var(--crm-container-bg-color);
+  --crm-dropdown-2-bg-color: var(--crm-container-bg-color);
 /* Notifications '--crm-notify-' */
-  --crm-notify-bg: var(--crm-c-container-bg);
+  --crm-notify-bg-color: var(--crm-container-bg-color);
 /* Icons '--crm-icon-' */
 /* Wizard '--crm-wizard-' */
-  --crm-wizard-bg: var(--crm-c-container-bg);
-  --crm-wizard-active-bg: var(--crm-c-primary);
-  --crm-wizard-active-col: var(--crm-c-primary-text);
+  --crm-wizard-bg-color: var(--crm-container-bg-color);
+  --crm-wizard-active-bg-color: var(--crm-primary-color);
+  --crm-wizard-active-color: var(--crm-primary-text-color);
 /* Alpha filter '--crm-filter-' */
-  --crm-filter-bg: var(--crm-c-blue-dark);
+  --crm-filter-bg-color: var(--crm-c-blue-dark);
 /* Frontend '--crm-f- */
 }

--- a/ext/riverlea/streams/walbrook/_dark.css
+++ b/ext/riverlea/streams/walbrook/_dark.css
@@ -36,22 +36,22 @@
   --crm-panel-border-col: var(--crm-c-gray-500);
   --crm-panel-border: 1px;
   --crm-panel-bg: var(--crm-c-container-bg);
-/* Accordions '--crm-expand-' and '--crm-expand2-' for .crm-accrdion-light */
-  --crm-expand-header-bg-active: var(--crm-c-secondary-hover);
-  --crm-expand2-header-bg-active: var(--crm-c-secondary-hover);
+/* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
+  --crm-accordion-header-bg-active: var(--crm-c-secondary-hover);
+  --crm-accordion2-header-bg-active: var(--crm-c-secondary-hover);
 /* Alerts '--crm-alert' */
 /* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
   --crm-form-block-bg: var(--crm-c-container-bg);
   --crm-input-border-color: var(--crm-c-gray-500);
 /* Tabs '--crm-tabs'/
-/* Contact layout '--crm-dash-' */
-  --crm-dash-header-bg: var(--crm-c-layer2-bg);
-  --crm-dash-block-bg: var(--crm-c-container-bg);
-  --crm-dash-tabs-bg: var(--crm-c-layer1-bg);
-  --crm-dash-panel-bg: var(--crm-c-container-bg);
-  --crm-dash-tab-bg-hover: var(--crm-c-layer2-bg);
-  --crm-dash-box-shadow: inset 0 5px 18px -5px rgba(0, 0, 0, 0.75);
-  --crm-dash-edit-border: 1px solid var(--crm-c-link-hover);
+/* Contact layout '--crm-contact-' */
+  --crm-contact-header-bg: var(--crm-c-layer2-bg);
+  --crm-contact-block-bg: var(--crm-c-container-bg);
+  --crm-contact-tabs-bg: var(--crm-c-layer1-bg);
+  --crm-contact-panel-bg: var(--crm-c-container-bg);
+  --crm-contact-tab-bg-hover: var(--crm-c-layer2-bg);
+  --crm-contact-box-shadow: inset 0 5px 18px -5px rgba(0, 0, 0, 0.75);
+  --crm-contact-edit-border: 1px solid var(--crm-c-link-hover);
 /* Dialog '--crm-dialog-' */
   --crm-dialog-body-bg: var(--crm-c-container-bg);
 /* Dashlet for main dashboard '--crm-dashlet-' */

--- a/ext/riverlea/streams/walbrook/_dark.css
+++ b/ext/riverlea/streams/walbrook/_dark.css
@@ -24,7 +24,7 @@
   --crm-alert-warning-text: var(--crm-c-text-dark);
   --crm-c-info: var(--crm-c-blue-dark);
 /* Shadows */
-  --crm-block-shadow: 0 3px 18px 0 rgb(0,0,0);
+  --crm-shadow-block: 0 3px 18px 0 rgb(0,0,0);
 /* Sizes */
 /* Type */
   --crm-heading-bg: var(--crm-c-secondary);

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -61,7 +61,7 @@
   --crm-popup-shadow: var(--crm-block-shadow);
   --crm-body-inset: inset 0 10px 8px -10px rgba(0,0,0,.15),inset 0 -11px 8px -9px rgba(0,0,0,.15);
 /* Sizes */
-  --crm-roundness: 2px;
+  --crm-s-radius: 2px;
   --crm-padding-inset: 0; /* to support flush theme variations */
   --crm-page-padding: 0; /* Margin left/right */
 /* Type */
@@ -88,28 +88,28 @@
   --crm-panel-head-margin: var(--crm-m2);
   --crm-panel-head-height: 48px;
 /* Accordions */
-  --crm-expand-icon: "\f105"; /* unicode value for FontAwesome icon */
-  --crm-expand-icon-color: unset;
-  --crm-expand-icon-spacing: var(--crm-m3);
-  --crm-expand-gap: 0;
+  --crm-accordion-icon: "\f105"; /* unicode value for FontAwesome icon */
+  --crm-accordion-icon-color: unset;
+  --crm-accordion-icon-spacing: var(--crm-m3);
+  --crm-accordion-gap: 0;
 /* .crm-accordion-bold */
-  --crm-expand-header-bg: var(--crm-c-layer1-bg);
-  --crm-expand-header-bg-active: var(--crm-c-layer2-bg);
-  --crm-expand-header-color: var(--crm-c-text);
-  --crm-expand-header-padding: var(--crm-m2) var(--crm-m3);
-  --crm-expand-border: unset;
-  --crm-expand-border-width: unset;
-  --crm-expand-body-bg: transparent;
-  --crm-expand-body-box-shadow: var(--crm-body-inset);
+  --crm-accordion-header-bg: var(--crm-c-layer1-bg);
+  --crm-accordion-header-bg-active: var(--crm-c-layer2-bg);
+  --crm-accordion-header-color: var(--crm-c-text);
+  --crm-accordion-header-padding: var(--crm-m2) var(--crm-m3);
+  --crm-accordion-border: unset;
+  --crm-accordion-border-width: unset;
+  --crm-accordion-body-bg: transparent;
+  --crm-accordion-body-box-shadow: var(--crm-body-inset);
 /* .crm-accordion-light */
-  --crm-expand2-header-bg: var(--crm-c-primary);
-  --crm-expand2-header-bg-active: var(--crm-c-primary-hover);
-  --crm-expand2-header-weight: bold;
-  --crm-expand2-header-color: var(--crm-c-primary-text);
-  --crm-expand2-header-padding: var(--crm-expand-header-padding);
-  --crm-expand2-border: 0;
-  --crm-expand2-body-bg: transparent;
-  --crm-expand2-body-padding: 0;
+  --crm-accordion2-header-bg: var(--crm-c-primary);
+  --crm-accordion2-header-bg-active: var(--crm-c-primary-hover);
+  --crm-accordion2-header-weight: bold;
+  --crm-accordion2-header-color: var(--crm-c-primary-text);
+  --crm-accordion2-header-padding: var(--crm-accordion-header-padding);
+  --crm-accordion2-border: 0;
+  --crm-accordion2-body-bg: transparent;
+  --crm-accordion2-body-padding: 0;
 /* Alerts */
   --crm-alert-padding: var(--crm-r) var(--crm-r2);
   --crm-alert-success-text: var(--crm-c-success-on-page-bg);
@@ -121,7 +121,7 @@
   --crm-input-bg: var(--crm-c-container-bg);
   --crm-input-bg-image: none;
   --crm-input-border-color: #c2cfd8;
-  --crm-input-border-radius: var(--crm-roundness);
+  --crm-input-border-radius: var(--crm-s-radius);
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);
   --crm-input-padding: var(--crm-xs1) var(--crm-m1);
   --crm-input-label-weight: bold;
@@ -134,7 +134,7 @@
   --crm-tabs-bg: var(--crm-c-layer1-bg);
   --crm-tabs-padding: var(--crm-m) var(--crm-m) 0 var(--crm-m);
   --crm-tabs-border: var(--crm-c-divider);
-  --crm-tab-roundness: 2px 2px 0 0;
+  --crm-tab-radius: 2px 2px 0 0;
   --crm-tab-bg-hover: var(--crm-c-layer0-bg);
   --crm-tab-bg-active: var(--crm-c-container-bg);
   --crm-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
@@ -144,40 +144,40 @@
   --crm-tab-count-col: var(--crm-c-text);
   --crm-tab-border-active: var(--crm-c-divider);
 /* Contact dashboard */
-  --crm-dash-border: 0 solid transparent;
-  --crm-dash-roundness: 0;
-  --crm-dash-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
+  --crm-contact-border: 0 solid transparent;
+  --crm-contact-radius: 0;
+  --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
   --crm-side-tabs-width: 220px;
-  --crm-dash-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
-  --crm-dash-tabs-gap: 0;
-  --crm-dash-tabs-bg: var(--crm-c-container-bg);
-  --crm-dash-tabs-padding: unset;
-  --crm-dash-tab-bg: transparent;
-  --crm-dash-tab-bg-hover: var(--crm-c-layer2-bg);
-  --crm-dash-tab-padding: var(--crm-r) var(--crm-r1);
-  --crm-dash-tab-border: var(--crm-dash-border);
-  --crm-dash-tab-border-hover: unset;
-  --crm-dash-tab-col: unset;
-  --crm-dash-tab-count-bg: var(--crm-c-primary);
-  --crm-dash-tab-count-col: var(--crm-c-text-light);
-  --crm-dash-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-dash-icon-size: var(--crm-m2);
-  --crm-dash-box-shadow: inset 0 3px 18px -5px rgba(0, 0, 0, 0.25);
-  --crm-dash-panel-padding: var(--crm-r2);
-  --crm-dash-edit-border: 1px dashed var(--crm-c-gray-900);
-  --crm-dash-block-padding: var(--crm-m2);
-  --crm-dash-block-bg: var(--crm-c-container-bg);
-  --crm-dash-label-bg: var(--crm-c-container-bg);
-  --crm-dash-header-bg: var(--crm-c-gray-900);
-  --crm-dash-header-bg2: var(--crm-c-gray-800);
-  --crm-dash-header-col: var(--crm-c-text-light);
-  --crm-dash-header-size: var(--crm-l);
-  --crm-dash-header-padding: var(--crm-r) var(--crm-r1);
-  --crm-dash-image-size: 100px;
-  --crm-dash-image-radius: 200px;
-  --crm-dash-image-right: 30px; /* distance from right of dashboard */
-  --crm-dash-image-top: 30px; /* distance from top of dashboard */
-  --crm-dash-image-border: 2px solid #fff;
+  --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
+  --crm-contact-tabs-gap: 0;
+  --crm-contact-tabs-bg: var(--crm-c-container-bg);
+  --crm-contact-tabs-padding: unset;
+  --crm-contact-tab-bg: transparent;
+  --crm-contact-tab-bg-hover: var(--crm-c-layer2-bg);
+  --crm-contact-tab-padding: var(--crm-r) var(--crm-r1);
+  --crm-contact-tab-border: var(--crm-contact-border);
+  --crm-contact-tab-border-hover: unset;
+  --crm-contact-tab-col: unset;
+  --crm-contact-tab-count-bg: var(--crm-c-primary);
+  --crm-contact-tab-count-col: var(--crm-c-text-light);
+  --crm-contact-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
+  --crm-contact-icon-size: var(--crm-m2);
+  --crm-contact-box-shadow: inset 0 3px 18px -5px rgba(0, 0, 0, 0.25);
+  --crm-contact-panel-padding: var(--crm-r2);
+  --crm-contact-edit-border: 1px dashed var(--crm-c-gray-900);
+  --crm-contact-block-padding: var(--crm-m2);
+  --crm-contact-block-bg: var(--crm-c-container-bg);
+  --crm-contact-label-bg: var(--crm-c-container-bg);
+  --crm-contact-header-bg: var(--crm-c-gray-900);
+  --crm-contact-header-bg2: var(--crm-c-gray-800);
+  --crm-contact-header-col: var(--crm-c-text-light);
+  --crm-contact-header-size: var(--crm-l);
+  --crm-contact-header-padding: var(--crm-r) var(--crm-r1);
+  --crm-contact-image-size: 100px;
+  --crm-contact-image-radius: 200px;
+  --crm-contact-image-right: 30px; /* distance from right of dashboard */
+  --crm-contact-image-top: 30px; /* distance from top of dashboard */
+  --crm-contact-image-border: 2px solid #fff;
 /* Dialog */
   --crm-dialog-bg: var(--crm-c-container-bg);
   --crm-dialog-padding: 0;

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -4,9 +4,6 @@
 */
 
 :root {
-/* Fonts */
-  --crm-system-fonts: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
-  --crm-font: "Inter", "Open Sans", var(--crm-system-fonts);
 /* Colour names */
   --crm-c-gray-900: #222831;
   --crm-c-gray-800: #393a3f;
@@ -57,14 +54,15 @@
   --crm-c-info-light: var(--crm-c-blue-light);
   --crm-c-info-on-page-bg: var(--crm-c-blue-darker);
 /* Shadows */
-  --crm-block-shadow: 0 3px 18px 0 rgba(48,40,40,.25);
-  --crm-popup-shadow: var(--crm-block-shadow);
-  --crm-body-inset: inset 0 10px 8px -10px rgba(0,0,0,.15),inset 0 -11px 8px -9px rgba(0,0,0,.15);
+  --crm-shadow-block: 0 3px 18px 0 rgba(48,40,40,.25);
+  --crm-shadow-popup: var(--crm-shadow-block);
 /* Sizes */
   --crm-s-radius: 2px;
   --crm-padding-inset: 0; /* to support flush theme variations */
   --crm-page-padding: 0; /* Margin left/right */
 /* Type */
+  --crm-font-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
+  --crm-font: "Inter", "Open Sans", var(--crm-font-system);
   --crm-link-decoration-hover: none;
   --crm-heading-bg: var(--crm-c-layer2-bg);
   --crm-heading-col: var(--crm-c-text-dark);
@@ -100,7 +98,7 @@
   --crm-accordion-border: unset;
   --crm-accordion-border-width: unset;
   --crm-accordion-body-bg: transparent;
-  --crm-accordion-body-box-shadow: var(--crm-body-inset);
+  --crm-accordion-body-box-shadow: inset 0 10px 8px -10px rgba(0,0,0,.15),inset 0 -11px 8px -9px rgba(0,0,0,.15);
 /* .crm-accordion-light */
   --crm-accordion2-header-bg: var(--crm-c-primary);
   --crm-accordion2-header-bg-active: var(--crm-c-primary-hover);

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -22,37 +22,37 @@
   --crm-c-green-dark: rgb(21, 76, 42);
   --crm-c-red: #91223c;
   --crm-c-red-light: #ecb1bc;
-  --crm-c-red-dark: var(--crm-c-text);
+  --crm-c-red-dark: var(--crm-text-color);
   --crm-c-amber: #eab876;
   --crm-c-yellow: #f8e80b;
   --crm-c-teal: #399389;
 /* Practical colours */
-  --crm-c-text: #34303b;
-  --crm-c-link: var(--crm-c-blue-dark);
-  --crm-c-link-hover: var(--crm-c-blue-darker);
-  --crm-c-page-bg: #e8eef0;
-  --crm-c-container-bg: var(--crm-paper);
-  --crm-c-drag-bg: var(--crm-c-gray-200); /* background for drag/drop regions, select2 highlight */
-  --crm-c-code-bg: var(--crm-c-layer2-bg); /* bg for code blocks */
+  --crm-text-color: #34303b;
+  --crm-link-color: var(--crm-c-blue-dark);
+  --crm-link-hover-color: var(--crm-c-blue-darker);
+  --crm-page-bg-color: #e8eef0;
+  --crm-container-bg-color: var(--crm-paper);
+  --crm-drag-bg-color: var(--crm-c-gray-200); /* background for drag/drop regions, select2 highlight */
+  --crm-code-bg-color: var(--crm-layer2-bg-color); /* bg for code blocks */
 /* Emphasis colours */
-  --crm-c-primary: var(--crm-c-blue-dark);
-  --crm-c-secondary: var(--crm-c-purple);
-  --crm-c-success: var(--crm-c-green);
-  --crm-c-success-text: var(--crm-c-text);
-  --crm-c-success-light: var(--crm-c-green-light);
-  --crm-c-success-on-page-bg: var(--crm-c-green-dark);
-  --crm-c-warning: var(--crm-c-amber);
-  --crm-c-warning-text: var(--crm-c-text);
-  --crm-c-warning-light: var(--crm-c-amber-light);
-  --crm-c-warning-on-page-bg: #873502;
-  --crm-c-danger: var(--crm-c-red);
-  --crm-c-danger-text: var(--crm-c-text-light);
-  --crm-c-danger-light: var(--crm-c-red-light);
-  --crm-c-danger-on-page-bg: var(--crm-c-danger);
-  --crm-c-info: var(--crm-c-blue);
-  --crm-c-info-text: var(--crm-c-text);
-  --crm-c-info-light: var(--crm-c-blue-light);
-  --crm-c-info-on-page-bg: var(--crm-c-blue-darker);
+  --crm-primary-color: var(--crm-c-blue-dark);
+  --crm-secondary-color: var(--crm-c-purple);
+  --crm-success-color: var(--crm-c-green);
+  --crm-success-text-color: var(--crm-text-color);
+  --crm-success-light-color: var(--crm-c-green-light);
+  --crm-success-ink-color: var(--crm-c-green-dark);
+  --crm-warning-color: var(--crm-c-amber);
+  --crm-warning-text-color: var(--crm-text-color);
+  --crm-warning-light-color: var(--crm-c-amber-light);
+  --crm-warning-ink-color: #873502;
+  --crm-danger-color: var(--crm-c-red);
+  --crm-danger-text-color: var(--crm-text-light-color);
+  --crm-danger-light-color: var(--crm-c-red-light);
+  --crm-danger-ink-color: var(--crm-danger-color);
+  --crm-info-color: var(--crm-c-blue);
+  --crm-info-text-color: var(--crm-text-color);
+  --crm-info-light-color: var(--crm-c-blue-light);
+  --crm-info-ink-color: var(--crm-c-blue-darker);
 /* Shadows */
   --crm-shadow-block: 0 3px 18px 0 rgba(48,40,40,.25);
   --crm-shadow-popup: var(--crm-shadow-block);
@@ -64,8 +64,8 @@
   --crm-font-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue",sans-serif;
   --crm-font: "Inter", "Open Sans", var(--crm-font-system);
   --crm-link-decoration-hover: none;
-  --crm-heading-bg: var(--crm-c-layer2-bg);
-  --crm-heading-col: var(--crm-c-text-dark);
+  --crm-heading-bg-color: var(--crm-layer2-bg-color);
+  --crm-heading-color: var(--crm-text-dark-color);
   --crm-heading-padding: var(--crm-m2) var(--crm-m);
   --crm-heading-margin: 0;
   --crm-heading-radius: 0;
@@ -76,9 +76,9 @@
   --crm-btn-small-padding: var(--crm-s1) var(--crm-m1);
   --crm-btn-height: 40px;
 /* Tables */
-  --crm-table-row-bg: var(--crm-c-container-bg);
-  --crm-table-row-hover: var(--crm-c-gray-200);
-  --crm-table-sort-col: var(--crm-c-gray-500);
+  --crm-table-row-bg-color: var(--crm-container-bg-color);
+  --crm-table-row-hover-color: var(--crm-c-gray-200);
+  --crm-table-sort-color: var(--crm-c-gray-500);
   --crm-table-nested-padding: 0 0 var(--crm-r) 0;
   --crm-table-nested-head-border: 2px solid var(--crm-c-gray-300);
   --crm-table-nested-border: 0 solid transparent;
@@ -91,55 +91,55 @@
   --crm-accordion-icon-spacing: var(--crm-m3);
   --crm-accordion-gap: 0;
 /* .crm-accordion-bold */
-  --crm-accordion-header-bg: var(--crm-c-layer1-bg);
-  --crm-accordion-header-bg-active: var(--crm-c-layer2-bg);
-  --crm-accordion-header-color: var(--crm-c-text);
+  --crm-accordion-header-bg-color: var(--crm-layer1-bg-color);
+  --crm-accordion-header-bg-active-color: var(--crm-layer2-bg-color);
+  --crm-accordion-header-color: var(--crm-text-color);
   --crm-accordion-header-padding: var(--crm-m2) var(--crm-m3);
   --crm-accordion-border: unset;
   --crm-accordion-border-width: unset;
-  --crm-accordion-body-bg: transparent;
+  --crm-accordion-body-bg-color: transparent;
   --crm-accordion-body-box-shadow: inset 0 10px 8px -10px rgba(0,0,0,.15),inset 0 -11px 8px -9px rgba(0,0,0,.15);
 /* .crm-accordion-light */
-  --crm-accordion2-header-bg: var(--crm-c-primary);
-  --crm-accordion2-header-bg-active: var(--crm-c-primary-hover);
+  --crm-accordion2-header-bg-color: var(--crm-primary-color);
+  --crm-accordion2-header-bg-active-color: var(--crm-primary-hover-color);
   --crm-accordion2-header-weight: bold;
-  --crm-accordion2-header-color: var(--crm-c-primary-text);
+  --crm-accordion2-header-color: var(--crm-primary-text-color);
   --crm-accordion2-header-padding: var(--crm-accordion-header-padding);
   --crm-accordion2-border: 0;
-  --crm-accordion2-body-bg: transparent;
+  --crm-accordion2-body-bg-color: transparent;
   --crm-accordion2-body-padding: 0;
 /* Alerts */
   --crm-alert-padding: var(--crm-r) var(--crm-r2);
-  --crm-alert-success-text: var(--crm-c-success-on-page-bg);
-  --crm-alert-danger-text: var(--crm-c-text);
-  --crm-alert-info-text: var(--crm-c-info-on-page-bg);
+  --crm-alert-success-text-color: var(--crm-success-ink-color);
+  --crm-alert-danger-text-color: var(--crm-text-color);
+  --crm-alert-info-text-color: var(--crm-info-ink-color);
 /* Form */
   --crm-form-block-padding: var(--crm-r);
   --crm-form-block-border-radius: 0;
-  --crm-input-bg: var(--crm-c-container-bg);
+  --crm-input-bg-color: var(--crm-container-bg-color);
   --crm-input-bg-image: none;
   --crm-input-border-color: #c2cfd8;
   --crm-input-border-radius: var(--crm-s-radius);
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);
   --crm-input-padding: var(--crm-xs1) var(--crm-m1);
   --crm-input-label-weight: bold;
-  --crm-input-radio-color: var(--crm-c-primary);
-  --crm-inline-edit-border: 1px solid var(--crm-c-gray-900);
-  --crm-fieldset-border-color: unset;
-  --crm-fieldset-border: 0;
-  --crm-fieldset-padding: 0;
+  --crm-input-radio-color: var(--crm-primary-color);
+  --crm-input-inline-edit-border: 1px solid var(--crm-c-gray-900);
+  --crm-form-fieldset-border-color: unset;
+  --crm-form-fieldset-border: 0;
+  --crm-form-fieldset-padding: 0;
 /* Tabs */
-  --crm-tabs-bg: var(--crm-c-layer1-bg);
+  --crm-tabs-bg-color: var(--crm-layer1-bg-color);
   --crm-tabs-padding: var(--crm-m) var(--crm-m) 0 var(--crm-m);
   --crm-tabs-border: var(--crm-border);
   --crm-tab-radius: 2px 2px 0 0;
-  --crm-tab-bg-hover: var(--crm-paper);
-  --crm-tab-bg-active: var(--crm-c-container-bg);
+  --crm-tab-hover-bg-color: var(--crm-paper);
+  --crm-tab-bg-active: var(--crm-container-bg-color);
   --crm-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m);
   --crm-tab-weight: bold;
-  --crm-tab-count-bg: transparent;
-  --crm-tab-count-col: var(--crm-c-text);
+  --crm-tab-count-bg-color: transparent;
+  --crm-tab-count-color: var(--crm-text-color);
   --crm-tab-border-active: var(--crm-border);
 /* Contact dashboard */
   --crm-contact-border: 0 solid transparent;
@@ -148,27 +148,26 @@
   --crm-side-tabs-width: 220px;
   --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
   --crm-contact-tabs-gap: 0;
-  --crm-contact-tabs-bg: var(--crm-c-container-bg);
+  --crm-contact-tabs-bg-color: var(--crm-container-bg-color);
   --crm-contact-tabs-padding: unset;
-  --crm-contact-tab-bg: transparent;
-  --crm-contact-tab-bg-hover: var(--crm-c-layer2-bg);
+  --crm-contact-tab-bg-color: transparent;
+  --crm-contact-tab-hover-bg-color: var(--crm-layer2-bg-color);
   --crm-contact-tab-padding: var(--crm-r) var(--crm-r1);
   --crm-contact-tab-border: var(--crm-contact-border);
   --crm-contact-tab-border-hover: unset;
-  --crm-contact-tab-col: unset;
-  --crm-contact-tab-count-bg: var(--crm-c-primary);
-  --crm-contact-tab-count-col: var(--crm-c-text-light);
+  --crm-contact-tab-count-bg-color: var(--crm-primary-color);
+  --crm-contact-tab-count-color: var(--crm-text-light-color);
   --crm-contact-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-contact-icon-size: var(--crm-m2);
   --crm-contact-box-shadow: inset 0 3px 18px -5px rgba(0, 0, 0, 0.25);
   --crm-contact-panel-padding: var(--crm-r2);
   --crm-contact-edit-border: 1px dashed var(--crm-c-gray-900);
   --crm-contact-block-padding: var(--crm-m2);
-  --crm-contact-block-bg: var(--crm-c-container-bg);
-  --crm-contact-label-bg: var(--crm-c-container-bg);
-  --crm-contact-header-bg: var(--crm-c-gray-900);
-  --crm-contact-header-bg2: var(--crm-c-gray-800);
-  --crm-contact-header-col: var(--crm-c-text-light);
+  --crm-contact-block-bg-color: var(--crm-container-bg-color);
+  --crm-contact-label-bg-color: var(--crm-container-bg-color);
+  --crm-contact-header-bg-color: var(--crm-c-gray-900);
+  --crm-contact-header2-bg-color: var(--crm-c-gray-800);
+  --crm-contact-header-color: var(--crm-text-light-color);
   --crm-contact-header-size: var(--crm-l);
   --crm-contact-header-padding: var(--crm-r) var(--crm-r1);
   --crm-contact-image-size: 100px;
@@ -177,27 +176,27 @@
   --crm-contact-image-top: 30px; /* distance from top of dashboard */
   --crm-contact-image-border: 2px solid #fff;
 /* Dialog */
-  --crm-dialog-bg: var(--crm-c-container-bg);
+  --crm-dialog-bg-color: var(--crm-container-bg-color);
   --crm-dialog-padding: 0;
   --crm-dialog-line: var(--crm-border);
-  --crm-dialog-header-bg: var(--crm-c-layer2-bg);
-  --crm-dialog-header-col: var(--crm-c-text);
+  --crm-dialog-header-bg-color: var(--crm-layer2-bg-color);
+  --crm-dialog-header-color: var(--crm-text-color);
 /* Dashlet */
   --crm-dashlet-border: var(--crm-tab-border);
-  --crm-dashlet-bg: var(--crm-c-container-bg);
+  --crm-dashlet-bg-color: var(--crm-container-bg-color);
   --crm-dashlet-padding: 0;
-  --crm-dashlet-header-bg: var(--crm-c-secondary);
-  --crm-dashlet-header-col: var(--crm-c-text-light);
+  --crm-dashlet-header-bg-color: var(--crm-secondary-color);
+  --crm-dashlet-header-color: var(--crm-text-light-color);
   --crm-dashlet-header-padding: var(--crm-padding-reg);
   --crm-dashlet-tabs-border: var(--crm-tabs-border);
 /* Notifications */
-  --crm-notify-bg: var(--crm-paper);
-  --crm-notify-col: var(--crm-c-text);
+  --crm-notify-bg-color: var(--crm-paper);
+  --crm-notify-color: var(--crm-text-color);
   --crm-notify-accent-border: 0 0 0 3px; /* adds a border to one/several sides of the notification - set to 0 for none */
-  --crm-notify-danger: #d02e2e;
-  --crm-notify-warning: #c45008;
-  --crm-notify-success: #5a803c;
-  --crm-notify-info: #277fa5;
+  --crm-notify-danger-color: #d02e2e;
+  --crm-notify-warning-color: #c45008;
+  --crm-notify-success-color: #5a803c;
+  --crm-notify-info-color: #277fa5;
   /* Wizard */
   --crm-wizard-width: auto;
   --crm-wizard-margin: calc(-1 * var(--crm-form-block-padding)) calc(-1 * var(--crm-form-block-padding)) 0;
@@ -205,9 +204,9 @@
   --crm-wizard-radius: 0;
   --crm-wizard-angle: 20px;
   --crm-wizard-arrow-thickness: 2px;
-  --crm-wizard-active-col: var(--crm-c-link);
-  --crm-wizard-active-bg: var(--crm-c-page-bg);
-  --crm-wizard-border: 1px solid var(--crm-c-page-bg);
+  --crm-wizard-active-color: var(--crm-link-color);
+  --crm-wizard-active-bg-color: var(--crm-page-bg-color);
+  --crm-wizard-border: 1px solid var(--crm-page-bg-color);
 /* Frontend */
   --crm-f-fieldset-padding: var(--crm-padding-reg);
   --crm-f-legend-align: unset;

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -31,7 +31,7 @@
   --crm-c-link: var(--crm-c-blue-dark);
   --crm-c-link-hover: var(--crm-c-blue-darker);
   --crm-c-page-bg: #e8eef0;
-  --crm-c-container-bg: var(--crm-c-layer0-bg);
+  --crm-c-container-bg: var(--crm-paper);
   --crm-c-drag-bg: var(--crm-c-gray-200); /* background for drag/drop regions, select2 highlight */
   --crm-c-code-bg: var(--crm-c-layer2-bg); /* bg for code blocks */
 /* Emphasis colours */
@@ -133,7 +133,7 @@
   --crm-tabs-padding: var(--crm-m) var(--crm-m) 0 var(--crm-m);
   --crm-tabs-border: var(--crm-border);
   --crm-tab-radius: 2px 2px 0 0;
-  --crm-tab-bg-hover: var(--crm-c-layer0-bg);
+  --crm-tab-bg-hover: var(--crm-paper);
   --crm-tab-bg-active: var(--crm-c-container-bg);
   --crm-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m);
@@ -191,7 +191,7 @@
   --crm-dashlet-header-padding: var(--crm-padding-reg);
   --crm-dashlet-tabs-border: var(--crm-tabs-border);
 /* Notifications */
-  --crm-notify-bg: var(--crm-c-layer0-bg);
+  --crm-notify-bg: var(--crm-paper);
   --crm-notify-col: var(--crm-c-text);
   --crm-notify-accent-border: 0 0 0 3px; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-danger: #d02e2e;

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -131,7 +131,7 @@
 /* Tabs */
   --crm-tabs-bg: var(--crm-c-layer1-bg);
   --crm-tabs-padding: var(--crm-m) var(--crm-m) 0 var(--crm-m);
-  --crm-tabs-border: var(--crm-c-divider);
+  --crm-tabs-border: var(--crm-border);
   --crm-tab-radius: 2px 2px 0 0;
   --crm-tab-bg-hover: var(--crm-c-layer0-bg);
   --crm-tab-bg-active: var(--crm-c-container-bg);
@@ -140,7 +140,7 @@
   --crm-tab-weight: bold;
   --crm-tab-count-bg: transparent;
   --crm-tab-count-col: var(--crm-c-text);
-  --crm-tab-border-active: var(--crm-c-divider);
+  --crm-tab-border-active: var(--crm-border);
 /* Contact dashboard */
   --crm-contact-border: 0 solid transparent;
   --crm-contact-radius: 0;
@@ -179,7 +179,7 @@
 /* Dialog */
   --crm-dialog-bg: var(--crm-c-container-bg);
   --crm-dialog-padding: 0;
-  --crm-dialog-line: var(--crm-c-divider);
+  --crm-dialog-line: var(--crm-border);
   --crm-dialog-header-bg: var(--crm-c-layer2-bg);
   --crm-dialog-header-col: var(--crm-c-text);
 /* Dashlet */

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -57,7 +57,7 @@
   --crm-shadow-block: 0 3px 18px 0 rgba(48,40,40,.25);
   --crm-shadow-popup: var(--crm-shadow-block);
 /* Sizes */
-  --crm-s-radius: 2px;
+  --crm-l-radius: 2px;
   --crm-padding-inset: 0; /* to support flush theme variations */
   --crm-page-padding: 0; /* Margin left/right */
 /* Type */
@@ -66,35 +66,35 @@
   --crm-link-decoration-hover: none;
   --crm-heading-bg-color: var(--crm-layer2-bg-color);
   --crm-heading-color: var(--crm-text-dark-color);
-  --crm-heading-padding: var(--crm-s-medium-2) var(--crm-s-medium);
+  --crm-heading-padding: var(--crm-l-medium-2) var(--crm-l-medium);
   --crm-heading-margin: 0;
   --crm-heading-radius: 0;
 /* Buttons */
   --crm-btn-radius: 2px;
-  --crm-btn-padding-block: var(--crm-s-medium); /* padding for top and bottom, one value */
-  --crm-btn-padding-inline: var(--crm-s-reg-2); /* padding for left and right, one value */
-  --crm-btn-small-padding: var(--crm-s-small-1) var(--crm-s-medium-1);
+  --crm-btn-padding-block: var(--crm-l-medium); /* padding for top and bottom, one value */
+  --crm-btn-padding-inline: var(--crm-l-reg-2); /* padding for left and right, one value */
+  --crm-btn-small-padding: var(--crm-l-small-1) var(--crm-l-medium-1);
   --crm-btn-height: 40px;
 /* Tables */
   --crm-table-row-bg-color: var(--crm-container-bg-color);
   --crm-table-row-hover-color: var(--crm-c-gray-200);
   --crm-table-sort-color: var(--crm-c-gray-500);
-  --crm-table-nested-padding: 0 0 var(--crm-s-reg) 0;
+  --crm-table-nested-padding: 0 0 var(--crm-l-reg) 0;
   --crm-table-nested-head-border: 2px solid var(--crm-c-gray-300);
   --crm-table-nested-border: 0 solid transparent;
 /* Panels */
-  --crm-panel-head-margin: var(--crm-s-medium-2);
+  --crm-panel-head-margin: var(--crm-l-medium-2);
   --crm-panel-head-height: 48px;
 /* Accordions */
   --crm-accordion-icon: "\f105"; /* unicode value for FontAwesome icon */
   --crm-accordion-icon-color: unset;
-  --crm-accordion-icon-spacing: var(--crm-s-medium-3);
+  --crm-accordion-icon-spacing: var(--crm-l-medium-3);
   --crm-accordion-gap: 0;
 /* .crm-accordion-bold */
   --crm-accordion-header-bg-color: var(--crm-layer1-bg-color);
   --crm-accordion-header-bg-active-color: var(--crm-layer2-bg-color);
   --crm-accordion-header-color: var(--crm-text-color);
-  --crm-accordion-header-padding: var(--crm-s-medium-2) var(--crm-s-medium-3);
+  --crm-accordion-header-padding: var(--crm-l-medium-2) var(--crm-l-medium-3);
   --crm-accordion-border: unset;
   --crm-accordion-border-width: unset;
   --crm-accordion-body-bg-color: transparent;
@@ -109,19 +109,19 @@
   --crm-accordion2-body-bg-color: transparent;
   --crm-accordion2-body-padding: 0;
 /* Alerts */
-  --crm-alert-padding: var(--crm-s-reg) var(--crm-s-reg-2);
+  --crm-alert-padding: var(--crm-l-reg) var(--crm-l-reg-2);
   --crm-alert-success-text-color: var(--crm-success-ink-color);
   --crm-alert-danger-text-color: var(--crm-text-color);
   --crm-alert-info-text-color: var(--crm-info-ink-color);
 /* Form */
-  --crm-form-block-padding: var(--crm-s-reg);
+  --crm-form-block-padding: var(--crm-l-reg);
   --crm-form-block-border-radius: 0;
   --crm-input-bg-color: var(--crm-container-bg-color);
   --crm-input-bg-image: none;
   --crm-input-border-color: #c2cfd8;
-  --crm-input-border-radius: var(--crm-s-radius);
+  --crm-input-border-radius: var(--crm-l-radius);
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);
-  --crm-input-padding: var(--crm-s-xsmall-1) var(--crm-s-medium-1);
+  --crm-input-padding: var(--crm-l-xsmall-1) var(--crm-l-medium-1);
   --crm-input-label-weight: bold;
   --crm-input-radio-color: var(--crm-primary-color);
   --crm-input-inline-edit-border: 1px solid var(--crm-c-gray-900);
@@ -130,17 +130,17 @@
   --crm-form-fieldset-padding: 0;
 /* Tabs */
   --crm-tabs-bg-color: var(--crm-layer1-bg-color);
-  --crm-tabs-padding: var(--crm-s-medium) var(--crm-s-medium) 0 var(--crm-s-medium);
+  --crm-tabs-padding: var(--crm-l-medium) var(--crm-l-medium) 0 var(--crm-l-medium);
   --crm-tabs-border: var(--crm-border);
   --crm-tab-radius: 2px 2px 0 0;
   --crm-tab-hover-bg-color: var(--crm-paper);
   --crm-tab-bg-active: var(--crm-container-bg-color);
   --crm-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-tab-padding: var(--crm-s-medium-2) var(--crm-s-reg-1) var(--crm-s-medium);
+  --crm-tab-padding: var(--crm-l-medium-2) var(--crm-l-reg-1) var(--crm-l-medium);
   --crm-tab-weight: bold;
   --crm-tab-count-bg-color: transparent;
   --crm-tab-count-color: var(--crm-text-color);
-  --crm-tab-border-active: var(--crm-border);
+  --crm-tab-active-border: var(--crm-border);
 /* Contact dashboard */
   --crm-contact-border: 0 solid transparent;
   --crm-contact-radius: 0;
@@ -152,24 +152,24 @@
   --crm-contact-tabs-padding: unset;
   --crm-contact-tab-bg-color: transparent;
   --crm-contact-tab-hover-bg-color: var(--crm-layer2-bg-color);
-  --crm-contact-tab-padding: var(--crm-s-reg) var(--crm-s-reg-1);
+  --crm-contact-tab-padding: var(--crm-l-reg) var(--crm-l-reg-1);
   --crm-contact-tab-border: var(--crm-contact-border);
-  --crm-contact-tab-border-hover: unset;
+  --crm-contact-tab-hover-border: unset;
   --crm-contact-tab-count-bg-color: var(--crm-primary-color);
   --crm-contact-tab-count-color: var(--crm-text-light-color);
   --crm-contact-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-contact-icon-size: var(--crm-s-medium-2);
+  --crm-contact-icon-size: var(--crm-l-medium-2);
   --crm-contact-box-shadow: inset 0 3px 18px -5px rgba(0, 0, 0, 0.25);
-  --crm-contact-panel-padding: var(--crm-s-reg-2);
+  --crm-contact-panel-padding: var(--crm-l-reg-2);
   --crm-contact-edit-border: 1px dashed var(--crm-c-gray-900);
-  --crm-contact-block-padding: var(--crm-s-medium-2);
+  --crm-contact-block-padding: var(--crm-l-medium-2);
   --crm-contact-block-bg-color: var(--crm-container-bg-color);
   --crm-contact-label-bg-color: var(--crm-container-bg-color);
   --crm-contact-header-bg-color: var(--crm-c-gray-900);
   --crm-contact-header2-bg-color: var(--crm-c-gray-800);
   --crm-contact-header-color: var(--crm-text-light-color);
-  --crm-contact-header-size: var(--crm-s-large);
-  --crm-contact-header-padding: var(--crm-s-reg) var(--crm-s-reg-1);
+  --crm-contact-header-size: var(--crm-l-large);
+  --crm-contact-header-padding: var(--crm-l-reg) var(--crm-l-reg-1);
   --crm-contact-image-size: 100px;
   --crm-contact-image-radius: 200px;
   --crm-contact-image-right: 30px; /* distance from right of dashboard */
@@ -178,7 +178,7 @@
 /* Dialog */
   --crm-dialog-bg-color: var(--crm-container-bg-color);
   --crm-dialog-padding: 0;
-  --crm-dialog-line: var(--crm-border);
+  --crm-dialog-footer-border: var(--crm-border);
   --crm-dialog-header-bg-color: var(--crm-layer2-bg-color);
   --crm-dialog-header-color: var(--crm-text-color);
 /* Dashlet */
@@ -210,9 +210,9 @@
 /* Frontend */
   --crm-f-fieldset-padding: var(--crm-padding-reg);
   --crm-f-legend-align: unset;
-  --crm-f-legend-size: var(--crm-s-reg-2);
+  --crm-f-legend-size: var(--crm-l-reg-2);
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
   --crm-f-label-align: left;
-  --crm-f-label-margin: var(--crm-s-small);
+  --crm-f-label-margin: var(--crm-l-small);
   --crm-f-label-width: unset;
 }

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -66,35 +66,35 @@
   --crm-link-decoration-hover: none;
   --crm-heading-bg-color: var(--crm-layer2-bg-color);
   --crm-heading-color: var(--crm-text-dark-color);
-  --crm-heading-padding: var(--crm-m2) var(--crm-m);
+  --crm-heading-padding: var(--crm-s-medium-2) var(--crm-s-medium);
   --crm-heading-margin: 0;
   --crm-heading-radius: 0;
 /* Buttons */
   --crm-btn-radius: 2px;
-  --crm-btn-padding-block: var(--crm-m); /* padding for top and bottom, one value */
-  --crm-btn-padding-inline: var(--crm-r2); /* padding for left and right, one value */
-  --crm-btn-small-padding: var(--crm-s1) var(--crm-m1);
+  --crm-btn-padding-block: var(--crm-s-medium); /* padding for top and bottom, one value */
+  --crm-btn-padding-inline: var(--crm-s-reg-2); /* padding for left and right, one value */
+  --crm-btn-small-padding: var(--crm-s-small-1) var(--crm-s-medium-1);
   --crm-btn-height: 40px;
 /* Tables */
   --crm-table-row-bg-color: var(--crm-container-bg-color);
   --crm-table-row-hover-color: var(--crm-c-gray-200);
   --crm-table-sort-color: var(--crm-c-gray-500);
-  --crm-table-nested-padding: 0 0 var(--crm-r) 0;
+  --crm-table-nested-padding: 0 0 var(--crm-s-reg) 0;
   --crm-table-nested-head-border: 2px solid var(--crm-c-gray-300);
   --crm-table-nested-border: 0 solid transparent;
 /* Panels */
-  --crm-panel-head-margin: var(--crm-m2);
+  --crm-panel-head-margin: var(--crm-s-medium-2);
   --crm-panel-head-height: 48px;
 /* Accordions */
   --crm-accordion-icon: "\f105"; /* unicode value for FontAwesome icon */
   --crm-accordion-icon-color: unset;
-  --crm-accordion-icon-spacing: var(--crm-m3);
+  --crm-accordion-icon-spacing: var(--crm-s-medium-3);
   --crm-accordion-gap: 0;
 /* .crm-accordion-bold */
   --crm-accordion-header-bg-color: var(--crm-layer1-bg-color);
   --crm-accordion-header-bg-active-color: var(--crm-layer2-bg-color);
   --crm-accordion-header-color: var(--crm-text-color);
-  --crm-accordion-header-padding: var(--crm-m2) var(--crm-m3);
+  --crm-accordion-header-padding: var(--crm-s-medium-2) var(--crm-s-medium-3);
   --crm-accordion-border: unset;
   --crm-accordion-border-width: unset;
   --crm-accordion-body-bg-color: transparent;
@@ -109,19 +109,19 @@
   --crm-accordion2-body-bg-color: transparent;
   --crm-accordion2-body-padding: 0;
 /* Alerts */
-  --crm-alert-padding: var(--crm-r) var(--crm-r2);
+  --crm-alert-padding: var(--crm-s-reg) var(--crm-s-reg-2);
   --crm-alert-success-text-color: var(--crm-success-ink-color);
   --crm-alert-danger-text-color: var(--crm-text-color);
   --crm-alert-info-text-color: var(--crm-info-ink-color);
 /* Form */
-  --crm-form-block-padding: var(--crm-r);
+  --crm-form-block-padding: var(--crm-s-reg);
   --crm-form-block-border-radius: 0;
   --crm-input-bg-color: var(--crm-container-bg-color);
   --crm-input-bg-image: none;
   --crm-input-border-color: #c2cfd8;
   --crm-input-border-radius: var(--crm-s-radius);
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);
-  --crm-input-padding: var(--crm-xs1) var(--crm-m1);
+  --crm-input-padding: var(--crm-s-xsmall-1) var(--crm-s-medium-1);
   --crm-input-label-weight: bold;
   --crm-input-radio-color: var(--crm-primary-color);
   --crm-input-inline-edit-border: 1px solid var(--crm-c-gray-900);
@@ -130,13 +130,13 @@
   --crm-form-fieldset-padding: 0;
 /* Tabs */
   --crm-tabs-bg-color: var(--crm-layer1-bg-color);
-  --crm-tabs-padding: var(--crm-m) var(--crm-m) 0 var(--crm-m);
+  --crm-tabs-padding: var(--crm-s-medium) var(--crm-s-medium) 0 var(--crm-s-medium);
   --crm-tabs-border: var(--crm-border);
   --crm-tab-radius: 2px 2px 0 0;
   --crm-tab-hover-bg-color: var(--crm-paper);
   --crm-tab-bg-active: var(--crm-container-bg-color);
   --crm-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-tab-padding: var(--crm-m2) var(--crm-r1) var(--crm-m);
+  --crm-tab-padding: var(--crm-s-medium-2) var(--crm-s-reg-1) var(--crm-s-medium);
   --crm-tab-weight: bold;
   --crm-tab-count-bg-color: transparent;
   --crm-tab-count-color: var(--crm-text-color);
@@ -152,24 +152,24 @@
   --crm-contact-tabs-padding: unset;
   --crm-contact-tab-bg-color: transparent;
   --crm-contact-tab-hover-bg-color: var(--crm-layer2-bg-color);
-  --crm-contact-tab-padding: var(--crm-r) var(--crm-r1);
+  --crm-contact-tab-padding: var(--crm-s-reg) var(--crm-s-reg-1);
   --crm-contact-tab-border: var(--crm-contact-border);
   --crm-contact-tab-border-hover: unset;
   --crm-contact-tab-count-bg-color: var(--crm-primary-color);
   --crm-contact-tab-count-color: var(--crm-text-light-color);
   --crm-contact-tab-hang: 0 0 -1px 0; /* lip to extend tab flush with active region - set to 0 for no lip */
-  --crm-contact-icon-size: var(--crm-m2);
+  --crm-contact-icon-size: var(--crm-s-medium-2);
   --crm-contact-box-shadow: inset 0 3px 18px -5px rgba(0, 0, 0, 0.25);
-  --crm-contact-panel-padding: var(--crm-r2);
+  --crm-contact-panel-padding: var(--crm-s-reg-2);
   --crm-contact-edit-border: 1px dashed var(--crm-c-gray-900);
-  --crm-contact-block-padding: var(--crm-m2);
+  --crm-contact-block-padding: var(--crm-s-medium-2);
   --crm-contact-block-bg-color: var(--crm-container-bg-color);
   --crm-contact-label-bg-color: var(--crm-container-bg-color);
   --crm-contact-header-bg-color: var(--crm-c-gray-900);
   --crm-contact-header2-bg-color: var(--crm-c-gray-800);
   --crm-contact-header-color: var(--crm-text-light-color);
-  --crm-contact-header-size: var(--crm-l);
-  --crm-contact-header-padding: var(--crm-r) var(--crm-r1);
+  --crm-contact-header-size: var(--crm-s-large);
+  --crm-contact-header-padding: var(--crm-s-reg) var(--crm-s-reg-1);
   --crm-contact-image-size: 100px;
   --crm-contact-image-radius: 200px;
   --crm-contact-image-right: 30px; /* distance from right of dashboard */
@@ -210,9 +210,9 @@
 /* Frontend */
   --crm-f-fieldset-padding: var(--crm-padding-reg);
   --crm-f-legend-align: unset;
-  --crm-f-legend-size: var(--crm-r2);
+  --crm-f-legend-size: var(--crm-s-reg-2);
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
   --crm-f-label-align: left;
-  --crm-f-label-margin: var(--crm-s);
+  --crm-f-label-margin: var(--crm-s-small);
   --crm-f-label-width: unset;
 }


### PR DESCRIPTION
Overview
----------------------------------------
To make River CSS Variables (Custom Property) names stable for Civi 6.10 inconsistencies / etc are being ironed out, as described in [RL gitlab#161.](https://lab.civicrm.org/extensions/riverlea/-/issues/161).

Goal structure (eventually): `-crm-[COMPONENT]-[VARIANT]-[ELEMENT]-[PROPERTY]/[TYPE] `

Before
----------------------------------------
Commit 1:
- `--crm-roundness`, `--crm-tab-roundness`, `--crm-tabs-roundness`, `--crm-dash-roundness` - inconsistent with other variable names using `radius`. Preference for the same term that CSS uses (radius)
- `--crm-dash-X` to describe anything for the contact layout, not intuitive
- `--crm-expand-X` to describe accordions, also not inutitive, related classes use `.crm-accordion` names

Commit 2:
- `--crm-block-shadow`, `--crm-popup-shadow`, `--crm-bottom-shadow`, `--crm-body-inset`
- `--crm-small-font-size`, `--crm-system-fonts`
- `--crm-hover-clickable`

Commit 3:
- `--crm-c-divider: 1px solid var(--crm-c-gray-300);`
- `--crm-c-code-border`

Commit 4:
- `--crm-c-layer0-bg` used to denote lightest bg in light mode / darkest in dark mode
- `--crm-c-text` used to denote darkest foreground in light mode / lightest in dark mode
- (see discussion [here](https://lab.civicrm.org/extensions/riverlea/-/issues/161#note_193944) and [here](https://lab.civicrm.org/extensions/riverlea/-/issues/161#note_194187)).

Commit 5:
- `--crm-c-` used as prefix for practical, emphasis and background colors. Colors in other variables sometimes have a `-col` suffix, occasionally `-color` mostly nothing.

Commit 6:
- sizes are single letters followed by number with no prefix denoting size.

Commit 7: makes changes outside of /ext/riverlea repo

Commit 8: makes final few manual changes towards goal of `-crm-[COMPONENT]-[VARIANT]-[ELEMENT]-[PROPERTY]/[TYPE]` structure

After
----------------------------------------
Commit 1:
- `--crm-s-radius`, `--crm-tab-radius`, `--crm-tabs-radius`, `--crm-dash-radius`
- `--crm-contact-X` to describe anything for the contact layout
- `--crm-accordion-X` to describe accordions

Commit 2:
- `--crm-shadow-block`, `--crm-shadow-popup`, `--crm-shadow-bottom`, removed `--crm-body-inset` as only used internally by Walbrook.
- `--crm-font-small-size`, `--crm-font-system` - moved font variables under 'Type' heading
- `--crm-hover-clickable` to `--crm-link-hover-cursor` moved with other `-link` declarations

Commit 3:
- `--crm-border-color: var(--crm-c-gray-300);`
- `--crm-border: 1px solid var(--crm-border-color);`
- `--crm-code-border-color`

Commit 4: 
- `--crm-paper` used to denote lightest bg in light mode / darkest in dark mode (replaces `crm-layer0-bg`)
- `--crm-ink` used to denote darkest fg in light mode / lightest in dark mode

Commit 5:
- `--crm-c-` only used for literal colours, e.g. `--crm-c-gray-100` or `--crm-green`
- All other colours have a `-color` suffix.
- Some variables get renamed slightly to get closer to goal structure.
- Removed `--crm-contact-tab-color: var(--crm-tab-color);` - not used.
- Give all form variables either a `-form` or `-input` prefix
- Removed `crm-contact-panel-bg: var(--crm-paper);` as it now duplicates core _variables.css

Commit 6:
- Base sizes are denoted `--crm-s-` while xs, s, m, r, l, xl, xxl prefixes are expanded to small, medium, regular, large, large-1, large-2.
- `crm-big-input` becomes `crm-input-width` and `crm-huge-input` becomes `crm-input-large-width`. Both are moved to the input section.

Commit 7:
 - Updates variable names in other parts of CiviCRM than `/ext/riverlea`

Commit 8:
- `--crm-c-yellow-less-light` - removed as not used anywhere
- `--crm-c-dark-teal` becomes `--crm-c-teal-dark`
- `--crm-dropdown-hover` - becomes `--crm-dropdown-hover-text-color` (missed)
- `--crm-input-padding-large` becomes `crm-input-large-padding`
- `--crm-tab-border-active` becomes `crm-tab-active-border`
- `--crm-contact-tab-border-hover` becomes `crm-contact-tab-hover-border`
- `--crm-dropdown-2-*` becomes `--crm-dropdown2-*` (no space)
- `--crm-dialog-line` becomes `--crm-dialog-footer-border`
- changes `-s-` to `-l-` following [this discussion](https://lab.civicrm.org/extensions/riverlea/-/issues/161#note_194330) pointing out CSS calls these values lengths not sizes 

Technical Details
----------------------------------------
This PR introduces a new `-l-` for a length primitive (`--crm-l-medium`), similar to `-c-` for colour primitive (`--crm-c-green`) - to aid development (typing `--crm-l-` into inspector reveals all available sizes).

Comments
----------------------------------------
PR also includes two unrelated small fixes in `ext/riverlea/core/css/_variables.css`
 - `--crm-expand-icon-color: var(--text);` uses a non-existent variable, now points to `--crm-c-text`
 - `--crm-input-label-weight: 600;` uses an old weight, now `bold`
 
These rename PRs are designed to make no visual and mostly no structural changes, only semantic changes. It's suggested to do read-reviews only, until the last one, when a full UI test can be made on all four streams and light/dark mode.