### PR TITLE
Remove chain of functions that call broken function

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -678,47 +678,6 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
   }
 
   /**
-   * Add line items for recurring contribution.
-   *
-   * @param int $recurId
-   * @param \CRM_Contribute_BAO_Contribution $contribution
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public static function addRecurLineItems($recurId, $contribution) {
-    $foundLineItems = FALSE;
-
-    $lineSets = self::calculateRecurLineItems($recurId, $contribution->total_amount, $contribution->financial_type_id);
-    foreach ($lineSets as $lineItems) {
-      if (!empty($lineItems)) {
-        foreach ($lineItems as $key => $value) {
-          if ($value['entity_table'] == 'civicrm_membership') {
-            try {
-              // @todo this should be done by virtue of editing the line item as this link
-              // is deprecated. This may be the case but needs testing.
-              civicrm_api3('membership_payment', 'create', [
-                'membership_id' => $value['entity_id'],
-                'contribution_id' => $contribution->id,
-                'is_transactional' => FALSE,
-              ]);
-            }
-            catch (CRM_Core_Exception $e) {
-              // we are catching & ignoring errors as an extra precaution since lost IPNs may be more serious that lost membership_payment data
-              // this fn is unit-tested so risk of changes elsewhere breaking it are otherwise mitigated
-            }
-          }
-        }
-        $foundLineItems = TRUE;
-      }
-    }
-    if (!$foundLineItems) {
-      CRM_Price_BAO_LineItem::processPriceSet($contribution->id, $lineSets, $contribution);
-    }
-    return $lineSets;
-  }
-
-  /**
    * Update pledge associated with a recurring contribution.
    *
    * If the contribution has a pledge_payment record pledge, then update the pledge_payment record & pledge based on that linkage.
@@ -981,27 +940,6 @@ LEFT  JOIN civicrm_membership_payment mp  ON ( mp.contribution_id = con.id )
       return TRUE;
     }
     return FALSE;
-  }
-
-  /**
-   * Calculate line items for the relevant recurring calculation.
-   *
-   * @param int $recurId
-   * @param string $total_amount
-   * @param int $financial_type_id
-   *
-   * @return array
-   * @throws \CRM_Core_Exception
-   */
-  public static function calculateRecurLineItems($recurId, $total_amount, $financial_type_id) {
-    $originalContribution = civicrm_api3('Contribution', 'getsingle', [
-      'contribution_recur_id' => $recurId,
-      'contribution_test' => '',
-      'options' => ['limit' => 1],
-      'return' => ['id', 'financial_type_id'],
-    ]);
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($originalContribution['id']);
-    return self::reformatLineItemsForRepeatContribution($total_amount, $financial_type_id, $lineItems, $originalContribution);
   }
 
   /**

--- a/CRM/Core/Payment/BaseIPN.php
+++ b/CRM/Core/Payment/BaseIPN.php
@@ -86,15 +86,9 @@ class CRM_Core_Payment_BaseIPN {
       }
     }
 
-    $addLineItems = empty($contribution->id);
     $participant = &$objects['participant'];
     $contribution->contribution_status_id = CRM_Core_PseudoConstant::getKey('CRM_Contribute_DAO_Contribution', 'contribution_status_id', 'Failed');
     $contribution->save();
-
-    // Add line items for recurring payments.
-    if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id && $addLineItems) {
-      CRM_Contribute_BAO_ContributionRecur::addRecurLineItems($objects['contributionRecur']->id, $contribution);
-    }
 
     if (!empty($memberships)) {
       foreach ($memberships as $membership) {
@@ -161,10 +155,7 @@ class CRM_Core_Payment_BaseIPN {
       $contribution->contribution_status_id = $contributionStatuses['Cancelled'];
       $contribution->cancel_date = self::$_now;
       $contribution->save();
-      // Add line items for recurring payments.
-      if (!empty($objects['contributionRecur']) && $objects['contributionRecur']->id && $addLineItems) {
-        CRM_Contribute_BAO_ContributionRecur::addRecurLineItems($objects['contributionRecur']->id, $contribution);
-      }
+
       $memberships = [];
       if (!empty($objects['membership'])) {
         $memberships = &$objects['membership'];


### PR DESCRIPTION
Overview
----------------------------------------
Remove chain of functions that call broken function

Before
----------------------------------------
All these functions go through this missing function

<img width="1203" height="321" alt="image" src="https://github.com/user-attachments/assets/33a71854-e8aa-41fa-8327-e0138c29bac8" />


After
----------------------------------------
poof

Technical Details
----------------------------------------
I could possibly have removed the `->failed()` & `->cancelled()` functions on the BaseIPN class entirely (the top of the chain) as they are heavily deprecated but also, IPN classes can move a bit slowly and any that exist might not be hitting this chain

Comments
----------------------------------------
