### PR TITLE
Fix dev/core#6209: "Email Invoice" does not honor CC/BCC for event-related contributions

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -549,8 +549,8 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
         $sendTemplateParams['tplParams'] = $tplParams;
         $sendTemplateParams['from'] = $fromEmailAddress;
         $sendTemplateParams['toEmail'] = $email;
-        $sendTemplateParams['cc'] = $values['cc_confirm'] ?? NULL;
-        $sendTemplateParams['bcc'] = $values['bcc_confirm'] ?? NULL;
+        $sendTemplateParams['cc'] = $values['cc_receipt'] ?? NULL;
+        $sendTemplateParams['bcc'] = $values['bcc_receipt'] ?? NULL;
 
         [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
         // functions call for adding activity with attachment


### PR DESCRIPTION

Overview
----------------------------------------
As in original ticket ["Email Invoice" does not honor CC/BCC for event-related contributions](https://lab.civicrm.org/dev/core/-/issues/6209): cc/bcc emails are not sent when using "Email Invoice" for event-related contribs.

Before
----------------------------------------
The CC/BCC addresses are simply not specified in the email message.

After
----------------------------------------
The CC/BCC addresses are correctly specified in the email message, per the "Send Email" form values.

Technical Details
----------------------------------------
Looks like lots of old code in this section. The pre-PR code specifies use of `$values['cc_receipt']` and `$values['bcc_receipt']`, but those are never defined in scope.

Comments
----------------------------------------
Fingers crossed for passing tests!
