### PR TITLE
ElavonTest - Skip test on PHP 8.1 and Drupal 9 (Guzzle 6)

### DIFF
--- a/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
+++ b/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
@@ -55,6 +55,11 @@ class CRM_Core_Payment_ElavonTest extends \PHPUnit\Framework\TestCase implements
   }
 
   public function setUp(): void {
+    $guzzleVersion = \Composer\InstalledVersions::getVersion("guzzlehttp/guzzle");
+    if (version_compare($guzzleVersion, '7', '<') && version_compare(phpversion(), '8.1', '>=')) {
+      $this->markTestSkipped("On PHP 8.1+, testing with Guzzle's MockHandler requries v7+");
+    }
+
     $this->setUpElavonProcessor();
     $this->processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['Elavon']);
     parent::setUp();


### PR DESCRIPTION
Overview
----------------------------------------

We recently increased the minimum PHP (8.0 => 8.1), which means that Drupal 9 integration tests now run on PHP 8.1. D9 uses an older version of Guzzle (v6). It seems that the `MockHandler` used in this test fails PHP 8.1 + G6.

Discussion: https://chat.civicrm.org/civicrm/pl/zhox6wwewbfzjp5sdc4kissaoa

Before
----------------------------------------

Periodic tests like fail on `drupal9-dev`, `phpunit-core-exts`, `php81m57`. There's a hard fatal ([example](https://test.civicrm.org/job/CiviCRM-Test-QLow/253122/))

```
Initializing "Headless System" (b75d783ead963f7bf7c7a80f4f0e24dc) in "build0test_0wtqc"

Fatal error: During inheritance of Countable: Uncaught Return type of GuzzleHttp\Handler\MockHandler::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

/home/homer/buildkit/build/build-0/vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php:173
/home/homer/buildkit/build/build-0/vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php:15
/home/homer/buildkit/build/build-0/vendor/composer/ClassLoader.php:576
/home/homer/buildkit/build/build-0/vendor/composer/ClassLoader.php:427
/home/homer/buildkit/build/build-0/src/civicrm-core/Civi/Test/GuzzleTestTrait.php:111
/home/homer/buildkit/build/build-0/src/civicrm-core/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php:162
/home/homer/buildkit/build/build-0/src/civicrm-core/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php:144
/home/homer/buildkit/build/build-0/src/civicrm-core/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php:58
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
 in /home/homer/buildkit/build/build-0/vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php on line 15
```

After
----------------------------------------

Test is skipped in this configuration. But it should still run in other configurations (with PHP 8.1 and Guzzle 7).
