### PR TITLE
(NFC) RouterTest - Fix false-negatives on WordPress

### DIFF
--- a/tests/extensions/router-test/CRM/RouterTest/Page/StaticExamples.php
+++ b/tests/extensions/router-test/CRM/RouterTest/Page/StaticExamples.php
@@ -29,12 +29,12 @@ class CRM_RouterTest_Page_StaticExamples {
   public static function systemSendJsonResponse() {
     CRM_Utils_System::sendJSONResponse([
       __FUNCTION__ => 'OK',
-    ], 499);
+    ], 429);
   }
 
   public static function psr7(ServerRequestInterface $request): ResponseInterface {
     $parsed = json_decode($request->getBody()->getContents(), TRUE);
-    return new \GuzzleHttp\Psr7\Response(498,
+    return new \GuzzleHttp\Psr7\Response(428,
       ['X-Foo' => 'Bar', 'Content-Type' => 'application/json'],
       json_encode([
         __FUNCTION__ => 'hello ' . (is_numeric($parsed['number']) ? $parsed['number'] : ''),

--- a/tests/extensions/router-test/tests/phpunit/CRM/RouterTest/Page/StaticExamplesTest.php
+++ b/tests/extensions/router-test/tests/phpunit/CRM/RouterTest/Page/StaticExamplesTest.php
@@ -64,7 +64,7 @@ class CRM_RouterTest_Page_StaticExamplesTest extends \PHPUnit\Framework\TestCase
    */
   public function testSystemSendJsonResponse(): void {
     $result = $this->client->get('frontend://civicrm/route-test/system-send-json-response', ['http_errors' => FALSE]);
-    $this->assertEquals(499, $result->getStatusCode());
+    $this->assertEquals(429, $result->getStatusCode());
     $this->assertContentType('application/json', $result);
     $parsed = json_decode((string) $result->getBody(), TRUE);
     $this->assertEquals('OK', $parsed['systemSendJsonResponse']);
@@ -78,7 +78,7 @@ class CRM_RouterTest_Page_StaticExamplesTest extends \PHPUnit\Framework\TestCase
       'http_errors' => FALSE,
       \GuzzleHttp\RequestOptions::JSON => ['number' => 456.78],
     ]);
-    $this->assertEquals(498, $result->getStatusCode());
+    $this->assertEquals(428, $result->getStatusCode());
     $this->assertEquals('Bar', $result->getHeader('X-Foo')[0]);
     $this->assertContentType('application/json', $result);
     $parsed = json_decode((string) $result->getBody(), TRUE);


### PR DESCRIPTION
Overview
------------

This end-to-end test (new in 6.10) emits false-negatives when run in the nightly jobs on WordPress ([example](https://test.civicrm.org/job/CiviCRM-Test-QLow/235665/testReport/)). This fixes it by tweaking the sample values.

NOTE: The general idea is this: the test could return common status-code like HTTP 200, but that might pass for the wrong reason. To see if the framework really outputs the requested status-code, you have to put an unusual value.

Before
------

The unusual values (HTTP 498, HTTP 499) are too unusual for WordPress.

Specifically, WordPress's `status_header()` utility wants to find the code in a registry. If the status-code is unregistered, then WP coerces it to HTTP 200.

After
-----

The example values are still unusual (HTTP 429, HTTP 428)... but they appear in WP's registry. So it uses them. (No coercion to HTTP 200.)
