### PR TITLE
(dev/core#6251) Settings UI - Skip non-applicable validators. Fix color-overrides.

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -141,12 +141,12 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
     $errors = [];
 
     foreach ($settings as $settingName => $settingMeta) {
-      if (!empty($settingMeta['validate_callback'])) {
+      if (!empty($settingMeta['validate_callback']) && isset($fields[$settingName])) {
         $errorText = NULL;
         $callback = Civi\Core\Resolver::singleton()->get($settingMeta['validate_callback']);
         // These validate_callbacks are inconsistent. Some return FALSE, others throw an Exception.
         try {
-          $value = self::formatSettingValue($settingMeta, $fields[$settingName] ?? NULL);
+          $value = self::formatSettingValue($settingMeta, $fields[$settingName]);
           $valid = call_user_func_array($callback, [$value, $settingMeta]);
         }
         catch (CRM_Core_Exception $e) {


### PR DESCRIPTION
Overview
----------------------------------------

When saving a "Settings" page that includes a mandatory setting, there's no new data to save/validate. And that's OK.

(See https://lab.civicrm.org/dev/core/-/issues/6251)

Steps to Reproduce
--------------------------------------

* Add `$civicrm_setting['domain']['menubar_color'] = '#E22222';` to your `civicrm.settings.php`.
* Go to the "Display Preferences" screen.
* Press Save.

Before
----------------------------------------

There is no value of `menubar_color` that needs to be saved, but it tries to validate anyway. This leads to an error.

After
----------------------------------------

There is no value of `menubar_color` that needs to be saved, and it doesn't try to validate.

Comments
----------------------------------------

(1) In the Gitlab issue, @MegaphoneJon had mentioned:

> I temporarily worked around this by changing `disabled` to `readonly` in [this line in SettingsTrait](https://github.com/civicrm/civicrm-core/blame/master/CRM/Admin/Form/SettingTrait.php#L207) but I doubt this is the desired solution:
>
> * It causes the aesthetic issue to reappear.
> * There are some other places in that PR (like on the SMTP Settings page) where the `readonly` to `disabled` switch is also made.

In this variant, the styling should be unchanged. (There is no change in how the widgets are presented - only in how the validation is processed.)

(2) Theoretically, this issue could affect other settings, and they would also be resolved. Experimentally, I couldn't find others with the original symptom. I believe it's a matter of circumstance involving the mix of data-types and validation-rules. In any event, the basic logic seems sensible to me. ("If you don't have data to validate, then you don't need to call the validator.")

There is a *similar* issue affecting overrides for `mailing_backend`. However, `mailing_backend` is really unusual - it has a different implementation and other complications. That needs different fixes.