### PR TITLE
Upgrader - Require CIVICRM_CRED_KEYS

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -339,31 +339,44 @@ SET    version = '$version'
    * @return mixed, a string error message or boolean 'false' if OK
    */
   public function checkUpgradeableVersion($currentVer, $latestVer) {
-    $error = FALSE;
+    $errors = $this->getUpgradeBlockers($currentVer, $latestVer);
+    return empty($errors) ? FALSE : strip_tags(array_pop($errors));
+  }
+
+  /**
+   * Determine if $currentVer can be upgraded to $latestVer
+   *
+   * @param $currentVer
+   * @param $latestVer
+   *
+   * @return mixed, a string error message or boolean 'false' if OK
+   */
+  public function getUpgradeBlockers($currentVer, $latestVer): array {
+    $errors = [];
     // since version is suppose to be in valid format at this point, especially after conversion ($convertVer),
     // lets do a pattern check -
     if (!CRM_Utils_System::isVersionFormatValid($currentVer)) {
-      $error = ts('Database is marked with invalid version format. You may want to investigate this before you proceed further.');
+      $errors[] = ts('Database is marked with invalid version format. You may want to investigate this before you proceed further.');
     }
     elseif (version_compare($currentVer, $latestVer) > 0) {
       // DB version number is higher than codebase being upgraded to. This is unexpected condition-fatal error.
-      $error = ts('Your database is marked with an unexpected version number: %1. The automated upgrade to version %2 can not be run - and the %2 codebase may not be compatible with your database state. You will need to determine the correct version corresponding to your current database state. You may want to revert to the codebase you were using prior to beginning this upgrade until you resolve this problem.',
+      $errors[] = ts('Your database is marked with an unexpected version number: %1. The automated upgrade to version %2 can not be run - and the %2 codebase may not be compatible with your database state. You will need to determine the correct version corresponding to your current database state. You may want to revert to the codebase you were using prior to beginning this upgrade until you resolve this problem.',
         [1 => $currentVer, 2 => $latestVer]
       );
     }
     elseif (version_compare($currentVer, $latestVer) == 0) {
-      $error = ts('Your database has already been upgraded to CiviCRM %1',
+      $errors[] = ts('Your database has already been upgraded to CiviCRM %1',
         [1 => $latestVer]
       );
     }
     elseif (version_compare($currentVer, self::MINIMUM_UPGRADABLE_VERSION) < 0) {
-      $error = ts('CiviCRM versions prior to %1 cannot be upgraded directly to %2. This upgrade will need to be done in stages. First download an intermediate version (the LTS may be a good choice) and upgrade to that before proceeding to this version.',
+      $errors[] = ts('CiviCRM versions prior to %1 cannot be upgraded directly to %2. This upgrade will need to be done in stages. First download an intermediate version (the LTS may be a good choice) and upgrade to that before proceeding to this version.',
         [1 => self::MINIMUM_UPGRADABLE_VERSION, 2 => $latestVer]
       );
     }
 
     if (version_compare(phpversion(), CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER) < 0) {
-      $error = ts('CiviCRM %3 requires PHP version %1 (or newer), but the current system uses %2 ',
+      $errors[] = ts('CiviCRM %3 requires PHP version %1 (or newer), but the current system uses %2 ',
         [
           1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_PHP_VER,
           2 => phpversion(),
@@ -372,7 +385,7 @@ SET    version = '$version'
     }
 
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER) < 0) {
-      $error = ts('CiviCRM %4 requires MySQL version v%1 or MariaDB v%3 (or newer), but the current system uses %2 ',
+      $errors[] = ts('CiviCRM %4 requires MySQL version v%1 or MariaDB v%3 (or newer), but the current system uses %2 ',
         [
           1 => CRM_Upgrade_Incremental_General::MIN_INSTALL_MYSQL_VER,
           2 => CRM_Utils_SQL::getDatabaseVersion(),
@@ -383,12 +396,12 @@ SET    version = '$version'
 
     // check for mysql trigger privileges
     if (!\Civi::settings()->get('logging_no_trigger_permission') && !CRM_Core_DAO::checkTriggerViewPermission(FALSE, TRUE)) {
-      $error = ts('CiviCRM %1 requires MySQL trigger privileges.',
+      $errors[] = ts('CiviCRM %1 requires MySQL trigger privileges.',
         [1 => $latestVer]);
     }
 
     if (CRM_Core_DAO::getGlobalSetting('thread_stack', 0) < (1024 * self::MINIMUM_THREAD_STACK)) {
-      $error = ts('CiviCRM %1 requires MySQL thread stack >= %2k', [
+      $errors[] = ts('CiviCRM %1 requires MySQL thread stack >= %2k', [
         1 => $latestVer,
         2 => self::MINIMUM_THREAD_STACK,
       ]);
@@ -424,10 +437,10 @@ SET    version = '$version'
       $parts[] = ts('For details, see <a %1>Sysadmin Guide: Secret Keys</a>.', [
         1 => 'target="_blank" href="https://docs.civicrm.org/sysadmin/en/latest/setup/secret-keys/"',
       ]);
-      $error = implode("<br />\n", $parts);
+      $errors[] = implode("<br />\n", $parts);
     }
 
-    return $error;
+    return $errors;
   }
 
   /**

--- a/CRM/Upgrade/Page/Upgrade.php
+++ b/CRM/Upgrade/Page/Upgrade.php
@@ -82,8 +82,15 @@ class CRM_Upgrade_Page_Upgrade extends CRM_Core_Page {
     }
 
     // Throw error if db in unexpected condition
-    elseif ($error = $upgrade->checkUpgradeableVersion($currentVer, $latestVer)) {
-      throw new CRM_Core_Exception($error);
+    elseif ($errors = $upgrade->getUpgradeBlockers($currentVer, $latestVer)) {
+      $template->assign('preUpgradeMessage', implode("\n", array_map(fn($e) => "<p>$e</p>", $errors)));
+      $template->assign('currentVersion', $currentVer);
+      $template->assign('newVersion', $latestVer);
+      $template->assign('upgradeTitle', ts('Upgrade CiviCRM from v %1 To v %2',
+        [1 => $currentVer, 2 => $latestVer]
+      ));
+      $template->assign('upgraded', FALSE);
+      $template->assign('blocked', TRUE);
     }
 
     else {

--- a/templates/CRM/common/success.tpl
+++ b/templates/CRM/common/success.tpl
@@ -22,6 +22,7 @@
           </div>
           {$preUpgradeMessage}
         {/if}
+        {if empty($blocked)}
         <p><strong>{ts}Back up your database before continuing.{/ts}</strong>
             {ts}This process may change your database structure and values. In case of emergency you may need to revert to a backup.{/ts} {docURL page="sysadmin/upgrade"}</p>
         <p>{ts 1=$currentVersion 2=$newVersion}The database will be upgraded from %1 to %2.{/ts}</p>
@@ -32,6 +33,7 @@
             {ts}Upgrade Now{/ts}
           </button>
         </div>
+        {/if}
       </form>
     </div>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM v5.34 and v5.36 (~5 years ago) introduced the constants `CIVICRM_CRED_KEYS` and `CIVICRM_SIGN_KEYS`. These could not be added automatically to `civicrm.settings.php`, so we've had to provide a more managed roll-out.

| Constant | Generated automatically (new sites) | Upgrade message | On-going status-check |
| -- | -- | -- | -- |
| `CIVICRM_SIGN_KEYS` | v5.36 | v5.36 | v5.50+ |
| `CIVICRM_CRED_KEYS` | v5.34 | v5.34 | None |

This PR makes `CIVICRM_CRED_KEYS` required.

This fixes https://lab.civicrm.org/dev/core/-/issues/6233. The recent #34130 (from 6.10.alpha1) only works if `CIVICRM_CRED_KEYS` is well-defined.

(cc @demeritcowboy)

Before
----------------------------------------

`CIVICRM_CRED_KEYS` is defined automatically (for new sites) but technically optional. On long-running deployments (<5.34), the notification to configure it is easily forgotten.

After
----------------------------------------

`CIVICRM_CRED_KEYS` is mandatory for all deployments. If you don't have it, then the web-upgrader blocks with this message:

<img width="1184" height="434" alt="Screenshot 2025-12-08 at 4 57 43 PM" src="https://github.com/user-attachments/assets/978e2490-61d1-4751-bbe6-be0588165314" />

Similarly, the CLI upgrader blocks with this:

<img width="793" height="309" alt="Screenshot 2025-12-08 at 4 58 31 PM" src="https://github.com/user-attachments/assets/ee4f85db-5d9e-49a0-9870-f3598bfda9b1" />


Comments
----------------------------------------

* At the time when `CIVICRM_CRED_KEYS` was first introduced, there were some edge-cases risks to it. But now, we've had ~5 years with `CIVICRM_CRED_KEYS` being defined automatically on new deployments. It's pretty standard now.

* Displaying the example snippet should make it a lot easier to apply the update.

* There is a very small variation in how the example appears -- sometimes, you see the `FILE:` with the full file-path. And sometimes you don't. The underlying problem is that `CIVICRM_SETTINGS_PATH` does not always point to the civicrm settings path. However, this should only matter on Standalone -- and Standalone didn't even exist during the 5.34 transition. The folks who really need the extra info should see it. (And for the edge-case folks who don't... it's still clear that you need to update `civicrm.settings.php`.)
