### PR TITLE
Fix PHP warnings when viewing a case activity

### DIFF
--- a/CRM/Case/Selector/Search.php
+++ b/CRM/Case/Selector/Search.php
@@ -660,6 +660,8 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
         ],
         CRM_Core_Action::DETACH => [
           'name' => ts('Move To Case'),
+          'url' => '',
+          'qs' => '',
           'ref' => 'move_to_case_action',
           'title' => ts('Move To Case'),
           'extra' => 'onclick = "Javascript:fileOnCase( \'move\', %%aid%%, %%caseid%%, this ); return false;"',
@@ -669,6 +671,8 @@ class CRM_Case_Selector_Search extends CRM_Core_Selector_Base {
         ],
         CRM_Core_Action::COPY => [
           'name' => ts('Copy To Case'),
+          'url' => '',
+          'qs' => '',
           'ref' => 'copy_to_case_action',
           'title' => ts('Copy To Case'),
           'extra' => 'onclick = "Javascript:fileOnCase( \'copy\', %%aid%%, %%caseid%%, this ); return false;"',

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1665,7 +1665,7 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       return [
         new CRM_Utils_Check_Message(
           __FUNCTION__,
-          ts('Could not load a clean page to check'),
+          ts('Could not load a clean page to check: %1', [1 => $page]),
           ts('Guzzle client error'),
           \Psr\Log\LogLevel::ERROR,
           'fa-wordpress'


### PR DESCRIPTION
Overview
----------------------------------------
When viewing a case activity in PHP 8.3, you get two PHP warnings:
```
Warning: Undefined array key "url" in content_69405c5586dc17_42547823() (line 71 of /home/jon/local/mysite/web/sites/default/files/civicrm/templates_c/en_US/e6/60/f0/e660f07bff20b6e46cb6d545752132aeaf10e1b1_0.file_formButtons.tpl.php) 
Message 	Warning: Undefined array key "qs" in content_69405c5586dc17_42547823() (line 71 of /home/jon/local/mysite/web/sites/default/files/civicrm/templates_c/en_US/e6/60/f0/e660f07bff20b6e46cb6d545752132aeaf10e1b1_0.file_formButtons.tpl.php) 
```

Before
----------------------------------------
PHP warnings.

After
----------------------------------------
No warnings.

Comments
----------------------------------------
`templates/CRM/Case/Form/ActivityView.tpl` is the relevant template, comparing this array and that template should make this patch clear.
