### PR TITLE
WIP: Add functions to compare local/managed versions of forms and remove local version if it matches managed version

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Cleanup.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Cleanup.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Civi\Api4\Action\Afform;
+
+use Civi\Afform\Utils;
+use Civi\Api4\Generic\Result;
+use CRM_Afform_ExtensionUtil as E;
+
+/**
+ * @inheritDoc
+ * @package Civi\Api4\Action\Afform
+ */
+class Cleanup extends \Civi\Api4\Generic\BasicBatchAction {
+
+  /**
+   * Revert every record, and flush caches at the end.
+   *
+   * @inheritDoc
+   */
+  protected function processBatch(Result $result, array $items) {
+    parent::processBatch($result, $items);
+
+    // We may have changed list of files covered by the cache.
+    _afform_clear();
+  }
+
+  /**
+   * Revert (delete) a record.
+   *
+   * @inheritDoc
+   */
+  protected function doTask($item) {
+    /** @var \CRM_Afform_AfformScanner $scanner */
+    $scanner = \Civi::service('afform_scanner');
+    $files = [
+      \CRM_Afform_AfformScanner::METADATA_JSON,
+      \CRM_Afform_AfformScanner::LAYOUT_FILE,
+    ];
+
+    $localAfform = $scanner->getMeta($item['name'], TRUE, 'local');
+    $managedAfform = $scanner->getMeta($item['name'], TRUE, 'managed');
+
+    // @todo: Check this: We should return the right things
+    // to show, override, no change, change etc.
+    $item['current'] = 'local';
+    $item['is_modified'] = FALSE;
+    if (empty($localAfform)) {
+      $item['current'] = 'managed';
+      return $item;
+    }
+    if (empty($managedAfform)) {
+      return $item;
+    }
+
+    // Pass through filter to add field defaults (json saves all fields, PHP only saves changed ones)
+    $localAfform2 = _afform_fields_filter($localAfform, TRUE);
+    $managedAfform2 = _afform_fields_filter($managedAfform, TRUE);
+
+    $fieldsToIgnore = [
+      'modified_date',
+      'created_id',
+    ];
+    foreach ($fieldsToIgnore as $fieldKey) {
+      unset($localAfform2[$fieldKey]);
+      unset($managedAfform2[$fieldKey]);
+    }
+    $emptyArrayOrNullFields = [
+      'placement',
+      'placement_filters',
+    ];
+    foreach ($emptyArrayOrNullFields as $fieldKey) {
+      if (empty($localAfform2[$fieldKey])) {
+        $localAfform2[$fieldKey] = NULL;
+      }
+      if (empty($managedAfform2[$fieldKey])) {
+        $managedAfform2[$fieldKey] = NULL;
+      }
+    }
+    $differences = array_diff($localAfform2, $managedAfform2);
+    // @todo: Do a diff on xAfform['layout']
+    // @todo: Why is local returning a lot more keys in defn?
+
+    exit;
+    foreach ($files as $file) {
+      $metaPath = $scanner->createSiteLocalPath($item['name'], $file);
+      if (file_exists($metaPath)) {
+        if (!@unlink($metaPath)) {
+          throw new \CRM_Core_Exception("Failed to remove afform overrides in $file");
+        }
+      }
+    }
+
+    $original = (array) $scanner->getMeta($item['name']);
+
+    // If the dashlet setting changed, managed entities must be reconciled
+    if (Utils::shouldReconcileManaged($item, $original)) {
+      $this->flushManaged = TRUE;
+    }
+
+    // If the server_route changed, reset menu cache
+    if (Utils::shouldClearMenuCache($item, $original)) {
+      $this->flushMenu = TRUE;
+    }
+
+    return $item;
+  }
+
+  /**
+   * Adds extra return params so caches can be conditionally flushed.
+   *
+   * @return string[]
+   */
+  protected function getSelect() {
+    return ['name', 'title', 'placement', 'server_route', 'created_id'];
+  }
+
+}

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -10,11 +10,11 @@ use CRM_Afform_ExtensionUtil as E;
  * @param array $params
  * @return array
  */
-function _afform_fields_filter($params) {
+function _afform_fields_filter($params, bool $addMissing = FALSE) {
   $result = [];
   $fields = \Civi\Api4\Afform::getfields(FALSE)->setAction('create')->execute()->indexBy('name');
   foreach ($fields as $fieldName => $field) {
-    if (array_key_exists($fieldName, $params)) {
+    if (array_key_exists($fieldName, $params) || $addMissing) {
       $result[$fieldName] = $params[$fieldName];
 
       if ($field['data_type'] === 'Boolean' && !is_bool($params[$fieldName])) {


### PR DESCRIPTION
Overview
----------------------------------------
It can be quite difficult to work out which forms are overridden, which are the same as managed forms etc.

This PR is a work-in-progress to do the following:
- Make it possible to specifically retrieve the local and managed versions of the form.
- Make it possible to compare the two versions of the form.
- Show the user if they are the same and possibly delete the local copy if they match.
- Allow for doing a "diff" on forms when they are different so you can see the changes.

Before
----------------------------------------


After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw Be good to get your comments on this. The API call is currently more of a demo/Proof of concept but shows which functions we need to enhance to allow us to extract the data we need.
