### PR TITLE
Fix overwriting data when 2 event reg forms are open in separate tabs

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -538,7 +538,9 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm() {
-
+    if ($this->_id) {
+      $this->add('hidden', 'id', $this->_id);
+    }
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     $partiallyPaidStatusId = array_search('Partially paid', $participantStatuses);
     $this->assign('partiallyPaidStatusId', $partiallyPaidStatusId);
@@ -1610,7 +1612,7 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
    */
   public function getParticipantID(): ?int {
     if ($this->_id === NULL) {
-      $id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+      $id = CRM_Utils_Request::retrieve('id', 'Positive');
       $this->_id = $id ? (int) $id : FALSE;
     }
     return $this->_id ?: NULL;
@@ -1737,7 +1739,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
    */
   protected function assignUrlPath() {
     $this->assign('urlPath', 'civicrm/contact/view/participant');
-    $this->assign('urlPathVar', NULL);
+    $this->assign('urlPathVar', "id=$this->_id");
     if (!$this->_id && !$this->_contactId) {
       $breadCrumbs = [
         [

--- a/CRM/Event/Page/Tab.php
+++ b/CRM/Event/Page/Tab.php
@@ -101,7 +101,7 @@ class CRM_Event_Page_Tab extends CRM_Core_Page {
   public function preProcess() {
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $this->_action = CRM_Utils_Request::retrieve('action', 'String', $this, FALSE, 'browse');
-    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $this->_id = CRM_Utils_Request::retrieve('id', 'Positive');
 
     if (($context == 'standalone' || $context === 'search') && ($this->_action !== CRM_Core_Action::BROWSE && $this->_action !== CRM_Core_Action::VIEW && $this->_action !== CRM_Core_Action::UPDATE)) {
       $this->_action = CRM_Core_Action::ADD;


### PR DESCRIPTION
Overview
----------------------------------------
A new attempt at fixing what may be the oldest extant bug in CiviCRM.

Steps to replicate:
* Right-click **Edit** on a contact's participant record and open it in a new tab.
* Right-click **Add Event Registration** and open it in a new tab.
* Try to save the edited participant record.

Before
----------------------------------------
At best, you get `CRM_Core_Exception: getFieldValue failed`.  If you actually saved the new participant record before saving the first one, you'll find your first record's data overwritten with data from the second record.

After
----------------------------------------
Fixed???

Comments
----------------------------------------
This started as an attempt to fix the issues raised in #14732 that led #14244 to be reverted.  However, the code has been cleaned up extensively, so the original regressions appear to no longer exist.  I found one new one - the "Change Selections" was no longer appearing in the Event Fee block - but that was solved by adding the ID to the `urlPathVar`.

Let's see what the tests have to say!

@jmcclelland @agileware-justin @JKingsnorth @VangelisP you all have expressed interest in this getting fixed in Gitlab. Here's hoping this sticks!