### PR TITLE
Fix Pay Later incorrect value on free events

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -568,7 +568,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
     $this->assign('is_email_confirm', $this->_values['event']['is_email_confirm'] ?? NULL);
     // assign pay later stuff
-    $isPayLater = empty($this->getSubmittedValue('payment_processor_id'));
+    $isPayLater = empty($this->getSubmittedValue('payment_processor_id')) && !empty($this->getSubmittedValue('priceSetId'));
     $this->assign('is_pay_later', $isPayLater);
     $this->assign('pay_later_text', $isPayLater ? $this->getPayLaterLabel() : FALSE);
     $this->assign('pay_later_receipt', $isPayLater ? $this->_values['event']['pay_later_receipt'] : NULL);


### PR DESCRIPTION
Overview
----------------------------------------
"Pay Later" is calculated incorrectly in Civi 6.2+ on free events.

This is a regression, but a) it's not recent, b)  I only picked this up because of a PHP notice.  I'm fixing it in case there's actual negative side effects (there may easily be)  but I haven't observed them myself.

Before
----------------------------------------
`$isPayLater` is `TRUE` on free events.

After
----------------------------------------
`$isPayLater` is `FALSE` on free events.

Comments
----------------------------------------
This change was introduced as a result of [this comment thread](https://github.com/civicrm/civicrm-core/pull/32502#pullrequestreview-2714378145) on PR #32502.  However, a missing payment processor ID can mean "pay later" or "free event".  I add an additional check for whether a price set ID exists (this works even for "quick config" price sets) to ensure this is actually a paid event.
