### PR TITLE
(REF) CRM_Core_Error - Extract formatting utils

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -817,35 +817,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   printable HTML text
    */
   public static function formatHtmlException(Throwable $e) {
-    $msg = '';
-
-    // Exception metadata
-
-    // Exception backtrace
-    if ($e instanceof PEAR_Exception) {
-      $ei = $e;
-      if (is_callable([$ei, 'getCause'])) {
-        // DB_ERROR doesn't have a getCause but does have a __call function which tricks is_callable.
-        if (!$ei instanceof DB_Error) {
-          if ($ei->getCause() instanceof PEAR_Error) {
-            $msg .= '<table class="crm-db-error">';
-            $msg .= sprintf('<thead><tr><th>%s</th><th>%s</th></tr></thead>', ts('Error Field'), ts('Error Value'));
-            $msg .= '<tbody>';
-            foreach (['Type', 'Code', 'Message', 'Mode', 'UserInfo', 'DebugInfo'] as $f) {
-              $msg .= sprintf('<tr><td>%s</td><td>%s</td></tr>', $f, call_user_func([$ei->getCause(), "get$f"]));
-            }
-            $msg .= '</tbody></table>';
-          }
-          $ei = $ei->getCause();
-        }
-      }
-      $msg .= $e->toHtml();
-    }
-    else {
-      $msg .= '<p><b>' . get_class($e) . ': "' . htmlentities($e->getMessage()) . '"</b></p>';
-      $msg .= '<pre>' . htmlentities(self::formatBacktrace($e->getTrace())) . '</pre>';
-    }
-    return $msg;
+    return static::formatter('html')->formatException($e);
   }
 
   /**
@@ -856,26 +828,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   printable plain text
    */
   public static function formatTextException(Throwable $e) {
-    $msg = get_class($e) . ": \"" . $e->getMessage() . "\"\n";
-
-    $ei = $e;
-    while (is_callable([$ei, 'getCause'])) {
-      // DB_ERROR doesn't have a getCause but does have a __call function which tricks is_callable.
-      if (!$ei instanceof DB_Error) {
-        if ($ei->getCause() instanceof PEAR_Error) {
-          foreach (['Type', 'Code', 'Message', 'Mode', 'UserInfo', 'DebugInfo'] as $f) {
-            $msg .= sprintf(" * ERROR %s: %s\n", strtoupper($f), call_user_func([$ei->getCause(), "get$f"]));
-          }
-        }
-        $ei = $ei->getCause();
-      }
-      // if we have reached a DB_Error assume that is the end of the road.
-      else {
-        $ei = NULL;
-      }
-    }
-    $msg .= self::formatBacktrace($e->getTrace());
-    return $msg;
+    return static::formatter('text')->formatException($e);
   }
 
   /**

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -787,6 +787,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    *   Maximum number of characters to show from each argument string.
    * @return string
    *   printable plain-text
+   * @deprecated See formatter()
    */
   public static function formatBacktrace($backTrace, $showArgs = TRUE, $maxArgLen = 80) {
     return static::formatter('text', $showArgs, $maxArgLen)->formatBacktrace($backTrace);
@@ -798,6 +799,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param Throwable $e
    * @return string
    *   printable HTML text
+   * @deprecated See formatter()
    */
   public static function formatHtmlException(Throwable $e) {
     return static::formatter('html')->formatException($e);
@@ -809,6 +811,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    * @param Throwable $e
    * @return string
    *   printable plain text
+   * @deprecated See formatter()
    */
   public static function formatTextException(Throwable $e) {
     return static::formatter('text')->formatException($e);

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -379,7 +379,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
         'content' => '<div class="messages status no-popup">' . CRM_Core_Page::crmIcon('fa-info-circle') . ' ' . ts('Sorry but we are not able to provide this at the moment.') . '</div>',
       ];
       if ($config->backtrace && CRM_Core_Permission::check('view debug output')) {
-        $out['backtrace'] = self::parseBacktrace(debug_backtrace());
+        $out['backtrace'] = static::formatter('array')->formatBacktrace(debug_backtrace());
         $message .= '<p><em>See console for backtrace</em></p>';
       }
       CRM_Core_Session::setStatus($message, ts('Sorry an error occurred'), 'error');
@@ -790,23 +790,6 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function formatBacktrace($backTrace, $showArgs = TRUE, $maxArgLen = 80) {
     return static::formatter('text', $showArgs, $maxArgLen)->formatBacktrace($backTrace);
-  }
-
-  /**
-   * Render a backtrace array as an array.
-   *
-   * @param array $backTrace
-   *   Array of stack frames.
-   * @param bool $showArgs
-   *   TRUE if we should try to display content of function arguments (which could be sensitive); FALSE to display only the type of each function argument.
-   * @param int $maxArgLen
-   *   Maximum number of characters to show from each argument string.
-   * @return array
-   * @see debug_backtrace
-   * @see Exception::getTrace()
-   */
-  public static function parseBacktrace($backTrace, $showArgs = TRUE, $maxArgLen = 80) {
-    return static::formatter('array', $showArgs, $maxArgLen)->formatBacktrace($backTrace);
   }
 
   /**

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -344,7 +344,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     if (php_sapi_name() == "cli") {
       print ("Sorry. A non-recoverable error has occurred.\n$message \n$code\n$email\n\n");
       // Fix for CRM-16899
-      echo static::formatBacktrace(debug_backtrace());
+      echo static::formatter('text')->formatBacktrace(debug_backtrace());
       die("\n");
       // FIXME: Why doesn't this call abend()?
       // Difference: abend() will cleanup transaction and (via civiExit) store session state
@@ -409,7 +409,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     }
     catch (Exception $other) {
       // if the exception-handler generates an exception, then that sucks! oh, well. carry on.
-      CRM_Core_Error::debug_var('handleUnhandledException_nestedException', self::formatTextException($other), TRUE, TRUE, '', PEAR_LOG_ERR);
+      CRM_Core_Error::debug_var('handleUnhandledException_nestedException', self::formatter('text')->formatException($other), TRUE, TRUE, '', PEAR_LOG_ERR);
     }
     $config = CRM_Core_Config::singleton();
     $vars = [
@@ -427,7 +427,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // Case A: CLI
     if (php_sapi_name() == "cli") {
       printf("Sorry. A non-recoverable error has occurred.\n%s\n", $vars['message']);
-      print self::formatTextException($exception);
+      print self::formatter('text')->formatException($exception);
       die("\n");
       // FIXME: Why doesn't this call abend()?
       // Difference: abend() will cleanup transaction and (via civiExit) store session state
@@ -459,7 +459,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $content = $template->fetch('CRM/common/fatal.tpl');
 
     if ($config->backtrace) {
-      $content = self::formatHtmlException($exception) . $content;
+      $content = self::formatter('html')->formatException($exception) . $content;
     }
 
     // set the response code before starting the request
@@ -751,7 +751,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
    */
   public static function backtrace($msg = 'backTrace', $log = FALSE) {
     $backTrace = debug_backtrace();
-    $message = self::formatBacktrace($backTrace);
+    $message = self::formatter('text')->formatBacktrace($backTrace);
     if (!$log) {
       CRM_Core_Error::debug($msg, $message);
     }
@@ -877,7 +877,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     try {
       $messageWithDetails = $message . ' ' . $pearError->getUserInfo();
 
-      \Civi::log()->debug($messageWithDetails . "\n\n" . self::formatBacktrace($pearError->getBacktrace()));
+      \Civi::log()->debug($messageWithDetails . "\n\n" . static::formatter('text')->formatBacktrace($pearError->getBacktrace()));
     }
     catch (\Exception $e) {
       // well we tried

--- a/CRM/Core/Error/Formatter.php
+++ b/CRM/Core/Error/Formatter.php
@@ -1,0 +1,150 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Formatting helper for errors (backtraces and exceptions).
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ * @internal
+ */
+class CRM_Core_Error_Formatter {
+
+  protected string $format;
+  protected bool $showArgs;
+  protected int $maxArgLen;
+
+  /**
+   * @param string $format
+   *   Desired output format.
+   *   Ex: 'text', 'html', or 'array'
+   * @param bool $showArgs
+   *   TRUE if we should try to display content of function arguments (which could be sensitive); FALSE to display only the type of each function argument.
+   * @param int $maxArgLen
+   *   Maximum number of characters to show from each argument string.
+   */
+  public function __construct(string $format, bool $showArgs = TRUE, int $maxArgLen = 80) {
+    $this->format = $format;
+    $this->showArgs = $showArgs;
+    $this->maxArgLen = $maxArgLen;
+  }
+
+  /**
+   * @param array $trace
+   *   The backtrace. (List of stack-frames.)
+   * @return mixed
+   *   Varies by $format.
+   */
+  public function formatBacktrace(array $trace) {
+    return match($this->format) {
+      'array' => $this->formatArrayBacktrace($trace),
+      'text' => $this->formatTextBacktrace($trace),
+      'html' => $this->formatHtmlBacktrace($trace),
+      default => throw new \RuntimeException("Cannot format backtrace as {$this->format}"),
+    };
+  }
+
+  protected function formatHtmlBacktrace(array $trace): string {
+    return '<pre>' . htmlentities($this->formatTextBacktrace($trace)) . '</pre>';
+  }
+
+  /**
+   * Render a backtrace array as a string.
+   *
+   * @param array $backTrace
+   *   Array of stack frames.
+   * @return string
+   *   printable plain-text
+   */
+  protected function formatTextBacktrace(array $backTrace): string {
+    $message = '';
+    foreach ($this->formatArrayBacktrace($backTrace) as $idx => $trace) {
+      $message .= sprintf("#%s %s\n", $idx, $trace);
+    }
+    $message .= sprintf("#%s {main}\n", 1 + $idx);
+    return $message;
+  }
+
+  /**
+   * Render a backtrace array as an array.
+   *
+   * @param array $backTrace
+   *   Array of stack frames.
+   * @return array
+   * @see debug_backtrace
+   * @see Exception::getTrace()
+   */
+  protected function formatArrayBacktrace(array $backTrace): array {
+    $ret = [];
+    foreach ($backTrace as $trace) {
+      $args = [];
+      $fnName = $trace['function'] ?? NULL;
+      $className = isset($trace['class']) ? ($trace['class'] . $trace['type']) : '';
+
+      // Do not show args for a few password related functions
+      $skipArgs = $className == 'DB::' && $fnName == 'connect';
+
+      if (!empty($trace['args'])) {
+        foreach ($trace['args'] as $arg) {
+          if (!$this->showArgs || $skipArgs) {
+            $args[] = '(' . gettype($arg) . ')';
+            continue;
+          }
+          switch ($type = gettype($arg)) {
+            case 'boolean':
+              $args[] = $arg ? 'TRUE' : 'FALSE';
+              break;
+
+            case 'integer':
+            case 'double':
+              $args[] = $arg;
+              break;
+
+            case 'string':
+              $args[] = '"' . CRM_Utils_String::ellipsify(addcslashes((string) $arg, "\r\n\t\""), $this->maxArgLen) . '"';
+              break;
+
+            case 'array':
+              $args[] = '(Array:' . count($arg) . ')';
+              break;
+
+            case 'object':
+              $args[] = 'Object(' . get_class($arg) . ')';
+              break;
+
+            case 'resource':
+              $args[] = 'Resource';
+              break;
+
+            case 'NULL':
+              $args[] = 'NULL';
+              break;
+
+            default:
+              $args[] = "($type)";
+              break;
+          }
+        }
+      }
+
+      $ret[] = sprintf(
+        "%s(%s): %s%s(%s)",
+        $trace['file'] ?? '[internal function]',
+        $trace['line'] ?? '',
+        $className,
+        $fnName,
+        implode(", ", $args)
+      );
+    }
+    return $ret;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Move basic formatting utilities from `CRM_Core_Error` to `CRM_Core_Error_Formatter`.

Comments
----------------------------------------

`CRM_Core_Error` is a bit of  jumble, and I basically want it to be easier to read.

I left stubs for the old functions because they are referenced in `universe`. Never-the-less, `CRM_Core_Error` is a bit thinner.

Stylistically, this separates the simple/pure functions (used for formatting) from the side-effect-y functions (which are otherwise common in CRM_Core_Error).