### PR TITLE
PSR-7 - Normalize getPath(). Fix E2E test-failure.

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1040,9 +1040,28 @@ abstract class CRM_Utils_System_Base {
   }
 
   public function createRequestFromGlobals(): ServerRequestInterface {
-    $config = CRM_Core_Config::singleton();
     $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
-    $request = $request->withUri($request->getUri()->withPath($_GET[$config->userFrameworkURLVar]));
+
+    $path = '/' . CRM_Utils_System::currentPath();
+    // PSR-7, generally: "The path can either be empty or absolute (starting with a slash) or rootless (not starting with a slash)."
+    // Civi, specifically: The choice of leading "/" is largely cosmetic, but it must be consistent.
+    // Comparing the environments, the only consistent option is "absolute":
+    //
+    //    Environment | PSR Impl | Absolute Paths ("/") | Rootless Paths (No "/")
+    //    -------------------------------------------------------
+    //    Backdrop    | Guzzle 7 | OK                   | OK
+    //    Drupal 9    | Guzzle 6 | OK                   | Coerced to absolute
+    //    Drupal 10   | Guzzle 7 | OK                   | OK
+    //    Standalone  | Guzzle 7 | OK                   | OK
+    //    WordPress   | Guzzle 7 | OK                   | OK
+
+    $path = preg_replace_callback(';([^-_/\.a-zA-Z0-9]);', fn($m) => rawurlencode($m[1]), $path);
+    // In CiviCRM, the canonical representation of current path comes from $_GET[$var], which is %-DECODED.
+    // (N.B. Civi's router treats "/" and "%2F" as equivalent.) This $_GET[$var] convention is entrenched.
+    // For PSR-7, getPath() must be %-ENCODED.
+    // This filter re-creates the %-ENCODED path with normalized "/"s.
+
+    $request = $request->withUri($request->getUri()->withPath($path));
     return $request;
   }
 

--- a/tests/extensions/router-test/CRM/RouterTest/Page/PageWithPath.php
+++ b/tests/extensions/router-test/CRM/RouterTest/Page/PageWithPath.php
@@ -10,6 +10,12 @@ class CRM_RouterTest_Page_PageWithPath extends CRM_Core_Page {
       throw new \Exception("Expected path array");
     }
 
+    $expected = 'civicrm/route-test/page-with-path';
+    $actual = CRM_Utils_system::currentPath();
+    if ($actual !== $expected) {
+      throw new \Exception("currentPath() reports wrong path. Actual=$actual Expected=$expected");
+    }
+
     parent::run();
   }
 

--- a/tests/extensions/router-test/CRM/RouterTest/Page/PageWithPsr7.php
+++ b/tests/extensions/router-test/CRM/RouterTest/Page/PageWithPsr7.php
@@ -7,8 +7,10 @@ use Psr\Http\Message\RequestInterface;
 class CRM_RouterTest_Page_PageWithPsr7 extends CRM_Core_Page {
 
   public function run(?RequestInterface $request = NULL) {
-    if ($request->getUri()->getPath() !== 'civicrm/route-test/page-with-psr7') {
-      throw new \Exception("Expected path array");
+    $expected = '/civicrm/route-test/page-with-psr7';
+    $actual = $request->getUri()->getPath();
+    if ($actual !== $expected) {
+      throw new \Exception("PSR-7 reports wrong path. Actual=$actual Expected=$expected");
     }
 
     parent::run();


### PR DESCRIPTION
Overview
--------

This is a follow-up to #34038 (from `6.10.alpha`). In the daily E2E tests, the `$request` object shows some differing behaviors (with `PageWithPsr7Test` failing on Drupal 9). This is because some helpers behave differently in each environment.

This PR revises the `$request` object, choosing a behavior that it works consistently across al UFs. It also improves compliance with PSR-7.

Before
------

* The test passes on Standalone, D10, Backdrop, WordPress, where `$request->getPath()` does NOT include a leading `/`.
* The test fails on D9, where `$request->getPath()` DOES include a leading `/`.
* The value of  `$request->getPath()` does NOT have URL-encoding, which violates PSR-7.

After
-----

* The test passes on Standalone, D9, D10, Backdrop, WordPress. The `$request->getPath()` DOES include a leading `/`.
* The value of  `$request->getPath()` DOES have URL-encoding (*mostly ; details*), which complies with PSR-7.

Technical Details
-----------------

This change *would* be a BC-break (flipflopping on the leading `/`), but we caught it early. The functionality is new in 6.10.alpha, and this fix is for 6.10.beta. So downstream impact should be negligible.

This fixes URL-encoding on most platforms, but not Standalone. This is because Standalone does some things differently from the others -- and resolving that discrepancy requires another patch. I have a follow-up which aligns them, but I think it's more suited to master.