### PR TITLE
RiverLea: restores ul/ol styles and spacing for .replace-plain wysiwyg regions

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -55,7 +55,7 @@ body {
   list-style: none;
 }
 /* Restores list styles for rich text output to UA stylesheet definition */
-.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body,.crm-search-col-type-html,.af-markup,.notify-content) :is(ol,ul) {
+.crm-container :is(.crm-content,.note-editable,.html-adjust,.help,.status,.messages,.crm-status-message-body,.crm-search-col-type-html,.af-markup,.notify-content,.replace-plain,.crm-public .crm-section) :is(ol,ul) {
   list-style: revert;
   padding: revert;
   margin: revert;


### PR DESCRIPTION
Overview
----------------------------------------
List styling is reset in RiverLea, then restored on a case-by-case basis. Every so often a new case is spotted, this time on the event configuration screen.

Before
----------------------------------------
Backend…

<img width="638" height="343" alt="image" src="https://github.com/user-attachments/assets/f711feb1-ac66-4f43-811a-4af0295371d5" />

Front-end…

<img width="232" height="118" alt="image" src="https://github.com/user-attachments/assets/93c5506c-7422-48b9-b492-05bd3f40d5ef" />

After
----------------------------------------
Backend…

<img width="722" height="279" alt="image" src="https://github.com/user-attachments/assets/7b72dfc1-6c8a-4491-966b-505c31971287" />

Frontend…

<img width="369" height="130" alt="image" src="https://github.com/user-attachments/assets/21c684ea-72b3-43ae-8885-b131ab77a9fa" />
<img width="271" height="200" alt="image" src="https://github.com/user-attachments/assets/8a635a6a-39e6-42af-8f01-a6d588202459" />