### PR TITLE
Replace deprecated createFromFileObject() with Writer::from()

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -665,7 +665,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
     $form->set('user_job_id', $userJobID);
 
     $form->getUserJob();
-    $writer = Writer::createFromFileObject(new SplTempFileObject());
+    $writer = Writer::from(new SplTempFileObject());
     $headers = $form->getOutputColumnsHeaders();
     $writer->insertOne($headers);
     // Note this might be more inefficient by iterating the result

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -93,7 +93,7 @@ trait ResultDataTrait {
    * @param string $fileName
    */
   private function outputCSV(array $rows, array $columns, string $fileName) {
-    $csv = Writer::createFromFileObject(new \SplTempFileObject());
+    $csv = Writer::from(new \SplTempFileObject());
     $csv->setOutputBOM(Writer::BOM_UTF8);
 
     // Header row


### PR DESCRIPTION
## Overview
This pull request updates CSV writer instantiation to address a deprecation introduced in `league/csv` v9.27.0. The change replaces a deprecated factory method with the recommended modern alternative, without altering behaviour or output.

## Before
The CSV writer was instantiated using a deprecated factory method:

```php
$writer = Writer::createFromFileObject(new \SplTempFileObject());
```


## After

$writer = Writer::from(new \SplTempFileObject());

