### PR TITLE
core#6295 Fix to enable upgrading on Backdrop 1.33

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -1209,7 +1209,7 @@ AND    u.status = 1
    * @inheritdoc
    */
   public function renderMaintenanceMessage(string $content): void {
-    backdrop_set_breadcrumb('');
+    backdrop_set_breadcrumb([]);
     backdrop_maintenance_theme();
     if ($region = CRM_Core_Region::instance('html-header', FALSE)) {
       $this->addHTMLHead($region->render(''));


### PR DESCRIPTION
See https://lab.civicrm.org/dev/core/-/issues/6295

Overview
----------------------------------------
The upgrade page errors on Backdrop 1.33

Before
----------------------------------------
Error

After
----------------------------------------
No error


