### PR TITLE
[PHP8.5] Address null-value for currency

### DIFF
--- a/CRM/Contribute/Form/ContributeFormTrait.php
+++ b/CRM/Contribute/Form/ContributeFormTrait.php
@@ -166,4 +166,10 @@ trait CRM_Contribute_Form_ContributeFormTrait {
     return array_key_exists($entity, \Civi::service('action_object_provider')->getEntities());
   }
 
+  protected function assignCurrency(): void {
+    $currency = $this->getContributionValue('currency') ?: CRM_Core_Config::singleton()->defaultCurrency;
+    $this->assign('currency', $currency);
+    $this->assign('currencySymbol', CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', $currency, 'symbol', 'name'));
+  }
+
 }

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -362,6 +362,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $this->setPageTitle($this->_ppID ? ts('Pledge Payment') : ts('Contribution'));
     }
     $this->assign('payNow', $this->_payNow);
+    $this->assignCurrency();
   }
 
   private function preProcessPledge(): void {
@@ -555,11 +556,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['receive_date'] = date('Y-m-d H:i:s');
     }
 
-    $currency = $defaults['currency'] ?? NULL;
-    $this->assign('currency', $currency);
-    // Hack to get currency info to the js layer. CRM-11440.
-    CRM_Utils_Money::format(1);
-    $this->assign('currencySymbol', CRM_Utils_Money::$_currencySymbols[$currency] ?? NULL);
     $this->assign('totalAmount', $defaults['total_amount'] ?? NULL);
 
     // Inherit campaign from pledge.

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -291,7 +291,8 @@ SELECT  id, html_type
     $this->assign('partiallyPaid', array_search('Partially paid', $statuses));
     $this->assign('pendingRefund', array_search('Pending refund', $statuses));
     $this->assign('participantStatus', $this->getParticipantValue('status_id'));
-
+    // @todo - this is for calculate.tpl but may not work here
+    // the main form needs it - see Contribution_Form->assignCurrencySymbol()
     $this->assign('currencySymbol', CRM_Core_BAO_Country::defaultCurrencySymbol());
 
     // line items block

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -273,6 +273,8 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     $otherAmount = $qf->get('values');
     $config = CRM_Core_Config::singleton();
     $currencySymbol = CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_Currency', $config->defaultCurrency, 'symbol', 'name');
+    // @todo - this is for calculate.tpl but doesn't seem to work here because
+    // the main form needs it - see Contribution_Form->assignCurrencySymbol()
     $qf->assign('currencySymbol', $currencySymbol);
     $qf->assign('currency', $config->defaultCurrency);
     // get currency name for price field and option attributes


### PR DESCRIPTION
Overview
----------------------------------------
[PHP8.5] Address null-value for currency

Before
----------------------------------------
Test fail - but also functionality broken

The point of it is that if you enter $1 here the code knows to strip the $1 & treat the 1 as a number and calculate total_amount (below)

<img width="976" height="386" alt="image" src="https://github.com/user-attachments/assets/1f3fda2d-fa85-4d5a-997b-6b950e50768e" />


<img width="1038" height="420" alt="image" src="https://github.com/user-attachments/assets/501b6f6d-f5b9-44f8-88c3-b10f43e6c11e" />

After
----------------------------------------
<img width="976" height="386" alt="image" src="https://github.com/user-attachments/assets/4e877d2d-4096-4987-a860-c9f9895d8cc8" />


Technical Details
----------------------------------------
This was already more of my life than I wanted to spend on this code - I'm sure it could be better but..

Comments
----------------------------------------
