### PR TITLE
PHP 8.5 - Fix warnings about setAccessible()

### DIFF
--- a/CRM/Core/IDS.php
+++ b/CRM/Core/IDS.php
@@ -87,7 +87,6 @@ class CRM_Core_IDS {
 
     // Cleanup
     $reflection = new \ReflectionProperty('IDS_Init', 'instances');
-    $reflection->setAccessible(TRUE);
     $value = $reflection->getValue(NULL);
     unset($value[NULL]);
     $reflection->setValue(NULL, $value);

--- a/Civi/API/Subscriber/SiteEmailLegacyOptionValueAdapter.php
+++ b/Civi/API/Subscriber/SiteEmailLegacyOptionValueAdapter.php
@@ -199,7 +199,6 @@ class SiteEmailLegacyOptionValueAdapter extends AutoSubscriber {
     // Modify internal variables of the api request... don't try this at home
     $reflection = $apiRequest->reflect();
     $entityNameProperty = $reflection->getProperty('_entityName');
-    $entityNameProperty->setAccessible(TRUE);
     $entityNameProperty->setValue($apiRequest, 'SiteEmailAddress');
     $allowedFields = array_keys(\Civi::entity('SiteEmailAddress')->getFields());
     if ($reflection->hasProperty('where')) {

--- a/Civi/Test/Invasive.php
+++ b/Civi/Test/Invasive.php
@@ -25,7 +25,6 @@ class Invasive {
   public static function call($callable, $args = []) {
     list ($class, $object, $member) = self::parseRef($callable);
     $reflection = new \ReflectionMethod($class, $member);
-    $reflection->setAccessible(TRUE);
     return $reflection->invokeArgs($object, $args);
   }
 
@@ -43,7 +42,6 @@ class Invasive {
   public static function get($ref) {
     list ($class, $object, $member) = self::parseRef($ref);
     $reflection = new \ReflectionProperty($class, $member);
-    $reflection->setAccessible(TRUE);
     return $reflection->getValue($object);
   }
 
@@ -62,7 +60,6 @@ class Invasive {
   public static function set($ref, $value) {
     list ($class, $object, $member) = self::parseRef($ref);
     $reflection = new \ReflectionProperty($class, $member);
-    $reflection->setAccessible(TRUE);
     $reflection->setValue($object, $value);
   }
 

--- a/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthClient/AuthorizationCode.php
@@ -163,7 +163,6 @@ class AuthorizationCode extends AbstractGrantAction {
    */
   protected function callProtected($obj, $method, $args = []) {
     $r = new \ReflectionMethod(get_class($obj), $method);
-    $r->setAccessible(TRUE);
     return $r->invokeArgs($obj, $args);
   }
 

--- a/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
+++ b/ext/oauth-client/Civi/OAuth/OAuthTokenFacade.php
@@ -95,7 +95,6 @@ class OAuthTokenFacade {
    */
   protected function callProtected($obj, string $method, $args = []) {
     $r = new \ReflectionMethod(get_class($obj), $method);
-    $r->setAccessible(TRUE);
     return $r->invokeArgs($obj, $args);
   }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/UtilsTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/UtilsTest.php
@@ -48,7 +48,6 @@ class UtilsTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface
    */
   public function testGetTokens($input, $expected) {
     $method = new \ReflectionMethod('\Civi\Api4\Generic\AutocompleteAction', 'getTokens');
-    $method->setAccessible(TRUE);
 
     $action = Contact::autocomplete();
     $this->assertEquals($expected, $method->invoke($action, $input));


### PR DESCRIPTION
Overview
----------------------------------------

Fix warnings on PHP 8.5. Get `Civi\Test\InvasiveTest` to pass on PHP 8.5.

Technical Details
----------------------------------------

From PHP docs:

> Note: As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default....
>
> This function has been DEPRECATED as of PHP 8.5.0...

See also:

* https://www.php.net/manual/en/reflectionmethod.setaccessible.php 
* https://www.php.net/manual/en/reflectionproperty.setaccessible.php
