### PR TITLE
Use calculated function for `useForMember`

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2373,7 +2373,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param array $premiumParams
    */
   protected function doMembershipProcessing($contactID, $membershipParams, $premiumParams) {
-    if (!$this->_useForMember) {
+    if (!$this->isMembershipPriceSet()) {
       $this->set('membershipTypeID', $this->_params['selectMembership']);
     }
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1958,16 +1958,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $form->_paymentProcessor = $form->_paymentProcessors[$form->_params['payment_processor_id']];
     }
 
-    if (!empty($params['useForMember'])) {
-      $form->set('useForMember', 1);
-      $form->_useForMember = 1;
-    }
     $priceFields = $priceFields[$priceSetID]['fields'];
     $membershipPriceFieldIDs = [];
     foreach ($form->order->getLineItems() as $lineItem) {
       if (!empty($lineItem['membership_type_id'])) {
-        $form->set('useForMember', 1);
-        $form->_useForMember = 1;
         $membershipPriceFieldIDs['id'] = $priceSetID;
         $membershipPriceFieldIDs[] = $lineItem['price_field_value_id'];
       }

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -757,7 +757,7 @@ class CRM_Financial_BAO_Order {
     return $this->priceSetMetadata;
   }
 
-  public function isMembershipPriceSet() {
+  public function isMembershipPriceSet(): bool {
     if (!CRM_Core_Component::isEnabled('CiviMember')) {
       return FALSE;
     }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2940,7 +2940,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       ])['id'];
       $priceSetID = $this->createTestEntity('PriceSet', [
         'is_quick_config' => 0,
-        'extends' => 'CiviMember',
+        'extends' => CRM_Core_Component::getComponentID('CiviMember'),
         'financial_type_id' => 1,
         'title' => 'my Page',
         'name' => 'member_not_quick_config',


### PR DESCRIPTION
This part of the function is only really accessed by unit tests - removing them highlighted an issue in how 'useForMember' is calculated - making the tests more robust too