### PR TITLE
Move status based trxnParams over to `getTrxnParams()`

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2735,13 +2735,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
         $params['trxnParams']['fee_amount'] = $params['prevContribution']->fee_amount;
         $params['trxnParams']['net_amount'] = $params['prevContribution']->net_amount;
         $params['trxnParams']['status_id'] = $params['prevContribution']->contribution_status_id;
-        $previousContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $params['prevContribution']->contribution_status_id);
-        if (!(($previousContributionStatus === 'Pending' || $previousContributionStatus === 'In Progress')
-          && $contributionStatus === 'Completed')
-        ) {
-          $params['trxnParams']['payment_instrument_id'] = $params['prevContribution']->payment_instrument_id;
-          $params['trxnParams']['check_number'] = $params['prevContribution']->check_number;
-        }
 
         //if financial account is changed
         if ($financialProcessor->isFinancialAccountChanged()) {

--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -376,6 +376,19 @@ class CRM_Contribute_BAO_FinancialProcessor {
       // to the only place it is actually used - maybe it makes more sense?
       $trxnParams['status_id'] = $this->updatedContribution->contribution_status_id;
     }
+    else {
+      if (!(
+        ($this->getOriginalContributionStatus() === 'Pending' || $this->getOriginalContributionStatus() === 'In Progress')
+        && $this->getUpdatedContributionStatus() === 'Completed')
+      ) {
+        // The implies that we should take the payment_instrument_id and check_number
+        // from the original contribution, if we are not processing an incoming payment (change to completed).
+        // It likely should be the updated contribution we look at and the reason for looking at the
+        // original is that historically the updated record was unreliable.
+        $trxnParams['payment_instrument_id'] = $this->originalContribution->payment_instrument_id;
+        $trxnParams['check_number'] = $this->originalContribution->check_number;
+      }
+    }
     return $trxnParams;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Move status based trxnParams over to `getTrxnParams()`

Before
----------------------------------------
Moving trxn_params to `getTrxnParams()` is in progress

After
----------------------------------------
Baby step - these two values are moved over - with comments guessing at the legacy logic

Technical Details
----------------------------------------

Comments
----------------------------------------
