### PR TITLE
Status Check - Fix error on login during upgrade-process

### DIFF
--- a/CRM/Utils/Check/Component/Mailing.php
+++ b/CRM/Utils/Check/Component/Mailing.php
@@ -24,7 +24,7 @@ class CRM_Utils_Check_Component_Mailing extends CRM_Utils_Check_Component {
       return [];
     }
 
-    $methods = Civi::settings()->get('civimail_unsubscribe_methods');
+    $methods = Civi::settings()->get('civimail_unsubscribe_methods') ?: [];
     if (in_array('oneclick', $methods)) {
       return [];
     }


### PR DESCRIPTION
Overview
----------------------------------------

While doing some upgrade testing yesterday, I ran into an error during this flow:

* Install some old version
* Switch codebase to new version
* Login to web UI

During the login, it did a status check... and the whole page failed.

Before
----------------------------------------

Status-check produces hard failure if `civimail_unsubscribe_methods` (or perhaps its metadata) is malformed.

<img width="1140" height="459" alt="Screenshot 2025-12-09 at 11 27 07 AM" src="https://github.com/user-attachments/assets/b3a9eab0-563a-493a-b12e-28066949d511" />

After
----------------------------------------

Status-check less likely to fail.

Comments
----------------------------------------

I'm not exactly certain all the criteria that were needed to provoke it. There may have been some funny business (like exuberant calls to `git checkout X.Y`). But in any case, I don't see any downside to this extra guard.