### PR TITLE
Fixes Select2 regression in afCore.css from #34157 in 6.10.x

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -13,7 +13,7 @@ a.af-api4-action-idle {
 .af-container.af-layout-cols > * {
   flex: 1;
 }
-.af-container.af-layout-inline > * :not(.af-field-type-hidden) {
+.af-container.af-layout-inline > * :not(.select2-container *) {
   display: inline-block;
   margin-right: .5em;
   vertical-align: top;


### PR DESCRIPTION
Overview
----------------------------------------
#34157 added a regression to Select2 formatting that was inadvertently fixed with #34165 when River's version of afCore.css became the Civi-wide version. 

But 6.10 is still using the older version of afCore.css causing the regression in non River themes like Greenwich. As flagged by @MegaphoneJon in https://lab.civicrm.org/dev/core/-/issues/6297.

Before
----------------------------------------
<img width="807" height="118" alt="image" src="https://github.com/user-attachments/assets/f5563d8f-a159-4d13-b3b8-2df7364a95d6" />

After
----------------------------------------
<img width="1052" height="157" alt="image" src="https://github.com/user-attachments/assets/46f46a02-b4de-4e2b-b017-68cabdd77cd3" />

Technical Details
----------------------------------------
The original PR #34157 still works - hidden fields remain hidden. This shouldn't need carrying forward.