### PR TITLE
Account is always in english on contribution view

### DIFF
--- a/CRM/Contribute/Form/ContributionView.php
+++ b/CRM/Contribute/Form/ContributionView.php
@@ -95,7 +95,7 @@ class CRM_Contribute_Form_ContributionView extends CRM_Core_Form {
     if (!empty($financialTrxnId['financialTrxnId'])) {
       $values['to_financial_account_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialTrxn', $financialTrxnId['financialTrxnId'], 'to_financial_account_id');
       if ($values['to_financial_account_id']) {
-        $values['to_financial_account'] = CRM_Contribute_PseudoConstant::financialAccount($values['to_financial_account_id']);
+        $values['to_financial_account'] = CRM_Contribute_PseudoConstant::financialAccount($values['to_financial_account_id'], NULL, 'label');
       }
       $values['payment_processor_id'] = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialTrxn', $financialTrxnId['financialTrxnId'], 'payment_processor_id');
       if ($values['payment_processor_id']) {


### PR DESCRIPTION
Overview
----------------------------------------
The old name vs label issue.

Before
----------------------------------------
1. Install civi in french, or just change the label of a financial account to pretend it's french.
2. Make a contribution.
3. View it.
4. About 3/4 down it will look like this, with the english name:
<img width="482" height="86" alt="untitled4" src="https://github.com/user-attachments/assets/2bbeac0d-df47-4282-94c6-7bde46d866d4" />


After
----------------------------------------
It will look (something like) this:
<img width="610" height="91" alt="untitled3" src="https://github.com/user-attachments/assets/1f0d5bd0-4a43-4d47-b95f-87b9e37c3e48" />


Technical Details
----------------------------------------
Labels were added for fin accts in 5.79. This spot went unnoticed.

Comments
----------------------------------------
Chat convo: https://chat.civicrm.org/civicrm/pl/wcxm7hqs63fojjzcxrim4paagw
