### PR TITLE
Resolve Issue with Payment Allocation to Contribution Line Item

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -494,6 +494,8 @@ class CRM_Financial_BAO_Payment {
       $ratio = 0;
     }
 
+    $isPaymentCompletesContribution = self::isPaymentCompletesContribution($params['contribution_id'], $params['total_amount'], '');
+
     $items = LineItem::get(FALSE)
       ->addSelect('*', 'financial_item.status_id:name', 'financial_item.id', 'financial_item.financial_account_id', 'financial_item_id.currency', 'financial_item.financial_account_id.is_tax', 'financial_item.entity_id', 'financial_item.amount', 'allocated.amount')
       ->addJoin(
@@ -591,13 +593,39 @@ class CRM_Financial_BAO_Payment {
       }
       else {
         if (empty($item['balance']) && !empty($ratio) && $params['total_amount'] < 0) {
-          $item['allocation'] = $item['item_total'] * $ratio;
+          $item['allocation'] = round($item['item_total'] * $ratio, 2);
+        }
+        elseif ($isPaymentCompletesContribution) {
+          $item['allocation'] = $item['balance'];
         }
         else {
-          $item['allocation'] = $item['balance'] * $ratio;
+          $item['allocation'] = round($item['balance'] * $ratio, 2);
         }
       }
       $payableItems[$payableItemIndex] = $item;
+    }
+
+    if (empty($lineItemAllocations) && !empty($ratio) && isset($payableItems[$payableItemIndex])) {
+      $totalTaxAllocation = 0;
+      $totalAllocation = 0;
+      $lastNonTaxKey = $payableItemIndex;
+
+      foreach ($payableItems as $key => $item) {
+        if ($item['financial_item.financial_account_id.is_tax']) {
+          $totalTaxAllocation += $item['allocation'];
+        }
+        else {
+          $totalAllocation += $item['allocation'];
+          $lastNonTaxKey = $key;
+        }
+      }
+
+      $total = $totalTaxAllocation + $totalAllocation;
+      $leftPayment = $params['total_amount'] - $total;
+
+      if ($lastNonTaxKey !== NULL && $leftPayment > 0) {
+        $payableItems[$lastNonTaxKey]['allocation'] += $leftPayment;
+      }
     }
 
     return $payableItems;

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -513,6 +513,64 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test allocation of a payment across line items when the proportional
+   * split creates a rounding remainder.
+   *
+   * A payment of 100 against 3 line items of 100 each works out at
+   * 33.333 recurring per line item. Allocations should be rounded to
+   * 2 decimal places with the leftover cent assigned to the last line item,
+   * so that the sum of the allocations always equals the payment total.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreatePaymentLineItemAllocationRounding(): void {
+    $order = Order::create()
+      ->setContributionValues([
+        'contact_id' => $this->individualCreate(),
+        'financial_type_id:name' => 'Donation',
+      ])
+      ->addLineItem(['line_total_inclusive' => 100])
+      ->addLineItem(['line_total_inclusive' => 100])
+      ->addLineItem(['line_total_inclusive' => 100])
+      ->execute()->first();
+
+    // Pay 100 of 300. A third of each line item is 33.333 recurring so
+    // unrounded allocations would only add up to 99.99 once saved.
+    $payment = $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $order['id'],
+      'total_amount' => 100,
+    ]);
+    $this->checkPaymentIsValid($payment['id'], $order['id'], 100);
+
+    $allocations = EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_financial_item')
+      ->addWhere('financial_trxn_id', '=', $payment['id'])
+      ->addOrderBy('amount')
+      ->execute()->column('amount');
+    $this->assertEquals([33.33, 33.33, 33.34], $allocations, 'Allocations should be rounded with the remainder assigned to the last line item');
+    $this->assertEquals(100.00, array_sum($allocations), 'Allocated amounts should add up to the payment total');
+
+    // Pay the remaining 200. As this payment completes the contribution each
+    // line item should be allocated its exact outstanding balance
+    // (66.67, 66.67 & 66.66 after the first payment above).
+    $payment = $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $order['id'],
+      'total_amount' => 200,
+    ]);
+
+    $allocations = EntityFinancialTrxn::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_financial_item')
+      ->addWhere('financial_trxn_id', '=', $payment['id'])
+      ->addOrderBy('amount')
+      ->execute()->column('amount');
+    $this->assertEquals([66.66, 66.67, 66.67], $allocations, 'Completing payment should allocate the outstanding balance of each line item');
+    $this->assertEquals(200.00, array_sum($allocations), 'Allocated amounts should add up to the payment total');
+
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $order['id']]);
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+  }
+
+  /**
    * Function to assert db values
    *
    * @param array $payment


### PR DESCRIPTION
## Overview

This pull request addresses an issue where incorrect amounts were allocated to contribution line items during payment processing.

Considering the contribution entity table provided:

| Line    | Price | Quantity | Subtotal exc Tax | Tax | Tax total | Total inc Tax |
|---------|-------|----------|------------------|-----|-----------|---------------|
| Line 1  | 100   | 1        | 100              | 0%  | 0         | 100           |
| Line 2  | 200   | 1        | 200              | 0%  | 0         | 200           |
| Line 3  | 300   | 1        | 300              | 20% | 60        | 360           |
| **Total** |       |          |                  |     |           | **660**        |

## Before

Before this PR, the following EntityFinancialTrxn was created:

| Subtotal exc Tax | Payment 1 (200) | Payment 2 (200) | Payment 3 (200) |
|------------------|------------------|------------------|------------------|
| Line 1           | 100              | 30.30           | 30.30           | 30.30 |
| Line 2           | 200              | 60.61           | 60.60           | 60.60 |
| Line 3           | 300              | 90.91           | 83.00           | 69.02 |
| Tax line 1       | 0                | 0.00            | 0.00            | 0.00  |
| Tax line 2       | 0                | 0.00            | 0.00            | 0.00  |
| Tax line 3       | 60               | 18.18           | 18.18           | 18.18 |
| **Total**         | **660**            | **200.00**        | **192.08**        | **178.10** |

From this table, it's evident that incorrect amounts are assigned to line item 3 following the initial payment.

## After

After this PR, the following EntityFinancialTrxn is created:

| Subtotal exc Tax | Payment 1 (200) | Payment 2 (200) | Payment 3 (200) |
|------------------|------------------|------------------|------------------|
| Line 1           | 100              | 30.30           | 30.30           | 30.30 |
| Line 2           | 200              | 60.61           | 60.61           | 60.61 |
| Line 3           | 300              | 90.91           | 90.91           | 90.91 |
| Tax line 1       | 0                | 0.00            | 0.00            | 0.00  |
| Tax line 2       | 0                | 0.00            | 0.00            | 0.00  |
| Tax line 3       | 60               | 18.18           | 18.18           | 18.18 |
| **Total**         | **660**            | **200.00**        | **200.00**        | **200.00** |

Line Item 3 now receives the accurate allocation with subsequent payments.

## Replication Step

* Create a pending contribution with a tax line item (maybe 100 + tax 20)
* Make the first partial payment (maybe 60) - Check that the EntityFinancialTrxns created for the payment has the correct total
* Make the second partial payment (maybe 30) - Check that the EntityFinancialTrxns created for the payment has an incorrect total