### PR TITLE
Upgrade legacy smarty variable to token

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2503,19 +2503,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $dao->contribution_id = $this->id;
     if ($dao->find(TRUE)) {
       $premiumId = $dao->product_id;
-      $template->assign('option', $dao->product_option);
-
       $productDAO = new CRM_Contribute_DAO_Product();
       $productDAO->id = $premiumId;
       $productDAO->find(TRUE);
-      $template->assign('selectPremium', TRUE);
-      $template->assign('product_name', $productDAO->name);
       $template->assign('price', $productDAO->price);
-      $template->assign('sku', $productDAO->sku);
     }
-    else {
-      $template->assign('selectPremium', FALSE);
-    }
+
     $template->assign('title', $values['title'] ?? NULL);
     $values['amount'] = $input['total_amount'] ?? $input['amount'] ?? NULL;
     if (!$values['amount'] && isset($this->total_amount)) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -841,14 +841,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $selectProduct != 'no_thanks'
     ) {
       $startDate = $endDate = "";
-      $this->assign('selectPremium', TRUE);
       $productDAO = new CRM_Contribute_DAO_Product();
       $productDAO->id = $selectProduct;
       $productDAO->find(TRUE);
-      $this->assign('product_name', $productDAO->name);
       $this->assign('price', $productDAO->price);
-      $this->assign('sku', $productDAO->sku);
-      $this->assign('option', $premiumParams['options_' . $premiumParams['selectProduct']] ?? NULL);
 
       $periodType = $productDAO->period_type;
 

--- a/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
+++ b/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
@@ -12,7 +12,7 @@
 use Civi\WorkflowMessage\GenericWorkflowMessage;
 
 /**
- * Receipt sent when confirming a back office membership.
+ * Receipt sent when confirming an online membership from a contribution page.
  *
  * @support template-only
  *

--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -29,6 +29,21 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
    */
   public function upgrade_6_12_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $swaps = [
+      'if !empty($selectPremium)' => 'if {contribution_product.id|boolean}',
+      '$product_name' => 'contribution_product.product_id.name',
+      'if $option' => 'if {contribution_product.product_option|boolean}',
+      '$option' => 'contribution_product.product_option:label',
+      'if $sku' => 'if {contribution_product.product_id.sku|boolean}',
+      '$sku' => 'contribution_product.product_id.sku',
+    ];
+    foreach (['membership_online_receipt', 'contribution_online_receipt', 'contribution_offline_receipt'] as $type) {
+      foreach ($swaps as $from => $to) {
+        $this->addTask('Replace {' . $from . ' with ' . $to . 'in ' . $type,
+          'updateMessageToken', $type, $from, $type, $rev
+        );
+      }
+    }
   }
 
 }

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1502,6 +1502,10 @@ class CRM_Utils_Token {
           '$contributionPageId' => 'contribution.contribution_page_id',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$selectPremium' => 'contribution_product.id|boolean',
+          '$product_name' => 'contribution_product.product_id.name',
+          '$option' => 'contribution_product.product_option:label',
+          '$sku' => 'contribution_product.product_id.sku',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1542,6 +1546,10 @@ class CRM_Utils_Token {
           '$contributionPageId' => 'contribution.contribution_page_id',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$selectPremium' => 'contribution_product.id|boolean',
+          '$product_name' => 'contribution_product.product_id.name',
+          '$option' => 'contribution_product.product_option:label',
+          '$sku' => 'contribution_product.product_id.sku',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',
@@ -1554,6 +1562,10 @@ class CRM_Utils_Token {
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
           '$address' => 'contribution.address_id.display',
+          '$selectPremium' => 'contribution_product.id|boolean',
+          '$product_name' => 'contribution_product.product_id.name',
+          '$option' => 'contribution_product.product_option:label',
+          '$sku' => 'contribution_product.product_id.sku',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -145,12 +145,12 @@ trait ContributionPageTestTrait {
       'premiums_id' => $this->ids['Premium'][$identifier],
       'product_id' => $this->ids['Product']['5_dollars'],
       'weight' => 1,
-    ]);
+    ], $identifier . '5');
     $this->createTestEntity('PremiumsProduct', [
       'premiums_id' => $this->ids['Premium'][$identifier],
       'product_id' => $this->ids['Product']['10_dollars'],
       'weight' => 2,
-    ]);
+    ], $identifier . '10');
     return $contributionPageResult;
   }
 
