### PR TITLE
Add return value handling for MessageTemplate.send API

### DIFF
--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC. All rights reserved.                        |
@@ -84,6 +85,12 @@ function civicrm_api3_message_template_get($params) {
  *
  * @param array $params
  *
+ * @return array
+ *   API result array with:
+ *   - is_error: 0 on success, 1 on failure
+ *   - values: array of result values on success
+ *   - error_message: error description on failure
+ *
  * @throws CRM_Core_Exception
  * @throws \CRM_Core_Exception
  */
@@ -120,7 +127,12 @@ function civicrm_api3_message_template_send($params) {
       );
     }
   }
-  CRM_Core_BAO_MessageTemplate::sendTemplate($params);
+  [$sent] = CRM_Core_BAO_MessageTemplate::sendTemplate($params);
+  if ($sent) {
+    return civicrm_api3_create_success();
+  } else {
+    return civicrm_api3_create_error('Failed to send email');
+  }
 }
 
 /**

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -130,7 +130,8 @@ function civicrm_api3_message_template_send($params) {
   [$sent] = CRM_Core_BAO_MessageTemplate::sendTemplate($params);
   if ($sent) {
     return civicrm_api3_create_success();
-  } else {
+  }
+  else {
     return civicrm_api3_create_error('Failed to send email');
   }
 }


### PR DESCRIPTION
## Overview

This PR improves the `MessageTemplate.send` API by properly handling the return value from `CRM_Core_BAO_MessageTemplate::sendTemplate()` and returning appropriate success or error responses. It also enhances the API documentation with detailed return value specifications.

## Before

The `civicrm_api3_message_template_send()` function was calling `sendTemplate()` but ignoring its return value, making it impossible for API consumers to determine whether the email was actually sent successfully.

```php
function civicrm_api3_message_template_send($params) {
  // ... parameter processing ...
  CRM_Core_BAO_MessageTemplate::sendTemplate($params);
}
```

The function had no explicit return statement.

## After
The function now properly captures the return value from sendTemplate() and returns a standard API success or error response.

## Comments

**Future Enhancement:**
Currently, when email sending fails, the specific error details are logged by `CRM_Utils_Mail::send()` in `CRM/Utils/Mail.php`
 but are not propagated back through the return value. A follow-up improvement would be to modify `CRM_Utils_Mail::send()` to return the actual error message so that `MessageTemplate.send` can provide more specific error details to API consumers instead of the generic "Failed to send email" message.
