### PR TITLE
Set line_total input type for LineItem entity

### DIFF
--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -113,7 +113,7 @@ return [
     'line_total' => [
       'title' => ts('Line Item Total'),
       'sql_type' => 'decimal(20,2)',
-      'input_type' => NULL,
+      'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('qty * unit_price'),
       'add' => '1.7',


### PR DESCRIPTION
Overview
----------------------------------------
Allows it to be used in SK/FormBuilder if enabled.

Before
----------------------------------------
Quantity / unit price enabled but line_total not.

After
----------------------------------------
Line Total enabled

Technical Details
----------------------------------------


Comments
----------------------------------------
I'm writing a refund UI that lets you specify allocations per LineItem. That uses FormBuilder to load the lineitems with line_total as an editable text field. On submit a custom submit handler runs which takes those line totals and passes them to Payment::create as a refund with allocations per line item.
