### PR TITLE
(dev/core#6200) OAuth - Update permissions to allow JS initiation

### DIFF
--- a/ext/oauth-client/CRM/OAuth/BAO/OAuthClient.php
+++ b/ext/oauth-client/CRM/OAuth/BAO/OAuthClient.php
@@ -50,4 +50,20 @@ class CRM_OAuth_BAO_OAuthClient extends CRM_OAuth_DAO_OAuthClient {
       \CRM_Utils_System::url('civicrm/oauth-client/return', NULL, TRUE, NULL, FALSE, FALSE, TRUE);
   }
 
+  /**
+   * @param string|null $entityName
+   * @param int|null $userId
+   * @param array $conditions
+   * @inheritDoc
+   */
+  public function addSelectWhereClause(?string $entityName = NULL, ?int $userId = NULL, array $conditions = []): array {
+    $clauses = parent::addSelectWhereClause($entityName, $userId, $conditions);
+
+    $allowProviders = _oauth_client_providers_by_perm('get');
+    $none = [chr(0)];
+    $clauses['provider'][] = 'IN (' . CRM_Core_DAO::escapeStrings(empty($allowProviders) ? $none : $allowProviders) . ')';
+
+    return $clauses;
+  }
+
 }

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -18,6 +18,14 @@ class CRM_OAuth_Hook {
    *         - scopes: array (e.g. "read_profile", "frobnicate_widgets")
    *         - responseModes: array (e.g. "query", "web_message")
    *     - tags: string[], list of free-tags describing the purpose/behavior of this provider
+   *     - permissions: array, list of actions and their required permissions
+   *         Ex: ['meta' => 'access CiviMail', 'get' => 'access CiviMail', 'authorizationCode' => 'schedule mailings']
+   *         Actions are generally based on OAuthClient API.
+   *         Valid keys include:
+   *         - meta: Permissions required to view metadata (e.g. OAuthProvider)
+   *         - get: Permissions required to inspect basic info about OAuthClient
+   *         Permissions will be checked via CRM_Core_Permission::check(). They may be strings or arrays.
+   *         NOTE: For more info about supported actions+permissions, review Civi\Api4\OAuthClient::permissions().
    */
   public static function oauthProviders(array &$providers): void {
     $event = GenericHookEvent::create([

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -38,6 +38,23 @@ class CRM_OAuth_Hook {
   }
 
   /**
+   * Determine whether the user is allowed to generate the given token.
+   *
+   * @param \Civi\Api4\Action\OAuthClient\AbstractGrantAction $action
+   *   The proposed token parameters.
+   * @param array $client
+   * @param bool $allowed
+   */
+  public static function oauthGrant($action, array $client, bool &$allowed) {
+    $event = GenericHookEvent::create([
+      'action' => $action,
+      'client' => $client,
+      'allowed' => &$allowed,
+    ]);
+    \Civi::dispatcher()->dispatch('hook_civicrm_oauthGrant', $event);
+  }
+
+  /**
    * Fires a hook whenever we receive an updated OAuth token.
    *
    * @param string $flow

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -24,6 +24,9 @@ class CRM_OAuth_Hook {
    *         Valid keys include:
    *         - meta: Permissions required to view metadata (e.g. OAuthProvider)
    *         - get: Permissions required to inspect basic info about OAuthClient
+   *         - authorizationCode: Permissions required to add token using web page-flow
+   *         - userPassword: Permissions required to add token with username/password flow
+   *         - clientCredential: Permissions required to add token with client-credential flow
    *         Permissions will be checked via CRM_Core_Permission::check(). They may be strings or arrays.
    *         NOTE: For more info about supported actions+permissions, review Civi\Api4\OAuthClient::permissions().
    */

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
@@ -58,6 +58,13 @@ abstract class AbstractGrantAction extends \Civi\Api4\Generic\AbstractBatchActio
       if (empty($def['provider']) || !in_array($def['provider'], $allowedProviders)) {
         throw new UnauthorizedException(sprintf("Insufficient privileges for %s on provider %s", $this->getActionName(), $def['provider']));
       }
+
+      $allowed = \CRM_Core_Permission::check('manage OAuth client')
+        || \CRM_Core_Permission::check('manage OAuth client secrets');
+      \CRM_OAuth_Hook::oauthGrant($this, $def, $allowed);
+      if (!$allowed) {
+        throw new OAuthException("Grant parameters not allowed");
+      }
     }
     if (!preg_match(OAuthTokenFacade::STORAGE_TYPES, $this->storage)) {
       throw new \CRM_Core_Exception("Invalid token storage ($this->storage)");

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\Api4\Action\OAuthClient;
 
+use Civi\API\Exception\UnauthorizedException;
 use Civi\OAuth\OAuthTokenFacade;
 use Civi\OAuth\OAuthException;
 
@@ -51,6 +52,13 @@ abstract class AbstractGrantAction extends \Civi\Api4\Generic\AbstractBatchActio
    * @throws \CRM_Core_Exception
    */
   protected function validate() {
+    if ($this->getCheckPermissions()) {
+      $allowedProviders = _oauth_client_providers_by_perm(lcfirst($this->getActionName()));
+      $def = $this->getClientDef();
+      if (empty($def['provider']) || !in_array($def['provider'], $allowedProviders)) {
+        throw new UnauthorizedException(sprintf("Insufficient privileges for %s on provider %s", $this->getActionName(), $def['provider']));
+      }
+    }
     if (!preg_match(OAuthTokenFacade::STORAGE_TYPES, $this->storage)) {
       throw new \CRM_Core_Exception("Invalid token storage ($this->storage)");
     }

--- a/ext/oauth-client/Civi/Api4/OAuthClient.php
+++ b/ext/oauth-client/Civi/Api4/OAuthClient.php
@@ -62,13 +62,25 @@ class OAuthClient extends Generic\DAOEntity {
 
   public static function permissions(): array {
     return [
+      // In general, we aim for permissions on OAuthClient actions to be based
+      // on OAuthProvider metadata. However, given the systemic flexibility
+      // (third-party add-on actions; upstream generic actions; etc), it's hard
+      // to predict what happens if you do it generically. So instead, we follow
+      // this pattern:
+      //
+      // - Pick an action (`Civi\Api4\OAuthClient::foo()`).
+      // - Update the action logic to check permissions (`_oauth_client_providers_by_perm("foo")`)
+      // - In here, set the action to ALWAYS_ALLOW_PERMISSION.
+      //
+      // And if no one has done that yet... then we fallback to the safer default:
+      'default' => ['manage OAuth client'],
+
       // addSelectWhereClause() enforces limits on visibility...
       'get' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
 
       // Probably need this for everyone who can 'get' records...
       'meta' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
 
-      'default' => ['manage OAuth client'],
     ];
   }
 

--- a/ext/oauth-client/Civi/Api4/OAuthClient.php
+++ b/ext/oauth-client/Civi/Api4/OAuthClient.php
@@ -62,15 +62,13 @@ class OAuthClient extends Generic\DAOEntity {
 
   public static function permissions(): array {
     return [
-      'meta' => ['access CiviCRM'],
+      // addSelectWhereClause() enforces limits on visibility...
+      'get' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
+
+      // Probably need this for everyone who can 'get' records...
+      'meta' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
+
       'default' => ['manage OAuth client'],
-      'get' => [
-        [
-          'manage OAuth client',
-          'manage my OAuth contact tokens',
-          'manage all OAuth contact tokens',
-        ],
-      ],
     ];
   }
 

--- a/ext/oauth-client/Civi/Api4/OAuthClient.php
+++ b/ext/oauth-client/Civi/Api4/OAuthClient.php
@@ -81,6 +81,10 @@ class OAuthClient extends Generic\DAOEntity {
       // Probably need this for everyone who can 'get' records...
       'meta' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
 
+      // Access controlled via AbstractGrantAction::validate()
+      'authorizationCode' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
+      'userPassword' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
+      'clientCredential' => [\CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
     ];
   }
 

--- a/ext/oauth-client/Civi/Api4/OAuthProvider.php
+++ b/ext/oauth-client/Civi/Api4/OAuthProvider.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Api4;
 
+use CRM_Core_Permission;
+
 class OAuthProvider extends Generic\AbstractEntity {
 
   const TTL = 600;
@@ -32,6 +34,9 @@ class OAuthProvider extends Generic\AbstractEntity {
           'name' => 'class',
         ],
         [
+          'name' => 'permissions',
+        ],
+        [
           'name' => 'options',
         ],
         [
@@ -54,8 +59,8 @@ class OAuthProvider extends Generic\AbstractEntity {
    */
   public static function permissions() {
     return [
-      "meta" => ["access CiviCRM"],
-      "get" => ["access CiviCRM"],
+      "meta" => [CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
+      "get" => [CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION],
       "default" => ["administer CiviCRM"],
     ];
   }

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -25,8 +25,10 @@ function oauth_client_civicrm_permission(&$permissions) {
     'description' => ts('Create and delete OAuth client connections'),
   ];
   $permissions['manage OAuth client secrets'] = [
-    'label' => $prefix . ts('manage OAuth client secrets'),
-    'description' => ts('Access OAuth secrets'),
+    // NOTE: The original name here was misleading -- it actually confers access to
+    // sensitive parts of OAuthSysToken, e.g. `access_token`, `raw`, `refresh_token`
+    'label' => $prefix . ts('manage OAuth system tokens'),
+    'description' => ts('Access the secret content of OAuth system tokens'),
   ];
   $permissions['create OAuth tokens via auth code flow'] = [
     'label' => $prefix . ts('create OAuth tokens via auth code flow'),

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -30,10 +30,6 @@ function oauth_client_civicrm_permission(&$permissions) {
     'label' => $prefix . ts('manage OAuth system tokens'),
     'description' => ts('Access the secret content of OAuth system tokens'),
   ];
-  $permissions['create OAuth tokens via auth code flow'] = [
-    'label' => $prefix . ts('create OAuth tokens via auth code flow'),
-    'description' => ts('Create OAuth tokens via the authorization code flow'),
-  ];
   $permissions['manage my OAuth contact tokens'] = [
     'label' => $prefix . ts('manage my OAuth contact tokens'),
     'description' => ts("Manage user's own OAuth tokens"),

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -77,6 +77,26 @@ function oauth_client_civicrm_oauthProviders(&$providers) {
 }
 
 /**
+ * Get a list of providers for which the user has permission to do "X".
+ *
+ * @param string $perm
+ *   Ex: 'meta', 'get', or 'authorizationCode'
+ * @return array
+ *   List of provider names
+ */
+function _oauth_client_providers_by_perm(string $perm): array {
+  $cacheKey = $perm . '_' . CRM_Core_Session::getLoggedInContactID();
+  if (!isset(Civi::$statics[__FUNCTION__][$cacheKey])) {
+    $allProviders = \Civi\Api4\OAuthProvider::get(FALSE)->addSelect('name', 'permissions')->execute();
+    $allowProviders = array_filter($allProviders->getArrayCopy(), function ($provider) use ($perm) {
+      return CRM_Core_Permission::check($provider['permissions'][$perm] ?? $provider['permissions']['default']);
+    });
+    Civi::$statics[__FUNCTION__][$cacheKey] = array_values(array_column($allowProviders, 'name'));
+  }
+  return Civi::$statics[__FUNCTION__][$cacheKey];
+}
+
+/**
  * Implements hook_civicrm_mailSetupActions().
  *
  * @see CRM_Utils_Hook::mailSetupActions()

--- a/ext/oauth-client/providers/test_example_3.test.json
+++ b/ext/oauth-client/providers/test_example_3.test.json
@@ -1,5 +1,10 @@
 {
   "title": "Third Test Example",
+  "permissions": {
+    "meta": "administer payment processors",
+    "get": "administer payment processors",
+    "default": "administer payment processors"
+  },
   "options": {
     "urlAuthorize": "https://example.com/three/auth",
     "urlAccessToken": "https://example.com/three/token",

--- a/ext/oauth-client/providers/test_example_3.test.json
+++ b/ext/oauth-client/providers/test_example_3.test.json
@@ -2,7 +2,7 @@
   "title": "Third Test Example",
   "permissions": {
     "meta": "administer payment processors",
-    "get": "administer payment processors",
+    "get": [["administer payment processors", "access CiviContribute"]],
     "default": "administer payment processors"
   },
   "options": {

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -78,10 +78,10 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
       \CRM_Core_Config::singleton()->userPermissionClass->permissions = array_merge($base, $ps);
     };
 
-    $usePerms(['manage OAuth client']);
+    $usePerms(['manage OAuth client', 'administer payment processors']);
     $client = $this->createClient('test_example_3');
 
-    $usePerms(['manage OAuth client']);
+    $usePerms(['manage OAuth client', 'administer payment processors']);
     $result = Civi\Api4\OAuthClient::authorizationCode()
       ->addWhere('id', '=', $client['id'])
       ->setResponseMode('web_message')

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientTest.php
@@ -62,6 +62,51 @@ class api_v4_OAuthClientTest extends \PHPUnit\Framework\TestCase implements Head
     $this->assertEquals(0, $get->count());
   }
 
+  /**
+   * We may provide general 'get' access to OAuthClient for several users, but the 'secret'
+   * field specifically requires 'manage OAuth client'.
+   *
+   * @return void
+   */
+  public function testRestrictedSecret(): void {
+    $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
+
+    $usePerms = function($ps) {
+      $base = ['access CiviCRM'];
+      \CRM_Core_Config::singleton()->userPermissionClass->permissions = array_merge($base, $ps);
+    };
+
+    // With more perms, we can create the client...
+    $usePerms(['manage OAuth client', 'administer payment processors']);
+    $create = Civi\Api4\OAuthClient::create()->setValues([
+      'provider' => 'test_example_3',
+      'guid' => "example-id-$random" ,
+      'secret' => "example-secret-$random",
+    ])->execute();
+    $this->assertEquals(1, $create->count());
+    $client = $create->first();
+    $this->assertEquals("example-id-$random", $client['guid']);
+    $this->assertEquals("example-secret-$random", $client['secret']);
+
+    // With some perms, we can view the client... but not the secret...
+    $usePerms(['administer payment processors']);
+    $client = Civi\Api4\OAuthClient::get()
+      ->addWhere('provider', '=', 'test_example_3')
+      ->execute()
+      ->single();
+    $this->assertEquals("example-id-$random", $client['guid']);
+    $this->assertTrue(empty($client['secret']), 'Should not have read access to secret');
+
+    // And if we don't check perms, then the secret is visible...
+    $usePerms(['administer payment processors']);
+    $client = Civi\Api4\OAuthClient::get(FALSE)
+      ->addWhere('provider', '=', 'test_example_3')
+      ->execute()
+      ->single();
+    $this->assertEquals("example-id-$random", $client['guid']);
+    $this->assertEquals("example-secret-$random", $client['secret']);
+  }
+
   public function testCreateBadProvider() {
     $random = CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
     $usePerms = function($ps) {

--- a/ext/oauth-client/xml/Menu/oauth_client.xml
+++ b/ext/oauth-client/xml/Menu/oauth_client.xml
@@ -4,6 +4,6 @@
     <path>civicrm/oauth-client/return</path>
     <page_callback>CRM_OAuth_Page_Return</page_callback>
     <title>Return</title>
-    <access_arguments>create OAuth tokens via auth code flow;manage OAuth client</access_arguments>
+    <access_arguments>*always allow*</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------

OAuth flows can be initiated by general-administrators, and they can be initiated via PHP code for any kind of user, but they cannot be initiated by JS code for partial/subsystem administrators. This enables subsystem administrators to initiate via JS (*based on topical permissions*). (Full description: https://lab.civicrm.org/dev/core/-/issues/6200)

(Extracted from #33707.)

Technical Details
----------------------------------------

With this revision, each OAuth provider can declare separate permissions. Here is a (fake/illustrative) example:

```javascript
// FILE: test_example_3.test.json
{
  "title": "Third Test Example",
  "class": "My\\Example3",
  "permissions": {
    "meta": "administer payment processors"
    "get": "administer payment processors"
    "authorizationCode": "administer payment processors"
  },
  "options": {
    "urlAuthorize": "https://example.com/three/auth",
    "urlAccessToken": "https://example.com/three/token",
    "urlResourceOwnerDetails": "https://example.com/three/owner",
    "scopes": ["scope-3-foo", "scope-3-bar"],
    "responseModes": ["query", "web_message"]
  }
}
```

(*If no `permissions` are declared, or if you have an unrecognized action, then the default matches the traditional behavior -- mostly requiring `manage OAuth clients`.*)

What happens if we have the relevant permission (`administer payment processors`, in this example) and call OAuth APIs  in the browser?

We satisfy `meta => administer payment processors` -- so we can see the metadata:

```javascript
CRM.api4('OAuthProvider', 'get', {
  where:[["name","=","test_example_3"]]
});
```

We don't have permission to create/register a new `OAuthClient`. (That still requires `manage OAuth client`.) But once that is created (by admin or mgd), then we can `get` some information about it:

```javascript
CRM.api4('OAuthClient', 'get', {
  where:[["provider","=","test_example_3"]]
});
```

We can also initiate the auth-code flow:

```javascript
CRM.api4('OAuthClient', 'authorizationCode', {
  where:[["provider","=","test_example_3"]]
})
```

Which generates the URL with a corresponding state.

We don't have permission to generate tokens in other ways (e.g. `OAuthClient::userPassword()` or `OAuthClient::clientCredential()`).

Comments
----------------------------------------

(1) Fun fact: Having access to read via `OAuthClient.get` means that you can see basic information about the client (e.g. its `provider` type). But not everything -- the `secret` field still requires higher privileges (i.e. `manage OAuth client`). This exception was already in place -- I believe it arose from @highfalutin's prior work to enable `OAuthContactToken` use-cases. That made it easier to implement this. :)

(2) This is a draft - it's not mergeable in the current revision. In particular, there remains the specific problem of *token tagging* (*and auditing the other auth-code properties, generally*). The current revision allows you to say:

```javascript
CRM.api4('OAuthClient', 'authorizationCode', {
  where:[["provider","=","test_example_3"]],
  tag: "PaymentProcessor:123"
})
```

But it doesn't validate if your user should be allowed to tag a token for that specific purpose. (Without that validation, you might hot-wire to something you shouldn't have access to -- e.g. the email admin might have permission to create a token for Gmail; they hot-wire the `tag` and replace the token for Stripe... which breaks all your payments... even though they never had permission to work on payments...)