### PR TITLE
Fix JSON formatting for confirmation_type

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.json
+++ b/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.json
@@ -9,5 +9,5 @@
         "access CiviMail"
     ],
     "permission_operator": "AND",
-    "confirmation_type": "redirect_to_url",
+    "confirmation_type": "redirect_to_url"
 }


### PR DESCRIPTION
15:52:01 ./core/ext/civicrm_admin_ui/ang/afsearchMailingClickThroughsResults.aff.json: Parse error on line 12: 15:52:01 ... "redirect_to_url",}

port https://github.com/civicrm/civicrm-core/pull/34483

(does not warrant a point release)