### PR TITLE
PHP 8.5 deprecation

### DIFF
--- a/CRM/Core/OptionGroup.php
+++ b/CRM/Core/OptionGroup.php
@@ -104,8 +104,8 @@ class CRM_Core_OptionGroup {
    * @param string $orderBy
    *   the column to use for ordering.
    *
-   * @return array
-   *   The values as specified by the params
+   * @return array|null
+   *   The values as specified by the params. We should not return null, but we do - for some reason.
    */
   public static function &values(
     string $name, $flip = FALSE, $grouping = FALSE,

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -167,7 +167,7 @@ class FormattingUtil {
    */
   public static function formatDateValue($format, $value, &$operator = NULL, $index = NULL) {
     // Non-relative dates (or if no search operator)
-    if (!$operator || !array_key_exists($value, \CRM_Core_OptionGroup::values('relative_date_filters'))) {
+    if (!$operator || !array_key_exists($value, (array) \CRM_Core_OptionGroup::values('relative_date_filters'))) {
       return date($format, strtotime($value ?? ''));
     }
     if (isset($index) && !strstr($operator, 'BETWEEN')) {


### PR DESCRIPTION
Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead

/home/homer/buildkit/build/build-1/web/core/Civi/Api4/Utils/FormattingUtil.php:170 /home/homer/buildkit/build/build-1/web/core/Civi/Api4/Utils/FormattingUtil.php:143
