### PR TITLE
Standalone - Implement role access functions

### DIFF
--- a/CRM/Core/Permission/Standalone.php
+++ b/CRM/Core/Permission/Standalone.php
@@ -107,4 +107,22 @@ class CRM_Core_Permission_Standalone extends CRM_Core_Permission_Base {
     }
   }
 
+  public function checkGroupRole($roles): bool {
+    if (!$roles) {
+      return FALSE;
+    }
+    if (in_array('everyone', $roles, TRUE)) {
+      return TRUE;
+    }
+    $userContactId = \CRM_Core_Session::getLoggedInContactID();
+    if ($userContactId) {
+      return (bool) \Civi\Api4\UserRole::get(FALSE)
+        ->addWhere('user_id.contact_id', '=', $userContactId)
+        ->addWhere('role_id.name', 'IN', $roles)
+        ->selectRowCount()
+        ->execute()->count();
+    }
+    return FALSE;
+  }
+
 }

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -733,4 +733,13 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     $sess->initialize();
   }
 
+  public function getRoleNames(): array {
+    return \Civi\Api4\Role::get(FALSE)
+      ->addSelect('name', 'label')
+      ->addWhere('is_active', '=', TRUE)
+      ->addOrderBy('label')
+      ->execute()
+      ->column('label', 'name');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds missing functions to Standalone that are present in Wordpress, Drupal, etc. This allows CiviReport to control access by role, as it does for other CMSs.

Before
----------------------------------------
CiviReport in Standalone missing role-based access option.

<img width="1323" height="441" alt="image" src="https://github.com/user-attachments/assets/0f16b712-62ae-495b-b408-34b5a95709a6" />


After
----------------------------------------
<img width="1319" height="580" alt="image" src="https://github.com/user-attachments/assets/60fe023f-c225-4b48-b8a7-bf97708f925e" />

Also See: https://lab.civicrm.org/dev/core/-/issues/6008
