### PR TITLE
dev/core#6243: Unable to set 23:59 if Time Input Format is set to 24h

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -209,6 +209,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         'type' => 'datepicker',
         'label' => ts('Date'),
         'required' => TRUE,
+        'attributes' => ['formatType' => 'activityDateTime'],
       ],
       'followup_assignee_contact_id' => [
         'type' => 'entityRef',

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -528,6 +528,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if (empty($extra['maxDate']) && !empty($dateAttributes['minYear'])) {
           $extra['maxDate'] = $dateAttributes['maxYear'] . '-12-31';
         }
+        if (!empty($dateAttributes['time'])) {
+          $extra['time'] = $dateAttributes['time'];
+        }
       }
       // Support minDate/maxDate properties
       if (isset($extra['minDate'])) {

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -368,7 +368,7 @@ class CRM_Core_SelectValues {
         }
 
         $date['format'] = $dao->date_format;
-        $date['time'] = (bool) $dao->time_format;
+        $date['time'] = $dao->time_format ? $dao->time_format * 12 : FALSE;
       }
 
       if (empty($date['format'])) {


### PR DESCRIPTION
Overview
----------------------------------------
On New Activity  form, the activity date field doesn't respect time format, it always show in 12h format. 


Before
----------------------------------------
![before](https://github.com/user-attachments/assets/3fe9098c-acbb-4d48-a9b9-3254bac1bfb4)

After
----------------------------------------
![after](https://github.com/user-attachments/assets/e3feac8b-fb68-496c-875d-630a7489848a)


Technical Details
----------------------------------------
Main issue lies in CRM_Core_SelectValues::date that set time format in boolean instead of actual 12 or 24 hr format, which is what datepicker wrapper expect [here](https://github.com/civicrm/civicrm-core/blob/master/js/crm.datepicker.js#L49). 

Comments
----------------------------------------
ping @colemanw @demeritcowboy 