### PR TITLE
dev/financial#237 - failing test for skipLineItem

### DIFF
--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -471,6 +471,11 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'entity_table' => 'civicrm_contribution',
       'sequential' => 1,
     ], 0);
+
+    // Check we can update it even without line items.
+    $this->callAPISuccess('Contribution', 'create', ['id' => $contribution['id'], 'source' => 'SSF2']);
+    $updatedContribution = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $contribution['id']]);
+    $this->assertEquals('SSF2', $updatedContribution['contribution_source']);
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/ContributionTest.php
+++ b/tests/phpunit/api/v4/Entity/ContributionTest.php
@@ -88,4 +88,17 @@ class ContributionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(2, count($result));
   }
 
+  public function testEditWithSkipLineItem(): void {
+    $contact_id = $this->createTestRecord('Individual')['id'];
+    $contribution_id = $this->createTestRecord('Contribution', ['contact_id' => $contact_id, 'skipLineItem' => 1])['id'];
+    Contribution::update(FALSE)
+      ->addWhere('id', '=', $contribution_id)
+      ->addValue('trxn_id', 'abcde')
+      ->execute();
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('id', '=', $contribution_id)
+      ->execute()->first();
+    $this->assertEquals('abcde', $contribution['trxn_id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/financial/-/issues/237

Before
----------------------------------------
Can't edit a contribution with api if created with skipLineItem

After
----------------------------------------
Same

Technical Details
----------------------------------------
I'm not sure the right fix because it's not clear if https://github.com/civicrm/civicrm-core/pull/34335/commits/69c821c340266b15c92a2ac6b0be1afb784cf5f4 is suggesting that a contribution without line items should no longer be valid, or if it was just "didn't think this is needed anymore". So in the meantime here's a test.

Comments
----------------------------------------

