### PR TITLE
Extensions - Multiple updates for `enable-when-satisfied` / `parent` warning

### DIFF
--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -374,16 +374,15 @@ class CRM_Extension_Info {
       }
     }
 
-    if (in_array('mgmt:enable-when-satisfied', $this->tags)) {
-      if ($this->parent && !in_array($this->parent, $this->requires)) {
-        $this->requires[] = $this->parent;
-      }
-      else {
-        // FIXME: At time of writing, Civi::log() causes an (infinitely) recursive bootstrap if used here.
-        // So instead, we use a lower-level log API.
-        // \Civi::log('boot')->warning("Extension ($this->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
-        CRM_Core_Error::debug_log_message("Extension ($this->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
-      }
+    if (in_array('mgmt:enable-when-satisfied', $this->tags) && $this->parent && !in_array($this->parent, $this->requires)) {
+      $this->requires[] = $this->parent;
+    }
+
+    if (in_array('mgmt:enable-when-satisfied', $this->tags) && empty($this->parent)) {
+      // FIXME: At time of writing, Civi::log() causes an (infinitely) recursive bootstrap if used here.
+      // So instead, we use a lower-level log API.
+      // \Civi::log('boot')->warning("Extension ($this->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
+      CRM_Core_Error::debug_log_message("Extension ($this->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
     }
   }
 

--- a/CRM/Extension/Info.php
+++ b/CRM/Extension/Info.php
@@ -379,7 +379,10 @@ class CRM_Extension_Info {
         $this->requires[] = $this->parent;
       }
       else {
-        \Civi::log()->warning("Extension ($info->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
+        // FIXME: At time of writing, Civi::log() causes an (infinitely) recursive bootstrap if used here.
+        // So instead, we use a lower-level log API.
+        // \Civi::log('boot')->warning("Extension ($this->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
+        CRM_Core_Error::debug_log_message("Extension ($this->key) is tagged \"mgmt:enable-when-satisfied\", but no parent is declared.");
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

Address two issues involving the presentation of warnings. Both involve the handling nested extensions (i.e. `<tag>mgmt:enable-when-satisfied</tag>`):

1. If it generates a warning, then the warning should be emitted safely.
2. Reduce the cases where it generates warnings. (Be more permissive.)

Alternative to @ufundo's #34496. 

General Context
---------------------------------------

Create a few extensions (e.g. `myparent`, `myuncle`, `mychild`)

In `mychild`, we're going to play with settings in `info.xml` (esp `<parent>`, `<tags>`, and `<requires>`).

A good configuration has these:

*  `<tag>mgmt:enable-when-satisfied</tag>`, and
* `<parent>myparent</parent>`, and
* `<requires><ext>myuncle</ext></requires>`

This PR addresses some other edge-cases (where we don't have exactly that structure).

Before and After
----------------------------------------

1. If `mychild` has `<tag>mgmt:enable-when-satisfied</tag>` but no `<parent>`, then it *should* emit a safe warning.
    * __Before__: While emitting the warning, it gets stuck with infinite recursion.

        ```
        Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '512' frames
        ```
    * __After__: The warning is written in the CiviCRM log file.

        ```
        Extension (mychild) is tagged "mgmt:enable-when-satisfied", but no parent is declared.
        ```

    * __Why__: The `enable-when-satisfied` behavior is ***only*** complete/correct if the `<parent>` tag is provided. If it's missing, then `mychild` is never *uninstalled*. (This is the raison de'tre for `<parent>` tag.) It's easy for a developer to accidentally overlook this.
    * __Comment__: I think the code of the warning got moved around a bit during development -- probably wasn't tested in its final form.

3. If `mychild` has an extra reference to `<requires>...<ext>myparent</ext>...</requires>`, then this is valid (albeit a bit redundant).

    * __Before__: It attempts to show a warning. (It doesn't work because of (1); but if it did, it would be incorrect/misleading.)
    * __After__: No warning.
    * __Comment__: This is probably useful when you consider the POV of a contrib extension that is deployed on older+newer versions of `civicrm-core`. The `<parent>` tag isn't recognized on older versions. Making the second declaration means that you get better fallback behavior on the older versions.
 
Comments
--------------------------------------

There is general test-coverage for the normal/main behaviors of `enable-when-satisfied` (in `tests/phpunit/CRM/Extension/Manager/SubmoduleTest.php`). 

In discussion of #34496, some of Ben's comments inquired-about/suggested looser coupling between `enable-when-satisfied` and `<parent>`. I'm not sure the purpose (from a functionality POV), but I don't have an objection either. A follow-up  like https://github.com/civicrm/civicrm-core/commit/3a99f0d536baf40273bdd5604747af5c81b79440 would go in that direction.