### PR TITLE
Api4 - Fix query error when option values contain special characters

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -266,7 +266,8 @@ class Api4SelectQuery extends Api4Query {
           $options = FormattingUtil::getPseudoconstantList($field, $item);
           if ($options) {
             asort($options);
-            $column = "FIELD($column,'" . implode("','", array_keys($options)) . "')";
+            $keys = \CRM_Core_DAO::escapeStrings(array_keys($options));
+            $column = "FIELD($column, $keys)";
           }
         }
       }

--- a/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
+++ b/tests/phpunit/api/v4/Custom/PseudoconstantTest.php
@@ -151,7 +151,8 @@ class PseudoconstantTest extends Api4TestBase {
       ['id' => 'r', 'name' => 'red', 'label' => 'RED', 'color' => '#ff0000', 'description' => 'Red color', 'icon' => 'fa-red'],
       // String '2' gets checked below via `assertSame` to ensure it doesn't get cast to int
       ['id' => '2', 'name' => 'green', 'label' => 'GREEN', 'color' => '#00ff00', 'description' => 'Green color', 'icon' => 'fa-green'],
-      ['id' => 'b', 'name' => 'blue', 'label' => 'BLUE', 'color' => '#0000ff', 'description' => 'Blue color', 'icon' => 'fa-blue'],
+      // Add a single quote character in BL'UE to test escaping
+      ['id' => "b'l", 'name' => 'blue', 'label' => "BL'UE", 'color' => '#0000ff', 'description' => 'Blue color', 'icon' => 'fa-blue'],
     ];
 
     $this->createTestRecord('CustomGroup', [
@@ -160,7 +161,7 @@ class PseudoconstantTest extends Api4TestBase {
     ]);
     CustomField::create(FALSE)
       ->addValue('custom_group_id.name', 'myPseudoconstantTest')
-      ->addValue('option_values', ['r' => 'red', 'g' => 'green', 'b' => 'blü'])
+      ->addValue('option_values', ['r' => 'red', 'g' => 'green', "b'l" => 'blü'])
       ->addValue('label', 'Color')
       ->addValue('html_type', 'Select')
       ->execute();
@@ -196,7 +197,7 @@ class PseudoconstantTest extends Api4TestBase {
     $cid = $this->createTestRecord('Contact', [
       'first_name' => 'col',
       'myPseudoconstantTest.Color:label' => 'blü',
-      'myPseudoconstantTest.Multicolor:label' => ['RED', 'BLUE'],
+      'myPseudoconstantTest.Multicolor:label' => ['RED', "BL'UE"],
     ])['id'];
 
     $result = Contact::get(FALSE)
@@ -207,10 +208,10 @@ class PseudoconstantTest extends Api4TestBase {
 
     $this->assertEquals('blü', $result['myPseudoconstantTest.Color:label']);
     $this->assertEquals('bl_', $result['myPseudoconstantTest.Color:name']);
-    $this->assertEquals('b', $result['myPseudoconstantTest.Color']);
-    $this->assertEquals(['RED', 'BLUE'], $result['myPseudoconstantTest.Multicolor:label']);
+    $this->assertEquals("b'l", $result['myPseudoconstantTest.Color']);
+    $this->assertEquals(['RED', "BL'UE"], $result['myPseudoconstantTest.Multicolor:label']);
     $this->assertEquals(['red', 'blue'], $result['myPseudoconstantTest.Multicolor:name']);
-    $this->assertEquals(['r', 'b'], $result['myPseudoconstantTest.Multicolor']);
+    $this->assertEquals(['r', "b'l"], $result['myPseudoconstantTest.Multicolor']);
 
     $cid1 = $this->createTestRecord('Contact', [
       'first_name' => 'two',
@@ -218,7 +219,7 @@ class PseudoconstantTest extends Api4TestBase {
     ])['id'];
     $cid2 = $this->createTestRecord('Contact', [
       'first_name' => 'two',
-      'myPseudoconstantTest.Multicolor:label' => 'GREEN',
+      'myPseudoconstantTest.Multicolor:label' => "BL'UE",
     ])['id'];
 
     // Test ordering by label


### PR DESCRIPTION
Overview
----------------------------------------
Ensures Api4 correctly handles option keys and values with special characters.