### PR TITLE
RiverLea: resolves modal resize bug/regression

### DIFF
--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -82,10 +82,8 @@
   border-radius: var(--crm-dialog-radius);
   background: var(--crm-dialog-body-bg);
   color: var(--crm-c-text);
-  height: auto !important;
   margin: var(--crm-dialog-padding) 0;
-  position: static;
-  z-index: 1;
+  position: relative;
   padding: var(--crm-dialog-body-padding);
 }
 .crm-container.ui-dialog:has(.ui-dialog-buttonpane) .ui-dialog-content {

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -6,7 +6,6 @@
   border-radius: var(--crm-dialog-radius);
   box-shadow: var(--crm-popup-shadow);
   color: var(--crm-c-text);
-  max-height: 90%;
   padding: var(--crm-dialog-padding);
 }
 .crm-container.ui-dialog .ui-dialog-header,
@@ -78,7 +77,9 @@
   background: var(--crm-dialog-body-bg);
 }
 .crm-container.ui-dialog .ui-dialog-content {
-  max-height: calc(100vh - 280px) !important;
+  max-height: calc(100vh - 280px) !important; /* vs JQuery */
+  height: calc(100% - 94px) !important;
+  width: 100% !important;
   border-radius: var(--crm-dialog-radius);
   background: var(--crm-dialog-body-bg);
   color: var(--crm-c-text);


### PR DESCRIPTION
As spotted by @colemanw - resizing modals in RiverLea gives a bad UI failure. I know this was tested quite a bit ahead of 6.0 so I don't think this has always been there, tho I can recreate on 6.7 so it's def not completely new.

Before
----------------------------------------
Modal footer falls out of bounding box on resize, padding increases 1rem to the right and bottom with every resize while the modal is open:

<img width="2062" height="1466" alt="image" src="https://github.com/user-attachments/assets/4ead773c-9a6d-4e60-a2eb-770437f3e10d" />

After
----------------------------------------
Modal footer doesn't escape, padding doesn't bloom…

<img width="830" height="620" alt="image" src="https://github.com/user-attachments/assets/d9ec923c-f8d2-4e03-b920-917a597a7819" />

Comments
----------------------------------------
The two commits fix the two bugs. 

The fix for the second bug is built on forcing the modal body region to be 100% width and height, less the height of the button bar at the bottom. This is using the height of the Minetta modal footer, which isn't a perfect fix as someone could make their buttons huge.

But currently, this has only a hard-to-find visual impact on Walbrook where one end of the scrollbar on a resized modal is slightly clipped in the bottom right-hand corner when scrolled down fully. No functional impact, hard to spot visually.
