### PR TITLE
RiverLea: Front-end, remove narrow Minetta/Walbrook width, make things inline/more consistent, less opinionated

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -390,7 +390,7 @@
   --crm-notify-bg-color: rgba(0,0,0,0.85);
   --crm-notify-padding: var(--crm-l-medium-2);
   --crm-notify-color: var(--crm-text-light-color);
-  --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
+  --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides, 0 for none */
   --crm-notify-radius: var(--crm-l-radius);
   --crm-notify-danger-color: hsl(from var(--crm-danger-color) h s calc(l + 20));
   --crm-notify-warning-color: hsl(from var(--crm-warning-color) h s calc(l + 20));
@@ -457,11 +457,13 @@
   --crm-f-input-font-size: var(--crm-l-reg-1);
   --crm-f-input-width: 300px;
   --crm-f-form-focus-bg-color: unset;
-  --crm-f-form-focus-border-color: var(--crm-success-light-color);
   --crm-f-form-focus-outline-color: var(--crm-success-light-color);
+  --crm-f-form-focus-border-color: var(--crm-f-form-focus-outline-color);
+  --crm-f-form-focus-border-width: 0 5px 0 0; /* adds a border to one/several sides, 0 for none */
   --crm-f-form-error-bg-color: unset;
-  --crm-f-form-error-border-color: var(--crm-danger-light-color);
   --crm-f-form-error-outline-color: var(--crm-danger-light-color);
+  --crm-f-form-error-border-color: var(--crm-f-form-error-outline-color);
+  --crm-f-form-error-border-width: 0 5px 0 0;
   --crm-f-logo-height: 40px;
   --crm-f-logo-align: center; /* left, right or center */
 }

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -430,7 +430,7 @@
   --crm-filter-item-shadow: 0px 0px 3px rgba(0,0,0,0.1);
   --crm-filter-spacing: space-between; /* choose 'space-between' to spread out evenly, 'start' for left align, or 'end' for right. */
 /* Frontend */
-  --crm-f-form-width: 800px;
+  --crm-f-form-width: unset;
   --crm-f-box-shadow: var(--crm-shadow-block);
   --crm-f-fieldset-bg-color: var(--crm-page-bg-color);
   --crm-f-fieldset-padding: var(--crm-l-reg) 0;
@@ -439,23 +439,29 @@
   --crm-f-fieldset-box-shadow: var(--crm-f-box-shadow);
   --crm-f-legend-position: left; /* chose 'left', 'right' or 'inherit' for browser-default of mid fieldset border */
   --crm-f-legend-align: left;
-  --crm-f-legend-size: var(--crm-l-reg-3);
-  --crm-f-legend-padding: 0;
-  --crm-f-form-padding: var(--crm-padding-reg);
-  --crm-f-form-layout: block; /* 'grid' = inline, 'block' = stacked */
+  --crm-f-legend-size: var(--crm-l-reg-2);
+  --crm-f-legend-padding: 0 0 var(--crm-l-small) 0;
+  --crm-f-legend-margin: var(--crm-f-legend-padding);
+  --crm-f-legend-border: 0;
+  --crm-f-form-padding: var(--crm-l-medium);
+  --crm-f-form-layout: grid; /* 'grid' = inline, 'block' = stacked */
   --crm-f-label-position: left; /* 'unset' = stacked, 'left' = left align, in combination with width/margin below */
   --crm-f-label-align: right;
   --crm-f-label-width: 200px;
   --crm-f-label-gap: var(--crm-l-medium); /* applies for inline label + input */
-  --crm-f-label-margin: var(--crm-l-small);
+  --crm-f-label-margin: 0;
   --crm-f-label-weight: bold;
   --crm-f-label-color: inherit;
   --crm-f-input-radius: var(--crm-l-radius);
   --crm-f-input-padding: var(--crm-l-reg-2) var(--crm-l-medium-2);
   --crm-f-input-font-size: var(--crm-l-reg-1);
   --crm-f-input-width: 300px;
