### PR TITLE
REF: Consistency for Afform Autofill code

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ActivityAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ActivityAutofill.php
@@ -35,9 +35,9 @@ class ActivityAutofill extends AbstractBehavior implements EventSubscriberInterf
     return E::ts('Automatically identify this activity.');
   }
 
-  public static function getModes(string $type): array {
+  public static function getModes(string $entityName): array {
     $modes = [];
-    if ($type == 'Activity') {
+    if ($entityName === 'Activity') {
       $modes[] = [
         'name' => 'entity_id',
         'label' => E::ts('Activity being Viewed'),

--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -47,9 +47,9 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
     return '~/afGuiEditor/behaviors/autofillRelationshipBehavior.html';
   }
 
-  public static function getModes(string $contactType):array {
+  public static function getModes(string $entityName):array {
     $modes = [];
-    if ($contactType === 'Individual') {
+    if ($entityName === 'Individual') {
       $modes[] = [
         'name' => 'user',
         'label' => E::ts('Current User'),
@@ -66,10 +66,10 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
     $relationshipTypes = \Civi\Api4\RelationshipType::get(FALSE)
       ->addSelect('name_a_b', 'name_b_a', 'label_a_b', 'label_b_a', 'description', 'contact_type_a', 'contact_type_b')
       ->addWhere('is_active', '=', TRUE)
-      ->addClause('OR', ['contact_type_a', '=', $contactType], ['contact_type_a', 'IS NULL'], ['contact_type_b', '=', $contactType], ['contact_type_b', 'IS NULL'])
+      ->addClause('OR', ['contact_type_a', '=', $entityName], ['contact_type_a', 'IS NULL'], ['contact_type_b', '=', $entityName], ['contact_type_b', 'IS NULL'])
       ->execute();
     foreach ($relationshipTypes as $relationshipType) {
-      if (!$relationshipType['contact_type_a'] || $relationshipType['contact_type_a'] === $contactType) {
+      if (!$relationshipType['contact_type_a'] || $relationshipType['contact_type_a'] === $entityName) {
         $modes[] = [
           'name' => 'relationship:' . $relationshipType['name_a_b'],
           'label' => $relationshipType['label_a_b'],
@@ -80,7 +80,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
       }
       if (
         $relationshipType['name_b_a'] && $relationshipType['name_a_b'] != $relationshipType['name_b_a'] &&
-        (!$relationshipType['contact_type_b'] || $relationshipType['contact_type_b'] === $contactType)
+        (!$relationshipType['contact_type_b'] || $relationshipType['contact_type_b'] === $entityName)
       ) {
         $modes[] = [
           'name' => 'relationship:' . $relationshipType['name_b_a'],

--- a/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
+++ b/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
@@ -44,7 +44,7 @@ class GroupSubscription extends AbstractBehavior implements EventSubscriberInter
     return \CRM_Core_Component::isEnabled('CiviMail') ? 'double-opt-in' : 'no-confirm';
   }
 
-  public static function getModes(string $contactType): array {
+  public static function getModes(string $entityName): array {
     $modes = [];
     if (\CRM_Core_Component::isEnabled('CiviMail')) {
       $modes[] = [

--- a/ext/afform/core/Civi/Afform/Behavior/ParticipantAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ParticipantAutofill.php
@@ -4,8 +4,8 @@ namespace Civi\Afform\Behavior;
 use Civi\Afform\AbstractBehavior;
 use Civi\Afform\Event\AfformPrefillEvent;
 use Civi\Token\TokenRow;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use CRM_Afform_ExtensionUtil as E;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @service
@@ -35,9 +35,9 @@ class ParticipantAutofill extends AbstractBehavior implements EventSubscriberInt
     return E::ts('Automatically identify this participant.');
   }
 
-  public static function getModes(string $type): array {
+  public static function getModes(string $entityName): array {
     $modes = [];
-    if ($type == 'Participant') {
+    if ($entityName === 'Participant') {
       $modes[] = [
         'name' => 'entity_id',
         'label' => E::ts('Participant being Viewed'),
@@ -51,7 +51,7 @@ class ParticipantAutofill extends AbstractBehavior implements EventSubscriberInt
   public static function onAfformPrefill(AfformPrefillEvent $event): void {
     /* @var \Civi\Api4\Action\Afform\Prefill $apiRequest */
     $apiRequest = $event->getApiRequest();
-    if ($event->getEntityType() == 'Participant') {
+    if ($event->getEntityType() === 'Participant') {
       $entity = $event->getEntity();
       $id = $event->getEntityId();
       $autoFillMode = $entity['participant-autofill'] ?? '';

--- a/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
+++ b/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
@@ -35,9 +35,9 @@ class CaseAutofill extends AbstractBehavior implements EventSubscriberInterface 
     return E::ts('Automatically identify this case based on the case being viewed when this form is placed on the case summary screen or when email with the link to the form is send from the Case.');
   }
 
-  public static function getModes(string $type):array {
+  public static function getModes(string $entityName):array {
     $modes = [];
-    if ($type == 'Case') {
+    if ($entityName === 'Case') {
       $modes[] = [
         'name' => 'entity_id',
         'label' => E::ts('Case being Viewed'),
@@ -51,7 +51,7 @@ class CaseAutofill extends AbstractBehavior implements EventSubscriberInterface 
   public static function onAfformPrefill(AfformPrefillEvent $event): void {
     /* @var \Civi\Api4\Action\Afform\Prefill $apiRequest */
     $apiRequest = $event->getApiRequest();
-    if ($event->getEntityType() == 'Case') {
+    if ($event->getEntityType() === 'Case') {
       $entity = $event->getEntity();
       $id = $event->getEntityId();
       $autoFillMode = $entity['case-autofill'] ?? '';


### PR DESCRIPTION
Overview
----------------------------------------
Rename and move files for consistency between all classes.

Replaces #34116

Implements a submodule per #34113 so we don't have to introduce a hard-dependency on afform extension for civi_event.

Before
----------------------------------------
Some inconsistent variable names and participant autofill should be in civi-event.

After
----------------------------------------
More consistency


Technical Details
----------------------------------------


Comments
----------------------------------------

