### PR TITLE
standaloneusers - add support for PHP standard library / Drupal 10 password hashs

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/PasswordAlgorithms/PhpStandard.php
+++ b/ext/standaloneusers/Civi/Standalone/PasswordAlgorithms/PhpStandard.php
@@ -1,0 +1,33 @@
+<?php
+namespace Civi\Standalone\PasswordAlgorithms;
+
+class PhpStandard implements AlgorithmInterface {
+
+  /**
+   * @var int
+   */
+  public static $bcryptCost = 13;
+
+  /**
+   * Checks if a password matches the stored value
+   *
+   * @todo this will allow any password hashing password_verify supports.
+   * We should have a mechanism for re-encrypting if it is below our current
+   * standards (or rejecting if we are super strict)
+   *
+   * @return bool
+   */
+  public function checkPassword(string $plaintext, string $storedPassword): bool {
+    return \password_verify($plaintext, $storedPassword);
+  }
+
+  /**
+   * Creates a hashed value to store for given password.
+   */
+  public function hashPassword(string $plaintext): string {
+    return \password_hash($plaintext, \PASSWORD_BCRYPT, [
+      'cost' => self::$bcryptCost,
+    ]);
+  }
+
+}

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -128,8 +128,14 @@ class Security {
   protected function checkHashedPassword(string $plaintextPassword, string $storedHashedPassword): bool {
 
     if (preg_match('@^\$S\$[A-Za-z./0-9]{52}$@', $storedHashedPassword)) {
-      // Looks like a default D7 password.
+      // Looks like a D7 password.
       $algo = new \Civi\Standalone\PasswordAlgorithms\Drupal7();
+      return $algo->checkPassword($plaintextPassword, $storedHashedPassword);
+    }
+
+    if (preg_match('@^\$2y\$[0-9]{1,2}\$@', $storedHashedPassword)) {
+      // Looks like a D10/php standard library password.
+      $algo = new \Civi\Standalone\PasswordAlgorithms\PhpStandard();
       return $algo->checkPassword($plaintextPassword, $storedHashedPassword);
     }
 
@@ -150,7 +156,6 @@ class Security {
       \$([a-zA-Z0-9\/+.-]+) # Match 4 salt
       \$([a-zA-Z0-9\/+]+)   # Match 5 B64 encoded hash
       $/x', $storedHashedPassword, $matches)) {
-
       Civi::log()->warning("Denying access to user whose stored password is not in a format we can parse.");
       return FALSE;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Allows user to log in with passwords migrated from Drupal 10.

Before
----------------------------------------
- only support D7 passwords (using copy of D7 implementation)

After
----------------------------------------
- still support verifying D7 passwords
- still hash new passwords using D7 method for now (though I would propose changing to use this one by default for new hashes)
- check bcrypt hashes using standard library function, enables logging in with passwords migrated from D10

Technical Details
----------------------------------------
I'm no crypo-expert, but it seems a lot safer to me to use a standard library function than our copied implementation of D7 (which we did find a mistake in at one point in the early days of Standalone).

The standard library hash function provides parameters for easily changing algos/upping compute cost in future.  The default is Bcrypt, which seems good enough for me. The default cost is 12, I made it 13 because Civi seems like it should be slightly more secure than your average app. This could be a setting, but does it really need to be?

The verify function will use details in the hash to determine the algorithm. It will accept any algo it knows about, so I suppose in theory it could mean your checking using an algo that is weaker than you'd like. But this is only if you have that hash saved in your database.

Comments
----------------------------------------
Drupal have also switched to using this.
