### PR TITLE
Riverlea - update stream descriptions

### DIFF
--- a/ext/riverlea/managed/RiverleaStream_HackneyBrook.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_HackneyBrook.mgd.php
@@ -13,7 +13,7 @@ return [
       'values' => [
         'name' => 'hackneybrook',
         'label' => E::ts('Hackney Brook'),
-        'description' => 'named after the Hackney Brook, a tributary of the River Lea that ran through Finsbury Park',
+        'description' => 'Named after the Hackney Brook, a tributary of the River Lea that ran through Finsbury Park',
         'is_reserved' => TRUE,
         'extension' => E::SHORT_NAME,
         'file_prefix' => 'streams/hackneybrook/',

--- a/ext/riverlea/managed/RiverleaStream_Minetta.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Minetta.mgd.php
@@ -12,8 +12,8 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'minetta',
-        'description' => 'Generic CiviCRM UI, somewhat familiar to users of CiviCRM since 2014. Named after Minetta Creek, which runs under Greenwich, New York',
         'label' => E::ts('Minetta'),
+        'description' => 'Familiar to users of CiviCRM since 2014. Named after Minetta Creek, which runs under Greenwich, New York',
         'is_reserved' => TRUE,
         'extension' => E::SHORT_NAME,
         'file_prefix' => 'streams/minetta/',

--- a/ext/riverlea/managed/RiverleaStream_Thames.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Thames.mgd.php
@@ -12,8 +12,8 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'thames',
-        'description' => 'Aaaaah',
         'label' => E::ts('Thames'),
+        'description' => 'A kindly theme with lots of blue tones. Successor to Aah.',
         'is_reserved' => TRUE,
         'extension' => E::SHORT_NAME,
         'file_prefix' => 'streams/thames/',

--- a/ext/riverlea/managed/RiverleaStream_Walbrook.mgd.php
+++ b/ext/riverlea/managed/RiverleaStream_Walbrook.mgd.php
@@ -12,8 +12,8 @@ return [
       'version' => 4,
       'values' => [
         'name' => 'walbrook',
-        'description' => 'Based on Shoreditch theme. Named after after River Walbrook, which runs under Shoreditch, London',
         'label' => E::ts('Walbrook'),
+        'description' => 'Named after after River Walbrook, which runs under Shoreditch, London',
         'is_reserved' => TRUE,
         'extension' => E::SHORT_NAME,
         'file_prefix' => 'streams/walbrook/',


### PR DESCRIPTION
Overview
----------------------------------------
The new Theme picker exposes the Stream descriptions in the UI - so let's improve them.

Comments
----------------------------------------
Capitalisation seems uncontroversial. After that it gets harder...

To my mind we should aim for descriptions that actually describe the themes, as opposed "a theme that looks like another theme" - which means nothing to folks who aren't familiar with historical themes available in CiviCRM. We should also try to move the convo on from "this is the new Shoreditch".

But I struggle to find words to describe them - other than Thames, which is unapologetically blue.

@vingle @artfulrobot any ideas?
