### PR TITLE
Fix specGatherer crash with null groupingKey

### DIFF
--- a/Civi/Api4/Service/Spec/SpecGatherer.php
+++ b/Civi/Api4/Service/Spec/SpecGatherer.php
@@ -237,7 +237,7 @@ class SpecGatherer extends AutoService implements EventSubscriberInterface {
     elseif (is_array($grouping)) {
       $groupingValues = [];
       foreach ($grouping as $groupingKey) {
-        if ($spec->hasValue($groupingKey)) {
+        if (is_string($groupingKey) && $spec->hasValue($groupingKey)) {
           $groupingValues[$groupingKey] = $spec->getValue($groupingKey);
         }
       }


### PR DESCRIPTION
@colemanw 

The code on line233 checks that the single grouping key is a string before calling `$spec->hasValue()`, but the code inside the loop for multiple grouping keys does not.

This looks like an oversight?

This PR copies the same pattern for multiple grouping keys as for single. 

It fixed a crash (when accessing the api4 explorer, for example) on a site I'm working on. It's a bit of a weird site (I'm migrating data directly from 4.2.9!) but it still looks like a sensible guard, nobody likes type errors, right?!