### PR TITLE
Allow IS NULL / No Value for bools in SK

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -32,6 +32,7 @@
         'IS EMPTY': ts('Is Empty'),
         'IS NOT EMPTY': ts('Not Empty'),
         'IS NOT NULL': ts('Any Value'),
+        'IS NULL': ts('No Value'),
       };
 
       this.$onInit = function() {
@@ -80,7 +81,7 @@
         var field = ctrl.field || {},
           allowedOps = field.operators;
         if (!allowedOps && field.data_type === 'Boolean') {
-          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT NULL'];
+          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT NULL', 'IS NULL'];
         }
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -113,7 +113,8 @@ class Admin {
       'NOT BETWEEN' => E::ts('Not Between'),
       'IS EMPTY' => E::ts('Is Empty'),
       'IS NOT EMPTY' => E::ts('Not Empty'),
-      'IS NOT NULL' => E::ts('Any value'),
+      'IS NOT NULL' => E::ts('Any Value'),
+      'IS NULL' => E::ts('No Value'),
     ];
   }
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
@@ -86,7 +86,7 @@
         const field = ctrl.field || {};
         let allowedOps = field.operators;
         if (!allowedOps && field.data_type === 'Boolean') {
-          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT NULL'];
+          allowedOps = ['=', '!=', 'IS EMPTY', 'IS NOT NULL', 'IS NULL'];
         }
         if (!allowedOps && _.includes(['Boolean', 'Float', 'Date'], field.data_type)) {
           allowedOps = ['=', '!=', '<', '>', '<=', '>=', 'IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN', 'IS EMPTY', 'IS NOT EMPTY'];


### PR DESCRIPTION
We have Any Value, so it makes sense to also have No Value.

If you have a bool custom field and whether it is set or not is meaningful, then you can't easily search this field. For example, we have an opt in field that can be Yes, No or null and I want to find all the people who have answered Yes or have not answered (null). I can currently search (= Yes OR (Is Empty AND != No)) but that's awkward and unintuitive, when I could just search (= Yes OR No Value).