### PR TITLE
Replace deprecated output() with download()

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -671,7 +671,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
     // Note this might be more inefficient by iterating the result
     // set & doing insertOne - possibly something to explore later.
     $writer->insertAll($form->getOutputRows($status));
-    $writer->output($saveFileName);
+    $writer->download($saveFileName);
     CRM_Utils_System::civiExit();
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -109,7 +109,7 @@ trait ResultDataTrait {
       $csv->insertOne($row);
     }
     // Echo headers and content directly to browser
-    $csv->output($fileName);
+    $csv->download($fileName);
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3398,7 +3398,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
     fwrite($stream, $output);
     rewind($stream);
     $this->assertEquals("\xEF\xBB\xBF", substr($output, 0, 3));
-    $csv = Reader::createFromString($output);
+    $csv = Reader::fromString($output);
     if ($isFirstRowHeaders) {
       $csv->setHeaderOffset(0);
     }


### PR DESCRIPTION
## Overview
This pull request updates CSV output handling to address a deprecation introduced in `league/csv` v9.18.0. The change replaces a deprecated method with the recommended alternative, without changing the resulting response or file contents.

## Before
The CSV response was sent using a deprecated method:

```php
$csv->output($filename);
```

## After


```php
$csv->download($filename);
```

