### PR TITLE
CoreForm - Support Toggle widget as a core input type

### DIFF
--- a/CRM/Admin/Form/ScheduleReminders.php
+++ b/CRM/Admin/Form/ScheduleReminders.php
@@ -168,14 +168,14 @@ class CRM_Admin_Form_ScheduleReminders extends CRM_Admin_Form {
     $this->addField('absolute_date', [], FALSE, FALSE);
     $this->addField('start_action_offset', ['class' => 'four']);
     $this->addField('start_action_condition', ['placeholder' => FALSE])->setAttribute('class', 'crm-form-select');
-    $this->addField('record_activity', ['type' => 'advcheckbox']);
-    $this->addField('is_repeat', ['type' => 'advcheckbox']);
+    $this->addField('record_activity');
+    $this->addField('is_repeat');
     $this->addField('repetition_frequency_interval', ['label' => ts('Every'), 'class' => 'four']);
     $this->addField('end_frequency_interval', ['label' => ts('Until'), 'class' => 'four']);
     $this->addField('end_action', ['placeholder' => FALSE])->setAttribute('class', 'crm-form-select');
     $this->addField('effective_start_date', ['label' => ts('Effective From')], FALSE, FALSE);
     $this->addField('effective_end_date', ['label' => ts('To')], FALSE, FALSE);
-    $this->addField('is_active', ['type' => 'advcheckbox']);
+    $this->addField('is_active', ['on' => ts('On'), 'off' => ts('Off')]);
     $this->addAutocomplete('recipient_manual', ts('Manual Recipients'), ['select' => ['multiple' => TRUE]]);
     $this->addAutocomplete('group_id', ts('Group'), ['entity' => 'Group', 'select' => ['minimumInputLength' => 0]]);
 

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1434,6 +1434,13 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
   }
 
+  /**
+   * @param string $name
+   * @param string $title
+   * @param array $attributes
+   * @param bool $required
+   * @return HTML_QuickForm_Element
+   */
   public function addToggle(string $name, string $title, array $attributes = [], bool $required = FALSE) {
     $attributes += [
       'on' => ts('Yes'),
@@ -1448,10 +1455,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
       $value = htmlspecialchars($value);
       $toggleText .= "<span class='crm-form-toggle-text crm-form-toggle-text-{$key}'>{$value}</span>";
     }
-    $this->addElement('advcheckbox', $name, $title, $toggleText, $attributes);
+    $element = $this->addElement('advcheckbox', $name, $title, $toggleText, $attributes);
     if ($required) {
       $this->addRule($name, ts('%1 is a required field.', [1 => $title]), 'required');
     }
+    return $element;
   }
 
   /**
@@ -1759,8 +1767,6 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *   a controlled way. To convert the field the jcalendar code needs to be removed from the
    *   tpl as well. That file is intended to be EOL.
    *
-   * @throws \CRM_Core_Exception
-   * @throws \Exception
    * @return mixed
    *   HTML_QuickForm_element
    *   void
@@ -1929,6 +1935,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $text = $props['text'] ?? NULL;
         unset($props['text']);
         return $this->addElement('advcheckbox', $name, $label, $text, $props);
+
+      case 'Toggle':
+        return $this->addToggle($name, $label, $props, $required);
 
       case 'File':
         // We should not build upload file in search mode.

--- a/schema/Core/ActionSchedule.entityType.php
+++ b/schema/Core/ActionSchedule.entityType.php
@@ -167,7 +167,7 @@ return [
     'is_repeat' => [
       'title' => ts('Repeat'),
       'sql_type' => 'boolean',
-      'input_type' => 'CheckBox',
+      'input_type' => 'Toggle',
       'required' => TRUE,
       'add' => '3.4',
       'default' => FALSE,
@@ -254,7 +254,7 @@ return [
     'is_active' => [
       'title' => ts('Schedule is Active?'),
       'sql_type' => 'boolean',
-      'input_type' => 'CheckBox',
+      'input_type' => 'Toggle',
       'required' => TRUE,
       'description' => ts('Is this option active?'),
       'add' => '3.4',
@@ -322,7 +322,7 @@ return [
     'record_activity' => [
       'title' => ts('Record Activity'),
       'sql_type' => 'boolean',
-      'input_type' => 'CheckBox',
+      'input_type' => 'Toggle',
       'required' => TRUE,
       'description' => ts('Record Activity for this reminder?'),
       'add' => '3.4',


### PR DESCRIPTION
Overview
----------------------------------------
Supports Toggle in entityType definitions, and demonstrates its use in the addField function, utilizing it on the ScheduleReminders form.

Before
----------------------------------------
<img width="1806" height="820" alt="image" src="https://github.com/user-attachments/assets/7c2fccd7-70d6-44e9-9afb-2fb76bcf0126" />


After
------
<img width="1800" height="854" alt="image" src="https://github.com/user-attachments/assets/8f95f9fa-6004-41ea-882b-345c3b87a5a6" />

