### PR TITLE
composer.json - Update autoprefixer, but declare conflict with v1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
       "cweagans/composer-patches": true
     }
   },
+  "conflict": {
+    "padaliyajay/php-autoprefixer": "1.5"
+  },
   "require": {
     "php": "~8.0",
     "ext-bcmath": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f5091886efcda6a51c86dac19fbcf6d",
+    "content-hash": "2e8e4a0522781735a2eb5f235acedb17",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1983,16 +1983,16 @@
         },
         {
             "name": "padaliyajay/php-autoprefixer",
-            "version": "1.3",
+            "version": "1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/padaliyajay/php-autoprefixer.git",
-                "reference": "f05f374f0c1e463db62209613f52b38bf4b52430"
+                "reference": "17ac9d20c0e4521163a061d4f99f3d31f88e797e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padaliyajay/php-autoprefixer/zipball/f05f374f0c1e463db62209613f52b38bf4b52430",
-                "reference": "f05f374f0c1e463db62209613f52b38bf4b52430",
+                "url": "https://api.github.com/repos/padaliyajay/php-autoprefixer/zipball/17ac9d20c0e4521163a061d4f99f3d31f88e797e",
+                "reference": "17ac9d20c0e4521163a061d4f99f3d31f88e797e",
                 "shasum": ""
             },
             "require": {
@@ -2016,9 +2016,9 @@
             "description": "CSS Autoprefixer written in pure PHP.",
             "support": {
                 "issues": "https://github.com/padaliyajay/php-autoprefixer/issues",
-                "source": "https://github.com/padaliyajay/php-autoprefixer/tree/1.3"
+                "source": "https://github.com/padaliyajay/php-autoprefixer/tree/1.4"
             },
-            "time": "2019-11-26T09:55:37+00:00"
+            "time": "2022-08-02T02:37:28+00:00"
         },
         {
             "name": "pear/auth_sasl",


### PR DESCRIPTION
Overview
----------------------------------------

This should prevent deployment problems with CiviCRM v6.9 on D9/D10 that stem from the new release of `php-autoprefixer` (1.5) without blocking future updates (1.6)

See also: https://chat.civicrm.org/civicrm/pl/y36pfqqybtnx3kgt7nhim8dr9c

Before
----------------------------------------

* __Standalone/D7/BD/WP__: These use `composer.lock` which is pinned to v1.3.
* __Drupal 9/10__: These do not use the same `composer.lock`. Their versions float. In practice, that means they have been using v1.4 -- until about a week ago, when v1.5 came out.
* __Bad Combination__: If you compile Greenwich (S)CSS on v1.5, it fails.

After
----------------------------------------

* __Standalone/D7/BD/WP__: These use `composer.lock` which is pinned to v1.4. (*Small upgrade*)
* __Drupal 9/10__: These do not use the same `composer.lock`. Their versions float. In practice, that means v1.4 for now (*small downgrade*) -- but in the future, it will allow v1.6.
* __Good Combination__: If you compile Greenwich (S)CSS on v1.4, it appears to work normally.
    * Looking forward, there's [an active thread](https://github.com/padaliyajay/php-autoprefixer/issues/31) working toward a fix (which should hopefully be in v1.6).

Technical Details
----------------------------------------

`civicrm-core` does not directly depend on `php-autoprefixer`. It's a transitive dependency through `civicrm/composer-compile-lib` (which requires `php-autoprefixer` at `~1.2`.)

Another option would be to do something to `require` exactly v1.3 or v1.4, and then do follow-ups to un-pin. My fear is that this might require coordinated updates across multiple repos (*now - and again later, for un-pinning*). I think the progress on `#31` suggests that it will straighten-out upstream. Declaring the `conflict` feels more minimally-invasive.