### PR TITLE
Manage expiration dates for user jobs based on job status

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -76,7 +76,9 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
       }
       UserJob::update(FALSE)
         ->addWhere('id', '=', $userJobId)
-        ->setValues(['status_id:name' => $newStatus, 'end_date' => 'now'])
+        ->addValue('status_id:name', $newStatus)
+        ->addValue('end_date', 'now')
+        ->addValue('expires_date', $newStatus === 'completed' ? '+1 week' : NULL)
         ->execute();
     }
   }

--- a/CRM/Import/Form/DataSource.php
+++ b/CRM/Import/Form/DataSource.php
@@ -257,7 +257,7 @@ abstract class CRM_Import_Form_DataSource extends CRM_Import_Forms {
       // @todo - this Template key is obsolete - definitely in Civiimport - probably entirely.
       $userJob['metadata']['Template']['mapping_id'] = $mappingID;
       $userJob['created_id'] = CRM_Core_Session::getLoggedInContactID();
-      $userJob['expires_date'] = '+1 week';
+      $userJob['expires_date'] = '+1 month';
       $userJobID = UserJob::create(FALSE)->setValues($userJob)->execute()->first()['id'];
       $this->set('user_job_id', $userJobID);
       $userJob['metadata']['submitted_values']['savedMapping'] = $mappingID;

--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -450,7 +450,7 @@ class CRM_Import_Forms extends CRM_Core_Form {
         'job_type' => $this->getUserJobType(),
         'status_id:name' => 'draft',
         // This suggests the data could be cleaned up after this.
-        'expires_date' => '+ 1 week',
+        'expires_date' => '+1 month',
         'metadata' => [
           'submitted_values' => $submittedValues,
           'template_id' => $this->getTemplateID(),

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/CreateBatch.php
@@ -75,7 +75,7 @@ class CreateBatch extends AbstractAction {
       'job_type' => 'search_batch_import',
       'status_id:name' => 'draft',
       'is_template' => FALSE,
-      'expires_date' => $this->savedSearch['expires_date'],
+      'expires_date' => '+1 month',
       'search_display_id' => $this->display['id'],
       'metadata' => [
         'DataSource' => [


### PR DESCRIPTION
Before
----------------------------------------
Search batch imports (and their associated temp tables) hang around forever unless you delete them.

After
----------------------------------------
Set the expiration for all user jobs on creation to 30 days in the future (so draft imports don't hang around forever if they are abandoned).

Change that expiration date to a week from the completion date when they are completed (they are done, we don't need to keep them for long anymore).

If the user job is incomplete or complete with errors, we remove the expiration date. We don't want to delete these imports until the user has addressed the issue or decided to delete it manually.

Comments
----------------------------------------
I also note that the user job status isn't updated when rows are manually imported and the errors are then all resolved or the incomplete status should now be complete. I'll address that in a separate PR.