### PR TITLE
Reduce file-conflict risk. Trim require_once expressions.

### DIFF
--- a/CRM/Core/BAO/MessageTemplate.php
+++ b/CRM/Core/BAO/MessageTemplate.php
@@ -19,8 +19,6 @@
 use Civi\Api4\MessageTemplate;
 use Civi\WorkflowMessage\WorkflowMessage;
 
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Core_BAO_MessageTemplate.
  */

--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -20,7 +20,7 @@
  */
 
 require_once 'Log.php';
-require_once 'Mail.php';
+require_once 'PEAR.php';
 
 require_once 'api/api.php';
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -18,8 +18,6 @@
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\MailingGroup;
 
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Mailing_BAO_Mailing
  */

--- a/CRM/Mailing/BAO/MailingJob.php
+++ b/CRM/Mailing/BAO/MailingJob.php
@@ -19,8 +19,6 @@ use Civi\FlexMailer\FlexMailer;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'Mail.php';
-
 /**
  * Class CRM_Mailing_BAO_MailingJob
  */

--- a/CRM/Mailing/Event/BAO/MailingEventConfirm.php
+++ b/CRM/Mailing/Event/BAO/MailingEventConfirm.php
@@ -17,8 +17,6 @@ use Civi\Token\TokenProcessor;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Mailing_Event_BAO_Confirm
  */

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -17,8 +17,6 @@
 
 use Civi\Token\TokenProcessor;
 
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Mailing_Event_BAO_Reply
  */

--- a/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventResubscribe.php
@@ -17,8 +17,6 @@ use Civi\Token\TokenProcessor;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Mailing_Event_BAO_MailingEventResubscribe
  */

--- a/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
@@ -17,9 +17,6 @@ use Civi\Token\TokenProcessor;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Mailing_Event_BAO_Subscribe
  */

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -17,8 +17,6 @@ use Civi\Token\TokenProcessor;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'Mail/mime.php';
-
 /**
  * Class CRM_Mailing_Event_BAO_Unsubscribe
  */

--- a/CRM/PCP/BAO/PCP.php
+++ b/CRM/PCP/BAO/PCP.php
@@ -647,8 +647,6 @@ WHERE pcp.id = %1 AND cc.contribution_status_id = %2 AND cc.is_test = 0";
       return FALSE;
     }
 
-    require_once 'Mail/mime.php';
-
     //set loginUrl
     $loginURL = $config->userSystem->getLoginURL();
 

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -393,7 +393,6 @@ class CRM_Utils_Mail {
       $headers['Reply-To'] = $headers['From'];
     }
 
-    require_once 'Mail/mime.php';
     $msg = new Mail_mime();
     if ($textMessage) {
       $msg->setTxtBody($textMessage);


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a fatal that arises from a conflict/ambiguity in the handling of `include_path`. The general gist is... remove old-style calls to `require_once` (*which rely on the `include_path`*) and instead rely more on the class-loader (*which does not*).

Aside: For review, you probably don't need to reproduce the exact bug that I had. (The patch does work for that...) Rather, think about whether the patch is safe/desirable for regular scenarios.

Use-Case / Steps to Reproduce
----------------------------------------

* Deploy CiviCRM on a case-insensitive filesystem (e.g. macOS)
* Observe: CiviCRM includes a library `pear/mail` with the `Mail` class (`Mail.php` on the `include_path`)
* Install an extension whose name ends in `mail` (e.g. `org.example1.mail` or `com.example2.mail`)
* Observe: Inside the extension, it has `mail.php`. this is also on the `include_path`. But this file could be equally understood as `Mail.php` or `MAIL.PHP` or `MaiL.pHp`.

Before
----------------------------------------

* `mail.php` (from the extension) and `Mail.php` (from PEAR Mail) are both on the `include_path`. The interpretation of `require_once "Mail.php"` varies:
    * On case-sensitive filesystems, it finds an exact match in PEAR's `Mail.php`.
    * On case-insensitive filesystems, it finds a soft match in the extension's `mail.php`. But the file is already loaded. Loading it a second time (by an alternate name) can lead to failures (e.g. cannot redeclare `function mail_civicrm_config()`).

After
----------------------------------------

* Fewer calls to `require_once "Mail.php"`. When autoloading the `Mail` class, it goes directly to the proper file (without using the `include_path`). No fatal.

Comments
----------------------------------------

* The `require_once` was necessary in olden days.