### PR TITLE
Fix repeating scheduled reminders

### DIFF
--- a/Civi/ActionSchedule/RecipientBuilder.php
+++ b/Civi/ActionSchedule/RecipientBuilder.php
@@ -219,7 +219,7 @@ class RecipientBuilder {
     $repeatInsert = $query
       ->merge($this->joinReminder('INNER JOIN', 'rel', $query))
       ->merge($this->selectIntoActionLog(self::PHASE_RELATION_REPEAT, $query))
-      ->merge($this->prepareRepetitionEndFilter($query['casDateField']))
+      ->merge($this->prepareRepetitionEndFilter())
       ->where($this->actionSchedule->start_action_date ? $startDateClauses[0] : [])
       ->groupBy("reminder.contact_id, reminder.entity_id, reminder.entity_table")
       ->having("SUM(ISNULL(reminder.action_date_time)) = 0")
@@ -245,7 +245,7 @@ class RecipientBuilder {
     $addlCheck = \CRM_Utils_SQL_Select::from($query['casAddlCheckFrom'])
       ->select('*')
       ->merge($query, ['params', 'wheres', 'joins'])
-      ->merge($this->prepareRepetitionEndFilter($query['casDateField']))
+      ->merge($this->prepareRepetitionEndFilter())
       ->limit(1)
       ->strict()
       ->toSQL();
@@ -458,7 +458,8 @@ WHERE      $group.id = {$groupId}
    * @param string $dateField
    * @return \CRM_Utils_SQL_Select
    */
-  protected function prepareRepetitionEndFilter($dateField) {
+  protected function prepareRepetitionEndFilter() {
+    $dateField = $this->actionSchedule->end_date;
     $repeatEventDateExpr = ($this->actionSchedule->end_action == 'before' ? 'DATE_SUB' : 'DATE_ADD')
       . "({$dateField}, INTERVAL {$this->actionSchedule->end_frequency_interval} {$this->actionSchedule->end_frequency_unit})";
 


### PR DESCRIPTION
Overview
----------------------------------------
Scheduled reminders have a start date (fixed or absolute), and if repeating, a (relative) end date. Relative dates are of the form `<frequency> <interval> <before/after> <field containing a date>`, e.g. `3 weeks before start date`.

The db fields for `<field containing a date>` are `start_action_date` and `end_date`.  However, when calculating end dates, `start_action_date` is used.

This means that if `start_action_date` and `end_date` are not the same, then the end date will be miscalculated.

To replicate:
* Create an event with a start and end date a week apart, with yesterday being the start date.
* Create a scheduled reminder that goes out 2 hours before the start date, then daily until 2 hours before the end date.
* Execute the scheduled reminders job, note that the reminders go out.
* Execute the scheduled reminder again the next day (in practice, you're just gonna set the `action_date_time` on existing `civicrm_action_log` entries to yesterday).

Before
----------------------------------------
No reminder goes out after the first reminder.

After
----------------------------------------
Reminders go out daily.

Technical Details
----------------------------------------
`$query['casDateField']` is always set to the `start_action_date` or the `absolute_date` - both of which reference the start date.  The `end_date` field is pretty much ignored in the code.

Comments
----------------------------------------
#12923 came *so* close to fixing this - they correctly recognized that `prepareRepetitionEndFilter()` was using the start date because it broke when an absolute date was used, but their scope was more limited.