### PR TITLE
dev/core#6261 Activity - Correctly display disabled activity types in edit form

### DIFF
--- a/CRM/Activity/BAO/ActivityType.php
+++ b/CRM/Activity/BAO/ActivityType.php
@@ -61,21 +61,9 @@ class CRM_Activity_BAO_ActivityType {
    */
   public function setActivityType($activity_type_id) {
     if ($activity_type_id && is_numeric($activity_type_id)) {
-
-      /*
-       * These are pulled from CRM_Activity_Form_Activity.
-       * To avoid unexpectedly changing things like introducing hidden
-       * business logic or changing permission checks I've kept it using
-       * the same function call. It may or may not be desired to have
-       * that but this at least doesn't introduce anything that wasn't
-       * there before.
-       */
-      $machineNames = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $activity_type_id, 'name');
-      $displayLabels = CRM_Core_OptionGroup::values('activity_type', FALSE, FALSE, FALSE, 'AND v.value = ' . $activity_type_id, 'label');
-
       $this->_activityType = [
-        'machineName' => $machineNames[$activity_type_id] ?? NULL,
-        'displayLabel' => $displayLabels[$activity_type_id] ?? NULL,
+        'machineName' => CRM_Core_Pseudoconstant::getName('CRM_Activity_BAO_Activity', 'activity_type_id', $activity_type_id),
+        'displayLabel' => CRM_Core_Pseudoconstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $activity_type_id),
         'id' => $activity_type_id,
       ];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Disabled activity types will now show correctly on activity edit form.

Fixes [dev/core#6261](https://lab.civicrm.org/dev/core/-/issues/6261).

Technical Details
------------
There was some in-progress refactoring on that form. I was able to push it forward with a bit of additional cleanup to remove some redundant handling & switch to better pseudoconstant lookup functions.