### PR TITLE
Stop calculating and assigning unused customGroup

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2351,25 +2351,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $values = array_merge($values, $this->loadEventMessageTemplateParams($eventID, $participantID, $this->id));
     }
 
-    $groupTree = CRM_Core_BAO_CustomGroup::getTree('Contribution', NULL, $this->id);
-
-    $customGroup = [];
-    foreach ($groupTree as $key => $group) {
-      if ($key === 'info') {
-        continue;
-      }
-
-      foreach ($group['fields'] as $k => $customField) {
-        $groupLabel = $group['title'];
-        if (!empty($customField['customValue'])) {
-          foreach ($customField['customValue'] as $customFieldValues) {
-            $customGroup[$groupLabel][$customField['label']] = $customFieldValues['data'] ?? NULL;
-          }
-        }
-      }
-    }
-    $values['customGroup'] = $customGroup;
-
     $values['is_pay_later'] = $this->is_pay_later;
 
     return $values;
@@ -2457,9 +2438,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $template->assign('is_monetary', 1);
     $template->assign('is_recur', !empty($this->contribution_recur_id));
     $template->assign('address', CRM_Utils_Address::format($input));
-    if (!empty($values['customGroup'])) {
-      $template->assign('customGroup', $values['customGroup']);
-    }
+
     if ($this->_component === 'event') {
       $template->assign('title', $values['event']['title']);
       $template->assign('event', $values['event']);

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -244,7 +244,6 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
       'address' => "Giver {$contact_contributor}\n123 Main St.\n",
       'softContributions' => NULL,
       'title' => 'Contribution',
-      'customGroup' => [],
       'is_pay_later' => '0',
     ], $gathered_values);
   }


### PR DESCRIPTION


Overview
----------------------------------------
Stop calculating and assigning unused customGroup

This is a parameter used in back-office templates
but this is a front-end-only piece of code - with lots of legacy cruft from previous lives....

Before
----------------------------------------
<img width="1240" height="228" alt="image" src="https://github.com/user-attachments/assets/79cf5a01-a42b-4529-b219-b2dd56c02caa" />


After
----------------------------------------
poof


Technical Details
----------------------------------------

Comments
----------------------------------------
