### PR TITLE
Move assignment of honor profile & soft credit info to Workflow Message subsystem

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -168,16 +168,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         [$displayName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
       }
 
-      // Assign honoree values for the receipt.
-      $honorValues = $values['honor'] ?? ['honor_profile_id' => NULL, 'honor_id' => NULL, 'honor_profile_values' => []];
-      foreach (CRM_Contribute_BAO_ContributionSoft::getHonorTemplateVariables(
-        $honorValues['honor_profile_id'] ? (int) $honorValues['honor_profile_id'] : NULL,
-        $honorValues['honor_id'] ? (int) $honorValues['honor_id'] : NULL,
-        $honorValues['honor_profile_values'] ?? [],
-      ) as $honorFieldName => $honorFieldValue) {
-        $template->assign($honorFieldName, $honorFieldValue);
-      }
-
       $title = $values['title'] ?? CRM_Contribute_BAO_Contribution_Utils::getContributionPageTitle($values['contribution_page_id']);
 
       // Set email variables explicitly to avoid leaky smarty variables.
@@ -196,7 +186,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'is_pay_later' => $values['is_pay_later'] ?? FALSE,
         'receipt_date' => empty($values['receipt_date']) ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
         'pay_later_receipt' => $values['pay_later_receipt'] ?? NULL,
-        'honor_block_is_active' => $values['honor_block_is_active'] ?? NULL,
         'contributionStatus' => $values['contribution_status'] ?? NULL,
       ];
 

--- a/CRM/Contribute/BAO/ContributionSoft.php
+++ b/CRM/Contribute/BAO/ContributionSoft.php
@@ -277,7 +277,8 @@ class CRM_Contribute_BAO_ContributionSoft extends CRM_Contribute_DAO_Contributio
 
     $query = "
     SELECT ccs.id, pcp_id, ccs.contribution_id as contribution_id, cpcp.title as pcp_title, pcp_display_in_roll, pcp_roll_nickname, pcp_personal_note, ccs.currency as currency, amount, ccs.contact_id as contact_id, c.display_name, ccs.soft_credit_type_id
-    FROM civicrm_contribution_soft ccs INNER JOIN civicrm_contact c on c.id = ccs.contact_id
+    FROM civicrm_contribution_soft ccs
+      INNER JOIN civicrm_contact c on c.id = ccs.contact_id
     LEFT JOIN civicrm_pcp cpcp ON ccs.pcp_id = cpcp.id
     WHERE contribution_id IN (%1)
     ";

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1254,9 +1254,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $honorId = $ids[0] ?? NULL;
       }
 
-      $null = [];
+      $values = $this->getSubmittedValue('honor');
       $honorId = CRM_Contact_BAO_Contact::createProfileContact(
-        $params['honor'], $null,
+        $values, [],
         $honorId, NULL,
         $form->_values['honoree_profile_id']
       );
@@ -1271,9 +1271,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             $params['soft_credit_type_id'],
             CRM_Core_OptionGroup::values("soft_credit_type")
           ),
-          'honor_id' => $honorId,
-          'honor_profile_id' => $form->_values['honoree_profile_id'],
-          'honor_profile_values' => $params['honor'],
         ];
       }
     }

--- a/CRM/Contribute/WorkflowMessage/ContributionOnlineReceipt.php
+++ b/CRM/Contribute/WorkflowMessage/ContributionOnlineReceipt.php
@@ -27,4 +27,53 @@ class CRM_Contribute_WorkflowMessage_ContributionOnlineReceipt extends GenericWo
   use CRM_Core_WorkflowMessage_SingleProfileTrait;
   public const WORKFLOW = 'contribution_online_receipt';
 
+  /**
+   * Array of soft credit types.
+   *
+   * Only used when this template is used for non-online receipts - ie no
+   * contribution page.
+   *
+   * This is pretty clumsy & would be good to replace. The template
+   * has to combine 2 arrays. Definitely do not expand to other templates.
+   *
+   * @var array
+   *
+   * @scope tplParams as softCreditTypes
+   */
+  public $softCreditTypes;
+
+  /**
+   * The soft credit type of the honor block profile.
+   *
+   * @var string
+   *
+   * @scope tplParams as soft_credit_type
+   */
+  public $softCreditType;
+
+  /**
+   * Array of soft credits.
+   *
+   * This is pretty clumsy & would be good to replace. The template
+   * has to combine 2 arrays. Definitely do not expand to other templates.
+   *
+   * @var array
+   *
+   * @scope tplParams as softCredits
+   */
+  public $softCreditsForOffline;
+
+  public function getSoftCreditForOffline(): array {
+    $offlineSoftCredits = [];
+    if (!$this->getProfilesByModule('soft_credit')) {
+      foreach ($this->getSoftCredits() as $softCredit) {
+        $offlineSoftCredits[] = [
+          ts('Name') => $softCredit['contact_id.display_name'],
+          ts('Amount') => CRM_Utils_Money::format($softCredit['amount'], $softCredit['currency']),
+        ];
+      }
+    }
+    return $offlineSoftCredits;
+  }
+
 }

