### PR TITLE
dev/core#6227 permit forcing new search

### DIFF
--- a/api/v3/Job.php
+++ b/api/v3/Job.php
@@ -552,7 +552,7 @@ function civicrm_api3_job_process_batch_merge($params) {
   $gid = $params['gid'] ?? NULL;
   $mode = $params['mode'] ?? 'safe';
 
-  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, $params['criteria'] ?? [], $params['check_permissions'] ?? FALSE, NULL, $params['search_limit']);
+  $result = CRM_Dedupe_Merger::batchMerge($rule_group_id, $gid, $mode, 1, 2, $params['criteria'] ?? [], $params['check_permissions'] ?? FALSE, NULL, $params['search_limit'], (bool) $params['is_force_new_search']);
 
   return civicrm_api3_create_success($result, $params);
 }
@@ -586,6 +586,12 @@ function _civicrm_api3_job_process_batch_merge_spec(&$params) {
     'title' => ts('Number of contacts to look for matches for.'),
     'type' => CRM_Utils_Type::T_INT,
     'api.default' => (int) Civi::settings()->get('dedupe_default_limit'),
+  ];
+  $params['is_force_new_search'] = [
+    'title' => ts('Force a new search, refreshing any cached search'),
+    'type' => CRM_Utils_Type::T_BOOLEAN,
+    // Arguably for batch mode we should default to TRUE...
+    'api.default' => FALSE,
   ];
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6227 permit forcing new search

Before
----------------------------------------
`is_force_new_search` is passed through from `Contact.getDuplicates()` but not `Job.process_batch_merge`

After
----------------------------------------
Can be passed through

Technical Details
----------------------------------------
I rather suspect TRUE might be a more appropriate default in a batch context but I think any expansion could be a follow on. I also think maybe the cache should expire more organically - noted on the gitlab

Comments
----------------------------------------
