### PR TITLE
dev/core#6269 | Make sure build membership is run when pledge_id is null.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -355,7 +355,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
 
     //build pledge block.
     //don't build membership block when pledge_id is passed
-    if ($this->getPledgeID() && empty($this->getExistingContributionID())) {
+    if (empty($this->getPledgeID()) && empty($this->getExistingContributionID())) {
       $this->_separateMembershipPayment = FALSE;
       if (CRM_Core_Component::isEnabled('CiviMember')) {
         $this->_separateMembershipPayment = $this->buildMembershipBlock();


### PR DESCRIPTION
Overview
----------------------------------------
_Regression_

Before
----------------------------------------
_Membership block isn't created_

After
----------------------------------------
_Membership block is created_