### PR TITLE
rename new method `AbstractProcessor::getEntityValues` => `getSubmittedValues`

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -76,11 +76,11 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   protected $_entityValues = [];
 
   /**
-   * Get the (submitted) values from all the entities on the form
+   * Get the submitted values from all the entities on the form
    *
    * @return array
    */
-  public function getEntityValues() {
+  public function getSubmittedValues() {
     return $this->_entityValues;
   }
 

--- a/release-notes/6.9.0.md
+++ b/release-notes/6.9.0.md
@@ -415,7 +415,7 @@ Released December 3, 2025;
 - **Afform - Prevent double-validation messages
   ([33769](https://github.com/civicrm/civicrm-core/pull/33769))**
 
-- **Add getEntityValues() to Afform AbstractProcessor so that we have access to
+- **Add getSubmittedValues() to Afform AbstractProcessor so that we have access to
   all form values when processing a specific entity
   ([33741](https://github.com/civicrm/civicrm-core/pull/33741))**
 


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/34103

Hopefully helpful tweaked in the release notes draft as well (which is no longer the actual name of the original PR but is the useful wording)