### PR TITLE
SearchKit - Fix error in sortable columns

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -22,7 +22,7 @@
         const ctrl = this;
         this.$element = $element;
         this.limit = this.settings.limit;
-        this.sort = this.settings.sort ? _.cloneDeep(this.settings.sort) : [];
+        this.sort = Array.isArray(this.settings.sort) ? _.cloneDeep(this.settings.sort) : [];
         this.seed = Date.now();
         this.uniqueId = generateUniqueId(20);
         this.placeholders = [];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes console error in SearchKit.


Technical Details
----------------------------------------
Console error was being triggered with `this.sort` is not an array.

This bug was being masked by lo-dash but revealed with a81b8bd02c36dd5d8dcc84ec5edf1c990d86eca1.