### PR TITLE
Revert "ElavonTest - Skip test on PHP 8.1 and Drupal 9 (Guzzle 6)"

### DIFF
--- a/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
+++ b/ext/elavon/tests/phpunit/CRM/Core/Payment/ElavonTest.php
@@ -55,11 +55,6 @@ class CRM_Core_Payment_ElavonTest extends \PHPUnit\Framework\TestCase implements
   }
 
   public function setUp(): void {
-    $guzzleVersion = \Composer\InstalledVersions::getVersion("guzzlehttp/guzzle");
-    if (version_compare($guzzleVersion, '7', '<') && version_compare(phpversion(), '8.1', '>=')) {
-      $this->markTestSkipped("On PHP 8.1+, testing with Guzzle's MockHandler requries v7+");
-    }
-
     $this->setUpElavonProcessor();
     $this->processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['Elavon']);
     parent::setUp();


### PR DESCRIPTION
Overview
----------

The problem identified in #34555 (re: Guzzle 6 `MockHandler`) affects a total of 4 core-extensions. Given the quantity, we should use a slightly gentler technique to hush the deprecation warnings (as in the more recent https://github.com/civicrm/civicrm-buildkit/pull/1010).

Before
------

Skip test completely

After
-----

Let the test run, but ignore deprecation warnings from Guzzle 6.

Technical Details
------------

Here is an example of running `phpunit-core-exts` on D9/php81 with the recent updates for `civi-test-run`. ([log](https://test.civicrm.org/job/CiviCRM-Test-QLow/254042/console)) The key thing is that extensions like `ewaysingle` and `oauth-client` are running their Guzzle tests successfully. The warning is logged on the console, but the [test report](https://test.civicrm.org/job/CiviCRM-Test-QLow/254042/testReport/) is postiive.

```
## [path:ext/ewaysingle] Suppress Guzzle 6 deprecation warnings on PHP 8.1
Updated: convertDeprecationsToExceptions="false"
833###[ vtime ]##########################################################
## Command: phpunit9 --stderr --printer \Civi\Test\TAP --log-junit=/home/homer/workspace/CiviCRM-Test-QLow/build/junit/junit-ewaysingle-headless.xml --group headless --exclude-group ornery
## Started: Sat Jan 24 01:04:01 AM UTC 2026
######################################################################
TAP version 13
PHPUnit 9.6.31 by Sebastian Bergmann and contributors.


Initializing "Headless System" (887a6b723c6a06ce9d3020e95021b0cb) in "build6test_4eh8x"
ok 1 - CRM_Core_Payment_EwayTest::testSinglePayment
# Deprecated: Return type of GuzzleHttp\Handler\MockHandler::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/homer/buildkit/build/build-6/vendor/guzzlehttp/guzzle/src/Handler/MockHandler.php on line 173
ok 2 - CRM_Core_Payment_EwayTest::testErrorSinglePayment
1..2
```