### PR TITLE
Extensions - Allow integration-extensions to be enabled automatically/as-needed

### DIFF
--- a/CRM/Extension/Container/Basic.php
+++ b/CRM/Extension/Container/Basic.php
@@ -208,6 +208,15 @@ class CRM_Extension_Container_Basic implements CRM_Extension_Container_Interface
       if (!is_array($this->relPaths)) {
         $this->relPaths = [];
         $infoPaths = CRM_Utils_File::findFiles($this->baseDir, 'info.xml', FALSE, $this->maxDepth);
+
+        // If an extension has its own `./ext` subfolder, then look for submodules.
+        // These may exceed declared $maxDepth, but the positioning must be exact.
+        foreach ($infoPaths as $infoPath) {
+          $submodules = (array) glob(dirname($infoPath) . '/ext/*/info.xml');
+          $infoPaths = array_unique(array_merge($infoPaths, $submodules));
+        }
+
+        // Check each info.xml
         foreach ($infoPaths as $infoPath) {
           $relPath = CRM_Utils_File::relativize(dirname($infoPath), $this->baseDir);
           try {

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -61,6 +61,16 @@ class CRM_Extension_Info {
   public $requires = [];
 
   /**
+   * (Optional) The parent of a submodule.
+   *
+   * If the parent is installed, then the submodule becomes eligible for auto-installation.
+   * If the parent is uninstalled, then the submodule must be uninstalled.
+   *
+   * @var string|null
+   */
+  public $parent = NULL;
+
+  /**
    * @var array
    *   List of expected mixins.
    *   Ex: ['civix@2.0.0']
@@ -361,6 +371,15 @@ class CRM_Extension_Info {
       }
       else {
         $this->$attr = $eval(CRM_Utils_XML::xmlObjToArray($val));
+      }
+    }
+
+    if (in_array('mgmt:enable-when-satisfied', $this->tags)) {
+      if ($this->parent && !in_array($this->parent, $this->requires)) {
+        $this->requires[] = $this->parent;
+      }
+      else {
+        \Civi::log()->warning("Extension ($info->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
       }
     }
   }

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -396,6 +396,16 @@ class CRM_Extension_Info {
     }
   }
 
+  public function isInstallable(): bool {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    foreach ($this->requires as $require) {
+      if (!$manager->isEnabled($require)) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
   /**
    * Filter out invalid requirements, e.g. extensions that have been moved to core.
    *

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -274,7 +274,7 @@ class CRM_Extension_Manager {
     foreach ($keys as $key) {
       /** @var CRM_Extension_Info $info */
       /** @var CRM_Extension_Manager_Base $typeManager */
-      list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+      [$info, $typeManager] = $this->_getInfoTypeHandler($key);
 
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
@@ -334,7 +334,7 @@ class CRM_Extension_Manager {
     }
     foreach ($keys as $key) {
       // throws Exception
-      list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+      [$info, $typeManager] = $this->_getInfoTypeHandler($key);
 
       switch ($origStatuses[$key]) {
         case self::STATUS_INSTALLED:
@@ -410,7 +410,7 @@ class CRM_Extension_Manager {
           case self::STATUS_INSTALLED:
             $this->addProcess([$key], 'disabling');
             // throws Exception
-            list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+            [$info, $typeManager] = $this->_getInfoTypeHandler($key);
             $typeManager->onPreDisable($info);
             $this->_setExtensionActive($info, 0);
             $typeManager->onPostDisable($info);
@@ -419,7 +419,7 @@ class CRM_Extension_Manager {
 
           case self::STATUS_INSTALLED_MISSING:
             // throws Exception
-            list ($info, $typeManager) = $this->_getMissingInfoTypeHandler($key);
+            [$info, $typeManager] = $this->_getMissingInfoTypeHandler($key);
             $typeManager->onPreDisable($info);
             $this->_setExtensionActive($info, 0);
             $typeManager->onPostDisable($info);
@@ -483,7 +483,7 @@ class CRM_Extension_Manager {
         case self::STATUS_DISABLED:
           $this->addProcess([$key], 'uninstalling');
           // throws Exception
-          list ($info, $typeManager) = $this->_getInfoTypeHandler($key);
+          [$info, $typeManager] = $this->_getInfoTypeHandler($key);
           $typeManager->onPreUninstall($info);
           $this->_removeExtensionEntry($info);
           $typeManager->onPostUninstall($info);
@@ -491,7 +491,7 @@ class CRM_Extension_Manager {
 
         case self::STATUS_DISABLED_MISSING:
           // throws Exception
-          list ($info, $typeManager) = $this->_getMissingInfoTypeHandler($key);
+          [$info, $typeManager] = $this->_getMissingInfoTypeHandler($key);
           $typeManager->onPreUninstall($info);
           $this->_removeExtensionEntry($info);
           $typeManager->onPostUninstall($info);

--- a/CRM/Extension/Manager.php
+++ b/CRM/Extension/Manager.php
@@ -252,6 +252,13 @@ class CRM_Extension_Manager {
    */
   public function install($keys, $mode = 'install') {
     $keys = (array) $keys;
+    while ($keys) {
+      $this->_install($keys, $mode);
+      $keys = $this->findInstallableSubmodules();
+    }
+  }
+
+  private function _install(array $keys, $mode = 'install') {
     $origStatuses = $this->getStatuses();
 
     // TODO: to mitigate the risk of crashing during installation, scan
@@ -391,12 +398,17 @@ class CRM_Extension_Manager {
     $disableRequirements = $this->findDisableRequirements($keys);
 
     $requiredExtensions = $this->mapper->getKeysByTag('mgmt:required');
+    $submodules = $this->mapper->getKeysByTag('mgmt:enable-when-satisfied');
+    $blockedRequirements = array_diff($disableRequirements, $submodules, $keys);
 
     // This munges order, but makes it comparable.
-    sort($disableRequirements);
-    if ($keys !== $disableRequirements) {
-      throw new CRM_Extension_Exception_DependencyException("Cannot disable extension due to dependencies. Consider disabling all these: " . implode(',', $disableRequirements));
+    sort($blockedRequirements);
+    if ($blockedRequirements) {
+      throw new CRM_Extension_Exception_DependencyException("Cannot disable extension due to dependencies. Consider disabling all these: " . implode(',', $blockedRequirements));
     }
+
+    // Nothing blocked -- so we have requested $keys and implied submodules. Uninstall in topological order.
+    $keys = $disableRequirements;
 
     $this->addProcess($keys, 'disable');
 
@@ -465,6 +477,8 @@ class CRM_Extension_Manager {
 
     // TODO: to mitigate the risk of crashing during installation, scan
     // keys/statuses/types before doing anything
+
+    $keys = array_unique(array_merge($this->findChildSubmodules($keys), $keys));
 
     // Component data still lives inside of core-core. Uninstalling is nonsensical.
     $notUninstallable = array_intersect($keys, $this->mapper->getKeysByTag('component'));
@@ -875,6 +889,36 @@ class CRM_Extension_Manager {
       }
     }
     return $sorter->sort();
+  }
+
+  /**
+   * Get a list of submodules that are ready to be installed.
+   *
+   * @return array
+   * @throws \CRM_Extension_Exception
+   */
+  protected function findInstallableSubmodules(): array {
+    return array_filter(
+      $this->mapper->getKeysByTag('mgmt:enable-when-satisfied'),
+      fn($m) => !$this->isEnabled($m) && $this->mapper->keyToInfo($m)->isInstallable()
+    );
+  }
+
+  /**
+   * Find the immediate children for some list of extensions.
+   *
+   * @param string|array $parents
+   *   List of extensions. For each, we want to know about its children.
+   * @return array
+   *   List of children
+   * @throws \CRM_Extension_Exception
+   */
+  protected function findChildSubmodules($parents): array {
+    $parents = (array) $parents;
+    return array_filter(
+      $this->mapper->getKeysByTag('mgmt:enable-when-satisfied'),
+      fn($child) => in_array($this->mapper->keyToInfo($child)->parent, $parents)
+    );
   }
 
   /**

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -118,9 +118,9 @@ class CRM_Extension_QueueTasks {
   }
 
   /**
-   * Scan the downloaded extensions and verify that their requirements are satisfied.
+   * Enable the listed extensions.
    */
-  public static function enable(CRM_Queue_TaskContext $ctx, string $stagingPath, array $keys): bool {
+  public static function enable(CRM_Queue_TaskContext $ctx, ?string $stagingPath, array $keys): bool {
     CRM_Extension_System::singleton()->getManager()->enable($keys);
     return TRUE;
   }

--- a/tests/extensions/test.extension.parenttest/ext/childtest/childtest.php
+++ b/tests/extensions/test.extension.parenttest/ext/childtest/childtest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Implements civicrm_install
+ */
+function childtest_civicrm_install() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_uninstall
+ */
+function childtest_civicrm_uninstall() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_enable
+ */
+function childtest_civicrm_enable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_disable
+ */
+function childtest_civicrm_disable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}

--- a/tests/extensions/test.extension.parenttest/ext/childtest/info.xml
+++ b/tests/extensions/test.extension.parenttest/ext/childtest/info.xml
@@ -1,0 +1,12 @@
+<extension key='test.extension.childtest' type='module'>
+  <file>childtest</file>
+  <name>test_extension_childtest</name>
+  <tags>
+    <tag>mgmt:hidden</tag>
+    <tag>mgmt:enable-when-satisfied</tag>
+  </tags>
+  <parent>test.extension.parenttest</parent>
+  <requires>
+    <ext>test.extension.uncletest</ext>
+  </requires>
+</extension>

--- a/tests/extensions/test.extension.parenttest/info.xml
+++ b/tests/extensions/test.extension.parenttest/info.xml
@@ -1,0 +1,7 @@
+<extension key='test.extension.parenttest' type='module'>
+  <file>parenttest</file>
+  <name>test_extension_parenttest</name>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
+</extension>

--- a/tests/extensions/test.extension.parenttest/parenttest.php
+++ b/tests/extensions/test.extension.parenttest/parenttest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Implements civicrm_install
+ */
+function parenttest_civicrm_install() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_uninstall
+ */
+function parenttest_civicrm_uninstall() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_enable
+ */
+function parenttest_civicrm_enable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_disable
+ */
+function parenttest_civicrm_disable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}

--- a/tests/extensions/test.extension.uncletest/info.xml
+++ b/tests/extensions/test.extension.uncletest/info.xml
@@ -1,0 +1,7 @@
+<extension key='test.extension.uncletest' type='module'>
+  <file>uncletest</file>
+  <name>test_extension_uncletest</name>
+  <tags>
+    <tag>mgmt:hidden</tag>
+  </tags>
+</extension>

--- a/tests/extensions/test.extension.uncletest/uncletest.php
+++ b/tests/extensions/test.extension.uncletest/uncletest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Implements civicrm_install
+ */
+function uncletest_civicrm_install() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_uninstall
+ */
+function uncletest_civicrm_uninstall() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_enable
+ */
+function uncletest_civicrm_enable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}
+
+/**
+ * Implements civicrm_disable
+ */
+function uncletest_civicrm_disable() {
+  CRM_Extension_Manager_SubmoduleTest::logHook(__FUNCTION__);
+}

--- a/tests/phpunit/CRM/Extension/InfoTest.php
+++ b/tests/phpunit/CRM/Extension/InfoTest.php
@@ -83,6 +83,14 @@ class CRM_Extension_InfoTest extends CiviUnitTestCase {
     $this->assertEquals(['org.civicrm.a', 'org.civicrm.b'], $info->requires);
   }
 
+  public function testSubmodule(): void {
+    $info = CRM_Extension_Info::loadFromFile(Civi::paths()->getPath('[civicrm.root]/tests/extensions/test.extension.parenttest/ext/childtest/info.xml'));
+    $this->assertTrue(in_array('mgmt:enable-when-satisfied', $info->tags), 'childtest is marked as submodule');
+    // For submodules, <parent>X</parent> implies <requires><ext>X</ext></requires>.
+    $this->assertEquals('test.extension.parenttest', $info->parent);
+    $this->assertTrue(in_array('test.extension.parenttest', $info->requires));
+  }
+
   public static function getExampleAuthors() {
     $authorAliceXml = '<author><name>Alice</name><email>alice@example.org</email><role>Maintainer</role></author>';
     $authorAliceArr = ['name' => 'Alice', 'email' => 'alice@example.org', 'role' => 'Maintainer'];

--- a/tests/phpunit/CRM/Extension/Manager/SubmoduleTest.php
+++ b/tests/phpunit/CRM/Extension/Manager/SubmoduleTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Class CRM_Extension_Manager_SubmoduleTest
+ *
+ * The test scenarios here involve multiple actions (install/disable/uninstall) and targets (parent/uncle/child).
+ * It takes a lot of words to describe each sequence. For naming the test-functions, we follow a convention:
+ *
+ * - Actions: [I]nstall, [D]isable, [U]ninstall
+ * - Targets: [P]arent, [C]hild, [U]ncle
+ *
+ * Ex: [I]nstall [P]arent + [I]nstall [U]ncle + [D]isable [P]arent = IP_IU_DU
+ *
+ * @group headless
+ */
+class CRM_Extension_Manager_SubmoduleTest extends CiviUnitTestCase {
+
+  /**
+   * @var string
+   */
+  protected $basedir;
+
+  /**
+   * @var \CRM_Extension_System
+   */
+  protected $system;
+
+  public function setUp():void {
+    parent::setUp();
+    // $query = "INSERT INTO civicrm_domain ( name, version ) VALUES ( 'domain', 3 )";
+    // $result = CRM_Core_DAO::executeQuery($query);
+    global $_test_extension_manager_submodule_log;
+    $_test_extension_manager_submodule_log = [];
+    $this->basedir = $this->createTempDir('ext-');
+    $this->system = new CRM_Extension_System([
+      'extensionsDir' => $this->basedir,
+      'extensionsURL' => 'http://testbase/',
+    ]);
+    $this->setExtensionSystem($this->system);
+  }
+
+  public function tearDown(): void {
+    parent::tearDown();
+    $this->system = NULL;
+  }
+
+  public function testIP_IU_DU_UU_DP_UP(): void {
+    $manager = $this->system->getManager();
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+
+    $manager->install(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['parenttest_civicrm_install', 'parenttest_civicrm_enable']);
+
+    $manager->install(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'installed', 'uncletest' => 'installed']);
+    $this->assertHookLog(['uncletest_civicrm_install', 'uncletest_civicrm_enable', 'childtest_civicrm_install', 'childtest_civicrm_enable']);
+
+    $manager->disable(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'disabled', 'uncletest' => 'disabled']);
+    $this->assertHookLog(['childtest_civicrm_disable', 'uncletest_civicrm_disable']);
+
+    $manager->uninstall(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'disabled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['uncletest_civicrm_uninstall']);
+
+    $manager->disable(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'disabled', 'childtest' => 'disabled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['parenttest_civicrm_disable']);
+
+    $manager->uninstall(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+    $this->assertHookLog(['childtest_civicrm_uninstall', 'parenttest_civicrm_uninstall']);
+  }
+
+  public function testIU_IP_DP_UP(): void {
+    $manager = $this->system->getManager();
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'uninstalled']);
+
+    $manager->install(['test.extension.uncletest']);
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'installed']);
+    $this->assertHookLog(['uncletest_civicrm_install', 'uncletest_civicrm_enable']);
+
+    $manager->install(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'installed', 'childtest' => 'installed', 'uncletest' => 'installed']);
+    $this->assertHookLog(['parenttest_civicrm_install', 'parenttest_civicrm_enable', 'childtest_civicrm_install', 'childtest_civicrm_enable']);
+
+    $manager->disable(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'disabled', 'childtest' => 'disabled', 'uncletest' => 'installed']);
+    $this->assertHookLog(['childtest_civicrm_disable', 'parenttest_civicrm_disable']);
+
+    $manager->uninstall(['test.extension.parenttest']);
+    $this->assertModules(['parenttest' => 'uninstalled', 'childtest' => 'uninstalled', 'uncletest' => 'installed']);
+    $this->assertHookLog(['childtest_civicrm_uninstall', 'parenttest_civicrm_uninstall']);
+  }
+
+  public function assertHookLog(array $expected): void {
+    global $_test_extension_manager_submodule_log;
+    $this->assertEquals($expected, $_test_extension_manager_submodule_log);
+    $_test_extension_manager_submodule_log = [];
+  }
+
+  public function assertModules(array $expected): void {
+    $manager = $this->system->getManager();
+    foreach ($expected as $module => $expectStatus) {
+      $key = "test.extension.{$module}";
+      $this->assertEquals($expectStatus, $manager->getStatus($key), "Module $module should have status {$expectStatus}.");
+    }
+  }
+
+  /**
+   * @param string $name
+   */
+  public static function logHook(string $name) {
+    global $_test_extension_manager_submodule_log;
+    $_test_extension_manager_submodule_log[] = $name;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Integration extensions create a challenge of *multiplicative administrative work*. As more extensions are conditionally integrated with each other, there are more artifacts to manage. This PR helps reduce that overhead by defining a new flag, `enable-when-satisfied`.

Consider this `info.xml`:

```xml
<extension key="mypkg_otherpkg">
  <requires>
    <ext>mypkg</ext>
    <ext>otherpkg</ext>
  </requires>
  <parent>mypkg</parent> <!-- New -->
  <tags>
    <tag>mgmt:hidden</tag>
    <tag>mgmt:enable-when-satisfied</tag> <!-- New -->
  </tags>
</extension>
```

The extension `mypkg_otherpkg` has an automatic lifecycle:

* `mypkg_otherpkg` is enabled if ___all requirements___ (`mypkg` and `otherpkg`) are enabled.
* `mypkg_otherpkg` is disabled if ___any requirements___ (`mypkg` or `otherpkg`) are disabled. 
* `mypkg_otherpkg` is uninstalled if the ___parent___ (`mypkg`) is uninstalled. (This is the only way that the `<parent>` is special.)

From the perspective of the admin, this integration-extension is invisible.  They decide whether to enable the main extensions (`mypkg` and/or `otherpkg`). The smaller integration bits come along automatically based on their high-level decision.

(_This is inspired by conversations with @mattwire and @jaapjansma. It is re-rolled from #33908. The technical behavior is largely the same, but some of the labels and implications have been changed/tightened, and it has a lot of discussion based on the original labels. It should be easier to read as a separate PR._)

Motivation
----------------------------------------

As we develop larger portions of CiviCRM's functionality in extensions, we get exposed to the problem of _integrations between extensions_. For example:

* When adding OAuth support to Stripe, you have an integration between two extensions (`oauth-client`, `stripe`).
* Similarly, the `emailapi` extension defines an APIv3 action -- but it also integrates that action with CiviRules and ActionProvider.

In each case, you have a piece of integration-code (such as the Stripe-OAuth connector or the EmailApi-CiviRules connector). Where should this go?

* You could embed the integration-code into one extension (e.g. `stripe` includes its own OAuth integration; `emailapi` includes its own CiviRules integration).
    * _However_, as you start to include more artifacts (like scanned-classes, managed-entities, and settings), then you need to sprinkle-in conditionals and overrides that are hard to trace/intuit.
* You could put this in an entirely new project (`stripe_oauth.git`, `emailapi_civirules.git`, etc).
    * _However_, this becomes annoying for the site administrator (*more things to download, more things to enable, more things to disable*) and the developer (*more git repos to manage*).
* You could put this integration into an _auto-activated sub-extension_ (e.g. `stripe.git/ext/stripe-oauth` or `emailapi.git/ext/emailapi-rules`).
    * For the site administrator, this means you don't need any extra downloads.
    * For the developer, this means you don't need any extra repos or releases.
    * It follows a familiar file-layouts and tooling (*it's just another extension*) and doesn't require sprinkled-in conditionals/overrides.
    * It provides separation-of-concerns -- the integration code lives in a distinct folder.
    * It provides a full API -- the subfolder can include any mix of PHP classes, services, managed entities, settings, mixins, JS files, CSS files, etc.

Example
----------------------------------------

For the moment, we setup an example using `civix generate:module`. (If this PR is merged, then we can also implement `civix` generator for this pattern.)

Steps:

```bash
## Create a primary/parent module
civix generate:module myparent
mkdir myparent/ext

## Create a submodule
cd myparent/ext
civix generate:module mychild

## Update the child's metadata
nano mychild/info.xml
```

In the `info.xml`, set a few flags:

```diff
   <name>mychild</name>

+  <!-- Specify the list of required extensions. -->
+  <requires>
+    <ext>myparent</ext>
+    <ext>myuncle</ext>
+  </requires>

+  <!-- Specify the parent's name. Helps with install/uninstall. -->
+  <parent>myparent</parent>

+  <!-- Specify how the lifecycle (enable/disable) will be managed. -->
+  <tags>
+    <tag>mgmt:hidden</tag>
+    <tag>mgmt:enable-when-satisfied</tag>
+  </tags>
```

This PR does not _require_ any specific file-layout.  (`mgmt:enable-when-satisfied` and `<parent>` will behave the same way, regardless of folder naming.) However, if you are trying to work with existing distribution channels (such as `cv dl` and `composer require`), then you would probably develop and publish `myparent` as the main extensions (and include `mychild` as incidental/optional enhancement).
