### PR TITLE
(dev/core#6231) CachedExtLoader.XXX.php - Handle stampede better

### DIFF
--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -87,7 +87,7 @@ class CRM_Extension_ClassLoader {
     else {
       $this->loader = $this->buildClassLoader();
       $ser = serialize($this->loader);
-      file_put_contents($file,
+      (new Symfony\Component\Filesystem\Filesystem())->dumpFile($file,
         sprintf("<?php\nreturn unserialize(%s);", var_export($ser, 1))
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------

As discussed in [dev/core#6231](https://lab.civicrm.org/dev/core/-/issues/6231), a sporadic failure in CiviMail's `ConcurrenctDeliveryTest` suggests that there may be a race in which `CachedExtLoader.XXX.php` is written inconsistently. (There was also a bug-report somewhere in the past... 18 months?... where it sounded like someone organically had a similar corruption. I haven't found it, but I think the issue can affect live sites -- just very infrequently.)

The file should be written atomically.

Before
----------------------------------------

Write cache-file without any concurrrency guards.

After
----------------------------------------

Write cache-file with Symfony's `dumpFile()`. This includes an implementation of a common pattern for (near) atomicity based on  "write to temp, then swap/rename".

Technical Details
----------------------------------------

* Unfortunately, it's hard to test the race. (Anecdotally, it's a small percentage of runs which produce it.)

* IMHO, the main consideration in this patch whether the dependency is safe to use.

    Our `composer.json` specifies that `symfony/filesystem` is required, and some CMS's also require `symfony/filesystem`. Consequently, our `composer.json` allows a very broad range of versions.

    Fortunately, it appears that all relevant versions of `symfony/filesystem` have `dumpFile()` implementations that use `tempnam()` + `rename()`. Here are some spot-checks:

    * https://github.com/symfony/filesystem/blob/v4.4.0/Filesystem.php#L670-L697
    * https://github.com/symfony/filesystem/blob/v6.4.24/Filesystem.php#L670-L709
    * https://github.com/symfony/filesystem/blob/v8.0.0/Filesystem.php#L640-L679
