### PR TITLE
PHPUnit - Remove reference to obsolete `checkInternalType`

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -262,13 +262,7 @@ trait Api3TestTrait {
    * @param string $entity
    * @param array $params
    * @param string $type
-   *   Per http://php.net/manual/en/function.gettype.php possible types.
-   *   - boolean
-   *   - integer
-   *   - double
-   *   - string
-   *   - array
-   *   - object
+   *   Only 'integer' is supported
    *
    * @return array|int
    */
@@ -286,7 +280,7 @@ trait Api3TestTrait {
         $this->assertTrue(is_numeric($result), "expected a numeric value but got " . print_r($result, 1));
       }
       else {
-        $this->assertType($type, $result, "returned result should have been of type $type but was ");
+        throw new \CRM_Core_Exception("Unsupported type '$type' for callAPISuccessGetValue");
       }
     }
     return $result;

--- a/Civi/Test/GenericAssertionsTrait.php
+++ b/Civi/Test/GenericAssertionsTrait.php
@@ -12,17 +12,6 @@ namespace Civi\Test;
 trait GenericAssertionsTrait {
 
   /**
-   * @param string $expected
-   *   Ex: 'array', 'object', 'int'
-   * @param $actual
-   *   The variable/item to check.
-   * @param string $message
-   */
-  public function assertType($expected, $actual, $message = '') {
-    return $this->assertInternalType($expected, $actual, $message);
-  }
-
-  /**
    * Assert that two array-trees are exactly equal.
    *
    * The ordering of keys do not affect the outcome (within either the roots


### PR DESCRIPTION
Overview
----------------------------------------
Function was [removed in PHPUnit 9.0](https://github.com/sebastianbergmann/phpunit/issues/3369). We only had 1 reference to it.