### PR TITLE
CustomData - Move participant custom options to a managed file

### DIFF
--- a/ext/civi_event/info.xml
+++ b/ext/civi_event/info.xml
@@ -40,6 +40,7 @@
   <mixins>
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
+    <mixin>mgd-php@2.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Event</namespace>

--- a/ext/civi_event/managed/OptionValues_custom_data_type.mgd.php
+++ b/ext/civi_event/managed/OptionValues_custom_data_type.mgd.php
@@ -1,0 +1,68 @@
+<?php
+use CRM_Event_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'OptionGroup_custom_data_type_OptionValue_ParticipantRole',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'custom_data_type',
+        'label' => E::ts('Role'),
+        'value' => 1,
+        'name' => 'ParticipantRole',
+        'grouping' => 'role_id',
+        'is_reserved' => TRUE,
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionGroup_custom_data_type_OptionValue_ParticipantEventName',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'custom_data_type',
+        'label' => E::ts('Event Name'),
+        'value' => 2,
+        'name' => 'ParticipantEventName',
+        'grouping' => 'event_id',
+        'is_reserved' => TRUE,
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionGroup_custom_data_type_OptionValue_ParticipantEventType',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'custom_data_type',
+        'label' => E::ts('Event Type'),
+        'value' => 3,
+        'name' => 'ParticipantEventType',
+        'grouping' => 'event_id.event_type_id',
+        'is_reserved' => TRUE,
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+      ],
+    ],
+  ],
+];

--- a/sql/civicrm_data/civicrm_option_group/custom_data_type.sqldata.php
+++ b/sql/civicrm_data/civicrm_option_group/custom_data_type.sqldata.php
@@ -1,29 +1,10 @@
 <?php
+// @see ext/civi_event/managed/OptionValues_custom_data_type.mgd.php
+// Note: When adding options to this group, the 'name' *must* begin with the exact name of the base entity,
+// as that's the (very lo-tech) way these options are matched with their base entity.
+// Wrong: 'name' => 'ActivitiesByStatus'
+// Right: 'name' => 'ActivityByStatus'
 return CRM_Core_CodeGen_OptionGroup::create('custom_data_type', 'a/0034')
   ->addMetadata([
     'title' => ts('Custom Data Type'),
-  ])
-  // Note: When adding options to this group, the 'name' *must* begin with the exact name of the base entity,
-  // as that's the (very lo-tech) way these options are matched with their base entity.
-  // Wrong: 'name' => 'ActivitiesByStatus'
-  // Right: 'name' => 'ActivityByStatus'
-  ->addValues([
-    [
-      'label' => ts('Role'),
-      'value' => 1,
-      'name' => 'ParticipantRole',
-      'grouping' => 'role_id',
-    ],
-    [
-      'label' => ts('Event Name'),
-      'value' => 2,
-      'name' => 'ParticipantEventName',
-      'grouping' => 'event_id',
-    ],
-    [
-      'label' => ts('Event Type'),
-      'value' => 3,
-      'name' => 'ParticipantEventType',
-      'grouping' => 'event_id.event_type_id',
-    ],
   ]);


### PR DESCRIPTION
Overview
----------------------------------------
Prevents possible crash if required option values are corrupted.


Technical Details
----------------------------------------
Spotted in the wild: a site with corrupt option values causing a sitewide crash.

Moving these to a reserved, managed file means they can't be updated by the user, and if they do get updated some other way they'll be immediately reverted to the correct values.