### PR TITLE
PHP 8.5 - Fix warning on EntityMetadataBase::getSqlOptions()

### DIFF
--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -166,7 +166,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
         $select->select('`component_id`');
       }
       // Order by: prefer order_column; or else 'weight' column; or else label_column; or as a last resort, $idCol
-      $orderColumns = [$pseudoconstant['order_column'] ?? NULL, 'weight', $pseudoconstant['label_column'] ?? NULL, $idCol];
+      $orderColumns = array_filter([$pseudoconstant['order_column'] ?? NULL, 'weight', $pseudoconstant['label_column'] ?? NULL, $idCol]);
       foreach ($orderColumns as $orderColumn) {
         if (isset($fields[$orderColumn])) {
           $select->orderBy($orderColumn);


### PR DESCRIPTION
Overview
----------

Fix warning on PHP 8.5 involving `getSqlOptions()` and its list of `$orderColumns`. The warning looks like this:

```
[PHP Deprecation] Using null as an array offset is deprecated, use an empty string instead at /Users/totten/bknix/build/dev/web/core/Civi/Schema/EntityMetadataBase.php:171
```

Before
------

`$orderColumns` is a list of columns to use in SQL sorting.  It combines data from several places -- and some of those places are optional. Unused options are indicated as `NULL`.

You can see the `NULL` values are optional because there is a subsequent guard:

```
if isset($fields[$orderColumn]]) {
```

On PHP<=8.4, the guard quietly skips the NULL columns. On PHP >=8.5, it emits a warning.

After
-----

`$orderColumns` is the same list, except it omits NULL values soone).

Comments
--------

Technically, if you had a legit field named `NULL` or `0` or `''` or `FALSE`, then this call to `array_filter()` might change the behavior slightly. But I don't think it's valid for *entities* to define *fields* with any of those column-names.
