### PR TITLE
Payment Processors - Allow "Connect to..." buttons to initialize API keys

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3012,6 +3012,40 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * When configuring an artifact that relies on an external API key, provide options for
+   * the web-user to initialize the key. This might mean (e.g.) starting the
+   * OAuth "Authorization Grant" workflow.
+   *
+   * Note: This event supports targeted aliases:
+   *   - Formula: hook_civicrm_initiators::{$context['for']}
+   *   - Example: hook_civicrm_initiators::PaymentProcessor
+   *
+   * @since 6.10
+   * @param array $context
+   *   Descriptor for the context/record wherein we want an API key. Some combination of:
+   *   - for: string (REQUIRED), a symbol that identifies the kind of context, e.g.
+   *      - "PaymentProcessor" (v6.10+): Add or reset the API key for a PaymentProcessor
+   *   - payment_processor_type: string (OPTIONAL), a symbol like "Stripe" which identifies the type of payment-processor
+   *   - payment_processor_id: int (OPTIONAL), unique id for the PaymentProcessor record
+   *   - is_test: bool (OPTIONAL), whether this payproc is for testing
+   * @param array $available
+   *   List of available actions. Each item has a symbolic-key, and it has the properties:
+   *     - title: string
+   *     - render: callable, the function which renders the initiator buttons
+   *        Signature: function(CRM_Core_Region $region, array $context, array $initiator):
+   * @param string|null $default
+   *
+   * @return mixed
+   */
+  public static function initiators(array $context, array &$available, &$default) {
+    $null = NULL;
+    return self::singleton()->invoke(['context', 'available', 'default'], $context, $available, $default,
+      $null, $null, $null,
+      'civicrm_initiators'
+    );
+  }
+
+  /**
    * This hook is called to modify api params of EntityRef form field
    *
    * @param array $params

--- a/Civi/Connect/Initiators.php
+++ b/Civi/Connect/Initiators.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Civi\Connect;
+
+/**
+ * A list of URLs (actions) that you can use to generate an API key for a remote service.
+ *
+ * The canonical "initiator" action would be to have the web-user request
+ * an "Authorization Grant" on a remote server using OAuth2. However, the
+ * exact management of OAuth2 clients (credentials, lifecycle, etc) can vary
+ * by service+topology. This mechanism is not specifically tied to OAuth2.
+ */
+class Initiators {
+
+  public static function create(array $context): Initiators {
+    $instance = new Initiators($context);
+    \CRM_Utils_Hook::initiators($instance->context, $instance->available, $instance->default);
+    $instance->normalize();
+    return $instance;
+  }
+
+  /**
+   * Descriptor for the context/purpose for which we want an API key.
+   *
+   * @var array
+   *   Some combination of:
+   *     - for: string (REQUIRED), a symbol that identifies the kind of context. Possible values:
+   *         - "PaymentProcessor" (v6.7+): Add or reset the API key for a PaymentProcessor
+   *     - payment_processor_type: string (OPTIONAL), a symbol like "PayPal" or "Stripe" which identifies the type of payment-processor
+   *     - payment_processor_id: int (OPTIONAL), unique id for the PaymentProcessor record
+   *     - is_test: bool (OPTIONAL), whether this payproc is for testing
+   * @readonly
+   */
+  public array $context;
+
+  /**
+   * Identifier for the suggested/default initiator.
+   *
+   * @var string|null
+   *   The symbolic-key (match the index of $this->available).
+   */
+  public ?string $default = NULL;
+
+  /**
+   * List of available actions. Each item has a symbolic-key, and it has the properties:
+   *
+   * @var array
+   *     - title: string
+   *     - render: callback to generate the UI widget
+   *        Signature: function(CRM_Core_Region $region, array $context, array $initiator):
+   *     - name: string (COMPUTED; same as array-key)
+   *     - url: string (COMPUTED; HTTP address for this initiator)
+   *     - is_default: bool (COMPUTED)
+   */
+  public array $available = [];
+
+  /**
+   * @param array $context
+   */
+  public function __construct(array $context) {
+    if (empty($context['for']) || !is_string($context['for'])) {
+      throw new \CRM_Core_Exception('Initiators: Missing required context value \"for\"');
+    }
+    $this->context = $context;
+  }
+
+  public function normalize() {
+    foreach ($this->available as $key => &$initiator) {
+      $initiator['name'] = $key;
+      $initiator['is_default'] = ($key === $this->default);
+    }
+
+    $lcMessages = \CRM_Core_I18n::getLocale();
+    $collator = new \Collator($lcMessages . '.utf8');
+    uasort($this->available, fn($a, $b) => $collator->compare($a['title'], $b['title']));
+
+    return $this;
+  }
+
+  public function get(string $name): ?array {
+    return $this->available[$name] ?? NULL;
+  }
+
+}

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -472,6 +472,11 @@ class Container {
         \Civi::dispatcher()->dispatch($eventName . "::" . $e->{$methodName}(), $e);
       };
     };
