### PR TITLE
Fix Participant Fee Calculation On Contribution Edit

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -122,8 +122,8 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
     $firstParticipantDetailsAfter = $this->callAPISuccessGetSingle('Participant', ['id' => $firstParticipant['id']]);
     $secondParticipantDetailsAfter = $this->callAPISuccessGetSingle('Participant', ['id' => $secondParticipant['id']]);
 
-    $this->assertEquals($firstParticipant['fee_amount'], $firstParticipantDetailsAfter['participant_fee_amount']);
-    $this->assertEquals($secondParticipant['fee_amount'], $secondParticipantDetailsAfter['participant_fee_amount']);
+    $this->assertEquals(CRM_Utils_Money::format($contribution['total_amount'] / count($orderParams['line_items']), NULL, NULL, TRUE), $firstParticipantDetailsAfter['participant_fee_amount']);
+    $this->assertEquals(CRM_Utils_Money::format($contribution['total_amount'] / count($orderParams['line_items']), NULL, NULL, TRUE), $secondParticipantDetailsAfter['participant_fee_amount']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Currently when there are multiple participants related to one contribution and user edits the contribution the aprticipant fees gets changed incorrectly. The issue is well explained here https://lab.civicrm.org/dev/core/-/issues/3859.

We have had previous [PRs](https://github.com/civicrm/civicrm-core/pull/32484) around same issue but issue still does not seem to be fixed. This PR fixes the issue by equally dividing the whole contribution amount between all the related participants.
