### PR TITLE
Api4 - Make `setUsage` function chainable

### DIFF
--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -281,9 +281,12 @@ class FieldSpec {
 
   /**
    * @param string[] $usage
+   * @return $this
    */
-  public function setUsage(array $usage): void {
+  public function setUsage(array $usage) {
     $this->usage = $usage;
+
+    return $this;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Minor improvement to Api4 spec function.

Technical Details
----------------------------------------
All the other FieldSpec functions are chainable so let's be consistent.