### PR TITLE
Draft: Cache result of getEntities

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -43,10 +43,16 @@ class CRM_Core_DAO_AllCoreTables {
    *   [EntityName => [table => table_name, class => CRM_DAO_ClassName]][]
    */
   public static function getEntities(): array {
+    $cacheKey = 'getEntities';
+    if (isset(Civi::$statics[__CLASS__][$cacheKey])) {
+      return Civi::$statics[__CLASS__][$cacheKey];
+    }
     $allEntities = EntityRepository::getEntities();
     // Filter out entities without a table or class
+    $filteredEntities =  array_filter($allEntities, fn($entity) => (!empty($entity['table']) && !empty($entity['class'])));
+    Civi::$statics[__CLASS__][$cacheKey] = $filteredEntities;
+    return $filteredEntities;
 
-    return array_filter($allEntities, fn($entity) => (!empty($entity['table']) && !empty($entity['class'])));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
While analysing performance of a particularly slow Drupal view  using CiviCRM entity I spotted a lot of calls to getEntities. Given there are no params involved here it seems like we could get some wins by caching.

Before
----------------------------------------
Each time the function is called it gets all entities.

After
----------------------------------------
We cache result in Civi::$statics

Technical Details
----------------------------------------

Comments
----------------------------------------

