### PR TITLE
attempt btn-xs cleanup

### DIFF
--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -586,16 +586,3 @@
 #bootstrap-theme .btn-group-xs button:has(i.crm-i) {
   padding: 0 var(--crm-l-small-2) 0 0;
 }
-#bootstrap-theme .btn-xs:has(i.crm-i),
-#bootstrap-theme .btn-group > .btn-xs + .dropdown-toggle:has(i.crm-i),
-#bootstrap-theme .btn-group-xs > .btn + .dropdown-toggle:has(i.crm-i),
-.crm-container button.dropdown-toggle.btn-xs:has(i.crm-i) {
-  padding: var(--crm-btn-icon-padding) var(--crm-l-medium) var(--crm-btn-icon-padding) 0
-}
-#bootstrap-theme .btn-xs i.crm-i,
-#bootstrap-theme .btn-group-xs > .btn i.crm-i {
-  width: auto;
-  padding: var(--crm-btn-small-padding);
-  min-width: 1rem;
-  height: 1.5rem;
-}


### PR DESCRIPTION
Overview
----------------------------------------
These rules seem to be upsetting the padding of `btn-xs`. In particular the left and right padding are offset.

Before
----------------------------------------

button padding is shrunk, but unevenly

<img width="278" height="182" alt="image" src="https://github.com/user-attachments/assets/dc260a67-0f75-4bd0-a23c-cdfac422a5e0" />

<img width="840" height="567" alt="image" src="https://github.com/user-attachments/assets/dae1b42c-b86d-468e-8cff-9c34e73fa6f3" />


After
----------------------------------------

button padding isnt touched. buttons are still smaller, they have a bit more padding, but its even

<img width="219" height="137" alt="image" src="https://github.com/user-attachments/assets/d145416b-6dc5-4a22-a428-f2e84f2a189b" />


<img width="454" height="169" alt="image" src="https://github.com/user-attachments/assets/df057c83-a5ef-4ce1-873c-7cfed0a2fc70" />




Comments
----------------------------------------
@vingle 
