### PR TITLE
CRM.alert - simple dialog implementation for frontend

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3250,6 +3250,7 @@ span.crm-select-item-color {
   background-image: url("../packages/jquery/css/images/pbar-ani.gif");
 }
 
+.crm-container .crm-dialog,
 .crm-container.ui-dialog {
   background-color: #fff;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
@@ -4121,4 +4122,19 @@ html.crm-standalone body {
   padding: 0;
   font-family: var(--crm-font, sans-serif);
   background-color: var(--crm-page-bg-color, #f8f8f8);
+}
+
+/* HTML5 dialogs */
+.crm-container .crm-dialog {
+  margin: auto;
+  min-width: 10rem;
+  border-radius: 8px;
+  border-width: 0;
+}
+.crm-container .crm-dialog h1 {
+  font-size: 1rem;
+}
+.crm-container .crm-dialog .crm-buttons {
+  display: flex;
+  justify-content: flex-end;
 }

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -225,3 +225,15 @@
     width: 90vw !important;
   }
 }
+
+/* HTML5 dialogs */
+.crm-container .crm-dialog {
+  margin: auto;
+  min-width: 10rem;
+  border-radius: var(--crm-dialog-radius);
+  border-width: 0;
+  background-color: var(--crm-dialog-body-bg-color);
+}
+.crm-container .crm-dialog h1 {
+  font-size: var(--crm-font-size);
+}

--- a/js/Common.js
+++ b/js/Common.js
@@ -1500,18 +1500,18 @@ if (!CRM.vars) CRM.vars = {};
     else {
       // TODO: add icon/styling appropriate to type?
       // TODO: allow specifying notices which dont need to block the user
-      const alert = document.createElement('dialog');
-      alert.classList.add('crm-dialog');
+      const alertDialog = document.createElement('dialog');
+      alertDialog.classList.add('crm-dialog');
 
       if (title.length) {
         const header = document.createElement('h1');
         header.innerText = title;
-        alert.append(header);
+        alertDialog.append(header);
       }
       if (text.length) {
         const body = document.createElement('p');
         body.innerText = text;
-        alert.append(body);
+        alertDialog.append(body);
       }
       const alertButtons = document.createElement('div');
       alertButtons.classList.add('crm-buttons', 'crm-flex-justify-end');
@@ -1520,10 +1520,13 @@ if (!CRM.vars) CRM.vars = {};
             OK
           </button>
       `;
-      alert.append(alertButtons);
+      alertDialog.append(alertButtons);
 
-      document.querySelector('.crm-container').append(alert);
-      alert.showModal();
+      // ideally append to crmContainer for styling. fallback to body if not available
+      const crmContainer = document.querySelector('.crm-container');
+      (crmContainer ? crmContainer : document.body).append(alertDialog);
+      alertDialog.showModal();
+      return null;
     }
   };
 

--- a/js/Common.js
+++ b/js/Common.js
@@ -1498,10 +1498,17 @@ if (!CRM.vars) CRM.vars = {};
       return $('#crm-notification-container').notify('create', params, options);
     }
     else {
+      if (document.querySelectorAll('dialog.crm-alert').length > 3) {
+        // something is producing alerts faster than user can close them
+        console.warn('Too many calls to CRM.alert! Diverting messages to console rather than creating more popups');
+        console.warn(title.length ? `${title}: ${text}` : text);
+        return null;
+      }
+
       // TODO: add icon/styling appropriate to type?
       // TODO: allow specifying notices which dont need to block the user
       const alertDialog = document.createElement('dialog');
-      alertDialog.classList.add('crm-dialog');
+      alertDialog.classList.add('crm-dialog', 'crm-alert');
 
       if (title.length) {
         const header = document.createElement('h1');

--- a/js/Common.js
+++ b/js/Common.js
@@ -1498,12 +1498,32 @@ if (!CRM.vars) CRM.vars = {};
       return $('#crm-notification-container').notify('create', params, options);
     }
     else {
+      // TODO: add icon/styling appropriate to type?
+      // TODO: allow specifying notices which dont need to block the user
+      const alert = document.createElement('dialog');
+      alert.classList.add('crm-dialog');
+
       if (title.length) {
-        text = title + "\n" + text;
+        const header = document.createElement('h1');
+        header.innerText = title;
+        alert.append(header);
       }
-      // strip html tags as they are not parsed in standard alerts
-      alert($("<div/>").html(text).text());
-      return null;
+      if (text.length) {
+        const body = document.createElement('p');
+        body.innerText = text;
+        alert.append(body);
+      }
+      const alertButtons = document.createElement('div');
+      alertButtons.classList.add('crm-buttons', 'crm-flex-justify-end');
+      alertButtons.innerHTML = `
+          <button class="crm-button" autofocus onclick="this.closest('dialog').remove()">
+            OK
+          </button>
+      `;
+      alert.append(alertButtons);
+
+      document.querySelector('.crm-container').append(alert);
+      alert.showModal();
     }
   };
 


### PR DESCRIPTION
Overview
----------------------------------------
Add something better than `window.alert` for frontend alerts.

Before
----------------------------------------
- frontend calls to CRM.alert use `window.alert`:
<img width="1299" height="1282" alt="image" src="https://github.com/user-attachments/assets/7bc53078-e28a-444a-a335-729d7345a643" />


After
----------------------------------------
- frontend calls to CRM.alert are shown in a modal dialog which inherits RL styling:
<img width="1348" height="1245" alt="image" src="https://github.com/user-attachments/assets/0b44952a-fdd6-44e8-a1f6-3cec0e74ba9b" />



Comments
----------------------------------------
It would be nice to allow for HTML in the dialog - but I don't totally trust the inputs and not sure how to sanitize effectively.

It would be nice to be able to distinguish between two types of alerts:

a) user-blocking front and centre modal alerts
b) alerts that are just for info and could be shown to the side/auto-dismissed

Currently CiviCRM treats all calls to CRM.alert as A on the frontend, and B on the backend. This PR doesn't change that. But it would be nice to have something in the `CRM.alert` signature to distinguish between these two types of alert. Then maybe something similar to this could be used in the backend also, when something should be user-blocking.