### PR TITLE
Afform Translations: Fixing search translated field definition

### DIFF
--- a/templates/Civi/I18n/afsearchTranslations.tpl
+++ b/templates/Civi/I18n/afsearchTranslations.tpl
@@ -1,5 +1,5 @@
 {* Template used by Civi/I18n/TranslationAfformProvider.php *}
 <div af-fieldset="">
-  {literal}<af-field name="source,TranslationSource_Translation_entity_id_01.string" defn="{required: false, input_attrs: {placeholder: '\ud83d\udd0d  {/literal}{ts}Search{/ts}{literal}'}, input_type: 'Text', label: false}" />{/literal}
+  {literal}<af-field name="source,TranslationSource_Translation_source_key_01.string" defn="{required: false, input_attrs: {placeholder: '\ud83d\udd0d  {/literal}{ts}Search{/ts}{literal}'}, input_type: 'Text', label: false}" />{/literal}
   <crm-search-display-table search-name="Translations_{$langCode}" display-name="Translations_Table_{$langCode}"></crm-search-display-table>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

See [dev/core#6191](https://lab.civicrm.org/dev/core/-/issues/6191)

Before
----------------------------------------
Unable to search for strings

After
----------------------------------------
Ability to search for strings

Technical Details
----------------------------------------
I think that the definitions must have changed and so the field was not correct. It was causing the entire search to not work. I changed it to match the proper field, tested, and now it is searching on the `source` and `translation`

cc @colemanw @totten 