### PR TITLE
SearchKit - Add nested table displays feature

### DIFF
--- a/ext/search_kit/Civi/Api4/Result/SearchDisplayRunResult.php
+++ b/ext/search_kit/Civi/Api4/Result/SearchDisplayRunResult.php
@@ -37,4 +37,10 @@ class SearchDisplayRunResult extends \Civi\Api4\Generic\Result {
    */
   public $toolbar = NULL;
 
+  /**
+   * Nested search metedata
+   * @var array|null
+   */
+  public $nested = NULL;
+
 }

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -166,7 +166,7 @@
       function getJoin(savedSearch, fullNameOrAlias) {
         let alias = _.last(fullNameOrAlias.split(' AS ')),
           path = alias,
-          baseEntity = searchEntity,
+          baseEntity = savedSearch?.api_entity || searchEntity,
           labels = [],
           join,
           result;
@@ -222,7 +222,7 @@
           field;
         // If 2 or more segments, the first might be the name of a join
         if (dotSplit.length > 1) {
-          join = getJoin(null, dotSplit[0]);
+          join = getJoin({api_entity: entityName}, dotSplit[0]);
           if (join) {
             dotSplit.shift();
             entityName = join.entity;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminNested.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminNested.component.js
@@ -1,0 +1,120 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('crmSearchAdminNested', {
+    bindings: {
+      display: '<',
+    },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/crmSearchAdmin/crmSearchAdminNested.html',
+    controller: function ($scope, searchMeta, crmApi4) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.$onInit = function() {
+        const searchName = ctrl.display.settings?.nested?.search;
+        if (searchName) {
+          getNestedSearchInfo(searchName).then((result) => {
+            // If search doesn't exist, it can't be used
+            if (!result.savedSearch) {
+              delete ctrl.display.settings.nested;
+            }
+          });
+        }
+        else if (ctrl.display.settings.nested) {
+          delete ctrl.display.settings.nested;
+        }
+      };
+
+      function getNestedField(fieldName) {
+        return searchMeta.getField(fieldName, ctrl.savedSearch.api_entity);
+      }
+
+      function getNestedSearchInfo(searchName) {
+        ctrl.searchDisplays = null;
+        const apiCalls = crmApi4({
+          searchDisplays: ['SearchDisplay', 'get', {
+            select: ['name', 'label'],
+            where: [
+              ['saved_search_id.name', '=', searchName],
+              // For now this is the only type of embedded display we support
+              ['type:name', '=', 'crm-search-display-table'],
+            ],
+          }],
+          savedSearch: ['SavedSearch', 'get', {
+            select: ['api_entity', 'api_params'],
+            where: [['name', '=', searchName]],
+          }, 0],
+        });
+        apiCalls.then((result) => {
+          ctrl.searchDisplays = result.searchDisplays;
+          ctrl.savedSearch = result.savedSearch;
+          // Parse fields
+          ctrl.nestedFields = ctrl.savedSearch.api_params.select.reduce((fields, fieldName) => {
+            const field = getNestedField(fieldName);
+            if (field) {
+              fields.push({
+                id: fieldName.split(':')[0],
+                text: field.label,
+              });
+            }
+            return fields;
+          }, []);
+        });
+        return apiCalls;
+      }
+
+      this.onChangeNestedSearch = () => {
+        const searchName = ctrl.display.settings?.nested?.search;
+        if (!searchName) {
+          delete ctrl.display.settings.nested;
+          ctrl.savedSearch = null;
+          ctrl.searchDisplays = null;
+        } else {
+          ctrl.display.settings.nested.filters = [];
+          getNestedSearchInfo(searchName).then((result) => {
+            if (result.searchDisplays.length) {
+              ctrl.display.settings.nested.display = result.searchDisplays[0].name;
+              // Set default filter
+              const baseEntity = searchMeta.getBaseEntity();
+              ctrl.savedSearch.api_params.select.forEach((fieldName) => {
+                const field = getNestedField(fieldName);
+                if (field?.fk_entity === baseEntity.name) {
+                  ctrl.display.settings.nested.filters.push({
+                    field: field.name,
+                    data: baseEntity.primary_key[0],
+                  });
+                }
+              });
+              ctrl.noIdFilterFound = !ctrl.display.settings.nested.filters.length;
+            }
+          });
+        }
+      };
+
+      this.onChangeNestedFilter = (index) => {
+        if (!ctrl.display.settings.nested.filters[index].field) {
+          ctrl.display.settings.nested.filters.splice(index, 1);
+        }
+      };
+
+      this.addFilter = (fieldName) => {
+        ctrl.display.settings.nested.filters = ctrl.display.settings.nested.filters || [];
+        ctrl.display.settings.nested.filters.push({
+          field: fieldName,
+          data: null,
+        });
+      };
+
+      this.fieldsForFilter = function() {
+        return {
+          results: ctrl.crmSearchAdmin.getAllFields('', ['Field', 'Custom', 'Extra']),
+        };
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminNested.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminNested.html
@@ -1,0 +1,44 @@
+<div class="help-block">
+  {{:: ts('Embed a second search display to give extra details about each row.') }}
+</div>
+<div class="form-inline">
+  <input placeholder="{{:: ts('Saved Search') }}" class="form-control" crm-autocomplete="'SavedSearch'" crm-autocomplete-params="{key: 'name', formName: 'searchAdmin', fieldName: 'nestedSearch'}" auto-open="true" ng-model="$ctrl.display.settings.nested.search" ng-change="$ctrl.onChangeNestedSearch()">
+  <select class="form-control" ng-model="$ctrl.display.settings.nested.display" ng-if="$ctrl.display.settings.nested.search" ng-disabled="!$ctrl.searchDisplays">
+    <option ng-repeat="display in $ctrl.searchDisplays" value="{{:: display.name }}">{{:: display.label }}</option>
+  </select>
+</div>
+<div class="help-block bg-warning" ng-if="$ctrl.searchDisplays && !$ctrl.searchDisplays.length">
+  <i class="crm-i fa-exclamation-triangle" aria-hidden="true" role="img"></i>
+  {{:: ts('The selected saved search does not have any table displays.') }}
+</div>
+<table class="table table-condensed" ng-if="$ctrl.searchDisplays.length">
+  <thead>
+  <tr>
+    <th>{{:: ts('Filter Nested Display') }}</th>
+    <th>{{:: ts('With Value') }}</th>
+  </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat="filter in $ctrl.display.settings.nested.filters">
+      <td>
+        <input class="form-control" ng-model="filter.field" crm-ui-select="{data: $ctrl.nestedFields, placeholder: ' '}" ng-change="$ctrl.onChangeNestedFilter($index)">
+      </td>
+      <td>
+        <input class="form-control" ng-model="filter.data" crm-ui-select="{data: $ctrl.fieldsForFilter, placeholder: ts('Choose field')}">
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">
+        <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
+               crm-ui-select="{data: $ctrl.nestedFields, placeholder: ts('Add Filter')}"
+               on-crm-ui-select="$ctrl.addFilter(selection)" >
+      </td>
+    </tr>
+  </tfoot>
+</table>
+<div class="help-block bg-warning" ng-if="$ctrl.noIdFilterFound && !$ctrl.display.settings.nested.filters.length">
+  <i class="crm-i fa-info-circle" aria-hidden="true" role="img"></i>
+  {{:: ts('No join field found. You may need to add a field to the nested display first.') }}
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -117,6 +117,13 @@
       </div>
     </div>
   </details>
+
+  <details class="crm-accordion-bold">
+    <summary>{{:: ts('Nested Display') }}</summary>
+    <div class="crm-accordion-body">
+      <crm-search-admin-nested display="$ctrl.display"></crm-search-admin-nested>
+    </div>
+  </details>
 </fieldset>
 
 <fieldset class="crm-search-admin-edit-columns-wrapper">

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -197,8 +197,16 @@
         }, 900);
       },
 
-      hasExtraFirstColumn: function() {
-        return this.settings.actions || this.settings.draggable || this.settings.collapsible || this.settings.editableRow || (this.settings.tally && this.settings.tally.label);
+      hasExtraFirstColumn: function(row) {
+        if (row && row.isNested) {
+          return false;
+        }
+        return this.settings.actions ||
+          this.settings.draggable ||
+          this.settings.collapsible ||
+          this.settings.editableRow ||
+          (this.settings.tally && this.settings.tally.label) ||
+          (this.settings.nested && this.settings.nested.search && this.settings.nested.display);
       },
 
       getFilters: function() {

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,10 +1,11 @@
 <tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}" ng-if="!row.hidden">
-  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: $ctrl.getRowClass(row) }}">
+  <td ng-if=":: $ctrl.hasExtraFirstColumn(row)" class="crm-search-ctrl-column {{:: $ctrl.getRowClass(row) }}">
     <span ng-if=":: $ctrl.settings.draggable" class="crm-draggable" title="{{:: ts('Drag to reposition') }}">
       <i class="crm-i fa-arrows-v" role="img" aria-hidden="true"></i>
     </span>
     <input ng-if=":: $ctrl.settings.actions" type="checkbox" ng-checked="$ctrl.isRowSelected(row)" ng-click="$ctrl.toggleRow(row, $event)" ng-disabled="!!$ctrl.loadingAllRows">
     <crm-search-display-toggle-collapse ng-if=":: $ctrl.settings.collapsible" default-collapsed="$ctrl.settings.collapsible" rows="$ctrl.results" row-index="rowIndex"></crm-search-display-toggle-collapse>
+    <crm-search-display-toggle-nested ng-if=":: $ctrl.settings.nested.display" row="row" results="$ctrl.results" settings="$ctrl.settings" row-index="rowIndex"></crm-search-display-toggle-nested>
     <div class="btn-group" ng-if="$ctrl.settings.editableRow.full && $ctrl.editing === row.key">
       <button type="button" class="btn btn-sm btn-success" ng-click="$ctrl.saveEditing(row)">
         <span class="sr-only">{{:: ts('Save') }}</span>
@@ -17,6 +18,9 @@
     </div>
   </td>
   <td ng-repeat="(colIndex, colData) in row.columns track by $index" ng-if="$ctrl.columns[colIndex].enabled" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.columns[colIndex].key }}">
