### PR TITLE
[REF] Api4 - More concise getOptionValueFields

### DIFF
--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -390,14 +390,7 @@ class CoreUtil {
    * @return array
    */
   public static function getOptionValueFields($optionGroup, $key = 'name'): array {
-    // Prevent crash during upgrade
-    if (array_key_exists('option_value_fields', \CRM_Core_DAO_OptionGroup::getSupportedFields())) {
-      $fields = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionGroup, 'option_value_fields', $key);
-    }
-    if (!isset($fields)) {
-      return ['name', 'label', 'description'];
-    }
-    return explode(',', $fields);
+    return \CRM_Core_DAO_OptionGroup::getDbVal('option_value_fields', $optionGroup, $key) ?: ['name', 'label', 'description'];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Reduces overly-verbose code.

Technical Details
----------------------------------------
Refactor: these 7 sloc can be eliminated by calling the new getDbVal function which does the same thing.