### PR TITLE
Fix Batch export duplicate FinancialTrxns being exported when contribution was pay later

### DIFF
--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -97,12 +97,15 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
       LEFT JOIN civicrm_financial_item fi ON fi.id = efti.entity_id
       LEFT JOIN civicrm_financial_account fac ON fac.id = fi.financial_account_id
       LEFT JOIN civicrm_financial_account fa ON fa.id = fi.financial_account_id
-      WHERE eb.batch_id = ( %1 )";
+      WHERE eb.batch_id = ( %1 )
+      GROUP BY ft.id";
 
     CRM_Utils_Hook::batchQuery($sql);
 
     $params = [1 => [$batchId, 'String']];
+    CRM_Core_DAO::disableFullGroupByMode();
     $dao = CRM_Core_DAO::executeQuery($sql, $params);
+    CRM_Core_DAO::reenableFullGroupByMode();
 
     return $dao;
   }

--- a/CRM/Financial/BAO/ExportFormat/IIF.php
+++ b/CRM/Financial/BAO/ExportFormat/IIF.php
@@ -96,7 +96,6 @@ class CRM_Financial_BAO_ExportFormat_IIF extends CRM_Financial_BAO_ExportFormat 
    * @return Object
    */
   public function generateExportQuery($batchId) {
-
     $sql = "SELECT
       ft.id as financial_trxn_id,
       ft.trxn_date,
@@ -136,10 +135,13 @@ class CRM_Financial_BAO_ExportFormat_IIF extends CRM_Financial_BAO_ExportFormat 
       LEFT JOIN civicrm_contact contact_to ON contact_to.id = fa_to.contact_id
       LEFT JOIN civicrm_entity_financial_trxn efti ON (efti.financial_trxn_id  = ft.id AND efti.entity_table = 'civicrm_financial_item')
       LEFT JOIN civicrm_financial_item fi ON fi.id = efti.entity_id
-      WHERE eb.batch_id = ( %1 )";
+      WHERE eb.batch_id = ( %1 )
+      GROUP BY ft.id";
 
     $params = [1 => [$batchId, 'String']];
+    CRM_Core_DAO::disableFullGroupByMode();
     $dao = CRM_Core_DAO::executeQuery($sql, $params);
+    CRM_Core_DAO::reenableFullGroupByMode();
 
     return $dao;
   }

--- a/CRM/Financial/Form/Export.php
+++ b/CRM/Financial/Form/Export.php
@@ -16,9 +16,8 @@
  */
 
 /**
- * This class provides the functionality to delete a group of
- * contributions. This class provides functionality for the actual
- * deletion.
+ * This class provides the functionality to export batches to file
+ *
  */
 class CRM_Financial_Form_Export extends CRM_Core_Form {
 


### PR DESCRIPTION
Overview
----------------------------------------
Using the contribution batch functionality in CiviCRM. When a batch is closed and displayed on screen it shows the correct number of lines.
However, when exported as CSV or IIF it generates duplicate lines for some transactions (seems to be when the contribution is pay later.

A simple "group by" prevents this from happening.

Before
----------------------------------------
Multiple transactions duplicated in export.

After
----------------------------------------
Transactions not duplicated in export.

Technical Details
----------------------------------------
Simply adds in "group by" financial_trxn_id. However, it also disables full_group_by while running the query (as is done for most of the reports in CiviCRM currently. Since it is a large query I wanted to make minimal changes (it's not been changed in 13 years) and supporting full_group_by requires going through each line and choosing which aggregate function to use for each.

Comments
----------------------------------------
