### PR TITLE
PHPUnit - Remove unused function

### DIFF
--- a/Civi/Test/GenericAssertionsTrait.php
+++ b/Civi/Test/GenericAssertionsTrait.php
@@ -64,19 +64,6 @@ trait GenericAssertionsTrait {
   }
 
   /**
-   * @param string|int $key
-   * @param array $list
-   */
-  public function assertArrayValueNotNull($key, &$list) {
-    $this->assertArrayKeyExists($key, $list);
-
-    $value = $list[$key] ?? NULL;
-    $this->assertTrue($value,
-      sprintf("%s element not null?", $key)
-    );
-  }
-
-  /**
    * Assert the 2 arrays have the same values.
    *
    * The order of arrays, and keys of the arrays, do not affect the outcome.


### PR DESCRIPTION
Overview
----------------------------------------
Very confusing what this function was supposed to do. Fortunately it was unused, so dropping it.