### PR TITLE
Fix CRM_Utils_System_WordPress::createUser() to return expected FALSE on failure

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -977,6 +977,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
      */
     do_action('civicrm_post_create_user', $uid, $params, $logged_in);
 
+    if (is_wp_error($uid)) {
+      $uid = FALSE;
+    }
+
     return $uid;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
`createUser()` is expected to return either an integer CMS user ID or FALSE on failure. But for WordPress it was returning a WordPress error object which then caused `CRM_Core_BAO_CMSUser::create()` to pass a WP object to ufmatch create which then causes a DB error and attempts to create a new record with UID = 1.

Before
----------------------------------------
Wrong return values on failure (eg. username already exists).

After
----------------------------------------
Correct return value, matches all other CMS code.

Technical Details
----------------------------------------


Comments
----------------------------------------

