### PR TITLE
AdminUI mailing screen dates should disregard test emails

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse.mgd.php
@@ -259,6 +259,7 @@ return [
               'MailingJob AS Mailing_MailingJob_mailing_id_01',
               'LEFT',
               ['id', '=', 'Mailing_MailingJob_mailing_id_01.mailing_id'],
+              ["Mailing_MailingJob_mailing_id_01.is_test", "=", FALSE],
             ],
           ],
           'having' => [],


### PR DESCRIPTION
Overview
----------------------------------------
If you send a test email before you schedule a mailing, you get confusing results

Before
----------------------------------------
- will show Scheduled/Completed Date based on when the test mailing completed:
<img width="1271" height="173" alt="image" src="https://github.com/user-attachments/assets/9e7b3698-5844-4a7f-aa3c-a972b9ac8935" />

(only actually sent at 12:30, and why is it Running but also has Completed Date??)

After
----------------------------------------
- fixed


Comments
----------------------------------------
Regression from https://github.com/civicrm/civicrm-core/pull/26532

Can be quite worrying for users.
