### PR TITLE
Remove check for text content in HTML email

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -304,9 +304,6 @@ class CRM_Utils_Mail {
     }
 
     $htmlMessage = $params['html'] ?? FALSE;
-    if (trim(CRM_Utils_String::htmlToText((string) $htmlMessage)) === '') {
-      $htmlMessage = FALSE;
-    }
     $attachments = $params['attachments'] ?? NULL;
     if (!empty($params['text']) && trim($params['text'])) {
       $textMessage = $params['text'];


### PR DESCRIPTION
Overview
----------------------------------------
Remove the check for text content of an HTML email to solve issue [#6259](https://lab.civicrm.org/dev/core/-/issues/6259).

Before
----------------------------------------
Before sending an email, its HTML part was checked for content by converting it to text with `htmlToText`. If this conversion led to an empty text, the HTML part was removed from the email body.

This lead to issue [#6259](https://lab.civicrm.org/dev/core/-/issues/6259) if the HTML part couldn't be converted.

After
----------------------------------------
If the email contains an HTML part, it is sent no matter what it contains. Should the conversion from HTML to text fail, the email contains only the HTML part.

Comments
----------------------------------------
Enforcing a text part of an email is not necessary anymore since all major email clients support HTML.
