### PR TITLE
Standalone - override below-cms-menu menu position setting

### DIFF
--- a/css/menubar-standalone.css
+++ b/css/menubar-standalone.css
@@ -1,4 +1,3 @@
-/* The title of this file is menubar-standalone, but the CSS is more general than that. @todo fixme */
 @media (min-width: $breakMin) {
 
   body.crm-menubar-visible.crm-menubar-over-cms-menu {
@@ -10,6 +9,10 @@
   }
   body.crm-menubar-visible.crm-menubar-over-cms-menu #admin-bar {
     visibility: hidden;
+  }
+  /* ignore the crm-menubar-below-cms-menu setting */
+  body.crm-menubar-below-cms-menu > #civicrm-menu-nav #civicrm-menu {
+    top: 0;
   }
 
 }

--- a/ext/standaloneusers/standaloneusers.php
+++ b/ext/standaloneusers/standaloneusers.php
@@ -127,4 +127,7 @@ function standaloneusers_civicrm_searchKitTasks(array &$tasks, bool $checkPermis
 function standaloneusers_civicrm_alterSettingsMetaData(&$settings) {
   $settings['inheritLocale']['title'] = E::ts('Use User Language');
   $settings['inheritLocale']['description'] = E::ts('If Yes, the system will use the Language set on the logged-in user\'s record. This can be changed later if using the CiviCRM language switcher.');
+
+  // below-cms-menu doesn't make sense on Standalone
+  unset($settings['menubar_position']['options']['below-cms-menu']);
 }


### PR DESCRIPTION
Overview
----------------------------------------
`below-cms-menu` menubar position doesn't make sense on Standalone. Stop people picking that option, and override the css if they have that option set (e.g. following migration).