### PR TITLE
Don't crash when deleting ECK entity with custom fields

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -2206,6 +2206,13 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
 
     $customEntityMap = self::getCustomEntityTypeMap();
     foreach ($customEntityMap as $customEntity) {
+
+      if (!\Civi\Schema\EntityRepository::tableExists($customEntity['table_name'])) {
+        // If we just deleted an ECK entity we'll get here with a NULL table_name
+        // when Managed entity reconcile is triggered as part of the delete process.
+        // ECK already deleted the CustomFields anyway.
+        return;
+      }
       // Go by table_name for the sake of contact types and complex entities with alternate tables
       $field = Civi::table($customEntity['table_name'])->getField($customEntity['grouping']);
       if (array_intersect_assoc($field[$mode] ?? [], $property)) {


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a crash when deleting an ECK entity.

Part of the delete process calls Managed.reconcile which triggers `onDeleteEntity` but ECK already deleted the custom fields and the ECK entity itself.

So `Civi::table($customEntity['table_name'])` crashes because table_name is NULL.

Before
----------------------------------------
Crash on delete when the ECK entity has custom fields

After
----------------------------------------
No crash

Technical Details
----------------------------------------

Comments
----------------------------------------

