### PR TITLE
composer.json - Make dependency on psr/http-client more explicit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
     "symfony/process": "~4.4 ||  ~5.4 || ~5.0 || ~6.0 || ~7.0",
     "symfony/var-dumper": "~4.4 || ~5.1 || ~6.0 || ~7.0",
     "symfony/service-contracts": "~2.2 || ~3.1",
+    "psr/http-client": "^1.0",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
     "symfony/finder": "~4.4 || ~5.4 || ~6.0 || ~7.0",
     "tecnickcom/tcpdf": "6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f5091886efcda6a51c86dac19fbcf6d",
+    "content-hash": "e36b7b29a2dbabfb671767986f8c865b",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Backport https://github.com/civicrm/civicrm-core/pull/34534 from 6.12-dev to 6.10-stable.