### PR TITLE
Draft: Adds caching to getFields calls

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -364,6 +364,15 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
     $onlySubType = FALSE,
     $checkPermission = CRM_Core_Permission::EDIT
   ) {
+    $cache_params = ['customDataType' => $customDataType, 'showAll' => $showAll, 'inline' => $inline, 'customDataSubType' => $customDataSubType, 'customDataSubName' => 'customDataSubName', 'onlyParent' => $onlyParent, 'onlySubtype' => $onlySubType, 'checkPermission' => $checkPermission];
+    $cache_params_str = 'get_fields_' . serialize($cache_params);
+    if (isset(Civi::$statics[__CLASS__][$cache_params_str])) {
+      $fields = Civi::$statics[__CLASS__][$cache_params_str];
+      if (!empty($fields)){
+        return $fields;
+      }
+    }
+
     if ($checkPermission === TRUE) {
       CRM_Core_Error::deprecatedWarning('Unexpected TRUE passed to CustomField::getFields $checkPermission param.');
       $checkPermission = CRM_Core_Permission::EDIT;
@@ -469,6 +478,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       }
     }
 
+    Civi::$statics[__CLASS__][$cache_params_str] = $fields;
     return $fields;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Similar to #34554 attempt to cache calls here.

Note as per #34554 we will need some better handling here if the schema is changing. 

This is an attempt to help with multiple calls to this resulting out of a CiviCRM Entity enabled Drupal view.

Before
----------------------------------------

Repeated calls to this function

After
----------------------------------------

Same number of calls be we stop here and return the value we found earlier instead of heading into the DB to find out the meta data for the fields on the entity.

Technical Details
----------------------------------------

Some related discussion https://chat.civicrm.org/civicrm/pl/s856k6x3zbdq5bcfrshs8kd3yr

Comments
----------------------------------------
This isn't ready yet as it's probably going to fail on some upgrades and would break badly if you make a custom field I think... But the making of custom fields got us to this place so perhaps that's a feature!
