### PR TITLE
Add supply_date field to LineItem

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -29,6 +29,15 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
    */
   public function upgrade_6_12_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+
+    $this->addTask('Add column "LineItem.supply_date"', 'alterSchemaField', 'LineItem', 'supply_date', [
+      'title' => ts('Supply Date'),
+      'sql_type' => 'date',
+      'input_type' => 'Select Date',
+      'description' => ts('Date goods or services were provided.'),
+      'add' => '6.12',
+    ]);
+
   }
 
 }

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -200,5 +200,12 @@ return [
       'add' => '5.40',
       'default' => NULL,
     ],
+    'supply_date' => [
+      'title' => ts('Supply Date'),
+      'sql_type' => 'date',
+      'input_type' => 'Select Date',
+      'description' => ts('Date goods or services were provided.'),
+      'add' => '6.12',
+    ],
   ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new field `supply_date` to LineItem.  (At least) UK invoices should include the date goods or services were supplied, which may or may not be the same as the invoice date.  An invoice (linked to Contribution and Order) can contain line items with different supply dates. Ref: https://www.gov.uk/invoicing-and-taking-payment-from-customers/invoices-what-they-must-include

Before
----------------------------------------
No field for supply date on LineItem

After
----------------------------------------
`supply_date` field on LineItem

Technical Details
----------------------------------------
I think 'date' type is more appropriate that 'datetime' ...

Comments
----------------------------------------
TBD whether this is populated automatically.  The use-case prompting this is where an invoice is being produced for services provided over the preceding month.  Dates will be filled in manually, or from integration with some work tracking system.
