### PR TITLE
Extract isPledge on contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -131,7 +131,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       $pledge = CRM_Pledge_BAO_Pledge::create($pledgeParams);
 
-      $form->_params['pledge_id'] = $pledge->id;
+      $this->setPledgeID($pledge->id);
 
       //send acknowledgment email. only when pledge is created
       if ($pledge->id && $isEmailReceipt) {
@@ -821,9 +821,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @return null|string
    */
   public function wrangleFinancialTypeID($financialTypeID) {
-    if (empty($financialTypeID) && !empty($this->_values['pledge_id'])) {
+    if (empty($financialTypeID) && $this->getPledgeID()) {
       $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge',
-        $this->_values['pledge_id'],
+        $this->getPledgeID(),
         'financial_type_id'
       );
     }
@@ -992,9 +992,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $isEmailReceipt = !empty($form->_values['is_email_receipt']);
     $isSeparateMembershipPayment = !empty($params['separate_membership_payment']);
-    $pledgeID = !empty($params['pledge_id']) ? $params['pledge_id'] : $form->_values['pledge_id'] ?? NULL;
+    $pledgeID = $this->getPledgeID();
     if (!$isSeparateMembershipPayment && !empty($form->_values['pledge_block_id']) &&
-      (!empty($params['is_pledge']) || $pledgeID)) {
+      (!empty($params['is_pledge']) || $this->getPledgeID())) {
       $isPledge = TRUE;
     }
     else {
@@ -1926,8 +1926,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $form->_fields['billing_first_name'] = 1;
     $form->_fields['billing_last_name'] = 1;
     // CRM-18854 - Set form values to allow pledge to be created for api test.
+    $form->setPledgeID($params['pledge_id'] ?? NULL);
     if (!empty($params['pledge_block_id'])) {
-      $form->_values['pledge_id'] = $params['pledge_id'] ?? NULL;
       $form->_values['pledge_block_id'] = $params['pledge_block_id'];
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($params['id']);
       $form->_values['max_reminders'] = $pledgeBlock['max_reminders'];
@@ -2058,7 +2058,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($this->_params);
 
     // CRM-18854
-    if (!empty($this->_params['is_pledge']) && empty($this->_values['pledge_id']) && !empty($this->_values['adjust_recur_start_date'])) {
+    if (!empty($this->_params['is_pledge']) && !$this->getPledgeID() && $this->getContributionPageValue('adjust_recur_start_date')) {
       $pledgeBlock = CRM_Pledge_BAO_PledgeBlock::getPledgeBlock($this->_id);
       if (!empty($this->_params['start_date']) || empty($pledgeBlock['is_pledge_start_date_visible'])
           || empty($pledgeBlock['is_pledge_start_date_editable'])) {

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -191,10 +191,10 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
      */
 
     //build set default for pledge overdue payment.
-    if (!empty($this->_values['pledge_id'])) {
+    if ($this->getPledgeID()) {
       //used to record completed pledge payment ids used later for honor default
       $completedContributionIds = [];
-      $pledgePayments = CRM_Pledge_BAO_PledgePayment::getPledgePayments($this->_values['pledge_id']);
+      $pledgePayments = CRM_Pledge_BAO_PledgePayment::getPledgePayments($this->getPledgeID());
 
       $paymentAmount = 0;
       $duePayment = FALSE;
@@ -357,7 +357,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     //build pledge block.
     //don't build membership block when pledge_id is passed
-    if (empty($this->_values['pledge_id']) && empty($this->getExistingContributionID())) {
+    if ($this->getPledgeID() && empty($this->getExistingContributionID())) {
       $this->_separateMembershipPayment = FALSE;
       if (CRM_Core_Component::isEnabled('CiviMember')) {
         $this->_separateMembershipPayment = $this->buildMembershipBlock();
@@ -377,14 +377,14 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         $this->buildPriceSet();
       }
       if ($this->_values['is_monetary'] &&
-        $this->_values['is_recur'] && empty($this->_values['pledge_id'])
+        $this->_values['is_recur'] && !$this->getPledgeID()
       ) {
         $this->buildRecur();
       }
     }
 
     //we allow premium for pledge during pledge creation only.
-    if (empty($this->_values['pledge_id']) && empty($this->getExistingContributionID())) {
+    if (!$this->getPledgeID() && empty($this->getExistingContributionID())) {
       $this->buildPremiumsBlock(TRUE);
     }
 
@@ -1036,7 +1036,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
     //validate the pledge fields.
     if (!empty($self->_values['pledge_block_id'])) {
       //validation for pledge payment.
-      if (!empty($self->_values['pledge_id'])) {
+      if (!empty($self->getPledgeID())) {
         if (empty($fields['pledge_amount'])) {
           $errors['pledge_amount'] = ts('At least one payment option needs to be checked.');
         }
@@ -1596,7 +1596,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    */
   private function buildPledgeBlock() {
     //build pledge payment fields.
-    if (!empty($this->_values['pledge_id'])) {
+    if ($this->getPledgeID()) {
       //get all payments required details.
       $allPayments = [];
       $returnProperties = [
@@ -1606,7 +1606,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
         'currency',
       ];
       CRM_Core_DAO::commonRetrieveAll('CRM_Pledge_DAO_PledgePayment', 'pledge_id',
-        $this->_values['pledge_id'], $allPayments, $returnProperties
+        $this->getPledgeID(), $allPayments, $returnProperties
       );
       // get all status
       $allStatus = CRM_Contribute_PseudoConstant::contributionStatus(NULL, 'name');


### PR DESCRIPTION
Overview
----------------------------------------
Extract isPledge on contribution page

Before
----------------------------------------
Hard to trace where it is coming from

After
----------------------------------------

This helps clarify where it comes from - pledgeId could be passed as a url parameter whereas is_pledge is a field on the form (if enabled)

Technical Details
----------------------------------------
There is a risk that the switch to apiv4 would cause problems if pledge is disabled - this addresses by only returning pledgeID if pledgeBlockValue can be retrieved - which does a check for whether the entity is enabled

Comments
----------------------------------------
