### PR TITLE
Get merged to contact for batch entry imports, so we don't import to deleted contact

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1489,4 +1489,28 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     return 'Individual';
   }
 
+  /**
+   * Check if the contact ID has been deleted and merged to another contact.
+   *
+   * Return the ID of the merged to contact or the original ID if not.
+   *
+   * @param int $contactID
+   * @return int
+   * @throws \CRM_Core_Exception
+   */
+  protected function getMergedToContactIfDeleted($contactID): int {
+    if ($this->getExistingContactValue($contactID, 'is_deleted')) {
+      $result = Contact::getMergedTo(FALSE)
+        ->setContactId($contactID)
+        ->execute()->first();
+      if ($result) {
+        $contactID = $result['id'];
+      }
+      else {
+        throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact %1', [1 => $contactID]));
+      }
+    }
+    return $contactID;
+  }
+
 }

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -574,22 +574,12 @@ abstract class ImportParser extends \CRM_Import_Parser {
         throw new \CRM_Core_Exception(ts('No matching %1 found', [1 => $entity]));
       }
     }
-    if ($contactID && !isset($contactParams['is_deleted']) && $this->getExistingContactValue($contactID, 'is_deleted')) {
+    if ($contactID && !isset($contactParams['is_deleted'])) {
       // The contact may have been merged since the contact ID was determined (common in cases where
-      // a list of contacts is exported and the some time later imported with augmented data.
+      // a list of contacts is exported and then some time later imported with augmented data.
       // As long as is_deleted is not set (ie the importer is not trying to undelete the contact) we can
-      // use the merged to contact instead, if exists.
-      // Note using checkPermissions = FALSE as currently this requires administer CiviCRM
-      // but potentially reviewing that.
-      $result = Contact::getMergedTo(FALSE)
-        ->setContactId($contactID)
-        ->execute()->first();
-      if ($result) {
-        $contactID = $result['id'];
-      }
-      else {
-        throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact %1', [1 => $contactID]));
-      }
+      // use the merged to contact instead, if it exists.
+      $contactID = $this->getMergedToContactIfDeleted($contactID);
     }
     return $contactID;
   }

--- a/ext/search_kit/CRM/Search/Import/Parser.php
+++ b/ext/search_kit/CRM/Search/Import/Parser.php
@@ -79,6 +79,9 @@ class CRM_Search_Import_Parser extends CRM_Import_Parser {
       if ($entity['entity_name'] === 'Contribution' && isset($mappedRow[$entityKey])) {
         $contributionKey = $entityKey;
         $contributionValues = $this->getEntityValues($mappedRow, $entity);
+        if (isset($contributionValues['contact_id'])) {
+          $contributionValues['contact_id'] = $this->getMergedToContactIfDeleted($contributionValues['contact_id']);
+        }
       }
     }
     if (!$contributionValues) {
@@ -146,6 +149,9 @@ class CRM_Search_Import_Parser extends CRM_Import_Parser {
           continue;
         }
         $entityValues = $this->getEntityValues($mappedRow, $entity);
+        if (isset($entityValues['contact_id'])) {
+          $entityValues['contact_id'] = $this->getMergedToContactIfDeleted($entityValues['contact_id']);
+        }
         $saved = civicrm_api4($entity['entity_name'], 'save', [
           'records' => [$entityValues],
         ])->single();


### PR DESCRIPTION
Overview
----------------------------------------
You might think that this would be avoided by the user having to select the contact on the batch entry form, but in fact the batch row can be created and then before it is submitted, a contact selected can be merged. It is also possible for the user to selected deleted contacts, if they enter their contact id directly.

Before
----------------------------------------
Contribution imported to deleted contact.

After
----------------------------------------
Contribution imported to the merged to contact or exception thrown if contact deleted and not merged to another contact.

Technical Details
----------------------------------------
Thought it was best to add this to the parent class and share the function between Civiimport and batch entry imports. Not a big difference, but might as well in case we want to share more of the contact logic in the future.