### PR TITLE
Fix typo

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -120,7 +120,7 @@ class Submit extends AbstractProcessor {
     // todo - add only if needed?
     $this->setResponseItem('token', $this->generatePostSubmitToken());
 
-    if (isset($this->_response['redirect']) || isset($this->_reponse['message'])) {
+    if (isset($this->_response['redirect']) || isset($this->_response['message'])) {
       // redirect / message is already set, ignore defaults
     }
     elseif ($this->_afform['confirmation_type'] === 'show_confirmation_message') {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a typo that causes custom afform submission messages to be overwritten

Before
----------------------------------------
The afform's configured confirmation message is always returned

After
----------------------------------------
The afform's configured confirmation message is only returned if a custom message has not been set

Technical Details
----------------------------------------
Corrects 'reponse' to be 'response'