### PR TITLE
dont arrayify _name in CRM_Contact_Form_Task_AddToTag

### DIFF
--- a/CRM/Contact/Form/Task/AddToTag.php
+++ b/CRM/Contact/Form/Task/AddToTag.php
@@ -116,10 +116,7 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
     // merge contact and taglist tags
     $allTags = CRM_Utils_Array::crmArrayMerge($contactTags, $tagList);
 
-    $this->_name = [];
     foreach ($allTags as $key => $dnc) {
-      $this->_name[] = $this->_tags[$key];
-
       list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_contactIds, $key,
         'civicrm_contact', FALSE);
 

--- a/CRM/Contact/Form/Task/RemoveFromTag.php
+++ b/CRM/Contact/Form/Task/RemoveFromTag.php
@@ -104,10 +104,7 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
     // merge contact and taglist tags
     $allTags = CRM_Utils_Array::crmArrayMerge($contactTags, $tagList);
 
-    $this->_name = [];
     foreach ($allTags as $key => $dnc) {
-      $this->_name[] = $this->_tags[$key];
-
       list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_contactIds, $key,
         'civicrm_contact', FALSE);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/issues/6316

Before
----------------------------------------
- form `_name` gets overwritten with an array in the post process.
- this breaks calls to `getSubmittedValues` in hooks.

After
----------------------------------------
- form `_name` gets overwritten with an array in the post process. 
- calls to `getSubmittedValues` in hooks dont crash


Technical Details
----------------------------------------
Not sure why this is being done - can't see anything close by that it would affect. It 'r-runs' ok for me. Will see what tests says.

Downstream - maybe a pre-existing hook listener could specificallly listen for an arrayified $formName in postProcess and this would break it?
