### PR TITLE
Remove pcp-notify-send from unreachable code point

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1486,13 +1486,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $softParams['pcp_roll_nickname'] = $pcp['pcp_roll_nickname'] ?? NULL;
     $softParams['pcp_personal_note'] = $pcp['pcp_personal_note'] ?? NULL;
     $softParams['soft_credit_type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_ContributionSoft', 'soft_credit_type_id', 'pcp');
-    $contributionSoft = CRM_Contribute_BAO_ContributionSoft::add($softParams);
-    //Send notification to owner for PCP if the contribution is already completed.
-    if ($contributionSoft->pcp_id && empty($pcpId)
-      && 'Completed' === CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id)
-    ) {
-      CRM_Contribute_BAO_ContributionSoft::pcpNotifyOwner($contribution['id'], (array) $contributionSoft);
-    }
+    CRM_Contribute_BAO_ContributionSoft::add($softParams);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
Remove pcp-notify-send from unreachable code point

Before
----------------------------------------
I accidentally caused a bug here in the last few days as I switched the input from an object to an array and contribution_status_id is not available

However, the check is whether the status id is Completed and it is impossible for it to be completed as
just a few lines[ earlier getContributionParams](https://github.com/civicrm/civicrm-core/blob/433ed4ace9cf17ae34a927a7e35a0bf775f7602d/CRM/Contribute/Form/Contribution/Confirm.php#L298) 
forces it to Pending.

The notification can only be send from completeOrder

After
----------------------------------------
poof 

Technical Details
----------------------------------------

Comments
----------------------------------------
