### PR TITLE
Expose participant tokens on Payment or refund

### DIFF
--- a/CRM/Contribute/WorkflowMessage/PaymentOrRefundNotification.php
+++ b/CRM/Contribute/WorkflowMessage/PaymentOrRefundNotification.php
@@ -16,6 +16,7 @@ use Civi\WorkflowMessage\GenericWorkflowMessage;
  * Receipt sent when confirming contribution add payment.
  *
  * @method int getEventID()
+ * @method int getParticipantID()
  *
  * @support template-only
  * @see CRM_Financial_BAO_Payment::sendConfirmation()
@@ -30,5 +31,12 @@ class CRM_Contribute_WorkflowMessage_PaymentOrRefundNotification extends Generic
    * @scope tokenContext as eventId, tplParams as eventID
    */
   public $eventID;
+
+  /**
+   * @var int
+   *
+   * @scope tokenContext as participantId
+   */
+  public $participantID;
 
 }


### PR DESCRIPTION


Overview
----------------------------------------
Expose participant tokens on Payment or refund

Before
----------------------------------------
This variable is already pushed in as part of the model so declaring it here makes it more explicitly available - although I'm primarily adding it to support including the profileTrait from the Contribution workflow trait - which assumes that if there is an eventID declared the participantID will also be declared

After
----------------------------------------
participantID property also declared

Technical Details
----------------------------------------

Comments
----------------------------------------
towards https://github.com/civicrm/civicrm-core/pull/34257