+  </td>
+  <td ng-if="row.isNested" colspan="{{:: $ctrl.columns.length + 1 }}">
+    <crm-search-display-table search="$ctrl.results.nested.search" display="$ctrl.results.nested.display" api-entity="{{:: $ctrl.results.nested.api_entity }}" settings="$ctrl.results.nested.settings" filters="row.nestedFilters"></crm-search-display-table>
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleNested.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleNested.component.js
@@ -1,0 +1,47 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchDisplayTable').component('crmSearchDisplayToggleNested', {
+    bindings: {
+      row: '<',
+      results: '<',
+      rowIndex: '<',
+      settings: '<',
+    },
+    templateUrl: '~/crmSearchDisplayTable/crmSearchDisplayToggleNested.html',
+    controller: function($scope, $element) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
+        ctrl = this;
+
+      this.$onInit = function() {
+
+      };
+
+      this.toggleNested = function() {
+        ctrl.row.showNested = !ctrl.row.showNested;
+        if (ctrl.row.showNested) {
+          ctrl.results.splice(ctrl.rowIndex + 1, 0, {
+            isNested: true,
+            columns: [],
+            key: null,
+            cssClass: 'crm-search-display-table-nested-row',
+            nestedFilters: getNestedFilters(),
+          });
+        }
+        else {
+          ctrl.results.splice(ctrl.rowIndex + 1, 1);
+        }
+      };
+
+      function getNestedFilters() {
+        const data = _.cloneDeep(ctrl.row.data);
+        return ctrl.settings.nested.filters.reduce((filters, filter) => {
+          filters[filter.field] = data[filter.data];
+          return filters;
+        }, {});
+      }
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleNested.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayToggleNested.html
@@ -1,0 +1,3 @@
+<button class="btn" type="button" title="{{:: ts('Show sub-rows') }}" ng-click="$ctrl.toggleNested()">
+  <i class="crm-i" ng-class="{'fa-caret-right': !$ctrl.row.showNested, 'fa-caret-down': $ctrl.row.showNested}" role="img" aria-hidden="true"></i>
+</button>


### PR DESCRIPTION
Overview
----------------------------------------
New feature allows a nested display-within-a-display. Each table row expands to reveal a second display. Useful for e.g. contributions + line items, or cases + activities.

<img width="1868" height="1792" alt="image" src="https://github.com/user-attachments/assets/b9a2ae9c-1fe7-4d03-84cd-efeb5e171df7" />


Technical Details
----------------------------------------
Configurable filters are passed from each parent row into the child display to provide context.

For now, this is limited to table displays.