### PR TITLE
Support membership_type_id pseudoconstant on PriceFieldValue

### DIFF
--- a/schema/Price/PriceFieldValue.entityType.php
+++ b/schema/Price/PriceFieldValue.entityType.php
@@ -154,6 +154,11 @@ return [
       'input_attrs' => [
         'label' => ts('Membership Type'),
       ],
+      'pseudoconstant' => [
+        'table' => 'civicrm_membership_type',
+        'key_column' => 'id',
+        'label_column' => 'name',
+      ],
       'entity_reference' => [
         'entity' => 'MembershipType',
         'key' => 'id',


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/issues/6222

Before
----------------------------------------
Can't use API4 pseudoconstants on PriceFieldValue.membership_type_id

After
----------------------------------------
Can use API4 pseudoconstants on PriceFieldValue.membership_type_id

Technical Details
----------------------------------------
Adds metadata

Comments
----------------------------------------
@rbaugh 
