### PR TITLE
Make drupal 10/11 installs not fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,6 @@
       "cweagans/composer-patches": true
     }
   },
-  "conflict": {
-    "padaliyajay/php-autoprefixer": "1.5"
-  },
   "require": {
     "php": "~8.0",
     "ext-bcmath": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e8e4a0522781735a2eb5f235acedb17",
+    "content-hash": "3f5091886efcda6a51c86dac19fbcf6d",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -6013,5 +6013,5 @@
     "platform-overrides": {
         "php": "8.0.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allow php-autoprefixer again to get changes needed for sabberworm 9

(*Follow-up  to #34193 which drops that workaround -- now that php-autoprefixer@1.5 works.*)

Before
----------------------------------------
During the compile task you get `Fatal error: Uncaught Error: Object of class Sabberworm\CSS\CSSList\KeyFrame could not be converted to string in ...\vendor\padaliyajay\php-autoprefixer\src\Autoprefixer.php:82`

After
----------------------------------------
Works

Technical Details
----------------------------------------
Yesterday dompdf svg-lib started allowing sabberworm 9: https://github.com/dompdf/php-svg-lib/commit/1465ed878e4cffea9f6ab6fd60f2ab83648418e5. Because of flaws in php-autoprefixer 1.5 we had cleverly prevented it, but then when they fixed the flaws, instead of releasing a new version they re-released 1.5. That was fine when sabberworm was being restricted indirectly to v8, but now we need the changes in autoprefixer 1.5 in order to avoid fails with sabberworm 9.

Comments
----------------------------------------
I checked and this also still works with sabberworm 8 if for some reason a site still ends up with that.

We might want to do a 6.9 backport because even if you're not upgrading civi, using composer on a site to do some other update might update sabberworm, and then the compile will fail.

To test this is always a little tricky because of chicken-egg with packagist. One method is edit composer.json's repositories section and add this:
```json
       {
            "type": "vcs",
            "url": "https://github.com/demeritcowboy/civicrm-core"
        },
        {
            "type": "vcs",
            "url": "https://github.com/demeritcowboy/civicrm-drupal-8"
        },
```
And then in your composer require to get the civi code use `civicrm-core:dev-sabberworm` instead of `civicrm-core:dev-master`. That will use my branch with this change for both code and composer's purposes, and then also my drupal-8 repo is modified to allow `dev-sabberworm` as a branch, otherwise that constraint would fail.