--- a/CRM/Core/WorkflowMessage/SingleProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/SingleProfileTrait.php
@@ -40,4 +40,48 @@ trait CRM_Core_WorkflowMessage_SingleProfileTrait {
    */
   public $profilePostForm;
 
+  /**
+   * @var array
+   *
+   * @scope tplParams as honoreeProfile
+   */
+  public $profileSoftCredit;
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as onBehalfProfile
+   */
+  public $profileOnBehalf;
+
+  /**
+   * @var array
+   *
+   * @scope tplParams as onBehalfProfile_grouptitle
+   */
+  public $profileOnBehalfTitle;
+
+  /**
+   * @var bool
+   *
+   * @scope tplParams as honor_block_is_active
+   */
+  public $isSoftCreditProfileActive;
+
+  public function getIsSoftCreditProfileActive(): bool {
+    return !empty($this->getProfileByModule('soft_credit')['fields']);
+  }
+
+  public function getProfileSoftCredit(): array {
+    return $this->getProfileByModule('soft_credit')['fields'] ?? [];
+  }
+
+  public function getProfileOnBehalf(): array {
+    return $this->getProfileByModule('on_behalf')['fields'] ?? [];
+  }
+
+  public function getProfileOnBehalfTitle(): string {
+    return $this->getProfileByModule('on_behalf')['title'] ?? '';
+  }
+
 }

--- a/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
+++ b/CRM/Member/WorkflowMessage/MembershipOnlineReceipt.php
@@ -26,4 +26,16 @@ class CRM_Member_WorkflowMessage_MembershipOnlineReceipt extends GenericWorkflow
   use CRM_Core_WorkflowMessage_SingleProfileTrait;
   public const WORKFLOW = 'membership_online_receipt';
 
+  /**
+   * The soft credit type of the honor block profile.
+   *
+   * This is a bit ugly - ideally the template would have all soft credits
+   * assigned and iterate for what it needs.
+   *
+   * @var string
+   *
+   * @scope tplParams as soft_credit_type
+   */
+  public $softCreditType;
+
 }

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1405,7 +1405,6 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
     $processor->setDoDirectPaymentResult(['payment_status_id' => 1, 'fee_amount' => .72]);
     $this->submitOnlineContributionForm([
-      'priceSetId' => $this->getPriceSetID('ContributionPage'),
       'price_' . $this->ids['PriceField']['radio_field'] => $this->ids['PriceFieldValue']['10_dollars'],
       'id' => $this->getContributionPageID(),
       'soft_credit_type_id' => 2,
@@ -1426,6 +1425,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       [
         'In Memory of',
         'Name    James Bond',
+        'Vaxhaul Cross',
       ],
     );
   }

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetIPNTest.php
@@ -301,7 +301,7 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
     $this->addProfile('honoree_individual', $this->ids['ContributionPage'][0], 'soft_credit');
 
     $this->callAPISuccess('ContributionSoft', 'create', [
-      'contact_id' => $this->individualCreate(),
+      'contact_id' => $this->individualCreate(['first_name' => 'Dearly', 'last_name' => 'Beloved'], 'on_behalf'),
       'contribution_id' => $this->ids['Contribution']['default'],
       'soft_credit_type_id' => 'in_memory_of',
       'amount' => 200,
@@ -327,6 +327,8 @@ class CRM_Core_Payment_AuthorizeNetIPNTest extends CiviUnitTestCase {
       'Dear Anthony',
       'Thanks for your auto renew membership sign-up',
       'In Memory of',
+      'Dearly',
+      'Beloved',
     ]);
     $mails = $mut->getAllMessages();
     foreach ($mails as $mail) {

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -189,7 +189,7 @@
       {/if}
     {/if}
 
-     {if $honor_block_is_active}
+    {if $honor_block_is_active}
       <tr>
        <th {$headerStyle}>
         {$soft_credit_type}
@@ -205,7 +205,7 @@
          </td>
         </tr>
       {/foreach}
-      {elseif !empty($softCreditTypes) and !empty($softCredits)}
+    {elseif !empty($softCreditTypes) and !empty($softCredits)}
       {foreach from=$softCreditTypes item=softCreditType key=n}
        <tr>
         <th {$headerStyle}>


### PR DESCRIPTION
Overview
----------------------------------------
Move assignment of honor profile & soft credit info to Workflow Message subsystem

Before
----------------------------------------
Assigned in multiple places - hard to follow, prone to leakage. 

After
----------------------------------------
Consolidated into the message template subsystem

Values still displayed

<img width="740" height="413" alt="image" src="https://github.com/user-attachments/assets/ae0729d5-ac1d-4fe5-9549-4a0bf37444cf" />


Technical Details
----------------------------------------
I also moved the code that assigns soft credits when the online contribution page is used in offline context but notably 'Name' had no translation so I have doubts about how much it is used... It now translates

Comments
----------------------------------------
There was an existing test - I added 1 extra check to it

This also addresses the leakage with OnBehalf that @jmcclelland was hitting - Jamie can I get you to commit to some rc testing of this as there are a bunch of related changes merged to master so a good rc test would be in order...