### PR TITLE
api: MessageTemplate.send - Return specific SMTP error messages

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -24,7 +24,6 @@ require_once 'Mail/mime.php';
  * Class CRM_Core_BAO_MessageTemplate.
  */
 class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implements \Civi\Core\HookInterface {
-
   /**
    * @deprecated
    * @param array $params
@@ -411,7 +410,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
    *   A string-keyed array of function params, see function body for details.
    *
    * @return array
-   *   Array of four parameters: a boolean whether the email was sent, and the subject, text and HTML templates
+   *   Array of five parameters: a boolean whether the email was sent, the subject, text and HTML templates, and error message (null if no error)
    * @throws \CRM_Core_Exception
    */
   public static function sendTemplate(array $params): array {
@@ -432,6 +431,7 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
 
     // send the template, honouring the target user’s preferences (if any)
     $sent = FALSE;
+    $errorMessage = NULL;
     if (!empty($params['toEmail'])) {
 
       $config = CRM_Core_Config::singleton();
@@ -465,10 +465,10 @@ class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implemen
         }
       }
 
-      $sent = CRM_Utils_Mail::send($params);
+      $sent = CRM_Utils_Mail::send($params, $errorMessage);
     }
 
-    return [$sent, $mailContent['subject'], $mailContent['text'], $mailContent['html']];
+    return [$sent, $mailContent['subject'], $mailContent['text'], $mailContent['html'], $errorMessage];
   }
 
   /**

--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC. All rights reserved.                        |
@@ -24,6 +25,7 @@ require_once 'Mail/mime.php';
  * Class CRM_Core_BAO_MessageTemplate.
  */
 class CRM_Core_BAO_MessageTemplate extends CRM_Core_DAO_MessageTemplate implements \Civi\Core\HookInterface {
+
   /**
    * @deprecated
    * @param array $params

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -15,7 +15,6 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Utils_Mail {
-
   /**
    * Create a new mailer to send any mail from the application.
    *
@@ -156,11 +155,13 @@ class CRM_Utils_Mail {
    *
    * @param array $params
    *   (by reference).
+   * @param string|null $errorMessage
+   *   Optional reference to capture error messages if sending fails.
    *
    * @return bool
    *   TRUE if a mail was sent, else FALSE.
    */
-  public static function send(array &$params): bool {
+  public static function send(array &$params, &$errorMessage = NULL): bool {
     // first call the mail alter hook
     CRM_Utils_Hook::alterMailParams($params, 'singleEmail');
 
@@ -212,15 +213,16 @@ class CRM_Utils_Mail {
         $result = $mailer->send($to, $headers, $message ?? '', $originalValues);
       }
       catch (Exception $e) {
-        \Civi::log()->error('Mailing error: ' . $e->getMessage());
+        $errorMessage = $e->getMessage();
+        \Civi::log()->error('Mailing error: ' . $errorMessage);
         CRM_Core_Session::setStatus(ts('Unable to send email. Please report this message to the site administrator'), ts('Mailing Error'), 'error');
         return FALSE;
       }
       if (is_a($result, 'PEAR_Error')) {
-        $message = self::errorMessage($mailer, $result);
+        $errorMessage = self::errorMessage($mailer, $result);
         // append error message in case multiple calls are being made to
         // this method in the course of sending a batch of messages.
-        \Civi::log()->error('Mailing error: ' . $message);
+        \Civi::log()->error('Mailing error: ' . $errorMessage);
         CRM_Core_Session::setStatus(ts('Unable to send email. Please report this message to the site administrator'), ts('Mailing Error'), 'error');
         return FALSE;
       }
@@ -546,7 +548,8 @@ class CRM_Utils_Mail {
 
     if (!empty($name)) {
       // escape the special characters
-      $name = str_replace(['<', '"', '>'],
+      $name = str_replace(
+        ['<', '"', '>'],
         ['\<', '\"', '\>'],
         $name
       );
@@ -607,10 +610,14 @@ class CRM_Utils_Mail {
     // and will be added to the <html> tag even if you do not include it.
     $html = preg_replace('/(<html)(.+?xmlns=["\'].[^\s]+["\'])(.+)?(>)/', '\1\3\4', $html);
 
-    file_put_contents($pdf_filename, CRM_Utils_PDF_Utils::html2pdf($html,
+    file_put_contents(
+      $pdf_filename,
+      CRM_Utils_PDF_Utils::html2pdf(
+        $html,
         $fileName,
         TRUE,
-        $format)
+        $format
+      )
     );
     return [
       'fullPath' => $pdf_filename,

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  +--------------------------------------------------------------------+
  | Copyright CiviCRM LLC. All rights reserved.                        |
@@ -15,6 +16,7 @@
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 class CRM_Utils_Mail {
+
   /**
    * Create a new mailer to send any mail from the application.
    *

--- a/api/v3/MessageTemplate.php
+++ b/api/v3/MessageTemplate.php
@@ -127,12 +127,12 @@ function civicrm_api3_message_template_send($params) {
       );
     }
   }
-  [$sent] = CRM_Core_BAO_MessageTemplate::sendTemplate($params);
+  [$sent, $subject, $text, $html, $errorMessage] = CRM_Core_BAO_MessageTemplate::sendTemplate($params);
   if ($sent) {
     return civicrm_api3_create_success();
   }
   else {
-    return civicrm_api3_create_error('Failed to send email');
+    return civicrm_api3_create_error($errorMessage ?: 'Failed to send email');
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
This PR improves error reporting in the MessageTemplate.send API by returning specific SMTP error messages instead of a generic failure message. This is a follow-up enhancement to [#34504](https://github.com/civicrm/civicrm-core/pull/34504), implementing the "Future Enhancement" mentioned in that PR's comments.

Before
----------------------------------------
When `MessageTemplate.send` failed to send an email, it always returned a generic error message regardless of the actual failure reason.

After
----------------------------------------
The API now captures and returns the specific error message.

Technical Details
----------------------------------------
Modified `civicrm_api3_message_template_send()` to capture the 5th return value from `CRM_Core_BAO_MessageTemplate::sendTemplate() `. 

Added unit test `testSendTemplate_ErrorMessage() `that verifies error propagation by temporarily configuring invalid SMTP settings. 

Technical Details
----------------------------------------

I believe the change is backward compatible: existing code that only checks the is_error flag will continue to work without modification.