### PR TITLE
Fully hide hidden fields on Afforms

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -13,10 +13,14 @@ a.af-api4-action-idle {
 .af-container.af-layout-cols > * {
   flex: 1;
 }
-.af-container.af-layout-inline > * {
+.af-container.af-layout-inline > * :not(.af-field-type-hidden) {
   display: inline-block;
   margin-right: .5em;
   vertical-align: top;
+}
+/* Hidden fields */
+.af-field-type-hidden {
+  display: none;
 }
 .af-container.af-layout-cols > .af-title {
   flex: 0 0 100%;

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -152,6 +152,9 @@ af-form > fieldset > legend {
   padding-block: var(--crm-f-form-padding);
   display: block;
 }
+.crm-container.crm-public .af-field-type-hidden {
+  display: none;
+}
 .crm-container.crm-public .af-container.af-layout-inline,
 .crm-container.crm-public .af-container.af-layout-cols {
   padding: var(--crm-f-form-padding);

--- a/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
+++ b/ext/riverlea/core/org.civicrm.afform-ang/afCore.css
@@ -129,6 +129,11 @@ fieldset.af-container.af-layout-inline {
   border: 0;
 }
 
+/* Hidden fields */
+.af-field-type-hidden {
+  display: none;
+}
+
 /* Radio buttons */
 .af-field-type-radio .crm-af-field {
   display: flex;


### PR DESCRIPTION
Overview
----------------------------------------
The container for an Afform hidden field still occupies space on the form. This PR fixes that by adding CSS to make hidden fields hidden.

Before
----------------------------------------
<img width="945" height="663" alt="image" src="https://github.com/user-attachments/assets/3d137062-e2c9-4ff6-95ba-ddd0eef15de4" />

After
----------------------------------------
<img width="945" height="663" alt="image" src="https://github.com/user-attachments/assets/b98bf84e-0330-4271-8736-274014e41ad1" />

Technical Details
----------------------------------------
Adds `display:none` to `af-field-type-hidden`

Comments
----------------------------------------
@vingle @vurt2 
