### PR TITLE
Improve trigger whitespace

### DIFF
--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -139,7 +139,7 @@ class TimestampTriggers {
         'table' => [$this->getTableName()],
         'when' => 'BEFORE',
         'event' => ['INSERT'],
-        'sql' => "\nSET NEW.{$this->getCreatedDate()} = CURRENT_TIMESTAMP;\n",
+        'sql' => "SET NEW.{$this->getCreatedDate()} = CURRENT_TIMESTAMP;\n",
       ];
     }
 


### PR DESCRIPTION

Overview
----------------------------------------
Improve trigger whitespace

Before
----------------------------------------
It you try to track the triggers in version control this whitespace is prone to be bouncy becuase it puts a new line straight after a space in the parent function - which many text editors remove on save.

After
----------------------------------------
just the space, no new line

Technical Details
----------------------------------------


I thought about putting the new line in the trigger sql compiler instead of the space but it's actually good when diffing to see the trigger name in the changed line and the use case for looking at these triggers has a pretty low surface area...

Also, the bigger triggers don't have the new line & adding one  would apply to them too causing a one-off which space change hit

Comments
----------------------------------------
