### PR TITLE
Use ContributionProduct tokens for offline contribution receipt

### DIFF
--- a/CRM/Contribute/ContributionProductTokens.php
+++ b/CRM/Contribute/ContributionProductTokens.php
@@ -9,6 +9,8 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
  */
+use Civi\Token\TokenRow;
+use Civi\Token\Event\TokenValueEvent;
 
 /**
  * Class CRM_Contribute_ContributionProductTokens
@@ -40,6 +42,60 @@ class CRM_Contribute_ContributionProductTokens extends CRM_Core_EntityTokens {
     }
     $tokens += $this->getRelatedTokensForEntity('Product', 'product_id', ['name', 'sku']);
     return $tokens;
+  }
+
+  /**
+   * @param \Civi\Token\TokenRow $row
+   * @param string $field
+   * @return string|int
+   */
+  protected function getFieldValue(TokenRow $row, string $field) {
+    if ($field === 'product_option:label') {
+      // Per PR comments - this should almost certainly have been option values
+      // https://github.com/civicrm/civicrm-core/pull/29691
+      // However, given the choice made at the time it would require undoing all that
+      // and re-doing to expose the values 'well' as tokens. So here we imitate what the api
+      // would ideally do (contribution_product.product_option:name, contribution_product.product_option:label}
+      // Note that to do this conversion we need to know the product_id - which we do in
+      // this token context, lest so in a generic api situation.
+      // This has test cover..
+      $productOption = $this->getFieldValue($row, 'product_option');
+      $productOptions = $this->getFieldValue($row, 'product_id.options');
+      return is_array($productOptions) ? $productOptions[$productOption] : '';
+    }
+    return parent::getFieldValue($row, $field);
+  }
+
+  protected function getBespokeTokens(): array {
+    return [
+      'product_option:label' => [
+        'title' => ts('Product Option'),
+        'name' => 'product_option:label',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'string',
+      ],
+    ];
+  }
+
+  /**
+   * Get the fields required to prefetch the entity.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getPrefetchFields(TokenValueEvent $e): array {
+    $return = parent::getPrefetchFields($e);
+    // Api doesn't actually handle this field - flow on from decision not to make it an
+    // option value.
+    foreach ($return as $index => $value) {
+      if ($value === 'product_option:label') {
+        $return[$index] = 'product_id.options';
+      }
+    }
+    return $return;
   }
 
 }

--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
@@ -191,9 +191,14 @@ United States';
 
     $product = Product::get(FALSE)->setLimit(1)->execute()->first();
     if ($product) {
+      $option = '';
+      if (is_array($product['options'])) {
+        $option = reset($product['options']);
+      }
       $messageTemplate->setContributionProduct([
         'product_id.name' => $product['name'],
         'product_id.sku' => $product['sku'],
+        'product_option:label' => $option,
         'id' => 1,
         'fulfilled_date' => 'yesterday',
       ]);

--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
@@ -3,6 +3,7 @@
 use Civi\Api4\PriceField;
 use Civi\Api4\PriceFieldValue;
 use Civi\Api4\PriceSet;
+use Civi\Api4\Product;
 use Civi\Api4\WorkflowMessage;
 use Civi\Test;
 use Civi\WorkflowMessage\GenericWorkflowMessage;
@@ -187,6 +188,16 @@ United States';
     $financialTrxn['card_type_id:name'] = \CRM_Core_PseudoConstant::getName('CRM_Financial_BAO_FinancialTrxn', 'card_type_id', $financialTrxn['card_type_id']);
 
     $messageTemplate->setFinancialTrxn($financialTrxn);
+
+    $product = Product::get(FALSE)->setLimit(1)->execute()->first();
+    if ($product) {
+      $messageTemplate->setContributionProduct([
+        'product_id.name' => $product['name'],
+        'product_id.sku' => $product['sku'],
+        'id' => 1,
+        'fulfilled_date' => 'yesterday',
+      ]);
+    }
   }
 
   /**

--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -1,10 +1,12 @@
 <?php
 
+use Civi\Api4\ContributionProduct;
 use Civi\Api4\Membership;
 
 /**
  * @method int|null getContributionID()
  * @method $this setContributionID(?int $contributionID)
+ * @method $this setContributionProductID(?int $contributionProductID)
  * @method int|null getFinancialTrxnID()
  * @method $this setFinancialTrxnID(?int $financialTrxnID)
  */
@@ -17,6 +19,15 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    * @scope tokenContext as contribution
    */
   public $contribution;
+
+  /**
+   * The contribution product (premium) if any.
+   *
+   * @var array|null
+   *
+   * @scope tokenContext as contributionProduct
+   */
+  public $contributionProduct;
 
   /**
    * @return array|null
@@ -39,6 +50,12 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    * @scope tokenContext as contributionId, tplParams as contributionID
    */
   public $contributionID;
