### PR TITLE
Afform - Fix regression with rejected Autocomplete request via Authx

### DIFF
--- a/ext/afform/core/Civi/Afform/PageTokenCredential.php
+++ b/ext/afform/core/Civi/Afform/PageTokenCredential.php
@@ -254,7 +254,7 @@ class PageTokenCredential extends AutoService implements EventSubscriberInterfac
         'checkRequest' => fn($request, $jwt) => ($request['name'] === $jwt['afform']),
       ],
       ';^\w+ autocomplete$;' => [
-        'allowFields' => ['fieldName', 'filters', 'formName', 'ids', 'input', 'page', 'values'],
+        'allowFields' => ['fieldName', 'filters', 'formName', 'ids', 'input', 'page', 'values', 'searchField', 'key', 'exclude', 'quickEdit'],
         'checkRequest' => fn($request, $jwt) => ('afform:' . $jwt['afform']) === $request['formName'],
       ],
       ';^SearchDisplay run$;' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6225 - Autocompletion fails to load](https://lab.civicrm.org/dev/core/-/issues/6225)

Comments
----------------------------------------
New params were added to the Autocomplete API but were not added to this whitelist. This makes me think perhaps it should not be a whitelist if keeping in sync is so problematic.