### PR TITLE
Stop assigning legacy lineItem array to online event receipt

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2598,7 +2598,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $template->assign('isPrimary', 0);
         $template->assign('customProfile', NULL);
         //set additionalParticipant true
-        $values['params']['additionalParticipant'] = TRUE;
         foreach ($additionalIDs as $participantID) {
           $amount = [];
           //to change the status pending to completed
@@ -2633,7 +2632,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
 
       // for primary contact
-      $values['params']['additionalParticipant'] = FALSE;
       $template->assign('isPrimary', 1);
       $template->assign('amount', $primaryAmount);
       $template->assign('register_date', CRM_Utils_Date::isoToMysql($this->_relatedObjects['participant']->register_date));
@@ -4080,18 +4078,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $values['custom_pre_id'] = $custom_pre_id;
     $values['custom_post_id'] = $custom_post_ids;
 
-    // set lineItem for event contribution
-    if ($contributionID) {
-      $participantIds = CRM_Event_BAO_Participant::getParticipantIds($contributionID);
-      if (!empty($participantIds)) {
-        foreach ($participantIds as $pIDs) {
-          $lineItem = CRM_Price_BAO_LineItem::getLineItems($pIDs);
-          if (!CRM_Utils_System::isNull($lineItem)) {
-            $values['lineItem'][] = $lineItem;
-          }
-        }
-      }
-    }
     return $values;
   }
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1158,29 +1158,6 @@ WHERE civicrm_event.is_active = 1
           $sendTemplateParams['tplParams']['address'] = $displayAddress;
         }
 
-        // set lineItem details
-        $lineItem = $values['lineItem'] ?? NULL;
-        if ($lineItem) {
-          // check if additional participant, if so filter only to relevant ones
-          // CRM-9902
-          if (!empty($values['params']['additionalParticipant'])) {
-            $ownLineItems = [];
-            foreach ($lineItem as $liKey => $liValue) {
-              $firstElement = array_pop($liValue);
-              if ($firstElement['entity_id'] == $participantId) {
-                $ownLineItems[0] = $lineItem[$liKey];
-                break;
-              }
-            }
-            if (!empty($ownLineItems)) {
-              $sendTemplateParams['tplParams']['lineItem'] = $ownLineItems;
-            }
-          }
-          else {
-            $sendTemplateParams['tplParams']['lineItem'] = $lineItem;
-          }
-        }
-
         if ($returnMessageText) {
           [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
           return [

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -830,7 +830,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             $this->assign('customProfile', $customProfile);
             $this->set('customProfile', $customProfile);
           }
-          $this->_values['params']['additionalParticipant'] = FALSE;
         }
         else {
           //take the Additional participant number.
@@ -852,17 +851,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
             // @todo - unused in core offline receipt template from 5.67. Remove at somepoint
             $this->assign('amounts', $amount);
           }
-          if ($this->_lineItem) {
-            $lineItems = $this->_lineItem;
-            $lineItem = [];
-            if ($lineItemValue = ($lineItems[$participantNum] ?? NULL)) {
-              $lineItem[] = $lineItemValue;
-            }
-            $this->assign('lineItem', $lineItem);
-          }
-          $this->_values['params']['additionalParticipant'] = TRUE;
-          // Removed from tpl in 5.67
-          $this->assign('isAdditionalParticipant', $this->_values['params']['additionalParticipant']);
         }
 
         //pass these variables since these are run time calculated.

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1585,6 +1585,7 @@ class CRM_Utils_Token {
           '$dataArray' => ts('see default template for how to show this'),
           '$individual' => ts('see default template for how to show this'),
           '$amount' => ts('see default template for how to show this'),
+          '$additionalParticipant' => ts('see default template for how to show this'),
           '$location' => 'event.location',
           '$register_date' => 'participant.register_date',
           '$participant.role' => 'participant.role_id:label',

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1585,7 +1585,7 @@ class CRM_Utils_Token {
           '$dataArray' => ts('see default template for how to show this'),
           '$individual' => ts('see default template for how to show this'),
           '$amount' => ts('see default template for how to show this'),
-          '$additionalParticipant' => ts('see default template for how to show this'),
+          '$isAdditionalParticipant' => ts('see default template for how to show this'),
           '$location' => 'event.location',
           '$register_date' => 'participant.register_date',
           '$participant.role' => 'participant.role_id:label',


### PR DESCRIPTION

Overview
----------------------------------------
Stop assigning legacy lineItem array to online event receipt

Before
----------------------------------------
Per https://github.com/civicrm/civicrm-core/pull/34324 we deprecated `$line_item` in favour of `$line_items` some time back. The latter is more shallowly nested and does not preclude line items from more than one price set - which we intend to permit in future. The former has been deprecated for a while

After
----------------------------------------
Assignments removed from online event flow. Note this also removes `isAdditionalParticipant` which was used in the same template construct and the variable being used in conjunction with it

Technical Details
----------------------------------------

These assigns are all postProcess - buildForm not changed

Comments
----------------------------------------
