### PR TITLE
Timezone: one transition missing from ics files

### DIFF
--- a/CRM/Utils/ICalendar.php
+++ b/CRM/Utils/ICalendar.php
@@ -185,7 +185,7 @@ class CRM_Utils_ICalendar {
         'transitions' => [],
       ];
 
-      $last_transition = array_shift($transitions);
+      $last_transition = reset($transitions);
 
       foreach ($transitions as $transition) {
         $item['transitions'][] = [


### PR DESCRIPTION
Overview
----------------------------------------
If you have several event in the same ics (which is possible by using eventics and the hook `eventics_alter_event_data`), you could have in the same ics events that are before and after the time change switch which is not properly interpreted by email clients.

In the ics file, the Timezone definition only contain either DAYLIGHT or STANDARD but not both which should be required in my case.

Before
----------------------------------------
Only one timezone definition in the ics file

After
----------------------------------------
The 2 applicable timezones are added to the ics.

Technical Details
----------------------------------------
Using `array_shift` is removing the first item, contrary to `reset`. We only want to get the value of the first item, not remove it.

Comment
----------------------------------------
See https://icalendar.org/iCalendar-RFC-5545/3-6-5-time-zone-component.html for example of working ics VTIMEZONE