### PR TITLE
allow Search Displays to use all columns from their Saved Search

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -46,7 +46,7 @@ class Run extends AbstractRunAction {
   protected function processResult(SearchDisplayRunResult $result) {
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->_apiParams;
-    if (!empty($this->display['settings']['useDefaultSearchColumns'])) {
+    if ('auto' === ($this->display['settings']['columnMode'] ?? NULL)) {
       $defaultDisplay = \Civi\Api4\SearchDisplay::getDefault(FALSE)
         ->setSavedSearch($this->savedSearch)
         ->setType($this->display['type'])

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -46,6 +46,13 @@ class Run extends AbstractRunAction {
   protected function processResult(SearchDisplayRunResult $result) {
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->_apiParams;
+    if (!empty($this->display['settings']['useDefaultSearchColumns'])) {
+      $defaultDisplay = \Civi\Api4\SearchDisplay::getDefault(FALSE)
+        ->setSavedSearch($this->savedSearch)
+        ->setType($this->display['type'])
+        ->execute()->single();
+      $this->display['settings']['columns'] = $defaultDisplay['settings']['columns'];
+    }
     $page = $index = NULL;
     $key = $this->return;
     // Pager can operate in "page" mode for traditional pager, or "scroll" mode for infinite scrolling

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -46,7 +46,6 @@ class Run extends AbstractRunAction {
   protected function processResult(SearchDisplayRunResult $result) {
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->_apiParams;
-    $settings = $this->display['settings'];
     $page = $index = NULL;
     $key = $this->return;
     // Pager can operate in "page" mode for traditional pager, or "scroll" mode for infinite scrolling
@@ -90,12 +89,12 @@ class Run extends AbstractRunAction {
         // Pager mode: `page:n`
         // AJAX scroll mode: `scroll:n`
         // Or NULL for unlimited results
-        if (($settings['pager'] ?? FALSE) !== FALSE && $key && preg_match('/^(page|scroll):\d+$/', $key)) {
+        if (($this->display['settings']['pager'] ?? FALSE) !== FALSE && $key && preg_match('/^(page|scroll):\d+$/', $key)) {
           [$pagerMode, $page] = explode(':', $key);
-          $limit = !empty($settings['pager']['expose_limit']) && $this->limit ? $this->limit : NULL;
+          $limit = !empty($this->display['settings']['pager']['expose_limit']) && $this->limit ? $this->limit : NULL;
         }
         $apiParams['debug'] = $this->debug;
-        $apiParams['limit'] = $limit ?? $settings['limit'] ?? NULL;
+        $apiParams['limit'] = $limit ?? $this->display['settings']['limit'] ?? NULL;
         $apiParams['offset'] = $page ? $apiParams['limit'] * ($page - 1) : 0;
         // In scroll mode, add one extra to the limit as a lookahead to see if there are more results
         if ($apiParams['limit'] && $pagerMode === 'scroll') {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -34,7 +34,28 @@
         // Table can be draggable if the main entity is a SortableEntity.
         ctrl.sortableEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'SortableEntity');
         ctrl.hierarchicalEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'HierarchicalEntity');
-        ctrl.parent.initColumns({label: true, sortable: true});
+        // if this is a brand new display, start with default columns
+        // instead of adding columns array
+        if (!ctrl.display.settings.columns) {
+          ctrl.display.settings.useDefaultSearchColumns = true;
+        }
+        // otherwise run the default columns initialiser
+        else {
+          ctrl.parent.initColumns({label: true, sortable: true});
+        }
+      };
+
+      this.getSetCustomColumns = (value) => {
+        if (value !== undefined) {
+          this.display.settings.useDefaultSearchColumns = !value;
+          // if switching to custom columns and no columns already exist then
+          // initialise with all the columns to start
+          if (value && !(this.display.settings.columns && this.display.settings.columns.length)) {
+            this.parent.initColumns({label: true, sortable: true});
+          }
+          return value;
+        }
+        return !this.display.settings.useDefaultSearchColumns;
       };
 
       this.toggleEditableRowMode = function(name, value) {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -34,28 +34,29 @@
         // Table can be draggable if the main entity is a SortableEntity.
         ctrl.sortableEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'SortableEntity');
         ctrl.hierarchicalEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'HierarchicalEntity');
-        // if this is a brand new display, start with default columns
-        // instead of adding columns array
-        if (!ctrl.display.settings.columns) {
-          ctrl.display.settings.useDefaultSearchColumns = true;
-        }
-        // otherwise run the default columns initialiser
-        else {
-          ctrl.parent.initColumns({label: true, sortable: true});
+
+        // set columnMode if unset
+        if (!ctrl.display.settings.columnMode) {
+          // if we already have columns defined, this is loading a display
+          // created before columnMode => so use `custom` to preserve existing
+          // behaviour
+          if (ctrl.display.settings.columns) {
+            ctrl.display.settings.columnMode = 'custom';
+          }
+          // otherwise the default for new displays is `auto`
+          else {
+            ctrl.display.settings.columnMode = 'auto';
+          }
         }
       };
 
-      this.getSetCustomColumns = (value) => {
-        if (value !== undefined) {
-          this.display.settings.useDefaultSearchColumns = !value;
-          // if switching to custom columns and no columns already exist then
-          // initialise with all the columns to start
-          if (value && !(this.display.settings.columns && this.display.settings.columns.length)) {
-            this.parent.initColumns({label: true, sortable: true});
-          }
-          return value;
+      this.setColumnMode = (value) => {
+        // if switching from auto columns and no columns already exist then
+        // initialise with all the columns to start
+        if (value !== 'auto' && !(this.display.settings.columns && this.display.settings.columns.length)) {
+          this.parent.initColumns({label: true, sortable: true});
         }
-        return !this.display.settings.useDefaultSearchColumns;
+        this.display.settings.columnMode = value;
       };
 
       this.toggleEditableRowMode = function(name, value) {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -121,19 +121,20 @@
 
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>
-    {{:: ts('Custom Columns') }}
+    {{:: ts('Columns') }}
   </legend>
-  <div class="crm-form-toggle-container">
-    <input type="checkbox" class="crm-form-toggle" ng-model="$ctrl.getSetCustomColumns" ng-model-options="{getterSetter: true}" />
-    <span class="crm-form-toggle-text crm-form-toggle-text-on">
+  <div class="form-inline">
+    <label class="radio-inline">
+      <input type="radio" ng-click="$ctrl.setColumnMode('auto')" ng-checked="$ctrl.display.settings.columnMode === 'auto'">
+      {{:: ts('Use default columns from search') }}
+    </label>
+    <label class="radio-inline">
+      <input type="radio" ng-click="$ctrl.setColumnMode('custom')" ng-checked="$ctrl.display.settings.columnMode === 'custom'">
       {{:: ts('Use custom columns') }}
-    </span>
-    <span class="crm-form-toggle-text crm-form-toggle-text-off">
-      {{:: ts('Use default columns from Search') }}
-    </span>
+    </label>
   </div>
-  <div ng-if="!$ctrl.display.settings.useDefaultSearchColumns" ng-include="'~/crmSearchAdmin/displays/common/addColMenu.html'"></div>
-  <fieldset ng-if="!$ctrl.display.settings.useDefaultSearchColumns" class="crm-search-admin-edit-columns" ng-model="$ctrl.display.settings.columns" ui-sortable="$ctrl.parent.sortableOptions">
+  <div ng-if="$ctrl.display.settings.columnMode !== 'auto'" ng-include="'~/crmSearchAdmin/displays/common/addColMenu.html'"></div>
+  <fieldset ng-if="$ctrl.display.settings.columnMode !== 'auto'" class="crm-search-admin-edit-columns" ng-model="$ctrl.display.settings.columns" ui-sortable="$ctrl.parent.sortableOptions">
     <fieldset ng-repeat="col in $ctrl.display.settings.columns" class="crm-draggable">
       <i class="crm-i fa-arrows crm-search-move-icon" role="img" aria-hidden="true"></i>
       <button type="button" class="btn btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Remove') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -121,10 +121,19 @@
 
 <fieldset class="crm-search-admin-edit-columns-wrapper">
   <legend>
-    {{:: ts('Columns') }}
+    {{:: ts('Custom Columns') }}
   </legend>
-  <div ng-include="'~/crmSearchAdmin/displays/common/addColMenu.html'"></div>
-  <fieldset class="crm-search-admin-edit-columns" ng-model="$ctrl.display.settings.columns" ui-sortable="$ctrl.parent.sortableOptions">
+  <div class="crm-form-toggle-container">
+    <input type="checkbox" class="crm-form-toggle" ng-model="$ctrl.getSetCustomColumns" ng-model-options="{getterSetter: true}" />
+    <span class="crm-form-toggle-text crm-form-toggle-text-on">
+      {{:: ts('Use custom columns') }}
+    </span>
+    <span class="crm-form-toggle-text crm-form-toggle-text-off">
+      {{:: ts('Use default columns from Search') }}
+    </span>
+  </div>
+  <div ng-if="!$ctrl.display.settings.useDefaultSearchColumns" ng-include="'~/crmSearchAdmin/displays/common/addColMenu.html'"></div>
+  <fieldset ng-if="!$ctrl.display.settings.useDefaultSearchColumns" class="crm-search-admin-edit-columns" ng-model="$ctrl.display.settings.columns" ui-sortable="$ctrl.parent.sortableOptions">
     <fieldset ng-repeat="col in $ctrl.display.settings.columns" class="crm-draggable">
       <i class="crm-i fa-arrows crm-search-move-icon" role="img" aria-hidden="true"></i>
       <button type="button" class="btn btn-xs pull-right" ng-click="$ctrl.parent.removeCol($index)" title="{{:: ts('Remove') }}">

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -31,7 +31,7 @@
           this.placeholders.push({});
         }
 
-        if (this.settings.useDefaultSearchColumns) {
+        if (this.settings.columnMode === 'auto') {
           // start with no columns in case we run before
           // we've fetched the right ones
           this.columns = [];

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -30,11 +30,37 @@
         for (let p=0; p < placeholderCount; ++p) {
           this.placeholders.push({});
         }
-        // Break reference so original settings are preserved
-        this.columns = _.cloneDeep(this.settings.columns);
-        this.columns.forEach((col) => {
-          col.enabled = true;
-          col.fetched = true;
+
+        if (this.settings.useDefaultSearchColumns) {
+          // start with no columns in case we run before
+          // we've fetched the right ones
+          this.columns = [];
+          // TODO: default permission is access CiviCRM
+          // need to tweak permissions for frontend forms
+          crmApi4('SearchDisplay', 'getDefault', {
+            savedSearch: this.search
+          })
+          .then((result) => this.columns = result[0].settings.columns)
+          .then(() => this.columns.forEach((col) => {
+            // Used by crmSearchDisplayTable.toggleColumns
+            col.enabled = true;
+            col.fetched = true;
+          }))
+          .catch((error) => CRM.alert(ts('Error loading search columns')));
+        }
+        else {
+          // Break reference so original settings are preserved
+          this.columns = _.cloneDeep(this.settings.columns);
+
+          // Add keys used by crmSearchDisplayTable.toggleColumns
+          this.columns.forEach((col) => {
+            col.enabled = true;
+            col.fetched = true;
+          });
+        }
+
+        _.each(ctrl.onInitialize, function(callback) {
+          callback.call(ctrl, $scope, $element);
         });
         ctrl.onInitialize.forEach(callback => callback.call(ctrl, $scope, $element));
 
@@ -273,13 +299,13 @@
       },
 
       getFieldClass: function(colIndex, colData) {
-        return (colData.cssClass || '') + ' crm-search-col-type-' + this.settings.columns[colIndex].type + (this.settings.columns[colIndex].break ? '' : ' crm-inline-block');
+        return (colData.cssClass || '') + ' crm-search-col-type-' + this.columns[colIndex].type + (this.columns[colIndex].break ? '' : ' crm-inline-block');
       },
 
       getFieldTemplate: function(colIndex, colData) {
-        let colType = this.settings.columns[colIndex].type;
+        let colType = this.columns[colIndex].type;
         if (colType === 'include') {
-          return this.settings.columns[colIndex].path;
+          return this.columns[colIndex].path;
         }
         if (colType === 'field') {
           if (colData.edit) {


### PR DESCRIPTION
Before
----------------------------------------
- Search Displays (except the default display) always have a separate list of columns from their Saved Search
- this starts off being all the columns, but then diverges if the Saved Search changes
- if you add a column to the Saved Search, you have to add it to any Search Displays based off it manually
- you can get round this using the Default Search Display, but then you can't tweak the search settings

After
----------------------------------------
- by default new table displays will show all the columns from its Search
- you have the option to customise the columns if you want
- pre-existing search displays will be treated as having custom columns defined

Technical Details
----------------------------------------
The motivation here is that, unlike the other table settings for headers/tallies/actions etc, the Display columns somewhat duplicates the Search Display it depends on.


Comments
----------------------------------------
This is useful for reporting. You can generate a Managed Search Display which includes a somewhat dynamic list of Custom Fields (like https://lab.civicrm.org/extensions/search_kit_report_starter_pack/-/merge_requests/30), and you can create a Search Display that show them all.

It's first step on an alternative to https://github.com/civicrm/civicrm-core/pull/33959 .

TODO:
- permissions issue to fetch the default display if you dont have Access CiviCRM
- it might be nice to allow a sort of hybrid mode: tweak the display for a few specific columns, use defaults for all the rest

Demo:



https://github.com/user-attachments/assets/58687dc1-6344-43e8-93d0-38e1f781bfba

Note how currently adding those columns after you create the display requires adding on the search, then going to the display and adding the column from the dropdown.





