### PR TITLE
dev/core#6122 : Multivalued custom group of style tab crashes on Individual subtypes when group is for Contacts

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -110,6 +110,8 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $this->assertEquals($result1, $result);
     $result = CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, 'Big_Bank');
     $this->assertEquals($result1, $result);
+    $result = CRM_Core_BAO_CustomGroup::getTree('Contact', NULL, NULL, NULL, 'Big_Bank');
+    $this->assertEquals($result1, $result);
     try {
       CRM_Core_BAO_CustomGroup::getTree('Organization', NULL, NULL, NULL, ['Small Kind Bank']);
     }
@@ -192,6 +194,47 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
     $customField = $this->customFieldCreate(['custom_group_id' => $customGroup['id']]);
     $result = CRM_Core_BAO_CustomGroup::getTree('Activity', NULL, NULL, NULL, 1);
     $this->assertEquals('Custom Field', $result[$customGroup['id']]['fields'][$customField['id']]['label']);
+  }
+
+  /**
+   * @param string $inputEntity
+   * @param string $inputSubtype
+   * @param ?string $expected
+   * @dataProvider validateSubtypeProvider
+   */
+  public function testValidateSubTypeByEntity(string $inputEntity, string $inputSubtype, ?string $expected): void {
+    $contactType = $this->callAPISuccess('ContactType', 'create', [
+      'name' => 'qjx_42s',
+      'label' => 'Quack Quack',
+      'parent_id' => 'Individual',
+    ]);
+    if ($expected === NULL) {
+      try {
+        \Civi\Test\Invasive::call(['CRM_Core_BAO_CustomGroup', 'validateSubTypeByEntity'], [$inputEntity, $inputSubtype]);
+        $this->callAPISuccess('ContactType', 'delete', ['id' => $contactType['id']]);
+        $this->fail('Should have thrown an exception');
+      }
+      catch (CRM_Core_Exception $e) {
+        $this->assertEquals('Invalid Filter', $e->getMessage());
+      }
+    }
+    else {
+      $this->assertEquals($expected, \Civi\Test\Invasive::call(['CRM_Core_BAO_CustomGroup', 'validateSubTypeByEntity'], [$inputEntity, $inputSubtype]));
+    }
+    $this->callAPISuccess('ContactType', 'delete', ['id' => $contactType['id']]);
+  }
+
+  public static function validateSubtypeProvider(): array {
+    return [
+      ['Individual', 'qjx_42s', 'qjx_42s'],
+      ['Individual', 'Qjx_42S', 'qjx_42s'],
+      ['Individual', 'Quack Quack', NULL],
+      ['Individual', 'duck', NULL],
+      ['Contact', 'qjx_42s', 'qjx_42s'],
+      ['Contact', 'Qjx_42S', 'qjx_42s'],
+      ['Contact', 'Quack Quack', NULL],
+      ['Contact', 'duck', NULL],
+    ];
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
It's because it's trying to validate the Individual subtype against the list of valid subtypes for Contact, but Contact doesn't have any.

1. Create a custom group for Contacts.
2. Set it to allow multiple.
3. Set style to Tab (not tab with table).
4. Add a field.
5. Create or find a contact who is a subtype of Individual.
6. Click on the custom tab.
7. Click to edit.
8. Click the link to add another record.
9. Crash


Before
----------------------------------------
```
CRM_Core_Exception: Invalid Filter in /srv/buildkit/build/d10-master/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomGroup.php on line 532

0 CRM_Core_BAO_CustomGroup::validateSubTypeByEntity() /srv/buildkit/build/d10-master/vendor/civicrm/civicrm-core/CRM/Core/BAO/CustomGroup.php:532
1 CRM_Core_BAO_CustomGroup::getTree() /srv/buildkit/build/d10-master/vendor/civicrm/civicrm-core/CRM/Custom/Form/CustomDataByType.php:65
2 CRM_Custom_Form_CustomDataByType->preProcess() /srv/buildkit/build/d10-master/vendor/civicrm/civicrm-core/CRM/Core/Form.php:750
3 CRM_Core_Form->buildForm() /srv/buildkit/build/d10-master/vendor/civicrm/civicrm-core/CRM/Core/QuickForm/Action/Display.php:76
```

After
----------------------------------------
Fixed

Technical Details
----------------------------------------
Issue arise when there is a call CRM_Core_BAO_CustomGroup::validateSubTypeByEntity('Contact', 'Student') . As Student is a level 2 child in a contact subtype hierarchy i.e. Contact -> Individual -> Student , I made the changes in the function itself to handle such scenario.  

Comments
----------------------------------------
ping @colemanw @seamuslee001 