### PR TITLE
riverlea - fix disappearing text in dark mode using .list-group-item

### DIFF
--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -2715,8 +2715,8 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   display: block;
   padding: 10px 15px;
   margin-bottom: -1px;
-  background-color: white;
-  border: 1px solid #ddd;
+  background-color: transparent;
+  border: 1px solid var(--crm-border-color);
 }
 #bootstrap-theme .list-group-item:first-child {
   border-top-left-radius: 4px;


### PR DESCRIPTION
Overview
----------------------------------------
If you use this class in dark mode  your text is white and your background is white.

I set the background to transparent to match how we implement `.panel` `.panel-body`, which is a similar case.

Seem OK @vingle ?
