### PR TITLE
dev/joomla#54 New menu-based URL for HTTP method of calling cron

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -595,11 +595,10 @@
      <adminGroup>Customize Data and Screens</adminGroup>
      <weight>97</weight>
   </item>
-
   <item>
      <path>civicrm/admin/runjobs</path>
      <desc>URL used for running scheduled jobs.</desc>
-     <page_callback>CRM_Utils_System::executeScheduledJobs</page_callback>
+     <page_callback>CRM_Utils_System::executeScheduledJobsAsAdmin</page_callback>
      <access_arguments>access CiviCRM,administer CiviCRM system</access_arguments>
   </item>
   <item>

--- a/CRM/Core/xml/Menu/Misc.xml
+++ b/CRM/Core/xml/Menu/Misc.xml
@@ -284,4 +284,11 @@
     <page_callback>CRM_Contact_Form_Task_Delete</page_callback>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+     <path>civicrm/cron/runjobs</path>
+     <desc>URL used for running scheduled jobs as external cron script.</desc>
+     <page_callback>CRM_Utils_System::executeScheduledJobsAsCron</page_callback>
+     <access_callback>1</access_callback>
+     <is_public>true</is_public>
+  </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
As part of work on [Joomla 5 compatibility (dev/joomla#54)](https://lab.civicrm.org/dev/joomla/-/issues/54), one key problem identified is that using `cli.php` or `cron.php` boots CiviCRM first, before the CMS (Joomla). This is the opposite way round to when the web app (site) is accessed. Consequently, the order of precedence when autoloading classes and dependencies is wrong / different, and this causes the cron job to fail on J5+.

This PR is a proposed method to fix the problem for `cron.php`, by providing a route to design it out.

Note that #33825 provides a fix for `cli.php`.

Before
----------------------------------------
If you wish to execute your cron jobs via the [HTTP method](https://docs.civicrm.org/sysadmin/en/latest/setup/jobs/#http), you call a URL as follows:

`https://example.org/administrator/components/com_civicrm/civicrm/bin/cron.php`

This is an external script that has to manually bootstrap CiviCRM and then the CMS. It does not currently work on J4+.

After
----------------------------------------
Inspired by what has been done for the [PayPal IPN notify URL](https://docs.civicrm.org/sysadmin/en/latest/setup/payment-processors/recurring/#ipnnotifyurl), you can now call the following URL to execute cron jobs:

`https://example.org/?option=com_civicrm&task=civicrm/cron/runjobs`

This is now just a normal CiviCRM menu action / page access that therefore follows the usual boot sequence.

Longer-term, this brings the HTTP cron action into line with the rest of CiviCRM and allows us to design out `cron.php` if so desired.

Technical Details
----------------------------------------
Parameters passed to the call are the same (`name`, `pass`, `key` etc). Only the URL changes.

Tested and working on CiviCRM 6.6.1 (+ various J5 compatibility mods covered by other PRs) and Joomla 5.4.1.

The proposed solution adds a new method, `CRM_Utils_System::executeScheduledJobsAsCron()`, which largely copies the code from `cron.php`, updated as necessary.

For absolute clarity, it is also proposed to rename the existing method `executeScheduledJobs()` to `executeScheduledJobsAsAdmin()` (and update menu XML accordingly).

Comments
----------------------------------------
Although this PR presents a solution for Joomla, in principle this would work on any CMS (although may require other changes - not sure how well `cron.php` is supported on other platforms).

This PR is presented as a proof-of-concept. If it is agreed to adopt, the documentation will need updating (I can do this in due course).

Possibly an alternative solution is to use the REST API interface? (Link in documentation broken, think it should go to this page: https://docs.civicrm.org/dev/en/latest/api/v4/rest/)