### PR TITLE
Permissions - Add user roles as synthetic permissions & use in CiviReport dashlets (dev/core#6290)

### DIFF
--- a/CRM/Core/Permission/List.php
+++ b/CRM/Core/Permission/List.php
@@ -64,6 +64,21 @@ class CRM_Core_Permission_List {
         'is_synthetic' => $cmsPerm['is_synthetic'] ?? FALSE,
       ];
     }
+
+    // Translate user-roles into synthetic permissions
+    $userRoles = (array) $config->userSystem->getRoleNames();
+    foreach ($userRoles as $roleName => $roleLabel) {
+      if ($roleName === 'everyone') {
+        // Not a role, already covered by "Generic: Allow all users"
+        continue;
+      }
+      $e->permissions["has user role $roleName"] = [
+        'group' => 'userRole',
+        'title' => ts('User Role: %1', [1 => $roleLabel]),
+        'description' => ts('All logged-in users with the "%1" role', [1 => $roleLabel]),
+        'is_synthetic' => TRUE,
+      ];
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/6290

Solves https://lab.civicrm.org/dev/core/-/issues/6008

Solves missing role-based permission checks  in CiviReport dashlets by implementing role-based synthetic permissions which will also be useful to other purposes.

Technical Details
-----
This allows CMS user roles (Wordpress, Drupal, Standalone) to be checked via the permission system, opening up the possibility of controlling access to pages, forms, etc based on role rather than permission.

So far, this makes use of them in CiviReport-generated navigation menu items and dashlets.