### PR TITLE
Use submitted date format instead of template format for contact import

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -436,6 +436,14 @@ class CRM_Import_Forms extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   protected function createUserJob(): int {
+    // Override the template date format with the submitted date format on the contact import form.
+    // This could be removed once the contact import is migrated to civiimport.
+    $submittedValues = $this->getSubmittedValues();
+    $importOptions = $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_options'] : [];
+    if (isset($submittedValues['dateFormats'])) {
+      $importOptions['date_format'] = $submittedValues['dateFormats'];
+    };
+
     $id = UserJob::create(FALSE)
       ->setValues([
         'created_id' => CRM_Core_Session::getLoggedInContactID(),
@@ -444,12 +452,12 @@ class CRM_Import_Forms extends CRM_Core_Form {
         // This suggests the data could be cleaned up after this.
         'expires_date' => '+ 1 week',
         'metadata' => [
-          'submitted_values' => $this->getSubmittedValues(),
+          'submitted_values' => $submittedValues,
           'template_id' => $this->getTemplateID(),
           // @todo - this Template key is obsolete - definitely in Civiimport - probably entirely.
           'Template' => ['mapping_id' => $this->getSavedMappingID()],
           'import_mappings' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_mappings'] : [],
-          'import_options' => $this->getTemplateJob() ? $this->getTemplateJob()['metadata']['import_options'] : [],
+          'import_options' => $importOptions,
           'entity_configuration' => $this->getTemplateJob() ? ($this->getTemplateJob()['metadata']['entity_configuration'] ?? []) : [],
           'bundled_actions' => $this->getTemplateJob() ? ($this->getTemplateJob()['metadata']['bundled_actions'] ?? []) : [],
           'base_entity' => $this->getBaseEntity(),


### PR DESCRIPTION
If you try to use a contact import template /saved field mapping that has a different date format than your import file and set the date format appropriately on the first page, the date format you set is not respected, so you get an import error.

To reproduce:
1. Create an import saved field mapping for contacts with a date format.
2. Use the saved field mapping, but choose a different date format (and adjust your import file to match).
The result will be an invalid error for each row. 

Before
----------------------------------------
UserJob Template date_format is used, so it cannot be changed by the user even if they think they are changing it.

After
----------------------------------------
User-selected date format is used. No change for other imports that do not give date format options on the first page.