### PR TITLE
Fix: Add missing .fail() handlers to CRM.$.post calls to handle netwo…

### DIFF
--- a/templates/CRM/Campaign/Form/Gotv.tpl
+++ b/templates/CRM/Campaign/Form/Gotv.tpl
@@ -215,7 +215,9 @@
         }
       },
       'json'
-    );
+    ).fail(function() {
+      CRM.alert('{/literal}{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}{literal}', '{/literal}{ts escape="js"}Request Failed{/ts}{literal}', 'error');
+    });
   }
 </script>
 {/literal}

--- a/templates/CRM/Campaign/Form/Task/Interview.tpl
+++ b/templates/CRM/Campaign/Form/Task/Interview.tpl
@@ -311,7 +311,9 @@ var surveyActivityIds = {/literal}{$surveyActivityIds}{literal};
         CRM.$('#responseErrors').show( ).html(allErrors);
       }
     }
-  }, 'json');
+  }, 'json').fail(function() {
+    CRM.alert('{/literal}{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}{literal}', '{/literal}{ts escape="js"}Request Failed{/ts}{literal}', 'error');
+  });
 }
 
 function releaseOrReserveVoter(voterId) {
@@ -362,7 +364,9 @@ function releaseOrReserveVoter(voterId) {
         CRM.$( '#field_' + voterId + '_is_release_or_reserve' ).val( isReleaseOrReserve );
       }
     },
-  'json');
+  'json').fail(function() {
+    CRM.alert('{/literal}{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}{literal}', '{/literal}{ts escape="js"}Request Failed{/ts}{literal}', 'error');
+  });
 }
 
 function registerInterviewforall( ) {

--- a/templates/CRM/Contact/Page/DedupeFind.tpl
+++ b/templates/CRM/Contact/Page/DedupeFind.tpl
@@ -316,7 +316,9 @@
 
     CRM.$.post(dataUrl, {pnid: id, is_selected: is_selected, cacheKey : cacheKey}, function (data) {
       // nothing to do for now
-    }, 'json');
+    }, 'json').fail(function() {
+      CRM.alert('{/literal}{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}{literal}', '{/literal}{ts escape="js"}Request Failed{/ts}{literal}', 'error');
+    });
   }
 </script>
 {/literal}

--- a/templates/CRM/Financial/Form/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Form/BatchTransaction.tpl
@@ -343,7 +343,9 @@ function bulkAssignRemove( action ) {
     else {
       CRM.alert(data.status);
     }
-  }, 'json');
+  }, 'json').fail(function() {
+    CRM.alert('{/literal}{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}{literal}', '{/literal}{ts escape="js"}Request Failed{/ts}{literal}', 'error');
+  });
 }
 </script>
 {/literal}

--- a/templates/CRM/Financial/Page/BatchTransaction.tpl
+++ b/templates/CRM/Financial/Page/BatchTransaction.tpl
@@ -132,7 +132,7 @@ function removeFromBatch(financial_trxn_id) {
 }
 
 function noServerResponse() {
-  CRM.alert({/literal}'{ts escape="js"}No response from the server. Check your internet connection and try reloading the page.{/ts}', '{ts escape="js"}Network Error{/ts}'{literal}, 'error');
+  CRM.alert({/literal}'{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}', '{ts escape="js"}Request Failed{/ts}'{literal}, 'error');
 }
 
 function saveRecord(recordID, op, recordBAO, entityID) {
@@ -169,7 +169,7 @@ function batchSummary(entityID) {
       CRM.$("#row_" + i).text(val);
     });
   },
-  'json');
+  'json').fail(noServerResponse);
 }
 
 function checkMismatch() {

--- a/templates/CRM/common/dedupe.tpl
+++ b/templates/CRM/common/dedupe.tpl
@@ -19,7 +19,9 @@
           window.location.reload();
         }
       }
-    }, 'json' );
+    }, 'json' ).fail(function() {
+      CRM.alert('{/literal}{ts escape="js"}Unable to complete the request. The server returned an error or could not be reached.{/ts}{literal}', '{/literal}{ts escape="js"}Request Failed{/ts}{literal}', 'error');
+    });
   }
 </script>
 {/literal}


### PR DESCRIPTION
…rk errors

Overview
----------------------------------------
While testing https://lab.civicrm.org/dev/core/-/issues/6258 - i realised that it (and quite a few other places) do not check the jquery failed closures on $.post, so no errors are displayed on the users page. This fixes all the ones i could find.

Before
----------------------------------------
No errors displayed if jquery $.post fails due to network and/or server problems

After
----------------------------------------
<img width="381" height="137" alt="Screenshot From 2026-01-01 13-48-45" src="https://github.com/user-attachments/assets/a19f5fbc-eb4c-411c-87d2-5a48beeeb23a" />

Technical Details
----------------------------------------
See example here of correct usage of $.post https://api.jquery.com/jQuery.post/#jqxhr-object

Comments
----------------------------------------
I really only tested the campaign surveys feature as per https://lab.civicrm.org/dev/core/-/issues/6258 - but all the others fixes follow a similar pattern
