### PR TITLE
Prevent deletion of addresses when country is default and no other values

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -380,7 +380,8 @@ class CRM_Contact_Form_Edit_Address {
   private static function enforceRequired(CRM_Core_Form $form): bool {
     if ($form->isSubmitted()) {
       $addresses = (array) $form->getSubmittedValue('address');
-      foreach ($addresses as $address) {
+      foreach ($addresses as $idx => $address) {
+        $address['id'] = $form->_values['address'][$idx]['id'] ?? "";
         if (!empty($address['master_id']) || CRM_Core_BAO_Address::dataExists($address)) {
           return TRUE;
         }

--- a/CRM/Core/BAO/Address.php
+++ b/CRM/Core/BAO/Address.php
@@ -312,7 +312,7 @@ class CRM_Core_BAO_Address extends CRM_Core_DAO_Address implements Civi\Core\Hoo
       }
       elseif (!CRM_Utils_System::isNull($value)) {
         // name could be country or country id
-        if (substr($name, 0, 7) == 'country') {
+        if (substr($name, 0, 7) == 'country' && empty($params['id'])) {
           // make sure its different from the default country
           // iso code
           $defaultCountry = CRM_Core_BAO_Country::defaultContactCountry();


### PR DESCRIPTION
Before
----------------------------------------
If you edit a contact's address and leave them with only a country, where that country is equal to the default country, but no other values, then the address is not saved, but deleted.

After
----------------------------------------
The country-only address is saved after editing.
No change in behaviour when creating a new address (the address is not created if there is only a country and it is the default).