### PR TITLE
Further removal of deprecate token assignments

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1463,12 +1463,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $contributionParams['total_amount'] = $params['amount'];
 
       $contribution = CRM_Contribute_BAO_Contribution::add($contributionParams);
-
-      if (Civi::settings()->get('invoicing')) {
-        $smarty = CRM_Core_Smarty::singleton();
-        // @todo - probably this assign is no longer needed as we use a token.
-        $smarty->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
-      }
     }
 
     // process soft credit / pcp params first
@@ -2239,8 +2233,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
 
       array_unshift($this->statusMessage, ts('The contribution record has been saved.'));
 
-      $this->invoicingPostProcessHook($submittedValues, $action);
-
       //send receipt mail.
       //FIXME: 'payment.create' could send a receipt.
       if ($contribution->id && !empty($formValues['is_email_receipt'])) {
@@ -2298,35 +2290,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->_defaults['contribution_status_id'] ?? NULL
     );
     return $contribution;
-  }
-
-  /**
-   * Assign tax calculations to contribution receipts.
-   *
-   * @param array $submittedValues
-   * @param int $action
-   */
-  protected function invoicingPostProcessHook($submittedValues, $action): void {
-    if (!Civi::settings()->get('invoicing')) {
-      return;
-    }
-    // @todo - all of the below is obsolete - it supports old templates that have tokens that
-    // have not been used in core since 2022-ish
-
-    if ($action & CRM_Core_Action::UPDATE) {
-      $totalTaxAmount = $submittedValues['tax_amount'] ?? $this->_values['tax_amount'];
-      // Assign likely replaced by a token
-      $this->assign('totalTaxAmount', $totalTaxAmount);
-    }
-    else {
-      if (!empty($submittedValues['price_set_id'])) {
-        $this->assign('totalTaxAmount', $submittedValues['tax_amount']);
-        $this->assign('getTaxDetails', (bool) $this->getOrder()->getTotalTaxAmount());
-      }
-      else {
-        $this->assign('totalTaxAmount', $submittedValues['tax_amount'] ?? NULL);
-      }
-    }
   }
 
   /**

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1049,8 +1049,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // lets store it in the form variable so postProcess hook can access it via getContributionID()
       $this->_contributionID = $contribution->id;
     }
-    // @fixme: This is assigned to the smarty template for the receipt. It's value should be calculated and not taken from $params.
-    $form->assign('totalTaxAmount', $params['tax_amount'] ?? NULL);
 
     // process soft credit / pcp params first
     $this->formatSoftCreditParams($params);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1576,8 +1576,6 @@ DESC limit 1");
     $customValues = $this->getCustomValuesForReceipt();
     $this->assign('customValues', $customValues);
     $this->assign('total_amount', $this->order->getTotalAmount());
-    $this->assign('totalTaxAmount', $this->order->getTotalTaxAmount());
-    $this->assign('taxTerm', $this->getSalesTaxTerm());
 
     if ($this->_mode) {
       // @todo move this outside shared code as Batch entry just doesn't


### PR DESCRIPTION
When we assign to smarty in some cases it is for the form but in the postProcess it is for the emails. We now assign taxTerm globally for emails and have been warning against totalTaxAmount, totalAmount and getTaxDetails in our system checks so this removes some assignments

Builds on https://github.com/civicrm/civicrm-core/pull/34328