### PR TITLE
Remove duplicate for alietz and fix organization

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -88,7 +88,7 @@
 
 - github      : alietz
   name        : Andreas Lietz
-  organization: OrtmannTeam GmbH
+  organization: Stiftung Pfadfinden
 
 - github      : alifrumin
   name        : Alice Frumin
@@ -1975,6 +1975,3 @@
 - github      : MundMBo
   name        : Marvin Müller
 
-- github      : alietz
-  name        : Andreas Lietz
-  organization: Stiftung Pfadfinden


### PR DESCRIPTION
My handle was in the list twice, once with the company I work for and once with Stiftung Pfadfinden for which I develop for CiviCRM. Sorry for the mixup!
