### PR TITLE
Cache callback options in BasicGetFieldsAction

### DIFF
--- a/ext/civicrm_search_ui/Civi/Api4/Report.php
+++ b/ext/civicrm_search_ui/Civi/Api4/Report.php
@@ -176,35 +176,23 @@ class Report extends Generic\AbstractEntity {
   }
 
   public static function getEntityOptions(): array {
-    $cacheKey = __CLASS__ . __FUNCTION__;
-    $options = \Civi::cache()->get($cacheKey);
-    if (!is_array($options)) {
-      $options = Entity::get(FALSE)
-        ->addSelect('name', 'title')
-        ->addWhere('searchable', '!=', 'none')
-        ->addOrderBy('title')
-        ->execute()
-        ->indexBy('name')
-        ->column('title');
-      \Civi::cache()->set($cacheKey, $options);
-    }
-    return $options;
+    return Entity::get(FALSE)
+      ->addSelect('name', 'title')
+      ->addWhere('searchable', '!=', 'none')
+      ->addOrderBy('title')
+      ->execute()
+      ->indexBy('name')
+      ->column('title');
   }
 
   public static function getExtensionOptions(): array {
-    $cacheKey = __CLASS__ . __FUNCTION__;
-    $options = \Civi::cache()->get($cacheKey);
-    if (!is_array($options)) {
-      $options = Extension::get(FALSE)
-        ->addSelect('key', 'label')
-        ->addWhere('status', '=', 'installed')
-        ->addOrderBy('label')
-        ->execute()
-        ->indexBy('key')
-        ->column('label');
-      \Civi::cache()->set($cacheKey, $options);
-    }
-    return $options;
+    return Extension::get(FALSE)
+      ->addSelect('key', 'label')
+      ->addWhere('status', '=', 'installed')
+      ->addOrderBy('label')
+      ->execute()
+      ->indexBy('key')
+      ->column('label');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/34227 (the diff will look much smaller if that is merged) . Cache options provided by callbacks as well, where it is safe to do so.

Before
----------------------------------------
- field option callbacks are run for every row when formatting records in BasicGetAction
- sometimes this is necessary, because the callback takes the other field values for the row as a parameter, and the options differ dependent on the row values
- many times callbacks take no parameters, or just the field name - in which case calling for each row is very wasteful

After
----------------------------------------
- where callbacks take no parameters, or just the field name, we cache the result
- significant performance gain!

Technical Details
----------------------------------------
Note: this only affects BasicEntities. The only examples in core being Afform and now Report.

It is a little more complex, because we need to inspect the callback to work out how many params it's taking. I don't see any examples in core where this is actually put to the test (i.e. where , but I tested it with a dummy entity of my own and worked as expected (ie. did not attempt to cache when the callback function took $values param).

Using the same test as https://github.com/civicrm/civicrm-core/pull/34227

Baseline:
```
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Flushing system caches

real	0m2.154s
user	0m1.877s
sys	0m0.139s

real	0m1.633s
user	0m1.325s
sys	0m0.107s

real	0m1.610s
user	0m1.272s
sys	0m0.116s
Already on 'master'
Your branch is up to date with 'origin/master'.
Flushing system caches

real	0m2.206s
user	0m1.893s
sys	0m0.161s

real	0m1.678s
user	0m1.333s
sys	0m0.112s

real	0m1.540s
user	0m1.246s
sys	0m0.098s
Already on 'master'
Your branch is up to date with 'origin/master'.
Flushing system caches

real	0m2.150s
user	0m1.862s
sys	0m0.148s

real	0m1.637s
user	0m1.308s
sys	0m0.104s

real	0m1.517s
user	0m1.246s
sys	0m0.105s
```

With this patch applied:
```
Switched to branch 'basic-get-callback-caching'
Flushing system caches

real	0m1.890s
user	0m1.636s
sys	0m0.141s

real	0m1.168s
user	0m1.017s
sys	0m0.099s

real	0m1.191s
user	0m0.999s
sys	0m0.093s
Already on 'basic-get-callback-caching'
Flushing system caches

real	0m1.958s
user	0m1.662s
sys	0m0.155s

real	0m1.253s
user	0m1.040s
sys	0m0.099s

real	0m1.138s
user	0m0.989s
sys	0m0.087s
Already on 'basic-get-callback-caching'
Flushing system caches

real	0m1.859s
user	0m1.604s
sys	0m0.142s

real	0m1.103s
user	0m0.975s
sys	0m0.084s

real	0m1.100s
user	0m0.935s
sys	0m0.089s
```

Almost 30% improvement! As before, on a bigger site with more Afforms, and repeat requests, more improvements. Having said that, in this particular example I think `CRM_Core_BAO_Managed::getBaseModules` might be a chunk of the improvement, which might be relatively rare field to fetch.




