### PR TITLE
Support lineItem allocations when using Payment API

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -1092,6 +1092,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
           $line['financial_type_id'] = CRM_Core_DAO::getFieldValue('CRM_Price_DAO_PriceFieldValue', $line['price_field_value_id'], 'financial_type_id');
         }
         $createdLineItem = CRM_Price_BAO_LineItem::create($line);
+
         if (!$this->isUpdate()) {
           $financialItem = CRM_Financial_BAO_FinancialItem::add($createdLineItem, $this->getUpdatedContribution());
           $line['financial_item_id'] = $financialItem->id;

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -144,6 +144,20 @@ function civicrm_api3_payment_create($params) {
     // Since this isn't a new payment, prevent order completed actions.
     $disableActionsOnCompleteOrder = TRUE;
   }
+
+  // The "line_item" parameter was/is undocumented for API3 and had issues.
+  // Extracted from CRM_Financial_BAO_Payment::getPayableItems() and cleaned up
+  //   since this is the only place it could be passed in.
+  if (!empty($params['line_item'])) {
+    $params['line_item_allocation'] = [];
+    // The format is a bit weird here - $params['line_item'] => [[1 => 10], [2 => 40]]
+    // Squash to [1 => 10, 2 => 40]
+    foreach ($params['line_item'] as $lineItem) {
+      $params['line_item_allocation'] += $lineItem;
+    }
+    unset($params['line_item']);
+  }
+
   $trxn = CRM_Financial_BAO_Payment::create($params, $disableActionsOnCompleteOrder);
 
   $values = [];

--- a/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
@@ -127,8 +127,14 @@ class Create extends \Civi\Api4\Generic\AbstractCreateAction {
       ],
       [
         'name' => 'pan_truncation',
-        'type' => 'String',
+        'data_type' => 'String',
         'description' => ts('PAN Truncation (Last 4 digits of credit card)'),
+      ],
+      [
+        'name' => 'line_item_allocation',
+        'data_type' => 'Array',
+        'description' => ts('Line Item Allocation. Specify an array of line item IDs => amounts to allocate specific amounts'),
+        'default_value' => [],
       ],
     ];
     $customFields = CustomField::get(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
By default recording a Payment or Refund using the Payment API will allocate the payment/refund proportionally across all LineItems.

You can pass in an array `line_item` with specific allocations if, for example, you want to allocate a refund to a specific lineitem or customise. Note: You can't pass that parameter into API4 but can specify it as a custom parameter in API3.

Of course, it doesn't work properly when you pass it in via API3 which suggests it might not actually have been used anywhere yet..


Before
----------------------------------------
Passing in specific allocations for lineItems doesn't work very well, allows you to do bad things and is likely to crash. Oh, and if a lineItem has a tax value associated it will double the amount of the payment/refund!

After
----------------------------------------
Passing in specific allocations for lineItems works better, various checks on the amounts passed in are checked and it assumes that any unspecified lineItem should be allocated "0.0" of the refund/payment amount.

Technical Details
----------------------------------------
This is an initial PR that explores the functionality of the parameter and makes it actually work in a sane way. Might need additional tests to verify some of these scenarios. Also we need to be able to expose lineItem allocations in API4.

Comments
----------------------------------------
Need to consider what happens when multiple payments/refunds are recorded in terms of checks/balances.
