### PR TITLE
SearchKit - Make Mailing Groups searchable

### DIFF
--- a/ext/civi_mail/Civi/Api4/MailingGroup.php
+++ b/ext/civi_mail/Civi/Api4/MailingGroup.php
@@ -13,12 +13,13 @@ namespace Civi\Api4;
 /**
  * Mailing groups are the groups or mailings included or excluded from mailing recipients.
  *
- * @searchable none
+ * @searchable bridge
  *
  * @see https://docs.civicrm.org/user/en/latest/email/what-is-civimail/
  * @since 5.48
  * @package Civi\Api4
  */
 class MailingGroup extends Generic\DAOEntity {
+  use Generic\Traits\EntityBridge;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Makes it possible to find Mailing Groups in SearchKit. This improves feature parity with the Mailing Summary Report in CiviReport.

See https://civicrm.stackexchange.com/questions/50065/is-it-possible-to-search-for-groups-included-in-mailing-in-searchkit

Before
----------------------------------------
Cannot search for Mailing Groups in SearchKit

After
----------------------------------------
<img width="1774" height="278" alt="image" src="https://github.com/user-attachments/assets/143b01be-0523-4140-a57a-302263160831" />

