### PR TITLE
core#6192: FormBuilder: required dates don't show which field is empty

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -116,6 +116,12 @@
                   ngModel.$setValidity('incompleteDateTime', !(element.val().length && element.val().length !== requiredLength));
                 });
               });
+
+              // Add HTML5 required attribute to datepicker input
+              const visibleInput = element.next('input.crm-form-date');
+              if (attrs.required === true && visibleInput.length) {
+                visibleInput.attr('required', 'required');
+              }
           });
         }
       };


### PR DESCRIPTION
Overview
----------------------------------------
If you don't fill in a required field in FormBuilder, the screen scrolls back up to that field and pops up the message "Please fill in this field".  However, that doesn't happen for date fields.

Reproduction steps
----------------------------------------
1. Create a new FormBuilder.
1. Add birth date.
1. Make birth date and first name required.
2. Submit the form with no values filled in - see the correct behavior for first name.
3. Submit the form with only first name filled in.

Before
----------------------------------------
You can't see which field isn't filled in.

After
----------------------------------------
![before](https://github.com/user-attachments/assets/4c6659c6-4fd6-4f50-b5c7-3dbfcb5f2cec)



Comments
----------------------------------------
ping @colemanw @MegaphoneJon 