### PR TITLE
Add deprecation comment on processPriceSet

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -359,6 +359,9 @@ WHERE li.contribution_id = %1";
    *
    * @param bool $update
    *
+   * @deprecated we are working hard to remove remaining callers to this function.
+   * Use the v4 order api instead.
+   *
    * @throws \CRM_Core_Exception
    */
   public static function processPriceSet($entityId, $lineItems, $contributionDetails = NULL, $entityTable = 'civicrm_contribution', $update = FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
Add deprecation comment on processPriceSet

Before
----------------------------------------
I've been working hard to get to the point where we can noisily deprecate this function but there are still core callers 

After
----------------------------------------
In the meantime we can at least mark it as deprecated

Technical Details
----------------------------------------

Comments
----------------------------------------
