### PR TITLE
River Lea: renames variable so it uses the correct component prefix

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -302,7 +302,7 @@
   --crm-contact-border: var(--crm-tab-border);
   --crm-contact-radius: var(--crm-l-radius);
   --crm-contact-direction: flex; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
-  --crm-side-tabs-width: unset;
+  --crm-contact-side-tabs-width: unset; /* if grid is set, a width for the side tabs needs to be set here */
   --crm-contact-tabs-flow: row; /* choose 'row' for tabs at top, or 'column' for tabs at side */
   --crm-contact-tabs-gap: var(--crm-tabs-gap);
   --crm-contact-tabs-bg-color: var(--crm-tabs-bg-color);

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -115,7 +115,7 @@
 .crm-contact-page #mainTabContainer.ui-tabs {
   border: var(--crm-contact-border);
   display: var(--crm-contact-direction);
-  grid-template-columns: var(--crm-side-tabs-width) auto;
+  grid-template-columns: var(--crm-contact-side-tabs-width) auto;
   flex-direction: column;
 }
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list {

--- a/ext/riverlea/core/css/contactSummary.css
+++ b/ext/riverlea/core/css/contactSummary.css
@@ -426,7 +426,7 @@ div.crm-summary-contactname-block + .crm-actions-ribbon {
 @media (max-width: 767px) {
   #crm-main-content-wrapper {
     --crm-contact-heading-inset: 0; /* resets any inset on the title/action links */
-    --crm-side-tabs-width: auto; /* resets offset inline edit */
+    --crm-contact-side-tabs-width: auto; /* resets offset inline edit */
   }
   .crm-container #mainTabContainer {
     flex-direction: column;

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -73,7 +73,7 @@
   /* Contact dashboard */
   --crm-contact-border: 0;
   --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
-  --crm-side-tabs-width: 200px;
+  --crm-contact-side-tabs-width: 200px;
   --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
   --crm-contact-tabs-gap: var(--crm-l-medium);
   --crm-contact-tabs-bg-color: transparent;
@@ -89,7 +89,7 @@
   --crm-contact-tab-hang: 0 -1px 0 0; /* lip to extend tab flush with active region - set to 0 for no lip */
   --crm-contact-tab-radius: var(--crm-contact-radius) 0 0 var(--crm-contact-radius);
   --crm-contact-summary-row-bg-color: var(--crm-layer2-bg-color);
-  --crm-contact-heading-inset: var(--crm-side-tabs-width);
+  --crm-contact-heading-inset: var(--crm-contact-side-tabs-width);
   --crm-contact-panel-padding: var(--crm-l-reg);
   --crm-contact-panel-bg-color: var(--crm-contact-tab-hover-bg-color);
   --crm-contact-panel-border: var(--crm-border);

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -155,7 +155,7 @@
   --crm-contact-border: 0 solid transparent;
   --crm-contact-radius: var(--crm-r-5);
   --crm-contact-direction: grid;
-  --crm-side-tabs-width: 220px;
+  --crm-contact-side-tabs-width: 220px;
   --crm-contact-tabs-flow: column;
   --crm-contact-tabs-gap: 0;
   --crm-contact-tabs-bg-color: var(--crm-c-blue-overlay);

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -145,7 +145,7 @@
   --crm-contact-border: 0 solid transparent;
   --crm-contact-radius: 0;
   --crm-contact-direction: grid; /* choose 'flex' for tabs at top, or 'grid' for tabs at side */
-  --crm-side-tabs-width: 220px;
+  --crm-contact-side-tabs-width: 220px;
   --crm-contact-tabs-flow: column; /* choose 'row' for tabs at top, or 'column' for tabs at side */
   --crm-contact-tabs-gap: 0;
   --crm-contact-tabs-bg-color: var(--crm-container-bg-color);


### PR DESCRIPTION
Overview
----------------------------------------
Aware this is a late change for the 6.10 branch, but 6.10 is the deadline for locking River's variable names, and while working on the docs for that, I just noticed a naming bug. All the variables for the Contact Layout are prefixed `--crm-contact-` except for one that was called `--crm-side-tabs-width`, despite sitting in the contact section. 

Before
----------------------------------------
Variable name is `--crm-side-tabs-width` everywhere.

After
----------------------------------------
Variable name is `--crm-contact-side-tabs-width` everywhere, plus an inline comment is added to explain what this variable does.

Technical Details
----------------------------------------
This PR is just a semantic change, no structural or visual changes take place.

Comments
----------------------------------------
Sorry for the late PR!