### PR TITLE
[core#6299] Fix URL to own Joomla user account from CiviCRM contact

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -957,14 +957,14 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function getUserRecordUrl($contactID) {
     $uid = CRM_Core_BAO_UFMatch::getUFId($contactID);
-    $userRecordUrl = NULL;
     $factoryClassName = $this->factoryClassName();
     // if logged in user has user edit access, then allow link to other users joomla profile
-    if ($factoryClassName::getApplication()->getIdentity()?->authorise('core.edit', 'com_users')) {
+    // always allow access to the user's own profile
+    if (
+        $factoryClassName::getApplication()->getIdentity()?->authorise('core.edit', 'com_users') ||
+        (CRM_Core_Session::singleton()->get('userID') == $contactID)
+    ) {
       return CRM_Core_Config::singleton()->userFrameworkBaseURL . "index.php?option=com_users&view=user&task=user.edit&id=" . $uid;
-    }
-    elseif (CRM_Core_Session::singleton()->get('userID') == $contactID) {
-      return CRM_Core_Config::singleton()->userFrameworkBaseURL . "index.php?option=com_admin&view=profile&layout=edit&id=" . $uid;
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix for issue [#6299](https://lab.civicrm.org/dev/core/-/issues/6299). Corrects the URL generated to allow a user to access their own CMS user profile from their corresponding CiviCRM contact page.

Before
----------------------------------------
The URL to the CMS user account from a user's own contact page (when they don't have edit privileges to all users) is incorrect and results in an error because the requested `option` and `view` do not exist.

`index.php?option=com_admin&view=profile&layout=edit&id=...`

<img width="606" height="151" alt="Screenshot 2026-01-30 163441" src="https://github.com/user-attachments/assets/dc81392d-9322-46af-b904-c024eaabc929" />

After
----------------------------------------
URL is now correct (and the same as if the logged-in user has edit privileges - the same URL is required in both cases).

`index.php?option=com_users&view=user&task=user.edit&id=...`

Technical Details
----------------------------------------
The correct URL was established by inspecting the `User Menu > Edit Account` link in the top-right of Joomla admin. The `view` parameter can be dropped but I haven't removed it just in case this is being left in for backwards compatibility.

Comments
----------------------------------------
Tested on CiviCRM 6.10.1 and Joomla 5.4.2.
