### PR TITLE
CustomGroup - Fix styling of frozen element

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -219,7 +219,7 @@ class CRM_Custom_Form_Group extends CRM_Admin_Form {
     if (!$this->_isGroupEmpty) {
       $this->getElement('extends')->freeze();
       $this->getElement('extends_entity_column_id')->freeze();
-      $this->getElement('is_multiple')->freeze();
+      $this->getElement('is_multiple')->setAttribute('disabled', 'disabled');
       // Don't allow max to be lowered if data already exists
       $this->getElement('max_multiple')->setAttribute('min', $this->_values['max_multiple'] ?? '0');
     }


### PR DESCRIPTION
Overview
----------------------------------------
'Toggle' elements don't look good frozen, better to use 'disabled'

Before
----------------------------------------
<img width="1768" height="260" alt="image" src="https://github.com/user-attachments/assets/16c654e8-03cb-4908-9dc5-b19e7f67dfaf" />


After
----------------------------------------
<img width="1752" height="262" alt="image" src="https://github.com/user-attachments/assets/0a4f48a1-0e73-4893-8ef7-3dfd0a112be1" />

