### PR TITLE
Fix contribution page highlight

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -30,7 +30,7 @@
       );
       // Copied from `updatePriceSetHighlight()` below which isn't available here.
       // @todo - consider adding this to the actions assigned in Calculate.tpl
-      CRM.$('#priceset .price-set-row span').removeClass('highlight');
+      CRM.$('#priceset .price-set-row span div').removeClass('highlight');
       CRM.$('#priceset .price-set-row input:checked').parent().addClass('highlight');
       // Return the focus we blurred earlier.
       currentFocus.trigger('focus');
@@ -380,7 +380,7 @@
     CRM.$(function($) {
       // highlight price sets
       function updatePriceSetHighlight() {
-        $('#priceset .price-set-row span').removeClass('highlight');
+        $('#priceset .price-set-row span div').removeClass('highlight');
         $('#priceset .price-set-row input:checked').parent().addClass('highlight');
       }
       $('#priceset input[type="radio"]').change(updatePriceSetHighlight);


### PR DESCRIPTION
Overview
----------------------------------------
There's a regression in Civi 6.9 from f20248d1dda24e04554eda2c91387c5607afaf64 that causes the "highlight" class on price options to never get removed.

To replicate this, pull up a contribution page, select a price option, then select another. Search for `.highlight` in your HTML.

Before
----------------------------------------
Any price option, once highlighted, remains highlighted.

After
----------------------------------------
Only the selected option is highlighted.

Technical Details
----------------------------------------
f20248d1dda24e04554eda2c91387c5607afaf64 adds a `div with class `crm-option-label-pair` to all price options.  `updatePriceSetHighlight` adds the `highlight` class to the parent element of the selected input, and attempts to remove `highlight` from all the relevant `span` elements. With the addition of the new element, the `span` is now the grandparent, not the parent.  So we need to remove the highlight from the new parent.