### PR TITLE
Swap out receive_date in the online contribution template, stop assigning

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2546,9 +2546,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $template->assign('trxn_id', $this->trxn_id);
-    $template->assign('receive_date',
-      CRM_Utils_Date::processDate($this->receive_date)
-    );
     $values['receipt_date'] = (empty($this->receipt_date) ? NULL : $this->receipt_date);
     $template->assign('action', $this->is_test ? 1024 : 1);
     $template->assign('receipt_text', $values['receipt_text'] ?? NULL);

--- a/CRM/Contribute/Form/AdditionalInfo.php
+++ b/CRM/Contribute/Form/AdditionalInfo.php
@@ -254,10 +254,6 @@ class CRM_Contribute_Form_AdditionalInfo {
       $contributorEmail
       ) = CRM_Contact_BAO_Contact_Location::getEmailDetails($params['contact_id']);
 
-    if (!empty($params['receive_date'])) {
-      $form->assign('receive_date', CRM_Utils_Date::processDate($params['receive_date']));
-    }
-
     [$sendReceipt] = CRM_Core_BAO_MessageTemplate::sendTemplate(
       [
         'workflow' => 'contribution_offline_receipt',

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1276,9 +1276,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     $this->set('params', $this->_params);
-    // It actually makes no sense that we would set receive_date in params
-    // for credit card payments....
-    $this->assign('receive_date', $this->_params['receive_date'] ?? date('Y-m-d H:i:s'));
 
     // Result has all the stuff we need
     // lets archive it to a financial transaction

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1733,9 +1733,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if ($this->_amount == 0) {
       $now = date('YmdHis');
       $this->_params['receive_date'] = $now;
-      $receiveDate = CRM_Utils_Date::mysqlToIso($now);
       $this->set('params', $this->_params);
-      $this->assign('receive_date', $receiveDate);
     }
 
     $this->set('membership_amount', $minimumFee);
@@ -2508,9 +2506,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     if (!empty($form->_params['start_date'])) {
       $form->_params['start_date'] = date('YmdHis');
     }
-    $form->assign('receive_date',
-      CRM_Utils_Date::mysqlToIso($form->_params['receive_date'])
-    );
 
     if (isset($paymentParams['contribution_source'])) {
       $paymentParams['source'] = $paymentParams['contribution_source'];

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -210,9 +210,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
 
     $this->assign('trxn_id', $this->_trxnId);
 
-    $this->assign('receive_date',
-      CRM_Utils_Date::mysqlToIso($this->_params['receive_date'] ?? NULL)
-    );
+    $this->assign('receive_date', CRM_Utils_Date::mysqlToIso($this->getContributionValue('receive_date')));
 
     $defaults = [];
     $fields = [];

--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -614,9 +614,8 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         if (!$pending && !empty($participantRecord['is_primary']) &&
           !$this->_allowWaitlist && !$this->_requireApproval
         ) {
-          // transactionID & receive date required while building email template
+          // transactionID required while building email template
           $this->assign('trxn_id', $participantRecord['trxn_id'] ?? NULL);
-          $this->assign('receive_date', CRM_Utils_Date::mysqlToIso($participantRecord['receive_date'] ?? NULL));
           $this->set('receiveDate', CRM_Utils_Date::mysqlToIso($participantRecord['receive_date'] ?? NULL));
           $this->set('trxnId', $participantRecord['trxn_id'] ?? NULL);
         }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1227,9 +1227,6 @@ DESC limit 1");
 
       $this->set('params', $formValues);
       $this->assign('trxn_id', $result['trxn_id'] ?? NULL);
-      $this->assign('receive_date',
-        CRM_Utils_Date::mysqlToIso($params['receive_date'])
-      );
 
       // required for creating membership for related contacts
       $params['action'] = $this->_action;

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -490,7 +490,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
     $this->storeContactFields($this->_params);
     $this->beginPostProcess();
     $now = CRM_Utils_Date::getToday(NULL, 'YmdHis');
-    $this->assign('receive_date', $this->_params['receive_date'] ?? CRM_Utils_Time::date('Y-m-d H:i:s'));
     $this->processBillingAddress($this->getContributionContactID(), (string) $this->_contributorEmail);
     $this->_params['total_amount'] = $this->_params['total_amount'] ?? CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $this->_memType, 'minimum_fee');
     $customFieldsFormatted = CRM_Core_BAO_CustomField::postProcess($this->getSubmittedValues(),

--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -38,6 +38,9 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
       '$sku' => 'contribution_product.product_id.sku',
       'if $is_deductible AND !empty($price)' => 'if {contribution.non_deductible_amount|boolean} AND {contribution_product.product_id.price|boolean}',
       'ts 1=$price|crmMoney:$currency' => "ts 1='{contribution_product.product_id.price|crmMoney}'",
+      'if !empty($receive_date)' => 'if {contribution.receive_date|boolean}',
+      '$receive_date|crmDate' => 'contribution.receive_date',
+      '$receive_date' => 'contribution.receive_date',
     ];
     foreach (['membership_online_receipt', 'contribution_online_receipt', 'contribution_offline_receipt'] as $type) {
       foreach ($swaps as $from => $to) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1508,6 +1508,7 @@ class CRM_Utils_Token {
           '$sku' => 'contribution_product.product_id.sku',
           '$price' => 'contribution_product.product_id.price|crmMoney',
           '$is_deductible' => 'contribution.non_deductible_amount|boolean',
+          '$receive_date' => 'contribution.receive_date',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -3196,7 +3196,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
   /**
    * Test completing a pledge with the completeTransaction api..
    *
-   * Note that we are creating a logged in user because email goes out from
+   * Note that we are creating a logged-in user because email goes out from
    * that person.
    */
   public function testCompleteTransactionUpdatePledgePayment(): void {
@@ -3222,10 +3222,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $mut->checkMailLog([
       'amount:::$500.00',
       // The `receive_date` should remain as it was created.
-      // TODO: the latest payment transaction date (and maybe other details,
-      // such as amount and payment instrument) would be a useful token to make
-      // available.
-      'receive_date:::20120511000000',
+      'receive_date:::20120511',
       "receipt_date:::\n",
     ]);
     $mut->stop();

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -142,13 +142,13 @@
   {/if}
 
 
-     {if !empty($receive_date)}
+    {if {contribution.receive_date|boolean}}
       <tr>
        <td {$labelStyle}>
         {ts}Date{/ts}
        </td>
        <td {$valueStyle}>
-        {$receive_date|crmDate}
+         {contribution.receive_date}
        </td>
       </tr>
      {/if}


### PR DESCRIPTION
Overview
----------------------------------------
Swap out receive_date in the online contribution template, stop assigning 

Before
----------------------------------------
`$receive_date` has been swapped to a token in all templates except Contribution online

After
----------------------------------------
Now it is swapped over. I removed the assigns in the form layer but I have a feeling people use that variable for comparisons and so I decided to continue assigning it in from the workflow template in one of the 2 formats currently taking place (20260113 vs 20260113125959) - I went with the shorter one which seemed more prevalent - it is still deprecated as people should use the token like `{contribution.receive_date|crmDate:"%Y%m%d"}` - I don't think we have a 'word' version of that

Technical Details
----------------------------------------


Comments
----------------------------------------