-  --crm-f-form-focus-bg-color: var(--crm-c-green-light);
-  --crm-f-form-error-bg-color: var(--crm-c-gray-200);
+  --crm-f-form-focus-bg-color: unset;
+  --crm-f-form-focus-border-color: var(--crm-success-light-color);
+  --crm-f-form-focus-outline-color: var(--crm-success-light-color);
+  --crm-f-form-error-bg-color: unset;
+  --crm-f-form-error-border-color: var(--crm-danger-light-color);
+  --crm-f-form-error-outline-color: var(--crm-danger-light-color);
   --crm-f-logo-height: 40px;
   --crm-f-logo-align: center; /* left, right or center */
 }

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -14,8 +14,8 @@
 .crm-container.crm-public .crm-container.crm-public .af-container:not(.af-container-style-pane),
 .crm-container.crm-public :is(.additional_participants-section,.event_fee_s_-section,.email-5-section,#crm-profile-block,.crm-event-info-form-block) {
   background-color: var(--crm-f-fieldset-bg-color);
-  margin: var(--crm-f-fieldset-margin) !important;
-  padding: var(--crm-f-fieldset-padding) !important;
+  margin: var(--crm-f-fieldset-margin);
+  padding: var(--crm-f-fieldset-padding);
   border: var(--crm-f-fieldset-border);
   box-shadow: var(--crm-f-fieldset-box-shadow);
 }
