### PR TITLE
dev/core#6301 - Option A - explicitly handle floats when giving to brick/money

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -9,7 +9,6 @@
  +--------------------------------------------------------------------+
  */
 
-use Brick\Money\Money;
 use Civi\Api4\Contribution;
 use Civi\Api4\ContributionRecur;
 use Civi\Api4\LineItem;
@@ -96,7 +95,7 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
         if (count($lines) === 1) {
           $contributionAmount = $lines->first()['contribution_id.total_amount'];
           // USD here is just ensuring both are in the same format.
-          if (Money::of($contributionAmount, 'USD')->compareTo(Money::of($event->object->amount, 'USD'))) {
+          if (CRM_Utils_Money::moneyOf($contributionAmount, 'USD')->compareTo(CRM_Utils_Money::moneyOf($event->object->amount, 'USD'))) {
             // If different then we need to update
             // the contribution. Note that if this is being called
             // as a result of the contribution having been updated then there will

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -16,7 +16,6 @@ use Civi\Token\Event\TokenValueEvent;
 use Civi\Token\TokenRow;
 use Civi\ActionSchedule\Event\MailingQueryEvent;
 use Civi\Token\TokenProcessor;
-use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 
 /**
@@ -127,7 +126,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       }
 
       return $row->format('text/plain')->tokens($entity, $field,
-        Money::of($fieldValue, $currency, NULL, RoundingMode::HALF_UP));
+        CRM_Utils_Money::moneyOf($fieldValue, $currency, NULL, RoundingMode::HALF_UP));
 
     }
     if ($this->isDateField($field)) {

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -3,7 +3,6 @@
 namespace Civi\Core;
 
 use Brick\Money\Currency;
-use Brick\Money\Money;
 use Brick\Math\RoundingMode;
 use Civi;
 use CRM_Core_Config;
@@ -45,7 +44,7 @@ class Format extends \Civi\Core\Service\AutoService {
       $currency = Civi::settings()->get('defaultCurrency');
     }
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP);
+    $money = CRM_Utils_Money::moneyOf($amount, $currencyObject, NULL, RoundingMode::HALF_UP);
     $formatter = $this->getMoneyFormatter($currency, $locale);
     return $money->formatWith($formatter);
   }
@@ -94,7 +93,7 @@ class Format extends \Civi\Core\Service\AutoService {
     }
     $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    return Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+    return CRM_Utils_Money::moneyOf($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**
@@ -122,7 +121,7 @@ class Format extends \Civi\Core\Service\AutoService {
   public function machineMoney($amount, string $currency = 'USD'): string {
     $formatter = $this->getMoneyFormatter($currency, 'en_US', NumberFormatter::DECIMAL, [NumberFormatter::GROUPING_USED => FALSE]);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    return Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+    return CRM_Utils_Money::moneyOf($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**
@@ -145,7 +144,7 @@ class Format extends \Civi\Core\Service\AutoService {
       NumberFormatter::MAX_FRACTION_DIGITS => 9,
     ]);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, new AutoContext());
+    $money = CRM_Utils_Money::moneyOf($amount, $currencyObject, new AutoContext());
     return $money->formatWith($formatter);
   }
 
@@ -169,7 +168,7 @@ class Format extends \Civi\Core\Service\AutoService {
       NumberFormatter::MAX_FRACTION_DIGITS => 9,
     ]);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, new AutoContext());
+    $money = CRM_Utils_Money::moneyOf($amount, $currencyObject, new AutoContext());
     return $money->formatWith($formatter);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6301

Before
----------------------------------------
Implicitly using floats to do precision math, which is now deprecated in brick.

After
----------------------------------------
Explicitly using floats to do precision math.

Technical Details
----------------------------------------
See lab ticket and upstream issue it references. The argument for option A is we're already using floats from many different sources, where we've either already accepted the risk or it doesn't matter by the time it gets to the formatter. Also it's probably the least disruptive.

But this does put up for discussion re-examining even using brick at all.

Comments
----------------------------------------
I've put against 6.11 because the version of brick/math and/or brick/money is determined by the combo of the cms and composer.json and the lock file is ignored, so e.g. even civi 6.4 drupal8 sites are picking up the latest brick/math and the only mitigation there is to restrict brick/math at the cms composer.json level.

The lock file in jenkins is of course not ignored, which is why this hasn't come up here yet. And we can't update brick/math in composer.lock here to the latest yet because it requires php 8.2. My workaround to demonstrate the problem was https://github.com/civicrm/civicrm-core/pull/34632