### PR TITLE
SearchKit/API - Nicer-formatted SQL

### DIFF
--- a/CRM/Utils/SQL/Select.php
+++ b/CRM/Utils/SQL/Select.php
@@ -398,7 +398,7 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
         $this->setOps[] = ['', $subQuery];
       }
       else {
-        $this->setOps[] = [" $setOperation ", $subQuery];
+        $this->setOps[] = [$setOperation, $subQuery];
       }
     }
     return $this;
@@ -561,19 +561,24 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
     }
 
     if ($this->selects) {
-      $sql .= 'SELECT ' . $this->distinct . implode(', ', $this->selects) . "\n";
+      $sql .= 'SELECT' . (isset($this->distinct) ? ' ' . $this->distinct : '') . "\n";
+      $sql .= '  ' . implode(",\n  ", $this->selects) . "\n";
     }
     else {
-      $sql .= 'SELECT *' . "\n";
+      $sql .= "SELECT *\n";
     }
     if ($this->from !== NULL) {
       $sql .= 'FROM ' . $this->from . "\n";
     }
     elseif (is_array($this->setOps)) {
-      $sql .= 'FROM (';
+      $sql .= "FROM (\n";
       foreach ($this->setOps as $setOp) {
-        $sql .= $setOp[0];
-        $sql .= '(' . (is_object($setOp[1]) ? $setOp[1]->toSQL() : $setOp[1]) . ')';
+        // $setOp[0] is blank on the first iteration, and subsequently contains a keyword like "UNION ALL".
+        $sql .= '  ' . ($setOp[0] ? "{$setOp[0]} " : '') . "(\n";
+        $setSql = (is_object($setOp[1]) ? $setOp[1]->toSQL() : $setOp[1]);
+        // Add indentation
+        $setSql = trim(str_replace("\n", "\n    ", $setSql));
+        $sql .= '    ' . $setSql . "\n  )\n";
       }
       $sql .= ") {$this->setAlias}\n";
     }
@@ -584,7 +589,7 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
       $sql .= 'WHERE (' . implode(")\n  AND (", $this->wheres) . ")\n";
     }
     if ($this->groupBys) {
-      $sql .= 'GROUP BY ' . implode(', ', $this->groupBys) . "\n";
+      $sql .= "GROUP BY\n  " . implode(",\n  ", $this->groupBys) . "\n";
     }
     if ($this->havings) {
       $sql .= 'HAVING (' . implode(")\n  AND (", $this->havings) . ")\n";
@@ -593,7 +598,7 @@ class CRM_Utils_SQL_Select extends CRM_Utils_SQL_BaseParamQuery {
       $orderBys = CRM_Utils_Array::crmArraySortByField($this->orderBys,
         ['weight', 'guid']);
       $orderBys = CRM_Utils_Array::collect('value', $orderBys);
-      $sql .= 'ORDER BY ' . implode(', ', $orderBys) . "\n";
+      $sql .= "ORDER BY\n  " . implode(",\n  ", $orderBys) . "\n";
     }
     if ($this->limit !== NULL) {
       $sql .= 'LIMIT ' . $this->limit . "\n";

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -930,7 +930,7 @@ class Api4SelectQuery extends Api4Query {
     foreach ($this->openJoin['subjoins'] as $subjoin) {
       $subjoinClause .= " INNER JOIN {$subjoin['table']} `{$subjoin['alias']}` ON (" . implode(' AND ', $subjoin['conditions']) . ")";
     }
-    $this->query->join($tableAlias, "$side JOIN ($tableExpr `$tableAlias`$subjoinClause) ON " . implode(' AND ', $conditions));
+    $this->query->join($tableAlias, "$side JOIN ($tableExpr `$tableAlias`$subjoinClause)\n  ON " . implode("\n  AND ", $conditions));
     $this->openJoin = NULL;
   }
 
@@ -951,7 +951,7 @@ class Api4SelectQuery extends Api4Query {
       ];
     }
     else {
-      $this->query->join($tableAlias, "$side JOIN $tableExpr `$tableAlias` ON " . implode(' AND ', $conditions));
+      $this->query->join($tableAlias, "$side JOIN $tableExpr `$tableAlias`\n  ON " . implode("\n  AND ", $conditions));
     }
   }
 

--- a/Civi/Test/GenericAssertionsTrait.php
+++ b/Civi/Test/GenericAssertionsTrait.php
@@ -103,4 +103,21 @@ trait GenericAssertionsTrait {
     $this->assertEquals($array1, $array2);
   }
 
