### PR TITLE
(REF) OAuth - Add more documentation (hook-stubs)

### DIFF
--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -35,6 +35,29 @@ class CRM_OAuth_Hook {
    *   Ex: 'OAuthSysToken', 'OAuthContactToken', 'OAuthSessionToken'
    * @param array $token
    *   Ex: ['tag' => 'foo', 'client_id' => 123]
+   *
+   *   The following fields are equally applicable to all storage-types:
+   *
+   *   - access_token
+   *   - client_id
+   *   - expires
+   *   - grant_type
+   *   - raw
+   *   - refresh_token
+   *   - resource_owner
+   *   - resource_owner_name
+   *   - scopes
+   *   - tag
+   *   - token_type
+   *
+   *   Some fields depend on the storage-type:
+   *
+   *    - id (OAuthSysToken, OAuthContactToken)
+   *    - contact_id (OAuthContactToken)
+   *    - cardinal (OAuthSessionToken)
+   *    - created_date (extant records; OAuthSysToken, OAuthContactToken)
+   *    - modified_date (extant records; OAuthSysToken, OAuthContactToken)
+   *
    * @return void
    */
   public static function oauthToken(string $flow, string $type, array &$token) {

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -37,7 +37,7 @@ class CRM_OAuth_Hook {
    *   Ex: ['tag' => 'foo', 'client_id' => 123]
    * @return void
    */
-  public static function hook_civicrm_oauthToken(string $flow, string $type, array &$token) {
+  public static function oauthToken(string $flow, string $type, array &$token) {
     $event = GenericHookEvent::create([
       'flow' => $flow,
       'type' => $type,

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -5,6 +5,28 @@ use Civi\Core\Event\GenericHookEvent;
 class CRM_OAuth_Hook {
 
   /**
+   * Generate a list of available OAuth providers.
+   *
+   * @param array $providers
+   *   Alterable list of providers, keyed by symbolic name. Each has these properties:
+   *     - name: string (MUST match the key in the array)
+   *     - class: string, the controller class which generates and sends token requests (default: CiviGenericProvider)
+   *     - options: array, constructor arguments for the driver class. Typical properties are:
+   *         - urlAuthorize: string (e.g. "https://api.example.com/auth")
+   *         - urlAccessToken: string (e.g. "https://api.example.com/token")
+   *         - urlResourceOwnerDetails: string (e.g. "https://api.example.com/owner")
+   *         - scopes: array (e.g. "read_profile", "frobnicate_widgets")
+   *         - responseModes: array (e.g. "query", "web_message")
+   *     - tags: string[], list of free-tags describing the purpose/behavior of this provider
+   */
+  public static function oauthProviders(array &$providers): void {
+    $event = GenericHookEvent::create([
+      'providers' => &$providers,
+    ]);
+    \Civi::dispatcher()->dispatch('hook_civicrm_oauthProviders', $event);
+  }
+
+  /**
    * Fires a hook whenever we receive an updated OAuth token.
    *
    * @param string $flow

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -64,4 +64,23 @@ class CRM_OAuth_Hook {
     Civi::dispatcher()->dispatch('hook_civicrm_oauthReturn', $event);
   }
 
+  /**
+   * Fires whenever a user returns to our site (from an unsuccessful AuthCode flow).
+   *
+   * @param string|null $error
+   * @param string|null $description
+   * @param string|null $uri
+   * @param string $state
+   * @return void
+   */
+  public static function oauthReturnError(?string $error, ?string $description, ?string $uri, string $state): void {
+    $event = \Civi\Core\Event\GenericHookEvent::create([
+      'error' => $error,
+      'description' => $description,
+      'uri' => $uri,
+      'state' => $state,
+    ]);
+    Civi::dispatcher()->dispatch('hook_civicrm_oauthReturnError', $event);
+  }
+
 }

--- a/ext/oauth-client/CRM/OAuth/Hook.php
+++ b/ext/oauth-client/CRM/OAuth/Hook.php
@@ -46,4 +46,22 @@ class CRM_OAuth_Hook {
     \Civi::dispatcher()->dispatch('hook_civicrm_oauthToken', $event);
   }
 
+  /**
+   * Fires whenever a user returns to our site (from a successful AuthCode flow).
+   *
+   * @param array $tokenRecord
+   *   The newly created token record (e.g OAuthSysToken or OAuthContactToken)
+   * @param string|null $nextUrl
+   *   When the user returns from an OAuth provider, we can redirect them to an internal page.
+   *   This alterable string identifies the next page.
+   * @return void
+   */
+  public static function oauthReturn(array $tokenRecord, ?string &$nextUrl): void {
+    $event = \Civi\Core\Event\GenericHookEvent::create([
+      'token' => $tokenRecord,
+      'nextUrl' => &$nextUrl,
+    ]);
+    Civi::dispatcher()->dispatch('hook_civicrm_oauthReturn', $event);
+  }
+
 }

--- a/ext/oauth-client/CRM/OAuth/Page/Return.php
+++ b/ext/oauth-client/CRM/OAuth/Page/Return.php
@@ -17,13 +17,12 @@ class CRM_OAuth_Page_Return extends CRM_Core_Page {
     if (CRM_Utils_Request::retrieve('error', 'String')) {
       CRM_Utils_System::setTitle(ts('OAuth Error'));
       $error = CRM_Utils_Array::subset($_GET, ['error', 'error_description', 'error_uri']);
-      $event = \Civi\Core\Event\GenericHookEvent::create([
-        'error' => $error['error'] ?? NULL,
-        'description' => $error['description'] ?? NULL,
-        'uri' => $error['uri'] ?? NULL,
-        'state' => $state,
-      ]);
-      Civi::dispatcher()->dispatch('hook_civicrm_oauthReturnError', $event);
+      CRM_OAuth_Hook::oauthReturnError(
+        $error['error'] ?? NULL,
+        $error['description'] ?? NULL,
+        $error['uri'] ?? NULL,
+        $state,
+      );
 
       Civi::log()->info('OAuth returned error', [
         'error' => $error,

--- a/ext/oauth-client/CRM/OAuth/Page/Return.php
+++ b/ext/oauth-client/CRM/OAuth/Page/Return.php
@@ -47,11 +47,7 @@ class CRM_OAuth_Page_Return extends CRM_Core_Page {
       ]);
 
       $nextUrl = $state['landingUrl'] ?? NULL;
-      $event = \Civi\Core\Event\GenericHookEvent::create([
-        'token' => $tokenRecord,
-        'nextUrl' => &$nextUrl,
-      ]);
-      Civi::dispatcher()->dispatch('hook_civicrm_oauthReturn', $event);
+      CRM_OAuth_Hook::oauthReturn($tokenRecord, $nextUrl);
       if ($nextUrl !== NULL) {
         CRM_Utils_System::redirect($nextUrl);
       }

--- a/ext/oauth-client/Civi/Api4/Action/OAuthProvider/GetProviders.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthProvider/GetProviders.php
@@ -4,7 +4,6 @@ namespace Civi\Api4\Action\OAuthProvider;
 
 use Civi\Api4\Generic\BasicGetAction;
 use Civi\Api4\OAuthProvider;
-use Civi\Core\Event\GenericHookEvent;
 use Civi\OAuth\CiviGenericProvider;
 
 class GetProviders extends BasicGetAction {
@@ -13,10 +12,7 @@ class GetProviders extends BasicGetAction {
     $cache = \Civi::cache('long');
     if (!$cache->has('OAuthProvider_list')) {
       $providers = [];
-      $event = GenericHookEvent::create([
-        'providers' => &$providers,
-      ]);
-      \Civi::dispatcher()->dispatch('hook_civicrm_oauthProviders', $event);
+      \CRM_OAuth_Hook::oauthProviders($providers);
 
       foreach ($providers as $name => &$provider) {
         if ($provider['name'] !== $name) {

--- a/ext/oauth-client/Civi/Api4/Action/OAuthProvider/GetProviders.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthProvider/GetProviders.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Civi\Api4\Action\OAuthProvider;
+
+use Civi\Api4\Generic\BasicGetAction;
+use Civi\Api4\OAuthProvider;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\OAuth\CiviGenericProvider;
+
+class GetProviders extends BasicGetAction {
+
+  protected function getRecords() {
+    $cache = \Civi::cache('long');
+    if (!$cache->has('OAuthProvider_list')) {
+      $providers = [];
+      $event = GenericHookEvent::create([
+        'providers' => &$providers,
+      ]);
+      \Civi::dispatcher()->dispatch('hook_civicrm_oauthProviders', $event);
+
+      foreach ($providers as $name => &$provider) {
+        if ($provider['name'] !== $name) {
+          throw new \CRM_Core_Exception(sprintf("Mismatched OAuth provider names: \"%s\" vs \"%s\"",
+            $provider['name'], $name));
+        }
+        if (!isset($provider['class'])) {
+          $provider['class'] = CiviGenericProvider::class;
+        }
+      }
+
+      $cache->set('OAuthProvider_list', $providers, OAuthProvider::TTL);
+    }
+    return $cache->get('OAuthProvider_list');
+  }
+
+}

--- a/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
@@ -63,7 +63,7 @@ class Refresh extends BasicBatchAction {
       }
     }
 
-    \CRM_OAuth_Hook::hook_civicrm_oauthToken('refresh', $this->getEntityName(), $row);
+    \CRM_OAuth_Hook::oauthToken('refresh', $this->getEntityName(), $row);
 
     civicrm_api4($this->getEntityName(), 'update', [
       // You may have permission to refresh even if you can't inspect/update secrets directly.

--- a/ext/oauth-client/Civi/Api4/OAuthProvider.php
+++ b/ext/oauth-client/Civi/Api4/OAuthProvider.php
@@ -2,9 +2,6 @@
 
 namespace Civi\Api4;
 
-use Civi\Core\Event\GenericHookEvent;
-use Civi\OAuth\CiviGenericProvider;
-
 class OAuthProvider extends Generic\AbstractEntity {
 
   const TTL = 600;
@@ -14,29 +11,7 @@ class OAuthProvider extends Generic\AbstractEntity {
    * @return Generic\BasicGetAction
    */
   public static function get($checkPermissions = TRUE) {
-    $action = new Generic\BasicGetAction('OAuthProvider', __FUNCTION__, function () {
-      $cache = \Civi::cache('long');
-      if (!$cache->has('OAuthProvider_list')) {
-        $providers = [];
-        $event = GenericHookEvent::create([
-          'providers' => &$providers,
-        ]);
-        \Civi::dispatcher()->dispatch('hook_civicrm_oauthProviders', $event);
-
-        foreach ($providers as $name => &$provider) {
-          if ($provider['name'] !== $name) {
-            throw new \CRM_Core_Exception(sprintf("Mismatched OAuth provider names: \"%s\" vs \"%s\"",
-              $provider['name'], $name));
-          }
-          if (!isset($provider['class'])) {
-            $provider['class'] = CiviGenericProvider::class;
-          }
-        }
-
-        $cache->set('OAuthProvider_list', $providers, self::TTL);
-      }
-      return $cache->get('OAuthProvider_list');
-    });
+    $action = new Action\OAuthProvider\GetProviders('OAuthProvider', __FUNCTION__);
     return $action->setCheckPermissions($checkPermissions);
   }
 

--- a/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
@@ -76,7 +76,7 @@ class OAuthTokenFacade {
       \Civi::log()->warning("Failed to resolve resource_owner");
     }
 
-    \CRM_OAuth_Hook::hook_civicrm_oauthToken('init', $options['storage'], $tokenRecord);
+    \CRM_OAuth_Hook::oauthToken('init', $options['storage'], $tokenRecord);
 
     return civicrm_api4($options['storage'], 'create', [
       'checkPermissions' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------

This  updates the `oauth-client` to consistently define its hooks with _stub-functions_ so that they can include _docblocks_. As other PRs like #33835 or #34070 add more options to the hooks, this will allow a place to add docblocks.

Before
----------------------------------------

Various calls to `Civi::dispatcher()->dispatch()`, with no particular docs for each hook.

After
----------------------------------------

All hooks defined by this extension have stubs in `CRM_OAuth_Hook`.

Comments
----------------------------------------

I also included another small refactoring from #34070 (3e1bd9fc38a832488c29a81820b7d5cea44d4df3) to prevent merge-conflicts. Like everything else in this branch, it's just a formulaic move that shifts code from one file to another (without any change in semantics).