### PR TITLE
scssphp - Fix warnings. Update v1.10.3 => v1.13.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3842,16 +3842,16 @@
         },
         {
             "name": "scssphp/scssphp",
-            "version": "v1.10.3",
+            "version": "v1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/scssphp/scssphp.git",
-                "reference": "0f1e1516ed2412ad43e42a6a319e77624ba1f713"
+                "reference": "63d1157457e5554edf00b0c1fabab4c1511d2520"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/0f1e1516ed2412ad43e42a6a319e77624ba1f713",
-                "reference": "0f1e1516ed2412ad43e42a6a319e77624ba1f713",
+                "url": "https://api.github.com/repos/scssphp/scssphp/zipball/63d1157457e5554edf00b0c1fabab4c1511d2520",
+                "reference": "63d1157457e5554edf00b0c1fabab4c1511d2520",
                 "shasum": ""
             },
             "require": {
@@ -3868,7 +3868,7 @@
                 "thoughtbot/bourbon": "^7.0",
                 "twbs/bootstrap": "~5.0",
                 "twbs/bootstrap4": "4.6.1",
-                "zurb/foundation": "~6.5"
+                "zurb/foundation": "~6.7.0"
             },
             "suggest": {
                 "ext-iconv": "Can be used as fallback when ext-mbstring is not available",
@@ -3878,6 +3878,12 @@
                 "bin/pscss"
             ],
             "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false,
+                    "forward-command": false
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "ScssPhp\\ScssPhp\\": "src/"
@@ -3910,9 +3916,9 @@
             ],
             "support": {
                 "issues": "https://github.com/scssphp/scssphp/issues",
-                "source": "https://github.com/scssphp/scssphp/tree/v1.10.3"
+                "source": "https://github.com/scssphp/scssphp/tree/v1.13.0"
             },
-            "time": "2022-05-16T07:22:18+00:00"
+            "time": "2024-08-17T21:02:11+00:00"
         },
         {
             "name": "soundasleep/html2text",
@@ -6020,5 +6026,5 @@
     "platform-overrides": {
         "php": "8.1.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Overview
----------------------------------------

When you run `composer install` or `composer compile` for `civicrm-core`, it runs some compilation tasks -- such as building Greenwich's CSS. This task has a PHP warning (though it's hard to see).

Before
----------------------------------------

By default, `composer install` tends to suppress output from compilation-tasks (*unless there's a hard exit*).

However, you can see the full output by running `composer compile` (or tweaking the verbosity)

```bash
composer compile

## or
composer install -v

## or
COMPOSER_COMPILE_PASSTHRU=always composer install
```

Then you'll see a few instances of the warning:

```
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /Users/totten/bknix/build/dev/web/core/vendor/scssphp/scssphp/src/Compiler.php on line 3551

Call Stack:
    0.0007     526056   1. {main}() Command line code:0
    0.0022    1050008   2. CCL\Tasks::scss($tasks = ['active' => TRUE, 'title' => 'Greenwich CSS (<comment>dist/bootstrap3.css</comment>)', 'watch-files' => [0 => 'scss', 1 => '../../bower_components/select2/select2-bootstrap.css'], 'run' => [0 => '@php-eval \\CCL::copy(\'../../bower_components/select2/select2-bootstrap.css\', \'extern/select2/select2-bootstrap.scss\');', 1 => '@php-method \\CCL\\Tasks::scss'], 'scss-files' => ['dist/bootstrap3.css' => 'scss/main.scss'], 'scss-imports' => [0 => 'scss', 1 => 'extern/bootstrap3/assets/stylesheets', 2 => 'extern/select2'], 'source-file' => '/Users/totten/bknix/build/dev/web/core/ext/greenwich/composer.compile.json']) Command line code:1
    0.0023    1061624   3. CCL\Tasks\Scss::compile($task = ['active' => TRUE, 'title' => 'Greenwich CSS (<comment>dist/bootstrap3.css</comment>)', 'watch-files' => [0 => 'scss', 1 => '../../bower_components/select2/select2-bootstrap.css'], 'run' => [0 => '@php-eval \\CCL::copy(\'../../bower_components/select2/select2-bootstrap.css\', \'extern/select2/select2-bootstrap.scss\');', 1 => '@php-method \\CCL\\Tasks::scss'], 'scss-files' => ['dist/bootstrap3.css' => 'scss/main.scss'], 'scss-imports' => [0 => 'scss', 1 => 'extern/bootstrap3/assets/stylesheets', 2 => 'extern/select2'], 'source-file' => '/Users/totten/bknix/build/dev/web/core/ext/greenwich/composer.compile.json']) /Users/totten/bknix/build/dev/web/core/vendor/civicrm/composer-compile-lib/src/Tasks.php:15
    0.0023    1061624   4. Composer\Autoload\ClassLoader->loadClass($class = 'CCL\\ScssCompiler') /Users/totten/bknix/build/dev/web/core/vendor/civicrm/composer-compile-lib/src/Tasks/Scss.php:23
    0.0023    1061784   5. Composer\Autoload\{closure:/Users/totten/bknix/build/dev/web/core/vendor/composer/ClassLoader.php:575-577}($file = '/Users/totten/bknix/build/dev/web/core/vendor/composer/../civicrm/composer-compile-lib/src/ScssCompiler.php') /Users/totten/bknix/build/dev/web/core/vendor/composer/ClassLoader.php:427
    0.0023    1073312   6. include('/Users/totten/bknix/build/dev/web/core/vendor/civicrm/composer-compile-lib/src/ScssCompiler.php') /Users/totten/bknix/build/dev/web/core/vendor/composer/ClassLoader.php:576
    0.0023    1073312   7. Composer\Autoload\ClassLoader->loadClass($class = 'ScssPhp\\ScssPhp\\Compiler') /Users/totten/bknix/build/dev/web/core/vendor/civicrm/composer-compile-lib/src/ScssCompiler.php:4
    0.0023    1073440   8. Composer\Autoload\{closure:/Users/totten/bknix/build/dev/web/core/vendor/composer/ClassLoader.php:575-577}($file = '/Users/totten/bknix/build/dev/web/core/vendor/composer/../scssphp/scssphp/src/Compiler.php') /Users/totten/bknix/build/dev/web/core/vendor/composer/ClassLoader.php:427
```

After
----------------------------------------

Warning goes away.

Comments
----------------------------------------

The output in `ext/greenwich/dist/` appears the same before+after, e.g.

```
$ md5sum ext/greenwich/dist/*
4c04ae4acd8a4853fd1bf49519083926  ext/greenwich/dist/bootstrap3.css
43920d52d5372d91b74c923a5f5009b2  ext/greenwich/dist/bootstrap3.min.css
```