### PR TITLE
JS - Cleanup some references to deprecated cj

### DIFF
--- a/templates/CRM/Batch/Form/Entry.js
+++ b/templates/CRM/Batch/Form/Entry.js
@@ -16,11 +16,11 @@ CRM.$(function($) {
     // validate rows
     checkColumns($(this));
   });
-   cj('.pledge-adjust-option').click(function(){
-	var blockNo = cj(this).attr('id');
-	cj('select[id="option_type_' + blockNo + '"]').show();
-	cj('select[id="option_type_' + blockNo + '"]').removeAttr('disabled');
-	cj('#field_' + blockNo + '_total_amount').removeAttr('readonly');
+   $('.pledge-adjust-option').click(function(){
+	var blockNo = $(this).attr('id');
+	$('select[id="option_type_' + blockNo + '"]').show();
+	$('select[id="option_type_' + blockNo + '"]').removeAttr('disabled');
+	$('#field_' + blockNo + '_total_amount').removeAttr('readonly');
     });
   $('input[name^="soft_credit_contact_"]').on('change', function(){
     var rowNum = $(this).attr('id').replace('soft_credit_contact_id_','');
@@ -93,9 +93,9 @@ CRM.$(function($) {
 
   }
   else if (CRM.batch.type_id == 2){
-	cj('select[id^="member_option_"]').each(function () {
-	    if (cj(this).val() == 1) {
-		cj(this).attr('disabled', true);
+	$('select[id^="member_option_"]').each(function () {
+	    if ($(this).val() == 1) {
+		$(this).attr('disabled', true);
 	    }
 	});
 

--- a/templates/CRM/Case/Form/CaseView.js
+++ b/templates/CRM/Case/Form/CaseView.js
@@ -1,5 +1,5 @@
 // https://civicrm.org/licensing
-(function($, CRM) {
+(function($) {
 
   function refresh(table) {
     $('#crm-main-content-wrapper').crmSnippet('refresh');
@@ -304,4 +304,4 @@
         }
       });
   });
-}(cj, CRM));
+}(CRM.$));

--- a/templates/CRM/Contact/Form/Search/Builder.js
+++ b/templates/CRM/Contact/Form/Search/Builder.js
@@ -1,5 +1,5 @@
 // http://civicrm.org/licensing
-(function($, CRM, _) {
+(function($, _) {
   'use strict';
 
   /* jshint validthis: true */
@@ -364,4 +364,4 @@
       $('select[id^=mapper][id$="_1"]', '#Builder').each(handleUserInputField);
     }
   });
-})(cj, CRM, CRM._);
+})(CRM.$, CRM._);

--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -342,8 +342,8 @@
     {literal}
     <script>
       CRM.$(function($) {
-        cj('.premium-short').hide();
-        cj('.premium-full').show();
+        $('.premium-short').hide();
+        $('.premium-full').show();
       });
     </script>
     {/literal}

--- a/templates/CRM/Core/DatePickerRangejs.tpl
+++ b/templates/CRM/Core/DatePickerRangejs.tpl
@@ -11,7 +11,7 @@
   <script type="text/javascript">
     CRM.$(function($) {
       $("#{/literal}{$relativeName}{literal}").change(function() {
-        var n = cj(this).parent().parent();
+        const n = $(this).parent().parent();
         if ($(this).val() == "0") {
           $(".crm-absolute-date-range", n).show();
         } else {

--- a/templates/CRM/Profile/Form/Dynamic.tpl
+++ b/templates/CRM/Profile/Form/Dynamic.tpl
@@ -213,8 +213,8 @@
 <script type="text/javascript">
 
 CRM.$(function($) {
-  cj('#selector tr:even').addClass('odd-row ');
-  cj('#selector tr:odd ').addClass('even-row');
+  $('#selector tr:even').addClass('odd-row ');
+  $('#selector tr:odd ').addClass('even-row');
 });
 {/literal}
 </script>


### PR DESCRIPTION
Overview
----------------------------------------
Updates references to deprecated variable name.

Technical Details
----------------------------------------
`cj` is a deprecated alias of `CRM.$` (locally aliased as `$`). In these cases both are available so the switch is easy to make.