### PR TITLE
crmDashboard - cleanup, free from page controller, add tests

### DIFF
--- a/CRM/Contact/Page/DashBoard.php
+++ b/CRM/Contact/Page/DashBoard.php
@@ -58,38 +58,6 @@ class CRM_Contact_Page_DashBoard extends CRM_Core_Page {
   }
 
   /**
-   * partialsCallback from crmDashboard.ang.php
-   *
-   * Generates an html template for each angular-based dashlet.
-   *
-   * @param $moduleName
-   * @param $module
-   * @return array
-   */
-  public static function angularPartials($moduleName, $module) {
-    $partials = [];
-    foreach (CRM_Core_BAO_Dashboard::getContactDashlets() as $dashlet) {
-      if (!empty($dashlet['directive'])) {
-        // FIXME: Wrapping each directive in <div id='bootstrap-theme'> produces invalid html (duplicate ids in the dom)
-        // but it's the only practical way to selectively apply boostrap3 theming to specific dashlets
-        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<div id='bootstrap-theme'><{$dashlet['directive']}></{$dashlet['directive']}></div>";
-      }
-    }
-    return $partials;
-  }
-
-  /**
-   * settingsFactory from crmDashboard.ang.php
-   *
-   * @return array
-   */
-  public static function angularSettings() {
-    return [
-      'dashlets' => CRM_Core_BAO_Dashboard::getContactDashlets(),
-    ];
-  }
-
-  /**
    * Get community message output.
    *
    * @return string

--- a/CRM/Contact/Page/DashBoard.php
+++ b/CRM/Contact/Page/DashBoard.php
@@ -42,18 +42,6 @@ class CRM_Contact_Page_DashBoard extends CRM_Core_Page {
     $loader->addModules('crmDashboard');
     $loader->setPageName('civicrm/dashboard');
 
-    // For each dashlet that requires an angular directive, load the angular module which provides that directive
-    foreach (CRM_Core_BAO_Dashboard::getContactDashlets() as $dashlet) {
-      if (!empty($dashlet['directive'])) {
-        foreach ($loader->getAngular()->getModules() as $name => $module) {
-          if (!empty($module['exports'][$dashlet['directive']])) {
-            $loader->addModules($name);
-            continue;
-          }
-        }
-      }
-    }
-
     return parent::run();
   }
 

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -130,9 +130,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     $partials = [];
     foreach (self::getContactDashlets() as $dashlet) {
       if (!empty($dashlet['directive'])) {
-        // FIXME: Wrapping each directive in <div id='bootstrap-theme'> produces invalid html (duplicate ids in the dom)
-        // but it's the only practical way to selectively apply boostrap3 theming to specific dashlets
-        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<div id='bootstrap-theme'><{$dashlet['directive']}></{$dashlet['directive']}></div>";
+        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<{$dashlet['directive']}></{$dashlet['directive']}>";
       }
     }
     return $partials;

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -15,7 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-use Civi\Api4\DashboardContact;
 
 /**
  * Class contains Contact dashboard related functions.
@@ -47,57 +46,62 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
   public static function getContactDashlets(): array {
     $cid = CRM_Core_Session::getLoggedInContactID();
     if ($cid && !isset(Civi::$statics[__CLASS__][__FUNCTION__][$cid])) {
-      Civi::$statics[__CLASS__][__FUNCTION__][$cid] = [];
-      // If empty, then initialize default dashlets for this user.
-      if (0 === DashboardContact::get(FALSE)->selectRowCount()->addWhere('contact_id', '=', $cid)->execute()->count()) {
-        self::initializeDashlets();
-      }
-      $contactDashboards = (array) DashboardContact::get(FALSE)
-        ->addSelect('column_no', 'is_active', 'dashboard_id', 'weight', 'contact_id')
+      $results = [];
+
+      // Get all dashlets we have access to
+      $availableDashlets = (array) \Civi\Api4\Dashboard::get(TRUE)
+        ->addWhere('domain_id', '=', 'current_domain')
+        ->addWhere('is_active', '=', TRUE)
+        ->execute()
+        ->indexBy('id');
+
+      $dashletsUsed = \Civi\Api4\DashboardContact::get(FALSE)
         ->addWhere('contact_id', '=', $cid)
+        ->addWhere('dashboard_id', 'IN', array_keys($availableDashlets))
+        ->addSelect('column_no', 'is_active', 'dashboard_id', 'weight', 'contact_id')
         ->addOrderBy('weight')
-        ->execute()->indexBy('dashboard_id');
+        ->execute();
 
-      $params = [
-        'select' => ['*', 'dashboard_contact.*'],
-        'where' => [
-          ['domain_id', '=', 'current_domain'],
-        ],
-      ];
+      if (!$dashletsUsed->count()) {
+        // if none used this may be the first time using the dashboard
+        // for this contact - initialise then fetch again
+        self::initializeDashlets();
 
-      // Get Dashboard + any joined DashboardContact records.
-      $results = (array) civicrm_api4('Dashboard', 'get', $params);
-      foreach ($results as $item) {
-        $item['dashboard_contact.id'] = $contactDashboards[$item['id']]['id'] ?? NULL;
-        $item['dashboard_contact.contact_id'] = $contactDashboards[$item['id']]['contact_id'] ?? NULL;
-        $item['dashboard_contact.weight'] = $contactDashboards[$item['id']]['weight'] ?? NULL;
-        $item['dashboard_contact.column_no'] = $contactDashboards[$item['id']]['column_no'] ?? NULL;
-        $item['dashboard_contact.is_active'] = $contactDashboards[$item['id']]['is_active'] ?? NULL;
-        if ($item['is_active'] && self::checkPermission($item['permission'], $item['permission_operator'])) {
-          Civi::$statics[__CLASS__][__FUNCTION__][$cid][] = $item;
-        }
+        $dashletsUsed = \Civi\Api4\DashboardContact::get(FALSE)
+          ->addWhere('contact_id', '=', $cid)
+          ->addWhere('dashboard_id', 'IN', array_keys($availableDashlets))
+          ->addSelect('column_no', 'is_active', 'dashboard_id', 'weight', 'contact_id')
+          ->addOrderBy('weight')
+          ->execute();
       }
-      usort(Civi::$statics[__CLASS__][__FUNCTION__][$cid], static function ($a, $b) {
-        // Sort by dashboard contact weight, preferring not null to null.
-        // I had hoped to do this in mysql either by
-        // 1) making the dashboard contact part of the query NOT permissioned while
-        // the parent query IS or
-        // 2) using FIELD like
-        // $params['orderBy'] = ['FIELD(id,' . implode(',', array_keys($contactDashboards)) . ')' => 'ASC'];
-        // 3) or making the dashboard contact acl more inclusive such that 'view own contact'
-        // is not required to view own contact's acl
-        // but I couldn't see a way to make any of the above work. Perhaps improve in master?
-        if (!isset($b['dashboard_contact.weight']) && !isset($a[$b['dashboard_contact.weight']])) {
-          return 0;
-        }
-        if (!isset($b['dashboard_contact.weight'])) {
-          return -1;
-        }
-        if (!isset($a['dashboard_contact.weight'])) {
-          return 1;
-        }
-        return $a['dashboard_contact.weight'] <=> $b['dashboard_contact.weight'];
-      });
+
+      // first add linked dashlet records, in order to respect the linked weights
+      foreach ($dashletsUsed as $dashletUsed) {
+        $dashletRecord = $availableDashlets[$dashletUsed['dashboard_id']];
+        $results[] = array_merge($dashletRecord, [
+          'dashboard_contact.id' => $dashletUsed['id'],
+          'dashboard_contact.contact_id' => $dashletUsed['contact_id'],
+          'dashboard_contact.weight' => $dashletUsed['weight'],
+          'dashboard_contact.column_no' => $dashletUsed['column_no'],
+          'dashboard_contact.is_active' => $dashletUsed['is_active'],
+        ]);
+        // remove from availableDashlets so we dont add again below
+        unset($availableDashlets[$dashletUsed['dashboard_id']]);
+      }
+      // now add the remaining unlinked dashlets
+      foreach ($availableDashlets as $dashlet) {
+        $results[] = array_merge($dashlet, [
+          'dashboard_contact.id' => NULL,
+          'dashboard_contact.contact_id' => NULL,
+          'dashboard_contact.weight' => NULL,
+          'dashboard_contact.column_no' => NULL,
+          'dashboard_contact.is_active' => NULL,
+        ]);
+      }
+
+      // TODO: move this permission check to the row level access in Api4
+      $results = array_values(array_filter($results, fn ($record) => self::checkPermission($record['permission'], $record['permission_operator'])));
+      Civi::$statics[__CLASS__][__FUNCTION__][$cid] = $results;
     }
     return Civi::$statics[__CLASS__][__FUNCTION__][$cid] ?? [];
   }
@@ -124,7 +128,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
     }
     CRM_Utils_Hook::dashboard_defaults($allDashlets, $defaultDashlets);
     if (is_array($defaultDashlets) && !empty($defaultDashlets)) {
-      DashboardContact::save(FALSE)
+      \Civi\Api4\DashboardContact::save(FALSE)
         ->setRecords($defaultDashlets)
         ->setDefaults(['contact_id' => CRM_Core_Session::getLoggedInContactID()])
         ->execute();

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -126,12 +126,16 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
    * @param $module
    * @return array
    */
