### PR TITLE
OAuth Client - Facilitate services on the `connect.civicrm.org` bridge

### DIFF
--- a/ext/oauth-client/Civi/Api4/OAuthClient.php
+++ b/ext/oauth-client/Civi/Api4/OAuthClient.php
@@ -4,6 +4,7 @@ namespace Civi\Api4;
 
 use Civi\Api4\Action\OAuthClient\Create;
 use Civi\Api4\Action\OAuthClient\Update;
+use Civi\Api4\Generic\Traits\ManagedEntity;
 
 /**
  * OAuthClient entity.
@@ -13,6 +14,8 @@ use Civi\Api4\Action\OAuthClient\Update;
  * @package Civi\Api4
  */
 class OAuthClient extends Generic\DAOEntity {
+
+  use ManagedEntity;
 
   public static function create($checkPermissions = TRUE) {
     $action = new Create(static::class, __FUNCTION__);

--- a/ext/oauth-client/Civi/OAuth/CiviConnect.php
+++ b/ext/oauth-client/Civi/OAuth/CiviConnect.php
@@ -4,6 +4,7 @@ namespace Civi\OAuth;
 
 use Civi;
 use Civi\Core\Service\AutoService;
+use CRM_OAuth_ExtensionUtil as E;
 use CRM_Utils_Cache_Interface;
 use GuzzleHttp\Client;
 
@@ -50,6 +51,42 @@ class CiviConnect extends AutoService {
       return $key['id'];
     }
     return NULL;
+  }
+
+  /**
+   * Get a list of available bridge servers.
+   *
+   * @return array
+   */
+  public function getHosts(): array {
+    $urlText = \Civi::settings()->get('oauth_civi_connect_urls');
+    $urls = [];
+    foreach (preg_split(';[ \r\n\t]+;', trim($urlText)) as $urlLine) {
+      [$name, $url] = explode('=', $urlLine, 2);
+      $urls[$name] = rtrim($url, '/');
+    }
+
+    $hosts = [];
+    $hosts['live'] = [
+      'url' => $urls['live'] ?? NULL,
+      'name()' => fn($name) => $name,
+      'title()' => fn($title) => $title,
+      'tag' => 'CiviConnect',
+    ];
+    $hosts['sandbox'] = [
+      'url' => $urls['sandbox'] ?? NULL,
+      'name()' => fn($name) => $name . '_sandbox',
+      'title()' => fn($title) => E::ts('%1 (Sandbox)', [1 => $title]),
+      'tag' => 'CiviConnectSandbox',
+    ];
+    $hosts['local'] = [
+      'url' => $urls['local'] ?? NULL,
+      'name()' => fn($name) => $name . '_local',
+      'title()' => fn($title) => E::ts('%1 (Local)', [1 => $title]),
+      'tag' => 'CiviConnectLocal',
+    ];
+
+    return $hosts;
   }
 
   /**

--- a/ext/oauth-client/Civi/OAuth/CiviConnect.php
+++ b/ext/oauth-client/Civi/OAuth/CiviConnect.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Civi\OAuth;
+
+use Civi;
+use Civi\Core\Service\AutoService;
+
+/**
+ * Manage a connection to the `connect.civicrm.org` bridge-server.
+ */
+class CiviConnect extends AutoService {
+
+  /**
+   * @service oauth_client.civi_connect
+   * @inject crypto.registry
+   * @return \Civi\OAuth\CiviConnect
+   */
+  public static function factory(\Civi\Crypto\CryptoRegistry $registry) {
+    $instance = new static();
+    // Registering our key via factory() means that we guarantee CRED key is already registered,
+    // which helps with parsing. If using the factory is a problem, then CONNECT key probably
+    // needs async registration, eg `$registry->addKey(['callback' => ...])`.
+    if (!empty(Civi::settings()->get('oauth_civi_connect_keypair'))) {
+      $registry->addKey($instance->createRegistration());
+    }
+    else {
+      $instance->generateCreds();
+    }
+    return $instance;
+  }
+
+  /**
+   * Find or create the connection parameters for CiviConnect bridge service.
+   *
+   * @return array
+   *   Tuple: [clientId, clientSecret]
+   */
+  public function getCreds(): array {
+    return [$this->getId(), $this->createAuthToken()];
+  }
+
+  public function getId(): ?string {
+    $registry = Civi::service('crypto.registry');
+    foreach ($registry->findKeysByTag('CONNECT') as $key) {
+      return $key['id'];
+    }
+    return NULL;
+  }
+
+  /**
+   * Generate a new key-pair to identify the current deployment.
+   *
+   * @return static
+   */
+  public function generateCreds(): CiviConnect {
+    $keyPair = sodium_crypto_sign_keypair();
+    Civi::settings()->set('oauth_civi_connect_keypair',
+      Civi::service('crypto.token')->encrypt($keyPair, 'CRED')
+    );
+    Civi::service('crypto.registry')->addKey($this->createRegistration());
+    return $this;
+  }
+
+  /**
+   * Generate metadata/registration record for our key-pair.
+   *
+   * @return array
+   * @see \Civi\Crypto\CryptoRegistry::addKey()
+   */
+  protected function createRegistration(): array {
+    $encryptedKeyPair = Civi::settings()->get('oauth_civi_connect_keypair');
+    $keyPair = Civi::service('crypto.token')->decrypt($encryptedKeyPair, 'CRED');
+    return [
+      'key' => $keyPair,
+      'suite' => 'jwt-eddsa-keypair',
+      'tags' => ['CONNECT'],
+      'id' => $this->createId($keyPair),
+    ];
+  }
+
+  public function createAuthToken(array $claims = []): string {
+    return Civi::service('crypto.jwt')->encode(array_merge([
+      'exp' => \CRM_Utils_Time::strtotime('+1 hour'),
+      'scope' => 'CiviConnect',
+    ], $claims), 'CONNECT');
+  }
+
+  private function createId(string $keyPair): string {
+    return 'eddsa_' . base64_encode(sodium_crypto_sign_publickey($keyPair));
+  }
+
+}

--- a/ext/oauth-client/Civi/OAuth/CiviConnectProviders.php
+++ b/ext/oauth-client/Civi/OAuth/CiviConnectProviders.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Civi\OAuth;
+
+use Civi\Core\Service\AutoService;
+use CRM_OAuth_ExtensionUtil as E;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * OAuth providers that are tagged as `CiviConnect` should have some special behaviors, e.g.
+ *
+ * - Inspect the setting `oauth_civi_connect_urls`.
+ * - In the provider definition, replace `{civi_connect_url}` with a real URL.
+ * - If the settings have enabled "sandbox" or "local" options, then also use those.
+ *
+ * @service oauth_client.civi_connect_providers
+ */
+class CiviConnectProviders extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents() {
+    return [
+      '&hook_civicrm_oauthProviders' => ['hook_civicrm_oauthProviders', -1000],
+      '&hook_civicrm_initiators::PaymentProcessor' => ['pickDefaultPaymentInitiators', -1000],
+    ];
+  }
+
+  /**
+   * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_oauthProviders/
+   */
+  public function hook_civicrm_oauthProviders(array &$providers) {
+    // Any providers tagged as `CiviConnect` are actually templates.
+    $templates = array_filter($providers, fn($p) => in_array('CiviConnect', $p['tags'] ?? []));
+    foreach (array_keys($templates) as $templateName) {
+      unset($providers[$templateName]);
+    }
+
+    // For each of these templates, we'll fill-in data and point to the available CiviConnect server(s).
+    $hosts = \Civi::service('oauth_client.civi_connect')->getHosts();
+    foreach ($templates as $templateName => $template) {
+      foreach ($hosts as $host) {
+        if (empty($host['url'])) {
+          continue;
+        }
+
+        $vars = [
+          '{civi_connect_url}' => $host['url'],
+        ];
+        $provider = $this->filterTree($template,
+          fn($s) => strtr($s, $vars)
+        );
+        $provider['name'] = call_user_func($host['name()'], $templateName);
+        $provider['title'] = call_user_func($host['title()'], $provider['title']);
+        $provider['tags'] = preg_replace('/^CiviConnect$/', $host['tag'], $provider['tags']);
+        $providers[$provider['name']] = $provider;
+      }
+    }
+
+    ksort($providers);
+  }
+
+  /**
+   * Recursively apply a filter to all string-values in an array-tree.
+   *
+   * @param array $array
+   * @param callable $filter
+   * @return array
+   */
+  protected function filterTree(array $array, callable $filter): array {
+    foreach ($array as &$item) {
+      if (is_string($item)) {
+        $item = $filter($item);
+      }
+      if (is_array($item)) {
+        $item = $this->filterTree($item, $filter);
+      }
+    }
+    return $array;
+  }
+
+  /**
+   * In "Edit Payment Processors", there are options for different initiators. If they have
+   * any of our tags ("CiviConnect", "CiviConnectSandbox", "CiviConnectLocal"), then use them
+   * to help pick our defaults.
+   *
+   * - Payment Processors have two variants -- live and testing.
+   * - CiviConnect providers can have two variants -- live and sandbox (and possibly local).
+   * - There's an affinity for live<=>live and testing<=>sandbox.
+   * - Or, if you've got local override, then that's generally preferred.
+   *
+   * @param array $context
+   * @param array $available
+   * @param $default
+   *
+   * @see \CRM_Utils_Hook::initiators()
+   */
+  public function pickDefaultPaymentInitiators(array $context, array &$available, &$default): void {
+    if (empty($available) || $default !== NULL) {
+      return;
+    }
+
+    $options = [];
+
+    // Dumb guess: Pick the first
+    foreach ($available as $key => $initiator) {
+      $options[50] = $key;
+      break;
+    }
+
+    // But it's better if we match by type (e.g. live<=>live, testing<=>sandbox).
+    foreach ($available as $key => $initiator) {
+      $envTag = array_values(array_intersect(
+        ['CiviConnect', 'CiviConnectSandbox', 'CiviConnectLocal'],
+        $initiator['tags'] ?? []
+      ))[0] ?? NULL;
+      if ($envTag === 'CiviConnect' && !$context['is_test']) {
+        $options[20] = $key;
+      }
+      elseif ($envTag === 'CiviConnectSandbox' && $context['is_test']) {
+        $options[20] = $key;
+      }
+      elseif ($envTag === 'CiviConnectLocal') {
+        $options[10] = $key;
+      }
+    }
+
+    ksort($options);
+    $default = array_shift($options);
+  }
+
+  // The sub-step of reconciling mgd's seems quirky. If we can't make it automatic, then just leave if dumb for now.
+  // public static function onChangeUrls() {
+  //   \Civi::cache('long')->delete('OAuthProvider_list');
+  //   \CRM_Core_ManagedEntities::singleton()->reconcile([E::LONG_NAME]);
+  // }
+
+}

