### PR TITLE
fix JWT submission token in Afform

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -876,7 +876,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   public function replaceTokens(string $text): string {
     $matches = [];
-    preg_match_all('/[[a-zA-Z0-9_]{1,}\.[0-9]{1,}\.[^]]+]/', $text, $matches);
+    preg_match_all('/[[a-zA-Z0-9_]{1,}+]/', $text, $matches);
 
     foreach ($matches[0] as $match) {
       // strip [ ] and split on .
@@ -889,6 +889,9 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       }
       else {
         $value = $this->_entityValues[$entityName][$index]['fields'][$field];
+      }
+      if ($entityName === 'token') {
+        $value = $this->_response['token'] ?? '';
       }
       $text = str_replace($match, $value, $text);
     }


### PR DESCRIPTION
Overview
----------------------------------------
If you put a JWT submission token into a FormBuilder submission redirect url, it's not rendered.

Before
----------------------------------------
Not rendered.

After
----------------------------------------
Rendered.

Technical Details
----------------------------------------
This is a poor fix because I suspect @ufundo had a good reason for having a non-trivial regex here - and it makes a special case for a token named `token`.  There's probably a more general case here, but given that https://lab.civicrm.org/dev/core/-/issues/6305 was just created, it might make more sense to merge this and change it again once the scope of that issue is fleshed out.

Comments
----------------------------------------
This regressed about 7 months ago with the introduction of https://github.com/civicrm/civicrm-core/pull/32965, which introduced a tighter regex for determining what was a token.

Also - is it too late to rename the JWT submission token to something other than "token"? 
