### PR TITLE
[php 8] dedupe - empty string instead of null

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -2318,7 +2318,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
    */
   private static function getFieldValueAndLabel(string $field, array $contact, bool $checkPermissions): array {
     $fields = self::getMergeFieldsMetadata($checkPermissions);
-    $value = $label = $contact[$field] ?? NULL;
+    $value = $label = $contact[$field] ?? '';
     $fieldSpec = $fields[$field];
     if (!empty($fieldSpec['serialize']) && is_array($value)) {
       // In practice this only applies to preferred_communication_method as the sub types are skipped above


### PR DESCRIPTION
Overview
----------------------------------------
For test fail in https://github.com/civicrm/civicrm-core/pull/34712

Before
----------------------------------------
null

After
----------------------------------------
empty string which inside this function ends up handled the same way

Technical Details
----------------------------------------

Comments
----------------------------------------
Philosophical question: What does it mean to merge null into a contact? Is that the same as merging emptiness?
