### PR TITLE
Riverlea: fixes visibility of items set to .disabled in dropdown

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -281,7 +281,7 @@ dl dl {
 }
 .crm-container .disabled,
 .crm-container .crm-disabled,
-.crm-container .disabled *:not(.btn,button,i,span,a),
+.crm-container .disabled *:not(.btn,button,i,span,a,em),
 .crm-container .cancelled,
 .crm-container .cancelled td,
 .crm-container li.disabled a.ui-tabs-anchor {

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -311,25 +311,16 @@
 .crm-container .dropdown-menu > .active > a:focus {
   color: var(--crm-dropdown-hover-text-color) !important; /* vs BS .btn-secondary:hover */
   background-color: var(--crm-dropdown-hover-bg-color);
-  text-decoration: none;
   border-radius: var(--crm-l-radius);
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a:hover i.crm-i,
 .crm-container .dropdown-menu > li:not(.disabled) > a:focus i.crm-i {
   color: var(--crm-dropdown-hover-text-color);
 }
-.crm-container .dropdown-menu > .disabled > a,
 .crm-container .dropdown-menu > .disabled > a:hover,
 .crm-container .dropdown-menu > .disabled > a:focus {
-  color: var(--crm-inactive-color);
-}
-.crm-container .dropdown-menu > .disabled > a:hover,
-.crm-container .dropdown-menu > .disabled > a:focus {
-  text-decoration: none;
   cursor: not-allowed;
   background-color: transparent;
-  background-image: none;
-  filter: progid:DXImageTransform.Microsoft.gradient(enabled=false);
 }
 .crm-container .open > .dropdown-menu,
 .crm-container .open .btn.dropdown-toggle + .dropdown-menu {


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit dropdowns set a background and text colour. The `.disabled` class has its own colour, which can clash with this, rendering the text invisible. As discussed [here](https://chat.civicrm.org/civicrm/pl/pw8zstdnzbrsfbqq1sxxc5sw6r).

Before
----------------------------------------
Text is illegible in Minetta.

<img width="320" height="144" alt="image" src="https://github.com/user-attachments/assets/b7c70016-2460-4cd3-9adc-098153f203cb" />

After
----------------------------------------
Text is visible.

<img width="345" height="164" alt="image" src="https://github.com/user-attachments/assets/3ae00141-db45-4752-962a-40f59195cf56" />

Technical Details
----------------------------------------
The problematic CSS that's removed here was imported into RiverLea directly from Boostrap3.css - it's unnecessary. Some of the other style definitions weren't needed any more either, so have been removed while I was there.