### PR TITLE
Fix Relationship Custom Field Bug In Search Kit

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -644,13 +644,14 @@ class Api4SelectQuery extends Api4Query {
     $this->openJoin['bridgeKey'] = $joinRef->getReferenceKey();
     $this->openJoin['bridgeCondition'] = array_intersect_key($linkConditions, [1 => 1]);
 
+    // Info needed for joining custom fields extending the bridge entity
+    $this->explicitJoins[$alias]['bridge_table_alias'] = $bridgeAlias;
+
     $outerConditions = [];
     foreach (array_filter($joinTree) as $clause) {
       $outerConditions[] = $this->treeWalkClauses($clause, 'ON');
     }
 
-    // Info needed for joining custom fields extending the bridge entity
-    $this->explicitJoins[$alias]['bridge_table_alias'] = $bridgeAlias;
     // Invert the join so all nested joins will link to the bridge entity
     $this->openJoin['table'] = $bridgeTableExpr;
     $this->openJoin['alias'] = $bridgeAlias;
@@ -943,7 +944,7 @@ class Api4SelectQuery extends Api4Query {
    */
   private function addJoin(string $side, string $tableExpr, string $tableAlias, string $baseTableAlias, array $conditions): void {
     // If this join is based off the current open join, incorporate it
-    if ($baseTableAlias === ($this->openJoin['alias'] ?? NULL)) {
+    if ($baseTableAlias === ($this->openJoin['alias'] ?? NULL) || $baseTableAlias === ($this->openJoin['bridgeAlias'] ?? NULL)) {
       $this->openJoin['subjoins'][] = [
         'table' => $tableExpr,
         'alias' => $tableAlias,

--- a/Civi/Api4/Service/Schema/Joinable/Joinable.php
+++ b/Civi/Api4/Service/Schema/Joinable/Joinable.php
@@ -113,6 +113,11 @@ class Joinable {
       $baseTableAlias = $openJoin['bridgeAlias'];
       $baseColumn = $openJoin['bridgeKey'];
     }
+    // Custom field on bridge table itself; pass-through the $baseColumn as-is
+    elseif (!empty($openJoin['bridgeKey']) && $baseTableAlias === $openJoin['bridgeAlias']) {
+      $conditions = $openJoin['bridgeCondition'];
+      $baseTableAlias = $openJoin['bridgeAlias'];
+    }
     if ($this->baseColumn && $this->targetColumn) {
       $conditions[] = sprintf(
         '`%s`.`%s` =  `%s`.`%s`',

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -660,7 +660,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           ],
           'where' => [
             ['id', 'IN', $cids],
-            ['Contact_RelationshipCache_Contact_01.near_relation:name', '=', '"Child of"'],
+            ['Contact_RelationshipCache_Contact_01.near_relation:name', '=', 'Child of'],
             ['Contact_RelationshipCache_Contact_01.test_rel_fields.Opts', '=', 'r'],
           ],
           'join' => [

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -660,15 +660,27 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
           ],
           'where' => [
             ['id', 'IN', $cids],
-            ['Contact_RelationshipCache_Contact_01.near_relation:name', '=', 'Child of'],
-            ['Contact_RelationshipCache_Contact_01.test_rel_fields.Opts', '=', 'r'],
           ],
           'join' => [
             [
-              'Contact AS Contact_RelationshipCache_Contact_01',
-              'INNER',
-              'RelationshipCache',
-              ['id', '=', 'Contact_RelationshipCache_Contact_01.far_contact_id'],
+              "Contact AS Contact_RelationshipCache_Contact_01",
+              "INNER",
+              "RelationshipCache",
+              [
+                "id",
+                "=",
+                "Contact_RelationshipCache_Contact_01.far_contact_id",
+              ],
+              [
+                "Contact_RelationshipCache_Contact_01.near_relation:name",
+                "=",
+                "\"Child of\"",
+              ],
+              [
+                "Contact_RelationshipCache_Contact_01.test_rel_fields.Opts",
+                "=",
+                "\"r\"",
+              ],
             ],
           ],
         ],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -620,6 +620,67 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('Red', $result[1]['columns'][1]['val']);
   }
 
+  public function testRelatedContactSearchWithRelationshipCustomFieldFilter(): void {
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Relationship',
+      'name' => 'test_rel_fields',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'test_rel_fields',
+      'label' => 'Opts',
+      'html_type' => 'Select',
+      'option_values' => ['r' => 'Red', 'g' => 'Green', 'b' => 'Blue'],
+    ]);
+
+    $cids = $this->saveTestRecords('Individual', [
+      'records' => 3,
+    ])->column('id');
+
+    $this->saveTestRecords('Relationship', [
+      'defaults' => [
+        'contact_id_a' => $cids[0],
+        'relationship_type_id:name' => 'Child of',
+      ],
+      'records' => [
+        ['contact_id_b' => $cids[1], 'test_rel_fields.Opts' => 'r'],
+        ['contact_id_b' => $cids[2], 'test_rel_fields.Opts' => 'g'],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Individual',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'Contact_RelationshipCache_Contact_01.test_rel_fields.Opts:label',
+          ],
+          'where' => [
+            ['id', 'IN', $cids],
+            ['Contact_RelationshipCache_Contact_01.near_relation:name', '=', '"Child of"'],
+            ['Contact_RelationshipCache_Contact_01.test_rel_fields.Opts', '=', 'r'],
+          ],
+          'join' => [
+            [
+              'Contact AS Contact_RelationshipCache_Contact_01',
+              'INNER',
+              'RelationshipCache',
+              ['id', '=', 'Contact_RelationshipCache_Contact_01.far_contact_id'],
+            ],
+          ],
+        ],
+      ],
+      'display' => NULL,
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+    $this->assertEquals('Red', $result[0]['columns'][1]['val']);
+  }
+
   /**
    * Test smarty rewrite syntax.
    */


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a fix and a test case as requested on [this](https://lab.civicrm.org/dev/core/-/issues/6118) issue for a search kit bug that is described below

When building a search kit query based on the contact entity but joining in related contacts, and where a custom field on a relationship is used within the initial ‘search for’ criteria, the report is returning no results.

## Reproduction steps

1. Create a custom field on a relationship type (e.g. “Test Custom Field” on “Employer of”).
2. Create a new contact.
3. Assign this contact an ‘employee of’ relationship to another contact and populate the custom field value.
4. Go to SearchKit → Create New Search.
5. Build a search for contacts, then add a Related Contact with this relationship type.
6. Within the ‘Search For’ settings, try to filter by not just the relationship type, but also the custom field on the relationship, search returns no results whereas there are matching records available.
