### PR TITLE
Deprecate stray function

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1797,8 +1797,10 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    * @param array $lineItem
    *
    * @throws \CRM_Core_Exception
+   * @deprecated since 6.11 will be removed around 6.19
    */
   public function processPriceSet($membershipId, $lineItem) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     //FIXME : need to move this too
     if (!$membershipId || !is_array($lineItem)
       || CRM_Utils_System::isNull($lineItem)


### PR DESCRIPTION
Overview
----------------------------------------
I don't think `Membership::processPriceSet()` has been used in a long long time