@@ -295,6 +295,24 @@ trait ContributionPageTestTrait {
       'amount' => 55,
       'name' => 'check_box',
     ], 'check_box');
+    $this->createTestEntity('Product', [
+      'name' => 'Blue Creature',
+      'sku' => 'sku-be-do',
+      'price' => 0.97,
+      'options' => 'brainy smurf, clumsy smurf, papa smurf, skusmurf=SKU Smurf',
+    ], 'ContributionPage');
+    $this->createTestEntity('Premium', [
+      'entity_id'  => $this->ids['ContributionPage']['ContributionPage'],
+      'entity_table' => 'civicrm_contribution_page',
+      'premiums_active' => TRUE,
+    ], 'ContributionPage');
+    $this->createTestEntity('PremiumsProduct', [
+      'premiums_id'  => $this->ids['Premium']['ContributionPage'],
+      'product_id' => $this->ids['Product']['ContributionPage'],
+      'financial_type_id:name' => 'Donation',
+      'weight' => 5,
+    ], 'ContributionPage');
+
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -670,6 +670,24 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertMailSentContainingHeaderString('Test Frontend title');
   }
 
+  public function testSubmitWithPremium(): void {
+    $this->contributionPageWithPriceSetCreate();
+    $this->submitOnlineContributionForm([
+      'id' => $this->getContributionPageID(),
+      'selectProduct' => $this->ids['Product']['ContributionPage'],
+      'options_' . $this->ids['Product']['ContributionPage'] => 'clumsy smurf',
+      'price_' . $this->ids['PriceField']['radio_field'] => $this->ids['PriceFieldValue']['10_dollars'],
+    ] + $this->getBillingSubmitValues());
+
+    $this->assertMailSentCount(1);
+    $this->assertMailSentContainingStrings([
+      'clumsy smurf',
+      'Blue Creature',
+      'sku-be-do',
+      '.97',
+    ]);
+  }
+
   /**
    * Test a zero dollar membership (quick config, not separate payment).
    *

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -81,12 +81,6 @@
   credit_card_number:::{$credit_card_number}
   credit_card_exp_date:::{$credit_card_exp_date}
   {/if}
-  {if !empty($selectPremium)}
-  selectPremium:::{$selectPremium}
-  product_name:::{$product_name}
-  option:::{$option}
-  sku:::{$sku}
-  {/if}
   {if !empty($start_date)}
   start_date:::{$start_date}
   end_date:::{$end_date}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -329,7 +329,7 @@
       </tr>
      {/if}
 
-     {if !empty($selectPremium)}
+     {if {contribution_product.id|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Premium Information{/ts}
@@ -337,26 +337,26 @@
       </tr>
       <tr>
        <td colspan="2" {$labelStyle}>
-        {$product_name}
+         {contribution_product.product_id.name}
        </td>
       </tr>
-      {if $option}
+      {if {contribution_product.product_option|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Option{/ts}
         </td>
         <td {$valueStyle}>
-         {$option}
+          {contribution_product.product_option:label}
         </td>
        </tr>
       {/if}
-      {if $sku}
+      {if {contribution_product.product_id.sku|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}SKU{/ts}
         </td>
         <td {$valueStyle}>
-         {$sku}
+          {contribution_product.product_id.sku}
         </td>
        </tr>
       {/if}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -322,7 +322,7 @@
       </tr>
     {/if}
 
-    {if !empty($selectPremium)}
+    {if {contribution_product.id|boolean}}
       <tr>
         <th {$headerStyle}>
           {ts}Premium Information{/ts}
@@ -330,26 +330,26 @@
       </tr>
       <tr>
         <td colspan="2" {$labelStyle}>
-          {$product_name}
+          {contribution_product.product_id.name}
         </td>
       </tr>
-      {if $option}
+      {if {contribution_product.product_option|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}Option{/ts}
           </td>
           <td {$valueStyle}>
-            {$option}
+            {contribution_product.product_option:label}
           </td>
         </tr>
       {/if}
-      {if $sku}
+      {if {contribution_product.product_id.sku|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}SKU{/ts}
           </td>
           <td {$valueStyle}>
-            {$sku}
+            {contribution_product.product_id.sku}
           </td>
         </tr>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/34556 and swaps out some old smarty variables in the upgrade script with deprecation & removal of the assign

Before
----------------------------------------
variables no longer in core templates but no further action taken

After
----------------------------------------
Variables swapped out in upgrade script with deprecation notices if still present

Technical Details
----------------------------------------

Comments
----------------------------------------
