### PR TITLE
Remove some more email smarty assignments that are deprecated

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -858,12 +858,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             if ($lineItemValue = ($lineItems[$participantNum] ?? NULL)) {
               $lineItem[] = $lineItemValue;
             }
-            if (\Civi::settings()->get('invoicing')) {
-              $individual = $this->get('individual');
-              $this->assign('totalAmount', $individual[$participantNum]['totalAmtWithTax']);
-              $this->assign('totalTaxAmount', $individual[$participantNum]['totalTaxAmt']);
-              $this->assign('individual', [$individual[$participantNum]]);
-            }
             $this->assign('lineItem', $lineItem);
           }
           $this->_values['params']['additionalParticipant'] = TRUE;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1588,6 +1588,7 @@ class CRM_Utils_Token {
           '$location' => 'event.location',
           '$register_date' => 'participant.register_date',
           '$participant.role' => 'participant.role_id:label',
+          '$totalAmount' => 'contribution.total_amount',
           '$totalTaxAmount' => 'contribution.tax_amount',
           '$event.participant_role' => 'participant.role_id:label',
           '$paidBy' => 'contribution.payment_instrument_id:label',


### PR DESCRIPTION
Overview
----------------------------------------
Remove some more email smarty assignments that are deprecated

Before
----------------------------------------
Variables removed from core templates and mostly deprecated via System Check

After
----------------------------------------
Assignments removed - the one not yet notified in the system check is added

Technical Details
----------------------------------------

Comments
----------------------------------------