### PR TITLE
dev/core#6211 Fix api handling of employer relationship

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -179,7 +179,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship implemen
     if (!empty($params['id'])) {
       $relationship->id = $params['id'];
       // Only load the relationship if we're missing required params
-      $requiredParams = ['contact_id_a', 'contact_id_b', 'relationship_type_id'];
+      $requiredParams = ['contact_id_a', 'contact_id_b', 'relationship_type_id', 'is_active'];
       foreach ($requiredParams as $requiredKey) {
         if (!isset($params[$requiredKey])) {
           $relationship->find(TRUE);

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -102,6 +102,11 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
       'relationship_type_id' => $employerRelationshipID,
       'is_current_employer' => 1,
     ]);
+    // Update relationship
+    $this->callAPISuccess('Relationship', 'create', [
+      'id' => $employerRelationship['id'],
+      'description' => 'Employer of',
+    ]);
 
     //Check if current employer is correctly set.
     $employer = $this->callAPISuccessGetValue('Contact', [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6211](https://lab.civicrm.org/dev/core/-/issues/6211), adds tests.

Technical Details
-------
Yes, the fix really is as dumb as ensuring a value for `is_active` is loaded.
This is because it's needed by `CRM_Contact_BAO_Relationship::isCurrentEmployerNeedingToBeCleared`, and without it the function wrongly assumes the relationship is being disabled & the employer should be cleared.