### PR TITLE
Fix #34153 - membership_type pseudoconstant

### DIFF
--- a/schema/Price/PriceFieldValue.entityType.php
+++ b/schema/Price/PriceFieldValue.entityType.php
@@ -157,7 +157,7 @@ return [
       'pseudoconstant' => [
         'table' => 'civicrm_membership_type',
         'key_column' => 'id',
-        'label_column' => 'name',
+        'label_column' => 'title',
       ],
       'entity_reference' => [
         'entity' => 'MembershipType',


### PR DESCRIPTION
Overview
----------------------------------------
Follow-up fix for #34153 - membership_type label should map to title not name.

Before
----------------------------------------
Label maps to name

After
----------------------------------------
Label maps to title

Technical Details
----------------------------------------


Comments
----------------------------------------
Note: Kind of an unreleased regression. The membership_type title/frontend_title is new/unreleased and we just merged pseudoconstant support in #34153

