### PR TITLE
SearchKit - Add support for optional tokens

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -1139,15 +1139,27 @@ class CRM_Utils_String {
    * @return array
    */
   public static function getSquareTokens(string $raw): array {
+    // '?' indicates the token is optional; we might support other qualifiers in the future.
+    $allowedQualifiers = [
+      '?',
+    ];
     $matches = $tokens = [];
     if (str_contains($raw, '[')) {
       preg_match_all('/\\[([^]]+)\\]/', $raw, $matches);
-      foreach (array_unique($matches[1]) as $match) {
-        [$field, $suffix] = array_pad(explode(':', $match), 2, NULL);
-        $tokens[$match] = [
-          'token' => "[$match]",
+      foreach (array_unique($matches[1]) as $tokenStr) {
+        $tokenContent = $tokenStr;
+        $qualifier = '';
+        if (in_array($tokenStr[0], $allowedQualifiers)) {
+          $qualifier = $tokenStr[0];
+          $tokenContent = substr($tokenStr, 1);
+        }
+        [$field, $suffix] = array_pad(explode(':', $tokenContent), 2, NULL);
+        $tokens[$tokenStr] = [
+          'token' => "[$tokenStr]",
+          'content' => $tokenContent,
           'field' => $field,
           'suffix' => $suffix,
+          'qualifier' => $qualifier,
         ];
       }
     }

--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -139,12 +139,16 @@ class GetLinks extends BasicGetAction {
       // Swap path tokens with values
       if ($this->getValues() && !empty($link['path'])) {
         $tokens = \CRM_Utils_String::getSquareTokens($link['path']);
-        foreach ($tokens as $fieldExpr => $token) {
-          $value = $this->getValue($fieldExpr);
+        foreach ($tokens as $token) {
+          $value = $this->getValue($token['content']);
+          // A '?' in the token makes it optional
+          if (!isset($value) && $token['qualifier'] === '?') {
+            $value = '';
+          }
           if (isset($value)) {
             $link['path'] = str_replace($token['token'], $value, $link['path']);
           }
-          // If $values was supplied, treat all tokens as mandatory and remove links with null values
+          // If $values was supplied, remove links with missing required tokens
           // This hides invalid links from SearchKit e.g. `civicrm/group/edit?id=null`
           // Note: skip if expandMultiple is true to give hooks the chance to fill in missing tokens
           elseif (!$this->expandMultiple) {

--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -397,13 +397,13 @@ trait SavedSearchInspectorTrait {
   }
 
   /**
-   * Search a string for all square bracket tokens and return their contents (without the brackets)
+   * Search a string for all square bracket tokens and return their contents (without the brackets or qualifiers)
    *
    * @param string $str
    * @return array
    */
   protected function getTokens(string $str): array {
-    return array_keys(\CRM_Utils_String::getSquareTokens($str));
+    return array_column(\CRM_Utils_String::getSquareTokens($str), 'content');
   }
 
   /**

--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -15,7 +15,7 @@ return [
     'icon' => 'fa-money',
   ],
   'getPaths' => fn() => [
-    'add' => 'civicrm/grant/add?reset=1&action=add&cid=[contact_id]',
+    'add' => 'civicrm/grant/add?reset=1&action=add&cid=[?contact_id]',
     'view' => 'civicrm/grant/view?reset=1&action=view&id=[id]',
     'update' => 'civicrm/grant/add?reset=1&action=update&id=[id]',
     'delete' => 'civicrm/grant/add?reset=1&action=delete&id=[id]',

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -605,4 +605,80 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
     $this->fail('Exception expected');
   }
 
+  /**
+   * @dataProvider tokenProvider
+   */
+  public function testGetSquareTokens(string $input, array $expected): void {
+    $result = CRM_Utils_String::getSquareTokens($input);
+    $this->assertEquals($expected, $result);
+  }
+
+  public function tokenProvider(): array {
+    return [
+      'empty string' => [
+        '',
+        [],
+      ],
+      'invalid token' => [
+        'hello [world',
+        [],
+      ],
+      'optional token' => [
+        'Hello [?name]',
+        [
+          '?name' => [
+            'token' => '[?name]',
+            'field' => 'name',
+            'content' => 'name',
+            'suffix' => NULL,
+            'qualifier' => '?',
+          ],
+        ],
+      ],
+      'token with suffix' => [
+        'Hello [name:suffix]',
+        [
+          'name:suffix' => [
+            'token' => '[name:suffix]',
+            'content' => 'name:suffix',
+            'field' => 'name',
+            'suffix' => 'suffix',
+            'qualifier' => '',
+          ],
+        ],
+      ],
+      'duplicate tokens' => [
+        'Hello [name] and [name]',
+        [
+          'name' => [
+            'token' => '[name]',
+            'content' => 'name',
+            'field' => 'name',
+            'suffix' => NULL,
+            'qualifier' => '',
+          ],
+        ],
+      ],
+      'mixed tokens' => [
+        "[?first_name:prefix]\n[last_name]",
+        [
+          '?first_name:prefix' => [
+            'token' => '[?first_name:prefix]',
+            'content' => 'first_name:prefix',
+            'field' => 'first_name',
+            'suffix' => 'prefix',
+            'qualifier' => '?',
+          ],
+          'last_name' => [
+            'token' => '[last_name]',
+            'content' => 'last_name',
+            'field' => 'last_name',
+            'suffix' => NULL,
+            'qualifier' => '',
+          ],
+        ],
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the CiviGrant dashboard create link by making the contact id in the url optional.


Technical Details
----------------------------------------
Tokens like `[?field_name]` are now treated as optional in URLs


