### PR TITLE
River: variable rename tidy - removes unused variable, corrects name of two others

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -240,9 +240,8 @@
   --crm-form-block-bg-color: var(--crm-container-bg-color);
   --crm-form-block-padding: var(--crm-l-medium);
   --crm-form-block-border-radius: var(--crm-l-radius);
-  --crm-form-block-header-color: var(--crm-inverse-bg-color);
   --crm-form-fieldset-border-color: var(--crm-c-gray-400);
-  --crm-form-fieldset-border: 1px 0 0 0;
+  --crm-form-fieldset-border-width: 1px 0 0 0;
   --crm-form-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
   --crm-form-checkbox-list-bg-color: var(--crm-table-row-hover-color);
   --crm-input-bg-color: var(--crm-paper);
@@ -390,7 +389,7 @@
   --crm-notify-bg-color: rgba(0,0,0,0.85);
   --crm-notify-padding: var(--crm-l-medium-2);
   --crm-notify-color: var(--crm-text-light-color);
-  --crm-notify-accent-border: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
+  --crm-notify-accent-border-width: 2px 0 0 0; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: var(--crm-l-radius);
   --crm-notify-danger-color: hsl(from var(--crm-danger-color) h s calc(l + 20));
   --crm-notify-warning-color: hsl(from var(--crm-warning-color) h s calc(l + 20));

--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -167,7 +167,7 @@
   margin-bottom: var(--crm-l-reg);
   max-height: 600px;
   overflow: auto;
-  border-width: var(--crm-notify-accent-border);
+  border-width: var(--crm-notify-accent-border-width);
   border-style: solid;
   border-color: transparent;
 }

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -108,7 +108,7 @@
   padding: var(--crm-form-fieldset-padding);
   margin: var(--crm-padding-reg) 0;
   border: 1px solid var(--crm-form-fieldset-border-color);
-  border-width: var(--crm-form-fieldset-border);
+  border-width: var(--crm-form-fieldset-border-width);
 }
 .crm-container fieldset legend {
   font-weight: bold;

--- a/ext/riverlea/streams/hackneybrook/_main.css
+++ b/ext/riverlea/streams/hackneybrook/_main.css
@@ -63,7 +63,7 @@
   --crm-input-box-shadow: 0;
   --crm-input-label-weight: normal;
   --crm-input-label-width: 10em;
-  --crm-form-fieldset-border: 1px;
+  --crm-form-fieldset-border-width: 1px;
   /* Tabs */
   --crm-tabs-border: var(--crm-border);
   --crm-tab-count-bg-color: var(--crm-c-blue-dark);
@@ -124,7 +124,7 @@
   /* Notifications */
   --crm-notify-bg-color: rgb(0,0,0);
   --crm-notify-padding: 10px 10px 15px 15px;
-  --crm-notify-accent-border: 0 0 0 4px; /* adds a border to one/several sides of the notification - set to 0 for none */
+  --crm-notify-accent-border-width: 0 0 0 4px; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-radius: 0;
   /* Icons */
   --crm-icon-danger-color: var(--crm-danger-color);

--- a/ext/riverlea/streams/thames/_main.css
+++ b/ext/riverlea/streams/thames/_main.css
@@ -209,7 +209,7 @@
 /* Notifications */
   --crm-notify-bg-color: var(--crm-paper);
   --crm-notify-color: var(--crm-text-color);
-  --crm-notify-accent-border: 0.875rem 0 0 0;
+  --crm-notify-accent-border-width: 0.875rem 0 0 0;
   --crm-notify-radius: 4px;
   --crm-notify-danger-color: var(--crm-danger-color);
   --crm-notify-warning-color: var(--crm-warning-color);

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -126,7 +126,7 @@
   --crm-input-radio-color: var(--crm-primary-color);
   --crm-input-inline-edit-border: 1px solid var(--crm-c-gray-900);
   --crm-form-fieldset-border-color: unset;
-  --crm-form-fieldset-border: 0;
+  --crm-form-fieldset-border-width: 0;
   --crm-form-fieldset-padding: 0;
 /* Tabs */
   --crm-tabs-bg-color: var(--crm-layer1-bg-color);
@@ -192,7 +192,7 @@
 /* Notifications */
   --crm-notify-bg-color: var(--crm-paper);
   --crm-notify-color: var(--crm-text-color);
-  --crm-notify-accent-border: 0 0 0 3px; /* adds a border to one/several sides of the notification - set to 0 for none */
+  --crm-notify-accent-border-width: 0 0 0 3px; /* adds a border to one/several sides of the notification - set to 0 for none */
   --crm-notify-danger-color: #d02e2e;
   --crm-notify-warning-color: #c45008;
   --crm-notify-success-color: #5a803c;


### PR DESCRIPTION
Left overs from the rename epic (https://github.com/civicrm/civicrm-core/pull/34067) that I only spotted [while writing the docs](https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1268):

 1. `--crm-form-block-header-color` removed - it's not called by anything.
 2. `--crm-form-fieldset-border` doesn't define the entire border, just the width, so needs to be `--crm-form-fieldset-border-width` for clarity / future linting
 3. `--crm-notify-accent-border` the same, changing to `--crm-notify-accent-border-width`.
 
Regarding changes 2 and 3 - there's lots of border related variables that either end `-border` and define a full border (`1px solid #000`), or end `-color` or `-width` or `-radius` and define just that. These two variables should have been called `-width`.

Before
----------------------------------------
`--crm-form-block-header-color` exists
`--crm-form-fieldset-border`
`--crm-notify-accent-border`

After
----------------------------------------
`--crm-form-block-header-color` doesn't exist
`--crm-form-fieldset-border-width`
`--crm-notify-accent-border-width`

Comments
----------------------------------------
Putting into 6.10 because of the new 'no variable name changes after 6.10 without a year of aliasing' rule. Also there is no visual or functional change here, just variable re-naming.

But can instead keep the old names as aliases for a year, and put this PR in to 6.11 / 6.12 if preferred (which is what happens with changing/deleted variables from 6.11 onwards).