### PR TITLE
Move determination of amount params for new transaction to `getTrxnParams()`

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2726,11 +2726,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $skipRecords = TRUE;
 
       //build financial transaction params
-      $trxnParams = $financialProcessor->getTrxnParams($params);
-
-      $params['trxnParams'] = $trxnParams;
 
       if ($isUpdate) {
+        $trxnParams = $financialProcessor->getTrxnParams($params);
+        $params['trxnParams'] = $trxnParams;
         $updated = FALSE;
         $params['trxnParams']['total_amount'] = $trxnParams['total_amount'] = $params['total_amount'] = $params['prevContribution']->total_amount;
         $params['trxnParams']['fee_amount'] = $params['prevContribution']->fee_amount;
@@ -2854,14 +2853,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
 
       else {
-        $trxnParams['total_amount'] = $contribution->total_amount;
-        $trxnParams['fee_amount'] = $contribution->fee_amount;
-        $trxnParams['net_amount'] = $contribution->net_amount;
-        // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
-        // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
-        // this should really default to completed (after discussion). But after moving this
-        // to the only place it is actually used - maybe it makes more sense?
-        $trxnParams['status_id'] = $contribution->contribution_status_id;;
+        $trxnParams = $params['trxnParams'] = $financialProcessor->getTrxnParams($params);
         // records finanical trxn and entity financial trxn
         // also make it available as return value
         $financialProcessor->recordAlwaysAccountsReceivable($trxnParams, $params);

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -331,7 +331,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
       'trxn_date' => $this->getInputValue('receive_date') ?: date('YmdHis'),
       'currency' => $this->getUpdatedContribution()->currency,
       // CRM-17751, Fallback to original contribution is historical and probably not needed now as it was probably because updatedContribution
-      // we not always reliable. when we were not consistently reloading it.
+      // was not historically always reliably reloaded.
       'trxn_id' => $this->getInputValue('trxn_id') ?: $this->getUpdatedContribution()->trxn_id ?: $this->getOriginalContributionValue('trxn_id'),
       'payment_instrument_id' => $this->getInputValue('payment_instrument_id') ?: $this->getUpdatedContribution()->payment_instrument_id,
       'check_number' => $this->getInputValue('check_number'),
@@ -364,6 +364,17 @@ class CRM_Contribute_BAO_FinancialProcessor {
         // CRM-17751 allow a separate trxn_id for the refund to be passed in via api & form.
         $trxnParams['trxn_id'] = $this->getInputValue('refund_trxn_id');
       }
+    }
+    if (empty($this->originalContribution)) {
+      // New contribution - populate amounts too
+      $trxnParams['total_amount'] = $this->updatedContribution->total_amount;
+      $trxnParams['fee_amount'] = $this->updatedContribution->fee_amount;
+      $trxnParams['net_amount'] = $this->updatedContribution->net_amount;
+      // @todo - this is getting the status id from the contribution - that is BAD - ie the contribution could be partially
+      // paid but each payment is completed. The work around is to pass in the status_id in the trxn_params but
+      // this should really default to completed (after discussion). But after moving this
+      // to the only place it is actually used - maybe it makes more sense?
+      $trxnParams['status_id'] = $this->updatedContribution->contribution_status_id;
     }
     return $trxnParams;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Move determination of amount params for new transaction to `getTrxnParams()`

Before
----------------------------------------
`trxnParams` loaded before the handling stage and then if the contribution is being created (not augmented) amount params are added to it in the handling stage

After
----------------------------------------
`getTrxnParams()` is loading the amount params for new transactions. the get call is moved inside the 2 bits of the handling because they don't otherwise have any cross over so this prepares for future extracting those parts

Technical Details
----------------------------------------

Comments
----------------------------------------
