### PR TITLE
Allow getToFinancialAccount to return a NULL value

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -171,10 +171,10 @@ class CRM_Contribute_BAO_FinancialProcessor {
   /**
    * @param array $params
    *
-   * @return int
+   * @return int|NULL
    * @throws CRM_Core_Exception
    */
-  private function getToFinancialAccount(array $params): int {
+  private function getToFinancialAccount(array $params): ?int {
     if ($this->isAccountsReceivableTransaction()) {
       return CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
         $params['financial_type_id'],


### PR DESCRIPTION
Overview
----------------------------------------
getToFinancialAccount is typed to be returning an int. However it is possible that a NULL value might be returned partly due to the  call of getInsturmentFinancialAccount https://github.com/civicrm/civicrm-core/blob/25b09f347da0de04bafbf0180566ed0a825d9221/CRM/Financial/BAO/EntityFinancialAccount.php#L164

Before
----------------------------------------
Typed to return int

After
----------------------------------------
Typed to return int or NULL

ping @eileenmcnaughton 