### PR TITLE
Standaloneusers - move canonical role creation from core installer to extension installer

### DIFF
--- a/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Upgrader.php
@@ -34,19 +34,13 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
   }
 
   /**
-   * Example: Run an external SQL script when the module is installed.
+   * Post Install
+   * - ensure necessary Role records exist
+   * - ensure authx settings allow for login
    *
-   * public function install() {
-   * $this->executeSqlFile('sql/myinstall.sql');
-   * }
-   *
-   * /**
-   * Example: Work with entities usually not available during the install step.
-   *
-   * This method can be used for any post-install tasks. For example, if a step
-   * of your installation depends on accessing an entity that is itself
-   * created during the installation (e.g., a setting or a managed entity), do
-   * so here to avoid order of operation problems.
+   * Note: the core installer will also create a default user
+   * based on user default in StandaloneUsers.civi-setup.php,
+   * which runs *after* this
    */
   public function postInstall() {
 
@@ -56,17 +50,128 @@ class CRM_Standaloneusers_Upgrader extends CRM_Extension_Upgrader_Base {
       ['pass']
     )));
 
-    // `standaloneusers` is installed as part of the overall install process for `Standalone`.
-    // A subsequent step will configure some default users (*depending on local options*).
-    // See also: `StandaloneUsers.civi-setup.php`
+    // Ensure default roles exist
+    \Civi\Api4\Role::save(FALSE)
+      ->setMatch(['name'])
+      ->setRecords([
+        [
+          'name' => CRM_Standaloneusers_BAO_Role::ANONYMOUS_ROLE_NAME,
+          'label' => ts('Everyone, including anonymous users'),
+          'is_active' => TRUE,
+          // Provide default open permissions
+          'permissions' => [
+            'access CiviMail subscribe/unsubscribe pages',
+            'make online contributions',
+            'view event info',
+            'register for events',
+            'access password resets',
+            'authenticate with password',
+          ],
+        ],
+        [
+          'name' => CRM_Standaloneusers_BAO_Role::SUPERADMIN_ROLE_NAME,
+          'label' => ts('Administrator'),
+          'is_active' => TRUE,
+          'permissions' => [
+            'all CiviCRM permissions and ACLs',
+          ],
+        ],
+        [
+          'name' => 'staff',
+          'label' => ts('Staff'),
+          'is_active' => TRUE,
+          'permissions' => [
+            'access AJAX API',
+            'access CiviCRM',
+            'access Contact Dashboard',
+            'access uploaded files',
+            'add contacts',
+            'view my contact',
+            'view all contacts',
+            'edit all contacts',
+            'edit my contact',
+            'delete contacts',
+            'import contacts',
+            'access deleted contacts',
+            'merge duplicate contacts',
+            'edit groups',
+            'manage tags',
+            'administer Tagsets',
+            'view all activities',
+            'delete activities',
+            'add contact notes',
+            'view all notes',
+            'access CiviContribute',
+            'delete in CiviContribute',
+            'edit contributions',
+            'make online contributions',
+            'view my invoices',
+            'access CiviEvent',
+            'delete in CiviEvent',
+            'edit all events',
+            'edit event participants',
+            'register for events',
+            'view event info',
+            'view event participants',
+            'gotv campaign contacts',
+            'interview campaign contacts',
+            'manage campaign',
+            'release campaign contacts',
+            'reserve campaign contacts',
+            'sign CiviCRM Petition',
+            'access CiviGrant',
+            'delete in CiviGrant',
+            'edit grants',
+            'access CiviMail',
+            'access CiviMail subscribe/unsubscribe pages',
+            'delete in CiviMail',
+            'view public CiviMail content',
+            'access CiviMember',
+            'delete in CiviMember',
+            'edit memberships',
+            'access all cases and activities',
+            'access my cases and activities',
+            'add cases',
+            'delete in CiviCase',
+            'access CiviPledge',
+            'delete in CiviPledge',
+            'edit pledges',
+            'access CiviReport',
+            'access Report Criteria',
+            'administer reserved reports',
+            'save Report Criteria',
+            'profile create',
+            'profile edit',
+            'profile listings',
+            'profile listings and forms',
+            'profile view',
+            'close all manual batches',
+            'close own manual batches',
+            'create manual batch',
+            'delete all manual batches',
+            'delete own manual batches',
+            'edit all manual batches',
+            'edit own manual batches',
+            'export all manual batches',
+            'export own manual batches',
+            'reopen all manual batches',
+            'reopen own manual batches',
+            'view all manual batches',
+            'view own manual batches',
+            'access all custom data',
+            'access contact reference fields',
+            // standaloneusers provides concrete permissions in place of
+            // the synthetic ones on other UF
+            'cms:administer users',
+            'cms:view user account',
+            // The admninister CiviCRM data implicitly sets other permissions as well.
+            // Such as, edit message templates and admnister dedupe rules.
+            'administer CiviCRM Data',
+          ],
+        ],
+      ])
+      ->execute();
   }
