### PR TITLE
SearchKit - Fix console error from empty cssRules

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -144,8 +144,8 @@
           headerClasses.push(column.alignment);
         }
         // Include unconditional css rules
-        if (column.cssRules) {
-          column.cssRules.forEach(function (cssRule) {
+        if (Array.isArray(column.cssRules)) {
+          column.cssRules.forEach(cssRule => {
             if (cssRule.length === 1) {
               headerClasses.push(cssRule[0]);
             }


### PR DESCRIPTION
Overview
----------------------------------------
Fix js errors on some packaged search displays, e.g. the AdminUI mailing screen.

Before
----------------------------------------
<img width="3456" height="1218" alt="image" src="https://github.com/user-attachments/assets/84f1d73d-1871-4104-be8f-498986cb1361" />


After
----------------------------------------
<img width="3456" height="1212" alt="image" src="https://github.com/user-attachments/assets/8a2612b0-75c8-424f-9d73-9da7bdfb51ff" />

