### PR TITLE
Fix ContributionPageConfirm to create lineitems right the first time

### DIFF
--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1691,7 +1691,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(2, $membershipPayments['count']);
     $lines = $this->validateTripleLines($contribution['id'], $preExistingMembershipID);
-    $this->assertEquals($preExistingMembershipID + 2, $lines[4]['entity_id']);
+    $this->assertEquals($preExistingMembershipID + 2, $lines[2]['entity_id']);
 
     $this->callAPISuccessGetSingle('MembershipPayment', ['contribution_id' => $contribution['id'], 'membership_id' => $preExistingMembershipID + 1, 'version' => 3]);
     $membership = $this->callAPISuccessGetSingle('membership', ['id' => $preExistingMembershipID + 1]);
@@ -1726,11 +1726,13 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'contribution_id' => $id,
     ])['values'];
     $this->assertCount(5, $lines);
-    $this->assertEquals('civicrm_membership', $lines[1]['entity_table']);
-    $this->assertEquals($preExistingMembershipID + 1, $lines[1]['entity_id']);
     $this->assertEquals('civicrm_contribution', $lines[0]['entity_table']);
     $this->assertEquals($id, $lines[0]['entity_id']);
-    $this->assertEquals('civicrm_membership', $lines[4]['entity_table']);
+    $this->assertEquals('civicrm_membership', $lines[1]['entity_table']);
+    $this->assertEquals($preExistingMembershipID + 1, $lines[1]['entity_id']);
+    $this->assertEquals('civicrm_membership', $lines[2]['entity_table']);
+    $this->assertEquals('civicrm_contribution', $lines[3]['entity_table']);
+    $this->assertEquals('civicrm_contribution', $lines[4]['entity_table']);
     return $lines;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Save MembershipLineItems correctly the first time rather than saving them weirdly & fixing

Before
----------------------------------------
Recent work by @rbaugh simplified the Confirm membership code but kept the anti pattern of not creating the membership line items correctly in the first place but hacking them up later

After
----------------------------------------
Removes the anti-pattern with the path to using Order::create instead a bit closer

Technical Details
----------------------------------------
I still have to hack the contribution_recur_id onto the membership. Ideally this would be done using the Order api - @mattwire just added functionality for it to the order api & it's achingly close to fully switching - my main hang up is the Custom Fields - I haven't got a helper to prepare them for v4 api & it is a bridge too far just now - although it might be something @colemanw can help with

Comments
----------------------------------------
