### PR TITLE
Move valid status transition check from API3 to Contribution BAO

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -510,6 +510,13 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
    * @throws \CRM_Core_Exception
    */
   public static function create(&$params) {
+    // Check for invalid status transitions
+    if (!empty($params['id']) && !empty($params['contribution_status_id'])) {
+      $values = ['contribution_status_id' => (int) CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $params['id'], 'contribution_status_id')];
+      if ($values['contribution_status_id'] !== (int) $params['contribution_status_id']) {
+        CRM_Contribute_BAO_Contribution::checkStatusValidation($values, $params);
+      }
+    }
 
     $transaction = new CRM_Core_Transaction();
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2734,8 +2734,17 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    */
   public static function checkStatusValidation(array $oldContributionValues, array $newContributionValues): void {
-    $newContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $newContributionValues['contribution_status_id']);
-    $oldContributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $oldContributionValues['contribution_status_id']);
+    $contributionStatuses = array_column(\Civi::entity('Contribution')->getOptions('contribution_status_id'), NULL, 'id');
+    $newContributionStatusName = $contributionStatuses[$newContributionValues['contribution_status_id']]['name'];
+    $oldContributionStatusName = $contributionStatuses[$oldContributionValues['contribution_status_id']]['name'];
+    if (empty($contributionStatuses[$newContributionValues['contribution_status_id']]['is_reserved'])) {
+      // Allow transitioning to a custom status from any normal/reserved status
+      return;
+    }
+    if (empty($contributionStatuses[$oldContributionValues['contribution_status_id']]['is_reserved'])) {
+      // Allow transitioning from a custom status to any normal/reserved status
+      return;
+    }
 
     $checkStatus = [
       'Cancelled' => ['Completed', 'Refunded'],
@@ -2747,12 +2756,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'Pending refund' => ['Completed', 'Refunded'],
       'Failed' => ['Pending'],
     ];
-    $validNewStatues = $checkStatus[$oldContributionStatus] ?? [];
+    $validNewStatues = $checkStatus[$oldContributionStatusName] ?? [];
 
-    if (!in_array($newContributionStatus, $validNewStatues, TRUE)) {
+    if (!in_array($newContributionStatusName, $validNewStatues, TRUE)) {
       throw new CRM_Core_Exception(ts('Cannot change contribution status from %1 to %2.', [
-        1 => $oldContributionStatus,
-        2 => $newContributionStatus,
+        1 => $oldContributionStatusName,
+        2 => $newContributionStatusName,
       ]));
     }
   }

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -161,6 +161,9 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
       if (isset($fields['is_active'])) {
         $select->select('`is_active`');
       }
+      if (isset($fields['is_reserved'])) {
+        $select->select('`is_reserved`');
+      }
       // Also component_id for filtering (this is legacy, the new way for extensions to add options is via hook)
       if (isset($fields['component_id'])) {
         $select->select('`component_id`');

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -53,15 +53,6 @@ function civicrm_api3_contribution_create($params) {
       throw new CRM_Core_Exception('You do not have permission to create this contribution');
     }
   }
-  if (!empty($params['id']) && !empty($params['contribution_status_id'])) {
-    //throw error for invalid status change such as setting completed back to pending
-    //@todo this sort of validation belongs in the BAO not the API - if it is not an OK
-    // action it needs to be blocked there. If it is Ok through a form it needs to be OK through the api
-    $values = ['contribution_status_id' => (int) CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $params['id'], 'contribution_status_id')];
-    if ($values['contribution_status_id'] !== (int) $params['contribution_status_id']) {
-      CRM_Contribute_BAO_Contribution::checkStatusValidation($values, $params);
-    }
-  }
   if (!empty($params['id']) && !empty($params['financial_type_id'])) {
     $error = [];
     CRM_Contribute_BAO_Contribution::checkFinancialTypeChange($params['financial_type_id'], $params['id'], $error);


### PR DESCRIPTION
Overview
----------------------------------------
Contributions are only allowed to transition to/from certain statuses.

This was enforced for API3 and one of the contribution forms. However, it was not enforced for other forms, the BAO or API4.

Before
----------------------------------------
Valid status transitions only checked in API3 and one form.

After
----------------------------------------
Valid status transitions checked in BAO, so should catch everywhere now.

Technical Details
----------------------------------------
The reserved contribution statuses and used in various places in the code and are automatically transitioned based on criteria such whether they are fully paid etc. Setting them to a non-allowed status can cause some of that logic to break and should not be allowed.

It is also possible to create custom contribution statuses. I've updated the status check to always allow transitions to/from any custom status to any reserved status. That allows you to continue doing custom things if you are using your own statuses - and you are responsible for your own breakage if you break something!

Comments
----------------------------------------
This fixes a longstanding "ToDo" in the API3 contribution code.
