### PR TITLE
Deprecate calling `getLineItemArray()` for existing contribution

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -452,6 +452,7 @@ WHERE li.contribution_id = %1";
       }
     }
     else {
+      CRM_Core_Error::deprecatedWarning('use the api to load line items for existing entities');
       $setID = NULL;
       $totalEntityId = count($entityId);
       if ($entityTable == 'contribution') {


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate calling LoadLineItems for existing contribution

Before
----------------------------------------
No core callers still call `getLineItemArray()`  for an existing contribution

After
----------------------------------------
Noisy deprecation added

Technical Details
----------------------------------------


Comments
----------------------------------------

