### PR TITLE
SearchKit - Only use first search field in default sort

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/DefaultDisplaySubscriber.php
@@ -169,11 +169,20 @@ class DefaultDisplaySubscriber extends \Civi\Core\Service\AutoService implements
    * @param $entityName
    * @return array
    */
-  protected static function getDefaultSort($entityName) {
+  protected static function getDefaultSort($entityName): array {
     $result = [];
-    $sortFields = (array) (CoreUtil::getInfoItem($entityName, 'order_by') ?: CoreUtil::getSearchFields($entityName));
-    foreach ($sortFields as $sortField) {
-      $result[] = [$sortField, 'ASC'];
+    $sortFields = (array) CoreUtil::getInfoItem($entityName, 'order_by');
+    if ($sortFields) {
+      foreach ($sortFields as $sortField) {
+        $result[] = [$sortField, 'ASC'];
+      }
+    }
+    // If there are no explicit sort fields, use the first search field (using all of them might cause performance problems)
+    else {
+      $searchFields = CoreUtil::getSearchFields($entityName);
+      if ($searchFields) {
+        $result[] = [$searchFields[0], 'ASC'];
+      }
     }
     return $result;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Performance improvement for SearchKit default displays.

Technical Details
----------------------------------------
Sql isn't happy with an unlimited number of ORDER BY clauses; adding too many can kill performance. This makes the default more sensible.

Note: `search_fields` defaults to the `label_field`, so if none are specified it will use that.