### PR TITLE
AfformTranslation: avoid translating string that already uses ts()

### DIFF
--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -135,7 +135,10 @@ class StringVisitor {
   }
 
   protected function isWorthy($value): bool {
-    return !is_array($value) && (strpos($value, '{{') === FALSE) && !empty($value);
+    return !is_array($value)
+      && (strpos($value, '{{') === FALSE)
+      && (strpos($value, 'ts(') === FALSE)
+      && !empty($value);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
For afform translation, we extract string to be put in civicrm_translation_source. This is a fix to avoid extracting string that are supposed to be translated using ts() / E::ts(). While this should be avoided, there are some case that we can't avoid (translation with parameters).

This should also avoid those string from getting extracted in transifex, see https://github.com/civicrm/civistrings/pull/18