### PR TITLE
dev/core#6239: AdminUI: Cannot delete mailing

### DIFF
--- a/CRM/Mailing/Form/Delete.php
+++ b/CRM/Mailing/Form/Delete.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+ /**
+  *
+  * @package CRM
+  * @copyright CiviCRM LLC https://civicrm.org/licensing
+  */
+
+use CRM_Mailing_ExtensionUtil as E;
+
+/**
+ * Form controller class
+ *
+ * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
+ */
+class CRM_Mailing_Form_Delete extends CRM_Core_Form {
+
+  /**
+   * The set id.
+   *
+   * @var int
+   */
+  protected $_id;
+
+  /**
+   * The title of the set being deleted.
+   *
+   * @var string
+   */
+  protected $_title;
+
+  /**
+   * Set up variables to build the form.
+   *
+   * @return void
+   */
+  public function preProcess() {
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+
+    $this->_title = CRM_Core_DAO::getFieldValue('CRM_Mailing_DAO_Mailing',
+      $this->_id, 'name'
+    );
+  }
+
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm(): void {
+    $this->assign('title', $this->_title);
+    $this->addButtons([
+      [
+        'type' => 'next',
+        'name' => ts('Delete'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+  }
+
+  /**
+   * Process the form when submitted.
+   *
+   * @return void
+   */
+  public function postProcess() {
+    if (CRM_Mailing_BAO_Mailing::deleteRecord(['id' => $this->_id])) {
+      CRM_Core_Session::setStatus(ts('The \'%1\' mailing has been deleted.',
+        [1 => $this->_title]
+      ), ts('Deleted'), 'success');
+    }
+    else {
+      CRM_Core_Session::setStatus(ts('The \'%1\' mailing has not been deleted!',
+        [1 => $this->_title]
+      ), 'Unable to Delete', 'error');
+    }
+  }
+
+}

--- a/CRM/Mailing/Page/Browse.php
+++ b/CRM/Mailing/Page/Browse.php
@@ -182,27 +182,6 @@ class CRM_Mailing_Page_Browse extends CRM_Core_Page {
       CRM_Core_Session::setStatus(ts('The mailing has been resumed.'), ts('Resumed'), 'success');
       CRM_Utils_System::redirect($context);
     }
-    elseif ($this->_action & CRM_Core_Action::DELETE) {
-      if (CRM_Utils_Request::retrieve('confirmed', 'Boolean', $this)) {
-
-        // check for action permissions.
-        if (!CRM_Core_Permission::checkActionPermission('CiviMail', $this->_action)) {
-          CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-        }
-
-        CRM_Mailing_BAO_Mailing::deleteRecord(['id' => $this->_mailingId]);
-        CRM_Core_Session::setStatus(ts('Selected mailing has been deleted.'), ts('Deleted'), 'success');
-        CRM_Utils_System::redirect($context);
-      }
-      else {
-        $controller = new CRM_Core_Controller_Simple('CRM_Mailing_Form_Browse',
-          ts('Delete Mailing'),
-          $this->_action
-        );
-        $controller->setEmbedded(TRUE);
-        $controller->run();
-      }
-    }
     elseif ($this->_action & CRM_Core_Action::RENEW) {
       // archive this mailing, CRM-3752.
       if (CRM_Utils_Request::retrieve('confirmed', 'Boolean', $this)) {

--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -271,9 +271,8 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
         ],
         CRM_Core_Action::DELETE => [
           'name' => ts('Delete'),
-          'url' => 'civicrm/mailing/browse',
-          'qs' => 'action=delete&mid=%%mid%%&reset=1',
-          'extra' => 'onclick="if (confirm(\'' . $deleteExtra . '\')) this.href+=\'&amp;confirmed=1\'; else return false;"',
+          'url' => 'civicrm/mailing/delete',
+          'qs' => 'id=%%mid%%&reset=1',
           'title' => ts('Delete Mailing'),
           'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::DELETE),
         ],

--- a/CRM/Mailing/xml/Menu/Mailing.xml
+++ b/CRM/Mailing/xml/Menu/Mailing.xml
@@ -205,4 +205,10 @@
     <access_arguments>*always allow*</access_arguments>
     <is_public>true</is_public>
   </item>
+  <item>
+    <path>civicrm/mailing/delete</path>
+    <page_callback>CRM_Mailing_Form_Delete</page_callback>
+    <title>Delete Mailing</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse.mgd.php
@@ -225,7 +225,7 @@ $columns = array_merge($columns, [
         'icon' => 'fa-trash',
         'text' => E::ts('Delete'),
         'style' => 'danger',
-        'path' => 'civicrm/mailing/browse?action=delete&mid=[id]&reset=1',
+        'path' => 'civicrm/mailing/delete?id=[id]&reset=1',
         'condition' => [],
       ],
     ],

--- a/templates/CRM/Mailing/Form/Delete.tpl
+++ b/templates/CRM/Mailing/Form/Delete.tpl
@@ -1,0 +1,18 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+{* this template is used for confirmation of delete for a price set  *}
+    <div class="messages status no-popup">
+     <img src="{$config->resourceBase}i/Inform.gif" alt="{ts escape='htmlattribute'}status{/ts}"/>
+          {ts}WARNING: {/ts}{ts}This action cannot be undone.{/ts} {ts 1=$title}Do you want to delete '%1' mailing continue?{/ts}
+    </div>
+
+<div class="form-item">
+    {include file="CRM/common/formButtons.tpl" location=''}
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
The issue arises when as a part of improving the mailing search page, by replacing with Admin UI [here](https://github.com/civicrm/civicrm-core/pull/26532) we have overridden the civicrm/mailing/browse and civicrm/mailing route, that now redirects to afform with embedded searchdisplay. As a result some of the action link, in here, the delete link doesn't work anymore and in the popup it opens the search form again.   


Before
----------------------------------------
![before](https://github.com/user-attachments/assets/cf9ac1b9-6d92-45c7-bf3c-372196f2cc76)


After
----------------------------------------
With civicrm_admin_ui :
![before](https://github.com/user-attachments/assets/2d408bf5-b974-4e50-bca6-ac21f7a5edc9)

Without civicrm_admin_ui : 
![before](https://github.com/user-attachments/assets/7ca762ff-9488-44d7-8d62-9ef4f8ed8151)


Technical Details
----------------------------------------
The only other alternative I can think of for implementing a button/link with a popup confirmation is via custom code, similar to how action buttons are implemented in Mosaico templates. However, I can’t see a clear way to expose it alongside other mailing actions such as Preview, Copy, etc


Comments
----------------------------------------
ping @colemanw @larssandergreen 