### PR TITLE
RiverLea: fixes left padding size on small bootstrap buttons

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -112,7 +112,6 @@
   --crm-padding-small: var(--crm-l-small);
   --crm-padding-inset: var(--crm-l-medium);
   --crm-page-padding: var(--crm-l-large-1); /* Margin left/right */
-  --crm-page-width: 100%; /* Default that CMS can overwrite */
   --crm-flex-gap: var(--crm-l-medium);
 /* Type */
   --crm-font-system: unset;
@@ -137,7 +136,7 @@
   --crm-btn-radius: 3px;
   --crm-btn-padding-block: var(--crm-l-xsmall-1); /* padding for top and bottom, one value */
   --crm-btn-padding-inline: var(--crm-l-medium-1); /* padding for left and right, one value */
-  --crm-btn-small-padding: var(--crm-l-xsmall) var(--crm-l-small);
+  --crm-btn-small-padding: var(--crm-l-xsmall) var(--crm-l-medium);
   --crm-btn-large-padding: var(--crm-l-medium) var(--crm-l-reg);
   --crm-btn-align: center;
   --crm-btn-height: 28px;

--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -180,7 +180,7 @@
 }
 #bootstrap-theme .btn-xs,
 #bootstrap-theme .btn-group-xs > .btn {
-  padding: var(--crm-l-xsmall) var(--crm-l-small-2);
+  padding: var(--crm-btn-small-padding);
   font-size: var(--crm-l-medium-2);
   border-radius: var(--crm-btn-radius);
   height: auto;


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/34162 following discussion with @ufundo. 

Before
----------------------------------------
<img width="848" height="99" alt="image" src="https://github.com/user-attachments/assets/21612c11-58fe-4449-a2f0-51ea3cb0689f" />
<img width="373" height="212" alt="image" src="https://github.com/user-attachments/assets/d3efc5a7-0959-4cb3-b981-f8c17efc893c" />

After
----------------------------------------
<img width="825" height="97" alt="image" src="https://github.com/user-attachments/assets/6719d03e-af5a-462c-8c16-356f975c1ce6" />
<img width="407" height="232" alt="image" src="https://github.com/user-attachments/assets/d3dbcc71-0dbc-4faf-a6ab-04dd4ce7337b" />
