### PR TITLE
dev/core#6304 Fix display of Autocomplete-select multiselect fields o…

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1120,7 +1120,13 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
   private static function formatDisplayValue($value, $field, $entityId = NULL) {
 
     if (self::isSerialized($field) && !is_array($value)) {
-      $value = CRM_Utils_Array::explodePadded($value);
+      // The autocomplete widget for selecting a default value uses a comma in-between values.
+      if ($field['html_type'] === 'Autocomplete-Select' && str_contains($value, ',')) {
+        $value = explode(',', $value);
+      }
+      else {
+        $value = CRM_Utils_Array::explodePadded($value);
+      }
     }
     // CRM-12989 fix
     if ($field['html_type'] == 'CheckBox' && $value) {

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -236,6 +236,20 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
           '10.99 USD' => '10.99',
         ],
       ],
+      [
+        'data_type' => 'String',
+        'html_type' => 'Autocomplete-Select',
+        'serialize' => 1,
+        'option_values' => [
+          '1' => 'Hello',
+          '2' => 'hey',
+          '3' => 'Testing',
+        ],
+        'tests' => [
+          'Hello' => '1',
+          'Hello, hey' => '1,2',
+        ],
+      ],
     ];
     foreach ($fieldsToCreate as $num => $field) {
       $params = $field + ['label' => 'test field ' . $num, 'custom_group_id' => $customGroup['id']];


### PR DESCRIPTION
…n Registration Confirm / Thankyou pages

Overview
----------------------------------------
This aims to fix the display of Autocomplete-Select multiselect fields on Confirm and THank you pages for event registrations

Before
----------------------------------------
Autocomplete-Select select fields don't display correctly

After
----------------------------------------
Do display correctly

ping @Edzelopez @colemanw 