### PR TITLE
Save date format on User Job, when set on the data source form

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -489,10 +489,9 @@ class CRM_Import_Forms extends CRM_Core_Form {
       $this->getUserJob()['metadata'],
       [$key => $data]
     );
-    if (isset($metaData['import_options']['date_format'])) {
-      // The Select is sloppy with typing.
-      $metaData['import_options']['date_format'] = (int) $metaData['import_options']['date_format'];
-    }
+    // The Select is sloppy with typing.
+    // We need to prioritize the submitted value to save the user input from Choose Data Source in the interim until the date format is removed.
+    $metaData['import_options']['date_format'] = (int) $metaData['submitted_values']['dateFormats'] ?? NULL ?: (int) $metaData['import_options']['date_format'];
     $this->userJob['metadata'] = $metaData;
     if ($this->isUpdateTemplateJob()) {
       $this->updateTemplateUserJob($metaData);


### PR DESCRIPTION
Before
----------------------------------------
If using an import template by going to Import Templates and clicking Use Template, then changing the date format, the selected date format from the Choose Data Source form is not saved to the User Job. This is because the date format in submitted_values isn't used, only the format in import_options is used.

After
----------------------------------------
Date format is changed to the user submitted value.

Technical Details
----------------------------------------
We don't need the check if `$metaData['import_options']['date_format']` is set, because it was just set in `getUserJob()`.
