### PR TITLE
River: Fixes FormBuilder header colour regression /dev/core/6286

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -240,6 +240,7 @@
   --crm-form-block-bg-color: var(--crm-container-bg-color);
   --crm-form-block-padding: var(--crm-l-medium);
   --crm-form-block-border-radius: var(--crm-l-radius);
+  --crm-form-block-header-color: var(--crm-c-gray-700);
   --crm-form-fieldset-border-color: var(--crm-c-gray-400);
   --crm-form-fieldset-border-width: 1px 0 0 0;
   --crm-form-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);


### PR DESCRIPTION
Overview
----------------------------------------
The CSS Variable `--crm-form-block-header-color:` isn't defined in 6.10 (it is in 6.11 & 6.12). As a result some regions are illegible. First identified in https://lab.civicrm.org/dev/core/-/issues/6286.

Before
----------------------------------------
<img width="1160" height="434" alt="image" src="https://github.com/user-attachments/assets/30ae3158-cd20-418d-9d08-1dde3ce4d718" />

After
----------------------------------------
<img width="1156" height="440" alt="image" src="https://github.com/user-attachments/assets/c807a989-05e2-4b39-a2b1-0ac7946cfa9d" />
<img width="585" height="233" alt="image" src="https://github.com/user-attachments/assets/2a432031-9263-4f69-9cf1-38bd18376248" />

Technical Details
----------------------------------------
6.11 and 6.12 assign `--crm-form-block-header-color: var(--crm-inverse-bg-color);` - but this causes a legibility issue in darkmode as `--crm-inverse-bg-color` is lightened too much in dark mode. So for 6.10 have solved this with a non-changing dark-grey variable. 