### PR TITLE
Afform - allow money number inputs to set decimal places

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -25,7 +25,7 @@
     <input type="number" class="form-control four" ng-model="$ctrl.node.defn.input_attrs.max" ng-change="$ctrl.onChangeMax()" title="{{:: ts('Maximum value') }}" placeholder="{{:: ts('Max') }}">
   </div>
 </li>
-<li ng-if="($ctrl.fieldDefn.input_type === 'Number' || $ctrl.fieldDefn.input_type === 'Range') && $ctrl.fieldDefn.data_type === 'Float' && !hasOptions()">
+<li ng-if="['Number', 'Range'].includes($ctrl.fieldDefn.input_type) && ['Float', 'Money'].includes($ctrl.fieldDefn.data_type) && !hasOptions()">
   <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Decimal places:') }}</label>
     <select class="form-control" ng-model="getSet('input_attrs.step')" ng-model-options="{getterSetter: true}" title="{{:: ts('Decimal places') }}">


### PR DESCRIPTION
Overview
----------------------------------------
Improve FormBuilder configuration for Money fields.

Before
----------------------------------------
Cannot set decimal places for number inputs on Money fields.

After
----------------------------------------
<img width="534" height="802" alt="image" src="https://github.com/user-attachments/assets/5322f39c-3190-43d2-8988-cb6e686537ed" />