### PR TITLE
[Test Only] Clean up test add additional created entities to clean up.

### DIFF
--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -567,9 +567,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals(0, $result['count']);
 
     // Tear down - reverse of creation to be safe
+    $this->contactDelete($memberContactId[3]);
     $this->contactDelete($memberContactId[2]);
     $this->contactDelete($memberContactId[1]);
     $this->contactDelete($memberContactId[0]);
+    $this->contactDelete($employerId[2]);
     $this->contactDelete($employerId[1]);
     $this->contactDelete($employerId[0]);
     $this->membershipTypeDelete(['id' => $membershipTypeId]);


### PR DESCRIPTION
Looks like some additional contacts and memberships got added but not deleted.

Overview
----------------------------------------
In this test we create various entities and clean up at the end.

Before
----------------------------------------
Some contacts didn't get removed.

After
----------------------------------------
We call contactDelete on these entities.

Technical Details
----------------------------------------


Comments
----------------------------------------
It seems like we should be handling this in an automated fashion?  But :shrug: this seemed like a minimal change.
