### PR TITLE
dev/core#6301 - Option B - explicitly handle floats when giving to brick/money

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -96,7 +96,8 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
         if (count($lines) === 1) {
           $contributionAmount = $lines->first()['contribution_id.total_amount'];
           // USD here is just ensuring both are in the same format.
-          if (Money::of($contributionAmount, 'USD')->compareTo(Money::of($event->object->amount, 'USD'))) {
+          // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+          if (Money::of((string) $contributionAmount, 'USD')->compareTo(Money::of((string) $event->object->amount, 'USD'))) {
             // If different then we need to update
             // the contribution. Note that if this is being called
             // as a result of the contribution having been updated then there will

--- a/CRM/Utils/Money.php
+++ b/CRM/Utils/Money.php
@@ -145,7 +145,8 @@ class CRM_Utils_Money {
   }
 
   /**
-   * Subtract currencies using integers instead of floats, to preserve precision
+   * Subtract currencies using integers instead of floats, to preserve precision,
+   * except that's not what this function does at all.
    *
    * @param string|float $leftOp
    * @param string|float $rightOp
@@ -157,8 +158,11 @@ class CRM_Utils_Money {
   public static function subtractCurrencies($leftOp, $rightOp, $currency) {
     if (is_numeric($leftOp) && is_numeric($rightOp)) {
       $currencyObject = self::getCurrencyObject($currency);
-      $leftMoney = Money::of($leftOp, $currencyObject, new DefaultContext(), RoundingMode::CEILING);
-      $rightMoney = Money::of($rightOp, $currencyObject, new DefaultContext(), RoundingMode::CEILING);
+      // Casting to string and then using minus is not the best way to use
+      // brick/money because you lose any added value that Money offers for
+      // precision. Do not copy this pattern.
+      $leftMoney = Money::of((string) $leftOp, $currencyObject, new DefaultContext(), RoundingMode::CEILING);
+      $rightMoney = Money::of((string) $rightOp, $currencyObject, new DefaultContext(), RoundingMode::CEILING);
       return $leftMoney->minus($rightMoney)->getAmount()->toFloat();
     }
   }
@@ -202,7 +206,8 @@ class CRM_Utils_Money {
   protected static function formatLocaleNumeric(string $amount, $locale = NULL, $currency = NULL, $numberOfPlaces = 2): string {
     $currency ??= CRM_Core_Config::singleton()->defaultCurrency;
     $currencyObject = self::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, new CustomContext($numberOfPlaces), RoundingMode::HALF_UP);
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern. I'm not sure why the function declaration above declares $amount as string to begin with.
+    $money = Money::of((string) $amount, $currencyObject, new CustomContext($numberOfPlaces), RoundingMode::HALF_UP);
     $formatter = new \NumberFormatter($locale ?? CRM_Core_I18n::getLocale(), NumberFormatter::DECIMAL);
     $formatter->setAttribute(\NumberFormatter::MIN_FRACTION_DIGITS, $numberOfPlaces);
     return $money->formatWith($formatter);
@@ -236,7 +241,8 @@ class CRM_Utils_Money {
       return self::formatNumericByFormat($amount, '%!.' . $numberOfPlaces . 'i');
     }
     $currencyObject = self::getCurrencyObject(CRM_Core_Config::singleton()->defaultCurrency);
-    $money = Money::of($amount, $currencyObject, new CustomContext($numberOfPlaces), RoundingMode::HALF_UP);
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+    $money = Money::of((string) $amount, $currencyObject, new CustomContext($numberOfPlaces), RoundingMode::HALF_UP);
     // @todo - we specify en_US here because we don't want this function to do
     // currency replacement at the moment because
     // formatLocaleNumericRoundedByPrecision is doing it and if it

--- a/Civi/Core/Format.php
+++ b/Civi/Core/Format.php
@@ -45,7 +45,8 @@ class Format extends \Civi\Core\Service\AutoService {
       $currency = Civi::settings()->get('defaultCurrency');
     }
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP);
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+    $money = Money::of((string) $amount, $currencyObject, NULL, RoundingMode::HALF_UP);
     $formatter = $this->getMoneyFormatter($currency, $locale);
     return $money->formatWith($formatter);
   }
@@ -94,7 +95,8 @@ class Format extends \Civi\Core\Service\AutoService {
     }
     $formatter = $this->getMoneyFormatter($currency, $locale, NumberFormatter::DECIMAL);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    return Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+    return Money::of((string) $amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**
@@ -122,7 +124,8 @@ class Format extends \Civi\Core\Service\AutoService {
   public function machineMoney($amount, string $currency = 'USD'): string {
     $formatter = $this->getMoneyFormatter($currency, 'en_US', NumberFormatter::DECIMAL, [NumberFormatter::GROUPING_USED => FALSE]);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    return Money::of($amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+    return Money::of((string) $amount, $currencyObject, NULL, RoundingMode::HALF_UP)->formatWith($formatter);
   }
 
   /**
@@ -145,7 +148,8 @@ class Format extends \Civi\Core\Service\AutoService {
       NumberFormatter::MAX_FRACTION_DIGITS => 9,
     ]);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, new AutoContext());
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+    $money = Money::of((string) $amount, $currencyObject, new AutoContext());
     return $money->formatWith($formatter);
   }
 
@@ -169,7 +173,8 @@ class Format extends \Civi\Core\Service\AutoService {
       NumberFormatter::MAX_FRACTION_DIGITS => 9,
     ]);
     $currencyObject = CRM_Utils_Money::getCurrencyObject($currency);
-    $money = Money::of($amount, $currencyObject, new AutoContext());
+    // Casting to string for all possible types loses the precision advantages of brick/money. Do not copy this pattern.
+    $money = Money::of((string) $amount, $currencyObject, new AutoContext());
     return $money->formatWith($formatter);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6301

Before
----------------------------------------
Implicitly using floats to do precision math, which is now deprecated in brick.

After
----------------------------------------
Explicitly using floats to do precision math.

Technical Details
----------------------------------------
See lab ticket and upstream issue it references. The argument for option B over A is this comment: https://github.com/civicrm/civicrm-core/pull/34636#issuecomment-3832199417

But this does put up for discussion re-examining even using brick at all.

N.B. I removed the one in EntityTokens from this PR because on closer inspection it is either an int or string already.

Comments
----------------------------------------
I've put against 6.11 because the version of brick/math and/or brick/money is determined by the combo of the cms and composer.json and the lock file is ignored, so e.g. even civi 6.4 drupal8 sites are picking up the latest brick/math and the only mitigation there is to restrict brick/math at the cms composer.json level.

The lock file in jenkins is of course not ignored, which is why this hasn't come up here yet. And we can't update brick/math in composer.lock here to the latest yet because it requires php 8.2. My workaround to demonstrate the problem was https://github.com/civicrm/civicrm-core/pull/34632
