### PR TITLE
[NFC] Unfuzzle code comment

### DIFF
--- a/CRM/Core/Smarty/plugins/modifier.substring.php
+++ b/CRM/Core/Smarty/plugins/modifier.substring.php
@@ -24,8 +24,6 @@
  * Author: Thorsten Albrecht <thor_REMOVE.THIS_@wolke7.net>
  * Purpose: "substring" allows you to retrieve a small part (substring) of a string.
  * Notes: The substring is specified by giving the start  position and the length.
- * Unlike the original function substr() in PHP the position of the characters
- * in the string starts at 1 (not at 0 as usual in php).
  * Example smarty code:
  *   {$my_string|substring:2:4}
  *   returns substring from character 2 until character 6


### PR DESCRIPTION
Overview
----------------------------------------
Possibly the most wrong code comment ever.

Before
----------------------------------------
It's like looking at the sky and pointing at the sun and saying "that's not the sun".

After
----------------------------------------


Technical Details
----------------------------------------
If you move your eyes a few lines down, not only do you see that it does function like the php function, it is exactly the php function.

If you want to prove it to yourself, you can run this little script with `cv scr`
```php
<?php
$s = CRM_Core_Smarty::singleton();
$s->assign('my_string', 'bassoon');
echo $s->fetch('string:{$my_string|substring:1:3}');
```

According to the comment, that will print `bas`. It does not.

Comments
----------------------------------------
It was like this when it was first added.
