### PR TITLE
SearchKit - Enable comparing partial dates 

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -288,9 +288,10 @@ abstract class Api4Query {
   public function composeClause(array $clause, string $type, int $depth) {
     $field = NULL;
     // Pad array for unary operators
-    [$expr, $operator, $value, $isExpression] = array_pad($clause, 4, NULL);
-    // isExpression defaults to FALSE in WHERE & HAVING clauses, and defaults to TRUE in ON clauses
-    $isExpression ??= ($type === 'ON');
+    [$valueA, $operator, $valueB, $isBAnExpression] = array_pad($clause, 4, NULL);
+    // Typical Api4 convention is [field, op, value], so $valueA is always parsed as an expression.
+    // Is $valueB an expression? Defaults to FALSE in WHERE & HAVING clauses, TRUE in ON clauses.
+    $isBAnExpression ??= ($type === 'ON');
     if (!in_array($operator, CoreUtil::getOperators(), TRUE)) {
       throw new \CRM_Core_Exception('Illegal operator');
     }
@@ -298,27 +299,27 @@ abstract class Api4Query {
 
     // For HAVING, expr must be an item in the SELECT clause
     if ($type === 'HAVING') {
-      // Expr references a fieldName or alias
-      if (isset($this->selectAliases[$expr])) {
-        $fieldAlias = $expr;
+      // $valueA references a fieldName or alias
+      if (isset($this->selectAliases[$valueA])) {
+        $fieldAlias = $valueA;
         // Attempt to format if this is a real field
-        if (isset($this->apiFieldSpec[$expr]) && !$isExpression) {
-          $field = $this->getField($expr);
-          FormattingUtil::formatInputValue($value, $expr, $field, $this->entityValues, $operator);
+        if (isset($this->apiFieldSpec[$valueA]) && !$isBAnExpression) {
+          $field = $this->getField($valueA);
+          FormattingUtil::formatInputValue($valueB, $valueA, $field, $this->entityValues, $operator);
         }
       }
-      // Expr references a non-field expression like a function; convert to alias
-      elseif (in_array($expr, $this->selectAliases)) {
-        $fieldAlias = array_search($expr, $this->selectAliases);
+      // $valueA references a non-field expression like a function; convert to alias
+      elseif (in_array($valueA, $this->selectAliases)) {
+        $fieldAlias = array_search($valueA, $this->selectAliases);
       }
       // If either the having or select field contains a pseudoconstant suffix, match and perform substitution
-      elseif (!$isExpression) {
-        [$fieldName] = explode(':', $expr);
+      elseif (!$isBAnExpression) {
+        [$fieldName] = explode(':', $valueA);
         foreach ($this->selectAliases as $selectAlias => $selectExpr) {
           [$selectField] = explode(':', $selectAlias);
           if ($selectAlias === $selectExpr && $fieldName === $selectField && isset($this->apiFieldSpec[$fieldName])) {
             $field = $this->getField($fieldName);
-            FormattingUtil::formatInputValue($value, $expr, $field, $this->entityValues, $operator);
+            FormattingUtil::formatInputValue($valueB, $valueA, $field, $this->entityValues, $operator);
             $fieldAlias = $selectAlias;
             break;
           }
@@ -327,83 +328,86 @@ abstract class Api4Query {
       // Format a function in the HAVING clause
       if (isset($fieldAlias) && !isset($field)) {
         try {
-          $expr = $this->getExpression($this->selectAliases[$fieldAlias], ['SqlFunction']);
+          $exprA = $this->getExpression($this->selectAliases[$fieldAlias], ['SqlFunction']);
           $fauxField = [
             'name' => NULL,
-            'data_type' => $expr->getRenderedDataType($this),
+            'data_type' => $exprA->getRenderedDataType($this),
           ];
-          FormattingUtil::formatInputValue($value, NULL, $fauxField, $this->entityValues, $operator);
+          FormattingUtil::formatInputValue($valueB, NULL, $fauxField, $this->entityValues, $operator);
         }
         catch (\CRM_Core_Exception $e) {
           // Not a function
         }
       }
       if (!isset($fieldAlias)) {
-        if (in_array($expr, $this->getSelect())) {
-          throw new UnauthorizedException("Unauthorized field '$expr'");
+        if (in_array($valueA, $this->getSelect())) {
+          throw new UnauthorizedException("Unauthorized field '$valueA'");
         }
         else {
-          throw new \CRM_Core_Exception("Invalid expression in HAVING clause: '$expr'. Must use a value from SELECT clause.");
+          throw new \CRM_Core_Exception("Invalid expression in HAVING clause: '$valueA'. Must use a value from SELECT clause.");
         }
       }
       $fieldAlias = '`' . $fieldAlias . '`';
       // Comparing two fields in the HAVING clause
-      if ($isExpression) {
-        $targetField = isset($this->selectAliases[$value]) ? $value : array_search($value, $this->selectAliases);
+      if ($isBAnExpression) {
+        $targetField = isset($this->selectAliases[$valueB]) ? $valueB : array_search($valueB, $this->selectAliases);
         if (!$targetField) {
-          throw new \CRM_Core_Exception("Invalid expression in HAVING clause: '$value'. Must use a value from SELECT clause.");
+          throw new \CRM_Core_Exception("Invalid expression in HAVING clause: '$valueB'. Must use a value from SELECT clause.");
         }
         return sprintf('%s %s `%s`', $fieldAlias, $operator, $targetField);
       }
     }
 
-    // $isExpression is usually FALSE for WHERE clauses unless explicitly enabled by 4th param
-    elseif (!$isExpression) {
-      // 1st param is always treated as a sql expression
-      $expr = $this->getExpression($expr, ['SqlField', 'SqlFunction', 'SqlEquation']);
-      if ($expr->getType() === 'SqlField') {
-        $fieldName = count($expr->getFields()) === 1 ? $expr->getFields()[0] : NULL;
-        $field = $this->getField($fieldName, TRUE);
-        FormattingUtil::formatInputValue($value, $fieldName, $field, $this->entityValues, $operator);
+    // Handle WHERE & ON clauses
+    else {
+      // $isBAnExpression is usually FALSE for WHERE clauses unless explicitly enabled by 4th param
+      if (!$isBAnExpression) {
+        // 1st param is always treated as a sql expression
+        $exprA = $this->getExpression($valueA, ['SqlField', 'SqlFunction', 'SqlEquation']);
+        if ($exprA->getType() === 'SqlField') {
+          $fieldName = count($exprA->getFields()) === 1 ? $exprA->getFields()[0] : NULL;
+          $field = $this->getField($fieldName, TRUE);
+          FormattingUtil::formatInputValue($valueB, $fieldName, $field, $this->entityValues, $operator);
+        }
+        elseif ($exprA->getType() === 'SqlFunction') {
+          $fauxField = [
+            'name' => NULL,
+            'data_type' => $exprA::getDataType(),
+          ];
+          FormattingUtil::formatInputValue($valueB, NULL, $fauxField, $this->entityValues, $operator);
+        }
+        $fieldAlias = $exprA->render($this);
       }
-      elseif ($expr->getType() === 'SqlFunction') {
-        $fauxField = [
-          'name' => NULL,
-          'data_type' => $expr::getDataType(),
-        ];
-        FormattingUtil::formatInputValue($value, NULL, $fauxField, $this->entityValues, $operator);
+
+      // $isBAnExpression is usually TRUE for ON clauses unless explicitly disabled by 4th param
+      if ($isBAnExpression) {
+        $exprA = $this->getExpression($valueA);
+        $fieldName = count($exprA->getFields()) === 1 ? $exprA->getFields()[0] : NULL;
+        $fieldAlias = $exprA->render($this);
+        if (is_string($valueB)) {
+          $exprB = $this->getExpression($valueB);
+          // Format string input
+          if ($exprA->getType() === 'SqlField' && $exprB->getType() === 'SqlString') {
+            // Strip surrounding quotes
+            $renderedB = substr($exprB->getExpr(), 1, -1);
+            FormattingUtil::formatInputValue($renderedB, $fieldName, $this->apiFieldSpec[$fieldName], $this->entityValues, $operator);
+            return $this->createSQLClause($fieldAlias, $operator, $renderedB, $this->apiFieldSpec[$fieldName], $depth);
+          }
+          else {
+            $renderedB = $exprB->render($this);
+            return sprintf('%s %s %s', $fieldAlias, $operator, $renderedB);
+          }
+        }
+        elseif ($exprA->getType() === 'SqlField') {
+          $field = $this->getField($fieldName);
+          FormattingUtil::formatInputValue($valueB, $fieldName, $field, $this->entityValues, $operator);
+        }
       }
-      $fieldAlias = $expr->render($this);
     }
 
-    // $isExpression is usually TRUE for ON clauses unless explicitly disabled by 4th param
-    elseif ($isExpression) {
-      $expr = $this->getExpression($expr);
-      $fieldName = count($expr->getFields()) === 1 ? $expr->getFields()[0] : NULL;
-      $fieldAlias = $expr->render($this);
-      if (is_string($value)) {
-        $valExpr = $this->getExpression($value);
-        // Format string input
-        if ($expr->getType() === 'SqlField' && $valExpr->getType() === 'SqlString') {
-          // Strip surrounding quotes
-          $value = substr($valExpr->getExpr(), 1, -1);
-          FormattingUtil::formatInputValue($value, $fieldName, $this->apiFieldSpec[$fieldName], $this->entityValues, $operator);
-          return $this->createSQLClause($fieldAlias, $operator, $value, $this->apiFieldSpec[$fieldName], $depth);
-        }
-        else {
-          $value = $valExpr->render($this);
-          return sprintf('%s %s %s', $fieldAlias, $operator, $value);
-        }
-      }
-      elseif ($expr->getType() === 'SqlField') {
-        $field = $this->getField($fieldName);
-        FormattingUtil::formatInputValue($value, $fieldName, $field, $this->entityValues, $operator);
-      }
-    }
-
-    $sqlClause = $this->createSQLClause($fieldAlias, $operator, $value, $field, $depth);
+    $sqlClause = $this->createSQLClause($fieldAlias, $operator, $valueB, $field, $depth);
     if ($sqlClause === NULL) {
-      throw new \CRM_Core_Exception("Invalid value in $type clause for '$expr'");
+      throw new \CRM_Core_Exception("Invalid value in $type clause for '$valueA'");
     }
     return $sqlClause;
   }

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -46,6 +46,7 @@ abstract class SqlFunction extends SqlExpression {
   const CATEGORY_AGGREGATE = 'aggregate',
     CATEGORY_COMPARISON = 'comparison',
     CATEGORY_DATE = 'date',
+    CATEGORY_PARTIAL_DATE = 'partial_date',
     CATEGORY_MATH = 'math',
     CATEGORY_STRING = 'string';
 

--- a/Civi/Api4/Query/SqlFunctionDATE.php
+++ b/Civi/Api4/Query/SqlFunctionDATE.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionDATE extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static $dataType = 'Date';
 

--- a/Civi/Api4/Query/SqlFunctionDAYOFWEEK.php
+++ b/Civi/Api4/Query/SqlFunctionDAYOFWEEK.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionDAYOFWEEK extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static $dataType = 'Integer';
 

--- a/Civi/Api4/Query/SqlFunctionEXTRACT.php
+++ b/Civi/Api4/Query/SqlFunctionEXTRACT.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionEXTRACT extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static function params(): array {
     return [
@@ -28,7 +28,7 @@ class SqlFunctionEXTRACT extends SqlFunction {
       ],
       [
         'name' => 'FROM',
-        'must_be' => ['SqlField'],
+        'must_be' => ['SqlField', 'SqlString', 'SqlFunction'],
       ],
     ];
   }

--- a/Civi/Api4/Query/SqlFunctionMONTH.php
+++ b/Civi/Api4/Query/SqlFunctionMONTH.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionMONTH extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static $dataType = 'Integer';
 

--- a/Civi/Api4/Query/SqlFunctionQUARTER.php
+++ b/Civi/Api4/Query/SqlFunctionQUARTER.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionQUARTER extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static $dataType = 'Integer';
 

--- a/Civi/Api4/Query/SqlFunctionTIME.php
+++ b/Civi/Api4/Query/SqlFunctionTIME.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionTIME extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static $dataType = 'Time';
 

--- a/Civi/Api4/Query/SqlFunctionYEAR.php
+++ b/Civi/Api4/Query/SqlFunctionYEAR.php
@@ -16,7 +16,7 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionYEAR extends SqlFunction {
 
-  protected static $category = self::CATEGORY_DATE;
+  protected static $category = self::CATEGORY_PARTIAL_DATE;
 
   protected static $dataType = 'Integer';
 

--- a/ext/civigrant/managed/SavedSearch_CiviGrant_Dashboard_Graph.mgd.php
+++ b/ext/civigrant/managed/SavedSearch_CiviGrant_Dashboard_Graph.mgd.php
@@ -22,8 +22,9 @@ return [
           'orderBy' => ['money_transfer_date' => 'ASC'],
           'where' => [
             [
-              'money_transfer_date',
-              'IS NOT EMPTY',
+              'YEAR(money_transfer_date)',
+              '>=',
+              'now - 4 year',
             ],
           ],
           'groupBy' => [

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -17,7 +17,8 @@
       const allTypes = {
         aggregate: ts('Aggregate'),
         comparison: ts('Comparison'),
-        date: ts('Date'),
+        date: ts('Date Calculation'),
+        partial_date: ts('Partial Date'),
         math: ts('Math'),
         string: ts('Text')
       };
@@ -136,7 +137,7 @@
               allowedTypes.push('math');
             }
             if (_.includes(['Date', 'Timestamp'], ctrl.fieldArg.field.data_type)) {
-              allowedTypes.push('date');
+              allowedTypes.push('date', 'partial_date');
             }
           }
           _.each(allowedTypes, function(type) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInput.component.js
@@ -59,7 +59,8 @@
             formatted.forEach((v, i) => formatted[i] = formatDataType(v));
             return formatted;
           }
-          if (['Integer', 'Float'].includes(ctrl.field ? ctrl.field.data_type : null)) {
+          // Format numbers but skip partial date functions which get special handling
+          if (['Integer', 'Float'].includes(ctrl.field ? ctrl.field.data_type : null) && ctrl.field.category !== 'partial_date') {
             let newVal = Number(val);
             // FK Entities can use a mix of numeric & string values (see "static" options)
             // Also see afGuiFieldValue.convertDataType

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -185,7 +185,8 @@
       }
 
       function isDateField(field) {
-        return field.data_type === 'Date' || field.data_type === 'Timestamp';
+        // Partial date functions get special handling to be treated as dates
+        return field.category === 'partial_date' || field.data_type === 'Date' || field.data_type === 'Timestamp';
       }
 
     }


### PR DESCRIPTION
Overview
----------------------------------------
This makes it easy to make a search for e.g. all Grants from the past 3 calendar years.

Before
----------------------------------------
No way to find all records within a blocky timeframe (e.g. entire years). You could search a relative date but it wouldn't be blocky. E.g. you could find all grants that were 3 years older than *today*, but you couldn't find all grants from Jan 1, 3 years ago.

After
----------------------------------------
Now you can. Added it to the CiviGrant Dashboard.

Technical Details
----------------------------------------
The first commit makes the diff look big because of all the cleanup... but it was needed!
