### PR TITLE
Use getSubmittedValue to retrieve the submitted premium options

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2499,16 +2499,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $template->assign('softCreditTypes', $softCreditTypes ?? NULL);
     $template->assign('softCredits', $softCredits ?? NULL);
 
-    $dao = new CRM_Contribute_DAO_ContributionProduct();
-    $dao->contribution_id = $this->id;
-    if ($dao->find(TRUE)) {
-      $premiumId = $dao->product_id;
-      $productDAO = new CRM_Contribute_DAO_Product();
-      $productDAO->id = $premiumId;
-      $productDAO->find(TRUE);
-      $template->assign('price', $productDAO->price);
-    }
-
     $template->assign('title', $values['title'] ?? NULL);
     $values['amount'] = $input['total_amount'] ?? $input['amount'] ?? NULL;
     if (!$values['amount'] && isset($this->total_amount)) {

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2503,19 +2503,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $dao->contribution_id = $this->id;
     if ($dao->find(TRUE)) {
       $premiumId = $dao->product_id;
-      $template->assign('option', $dao->product_option);
-
       $productDAO = new CRM_Contribute_DAO_Product();
       $productDAO->id = $premiumId;
       $productDAO->find(TRUE);
-      $template->assign('selectPremium', TRUE);
-      $template->assign('product_name', $productDAO->name);
       $template->assign('price', $productDAO->price);
-      $template->assign('sku', $productDAO->sku);
     }
-    else {
-      $template->assign('selectPremium', FALSE);
-    }
+
     $template->assign('title', $values['title'] ?? NULL);
     $values['amount'] = $input['total_amount'] ?? $input['amount'] ?? NULL;
     if (!$values['amount'] && isset($this->total_amount)) {

--- a/CRM/Contribute/ContributionProductTokens.php
+++ b/CRM/Contribute/ContributionProductTokens.php
@@ -40,7 +40,7 @@ class CRM_Contribute_ContributionProductTokens extends CRM_Core_EntityTokens {
     if (!array_key_exists('Contribution', \Civi::service('action_object_provider')->getEntities())) {
       return $tokens;
     }
-    $tokens += $this->getRelatedTokensForEntity('Product', 'product_id', ['name', 'sku']);
+    $tokens += $this->getRelatedTokensForEntity('Product', 'product_id', ['name', 'sku', 'price']);
     return $tokens;
   }
 

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1283,7 +1283,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // Result has all the stuff we need
     // lets archive it to a financial transaction
     if ($financialType->is_deductible) {
-      $this->assign('is_deductible', TRUE);
       $this->set('is_deductible', TRUE);
     }
     $contributionParams = [

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -844,7 +844,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $productDAO = new CRM_Contribute_DAO_Product();
       $productDAO->id = $selectProduct;
       $productDAO->find(TRUE);
-      $this->assign('price', $productDAO->price);
 
       $periodType = $productDAO->period_type;
 
@@ -2474,7 +2473,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $financialType = new CRM_Financial_DAO_FinancialType();
     $financialType->id = $financialTypeID;
     $financialType->find(TRUE);
-    $this->assign('is_deductible', $this->isDeductible($financialTypeID));
 
     // add some financial type details to the params list
     // if folks need to use it

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -41,6 +41,24 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   public $submitOnce = TRUE;
 
   /**
+   * @return int|null
+   */
+  private function getSelectedProductID(): ?int {
+    $selectedProductID = $this->getSubmittedValue('selectProduct') ?: NULL;
+    if ($selectedProductID === 'no_thanks') {
+      $selectedProductID = NULL;
+    }
+    return $selectedProductID;
+  }
+
+  /**
+   * @return mixed|null
+   */
+  private function getSelectedProductOption(): mixed {
+    return $this->getSubmittedValue('options_' . $this->getSelectedProductID());
+  }
+
+  /**
    * @param int|null $financialTypeID
    *
    * @return bool
@@ -233,20 +251,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     else {
       if ($this->isDeductible($financialTypeID)) {
-        if (isset($params['selectProduct'])) {
-          $selectProduct = $params['selectProduct'] ?? NULL;
-        }
         // if there is a product - compare the value to the contribution amount
-        if (isset($selectProduct) &&
-          $selectProduct !== 'no_thanks'
-        ) {
+        if ($this->getSelectedProductID()) {
           $productDAO = new CRM_Contribute_DAO_Product();
-          $productDAO->id = $selectProduct;
+          $productDAO->id = $this->getSelectedProductID();
           $productDAO->find(TRUE);
           // product value exceeds contribution amount
           if ($params['amount'] < $productDAO->price) {
-            $nonDeductibleAmount = $params['amount'];
-            return $nonDeductibleAmount;
+            return $params['amount'];
           }
           // product value does NOT exceed contribution amount
           else {
@@ -497,9 +509,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (!$this->isQuickConfig()) {
       $this->assign('lineItem', [$this->getPriceSetID() => $this->order->getLineItems()]);
     }
-
-    if (!empty($params['selectProduct']) && $params['selectProduct'] !== 'no_thanks') {
-      $option = $params['options_' . $params['selectProduct']] ?? NULL;
+    if ($this->getSelectedProductID()) {
+      $option = $this->getSelectedProductOption();
       $this->buildPremiumsBlock(FALSE, $option);
       $this->set('option', $option);
     }
@@ -830,19 +841,16 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   /**
    * Process the form.
    *
-   * @param array $premiumParams
    * @param CRM_Contribute_BAO_Contribution $contribution
    */
-  protected function postProcessPremium($premiumParams, $contribution) {
+  protected function postProcessPremium($contribution) {
     $hour = $minute = $second = 0;
     // assigning Premium information to receipt tpl
-    $selectProduct = $premiumParams['selectProduct'] ?? NULL;
-    if ($selectProduct &&
-      $selectProduct != 'no_thanks'
-    ) {
+    $selectProduct = $this->getSelectedProductID();
+    if ($this->getSelectedProductID()) {
       $startDate = $endDate = "";
       $productDAO = new CRM_Contribute_DAO_Product();
-      $productDAO->id = $selectProduct;
+      $productDAO->id = $this->getSelectedProductID();
       $productDAO->find(TRUE);
 
       $periodType = $productDAO->period_type;
@@ -902,16 +910,16 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       //create Premium record
       $params = [
-        'product_id' => $premiumParams['selectProduct'],
+        'product_id' => $this->getSelectedProductID(),
         'contribution_id' => $contribution->id,
-        'product_option' => $premiumParams['options_' . $premiumParams['selectProduct']] ?? NULL,
+        'product_option' => $this->getSelectedProductOption(),
         'quantity' => 1,
         'start_date' => CRM_Utils_Date::customFormat($startDate, '%Y%m%d'),
         'end_date' => CRM_Utils_Date::customFormat($endDate, '%Y%m%d'),
       ];
-      if (!empty($premiumParams['selectProduct'])) {
+      if ($this->getSelectedProductID()) {
         $daoPremiumsProduct = new CRM_Contribute_DAO_PremiumsProduct();
-        $daoPremiumsProduct->product_id = $premiumParams['selectProduct'];
+        $daoPremiumsProduct->product_id = $this->getSelectedProductID();
         $daoPremiumsProduct->premiums_id = $dao->id;
         $daoPremiumsProduct->find(TRUE);
         $params['financial_type_id'] = $daoPremiumsProduct->financial_type_id;
@@ -934,7 +942,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         CRM_Core_BAO_FinancialTrxn::createPremiumTrxn($trxnParams);
       }
     }
-    elseif ($selectProduct === 'no_thanks') {
+    elseif ($this->getSubmittedValue('selectProduct') === 'no_thanks') {
       //Fixed For CRM-3901
       $daoContrProd = new CRM_Contribute_DAO_ContributionProduct();
       $daoContrProd->contribution_id = $contribution->id;
@@ -1384,9 +1392,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param array $membershipParams
    * @param int $contactID
    * @param array $customFieldsFormatted
-   * @param array $premiumParams
    */
-  protected function processMembership($membershipParams, $contactID, $customFieldsFormatted, $premiumParams): void {
+  protected function processMembership($membershipParams, $contactID, $customFieldsFormatted): void {
 
     $membershipType = $this->getFirstSelectedMembershipType();
 
@@ -1413,7 +1420,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $membershipParams['contribution_source'] = $this->_params['membership_source'];
     }
 
-    $this->postProcessMembership($membershipParams, $contactID, $premiumParams, $customFieldsFormatted, $membershipType, $isPaidMembership, $this->_membershipId, $financialTypeID,);
+    $this->postProcessMembership($membershipParams, $contactID, $customFieldsFormatted, $membershipType, $isPaidMembership, $this->_membershipId, $financialTypeID,);
 
     $this->set('membershipTypeID', $membershipParams['selectMembership']);
   }
@@ -1426,7 +1433,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param int $contactID
    *   Contact id.
    *
-   * @param array $premiumParams
    * @param null $customFieldsFormatted
    *
    * @param array $membershipDetails
@@ -1441,7 +1447,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   protected function postProcessMembership(
-    $membershipParams, $contactID, $premiumParams,
+    $membershipParams, $contactID,
     $customFieldsFormatted, $membershipDetails, $isPaidMembership, $membershipID,
     $financialTypeID) {
     $membershipContribution = NULL;
@@ -1480,7 +1486,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       );
       if (!empty($paymentResult['contribution'])) {
         $paymentResults[] = ['contribution_id' => $paymentResult['contribution']->id, 'result' => $paymentResult];
-        $this->postProcessPremium($premiumParams, $paymentResult['contribution']);
+        $this->postProcessPremium($paymentResult['contribution']);
         //note that this will be over-written if we are using a separate membership transaction. Otherwise there is only one
         $membershipContribution = $paymentResult['contribution'];
         // Save the contribution ID so that I can be used in email receipts
@@ -2037,7 +2043,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->_params['payment_processor_id'] = $this->_paymentProcessor['id'];
     }
 
-    $premiumParams = $membershipParams = $params = $this->_params;
+    $membershipParams = $params = $this->_params;
     if (!empty($params['image_URL'])) {
       CRM_Contact_BAO_Contact::processImageParams($params);
     }
@@ -2218,7 +2224,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // store the fact that this is a membership and membership type is selected
     if ($this->isMembershipSelected()) {
-      $this->doMembershipProcessing($contactID, $membershipParams, $premiumParams);
+      $this->doMembershipProcessing($contactID, $membershipParams);
     }
     else {
       // at this point we've created a contact and stored its address etc
@@ -2251,7 +2257,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
       if (empty($result['is_payment_failure'])) {
         // @todo move premium processing to complete transaction if it truly is an 'after' action.
-        $this->postProcessPremium($premiumParams, $result['contribution']);
+        $this->postProcessPremium($result['contribution']);
       }
       if (!empty($result['contribution'])) {
         // It seems this line is hit when there is a zero dollar transaction & in tests, not sure when else.
@@ -2325,9 +2331,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param int $contactID
    * @param array $membershipParams
-   * @param array $premiumParams
    */
-  protected function doMembershipProcessing($contactID, $membershipParams, $premiumParams) {
+  protected function doMembershipProcessing($contactID, $membershipParams) {
     if (!$this->isMembershipPriceSet()) {
       $this->set('membershipTypeID', $this->_params['selectMembership']);
     }
@@ -2392,7 +2397,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // CRM-12233.
       try {
         $membershipParams['amount'] = $this->getMainContributionAmount();
-        $this->processMembership($membershipParams, $contactID, $customFieldsFormatted, $premiumParams);
+        $this->processMembership($membershipParams, $contactID, $customFieldsFormatted);
       }
       catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
         CRM_Core_Session::singleton()->setStatus($e->getMessage());

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -841,14 +841,10 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $selectProduct != 'no_thanks'
     ) {
       $startDate = $endDate = "";
-      $this->assign('selectPremium', TRUE);
       $productDAO = new CRM_Contribute_DAO_Product();
       $productDAO->id = $selectProduct;
       $productDAO->find(TRUE);
-      $this->assign('product_name', $productDAO->name);
       $this->assign('price', $productDAO->price);
-      $this->assign('sku', $productDAO->sku);
-      $this->assign('option', $premiumParams['options_' . $premiumParams['selectProduct']] ?? NULL);
 
       $periodType = $productDAO->period_type;
 

--- a/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
+++ b/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
@@ -12,7 +12,7 @@
 use Civi\WorkflowMessage\GenericWorkflowMessage;
 
 /**
- * Receipt sent when confirming a back office membership.
+ * Receipt sent when confirming an online membership from a contribution page.
  *
  * @support template-only
  *

--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -29,6 +29,21 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
    */
   public function upgrade_6_12_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $swaps = [
+      'if !empty($selectPremium)' => 'if {contribution_product.id|boolean}',
+      '$product_name' => 'contribution_product.product_id.name',
+      'if $option' => 'if {contribution_product.product_option|boolean}',
+      '$option' => 'contribution_product.product_option:label',
+      'if $sku' => 'if {contribution_product.product_id.sku|boolean}',
+      '$sku' => 'contribution_product.product_id.sku',
+    ];
+    foreach (['membership_online_receipt', 'contribution_online_receipt', 'contribution_offline_receipt'] as $type) {
+      foreach ($swaps as $from => $to) {
+        $this->addTask('Replace {' . $from . ' with ' . $to . 'in ' . $type,
+          'updateMessageToken', $type, $from, $type, $rev
+        );
+      }
+    }
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -36,6 +36,8 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
       '$option' => 'contribution_product.product_option:label',
       'if $sku' => 'if {contribution_product.product_id.sku|boolean}',
       '$sku' => 'contribution_product.product_id.sku',
+      'if $is_deductible AND !empty($price)' => 'if {contribution.non_deductible_amount|boolean} AND {contribution_product.product_id.price|boolean}',
+      'ts 1=$price|crmMoney:$currency' => "ts 1='{contribution_product.product_id.price|crmMoney}'",
     ];
     foreach (['membership_online_receipt', 'contribution_online_receipt', 'contribution_offline_receipt'] as $type) {
       foreach ($swaps as $from => $to) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1502,6 +1502,10 @@ class CRM_Utils_Token {
           '$contributionPageId' => 'contribution.contribution_page_id',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$selectPremium' => 'contribution_product.id|boolean',
+          '$product_name' => 'contribution_product.product_id.name',
+          '$option' => 'contribution_product.product_option:label',
+          '$sku' => 'contribution_product.product_id.sku',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1542,6 +1546,10 @@ class CRM_Utils_Token {
           '$contributionPageId' => 'contribution.contribution_page_id',
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
+          '$selectPremium' => 'contribution_product.id|boolean',
+          '$product_name' => 'contribution_product.product_id.name',
+          '$option' => 'contribution_product.product_option:label',
+          '$sku' => 'contribution_product.product_id.sku',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',
@@ -1554,6 +1562,10 @@ class CRM_Utils_Token {
           '$lineItem' => '$lineItems',
           '$billingName' => 'contribution.address_id.name',
           '$address' => 'contribution.address_id.display',
+          '$selectPremium' => 'contribution_product.id|boolean',
+          '$product_name' => 'contribution_product.product_id.name',
+          '$option' => 'contribution_product.product_option:label',
+          '$sku' => 'contribution_product.product_id.sku',
         ],
         'event_offline_receipt' => [
           '$contributeMode' => ts('no longer available / relevant'),

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1506,6 +1506,8 @@ class CRM_Utils_Token {
           '$product_name' => 'contribution_product.product_id.name',
           '$option' => 'contribution_product.product_option:label',
           '$sku' => 'contribution_product.product_id.sku',
+          '$price' => 'contribution_product.product_id.price|crmMoney',
+          '$is_deductible' => 'contribution.non_deductible_amount|boolean',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1550,6 +1552,8 @@ class CRM_Utils_Token {
           '$product_name' => 'contribution_product.product_id.name',
           '$option' => 'contribution_product.product_option:label',
           '$sku' => 'contribution_product.product_id.sku',
+          '$price' => 'contribution_product.product_id.price|crmMoney',
+          '$is_deductible' => 'contribution.non_deductible_amount|boolean',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -145,12 +145,12 @@ trait ContributionPageTestTrait {
       'premiums_id' => $this->ids['Premium'][$identifier],
       'product_id' => $this->ids['Product']['5_dollars'],
       'weight' => 1,
-    ]);
+    ], $identifier . '5');
     $this->createTestEntity('PremiumsProduct', [
       'premiums_id' => $this->ids['Premium'][$identifier],
       'product_id' => $this->ids['Product']['10_dollars'],
       'weight' => 2,
-    ]);
+    ], $identifier . '10');
     return $contributionPageResult;
   }
 
@@ -295,6 +295,24 @@ trait ContributionPageTestTrait {
       'amount' => 55,
       'name' => 'check_box',
     ], 'check_box');
+    $this->createTestEntity('Product', [
+      'name' => 'Blue Creature',
+      'sku' => 'sku-be-do',
+      'price' => 0.97,
+      'options' => 'brainy smurf, clumsy smurf, papa smurf, skusmurf=SKU Smurf',
+    ], 'ContributionPage');
+    $this->createTestEntity('Premium', [
+      'entity_id'  => $this->ids['ContributionPage']['ContributionPage'],
+      'entity_table' => 'civicrm_contribution_page',
+      'premiums_active' => TRUE,
+    ], 'ContributionPage');
+    $this->createTestEntity('PremiumsProduct', [
+      'premiums_id'  => $this->ids['Premium']['ContributionPage'],
+      'product_id' => $this->ids['Product']['ContributionPage'],
+      'financial_type_id:name' => 'Donation',
+      'weight' => 5,
+    ], 'ContributionPage');
+
   }
 
   /**

--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -89,6 +89,9 @@ return [
       'input_type' => NULL,
       'description' => ts('Sell price or market value for premiums. For tax-deductible contributions, this will be stored as non_deductible_amount in the contribution record.'),
       'add' => '1.4',
+      'usage' => [
+        'token',
+      ],
     ],
     'currency' => [
       'title' => ts('Currency'),

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -670,6 +670,24 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertMailSentContainingHeaderString('Test Frontend title');
   }
 
+  public function testSubmitWithPremium(): void {
+    $this->contributionPageWithPriceSetCreate();
+    $this->submitOnlineContributionForm([
+      'id' => $this->getContributionPageID(),
+      'selectProduct' => $this->ids['Product']['ContributionPage'],
+      'options_' . $this->ids['Product']['ContributionPage'] => 'clumsy smurf',
+      'price_' . $this->ids['PriceField']['radio_field'] => $this->ids['PriceFieldValue']['10_dollars'],
+    ] + $this->getBillingSubmitValues());
+
+    $this->assertMailSentCount(1);
+    $this->assertMailSentContainingStrings([
+      'clumsy smurf',
+      'Blue Creature',
+      'sku-be-do',
+      '.97',
+    ]);
+  }
+
   /**
    * Test a zero dollar membership (quick config, not separate payment).
    *

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -81,12 +81,6 @@
   credit_card_number:::{$credit_card_number}
   credit_card_exp_date:::{$credit_card_exp_date}
   {/if}
-  {if !empty($selectPremium)}
-  selectPremium:::{$selectPremium}
-  product_name:::{$product_name}
-  option:::{$option}
-  sku:::{$sku}
-  {/if}
   {if !empty($start_date)}
   start_date:::{$start_date}
   end_date:::{$end_date}

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -85,17 +85,11 @@
   start_date:::{$start_date}
   end_date:::{$end_date}
   {/if}
-  {if $is_deductible}
-  is_deductible:::{$is_deductible}
-  {/if}
   {if !empty($contact_email)}
   contact_email:::{$contact_email}
   {/if}
   {if !empty($contact_phone)}
   contact_phone:::{$contact_phone}
-  {/if}
-  {if !empty($price)}
-  price:::{$price}
   {/if}
   {if !empty($customPre_grouptitle)}
   customPre_grouptitle:::{$customPre_grouptitle}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -393,10 +393,10 @@
         </td>
        </tr>
       {/if}
-      {if $is_deductible AND !empty($price)}
+      {if {contribution.non_deductible_amount|boolean} AND {contribution_product.product_id.price|boolean}}
         <tr>
          <td colspan="2" {$valueStyle}>
-          <p>{ts 1=$price|crmMoney:$currency}The value of this premium is %1. This may affect the amount of the tax deduction you can claim. Consult your tax advisor for more information.{/ts}</p>
+          <p>{ts 1='{contribution_product.product_id.price|crmMoney}'}The value of this premium is %1. This may affect the amount of the tax deduction you can claim. Consult your tax advisor for more information.{/ts}</p>
          </td>
         </tr>
       {/if}

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -329,7 +329,7 @@
       </tr>
      {/if}
 
-     {if !empty($selectPremium)}
+     {if {contribution_product.id|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Premium Information{/ts}
@@ -337,26 +337,26 @@
       </tr>
       <tr>
        <td colspan="2" {$labelStyle}>
-        {$product_name}
+         {contribution_product.product_id.name}
        </td>
       </tr>
-      {if $option}
+      {if {contribution_product.product_option|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}Option{/ts}
         </td>
         <td {$valueStyle}>
-         {$option}
+          {contribution_product.product_option:label}
         </td>
        </tr>
       {/if}
-      {if $sku}
+      {if {contribution_product.product_id.sku|boolean}}
        <tr>
         <td {$labelStyle}>
          {ts}SKU{/ts}
         </td>
         <td {$valueStyle}>
-         {$sku}
+          {contribution_product.product_id.sku}
         </td>
        </tr>
       {/if}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -322,7 +322,7 @@
       </tr>
     {/if}
 
-    {if !empty($selectPremium)}
+    {if {contribution_product.id|boolean}}
       <tr>
         <th {$headerStyle}>
           {ts}Premium Information{/ts}
@@ -330,26 +330,26 @@
       </tr>
       <tr>
         <td colspan="2" {$labelStyle}>
-          {$product_name}
+          {contribution_product.product_id.name}
         </td>
       </tr>
-      {if $option}
+      {if {contribution_product.product_option|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}Option{/ts}
           </td>
           <td {$valueStyle}>
-            {$option}
+            {contribution_product.product_option:label}
           </td>
         </tr>
       {/if}
-      {if $sku}
+      {if {contribution_product.product_id.sku|boolean}}
         <tr>
           <td {$labelStyle}>
             {ts}SKU{/ts}
           </td>
           <td {$valueStyle}>
-            {$sku}
+            {contribution_product.product_id.sku}
           </td>
         </tr>
       {/if}

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -386,10 +386,10 @@
           </td>
         </tr>
       {/if}
-      {if $is_deductible AND !empty($price)}
+      {if {contribution.non_deductible_amount|boolean} AND {contribution_product.price|boolean}}
         <tr>
           <td colspan="2" {$valueStyle}>
-            <p>{ts 1=$price|crmMoney}The value of this premium is %1. This may affect the amount of the tax deduction you can claim. Consult your tax advisor for more information.{/ts}</p>
+            <p>{ts 1='{contribution_product.price|crmMoney}'}The value of this premium is %1. This may affect the amount of the tax deduction you can claim. Consult your tax advisor for more information.{/ts}</p>
          </td>
         </tr>
       {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Use getSubmittedValue to retrieve the submitted premium options

Before
----------------------------------------
`$premiumParams` passed through multiple layers of code before it is used - it is a copy of the values submitted by the user

After
----------------------------------------
`getSubmittedValue()` used where required - value not passed around

Technical Details
----------------------------------------
Builds on test cover in https://github.com/civicrm/civicrm-core/pull/34560 - although I might be able to rebase the top one off the stack once we have seen test output

Comments
----------------------------------------

