### PR TITLE
Stop passing around always NULL value

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1488,7 +1488,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $membershipParams['contribution_source'] = $this->_params['membership_source'];
     }
 
-    $this->postProcessMembership($membershipParams, $contactID, $customFieldsFormatted, $membershipType, $this->_membershipId);
+    $this->postProcessMembership($membershipParams, $contactID, $customFieldsFormatted, $membershipType);
 
     $this->set('membershipTypeID', $membershipParams['selectMembership']);
   }
@@ -1504,14 +1504,13 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param null $customFieldsFormatted
    *
    * @param array $membershipDetails
-   * @param int $membershipID
    *
    * @throws \CRM_Core_Exception
    * @throws \Civi\Payment\Exception\PaymentProcessorException
    */
   protected function postProcessMembership(
     $membershipParams, $contactID,
-    $customFieldsFormatted, $membershipDetails, $membershipID) {
+    $customFieldsFormatted, $membershipDetails) {
     $membershipContribution = NULL;
     $errors = $paymentResults = [];
 
@@ -1600,9 +1599,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           // Assigns line items with existing, or new, membership
           [$membership, $renewalMode] = $this->legacyProcessMembership(
             $contactID, $membershipTypeID,
-            date('YmdHis'), $membershipParams['cms_contactID'] ?? NULL,
+            $membershipParams['cms_contactID'] ?? NULL,
             $customFieldsFormatted,
-            $numTerms, $membershipID, $pending,
+            $numTerms, $pending,
             $contributionRecurID, $membershipSource, $isPayLater,
             $membershipContribution,
             $membershipLineItems
@@ -2366,15 +2365,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       $this->set('membershipTypeID', $this->_params['selectMembership']);
     }
 
-    if (!empty($this->getExistingContributionID())) {
-      // If we are using the ContributionPage in "Invoice Mode" we need to set the existing
-      //   Membership ID if we have one. Otherwise we will create a duplicate Membership.
-      // Contribution Pages don't support multiple memberships so we'll just use the first one.
-      // If there is more than one membership lineItem, the other memberships will not be updated.
-      $membershipLineItems = $this->getOrder()->getMembershipLineItems();
-      $this->_membershipId = reset($membershipLineItems)['entity_id'];
-    }
-
     if ($this->_action & CRM_Core_Action::PREVIEW) {
       $membershipParams['is_test'] = 1;
     }
@@ -2657,11 +2647,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param int $contactID
    * @param int $membershipTypeID
-   * @param string $changeToday
    * @param int $modifiedID
    * @param $customFieldsFormatted
    * @param $numRenewTerms
-   * @param int $membershipID
    * @param $pending
    * @param int $contributionRecurID
    * @param $membershipSource
@@ -2672,7 +2660,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @return array
    * @throws \CRM_Core_Exception
    */
-  private function legacyProcessMembership($contactID, $membershipTypeID, $changeToday, $modifiedID, $customFieldsFormatted, $numRenewTerms, $membershipID, $pending, $contributionRecurID, $membershipSource, $isPayLater, $contribution = NULL, $lineItems = []) {
+  private function legacyProcessMembership($contactID, $membershipTypeID, $modifiedID, $customFieldsFormatted, $numRenewTerms, $pending, $contributionRecurID, $membershipSource, $isPayLater, $contribution = NULL, $lineItems = []) {
     $renewalMode = FALSE;
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
     $statusFormat = '%Y-%m-%d';
@@ -2680,7 +2668,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // CRM-7297 - allow membership type to be be changed during renewal so long as the parent org of new membershipType
     // is the same as the parent org of an existing membership of the contact
     $currentMembership = CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,
-      $this->isTest(), $membershipID, TRUE
+      $this->isTest(), NULL, TRUE
     );
     if ($currentMembership) {
       $renewalMode = TRUE;

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -149,13 +149,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   public $_contactID;
 
   /**
-   * The Membership ID for membership renewal
-   *
-   * @var int
-   */
-  public $_membershipId;
-
-  /**
    * Price Set ID, if the new price set method is used
    *
    * @var int

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -757,6 +757,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
   public static function getContactMembership($contactID, $memType, $isTest, $membershipId = NULL, $onlySameParentOrg = FALSE) {
     //check for owner membership id, if it exists update that membership instead: CRM-15992
     if ($membershipId) {
+      CRM_Core_Error::deprecatedWarning('passing in membership ID is deprecated');
       $ownerMemberId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership',
         $membershipId,
         'owner_membership_id', 'id'


### PR DESCRIPTION
Overview
----------------------------------------
Stop passing around always NULL value

This takes a bit of tracing but the membershipId is set in only one place and from there it is passed around and used in only legacyMembershipProcessing

However, it is only set if there IS an existing contribution in play and only used if there is not

Before
----------------------------------------
parameter set, here https://github.com/civicrm/civicrm-core/pull/34650/changes#diff-fa1d97e1889c16127a161492e1fed358409b2d2b39cc37e799e648ac68b5efd8L2369

<img width="1023" height="242" alt="image" src="https://github.com/user-attachments/assets/28884c4f-29b8-4849-92f7-664ccd46de7a" />


passed around and eventually into a function where it is looked at - but it is always NULL when it reaches the function 

<img width="791" height="376" alt="image" src="https://github.com/user-attachments/assets/bcbc3b38-dcea-402e-a579-30fee1f6ee2b" />

After
----------------------------------------
gone - I also removed the ignored `$changeDate` variable

Technical Details
----------------------------------------


Comments
----------------------------------------
