### PR TITLE
composer.json - Make dependency on psr/http-client more explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
     "symfony/process": "~4.4 ||  ~5.4 || ~5.0 || ~6.0 || ~7.0",
     "symfony/var-dumper": "~4.4 || ~5.1 || ~6.0 || ~7.0",
     "symfony/service-contracts": "~2.2 || ~3.1",
+    "psr/http-client": "^1.0",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
     "symfony/finder": "~4.4 || ~5.4 || ~6.0 || ~7.0",
     "tecnickcom/tcpdf": "6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b314c95e432f8a7d892e1f417262a42a",
+    "content-hash": "4274217bd852ede49d265c6f86ef7631",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -6031,5 +6031,5 @@
     "platform-overrides": {
         "php": "8.1.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Overview
--------

CiviCRM already depends on in this package, in that the test-suites both use+implement the `ClientInterfaace`.

This hasn't been a problem because the dependency was *implicit* in multiple ways, but the implicit dependency has become a bit flaky. After recent upstream changes in PHP Spreadsheet, we see test-failures on Civi-D9 (with stable versions of CiviCRM).

Before
------

* CiviCRM depends on Guzzle 6|7.
    * Guzzle 7 depends on `psr/http-client`. Most CiviCRM instances have G7.
    * But some systems (like Drupal 9 and maybe older Joomla's) have G6.
* CiviCRM depends on PHPSpreadsheet.
    * Up through 1.30.1, PHPSpreadsheet depends on `psr/http-client`.
    * In the recent 1.30.2, PHPSpreadsheet no longer depends on it.

With the recent release of PHPSpreadsheet 1.30.2, there are now some scenarios (as in new or updated D9 builds) where `psr/http-client` goes missing. This leads to failures in the test matrix.

After
-----

* In `composer.json`, `psr/http-client` is explicitly required.
* So all builds (even D9) should get it.
* For any TAR/ZIP based builds, this patch doesn't actually change anything. (The `composer.lock` still lists the same packages+versions as before.)

Comments
-----------

I'm a little torn about sequencing across branches -- this fixes test issues on dev+RC+stable+ESR. But `composer.{json,lock}` are more prone to merge-conflicts. I think we just roll a hard dice -- do the patches on each branch and resolve any conflicts that might arise. 

But I might also need the fix for Cv/Civix testing (which tend to target ESR@-2)... in which case, maybe we wind up [using a `civibuild` trick](https://github.com/civicrm/civicrm-buildkit/blob/514c3c88e743f25c9442f1125be101dc783c0a13/src/civibuild.lib.sh#L601-L613).