### PR TITLE
Afform - two fixes for reloading stored values on search forms

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -235,6 +235,15 @@
         if (typeof value === 'string' && ctrl.isMultiple()) {
           value = value.split(',');
         }
+        // When reloading values for fields with operators, the stored value is an object "operator"
+        if (typeof value === 'object' && value !== null && ctrl.search_operator) {
+          // if the operator is a user select, load from the passed value
+          // (we expect the value to be an Object with a single key)
+          if (ctrl.defn.expose_operator) {
+            ctrl.search_operator = Object.keys(value)[0];
+          }
+          value = value[ctrl.search_operator] ? value[ctrl.search_operator] : null;
+        }
         // Support "Select Current User" default
         if (ctrl.defn.input_type === 'EntityRef' && ['Contact', 'Individual'].includes(ctrl.fkEntity) && value === 'user_contact_id') {
           value = CRM.config.cid;

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -57,7 +57,10 @@
           if (!this.storeValues) {
             return;
           }
-          return CRM.cache.get(getCacheKey(), {})[fieldName];
+          if (!this.reloadedStoredValues) {
+            this.reloadedStoredValues = CRM.cache.get(getCacheKey(), {});
+          }
+          return this.reloadedStoredValues[fieldName];
         };
         this.$onInit = function() {
           if (this.storeValues) {


### PR DESCRIPTION
Overview
---------------------------------------
Fixes for the "save values" functionality on afform.

Before
----------------------------------------
- if you have make multiple filter selections, only the first is reloaded
- if you have fields with operators, reloading their values is garbled

(set the total amount field to = 5, refresh the page, reloads as `[object Object]`

https://github.com/user-attachments/assets/244e68af-646d-4583-9620-c737bf8275af


After
----------------------------------------
- reloading multiple filters works as expected
- reloading fields with operators works as expected

Technical Details
----------------------------------------
The first issue is caused by reloading the first field saving over the saved values, with only that field having a value.

The second issue is caused because the field value is saved as `{'operator': 'compare value'}`, and then that whole object is passed into the [compare value] slot. 

Comments
----------------------------------------
The second issue also fixes similar issue with reloading saved searches - but it's easier to see what's going on with Store Values.