### PR TITLE
Adding translation of addition FormBuilder settings

### DIFF
--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -52,7 +52,7 @@ class StringVisitor {
     }
 
     $formFields = ['title', 'confirmation_message', 'redirect'];
-    foreach($formFields as $field) {
+    foreach ($formFields as $field) {
       if (!empty($form[$field])) {
         $form[$field] = $callback($form[$field]);
       }
@@ -66,8 +66,6 @@ class StringVisitor {
    *
    * Whenever we find a string, apply a filter.
    *
-   * @param array $form
-   *   Metadata describing the form. Ex: ['title' => 'Hello world']
    * @param \phpQueryObject|null $doc
    *   Parsed layout for the form.
    * @param callable $callback

--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -49,10 +49,13 @@ class StringVisitor {
    * @throws \CRM_Core_Exception
    */
   public function visit(array &$form, $doc, $callback) {
-    $formFields = ['title', 'confirmation_message', 'redirect'];
-    foreach($formFields as $field) {
-      if (!empty($form[$field])) {
-        $form[$field] = $callback($form[$field]);
+    // Extract FormBuilder fields
+    if (!empty($form)) {
+      $formFields = ['title', 'confirmation_message', 'redirect'];
+      foreach($formFields as $field) {
+        if (!empty($form[$field])) {
+          $form[$field] = $callback($form[$field]);
+        }
       }
     }
 

--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -24,11 +24,39 @@ class StringVisitor {
     $doc = \phpQuery::newDocument($html, 'text/html');
     $strings = [];
 
-    (new StringVisitor())->visit($form, $doc, function ($s) use (&$strings) {
+    (new StringVisitor())->visitMetadata($form, function ($s) use (&$strings) {
+      $strings[] = $s;
+      return $s;
+    });
+    (new StringVisitor())->visit($doc, function ($s) use (&$strings) {
       $strings[] = $s;
       return $s;
     });
     return array_unique($strings);
+  }
+
+  /**
+   * Search an affor for translatable strings. Specifically, in metadata
+   * such as ('title', 'redirect', 'confirmation_message')
+   *
+   * @param array $form
+   *   Metadata describing the form. Ex: ['title' => 'Hello world']
+   * @param callable $callback
+   *   Filter the value of a string. This should return the new value.
+   *   Function(string $value, string $context): string
+   * @return void
+   */
+  public function visitMetadata(array &$form, $callback) {
+    if ($form === NULL) {
+      return;
+    }
+
+    $formFields = ['title', 'confirmation_message', 'redirect'];
+    foreach($formFields as $field) {
+      if (!empty($form[$field])) {
+        $form[$field] = $callback($form[$field]);
+      }
+    }
   }
 
   /**
@@ -48,17 +76,7 @@ class StringVisitor {
    * @return void
    * @throws \CRM_Core_Exception
    */
-  public function visit(array &$form, $doc, $callback) {
-    // Extract FormBuilder fields
-    if (!empty($form)) {
-      $formFields = ['title', 'confirmation_message', 'redirect'];
-      foreach($formFields as $field) {
-        if (!empty($form[$field])) {
-          $form[$field] = $callback($form[$field]);
-        }
-      }
-    }
-
+  public function visit($doc, $callback) {
     if ($doc === NULL) {
       return;
     }

--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -49,8 +49,11 @@ class StringVisitor {
    * @throws \CRM_Core_Exception
    */
   public function visit(array &$form, $doc, $callback) {
-    if (!empty($form['title'])) {
-      $form['title'] = $callback($form['title']);
+    $formFields = ['title', 'confirmation_message', 'redirect'];
+    foreach($formFields as $field) {
+      if (!empty($form[$field])) {
+        $form[$field] = $callback($form[$field]);
+      }
     }
 
     if ($doc === NULL) {

--- a/ext/afform/core/Civi/Afform/Translator.php
+++ b/ext/afform/core/Civi/Afform/Translator.php
@@ -36,8 +36,7 @@ class Translator extends AutoService implements EventSubscriberInterface {
     $changeSet = ChangeSet::create('translate')
       ->alterHtml(
         ';\.aff\.html$;', function (\phpQueryObject $doc) {
-          $form = [];
-          (new StringVisitor())->visit($form, $doc, fn($s) => _ts($s));
+          (new StringVisitor())->visit($doc, fn($s) => _ts($s));
         }
       );
     $angular->add($changeSet);

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -229,7 +229,12 @@ function afform_civicrm_buildAsset($asset, $params, &$mimeType, &$content) {
     'select' => ['redirect', 'name', 'title', 'autosave_draft', 'confirmation_type', 'confirmation_message'],
     'where' => [['name', '=', $params['name']]],
   ], 0);
-  $formMetaData['title'] = _ts($formMetaData['title']);
+  $translateFields = ['title', 'redirect', 'confirmation_message'];
+  foreach($translateFields as $translateField) {
+    if (!empty($formMetaData[$translateField])) {
+      $formMetaData[$translateField] = _ts($formMetaData[$translateField]);
+    }
+  }
   $smarty = CRM_Core_Smarty::singleton();
   $smarty->assign('afform', [
     'camel' => $moduleName,

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -2,6 +2,7 @@
 
 require_once 'afform.civix.php';
 
+use Civi\Afform\StringVisitor;
 use CRM_Afform_ExtensionUtil as E;
 
 /**
@@ -229,12 +230,10 @@ function afform_civicrm_buildAsset($asset, $params, &$mimeType, &$content) {
     'select' => ['redirect', 'name', 'title', 'autosave_draft', 'confirmation_type', 'confirmation_message'],
     'where' => [['name', '=', $params['name']]],
   ], 0);
-  $translateFields = ['title', 'redirect', 'confirmation_message'];
-  foreach($translateFields as $translateField) {
-    if (!empty($formMetaData[$translateField])) {
-      $formMetaData[$translateField] = _ts($formMetaData[$translateField]);
-    }
-  }
+
+  // Translate Metadata
+  (new StringVisitor())->visitMetadata($formMetaData, fn($s) => _ts($s));
+
   $smarty = CRM_Core_Smarty::singleton();
   $smarty->assign('afform', [
     'camel' => $moduleName,


### PR DESCRIPTION
Overview
----------------------------------------

This now adds the translation of additional FormBuilder settings

+ Redirect path
+ Confirmation message

Technical Details
----------------------------------------

+ StringVisitor was modified to write these details out, but cannot be used to translate them since an empty Form is being sent on the loading portion
+ Adds the translation on Form loading

Comments
----------------------------------------

@colemanw I feel like the definition of the Form fields should be placed somewhere common, because at this point it is maintaining two definitions that are the same. I kinda don't like that, because if we introduce new things we have to keep updating them both. I suppose this could also be extracted into it's own function because again it's doing the same thing each time (if we passed a callback).

Do you have any idea of where I should put that? Like should we create a new `visit()` function that essentially handles just the form fields with a callback?

```
$formFields = ['title', 'confirmation_message', 'redirect'];
```