### PR TITLE
set $config->userFrameworkFrontend in Standalone

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -731,6 +731,8 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   public function postContainerBoot(): void {
     $sess = \CRM_Core_Session::singleton();
     $sess->initialize();
+
+    \CRM_Core_Config::singleton()->userFrameworkFrontend = self::isFrontEndPage();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Standalone has never set this, which suggests it can't be that important. My inclination would be to switch remaining uses to `isFrontendPage` rather than adding here. But opening a draft in case we do need it, as this seems to be the place you would add it.