### PR TITLE
Afform - Allow behaviors to declare their own attributes

### DIFF
--- a/ext/afform/core/Civi/Afform/AbstractBehavior.php
+++ b/ext/afform/core/Civi/Afform/AbstractBehavior.php
@@ -66,4 +66,10 @@ abstract class AbstractBehavior extends AutoService implements BehaviorInterface
     return \CRM_Utils_String::convertStringToDash($behaviorName);
   }
 
+  public static function getAttributes(): array {
+    return [
+      static::getKey() => 'text',
+    ];
+  }
+
 }

--- a/ext/afform/core/Civi/Afform/BehaviorInterface.php
+++ b/ext/afform/core/Civi/Afform/BehaviorInterface.php
@@ -41,7 +41,21 @@ interface BehaviorInterface {
    * Dashed name, name of entity attribute for selected mode
    * @return string
    */
-  public static function getKey():string;
+  public static function getKey(): string;
+
+  /**
+   * Array of attributes added to the entity by this behavior.
+   *
+   * Array is keyed by attribute name, with a value of an ArrayHtml data type, e.g.
+   * ```
+   * [
+   *   'my-mode' => 'text',
+   *   'my-config-data' => 'js',
+   * ]
+   * ```
+   * @return array
+   */
+  public static function getAttributes(): array;
 
   /**
    * Get array of modes for a given entity

--- a/ext/afform/core/Civi/Api4/Action/AfformBehavior/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/AfformBehavior/Get.php
@@ -28,6 +28,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
       }
       $result[] = [
         'key' => $behaviorClass::getKey(),
+        'attributes' => $behaviorClass::getAttributes(),
         'title' => $behaviorClass::getTitle(),
         'description' => $behaviorClass::getDescription(),
         'entities' => $entities,

--- a/ext/afform/core/Civi/Api4/AfformBehavior.php
+++ b/ext/afform/core/Civi/Api4/AfformBehavior.php
@@ -44,6 +44,11 @@ class AfformBehavior extends Generic\AbstractEntity {
           'description' => 'Unique identifier in dashed-format, name of entity attribute for selected mode',
         ],
         [
+          'name' => 'attributes',
+          'data_type' => 'Array',
+          'description' => 'Array of attributes added to the entity by this behavior, keyed by attribute name',
+        ],
+        [
           'name' => 'title',
           'data_type' => 'String',
           'description' => 'Localized title displayed on admin screen',


### PR DESCRIPTION
Overview
----------------------------------------
Solution for #33664

Before
----------------------------------------
Behaviors could add html attributes to afform entities, but the ArrayHtml encoder didn't know about them.

After
----------------------------------------
Declared attributes can be parsed correctly.

Technical Details
----------------------------------------
An afform behavior with advanced configuration can declare its own `getAttributes` function like:

```php
public static function getAttributes(): array {
    return [
      'my-mode' => 'text',
      'my-config-data' => 'js',
    ];
}
```