### PR TITLE
avoid leaky onbehalfprofile values in contributin receipt

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -389,8 +389,13 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $tplParams['onBehalfName'] = $displayName;
         $tplParams['onBehalfEmail'] = $email;
 
+        $template->assign('onBehalfProfile', NULL);
         if (!empty($values['onbehalf_profile_id'])) {
-          self::buildCustomDisplay($values['onbehalf_profile_id'], 'onBehalfProfile', $contactID, $template, $params['onbehalf_profile'], $fieldTypes);
+          [$groupTitle, $values] = self::getProfileNameAndFields($values['onbehalf_profile_id'], $contactID, $params['onbehalf_profile'], $fieldTypes);
+          if (!empty($values)) {
+            $template->assign('onBehalfProfile', $values);
+          }
+          $template->assign('onBehalfProfile_grouptitle', $groupTitle);
         }
       }
 
@@ -592,33 +597,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         CRM_Core_Error::debug_log_message('Failure: mail not sent for recurring notification.');
       }
     }
-  }
-
-  /**
-   * Add the custom fields for contribution page (ie profile).
-   *
-   * @deprecated assigning values to smarty like this is risky because
-   *  - it is hard to debug since $name is used in the assign
-   *  - it is potentially 'leaky' - it's better to do this on the form
-   *  or close to where it is used / required. See CRM-17519 for leakage e.g.
-   *
-   * @param int $gid
-   *   Uf group id.
-   * @param string $name
-   * @param int $cid
-   *   Contact id.
-   * @param $template
-   * @param array $params
-   *   Params to build component whereclause.
-   *
-   * @param array|null $fieldTypes
-   */
-  public static function buildCustomDisplay($gid, $name, $cid, &$template, &$params, $fieldTypes = NULL) {
-    [$groupTitle, $values] = self::getProfileNameAndFields($gid, $cid, $params, $fieldTypes);
-    if (!empty($values)) {
-      $template->assign($name, $values);
-    }
-    $template->assign($name . "_grouptitle", $groupTitle);
   }
 
   /**

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -391,11 +391,11 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
 
         $template->assign('onBehalfProfile', NULL);
         if (!empty($values['onbehalf_profile_id'])) {
-          [$groupTitle, $values] = self::getProfileNameAndFields($values['onbehalf_profile_id'], $contactID, $params['onbehalf_profile'], $fieldTypes);
-          if (!empty($values)) {
-            $template->assign('onBehalfProfile', $values);
+          [$onBehalfGroupTitle, $onBehalfProfileFields] = self::getProfileNameAndFields($values['onbehalf_profile_id'], $contactID, $params['onbehalf_profile'], $fieldTypes);
+          if (!empty($onBehalfProfileFields)) {
+            $template->assign('onBehalfProfile', $onBehalfProfileFields);
           }
-          $template->assign('onBehalfProfile_grouptitle', $groupTitle);
+          $template->assign('onBehalfProfile_grouptitle', $onBehalfGroupTitle);
         }
       }
 


### PR DESCRIPTION
Overview
----------------------------------------

I have a production example of two contributions made at about the same time in which the contribution receipt for one contribution included an "On behalf of" block that was intended for the other contribution.

Before
----------------------------------------

One contribution receipt might have an On Behalf section intended for another contribution.

After
----------------------------------------

Contribution receipts only contain data for the right contribution.


Technical Details
----------------------------------------
I have a lot of questions! I know @eileenmcnaughton you have helped me with some leaky template variables in the past?

1. I didn't see any other references to `ContributionPage::buildCustomDisplay`, and I noticed that it's deprecated, so I went ahead a removed it. I'm not sure if any extensions are using it? I don't think the function itself is the cause of the bug but decided it might be a good opportunity for code clean up.
2. I'm not whether I should be using `$template->assign()` or `$tplParams`? I used `$template->assign()` because that's what was there before, but it seems like the rest of the method is setting `$tplParams`  - which I assume get turned into `$template->assign`'s later on?