### PR TITLE
SearchKit - Make participant statuses searchable by non-admins

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1543,6 +1543,15 @@ class CRM_Core_Permission {
         'edit contributions',
       ],
     ];
+    $permissions['participant_status_type'] = [
+      'get' => [
+        ['access CiviCRM', 'access CiviEvent', 'view event participants'],
+      ],
+      'default' => [
+        'administer CiviCRM data',
+        'access CiviEvent',
+      ],
+    ];
 
     // Pledge permissions
     $permissions['pledge'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Makes participant status types visible in SearchKit for non-admins.

Technical Details
----------------------------------------
Status types do not contain sensitive information so should be searchable by anyone with the ability to view participants.