### PR TITLE
Riverlea - Fix missing colors in Select2 dropdowns

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -596,6 +596,16 @@ input.crm-form-checkbox) + label {
   animation-timing-function: var(--fa-animation-timing,linear);
 }
 
+/* Color dot for selecting e.g. tags */
+span.crm-select-item-color {
+  display: inline-block;
+  width: 1cap;
+  height: 1cap;
+  border-radius: 50%;
+  border: 1px solid var(--crm-text-color);
+  box-sizing: content-box;
+}
+
 /* Select dropdown */
 
 .select2-drop.select2-drop-active.crm-container {


### PR DESCRIPTION
Overview
----------------------------------------
Riverlea was missing a css rule to make colors visible in a select2 dropdown, which you can see for example by adding a couple Afform tags and then visiting any FormBuilder screen. In Greenwich, they look like this:

<img width="1268" height="474" alt="image" src="https://github.com/user-attachments/assets/4489abb7-dcfb-4f09-9c6a-656529d9b9e6" />


Before
----------------------------------------
<img width="1212" height="408" alt="image" src="https://github.com/user-attachments/assets/8f36e429-bfd7-4dc0-bbf2-f38ca4df5580" />
<img width="1212" height="418" alt="image" src="https://github.com/user-attachments/assets/fdf59a0d-6fce-4da8-bead-64a95195cdc0" />


After
----------------------------------------
<img width="1208" height="432" alt="image" src="https://github.com/user-attachments/assets/a8d89c48-1854-4c50-aea1-37adfebc2940" />
<img width="1214" height="412" alt="image" src="https://github.com/user-attachments/assets/f24aef66-edb3-4b8a-b92e-a88e7186c12b" />

