### PR TITLE
CRM.config.isFrontend - prefer  `CRM_Utils_System::isFrontendPage` to `CRM_Core_Config::singleton()->userFrameworkFrontend`

### DIFF
--- a/CRM/Core/Resources/Common.php
+++ b/CRM/Core/Resources/Common.php
@@ -147,7 +147,7 @@ class CRM_Core_Resources_Common {
     // Add global settings
     $settings = [
       'config' => [
-        'isFrontend' => $config->userFrameworkFrontend,
+        'isFrontend' => \CRM_Utils_System::isFrontEndPage(),
         'includeWildCardInName' => $config->includeWildCardInName,
       ],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Use the more commonly used determinate of "frontendedness" to set `CRM.config.isFrontend` value.

Technical Details
----------------------------------------
It looks like userFrameworkFrontend must be set individually in each UF (except Standalone). It's actually not ever set in Standalone, which means this JS var is always false at the moment. (This is part of my reasoning that `isFrontendPage` is more standard - things broke when Standalone didnt implement that, but no one seems to have noticed it doesnt set `userFrameworkFrontend`)
