### PR TITLE
Contribution Page: allow access in test-mode to administrators

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -396,7 +396,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
 
       CRM_Contribute_BAO_ContributionPage::setValues($this->_id, $this->_values);
       if (empty($this->_values['is_active'])) {
-        throw new CRM_Contribute_Exception_InactiveContributionPageException(ts('The page you requested is currently unavailable.'), $this->_id);
+        if ($this->isTest() && CRM_Core_Permission::check('administer CiviCRM')) {
+          CRM_Core_Session::setStatus(ts('This page is disabled. It is accessible in test mode to administrators only.'), '', 'alert', ['expires' => 0]);
+        }
+        else {
+          throw new CRM_Contribute_Exception_InactiveContributionPageException(ts('The page you requested is currently unavailable.'), $this->_id);
+        }
       }
 
       $endDate = CRM_Utils_Date::processDate($this->_values['end_date'] ?? NULL);


### PR DESCRIPTION
Overview
----------------------------------------

Allow administrators to access an inactive Contribution Page in test-mode.

- Why? So that we can fiddle with a new Contribution Page without making it accessible to the general public.
- Why only in test-mode? This hasn't been exhaustively tested, and for now I don't see any good reason to do so. It would also change the definition of what is an "active" page, and I wouldn't want people starting to give the "administer CiviCRM" permission to a role just because they want private contribution pages.

Before
----------------------------------------

Accessing a non-active Contribution Page generates a fatal error "The page you requested is currently unavailable.".

After
----------------------------------------

Administrators can access the page even if disabled.

<img width="2118" height="1104" alt="image" src="https://github.com/user-attachments/assets/17fd928e-0ee5-4207-8642-5bbb3ed28a28" />


Comments
---------------------

If there is agreement, I would do the same for Events.