### PR TITLE
(NFC) UrlFacadeTest - Emit more debug info about failures

### DIFF
--- a/tests/phpunit/E2E/Core/UrlFacadeTest.php
+++ b/tests/phpunit/E2E/Core/UrlFacadeTest.php
@@ -317,7 +317,12 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
        * @param \Psr\Http\Message\ResponseInterface $r
        */
       ->setResponseDecoder(function($r) {
-        return unserialize((string) $r->getBody(), ['allowed_classes' => [Url::class]]);
+        $data = (string) $r->getBody();
+        $isPlausible = preg_match('/^[bidsaO]:/', $data);
+        if (!$isPlausible) {
+          throw new \RuntimeException("UrlFacadeTest: Server sent malformed response:\n$data");
+        }
+        return unserialize($data, ['allowed_classes' => [Url::class]]);
       });
 
     return $rtf->execute($args);


### PR DESCRIPTION
Overview
-----------

`UrlFacadeTest` is an E2E test which calls `Civi::url()` within a real/normal instance of Drupal, WordPress, etc. To ensure that the function runs within a real environment, `Civi::url()` is executed within an HTTP request.

The test currently fails on php84. The substantive fix is https://github.com/civicrm/civicrm-packages/pull/429. This PR is a non-substantive update to clarify any future failures in `UrlFacadeTest`.

Before
------

When running `UrlFacadeTest` on php84 (edge), it fails with:

```
1) E2E\Core\UrlFacadeTest::testAbsoluteRelative
unserialize(): Error at offset 0 of 4202 bytes
```

This is hard to understand/debug...  but the error arises because the HTTP server complained about a PHP 8.4 issue. The error text cannot be decoded.

After
-----

It fails with a more detailed mesage:

```
1) E2E\Core\UrlFacadeTest::testAbsoluteRelative
RuntimeException: UrlFacadeTest: Server sent malformed respond:
<br />

<font size='1'><table class='xdebug-error xe-deprecated' dir='ltr' border='1' cellspacing='0'
cellpadding='1'> <tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000;
color: #fce94f; font-size: x-large;'> ( !  )</span> Deprecated: IDS_Report::__construct():
Implicitly marking parameter $events as nullable is deprecated, the explicit nullable type must be
used instead in /Users/totten/bknix/build/dev/web/core/packages/IDS/Report.php on line
<i>100</i></th></tr>
```

Comments
---------

* Flagged (NFC) because it doesn't change runtime behavior. Only affects reporting in UrlFacadeTest.

* This particular php84 problem was hard to debug because it only arose on the first invocation. To ensure that it failed consistently, I alternated between these commands:

  * (*buildkit*) `find build/dev/web/core/tests/ -name '*.rtf.php' -delete ;  loco clean php-fpm ; loco start php-fpm`
  * (*core*) `phpunit9 --debug --stop-on-failure tests/phpunit/E2E/Core/UrlFacadeTest.php`

