### PR TITLE
Correct column comment text for option value references (NFC)

### DIFF
--- a/schema/Activity/Activity.entityType.php
+++ b/schema/Activity/Activity.entityType.php
@@ -87,7 +87,7 @@ return [
       'sql_type' => 'int unsigned',
       'input_type' => 'Select',
       'required' => TRUE,
-      'description' => ts('FK to civicrm_option_value.id, that has to be valid, registered activity type.'),
+      'description' => ts('FK to civicrm_option_value.value, that has to be valid, registered activity type.'),
       'add' => '1.1',
       'default' => 1,
       'usage' => [

--- a/schema/Contact/Contact.entityType.php
+++ b/schema/Contact/Contact.entityType.php
@@ -616,7 +616,7 @@ return [
       'title' => ts('Email Greeting ID'),
       'sql_type' => 'int unsigned',
       'input_type' => 'Select',
-      'description' => ts('FK to civicrm_option_value.id, that has to be valid registered Email Greeting.'),
+      'description' => ts('FK to civicrm_option_value.value, that has to be valid registered Email Greeting.'),
       'add' => '3.0',
       'usage' => [
         'export',
@@ -651,7 +651,7 @@ return [
       'title' => ts('Postal Greeting ID'),
       'sql_type' => 'int unsigned',
       'input_type' => 'Select',
-      'description' => ts('FK to civicrm_option_value.id, that has to be valid registered Postal Greeting.'),
+      'description' => ts('FK to civicrm_option_value.value, that has to be valid registered Postal Greeting.'),
       'add' => '3.0',
       'usage' => [
         'export',
@@ -686,7 +686,7 @@ return [
       'title' => ts('Addressee ID'),
       'sql_type' => 'int unsigned',
       'input_type' => 'Select',
-      'description' => ts('FK to civicrm_option_value.id, that has to be valid registered Addressee.'),
+      'description' => ts('FK to civicrm_option_value.value, that has to be valid registered Addressee.'),
       'add' => '3.0',
       'usage' => [
         'export',


### PR DESCRIPTION
It's civicrm_option_value.value which is the (soft) foreign key, not the id field. This PR simply updates the comments to be correct.

Hopefully not controversial, just a tidy up really.

Happy 2026 all.

**Why bother?** Because I know when I was new I got confused by this; and just now, combing though I had to double check that what I thought was right was actually more correct than what the code said was the case. So I figured it was worth it.