### PR TITLE
River: '--crm-info-color-on-dark' was being called but not defined, replaces for something that is

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -123,7 +123,7 @@
   --crm-link-decoration-hover: underline;
   --crm-link-hover-cursor: pointer;
   --crm-heading-bg-color: var(--crm-info-light-color);
-  --crm-heading-color: var(--crm-info-color-on-dark);
+  --crm-heading-color: var(--crm-info-ink-color);
   --crm-heading-padding: var(--crm-l-small-1) var(--crm-l-medium-1);
   --crm-heading-margin: var(--crm-l-medium) 0;
   --crm-heading-radius: var(--crm-l-radius);


### PR DESCRIPTION
Overview
----------------------------------------
A nearly imperceptible syntax regression, probably from the recent mass variable renaming, meant that the `--crm-heading-color` variable was pointing to a variable that doesn't exist. This wasn't picked up as it didn't impact Dark mode, Walbrook, or Thames - and in Minetta/Hackney reverted to a very similar colour.

Still, good to remove something that's not working even if the different is slight…

Before
----------------------------------------
H3 text in Minetta + Hackney is `var(--crm-info-color-on-dark)` which doesn't exist. Reverts to `--crm-text-color` (dark grey)

<img width="662" height="196" alt="image" src="https://github.com/user-attachments/assets/e5b725f2-c9ed-4216-9637-54c471eafeb8" />

After
----------------------------------------
H3 text is `var(--crm-info-ink-color)` which does, and has the right contrast ratio on the `var(--crm-info-light-color);` background.

<img width="575" height="231" alt="image" src="https://github.com/user-attachments/assets/ec28a0a2-f237-46b5-8156-c790abb92c28" />

Technical Details
----------------------------------------
Only Minetta and Hackney light mode impacted. The other six scenarios were over-riden.