### PR TITLE
SchemaHelperInterface: Set default value for argument in @method

### DIFF
--- a/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
@@ -25,7 +25,7 @@ namespace CiviMix\Schema;
  * [[ CiviCRM 6.2+ / civimix-schema@5.85+ ]]
  *
  * @method bool createEntityTable(string $filePath)
- * @method bool alterSchemaField(string $entityName, string $fieldName, array $fieldSpec, ?string $position)
+ * @method bool alterSchemaField(string $entityName, string $fieldName, array $fieldSpec, ?string $position = NULL)
  *
  * [[ CiviCRM 6.10+ / civimix-schema@5.93+ ]]
  *


### PR DESCRIPTION
Overview
----------------------------------------
The argument `$position` of `SchemaHelper::alterSchemaField()` is optional with the default `NULL`:
https://github.com/civicrm/civicrm-core/blob/4cc75ee78ddff632fa2a07fde791d7bd29dca3d2/mixin/lib/civimix-schema%405/src/SchemaHelper.php#L123

Though this isn't indicated in the corresponding `@method` definition in `SchemaHelperInterface`:
https://github.com/civicrm/civicrm-core/blob/4cc75ee78ddff632fa2a07fde791d7bd29dca3d2/mixin/lib/civimix-schema%405/src/SchemaHelperInterface.php#L28

This makes static code analysis tools complain when only three arguments are given.

This PR adds the default value to the interface.