### PR TITLE
search_kit - fix adding columns after first run in search admin results table

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -24,6 +24,11 @@
         ctrl.settings.columns = _.transform(ctrl.search.api_params.select, function(columns, fieldExpr) {
           columns.push(searchMeta.fieldToColumn(fieldExpr, {label: true, sortable: true}));
         }).concat(ctrl.settings.columns);
+        ctrl.columns = _.cloneDeep(ctrl.settings.columns);
+        ctrl.columns.forEach((col) => {
+          col.enabled = true;
+          col.fetched = true;
+        });
         ctrl.debug.apiParams = JSON.stringify(ctrl.search.api_params, null, 2);
         delete ctrl.debug.sql;
         delete ctrl.debug.timeIndex;

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -30,13 +30,11 @@
         for (let p=0; p < placeholderCount; ++p) {
           this.placeholders.push({});
         }
-        this.columns = this.settings.columns.map((column) => {
-          // Break reference so original settings are preserved
-          const col = _.cloneDeep(column);
-          // Used by crmSearchDisplayTable.toggleColumns
+        // Break reference so original settings are preserved
+        this.columns = _.cloneDeep(this.settings.columns);
+        this.columns.forEach((col) => {
           col.enabled = true;
           col.fetched = true;
-          return col;
         });
         _.each(ctrl.onInitialize, function(callback) {
           callback.call(ctrl, $scope, $element);


### PR DESCRIPTION
Before
----------------------------------------
- start a new search kit
- run the results display
- add 2 extra columns
- re-run the results display
- only the first extra column is shown. the menu buttons disappear. JS errors in the console about isSortable


https://github.com/user-attachments/assets/ad0051a5-606f-4e1e-8f2c-b06d89d53454


After
----------------------------------------
- reclone the display columns from the settings when settings are changed
- it works
