### PR TITLE
Fix mismatched `E::ts()` references

### DIFF
--- a/ext/civi_campaign/managed/OptionValue_cg_extends_objects_survey.mgd.php
+++ b/ext/civi_campaign/managed/OptionValue_cg_extends_objects_survey.mgd.php
@@ -1,5 +1,5 @@
 <?php
-use CRM_Contribute_ExtensionUtil as E;
+use CRM_Campaign_ExtensionUtil as E;
 
 // This enables custom fields for Survey entities
 return [

--- a/ext/civi_case/managed/OptionValue_cg_extends_objects_case.mgd.php
+++ b/ext/civi_case/managed/OptionValue_cg_extends_objects_case.mgd.php
@@ -1,5 +1,5 @@
 <?php
-use CRM_Contribute_ExtensionUtil as E;
+use CRM_Case_ExtensionUtil as E;
 
 // This enables custom fields for Case entities
 return [


### PR DESCRIPTION
Overview
----------------------------------------

Fixes an issue discovered while testing the installation screen. For example, if you enable `CiviCampaign` and disable `CiviContribute`, then `CiviCampaign` fails.

Before
----------------------------------------

* CiviCampaign tries to use the `E` helper from CiviContribute
* CiviCase tries to use the `E` helper from CiviContribute

After
----------------------------------------

* CiviCampaign and CiviCase mind their own business.

