### PR TITLE
CustomField - always use sql TEXT for serialized fields

### DIFF
--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -308,20 +308,8 @@ class CRM_Core_BAO_CustomValueTable {
     }
 
     if ($isSerialized) {
-      switch ($type) {
-        case 'Text':
-          return 'text';
-
-        case 'String':
-        default:
-          // ensure minimum varchar of 255
-          // TODO: this can still be insufficient if you try to serialize
-          // long text values. in this case a `text` field would be better
-          // but how to know? we could switch to only using varchar for serialized
-          // ints and text otherwise?
-          $maxLength = max(255, $maxLength ?: 255);
-          return "varchar($maxLength)";
-      }
+      // Always use 'text' for serialized fields as their length cannot be known
+      return 'text';
     }
     switch ($type) {
       case 'String':

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -194,11 +194,6 @@ class CRM_Core_BAO_SchemaHandler {
   public static function buildSearchIndexSQL($params, $separator, $prefix = '', $existingIndex = '') {
     $sql = '';
 
-    // Don't index blob
-    if ($params['type'] == 'text') {
-      return NULL;
-    }
-
     // Perform case-insensitive match to see if index name begins with "index_" or "INDEX_"
     // (for legacy reasons it could be either)
     $searchIndexExists = stripos($existingIndex ?? '', 'index_') === 0;
@@ -207,7 +202,7 @@ class CRM_Core_BAO_SchemaHandler {
     // (skip indexing FK fields because it would be redundant to have 2 indexes)
     if (!empty($params['searchable']) && empty($params['fk_table_name']) && !$searchIndexExists) {
       $indexName = $params['name'];
-      if (self::getFieldLength($params['type']) > self::MAX_INDEX_LENGTH) {
+      if ($params['type'] === 'text' || self::getFieldLength($params['type']) > self::MAX_INDEX_LENGTH) {
         $indexName .= '(' . self::MAX_INDEX_LENGTH . ')';
       }
       $sql .= $separator;

--- a/templates/CRM/Custom/Form/Field.hlp
+++ b/templates/CRM/Custom/Form/Field.hlp
@@ -47,6 +47,9 @@
   <p>
     {ts}Adds a database index which helps speed up searches on this field significantly. However, it can require more storage and can slow down the system if the data is frequently updated.{/ts}
   </p>
+  <p>
+    {ts}This setting is not recommended for Multi-Select or Checkboxes, as indexes are usually not helpful for fields that store multiple values.{/ts}
+  </p>
 {/htxt}
 
 {htxt id='is_view'}

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -282,7 +282,7 @@
 
       $("#startDateRange, #endDateRange, #includedDatePart", $form).toggle(dataType === 'Date');
 
-      $("#textLength", $form).toggle(dataType === 'String');
+      $("#textLength", $form).toggle(dataType === 'String' && !serialize);
 
       $("#noteColumns, #noteRows, #noteLength", $form).toggle(dataType === 'Memo');
 


### PR DESCRIPTION
Overview
----------------------------------------
Automatically sets serialized fields to use sql column type TEXT, to avoid length limits.

Before
----------------------------------------
When creating a multiselect/checkbox field, you have to set the "Database field length." Most users would probably think "What the heck does that mean?" Only a handful of CiviCRM/MySQL experts on the planet might know the non-self-explanatory answer is that you must enter a field length that's `>=` `the sum of the length of all options` `+` `the number of options` `+` `1`.

<img width="1836" height="636" alt="image" src="https://github.com/user-attachments/assets/38662a4f-012a-474b-9bee-48ff54f4e948" />


After
----------------------------------------
Here's an idea, let's *not* require end-users to figure that out. Just setting all serialized fields to use 'text' means there are no constraints on length. That confusing "Database field length" is no longer shown for serialized (multiselect/checkbox) fields.

