### PR TITLE
Remove a couple more legacy tpl assignments

### DIFF
--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -295,13 +295,11 @@ class CRM_Contribute_Form_AdditionalInfo {
    *   instance of Contribution form.
    * @param array $params
    *   (reference ) an assoc array of name/value pairs.
-   * @param bool $ccContribution
-   *   is it credit card contribution.
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public static function emailReceipt(&$form, &$params, $ccContribution = FALSE) {
+  public static function emailReceipt($form, &$params) {
     $form->assign('receiptType', 'contribution');
 
     // retrieve individual prefix value for honoree
@@ -341,14 +339,8 @@ class CRM_Contribute_Form_AdditionalInfo {
       }
     }
 
-    $form->assign('ccContribution', $ccContribution);
-    if ($ccContribution) {
-      $form->assignBillingName($params);
-      $form->assign('address', CRM_Utils_Address::getFormattedBillingAddressFieldsFromParameters($params));
-
-      $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($params);
-      $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
-    }
+    $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($params);
+    $form->assignVariables($valuesForForm, ['credit_card_exp_date', 'credit_card_type', 'credit_card_number']);
 
     //handle custom data
     if (!empty($params['hidden_custom'])) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1524,6 +1524,7 @@ class CRM_Utils_Token {
           '$paidBy' => 'contribution.payment_instrument_id:label',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$address' => 'contribution.address_id.display',
         ],
         'membership_online_receipt' => [
           '$dataArray' => ts('see default template for how to show this'),
@@ -1552,6 +1553,7 @@ class CRM_Utils_Token {
           '$cancel_date' => 'contribution.cancel_date',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$address' => 'contribution.address_id.display',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),
@@ -1579,6 +1581,7 @@ class CRM_Utils_Token {
           '$participant.role' => 'participant.role_id:label',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$address' => 'contribution.address_id.display',
         ],
         'event_online_receipt' => [
           '`$participant.id`' => 'participant.id',


### PR DESCRIPTION


Overview
----------------------------------------
Remove a couple more legacy tpl assignments

Before
----------------------------------------
code is working hard to conditionally assign billing_name - which is already noisily deprecated & address which is not in the template now, along with only approving card info when not null

After
----------------------------------------
Slightly more noisy deprecation  assignments removed. Card values assigned whether NULL or not


Technical Details
----------------------------------------
Getting rid of these allows us to consolidate sending the email after the various entities are saved - and they are already removed

Comments
----------------------------------------
