### PR TITLE
Stop assigning customProfile to emails

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2625,13 +2625,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         }
       }
 
-      //build an array of custom profile and assigning it to template
-      $customProfile = CRM_Event_BAO_Event::buildCustomProfile($this->_relatedObjects['participant']->id, $values, NULL, $isTest);
-
-      if (count($customProfile)) {
-        $template->assign('customProfile', $customProfile);
-      }
-
       // for primary contact
       $values['params']['additionalParticipant'] = FALSE;
       $template->assign('isPrimary', 1);

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1867,19 +1867,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $this->assign('isRequireApproval', $this->_requireApproval);
 
     foreach ($additionalIDs as $participantID => $contactId) {
-      if ($participantID == $registerByID) {
-        $customProfile = CRM_Event_BAO_Event::buildCustomProfile($participantID, $this->_values, NULL, $isTest);
-
-        if (count($customProfile)) {
-          $this->assign('customProfile', $customProfile);
-          $this->set('customProfile', $customProfile);
-        }
-      }
-      else {
-        $this->assign('customProfile', NULL);
-      }
-
-      //send Confirmation mail to Primary & additional Participants if exists
+      // Send Confirmation mail to Primary & additional Participants if exists
       CRM_Event_BAO_Event::sendMail($contactId, $this->_values, $participantID, $isTest);
     }
   }

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -715,7 +715,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
       //build an array of custom profile and assigning it to template
       $customProfile = CRM_Event_BAO_Event::buildCustomProfile($registerByID, $this->_values, NULL, $this->isTest());
       if (count($customProfile)) {
-        $this->assign('customProfile', $customProfile);
+        // @todo - calculate this on the thank you page, where it is used rather than here & passing through.
         $this->set('customProfile', $customProfile);
       }
 
@@ -827,7 +827,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           $customProfile = CRM_Event_BAO_Event::buildCustomProfile($participantID, $this->_values, NULL, $this->isTest());
 
           if (count($customProfile)) {
-            $this->assign('customProfile', $customProfile);
+            // @todo - calculate this on the thank you page, where it is used rather than here & passing through.
             $this->set('customProfile', $customProfile);
           }
           $this->_values['params']['additionalParticipant'] = FALSE;
@@ -842,7 +842,6 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
           $participantParams = ['id' => $participantID];
           CRM_Event_BAO_Participant::getValues($participantParams, $participantValues, $ids);
           $this->_values['participant'] = $participantValues[$participantID];
-          $this->assign('customProfile', NULL);
           //Additional Participant should get only it's payment information
           if (!empty($this->_amount)) {
             $amount = [];


### PR DESCRIPTION


Overview
----------------------------------------
Stop assigning customProfile to emails

Before
----------------------------------------
value calculated & assigned, but overridden

After
----------------------------------------
Removed

Technical Details
----------------------------------------
Anything assigned is overriden by CRM_Core_WorkflowMessage_ProfileTrait which calculates and assigns this value

This scope specifies it ...

https://github.com/civicrm/civicrm-core/blob/bccdbabe916e13b6c0c049d8902bdbcc52cec9f4/CRM/Core/WorkflowMessage/ProfileTrait.php#L62

Comments
----------------------------------------
