### PR TITLE
i18n - Add support for 'plural' strings in clientside ts()

### DIFF
--- a/CRM/Utils/JS.php
+++ b/CRM/Utils/JS.php
@@ -20,22 +20,13 @@ class CRM_Utils_JS {
   /**
    * Parse a javascript file for translatable strings using ts().
    *
-   * @param string $jsCode
+   * @param string $content
    *   Raw Javascript code.
    * @return array
    *   Array of translatable strings
    */
-  public static function parseStrings($jsCode) {
-    $strings = [];
-    // Match all calls to ts() in an array.
-    // Note: \s also matches newlines with the 's' modifier.
-    preg_match_all('~
-      [^\w]ts\s*                                    # match "ts" with whitespace
-      \(\s*                                         # match "(" argument list start
-      ((?:(?:\'(?:\\\\\'|[^\'])*\'|"(?:\\\\"|[^"])*")(?:\s*\+\s*)?)+)\s*
-      [,\)]                                         # match ")" or "," to finish
-      ~sx', $jsCode, $matches);
-    foreach ($matches[1] as $text) {
+  public static function parseStrings(string $content): array {
+    $cleanString = function(string $text): string {
       $quote = $text[0];
       // Remove newlines
       $text = str_replace("\\\n", '', $text);
@@ -43,7 +34,33 @@ class CRM_Utils_JS {
       $text = str_replace('\\' . $quote, $quote, $text);
       // Remove end quotes
       $text = substr(ltrim($text, $quote), 0, -1);
+      return $text;
+    };
+
+    $strings = [];
+    // TODO: This regex is duplicated in `Civi\Strings\Parser\JsParser`
+    // Match all calls to ts() including an optional second argument
+    preg_match_all('~
+      [^\w]ts\s*                                    # match "ts" with whitespace
+      \(\s*                                         # match "(" argument list start
+      ((?:(?:\'(?:\\\\\'|[^\'])*\'|"(?:\\\\"|[^"])*")(?:\s*\+\s*)?)+)\s*    # first argument
+      (?:,\s*                                       # optional second argument start
+        \{[^}]*                                     # object literal start
+        plural[\'"]?\s*:\s*                         # plural key
+        (\'(?:\\\\\'|[^\'])*\'|"(?:\\\\"|[^"])*")   # plural string value
+        [^}]*\}                                     # object literal end
+      )?\s*
+      [,\)]                                         # match ")" or "," to finish
+      ~sx', $content, $matches);
+
+    foreach ($matches[1] as $index => $text) {
+      $text = $cleanString($text);
       $strings[$text] = $text;
+      // If we have a plural form (second argument matched)
+      if (!empty($matches[2][$index])) {
+        $plural = $cleanString($matches[2][$index]);
+        $strings[$plural] = $plural;
+      }
     }
     return array_values($strings);
   }

--- a/ang/crmDashboard/Dashboard.html
+++ b/ang/crmDashboard/Dashboard.html
@@ -3,7 +3,7 @@
     <legend>
       <a href class="crm-hover-button" ng-click="$ctrl.toggleInactive()">
         <i class="crm-i fa-{{ $ctrl.showInactive ? 'minus' : 'plus' }}" role="img" aria-hidden="true"></i>
-        {{ $ctrl.inactive.length === 1 ? ts('1 Available Dashlet') : ts('%1 Available Dashlets', {1: $ctrl.inactive.length}) }}
+        {{ ts('1 Available Dashlet', {plural: '%count Available Dashlets', count: $ctrl.inactive.length}) }}
       </a>
       <input ng-if="$ctrl.showInactive" class="crm-form-text" ng-model="$ctrl.filterInactive" type="search" placeholder="{{:: ts('Filter by title...') }}">
     </legend>

--- a/ext/afform/admin/ang/afAdmin/afAdminList.html
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.html
@@ -106,7 +106,7 @@
       </td>
       <td ng-if="$ctrl.tab === 'form'">
         <a ng-if="afform.submission_count" ng-href="{{:: crmUrl('civicrm/admin/afform/submissions#/?name=' + afform.name) }}">
-          {{:: afform.submission_count === 1 ? ts('1 Submission') : ts('%1 Submissions', {1: afform.submission_count}) }}
+          {{:: ts('1 Submission', {plural: '%1 Submissions', count: afform.submission_count}) }}
         </a>
         <div ng-if="afform.submission_date">
           {{:: ts('Last submitted: %1', {1: afform.submission_date}) }}

--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -136,8 +136,8 @@ class StringVisitor {
 
   protected function isWorthy($value): bool {
     return !is_array($value)
-      && (strpos($value, '{{') === FALSE)
-      && (strpos($value, 'ts(') === FALSE)
+      && (!str_contains($value, '{{'))
+      && (!str_contains($value, 'ts('))
       && !empty($value);
   }
 

--- a/ext/civi_case/ang/civiCaseTasks/civiCaseTaskCaseRole.ctrl.js
+++ b/ext/civi_case/ang/civiCaseTasks/civiCaseTaskCaseRole.ctrl.js
@@ -2,7 +2,7 @@
   "use strict";
 
   angular.module('civiCaseTasks').controller('civiCaseTaskCaseRole', function($scope, crmApi4, searchTaskBaseTrait) {
-    const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+    const ts = $scope.ts = CRM.ts('civi_case');
     // Combine this controller with model properties (ids, entity, entityInfo) and searchTaskBaseTrait
     const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait);
 
@@ -89,9 +89,9 @@
           }
         });
       });
-      let msg = _.escape(added === 1 ? ts('1 case role added.') : ts('%1 case roles added.', {1: added}));
+      let msg = _.escape(ts('1 case role added.', {plural: '%count case roles added.', count: added}));
       if (duplicate) {
-        msg += '<br>' + _.escape(duplicate === 1 ? ts('1 case role already occupied by the selected contact.') : ts('%1 case roles already occupied by the selected contact.', {1: duplicate}));
+        msg += '<br>' + _.escape(ts('1 case role already occupied by the selected contact.', {plural: '%count case roles already occupied by the selected contact.', count: duplicate}));
       }
       CRM.alert(msg, ts('Saved'), 'success');
       this.close(result);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -31,7 +31,7 @@
           <div class="btn-group" ng-if="$ctrl.afformEnabled && $ctrl.savedSearch.id && !$ctrl.savedSearch.is_template">
             <button type="button" ng-click="$ctrl.openAfformMenu = true;" class="btn dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <i class="crm-i fa-list-alt" role="img" aria-hidden="true"></i>
-              {{ ($ctrl.afformCount !== undefined) ? ($ctrl.afformCount === 1 ? ts('1 Form') : ts('%1 Forms', {1: $ctrl.afformCount})) : ts('Forms...') }}
+              {{ ($ctrl.afformCount !== undefined) ? (ts('1 Form', {plural: '%1 Forms', count: $ctrl.afformCount})) : ts('Forms...') }}
               <span class="caret"></span>
             </button>
             <ul class="dropdown-menu dropdown-menu-right" ng-if=":: $ctrl.openAfformMenu">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -110,7 +110,7 @@
         crmApi4(apiCalls)
           .then(function(result) {
             CRM.alert(
-              result.length === 1 ? ts('1 record successfully imported.') : ts('%1 records successfully imported.', {1: result.length}),
+              ts('1 record successfully imported.', {plural: '%1 records successfully imported.', count: result.length}),
               ts('Saved'),
               'success'
             );

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/afforms.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/afforms.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
   <button type="button" ng-click="$ctrl.loadAfforms(); row.openAfformMenu = true;" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{ $ctrl.afforms ? (row.afform_count === 1 ? ts('1 Form') : ts('%1 Forms', {1: row.afform_count})) : ts('Forms...') }}
+    {{ $ctrl.afforms ? (ts('1 Form', {plural: '%1 Forms', count: row.afform_count})) : ts('Forms...') }}
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: row.openAfformMenu">

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/communications.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/communications.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
   <button type="button" ng-click="row.openScheduleMenu = true" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{:: row.data.schedule_id.length === 1 ? ts('1 Communication') : ts('%1 Communications', {1: row.data.schedule_id ? row.data.schedule_id.length : 0}) }} <span class="caret"></span>
+    {{:: ts('1 Communication', {plural: '%1 Communications', count: row.data.schedule_id ? row.data.schedule_id.length : 0}) }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: row.openScheduleMenu">
     <li ng-repeat="schedule_id in row.data.schedule_id" title="{{:: ts('Edit Scheduled Communication') }}">

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/displays.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/displays.html
@@ -3,7 +3,7 @@
     {{:: ts('0 Displays') }}
   </button>
   <button type="button" ng-if=":: row.data.display_name" ng-click="row.openDisplayMenu = true" class="btn btn-xs dropdown-toggle btn-primary-outline" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    {{:: row.data.display_name.length === 1 ? ts('1 Display') : ts('%1 Displays', {1: row.data.display_name.length}) }} <span class="caret"></span>
+    {{:: ts('1 Display', {plural: '%1 Displays', count: row.data.display_name.length}) }} <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" ng-if=":: row.openDisplayMenu">
     <li ng-repeat="display_name in row.data.display_name" ng-class="{disabled: row.data.display_acl_bypass[$index]}" title="{{:: row.data.display_acl_bypass[$index] ? ts('Display has permissions disabled') : ts('View display') }}">

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.js
@@ -72,9 +72,9 @@
           added++;
         }
       });
-      let msg = _.escape(added === 1 ? ts('1 relationship added.') : ts('%1 relationships added.', {1: added}));
+      let msg = _.escape(ts('1 relationship added.', {plural: '%1 relationships added.', count: added}));
       if (duplicate) {
-        msg += '<br>' + _.escape(duplicate === 1 ? ts('1 relationship already exists.') : ts('%1 relationships already exist.', {1: duplicate}));
+        msg += '<br>' + _.escape(ts('1 relationship already exists.', {plural: '%1 relationships already exist.', count: duplicate}));
       }
       CRM.alert(msg, ts('Saved'), 'success');
       this.close(result);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskTag.ctrl.js
@@ -89,14 +89,14 @@
     this.onSuccess = function(result) {
       let msg;
       if (ctrl.action === 'delete') {
-        msg = result.batchCount === 1 ? ts('1 tag removed.') : ts('%1 tags removed.', {1: result.batchCount});
+        msg = ts('1 tag removed.', {plural: '%1 tags removed.', count: result.batchCount});
         CRM.alert(msg, ts('Saved'), 'success');
       } else {
         const added = result.batchCount - result.countMatched;
-        msg = added === 1 ? ts('1 tag added') : ts('%1 tags added.', {1: added});
+        msg = ts('1 tag added', {plural: '%1 tags added.', count: added});
         msg += '<br/>';
         if (result.countMatched > 0) {
-          msg += result.countMatched === 1 ? ts('1 tag already exists and was not added.') : ts('%1 tags already exist and were not added.', {1: result.countMatched});
+          msg += ts('1 tag already exists and was not added.', {plural: '%1 tags already exist and were not added.', count: result.countMatched});
         }
         CRM.alert(msg, ts('Saved'), 'success');
       }

--- a/js/Common.js
+++ b/js/Common.js
@@ -14,16 +14,24 @@ CRM._ = _;
  */
 function ts(text, params) {
   "use strict";
-  var d = (params && params.domain) ? ('strings::' + params.domain) : null;
+  let d;
+  if (typeof params === 'object') {
+    if (params.plural && params.count > 1) {
+      text = params.plural;
+    }
+    if (params.domain) {
+      d = 'strings::' + params.domain;
+    }
+  }
   if (d && CRM[d] && CRM[d][text]) {
     text = CRM[d][text];
   }
   else if (CRM.strings[text]) {
     text = CRM.strings[text];
   }
-  if (typeof(params) === 'object') {
-    for (var i in params) {
-      if (typeof(params[i]) === 'string' || typeof(params[i]) === 'number') {
+  if (typeof params === 'object') {
+    for (let i in params) {
+      if (i !== 'plural' && ['string', 'number'].includes(typeof params[i])) {
         // sprintf emulation: escape % characters in the replacements to avoid conflicts
         text = text.replace(new RegExp('%' + i, 'g'), String(params[i]).replace(/%/g, '%-crmescaped-'));
       }

--- a/tests/phpunit/CRM/Utils/HTMLTest.php
+++ b/tests/phpunit/CRM/Utils/HTMLTest.php
@@ -114,6 +114,11 @@ class CRM_Utils_HTMLTest extends CiviUnitTestCase {
       '<div>{ts}Hello world{/ts}</div>',
       [],
     ];
+    // Plurals
+    $cases[] = [
+      '{{ ts("Singular \'%1\'", {plural: "%count Plurals \'%1\'", 1: "1"}) }}',
+      ["Singular '%1'", "%count Plurals '%1'"],
+    ];
 
     return $cases;
   }

--- a/tests/phpunit/CRM/Utils/JSTest.php
+++ b/tests/phpunit/CRM/Utils/JSTest.php
@@ -98,6 +98,13 @@ class CRM_Utils_JSTest extends CiviUnitTestCase {
       'alert(ts("Does the ts(\'example\') notation work?"));',
       ['Does the ts(\'example\') notation work?'],
     ];
+    $cases[] = [
+      ' ts("Singular \'%1\'", {
+        "1": "1",
+        "plural": "%count Plurals \'%1\'",
+      });',
+      ["Singular '%1'", "%count Plurals '%1'"],
+    ];
     return $cases;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Add a longtime missing feature in our clientside implementation of `ts()`

This permits js code and Angular templates to use the same 'plural' syntax as the php version of the function.

Requires https://github.com/civicrm/civistrings/pull/26

Example:

```js
ts('You saved 1 thing!', {
  plural: 'You saved %count things!',
  count: someVar
});
```