### PR TITLE
Api4 - Restore case-insensitive action names in ajax requests

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -29,7 +29,8 @@ class GetActions extends BasicGetAction {
   private $_actionsToGet;
 
   protected function getRecords() {
-    $this->_actionsToGet = $this->_itemsToGet('name');
+    // List of actions in the WHERE clause (strtolower in case the clause uses the case-insensitive LIKE operator)
+    $this->_actionsToGet = array_map('strtolower', (array) $this->_itemsToGet('name'));
 
     $className = CoreUtil::getApiClass($this->_entityName);
     $entityReflection = new \ReflectionClass($className);
@@ -77,7 +78,7 @@ class GetActions extends BasicGetAction {
    */
   private function loadAction($actionName, $method = NULL) {
     try {
-      if (!isset($this->_actions[$actionName]) && (!$this->_actionsToGet || in_array($actionName, $this->_actionsToGet))) {
+      if (!isset($this->_actions[$actionName]) && (!$this->_actionsToGet || in_array(strtolower($actionName), $this->_actionsToGet))) {
         $action = \Civi\API\Request::create($this->getEntityName(), $actionName, ['version' => 4]);
         $authorized = !$this->checkPermissions || \Civi::service('civi_api_kernel')->runAuthorize($this->getEntityName(), $actionName, ['version' => 4]);
         if (is_object($action) && $authorized) {

--- a/tests/phpunit/api/v4/Action/GetActionsTest.php
+++ b/tests/phpunit/api/v4/Action/GetActionsTest.php
@@ -30,6 +30,30 @@ use Civi\Test\TransactionalInterface;
  */
 class GetActionsTest extends Api4TestBase implements HookInterface, TransactionalInterface {
 
+  public function testCaseInsensitiveGetActions(): void {
+    // Case-insensitive operators
+    $actions = \Civi\Api4\Activity::getActions(FALSE)
+      ->addWhere('name', '=', 'GETFIELDS')
+      ->execute();
+    $this->assertCount(1, $actions);
+
+    $actions = \Civi\Api4\Activity::getActions(FALSE)
+      ->addWhere('name', 'LIKE', 'GETFIELDS')
+      ->execute();
+    $this->assertCount(1, $actions);
+
+    // Case-sensitive operator
+    $actions = \Civi\Api4\Activity::getActions(FALSE)
+      ->addWhere('name', 'REGEXP BINARY', 'GETFIELDS')
+      ->execute();
+    $this->assertCount(0, $actions);
+
+    $actions = \Civi\Api4\Activity::getActions(FALSE)
+      ->addWhere('name', 'REGEXP BINARY', 'getFields')
+      ->execute();
+    $this->assertCount(1, $actions);
+  }
+
   /**
    * Listens for civi.api4.authorize event to manually permit any user to use membership.get api
    *


### PR DESCRIPTION
Overview
----------------------------------------
Arguably a regression, causing issues with a few extensions.

Technical Details
------
Action names are technically case-sensitive, but this was not being enforced until https://github.com/civicrm/civicrm-core/commit/7a1c4b534fbb4c3fa2b880e86782f1fa7f291a4b inadvertently made the case matter.

This switches to a case-insensitive lookup to restore the previous behavior and avoid gotchas.

See:

- https://lab.civicrm.org/extensions/stripe/-/commit/a04d5ec4ffd025bb4da80b9949993aafc6ee24a4
- https://lab.civicrm.org/extensions/dataprocessor-export-tasks/-/merge_requests/5
- https://lab.civicrm.org/extensions/grapesjsmjml/-/merge_requests/12