### PR TITLE
RiverLea: fixes regression from #33802 - two variable names were mistyped

### DIFF
--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -246,7 +246,7 @@ table.advmultiselect {
 }
 .crm-container .panel-default > .panel-heading {
   color: var(--crm-c-text);
-  background-color: var(--crm-c-layout1-bg);
+  background-color: var(--crm-c-layer1-bg);
   border-bottom: var(--crm-panel-border);
 }
 .crm-container .panel-title {

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -283,7 +283,7 @@
   height: 1px;
   margin: var(--crm-m) 0;
   overflow: hidden;
-  background-color: var(--crm-c-layout2-bg);
+  background-color: var(--crm-c-layer2-bg);
 }
 #bootstrap-theme .dropdown-menu li .form-inline,
 #bootstrap-theme .dropdown-menu li .form-inline a:not(.select2-choice) {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -681,7 +681,7 @@ input.crm-form-checkbox) + label {
 }
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
-  background: var(--crm-c-layout2-bg);
+  background: var(--crm-c-layer2-bg);
   padding: var(--crm-s);
 }
 .crm-container .crm-select2-row-description p {

--- a/ext/riverlea/core/css/components/_nav.css
+++ b/ext/riverlea/core/css/components/_nav.css
@@ -17,7 +17,7 @@
 }
 .crm-container .nav > li > a:is(:hover,:focus) {
   text-decoration: none;
-  background-color: var(--crm-c-layout1-bg);
+  background-color: var(--crm-c-layer1-bg);
 }
 .crm-container .nav > li.disabled > a {
   color: var(--crm-c-inactive);
@@ -29,7 +29,7 @@
   background-color: transparent;
 }
 .crm-container .nav .open > :is(a,a:hover,a:focus) {
-  background-color: var(--crm-c-layout1-bg);
+  background-color: var(--crm-c-layer1-bg);
   border-color: var(--crm-c-link);
 }
 .crm-container .nav .nav-divider {

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -215,7 +215,7 @@
   cursor: auto;
 }
 .af-gui-entity-palette-select-list [ui-sortable] > div:not(.disabled):hover {
-  background-color: var(--crm-c-layout2-bg);
+  background-color: var(--crm-c-layer2-bg);
 }
 
 /* Edit canvas (right side) */
@@ -371,7 +371,7 @@ af-gui-container > .af-gui-bar,
   border-style: dotted;
   color: var(--crm-c-text);
   padding: var(--crm-padding-reg);
-  background-color: var(--crm-c-layout1-bg);
+  background-color: var(--crm-c-layer1-bg);
 }
 
 /* Markup area */
@@ -393,7 +393,7 @@ af-gui-container > .af-gui-bar,
 }
 #afGuiEditor .af-gui-content-editing-area .af-gui-edit-options-bar {
   width: 100%;
-  background-color: var(--crm-c-layout2-bg);
+  background-color: var(--crm-c-layer2-bg);
   display: flex;
   align-items: center;
   padding: var(--crm-m);
@@ -419,7 +419,7 @@ af-gui-container > .af-gui-bar,
   color: var(--crm-c-link);
 }
 #bootstrap-theme #afGuiEditor .af-gui-button > .btn.disabled .crm-editable-enabled:hover:not(:focus) {
-  border-color: var(--crm-c-layout1-bg) !important;
+  border-color: var(--crm-c-layer1-bg) !important;
 }
 #bootstrap-theme #afGuiEditor .af-gui-button > .btn-default.disabled {
   background-color: var(--crm-c-layer1-bg) !important;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -243,7 +243,7 @@
   display: block;
 }
 .crm-search crm-search-admin-link-group {
-  background: var(--crm-c-layout1-bg);
+  background: var(--crm-c-layer1-bg);
 }
 .crm-search crm-search-admin-link-group table {
   margin: var(--crm-padding-reg);


### PR DESCRIPTION
Overview
----------------------------------------
#33802 in mid-October introduced `--crm-layer-1-bg` and `--crm-layer-2-bg` - but during two of the rounds of find/replace I changed a few to `--crm-layout1-bg` and `--crm-layout2-bg` {facepalm}.

This corrects the problem for the version 6.9 release.

Before
----------------------------------------
No hover colour in Form Builder elements list:

<img width="305" height="88" alt="image" src="https://github.com/user-attachments/assets/fcc2ec51-2860-41d9-b0dd-667e1d693605" />

After
----------------------------------------
Hover colour in Form Builder elements list:

<img width="315" height="74" alt="image" src="https://github.com/user-attachments/assets/0ea14efc-3c83-4d29-97b0-10a3b0f2adf8" />

Technical Details
----------------------------------------
In version 6.10 these names get changed again in #34067 - so this PR shouldn't be carried forward to master as it's covered by that PR.