### PR TITLE
Status Check - Fix extraneous PHP warning

### DIFF
--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -103,11 +103,9 @@ class CRM_Utils_Check {
         }
 
         if ($statusMessages) {
-          if (count($statusMessages) > 1) {
-            $maxSeverity = self::getMaxSeverity(TRUE);
-            $statusTitle = self::toStatusLabel($maxSeverity);
-            $statusMessage = '<ul><li>' . implode('</li><li>', $statusMessages) . '</li></ul>';
-          }
+          $maxSeverity = self::getMaxSeverity(TRUE);
+          $statusTitle = self::toStatusLabel($maxSeverity);
+          $statusMessage = '<ul><li>' . implode('</li><li>', $statusMessages) . '</li></ul>';
 
           $statusMessage .= '<p><a href="' . CRM_Utils_System::url('civicrm/a/#/status') . '">' . ts('View details and manage alerts') . '</a></p>';
 


### PR DESCRIPTION
Overview
----------

Fixes an unreleased regression from #33414 (which is in 6.9.beta).

Steps to Reproduce
------------------

* Setup a new build where there is *exactly one* non-trivial status-issue.

    For example, I hacked this one into `CRM/Utils/Check/Component/Env.php`:

    ```php
    $messages[] = new CRM_Utils_Check_Message('zoop', 'Zoo zoo', ts('Zoo zoo'));
    ```

* Login as admin. (There may be some timers/caches which hide the alert. For my testing, I just did `civibuild restore` before each login. There may be another way to do that with a lighter touch.)

Before
------

There's the expected warning (on the right)... and *also* a large, superfluous, illegible PHP warning in the main body. (`Undefined variable $maxSeverity`).

<img width="1616" height="177" alt="Screenshot 2025-11-17 at 3 46 29 PM" src="https://github.com/user-attachments/assets/b24c8777-32b3-4e43-8edc-346ffd6b7d91" />

After
-----

The expected warning is shown (on the right)... and the *extra* PHP warning goes away.

<img width="398" height="173" alt="Screenshot 2025-11-17 at 3 43 25 PM" src="https://github.com/user-attachments/assets/c28420a0-c364-45bc-9fc9-46a1528294ed" />

