### PR TITLE
Add some more known potential bounce patterns that should be classifi…

### DIFF
--- a/CRM/Upgrade/Incremental/sql/6.10.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.10.alpha1.mysql.tpl
@@ -1,1 +1,11 @@
 {* file to handle db changes in 6.10.alpha1 during upgrade *}
+
+-- 1. Get the bounce_type_id for the spam bounces
+SELECT @bounce_type_id := id
+FROM civicrm_mailing_bounce_type
+WHERE name = 'Spam'
+LIMIT 1;
+
+-- 2. Add in the new bounce type patterns
+INSERT INTO civicrm_mailing_bounce_pattern(bounce_type_id, pattern) VALUES
+(@bounce_type_id, 'unsolicited mail'), (@bounce_type_id, 'Complaint via SES');

--- a/sql/civicrm_data/civicrm_mailing_bounce_type/Spam.sqldata.php
+++ b/sql/civicrm_data/civicrm_mailing_bounce_type/Spam.sqldata.php
@@ -36,4 +36,6 @@ return CRM_Core_CodeGen_BounceType::create('Spam')
     ['Local Policy Violation'],
     ['ni bilo mogo..?e dostaviti zaradi varnostnega pravilnika'],
     ['abuse report'],
+    ['unsolicited mail'],
+    ['Complaint via SES'],
   ]);

--- a/tests/phpunit/CRM/Mailing/BAO/BouncePatternTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/BouncePatternTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Class CRM_Mailing_BAO_BouncePatternTest
+ */
+class CRM_Mailing_BAO_BouncePatternTest extends CiviUnitTestCase {
+
+  public static function patternExamples(): array {
+    return [
+      'Gmail Unsolicited Mail' => ['smtp; 550-5.7.1 Gmail has detected that this message is likely 550-5.7.1 unsolicited mail', 'Spam'],
+      'SES complaint' => ['Complaint via SES', 'Spam'],
+    ];
+  }
+
+  /**
+   * Test Pattern Matching
+   * @dataProvider patternExamples
+   * @param string $bounce_message
+   * @param string $expectedBounceType
+   */
+  public function testPatternMatching(string $bounce_message, string $expectedBounceType): void {
+    $match = CRM_Mailing_BAO_BouncePattern::match($bounce_message);
+    if ($match['bounce_type_id']) {
+      $returnedBounceType = CRM_Core_DAO::singleValueQuery("SELECT name FROM civicrm_mailing_bounce_type WHERE id = %1", [1 => [$match['bounce_type_id'], 'Positive']]);
+    }
+    else {
+      $returnedBounceType = 'Syntax';
+    }
+    $this->assertSame($expectedBounceType, $returnedBounceType);
+  }
+
+}


### PR DESCRIPTION
…ed as Spam type rather than the default of syntax and add unit test of the bounce pattern matching

Overview
----------------------------------------
This adds in a couple of more patterns to be treated as spam, THe first comes from a known bounce email where the diagnostic report was like `"smtp; 550-5.7.1 [<ip address>      12] Gmail has detected that this message is likely 550-5.7.1 unsolicited mail. To reduce the amount of spam sent to Gmail, this` 

The 2nd comes from the airmail extension as per https://github.com/aghstrategies/com.aghstrategies.airmail/blob/master/CRM/Airmail/Backend/Ses.php#L76 and complaints should be treated as spam. 

Before
----------------------------------------
Some spam bounces treated as Syntax bounces as that is the default

After
----------------------------------------
More spam bounces correctly treated

@demeritcowboy @andrew-cormick-dockery 