### PR TITLE
Expose getSubmittedValues in AfformSubmit and AfformValidate events

### DIFF
--- a/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformSubmitEvent.php
@@ -90,4 +90,12 @@ class AfformSubmitEvent extends AfformBaseEvent {
     return $this;
   }
 
+  /**
+   * Get submitted values for all entities on the form
+   * @return array
+   */
+  public function getSubmittedValues() {
+    return $this->getApiRequest()->getSubmittedValues();
+  }
+
 }

--- a/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
@@ -13,20 +13,13 @@ class AfformValidateEvent extends AfformBaseEvent {
   private $errors = [];
 
   /**
-   * @var array
-   */
-  private $entityValues;
-
-  /**
    * AfformValidateEvent constructor.
    *
    * @param array $afform
    * @param \Civi\Afform\FormDataModel $formDataModel
    * @param \Civi\Api4\Action\Afform\Submit $apiRequest
-   * @param array $entityValues
    */
-  public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest, array $entityValues) {
-    $this->entityValues = $entityValues;
+  public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest) {
     parent::__construct($afform, $formDataModel, $apiRequest);
   }
 
@@ -45,10 +38,20 @@ class AfformValidateEvent extends AfformBaseEvent {
   }
 
   /**
+   * @deprecated
    * @return array
    */
   public function getEntityValues(): array {
-    return $this->entityValues;
+    \CRM_Core_Error::deprecatedFunctionWarning("getSubmittedValues");
+    return $this->getSubmittedValues();
+  }
+
+  /**
+   * Get submitted values for all entities on the form
+   * @return array
+   */
+  public function getSubmittedValues() {
+    return $this->getApiRequest()->getSubmittedValues();
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -51,7 +51,7 @@ class Submit extends AbstractProcessor {
     }
 
     // Call validation handlers
-    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this, $this->_entityValues);
+    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this);
     \Civi::dispatcher()->dispatch('civi.afform.validate', $event);
     $errors = $event->getErrors();
     if ($errors) {
@@ -142,7 +142,7 @@ class Submit extends AbstractProcessor {
    */
   public static function validateFieldInput(AfformValidateEvent $event): void {
     foreach ($event->getFormDataModel()->getEntities() as $afEntityName => $afEntity) {
-      $entityValues = $event->getEntityValues()[$afEntityName] ?? [];
+      $entityValues = $event->getSubmittedValues()[$afEntityName] ?? [];
       foreach ($entityValues as $values) {
         foreach ($afEntity['fields'] as $fieldName => $attributes) {
           $error = self::getFieldInputError($event, $afEntity['type'], $fieldName, $attributes, $values['fields'][$fieldName] ?? NULL);
@@ -227,7 +227,7 @@ class Submit extends AbstractProcessor {
   public static function validateEntityRefFields(AfformValidateEvent $event): void {
     $formName = $event->getAfform()['name'];
     foreach ($event->getFormDataModel()->getEntities() as $entityName => $entity) {
-      $entityValues = $event->getEntityValues()[$entityName] ?? [];
+      $entityValues = $event->getSubmittedValues()[$entityName] ?? [];
       foreach ($entityValues as $values) {
         foreach ($entity['fields'] as $fieldName => $attributes) {
           $error = self::getEntityRefError($formName, $entityName, $entity['type'], $fieldName, $attributes, $values['fields'][$fieldName] ?? NULL);
@@ -296,7 +296,7 @@ class Submit extends AbstractProcessor {
     if ($isRequired) {
       $conditionals = $attributes['af-if'] ?? [];
       foreach ($conditionals as $conditional) {
-        $isVisible = self::checkAfformConditional($conditional, $event->getEntityValues());
+        $isVisible = self::checkAfformConditional($conditional, $event->getSubmittedValues());
         if (!$isVisible) {
           break;
         }


### PR DESCRIPTION
Overview
----------------------------------------
As the function comment suggests, this doesn't give you *all* the entity values, only those submitted on the form. **Not** those set in the entity data. As such I think `getSubmittedValues` would be a much clearer name. 

There's some overlap with pre-existing getEntityValues on AfformValidateEvent - make that more consistent across Validate and Submit events.

Before
----------------------------------------
- getEntityValues gives you the submitted values
- a copy of the entity values is passed to the AfformValidateEvent constructor, but it can be accessed directly now from the apiEntity
- for AfformValidateEvent you do `$event->getEntityValues()`, form AfformSubmitEvent you have to do `$event->getApiRequest()->getEntityValues()`

After
----------------------------------------
- getEntityValues gives you the submitted values
- a copy of the entity values is passed to the AfformValidateEvent constructor, but it can be accessed directly now from the apiEntity
- for AfformValidateEvent and AfformSubmitEvent you can do `$event->getSubmittedValues()` (`$event->getEntityValues()` is left as an alias on AfformValidateEvent for backwards compatibility)


Comments
----------------------------------------
Maintaining the alias `getEntityValues` gives backward compatibility, though given it is only currently in the RC maybe this isn't necessary.

@mattwire as you added, would you be open to this name change? If you were, maybe we could merge the pure name change into the RC branch?