+
+  /**
+   * @var int
+   * @scope tokenContext as contribution_productId
+   */
+  public $contributionProductID;
 
   /**
    * @var int
@@ -226,6 +243,21 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
       $this->taxRateBreakdown = [];
     }
     return $this->taxRateBreakdown;
+  }
+
+  /**
+   * @return array|null
+   */
+  public function getContributionProduct(): ?array {
+    if (!isset($this->contributionProduct)) {
+      $this->contributionProduct = ContributionProduct::get(FALSE)
+        ->addWhere('contribution_id', '=', $this->getContributionID())
+        ->addOrderBy('id', 'DESC')->execute()->first() ?? [];
+    }
+    if (!empty($this->contributionProduct['id']) && !isset($this->contributionProductID)) {
+      $this->contributionProductID = $this->contributionProduct['id'];
+    }
+    return empty($this->contributionProduct) ? [] : $this->contributionProduct;
   }
 
   /**

--- a/CRM/Contribute/WorkflowMessage/ContributionTrait.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionTrait.php
@@ -250,9 +250,14 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
    */
   public function getContributionProduct(): ?array {
     if (!isset($this->contributionProduct)) {
-      $this->contributionProduct = ContributionProduct::get(FALSE)
-        ->addWhere('contribution_id', '=', $this->getContributionID())
-        ->addOrderBy('id', 'DESC')->execute()->first() ?? [];
+      if ($this->getContributionID()) {
+        $this->contributionProduct = ContributionProduct::get(FALSE)
+          ->addWhere('contribution_id', '=', $this->getContributionID())
+          ->addOrderBy('id', 'DESC')->execute()->first() ?? [];
+      }
+      else {
+        $this->contributionProduct = [];
+      }
     }
     if (!empty($this->contributionProduct['id']) && !isset($this->contributionProductID)) {
       $this->contributionProductID = $this->contributionProduct['id'];
@@ -271,6 +276,21 @@ trait CRM_Contribute_WorkflowMessage_ContributionTrait {
     $this->contribution = $contribution;
     if (!empty($contribution['id'])) {
       $this->contributionID = $contribution['id'];
+    }
+    return $this;
+  }
+
+  /**
+   * Set contribution object.
+   *
+   * @param array $contributionProduct
+   *
+   * @return $this
+   */
+  public function setContributionProduct(array $contributionProduct): self {
+    $this->contributionProduct = $contributionProduct;
+    if (!empty($contributionProduct['id'])) {
+      $this->contributionProductID = $contributionProduct['id'];
     }
     return $this;
   }

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -787,7 +787,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'is_email_receipt' => TRUE,
       'from_email_address' => 'test@test.com',
       'payment_processor_id' => $this->paymentProcessorID,
-      'credit_card_exp_date' => ['M' => 5, 'Y' => 2026],
+      'credit_card_exp_date' => ['M' => 5, 'Y' => date('Y', strtotime('+ 1 year'))],
       'credit_card_number' => '411111111111111',
       'credit_card_type' => 'Visa',
       'hidden_Premium' => 1,

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -736,7 +736,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
       'from_email_address' => 'test@test.com',
       'hidden_Premium' => 1,
     ]);
-    $contributionProduct = $this->callAPISuccess('contribution_product', 'getsingle', []);
+    $contributionProduct = $this->callAPISuccess('ContributionProduct', 'getsingle', []);
     $this->assertEquals('clumsy smurf', $contributionProduct['product_option']);
     $this->assertMailSentContainingStrings([
       'Premium Information',

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -270,7 +270,7 @@
          {ts}Option{/ts}
         </td>
         <td {$valueStyle}>
-          {contribution_product.product_option}
+          {contribution_product.product_option:label}
         </td>
        </tr>
       {/if}

--- a/xml/templates/message_templates/contribution_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_offline_receipt_html.tpl
@@ -253,7 +253,7 @@
       {/foreach}
      {/if}
 
-     {if !empty($formValues.product_name)}
+     {if {contribution_product.id|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Premium Information{/ts}
@@ -261,36 +261,36 @@
       </tr>
       <tr>
        <td colspan="2" {$labelStyle}>
-        {$formValues.product_name}
+        {contribution_product.product_id.name}
        </td>
       </tr>
-      {if $formValues.product_option}
+      {if {contribution_product.product_option|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Option{/ts}
         </td>
         <td {$valueStyle}>
-         {$formValues.product_option}
+          {contribution_product.product_option}
         </td>
        </tr>
       {/if}
-      {if $formValues.product_sku}
+      {if {contribution_product.product_id.sku|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}SKU{/ts}
         </td>
         <td {$valueStyle}>
-         {$formValues.product_sku}
+         {contribution_product.product_id.sku}
         </td>
        </tr>
       {/if}
-      {if !empty($fulfilled_date)}
+      {if {contribution_product.fulfilled_date|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Sent{/ts}
         </td>
         <td {$valueStyle}>
-         {$fulfilled_date|truncate:10:''|crmDate}
+          {contribution_product.fulfilled_date}
         </td>
        </tr>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Use ContributionProduct tokens for offline contribution receipt

Before
----------------------------------------
Using the `$formValues` array which is context dependent

After
----------------------------------------
Tokens used, tested

<img width="887" height="538" alt="image" src="https://github.com/user-attachments/assets/bb3876bd-5da0-4626-b3f4-3cbde7a66cbc" />

<img width="870" height="568" alt="image" src="https://github.com/user-attachments/assets/82713fe1-a4ed-402d-ac45-f63485e5ba06" />



Technical Details
----------------------------------------


Comments
----------------------------------------
I will follow up by converting the online receipts to use this