### PR TITLE
CRM.url - protect from null

### DIFF
--- a/js/crm.ajax.js
+++ b/js/crm.ajax.js
@@ -11,6 +11,9 @@
    */
   var tplURL;
   CRM.url = function (path, query, mode) {
+    if (path === null) {
+      throw new Error('null passed to CRM.url');
+    }
     if (typeof path === 'object') {
       tplURL = path;
       return path;


### PR DESCRIPTION
Before
----------------------------------------
- accidentally calling `CRM.url(null)` breaks all future calls to `CRM.url` on the page

After
----------------------------------------
- accidentally calling `CRM.url(null)` will throw an error for that caller; but it won't break future calls
