### PR TITLE
(dev/core#6251) Outbound Email - Fix multiple bugs when handling mandatory settings

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -163,14 +163,19 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Generic {
    */
   public function setDefaultValues() {
     parent::setDefaultValues();
+    $this->_defaults += $this->convertMailingBackendToFormValues(Civi::settings()->get('mailing_backend'));
+    return $this->_defaults;
+  }
 
-    $mailingBackend = Civi::settings()->get('mailing_backend');
+  protected function convertMailingBackendToFormValues(?array $mailingBackend): array {
+    $result = [];
+
     if (!empty($mailingBackend)) {
-      $this->_defaults += $mailingBackend;
+      $result += $mailingBackend;
 
       if (!empty($mailingBackend['smtpPassword'])) {
         try {
-          $this->_defaults['smtpPassword'] = \Civi::service('crypto.token')->decrypt($this->_defaults['smtpPassword']);
+          $result['smtpPassword'] = \Civi::service('crypto.token')->decrypt($result['smtpPassword']);
         }
         catch (Exception $e) {
           Civi::log()->error($e->getMessage());
@@ -180,18 +185,18 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Generic {
     }
     else {
       if (!isset($mailingBackend['smtpServer'])) {
-        $this->_defaults['smtpServer'] = 'localhost';
-        $this->_defaults['smtpPort'] = 25;
-        $this->_defaults['smtpAuth'] = 0;
+        $result['smtpServer'] = 'localhost';
+        $result['smtpPort'] = 25;
+        $result['smtpAuth'] = 0;
       }
 
       if (!isset($mailingBackend['sendmail_path'])) {
-        $this->_defaults['sendmail_path'] = '/usr/sbin/sendmail';
-        $this->_defaults['sendmail_args'] = '-i';
+        $result['sendmail_path'] = '/usr/sbin/sendmail';
+        $result['sendmail_args'] = '-i';
       }
     }
 
-    return $this->_defaults;
+    return $result;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Use-case:

* The `civicrm.settings.php` has an override for `mailing_backend`.
* You open the "Outbound Email" admin form. (This has several inputs, which correspond to subfields in `mailing_backend`.)
* You save the form.

This fixes multiple issues with that form, including https://lab.civicrm.org/dev/core/-/issues/6251. 

Before
-------

1. When submitting, it generates spurious PHP errors about validators. (dev/core#6251)
2. *All* subfields are locked, but some *appear* unlocked.
    * Example: I set `mailing_backend` to use SMTP on `localhost:1025`. 
        * The "SMTP Server" and "SMTP Port" appear locked.
        * The "SMTP Username" and "SMTP Password" appear unlocked. (However, entering data doesn't actually work - because the override applies to the whole of `mailing_backend`.)
3. If you submit the form and hit an unrelated error, then the form re-renders... _incorrectly_. (All the mandatory fields are missing.)

After
----------------------------------------

1. When submitting, it does *not* generate spurious PHP errors about validators. (dev/core#6251)
2. *All* locked subfields appear locked.
3. If you submit the form and hit an unrelated error, then the form re-renders... _correctly_.

