### PR TITLE
Fix setUFLocale for Drupal10 and Backdrop

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -498,8 +498,8 @@ AND    u.status = 1
 
       // Config must be re-initialized to reset the base URL
       // otherwise links will have the wrong language prefix/domain.
-      $config = CRM_Core_Config::singleton();
-      $config->free();
+      $domain = \CRM_Core_BAO_Domain::getDomain();
+      \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);
 
       return TRUE;
     }

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -778,8 +778,8 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
       // Config must be re-initialized to reset the base URL
       // otherwise links will have the wrong language prefix/domain.
-      $config = CRM_Core_Config::singleton();
-      $config->free();
+      $domain = \CRM_Core_BAO_Domain::getDomain();
+      \CRM_Core_BAO_ConfigSetting::applyLocale(\Civi::settings($domain->id), $domain->locales);
 
       return TRUE;
     }


### PR DESCRIPTION
Overview
----------------------------------------

Port of PR#30273 by Eileen. With help from Dominic of Systopia.

The fix was already in for Drupal 7, but it only worked for Drupal 7. Hence I'm taking the liberty of doing a PR against the RC, because it's a pretty annoying bug. It would manifest itself in different ways but we had trouble identifying the cause.

To reproduce:

- On Drupal10, enable multi-lingual and 2 languages, ex: French and English. Set English as the default.
- Enable the "cdntaxreceipt" extension, as well as "cdntaxreceipts translation"
- Set a contact's preferred language to French
- As an admin, set the interface to English
- Enter a contribution for that contact
- Generate a tax receipt in PDF from the interface

Before
----------------------------------------

Receipt is mostly in English (except for the org name).

Locale reverts back to the default site locale whenever we access `CRM_Core_Config::singleton()`.

After
----------------------------------------

Receipt is in French. Locale sticks.

Technical Details
----------------------------------------

The singleton will applyLocale, so doing a 'free' will reset it? There are things I don't quite understand, and I wanted to add a test, but it behaves differently whether it's via web or CLI (I don't know if it's because of my web environment, but I tried to remove as many variables as possible).

Ex, I tested this script, and it would not reproduce the bug:

```
<?php
echo '1- ' . ts('Done') . '; ' . (ts('Done') == 'Done' ? 'OK' : 'fail') . "\n";
CRM_Core_I18n::singleton()->setLocale('fr_CA');
echo '2- ' . ts('Done') . '; ' . (ts('Done') == 'Terminé' ? 'OK' : 'fail') . "\n";
$config = CRM_Core_Config::singleton();
echo '3- ' . ts('Done') . '; ' . (ts('Done') == 'Terminé' ? 'OK' : 'fail') . "\n";
```

and run it with `cv php:script test.php`.

When using the CLI, it never fails, regardless of this patch.