+    $aliasFuncEvent = function($eventName, $func) {
+      return function($e) use ($eventName, $func) {
+        \Civi::dispatcher()->dispatch($eventName . '::' . $func($e), $e);
+      };
+    };
 
     $dispatcher->addListener('civi.api4.validate', $aliasMethodEvent('civi.api4.validate', 'getEntityName'), 100);
     $dispatcher->addListener('civi.api4.authorizeRecord', $aliasMethodEvent('civi.api4.authorizeRecord', 'getEntityName'), 100);
@@ -479,6 +484,7 @@ class Container {
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\InstallationCanary', 'check']);
     $dispatcher->addListener('civi.core.install', ['\Civi\Core\DatabaseInitializer', 'initialize']);
     $dispatcher->addListener('&civi.mailing.track', ['CRM_Mailing_BAO_MailingTrackableURL', 'on_civi_mailing_track'], -500);
+    $dispatcher->addListener('hook_civicrm_initiators', $aliasFuncEvent('hook_civicrm_initiators', fn($e) => $e->context['for']), 100);
     $dispatcher->addListener('hook_civicrm_post', ['\CRM_Core_Transaction', 'addPostCommit'], -1000);
     $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);

--- a/js/crm.initiator.js
+++ b/js/crm.initiator.js
@@ -1,0 +1,50 @@
+// https://civicrm.org/licensing
+(function($, CRM, _, undefined) {
+
+  // Block access to the initators panel.
+  // usage: $('.foo').obscureInitiator({message: 'Foo Bar'});
+  // Note: This is similar to $.block(), but that's used around AJAX operations and shows a spinner -- the spinner is very confusing in this context.
+  $.fn.obscureInitiator = function(options) {
+    const $el = this;
+    if ($el.css('position') === 'static') {
+      $el.css('position', 'relative');
+    }
+
+    if ($el.children('.crm-initiator-obscure-content').length === 0) {
+      $el.wrapInner('<div class="crm-initiator-obscure-content"></div>');
+    }
+
+    $el.find('.crm-initiator-obscure-content').css({
+      filter: 'blur(2px) grayscale(30%)',
+      pointerEvents: 'none'
+    });
+
+    // Create overlay text (not blurred)
+    const $overlay = $('<div class="crm-initiator-overlay-message">')
+      .text(options.message)
+      .css({
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        background: 'rgba(255, 255, 255, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        fontSize: '1.1em',
+        color: '#222',
+        zIndex: 9999,
+        padding: '1em',
+        boxSizing: 'border-box',
+        pointerEvents: 'auto',
+        cursor: 'not-allowed'
+      });
+
+    if ($el.find('.crm-initiator-overlay-message').length === 0) {
+      $el.append($overlay);
+    }
+  };
+
+}(CRM.$, CRM, CRM._));

--- a/templates/CRM/Admin/Form/PaymentProcessor.tpl
+++ b/templates/CRM/Admin/Form/PaymentProcessor.tpl
@@ -53,16 +53,54 @@
     </tr>
     {/if}
   </table>
-<fieldset>
-<legend>{ts}Processor Details for Live Payments{/ts}</legend>
-  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames}
-</fieldset>
 
