### PR TITLE
Add Soft Credit search task

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -176,6 +176,15 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       ];
     }
 
+    if ($entity['name'] === 'Contribution') {
+      $tasks['Contribution']['add_soft_credit'] = [
+        'title' => E::ts('Add Soft Credits'),
+        'uiDialog' => ['templateUrl' => '~/crmSearchTasks/crmSearchTaskSoftCredit.html'],
+        'icon' => 'fa-user-plus',
+        'module' => 'crmSearchTasks',
+      ];
+    }
+
     if (CoreUtil::isContact($entity['name'])) {
       // Add contact tasks which support standalone mode
       $contactTasks = $this->checkPermissions ? \CRM_Contact_Task::permissionedTaskTitles(\CRM_Core_Permission::getPermission()) : NULL;

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskSoftCredit.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskSoftCredit.html
@@ -1,0 +1,18 @@
+<div id="bootstrap-theme" crm-dialog="crmSearchTask">
+  <form name="crmSearchTaskSoftCreditForm" ng-controller="crmSearchTaskSoftCredit as $ctrl">
+    <div class="form-inline">
+      <label for="crm-search-task-soft_credit-contact_id">{{:: ts('Contact') }} <i class="crm-marker">*</i></label>
+      <input id="crm-search-task-soft_credit-contact_id" class="form-control" ng-model="$ctrl.values.contact_id" crm-autocomplete="'Contact'" required>
+    </div>
+    <div class="form-inline">
+      <label for="crm-search-task-soft_credit-soft_credit_type">{{:: ts('Soft Credit Type') }} <i class="crm-marker">*</i></label>
+      <input id="crm-search-task-soft_credit-soft_credit_type" class="form-control" ng-model="$ctrl.values.soft_credit_type" required crm-ui-select="{data: $ctrl.softCreditTypes, allowClear: false}">
+    </div>
+    <div ng-if="$ctrl.run" class="crm-search-task-progress">
+      <h5>{{:: ts('Adding soft credits...') }}</h5>
+      <crm-search-batch-runner entity="'ContributionSoft'" action="save" params="$ctrl.run" ids="$ctrl.ids" id-field="contribution_id" get-entity="'Contribution'" get-mapping="{amount: 'total_amount'}" success="$ctrl.onSuccess(result)" error="$ctrl.onError()" ></crm-search-batch-runner>
+    </div>
+    <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
+    <crm-dialog-button text="ts('Save')" icons="{primary: 'fa-user-plus'}" on-click="$ctrl.submit()" disabled="$ctrl.run || !crmSearchTaskSoftCreditForm.$valid" />
+  </form>
+</div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskSoftCredit.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskSoftCredit.js
@@ -1,0 +1,42 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchTasks').controller('crmSearchTaskSoftCredit', function($scope, crmApi4, searchTaskBaseTrait) {
+    const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait);
+
+    ctrl.values = ctrl.task.values || {};
+    ctrl.softCreditTypes = [];
+
+    crmApi4('OptionValue', 'get', {
+      select: ['value','label','is_default'],
+      where: [['option_group_id:name','=','soft_credit_type'],['is_active','=',true]]
+    }).then(function(result) {
+      angular.copy(
+        result.map(o => ({id: o.value, text: o.label})),
+        ctrl.softCreditTypes
+      );
+      const defaultOpt = result.find(o => o.is_default);
+      if (defaultOpt) {
+        ctrl.values.soft_credit_type = defaultOpt.value;
+      }
+    });
+
+    ctrl.submit = function() {
+      var params = {};
+      params.defaults = {
+        contact_id: ctrl.values.contact_id,
+        soft_credit_type_id: ctrl.values.soft_credit_type
+      };
+      ctrl.start(params);
+    };
+
+    this.onSuccess = function(result) {
+      // ContributionSoft API does not return countMatched even if a soft credit already exists for the same contact, type and amount.
+      let msg = result.batchCount === 1 ? ts('1 soft credit added') : ts('%1 soft credits added.', {1: result.batchCount});
+      CRM.alert(msg, ts('Saved'), 'success');
+      this.close(result);
+    };
+
+  });
+})(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Allows soft credits to be added to contributions as a search action (for the full amount of the contribution only), which will allow them to be added in bulk.

Technical Details
----------------------------------------
In order to make this work, we need to first get the amount of the contribution. I've added get-entity and get-mapping params to crmSearchBatchRunner, which allow us to specify which entity and which fields we want to get. This gets the relevant fields for each id and then adds those mapped fields and values to the records before saving. I can imagine this might be useful in other contexts.