### PR TITLE
[Test Only] Test inherited membership applies when existing inactive membership exists

### DIFF
--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -566,11 +566,53 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $result = $this->callAPISuccess('membership', 'get', $params);
     $this->assertEquals(0, $result['count']);
 
+    // Check Membership is granted via inheritance when:
+    // there is an inactive existing membership of the
+    // same type.  civicrm/civicrm-core/pull/24866
+    $employerId[3] = $this->organizationCreate([], 1);
+    $memberContactId[4] = $this->individualCreate(['employer_id' => $employerId[0]], 0);
+
+    $activeMembershipParams = [
+      'contact_id' => $employerId[3],
+      'membership_type_id' => $membershipTypeId,
+      'status_id' => 2, // Current
+      'source' => 'Test suite',
+      'start_date' => date('Y-m-d'),
+      'end_date' => '+1 year',
+    ];
+    $inactiveMembershipParams = [
+      'contact_id' => $memberContactId[4],
+      'membership_type_id' => $membershipTypeId,
+      'status_id' => 6, // Cancelled
+      'source' => 'Test suite',
+      'start_date' => date('Y-m-d'),
+      'end_date' => '+1 year',
+    ];
+    $getActiveMembershipParams = [
+      'contact_id' => $memberContactId[4],
+      'membership_type_id' => $membershipTypeId,
+      'status_id' => 2, // Current
+    ];
+
+    // Create inactive membership on the employee.
+    $this->contactMembershipCreate($inactiveMembershipParams);
+
+    // Check no current membership
+    $result = $this->callAPISuccess('membership', 'get', $getActiveMembershipParams);
+    $this->assertEquals(0, $result['count']);
+
+    // Add inherited membership
+    $this->contactMembershipCreate($activeMembershipParams);
+    $result = $this->callAPISuccess('membership', 'get', $getActiveMembershipParams);
+    $this->assertEquals(1, $result['count']);
+
     // Tear down - reverse of creation to be safe
+    $this->contactDelete($memberContactId[4]);
     $this->contactDelete($memberContactId[3]);
     $this->contactDelete($memberContactId[2]);
     $this->contactDelete($memberContactId[1]);
     $this->contactDelete($memberContactId[0]);
+    $this->contactDelete($employerId[3]);
     $this->contactDelete($employerId[2]);
     $this->contactDelete($employerId[1]);
     $this->contactDelete($employerId[0]);


### PR DESCRIPTION
Adds test to demonstrate issue in #24866

Overview
----------------------------------------

As per #24866 

Before
----------------------------------------
Tests pass.

After
----------------------------------------
Tests fail???

Technical Details
----------------------------------------
We should expect a membership to be granted if there is an existing membership of the same type that is inactive. This attempts to confirm if this is an issue.

Comments
----------------------------------------
Probably shouldn't be merged without #24866 and might be better to relocate this there.
