### PR TITLE
REF: Tests: Don't create two contributions when API version = 4

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1109,7 +1109,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       'version' => 3,
     ], $params);
     if ($params['version'] === 4) {
-      $this->createTestEntity('Contribution', $params, $identifier);
+      return $this->createTestEntity('Contribution', $params, $identifier)['id'];
     }
     return $this->callAPISuccess('Contribution', 'create', $params)['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
If you pass in the parameter "version = 4" to contributionCreate in CiviUnitTestCase you end up with 2 contributions created, one with API3 and one with API4..

Before
----------------------------------------
Two contributions created

After
----------------------------------------
One contribution created

Technical Details
----------------------------------------


Comments
----------------------------------------

