### PR TITLE
RiverLea: fixes regression from #33836 on table cell width

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -28,6 +28,7 @@
 .crm-container .form-layout-compressed td.label,
 .crm-container .selector td.label,
 .crm-container .form-layout-compressed th.label {
+  width: var(--crm-input-label-width);
   min-width: var(--crm-input-label-width);
   text-align: var(--crm-input-label-align);
   margin: var(--crm-m) var(--crm-m2) 0 0;


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/33836 fixed an issue with the label column for table-based forms having an inconsistent width. The change from `width` to `min-width` had problems - this PR restores `width` while keeping `min-width`.

Before
----------------------------------------
Chaos

<img width="1399" height="453" alt="image" src="https://github.com/user-attachments/assets/cd65068c-dbfd-4da6-9883-109106118d7d" />

After
----------------------------------------
Calm

<img width="1382" height="472" alt="image" src="https://github.com/user-attachments/assets/3c6025ea-87af-496b-b721-de7964aabd35" />

Comments
----------------------------------------
This prob needs back-porting to 6.8beta…