### PR TITLE
River: fix regression on dashboard that adds Civi's H3 bg colour to the dashlet header H3s

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -208,7 +208,7 @@ body.civicrm-iframe-page {
   text-transform: uppercase;
 }
 .crm-container h3,
-#bootstrap-theme h3 {
+#bootstrap-theme h3:not(.crm-dashlet-header h3) {
   background-color: var(--crm-heading-bg-color);
   font-size: var(--crm-l-reg-1);
   font-weight: bold;


### PR DESCRIPTION
6.11 version of https://github.com/civicrm/civicrm-core/pull/34492

Overview
----------------------------------------
Civi has long had default style for `h3` tags - blue background with padding in Greenwich. H3s that appear elsewhere, eg the headers on the dashboard should be able to have their own styling but the recent addition of `#bootstrap-theme` to the dashboard has changed the specificity for the default h3 tags and forced the styling on all dashlet headers. 

This has impacted all streams and light/dark modes. This PR reverts that.

Before
----------------------------------------
<img width="955" height="94" alt="image" src="https://github.com/user-attachments/assets/89d1d017-7440-4450-81b3-5455e7d61177" />
<img width="919" height="87" alt="image" src="https://github.com/user-attachments/assets/f3d93c4f-0b8b-4cd5-b680-fb5e12637399" />

Walbrook
<img width="906" height="130" alt="image" src="https://github.com/user-attachments/assets/624d7875-357f-412c-9702-3badc2983b49" />

Hackney
<img width="923" height="88" alt="image" src="https://github.com/user-attachments/assets/31e20288-b5e4-4a0f-b9d4-bb8dfe5354c4" />

Thames
<img width="864" height="90" alt="image" src="https://github.com/user-attachments/assets/66ba9283-fdce-4b51-bd5c-1b5704c40679" />

After
----------------------------------------
<img width="930" height="91" alt="image" src="https://github.com/user-attachments/assets/1e78a2dd-82fb-4099-8f47-2598edc5e35a" />
<img width="877" height="85" alt="image" src="https://github.com/user-attachments/assets/bcacc7d9-d90c-40b3-9166-915d545e9ef7" />

Walbrook
<img width="968" height="112" alt="image" src="https://github.com/user-attachments/assets/18e141c4-71b5-45f4-a06b-17a100cf0b5c" />

Hackney
<img width="853" height="101" alt="image" src="https://github.com/user-attachments/assets/0cf840e9-7cb2-4566-910c-d5f65cf152d5" />

Thames
<img width="882" height="87" alt="image" src="https://github.com/user-attachments/assets/f2bfbc60-f269-43b0-99c6-15f6744cdf2e" />