### PR TITLE
Riverlea - include dark mode setting in styleloader cache key

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -161,10 +161,14 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
     $streamMeta = $this->getAvailableStreamMeta()[$stream] ?? [];
     $streamModified = $streamMeta['modified_date'] ?? NULL;
 
+    $isFrontend = \CRM_Utils_System::isFrontendPage();
+    $darkMode = $isFrontend ? \Civi::settings()->get('riverlea_dark_mode_frontend') : \Civi::settings()->get('riverlea_dark_mode_backend');
+
     return [
       'stream' => $stream,
       'modified' => $streamModified,
-      'is_frontend' => \CRM_Utils_System::isFrontendPage(),
+      'is_frontend' => $isFrontend,
+      'dark_mode' => $darkMode,
     ];
   }
 


### PR DESCRIPTION
Before
----------------------------------------
- When asset caching is enabled, changes to Riverlea's dark mode setting (always light, always dark, respect user choice) wont take effect until the cache is cleared

After
----------------------------------------
- changes to Riverlea's dark mode setting (always light, always dark, respect user choice) will take effect until the cache is cleared

Technical Details
----------------------------------------
The setting is currently only read when the asset builder is compiling the asset. If the setting value changes, the asset builder won't notice. Adding the relevant setting value to the cache params above the caching layer ensures it *does* notice immediately.

