### PR TITLE
RiverLea: adds support for Personal Campaign Pages / funding thermometer

### DIFF
--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -681,3 +681,96 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
     transform: rotate(360deg);
   }
 }
+
+/* PCP Pages */
+
+.crm-container .campaign {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--crm-padding-reg);
+  align-items: start;
+}
+.campaign > * {
+  min-width: 100%;
+}
+.crm-container .pcp-page-pcpinfo-intro {
+  flex: 1;
+  min-width: min(100%, 300px);
+}
+.crm-container .pcp-intro-text {
+  padding-bottom: var(--crm-padding-reg);
+  font-size: var(--crm-l-reg-4);
+}
+.crm-container .pcp-image {
+  float: left;
+  margin: 0 var(--crm-padding-reg) var(--crm-padding-reg) 0;
+  width: max(50%, 150px);
+}
+.crm-container .pcp-widgets {
+  border: var(--crm-border);
+  border-radius: var(--crm-l-radius);
+  padding: var(--crm-padding-reg);
+  display: grid;
+  grid-template-columns: 9rem 9rem;
+  gap: var(--crm-padding-reg);
+  background: var(--crm-container-bg-color);
+  min-width: auto;
+}
+.crm-container .pcp-donate {
+  grid-column: 1 / span 2;
+}
+.crm-container .pcp-donate .button {
+  width: 100% !important; /* vs _buttons.css */
+  justify-content: center;
+}
+.crm-container .goal-amount,
+.crm-container .raised-amount {
+  font-weight: bold;
+  color: var(--crm-success-ink-color);
+}
+.crm-container .thermometer-fill-wrapper {
+  background: var(--crm-layer1-bg-color);
+  height: 220px;
+  position: relative;
+  margin: var(--crm-l-reg-4) 0;
+  width: var(--crm-l-large-1);
+  outline: var(--crm-border);
+}
+.crm-container .thermometer-fill {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  width: var(--crm-l-large-1);
+  background: var(--crm-success-color);
+}
+.crm-container .thermometer-pointer {
+  padding-left: 3.5rem;
+  position: absolute;
+  line-height: 1;
+  color: var(--crm-success-ink-color);
+  font-size: var(--crm-font-small-size);
+  width: 9rem;
+  top: -0.75rem;
+}
+.crm-container .honor_roll {
+  margin: var(--crm-l-reg-4) 0;
+  padding: var(--crm-padding-inset);
+  background-color: var(--crm-page-bg-color);
+  border: var(--crm-border);
+  border-radius: var(--crm-l-radius);
+  height: 220px;
+  overflow: hidden;
+}
+.crm-container .honor_roll marquee {
+  background-color: transparent;
+}
+.crm-container .pcp-honor_roll-nickname {
+  font-weight: bold;
+}
+.crm-container .pcp-create-your-own {
+  text-align: center;
+}
+.crm-container .pcp_honor_roll_entry,
+.crm-container .pcp-page-text {
+  margin-bottom: var(--crm-padding-reg);
+}


### PR DESCRIPTION
Overview
----------------------------------------
RiverLea never migrated the PCP/Funding thermometer css from civicrm.css. This PR does that now, with the following changes:
 - uses css variables wherever possible
 - uses flexbox and grid instead of float left/right+margin.
 - uses min/max widths with flexbox/grid for responsive support, without the need for media queries.
 - changes the gif backgrounds for css colour… 
 - makes the intro text larger than the rest of the text.
 - makes the donate button full-width.

Before
----------------------------------------
<img width="962" height="803" alt="image" src="https://github.com/user-attachments/assets/9d7b54ed-d49f-4e9e-aed4-10974ec04965" />

After
----------------------------------------
Minetta - full-width:

<img width="1958" height="1646" alt="image" src="https://github.com/user-attachments/assets/893e815a-73b3-44a3-8ea9-d3c68a10f9d1" />

Minetta medium-width:
(image hits min-width, intro text wraps)

<img width="1356" height="1310" alt="image" src="https://github.com/user-attachments/assets/93ada171-5205-476e-b5a4-38d77683d630" />

Minetta narrow:
(sidebar wraps below, image goes back to 50% width)

<img width="610" height="710" alt="image" src="https://github.com/user-attachments/assets/10daed22-ba58-4e52-8fec-8a6767beb26f" />

Minetta dark-mode:

<img width="1914" height="1410" alt="image" src="https://github.com/user-attachments/assets/7ff3e736-83f2-4889-8b8f-26b96223c30f" />

Walbrook:

<img width="1836" height="1536" alt="image" src="https://github.com/user-attachments/assets/32d83901-f089-4c4f-b4b0-d53b1a8f9412" />

Walbrook dark-mode:

<img width="1876" height="1558" alt="image" src="https://github.com/user-attachments/assets/58b876d0-1f6d-4290-ae2c-5781e2f01fed" />

Thames:

<img width="1546" height="998" alt="image" src="https://github.com/user-attachments/assets/1f3207be-9053-4c98-bae3-868a832261e0" />

Hackney:

<img width="1514" height="1040" alt="image" src="https://github.com/user-attachments/assets/b67e3ec5-267a-4c4f-b7f9-ce0beef1a220" />

Comments
----------------------------------------
The thermometer currently uses `--crm-success-color` - but there might be an argument to add a `--crm-thermometer-color`.

As there's currently *no* CSS for campaign pages, this new css is relatively low risk.