### PR TITLE
Consolidate campaign_id handling

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -126,8 +126,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $pledgeParams['acknowledge_date'] = date('Ymd');
       $pledgeParams['original_installment_amount'] = $pledgeParams['installment_amount'];
 
-      //inherit campaign from contirb page.
-      $pledgeParams['campaign_id'] = $contributionParams['campaign_id'] ?? NULL;
+      $pledgeParams['campaign_id'] = $this->getCampaignID();
 
       $pledge = CRM_Pledge_BAO_Pledge::create($pledgeParams);
 
@@ -451,10 +450,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     $this->_params['invoiceID'] = $this->get('invoiceID');
 
-    //carry campaign from profile.
-    if (array_key_exists('contribution_campaign_id', $this->_params)) {
-      $this->_params['campaign_id'] = $this->_params['contribution_campaign_id'];
-    }
+    // @todo stop setting this - use directly
+    $this->_params['campaign_id'] = $this->getCampaignID();
 
     // assign contribution page id to the template so we can add css class for it
     $this->assign('contributionPageID', $this->_id);
@@ -969,8 +966,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *   passed consistently & 2) documenting them here.
    *   - contact_id
    *   - line_item
-   *   - is_test
-   *   - campaign_id
+   *   - is_test (no longer used)
+   *   - campaign_id (no longer used)
    *   - contribution_page_id
    *   - source
    *   - payment_type_id
@@ -1140,8 +1137,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // We set trxn_id=invoiceID specifically for paypal IPN. It is reset this when paypal sends us the real trxn id, CRM-2991
     $recurParams['processor_id'] = $recurParams['trxn_id'] = ($params['trxn_id'] ?? $params['invoiceID']);
 
-    $campaignId = $params['campaign_id'] ?? $this->_values['campaign_id'] ?? NULL;
-    $recurParams['campaign_id'] = $campaignId;
+    $recurParams['campaign_id'] = $this->getCampaignID();
     $recurring = CRM_Contribute_BAO_ContributionRecur::add($recurParams);
     $this->_params['contributionRecurID'] = $recurring->id;
 
@@ -1525,11 +1521,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $membershipContributionID = $membershipContribution->id;
     }
 
-    //@todo - why is this nested so deep? it seems like it could be just set on the calling function on the form layer
-    if (isset($membershipParams['onbehalf']) && !empty($membershipParams['onbehalf']['member_campaign_id'])) {
-      $this->_params['campaign_id'] = $membershipParams['onbehalf']['member_campaign_id'];
-    }
-
     if (!empty($membershipContributionID)) {
       $typesTerms = $membershipParams['types_terms'] ?? [];
       $this->_params['createdMembershipIDs'] = [];
@@ -1559,9 +1550,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           $pending = FALSE;
         }
 
-        // @fixme: Can we use eg. $this->getSubmittedValue('campaign_id') ?: $this->getContributionPageValue('campaign_id');
-        $campaignID = $this->_params['campaign_id'] ?? ($this->_values['campaign_id'] ?? NULL);
-
         if (!$this->getExistingContributionID()) {
           // @todo get rid of this function!
           // Need to check that it's not actually doing anything useful in other scenarios
@@ -1573,7 +1561,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             $customFieldsFormatted,
             $numTerms, $membershipID, $pending,
             $contributionRecurID, $membershipSource, $isPayLater,
-            $campaignID,
             $membershipContribution,
             $membershipLineItems
           );
@@ -1760,7 +1747,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       'contact_id' => $contactID,
       'line_item' => [$this->getPriceSetID() => $this->getSecondaryMembershipContributionLineItems()],
       'is_test' => $isTest,
-      'campaign_id' => $tempParams['campaign_id'] ?? $this->_values['campaign_id'] ?? NULL,
+      'campaign_id' => $this->getCampaignID(),
       'contribution_page_id' => $this->_id,
       'source' => $tempParams['source'] ?? $tempParams['description'] ?? NULL,
       'financial_type_id' => $financialTypeID,
@@ -2125,15 +2112,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             $behalfOrganization[$onBehalfField] = $values;
           }
           elseif (!str_contains($onBehalfField, '-')) {
-            if (in_array($onBehalfField, [
-              'contribution_campaign_id',
-              'member_campaign_id',
-            ])) {
-              $onBehalfField = 'campaign_id';
-            }
-            else {
-              $behalfOrganization[$onBehalfField] = $values;
-            }
+            $behalfOrganization[$onBehalfField] = $values;
             $this->_params[$onBehalfField] = $values;
           }
         }
