### PR TITLE
Remove system rebuild from Job form controller

### DIFF
--- a/CRM/Admin/Form/Job.php
+++ b/CRM/Admin/Form/Job.php
@@ -203,8 +203,6 @@ class CRM_Admin_Form_Job extends CRM_Admin_Form {
    * Process the form submission.
    */
   public function postProcess() {
-
-    Civi::rebuild(['system' => TRUE])->execute();
     $redirectUrl = CRM_Utils_System::url('civicrm/admin/job', 'reset=1');
     if ($this->_action & CRM_Core_Action::DELETE) {
       CRM_Core_BAO_Job::deleteRecord(['id' => $this->_id]);


### PR DESCRIPTION
Overview
----------------------------------------
Try to remove some old code that may not be needed and causes very unintuitive behaviour

Before
----------------------------------------
- Job form post process does a system rebuild, which clears lots of things
- if you try to execute the "Job.cleanup" job from the Scheduled Jobs page, you don't expect it to do a system rebuild (because the `memCache` param that triggers that defaults to FALSE)
- if you set the `memCache` param explicitly to false, Executing the job still triggers the system rebuild, because it's in the form controller
- once upon a time, this flush had a param that I guess meant "flush Job cache specifically"

After
----------------------------------------
- no system rebuild
- let's see what tests say

Technical Details
----------------------------------------
I don't know what the flush Job cache that was originally requested is or whether it is still needed in some form, and maybe `system` is the only target that allows us to do it. 

Comments
----------------------------------------
This is mainly only a problem to me because of https://lab.civicrm.org/dev/core/-/issues/6137 (ie the system rebuild is breaking Drupal webforms)

That specific issue would be resolved by https://github.com/civicrm/civicrm-core/pull/33728 and then I would have less appetite for this PR.

But if this line is just not needed at all it would be nice to be rid of it.