### PR TITLE
Revert "Use labels for pseudoconstants in import SearchDisplays"

### DIFF
--- a/ext/civiimport/Managed/ImportSearches.mgd.php
+++ b/ext/civiimport/Managed/ImportSearches.mgd.php
@@ -49,16 +49,12 @@ foreach ($importEntities as $importEntity) {
       ],
     ],
   ];
-  $pseudoconstants = civicrm_api4($fields['_entity_id']['fk_entity'], 'getFields', [
-    'where' => [['options', 'IS NOT EMPTY']],
-    'select' => ['name'],
-    'checkPermissions' => FALSE,
-  ])->column('name');
+
   $columns = [];
   foreach ($fields as $field) {
     $columns[] = [
       'type' => 'field',
-      'key' => in_array($field['name'], $pseudoconstants) ? $field['name'] . ':label' : $field['name'],
+      'key' => $field['name'],
       'dataType' => $field['data_type'] ?? 'String',
       'label' => $field['title'] ?? $field['label'],
       'sortable' => TRUE,


### PR DESCRIPTION
This is an unreleased regression due to #33717.

The issue is that this only works if the field name in the SearchDisplay for the import has the same name as the field itself, which isn't normally true. It also breaks things if the SD field happens to have the same name as a core field, but is not actually the same field.