@@ -104,7 +104,8 @@ af-form > fieldset > legend {
 .crm-container.crm-public .crm-section:has( > .content input:focus),
 .crm-container.crm-public .crm-section:has( > .content select:focus),
 .crm-container.crm-public .crm-section:has( > .content textarea:focus) {
-  border-right: 5px solid var(--crm-f-form-focus-border-color);
+  border: 0 solid var(--crm-f-form-focus-border-color);
+  border-width: var(--crm-f-form-focus-border-width);
   background: var(--crm-f-form-focus-bg-color);
 }
 .crm-container.crm-public .crm-section:has( > .content input.error),
@@ -114,20 +115,23 @@ af-form > fieldset > legend {
 .crm-container.crm-public .crm-section:has( > .content textarea.crm-inline-error),
 .crm-container.crm-public .crm-section:has( > .content select.crm-inline-error),
 .crm-container.crm-public .crm-section:has( > .content .crm-error) {
-  border-right: 5px solid var(--crm-f-form-error-border-color);
+  border: 0 solid var(--crm-f-form-error-border-color);
+  border-width: var(--crm-f-form-error-border-width);
   background: var(--crm-f-form-error-bg-color);
 }
 .crm-container.crm-public .crm-section :is(input,textarea,select):is(.error,.crm-inline-error,.crm-error) {
-  outline: 3px solid var(--crm-f-form-error-outline-color) !important;
+  outline: 3px solid var(--crm-f-form-error-outline-color);
+  border-color: inherit;
 }
 .crm-container.crm-public :is(input,select,textarea):focus {
-  outline: 3px solid var(--crm-f-form-focus-outline-color) !important;
+  outline: 3px solid var(--crm-f-form-focus-outline-color);
+  border-color: inherit;
 }
 .crm-container.crm-public input.alert-danger {
   background: transparent; /* reset to make pattern consistent */
 }
 .crm-container.crm-public label.alert-danger.crm-inline-error {
-  color: var(--crm-danger-color);
+  color: var(--crm-danger-ink-color);
   background: transparent;
   padding-left: var(--crm-flex-gap);
   font-weight: normal;
@@ -221,7 +225,7 @@ af-form > fieldset > legend {
 }
 /* Social share footer */
 .crm-container .crm-socialnetwork :is(h2,p.clear) {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 /* Empowered by logo */

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -10,24 +10,23 @@
   margin-inline: auto;
   width: clamp(calc(var(--crm-f-form-width) / 2),100%,var(--crm-f-form-width));
 }
-.crm-container.crm-public fieldset:not(.collapsed,
-.crm-inactive-dashlet-fieldset,
-.af-container-style-pane),
-.crm-container.crm-public .crm-event-info-form-block,
-.crm-container.crm-public #crm-profile-block,
+.crm-container.crm-public fieldset:not(.collapsed,.crm-inactive-dashlet-fieldset,.af-container-style-pane),
 .crm-container.crm-public .crm-container.crm-public .af-container:not(.af-container-style-pane),
-.crm-container.crm-public .email-5-section {
+.crm-container.crm-public :is(.additional_participants-section,.event_fee_s_-section,.email-5-section,#crm-profile-block,.crm-event-info-form-block) {
   background-color: var(--crm-f-fieldset-bg-color);
-  margin: var(--crm-f-fieldset-margin);
-  padding: var(--crm-f-fieldset-padding);
+  margin: var(--crm-f-fieldset-margin) !important;
+  padding: var(--crm-f-fieldset-padding) !important;
   border: var(--crm-f-fieldset-border);
   box-shadow: var(--crm-f-fieldset-box-shadow);
 }
 .crm-container.crm-public fieldset legend {
   padding: var(--crm-f-legend-padding);
+  margin: var(--crm-f-legend-margin);
+  border-bottom: var(--crm-f-legend-border);
   font-size: var(--crm-f-legend-size);
   text-align: var(--crm-f-legend-align);
-  float: var(--crm-f-legend-position);
+  float: var(--crm-f-legend-position) !important; /* vs Bootstrap */
+  width: 100%;
 }
 .crm-container.crm-public fieldset legend + * {
   clear: both;
@@ -41,14 +40,16 @@ af-form > fieldset > legend {
 }
 .crm-container.crm-public .header-dark {
   background: var(--crm-secondary-color);
-  color: var(--crm-text-light-color);
-  padding: var(--crm-l-medium-1) var(--crm-f-fieldset-padding);
+  color: var(--crm-secondary-text-color);
+  padding: var(--crm-l-small-1) var(--crm-l-medium-2);
   font-weight: bold;
   font-size: var(--crm-l-reg-1);
   border-radius: var(--crm-l-radius);
+  margin-bottom: var(--crm-l-medium);
 }
 .crm-container.crm-public .crm-section:not(.alert) {
   padding: 0;
+  margin: 0; /* Drupal/Claro reset */
 }
 .crm-container.crm-public fieldset > fieldset,
 .crm-container.crm-public fieldset:has(> fieldset) {
@@ -67,6 +68,16 @@ af-form > fieldset > legend {
 }
 .crm-container.crm-public table.form-layout-compressed {
   display: table;
+  margin: 0;
+  min-width: var(--crm-input-label-width);
+}
+.crm-container.crm-public #editrow-tag table,
+.crm-container.crm-public #editrow-tag table tr {
+  border: 0;
+  box-shadow: none;
+}
+.crm-container.crm-public #editrow-tag table td {
+  padding: 0;
 }
 .crm-container.crm-public span#msgbox {
   border-radius: var(--crm-l-radius);
@@ -76,26 +87,50 @@ af-form > fieldset > legend {
   display: none;
 }
 /* Input */
-.crm-container.crm-public .crm-section:has( > .label):not(.crm-public-form-item) {
-  margin: 0 calc(-1 * var(--crm-f-form-padding));
-}
 .crm-container.crm-public .crm-section:has( > .label) {
   display: var(--crm-f-form-layout);
   grid-template-columns: var(--crm-f-label-width) 1fr 0;
-  padding: var(--crm-f-form-padding);
+  padding-block: var(--crm-f-form-padding);
+  align-items: center;
+  gap: var(--crm-f-label-gap);
+}
+#priceset .crm-section,
+.crm-container.crm-public .crm-section:has(.crm-option-label-pair) {
+  align-items: start;
+}
+.crm-container.crm-public .crm-section .content {
+  margin-left: 0;
 }
 .crm-container.crm-public .crm-section:has( > .content input:focus),
 .crm-container.crm-public .crm-section:has( > .content select:focus),
 .crm-container.crm-public .crm-section:has( > .content textarea:focus) {
-  background-color: var(--crm-f-form-focus-bg-color);
+  border-right: 5px solid var(--crm-f-form-focus-border-color);
+  background: var(--crm-f-form-focus-bg-color);
 }
 .crm-container.crm-public .crm-section:has( > .content input.error),
 .crm-container.crm-public .crm-section:has( > .content textarea.error),
 .crm-container.crm-public .crm-section:has( > .content select.error),
 .crm-container.crm-public .crm-section:has( > .content input.crm-inline-error),
 .crm-container.crm-public .crm-section:has( > .content textarea.crm-inline-error),
-.crm-container.crm-public .crm-section:has( > .content select.crm-inline-error) {
-  background-color: var(--crm-f-form-error-bg-color);
+.crm-container.crm-public .crm-section:has( > .content select.crm-inline-error),
+.crm-container.crm-public .crm-section:has( > .content .crm-error) {
+  border-right: 5px solid var(--crm-f-form-error-border-color);
+  background: var(--crm-f-form-error-bg-color);
+}
+.crm-container.crm-public .crm-section :is(input,textarea,select):is(.error,.crm-inline-error,.crm-error) {
+  outline: 3px solid var(--crm-f-form-error-outline-color) !important;
+}
+.crm-container.crm-public :is(input,select,textarea):focus {
+  outline: 3px solid var(--crm-f-form-focus-outline-color) !important;
+}
+.crm-container.crm-public input.alert-danger {
+  background: transparent; /* reset to make pattern consistent */
+}
+.crm-container.crm-public label.alert-danger.crm-inline-error {
+  color: var(--crm-danger-color);
+  background: transparent;
+  padding-left: var(--crm-flex-gap);
+  font-weight: normal;
 }
 .crm-container.crm-public input[type="text"],
 .crm-container.crm-public input[type="password"],
@@ -107,7 +142,7 @@ af-form > fieldset > legend {
   border-radius: var(--crm-f-input-radius);
   padding: var(--crm-f-input-padding);
   font-size: var(--crm-f-input-font-size);
-  min-width: var(--crm-f-input-width);
+  --crm-input-width: var(--crm-f-input-width);
 }
 .crm-container.crm-public select.crm-form-select {
   min-width: auto;
@@ -184,6 +219,11 @@ af-form > fieldset > legend {
   padding-inline: var(--crm-f-form-padding);
   font-size: var(--crm-l-reg-1);
 }
+/* Social share footer */
+.crm-container .crm-socialnetwork :is(h2,p.clear) {
+    margin-top: 0;
+}
+
 /* Empowered by logo */
 
 .crm-public-footer {
@@ -210,17 +250,14 @@ af-form > fieldset > legend {
   margin-right: var(--crm-f-label-gap);
   color: var(--crm-f-label-color);
 }
+.crm-container.crm-public .label > label {
+  margin: 0;
+}
 @media (min-width: 480px) {
-  .crm-container.crm-public {
-    --crm-page-padding: var(--crm-f-form-padding);
-  }
   .crm-container.crm-public .crm-section .label {
     float: var(--crm-f-label-position);
     width: var(--crm-f-label-width);
     text-align: var(--crm-f-label-align);
-  }
-  .crm-container.crm-public .crm-section .content {
-    margin-left: calc(var(--crm-f-label-width) + var(--crm-f-label-gap));
   }
 }
 @media (max-width: 479px) {

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -76,4 +76,8 @@
 /* Alpha filter '--crm-filter-' */
   --crm-filter-item-bg-color: var(--crm-layer1-bg-color);
 /* Frontend '--crm-f- */
+  --crm-f-form-focus-bg-color: var(--crm-success-color);
+  --crm-f-form-focus-border-color: var(--crm-alert-success-border-color);
+  --crm-f-form-error-bg-color: var(--crm-danger-color);
+  --crm-f-form-error-border-color: var(--crm-alert-danger-border-color);
 }

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -62,7 +62,6 @@
   --crm-input-border-color: var(--crm-c-gray-300);
   --crm-input-box-shadow: 0;
   --crm-input-label-weight: normal;
-  --crm-input-label-width: 10em;
   --crm-form-fieldset-border: 1px;
   /* Tabs */
   --crm-tabs-border: var(--crm-border);
@@ -132,6 +131,7 @@
   --crm-icon-warning-color: var(--crm-warning-color);
   --crm-icon-info-color: var(--crm-notify-info-color);
   /* Frontend */
+  --crm-f-form-width: 800px;
   --crm-f-legend-align: unset;
   --crm-f-legend-size: var(--crm-l-reg-2);
   --crm-f-form-width: 50vw;
@@ -140,4 +140,10 @@
   --crm-f-label-margin: 0 var(--crm-l-small);
   --crm-f-label-width: unset;
   --crm-f-label-weight: bold;
+  --crm-f-form-focus-bg-color: var(--crm-success-light-color);
+  --crm-f-form-focus-border-color: var(--crm-success-color);
+  --crm-f-form-focus-outline-color: unset;
+  --crm-f-form-error-bg-color: var(--crm-danger-light-color);
+  --crm-f-form-error-border-color: var(--crm-danger-color);
+  --crm-f-form-error-outline-color: unset;
 }

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -14,7 +14,6 @@
   --crm-link-color: var(--crm-c-teal);
   --crm-link-hover-color: var(--crm-c-yellow);
 /* Backgrounds, '--crm-c-*-bg' */
-  --crm-page-bg-color: var(--crm-paper);
   --crm-container-bg-color: var(--crm-c-gray-800);
   --crm-inverse-bg-color: var(--crm-c-gray-300);
 /* Emphasis colours, e.g. warning, danger, info '--crm-c-' */

--- a/ext/riverlea/streams/minetta/_main.css
+++ b/ext/riverlea/streams/minetta/_main.css
@@ -10,6 +10,9 @@
   --crm-alert-warning-bg-color: var(--crm-c-yellow-light);
 /* Tabs */
   --crm-tab-hover-bg-color: var(--crm-container-bg-color);
+/* Front */
+  --crm-f-legend-border: var(--crm-border);
+  --crm-f-logo-align: right;
 }
 
 /* Custom CSS */

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -244,8 +244,12 @@
   --crm-f-label-align: left;
   --crm-f-label-width: unset;
   --crm-f-input-width: 100%;
-  --crm-f-form-focus-bg-color: var(--crm-c-green);
-  --crm-f-form-error-bg-color: var(--crm-c-red);
+  --crm-f-form-focus-border-color: unset;
+  --crm-f-form-focus-bg-color: unset;
+  --crm-f-form-focus-outline-color: var(--crm-c-green);
+  --crm-f-form-error-border-color: unset;
+  --crm-f-form-error-bg-color: unset;
+  --crm-f-form-error-outline-color: var(--crm-c-red);
 }
 
 /* Only affect body colour in standalone */

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -209,10 +209,10 @@
   --crm-wizard-border: 1px solid var(--crm-page-bg-color);
 /* Frontend */
   --crm-f-fieldset-padding: var(--crm-padding-reg);
-  --crm-f-legend-align: unset;
+  --crm-f-fieldset-bg-color: var(--crm-container-bg-color);
   --crm-f-legend-size: var(--crm-l-reg-2);
   --crm-f-label-position: unset; /* 'unset' = stacked, 'left' = left align, in combination with width below */
   --crm-f-label-align: left;
-  --crm-f-label-margin: var(--crm-l-small);
+  --crm-f-label-margin: 0;
   --crm-f-label-width: unset;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Since RiverLea launched we've been recommending people not use it for front-end because it's had very little testing, very little community feedback or input. I'd made some quick designs borrowing patterns for form-engines like Google of a narrow, central page with glowing bg for selected inputs (green when active, red when an error). But this is pretty opinionated and for anyone jumping from Greenwich it's a big jump.

This PR does multiple small things with front-end RiverLea, but the general gist is: making Minetta and Walbrook less opinionated (closer to Greenwich/Island) and make all of it a bit better aligned and more tidy. In more depth:

- remove 800px page-width from core CSS variables
- add 800px page-width to Hackney
- Remove page-padding hard reset from front.css
- Reset label margin to 0 in core css variables 
- Reset margin on tables, add a min-width to avoid squash on pricing…
- Changing ‘form-padding' to padding-block, and reduce from 1rem to 0.5rem
- Change Minetta label/input to Grid from Block
- Change input width to allow for inheritance of set input widths (e.g. narrower date picker, wider `.huge`)
- Add styling for Legends (border for Minetta), new variables - `--crm-f-legend-margin` and `--crm-f-legend-border`
- Header dark padding - and text color clash
- Added fields styling for event and contribution price lists to keep a tidy alignment
- Styles error+active input focus with new variables: `--crm-f-form-focus-bg-color, --crm-f-form-focus-border-color, 
  --crm-f-form-focus-outline-color, --crm-f-form-error-bg-color, --crm-f-form-error-border-color,  --crm-f-form-error-outline-color` (this came in both commits, commit 2 added variables for border-width).
- Commit 2: adds new page background colour variable (`--crm-f-page-bg-color`) with dark-mode handling and matches it to current colours (so a custom front-end colour could be set).

| Stream/Area                                                | Before | After |
| --------------------------------------------------- | ---------- | ------- |
|  Minetta / events reg         |   <img width="1613" height="780" alt="image" src="https://github.com/user-attachments/assets/fc995f4a-efc3-4c89-9fbc-9b29cbaec974" />  |  <img width="1636" height="808" alt="image" src="https://github.com/user-attachments/assets/12a0cc36-a10b-4266-aff0-9d31727c1903" />  |
| Minetta / events details    |.<img width="765" height="465" alt="image" src="https://github.com/user-attachments/assets/9dbd7ff6-a585-4254-a479-1a190589db9f" />  |  <img width="724" height="405" alt="image" src="https://github.com/user-attachments/assets/42e7d71d-4668-464f-97bd-e11031b2553c" /> |
|  Minetta / profiles              |  <img width="1608" height="746" alt="image" src="https://github.com/user-attachments/assets/d0b97a3c-70e5-441b-959f-5d7549a84a66" /> |  <img width="1625" height="792" alt="image" src="https://github.com/user-attachments/assets/b1ac1622-fe66-4cb0-937f-18afcab4fc8a" />  |
|  Minetta / contrib page      |  <img width="1563" height="784" alt="image" src="https://github.com/user-attachments/assets/a649bf04-f506-4bb9-b8b3-a3ba91e8c552" /> |  <img width="1607" height="670" alt="image" src="https://github.com/user-attachments/assets/dfbec1d9-a812-4fc9-8da4-80831cd7cf72" />  |
| Minetta / contrib confirm |  <img width="1637" height="729" alt="image" src="https://github.com/user-attachments/assets/61cefa48-0085-4530-b8ce-71f42c51c92e" /> | <img width="1613" height="679" alt="image" src="https://github.com/user-attachments/assets/0bab83aa-5866-4c22-ba6f-8c4b1c63c706" /> |
|  Minetta / form builder    |  <img width="1607" height="701" alt="image" src="https://github.com/user-attachments/assets/298f3e2b-c103-487f-be8b-7109f27f91b5" />  |  <img width="1616" height="624" alt="image" src="https://github.com/user-attachments/assets/2d7b30be-fe68-4482-84e8-37193fa5ce7d" />  |
|  Walbrook / events reg         |  <img width="1543" height="795" alt="image" src="https://github.com/user-attachments/assets/425f973a-4092-4ddb-9185-6ffef189aa89" />  |  <img width="1635" height="822" alt="image" src="https://github.com/user-attachments/assets/ee37b55a-a7d3-4c57-bbf4-4f80d1bb3e4f" />  |
|  Walbrook / profiles              |            | <img width="1644" height="602" alt="image" src="https://github.com/user-attachments/assets/8803f552-271c-4b63-afc0-d814ce3afa3a" />  |
|  Walbrook / contrib page      | <img width="1642" height="740" alt="image" src="https://github.com/user-attachments/assets/f7643814-d05f-4778-a996-6d889e0454e1" /> | <img width="1624" height="787" alt="image" src="https://github.com/user-attachments/assets/6ee927ae-c35d-4ac4-a124-9a7b74e2297c" />  |
|  Walbrook / form builder      |  <img width="1616" height="582" alt="image" src="https://github.com/user-attachments/assets/5e9778e5-3aa7-411d-9c70-a5a1c348c0d3" />  | <img width="1631" height="816" alt="image" src="https://github.com/user-attachments/assets/e31205c3-8985-46c7-ba30-0c2cff6c0eb4" /> |
|  Walbrook / social share      |  <img width="785" height="290" alt="image" src="https://github.com/user-attachments/assets/c258150e-e54a-4dc9-b198-b65ae6ae1ee5" />  | <img width="763" height="259" alt="image" src="https://github.com/user-attachments/assets/d97e7a22-d7c8-4b5d-8ef0-6e214df857d9" /> |
|  Hackney / events reg         |  <img width="1636" height="797" alt="image" src="https://github.com/user-attachments/assets/8dc245a8-ebcf-472f-9034-4b820e3abb56" />  | <img width="1630" height="820" alt="image" src="https://github.com/user-attachments/assets/58f7762a-7076-469e-8db7-623281a3eb60" /> |
|  Hackney / contrib confirm   |  <img width="1621" height="695" alt="image" src="https://github.com/user-attachments/assets/5cdcca87-d6ea-4c05-a4b1-9a1e97e0c47a" />  |  <img width="1593" height="670" alt="image" src="https://github.com/user-attachments/assets/818cccf9-2ed8-4cfd-a059-7e3b63d1c2a0" />  |
|  Thames / event page      |  <img width="1177" height="825" alt="image" src="https://github.com/user-attachments/assets/28b5bd2b-31f6-4b7b-96d3-503b2b9bc8c9" />  |  <img width="1314" height="827" alt="image" src="https://github.com/user-attachments/assets/f4c4bf46-394d-4df5-b3b5-9a1969bd08c7" />  |
| Thames / contrib confirm |  <img width="1145" height="758" alt="image" src="https://github.com/user-attachments/assets/32877310-d7c8-4b9e-929b-126f0b129559" />  |  <img width="1078" height="766" alt="image" src="https://github.com/user-attachments/assets/0982ab73-4208-4faf-99fe-841e331aa759" /> |
|  Thames / form builder      |  <img width="1150" height="652" alt="image" src="https://github.com/user-attachments/assets/8a18ec50-2d46-4970-b0a5-ae8c80a7ac42" /> |  <img width="1300" height="674" alt="image" src="https://github.com/user-attachments/assets/dee51411-621f-4881-ab70-0d8061f626c6" />  |

Technical Details
----------------------------------------
Keeping this PR as a draft as it's built on top of https://github.com/civicrm/civicrm-core/pull/34067 (so most of the changes in this PR are that other PR) - will take out of draft when that's merged…

Comments
----------------------------------------
There's so many things to test with front-end it's hard to do this safely without either a team of people or lots of time. That's why we've been saying don't use River Lea on the front-end. If people _have_ made things on top of RiverLea front-end then this PR could break them. BUT, I think it's a better starting point to build from, and obvs if that breaking needs to happen, then the sooner the better.