### PR TITLE
Fix crash if we have no tasks

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SearchDisplayTasksSubscriber.php
@@ -51,10 +51,10 @@ class SearchDisplayTasksSubscriber extends \Civi\Core\Service\AutoService implem
     $entityName = ($entityName === 'RelationshipCache') ? 'Relationship' : $entityName;
     if (is_array($enabledActions)) {
       if ($entityName) {
-        $event->tasks[$entityName] = array_intersect_key($event->tasks[$entityName], array_flip($enabledActions));
+        $event->tasks[$entityName] = array_intersect_key($event->tasks[$entityName] ?? [], array_flip($enabledActions));
       }
       if (CoreUtil::isContact($entityName)) {
-        $event->tasks['Contact'] = array_intersect_key($event->tasks['Contact'], array_flip($enabledActions));
+        $event->tasks['Contact'] = array_intersect_key($event->tasks['Contact'] ?? [], array_flip($enabledActions));
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
For non-admin users there might be no tasks. `array_intersect_key` will crash if passed NULL instead of array.

Before
----------------------------------------
Crash if no tasks available.

After
----------------------------------------
No crash.

Technical Details
----------------------------------------

Comments
----------------------------------------

