### PR TITLE
Afform - ability to output Confirmation Messages in HTML

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -340,7 +340,7 @@
         if (submissionResponse[0].message) {
           $element.hide();
           const $confirmation = $('<div class="afform-confirmation" />');
-          $confirmation.text(submissionResponse[0].message);
+          $confirmation.html(submissionResponse[0].message);
           $confirmation.insertAfter($element);
         }
         else if (dialog.length) {


### PR DESCRIPTION
Overview
----------------------------------------
Allows for an HTML confirmation message

Before
----------------------------------------
<img width="725" height="216" alt="Selection_025" src="https://github.com/user-attachments/assets/3b72e5fb-6bcc-4f70-8643-dd33c775f5d2" />


After
----------------------------------------
<img width="774" height="346" alt="Selection_024" src="https://github.com/user-attachments/assets/881b0499-3eb1-4533-8a60-1bb325110a00" />

Technical Details
----------------------------------------

I just changed the output to use `.html` instead of `.text`. My only question is whether we need to sanitize the confirmation message when it's saved or is this done? I couldn't quite figure out whether that is being done.

cc @colemanw 