### PR TITLE
Added brackets to fix standalone User-ID check

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/PasswordReset.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/PasswordReset.php
@@ -118,7 +118,7 @@ class PasswordReset extends AbstractAction {
     else {
       $userID = (int) substr($decodedToken['sub'], 4);
     }
-    if (!$userID > 0) {
+    if (!($userID > 0)) {
       // Hacker
       Civi::log()->warning("Rejected passwordResetToken with invalid userID.", compact('token', 'userID'));
       return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Add missing brackets to prevent the not operator to be applied on `$userID`.

Before
----------------------------------------
`if (!$userID > 0)`
A userID of 0 would be switched to 1 and therefore greater than 0.

After
----------------------------------------
`if (!($userID > 0))`
The negation is applied to the comparison - which seems to be desired here...