### PR TITLE
Adding additional menu options

### DIFF
--- a/managed/translation/SavedSearch_Translation.mgd.php
+++ b/managed/translation/SavedSearch_Translation.mgd.php
@@ -120,14 +120,24 @@ foreach ($locales as $index => $langCode) {
                     'IS EMPTY',
                   ],
                 ],
+                [
+                  'icon': 'fa-pencil',
+                  'side': 'left',
+                  'if': []
+                ],
               ],
             ],
           ],
-          'actions' => FALSE,
+          'actions' => [
+            'delete',
+            'download',
+          ],
           'classes' => [
             'table',
             'table-striped',
+            'crm-sticky-header',
           ],
+          'actions_display_mode': 'menu',
         ],
       ],
       'match' => [


### PR DESCRIPTION
Overview
----------------------------------------
This adds some additional features to the translation menu that I think will be useful.

+ Ability to delete certain words from the system
+ Ability to download all the words (to send to a translation service or internally)
+ Pencil beside each word regardless if it's empty or not to indicate that it can be edited

Before
----------------------------------------
<img width="1864" height="417" alt="Selection_005" src="https://github.com/user-attachments/assets/3947d4ed-15dc-4927-9812-f4ca7b64566e" />


After
----------------------------------------
<img width="1857" height="445" alt="Selection_006" src="https://github.com/user-attachments/assets/e9973cc1-97e0-4828-b839-139be55a4ba9" />

Comments
----------------------------------------

There were a few other things I wanted to add but I couldn't quite figure out how to do

+ Add a dropdown with the options `View all translated and untranslated words, View translated words, and View untranslated words` to make it easier to filter by these options but I don't think this is possible in Form Builder yet.. or is it? How would I do that (maybe a new PR)
+ I _really_ want to push the strings through a `{ts}{/ts}` call and show then in italics if there is a system translation, but when you do that it they lose the ability to be editable. I also couldn't quite get this to work. My rationale is that I worry most users won't understand that they only need to translate what they want to and not everything, but I realize that only _changed_ labels are appearing at this point so that does reduce this down quite a bit