### PR TITLE
Respect check_permissions on apiv3 PaymentProcessor.refund action

### DIFF
--- a/api/v3/PaymentProcessor.php
+++ b/api/v3/PaymentProcessor.php
@@ -176,7 +176,7 @@ function _civicrm_api3_payment_processor_pay_spec(&$params) {
  * @throws \Civi\Payment\Exception\PaymentProcessorException
  */
 function civicrm_api3_payment_processor_refund($params) {
-  if (!CRM_Core_Permission::check('refund contributions')) {
+  if (!empty($params['check_permissions']) && !CRM_Core_Permission::check('refund contributions')) {
     throw new UnauthorizedException(ts('You do not have permission to issue refunds'));
   }
   /** @var \CRM_Core_Payment $processor */


### PR DESCRIPTION
Overview
----------------------------------------
Respect check_permissions on apiv3 PaymentProcessor.refund action

Before
----------------------------------------
The recently added check on the permission to do a refund ignores 'check_permission' => FALSE (which is default for php calls but never permitted for js calls)

After
----------------------------------------
Permission respected in line with general apiv3 expectations

Technical Details
----------------------------------------
@mattwire  looks like this comes from https://github.com/civicrm/civicrm-core/pull/33694

Comments
----------------------------------------
