### PR TITLE
Fix RoundingMode compatibility with brick/math 0.12+ (PHP 8.1+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "tplaner/when": "~3.1",
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
-    "brick/money": "~0.5",
+    "brick/money": "~0.5 || ~0.9 || ~0.10",
     "pear/mail_mime": "~1.10",
     "pear/db": "~1.12.2",
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",


### PR DESCRIPTION

## Problem
When brick/math 0.12+ is installed (which uses PHP 8.1 enums for RoundingMode),  transaction fails with: "Brick\Money\Money::of(): Argument #4 ($roundingMode) must be of type int, Brick\Math\RoundingMode given"

## Solution
Expands brick/money version constraint to allow 0.9.x and 0.10.x to process GoCardless payments (extension)
