### PR TITLE
Notice fix when a premium with options AND a premium without options configured

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -71,9 +71,11 @@
               </div>
               {if $showPremiumSelectionFields}
                 {assign var="premium_option" value="options_"|cat:$row.id}
-                  <div class="premium-full-options">
-                    <p>{$form.$premium_option.html}</p>
-                  </div>
+                  {if array_key_exists('premium_option', $form)}
+                    <div class="premium-full-options">
+                      <p>{$form.$premium_option.html}</p>
+                    </div>
+                  {/if}
               {else}
                 <div class="premium-full-options">
                   <p><strong>{$row.options|purify}</strong></p>


### PR DESCRIPTION

Overview
----------------------------------------
Notice fix when a premium with options AND a premium without options configured

Before
----------------------------------------
<img width="1097" height="386" alt="image" src="https://github.com/user-attachments/assets/2e2ce565-c7d9-4497-955e-aa0163303f20" />


After
----------------------------------------
fixed

Technical Details
----------------------------------------
There is a more serious issue here that I haven't tackled - maybe @vingle might take a look or someone else...

The premiums appear unselectable in the greenwich-like theme (default, d7)

<img width="1077" height="446" alt="image" src="https://github.com/user-attachments/assets/9903b42e-456d-4a9d-be3a-9ec5732961ce" />

It turns out the 'button' is the word 'Coffee Mug' or Tea Mug

<img width="1051" height="611" alt="image" src="https://github.com/user-attachments/assets/84b11cda-8b67-4648-a7fc-d74990a14371" />


<img width="1051" height="611" alt="image" src="https://github.com/user-attachments/assets/47e00a45-34ab-4834-a4bf-747902f5bd92" />

Comments
----------------------------------------

