### PR TITLE
Fix [PHP Warning] Undefined array key "router" "navigation"

### DIFF
--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -87,9 +87,9 @@ class Rebuilder {
 
     if (isset($targets['menu'])) {
       \CRM_Core_Error::deprecatedWarning("In Civi::rebuild(), the 'menu' option is deprecated. For CiviCRM 6.9+, please specify combination of 'router', 'navigation', and/or 'system'.");
-      $targets['router'] = $targets['router'] || $targets['menu'];
-      $targets['navigation'] = $targets['navigation'] || $targets['menu'];
-      $targets['system'] = $targets['system'] || $targets['menu'];
+      $targets['router'] = !empty($targets['router']) || $targets['menu'];
+      $targets['navigation'] = !empty($targets['navigation']) || $targets['menu'];
+      $targets['system'] = !empty($targets['system']) || $targets['menu'];
       unset($targets['menu']);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------

In f204660c7c842cab42d7fc60ea21d94ca15cf33c we replace menu with various other options. However calling with 'menu' currently assumes that 'router' 'navigation' and 'system' are set. By wrapping in !empty() we get their true/false value if set and false if not.

Before
----------------------------------------


```
cv php:eval "CRM_Core_Invoke::rebuildMenuAndCaches();"
[PHP User Deprecation] In Civi::rebuild(), the 'menu' option is deprecated. For CiviCRM 6.9+, please specify combination of 'router', 'navigation', and/or 'system'. Caller: CRM_Core_Invoke::rebuildMenuAndCaches at vendor/civicrm/civicrm-core/CRM/Core/Error.php:1161
[PHP Warning] Undefined array key "router" at vendor/civicrm/civicrm-core/Civi/Core/Rebuilder.php:90
[PHP Warning] Undefined array key "navigation" at vendor/civicrm/civicrm-core/Civi/Core/Rebuilder.php:91

```

After
----------------------------------------
```
cv php:eval "CRM_Core_Invoke::rebuildMenuAndCaches();"
[PHP User Deprecation] In Civi::rebuild(), the 'menu' option is deprecated. For CiviCRM 6.9+, please specify combination of 'router', 'navigation', and/or 'system'. Caller: CRM_Core_Invoke::rebuildMenuAndCaches at vendor/civicrm/civicrm-core/CRM/Core/Error.php:1161
```

Deprecation addressed in https://github.com/civicrm/civicrm-core/pull/34146