### PR TITLE
Datepicker - Include "required" attribute

### DIFF
--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -35,7 +35,7 @@
       if (settings.time !== false) {
         $timeField = $('<input>').insertAfter($dataField);
         placeholder = settings.timePlaceholder || $dataField.attr('time-placeholder');
-        CRM.utils.copyAttributes($dataField, $timeField, ['class', 'disabled']);
+        CRM.utils.copyAttributes($dataField, $timeField, ['class', 'disabled', 'required']);
         $timeField
           .removeClass('two four eight twelve twenty medium big huge crm-auto-width')
           .addClass('crm-form-text crm-form-time six')
@@ -55,7 +55,7 @@
       if (settings.date !== false) {
         // Render "number" field for year-only format, calendar popup for all other formats
         $dateField = $('<input type="' + type + '">').insertAfter($dataField);
-        CRM.utils.copyAttributes($dataField, $dateField, ['style', 'class', 'disabled', 'aria-label']);
+        CRM.utils.copyAttributes($dataField, $dateField, ['style', 'class', 'disabled', 'aria-label', 'required']);
         placeholder = settings.placeholder || $dataField.attr('placeholder');
         $dateField.addClass('crm-form-' + type);
         if (!settings.minDate && isInt(settings.start_date_years)) {


### PR DESCRIPTION
Overview
----------------------------------------
If you don't fill in a required field in FormBuilder, the screen scrolls back up to that field and pops up the message "Please fill in this field".  However, that doesn't happen for date fields.

Alternate PR to https://github.com/civicrm/civicrm-core/pull/34188

Reproduction steps
----------------------------------------
1. Create a new FormBuilder.
1. Add birth date.
1. Make birth date and first name required.
2. Submit the form with no values filled in - see the correct behavior for first name.
3. Submit the form with only first name filled in.
