### PR TITLE
Cache option values in BasicGetFieldsAction 

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -222,7 +222,7 @@ class BasicGetFieldsAction extends BasicGetAction {
    */
   protected function getPseudoconstantOptions(array $field): array {
     if (!empty($field['pseudoconstant']['optionGroupName'])) {
-      return $this->fetchOptionValues($field['pseudoconstant']['optionGroupName']);
+      return $this->getOptionValues($field['pseudoconstant']['optionGroupName']);
     }
     if (!empty($field['pseudoconstant']['callback'])) {
       return call_user_func(
@@ -232,6 +232,23 @@ class BasicGetFieldsAction extends BasicGetAction {
       );
     }
     throw new \CRM_Core_Exception('Unsupported pseudoconstant type for field "' . $field['name'] . '"');
+  }
+
+  private function getOptionValues(string $optionGroupName): array {
+    $cacheKey = implode('_', [
+      \CRM_Core_Config::domainID(),
+      \CRM_Core_I18n::getLocale(),
+      'optionGroup',
+      $optionGroupName,
+    ]);
+    $options = \Civi::cache('metadata')->get($cacheKey);
+
+    if (!is_array($options)) {
+      $options = $this->fetchOptionValues($optionGroupName);
+      \Civi::cache('metadata')->set($cacheKey, $options);
+    }
+
+    return $options;
   }
 
   private function fetchOptionValues(string $optionGroupName): array {

--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -256,7 +256,7 @@ class BasicGetFieldsAction extends BasicGetAction {
     $select = CoreUtil::getOptionValueFields($optionGroupName);
     unset($select['id'], $select['value']);
     array_unshift($select, 'value AS id');
-    $query = "SELECT " . implode(', ', $select) . " FROM civicrm_option_value WHERE option_group_id = %1";
+    $query = "SELECT " . implode(', ', $select) . " FROM civicrm_option_value WHERE option_group_id = %1 ORDER BY weight";
     return \CRM_Core_DAO::executeQuery($query, [1 => [$optionGroupId, 'Int']])->fetchAll();
   }
 

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -325,13 +325,13 @@ class FormattingUtil {
    * @throws \CRM_Core_Exception
    */
   public static function getPseudoconstantList(array $field, string $fieldAlias, $values = [], $action = 'get') {
-    $valueType = FormattingUtil::getSuffix($fieldAlias);
+    $valueType = self::getSuffix($fieldAlias);
     // For create actions, only unique identifiers can be used.
     // For get actions any valid suffix is ok.
     if (!$valueType || ($action === 'create' && !isset(self::$pseudoConstantContexts[$valueType]))) {
       throw new \CRM_Core_Exception('Illegal expression');
     }
-    $fieldPath = FormattingUtil::removeSuffix($fieldAlias);
+    $fieldPath = self::removeSuffix($fieldAlias);
 
     $entityValues = self::filterByPath($values, $fieldPath, $field['name']);
     try {


### PR DESCRIPTION
Overview
----------------------------------------
Avoid fetching OptionValues for every row in BasicGetFieldsAction. Improves the performance of getting BasicEntities, with the most notable core example being Afform.

Before
----------------------------------------
- in BasicGetAction, the OptionValues for a field with `pseudoconstant.optionGroupName` are fetched for every row in order to format pseudoconstants

After
----------------------------------------
- OptionValues are stashed in the cache so they can be reused on subsequent rows

Technical Details
----------------------------------------
Here's a test script:
```
git checkout "$1"
cv flush
time cv api4 Afform.get +s confirmation_type:label +s base_module:label > "$1".get1.json
time cv api4 Afform.get +s confirmation_type:label +s base_module:label > "$1".get2.json
time cv api4 Afform.get +s confirmation_type:label +s base_modele:label > "$1".get3.json
```

3 runs on master:
```
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Flushing system caches

real	0m2.154s
user	0m1.877s
sys	0m0.139s

real	0m1.633s
user	0m1.325s
sys	0m0.107s

real	0m1.610s
user	0m1.272s
sys	0m0.116s
Already on 'master'
Your branch is up to date with 'origin/master'.
Flushing system caches

real	0m2.206s
user	0m1.893s
sys	0m0.161s

real	0m1.678s
user	0m1.333s
sys	0m0.112s

real	0m1.540s
user	0m1.246s
sys	0m0.098s
Already on 'master'
Your branch is up to date with 'origin/master'.
Flushing system caches

real	0m2.150s
user	0m1.862s
sys	0m0.148s

real	0m1.637s
user	0m1.308s
sys	0m0.104s

real	0m1.517s
user	0m1.246s
sys	0m0.105s
```

3 runs on this branch:
```
Switched to branch 'basic-get-option-caching'
Flushing system caches

real	0m2.116s
user	0m1.866s
sys	0m0.144s

real	0m1.509s
user	0m1.270s
sys	0m0.091s

real	0m1.444s
user	0m1.238s
sys	0m0.109s
Already on 'basic-get-option-caching'
Flushing system caches

real	0m2.205s
user	0m1.902s
sys	0m0.160s

real	0m1.450s
user	0m1.277s
sys	0m0.094s

real	0m1.425s
user	0m1.203s
sys	0m0.104s
Already on 'basic-get-option-caching'
Flushing system caches

real	0m2.128s
user	0m1.865s
sys	0m0.159s

real	0m1.534s
user	0m1.288s
sys	0m0.105s

real	0m1.540s
user	0m1.276s
sys	0m0.107s
```

So its pretty slight but 5% improvement, on a basic site with 70 afforms. I would expect a lot of sites have more forms, and repeated calls over multiple requests = more savings.

I also have a follow up which adds caching to callbacks, which has more significant performance boost. 

Previous caching for pseudoconstant field options seems to only apply to schema/table based fields - this is the exceptional case because it's on tableless entity.

It is a bit odd to me that we dont have a global cache for option values, as far as I can see. There's another `CRM_Core_optionValue::getValues(['name' => $name])` type call in SettingsMetadata which might benefit from using the same cache.
