### PR TITLE
Fix payment processor selection persistence

### DIFF
--- a/templates/CRM/common/paymentBlock.tpl
+++ b/templates/CRM/common/paymentBlock.tpl
@@ -25,6 +25,11 @@
     // to be hidden (or removed) in which case it can go from this function.
     var billing_block = cj("div#billing-payment-block");
     if (isHide) {
+      var current_selection = cj('input[name="payment_processor_id"]:checked').val();
+      if (current_selection) {
+        billing_block.data('saved-ppid', current_selection);
+      }
+
       payment_options.hide();
       payment_processor.hide();
       payment_information.hide();
@@ -40,8 +45,16 @@
       payment_information.show();
       billing_block.show();
       cj('#billing-payment-block select.crm-select2').removeClass('crm-no-validate');
-      // also set selected payment methods
-      cj('input[name="payment_processor_id"][checked=checked]').prop('checked', true);
+
+      var saved_selection = billing_block.data('saved-ppid');
+      var restored_input = (saved_selection) ? cj('input[name="payment_processor_id"][value="' + saved_selection + '"]') : [];
+      if (restored_input.length) {
+        restored_input.prop('checked', true);
+        billing_block.removeData('saved-ppid');
+      }
+      else if (cj('input[name="payment_processor_id"]:checked').length === 0) {
+        cj('input[name="payment_processor_id"][checked=checked]').prop('checked', true);
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/civicrm/civicrm-core/pull/32342 along with original fix included https://github.com/civicrm/civicrm-core/pull/10826

From https://github.com/civicrm/civicrm-core/pull/32342:

>Steps to replicate:
Create a paid online event registration with price set of radio and checkbox price fields
Add pay later and one or more CC payment processor(s)
Go to event registration form live or on test mode.
Select a radio option and choose pay-later
Select any checkbox price option or change radio price option



Before
----------------------------------------
The payment processor selection switches to CC from pay-later and billing section is not exposed. I can replicate this issue in dmaster:

After
----------------------------------------
Fixed

Technical Details
----------------------------------------

On Hide: We now capture the currently selected payment_processor_id and store it in a data attribute on the billing block.

On Show: check for that data attribute.

If found: restore that specific processor.

If NOT found (and no other processor is currently active), fall back to the default behavior (selecting the processor marked checked=checked).

This preserves the fix for CRM-21038 (ensuring some processor is selected) while respecting explicit user choices during form updates.


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
