### PR TITLE
Errors - Use common helper to generate log IDs

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -169,7 +169,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       ];
       $status = $statusMap[get_class($e)] ?? 500;
 
-      $errorId = rtrim(chunk_split(CRM_Utils_String::createRandom(12, CRM_Utils_String::ALPHANUMERIC), 4, '-'), '-');
+      $errorId = CRM_Core_Error::createErrorId();
       $logMessage = "AJAX Error ({$errorId}): {$e->getMessage()}";
       $logContext = ['error_id' => $errorId, 'exception' => $e];
       if ($status === 500) {

--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -512,7 +512,7 @@ class CRM_Core_Error extends PEAR_ErrorStack {
 
     if ($log) {
       // Log the output to error_log with a unique reference.
-      $unique = bin2hex(random_bytes(6));
+      $unique = static::createErrorId();
       error_log("errorID:$unique\n$out");
 
       if (!$checkPermission) {
@@ -943,6 +943,15 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     $error = CRM_Core_Error::singleton();
     $error->push($code, $level, [$params], $message);
     return $error;
+  }
+
+  /**
+   * Create a random identifier for an error.
+   *
+   * @return string
+   */
+  public static function createErrorId(): string {
+    return rtrim(chunk_split(CRM_Utils_String::createRandom(12, CRM_Utils_String::ALPHANUMERIC), 4, '-'), '-');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Sometimes, when logging an error, you want to generate a unique ID for that error -- so that you can tell the user about it. The user will share this error-ID with a sysadmin.

This pattern is a workflow convenience -- the sysadmin can search the error-logs more easily if there's a distinctive ID.

Before
----------------------------------------

Two instances of the pattern. Both generate IDs with random alphanumerics, but they use different formulas.

After
----------------------------------------

Same formula. Helper function can be called in other places (where we might introduce similar pattern).

Comment
----------------------------------------

Between the two formulas... `random_bytes()` is better than `createRandom()`. But 12 chars are better than 6 bytes. Allowing the full range of alphanumerics is nice (shorter IDs). Longer ID's make it harder for user+admin to communicate out-of-band (phone/SMS/chat/etc). Neither generator would be used for security-keys, but we're not doing that. We just need something that's unique enough to help the sysadmin filter through logs. Both are OK for the job.

(I kept the one from APIv4.)