### PR TITLE
Fix financial items when changing from with tax financial type to no-tax financial type

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -163,7 +163,16 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
     // Get Line Items if we don't have them already.
     if (empty($params['line_item'])) {
-      CRM_Price_BAO_LineItem::getLineItemArray($params, $contributionID ? [$contributionID] : NULL);
+      if ($contributionID) {
+        $order = new CRM_Financial_BAO_Order();
+        $order->setExistingContributionID($contributionID);
+        $order->setOverrideTotalAmount($params['total_amount'] ?? NULL);
+        $order->setOverrideFinancialTypeID($params['financial_type_id'] ?? NULL);
+        $params['line_item'] = [$order->getLineItems()];
+      }
+      else {
+        CRM_Price_BAO_LineItem::getLineItemArray($params);
+      }
     }
 
     // We should really ALWAYS calculate tax amount off the line items.

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1045,7 +1045,11 @@ class CRM_Financial_BAO_Order {
       if ($this->getOverrideTotalAmount() !== FALSE) {
         $this->addTotalsToLineBasedOnOverrideTotal((int) $lineItem['financial_type_id'], $lineItem);
       }
-      elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount') {
+      elseif ($this->getPriceFieldMetadata($lineItem['price_field_id'])['name'] === 'other_amount'
+        // If we are loading an existing contribution then this switcheroo to treat the amount set
+        // as being the inclusive amount has already been done, so skip.
+        && !$this->getExistingContributionID() && !$this->getTemplateContributionID()
+      ) {
         // Other amount is a front end user entered form. It is reasonable to think it would be tax inclusive.
         $lineItem['line_total_inclusive'] = $lineItem['line_total'];
         $lineItem['line_total'] = $lineItem['line_total_inclusive'] ? $lineItem['line_total_inclusive'] / (1 + ($lineItem['tax_rate'] / 100)) : 0;

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -388,7 +388,7 @@ class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
     foreach ($financialItems as $financialItem) {
       $amount += $financialItem['amount'];
     }
-    $this->assertEquals('320.00', $amount);
+    $this->assertEquals('300.00', $amount);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When changing the financial type of a contribution from a type with tax to one without the correct behaviour is that the original financial items should be reversed - both the main one and the one for the tax and one new one should be created -  for the new tax free line item. 

However in the test that is touched in this PR it is locking in the wrong behaviour - presumably written to check a refactor did not break something - it is locking in that only the non-tax line item is reversed, and not the tax one. It does this because it is looking at the new line items, not the original ones, to see if there is a tax line to reverse


Before
----------------------------------------
Financial item for the tax on the line item is not reversed

After
----------------------------------------
now it is

Technical Details
----------------------------------------
This switches to ensuring the new line items are reliably uploaded and compares the new vs old line items - it is the minimum fix with further improvements in https://github.com/civicrm/civicrm-core/pull/34338

Comments
----------------------------------------

