### PR TITLE
[NFC] correct doc url parameter doc

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -30,7 +30,7 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
    * Sections can be added using hook_civicrm_preProcess
    *
    * @var array[]
-   *   {title: string, icon: string, weight: int, description: string, docUrl: array}
+   *   {title: string, icon: string, weight: int, description: string, doc_url: array}
    */
   public $sections = [];
 


### PR DESCRIPTION
`docUrl` in the comment but `doc_url` is needed
