### PR TITLE
Fix crash when you don't have a target contact and are updating a case activity

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -393,7 +393,7 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
     $params['activity_type_id'] = $this->_activityTypeId;
 
     // format with contact (target contact) values
-    if (isset($params['target_contact_id'])) {
+    if (!empty($params['target_contact_id'])) {
       $params['target_contact_id'] = explode(',', $params['target_contact_id']);
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
If you are updating a case activity (using the Manage case page) and don't have a target contact set it crashes with DB constraint error.

Before
----------------------------------------
Crash

After
----------------------------------------
No crash

Technical Details
----------------------------------------
isset matches "" which gets exploded into an array [0 => ""].

!empty does not match "" so we get an actual empty array.

Comments
----------------------------------------

