### PR TITLE
dev/core#6249 - smarty 2 compatibility for extension admin screen

### DIFF
--- a/templates/CRM/Admin/Page/ExtensionDetails.tpl
+++ b/templates/CRM/Admin/Page/ExtensionDetails.tpl
@@ -93,8 +93,8 @@
     <tr>
       <td class="label">{ts}License{/ts}</td>
       <td>
-        {if !empty($extension.urls['Licensing']) }
-          <a href="{$extension.urls['Licensing']}" target="_blank">{$extension.license|escape}</a>
+        {if !empty($extension.urls.Licensing)}
+          <a href="{$extension.urls.Licensing}" target="_blank">{$extension.license|escape}</a>
         {else}
           {$extension.license|escape}
         {/if}


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6249

Before
----------------------------------------
Lots of red warnings on extension admin screen if using smarty 2.
If you expand an entry to see details, then when the license link is clickable, it just links back to the extension screen.

After
----------------------------------------
When license url link exists, it's clickable and leads to the right place.

Technical Details
----------------------------------------


Comments
----------------------------------------

