### PR TITLE
dev/core#6301 - followup to #34644

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -127,8 +127,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       }
 
       return $row->format('text/plain')->tokens($entity, $field,
-        Money::of($fieldValue, $currency, NULL, RoundingMode::HALF_UP));
-
+        Money::of((string) $fieldValue, $currency, NULL, RoundingMode::HALF_UP));
     }
     if ($this->isDateField($field)) {
       try {
@@ -333,7 +332,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
   /**
    * @param \Civi\Token\TokenRow $row
    * @param string $field
-   * @return string|int
+   * @return string|int|float
    */
   protected function getFieldValue(TokenRow $row, string $field) {
     $entityName = $this->getEntityName();


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6301

Before
----------------------------------------
I had left out EntityTokens.php in https://github.com/civicrm/civicrm-core/pull/34644 because the docblock for getFieldValue suggested it was only int or string and it appeared to be true too, but when it returns early if it's already set in `context` for a non-id field it can be a float.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

