### PR TITLE
Scheduled Reminders: remove the No Language filter option

### DIFF
--- a/CRM/Core/BAO/ActionSchedule.php
+++ b/CRM/Core/BAO/ActionSchedule.php
@@ -157,8 +157,7 @@ class CRM_Core_BAO_ActionSchedule extends CRM_Core_DAO_ActionSchedule implements
    * @return array
    */
   public static function getFilterContactLanguageOptions(): array {
-    $languages = CRM_Core_I18n::languages(TRUE);
-    return $languages + [CRM_Core_I18n::NONE => ts('Contacts with no preferred language')];
+    return CRM_Core_I18n::languages(TRUE);
   }
 
   /**

--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -383,10 +383,15 @@ class RecipientBuilder {
     $filter_contact_language = explode(\CRM_Core_DAO::VALUE_SEPARATOR, $actionSchedule->filter_contact_language);
     $w = '';
     if (($key = array_search(\CRM_Core_I18n::NONE, $filter_contact_language)) !== FALSE) {
-      $w .= "{$contactTableAlias}.preferred_language IS NULL OR {$contactTableAlias}.preferred_language = '' OR ";
+      // @todo Deprecate this, since contacts should always have a preferred language (the site default)
+      // It was removed from the interface in 2025-12
+      $w .= "{$contactTableAlias}.preferred_language IS NULL OR {$contactTableAlias}.preferred_language = ''";
       unset($filter_contact_language[$key]);
     }
     if (count($filter_contact_language) > 0) {
+      if ($w) {
+        $w .= ' OR ';
+      }
       $w .= "{$contactTableAlias}.preferred_language IN ('" . implode("','", $filter_contact_language) . "')";
     }
     $w = "($w)";


### PR DESCRIPTION
Overview
----------------------------------------

Removes the "Contacts with no preferred language" from Scheduled Reminders.

This option is only displayed when multi-lingual is enabled (I think it would be always useful, but that's another issue). 

This PR also fixes an SQL error if someone selects only "Contacts with no preferred language".

i.e. I was initially investigating why Scheduled Reminders were crashing, and then thought that no one should ever use this option anyway, so I'm removing it, while fixing existing installs.

Before
----------------------------------------

<img width="1754" height="568" alt="image" src="https://github.com/user-attachments/assets/23d47eb5-070f-44ff-867a-90a7c9e28427" />

After
----------------------------------------

Only list active languages:

<img width="1754" height="568" alt="image" src="https://github.com/user-attachments/assets/27cbb1e2-b5e0-4ac9-a053-0c9a6a5ed45f" />

Technical Details
----------------------------------------

- Contacts always have a preferred language, i.e. when they get created, their pref-lang is the default site language.
- This PR does not completely remove the SQL filter, since people might have existing reminders that use those conditions, and for some reason, maybe they have contacts with no preferred language. I didn't feel like going down that rabbit hole. If an existing install has contacts with no pref-lang, then they should fix their data. It's been many years since we changed this behaviour (always set a pref-lang).
