### PR TITLE
(dev/core#5409) Require PHP 8.1. Upgrade league/csv to 9.28.

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -35,12 +35,12 @@ class CRM_Upgrade_Incremental_General {
    *
    * A site running an earlier version will be told to upgrade.
    */
-  const MIN_RECOMMENDED_PHP_VER = '8.1.0';
+  const MIN_RECOMMENDED_PHP_VER = '8.2.0';
 
   /**
    * The minimum PHP version required to install Civi.
    */
-  const MIN_INSTALL_PHP_VER = '8.0.0';
+  const MIN_INSTALL_PHP_VER = '8.1.2';
 
   /**
    * The minimum recommended MySQL version.

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.0.0"
+      "php": "8.1.33"
     },
     "allow-plugins": {
       "civicrm/composer-compile-plugin": true,
@@ -91,7 +91,7 @@
     "adrienrn/php-mimetyper": "0.2.2",
     "civicrm/composer-downloads-plugin": "^3.0 || ^4.0",
     "laravel/serializable-closure": "^1.3",
-    "league/csv": "^9.8.0",
+    "league/csv": "^9.28",
     "league/oauth2-client": "^2.8",
     "league/oauth2-google": "^4.0",
     "tplaner/when": "~3.1",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "config": {
     "platform": {
-      "php": "8.1.33"
+      "php": "8.1.2"
     },
     "allow-plugins": {
       "civicrm/composer-compile-plugin": true,
@@ -47,7 +47,7 @@
     }
   },
   "require": {
-    "php": "~8.0",
+    "php": ">=8.1.2",
     "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-fileinfo": "*",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     }
   },
   "require": {
-    "php": ">=8.1.2",
+    "php": "^8.1.2",
     "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d97f27613b8672b181af2e3d73b21c39",
+    "content-hash": "b314c95e432f8a7d892e1f417262a42a",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -6004,7 +6004,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0",
+        "php": "^8.1.2",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-fileinfo": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f5091886efcda6a51c86dac19fbcf6d",
+    "content-hash": "8273a419ce480184a7b90af3d1345c64",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -1413,35 +1413,42 @@
         },
         {
             "name": "league/csv",
-            "version": "9.8.0",
+            "version": "9.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47"
+                "reference": "6582ace29ae09ba5b07049d40ea13eb19c8b5073"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
-                "reference": "9d2e0265c5d90f5dd601bc65ff717e05cec19b47",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/6582ace29ae09ba5b07049d40ea13eb19c8b5073",
+                "reference": "6582ace29ae09ba5b07049d40ea13eb19c8b5073",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": "^7.4 || ^8.0"
+                "ext-filter": "*",
+                "php": "^8.1.2"
             },
             "require-dev": {
-                "ext-curl": "*",
                 "ext-dom": "*",
-                "friendsofphp/php-cs-fixer": "^v3.4.0",
-                "phpstan/phpstan": "^1.3.0",
-                "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.1.0",
-                "phpunit/phpunit": "^9.5.11"
+                "ext-xdebug": "*",
+                "friendsofphp/php-cs-fixer": "^3.92.3",
+                "phpbench/phpbench": "^1.4.3",
+                "phpstan/phpstan": "^1.12.32",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.2",
+                "phpstan/phpstan-strict-rules": "^1.6.2",
+                "phpunit/phpunit": "^10.5.16 || ^11.5.22 || ^12.5.4",
+                "symfony/var-dumper": "^6.4.8 || ^7.4.0 || ^8.0"
             },
             "suggest": {
-                "ext-dom": "Required to use the XMLConverter and or the HTMLConverter classes",
-                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+                "ext-dom": "Required to use the XMLConverter and the HTMLConverter classes",
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters",
+                "ext-mbstring": "Needed to ease transcoding CSV using mb stream filters",
+                "ext-mysqli": "Requiered to use the package with the MySQLi extension",
+                "ext-pdo": "Required to use the package with the PDO extension",
+                "ext-pgsql": "Requiered to use the package with the PgSQL extension",
+                "ext-sqlite3": "Required to use the package with the SQLite3 extension"
             },
             "type": "library",
             "extra": {
@@ -1493,7 +1500,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-04T00:13:07+00:00"
+            "time": "2025-12-27T15:18:42+00:00"
         },
         {
             "name": "league/oauth2-client",
@@ -6011,7 +6018,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.0.0"
+        "php": "8.1.33"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8273a419ce480184a7b90af3d1345c64",
+    "content-hash": "d97f27613b8672b181af2e3d73b21c39",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -6018,7 +6018,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.33"
+        "php": "8.1.2"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update php to 8.1.33, league/csv to 9.28.0

Before
----------------------------------------
This is when we let a php version go  - this allows us to get off the old csv/league that had 8.4+ issue

After
----------------------------------------



Technical Details
----------------------------------------


Comments
----------------------------------------
