### PR TITLE
CustomField - New web-component for creating field options

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2064,9 +2064,9 @@ WHERE  id IN ( %1, %2 )
       // An option_type of 2 would be a 'message' from the form layer not to handle
       // the option_values key. If not set then it is not ignored.
       $optionsType = (int) ($params['option_type'] ?? 0);
-      if (($optionsType !== 2 && empty($params['id']))
-        && (empty($params['option_group_id']) && !empty($params['option_value'])
-        )
+      if ($optionsType === 1 &&
+        empty($params['option_group_id']) &&
+        !empty($params['option_value'])
       ) {
         // first create an option group for this custom group
         $customGroupTitle = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $params['custom_group_id'], 'title');

--- a/Civi/Api4/Action/CustomField/CustomFieldSaveTrait.php
+++ b/Civi/Api4/Action/CustomField/CustomFieldSaveTrait.php
@@ -48,7 +48,7 @@ trait CustomFieldSaveTrait {
         }
         $field['option_label'][] = $value['label'] ?? $value['name'];
         $field['option_name'][] = $value['name'] ?? NULL;
-        $field['option_value'][] = $value['id'];
+        $field['option_value'][] = $value['value'] ?? $value['id'];
         $field['option_status'][] = $value['is_active'] ?? 1;
         $field['option_weight'][] = $value['weight'] ?? ++$weight;
         $field['option_color'][] = $value['color'] ?? NULL;

--- a/Civi/Api4/Action/CustomField/CustomFieldSaveTrait.php
+++ b/Civi/Api4/Action/CustomField/CustomFieldSaveTrait.php
@@ -22,9 +22,7 @@ trait CustomFieldSaveTrait {
    */
   protected function write(array $items) {
     foreach ($items as &$field) {
-      if (empty($field['id'])) {
-        self::formatOptionValues($field);
-      }
+      self::formatOptionValues($field);
     }
     return parent::write($items);
   }
@@ -35,7 +33,7 @@ trait CustomFieldSaveTrait {
    * @param array $field
    */
   private static function formatOptionValues(array &$field): void {
-    $field['option_type'] = !empty($field['option_values']);
+    $field['option_type'] = (int) !empty($field['option_values']);
     if (!empty($field['option_values'])) {
       $weight = 0;
       $field['option_label'] = $field['option_value'] = $field['option_status'] = $field['option_weight'] =

--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -71,6 +71,9 @@ function civicrm_api3_custom_field_create(array $params): array {
     // because that odd behaviour is locked in via a test.
     $params['option_value'] = 1;
   }
+  if (!empty($params['option_value'])) {
+    $params['option_type'] ??= 1;
+  }
   $values = [];
   $customField = CRM_Core_BAO_CustomField::create($params);
   _civicrm_api3_object_to_array_unique_fields($customField, $values[$customField->id]);

--- a/js/CrmOptionsRepeat.js
+++ b/js/CrmOptionsRepeat.js
@@ -1,0 +1,161 @@
+class CrmOptionsRepeat extends HTMLElement {
+  constructor() {
+    super();
+    this.fieldMap = new Map();
+  }
+
+  connectedCallback() {
+    // Ensure initialization happens after DOM is fully loaded
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', () => this.init());
+    }
+    else {
+      this.init();
+    }
+  }
+
+  init() {
+    this.table = this.querySelector('table tbody');
+    this.hiddenInput = this.querySelector(':scope > input[type="hidden"]');
+
+    // Get the template row and store it
+    this.templateRow = this.table.querySelector('tr').cloneNode(true);
+
+    // Create field mapping from the template row
+    const templateInputs = this.templateRow.querySelectorAll('input');
+    templateInputs.forEach((input, index) => {
+      const originalName = input.getAttribute('name');
+      this.fieldMap.set(index, originalName);
+      input.removeAttribute('name');
+      input.removeAttribute('id');
+      if (input.type === 'radio') {
+        input.setAttribute('name', originalName + Math.random().toString(36).substring(2));
+      }
+    });
+
+    // Initialize data from hidden input or create new array
+    this.data = [];
+    try {
+      if (this.hiddenInput.value) {
+        this.data = JSON.parse(this.hiddenInput.value);
+      }
+    } catch (e) {
+    }
+
+    // Clear existing rows
+    this.table.innerHTML = '';
+
+    // Add initial rows from data or at least one row
+    if (this.data.length > 0) {
+      this.data.forEach(rowData => this.addRow(rowData));
+    } else {
+      this.addRow();
+    }
+
+    // Add event listeners
+    this.addEventListener('click', (e) => {
+      const addButton = e.target.closest('.crm-options-repeat-add');
+      if (addButton) {
+        e.preventDefault();
+        this.addRow();
+      }
+      const removeButton = e.target.closest('.crm-options-repeat-remove');
+      if (removeButton) {
+        e.preventDefault();
+        this.removeRow(removeButton.closest('tr'));
+      }
+      const sortButton = e.target.closest('.crm-options-repeat-sort');
+      if (sortButton) {
+        e.preventDefault();
+        this.sortByColumn(sortButton.closest('th'));
+      }
+    });
+
+    // Listen for input changes
+    this.addEventListener('input', () => this.updateData());
+
+    // Add sortable
+    if (this.templateRow.querySelector('.crm-draggable')) {
+      CRM.$(this.table).sortable({
+        handle: '.crm-draggable',
+        containment: this,
+        update: () => this.updateData(),
+      });
+    }
+  }
+
+  removeRow(row) {
+    if (this.table.querySelectorAll('tr').length > 1) {
+      row.remove();
+      this.updateData();
+    }
+  }
+
+  sortByColumn(sortHeader) {
+    const columnIndex = Array.from(sortHeader.parentNode.children).indexOf(sortHeader);
+
+    // Sort rows based on the clicked column's values
+    const rows = Array.from(this.table.querySelectorAll('tr'));
+    const sortedRows = rows.sort((a, b) => {
+      const cellA = a.children[columnIndex]?.querySelector('input')?.value || '';
+      const cellB = b.children[columnIndex]?.querySelector('input')?.value || '';
+
+      // Sort numerically or alphabetically, if applicable
+      if (!isNaN(cellA) && !isNaN(cellB)) {
+        return Number(cellA) - Number(cellB);
+      }
+      return cellA.localeCompare(cellB, undefined, {numeric: true});
+    });
+
+    // Reattach sorted rows to the table
+    this.table.innerHTML = '';
+    sortedRows.forEach(row => this.table.appendChild(row));
+
+    // Update data after sorting
+    this.updateData();
+  }
+
+  addRow(data = {}) {
+    const newRow = this.templateRow.cloneNode(true);
+
+    // Set values if data exists
+    newRow.querySelectorAll('input').forEach((input, index) => {
+      const fieldName = this.fieldMap.get(index);
+
+      if (data[fieldName] !== undefined) {
+        if (input.type === 'checkbox' || input.type === 'radio') {
+          input.checked = data[fieldName];
+        } else {
+          input.value = data[fieldName];
+        }
+      }
+      else if (input.value && !isNaN(input.value)) {
+        // Iterate numeric default value
+        input.value = this.table.querySelectorAll('tr').length + (+input.value);
+      }
+    });
+
+    this.table.appendChild(newRow);
+    this.updateData();
+  }
+
+  updateData() {
+    const rows = Array.from(this.table.querySelectorAll('tr'));
+    this.data = rows.map(row => {
+      const rowData = {};
+      row.querySelectorAll('input').forEach((input, index) => {
+        const fieldName = this.fieldMap.get(index);
+        if (input.type === 'checkbox' || input.type === 'radio') {
+          rowData[fieldName] = input.checked;
+        } else {
+          rowData[fieldName] = input.value;
+        }
+      });
+      return rowData;
+    });
+    this.hiddenInput.value = JSON.stringify(this.data);
+  }
+}
+
+// Register the custom element
+customElements.define('crm-options-repeat', CrmOptionsRepeat);

--- a/templates/CRM/Custom/Form/Optionfields.tpl
+++ b/templates/CRM/Custom/Form/Optionfields.tpl
@@ -20,74 +20,85 @@
 
 <tr id="multiple">
 <td colspan="2" class="html-adjust">
-    <fieldset><legend>{ts}Multiple Choice Options{/ts}</legend>
-    <span class="description">
-        {ts}Enter up to ten (10) multiple choice options in this table (click 'another choice' for each additional choice). If you need more than ten options, you can create an unlimited number of additional choices using the Edit Multiple Choice Options link after saving this new field. If desired, you can mark one of the choices as the default choice. The option 'label' is displayed on the form, while the option 'value' is stored in the contact record. The label and value may be the same or different. Inactive options are hidden when the field is presented.{/ts}
-    </span>
-  {strip}
-  <table id="optionField">
-  <tr>
-        <th>&nbsp;</th>
-        <th> {ts}Default{/ts}</th>
-        <th> {ts}Label{/ts}</th>
-        <th> {ts}Value{/ts}</th>
-        <th> {ts}Order{/ts}</th>
-        <th> {ts}Active?{/ts}</th>
-    </tr>
+  <fieldset>
+    <legend>{ts}Multiple Choice Options{/ts}</legend>
+    <crm-options-repeat>
+      {$form.option_values.html|crmReplace:'type':'hidden'}
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>{ts}Default{/ts}</th>
+            <th>
+              {ts}Label{/ts}
+              <a class="crm-hover-button crm-options-repeat-sort" title="{ts escape='html'}Sort by label{/ts}">
+                <i class="crm-i fa-sort-alpha-down" aria-hidden="true" role="img"></i>
+                <span class="sr-only">{ts}Sort by label{/ts}</span>
+              </a>
+            </th>
 
-  {section name=rowLoop start=1 loop=12}
-  {assign var=index value=$smarty.section.rowLoop.index}
-  <tr id="optionField_{$index}" class="form-item {cycle values="odd-row,even-row"}">
-        <td>
-        {if $index GT 1}
-            <a onclick="showHideRow({$index}); return false;" name="optionField_{$index}" href="#" class="form-link"><i class="crm-i fa-trash" title="{ts escape='htmlattribute'}hide field or section{/ts}" role="img" aria-hidden="true"></i></a>
-        {/if}
-        </td>
-      <td>
-    <div id="radio{$index}" style="display:none">
-         {$form.default_option[$index].html}
-    </div>
-    <div id="checkbox{$index}" style="display:none">
-         {$form.default_checkbox_option.$index.html}
-    </div>
-      </td>
-      <td> {$form.option_label.$index.html}</td>
-      <td> {$form.option_value.$index.html}</td>
-      <td> {$form.option_weight.$index.html}</td>
-       <td> {$form.option_status.$index.html}</td>
-  </tr>
-    {/section}
-    </table>
-  <div id="optionFieldLink" class="add-remove-link">
-        <a onclick="showHideRow(); return false;" name="optionFieldLink" href="#" class="form-link"><i class="crm-i fa-plus-circle" role="img" aria-hidden="true"></i> {ts}add another choice{/ts}</a>
-    </div>
-  <span id="additionalOption" class="description">
-    {ts}If you need additional options - you can add them after you Save your current entries.{/ts}
-  </span>
-    {/strip}
-
-</fieldset>
+            <th>
+              {ts}Value{/ts}
+              <a class="crm-hover-button crm-options-repeat-sort" title="{ts escape='html'}Sort by value{/ts}">
+                <i class="crm-i fa-sort-numeric-down" aria-hidden="true" role="img"></i>
+                <span class="sr-only">{ts}Sort by value{/ts}</span>
+              </a>
+            </th>
+            <th>{ts}Enabled{/ts}</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a class="crm-draggable">
+                <i class="crm-i fa-arrows-up-down" role="img" aria-hidden="true"></i>
+                <span class="sr-only">{ts}Change order{/ts}</span>
+              </a>
+            </td>
+            <td><input type="radio" name="is_default" class="crm-form-radio"></td>
+            <td><input type="text" name="label" class="crm-form-text required" required></td>
+            <td><input type="text" name="value" class="crm-form-text required" required value="1"></td>
+            <td><input type="checkbox" name="is_active" class="crm-form-checkbox" checked></td>
+            <td>
+              <a class="crm-hover-button crm-options-repeat-remove" title="{ts escape='html'}Delete{/ts}">
+                <i class="crm-i fa-trash" role="img" aria-hidden="true"></i>
+                <span class="sr-only">{ts}Delete{/ts}</span>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="6">
+              <button type="button" class="crm-options-repeat-add">
+                <i class="crm-i fa-plus" role="img" aria-hidden="true"></i>
+                {ts}Add Option{/ts}
+              </button>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </crm-options-repeat>
+  </fieldset>
 </td>
 </tr>
 <script type="text/javascript">
-    var showRows   = new Array({$showBlocks});
-    var hideBlocks = new Array({$hideBlocks});
-    var rowcounter = 0;
-    {* hide and display the appropriate blocks as directed by the php code *}
-    on_load_init_blocks( showRows, hideBlocks, '' );
 
 {if !empty($form.option_group_id)}
 {literal}
-function showOptionSelect( ) {
-   if ( document.getElementsByName("option_type")[0].checked ) {
-      cj('#multiple').show();
-      cj('#option_group').hide();
-   } else {
-      cj('#multiple').hide();
-      cj('#option_group').show();
-   }
-}
-showOptionSelect( );
+  CRM.$(function($) {
+    const $form = $('form.{/literal}{$form.formClass}{literal}');
+
+    function showOptionSelect() {
+      const createNewOptions = $('[name="option_type"]:checked', $form).val() === '1';
+      $('#multiple').toggle(createNewOptions);
+      $('#option_group').toggle(!createNewOptions);
+    }
+
+    $('[name="option_type"]', $form).on('change', showOptionSelect);
+    showOptionSelect();
+  });
 {/literal}
 {/if}
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
New widget for adding options while creating a custom field.

Before
----------------------------------------
Old quickform-based widget was limited to adding 10 options.

After
----------------------------------------
- Unlimited options
- Draggable sorting
- Can be auto-sorted alphabetically
- Reusable widget could also be useful for price sets, etc.

Technical Details
----------------------------------------
- This creates the first general-use web component for CIvi core forms.
- See https://github.com/civicrm/civicrm-core/pull/34348 for auto-loading discussion.