### PR TITLE
Extract and tidy up getPreviousFinancialItem

### DIFF
--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -9,7 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Civi\Api4\FinancialAccount;
 use Civi\Api4\FinancialItem;
 
 /**
@@ -258,23 +257,17 @@ WHERE cc.id IN (' . implode(',', $contactIds) . ') AND con.is_test = 0';
    *
    * This function specifically excludes sales tax.
    *
-   * @param int $entityId
-   *
+   * @param int $lineItemID
+   * @param bool $isTax
    * @return array
+   * @throws CRM_Core_Exception
    */
-  public static function getPreviousFinancialItem($entityId) {
+  public static function getPreviousFinancialItem(int $lineItemID, bool $isTax = FALSE): array {
     $financialItemAPI = FinancialItem::get(FALSE)
-      ->addWhere('entity_id', '=', $entityId)
+      ->addWhere('entity_id', '=', $lineItemID)
       ->addWhere('entity_table', '=', 'civicrm_line_item')
+      ->addWhere('financial_account_id.is_tax', '=', $isTax)
       ->addOrderBy('id', 'DESC');
-
-    $salesTaxFinancialAccounts = FinancialAccount::get(FALSE)
-      ->addSelect('id')
-      ->addWhere('is_tax', '=', 1)
-      ->execute();
-    if ($salesTaxFinancialAccounts->count() > 0) {
-      $financialItemAPI->addWhere('financial_account_id', 'NOT IN', $salesTaxFinancialAccounts->column('id'));
-    }
     return $financialItemAPI->execute()->first();
   }
 


### PR DESCRIPTION

Overview
----------------------------------------
Extract and tidy up getPreviousFinancialItem

Before
----------------------------------------
Financial account for reversal financial item calculated from the financial type

After
----------------------------------------
Calculated from the actual financial item

Technical Details
----------------------------------------
The goal of this piece of code is to identify the previous transaction tax item and to reverse it. This switches to using the same method to get the sales financial item (& hence the financial account it was charged to) as is used for the main line item

Comments
----------------------------------------
