### PR TITLE
Use isTest() function to standardise checks

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -871,14 +871,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       'discount_id' => $params['discount_id'] ?? NULL,
       'fee_currency' => $params['currencyID'] ?? NULL,
       'campaign_id' => $params['campaign_id'] ?? NULL,
+      'is_test' => $this->isTest(),
     ];
-
-    if ($form->_action & CRM_Core_Action::PREVIEW || (($params['mode'] ?? NULL) === 'test')) {
-      $participantParams['is_test'] = 1;
-    }
-    else {
-      $participantParams['is_test'] = 0;
-    }
 
     if (!empty($form->_params['note'])) {
       $participantParams['note'] = $form->_params['note'];

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -206,13 +206,12 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
    *
    * @return int
    */
-  public function getAction() {
-    if ($this->_action & CRM_Core_Action::PREVIEW) {
+  public function getAction(): int {
+    if ($this->isTest()) {
       return CRM_Core_Action::VIEW | CRM_Core_Action::PREVIEW;
     }
-    else {
-      return CRM_Core_Action::VIEW;
-    }
+
+    return CRM_Core_Action::VIEW;
   }
 
   /**
@@ -696,11 +695,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       CRM_Event_BAO_Participant::transitionParticipants($cancelledIds, $cancelledId);
     }
 
-    $isTest = FALSE;
-    if ($this->_action & CRM_Core_Action::PREVIEW) {
-      $isTest = TRUE;
-    }
-
     $primaryParticipant = $this->get('primaryParticipant');
 
     if (empty($primaryParticipant['participantID'])) {
@@ -719,7 +713,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
     ) {
 
       //build an array of custom profile and assigning it to template
-      $customProfile = CRM_Event_BAO_Event::buildCustomProfile($registerByID, $this->_values, NULL, $isTest);
+      $customProfile = CRM_Event_BAO_Event::buildCustomProfile($registerByID, $this->_values, NULL, $this->isTest());
       if (count($customProfile)) {
         $this->assign('customProfile', $customProfile);
         $this->set('customProfile', $customProfile);
@@ -732,7 +726,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           $primaryContactId = $this->get('primaryContactId');
 
           //build an array of cId/pId of participants
-          $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($registerByID, NULL, $primaryContactId, $isTest, TRUE);
+          $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($registerByID, NULL, $primaryContactId, $this->isTest(), TRUE);
 
           //need to copy, since we are unsetting on the way.
           $copyParticipantCountLines = $participantCount;
@@ -797,7 +791,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       // @todo - don't call buildCustomProfile to get additionalParticipants.
       // CRM_Event_BAO_Participant::getAdditionalParticipantIds is a better fit.
       $additionalIDs = CRM_Event_BAO_Event::buildCustomProfile($registerByID,
-        NULL, $primaryContactId, $isTest,
+        NULL, $primaryContactId, $this->isTest(),
         TRUE
       );
       //let's send mails to all with meaningful text, CRM-4320.
@@ -830,7 +824,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $participantNum = 0;
         if ($participantID == $registerByID) {
           //build an array of custom profile and assigning it to template.
-          $customProfile = CRM_Event_BAO_Event::buildCustomProfile($participantID, $this->_values, NULL, $isTest);
+          $customProfile = CRM_Event_BAO_Event::buildCustomProfile($participantID, $this->_values, NULL, $this->isTest());
 
           if (count($customProfile)) {
             $this->assign('customProfile', $customProfile);
@@ -882,7 +876,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         $this->_values['params']['isRequireApproval'] = $this->_requireApproval;
 
         //send mail to primary as well as additional participants.
-        CRM_Event_BAO_Event::sendMail($contactId, $this->_values, $participantID, $isTest);
+        CRM_Event_BAO_Event::sendMail($contactId, $this->_values, $participantID, $this->isTest());
       }
     }
   }
@@ -951,10 +945,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       $contribParams['contribution_status_id'] = array_search('Pending', $allStatuses);
     }
 
-    $contribParams['is_test'] = 0;
-    if ($form->_action & CRM_Core_Action::PREVIEW || ($params['mode'] ?? NULL) === 'test') {
-      $contribParams['is_test'] = 1;
-    }
+    $contribParams['is_test'] = $this->isTest();
 
     if (!empty($contribParams['invoice_id'])) {
       $contribParams['id'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution',

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -987,7 +987,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
           $url = CRM_Utils_System::url('civicrm/event/info',
             "reset=1&id={$form->_values['event']['id']}&noFullMsg=true"
           );
-          if ($form->_action & CRM_Core_Action::PREVIEW) {
+          if ($form->isTest()) {
             $url .= '&action=preview';
           }
           if ($form->_pcpId) {

--- a/CRM/Event/Form/Registration/ThankYou.php
+++ b/CRM/Event/Form/Registration/ThankYou.php
@@ -53,7 +53,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
    * @return int
    */
   public function getAction(): int {
-    if ($this->_action & CRM_Core_Action::PREVIEW) {
+    if ($this->isTest()) {
       return CRM_Core_Action::VIEW | CRM_Core_Action::PREVIEW;
     }
 
@@ -165,7 +165,7 @@ class CRM_Event_Form_Registration_ThankYou extends CRM_Event_Form_Registration {
       CRM_Friend_BAO_Friend::retrieve($params, $data);
       if (!empty($data['is_active'])) {
         $friendText = $data['title'];
-        if ($this->_action & CRM_Core_Action::PREVIEW) {
+        if ($this->isTest()) {
           $friendURL = CRM_Utils_System::url('civicrm/friend',
             "eid={$this->getEventID()}&reset=1&action=preview&pcomponent=event"
           );

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -203,4 +203,11 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     }
   }
 
+  /**
+   * @return bool
+   */
+  public function isTest(): bool {
+    return $this->_action & CRM_Core_Action::PREVIEW;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Use isTest() function to standardise checks

Before
----------------------------------------
verbose `isTest()` checks

After
----------------------------------------
Consistent function

Technical Details
----------------------------------------
I can't find any evidence that `$params['mode']` would be test if the form mode is not - I think this is a hangover from shared code

Comments
----------------------------------------
