### PR TITLE
dev/core#6235 - Improve CiviCRM Drupal menu toggle

### DIFF
--- a/css/menubar-drupal8.css
+++ b/css/menubar-drupal8.css
@@ -9,19 +9,10 @@ body.crm-menubar-visible.crm-menubar-below-cms-menu {
 
 nav#civicrm-menu-nav .crm-menubar-toggle-btn {
   margin: 0;
-  position: absolute;
-  top: 0;
   height: 38px;
-}
-#crm-menubar-state:checked ~ .crm-menubar-toggle-btn {
-  left: 0!important;
 }
 nav#civicrm-menu-nav .crm-menubar-toggle-btn span.crm-menu-logo {
   top: 10px;
-  left: 20px;
-}
-nav#civicrm-menu-nav .crm-menubar-toggle-btn-icon {
-  left: 44px;
 }
 
 @media (min-width: $breakMin) {

--- a/js/crm.drupal8.js
+++ b/js/crm.drupal8.js
@@ -5,10 +5,18 @@ localStorage.setItem('Drupal.toolbar.activeTabID', JSON.stringify('toolbar-item-
 
 (function($) {
   function adjustToggle() {
-    if ($(window).width() < 768 && $('#toolbar-item-civicrm').length) {
-      $('#civicrm-menu-nav .crm-menubar-toggle-btn').css({
-        left: '' + $('#toolbar-item-civicrm').offset().left + 'px',
-        width: '' + $('#toolbar-item-civicrm').innerWidth() + 'px'
+    if ($('#toolbar-item-civicrm').length) {
+      if ($(window).width() < 768) {
+        $('#civicrm-menu-nav .crm-menubar-toggle-btn').css({
+          left: '' + $('#toolbar-item-civicrm').offset().left + 'px',
+          width: '' + $('#toolbar-item-civicrm').innerWidth() + 'px'
+        });
+      }
+    } else {
+      // we don't have a toolbar item (such as using when using Navigation module),
+      // "float" the toggle right
+      $('#civicrm-menu-nav').css({
+        'text-align': 'right'
       });
     }
   }


### PR DESCRIPTION
The Drupal menu toggle did not display correctly when placing the menu above the content, and acted odd in other contexts.

This commit does a few things:
- removes excess styles which caused the toggle to be deformed when displaying the menu above the content
- removes excess styles which caused the button to not be hidden on desktop
- removes excess styles which caused the toggle to jump left when clicked
- adds JS changes to move the toggle to the right if there is no toolbar button for CiviCRM (allowing room for the main Navigation menu on the left)