--- a/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
+++ b/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Civi\OAuth;
 
+use Civi;
 use League\OAuth2\Client\Token\AccessToken;
 
 /**
@@ -27,6 +28,17 @@ class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider
    * @var string
    */
   protected $tenant;
+
+  protected function fillProperties(array $options = []) {
+    // If this client is generated for CiviConnect bridge, then swap the credentials.
+    $needClient = ($options['clientId'] ?? NULL) === '{civi_connect}';
+    $needSecret = ($options['clientSecret'] ?? NULL) === '{civi_connect}';
+    if ($needClient && $needSecret) {
+      [$options['clientId'], $options['clientSecret']] = Civi::service('oauth_client.civi_connect')->getCreds();
+    }
+
+    parent::fillProperties($options);
+  }
 
   protected function getAuthorizationParameters(array $options) {
     $newOptions = parent::getAuthorizationParameters($options);

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -1,7 +1,8 @@
 <?php
 
 require_once 'oauth_client.civix.php';
-use CRM_OauthClient_ExtensionUtil as E;
+
+use CRM_OAuth_ExtensionUtil as E;
 
 /**
  * Implements hook_civicrm_config().
@@ -101,4 +102,36 @@ function oauth_client_civicrm_oauthReturn($token, &$nextUrl) {
  */
 function oauth_client_civicrm_alterMailStore(&$mailSettings) {
   CRM_OAuth_MailSetup::alterMailStore($mailSettings);
+}
+
+/**
+ * @see CRM_Utils_Hook::managed()
+ */
+function oauth_client_civicrm_managed(array &$entities, ?array $modules = NULL): void {
+  if ($modules !== NULL && !in_array(E::LONG_NAME, $modules)) {
+    return;
+  }
+
+  $providers = [];
+  \CRM_OAuth_Hook::oauthProviders($providers);
+
+  foreach ($providers as $provider) {
+    if (in_array('CiviConnect', $provider['tags'] ?? [])) {
+      $entities[] = [
+        'module' => E::LONG_NAME,
+        'name' => 'CiviConnect_' . $provider['name'],
+        'entity' => 'OAuthClient',
+        'params' => [
+          'version' => 4,
+          'values' => [
+            'provider' => $provider['name'],
+            'guid' => '{civi_connect}',
+            'secret' => '{civi_connect}',
+          ],
+        ],
+        'update' => 'always',
+        'cleanup' => 'unused',
+      ];
+    }
+  }
 }

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -116,7 +116,7 @@ function oauth_client_civicrm_managed(array &$entities, ?array $modules = NULL):
   \CRM_OAuth_Hook::oauthProviders($providers);
 
   foreach ($providers as $provider) {
-    if (in_array('CiviConnect', $provider['tags'] ?? [])) {
+    if (array_intersect($provider['tags'] ?? [], ['CiviConnect', 'CiviConnectSandbox', 'CiviConnectLocal'])) {
       $entities[] = [
         'module' => E::LONG_NAME,
         'name' => 'CiviConnect_' . $provider['name'],

--- a/ext/oauth-client/settings/OAuthClient.setting.php
+++ b/ext/oauth-client/settings/OAuthClient.setting.php
@@ -1,4 +1,6 @@
 <?php
+use CRM_OAuth_ExtensionUtil as E;
+
 return [
   'oauthClientRedirectUrl' => [
     'group_name' => 'Developer Preferences',
@@ -9,9 +11,23 @@ return [
     'html_type' => 'text',
     'default' => NULL,
     'add' => '5.32',
-    'title' => ts('Redirect URL'),
+    'title' => E::ts('Redirect URL'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'description' => ts('Override the redirect URL for OAuth2 requests. This is an absolute URL which should be equivalent to "civicrm/oauth-client/return".'),
+    'description' => E::ts('Override the redirect URL for OAuth2 requests. This is an absolute URL which should be equivalent to "civicrm/oauth-client/return".'),
+  ],
+  'oauth_civi_connect_keypair' => [
+    'group_name' => 'OAuth Preferences',
+    'group' => 'oauth',
+    'name' => 'oauth_civi_connect_keypair',
+    'type' => 'String',
+    'quick_form_type' => 'Element',
+    'html_type' => 'text',
+    'default' => NULL,
+    'add' => '6.8',
+    'title' => E::ts('CiviConnect Key Pair'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('Secret key to identify this site to the CiviConnect bridge. Use CryptoToken format.'),
   ],
 ];

--- a/ext/oauth-client/settings/OAuthClient.setting.php
+++ b/ext/oauth-client/settings/OAuthClient.setting.php
@@ -30,4 +30,18 @@ return [
     'is_contact' => 0,
     'description' => E::ts('Secret key to identify this site to the CiviConnect bridge. Use CryptoToken format.'),
   ],
+  'oauth_civi_connect_urls' => [
+    'group_name' => 'OAuth Preferences',
+    'group' => 'oauth',
+    'name' => 'oauth_civi_connect_urls',
+    'type' => 'String',
+    'html_type' => 'textarea',
+    'default' => "live=https://connect.civicrm.org\nsandbox=https://sandbox.connect.civicrm.org",
+    'add' => '6.8',
+    'title' => E::ts('CiviConnect: URLs'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('Define the bridge servers. You may define up to three: "live", "sandbox", and "local".'),
+    // 'on_change' => ['Civi\OAuth\CiviConnectProviders::onChangeUrls'],
+  ],
 ];

--- a/ext/oauth-client/tests/phpunit/Civi/OAuth/CiviConnectTest.php
+++ b/ext/oauth-client/tests/phpunit/Civi/OAuth/CiviConnectTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Civi\OAuth;
+
+use Civi\Test\HeadlessInterface;
+use Civi\Core\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class CiviConnectTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  public function setUpHeadless() {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+    return \Civi\Test::headless()->install('oauth-client')->apply();
+  }
+
+  public function testCreds() {
+    [$clientId, $authToken] = \Civi::service('oauth_client.civi_connect')->getCreds();
+    $this->assertMatchesRegularExpression('/^eddsa_[a-zA-Z0-9=+\/]+$/', $clientId);
+    $decode = \Civi::service('crypto.jwt')->decode($authToken, 'CONNECT');
+    $this->assertEquals('CiviConnect', $decode['scope']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Allows a streamlined process for connecting to OAuth services through `connect.civicrm.org`, which is a bridge server with dynamic registration (etc).

The availability of this process depends on the particular OAuth service and their business policies and their attitude toward dynamic-registration. For example, Stripe's business process is requiring us to setup an OAuth bridge with dynamic registration. By contrast, Google's business process looks less enthusiastic (likely requires more audits/paperwork). The primary goal here is to be _sufficient_ for Stripe while being _reasonably generic_ (so that the same kind of bridge could be setup for other OAuth services) without being _exhaustively generic_ (we don't have others that we can fully test)..

Before
----------------------------------------

To connect to a service with `oauth-client` extension:

1. __Development__: A developer defines the `OAuthProvider` (via JSON or PHP).
2. __Pre-Configuration__: 
    * The sysadmin logs into the related service-provider's web-site and generates credentials (`client_id` and `client_secret`).
    * The sysadmin updates CiviCRM and creates an `OAuthClient` record (with the `client_id` and `client_secret` for the desired provider).
3. __OAuth Tokens__: Now, the sysadmin can use OAuth flows to setup API keys.

After
----------------------------------------

1. __Development__: As before, a developer defines the `OAuthProvider` (via JSON or PHP).
    * _With an extra priviso_. They set some extra properties to enable CiviConnect.  
2. __Pre-Configuration__: The sysadmin does *not* need to do preconfiguration.
3. __OAuth Tokens__: The sysadmin can use OAuth flows to setup API keys. When they do this first time, it _will(*)_ present an extra confirmation screen with terms of service.

    <img width="1273" height="828" alt="Screenshot 2025-11-24 at 10 16 04 PM" src="https://github.com/user-attachments/assets/c5aa3bf9-3b6c-424c-ac03-28e732afb056" />

(*This PR doesn't actually implement the confirmation dialog. That has some interdependencies with other commits. The confirmation dialog is in #33707 and will be provided in a follow-up PR, as dependencies get resolved.*)

Technical Details
----------------------------------------

Here is an example of declaring an `OAuthProvider`:

```php
  function hook_civicrm_oauthProviders(array &$providers) {
    $providers['stripe'] = [
      'name' => 'stripe',
      'title' => ts('Stripe'),
      'class' => StripeProvider::class,
      'tags' => ['CiviConnect', 'PaymentProcessorType:Stripe', 'PaymentProcessorType:StripeCheckout'],
      'options' => [
        'urlCiviConnect' => '{civi_connect_url}',
        'urlAuthorize' => '{civi_connect_url}/stripe-connect/authorize',
        'urlAccessToken' => '{civi_connect_url}/stripe-connect/token',
        'responseModes' => [...'web_message'...],
         ...
      ],
      ...
    ];
  }
```

Key elements:

* The `tags` list includes `CiviConnect`. This means that the `OAuthClient` record will be auto-created.
* The `options.urlCiviConnect` is important for dynamic registration.
* The `options.urlAuthorize` and `options.urlAccessToken` point to the bridge server. (_A full list of routes on the bridge server is defined in [`infra/connect.git:config/routes.php`](https://lab.civicrm.org/infra/connect/-/blob/master/config/routes.php?ref_type=heads).)
* The `options.responseModes` includes `web_message`. This is a popup-based flavor of OAuth. It reduces the reliance on redirects and mitigates downsides of dynamic-registration. 
* The URLs for the CiviConnect bridge are based on a variable `{civi_connect_url}`. This variable comes from a system setting (`oauth_civi_connect_urls`) which identifies the bridge server(s).
    * By default, `oauth_civi_connect_urls` offers two bridge servers -- the `live` and `sandbox`.
    * The `live` bridge (`connect.civicrm.org`) is intended for real connections with real data.
    * The `sandbox` bridge (`sandbox.connect.civicrm.org`) is intended for fake connections with fake data.
    * For middle-of-the-road site-builders, it makes sense to offer these two options. There may be some advanced configurations where they're changed (e.g. developers working on patches with a local copy of bridge-server; e.g. demo sites which don't offer `live` bridge; e.g. multisite systems which don't offer `sandbox`).

        <details>
        <summary><b>Example: Customize bridge URLs for local-dev</b></summary>

        I want all my local dev sites to use a different bridge, so I put a file in `/etc/civicrm.settings.d/`:

        ```php
        global $civicrm_setting;

        $civicrm_setting['domain']['oauth_civi_connect_urls'] = implode("\n", [
          // 'live=https://connect.civicrm.org',
          'sandbox=https://sandbox.connect.civicrm.org',
          'local=http://connect.local.civi.bid:8001',
          ]);
        ```

        </details>


As mentioned earlier, this PR doesn't actually provide the confirmation dialog. But it does provide some key building blocks for the confirmation dialog:

* The checkbox "_Enable CiviConnect_" corresponds to a setting (`oauth_civi_connect_approved`).
* The checkbox "_Do not show this message again_" corresponds to a setting (`oauth_auto_confirm`).
* After one chooses to "Enable CiviConnect", the system shall call `Civi::service(' oauth_client.civi_connect')->register()` to tell the bridge that we exist and agreed to terms.