### PR TITLE
Make sure we don't process Contribution entity in Formbuilder using generic entity save

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -448,6 +448,11 @@ class Submit extends AbstractProcessor {
       if (empty($record['fields'])) {
         continue;
       }
+      if ($event->getEntityType() === 'Contribution') {
+        // "Contribution" requires more specialised processing using Order API and is handled by extensions like Afform Payments.
+        // We add a specific check here to ensure that it is not processed by the generic entity save.
+        continue;
+      }
       try {
         $idField = CoreUtil::getIdFieldName($event->getEntityType());
         $saved = $api4($event->getEntityType(), 'save', ['records' => [$record['fields']]])->first();


### PR DESCRIPTION
Overview
----------------------------------------
"Contribution" requires more specialised processing using Order API and is handled by extensions like Afform Payments.
We add a specific check here to ensure that it is not processed by the generic entity save.

Before
----------------------------------------
If "Contribution" entity is available in FormBuilder it might get processed by generic entity save.

After
----------------------------------------
If "Contribution" entity is available in FormBuilder it won't get processed by generic entity save.

Technical Details
----------------------------------------


Comments
----------------------------------------
@ufundo this should address part of https://lab.civicrm.org/extensions/afform_payments/-/merge_requests/4#note_194200
