### PR TITLE
Revert "Afform - Remove non-functional POC permission code"

### DIFF
--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -131,6 +131,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
       }
     }
 
+    $apiRequest->setCheckPermissions(($formField['security'] ?? NULL) !== 'FBAC');
     $apiRequest->setSavedSearch($formField['saved_search'] ?? NULL);
     $apiRequest->setDisplay($formField['search_display'] ?? NULL);
   }


### PR DESCRIPTION
Overview
----------------------------------------
This reverts commit d8ec5afaae173ed334e7a342aaf031165766033a.

Turns out the code was functional after all.