### PR TITLE
Refactor CRM_Core_OptionValue::getFields()

### DIFF
--- a/CRM/Core/OptionValue.php
+++ b/CRM/Core/OptionValue.php
@@ -265,14 +265,8 @@ class CRM_Core_OptionValue {
    */
   public static function getFields($mode = '', $contactType = 'Individual') {
     $key = "$mode $contactType";
-    if (empty(self::$_fields[$key]) || !self::$_fields[$key]) {
+    if (empty(self::$_fields[$key])) {
       self::$_fields[$key] = [];
-
-      $option = CRM_Core_DAO_OptionValue::import();
-
-      foreach (array_keys($option) as $id) {
-        $optionName = $option[$id];
-      }
 
       $nameTitle = [];
       if ($mode == 'contribute') {
@@ -291,40 +285,32 @@ class CRM_Core_OptionValue {
         ];
       }
       elseif ($mode == '') {
-        //the fields email greeting and postal greeting are meant only for Individual and Household
-        //the field addressee is meant for all contact types, CRM-4575
-        if (in_array($contactType, ['Individual', 'Household', 'Organization', 'All'])) {
-          $nameTitle = [
-            'addressee' => [
-              'name' => 'addressee',
-              'title' => ts('Addressee'),
-              'headerPattern' => '/^addressee$/i',
-            ],
-          ];
-          $title = [
-            'email_greeting' => [
-              'name' => 'email_greeting',
-              'title' => ts('Email Greeting'),
-              'headerPattern' => '/^email_greeting$/i',
-            ],
-            'postal_greeting' => [
-              'name' => 'postal_greeting',
-              'title' => ts('Postal Greeting'),
-              'headerPattern' => '/^postal_greeting$/i',
-            ],
-          ];
-          $nameTitle = array_merge($nameTitle, $title);
-        }
+        $nameTitle = [
+          'addressee' => [
+            'name' => 'addressee',
+            'title' => ts('Addressee'),
+            'headerPattern' => '/^addressee$/i',
+          ],
+          'email_greeting' => [
+            'name' => 'email_greeting',
+            'title' => ts('Email Greeting'),
+            'headerPattern' => '/^email_greeting$/i',
+          ],
+          'postal_greeting' => [
+            'name' => 'postal_greeting',
+            'title' => ts('Postal Greeting'),
+            'headerPattern' => '/^postal_greeting$/i',
+          ],
+        ];
       }
 
-      if (is_array($nameTitle)) {
-        foreach ($nameTitle as $name => $attribs) {
-          self::$_fields[$key][$name] = $optionName;
-          [$tableName, $fieldName] = explode('.', $optionName['where']);
-          self::$_fields[$key][$name]['where'] = "{$name}.label";
-          foreach ($attribs as $k => $val) {
-            self::$_fields[$key][$name][$k] = $val;
-          }
+      $optionName = CRM_Core_DAO_OptionValue::import()['name'];
+
+      foreach ($nameTitle as $name => $attribs) {
+        self::$_fields[$key][$name] = $optionName;
+        self::$_fields[$key][$name]['where'] = "{$name}.label";
+        foreach ($attribs as $k => $val) {
+          self::$_fields[$key][$name][$k] = $val;
         }
       }
     }


### PR DESCRIPTION
No change to behaviour. The intent here is to get rid of the weird foreach of CRM_Core_DAO_OptionValue::import() which only works if name is the only importable field (or at least the last one). But I also did some further refactoring to make this more readable.

This will allow #34126 to pass tests.