### PR TITLE
Support pseudoconstants for Contribution and LineItem parameters in Order APIv4

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -641,7 +641,6 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
    *   This function was added to consolidate that so we have one place where the IDs are generated
    *
    * @return string
-   * @throws \Random\RandomException
    */
   public static function generateInvoiceID(): string {
     try {

--- a/Civi/Api4/Action/Order/Create.php
+++ b/Civi/Api4/Action/Order/Create.php
@@ -26,14 +26,14 @@ class Create extends AbstractAction {
    *
    * @var array
    */
-  protected $contributionValues;
+  protected array $contributionValues;
 
   /**
    * Line items to process
    *
    * @var array
    */
-  protected $lineItems;
+  protected array $lineItems;
 
   /**
    * @param array $lineItem
@@ -60,13 +60,7 @@ class Create extends AbstractAction {
    */
   protected function getContributionValues(): array {
     $values = $this->contributionValues;
-    $financialType = $values['financial_type_id:name'] ?? $values['financial_type_id.name'] ?? NULL;
-    if (empty($values['financial_type_id']) && $financialType) {
-      $values['financial_type_id'] = (int) \CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'financial_type_id', $financialType);
-      if (!$values['financial_type_id']) {
-        throw new \CRM_Core_Exception(ts('Invalid financial type %1', [1 => $financialType]));
-      }
-    }
+    $this->formatWriteValues($values, 'Contribution', 'create');
     if (empty($values['invoice_id'])) {
       $values['invoice_id'] = \CRM_Contribute_BAO_Contribution::generateInvoiceID();
     }
@@ -86,6 +80,7 @@ class Create extends AbstractAction {
     $order->setDefaultFinancialTypeID($this->getContributionValues()['financial_type_id'] ?? NULL);
 
     foreach ($this->lineItems as $index => $lineItem) {
+      $this->formatWriteValues($lineItem, 'LineItem', 'create');
       $order->setLineItem($lineItem, $index);
     }
     $result[] = $order->save($this->getContributionValues())->first();

--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -449,12 +449,15 @@ abstract class AbstractAction implements \ArrayAccess {
    * This is because we DON'T want the wrapper to check permissions as this is an internal op.
    * @see \Civi\Api4\Action\Contact\GetFields
    *
+   * @param string|null $entityName
+   * @param string|null $actionName
+   *
    * @throws \CRM_Core_Exception
    * @return array
    */
-  public function entityFields() {
-    $entityName = $this->getEntityName();
-    $actionName = $this->getActionName();
+  public function entityFields(?string $entityName = NULL, ?string $actionName = NULL) {
+    $entityName = $entityName ?? $this->getEntityName();
+    $actionName = $actionName ?? $this->getActionName();
     if (empty(\Civi::$statics['Api4EntityFields'][$entityName][$actionName])) {
       $allowedTypes = ['Field', 'Filter', 'Extra'];
       $getFields = \Civi\API\Request::create($entityName, 'getFields', [
@@ -528,16 +531,18 @@ abstract class AbstractAction implements \ArrayAccess {
    * Replaces pseudoconstants in input values
    *
    * @param array $record
+   * @param string|null $entityName
+   * @param string|null $actionName
    * @throws \CRM_Core_Exception
    */
-  protected function formatWriteValues(&$record) {
+  protected function formatWriteValues(&$record, ?string $entityName = NULL, ?string $actionName = NULL) {
     $optionFields = [];
     // Collect fieldnames with a :pseudoconstant suffix & remove them from $record array
     foreach (array_keys($record) as $expr) {
       $suffix = strrpos($expr, ':');
       if ($suffix) {
         $fieldName = substr($expr, 0, $suffix);
-        $field = $this->entityFields()[$fieldName] ?? NULL;
+        $field = $this->entityFields($entityName, $actionName)[$fieldName] ?? NULL;
         if ($field) {
           $optionFields[$fieldName] = [
             'val' => $record[$expr],

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -232,9 +232,9 @@ trait DAOActionTrait {
   /**
    * @inheritDoc
    */
-  protected function formatWriteValues(&$record) {
+  protected function formatWriteValues(&$record, $entityName = NULL, $actionName = NULL) {
     $this->resolveFKValues($record);
-    parent::formatWriteValues($record);
+    parent::formatWriteValues($record, $entityName, $actionName);
   }
 
   /**

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/Update.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/Update.php
@@ -6,8 +6,8 @@ class Update extends \Civi\Api4\Generic\DAOUpdateAction {
   /**
    * @inheritdoc
    */
-  protected function formatWriteValues(&$record) {
-    $result = parent::formatWriteValues($record);
+  protected function formatWriteValues(&$record, $entityName = NULL, $actionName = NULL) {
+    parent::formatWriteValues($record, $entityName, $actionName);
 
     // Hrm, parent doesn't validate <callback> PC's by default.
     if (isset($this->values['provider'])) {
@@ -16,8 +16,6 @@ class Update extends \Civi\Api4\Generic\DAOUpdateAction {
         throw new \CRM_Core_Exception("Invalid provider name: " . $this->values['provider']);
       }
     }
-
-    return $result;
   }
 
 }

--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -24,9 +24,11 @@ trait WriteTrait {
    * Do most of our complex permissions checks here.
    *
    * @param array $record
+   * @param string|null $entityName
+   * @param string|null $actionName
    * @throws \CRM_Core_Exception
    */
-  protected function formatWriteValues(&$record) {
+  protected function formatWriteValues(&$record, $entityName = NULL, $actionName = NULL) {
 
     if ($this->getCheckPermissions()) {
       // We must have a logged in user if we're checking permissions.

--- a/tests/phpunit/CRM/Financial/BAO/OrderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/OrderTest.php
@@ -45,7 +45,7 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
         'entity_table' => 'civicrm_participant',
         'entity_id.event_id' => $this->getEventID(),
         'entity_id.contact_id' => $this->ids['Contact']['individual_0'],
-        'financial_type_id' => 3,
+        'financial_type_id:name' => 'Campaign Contribution',
         'price_field_value_id' => $this->ids['PriceFieldValue']['PaidEvent_student_early'],
       ])
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/6217

Order API create receives parameters for Contribution and LineItem entities. But it does not parse the parameters in the same way as directly calling API4 Contribution or LineItem so pseudoconstants are not supported.

Before
----------------------------------------
Can use some pseudoconstants in Contribution parameters (eg. `financial_type_id:name`).
Cannot use pseudoconstants in LineItem parameters.

After
----------------------------------------
Can use all supported pseudoconstants in Contribution and LineItem parameters for Order APIv4

Technical Details
----------------------------------------
Extends `formatWriteValues()` to support passing an optional, different `entityName` and `actionName` so that the pseudoconstants for that entity will be parsed/replaced with the actual values ready for writing to the database.

Comments
----------------------------------------
@colemanw @seamuslee001 @rbaugh 
