### PR TITLE
dev/core#2225 Add {contact.checksum_value} (without cs=)

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -304,14 +304,14 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
       }
 
       foreach ($this->activeTokens as $token) {
-        if ($token === 'checksum') {
+        if ($token === 'checksum' || $token === 'checksum_value') {
           $cs = \CRM_Contact_BAO_Contact_Utils::generateChecksum($row->context['contactId'],
             NULL,
             NULL,
             $row->context['hash'] ?? NULL
           );
           $row->format('text/html')
-            ->tokens('contact', $token, "cs={$cs}");
+            ->tokens('contact', $token, ($token === 'checksum') ? "cs={$cs}" : $cs);
         }
         elseif ($token === 'signature_html') {
           $row->format('text/html')->tokens('contact', $token, html_entity_decode($this->getFieldValue($row, $token)));
@@ -659,8 +659,17 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
   protected function getBespokeTokens(): array {
     return [
       'checksum' => [
-        'title' => ts('Checksum'),
+        'title' => ts('Checksum (with cs=)'),
         'name' => 'checksum',
+        'type' => 'calculated',
+        'options' => NULL,
+        'data_type' => 'String',
+        'input_type' => NULL,
+        'audience' => 'user',
+      ],
+      'checksum_value' => [
+        'title' => ts('Checksum value'),
+        'name' => 'checksum_value',
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'String',

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -632,7 +632,7 @@ London, 90210
     $address = $this->setupContactFromTokeData($tokenData);
     $advertisedTokens = CRM_Core_SelectValues::contactTokens();
 
-    // let's unset specical afform submission tokens which are kind of related to contact
+    // let's unset special afform submission tokens which are kind of related to contact
     // but not exactly as contact is not yet created
     unset($advertisedTokens['{afformSubmission.validateSubmissionUrl}']);
     unset($advertisedTokens['{afformSubmission.validateSubmissionLink}']);
@@ -957,7 +957,8 @@ emo
       '{contact.custom_5}' => 'test_link :: Custom Group',
       '{contact.custom_12}' => 'Yes No :: Custom Group',
       '{contact.custom_3}' => 'Test Date :: Custom Group',
-      '{contact.checksum}' => 'Checksum',
+      '{contact.checksum}' => 'Checksum (with cs=)',
+      '{contact.checksum_value}' => 'Checksum value',
       '{contact.id}' => 'Contact ID',
       '{important_stuff.favourite_emoticon}' => 'Best coolest emoticon',
       '{site.message_header}' => 'Message Header',
@@ -1337,6 +1338,7 @@ custom_5 |<a href="https://civicrm.org" target="_blank">https://civicrm.org</a>
 custom_12 |Yes
 custom_3 |01/20/2021 12:00AM
 checksum |cs=' . $checksum . '
+checksum_value |' . $checksum . '
 id |' . $tokenData['contact_id'] . '
 t_stuff.favourite_emoticon |
 sage_header |<div><!-- This content comes from the site message header token--></div>


### PR DESCRIPTION
Overview
----------------------------------------
Add a checksum_value token without the `cs=`, re-label current checksum token for clarity.

Comments
----------------------------------------
This only provides a new-style token, which I assume is OK at this point.