### PR TITLE
Remove deprecated curl_close()

### DIFF
--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -1434,9 +1434,6 @@ class CRM_Core_CodeGen_GenerateData {
     // grab URL and pass it to the browser
     $outstr = curl_exec($ch);
 
-    // close CURL resource, and free up system resources
-    curl_close($ch);
-
     $preg = "/'(<\?xml.+?)',/s";
     preg_match($preg, $outstr, $matches);
     if ($matches[1]) {

--- a/CRM/Core/Payment/FirstData.php
+++ b/CRM/Core/Payment/FirstData.php
@@ -269,12 +269,6 @@ class CRM_Core_Payment_FirstData extends CRM_Core_Payment {
     if (empty($responseData)) {
       throw new PaymentProcessorException('Error: No data returned from payment gateway.', 9007);
     }
-
-    //----------------------------------------------------------------------------------------------------
-    // Success so far - close the curl and check the data
-    //----------------------------------------------------------------------------------------------------
-    curl_close($ch);
-
     //----------------------------------------------------------------------------------------------------
     // Payment successfully sent to gateway - process the response now
     //----------------------------------------------------------------------------------------------------

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -952,7 +952,6 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
     if (!$res) {
       $errno = curl_errno($ch);
       $errstr = curl_error($ch);
-      curl_close($ch);
       throw new CRM_Core_Exception("cURL error: [$errno] $errstr");
     }
 
@@ -962,7 +961,6 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
       throw new CRM_Core_Exception("PayPal responded with http code $http_code");
     }
 
-    curl_close($ch);
     Civi::log()->debug('PayPalIPN: Verification response from PayPal: "' . $res . '".');
 
     // Check if PayPal verifies the IPN data, and if so, return true.

--- a/CRM/Core/Payment/Realex.php
+++ b/CRM/Core/Payment/Realex.php
@@ -152,8 +152,6 @@ class CRM_Core_Payment_Realex extends CRM_Core_Payment {
       throw new PaymentProcessorException(curl_error($submit), curl_errno($submit));
     }
 
-    curl_close($submit);
-
     // Tidy up the response xml
     $response_xml = preg_replace("/[\s\t]/", " ", $response_xml);
     $response_xml = preg_replace("/[\n\r]/", "", $response_xml);

--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -127,7 +127,6 @@ class CRM_Utils_Address_USPS {
     $response = curl_exec($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $curlError = curl_error($ch);
-    curl_close($ch);
 
     if ($curlError) {
       \Civi::log()->debug('USPS OAuth Error: ' . $curlError);
@@ -286,7 +285,6 @@ class CRM_Utils_Address_USPS {
       $response = curl_exec($ch);
       $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
       $curlError = curl_error($ch);
-      curl_close($ch);
 
       if ($curlError) {
         \Civi::log()->debug('USPS API Error: ' . $curlError);

--- a/CRM/Utils/HttpClient.php
+++ b/CRM/Utils/HttpClient.php
@@ -87,9 +87,6 @@ class CRM_Utils_HttpClient {
     if (curl_errno($ch)) {
       return self::STATUS_DL_ERROR;
     }
-    else {
-      curl_close($ch);
-    }
 
     fclose($fp);
 
@@ -126,9 +123,6 @@ class CRM_Utils_HttpClient {
     if (curl_errno($ch)) {
       return [self::STATUS_DL_ERROR, $data];
     }
-    else {
-      curl_close($ch);
-    }
 
     return [self::STATUS_OK, $data];
   }
@@ -162,9 +156,6 @@ class CRM_Utils_HttpClient {
     $data = curl_exec($ch);
     if (curl_errno($ch)) {
       return [self::STATUS_DL_ERROR, $data];
-    }
-    else {
-      curl_close($ch);
     }
 
     return [self::STATUS_OK, $data];

--- a/api/class.api.php
+++ b/api/class.api.php
@@ -290,7 +290,6 @@ class civicrm_api3 {
         $res->error = ['cURL error' => curl_error($ch)];
         return $res;
       }
-      curl_close($ch);
     }
     else {
       // Should be discouraged, because the API credentials and data

--- a/sql/GenerateReportData.php
+++ b/sql/GenerateReportData.php
@@ -1267,9 +1267,6 @@ class CRM_GCD {
     // grab URL and pass it to the browser
     $outstr = curl_exec($ch);
 
-    // close CURL resource, and free up system resources
-    curl_close($ch);
-
     $preg = "/'(<\?xml.+?)',/s";
     preg_match($preg, $outstr, $matches);
     if ($matches[1]) {


### PR DESCRIPTION
Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0
