### PR TITLE
ensure missing required field is named in error

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -304,6 +304,9 @@ class Submit extends AbstractProcessor {
     }
     if ($isRequired && $isVisible) {
       $label = $attributes['defn']['label'] ?? $fullDefn['label'] ?? $fieldName;
+      if (empty($label)) {
+        $label = $attributes['name'];
+      }
       return E::ts('%1 is a required field.', [1 => $label]);
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
On Afform, I sometimes get a validation error about a missing field, but the name of the missing field is omitted in the error, which makes fixing it hard.


Before
----------------------------------------

- I create an afform with an address location block. 
- I set the "Is Primary" and "Location Type" fields to hidden fields.
- I hide the "Is Primary" and "Location Type" labels
- I set the "Is Primary" default value to yes
- I forget to set the "Location Type" default value. Whoops!

When I try to submit the form, I get a "Validation Error" message (maybe another fix will be to tell me in that message which field is missing...).

In my ConfigAndLog I see:

> 2025-11-24 09:46:53-0600  [error] Afform Validation errors: Array
> (
>     [0] =>  is a required field.
> )

Hm - no very helpful!

After
----------------------------------------

Now, in my ConfigAndLog I see:

> 2025-11-24 09:47:42-0600  [error] Afform Validation errors: Array
> (
>     [0] => location_type_id is a required field.
> )

Technical Details
----------------------------------------

Note - I tried just adding `?? $attributes['name']` to the end of the line above, but that didn't work because I think one of the earlier values is an empty string, not NULL. Also, I'm not sure why $fieldName is not properly populated. Maybe a better fix would be to fix that problem?

Comments
----------------------------------------
I wonder if I should just delete those fields and set them in the left hand pane instead? In any event, it still seems like ensuring we have the name of the field is a good idea.
