### PR TITLE
(dev/core#6226) Error Handling - Use same formatting for PHP errors as other exceptions

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -401,7 +401,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * entire CRM_Core_Error system can be hollowed out and replaced with
    * something that follows a cleaner separation of concerns.
    *
-   * @param Exception $exception
+   * @param Throwable $exception
    */
   public static function handleUnhandledException($exception) {
     try {

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -43,7 +43,7 @@ class CRM_Core_Invoke {
       }
       return $result;
     }
-    catch (Exception $e) {
+    catch (Throwable $e) {
       CRM_Core_Config::singleton()->userSystem->handleUnhandledException($e);
     }
   }

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -2415,7 +2415,7 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
-   * @param CRM_Core_Exception $exception
+   * @param Throwable $exception
    */
   public static function unhandledException($exception) {
     $null = NULL;

--- a/Civi/Core/Event/UnhandledExceptionEvent.php
+++ b/Civi/Core/Event/UnhandledExceptionEvent.php
@@ -18,7 +18,7 @@ namespace Civi\Core\Event;
 class UnhandledExceptionEvent extends GenericHookEvent {
 
   /**
-   * @var \Exception
+   * @var \Throwable
    */
   public $exception;
 
@@ -30,7 +30,7 @@ class UnhandledExceptionEvent extends GenericHookEvent {
   public $request;
 
   /**
-   * @param $e
+   * @param \Throwable $e
    * @param $request
    */
   public function __construct($e, $request) {


### PR DESCRIPTION
Overview
----------------------------------------

On "Standalone", PHP errors (such as type-mismatch errors) are not displayed. This updates the catch-all rule where `CRM_Core_Invoke` finds unhandled problems and presents them.

The example screenshots are based on the steps from https://lab.civicrm.org/dev/core/-/issues/6226.

Before
----------------------------------------

`CRM_Core_Invoke` catches `Exception`s and presents them (*conditionally; dependent on system config*).

However, for PHP `Error`s, there is no output -- in the system log or the HTTP response.

> <img width="1438" height="836" alt="image" src="https://github.com/user-attachments/assets/a6f37622-485c-4a53-8ace-55112aaff0a3" />


After
----------------------------------------

`CRM_Core_Invoke` catches `Throwable`s (including `Error`s and `Exception`s). It presents them the same way  (*conditionally; dependent on system config*).

So `Error`s can be displayed (*with suitable system config*):

> <img width="1438" height="836" alt="image" src="https://github.com/user-attachments/assets/110825c3-389f-4f17-96a5-1f8dfa1cf626" />

Technical Details
----------------------------------------

It's a bit weird that the log the trace is printed before the `<html>` tag. That's not new -- it matches the existing output format. Should send separate PRs to tweak that format.

This fixes a symptom on Standalone. There will be an effect on all other UF's too -- more PHP errors (when generated by Civi) will be presented by Civi.

There is a very small contract change in `hook_civicrm_unhandled_exception` -- the provided exception may be any `Throwable`. However, all examples in `civicrm-core` and `universe` rely on soft/docblock-based typing. And substantively, any code that generically presents `Exception` should be able to generically present `Throwable`.

I don't believe this is technically a regression, so I submitted to `master`. However, you could argue that it's mildly critical. (And it really should be in 6.10, since that will be an ESR.) I based the branch on `6.9-rc`, so if we want to switch, then that's easy. 