### PR TITLE
WIP: Searckit Load more button option for search results

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.component.js
@@ -14,7 +14,8 @@
       function getDefaultSettings() {
         return _.cloneDeep({
           show_count: false,
-          expose_limit: false
+          expose_limit: false,
+          loadmore: false
         });
       }
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminPagerConfig.html
@@ -13,11 +13,19 @@
     <input ng-if="$ctrl.display.settings.limit" type="number" min="1" step="1" class="form-control four" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
   </div>
   <div class="form-group" ng-if="$ctrl.display.settings.pager">
-    <label for="crm-search-admin-display-limit">
-      {{:: ts('Page Size') }}
-    </label>
-    <input id="crm-search-admin-display-limit" type="number" min="1" step="1" class="form-control four" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
+    <div class="input-inline form-control">
+      <label for="crm-search-admin-display-limit">
+        {{:: ts('Page Size') }}
+      </label>
+      <input id="crm-search-admin-display-limit" type="number" min="1" step="1" class="form-control four" ng-model="$ctrl.display.settings.limit" ng-model-options="{updateOn: 'blur'}" ng-change="$ctrl.onChangeLimit()">
+    </div>
     <div class="checkbox-inline form-control">
+      <label>
+        <input type="checkbox" ng-model="$ctrl.display.settings.pager.loadmore" >
+        <span>{{:: ts('Load More') }}</span>
+      </label>
+    </div>
+    <div class="checkbox-inline form-control" ng-if="!$ctrl.display.settings.pager.loadmore">
       <label>
         <input type="checkbox" ng-model="$ctrl.display.settings.pager.expose_limit" >
         <span>{{:: ts('Adjustable Page Size') }}</span>
@@ -25,14 +33,14 @@
     </div>
     <div class="checkbox-inline form-control">
       <label>
-        <input type="checkbox" ng-model="$ctrl.display.settings.pager.show_count" >
-        <span>{{:: ts('Show Count in Pager') }}</span>
+        <input type="checkbox" ng-model="$ctrl.display.settings.pager.hide_single">
+        <span>{{:: ts('Hide Pager if One Page') }}</span>
       </label>
     </div>
     <div class="checkbox-inline form-control">
       <label>
-        <input type="checkbox" ng-model="$ctrl.display.settings.pager.hide_single">
-        <span>{{:: ts('Hide Pager if One Page') }}</span>
+        <input type="checkbox" ng-model="$ctrl.display.settings.pager.show_count" >
+        <span>{{:: ts('Show Count in Pager') }}</span>
       </label>
     </div>
   </div>

--- a/ext/search_kit/ang/crmSearchDisplay/Pager.html
+++ b/ext/search_kit/ang/crmSearchDisplay/Pager.html
@@ -3,8 +3,9 @@
     <div class="form-inline" ng-if="$ctrl.settings.pager.show_count" ng-include="'~/crmSearchDisplay/ResultCount.html'">
     </div>
   </div>
-  <div ng-if="!$ctrl.settings.pager.hide_single || ($ctrl.rowCount > $ctrl.limit)" class="text-center crm-flex-2">
-    <ul uib-pagination
+  <div ng-if="!$ctrl.settings.pager.hide_single || ($ctrl.rowCount > $ctrl.limit)" class="pager-wrapper">
+    <div ng-if="!$ctrl.settings.pager.loadmore" class="text-center crm-flex-2">
+      <ul uib-pagination
         class="pagination"
         boundary-link-numbers="true"
         total-items="$ctrl.rowCount"
@@ -15,9 +16,11 @@
         force-ellipses="true"
         previous-text="⬅"
         next-text="⮕"
-    ></ul>
-  </div>
-  <div>
+      ></ul>
+    </div>
+    <div ng-if="$ctrl.settings.pager.loadmore" class="text-center crm-flex-2">
+      <button type="button" ng-click="selectPage(page.number, $event)" class="btn btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    </div>
     <div class="form-inline text-right" ng-if="$ctrl.settings.pager.expose_limit && (!$ctrl.settings.pager.hide_single || $ctrl.rowCount > $ctrl.limit)">
       <label for="{{ 'crm-search-results-page-size-' + $ctrl.uniqueId }}" >
         {{:: ts('Page Size') }}


### PR DESCRIPTION
Overview
----------------------------------------
Add the ability to use a `Load More` button instead of a pager that would dynamically load the results below the existings onto the page.

Before
----------------------------------------

+ Only could choose a Pager as an option for Grids/Lists

After
----------------------------------------

+ Ability to choose `Load More`
+ Button appears which triggers an AJAX call (to be setup)
<img width="1243" height="359" alt="Selection_035" src="https://github.com/user-attachments/assets/3bce06f4-f795-46da-a0b9-8d5d279adad4" />


Comments
----------------------------------------

- [ ] Need help to get the button configured
- [ ] Add proper call to trigger ajax call
- [ ] Hide the `Load More` button if there are no more results