### PR TITLE
Make source of _amount clearer

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -274,7 +274,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
-    $this->_params['amount'] = $this->get('amount');
+    $this->_params['amount'] = $this->getMainContributionAmount();
     if (isset($this->_params['amount'])) {
       $this->setFormAmountFields($this->getPriceSetID());
     }


### PR DESCRIPTION
Overview
----------------------------------------
Make source of _amount clearer

Before
----------------------------------------
Value is being set on Main page & is hard to trace

<img width="1647" height="316" alt="image" src="https://github.com/user-attachments/assets/5d947dc6-8cbc-4c8b-bedd-d8c18ba1f584" />


After
----------------------------------------
the same function is used on the Confirm page

Technical Details
----------------------------------------
Confirm has access to the same calculations as Main & the same submitted values - there was a time when this was less true

Comments
----------------------------------------

