### PR TITLE
SearchKit - Fix In-Place Edit with Bypass Permissions

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1028,7 +1028,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $editable['record'][$editable['id_key']] = $data[$editable['id_path']];
       // Ensure field is appropriate to this entity sub-type
       $entityValues = FormattingUtil::filterByPath($data, $editable['id_path'], $editable['id_key']);
-      if (!$this->fieldBelongsToEntity($editable['entity'], $editable['value_key'], $entityValues)) {
+      if (!$this->fieldBelongsToEntity($editable['entity'], $editable['value_key'], $entityValues, empty($this->display['acl_bypass']))) {
         return NULL;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When Bypass Permissions is enabled, then In-Place Edit is supposed to work for less-permissioned users. A stray permission check was preventing that. This fixes it.

Before
-------
Create a search display with in-place edit, enable bypass permissions and view it in an afform as an anonymous user. In-place edit should work but doesn't.

After
------
Fixed.