### PR TITLE
Router - Test encoding of path chars. Align Standalone with everyone else.

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -267,7 +267,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   public static function currentPath() {
     $path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
 
-    return $path ? trim($path, '/') : NULL;
+    return $path ? trim(urldecode($path), '/') : NULL;
   }
 
   /**

--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -48,7 +48,8 @@ class WebEntrypoint {
     // parse the request uri (should we use URL for this?)
     $requestUri = $_SERVER['REQUEST_URI'] ?? '';
     $parts = explode('?', $requestUri);
-    $args = explode('/', $parts[0] ?? '');
+    $path = urldecode($parts[0] ?? ''); /* Civi's route model is canonically built around $_GET[$var]. Therefore, routes are canonically decoded. */
+    $args = explode('/', $path);
     // Remove empty path segments, a//b becomes equivalent to a/b
     $args = array_values(array_filter($args));
 

--- a/tests/extensions/router-test/CRM/RouterTest/Page/StaticExamples.php
+++ b/tests/extensions/router-test/CRM/RouterTest/Page/StaticExamples.php
@@ -11,6 +11,19 @@ class CRM_RouterTest_Page_StaticExamples {
     CRM_Utils_System::civiExit();
   }
 
+  public static function pathWithData() {
+    header('Content-type: text/plain');
+    echo "Path Data " . base64_encode(CRM_Utils_System::currentPath());
+    CRM_Utils_System::civiExit();
+  }
+
+  public static function psr7PathWithData(ServerRequestInterface $request): ResponseInterface {
+    return new \GuzzleHttp\Psr7\Response(200,
+      ['Content-Type' => 'text/plain'],
+      "Path Data " . base64_encode($request->getUri()->getPath())
+    );
+  }
+
   public static function submitJson() {
     $data = file_get_contents('php://input');
     $parsed = json_decode($data, TRUE);

--- a/tests/extensions/router-test/tests/phpunit/CRM/RouterTest/Page/StaticExamplesTest.php
+++ b/tests/extensions/router-test/tests/phpunit/CRM/RouterTest/Page/StaticExamplesTest.php
@@ -36,6 +36,38 @@ class CRM_RouterTest_Page_StaticExamplesTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
+   * @see \CRM_RouterTest_Page_StaticExamples::pathWithData()
+   */
+  public function testPathWithData(): void {
+    $result = $this->client->get('frontend://civicrm/route-test/path-with-data/foo%2Abar%25whiz%2Fbang');
+    $this->assertEquals(200, $result->getStatusCode());
+    $this->assertContentType('text/plain', $result);
+    $resultData = (string) $result->getBody();
+    $this->assertTrue(str_starts_with($resultData, 'Path Data '), "Response should start with 'Path Data'. Received: $resultData");
+    [, , $resultPath64] = explode(' ', $resultData);
+    $resultPath = base64_decode($resultPath64);
+    // CRM_Utils_System::currentPath() provides the decoded path, so %2A (etc) is replaced.
+    $this->assertEquals('civicrm/route-test/path-with-data/foo*bar%whiz/bang', $resultPath);
+  }
+
+  /**
+   * @see \CRM_RouterTest_Page_StaticExamples::psr7PathWithData()
+   */
+  public function testPsr7PathWithData(): void {
+    $result = $this->client->get('frontend://civicrm/route-test/psr7-path-with-data/foo%2Abar%25whiz%2Fbang');
+    $this->assertEquals(200, $result->getStatusCode());
+    $this->assertContentType('text/plain', $result);
+    $resultData = (string) $result->getBody();
+    $this->assertTrue(str_starts_with($resultData, 'Path Data '), "Response should start with 'Path Data'. Received: $resultData");
+    [, , $resultPath64] = explode(' ', $resultData);
+    $resultPath = base64_decode($resultPath64);
+
+    // PSR7 getPath() provides the encoded-path, so we see %2A and %25. However, Civi normalizes %2F as /.
+    // (Civi has clean+dirty URLs across multiple CMSs, and we can't guarantee %2F-vs-/ distinction across all configurations.)
+    $this->assertEquals('/civicrm/route-test/psr7-path-with-data/foo%2Abar%25whiz/bang', $resultPath);
+  }
+
+  /**
    * @see \CRM_RouterTest_Page_StaticExamples::submitJson()
    */
   public function testSubmitJson(): void {

--- a/tests/extensions/router-test/xml/Menu/router_test.xml
+++ b/tests/extensions/router-test/xml/Menu/router_test.xml
@@ -19,6 +19,18 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
+    <path>civicrm/route-test/path-with-data</path>
+    <page_callback>CRM_RouterTest_Page_StaticExamples::pathWithData</page_callback>
+    <title>ExamplePage</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/route-test/psr7-path-with-data</path>
+    <page_callback>CRM_RouterTest_Page_StaticExamples::psr7PathWithData</page_callback>
+    <title>ExamplePage</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
     <path>civicrm/route-test/submit-json</path>
     <page_callback>CRM_RouterTest_Page_StaticExamples::submitJson</page_callback>
     <title>ExamplePage</title>


### PR DESCRIPTION
Overview
----------------------------------------

(*~~This builds on #34247. That should be merged on 6.10 before we deal with this. After that, this PR should only have one commit.~~ Merged*)

Consider this scenario, where the path includes encoded characters:

* __Route__: `civicrm/route-test/path-data`
* __Request__: `civicrm/route-test/path-with-data/foo%2Abar%25whiz%2Fbang`
* __Question__: For `CRM_Utils_System::currentPath()`, how do you expect the `%2A`, `%25`, and `%2F` to appear?

This PR normalizes the answer.

Before
----------------------------------------

Given the same URL inputs, the `CRM_Utils_System::currentPath()` outputs vary by environment:

| Environment  | Source of currentPath() | Codec | Example Content
| -- | -- | -- | --
| Drupal (D7, D9, D10), BD, WP | `$_GET[$var]` | Decoded | `foo*bar%whiz/bang`
| Standalone | `$_SERVER['REQUEST_URI']` | Encoded (Partially) | `foo*bar%25whiz%2Fbang` (exception: `*` vs `%2A`)

(*This has a knock-on effect where `$request->getPath()` is also inconsistent.*)

After
----------------------------------------

In all environments, `CRM_Utils_System::currentPath()`outputs the decoded version (`foo*bar%whiz/bang`).

(*This has a knock-on effect where `$request->getPath()` is also consistent, but it implements the PSR-7 interface-spec and applies encoding as necessary.*)

Comments
----------------------------------------

If you want to geek-out, there are two main questions here:

* What behavior is desirable?
* What behavior is achievable?

There is a logic to both behaviors. A decoded value is better normalized. An encoded value preserves more nuance (e.g. `/` vs `%2F`). In a greenfield, I might personally prefer to retain the raw inputs. (Neither system actually seems to have that effect.*)  OTOH, I don't really see much practical advantage in choosing one over the other. The main thing is for `CRM_Utils_System::currentPath()` to be consistent with itself (to prevent [giraffe bugs](https://lab.civicrm.org/dev/core/-/issues/5346)).

There's much more inertia for returning the decoded value -- AFAIK, Civi has always processed the decoded path. In particular, we have living legacy of dirty-URL support (`?q=foo/bar`), and PHP's handling of `$_GET` makes it _much_ easier to handle decoded values. The encoded path in Standalone is an outlier.

(*I wrote the patch against 6.10 because it's tied in with #34247. However, the scope is a bit different - so I've submitted against `master`. But I don't mind changing to 6.10.*)