### PR TITLE
Fix faulty usage of CRM_Utils_SQL_TempTable

### DIFF
--- a/CRM/Dedupe/Finder.php
+++ b/CRM/Dedupe/Finder.php
@@ -62,12 +62,11 @@ class CRM_Dedupe_Finder {
   }
 
   private static function getIdTable($ids): CRM_Utils_SQL_TempTable {
-    $table = new CRM_Utils_SQL_TempTable();
-    $table->setAutodrop();
-    $table->setDurable();
-    $table->createWithColumns(
-      'id int(10)'
-    );
+    $table = CRM_Utils_SQL_TempTable::build()
+      ->setAutodrop()
+      ->setDurable()
+      ->setCategory('dedupetable')
+      ->createWithColumns('id int(10)');
     CRM_Core_DAO::executeQuery('ALTER TABLE ' . $table->getName() . ' ADD index(id)');
     $insert = ' INSERT INTO ' . $table->getName() . ' (`id`)
       VALUES (' . implode('), (', $ids) . ')';


### PR DESCRIPTION


Overview
----------------------------------------
Fix faulty usage of CRM_Utils_SQL_TempTable

Before
----------------------------------------
if 2 dedupe queries are running at once one may fail due to trying to create a table name that already exists

After
----------------------------------------
Unique table names used

Technical Details
----------------------------------------
By missing the build step we were not getting unique table names.

This regressed back at the start of this year and would normally be intermittent enough to defy detection. However, I think  the rc is appropriate even though it's not a super recent regression due to the straight-forwardness of the fix

Comments
----------------------------------------
