### PR TITLE
AuthX - Fix capitalization of permissions

### DIFF
--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -131,11 +131,11 @@ function authx_civicrm_permission(&$permissions) {
     'description' => E::ts('AuthX: Authenticate to services with API key'),
   ];
   $permissions['generate any authx credential'] = [
-    'label' => E::ts('Authx: Generate new JWT credentials for other users via the API'),
-    'description' => E::ts('Authx: Generate new JWT credentials for other users via the API'),
+    'label' => E::ts('AuthX: Generate new JWT credentials for other users via the API'),
+    'description' => E::ts('AuthX: Generate new JWT credentials for other users via the API'),
   ];
   $permissions['validate any authx credential'] = [
-    'label' => E::ts('Authx: Validate credentials for other users via the API'),
-    'description' => E::ts('Authx: Validate credentials for other users via the API'),
+    'label' => E::ts('AuthX: Validate credentials for other users via the API'),
+    'description' => E::ts('AuthX: Validate credentials for other users via the API'),
   ];
 }


### PR DESCRIPTION
Overview
----------------------------------------
There are 4 permissions defined by this extension. 2 were using a lowercase x in their labels, the other two uppercase. This updates them to consistently use an uppercase X