### PR TITLE
Towards saving MembershipLineItems correctly the first time

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -62,6 +62,16 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   }
 
   /**
+   * @return int|null
+   */
+  private function getPaymentInstrumentID(): ?int {
+    if (!empty($form->_paymentProcessor)) {
+      return $form->_paymentProcessor['payment_instrument_id'];
+    }
+    return NULL;
+  }
+
+  /**
    * @param int $contactID
    *
    * @return array
@@ -328,6 +338,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       //setting to make available to hook - although seems wrong to set on form for BAO hook availability
       'skipLineItem' => $params['skipLineItem'] ?? 0,
       'receipt_date' => $this->isEmailReceipt() ? date('YmdHis') : NULL,
+      'payment_instrument_id' => $this->getPaymentInstrumentID(),
     ];
 
     if ($recurringContributionID) {
@@ -1098,7 +1109,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $contributionParams['address_id'] = CRM_Contribute_BAO_Contribution::createAddress($params);
     // We may no longer need to set params['is_recur'] - it used to be used in processRecurringContribution
     $params['is_recur'] = $isRecur;
-    $params['payment_instrument_id'] = $contributionParams['payment_instrument_id'] ?? NULL;
     $recurringContributionID = !$isRecur ? NULL : $this->processRecurringContribution($params, [
       'contact_id' => $contactID,
       'financial_type_id' => $contributionParams['financial_type_id'],
@@ -1258,7 +1268,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $recurParams['frequency_interval'] = $params['frequency_interval'] ?? NULL;
     $recurParams['installments'] = $params['installments'] ?? NULL;
     $recurParams['currency'] = $this->getCurrency();
-    $recurParams['payment_instrument_id'] = $params['payment_instrument_id'];
+    $recurParams['payment_instrument_id'] = $this->getPaymentInstrumentID();
 
     // CRM-14354: For an auto-renewing membership with an additional contribution,
     // if separate payments is not enabled, make sure only the membership fee recurs
@@ -1826,12 +1836,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       'source' => $tempParams['source'] ?? $this->getSource(),
       'financial_type_id' => $financialTypeID,
     ];
-    $isMonetary = !empty($this->_values['is_monetary']);
-    if ($isMonetary) {
-      if (!$this->isPayLater()) {
-        $contributionParams['payment_instrument_id'] = $this->_paymentProcessor['payment_instrument_id'];
-      }
-    }
 
     $transaction = new CRM_Core_Transaction();
     $membershipContribution = $this->processFormContribution(
@@ -2533,9 +2537,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // @todo make sure this is consisently set at this point.
       $contributionParams['line_item'] = $paymentParams['line_item'];
     }
-    if (!empty($form->_paymentProcessor)) {
-      $contributionParams['payment_instrument_id'] = $paymentParams['payment_instrument_id'] = $form->_paymentProcessor['payment_instrument_id'];
-    }
+
     $transaction = new CRM_Core_Transaction();
     $contribution = $this->processFormContribution(
       $paymentParams,

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1666,7 +1666,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             $contactID, $membershipTypeID,
             $membershipParams['cms_contactID'] ?? NULL,
             $customFieldsFormatted,
-            $numTerms, $pending,
+            $numTerms,
             $contributionRecurID, $membershipSource, $isPayLater,
             $membershipContribution,
             $membershipLineItems
@@ -2661,7 +2661,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @param int $modifiedID
    * @param $customFieldsFormatted
    * @param $numRenewTerms
-   * @param $pending
    * @param int $contributionRecurID
    * @param $membershipSource
    * @param $isPayLater
@@ -2671,7 +2670,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @return array
    * @throws \CRM_Core_Exception
    */
-  private function legacyProcessMembership($contactID, $membershipTypeID, $modifiedID, $customFieldsFormatted, $numRenewTerms, $pending, $contributionRecurID, $membershipSource, $isPayLater, $contribution = NULL, $lineItems = []) {
+  private function legacyProcessMembership($contactID, $membershipTypeID, $modifiedID, $customFieldsFormatted, $numRenewTerms, $contributionRecurID, $membershipSource, $isPayLater, $contribution = NULL, $lineItems = []) {
     $allStatus = CRM_Member_PseudoConstant::membershipStatus();
     $statusFormat = '%Y-%m-%d';
     $currentMembership = $this->getExistingMembership($membershipTypeID);
@@ -2693,33 +2692,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       'membership_activity_status' => 'Scheduled',
     ];
 
-    if (!$pending) {
-      $dates = CRM_Member_BAO_MembershipType::getDatesForMembershipType($membershipTypeID, NULL, NULL, NULL, $numRenewTerms);
-
-      foreach (['join_date', 'start_date', 'end_date'] as $dateType) {
-        $memParams[$dateType] = $dates[$dateType] ?? NULL;
-      }
-
-      $status = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate(CRM_Utils_Date::customFormat($dates['start_date'],
-        $statusFormat
-      ),
-        CRM_Utils_Date::customFormat($dates['end_date'],
-          $statusFormat
-        ),
-        CRM_Utils_Date::customFormat($dates['join_date'],
-          $statusFormat
-        ),
-        'now',
-        TRUE,
-        $membershipTypeID,
-        $memParams
-      );
-      $updateStatusId = $status['id'] ?? NULL;
-    }
-    else {
-      // if IPN/Pay-Later set status to: PENDING
-      $updateStatusId = array_search('Pending', $allStatus);
-    }
+    // if IPN/Pay-Later set status to: PENDING
+    $updateStatusId = array_search('Pending', $allStatus);
 
     if (!empty($membershipSource)) {
       $memParams['source'] = $membershipSource;

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -663,7 +663,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   protected function getMainContributionLineItems(): array {
     $membershipLineItems = $this->getSecondaryMembershipContributionLineItems();
-    $allLineItems = $this->getOrder()->getLineItems();
+    $allLineItems = $this->getLineItems();
     if (!$membershipLineItems || $allLineItems === $membershipLineItems) {
       return $allLineItems;
     }

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1730,7 +1730,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertEquals($preExistingMembershipID + 1, $lines[1]['entity_id']);
     $this->assertEquals('civicrm_contribution', $lines[0]['entity_table']);
     $this->assertEquals($id, $lines[0]['entity_id']);
-    $this->assertEquals('civicrm_membership', $lines[4]['entity_table']);
+    $this->assertEquals('civicrm_membership', $lines[2]['entity_table']);
     return $lines;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Towards saving MembershipLineItems correctly the first time

Before
----------------------------------------
Recent work by @rbaugh simplified the Confirm membership code but kept the anti pattern of not creating the membership line items correctly in the first place but hacking them up later

After
----------------------------------------
Removes the anti-pattern with the path to using Order::create instead a bit closer

Technical Details
----------------------------------------
This means that all the financial items are correctly created when the contribution is created. The `entity_id` on the line item is not initially correct in all instances & gets hacked into correctness after the fact but it has no dependencies - all financial items are unaffected by the entity_id

Comments
----------------------------------------
