### PR TITLE
Generate Contribution examples with Pending status

### DIFF
--- a/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
+++ b/CRM/Contribute/WorkflowMessage/Contribution/BasicContribution.php
@@ -43,6 +43,17 @@ class CRM_Contribute_WorkflowMessage_Contribution_BasicContribution extends Work
         'is_show_line_items' => $this->getNonQuickConfigPriceSet() ? TRUE : FALSE,
         'contribution_params' => ['contribution_status_id' => \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Partially paid')],
       ];
+      yield [
+        'name' => 'workflow/' . $workflow . '/' . 'pending' . $currency,
+        'title' => ts('Pending Contribution') . ' : ' . $currency,
+        'tags' => ['preview'],
+        'workflow' => $workflow,
+        'is_show_line_items' => $this->getNonQuickConfigPriceSet() ? TRUE : FALSE,
+        'contribution_params' => [
+          'contribution_status_id' => \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending'),
+          'is_pay_later' => TRUE,
+        ],
+      ];
       $priceSet = $this->getNonQuickConfigPriceSet();
       if ($priceSet) {
         yield [


### PR DESCRIPTION
Overview
----------------------------------------
When using the Message Administration extension, workflow messages can be previewed.  Contributions with various statuses are available - this adds Pending contributions.

Before
----------------------------------------
Pending Contribution examples not available when previewing eg invoice template.

After
----------------------------------------
Pending Contribution examples are available.

Technical Details
----------------------------------------

Comments
----------------------------------------
To test, enable the Message Administration extension. Go to Mailings > Message Templates, select the invoice template and Preview.  The list should include a Pending contribution.

