### PR TITLE
dev/core#6124 - Fix regression with required custom file fields

### DIFF
--- a/CRM/Custom/Form/CustomDataTrait.php
+++ b/CRM/Custom/Form/CustomDataTrait.php
@@ -73,7 +73,8 @@ trait CRM_Custom_Form_CustomDataTrait {
         $groupField['custom_group_id.is_multiple'] = $customGroup['is_multiple'];
         $groupField['table_name'] = $customGroup['table_name'];
         $groupField['custom_field_id'] = $groupField['id'];
-        $groupField['required'] = $groupField['is_required'];
+        // dev/core#6124 QuickForms set 'required' based on other criteria
+        $groupField['required'] = FALSE;
         $groupField['input_type'] = $groupField['html_type'];
         $fields[$groupField['id']] = $groupField;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6124](https://lab.civicrm.org/dev/core/-/issues/6124).

Before
----------------------------------------
Required custom fields cause a for error if the field already has a value.

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
This regressed with 6a5544ab for an odd reason:

- Before that commit, fields were fetched with Api4.getFields which always returns 'required => false' for every custom field (the api doesn't ever consider custom fields required).
- That commit switched to a different getter which actually returns correct values for 'required'
- But for some reason, quickforms weren't expecting the value to be correct!

This hotfix patch restores the "incorrect" 'required' value which gets QuickForms working again as they were. For reasons I haven't dug into, the forms still manage to enforce required custom fields for every field type *except* files, so they clearly have their own extra/redundant lookup for the 'required' custom field property.