### PR TITLE
Remove handling for tax_amount set to 'null'

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -418,14 +418,9 @@ class CRM_Contribute_BAO_FinancialProcessor {
       $params['line_item'][$fieldId][$fieldValueId]['deferred_line_total'] = $itemParams['amount'];
       $params['line_item'][$fieldId][$fieldValueId]['financial_item_id'] = $financialItem->id;
 
-      if (($lineItemDetails['tax_amount'] && $lineItemDetails['tax_amount'] !== 'null') || ($context === 'changeFinancialType')) {
+      if (($lineItemDetails['tax_amount']) || ($context === 'changeFinancialType')) {
         $taxAmount = (float) $lineItemDetails['tax_amount'];
-        if ($context === 'changeFinancialType' && $lineItemDetails['tax_amount'] === 'null') {
-          // reverse the Sale Tax amount if there is no tax rate associated with new Financial Type
-          $taxAmount = $previousLineItem['tax_amount'] ?? 0;
-          $itemParams['financial_account_id'] = $this->getExistingFinancialItemForLine($lineItemDetails['id'], TRUE)['financial_account_id'];
-        }
-        elseif ($previousLineItemTotal != $lineItemDetails['line_total']) {
+        if ($previousLineItemTotal != $lineItemDetails['line_total']) {
           $taxAmount -= $previousLineItem['tax_amount'] ?? 0;
           $itemParams['financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getSalesTaxFinancialAccount($lineItemDetails['financial_type_id']);
         }


### PR DESCRIPTION


Overview
----------------------------------------
Remove handling for tax_amount set to 'null'

The code that loads the line item loads 0 rather than 'null' if it is 0.

Loading is here
https://github.com/civicrm/civicrm-core/blob/7fcd9f67d58eca442f6b68c5115ec9dd7059b775/CRM/Price/BAO/LineItem.php#L438

Or here
https://github.com/civicrm/civicrm-core/blob/7fcd9f67d58eca442f6b68c5115ec9dd7059b775/CRM/Price/BAO/LineItem.php#L234


Before
----------------------------------------
value is loaded as a float but code checks for it being null

After
----------------------------------------
null handling removed

Technical Details
----------------------------------------
This PR double checks it is never null.... we have a lot of tests on this code via the forms and via the api

https://github.com/civicrm/civicrm-core/pull/34353

Comments
----------------------------------------
