### PR TITLE
Stop assigning and add warning for financialTypeName, contributionTypeName

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -200,19 +200,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'contributionStatus' => $values['contribution_status'] ?? NULL,
       ];
 
-      if (!empty($values['financial_type_id'])) {
-        $tplParams['financialTypeId'] = $values['financial_type_id'];
-        $tplParams['financialTypeName'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialType',
-          $values['financial_type_id']);
-        // Legacy support
-        $tplParams['contributionTypeName'] = $tplParams['financialTypeName'];
-      }
-
-      $contributionPageId = $values['id'] ?? NULL;
-      if ($contributionPageId) {
-        $tplParams['contributionPageId'] = $contributionPageId;
-      }
-
       // address required during receipt processing (pdf and email receipt)
       $displayAddress = $values['address'] ?? NULL;
       if ($displayAddress) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1510,6 +1510,9 @@ class CRM_Utils_Token {
           '$price' => 'contribution_product.product_id.price|crmMoney',
           '$is_deductible' => 'contribution.non_deductible_amount|boolean',
           '$receive_date' => 'contribution.receive_date',
+          '$financialTypeId' => 'contribution.financial_type_id',
+          '$financialTypeName' => 'contribution.financial_type_id:name',
+          '$contributionTypeName' => 'contribution.financial_type_id:name',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1557,6 +1560,9 @@ class CRM_Utils_Token {
           '$sku' => 'contribution_product.product_id.sku',
           '$price' => 'contribution_product.product_id.price|crmMoney',
           '$is_deductible' => 'contribution.non_deductible_amount|boolean',
+          '$financialTypeId' => 'contribution.financial_type_id',
+          '$financialTypeName' => 'contribution.financial_type_id:name',
+          '$contributionTypeName' => 'contribution.financial_type_id:name',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -9,8 +9,8 @@
   receipt_text:::{$receipt_text}
   {/if}
   is_pay_later:::{contribution.is_pay_later}
-  financialTypeId:::{$financialTypeId}
-  financialTypeName:::{$financialTypeName}
+  financialTypeId:::{contribution.financial_type_id}
+  financialTypeName:::{contribution.financial_type_id:name}
   contactID:::{$contactID}
   contributionID:::{$contributionID}
   amount:::{contribution.total_amount}


### PR DESCRIPTION
…

These have been superceded for some time by tokens, along with financial_type_id & contribution_page_id

This removes the assignments for online contribution page & membership and adds them to the system check (contributionPageId was already there)
