### PR TITLE
Afform - Fix Smarty2 support for inline forms & search displays

### DIFF
--- a/ext/afform/core/templates/afform/InlineAfform.tpl
+++ b/ext/afform/core/templates/afform/InlineAfform.tpl
@@ -1,5 +1,5 @@
 <crm-angular-js modules="{$block.module}">
   <{$block.wrapper|default:'form'} id="bootstrap-theme">
-    <{$block.directive} options="{$afformOptions|json|escape}"></{$block.directive}>
+    <{$block.directive} options="{$afformOptions|@json|escape}"></{$block.directive}>
   </{$block.wrapper|default:'form'}>
 </crm-angular-js>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a bug where filters were not getting correctly passed in to e.g. the contact summary "Relationships" and "Notes" tabs due to a Smarty2 encoding issue.

Backport of https://github.com/civicrm/civicrm-core/pull/34614

Before
----------------------------------------
With Smarty2 enabled, the contact summary "Relationships" and "Notes" tabs incorrectly show every record in the database.

After
----------------------------------------
Filter works correctly in both Smarty2 and Smarty5.

Technical Details
----------------------------------------
Smarty2 requires the `@` symbol... Smarty5 ignores it.