### PR TITLE
dev/core#6232 - Event registration page no longer blocks registering past event end date

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -992,11 +992,11 @@ WHERE  civicrm_participant.id = {$participantId}
     }
 
     $regEndDate = CRM_Utils_Date::processDate($event['registration_end_date'] ?? NULL);
-    $eventEndDate = CRM_Utils_Date::processDate($event['event_end_date'] ?? NULL);
+    $eventEndDate = CRM_Utils_Date::processDate($event['end_date'] ?? NULL);
     if (($regEndDate && ($regEndDate < $now)) || (empty($regEndDate) && !empty($eventEndDate) && ($eventEndDate < $now))) {
       $endDate = CRM_Utils_Date::customFormat($event['registration_end_date'] ?? NULL);
       if (empty($regEndDate)) {
-        $endDate = CRM_Utils_Date::customFormat($event['event_end_date'] ?? NULL);
+        $endDate = CRM_Utils_Date::customFormat($event['end_date'] ?? NULL);
       }
       $errors[] = ts('Registration for this event ended on %1', [1 => $endDate]);
     }

--- a/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
@@ -114,7 +114,7 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
       // In this case we expect the value to be a relative date string.
       // Keep offset for later.
       $offset = $formValues[$fieldName];
-      $formValues[$fieldName] = date('YmdH0000', strtotime($offset));
+      $formValues[$fieldName] = date($dateFormat, strtotime($offset));
     }
 
     $this->updateEvent($formValues);
@@ -168,19 +168,18 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
         'expected_message' => 'Registration for this event ended on %EXPECTED_DATE%',
         'message_date_format' => 'YmdH0000',
       ],
-      /**
-       * It's not clear if this broke recently because this testcase was never
-       * actually checking the output. My expectation is that if the end date
-       * has past you shouldn't be able to register, but I tested in the UI and
-       * it still lets you register.  There's a message on the info page, but
-       * you can still manually enter a url to register and complete it.
-       */
-      //'event_end_date_in_past' => [
-      //  'field_name' => 'event_end_date',
-      //  'form_values' => ['event_end_date' => '- 1 day'],
-      //  'expected_message' => 'Registration for this event ended on %EXPECTED_DATE%',
-      //  'message_date_format' => 'YmdHi',
-      //],
+      'event_end_date_in_past' => [
+        'field_name' => 'end_date',
+        // the stock event always puts the registration end in the future, so
+        // we need to get rid of that to test this properly.
+        'form_values' => [
+          'end_date' => '- 1 day',
+          'registration_start_date' => NULL,
+          'registration_end_date' => NULL,
+        ],
+        'expected_message' => 'Registration for this event ended on %EXPECTED_DATE%',
+        'message_date_format' => 'YmdHi',
+      ],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6232

Before
----------------------------------------
Make an event with an end date in the past. Manually construct the url for the register page and visit it. It will let you and will also let you complete the registration.

After
----------------------------------------
Like old times.

Technical Details
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/30698 the checking was switched to get the event data via api4 instead of whereever `$this->_values` comes from. In api4 the field is named end_date not event_end_date.

Comments
----------------------------------------
Restored the testcase from https://github.com/civicrm/civicrm-core/pull/34229
