### PR TITLE
dev/core#4174 Send/Process Validation errors to FormBuilder front-end

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -205,7 +205,7 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       if (method_exists($e, 'getErrorData')) {
         $errorData = $e->getErrorData();
         if (!empty($errorData['validation'])) {
-          $response['error_code'] = (string)$error_data['error_code'] ?? '1';
+          $response['error_code'] = (string) $error_data['error_code'] ?? '1';
           $response['error_message'] = implode("\n", $errorData['validation']);
           $bFormError = TRUE;
         }

--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -207,6 +207,16 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
         ]);
       }
       $response['status'] = $status;
+
+      // Detect if it's an afform validation error and format it in a way
+      // that ext/afform/core/ang/af/afForm.component.js can handle it
+      if (method_exists($e, 'getErrorData')) {
+        $errorData = $e->getErrorData();
+        if (!empty($errorData['validation'])) {
+          $response['error_code'] = 42;
+          $response['error_message'] = implode("\n", $errorData['validation']);
+        }
+      }
     }
     return $response;
   }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -46,7 +46,7 @@ class Submit extends AbstractProcessor {
         ->execute()->count();
 
       if ($afformSubmissionData > 0) {
-        throw new \CRM_Core_Exception(ts('Submission is already processed.'));
+        throw new \CRM_Core_Exception(ts('Submission Processed'), 0, ['validation' => ts('Submission is already processed.')]);
       }
     }
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -397,10 +397,6 @@
           args: args,
           values: data,
         }).then(function(response) {
-          if (response.error_code) {
-            handleError(status, $element, response);
-            return;
-          }
           submissionResponse = response;
           if (ctrl.fileUploader.getNotUploadedItems().length) {
             _.each(ctrl.fileUploader.getNotUploadedItems(), function(file) {
@@ -442,11 +438,6 @@
           args: args,
           values: data,
         }).then(function(response) {
-          if (response.error_code) {
-            handleError(status, $element, response);
-            setDraftStatus('unsaved');
-            return;
-          }
           status.resolve();
           if (ctrl.fileUploader.getNotUploadedItems().length) {
             uploadingDraftFiles = true;
@@ -463,6 +454,8 @@
           }
         })
         .catch(function(error) {
+          setDraftStatus('unsaved');
+
           // see: CRM/Api4/Page/AJAX.php
           if (error.error_code !== '1') {
             displayError(error.error_message, ts('Please resolve these issues'), 'warning');
@@ -470,7 +463,6 @@
           else {
             displayError(error.error_message, ts('There is a problem'), 'error');
           }
-          setDraftStatus('unsaved');
         });
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -108,7 +108,7 @@
               });
               $element.unblock();
             }, (error) => {
-              disableForm(error.error_message);
+              disableForm(error.error_message, ts('Sorry'), 'error');
               $element.unblock();
             });
         }
@@ -365,26 +365,18 @@
         $('af-form[ng-form="' + ctrl.getFormMeta().name + '"]')
           .addClass('disabled')
           .find('button[ng-click="afform.submit()"]').prop('disabled', true);
-        CRM.alert(errorMsg, ts('Sorry'), 'error');
+        displayError(errorMsg, ts('Sorry'), 'error');
       }
 
-      function handleError(status, $element, error) {
-        status.reject();
-        $element.unblock();
-        // see: CRM/Api4/Page/AJAX.php
-        if (error.error_code == 42) {
-          if (typeof Swal === 'function') {
-            Swal.fire({
-              icon: 'warning',
-              html: error.error_message.replace("\n", '<br>')
-            });
-          }
-          else {
-            CRM.alert(error.error_message, ts('Form Error'));
-          }
+     function displayError(error, title, type) {
+        if (typeof Swal === 'function') {
+          Swal.fire({
+            icon: type,
+            html: error.error_message.replace("\n", '<br>')
+          });
         }
         else {
-          CRM.alert(error.error_message, ts('Form Error'));
+          CRM.alert(error.error_message, title, type);
         }
       }
 
@@ -426,7 +418,16 @@
           }
         })
         .catch(function(error) {
-          handleError(status, $element, error);
+          status.reject();
+          $element.unblock();
+
+          // see: CRM/Api4/Page/AJAX.php
+          if (error.error_code !== '1') {
+            displayError(error.error_message, ts('Please resolve these issues'), 'warning');
+          }
+          else {
+            displayError(error.error_message, ts('There is a problem'), 'error');
+          }
         });
       };
 
@@ -462,7 +463,13 @@
           }
         })
         .catch(function(error) {
-          handleError(status, $element, error);
+          // see: CRM/Api4/Page/AJAX.php
+          if (error.error_code !== '1') {
+            displayError(error.error_message, ts('Please resolve these issues'), 'warning');
+          }
+          else {
+            displayError(error.error_message, ts('There is a problem'), 'error');
+          }
           setDraftStatus('unsaved');
         });
       };


### PR DESCRIPTION
Overview
----------------------------------------
As per [dev/core#4174](https://lab.civicrm.org/dev/core/-/issues/4174) in Wordpress the server side validation (from extensions) is not shown on the front-end. The user has the impression things worked when they didn't.

Before
----------------------------------------

User sees that all was well and the form went through

After
----------------------------------------

The user sees a message indicating a failure

Technical Details
----------------------------------------

+ The errors are processed and passed through in the actual `response`
+ The Afform checks for any errors and essentially passes them off to the user
+ Refactored the error handling to be placed into a single `handleError` function

Comments
----------------------------------------

+ I added the code into the Draft processing, but I don't really have time to test it. So if someone wants to give that a test that would be good. I tried to also set the draft back to `unsaved` so that it wasn't in some weird state after an error