### PR TITLE
Errors/Exceptions - Fix misleading message. Add important details.

### DIFF
--- a/CRM/Core/Error/Formatter.php
+++ b/CRM/Core/Error/Formatter.php
@@ -99,7 +99,12 @@ class CRM_Core_Error_Formatter {
       $msg .= $e->toHtml();
     }
     else {
-      $msg .= '<p><b>' . get_class($e) . ': "' . htmlentities($e->getMessage()) . '"</b></p>';
+      $msg .= sprintf('<p><b>%s</b>: "%s" in <b>%s</b> on line <b>%s</b></p>',
+        htmlentities(get_class($e)),
+        htmlentities($e->getMessage()),
+        htmlentities($e->getFile()),
+        $e->getLine()
+      );
       $msg .= $this->formatHtmlBacktrace($e->getTrace());
     }
     return $msg;
@@ -114,7 +119,12 @@ class CRM_Core_Error_Formatter {
    *   printable plain text
    */
   protected function formatTextException(Throwable $e): string {
-    $msg = get_class($e) . ": \"" . $e->getMessage() . "\"\n";
+    $msg = sprintf("%s: \"%s\" in %s on line %s\n",
+      get_class($e),
+      $e->getMessage(),
+      $e->getFile(),
+      $e->getLine()
+    );
 
     $ei = $e;
     while (is_callable([$ei, 'getCause'])) {


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #34207, #34202 from `6.10.alpha`. These revisions enabled Standalone to display better formatting for PHP errors. However, some key details are missing from the error report.

Before
----------------------------------------

Consider this error message:

<img width="1049" height="332" alt="image" src="https://github.com/user-attachments/assets/e62e682e-640d-4fb8-bade-d1749330bbaf" />


It gives you lots of context. Great, right?

If you skim it, you might think that the unknown function `zz()` was called by `CRM/Core/Controller.php` on line 452. That is very wrong. (`CRM/Core/Controller.php(452)` actually made a call to `CRM_Core_Form::construct()`.) 

After
----------------------------------------

Where did the bad call actually happen? Now, it shows the true point-of-origin (`CRM/Core/Form.php` on line 381).

<img width="1261" height="365" alt="image" src="https://github.com/user-attachments/assets/7d0245d2-1b03-45e5-b499-56be1e2f95f6" />


Technical Details
----------------------------------------

`Throwable`s (like `Error` and `Exception`) include a backtrace (`getTrace()`), but that does *not* include the point-of-origin. For the point-of-origin, you have to look at the other properties (`getFile()`, `getLine()`, etc).

This can also be viewed as an unreported/preexisting bug in the display of `Exception`s (*which is also fixed here*). Why haven't we noticed? It goes to "PEAR" vs "Plain PHP":

* __PEAR__: Most Civi exceptions are `CRM_Core_Exception` (`PEAR_Exception`). These classes have a bunch of extra helpers for formatting/inspection. Normally, Civi uses these helpers to format typical exceptions -- and they _don't_ suffer the bug.
* __Plain PHP__: But if your problem is *not* a `PEAR_Exception`, then Civi uses this other formatter -- which had the bug. You just don't see it as much... but now that Standalone uses it for PHP `Error`s, you're more likely to see it.