### PR TITLE
OAuthState - Allow updates

### DIFF
--- a/ext/oauth-client/Civi/OAuth/OAuthState.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthState.php
@@ -47,11 +47,13 @@ class OAuthState extends AutoService {
    *   - tag (string, optional), The symbolic tag to apply to the new token
    *   - code_verifier (string, optional), An extra string that we will send to the token-endpoint to prove that we initiated the flow
    *   - grant_type (string, optional), The kind of flow that we are pursuing. Default: authorization_code
+   * @param string|null $stateId
+   *   If specified, use the given state ID.
    * @return string
    *   State token / identifier
    */
-  public function store($state): string {
-    $stateId = 'CC_' . \CRM_Utils_String::createRandom(29, \CRM_Utils_String::ALPHANUMERIC);
+  public function store($state, ?string $stateId = NULL): string {
+    $stateId ??= 'CC_' . \CRM_Utils_String::createRandom(29, \CRM_Utils_String::ALPHANUMERIC);
 
     $state['session'] = $this->getSessionId();
     $state['time'] = \CRM_Utils_Time::time();

--- a/ext/oauth-client/tests/phpunit/Civi/OAuth/StateTest.php
+++ b/ext/oauth-client/tests/phpunit/Civi/OAuth/StateTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Civi\OAuth;
+
+use Civi\Test\HeadlessInterface;
+use Civi\Core\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class StateTest extends \PHPUnit\Framework\TestCase implements
+    HeadlessInterface,
+    HookInterface,
+    TransactionalInterface {
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()->install('oauth-client')->apply();
+  }
+
+  public function setUp(): void {
+    parent::setUp();
+  }
+
+  public function tearDown(): void {
+    \CRM_Utils_Time::resetTime();
+    parent::tearDown();
+  }
+
+  public function testState(): void {
+    \CRM_Utils_Time::setTime('2025-11-01 01:00:00');
+
+    $stateId = \Civi::service('oauth2.state')->store([
+      'clientId' => 123,
+      'storage' => 'OAuthSysToken',
+      'ttl' => 5 * 60 * 60,
+    ]);
+    $state = \Civi::service('oauth2.state')->load($stateId);
+    $this->assertEquals(123, $state['clientId']);
+    $this->assertEquals('OAuthSysToken', $state['storage']);
+    // PHPUnit runs in CLI... so any state we generate is attached to wildcard session.
+    $this->assertEquals(OAuthState::SESSION_WILDCARD, $state['session']);
+
+    \CRM_Utils_Time::setTime('2025-11-02 06:01:00');
+    try {
+      \Civi::service('oauth2.state')->load($stateId);
+      $this->fail('State should expire');
+    }
+    catch (OAuthException $e) {
+      $this->assertMatchesRegularExpression(';Received invalid or expired state;', $e->getMessage());
+    }
+  }
+
+  public function testInvalidState(): void {
+    try {
+      \Civi::service('oauth2.state')->load('CC_123456789012345678901234567890123456789012345678901234567890');
+      $this->fail('State should expire');
+    }
+    catch (OAuthException $e) {
+      $this->assertMatchesRegularExpression(';Received invalid or expired state;', $e->getMessage());
+    }
+  }
+
+}

--- a/ext/oauth-client/tests/phpunit/Civi/OAuth/StateTest.php
+++ b/ext/oauth-client/tests/phpunit/Civi/OAuth/StateTest.php
@@ -61,4 +61,23 @@ class StateTest extends \PHPUnit\Framework\TestCase implements
     }
   }
 
+  public function testModifyState(): void {
+    $stateId = \Civi::service('oauth2.state')->store([
+      'clientId' => 123,
+      'storage' => 'OAuthSysToken',
+      'ttl' => 5 * 60 * 60,
+      'breakfast' => 'green eggs',
+    ]);
+    $state = \Civi::service('oauth2.state')->load($stateId);
+    $this->assertEquals(123, $state['clientId']);
+    $this->assertEquals('green eggs', $state['breakfast']);
+
+    $state['breakfast'] = 'green eggs and ham';
+    \Civi::service('oauth2.state')->store($state, $stateId);
+
+    $state2 = \Civi::service('oauth2.state')->load($stateId);
+    $this->assertEquals(123, $state2['clientId']);
+    $this->assertEquals('green eggs and ham', $state2['breakfast']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

This modifies the internal storage options for OAuth `state`. The content of `state` becomes mutable. This also adds test-coverage.

(Builds on #34047, which defined the `oauth2.state` service. Extracted from #33707 and updated with unit-test coverage.)

Before
----------------------------------------

* No test-coverage for `oauth2.state`
* State is write-once.

After
----------------------------------------

* Test-coverage for some existing aspects of `oauth2.state` (such as TTL and session ID) as well as new aspects.
* State can be updated.

