### PR TITLE
Do not merge - api possible bug demo only

### DIFF
--- a/ext/civigrant/Civi/Api4/Action/Phone/Call.php
+++ b/ext/civigrant/Civi/Api4/Action/Phone/Call.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Civi\Api4\Action\Phone;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+class Call extends AbstractAction {
+
+  /**
+   * Number.
+   *
+   * @var int
+   */
+  protected $number;
+
+  public function _run(Result $result) {
+    $result[] = ['called' => TRUE];
+  }
+
+}

--- a/ext/civigrant/Civi/Api4/Action/Queue/Call.php
+++ b/ext/civigrant/Civi/Api4/Action/Queue/Call.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Civi\Api4\Action\Queue;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+
+/**
+ * @method string getStartTimestamp()
+ * @method $this setStartDateTime(string $startDateTime)
+ */
+class Call extends AbstractAction {
+
+  /**
+   * Start Date Time in strtotime format.
+   *
+   * @var string
+   */
+  protected string $startDateTime = '';
+
+  /**
+   * Number.
+   *
+   * @var int
+   */
+  protected $number;
+
+  public function _run(Result $result) {
+    $result[] = ['called' => TRUE];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
I'm finding that when I add an api action to an existing entity (actually it was `Queue` ) the fields I declare don't show up in explorer - just trying to test that here & ask for help if it doesn't work

Before
----------------------------------------

After
----------------------------------------
So there is something a bit funky here that I can't quite figure out

If I do `Queue.call` I get my new field
<img width="1057" height="396" alt="image" src="https://github.com/user-attachments/assets/8da3cefe-14de-41ae-ba55-fe8865adb313" />

But the new field is not returned here in `getFields()`

https://core-34139-40lnusa.civi.bid/civicrm/api4#/explorer/Queue/getFields?action=call&select=%5B%22name%22%5D

```


CRM.api4('Queue', 'getFields', {
  action: "call",
  select: ["name"]
}).then(function(fields) {
  // do something with fields array
}, function(failure) {
  // handle failure
});


```

<img width="546" height="596" alt="image" src="https://github.com/user-attachments/assets/e4e97392-b8d6-4b97-8fb5-4fbee25983a4" />



Technical Details
----------------------------------------

Comments
----------------------------------------
