### PR TITLE
dev/core#6312 :: Prevent OrderCompleteSubscriber from running when payment method is changed

### DIFF
--- a/CRM/Financial/Form/PaymentEdit.php
+++ b/CRM/Financial/Form/PaymentEdit.php
@@ -228,15 +228,15 @@ class CRM_Financial_Form_PaymentEdit extends CRM_Core_Form {
         'trxn_date' => $submittedValues['trxn_date'],
       ]);
 
-      $newFinancialTrxn = $submittedValues;
-      unset($newFinancialTrxn['id']);
-      $newFinancialTrxn['to_financial_account_id'] = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($submittedValues['payment_instrument_id']);
-      $newFinancialTrxn['total_amount'] = $this->_values['total_amount'];
-      $newFinancialTrxn['currency'] = $this->_values['currency'];
-      $newFinancialTrxn['contribution_id'] = $this->getContributionID();
-      $newFinancialTrxn['is_send_contribution_notification'] = FALSE;
-      $newFinancialTrxn += $this->getSubmittedCustomFields();
-      civicrm_api3('Payment', 'create', $newFinancialTrxn);
+      $newFinancialTrxn['values'] = $submittedValues;
+      unset($newFinancialTrxn['values']['id']);
+      $newFinancialTrxn['values']['payment_instrument_id'] = $submittedValues['payment_instrument_id'];
+      $newFinancialTrxn['values']['total_amount'] = $this->_values['total_amount'];
+      $newFinancialTrxn['values']['contribution_id'] = $this->getContributionID();
+      $newFinancialTrxn['notificationForCompleteOrder'] = FALSE;
+      $newFinancialTrxn['disableActionsOnCompleteOrder'] = TRUE;
+      $newFinancialTrxn['values'] += $this->getSubmittedCustomFields(4);
+      civicrm_api4('Payment', 'create', $newFinancialTrxn);
     }
     else {
       // simply update the financial trxn

--- a/api/v3/Payment.php
+++ b/api/v3/Payment.php
@@ -134,13 +134,17 @@ function civicrm_api3_payment_create($params) {
     }
   }
   _civicrm_api3_format_params_for_create($params, 'FinancialTrxn');
+  // Default to actions enabled.
+  $disableActionsOnCompleteOrder = FALSE;
   // Check if it is an update
   if (!empty($params['id'])) {
     $amount = $params['total_amount'];
     civicrm_api3('Payment', 'cancel', $params);
     $params['total_amount'] = $amount;
+    // Since this isn't a new payment, prevent order completed actions.
+    $disableActionsOnCompleteOrder = TRUE;
   }
-  $trxn = CRM_Financial_BAO_Payment::create($params);
+  $trxn = CRM_Financial_BAO_Payment::create($params, $disableActionsOnCompleteOrder);
 
   $values = [];
   _civicrm_api3_object_to_array_unique_fields($trxn, $values[$trxn->id]);


### PR DESCRIPTION
Overview
----------------------------------------
Switches to using the API4 Payment::create and disables order complete actions.

Before
----------------------------------------
When a payment method is changed for a contribution payment, the original payment is cancelled/refunded and a new payment is recorded. This is to make sure the financial items are correct for accounting purposes. The original code was using API3 to recreate the payment with the new payment method, but this was triggering actions for completed orders which was causing the membership to be renewed.

After
----------------------------------------
With the change to using API4 for the Payment::create, we can pass in the `disableActionsOnCompleteOrder` which prevent the `OrderCompleteSubscriber` from firing. This then prevents the membership renewal from happening as the payment is just for updating the financial line item rather than actually making a new payment.

Comments
----------------------------------------
Not really sure if this is a regression, but with the changes in #34342, this seems to have become an issue as we now process membership renewals using `OrderCompleteSubscriber` and since this is making it seem like a new payment/order, it is causing memberships to advance. 

@eileenmcnaughton, @mattwire are there other areas that you can think of where this same cancel/refund and create is done on Payments that I should also look into?
