### PR TITLE
Simplify params in legacy code

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2937,21 +2937,14 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
 
       else {
-        // Setting these amounts is consistent with historical code but feels a bit off.
-        // Surely in this scenario we have a new contribution & can get them all from the
-        // contribution object (only).
-        $trxnParams['total_amount'] = $params['total_amount'] ?? NULL;
-        if (!isset($trxnParams['total_amount']) && !empty($params['prevContribution'])) {
-          $trxnParams['total_amount'] = $params['total_amount'] = $params['prevContribution']->total_amount;
-        }
-        $trxnParams['fee_amount'] = $params['fee_amount'] ?? NULL;
-        $trxnParams['net_amount'] = $params['net_amount'] ?? $contribution->net_amount;
-        $statusId = $params['contribution']->contribution_status_id;
+        $trxnParams['total_amount'] = $contribution->total_amount;
+        $trxnParams['fee_amount'] = $contribution->fee_amount;
+        $trxnParams['net_amount'] = $contribution->net_amount;
         // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
         // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
         // this should really default to completed (after discussion). But after moving this
         // to the only place it is actually used - maybe it makes more sense?
-        $trxnParams['status_id'] = $statusId;
+        $trxnParams['status_id'] = $contribution->contribution_status_id;;
         // records finanical trxn and entity financial trxn
         // also make it available as return value
         $financialProcessor->recordAlwaysAccountsReceivable($trxnParams, $params);


### PR DESCRIPTION


Overview
----------------------------------------
Simplify params in legacy code

Per the code comments this seems to be legacy handling for when the contribution was unreliably populated with the saved values, rather than 'for reasons'

The status_id also has comments we could consider... It would only be hit when it's pay later pending or a successful transaction. But it might be a can of worms we should leave shut

Before
----------------------------------------
Various attempts to get values from `$params`, or similar

After
----------------------------------------
values taken  from the just-saved contribution (which has also been reloaded since Oct 2025 so we know the fields are populated

Technical Details
----------------------------------------

Comments
----------------------------------------

