### PR TITLE
Fix wrapping for long search criteria

### DIFF
--- a/templates/CRM/Contact/Form/Search/ResultTasks.tpl
+++ b/templates/CRM/Contact/Form/Search/ResultTasks.tpl
@@ -42,7 +42,7 @@
     {* Search criteria are passed to tpl in the $qill array *}
    {if $qill}
      <tr>
-       <td class="nowrap">{include file="CRM/common/displaySearchCriteria.tpl"}</td>
+       <td>{include file="CRM/common/displaySearchCriteria.tpl"}</td>
      </tr>
    {/if}
   <tr>


### PR DESCRIPTION
Overview
----------------------------------------
If you have long search criteria, the webpage is wider than the browser window, so you need to scroll right to use the `Select Records` choices. 

Before
----------------------------------------
<img width="1187" height="566" alt="image" src="https://github.com/user-attachments/assets/29bafac3-d402-481f-b03c-750d7df945b1" />


After
----------------------------------------
<img width="1175" height="615" alt="image" src="https://github.com/user-attachments/assets/d6a5b55d-7eda-4657-b93a-8c2b940b6087" />


Technical Details
----------------------------------------
Minor change, other templates using `displaySearchCriteria.tpl` seem to already not use the `nowrap` CSS class.

Comments
----------------------------------------
N/A
