### PR TITLE
 Using null as an array offset is deprecated, use an empty string instead

### DIFF
--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -269,7 +269,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
             'title' => ts('Relationship Dates Validity'),
             'operatorType' => CRM_Report_Form::OP_SELECT,
             'options' => [
-              NULL => ts('- Any -'),
+              '' => ts('- Any -'),
               1 => ts('Not expired'),
               0 => ts('Expired'),
             ],
@@ -820,7 +820,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
       return NULL;
     }
 
-    list($from, $to) = $this->getFromTo($relative, $from, $to);
+    [$from, $to] = $this->getFromTo($relative, $from, $to);
 
     if ($from) {
       $from = ($type == CRM_Utils_Type::T_DATE) ? substr($from, 0, 8) : $from;


### PR DESCRIPTION
…
api_v3_ReportTemplateTest::testReportTemplateGetRowsAllReportsACL with data set #21 ('contact/relationship') Failure in api call for report_template getrows:  Using null as an array offset is deprecated, use an empty string instead #0 /home/homer/buildkit/build/build-3/web/core/CRM/Report/Form/Contact/Relationship.php(272): PHPUnit\Util\ErrorHandler->__invoke(8192, 'Using null as a...', '/home/homer/bui...', 272) #1 /home/homer/buildkit/build/build-3/web/core/api/v3/ReportTemplate.php(132): CRM_Report_Form_Contact_Relationship->__construct() #2 /home/homer/buildkit/build/build-3/web/core/api/v3/ReportTemplate.php(105): _civicrm_api3_report_template_getrows(Array) #3 /home/homer/buildkit/build/build-3/web/core/Civi/API/Provider/MagicFunctionProvider.php(89): civicrm_api3_report_template_getrows(Array) #4 /home/homer/buildkit/build/build-3/web/core/Civi/API/Kernel.php(159): Civi\API\Provider\MagicFunctionProvider->invoke(Array) #5 /home/homer/buildkit/build/build-3/web/core/Civi/API/Kernel.php(79): Civi\API\Kernel->runRequest(Array) #6 /home/homer/buildkit/build/build-3/web/core/api/api.php(28): Civi\API\Kernel->runSafe('report_template', 'getrows', Array) #7 /home/homer/buildkit/build/build-3/web/core/Civi/Test/Api3TestTrait.php(301): civicrm_api('report_template', 'getrows', Array) #8 /home/homer/buildkit/build/build-3/web/core/Civi/Test/Api3TestTrait.php(187): CiviUnitTestCaseCommon->civicrm_api('report_template', 'getrows', Array) #9 /home/homer/buildkit/build/build-3/web/core/tests/phpunit/api/v3/ReportTemplateTest.php(308): CiviUnitTestCaseCommon->callAPISuccess('report_template', 'getrows', Array) #10 phar:///home/homer/buildkit/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestCase.php(1323): api_v3_ReportTemplateTest->testReportTemplateGetRowsAllReportsACL('contact/relatio...') #11 /home/homer/buildkit/build/build-3/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php(4018): PHPUnit\Framework\TestCase->runTest() #12 phar:///home/homer/buildkit/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestCase.php(989): CiviUnitTestCase->runTest() #13 phar:///home/homer/buildkit/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestResult.php(589): PHPUnit\Framework\TestCase->runBare() #14 phar:///home/homer/buildkit/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestCase.php(780): PHPUnit\Framework\TestResult->run(Object(api_v3_ReportTemplateTest)) #15 phar:///home/homer/buildkit/extern/phpunit9/phpunit9.phar/phpunit/Framework/TestSuite.php(511): PHPUnit\Framework\TestCase->run(Object(PHPUnit\Framework\TestResult))

Overview
----------------------------------------
_A brief description of the pull request. Keep technical jargon to a minimum. Hyperlink relevant discussions._

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
