### PR TITLE
Remove postProcess lineItem assign

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1597,7 +1597,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
       }
     }
-    $this->assign('lineItem', $this->isQuickConfig() ? NULL : [$this->getPriceSetID() => $this->getLineItems()]);
 
     if (!empty($errors)) {
       $message = $this->compileErrorMessage($errors);


### PR DESCRIPTION


Overview
----------------------------------------
Remove postProcess lineItem assign



Before
----------------------------------------
'lineItem' is assigned in the postProcess (the same as the buildForm one in methodology so a like-for-like overwrite)

After
----------------------------------------
removed

Technical Details
----------------------------------------
We have been removing these where they are only used for the receipts (after a period of deprecation)
- the one in the buildForm is used for the display of the form tpl
- 
Comments
----------------------------------------

