### PR TITLE
Fix notice on Membership contribution Main page (rc only regression)

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -442,7 +442,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           throw new CRM_Contribute_Exception_InactiveContributionPageException(ts('The page you requested is currently unavailable.'), $this->_id);
         }
       }
-      $this->_values['financial_type_id'] = $this->getFinancialTypeID();
 
       $endDate = CRM_Utils_Date::processDate($this->_values['end_date'] ?? NULL);
       $now = date('YmdHis');


### PR DESCRIPTION
Overview
----------------------------------------
Fix notice on Membership contribution Main page (re regression) per https://github.com/civicrm/civicrm-core/pull/34571/files/dd410846ac706e20a180ca1d5bd24377fc9f2cd8#diff-a387458ba3c5d92e0dcc4c0ba4a2ad97cf36844f4c9b32fcd9862df33672f1a2

Before
----------------------------------------
<img width="1021" height="400" alt="image" src="https://github.com/user-attachments/assets/21a98da7-df98-467f-a9d2-17538750bed5" />

After
----------------------------------------

<img width="1251" height="525" alt="image" src="https://github.com/user-attachments/assets/3e938e9b-8632-4761-8478-be6e72deac50" />


Technical Details
----------------------------------------
This is a regression from https://github.com/civicrm/civicrm-core/pull/34571 pointed out by @rbaugh 

That PR removed the places that looked at what is stored in this value and on checking there are no remaining references to it

<img width="1251" height="525" alt="image" src="https://github.com/user-attachments/assets/69c23d7c-aa4c-46f9-91ae-1df8b819c1a4" />

Comments
----------------------------------------

