### PR TITLE
Remove fieldTypes filter on on-behalf fields for email

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -124,11 +124,9 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @param bool $returnMessageText
    *   Return the message text instead of sending the mail.
    *
-   * @param array $fieldTypes
-   *
    * @throws \CRM_Core_Exception
    */
-  public static function sendMail($contactID, $values, $isTest = FALSE, $returnMessageText = FALSE, $fieldTypes = NULL) {
+  public static function sendMail($contactID, $values, $isTest = FALSE, $returnMessageText = FALSE) {
     $gIds = [];
     $params = ['custom_pre_id' => [], 'custom_post_id' => []];
     $email = NULL;
@@ -383,7 +381,7 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         $tplParams['onBehalfEmail'] = $email;
 
         if (!empty($values['onbehalf_profile_id'])) {
-          self::buildCustomDisplay($values['onbehalf_profile_id'], 'onBehalfProfile', $contactID, $template, $params['onbehalf_profile'], $fieldTypes);
+          self::buildCustomDisplay($values['onbehalf_profile_id'], 'onBehalfProfile', $contactID, $template, $params['onbehalf_profile']);
         }
       }
 
@@ -460,13 +458,12 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @param int $gid
    * @param int $cid
    * @param array $params
-   * @param array $fieldTypes
    *
    * @return array
    *
    * @throws \CRM_Core_Exception
    */
-  protected static function getProfileNameAndFields($gid, $cid, $params, $fieldTypes = []) {
+  protected static function getProfileNameAndFields($gid, $cid, $params) {
     $groupTitle = NULL;
     $values = [];
     if ($gid) {
@@ -479,10 +476,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
           // suppress all file fields from display and formatting fields
           if (
             $v['data_type'] === 'File' || $v['name'] === 'image_URL' || $v['field_type'] === 'Formatting') {
-            unset($fields[$k]);
-          }
-
-          if (!empty($fieldTypes) && (!in_array($v['field_type'], $fieldTypes))) {
             unset($fields[$k]);
           }
         }
@@ -603,11 +596,9 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
    * @param $template
    * @param array $params
    *   Params to build component whereclause.
-   *
-   * @param array|null $fieldTypes
    */
-  public static function buildCustomDisplay($gid, $name, $cid, &$template, &$params, $fieldTypes = NULL) {
-    [$groupTitle, $values] = self::getProfileNameAndFields($gid, $cid, $params, $fieldTypes);
+  public static function buildCustomDisplay($gid, $name, $cid, &$template, &$params) {
+    [$groupTitle, $values] = self::getProfileNameAndFields($gid, $cid, $params);
     if (!empty($values)) {
       $template->assign($name, $values);
     }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1688,8 +1688,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     CRM_Contribute_BAO_ContributionPage::sendMail($contactID,
       $emailValues,
-      $this->isTest(), FALSE,
-      ['Contact', 'Organization', 'Membership']
+      $this->isTest()
     );
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Remove fieldTypes filter on on-behalf fields for email

Before
----------------------------------------
The `$fieldTypes` parameter is only set in one scenario - sending an email when it is pay later. It is passed through to `sendMail()` where it is only used when building the on-behalf profile fields for the email. In this scenario it passes in a direction to filter out any fields that do not extend `['Contact', 'Organization', 'Membership']`

If it made sense to do this then it would make sense to do it on fee, and payment processor receipts too. However, it appears to be impossible to configure fields into the profile that would be filtered out at this point

<img width="1541" height="255" alt="image" src="https://github.com/user-attachments/assets/b1fced5a-cbf3-42dd-a6ab-f2c3931dc961" />


After
----------------------------------------
poof

Technical Details
----------------------------------------
Towards some improvements in email profile handling for @jmcclelland  to address on behalf leakage

Comments
----------------------------------------

