### PR TITLE
Remove the undefined default preferred language

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -382,7 +382,6 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Generic {
   public static function getDefaultLanguageOptions() {
     $availableOptions = [
       '*default*' => ts('Use default site language'),
-      'undefined' => ts('Leave undefined'),
       'current_site_language' => ts('Use language in use at the time'),
     ];
     $availableLanguages = array_merge($availableOptions, CRM_Admin_Form_Setting_Localization::getDefaultLocaleOptions());

--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -756,9 +756,6 @@ class CRM_Core_I18n {
    */
   public static  function getContactDefaultLanguage() {
     $language = Civi::settings()->get('contact_default_language');
-    if ($language == 'undefined') {
-      return NULL;
-    }
     if (empty($language) || $language === '*default*') {
       $language = civicrm_api3('setting', 'getvalue', [
         'name' => 'lcMessages',
@@ -768,7 +765,6 @@ class CRM_Core_I18n {
     elseif ($language == 'current_site_language') {
       return CRM_Core_I18n::getLocale();
     }
-
     return $language;
   }
 

--- a/CRM/Upgrade/Incremental/php/SixEleven.php
+++ b/CRM/Upgrade/Incremental/php/SixEleven.php
@@ -29,6 +29,33 @@ class CRM_Upgrade_Incremental_php_SixEleven extends CRM_Upgrade_Incremental_Base
    */
   public function upgrade_6_11_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Set preferred language to default if undefined', 'setPreferredLanguageToDefaultIfNull');
+  }
+
+  /**
+   * CiviCRM had the option to leave the preferred language to undefined.
+   * This was confusing to admins because most multi-lingual organisations
+   * are either careful about collecting the language, or they operate in a
+   * main language and assume that any undefined are equivalent to the default
+   * site language. For example, they might have "French subscribers" and
+   * "English and any other language subscribers". Since "undefined" is not
+   * a language, having it undefined is de facto like having it to the default
+   * language.
+   */
+  public static function setPreferredLanguageToDefaultIfNull() {
+    // If the default contact language was undefined, change it to the
+    // default site language
+    $default = Civi::settings()->get('contact_default_language');
+    if ($default == 'undefined') {
+      Civi::settings()->set('contact_default_language', 'current_site_language');
+    }
+    // Update all contacts who were previously undefined
+    // The above $default might be "current_site_language" and needs resolving
+    $language = CRM_Core_I18n::getContactDefaultLanguage();
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_contact SET preferred_language = %1 WHERE preferred_language IS NULL OR preferred_language = ""', [
+      1 => [$language, 'String'],
+    ]);
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM had the option to leave the preferred language to undefined. This was confusing to admins because most multi-lingual organisations  are either careful about collecting the language, or they operate in a main language and assume that any undefined are equivalent to the default site language.

For example, they might have "French subscribers" and "English and any other language subscribers". Since "undefined" is not a language, having it undefined is de facto like having it to the default language.

In #34245, I had removed the language filter option from Scheduled Reminders (the filter is only visible when in multi-lingual, even if rather useful to all). I thought undefined had been removed already, but my colleagues pointed out that core still had a setting for it, and we could not find any reason to keep it.

Before
----------------------------------------

<img width="2110" height="870" alt="2025-12-10_14-44" src="https://github.com/user-attachments/assets/370b8ed2-292c-4698-a831-c49f8924f9fa" />


After
----------------------------------------

<img width="1712" height="680" alt="image" src="https://github.com/user-attachments/assets/952bf69f-62c7-4166-818e-1f542c75b37c" />

Technical Details
----------------------------------------

If a site used "undefined", the upgrade will change it to "use default site language" and update contacts who had no preferred language.

Comments
----------------------------------------

It would be nice to have a "frontend default behaviour" and "backend default behaviour". Ex:

- Contact is using a frontend form, so it should use the "language in use at the time"
- An admin is creating contacts, and in that case it's more difficult to make assumptions.