### PR TITLE
Support 'String' datatype for EntityReference customfield (as required for Afform)

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -120,6 +120,10 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
     if ($dataType === 'Date' && !empty($customField['time_format'])) {
       $dataType = 'Timestamp';
     }
+    if (!empty($customField['fk_entity'])) {
+      $dataType = CRM_Core_BAO_CustomValueTable::getDataTypeForPrimaryKey($customField['fk_entity'], $dataType);
+    }
+
     return $dataType;
   }
 
@@ -2787,7 +2791,8 @@ WHERE      f.id IN ($ids)";
       'type' => CRM_Core_BAO_CustomValueTable::fieldToSQLType(
         $field->data_type,
         $field->text_length,
-        $field->serialize
+        $field->serialize,
+        $field->fk_entity ?? ''
       ),
       'required' => $field->is_required,
       'searchable' => $field->is_searchable && $field->is_active,

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -220,7 +220,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
         $fieldName = $customGroup['name'] . '.' . $customField['name'];
         $field = [
           'title' => $customField['label'],
-          'sql_type' => \CRM_Core_BAO_CustomValueTable::fieldToSQLType($customField['data_type'], $customField['text_length'], !empty($customField['serialize'])),
+          'sql_type' => \CRM_Core_BAO_CustomValueTable::fieldToSQLType($customField['data_type'], $customField['text_length'], !empty($customField['serialize']), $customField['fk_entity'] ?? NULL),
           'data_type' => \CRM_Core_BAO_CustomField::getDataTypeString($customField),
           'input_type' => $inputTypeMap[$customField['html_type']] ?? $customField['html_type'],
           'input_attrs' => [

--- a/tests/phpunit/CRM/Custom/Page/AJAXTest.php
+++ b/tests/phpunit/CRM/Custom/Page/AJAXTest.php
@@ -32,7 +32,7 @@ class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
       'last_name' => 'Contact',
     ];
     $customFields = $ids['custom_field_id'];
-    $result = $this->callAPISuccess('contact', 'create', $params);
+    $result = $this->callAPISuccess('Contact', 'create', $params);
     $contactId = $result['id'];
 
     //enter values for custom fields
@@ -47,7 +47,7 @@ class CRM_Custom_Page_AJAXTest extends CiviUnitTestCase {
       "custom_{$customFields[2]}_-2" => "test value {$customFields[2]} two",
       "custom_{$customFields[2]}_-3" => "test value {$customFields[2]} three",
     ];
-    CRM_Core_BAO_CustomValueTable::postProcess($customParams, "civicrm_contact", $contactId, NULL);
+    CRM_Core_BAO_CustomValueTable::postProcess($customParams, "civicrm_contact", $contactId, 'Contact');
 
     $_GET = [
       'cid' => $contactId,


### PR DESCRIPTION
Overview
----------------------------------------
Afforms don't have an ID because they are not a database table...

If you want to create an EntityReference custom field you can't use it because it expects the field to be an integer but it gets filled with the Afform name.

Before
----------------------------------------
Can create Afform EntityReference custom field but it crashes when you try to use it because it tries to put afform string name into custom field value table.

After
----------------------------------------
Can create Afform EntityReference custom field and save the name of an afform into the field (it gets created as a string/varchar field).

Technical Details
----------------------------------------
EntityReference fields have always assumed that the "reference" is an integer ID, but that doesn't apply to Afforms... The UI/autofill works fine, but when you try and save you get a DB error, string is not of type int..

Comments
----------------------------------------
@colemanw Thoughts? Would be nice if this could be a bit more metadata-y but the CustomField code seems a bit special..
