### PR TITLE
Fix regression -pledge ID not returned from getPledgeID() - rc only regression

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -379,7 +379,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         $this->define('PledgeBlock', 'PledgeBlock', $pledgeBlock);
       }
     }
-    return NULL;
+    return $this->entities['PledgeBlock'] ?? NULL;
   }
 
   /**


### PR DESCRIPTION
I picked this up when I attempted to move the tests to the full test flow - it was being hidden in the legacy test. I ALSO picked up a long term bug whereby the status comparison was wrong - ie it was using the contributionStatus pseudoconstant rate that the one that actually mapped statuses for pledge.status_id. I guess I'll fix this on master instead but it suggests it might not much be used...

