### PR TITLE
Extension meta loading - avoid infinite loop, inaccurate log message

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -374,13 +374,8 @@ class CRM_Extension_Info {
       }
     }
 
-    if (in_array('mgmt:enable-when-satisfied', $this->tags)) {
-      if ($this->parent && !in_array($this->parent, $this->requires)) {
-        $this->requires[] = $this->parent;
-      }
-      else {
-        \Civi::log()->warning("Extension ($info->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
-      }
+    if ($this->parent && !in_array($this->parent, $this->requires)) {
+      $this->requires[] = $this->parent;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This log message caused an infinite loop when doing `cv flush` after updating 6.9 => 6.10 on Drupal 10, with an extension that had `mgmt:enable-when-satisfied` but had its parent in its required list.

Log => infinite loop may be something to do with customisations, but the log message is not accurate for the conditional. 

I also don't see why `enable-when-satifisfied` has anything to do with `parent implies requires`.



@totten ?