### PR TITLE
Removes RiverLea version number from info.xml

### DIFF
--- a/ext/riverlea/info.xml
+++ b/ext/riverlea/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>[civicrm.releaseDate]</releaseDate>
-  <version>1.4.10-[civicrm.version]</version>
+  <version>[civicrm.version]</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>[civicrm.majorVersion]</ver>


### PR DESCRIPTION
This was still showing the Civi 6.8, RiverLea version number, it either needed bumping up to 1.4.11 or removing. It's removed in 6.10, so removed it here too.

Before
----------------------------------------
Outputs **1.4.10-6.9** (confusingly close to 1.4.10-6.8 in the current release)

After
----------------------------------------
Outputs **6.9**.