### PR TITLE
Fixes s modifier to regex to account for new lines

### DIFF
--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -32,7 +32,7 @@
       </div>
       {* Include the edit options list for admins *}
       {if $formElement.html|strstr:"crm-option-edit-link"}
-        {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+        {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@s":"$1"}
       {/if}
 
     </td>

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -47,7 +47,7 @@
               {/foreach}
               {* Include the edit options list for admins *}
               {if $formElement.html|strstr:"crm-option-edit-link"}
-                {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+                {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@s":"$1"}
               {/if}
             </div>
           </td>
@@ -67,7 +67,7 @@
         {/if}
           {* Include the edit options list for admins *}
           {if $formElement.html|strstr:"crm-option-edit-link"}
-            {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+            {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@s":"$1"}
           {/if}
           </td>
   {/if}

--- a/templates/CRM/UF/Form/Fields.tpl
+++ b/templates/CRM/UF/Form/Fields.tpl
@@ -120,7 +120,7 @@
               </div>
               {* Include the edit options list for admins *}
               {if $formElement.html|strstr:"crm-option-edit-link"}
-                {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@":"$1"}
+                {$formElement.html|regex_replace:"@^.*(<a href=.*? class=.crm-option-edit-link.*?</a>)$@s":"$1"}
               {/if}
             {else}
               {$formElement.html}


### PR DESCRIPTION
Overview
----------------------------------------

Version 6.10.0

Hello,

I have an event registration form with a required custom field that is a checkbox. It doesn't have the 'required' class so the front end validation doesn't catch it (I assume this is by design)

After submitting without checking the box the page reloads and shows the validation error. However, there are now two checkboxes inside the same crm-section element.

I was able to replicate this on https://smaster.demo.civicrm.org

https://civicrm.stackexchange.com/questions/51157/registration-forms-checkbox-validation-duplicating-fields

Reproduction steps
----------------------------------------
- Create a custom profile with a required checkbox field.
- Submit the form without checking the checkbox to allow the server side validation to kick in.
- On page reload the checkboxes will be duplicated

Current behaviour
----------------------------------------
<img width="686" height="447" alt="image" src="https://github.com/user-attachments/assets/402de5c8-93d3-41d8-bb23-9c4d40e336c3" />

https://smaster.demo.civicrm.org/civicrm/event/register?reset=1&action=preview&id=3

There is still one element (.crm-section) but the checkboxes are duplicated within.

Expected behaviour
----------------------------------------
A validation error should be displayed