### PR TITLE
(dev/core#6251, alternate) CRM_Core_Form - Define `getMandatoryValues()` with particular UX

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -91,7 +91,7 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
     // Sort sections by weight
     uasort($sections, ['CRM_Utils_Sort', 'cmpFunc']);
 
-    $this->assign('readOnlyFields', $this->readOnlyFields);
+    $this->assign('readOnlyFields', array_keys($this->getMandatoryValues()));
     $this->assign('settingPageName', $filter);
     $this->assign('settingSections', $sections);
 

--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -51,15 +51,6 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Generic {
    */
   public function buildQuickForm() {
     $props = [];
-    $mandatory = Civi::settings()->getMandatory('mailing_backend');
-
-    //Load input as readonly whose values are overridden in civicrm.settings.php.
-    if ($mandatory !== NULL) {
-      foreach ($this->subfields as $subfield) {
-        $props[$subfield]['disabled'] = TRUE;
-        $this->readOnlyFields[] = $subfield;
-      }
-    }
 
     $outBoundOption = [
       CRM_Mailing_Config::OUTBOUND_OPTION_MAIL => ts('mail()'),
@@ -81,7 +72,7 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Generic {
 
     $this->_testButtonName = $this->getButtonName('refresh', 'test');
 
-    if ($mandatory === NULL) {
+    if (Civi::settings()->getMandatory('mailing_backend') === NULL) {
       $this->addFormRule(['CRM_Admin_Form_Setting_Smtp', 'subfieldFormRules']);
     }
     parent::buildQuickForm();
@@ -185,6 +176,19 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Generic {
     parent::setDefaultValues();
     $this->_defaults += $this->convertMailingBackendToFormValues(Civi::settings()->get('mailing_backend'));
     return $this->_defaults;
+  }
+
+  public function getMandatoryValues(): array {
+    $result = parent::getMandatoryValues();
+    $backend = Civi::settings()->getMandatory('mailing_backend');
+    if ($backend !== NULL) {
+      $result = array_merge(
+        $result,
+        array_fill_keys($this->subfields, NULL),
+        $this->convertMailingBackendToFormValues($backend)
+      );
+    }
+    return $result;
   }
 
   protected function convertMailingBackendToFormValues(?array $mailingBackend): array {

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -49,15 +49,14 @@ trait CRM_Admin_Form_SettingTrait {
    *
    * @var array
    */
-  protected $readOnlyFields = [];
+  private $mandatoryValues = [];
 
   /**
-   * Have read only fields been defined on the form.
-   *
-   * @return bool
+   * @return array
+   * @see CRM_Core_Form::getMandatoryValues()
    */
-  protected function hasReadOnlyFields(): bool {
-    return !empty($this->readOnlyFields);
+  public function getMandatoryValues(): array {
+    return $this->mandatoryValues;
   }
 
   /**
@@ -180,8 +179,8 @@ trait CRM_Admin_Form_SettingTrait {
     $this->assign('settings_fields', $settingMetaData);
     $this->assign('fields', $this->getSettingsOrderedByWeight());
 
-    if ($this->hasReadOnlyFields()) {
-      $this->freeze($this->readOnlyFields);
+    $mandatory = $this->getMandatoryValues();
+    if ($mandatory) {
       CRM_Core_Session::setStatus(ts("Some fields are loaded as 'readonly' as they have been set (overridden) in civicrm.settings.php."), '', 'info', ['expires' => 0]);
     }
   }
@@ -203,9 +202,9 @@ trait CRM_Admin_Form_SettingTrait {
       }
 
       // Disable input when values are overridden in civicrm.settings.php.
-      if (Civi::settings()->getMandatory($settingName) !== NULL) {
-        $props['html_attributes']['disabled'] = TRUE;
-        $this->readOnlyFields[] = $settingName;
+      $mandatory = Civi::settings()->getMandatory($settingName);
+      if ($mandatory !== NULL) {
+        $this->mandatoryValues[$settingName] = $mandatory;
       }
 
       $add = 'add' . $quickFormType;

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -702,6 +702,25 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     return [];
   }
 
+  public function getMandatoryValues(): array {
+    return [];
+  }
+
+  private function applyMandatoryValues(array $mandatoryValues): void {
+    foreach ($mandatoryValues as $name => $value) {
+      $mandatoryElement = $this->getElement($name);
+      $mandatoryElement->setAttribute('disabled', TRUE);
+      if ($mandatoryElement instanceof HTML_QuickForm_group) {
+        foreach ($mandatoryElement->getElements() as $subElement) {
+          $subElement->setAttribute('disabled', TRUE);
+        }
+      }
+    }
+    if ($this->_submitValues && !empty($mandatoryValues)) {
+      $this->_submitValues = array_merge($this->_submitValues, $mandatoryValues);
+    }
+  }
+
   /**
    * This is a virtual function that adds group and global rules to the form.
    *
@@ -770,7 +789,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
     $this->buildQuickForm();
 
-    $defaults = $this->setDefaultValues();
+    $mandatory = $this->getMandatoryValues();
+    $this->applyMandatoryValues($mandatory);
+
+    $defaults = array_merge($this->setDefaultValues() ?: [], $mandatory);
     if (isset($defaults['qfKey'])) {
       unset($defaults['qfKey']);
     }


### PR DESCRIPTION
Overview
----------------------------------------

Recent updates to settings UI provided revised conventions for mandatory settings -- i.e. presenting locked fields as regular HTML widgets (but `disabled`). It's based on helpers in  `CRM_Admin_Form_SettingTrait` (et al). However, there are quirks revealed in https://lab.civicrm.org/dev/core/-/issues/6251. This update addresses those quirks, and it promotes the UI idiom so that it's available in `CRM_Core_Form`.

(This is an alternative to #34442 and #34443 -- it does the job of both. However, it is longer and more centrally-placed.)

Before
----------------------------------------

* Bugs
    * Validation bug in "Display Preferences" when overriding `menubar_color`.
    * Validation bug in "Outbound Email" when overriding `mailing_backend`.
    * Rendering bug in "Outbound Email" when overriding `mailing_backend`. (Some fields wrongly displayed as editable.)
    * Re-rendering  bug in "Outbound Email" when overriding `mailing_backend`. (Mandatory subfields disappear on POST-back.)
* Form API
    * Your form-class may include `CRM_Admin_Form_SettingTrait`. Then, you can use other functions (like `buildQuickForm()`) to imperatively modify `$this->readOnlyFields`. 
    * This only works with `Settings` forms.
    * Any fields added this way will be appear with `disabled` widgets. 
    * However, the values of the fields are sometimes missing during POST-back.

After
----------------------------------------

* Bugs
    * Hopefully, fewer. At least, those 4 seem OK.
* Form API
    * Your form-class may implement `getMandatoryValues(): array`. This works a lot like `setDefaultValues(): array` (except the name is less exotic).
    * This works for any Quickform.
    * Any fields added this way will be appear with `disabled` widgets.  (*Same*)
    * Values are available during the initial GET and subsequent POST-backs.

Comments
-----------------------------------------

Quickform already has a mechanism called `freeze()`. Thoughts on comparison:

* The `HTML_Quickform_element::freeze()` UI tends to display all frozen fields as plain-text.  (Presumably, this is why it wasn't used for prior work.)
* The `HTML_Quickform_element::freeze()` API is more OOP -- theoretically, it's more composable.
* In practice, I don't think Civi devs are super-attuned to the OOP DX of `HTML_Quickform_element`. (Maybe I'm projecting...) It's not that OOP is bad or hard in itself. But when dealing with multi-phase page-lifecycle, it can be hard to know which parts of the OOP DX are valid in each phase.
* By contrast, `setDefaultValues(): array` is probably more familiar to Civi devs - and it is simpler (in the sense of being more declarative - less exposure to details of the class-model and page-lifecycle).
* If folks want to spend more time, then I'm sure you could come up with a DX that's even better. This is just where the branch landed after investigating/refactoring/fiddling for a while.

Aside: I wrote/tested against 6.10 (since 6251 was a regression), but this branch is a bit bigger, so I only posted to `master`.