### PR TITLE
AdminUI: Add price set usage information to Price Fields page

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchAdministerPriceFields.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdministerPriceFields.aff.html
@@ -1,3 +1,13 @@
+<div class="af-container af-container-style-pane help" >
+  <div af-fieldset="">
+    <p class="af-text">{{:: ts('This price set is used by the contribution page(s) listed below.') }}</p>
+    <crm-search-display-table search-name="Price_Set_Usage_Contribution_Pages" display-name="Price_Set_Usage_Contribution_Pages" filters="{price_set_id: routeParams.sid}"></crm-search-display-table>
+  </div>
+  <div af-fieldset="">
+    <p class="af-text">{{:: ts('This price set is used by the event(s) listed below.') }}</p>
+    <crm-search-display-table search-name="Price_Set_Usage_Events" display-name="Price_Set_Usage_Events" filters="{price_set_id: routeParams.sid}"></crm-search-display-table>
+  </div>
+</div>
 <div af-fieldset="">
   <crm-search-display-table search-name="Administer_Price_Fields" display-name="Administer_Price_Fields" filters="{price_set_id: routeParams.sid}"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Contribution_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Contribution_Pages.mgd.php
@@ -1,0 +1,116 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Price_Set_Usage_Contribution_Pages',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Price_Set_Usage_Contribution_Pages',
+        'label' => E::ts('Price Set Usage: Contribution Pages'),
+        'api_entity' => 'PriceSetEntity',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'PriceSetEntity_ContributionPage_entity_id_01.title',
+            'PriceSetEntity_ContributionPage_entity_id_01.financial_type_id:label',
+            'PriceSetEntity_ContributionPage_entity_id_01.start_date',
+            'PriceSetEntity_ContributionPage_entity_id_01.end_date',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [
+            [
+              'ContributionPage AS PriceSetEntity_ContributionPage_entity_id_01',
+              'INNER',
+              [
+                'entity_id',
+                '=',
+                'PriceSetEntity_ContributionPage_entity_id_01.id',
+              ],
+              [
+                'entity_table',
+                '=',
+                '\'civicrm_contribution_page\'',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Price_Set_Usage_Contribution_Pages_SearchDisplay_Price_Set_Usage_Contribution_Pages',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Price_Set_Usage_Contribution_Pages',
+        'label' => E::ts('Price Set Usage: Contribution Pages'),
+        'saved_search_id.name' => 'Price_Set_Usage_Contribution_Pages',
+        'type' => 'table',
+        'settings' => [
+          'description' => E::ts(NULL),
+          'sort' => [
+            [
+              'PriceSetEntity_ContributionPage_entity_id_01.title',
+              'ASC',
+            ],
+          ],
+          'limit' => 50,
+          'pager' => [
+            'hide_single' => TRUE,
+          ],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'PriceSetEntity_ContributionPage_entity_id_01.title',
+              'label' => E::ts('Contribution Page'),
+              'sortable' => TRUE,
+              'link' => [
+                'path' => '',
+                'entity' => 'ContributionPage',
+                'action' => 'update',
+                'join' => 'PriceSetEntity_ContributionPage_entity_id_01',
+                'target' => 'crm-popup',
+                'task' => '',
+              ],
+              'title' => E::ts('Update Contribution Page'),
+            ],
+            [
+              'type' => 'field',
+              'key' => 'PriceSetEntity_ContributionPage_entity_id_01.financial_type_id:label',
+              'label' => E::ts('Financial Type'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'PriceSetEntity_ContributionPage_entity_id_01.start_date',
+              'label' => E::ts('Dates'),
+              'sortable' => TRUE,
+              'rewrite' => '{if "[PriceSetEntity_ContributionPage_entity_id_01.start_date][PriceSetEntity_ContributionPage_entity_id_01.end_date]"} 
+[PriceSetEntity_ContributionPage_entity_id_01.start_date] - [PriceSetEntity_ContributionPage_entity_id_01.end_date]{/if}',
+            ],
+          ],
+          'actions' => FALSE,
+          'classes' => ['table', 'table-striped'],
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Events.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Events.mgd.php
@@ -1,0 +1,115 @@
+<?php
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'SavedSearch_Price_Set_Usage_Events',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Price_Set_Usage_Events',
+        'label' => E::ts('Price Set Usage: Events'),
+        'api_entity' => 'PriceSetEntity',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'PriceSetEntity_Event_entity_id_01.title',
+            'PriceSetEntity_Event_entity_id_01.event_type_id:label',
+            'PriceSetEntity_Event_entity_id_01.start_date',
+            'PriceSetEntity_Event_entity_id_01.end_date',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [
+            [
+              'Event AS PriceSetEntity_Event_entity_id_01',
+              'INNER',
+              [
+                'entity_id',
+                '=',
+                'PriceSetEntity_Event_entity_id_01.id',
+              ],
+              [
+                'entity_table',
+                '=',
+                '\'civicrm_event\'',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'match' => ['name'],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Price_Set_Usage_Events_SearchDisplay_Price_Set_Usage_Events',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Price_Set_Usage_Events',
+        'label' => E::ts('Price Set Usage: Events'),
+        'saved_search_id.name' => 'Price_Set_Usage_Events',
+        'type' => 'table',
+        'settings' => [
+          'description' => E::ts(NULL),
+          'sort' => [
+            [
+              'PriceSetEntity_Event_entity_id_01.title',
+              'ASC',
+            ],
+          ],
+          'limit' => 50,
+          'pager' => [
+            'hide_single' => TRUE,
+          ],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'PriceSetEntity_Event_entity_id_01.title',
+              'label' => E::ts('Event'),
+              'sortable' => TRUE,
+              'link' => [
+                'path' => '',
+                'entity' => 'Event',
+                'action' => 'view',
+                'join' => 'PriceSetEntity_Event_entity_id_01',
+                'target' => 'crm-popup',
+                'task' => '',
+              ],
+              'title' => E::ts('View Price Set Entity Event'),
+            ],
+            [
+              'type' => 'field',
+              'key' => 'PriceSetEntity_Event_entity_id_01.event_type_id:label',
+              'label' => E::ts('Type'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'PriceSetEntity_Event_entity_id_01.start_date',
+              'label' => E::ts('Dates'),
+              'sortable' => TRUE,
+              'rewrite' => '[PriceSetEntity_Event_entity_id_01.start_date] - [PriceSetEntity_Event_entity_id_01.end_date]',
+            ],
+          ],
+          'actions' => FALSE,
+          'classes' => ['table', 'table-striped'],
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Following on from https://github.com/civicrm/civicrm-core/pull/34143, this adds Price Set usage information at the top of the Price Fields page in AdminUI reproducing the behaviour of the core pages.

Before
----------------------------------------
Without AdminUI:
<img width="1376" height="449" alt="image" src="https://github.com/user-attachments/assets/fbf2e3a6-d944-4356-a5ba-916dc1589764" />

With AdminUI:
<img width="1376" height="449" alt="image" src="https://github.com/user-attachments/assets/aa3f2c24-f36a-440a-9bc3-e4566911ca01" />

After
----------------------------------------
With AdminUI:
<img width="1376" height="929" alt="image" src="https://github.com/user-attachments/assets/23cc5abd-b0ab-438a-91de-c80acc9566a5" />


Technical Details
----------------------------------------
I doubt wording like 'the event(s) listed' is great for translation, but that mirrors old text.  Improvements welcome to aid translation!

Comments
----------------------------------------
Ideally, we would only show the Contribution Pages or the Events, only one applies and we should be able to figure out which one ...

