### PR TITLE
Make option value and group fields importable

### DIFF
--- a/schema/Core/OptionGroup.entityType.php
+++ b/schema/Core/OptionGroup.entityType.php
@@ -35,6 +35,9 @@ return [
       'add' => '1.5',
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'import',
+      ],
     ],
     'name' => [
       'title' => ts('Option Group Name'),
@@ -51,6 +54,9 @@ return [
       'localizable' => TRUE,
       'description' => ts('Option Group title.'),
       'add' => '1.5',
+      'usage' => [
+        'import',
+      ],
     ],
     'description' => [
       'title' => ts('Option Group Description'),
@@ -59,6 +65,9 @@ return [
       'localizable' => TRUE,
       'description' => ts('Option group description.'),
       'add' => '1.5',
+      'usage' => [
+        'import',
+      ],
     ],
     'data_type' => [
       'title' => ts('Data Type'),
@@ -68,6 +77,9 @@ return [
       'add' => '4.7',
       'pseudoconstant' => [
         'callback' => ['CRM_Utils_Type', 'dataTypes'],
+      ],
+      'usage' => [
+        'import',
       ],
     ],
     'is_reserved' => [

--- a/schema/Core/OptionValue.entityType.php
+++ b/schema/Core/OptionValue.entityType.php
@@ -42,6 +42,9 @@ return [
       'add' => '1.5',
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'import',
+      ],
     ],
     'option_group_id' => [
       'title' => ts('Option Group ID'),
@@ -64,6 +67,9 @@ return [
         'key' => 'id',
         'on_delete' => 'CASCADE',
       ],
+      'usage' => [
+        'import',
+      ],
     ],
     'label' => [
       'title' => ts('Option Label'),
@@ -73,6 +79,9 @@ return [
       'localizable' => TRUE,
       'description' => ts('Option string as displayed to users - e.g. the label in an HTML OPTION tag.'),
       'add' => '1.5',
+      'usage' => [
+        'import',
+      ],
     ],
     'value' => [
       'title' => ts('Option Value'),
@@ -81,6 +90,9 @@ return [
       'required' => TRUE,
       'description' => ts('The actual value stored (as a foreign key) in the data record. Functions which need lookup option_value.title should use civicrm_option_value.option_group_id plus civicrm_option_value.value as the key.'),
       'add' => '1.5',
+      'usage' => [
+        'import',
+      ],
     ],
     'name' => [
       'title' => ts('Option Name'),
@@ -141,6 +153,9 @@ return [
       'input_attrs' => [
         'rows' => 8,
         'cols' => 60,
+      ],
+      'usage' => [
+        'import',
       ],
     ],
     'is_optgroup' => [


### PR DESCRIPTION
@eileenmcnaughton This seems like a reasonable set of fields to be able to import, but if you see something, I can add or remove.

The name / label / value thing could be a little confusing and we could remove name if we think it would be clearer.