-  public static function angularPartials($moduleName, $module) {
+  public static function angularPartials($moduleName, $module): array {
+    $angularDashletDirectives = \Civi\Api4\Dashboard::get(FALSE)
+      ->addWhere('directive', 'IS NOT EMPTY')
+      ->addSelect('directive', '')
+      ->execute()
+      ->column('directive');
+
     $partials = [];
-    foreach (self::getContactDashlets() as $dashlet) {
-      if (!empty($dashlet['directive'])) {
-        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<{$dashlet['directive']}></{$dashlet['directive']}>";
-      }
+    foreach ($angularDashletDirectives as $directive) {
+      $partials["~/{$moduleName}/directives/{$directive}.html"] = "<{$directive}></{$directive}>";
     }
     return $partials;
   }

--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -107,6 +107,38 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard {
   }
 
   /**
+   * settingsFactory from crmDashboard.ang.php
+   *
+   * @return array
+   */
+  public static function angularSettings() {
+    return [
+      'dashlets' => self::getContactDashlets(),
+    ];
+  }
+
+  /**
+   * partialsCallback from crmDashboard.ang.php
+   *
+   * Generates an html template for each angular-based dashlet.
+   *
+   * @param $moduleName
+   * @param $module
+   * @return array
+   */
+  public static function angularPartials($moduleName, $module) {
+    $partials = [];
+    foreach (self::getContactDashlets() as $dashlet) {
+      if (!empty($dashlet['directive'])) {
+        // FIXME: Wrapping each directive in <div id='bootstrap-theme'> produces invalid html (duplicate ids in the dom)
+        // but it's the only practical way to selectively apply boostrap3 theming to specific dashlets
+        $partials["~/$moduleName/directives/{$dashlet['directive']}.html"] = "<div id='bootstrap-theme'><{$dashlet['directive']}></{$dashlet['directive']}></div>";
+      }
+    }
+    return $partials;
+  }
+
+  /**
    * Set default dashlets for new users.
    *
    * Called when a user accesses their dashboard for the first time.

--- a/ang/crmDashboard.ang.php
+++ b/ang/crmDashboard.ang.php
@@ -14,5 +14,5 @@ return [
   'requires' => ['crmUi', 'crmUtil', 'ui.sortable', 'dialogService', 'api4'],
   'settingsFactory' => ['CRM_Core_BAO_Dashboard', 'angularSettings'],
   'permissions' => ['administer CiviCRM'],
-  'bundles' => ['visual'],
+  'bundles' => ['bootstrap3', 'visual'],
 ];

--- a/ang/crmDashboard.ang.php
+++ b/ang/crmDashboard.ang.php
@@ -9,10 +9,10 @@ return [
   ],
   'css' => ['css/dashboard.css'],
   'partials' => ['ang/crmDashboard'],
-  'partialsCallback' => ['CRM_Contact_Page_DashBoard', 'angularPartials'],
+  'partialsCallback' => ['CRM_Core_BAO_Dashboard', 'angularPartials'],
   'basePages' => [],
   'requires' => ['crmUi', 'crmUtil', 'ui.sortable', 'dialogService', 'api4'],
-  'settingsFactory' => ['CRM_Contact_Page_DashBoard', 'angularSettings'],
+  'settingsFactory' => ['CRM_Core_BAO_Dashboard', 'angularSettings'],
   'permissions' => ['administer CiviCRM'],
   'bundles' => ['visual'],
 ];

--- a/templates/CRM/Contact/Page/DashBoardDashlet.tpl
+++ b/templates/CRM/Contact/Page/DashBoardDashlet.tpl
@@ -10,7 +10,7 @@
 {* Alerts for critical configuration settings. *}
 {$communityMessages}
 <div class="clear"></div>
-<div class="crm-block crm-content-block">
+<div id="bootstrap-theme" class="crm-block crm-content-block">
 
   <crm-angular-js modules="crmDashboard">
     <crm-dashboard></crm-dashboard>

--- a/tests/phpunit/CRM/Core/BAO/DashboardTest.php
+++ b/tests/phpunit/CRM/Core/BAO/DashboardTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Civi\Test\ContactTestTrait;
+
+/**
+ * Class CRM_Core_BAO_DashboardTest
+ *
+ * @group headless
+ */
+class CRM_Core_BAO_DashboardTest extends CiviUnitTestCase {
+
+  use ContactTestTrait;
+
+  protected int $contactId;
+  protected string $dashletModule;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->contactId = $this->createLoggedInUser();
+
+    $angularDashlet = \Civi\Api4\Afform::create(FALSE)
+      ->addValue('name', 'afformDashlet')
+      ->addValue('title', 'Test Dashlet')
+      ->addValue('layout', '<af-form><crm-search-display-table saved-search="MySearch"></crm-search-display-table></af-form>')
+      ->addValue('placement', ['dashboard_dashlet'])
+      ->execute()
+      ->single();
+
+    $this->dashletModule = $angularDashlet['module_name'];
+  }
+
+  public function tearDown(): void {
+    parent::tearDown();
+
+    \Civi\Api4\Contact::delete(FALSE)->addWhere('id', '=', $this->contactId)->execute();
+    // TODO: shouldn't we delete? this follows what AfformPlacementTest does
+    \Civi\Api4\Afform::revert(FALSE)->addWhere('module_name', '=', $this->dashletModule)->execute();
+  }
+
+  /**
+   * Test CRM_Core_BAO_Dashboard::getContactDashlets
+   */
+  public function testGetContactDashlets(): void {
+    // note: getter triggers reinitialise on first load for each contact
+    // (or if all dashlets have been deleted)
+    $dashlets = array_column(CRM_Core_BAO_Dashboard::getContactDashlets(), NULL, 'name');
+
+    // check expected dashlets are available
+    $this->assertArrayKeyExists('blog', $dashlets);
+    $this->assertArrayKeyExists('activity', $dashlets);
+    $this->assertArrayKeyExists('afformDashlet', $dashlets);
+
+    // check a dashlet we dont have access to is not inclued
+    $this->assertEquals(array_key_exists('myCases', $dashlets), FALSE);
+
+    // blog should be placed (by the default initialisation)
+    $this->assertEquals($dashlets['blog']['dashboard_contact.contact_id'], $this->contactId);
+
+    // activities dashlet is available but not placed
+    $this->assertEquals($dashlets['activity']['dashboard_contact.contact_id'], NULL);
+
+    \Civi\Api4\DashboardContact::create(FALSE)
+      ->addValue('contact_id', $this->contactId)
+      ->addValue('column_no', 0)
+      ->addValue('weight', -100)
+      ->addValue('dashboard_id', $dashlets['activity']['id'])
+      ->execute();
+
+    $updatedDashlets = CRM_Core_BAO_Dashboard::getContactDashlets();
+
+    // check the activity dashboard is now placed
+    // and contact weight has been respected (activity comes in index 0, before blog)
+    $this->assertEquals($updatedDashlets[0]['name'], 'activity');
+    $this->assertEquals($updatedDashlets[0]['dashboard_contact.contact_id'], $this->contactId);
+  }
+
+  /**
+   * Test that dashlet directives are required by crmDashboard
+   */
+  public function testDashletModuleRequirements(): void {
+    $crmDashboard = \Civi::service('angular')->getModules()['crmDashboard'];
+
+    $this->assertEquals(in_array($this->dashletModule, $crmDashboard['requires']), TRUE);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup crmDashboard, including some code which was "just for the RC"... for 5.35 circa 2021 :)

Before
----------------------------------------
- getContactDashlets mixes OO and procedural Api4 and an undefined join "dashboard_contact.*" in the select query and php sort function
- crmDashboard is coupled to the `civicrm/dashboard` page controller - if you try to load it anywhere else then angular dashlets are broken (because modules they use are not loaded)
- crmDashboard places lots of `id="bootstrap-theme"` divs on the page
- no tests

After
----------------------------------------
- getContactDashlets is a bit cleaner
- crmDashboard loads any other modules it requires as angular module requirements, so it can be used on custom afforms
- crmDashboard is wrapped in a single `id="bootstrap-theme"` div
- basic tests


Technical Details
----------------------------------------
There are some comments about a bug based on Contact access / ACLs in `getContactDashlets`. I'm fairly confident the Api calls themselves are essentially unchanged, just a bit more neatly combined. 

Removed static cache in getContactDashlets as 2 of the 3 places that were using it use a more direct query now (one of which, for the module dependencies, will be cached anyway)

Previously the module dependency loading was based on the contact ID, and so uncacheable. Now all modules will be loaded regardless of logged in contact, which makes the loading cacheable again. Only the angularSettings callback contains user-variable content, which I think is as it should be.

Comments
----------------------------------------
The motivation is to fix using `crmDashboard` on a custom afform, so you can then set as a home page for you site. Currently it almost works, but angular dashlets dont load.