-
-  /**
-   * Example: Run an external SQL script when the module is uninstalled.
-   */
-  // public function uninstall() {
-  //  $this->executeSqlFile('sql/myuninstall.sql');
-  // }
 
   /**
    * On enable:

--- a/ext/standaloneusers/Civi/Api4/Action/RolePermission/Get.php
+++ b/ext/standaloneusers/Civi/Api4/Action/RolePermission/Get.php
@@ -12,6 +12,7 @@
 namespace Civi\Api4\Action\RolePermission;
 
 use Civi\Api4\Generic\BasicGetAction;
+use CRM_Standaloneusers_BAO_Role;
 
 class Get extends BasicGetAction {
 
@@ -22,7 +23,7 @@ class Get extends BasicGetAction {
       ->execute()->indexBy('name');
     $roles = \Civi\Api4\Role::get(FALSE)
       ->addSelect('name', 'permissions')
-      ->addWhere('name', '!=', 'admin')
+      ->addWhere('name', '!=', CRM_Standaloneusers_BAO_Role::SUPERADMIN_ROLE_NAME)
       ->execute()->column('permissions', 'name');
     $result = [];
     foreach ($permissions as $permissionName => $permission) {

--- a/ext/standaloneusers/Civi/Api4/RolePermission.php
+++ b/ext/standaloneusers/Civi/Api4/RolePermission.php
@@ -14,6 +14,7 @@ namespace Civi\Api4;
 
 use Civi\Api4\Generic\BasicGetFieldsAction;
 use Civi\Api4\Generic\Traits\HierarchicalEntity;
+use CRM_Standaloneusers_BAO_Role;
 use CRM_Standaloneusers_ExtensionUtil as E;
 
 /**
@@ -54,7 +55,7 @@ class RolePermission extends Generic\AbstractEntity {
     return (new BasicGetFieldsAction(static::getEntityName(), __FUNCTION__, function($getFields) {
       $roles = \Civi\Api4\Role::get(FALSE)
         ->addSelect('name', 'label')
-        ->addWhere('name', '!=', 'admin')
+        ->addWhere('name', '!=', CRM_Standaloneusers_BAO_Role::SUPERADMIN_ROLE_NAME)
         ->execute()
         ->column('label', 'name');
 

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -2,6 +2,7 @@
 namespace Civi\Standalone;
 
 use Civi;
+use CRM_Standaloneusers_BAO_Role;
 
 /**
  * Security related functions for Standaloneusers.
@@ -72,11 +73,11 @@ class Security {
         $permissionsPerRoleApiCall->addClause(
           'OR',
           ['id', 'IN', $roleIDs],
-          ['name', '=', 'everyone'],
+          ['name', '=', CRM_Standaloneusers_BAO_Role::ANONYMOUS_ROLE_NAME],
         );
       }
       else {
-        $permissionsPerRoleApiCall->addWhere('name', '=', 'everyone');
+        $permissionsPerRoleApiCall->addWhere('name', '=', CRM_Standaloneusers_BAO_Role::ANONYMOUS_ROLE_NAME);
       }
 
       // Get and cache an array of permission names for this user.

--- a/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
+++ b/ext/standaloneusers/managed/SavedSearch_Permissions.mgd.php
@@ -83,7 +83,7 @@ $items = [
 
 $roles = \Civi\Api4\Role::get(FALSE)
   ->addSelect('name', 'label')
-  ->addWhere('name', '!=', 'admin')
+  ->addWhere('name', '!=', CRM_Standaloneusers_BAO_Role::SUPERADMIN_ROLE_NAME)
   ->execute()
   ->column('label', 'name');
 

--- a/setup/plugins/init/StandaloneUsers.civi-setup.php
+++ b/setup/plugins/init/StandaloneUsers.civi-setup.php
@@ -40,125 +40,10 @@ if (!defined('CIVI_SETUP')) {
 
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installDatabase'));
 
-    $roles = \Civi\Api4\Role::save(FALSE)
-      ->setDefaults([
-        'is_active' => TRUE,
-      ])
-      ->setRecords([
-        [
-          'name' => 'everyone',
-          'label' => ts('Everyone, including anonymous users'),
-          // Provide default open permissions
-          'permissions' => [
-            'access CiviMail subscribe/unsubscribe pages',
-            'make online contributions',
-            'view event info',
-            'register for events',
-            'access password resets',
-            'authenticate with password',
-          ],
-        ],
-        [
-          'name' => 'staff',
-          'label' => ts('Staff'),
-          'permissions' => [
-            'access AJAX API',
-            'access CiviCRM',
-            'access Contact Dashboard',
-            'access uploaded files',
-            'add contacts',
-            'view my contact',
-            'view all contacts',
-            'edit all contacts',
-            'edit my contact',
-            'delete contacts',
-            'import contacts',
-            'access deleted contacts',
-            'merge duplicate contacts',
-            'edit groups',
-            'manage tags',
-            'administer Tagsets',
-            'view all activities',
-            'delete activities',
-            'add contact notes',
-            'view all notes',
-            'access CiviContribute',
-            'delete in CiviContribute',
-            'edit contributions',
-            'make online contributions',
-            'view my invoices',
-            'access CiviEvent',
-            'delete in CiviEvent',
-            'edit all events',
-            'edit event participants',
-            'register for events',
-            'view event info',
-            'view event participants',
-            'gotv campaign contacts',
-            'interview campaign contacts',
-            'manage campaign',
-            'release campaign contacts',
-            'reserve campaign contacts',
-            'sign CiviCRM Petition',
-            'access CiviGrant',
-            'delete in CiviGrant',
-            'edit grants',
-            'access CiviMail',
-            'access CiviMail subscribe/unsubscribe pages',
-            'delete in CiviMail',
-            'view public CiviMail content',
-            'access CiviMember',
-            'delete in CiviMember',
-            'edit memberships',
-            'access all cases and activities',
-            'access my cases and activities',
-            'add cases',
-            'delete in CiviCase',
-            'access CiviPledge',
-            'delete in CiviPledge',
-            'edit pledges',
-            'access CiviReport',
-            'access Report Criteria',
-            'administer reserved reports',
-            'save Report Criteria',
-            'profile create',
-            'profile edit',
-            'profile listings',
-            'profile listings and forms',
-            'profile view',
-            'close all manual batches',
-            'close own manual batches',
-            'create manual batch',
-            'delete all manual batches',
-            'delete own manual batches',
-            'edit all manual batches',
-            'edit own manual batches',
-            'export all manual batches',
-            'export own manual batches',
-            'reopen all manual batches',
-            'reopen own manual batches',
-            'view all manual batches',
-            'view own manual batches',
-            'access all custom data',
-            'access contact reference fields',
-            // standaloneusers provides concrete permissions in place of
-            // the synthetic ones on other UF
-            'cms:administer users',
-            'cms:view user account',
-            // The admninister CiviCRM data implicitly sets other permissions as well.
-            // Such as, edit message templates and admnister dedupe rules.
-            'administer CiviCRM Data',
-          ],
-        ],
-        [
-          'name' => 'admin',
-          'label' => ts('Administrator'),
-          'permissions' => [
-            'all CiviCRM permissions and ACLs',
-          ],
-        ],
-      ])
-      ->execute()->indexBy('name');
+    $roleIds = \Civi\Api4\Role::get(FALSE)
+      ->execute()
+      ->indexBy('name')
+      ->column('id');
 
     // Create contact+user for admin.
     $adminUser = $e->getModel()->extras['adminUser'];
@@ -192,7 +77,7 @@ if (!defined('CIVI_SETUP')) {
     // Assign 'admin' role to user
     \Civi\Api4\UserRole::create(FALSE)
       ->addValue('user_id', $userID)
-      ->addValue('role_id', $roles['admin']['id'])
+      ->addValue('role_id', $roleIds['admin'])
       ->execute();
 
     $message = "Created new user \"{$adminUser}\" (user ID #$userID, contact ID #$contactID) with 'admin' role and ";


### PR DESCRIPTION
Overview
----------------------------------------
This is helpful when migrating from non-Standalone. Currently you have to create these roles manually. This way it can be done during `cv en standaloneusers`. Also canonise the canonical role names with `const`s.


Before
----------------------------------------
- the only way the starting roles were created was when you were installing a fresh civicrm db
- if you already had a civicrm db, and wanted to migrate it to standalone, you had to manually create these somehow

After
----------------------------------------
- starting roles are created during the Standaloneusers install (which is a step during fresh install, or migration)


Comments
----------------------------------------
Our starting Roles (admin, staff, everyone) sort of stride the "example data" vs "essential data" line which I think defies a definitive answer to where they should be created:

- `everyone` has a very special _role_ - we need to know what permissions anonymous users have - it is programmatically essential.
- `admin` has some controls to prevent it being edited or deleted. I sort of think you might have a site without it (do all the superadmining by CLI, users with logins have less than superadmin permission). It sort of helps possibility of getting locked out from a site, though I don't think it's totally watertight (you can edit users so none has the admin role?)
- `staff` is basically a useful starting point of how you might want to configure an interim role.

From my perspective `everyone` should definitely be created in extension install, because you can't log in to your site without it. Given `admin` is currently canonised, I think it belongs in the same place (I'm less clear it _should_ be canonised, but out of scope).

Staff is less clear. I could be conviced to leave that one in the setup plugin. But it seems simpler to have them in the same place.

