### PR TITLE
dev/user-interface#91 Fixing regression of non-Riveria css on toggles

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4072,7 +4072,6 @@ span.crm-status-icon {
     font-size: inherit;
     width: 2.75em!important;
     height: 1.35em!important;
-    padding: 0.65em!important;
     box-sizing: content-box;
     border-radius: 1em;
     vertical-align: text-bottom;

--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -4091,7 +4091,7 @@ span.crm-status-icon {
     width: 1.25em;
     height: 1.25em;
     margin: 0 0.1em;
-    border: 1px solid;
+    border: 1px solid #fff;
     border-radius: 50%;
     background: #fff;
     -webkit-transition: 0.1s;
@@ -4102,7 +4102,7 @@ span.crm-status-icon {
     background-color: #20576f;
   }
   & input[type="checkbox"].crm-form-toggle:checked::before {
-    left: 1em;
+    left: 1.3em;
   }
   & input[type="checkbox"].crm-form-toggle:disabled {
     opacity: 0.4;


### PR DESCRIPTION
Fixing regression on toggle for non-Riveria themes. The padding was not removed and we are now forcing the height of the toggle so it was making a massive toggle.