### PR TITLE
RiverLea: removes orphaned variable `--crm-page-width`

### DIFF
--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -85,7 +85,6 @@ body.page-civicrm .breadcrumb__link {
 }
 #block-claro-content {
   --crm-page-padding: 3rem;
-  --crm-page-width: calc(100% - var(--crm-page-padding) - var(--crm-page-padding));
 }
 #block-claro-content .crm-container:not(.crm-public) .form-item,
 #block-claro-content .crm-container .button {
@@ -200,7 +199,6 @@ body.wp-admin .crm-sticky thead {
 *******************/
 
 html.crm-standalone {
-  --crm-page-width: 94vw;
   --crm-page-padding: 1px 3vw 1rem;
 }
 html.crm-standalone body {

--- a/ext/riverlea/core/css/joomla.css
+++ b/ext/riverlea/core/css/joomla.css
@@ -8,7 +8,6 @@ body.com_civicrm {
 }
 body.admin.com_civicrm {
   --crm-page-padding: 3rem;
-  --crm-page-width: 100%;
 }
 body.admin.com_civicrm #subhead-container,
 body.admin.com_civicrm .subhead-collapse,


### PR DESCRIPTION
Overview
----------------------------------------
At some point before v0.5 (June 2024) the variable `--crm-page-width` was used to set the width [here](https://lab.civicrm.org/extensions/riverlea/-/blob/main/core/css/_base.css#L443). But that was dropped, so the references to it can go from the variables files and core css. But [it was gone by 0.5](https://lab.civicrm.org/search?search=--crm-page-width&nav_source=navbar&project_id=2629&group_id=58&search_code=true&repository_ref=0.5) (can't search earlier).
  
Before
----------------------------------------
The variable `--crm-page-width` is set to some values but never used.

After
----------------------------------------
`--crm-page-width` is gone.

Technical Details
----------------------------------------
Be great to get this into 6.10 to go with the already merged variable name cleanup…

Comments
----------------------------------------
Best way to review this is to double check '--crm-page-width' isn't used anywhere by [searching Github](https://github.com/search?q=repo%3Acivicrm%2Fcivicrm-core%20--crm-page-width&type=code).