### PR TITLE
SearchKit - Add GetMarkup api action

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetMarkup.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetMarkup.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use CRM_Search_ExtensionUtil as E;
+
+/**
+ * Generate markup for embedding a SearchDisplay in a html document
+ *
+ * @method $this setFilters(array $filters)
+ * @method array getFilters()
+ * @package Civi\Api4\Action\SearchDisplay
+ * @since 6.12
+ */
+class GetMarkup extends \Civi\Api4\Generic\BasicBatchAction {
+
+  /**
+   * Filter values to be passed to the search display e.g. `['first_name' => 'Sue']`
+   * @var array
+   */
+  protected $filters = [];
+
+  /**
+   * @param array $display
+   * @return array{module: string, markup: string}
+   */
+  protected function doTask($display): array {
+    // E.g. "crmSearchDisplayTable"
+    $module = \CRM_Utils_String::convertStringToCamel($display['type:name'], FALSE);
+
+    // Note: Should be kept in-sync with \Civi\Search\AfformSearchMetadataInjector::preprocess
+    $markup = sprintf('<%s search="%s" display="%s" api-entity="%s" settings="%s" filters="%s"></%s>',
+      $display['type:name'],
+      htmlspecialchars(\CRM_Utils_JS::encode($display['saved_search_id.name']), ENT_COMPAT),
+      htmlspecialchars(\CRM_Utils_JS::encode($display['name']), ENT_COMPAT),
+      htmlspecialchars($display['saved_search_id.api_entity'], ENT_COMPAT),
+      htmlspecialchars(\CRM_Utils_JS::encode($display['settings']), ENT_COMPAT),
+      htmlspecialchars(\CRM_Utils_JS::encode($this->filters), ENT_COMPAT),
+      $display['type:name']
+    );
+
+    return [
+      'module' => $module,
+      'markup' => $markup,
+    ];
+  }
+
+  /**
+   * @return string[]
+   */
+  protected function getSelect() {
+    return ['name', 'type:name', 'settings', 'saved_search_id.name', 'saved_search_id.api_entity'];
+  }
+
+  /**
+   * Add a filter value to be passed to the search display.
+   *
+   * @param string $key
+   * @param mixed $value
+   * @return $this
+   */
+  public function addFilter(string $key, $value) {
+    $this->filters[$key] = $value;
+    return $this;
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -80,6 +80,15 @@ class SearchDisplay extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\SearchDisplay\GetMarkup
+   */
+  public static function getMarkup($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\GetMarkup(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
   public static function permissions() {
     $permissions = parent::permissions();
     $permissions['default'] = ['manage own search_kit'];

--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -56,6 +56,7 @@ class AfformSearchMetadataInjector {
               catch (\CRM_Core_Exception $e) {
                 return;
               }
+              // Note: Should be kept in-sync with \Civi\Api4\Action\SearchDisplay\GetMarkup::doTask
               pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
               pq($component)->attr('api-entity', htmlspecialchars($savedSearch['api_entity'], ENT_COMPAT));
               pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT));

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -10,6 +10,7 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, TransactionalInterface {
+  use \Civi\Test\Api4TestTrait;
 
   public function setUpHeadless() {
     return \Civi\Test::headless()
@@ -114,6 +115,43 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertEquals('My_test_display_', substr($display1['name'], 0, 16), "SearchDisplay 1");
     // This is for a different saved search so doesn't need a suffix appended
     $this->assertEquals('My_test_display', $display2['name'], "SearchDisplay 2");
+  }
+
+  public function testGetMarkup(): void {
+    $savedSearch = $this->createTestRecord('SavedSearch', [
+      'label' => 'testGetMarkup',
+      'name' => 'testGetMarkup',
+      'api_entity' => 'Individual',
+      'api_params' => [
+        'version' => 4,
+      ],
+    ]);
+    $searchDisplay = $this->createTestRecord('SearchDisplay', [
+      'label' => 'testGetMarkupDisplay',
+      'name' => 'testGetMarkupDisplay',
+      'saved_search_id' => $savedSearch['id'],
+      'type' => 'list',
+      'settings' => [
+        'columns' => [
+          [
+            'key' => 'id',
+            'rewrite' => '"[test] & <escape>"',
+          ],
+        ],
+      ],
+    ]);
+
+    $result = SearchDisplay::getMarkup(FALSE)
+      ->addWhere('id', '=', $searchDisplay['id'])
+      ->addFilter('first_name', 'Fil')
+      ->execute()->first();
+
+    $this->assertEquals('crmSearchDisplayList', $result['module']);
+
+    $expected = <<<MARKUP
+    <crm-search-display-list search="'testGetMarkup'" display="'testGetMarkupDisplay'" api-entity="Individual" settings="{columns: [{key: 'id', rewrite: '&quot;[test] &amp; &lt;escape&gt;&quot;'}]}" filters="{first_name: 'Fil'}"></crm-search-display-list>
+    MARKUP;
+    $this->assertSame($expected, $result['markup']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes you want to embed a search display into a page without the overhead of also putting it into an Afform. Example: https://github.com/systopia/de.systopia.eck/pull/199

This generates the markup for you to do so.