@@ -2403,9 +2382,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $membershipParams['onbehalf_contact_id'] = $this->_params['onbehalf_contact_id'];
     }
     //inherit campaign from contribution page.
-    if (!array_key_exists('campaign_id', $membershipParams)) {
-      $membershipParams['campaign_id'] = $this->_values['campaign_id'] ?? NULL;
-    }
+    $membershipParams['campaign_id'] = $this->getCampaignID();
 
     $this->_params = CRM_Core_Payment_Form::mapParams(NULL, $this->_params, $membershipParams, TRUE);
 
@@ -2419,12 +2396,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     else {
       $membershipParams['cms_contactID'] = $contactID;
-    }
-
-    if (!empty($membershipParams['onbehalf']) &&
-      is_array($membershipParams['onbehalf']) && !empty($membershipParams['onbehalf']['member_campaign_id'])
-    ) {
-      $this->_params['campaign_id'] = $membershipParams['onbehalf']['member_campaign_id'];
     }
 
     $customFieldsFormatted = [];
@@ -2570,7 +2541,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // CRM-21200: Don't overwrite contribution details during 'Pay now' payment
       if (empty($form->_params['contribution_id'])) {
         $contributionParams['contribution_page_id'] = $form->_id;
-        $contributionParams['campaign_id'] = $paymentParams['campaign_id'] ?? $form->_values['campaign_id'] ?? NULL;
+        $contributionParams['campaign_id'] = $this->getCampaignID();
       }
       // In case of 'Pay now' payment, append the contribution source with new text 'Paid later via page ID: N.'
       else {
@@ -2722,14 +2693,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param int $contributionRecurID
    * @param $membershipSource
    * @param $isPayLater
-   * @param int? $campaignID
    * @param null|CRM_Contribute_BAO_Contribution $contribution
    * @param array $lineItems
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  private function legacyProcessMembership($contactID, $membershipTypeID, $changeToday, $modifiedID, $customFieldsFormatted, $numRenewTerms, $membershipID, $pending, $contributionRecurID, $membershipSource, $isPayLater, $campaignID = NULL, $contribution = NULL, $lineItems = []) {
+  private function legacyProcessMembership($contactID, $membershipTypeID, $changeToday, $modifiedID, $customFieldsFormatted, $numRenewTerms, $membershipID, $pending, $contributionRecurID, $membershipSource, $isPayLater, $contribution = NULL, $lineItems = []) {
     $renewalMode = $updateStatusId = FALSE;
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
     $format = '%Y%m%d';
@@ -2738,7 +2708,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $ids = [];
 
     $memParams = [
-      'campaign_id' => $campaignID,
+      'campaign_id' => $this->getCampaignID(),
       'is_test' => $this->isTest(),
     ];
 

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1198,6 +1198,25 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
+   * Get the campaign ID.
+   *
+   * @return ?int
+   *
+   * @api This function will not change in a minor release and is supported for
+   *  use outside of core. This annotation / external support for properties
+   *  is only given where there is specific test cover.
+   */
+  public function getCampaignID(): ?int {
+    if ($this->getSubmittedValue('campaign_id')) {
+      return $this->getSubmittedValue('campaign_id');
+    }
+    if ($this->getSubmittedValue('contribution_campaign_id')) {
+      return $this->getSubmittedValue('contribution_campaign_id');
+    }
+    return $this->getContributionPageValue('campaign_id');
+  }
+
+  /**
    * Get the amount level description for the main contribution.
    *
    * If there is a separate membership contribution this is the 'other one'. Otherwise there


### PR DESCRIPTION
Overview
----------------------------------------
Consolidate campaign_id handling

Before
----------------------------------------
The campaign ID handling is very confusing but it ultimately only gets the campaign from one of 2 submitted values or from the contribution page. 

The 2 submitted values are `campaign_id` and `contribution_campaign_id` - which, at least in theory, could be on a profile

The form also had handling for a campaign value embedded in the `onbehalf` profile.
However, both within this form and in the admin UI putting campaign in from the Membership of Contribution entitiy is blocked so I feel comfortable that the old code for it being nested in 'onbehalf' is not actually function and can be removed

<img width="1261" height="443" alt="image" src="https://github.com/user-attachments/assets/7f6d4258-d4e2-46b4-a9f5-5b5883fa0d20" />

<img width="1261" height="443" alt="image" src="https://github.com/user-attachments/assets/53ef4032-8ed7-4337-a58d-7448081b885f" />


After
----------------------------------------
Consolidated onto single function that accesses the value from the source - either a submitted value or the contribution page value. 

Technical Details
----------------------------------------

Comments
----------------------------------------
