### PR TITLE
PHP 8.5 - Fix warning in ContactType::getAllContactTypes()

### DIFF
--- a/CRM/Contact/BAO/ContactType.php
+++ b/CRM/Contact/BAO/ContactType.php
@@ -776,9 +776,10 @@ WHERE ($subtypeClause)";
         // Cast int/bool types.
         self::formatFieldValues($contactType);
         // Fill data from parents
-        $contactType['parent'] = $parents[$contactType['parent_id']]['name'] ?? NULL;
-        $contactType['parent_label'] = $parents[$contactType['parent_id']]['label'] ?? NULL;
-        $contactType['icon'] ??= $parents[$contactType['parent_id']]['icon'] ?? NULL;
+        $parent = $parents[$contactType['parent_id'] ?? ''] ?? NULL;
+        $contactType['parent'] = $parent['name'] ?? NULL;
+        $contactType['parent_label'] = $parent['label'] ?? NULL;
+        $contactType['icon'] ??= $parent['icon'] ?? NULL;
       }
       $cache->set($cacheKey, $contactTypes);
     }


### PR DESCRIPTION
Overview
----------------------------------------

Fix frequent warnings that appear when installing Civi on PHP 8.5.


Before
----------------------------------------

When installing Civi on PHP 8.5, it emits many warnings. (More than 20... less than 100... maybe 50 warnings?) The warning looks like this:

```
[PHP Deprecation] Using null as an array offset is deprecated, use an empty string instead at /Users/totten/bknix/build/dev/web/core/CRM/Contact/BAO/ContactType.php:779
[PHP Deprecation] Using null as an array offset is deprecated, use an empty string instead at /Users/totten/bknix/build/dev/web/core/CRM/Contact/BAO/ContactType.php:780
[PHP Deprecation] Using null as an array offset is deprecated, use an empty string instead at /Users/totten/bknix/build/dev/web/core/CRM/Contact/BAO/ContactType.php:779
[PHP Deprecation] Using null as an array offset is deprecated, use an empty string instead at /Users/totten/bknix/build/dev/web/core/CRM/Contact/BAO/ContactType.php:780
```

The warning involves the expression `$parents[$contactType['parent_id']]` when the value of `$contactType['parent_id']` is an explicit `NULL`.

After
----------------------------------------

No such warning.

Comments
----------------------------------------

The full idiom used by these lines included a _null-coalescing operator_ (`??`):

```php
$parents[$contactType['parent_id']]['name'] ?? NULL
```

You might think that this protects from warnings when the chain-of-lookups has NULL parts. I might think that, too. But PHP 8.5 has its own opinion.