### PR TITLE
Update online receipts to use same product tokens as offline

### DIFF
--- a/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
+++ b/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
@@ -12,7 +12,7 @@
 use Civi\WorkflowMessage\GenericWorkflowMessage;
 
 /**
- * Receipt sent when confirming a back office membership.
+ * Receipt sent when confirming an online membership from a contribution page.
  *
  * @support template-only
  *

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -145,12 +145,12 @@ trait ContributionPageTestTrait {
       'premiums_id' => $this->ids['Premium'][$identifier],
       'product_id' => $this->ids['Product']['5_dollars'],
       'weight' => 1,
-    ]);
+    ], $identifier . '5');
     $this->createTestEntity('PremiumsProduct', [
       'premiums_id' => $this->ids['Premium'][$identifier],
       'product_id' => $this->ids['Product']['10_dollars'],
       'weight' => 2,
-    ]);
+    ], $identifier . '10');
     return $contributionPageResult;
   }
 
@@ -295,6 +295,24 @@ trait ContributionPageTestTrait {
       'amount' => 55,
       'name' => 'check_box',
     ], 'check_box');
+    $this->createTestEntity('Product', [
+      'name' => 'Blue Creature',
+      'sku' => 'sku-be-do',
+      'price' => 0.97,
+      'options' => 'brainy smurf, clumsy smurf, papa smurf, skusmurf=SKU Smurf',
+    ], 'ContributionPage');
+    $this->createTestEntity('Premium', [
+      'entity_id'  => $this->ids['ContributionPage']['ContributionPage'],
+      'entity_table' => 'civicrm_contribution_page',
+      'premiums_active' => TRUE,
+    ], 'ContributionPage');
+    $this->createTestEntity('PremiumsProduct', [
+      'premiums_id'  => $this->ids['Premium']['ContributionPage'],
+      'product_id' => $this->ids['Product']['ContributionPage'],
+      'financial_type_id:name' => 'Donation',
+      'weight' => 5,
+    ], 'ContributionPage');
+
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -670,6 +670,24 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertMailSentContainingHeaderString('Test Frontend title');
   }
 
+  public function testSubmitWithPremium(): void {
+    $this->contributionPageWithPriceSetCreate();
+    $this->submitOnlineContributionForm([
+      'id' => $this->getContributionPageID(),
+      'selectProduct' => $this->ids['Product']['ContributionPage'],
+      'options_' . $this->ids['Product']['ContributionPage'] => 'clumsy smurf',
+      'price_' . $this->ids['PriceField']['radio_field'] => $this->ids['PriceFieldValue']['10_dollars'],
+    ] + $this->getBillingSubmitValues());
+
+    $this->assertMailSentCount(1);
+    $this->assertMailSentContainingStrings([
+      'clumsy smurf',
+      'Blue Creature',
+      'sku-be-do',
+      '.97',
+    ]);
+  }
+
   /**
    * Test a zero dollar membership (quick config, not separate payment).
    *

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -81,12 +81,6 @@
   credit_card_number:::{$credit_card_number}
   credit_card_exp_date:::{$credit_card_exp_date}
   {/if}
-  {if !empty($selectPremium)}
-  selectPremium:::{$selectPremium}
-  product_name:::{$product_name}
-  option:::{$option}
-  sku:::{$sku}
-  {/if}
   {if !empty($start_date)}
   start_date:::{$start_date}
   end_date:::{$end_date}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -329,7 +329,7 @@
       </tr>
      {/if}
 
-     {if !empty($selectPremium)}
+     {if {contribution_product.id|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Premium Information{/ts}
@@ -337,26 +337,26 @@
       </tr>
       <tr>
        <td colspan="2" {$labelStyle}>
-        {$product_name}
+         {contribution_product.product_id.name}
        </td>
       </tr>
-      {if $option}
+      {if {contribution_product.product_option|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Option{/ts}
         </td>
         <td {$valueStyle}>
-         {$option}
+          {contribution_product.product_option:label}
         </td>
        </tr>
       {/if}
-      {if $sku}
+      {if {contribution_product.product_id.sku|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}SKU{/ts}
         </td>
         <td {$valueStyle}>
-         {$sku}
+          {contribution_product.product_id.sku}
         </td>
        </tr>
       {/if}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -322,7 +322,7 @@
       </tr>
     {/if}
 
-    {if !empty($selectPremium)}
+    {if {contribution_product.id|boolean}}
       <tr>
         <th {$headerStyle}>
           {ts}Premium Information{/ts}
@@ -330,26 +330,26 @@
       </tr>
       <tr>
         <td colspan="2" {$labelStyle}>
-          {$product_name}
+          {contribution_product.product_id.name}
         </td>
       </tr>
-      {if $option}
+      {if {contribution_product.product_option|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}Option{/ts}
           </td>
           <td {$valueStyle}>
-            {$option}
+            {contribution_product.product_option:label}
           </td>
         </tr>
       {/if}
-      {if $sku}
+      {if {contribution_product.product_id.sku|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}SKU{/ts}
           </td>
           <td {$valueStyle}>
-            {$sku}
+            {contribution_product.product_id.sku}
           </td>
         </tr>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Update online receipts to use same product tokens as offline


Before
----------------------------------------
Smarty variables used that rely on assignment

After
----------------------------------------
We recently switched the offline receipts to use tokens - this aligns the online receipt. Note that there are some additional online receipt tokens that are not in the offline receipt (e.g contact_name from the premiums table)
- I have not included those at this point

Technical Details
----------------------------------------
At this stage the smarty tokens are still assigned but I'm looking at a follow up upgrade

Comments
----------------------------------------
