### PR TITLE
Test Extensions - Switch to mgmt:hidden

### DIFF
--- a/CRM/Extension/System.php
+++ b/CRM/Extension/System.php
@@ -113,15 +113,13 @@ class CRM_Extension_System {
         $containers['default'] = $this->getDefaultContainer();
       }
 
-      $civiSubDirs = defined('CIVICRM_TEST')
-        ? ['ext', 'tools', 'tests']
-        : ['ext', 'tools'];
+      $civiSubDirs = ['ext', 'tools', 'tests/extensions'];
       foreach ($civiSubDirs as $civiSubDir) {
         $containers["civicrm_$civiSubDir"] = new CRM_Extension_Container_Basic(
           CRM_Utils_File::addTrailingSlash($this->parameters['civicrm_root']) . $civiSubDir,
           CRM_Utils_File::addTrailingSlash($this->parameters['resourceBase'], '/') . $civiSubDir,
           $this->getCache(),
-          "civicrm_$civiSubDir",
+          "civicrm_" . CRM_Utils_String::munge($civiSubDir),
           $this->parameters['maxDepth']
         );
       }

--- a/tests/extensions/test.extension.manager.moduletest/info.xml
+++ b/tests/extensions/test.extension.manager.moduletest/info.xml
@@ -2,6 +2,7 @@
   <file>moduletest</file>
   <name>test_extension_manager_moduletest</name>
   <tags>
+    <tag>mgmt:hidden</tag>
     <tag>mock</tag>
   </tags>
 </extension>

--- a/tests/extensions/test.extension.manager.moduleupgtest/info.xml
+++ b/tests/extensions/test.extension.manager.moduleupgtest/info.xml
@@ -2,6 +2,7 @@
   <file>moduleupgtest</file>
   <name>test_extension_manager_moduleupgtest</name>
   <tags>
+    <tag>mgmt:hidden</tag>
     <tag>mock</tag>
   </tags>
   <classloader>

--- a/tests/extensions/test.extension.manager.paymenttest/info.xml
+++ b/tests/extensions/test.extension.manager.paymenttest/info.xml
@@ -20,6 +20,7 @@
     <paymentType>1</paymentType>
   </typeInfo>
   <tags>
+    <tag>mgmt:hidden</tag>
     <tag>mock</tag>
   </tags>
 </extension>

--- a/tests/extensions/test.extension.manager.reporttest/info.xml
+++ b/tests/extensions/test.extension.manager.reporttest/info.xml
@@ -5,4 +5,7 @@
     <reportUrl>test/extension/manager/reporttest</reportUrl>
     <component>CiviContribute</component>
   </typeInfo>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
 </extension>

--- a/tests/extensions/test.extension.manager.searchtest/info.xml
+++ b/tests/extensions/test.extension.manager.searchtest/info.xml
@@ -5,4 +5,7 @@
     <searchUrl>test/extension/manager/searchtest</searchUrl>
     <component>CiviContribute</component>
   </typeInfo>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
 </extension>

--- a/tests/extensions/test.extension.uitest/info.xml
+++ b/tests/extensions/test.extension.uitest/info.xml
@@ -1,4 +1,7 @@
 <extension key='test.extension.uitest' type='module'>
   <file>uitest</file>
   <name>test_extension_uitest</name>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
 </extension>

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -85,7 +85,7 @@ class api_v3_ExtensionTest extends CiviUnitTestCase {
     $testExtensionResult = $this->callAPISuccess('extension', 'get', ['key' => 'test.extension.manager.paymenttest']);
     $ext = $result['values'][$testExtensionResult['id']];
     $this->assertNotNull($ext['typeInfo']);
-    $this->assertEquals(['mock'], $ext['tags']);
+    $this->assertEquals(['mgmt:hidden', 'mock'], $ext['tags']);
     $this->assertTrue($result['count'] >= 6);
   }
 

--- a/tests/phpunit/api/v4/Entity/ExtensionTest.php
+++ b/tests/phpunit/api/v4/Entity/ExtensionTest.php
@@ -34,13 +34,13 @@ class ExtensionTest extends Api4TestBase implements TransactionalInterface {
       ->addWhere('key', '=', 'test.extension.manager.moduletest')
       ->execute()->single();
     $this->assertEquals('test_extension_manager_moduletest', $moduleTest['label']);
-    $this->assertEquals(['mock'], $moduleTest['tags']);
+    $this->assertEquals(['mgmt:hidden', 'mock'], $moduleTest['tags']);
 
     $moduleTest = Extension::get(FALSE)
       ->addWhere('file', '=', 'moduletest')
       ->execute()->single();
     $this->assertEquals('test_extension_manager_moduletest', $moduleTest['label']);
-    $this->assertEquals(['mock'], $moduleTest['tags']);
+    $this->assertEquals(['mgmt:hidden', 'mock'], $moduleTest['tags']);
   }
 
   /**


### PR DESCRIPTION
Overview
--------

Make it easier to introduce test-only extensions for use in end-to-end tests.

This PR changes the mechanism by which we hide test-oriented extensions. In both cases, test-extensions are generally hidden. But the mechanism is different

Before
------

The folder `tests/` is scanned for extensions -- but only when `phpunit` is running (i.e.  only when constant `CIVICRM_TEST` is set).

* Consequently, the scan is useful during _headless_ testing.
* But for E2E testing, `phpunit` (`CIVICRM_TEST`) is inconsistent.  It's loaded into the main runner but *not* into HTTP-requests or sub-processes. Using such an extension for E2E tests would be unreliable/confusing.

After
-----

The folder `tests/extensions/` is scanned for extensions, unconditionally. But note that:

* The folder `tests/` doesn't exist on most production systems. (Excluded via `distmaker` and `.gitattributes`.)
* The folder `tests/extensions/` is much smaller than `tests/`. (When it exists, it's less expensive to scan.)
* All items in `tests/` are flagged with `mgmt:hidden`, so they don't appear in web UI.

Motivation
-----------

I was thinking about how to write tests for #34038 and related edge-cases. This gets into *router testing*. This is hard to do in our normal test harnesses.

* Routing is different on each UF. And there could be relevant interactions with UF routers. (Thus, E2E is more appropriate.)
* Routing tests require *dummy/example routes* and *dummy/example controllers* which exercise *funny edge-cases*. 
* We don't want those routes on normal/live servers.
* It's somewhat awkward to instrument a mock route in headless context (you might implement `hook_alterMenu` and flush the route-table)... but translating that to E2E is even more awkward.
* If you're debugging a test, it might be nice to *have the ability* to call the route manually. (If the route is mocked, then you can't do this. But if the route

With this PR, one might initialize a "router-test" extension:

```bash
cd tests/extensions
civix generate:module router-test
cd router-test
vi info.xml   ### Add mgmt:hidden
```

And then put a bunch of examples in there, e.g.

```bash
civix generate:page civicrm/my-test-route
civix generate:test --template=e2e CRM_MyRouteTest
```

Any test generated in this way would:

* Be omitted from production. (It lives under `./tests`.)
* Be available for manual inspection. (It's an extension that you can enable via CLI/API.)
