### PR TITLE
Standaloneusers - use php standard library password hashing by default

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/PasswordAlgorithms/PhpStandard.php
+++ b/ext/standaloneusers/Civi/Standalone/PasswordAlgorithms/PhpStandard.php
@@ -1,0 +1,33 @@
+<?php
+namespace Civi\Standalone\PasswordAlgorithms;
+
+class PhpStandard implements AlgorithmInterface {
+
+  /**
+   * @var int
+   */
+  public static $bcryptCost = 13;
+
+  /**
+   * Checks if a password matches the stored value
+   *
+   * @todo this will allow any password hashing password_verify supports.
+   * We should have a mechanism for re-encrypting if it is below our current
+   * standards (or rejecting if we are super strict)
+   *
+   * @return bool
+   */
+  public function checkPassword(string $plaintext, string $storedPassword): bool {
+    return \password_verify($plaintext, $storedPassword);
+  }
+
+  /**
+   * Creates a hashed value to store for given password.
+   */
+  public function hashPassword(string $plaintext): string {
+    return \password_hash($plaintext, \PASSWORD_BCRYPT, [
+      'cost' => self::$bcryptCost,
+    ]);
+  }
+
+}

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -93,10 +93,8 @@ class Security {
    * High level function to encrypt password using the site-default mechanism.
    */
   public function hashPassword(string $plaintext): string {
-    // For now, we just implement D7's but this should be configurable.
-    // Sites should be able to move from one password hashing algo to another
-    // e.g. if a vulnerability is discovered.
-    $algo = new \Civi\Standalone\PasswordAlgorithms\Drupal7();
+    // use PHP standard library hashing by default
+    $algo = new \Civi\Standalone\PasswordAlgorithms\PhpStandard();
     return $algo->hashPassword($plaintext);
   }
 

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -128,8 +128,14 @@ class Security {
   protected function checkHashedPassword(string $plaintextPassword, string $storedHashedPassword): bool {
 
     if (preg_match('@^\$S\$[A-Za-z./0-9]{52}$@', $storedHashedPassword)) {
-      // Looks like a default D7 password.
+      // Looks like a D7 password.
       $algo = new \Civi\Standalone\PasswordAlgorithms\Drupal7();
+      return $algo->checkPassword($plaintextPassword, $storedHashedPassword);
+    }
+
+    if (preg_match('@^\$2y\$[0-9]{1,2}\$@', $storedHashedPassword)) {
+      // Looks like a D10/php standard library password.
+      $algo = new \Civi\Standalone\PasswordAlgorithms\PhpStandard();
       return $algo->checkPassword($plaintextPassword, $storedHashedPassword);
     }
 
@@ -150,7 +156,6 @@ class Security {
       \$([a-zA-Z0-9\/+.-]+) # Match 4 salt
       \$([a-zA-Z0-9\/+]+)   # Match 5 B64 encoded hash
       $/x', $storedHashedPassword, $matches)) {
-
       Civi::log()->warning("Denying access to user whose stored password is not in a format we can parse.");
       return FALSE;
     }

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -103,10 +103,8 @@ class Security extends Civi\Core\Service\AutoService implements EventSubscriberI
    * High level function to encrypt password using the site-default mechanism.
    */
   public function hashPassword(string $plaintext): string {
-    // For now, we just implement D7's but this should be configurable.
-    // Sites should be able to move from one password hashing algo to another
-    // e.g. if a vulnerability is discovered.
-    $algo = new \Civi\Standalone\PasswordAlgorithms\Drupal7();
+    // use PHP standard library hashing by default
+    $algo = new \Civi\Standalone\PasswordAlgorithms\PhpStandard();
     return $algo->hashPassword($plaintext);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/34307 . Use standard library hashing by default for new/changed passwords, rather than (our copy of) Drupal 7 hashing.

After https://github.com/civicrm/civicrm-core/pull/34307
----------------------------------------
- D7 or standard library hashes work for logging in
- new / changed passwords are hashed using D7 algo

After
----------------------------------------
- D7 or standard library hashes still work for logging in
- new / changed passwords are hashed using standard library 

Technical Details
----------------------------------------
Ideally we would have a loopback to re-encrypt valid passwords using our preferred algo. But I think that could be a follow up.

Comments
----------------------------------------
Given D7 is EOL, it doesn't feel great to be using a copy of that password algo indefinitely. It feels like there will be many more eyes on the standard library implementation; and there are many fewer of our own lines of code that could have specific vulnerabilities in.

There's various code comments about having swappable algos. The standard library has some support for that already, so that would provide an easy route to exposing that if there is a need.