### PR TITLE
OAuth setScopes is not chainable

### DIFF
--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AbstractGrantAction.php
@@ -105,6 +105,7 @@ abstract class AbstractGrantAction extends \Civi\Api4\Generic\AbstractBatchActio
    */
   public function setScopes($scopes) {
     $this->scopes = is_string($scopes) ? [$scopes] : $scopes;
+    return $this;
   }
 
 }

--- a/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
+++ b/ext/oauth-client/tests/phpunit/api/v4/OAuthClientGrantTest.php
@@ -127,7 +127,7 @@ class api_v4_OAuthClientGrantTest extends \PHPUnit\Framework\TestCase implements
     return $client;
   }
 
-  private static function scopeProvider(): array {
+  public static function scopeProvider(): array {
     return [[NULL], ['scope-1-bar']];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
OAuth setScopes is not chainable

Before
----------------------------------------
Something like `Civi\Api4\OAuthClient::clientCredential()->addWhere('id', '=', 1)->setScopes('abc')->execute();` gives an error because it tries to run execute() on null.

After
----------------------------------------
Better

Technical Details
----------------------------------------


Comments
----------------------------------------
The added test is useful on its own as a check that you can set the scope at runtime but as a side-effect it also checks that setScopes is chainable.
