### PR TITLE
Afform - Remove non-functional POC permission code

### DIFF
--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -131,7 +131,6 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
       }
     }
 
-    $apiRequest->setCheckPermissions(($formField['security'] ?? NULL) !== 'FBAC');
     $apiRequest->setSavedSearch($formField['saved_search'] ?? NULL);
     $apiRequest->setDisplay($formField['search_display'] ?? NULL);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Removes unnecessary code that wasn't doing anything.

Technical Details
----------------------------------------
This was some original POC code that never actually worked (because it incorrectly checked `$formField['security']` instead of `$entity['security']`). Since it was written, a better way of granting form-based permission has been developed. So best to remove this line now that it's both broken AND obsolete.