### PR TITLE
Trim whitespace from participant profile fields before validation

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -680,12 +680,12 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   public static function checkProfileComplete($fields, &$errors, $eventId) {
     $email = '';
     foreach ($fields as $fieldname => $fieldvalue) {
-      if (substr($fieldname, 0, 6) == 'email-' && $fieldvalue) {
+      if (substr($fieldname, 0, 6) == 'email-' && trim($fieldvalue)) {
         $email = $fieldvalue;
       }
     }
 
-    if (!$email && !(!empty($fields['first_name']) && !empty($fields['last_name']))) {
+    if (!$email && !(trim($fields['first_name'] ?? '') !== '' && trim($fields['last_name'] ?? '') !== '')) {
       $defaults = $params = ['id' => $eventId];
       CRM_Event_BAO_Event::retrieve($params, $defaults);
       $message = ts("Mandatory fields (first name and last name, OR email address) are missing from this form.");


### PR DESCRIPTION
Overview
----------------------------------------
A user could submit an event registration form with whitespace-only values in the first name, last name, or email fields and pass the checkProfileComplete() validation. For example, entering "   " as a first name would be treated as a valid value.

Before
----------------------------------------
A user could submit an event registration form with whitespace-only values in the first name, last name, or email fields and pass the checkProfileComplete() validation. For example, entering "   " as a first name would be treated as a valid value.

After
----------------------------------------
Whitespace-only values are now treated as empty. The checkProfileComplete() method trims field values before checking whether they are populated, so a registration with only spaces in required profile fields will correctly trigger the validation error.

Technical Details
----------------------------------------
In CRM/Event/Form/Registration/Register.php, the checkProfileComplete() method now:
  - Wraps the email field check with trim() before evaluating truthiness
  - Uses trim() with null coalescing on first_name and last_name and compares against an empty string instead of relying on !empty()

Comments
----------------------------------------
None.