### PR TITLE
Remove billingName email template assignments

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2355,11 +2355,9 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    */
   public function _gatherMessageValues($values, ?int $eventID, ?int $participantID) {
     // set display address of contributor
-    $values['billingName'] = '';
     if ($this->address_id) {
       $addressDetails = CRM_Core_BAO_Address::getValues(['id' => $this->address_id], FALSE, 'id');
       $addressDetails = reset($addressDetails);
-      $values['billingName'] = $addressDetails['name'] ?? '';
     }
     // Else we assign the billing address of the contribution contact.
     else {
@@ -2485,7 +2483,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     // and this function should assign them (assigning null if not set).
     // the way the pcpParams & honor Params section works is a baby-step towards this.
     $template = CRM_Core_Smarty::singleton();
-    $template->assign('billingName', $values['billingName']);
     // It is unclear if onBehalfProfile is still assigned & where - but
     // it is still referred to in templates so avoid an e-notice.
     // Credit card type is assigned on the form layer but should also be

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1515,6 +1515,7 @@ class CRM_Utils_Token {
           '$domain_state' => 'domain.state_province_id:abbr',
           '$domain_country' => 'domain.country_id:abbr',
           '$lineItem' => '$lineItems',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'contribution_online_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
@@ -1524,6 +1525,7 @@ class CRM_Utils_Token {
           '$displayName' => 'contact.display_name',
           '$dataArray' => ts('see default template for how to show this'),
           '$lineItem' => '$lineItems',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1545,6 +1547,7 @@ class CRM_Utils_Token {
           '$currency' => 'contribution.currency',
           '$paidBy' => 'contribution.payment_instrument_id:label',
           '$lineItem' => '$lineItems',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'membership_online_receipt' => [
           '$dataArray' => ts('see default template for how to show this'),
@@ -1558,6 +1561,7 @@ class CRM_Utils_Token {
           '$currency' => 'contribution.currency',
           '$totalTaxAmount' => 'contribution.tax_amount',
           '$lineItem' => '$lineItems',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',
@@ -1568,6 +1572,7 @@ class CRM_Utils_Token {
           '$receipt_date' => 'contribution.receipt_date',
           '$cancel_date' => 'contribution.cancel_date',
           '$lineItem' => '$lineItems',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
@@ -1594,6 +1599,7 @@ class CRM_Utils_Token {
           '$participant_status_id' => 'participant.status_id',
           '$participant.role' => 'participant.role_id:label',
           '$lineItem' => '$lineItems',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'event_online_receipt' => [
           '`$participant.id`' => 'participant.id',
@@ -1608,27 +1614,32 @@ class CRM_Utils_Token {
           '$paidBy' => 'contribution.payment_instrument_id:label',
           '$title' => 'event.title',
           '$lineItem' => '$lineItems',
-          '$participant_status' => '{participant.status_id:label}',
+          '$participant_status' => 'participant.status_id:label',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'participant_transferred' => [
           '$location' => 'event.location',
           '$participant.role' => 'participant.role_id:label',
           '$event.participant_role' => 'participant.role_id:label',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'participant_cancelled' => [
           '$location' => 'event.location',
           '$participant.role' => 'participant.role_id:label',
           '$event.participant_role' => 'participant.role_id:label',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'participant_expired' => [
           '$location' => 'event.location',
           '$participant.role' => 'participant.role_id:label',
           '$event.participant_role' => 'participant.role_id:label',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'participant_confirm' => [
           '$location' => 'event.location',
           '$participant.role' => 'participant.role_id:label',
           '$event.participant_role' => 'participant.role_id:label',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'payment_or_refund_notification' => [
           '$location' => 'event.location',
@@ -1636,14 +1647,17 @@ class CRM_Utils_Token {
           '$event.participant_role' => 'participant.role_id:label',
           '$contactDisplayName' => 'contact.display_name',
           '$paymentsComplete' => 'contribution.balance_amount',
+          '$billingName' => 'contribution.address_id.name',
         ],
         'pledge_acknowledgement' => [
           '$domain' => ts('no longer available / relevant'),
           '$contact' => ts('no longer available / relevant'),
+          '$billingName' => 'contribution.address_id.name',
         ],
         'pledge_reminder' => [
           '$domain' => ts('no longer available / relevant'),
           '$contact' => ts('no longer available / relevant'),
+          '$billingName' => 'contribution.address_id.name',
         ],
       ],
     ];

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -241,7 +241,6 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
       'receipt_from_name' => 'CiviCRM Fundraising Dept.',
       'receipt_from_email' => 'donationFake@civicrm.org',
       'contribution_status' => 'Completed',
-      'billingName' => "Giver {$contact_contributor}",
       'address' => "Giver {$contact_contributor}\n123 Main St.\n",
       'softContributions' => NULL,
       'title' => 'Contribution',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3572,7 +3572,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->checkCreditCardDetails($mut, $order['id']);
     $mut->stop();
     $tplVars = CRM_Core_Smarty::singleton()->getTemplateVars();
-    $this->assertEquals('bob', $tplVars['billingName']);
+    $this->assertEquals('USD', $tplVars['currency']);
   }
 
   /**


### PR DESCRIPTION
This was removed from core templates in 2023 .eg. https://github.com/civicrm/civicrm-core/pull/27692/changes 

There have been several template changes since then that could be expected to have caused people to sync with the shipped ones so removing it with a little 'in case' noise seems timely

If people still have `$billingName` in their workflow templates they will get a system check show up
