### PR TITLE
Simplify contact getFields call

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1835,18 +1835,10 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
   public static function getMergeFieldsMetadata(bool $checkPermissions = TRUE): array {
     if (!isset(\Civi::$statics[__CLASS__]['merge_fields_metadata'][(int) $checkPermissions])) {
       $contactFields = (array) Contact::getFields($checkPermissions)
+        ->addWhere('name', 'NOT IN', self::ignoredFields('contact'))
         ->execute()
         ->indexBy('name');
-      $invalidFields = self::ignoredFields('contact');
-      foreach ($contactFields as $field => $value) {
-        if (in_array($field, $invalidFields, TRUE)) {
-          unset($contactFields[$field]);
-        }
-      }
-      $optionValueFields = CRM_Core_OptionValue::getFields();
-      foreach ($optionValueFields as $field => $params) {
-        $contactFields[$field]['title'] = $params['title'];
-      }
+
       \Civi::$statics[__CLASS__]['merge_fields_metadata'][(int) $checkPermissions] = $contactFields;
     }
     return \Civi::$statics[__CLASS__]['merge_fields_metadata'][(int) $checkPermissions];


### PR DESCRIPTION
Before you say it - it probably doesn't need the caching but outta scope

Overview
----------------------------------------
Simplify contact getFields call
Before you say it - it probably doesn't need the caching but outta scope

Before
----------------------------------------
- loads all fields & unsets some
- adds 3 fields into the getFields that are not used


<img width="392" height="278" alt="image" src="https://github.com/user-attachments/assets/710fe79d-8188-43b2-b383-134d59ddd742" />

After
----------------------------------------
Uses NOT IN, doesn't add the extra fields

I double checked api_key is not present in getFields afterwards (one of the NOT IN fields) and that the 3 fields 'somewhat appropriately' show up on the merge screen despite some 3-v-adjacent variants not being there

<img width="1021" height="400" alt="image" src="https://github.com/user-attachments/assets/ae331568-a4fd-4876-b700-02d7029f4e64" />


Technical Details
----------------------------------------
The  3 fields would have made sense when we were loading the contacts with apiv3 but are not present with apiv4

Comments
----------------------------------------
