### PR TITLE
afFieldset - filter out empty filter values when using operators

### DIFF
--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -98,7 +98,7 @@
             if (v === null || v === '') {
               return true;
             }
-            if (v && v.length === 0) {
+            if (Array.isArray(v) && v.length === 0) {
               return true;
             }
             if (typeof v === 'object' && Object.keys(v).length === 0) {

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -86,16 +86,45 @@
 
         /**
          * Get fieldset values to use for afform filters
+         *
+         * Filter out empty values (null, '', [], {}) at top level and one level
+         * below for object values (fields with ranges/operators)
+         *
          * @returns Object
          */
         this.getFilterValues = () => {
-          const data = this.getFieldData();
-          // filter out unset values
-          // intended to be equivalent to previous lodash implementation
-          // (typeof val !== 'undefined' && val !== null && (_.includes(['boolean', 'number', 'object'], typeof val) || val.length));
-          return Object.fromEntries(Object.entries(data).filter(([key, value]) =>
-            (['boolean', 'number', 'object'].includes(typeof value) && value !== null) || (value && value.length)
-          ));
+          // find null, '', [], {}
+          const isEmpty = (v) => {
+            if (v === null || v === '') {
+              return true;
+            }
+            if (v && v.length === 0) {
+              return true;
+            }
+            if (typeof v === 'object' && Object.keys(v).length === 0) {
+              return true;
+            }
+          };
+
+          // get a copy of the object
+          const data = _.cloneDeep(this.getFieldData());
+
+          Object.keys(data).forEach((key) => {
+            // first filter sub objects
+            if (typeof data[key] === 'object' && data[key] !== null) {
+              Object.keys(data[key]).forEach((subKey) => {
+                if (isEmpty(data[key][subKey])) {
+                  delete data[key][subKey];
+                }
+              });
+            }
+            // then filter top level
+            if (isEmpty(data[key])) {
+              delete data[key];
+            }
+          });
+
+          return data;
         };
 
         /**

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -147,7 +147,7 @@
         // this also kicks off the first run of the search (if there's no search button).
         function setUpWatches() {
           if (ctrl.afFieldset) {
-            $scope.$watch(ctrl.afFieldset.getFieldData, onChangeFilters, true);
+            $scope.$watch(ctrl.afFieldset.getFilterValues, onChangeFilters, true);
           }
           if (ctrl.settings.pager && ctrl.settings.pager.expose_limit) {
             $scope.$watch('$ctrl.limit', onChangePageSize);


### PR DESCRIPTION
Overview
----------------------------------------
Ignore clutter from the afform field data when determining search display filters.

Before
----------------------------------------
- afFieldset getFilterValues ignores empty field values at the top level
- for fields with operators,  empty values within the object are not ignored
- Search Displays refresh for non-substantive changes (e.g. when you select Choose date range, before you actually choose a date range)

https://github.com/user-attachments/assets/87438b9f-c863-4492-88c6-1e7d1e71fbdc



- when saving filter sets, you get junk from fields with operators

After
----------------------------------------
- filtering happens within object values also
- no unnecessary refreshes


https://github.com/user-attachments/assets/acf49fa2-72c1-4797-8ef7-04fd15ea1945




- saved filter sets are much cleaner


Technical Details
----------------------------------------
To get some visibility, I added this line to SearchDisplayBaseTrait

<img width="972" height="218" alt="image" src="https://github.com/user-attachments/assets/c3c18ee1-79db-48d5-887e-1cd92e720764" />


Before:

https://github.com/user-attachments/assets/56e1661c-4751-448b-99e6-c54fe9f1999f




After:

https://github.com/user-attachments/assets/1dc82237-dd88-4986-9b56-91a69c8a5a0a



Comments
----------------------------------------
I did wonder if we could try to avoid _setting_ these empty values. But an hour pouring through getSetValue and setValue in afField made me think that wasn't at all easy...