+  /**
+   * Assert 2 sql strings are the same, ignoring double spaces.
+   *
+   * @param string $expectedSQL
+   * @param string $actualSQL
+   * @param string $message
+   */
+  protected function assertLike(string $expectedSQL, string $actualSQL, string $message = 'different sql'): void {
+    // Normalize whitespace around brackets
+    $expected = str_replace(['(', ')'], [' ( ', ' ) '], $expectedSQL);
+    $actual = str_replace(['(', ')'], [' ( ', ' ) '], $actualSQL);
+    // Normalize all whitespace
+    $expected = trim(preg_replace('/\s+/', ' ', $expected));
+    $actual = trim(preg_replace('/\s+/', ' ', $actual));
+    $this->assertEquals($expected, $actual, $message);
+  }
+
 }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2450,19 +2450,6 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
   }
 
   /**
-   * Assert 2 sql strings are the same, ignoring double spaces.
-   *
-   * @param string $expectedSQL
-   * @param string $actualSQL
-   * @param string $message
-   */
-  protected function assertLike(string $expectedSQL, string $actualSQL, string $message = 'different sql'): void {
-    $expected = trim((preg_replace('/[ \r\n\t]+/', ' ', $expectedSQL)));
-    $actual = trim((preg_replace('/[ \r\n\t]+/', ' ', $actualSQL)));
-    $this->assertEquals($expected, $actual, $message);
-  }
-
-  /**
    * Create a price set for an event.
    *
    * @param float $feeTotal

--- a/tests/phpunit/api/v4/Api4TestBase.php
+++ b/tests/phpunit/api/v4/Api4TestBase.php
@@ -31,6 +31,7 @@ use PHPUnit\Framework\TestCase;
 class Api4TestBase extends TestCase implements HeadlessInterface {
 
   use Api4TestTrait;
+  use Test\GenericAssertionsTrait;
 
   /**
    * @see CiviUnitTestCase

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -65,10 +65,9 @@ class Api4SelectQueryTest extends Api4TestBase {
       'select' => ['SUM(amount) AS SUM_amount'],
     ]);
     $query = new Api4SelectQuery($api);
-    $this->assertEquals(
-      'SELECT SUM(`a`.`amount`) AS `SUM_amount`
-FROM `civicrm_pledge` a',
-      trim($query->getSql())
+    $this->assertLike(
+      'SELECT SUM(`a`.`amount`) AS `SUM_amount` FROM `civicrm_pledge` a',
+      $query->getSql()
     );
   }
 

--- a/tests/phpunit/api/v4/Query/ArbitraryForeignKeyJoinTest.php
+++ b/tests/phpunit/api/v4/Query/ArbitraryForeignKeyJoinTest.php
@@ -65,7 +65,8 @@ namespace api\v4\Query {
         ->setDebug(TRUE)
         ->execute();
       $sql = $apiCall->debug['sql'];
-      $this->assertStringEndsWith('LEFT JOIN (`civicrm_phone` `Phone`) ON `Phone`.`phone_numeric` = `a`.`phone_fk`', rtrim($sql[0]));
+      [$select, $join] = explode('LEFT JOIN', $sql[0]);
+      $this->assertLike('(`civicrm_phone` `Phone`) ON `Phone`.`phone_numeric` = `a`.`phone_fk`', $join);
 
       // Make sure it works both ways
       $apiCall = PhoneNumberJoin::get(FALSE)
@@ -74,7 +75,8 @@ namespace api\v4\Query {
         ->setDebug(TRUE)
         ->execute();
       $sql = $apiCall->debug['sql'];
-      $this->assertStringEndsWith('LEFT JOIN (`civicrm_phone` `Phone`) ON `a`.`phone_fk` = `Phone`.`phone_numeric`', rtrim($sql[0]));
+      [$select, $join] = explode('LEFT JOIN', $sql[0]);
+      $this->assertLike('(`civicrm_phone` `Phone`) ON `a`.`phone_fk` = `Phone`.`phone_numeric`', $join);
 
       // Joining without any ON conditions specified, ensure the API automatically adds the correct FK.
       $apiCall = PhoneNumberJoin::get(FALSE)
@@ -82,7 +84,8 @@ namespace api\v4\Query {
         ->setDebug(TRUE)
         ->execute();
       $sql = $apiCall->debug['sql'];
-      $this->assertStringEndsWith('LEFT JOIN (`civicrm_phone` `Phone`) ON `a`.`phone_fk` = `Phone`.`phone_numeric`', rtrim($sql[0]));
+      [$select, $join] = explode('LEFT JOIN', $sql[0]);
+      $this->assertLike('(`civicrm_phone` `Phone`) ON `a`.`phone_fk` = `Phone`.`phone_numeric`', $join);
     }
 
     /**


### PR DESCRIPTION
Overview
----------------------------------------
This adds more linebreaks to the sql output in Api4/SearchKit which makes it easier to see the whole query without so much sideways scrolling.

Before
------
<img width="2368" height="606" alt="image" src="https://github.com/user-attachments/assets/6d1e771f-4abb-4c9f-a652-c03210cc6062" />


After
-----
<img width="2376" height="1234" alt="image" src="https://github.com/user-attachments/assets/b47227a8-d03c-424b-aa69-00b69255a9f0" />


Technical Details
------
Mostly test fixes to be less brittle about expected whitespace.