### PR TITLE
Prioritize earliest contact id when finding match

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2394,7 +2394,7 @@ WHERE      civicrm_email.email = %1 AND civicrm_contact.is_deleted=0";
       $p[3] = [$ctype, 'String'];
     }
 
-    $query .= " ORDER BY civicrm_email.is_primary DESC";
+    $query .= " ORDER BY civicrm_email.is_primary DESC, civicrm_contact.id ASC";
 
     $dao = CRM_Core_DAO::executeQuery($query, $p);
 


### PR DESCRIPTION
Overview
----------------------------------------
When synchronizing contacts to a CMS (in my case Wordpress) CiviCRM grabs the the first matching record it finds via `matchContactOnEmail` without prioritizing the earliest Contact record.

Before
----------------------------------------

Migrating a CiviCRM database to a new CMS causes the CMS account to be associated to an incorrect Contact record preventing members from being able to renew their memberships.

+ Create a Contact record with a Membership
+ Organization imports additional lists of contact (thus making a duplicate record with the same email as above but nothing else)
+ Register for an event without dedupe


After
----------------------------------------

+ The change prioritizes the earliest Contact record, which I think is how Dedupe tends to work as well (in general) when merging contacts