-<fieldset>
-<legend>{ts}Processor Details for Test Payments{/ts}</legend>
-  {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$testFieldNames}
-</fieldset>
-{/if}
+  {if !empty($live_initiator_list)}
+    <fieldset class="crm-paymentProcessor-details">
+      <legend>{ts}Connection{/ts}</legend>
+
+      {if $action eq 1}
+        {* The PaymentProcessor doesn't exist yet -- our OAuth flow uses `tag=PaymentProcessor::123`, so need to save first.*}
+        <div class="alert alert-info">
+          {ts}After saving this payment processor, you will be prompted to login and establish the full connection.{/ts}
+        </div>
+      {elseif empty($form.user_name.value) && empty($form.password.value) }
+        <div class="alert alert-warning crm-initiators-block">
+          <p>{ts}This connection is not fully established. Use this button to login and authorize the connection.{/ts}</p>
+          {crmRegion name='live_initiator_region'}{/crmRegion}
+        </div>
+        <details>
+          <summary>{ts}Connection Details{/ts}</summary>
+          {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames}
+        </details>
+      {elseif !(empty($form.user_name.value) && empty($form.password.value))}
+        <div class="alert alert-success">
+          <p>{ts}This connection has been initialized.{/ts}</p>
+        </div>
+        <details>
+          <summary>{ts}Connection Details{/ts}</summary>
+          {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames}
+        </details>
+        <details>
+          <summary>{ts}Re-connect{/ts}</summary>
+          <div class="alert alert-info crm-initiators-block">
+            <p>{ts}If you have encountered a problem with this connection, then you may re-connect. This button will prompt you to login again and re-approve.{/ts}</p>
+            {crmRegion name='live_initiator_region'}{/crmRegion}
+          </div>
+        </details>
+      {/if}
+
+    </fieldset>
+  {else}
+    <fieldset class="crm-paymentProcessor-details">
+      <legend>{ts}Processor Details for Live Payments{/ts}</legend>
+      {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$liveFieldNames}
+    </fieldset>
+    <fieldset class="crm-paymentProcessor-details">
+      <legend>{ts}Processor Details for Test Payments{/ts}</legend>
+      {include file="CRM/Admin/Form/PaymentProcessor/Details.tpl" fieldNames=$testFieldNames}
+    </fieldset>
+  {/if}
+  {/if}
 
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>
@@ -83,6 +121,14 @@
       if ($elements.length === 2) {
         CRM.utils.syncFields($elements.first(), $elements.last());
       }
+      var disableInitiators = false;
+      $('input,select', $form).change(function(){
+        if (disableInitiators) return;
+        disableInitiators = true;
+        $('.crm-initiators-block').obscureInitiator({
+          message: CRM.ts()('Please save changes before updating the connection.')
+        });
+      });
     });
   {/literal}
   </script>


### PR DESCRIPTION
Overview
----------------------------------------

This updates the screens "New/Edit Payment Processor" -- to make it easier to setup API credentials.

Here are a couple video demonstrations of the admin-experience:

