### PR TITLE
Api4 - support summing boolean fields

### DIFF
--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -41,4 +41,18 @@ class SqlFunctionSUM extends SqlFunction {
     return ts('The sum of all values in the grouping.');
   }
 
+  /**
+   * @inheritdoc
+   *
+   * Sums of Boolean fields will yield integers
+   *
+   * As far as I can tell none of the suffix logic in parent will apply to SUM values
+   * so is not needed here
+   */
+  public function formatOutputValue(?string &$dataType, array &$values, string $key): void {
+    if ($dataType === 'Boolean') {
+      $dataType = 'Integer';
+    }
+  }
+
 }


### PR DESCRIPTION
Before
----------------------------------------
When using SUM sql function on a boolean field, the result value is interpreted as a boolean, and displayed as "Yes" for any non-zero value, or "No" for zero value

After
----------------------------------------
When using SUM sql function on a boolean field, the result value is left as an integer - representing the count of TRUE rows for that field.

Technical Details
----------------------------------------
I'm fairly sure we dont need to call `parent::formatOutputValue` here because suffix type formatting will never apply for sum fields.