### PR TITLE
CustomField - Fix setting default values

### DIFF
--- a/CRM/Core/BAO/CustomOption.php
+++ b/CRM/Core/BAO/CustomOption.php
@@ -81,7 +81,7 @@ class CRM_Core_BAO_CustomOption {
     $options = [];
 
     $field = CRM_Core_BAO_CustomField::getFieldObject($params['fid']);
-    $defVal = CRM_Utils_Array::explodePadded($field->default_value);
+    $defVal = (array) CRM_Utils_Array::explodePadded($field->default_value);
 
     // format the params
     $params['offset'] = ($params['page'] - 1) * $params['rp'];
@@ -130,8 +130,8 @@ class CRM_Core_BAO_CustomOption {
         $action -= CRM_Core_Action::DELETE;
       }
 
-      if ($field->html_type == 'CheckBox' || ($field->html_type == 'Select' && $field->serialize == 1)) {
-        $options[$dao->id]['is_default'] = (isset($defVal) && in_array($dao->value, $defVal));
+      if (CRM_Core_BAO_CustomField::isSerialized($field)) {
+        $options[$dao->id]['is_default'] = in_array($dao->value, $defVal);
       }
       else {
         $options[$dao->id]['is_default'] = ($field->default_value == $dao->value);

--- a/CRM/Custom/Form/Option.php
+++ b/CRM/Custom/Form/Option.php
@@ -95,14 +95,9 @@ class CRM_Custom_Form_Option extends CRM_Core_Form {
 
       $paramsField = ['id' => $this->_fid];
       CRM_Core_BAO_CustomField::retrieve($paramsField, $fieldDefaults);
-      if ($fieldDefaults['html_type'] == 'CheckBox'
-        // Multi-Select
-        || ($fieldDefaults['html_type'] == 'Select' && $fieldDefaults['serialize'] == 1)
-      ) {
+      if (CRM_Core_Bao_CustomField::isSerialized($fieldDefaults)) {
         if (!empty($fieldDefaults['default_value'])) {
-          $defaultCheckValues = explode(CRM_Core_DAO::VALUE_SEPARATOR,
-            substr($fieldDefaults['default_value'], 1, -1)
-          );
+          $defaultCheckValues = CRM_Utils_Array::explodePadded($fieldDefaults['default_value']);
           if (in_array($defaults['value'], $defaultCheckValues)) {
             $defaults['default_value'] = 1;
           }
@@ -416,30 +411,13 @@ SELECT count(*)
     $customField = new CRM_Core_DAO_CustomField();
     $customField->id = $this->_fid;
     if (
-      $customField->find(TRUE) &&
-      (
-        $customField->html_type == 'CheckBox' ||
-        // Multi Value Select
-        ($customField->html_type == 'Select' && $customField->serialize == 1)
-      )
+      $customField->find(TRUE) && CRM_Core_BAO_CustomField::isSerialized($customField)
     ) {
-      $defVal = explode(
-        CRM_Core_DAO::VALUE_SEPARATOR,
-        substr($customField->default_value, 1, -1)
-      );
+      $defVal = (array) CRM_Utils_Array::explodePadded($customField->default_value);
       if (!empty($params['default_value'])) {
         if (!in_array($customOption->value, $defVal)) {
-          if (empty($defVal[0])) {
-            $defVal = [$customOption->value];
-          }
-          else {
-            $defVal[] = $customOption->value;
-          }
-          $customField->default_value
-            = CRM_Core_DAO::VALUE_SEPARATOR .
-            implode(CRM_Core_DAO::VALUE_SEPARATOR, $defVal) .
-            CRM_Core_DAO::VALUE_SEPARATOR;
-          CRM_Core_BAO_CustomField::createField($customField, 'modify');
+          $defVal[] = $customOption->value;
+          $newDefaultValue = CRM_Core_DAO::serializeField($defVal, CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND);
         }
       }
       elseif (in_array($customOption->value, $defVal)) {
@@ -450,11 +428,7 @@ SELECT count(*)
           }
         }
 
-        $customField->default_value
-          = CRM_Core_DAO::VALUE_SEPARATOR .
-          implode(CRM_Core_DAO::VALUE_SEPARATOR, $tempVal) .
-          CRM_Core_DAO::VALUE_SEPARATOR;
-        CRM_Core_BAO_CustomField::createField($customField, 'modify');
+        $newDefaultValue = CRM_Core_DAO::serializeField($tempVal, CRM_Core_DAO::SERIALIZE_SEPARATOR_BOOKEND);
       }
     }
     else {
@@ -473,14 +447,16 @@ SELECT count(*)
       }
 
       if (!empty($params['default_value'])) {
-        $customField->default_value = $customOption->value;
-        CRM_Core_BAO_CustomField::createField($customField, 'modify');
+        $newDefaultValue = $customOption->value;
       }
       elseif ($customField->find(TRUE) && $customField->default_value == $customOption->value) {
         // this is the case where this option is the current default value and we have been reset
-        $customField->default_value = 'null';
-        CRM_Core_BAO_CustomField::createField($customField, 'modify');
+        $newDefaultValue = '';
       }
+    }
+
+    if (isset($newDefaultValue)) {
+      CRM_Core_BAO_CustomField::create(['id' => $this->_fid, 'default_value' => $newDefaultValue]);
     }
 
     if ($this->_id) {


### PR DESCRIPTION
Overview
----------------------------------------
During refactoring at some point, the ability to set the field default value broke. This fixes it.

Before
----------------------------------------
When editing custom field options, cannot set an option as the default value.

Disable the AdminUI extension to test this. AdminUI also has problems, but [that's another issue](https://github.com/civicrm/civicrm-core/pull/33981).

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Also fixed some messy legacy code that would have prevented the form from correctly handling new field types like Autocomplete multiselects.