### PR TITLE
Fix deprecation (php 8.5)

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -156,7 +156,7 @@ ORDER BY  civicrm_email.is_primary DESC, email_id ASC ";
       ],
     ];
 
-    $emails = $values = [];
+    $emails = [];
     $dao = CRM_Core_DAO::executeQuery($query, $params);
     $count = 1;
     while ($dao->fetch()) {
@@ -173,7 +173,7 @@ ORDER BY  civicrm_email.is_primary DESC, email_id ASC ";
         $emails[$count++] = $values;
       }
       else {
-        $emails[$dao->email_id] = $values;
+        $emails[$dao->email_id ?? ''] = $values;
       }
     }
     return $emails;


### PR DESCRIPTION
Using null as an array offset is deprecated, use an empty string instead #0 /home/homer/buildkit/build/build-1/web/core/CRM/Core/BAO/Email.php(176)
