### PR TITLE
dev/joomla#54 Resolve legacy CMS calls in Civi\Authx\Joomla

### DIFF
--- a/ext/authx/Civi/Authx/Joomla.php
+++ b/ext/authx/Civi/Authx/Joomla.php
@@ -17,18 +17,26 @@ class Joomla implements AuthxInterface {
    * Joomla constructor.
    */
   public function __construct() {
-    jimport('joomla.application.component.helper');
-    jimport('joomla.database.table');
-    jimport('joomla.user.helper');
+    if (version_compare(JVERSION, '4.0', 'lt')) {
+      jimport('joomla.application.component.helper');
+      jimport('joomla.database.table');
+      jimport('joomla.user.helper');
+    }
   }
 
   /**
    * @inheritDoc
    */
   public function checkPassword(string $username, string $password) {
-    $JUserTable = \JTable::getInstance('User', 'JTable');
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+      $JUserTable = new \Joomla\CMS\Table\User($db);
+    }
+    else {
+      $JUserTable = \JTable::getInstance('User', 'JTable');
+      $db = $JUserTable->getDbo();
+    }
 
-    $db = $JUserTable->getDbo();
     $query = $db->getQuery(TRUE);
     $query->select('id, name, username, email, password');
     $query->from($JUserTable->getTableName());
@@ -38,7 +46,11 @@ class Joomla implements AuthxInterface {
 
     if (!empty($users)) {
       $user = array_shift($users);
-      if (is_callable(['JUserHelper', 'verifyPassword'])) {
+      if (version_compare(JVERSION, '4.0', 'ge')) {
+        $verified = \Joomla\CMS\User\UserHelper::verifyPassword($password, $user->password, $user->id);
+        return $verified ? $user->id : NULL;
+      }
+      elseif (is_callable(['JUserHelper', 'verifyPassword'])) {
         $verified = \JUserHelper::verifyPassword($password, $user->password, $user->id);
         return $verified ? $user->id : NULL;
       }
@@ -54,8 +66,14 @@ class Joomla implements AuthxInterface {
    * @inheritDoc
    */
   public function loginSession($userId) {
-    $user = new \JUser($userId);
-    $session = \JFactory::getSession();
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $user = new \Joomla\CMS\User\User($userId);
+      $session = \Joomla\CMS\Factory::getApplication()->getSession();
+    }
+    else {
+      $user = new \JUser($userId);
+      $session = \JFactory::getSession();
+    }
     $session->set('user', $user);
   }
 
@@ -63,7 +81,13 @@ class Joomla implements AuthxInterface {
    * @inheritDoc
    */
   public function logoutSession() {
-    \JFactory::getSession()->destroy();
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $session = \Joomla\CMS\Factory::getApplication()->getSession();
+    }
+    else {
+      $session = \JFactory::getSession();
+    }
+    $session->destroy();
   }
 
   /**
@@ -80,18 +104,21 @@ class Joomla implements AuthxInterface {
 
     // In any event, this work-around passes `AllFlowsTest::testMultipleStateless`.
 
-    \JFactory::getSession()->destroy();
-    $user = new \JUser($userId);
-    $session = \JFactory::getSession();
-    $session->set('user', $user);
+    $this->logoutSession();
+    $this->loginSession($userId);
   }
 
   /**
    * @inheritDoc
    */
   public function getCurrentUserId() {
-    $user = \JFactory::getUser();
-    return ($user->guest) ? NULL : $user->id;
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $user = \Joomla\CMS\Factory::getApplication()->getIdentity();
+    }
+    else {
+      $user = \JFactory::getUser();
+    }
+    return (empty($user) || $user->guest) ? NULL : $user->id;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Part of the ongoing effort to make CiviCRM compatible with J4+. See [dev/joomla#54](https://lab.civicrm.org/dev/joomla/-/issues/54).

Before
----------------------------------------
Residual unconditional calls to legacy / deprecated Joomla CMS class names existed in civicrm-core.

After
----------------------------------------
When combined with #34068, I believe all of these have now been removed / dealt with, so civicrm-core should now be compatible with all known Joomla versions.

Technical Details
----------------------------------------
NOT TESTED as we do not use the Authx plugin.

@artfulrobot I understand via Nic Wistreich that you may have been looking at an authx instance? Might you be able to test?

Comments
----------------------------------------
This was based on a reasonably thorough sweep of civicrm-core for legacy Joomla references, so while I'm pretty sure we've got everything, I can't 100% guarantee this.

See specifically [this list](https://lab.civicrm.org/dev/joomla/-/issues/54#note_192606) for instances that I found need updating.
