### PR TITLE
Riverlea - move remaining theme settings from Display Preferences => Theme Settings, add notice

### DIFF
--- a/ext/riverlea/Civi/Riverlea/Page/ThemeAdmin.php
+++ b/ext/riverlea/Civi/Riverlea/Page/ThemeAdmin.php
@@ -29,7 +29,7 @@ class ThemeAdmin extends \CRM_Core_Page {
 
       // render option values if applicable
       // use raw value if not a valid option
-      if ($setting['options']) {
+      if ($setting['options'] ?? FALSE) {
         $valueLabel = $setting['options'][$value] ?? E::ts("%1 [unrecognised option]", [1 => $value]);
       }
       else {

--- a/ext/riverlea/riverlea.php
+++ b/ext/riverlea/riverlea.php
@@ -33,3 +33,37 @@ function riverlea_civicrm_install() {
 function riverlea_civicrm_enable() {
   _riverlea_civix_civicrm_enable();
 }
+
+/**
+ * Implements hook_civicrm_alterSettingsMetaData().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsMetaData
+ *
+ * @todo if/when Riverlea is required, update the canonical metadata for these settings
+ * and remove these overrides
+ */
+function riverlea_civicrm_alterSettingsMetaData(array &$settings) {
+  // use the bespoke theme picker, no need to render these inputs
+  $settings['theme_backend']['settings_pages'] = [];
+  $settings['theme_frontend']['settings_pages'] = [];
+  // move these from Display Settings => Theme Settings
+  $settings['menubar_color']['settings_pages'] = ['theme' => ['weight' => 300]];
+  $settings['menubar_position']['settings_pages'] = ['theme' => ['weight' => 300]];
+}
+
+/**
+ * Implements hook_civicrm_preProcess().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
+ *
+ * @todo this is transitional for users who are used to theme showing on Display Settings page.
+ * remove at some stage?
+ */
+function riverlea_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Admin_Form_Preferences_Display') {
+    $message = E::ts('For theme settings, see the <a href="%1">new Theme Settings page</a>', [1 => (string) \Civi::url('backend://civicrm/admin/theme')]);
+
+    \CRM_Core_Region::instance('crm-setting-form-display-top')
+      ->addMarkup("<div class='status status-info'>{$message}</div>");
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Complete move of Theme settings to Theme settings page.

Before
----------------------------------------
- Riverlea has a new Theme Settings page which combines theme picker with dark mode settings
- some theme related settings remain at the bottom of the Display Settings page
- Display Preferences page has **lots** of settings

After
----------------------------------------
- without Riverlea, no change
- with Riverlea, all theme related settings are on the new Theme settings page
- no Theme related settings on the Display page, slightly more manageable page
- a notice on the Display Preferences page to signpost folks to the new page

<img width="922" height="451" alt="image" src="https://github.com/user-attachments/assets/fc25ebc3-a8d2-4305-aca4-de6523b83ebe" />


Comments
----------------------------------------
Is the menubar position a theme setting?

Is "Display empowered by CiviCRM" a theme setting?

At one point I had thought it would be nice to subsume the menubar colour setting into stream variables - but I think this actually has other uses (like indicating environment) which benefit from the separate/overrideable setting.
