### PR TITLE
dev/core#4790: Can't set time format to 24 hr anymore

### DIFF
--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -209,6 +209,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
         'type' => 'datepicker',
         'label' => ts('Date'),
         'required' => TRUE,
+        'attributes' => ['formatType' => 'activityDateTime'],
       ],
       'followup_assignee_contact_id' => [
         'type' => 'entityRef',

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -528,6 +528,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         if (empty($extra['maxDate']) && !empty($dateAttributes['minYear'])) {
           $extra['maxDate'] = $dateAttributes['maxYear'] . '-12-31';
         }
+        if (!empty($dateAttributes['time'])) {
+          $extra['time'] = $dateAttributes['time'];
+        }
       }
       // Support minDate/maxDate properties
       if (isset($extra['minDate'])) {

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -368,7 +368,7 @@ class CRM_Core_SelectValues {
         }
 
         $date['format'] = $dao->date_format;
-        $date['time'] = (bool) $dao->time_format;
+        $date['time'] = $dao->time_format ? $dao->time_format * 12 : FALSE;
       }
 
       if (empty($date['format'])) {

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -1870,7 +1870,7 @@ class CRM_Utils_Date {
           $field['smarty_view_format'] = $dateAttributes['smarty_view_format'];
         }
         $field['datepicker']['extra'] = self::getDatePickerExtra($field);
-        $field['datepicker']['extra']['time'] = $fieldMetaData['type'] == CRM_Utils_Type::T_TIMESTAMP || $fieldMetaData['type'] == (CRM_Utils_Type::T_DATE + CRM_Utils_Type::T_TIME);
+        $field['datepicker']['extra']['time'] = $dateAttributes['time'];
         $field['datepicker']['attributes'] = self::getDatePickerAttributes($field);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
e.g. for date preferences set activityDate to 24 hr time. Then on a contribution the time field should be 24 hrs.
I have a feeling it's related to the same problem as [financial#221 (closed)](https://lab.civicrm.org/dev/financial/-/issues/221) and the fix there isn't entirely correct because something else changed about time_format. I'm not sure it's supposed to be a boolean but haven't confirmed.

Before
----------------------------------------
![before](https://github.com/user-attachments/assets/c12422a5-9f48-432a-a673-31eabd2b8490)


After
----------------------------------------
![after](https://github.com/user-attachments/assets/9d7c9015-d090-42d3-8675-e9bd06218311)



Technical Details
----------------------------------------
This inherit the fix of https://github.com/civicrm/civicrm-core/pull/34382  and extend the fix in CRM_Utils_Date::addDateMetadataToField that is used by CRM_Core_Form::addField

Comments
----------------------------------------
ping @colemanw @demeritcowboy 