### PR TITLE
Ref: Order API getLine() function

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -255,7 +255,7 @@ WHERE li.contribution_id = %1";
    * @param int $fid
    *   Price set field id.
    * @param array $params
-   *   Reference to form values.
+   *   Array of [price_FIELDID => [optionValueID => Quantity]]
    * @param array $fields
    *   Array of fields belonging to the price set used for particular event
    * @param array $values


### PR DESCRIPTION
Overview
----------------------------------------
Goal is to simplify `Order->calculateLineItems()` function.

This creates a copy of `CRM_Price_BAO_PriceSet::getLine()` on `CRM_Financial_BAO_Order` and then simplifies the copied function.

Before
----------------------------------------
Shared function. Doing multiple things.

After
----------------------------------------
Not shared function, only doing what we need for Order API.

Technical Details
----------------------------------------


Comments
----------------------------------------
I don't like that we are using `CRM_Price_BAO_LineItem::format()` since the name implies it's more of a formatting function.. so that could be a follow-up cleanup/simplification.