* [Video with PayPal](https://think.hm/tmp/PayPalOnboard-2025-11-20-23-00.mov)
* [Video with Stripe](https://think.hm/tmp/StripeOnboard-2025-11-24.mov)

(The videos are created with the larger patchset, #33707. PayPal support depends on other patches in https://lab.c.o/extensions/paypal. Similarly, Stripe depends on other patches in https://lab.civicrm.org/totten/stripe/-/tree/connect?ref_type=heads)

Before
----------------------------------------

When you create or edit a payment processor, it shows a litany of fields under "Processor Details".

<img width="1104" height="1174" alt="Screenshot from 2025-11-24 16-51-09" src="https://github.com/user-attachments/assets/a423e898-db52-49b1-b432-fd361a8c7305" />

As a user, you must manually:

* Open another browser
* Login to the payment processor's administrative console (e.g. `paypal.com` or `dashboard.stripe.com`)
* Click through the console to find the developer tools
* Create a username/password/API-key/client-ID/etc with suitable permissions.
* Copy/paste each credential from their site to your CiviCRM site.
* Save the new "Payment Processor" in Civi.

After
----------------------------------------

The "Processor Details" panel is replaced by a simpler panel (*if the payment processor supports it*). This removes a lot of guesswork and copy-paste (for the admin).

The simpler panel is called "Connection". As you proceed through configuration, the panel display changes:

* __New, unsaved payment processor__:

    <img width="1107" height="231" alt="Screenshot from 2025-11-24 17-05-32" src="https://github.com/user-attachments/assets/e309f5ff-91f0-483c-9096-ca1374276b7e" />

* __Saved payment processor__ (ready for connection):

    <img width="1108" height="312" alt="Screenshot from 2025-11-24 17-06-12" src="https://github.com/user-attachments/assets/75df7005-3eec-4654-bfb8-e6aee3290702" />

    Note: Clicking the button could take you to another page, and you could lose unsaved changes. To prevent this, we look for unsaved changes. When unsaved changes are present, the button is blurred:

    <img width="1108" height="312" alt="Screenshot from 2025-11-24 17-07-02" src="https://github.com/user-attachments/assets/771b3087-f786-40cb-9cbe-ecfc6d57311e" />

* __Configured payment processor__:

    <img width="1108" height="312" alt="Screenshot from 2025-11-24 17-09-14" src="https://github.com/user-attachments/assets/2af0bd03-e84a-4fb9-aeff-ac0f0801da30" />


N.B. Existing payment processors still have the same UI. They must implement additional features to support this flow.

In Depth: Examples
----------------------------------------

There's not much to test directly in these commits. But there are two example implementations of `hook_initiators`:

* __OAuth Client / Stripe__: The `oauth-client` will generate initiator buttons for payment processors... if you define suitable metadata. (Since Stripe is OAuth-compliant, we can use this.)
    * In 33707, `oauth-client` implements `hook_initiators`. If an OAuthProvider is tagged with `PaymentProcessorType:XXX`, then will show a button. ([code](https://github.com/totten/civicrm-core/commit/35e301d8bbc5856cde18330fba255868136bbb6b#diff-e9ae42173a2240e2eabd07919b631a09fe4cdec7400947cfa07620bdea27a4e1R34-R37))
    * In `totten/stripe.git@connect`, it declares an `OAuthProvider` and tags it as `PaymentProcessorType:StripeCheckout`. Whenever we edit a `StripeCheckout` payment-processor, it will offer OAuth buttons. ([code](https://lab.civicrm.org/totten/stripe/-/blob/a92f8adb56579ff5c896755f1f133ccac8ee43cc/connect/Civi/StripeConnect/StripeRegistration.php#L46))
* __PayPal Complete Payments (PPCP)__:  PPCP requires a special pageflow (inspired by OAuth but not compliant with OAuth), so the extension implements the hook directly. ([code](https://lab.civicrm.org/extensions/paypal/-/blob/76cdfac741ff4d2e8b60c5bbf0215dec8eeb24c5/Civi/Paypal/PaypalInitiator.php#L28))

In Depth: Evolution
---------------------------------

The signature of `hook_initiators` evolved a fair bit during the iterations of #33707. More than I want to remember. Some moments which come to mind:

* Initially, take inspiration from CiviMail. When using OAuth to setup inbound mail processors (Gmail/Exchange), we implement `hook_civicrm_mailSetupActions`. This is basically a list of action-links/buttons. So take the same idea -- but generalize slightly by providing `$context` and `$context['for']`.
     * _Old idea_: `hook_civicrm_mailSetupActions`
     * _New idea_: `hook_civicrm_initiators(['for' => 'PaymentProcessor'])`
     * _Shared idea_: We want to generate an action-URL (typically based on `OAuthClient::authorizationCode()` flow). We define a `callback` to output `string $nextUrl`.
* As in CiviMail, calling the action would actually _create_ the `PaymentProcessor`. I definitely preferred the UX -- fewer pages. However, there were some problems: it was impossible to attach credentials to the "Test" payment processor. Also, it was impossible to update/reset credentials on an existing payment processor. These points were resolved by putting the buttons in the "Edit" view, allowing them to be attached to any `PaymentProcessor` ID (live or test).
* To improve the UX, add support for OAuth with the "Web Message Response Mode (RFC)". The name is cryptic, but what it really means is that _we can show the `$nextUrl` in a popup_.
* The edit screen still felt too big, with too many widgets offered to handle edge-cases. Moving details into a collapsible `<details>` helped. Hiding the section with "Test" credentials helped. (You can still connect to a sandbox -- there are  buttons for "Connect to Foo (live)" and "Connect to Foo (sandbox)". But it only presents in Civi as one `PaymentProcessor`...)
* All this worked for Stripe -- Stripe is OAuth-compliant, and it permits some small liberties in how to implement the button/flow (as long as we stay within OAuth specs).
* PayPal also shows a login popup, and the flow is OAuth-inspired, but it's not OAuth-compliant.  The PayPal "Minibrowser" flow is described [here](https://developer.paypal.com/docs/multiparty/seller-onboarding/build-onboarding/#embed-signup-link). Observe how you must define the `<A>` tag and `<SCRIPT>` tag in a very specific way. This gives PayPal control over the `onclick` handler.

    ```html
    <a target="_blank"
      data-paypal-onboard-complete="onboardedCallback"
      href="<Action-URL>&displayMode=minibrowser"
      data-paypal-button="true">Sign up for PayPal</a>

    <script id="paypal-js"
      src="https://www.sandbox.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js"
      ></script>
    ```

    To support this flow, we have to output their markup.  (It's not sufficient to generate a `nextUrl` and open it from our JS.)

    So now `hook_initiators` defines a `render` callback to generate HTML blobs (with some mix of JS/CSS/HTML resources).

The end-result is a contract that... is not as slick as I would like... but it works OK, and it works with several flows (incl OAuth 2.0 Authorization Code with `query` or `web_message` response-modes; as well as PayPal Miniborwser flow).