### PR TITLE
Paypal IPN - use Payment::Create, match ContributionRecur on subscription ID.

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -229,12 +229,11 @@ class CRM_Core_Payment_PayPalIPN {
 
   /**
    * @param array $input
-   * @param bool $recur
    *
    * @return void
    * @throws \CRM_Core_Exception
    */
-  public function single(array $input, bool $recur = FALSE): void {
+  public function single(array $input): void {
     $contribution = $this->getContribution();
     // make sure the invoice is valid and matches what we have in the contribution record
     if ($contribution->invoice_id != $input['invoice']) {
@@ -243,15 +242,10 @@ class CRM_Core_Payment_PayPalIPN {
       return;
     }
 
-    if (!$recur) {
-      if ($contribution->total_amount != $input['total_amount']) {
-        Civi::log('paypal_standard')->debug('PayPalIPN: Amount values dont match between database and IPN request. (ID: ' . $contribution->id . ').');
-        echo "Failure: Amount values dont match between database and IPN request<p>";
-        return;
-      }
-    }
-    else {
-      $contribution->total_amount = $input['total_amount'];
+    if ($contribution->total_amount != $input['total_amount']) {
+      Civi::log('paypal_standard')->debug('PayPalIPN: Amount values dont match between database and IPN request. (ID: ' . $contribution->id . ').');
+      echo "Failure: Amount values dont match between database and IPN request<p>";
+      return;
     }
 
     // check if contribution is already completed, if so we ignore this ipn
@@ -414,7 +408,6 @@ class CRM_Core_Payment_PayPalIPN {
     // processor id & the handleNotification function (which should call the completetransaction api & by-pass this
     // entirely). The only thing the IPN class should really do is extract data from the request, validate it
     // & call completetransaction or call fail? (which may not exist yet).
-    CRM_Core_Error::deprecatedWarning('Unreliable method used to get payment_processor_id for PayPal IPN');
     Civi::log('paypal_standard')->warning('Unreliable method used to get payment_processor_id for PayPal IPN - this will cause problems if you have more than one instance');
     // Then we try and retrieve based on business email ID
     $paymentProcessorTypeID = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_PaymentProcessorType', 'PayPal_Standard', 'id', 'name');

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -175,7 +175,6 @@ class CRM_Financial_BAO_Payment {
         }
         CRM_Contribute_BAO_Contribution::completeOrder([
           'is_email_receipt' => $params['is_send_contribution_notification'],
-          'trxn_date' => $params['trxn_date'],
           'payment_instrument_id' => $paymentTrxnParams['payment_instrument_id'],
           'payment_processor_id' => $paymentTrxnParams['payment_processor_id'] ?? '',
         ], $contributionBAO->contribution_recur_id, $contribution['id'], TRUE, $disableActionsOnCompleteOrder);

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -108,7 +108,10 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   public function testIPNPaymentRecurSuccess(): void {
-    $this->setupRecurringPaymentProcessorTransaction([], ['total_amount' => '15.00', 'contribution_page_id' => $this->ids['ContributionPage'][0] ?? NULL]);
+    $this->setupRecurringPaymentProcessorTransaction(
+      ['is_email_receipt' => TRUE],
+      ['total_amount' => '15.00', 'contribution_page_id' => $this->ids['ContributionPage'][0] ?? NULL]
+    );
     $mut = new CiviMailUtils($this, TRUE);
     $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
     $paypalIPN->main();
@@ -159,7 +162,10 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $durationUnit = 'year';
     $this->setupMembershipRecurringPaymentProcessorTransaction(['duration_unit' => $durationUnit, 'frequency_unit' => $durationUnit]);
     $this->callAPISuccessGetSingle('membership_payment', []);
-    $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction());
+    // setupMembershipRecurringPaymentProcessorTransaction creates a lineItem of 200.00
+    //   so we expect IPN payment to match
+    $paypalRecurParams['mc_gross'] = '200.00';
+    $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurTransaction($paypalRecurParams));
     $paypalIPN->main();
     $contribution = $this->callAPISuccess('contribution', 'getsingle', ['id' => $this->_contributionID]);
     $membershipEndDate = $this->callAPISuccessGetValue('membership', ['return' => 'end_date']);
@@ -169,7 +175,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $this->assertSame(substr($contribution['contribution_source'], 0, 20), 'Online Contribution:');
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);
     $this->assertEquals(5, $contributionRecur['contribution_status_id']);
-    $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurSubsequentTransaction());
+    $paypalIPN = new CRM_Core_Payment_PayPalIPN($this->getPaypalRecurSubsequentTransaction($paypalRecurParams));
     $paypalIPN->main();
     $renewedMembershipEndDate = $this->membershipRenewalDate($durationUnit, $membershipEndDate);
     $this->assertEquals($renewedMembershipEndDate, $this->callAPISuccessGetValue('membership', ['return' => 'end_date']));
@@ -192,9 +198,13 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
 
   /**
    * Get IPN style details for an incoming recurring transaction.
+   *
+   * @param array $params
+   *
+   * @return array
    */
-  public function getPaypalRecurTransaction(): array {
-    return [
+  public function getPaypalRecurTransaction(array $params = []): array {
+    return array_merge([
       'contactID' => $this->_contactID,
       'contributionID' => $this->ids['Contribution']['default'],
       'invoice' => 'xyz',
@@ -202,6 +212,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'mc_gross' => '15.00',
       'module' => 'contribute',
       'payer_id' => '4NHU7ZUE92C',
+      'payment_date' => '02:38:09 Dec 07, 2025 PST',
       'payment_status' => 'Completed',
       'receiver_email' => 'sunil._1183377782_biz_api1.webaccess.co.in',
       'txn_type' => 'subscr_payment',
@@ -210,7 +221,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'first_name' => 'Robert',
       'txn_id' => '8XA571746W2698126',
       'residence_country' => 'US',
-    ];
+    ], $params);
   }
 
   /**
@@ -226,6 +237,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'settle_amount' => '95.00',
       'module' => 'contribute',
       'payer_id' => 'FV5ZW7TL874',
+      'payment_date' => date('H:i:s M d, Y' . ' PST'),
       'payment_status' => 'Completed',
       'receiver_email' => 'sunil._1183377782_biz_api1.webaccess.co.in',
       'txn_type' => 'web_accept',
@@ -243,8 +255,12 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
    *
    * @return array
    */
-  public function getPaypalRecurSubsequentTransaction(): array {
-    return array_merge($this->getPaypalRecurTransaction(), ['txn_id' => 'second_one']);
+  public function getPaypalRecurSubsequentTransaction(array $params = []): array {
+    return array_merge(
+      $this->getPaypalRecurTransaction(),
+      ['txn_id' => 'second_one'],
+      $params,
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This PR does two things:
- Convert the PayPal IPN handlers to use the recommended "repeattransaction" + Payment::Create pattern.
- Allow for matching on contributionRecur.processor_id if PayPal IPN does not contain CiviCRM contribution/contact/recurID (eg. if it was setup from a previous/non-CiviCRM system).

Before
----------------------------------------
- Using legacy Contribution.repeattransaction with Completed status.
- Can not process PayPal IPNs that were not created by CiviCRM.



After
----------------------------------------
- Using supported Contribution.repeattransaction with Pending status + Payment::create API.
- Can process PayPal IPNs that were not created by CiviCRM if the "processor_id" matches on the recurring contribution (this means you need to have manually setup the recurring contribution records in CiviCRM first, eg via an import.

Technical Details
----------------------------------------


Comments
----------------------------------------

