### PR TITLE
PHP 8.5 - Fix warning in Civi\Core\Url

### DIFF
--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -595,7 +595,7 @@ final class Url implements \JsonSerializable {
           break;
 
         // (s)sl
-        case 's';
+        case 's':
           $this->ssl = TRUE;
           break;
 


### PR DESCRIPTION
Before
----------------------------------------

```
[PHP Deprecation] Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead at /Users/totten/bknix/build/dev/web/core/Civi/Core/Url.php:598
```

After
----------------------------------------

Hush, little console, don't say a word.
Yes, that semicolon was absurd.
But if your colon turns out good,
then coders click "Merge" to save the 'hood.

Comments
----------------------------------------

This is clearly a typo. The surprising thing is that it worked before. But I guess that was a case of over-permissiveness, and the new warning is a good thing.