### PR TITLE
[NFC] missing test data - domain contact phone type

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3854,7 +3854,7 @@ WHERE a1.is_primary = 0
   protected function addLocationBlockToDomain(): void {
     $contactID = CRM_Core_BAO_Domain::getDomain()->contact_id;
     Phone::create()
-      ->setValues(['phone' => 123, 'contact_id' => $contactID])
+      ->setValues(['phone' => '123', 'phone_type_id:name' => 'Phone', 'contact_id' => $contactID])
       ->execute()
       ->first()['id'];
     Address::create()->setValues([


### PR DESCRIPTION
Overview
----------------------------------------
Addresses the pledge test fails in https://github.com/civicrm/civicrm-core/pull/34712 (more generically, calls to domain.get)

Before
----------------------------------------
phone created without a type

After
----------------------------------------
phone has a type

Technical Details
----------------------------------------
You can't have a phone without a type!

Comments
----------------------------------------

