### PR TITLE
Remove code for deleting soft credits from front end form

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1122,13 +1122,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         }
         CRM_Contribute_BAO_ContributionSoft::add($softParam);
       }
-
-      // delete any extra soft-credit while updating back-office contribution
-      foreach ((array) $softIDs as $softID) {
-        if (!in_array($softID, $params['soft_credit_ids'])) {
-          civicrm_api3('ContributionSoft', 'delete', ['id' => $softID]);
-        }
-      }
     }
   }
 
@@ -1229,7 +1222,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   private function formatSoftCreditParams(&$params) {
     $form = $this;
-    $softParams = $softIDs = [];
+    $softParams = [];
 
     if (!empty($form->_values['honoree_profile_id']) && !empty($params['soft_credit_type_id'])) {
       $honorId = NULL;
@@ -1277,22 +1270,19 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         ];
       }
     }
-    elseif (!empty($params['soft_credit_contact_id'])) {
+    elseif ($this->getSubmittedValue('soft_credit_contact_id')) {
       //build soft credit params
-      foreach ($params['soft_credit_contact_id'] as $key => $val) {
+      // Is this actually reachable or is it just left over from when this code was shared with the back office?
+      foreach ($this->getSubmittedValue('soft_credit_contact_id') as $key => $val) {
         if ($val && $params['soft_credit_amount'][$key]) {
           $softParams[$key]['contact_id'] = $val;
           $softParams[$key]['amount'] = CRM_Utils_Rule::cleanMoney($params['soft_credit_amount'][$key]);
           $softParams[$key]['soft_credit_type_id'] = $params['soft_credit_type'][$key];
-          if (!empty($params['soft_credit_id'][$key])) {
-            $softIDs[] = $softParams[$key]['id'] = $params['soft_credit_id'][$key];
-          }
         }
       }
     }
 
     $params['soft_credit'] = $softParams;
-    $params['soft_credit_ids'] = $softIDs;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove code for deleting soft credits from front end form

Both logic and the code suggests this is a hangover from when this code was shared with the back office function- where deleting soft credits could be selected by an admin

Before
----------------------------------------
Post process handling - but nothing to add it to the form

<img width="962" height="400" alt="image" src="https://github.com/user-attachments/assets/605c17d9-886f-4f6b-b0c6-256f52563e03" />

<img width="962" height="400" alt="image" src="https://github.com/user-attachments/assets/92cd4b74-810e-4f21-a53c-2ffa33fb30e4" />

<img width="962" height="400" alt="image" src="https://github.com/user-attachments/assets/044615ae-0605-42a5-9644-b32933b628de" />



After
----------------------------------------
poof

Technical Details
----------------------------------------
This is code that was previously shared with the back office form but has been separated

Comments
----------------------------------------
