### PR TITLE
Don't log about "you have invalid data in your database!" every time you visit the participant tab for uneventful people

### DIFF
--- a/CRM/Event/Selector/Search.php
+++ b/CRM/Event/Selector/Search.php
@@ -329,7 +329,13 @@ class CRM_Event_Selector_Search extends CRM_Core_Selector_Base implements CRM_Co
 
       // Skip registration if event_id is NULL
       if (empty($row['event_id'])) {
-        Civi::log()->warning('Participant record (' . $row['participant_id'] . ') without event ID. You have invalid data in your database!');
+        // The way the query is structured sometimes it will always return a
+        // result even when the contact has no participant records. That's not
+        // invalid data so don't log about that. For example visit the events
+        // tab for a contact with no participant record.
+        if (empty($row['contact_id']) || (bool) CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_participant WHERE contact_id = %1 LIMIT 1", [1 => [$row['contact_id'], 'Integer']])) {
+          Civi::log()->warning('Participant record (' . $row['participant_id'] . ') without event ID. You have invalid data in your database!');
+        }
         continue;
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
This has been bugging me for a long time.

Before
----------------------------------------
Logs mysteriously intermittently filled with `Participant record () without event ID. You have invalid data in your database!`

It happens when you visit the participant tab for a contact that has no participant records.

After
----------------------------------------
Still logs if there is a problem with a participant record.

Technical Details
----------------------------------------
I waffled between this and just checking for empty `$row['participant_id']`, but I suppose there might be some weird scenario where there is a participant record but for some reason the query returns blank for the id, and that would likely be some weird data you should fix.

I didn't want to wade into what the searchQuery object does to make the query - a more better thing might be to only return records when the contact actually has participant records. It uses left joins so it returns records regardless.

Comments
----------------------------------------
