### PR TITLE
Consolidate getFinancialID()

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -845,29 +845,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   }
 
   /**
-   * Wrangle financial type ID.
-   *
-   * This wrangling of the financialType ID was happening in a shared function rather than in the form it relates to &
-   * hence has been moved to that form Pledges are not relevant to the membership code so that portion will not go onto
-   * the membership form.
-   *
-   * Comments from previous refactor indicate doubt as to what was going on.
-   *
-   * @param int $financialTypeID
-   *
-   * @return null|string
-   */
-  public function wrangleFinancialTypeID($financialTypeID) {
-    if (empty($financialTypeID) && $this->getPledgeID()) {
-      $financialTypeID = CRM_Core_DAO::getFieldValue('CRM_Pledge_DAO_Pledge',
-        $this->getPledgeID(),
-        'financial_type_id'
-      );
-    }
-    return $financialTypeID;
-  }
-
-  /**
    * Process the form.
    *
    * @param CRM_Contribute_BAO_Contribution $contribution
@@ -1461,9 +1438,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param bool $isPaidMembership
    * @param int $membershipID
-   *
-   * @param int $financialTypeID
-   *   Line items for payment options chosen on the form.
    *
    * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
@@ -2261,7 +2235,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $paymentParams['line_item'] = [$this->getPriceSetID() => $this->getMainContributionLineItems()];
       $result = $this->processConfirm($paymentParams,
         $contactID,
-        $this->wrangleFinancialTypeID($this->_values['financial_type_id']),
+        $this->getFinancialTypeID(),
         $paymentParams['is_recur'] ?? NULL
       );
 

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1438,18 +1438,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     $isProcessSeparateMembershipTransaction = $this->isSeparateMembershipTransaction();
 
-    if ($this->isFormSupportsNonMembershipContributions()) {
-      $financialTypeID = $this->_values['financial_type_id'];
-    }
-    else {
-      $financialTypeID = $membershipType['financial_type_id'] ?? $membershipParams['financial_type_id'] ?? NULL;
-    }
-
     if (!empty($this->_params['membership_source'])) {
       $membershipParams['contribution_source'] = $this->_params['membership_source'];
     }
 
-    $this->postProcessMembership($membershipParams, $contactID, $customFieldsFormatted, $membershipType, $isPaidMembership, $this->_membershipId, $financialTypeID,);
+    $this->postProcessMembership($membershipParams, $contactID, $customFieldsFormatted, $membershipType, $isPaidMembership, $this->_membershipId);
 
     $this->set('membershipTypeID', $membershipParams['selectMembership']);
   }
@@ -1477,10 +1470,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   protected function postProcessMembership(
     $membershipParams, $contactID,
-    $customFieldsFormatted, $membershipDetails, $isPaidMembership, $membershipID,
-    $financialTypeID) {
+    $customFieldsFormatted, $membershipDetails, $isPaidMembership, $membershipID) {
     $membershipContribution = NULL;
-    $isTest = $membershipParams['is_test'] ?? FALSE;
     $errors = $paymentResults = [];
 
     $isRecurForFirstTransaction = $this->_params['is_recur'] ?? $membershipParams['is_recur'] ?? NULL;
@@ -1510,7 +1501,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $paymentResult = $this->processConfirm(
         $membershipParams,
         $contactID,
-        $financialTypeID,
+        $this->getFinancialTypeID(),
         $isRecurForFirstTransaction
       );
       if (!empty($paymentResult['contribution'])) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -660,7 +660,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @throws CRM_Core_Exception
    */
   protected function getFinancialTypeID(): int {
-    return $this->getContributionValue('financial_type_id') ?: $this->getContributionPageValue('financial_type_id');
+    if ($this->getContributionValue('financial_type_id')) {
+      return (int) $this->getContributionValue('financial_type_id');
+    }
+    if ($this->isFormSupportsNonMembershipContributions()) {
+      return (int) $this->getContributionPageValue('financial_type_id');
+    }
+    return (int) $this->getFirstSelectedMembershipType()['financial_type_id'];
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Consolidate getFinancialID()

Before
----------------------------------------
Logic scattered - 
The code logic in practice is to use
- the existing contribution, if exists
- the membership type financial type if ONLY membership rows have been created
- otherwise the payment processor value

After
----------------------------------------
Logic consolidated in `getFinancialTypeID()`

Technical Details
----------------------------------------
Also removed wrangle call 

https://github.com/civicrm/civicrm-core/blob/087928942caa53eceab260054d06eadfb0b7b156/CRM/Contribute/Form/ContributionBase.php#L444

is always set so the wrangle function will never do anything

For transparency form function used instead of property

Comments
----------------------------------------

