### PR TITLE
Force API4 Contribution::create to be called with contribution status = 'Pending'

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -178,11 +178,10 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     // We should really ALWAYS calculate tax amount off the line items.
     // In order to be a bit cautious we are just messaging rather than
     // overwriting in cases where we were not previously setting it here.
-    $taxAmount = $lineTotal = 0;
+    $taxAmount = 0;
     foreach ($params['line_item'] ?? [] as $lineItems) {
       foreach ($lineItems as $lineItem) {
         $taxAmount += (float) ($lineItem['tax_amount'] ?? 0);
-        $lineTotal += (float) ($lineItem['line_total'] ?? 0);
       }
     }
     if (($params['tax_amount'] ?? '') === 'null') {

--- a/ext/civi_contribute/Civi/Api4/Action/Contribution/ContributionSaveTrait.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Contribution/ContributionSaveTrait.php
@@ -24,6 +24,11 @@ trait ContributionSaveTrait {
     foreach ($items as &$item) {
       // Required by Contribution BAO
       $item['skipCleanMoney'] = TRUE;
+      if ($this->getActionName() === 'create' && isset($item['contribution_status_id'])
+        && $item['contribution_status_id'] !== \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'))
+      {
+        throw new \CRM_Core_Exception('It is not supported to call Contribution::create with a status other than Pending. Use the Payment::create API to create a payment and update the status');
+      }
     }
     return parent::write($items);
   }

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1109,7 +1109,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       'version' => 3,
     ], $params);
     if ($params['version'] === 4) {
-      $this->createTestEntity('Contribution', $params, $identifier);
+      return $this->createTestEntity('Contribution', $params, $identifier)['id'];
     }
     return $this->callAPISuccess('Contribution', 'create', $params)['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Related: https://lab.civicrm.org/extensions/afform_payments/-/issues/3


Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
