### PR TITLE
Make quicksearch ignore leading whitespace

### DIFF
--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -154,7 +154,7 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
         $prefix = \Civi::settings()->get('includeWildCardInName') ? '%' : '';
         foreach ($filterFields as $field) {
           $params = $apiParams;
-          $params['where'][] = [$field, 'LIKE', $prefix . $apiRequest->getInput() . '%'];
+          $params['where'][] = [$field, 'LIKE', $prefix . ltrim($apiRequest->getInput()) . '%'];
           // Strip all suffixes from inner select array (pseudoconstants will be evaluated by the outer query)
           $params['select'] = array_map(function ($field) {
             return explode(':', $field)[0];


### PR DESCRIPTION
Overview
----------------------------------------
Make quicksearch ignore leading whitespace

Before
----------------------------------------
Users sometimes copy & paste a name into quicksearch that includes leading space.  It's not obvious the space is there but means contacts are not found resulting in duplicates being created.

After
----------------------------------------
Leading space is ignored.


Comments
----------------------------------------
fyi @colemanw 
