### PR TITLE
RiverLea: adds z-index to close icon on notify message to avoid hover clash /extensions/riverlea/-/issues/164

### DIFF
--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -97,6 +97,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
   text-indent: 0;
   height: auto;
   width: auto;
+  z-index: 1;
 }
 #crm-notification-container .ui-notify-message a.ui-notify-cross::before,
 div.civicrm-community-messages a.civicrm-community-message-dismiss::before,


### PR DESCRIPTION
Overview
----------------------------------------
The alert notification dashlet in Thames has a clash between the hover state for the accordion and the close icon for the dashlet. There's a video demonstrating the problem here: https://lab.civicrm.org/extensions/riverlea/-/issues/164

Before
----------------------------------------
Cannot click the close icon on the special notification dashlet on the dashboard in Thames.

After
----------------------------------------
Z-index change brings the close icon on top, makes it clickable.

Technical Details
----------------------------------------
Tho this is a bug only visible in Thames, the fix is in River Core, which fixes it for Thames and any future Stream that might do something similar.