### PR TITLE
(dev/core#6216) PaymentProcessor - Ensure that admin can view financial types

### DIFF
--- a/CRM/Admin/Form/PaymentProcessor.php
+++ b/CRM/Admin/Form/PaymentProcessor.php
@@ -187,7 +187,7 @@ class CRM_Admin_Form_PaymentProcessor extends CRM_Admin_Form {
 
     // Financial Account of account type asset CRM-11515
     $accountType = CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name = 'Asset' ");
-    $financialAccount = \Civi\Api4\FinancialAccount::get()
+    $financialAccount = \Civi\Api4\FinancialAccount::get(FALSE)
       ->addSelect('id', 'label')
       ->addWhere('financial_account_type_id', '=', key($accountType))
       ->addWhere('is_active', '=', TRUE)


### PR DESCRIPTION
Overview
----------------------------------------

Fix a regression wherein subsystem-administrator (i.e. someone who manages CiviContribute not the entire system) is unable to edit payment processors.

For full steps to reproduce, see https://lab.civicrm.org/dev/core/-/issues/6216

(This is a follow-up to #32084 from `6.1.alpha`. ping @demeritcowboy @eileenmcnaughton)

Before
----------------------------------------

Smarty warnings. The required field "Financial Accounts" is unavailable.

<img width="926" height="647" alt="Screenshot from 2025-11-24 16-11-53" src="https://github.com/user-attachments/assets/00be99e1-ab7f-4c3a-9bca-204e5f833461" />

After
----------------------------------------

The field is available.

<img width="919" height="479" alt="Screenshot from 2025-11-24 16-12-47" src="https://github.com/user-attachments/assets/815efd66-4eec-4136-afd2-25db82a803fa" />

Comments
----------------------------------------

AFAICS, the purpose #32084 was to prevent display of _disabled financial accounts_. This still does that -- because it still applies a filter on `is_active=TRUE`. For example, if I disable the `Premiums inventory` account and reload the edit page, then it disappears from the dropdown.

This patch was initially drafted as part of #33707, but I wasn't sure if it was too crude. After tracing the issue to 6.1/32084, it does seem proportionate...