### PR TITLE
Deprecate legacy pattern allowing contribution line items to be created via membership create

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -350,6 +350,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
             foreach ($lineItems as $lineIndex => $lineItem) {
               $lineMembershipType = $lineItem['membership_type_id'] ?? NULL;
               if (!empty($params['contribution'])) {
+                CRM_Core_Error::deprecatedWarning('passing contribution into Membership Create is deprecated - use the Order api to get the line items right.');
                 $params['line_item'][$priceSetId][$lineIndex]['contribution_id'] = $params['contribution']->id;
               }
               if ($lineMembershipType && $lineMembershipType == ($params['membership_type_id'] ?? NULL)) {


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate legacy pattern allowing contribution line items to be created via membership create

Before
----------------------------------------
no warning not to do this

After
----------------------------------------
Warning

Technical Details
----------------------------------------
I *think* we still create line items for free memberships & these would have no financial impact - we may need to continue to support that via the Membership create (possibly but maybe the calling function should handle) but we should not be creating any financial items via this api

Comments
----------------------------------------
