### PR TITLE
Forms - Remove special handling for old widgets

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -412,12 +412,6 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
         $match = [];
         if (preg_match('/^(custom_\d+_)(\d+)$/', $key, $match)) {
           $params[$match[1] . '-1'] = $params[$key];
-
-          // for autocomplete transfer hidden value instead of label
-          if ($params[$key] && isset($params[$key . '_id'])) {
-            $params[$match[1] . '-1_id'] = $params[$key . '_id'];
-            unset($params[$key . '_id']);
-          }
           unset($params[$key]);
         }
       }

--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -2236,16 +2236,6 @@ ORDER BY civicrm_email.is_primary DESC";
           $data[$key . '_id'] = $value;
         }
         elseif (!$skipCustom && ($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key))) {
-          // for autocomplete transfer hidden value instead of label
-          if ($params[$key] && isset($params[$key . '_id'])) {
-            $value = $params[$key . '_id'];
-          }
-
-          // we need to append time with date
-          if ($params[$key] && isset($params[$key . '_time'])) {
-            $value .= ' ' . $params[$key . '_time'];
-          }
-
           // if auth source is not checksum / login && $value is blank, do not proceed - CRM-10128
           if (($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 &&
             ($value == '' || !isset($value) || (is_array($value) && empty($value)))

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2449,17 +2449,6 @@ AND      default_value IS NOT NULL";
     foreach ($params as $key => $value) {
       $customFieldInfo = CRM_Core_BAO_CustomField::getKeyID($key, TRUE);
       if ($customFieldInfo[0]) {
-
-        // for autocomplete transfer hidden value instead of label
-        if ($params[$key] && isset($params[$key . '_id'])) {
-          $value = $params[$key . '_id'];
-        }
-
-        // we need to append time with date
-        if ($params[$key] && isset($params[$key . '_time'])) {
-          $value .= ' ' . $params[$key . '_time'];
-        }
-
         CRM_Core_BAO_CustomField::formatCustomField($customFieldInfo[0],
           $customData,
           $value,

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -3124,15 +3124,6 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
                     $defaults['field'][$componentId][$name] = $customValue;
                     break;
                   }
-                  elseif (($tree['fields'][$customFieldDetails[0]]['data_type'] ?? NULL) == 'Date') {
-                    $skipValue = TRUE;
-
-                    // CRM-6681, $default contains formatted date, time values.
-                    $defaults[$fldName] = $customValue;
-                    if (!empty($defaults[$customKey . '_time'])) {
-                      $defaults['field'][$componentId][$name . '_time'] = $defaults[$customKey . '_time'];
-                    }
-                  }
                 }
               }
 

--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -736,16 +736,6 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     foreach ($params as $key => $value) {
 
       if (($customFieldId = CRM_Core_BAO_CustomField::getKeyID($key))) {
-        // for autocomplete transfer hidden value instead of label
-        if ($params[$key] && isset($params[$key . '_id'])) {
-          $value = $params[$key . '_id'];
-        }
-
-        // we need to append time with date
-        if ($params[$key] && isset($params[$key . '_time'])) {
-          $value .= ' ' . $params[$key . '_time'];
-        }
-
         // if auth source is not checksum / login && $value is blank, do not proceed - CRM-10128
         if (($session->get('authSrc') & (CRM_Core_Permission::AUTH_SRC_CHECKSUM + CRM_Core_Permission::AUTH_SRC_LOGIN)) == 0 &&
           ($value == '' || !isset($value))

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1462,12 +1462,6 @@ WHERE  id = $cfID
                   // sometime in the future
                   $customVal = $displayValue = CRM_Utils_Date::customFormat(
                     CRM_Utils_Date::processDate($params[$name]), $config->dateformatFull);
-
-                  if (!empty($params[$name . '_time'])) {
-                    $customVal = $displayValue = CRM_Utils_Date::customFormat(
-                      CRM_Utils_Date::processDate($params[$name], $params[$name . '_time']),
-                      $config->dateformatDatetime);
-                  }
                   $skip = TRUE;
                 }
                 // for checkboxes, change array of [key => bool] to array of [idx => key]

--- a/templates/CRM/Batch/Form/Entry.js
+++ b/templates/CRM/Batch/Form/Entry.js
@@ -327,9 +327,4 @@ function setDateFieldValue(fname, fieldValue, blockNo) {
   }
 
   cj('#field_' + blockNo + '_' + fname + '_display').val(displayDateValue);
-
-  // need to fix time formatting
-  if (dateValues[1]) {
-    cj('#field_' + blockNo + '_' + fname + '_time').val(dateValues[1].substr(0, 5));
-  }
 }

--- a/templates/CRM/Batch/Form/Entry.tpl
+++ b/templates/CRM/Batch/Form/Entry.tpl
@@ -496,11 +496,6 @@ function setDateFieldValue(fname, fieldValue, blockNo) {
     displayDateValue = cj.datepicker.formatDate(date_format, actualDateValue);
   }
   cj('[id^=field_' + blockNo + '_' + fname + '_display]').val(displayDateValue);
-
-  // need to fix time formatting
-  if (dateValues[1]) {
-    cj('#field_' + blockNo + '_' + fname + '_time').val(dateValues[1].substr(0, 5));
-  }
 }
 
 if (CRM.batch.type_id == 3){


### PR DESCRIPTION
Overview
----------------------------------------
This removes special form handling for widgets that no longer exist:

- the old jquery tokeninput (replaced by Select2)
- the old smarty date tpl

Both long gone from core and universe.