### PR TITLE
Update unit test to use apiv4 Payment.create - address failure to use  default

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
@@ -158,12 +158,8 @@ class Create extends \Civi\Api4\Generic\AbstractCreateAction {
   public function _run(\Civi\Api4\Generic\Result $result) {
     $this->values['is_send_contribution_notification'] = $this->notificationForCompleteOrder;
     $this->formatWriteValues($this->values);
-    $fields = $this->entityFields();
-    foreach ($fields as $name => $field) {
-      if (!isset($params[$name]) && !empty($field['default_value'])) {
-        $params[$name] = $field['default_value'];
-      }
-    }
+    $this->fillDefaults($this->values);
+
     $this->validateValues();
     $trxn = \CRM_Financial_BAO_Payment::create($this->values, $this->disableActionsOnCompleteOrder);
     $savedRecords = [];

--- a/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
@@ -164,12 +164,8 @@ class Create extends \Civi\Api4\Generic\AbstractCreateAction {
   public function _run(\Civi\Api4\Generic\Result $result) {
     $this->values['is_send_contribution_notification'] = $this->notificationForCompleteOrder;
     $this->formatWriteValues($this->values);
-    $fields = $this->entityFields();
-    foreach ($fields as $name => $field) {
-      if (!isset($params[$name]) && !empty($field['default_value'])) {
-        $params[$name] = $field['default_value'];
-      }
-    }
+    $this->fillDefaults($this->values);
+
     $this->validateValues();
     // This action bypasses the normal writeObjects()/write() pipeline (it calls the
     // Payment BAO directly, below), so the custom-field flattening that pipeline

--- a/ext/financialacls/tests/phpunit/Civi/Financialacls/ContributionTest.php
+++ b/ext/financialacls/tests/phpunit/Civi/Financialacls/ContributionTest.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\Financialacls;
 
+use Civi\Api4\Payment;
+
 require_once 'BaseTestClass.php';
 
 /**
@@ -120,11 +122,10 @@ class ContributionTest extends BaseTestClass {
     $params['financial_type_id'] = 'Donation';
     $params['total_amount'] = 300;
     $order = $this->callAPISuccess('Order', 'create', $params + ['version' => 3]);
-    $this->callAPISuccess('Payment', 'create', [
+    Payment::create(FALSE)->setValues([
       'contribution_id' => $order['id'],
       'total_amount' => $params['total_amount'],
-      'version' => 3,
-    ]);
+    ])->execute();
   }
 
   public function testSuperPermissions(): void {


### PR DESCRIPTION

Overview
----------------------------------------
Update unit test to use apiv4 Payment.create - address failure to use  default

Before
----------------------------------------
Test using apiv3 - no test demonstrating that the api v4 is not correctly setting default for `trxn_date`

After
----------------------------------------
Tested - fix pending...

Technical Details
----------------------------------------
The Payment.create v4 api has tried & failed to set the defaults - it has declared it here ...

https://github.com/civicrm/civicrm-core/blob/5491479f599a1226e2ed2ddaa8ea72d5ceb6729b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php#L54

- surely I don't have to add a `SpecProvider` just to set a field default??? @colemanw 
- 
Comments
----------------------------------------
@mattwire FYI
