### PR TITLE
SearchKit - Fix tokens in toolbar for multivalued field

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1925,7 +1925,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     // First pass: gather raw data from the where & having clauses
     $data = [];
     foreach (array_merge($this->_apiParams['where'], $this->_apiParams['having'] ?? []) as $clause) {
-      if ($clause[1] === '=' || $clause[1] === 'IN') {
+      if ($clause[1] === '=' || $clause[1] === 'IN' || $clause[1] === 'CONTAINS') {
         $data[$clause[0]] = $clause[2];
       }
     }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2691,6 +2691,51 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue($button['autoOpen']);
   }
 
+  /**
+   * Ensure a multivalued field like contact_sub_type can still be used as a token
+   * even though the filter operator will be CONTAINS.
+   */
+  public function testToolbarWithCustomLink(): void {
+    $params = [
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['first_name', 'contact_type', 'contact_sub_type'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'tesdDisplay',
+        'settings' => [
+          'actions' => TRUE,
+          'pager' => [],
+          'toolbar' => [
+            [
+              'text' => 'Add Contact',
+              'path' => 'civicrm/test/url?contact_type=[contact_type]&contact_sub_type=[contact_sub_type]',
+            ],
+          ],
+          'columns' => [
+            [
+              'key' => 'first_name',
+              'label' => 'First',
+              'type' => 'field',
+            ],
+          ],
+          'sort' => [],
+        ],
+      ],
+      'filters' => [
+        'contact_type' => 'Individual',
+        'contact_sub_type' => 'Student',
+      ],
+    ];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertStringEndsWith('contact_type=Individual&contact_sub_type=Student', $result->toolbar[0]['url']);
+  }
+
   public static function toolbarLinkPermissions(): array {
     $sets = [];
     $sets[] = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes some toolbar link tokens.

Technical Details
----------------------------------------
For multivalued fields, the operator will be contains but we still want the token to work.