### PR TITLE
remove non-billing email from billing address in receipts

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -41,6 +41,7 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
       'if !empty($receive_date)' => 'if {contribution.receive_date|boolean}',
       '$receive_date|crmDate' => 'contribution.receive_date',
       '$receive_date' => 'contribution.receive_date',
+      '$email' => 'contact.email_primary.email',
     ];
     foreach (['membership_online_receipt', 'contribution_online_receipt', 'contribution_offline_receipt'] as $type) {
       foreach ($swaps as $from => $to) {

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1513,6 +1513,7 @@ class CRM_Utils_Token {
           '$financialTypeId' => 'contribution.financial_type_id',
           '$financialTypeName' => 'contribution.financial_type_id:name',
           '$contributionTypeName' => 'contribution.financial_type_id:name',
+          '$email' => 'contact.email_primary.email',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1668,6 +1669,13 @@ class CRM_Utils_Token {
           '$contact' => ts('no longer available / relevant'),
           '$billingName' => 'contribution.address_id.name',
         ],
+        'membership_autorenew_billing' => [
+          '$email' => ts('no longer available / relevant'),
+        ],
+        'contribution_recurring_billing' => [
+          '$email' => ts('no longer available / relevant'),
+        ],
+
       ],
     ];
   }

--- a/xml/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_online_receipt_html.tpl
@@ -298,10 +298,9 @@
         <td colspan="2" {$valueStyle}>
           {contribution.address_id.name}<br/>
           {contribution.address_id.display}
-         {$email}
         </td>
        </tr>
-     {elseif !empty($email)}
+     {elseif {contact.email_primary.email|boolean}}
        <tr>
         <th {$headerStyle}>
          {ts}Registered Email{/ts}
@@ -309,7 +308,7 @@
        </tr>
        <tr>
         <td colspan="2" {$valueStyle}>
-         {$email}
+         {contact.email_primary.email}
         </td>
        </tr>
      {/if}

--- a/xml/templates/message_templates/contribution_recurring_billing_html.tpl
+++ b/xml/templates/message_templates/contribution_recurring_billing_html.tpl
@@ -37,7 +37,6 @@
         <td colspan="2" {$valueStyle}>
           {contribution.address_id.name}<br/>
           {contribution.address_id.display}
-         {$email}
         </td>
        </tr>
         <tr>

--- a/xml/templates/message_templates/membership_autorenew_billing_html.tpl
+++ b/xml/templates/message_templates/membership_autorenew_billing_html.tpl
@@ -37,7 +37,6 @@
         <td colspan="2" {$valueStyle}>
          {contribution.address_id.name}<br/>
          {contribution.address_id.display}
-         {$email}
         </td>
        </tr>
         <tr>


### PR DESCRIPTION
Overview
----------------------------------------

The donor email address shows up in the Billing Address space on contribution receipts, which is confusing. For example, consider this confirmation page:

<img width="615" height="631" alt="image" src="https://github.com/user-attachments/assets/9999b3d1-2078-49be-900b-c2496c4edabb" />

Before
----------------------------------------

Before the change, that confirmation page produces a receipt that creates some confusion about who is being billed:

<img width="780" height="604" alt="image" src="https://github.com/user-attachments/assets/f6fa8ee7-ae93-405b-af32-d58e42974395" />


After
----------------------------------------

The donor email is omitted.

<img width="801" height="597" alt="image" src="https://github.com/user-attachments/assets/c1c4c6ba-5270-4ecc-9b6d-a8f5ea558cbe" />


Comments
----------------------------------------
I'm not familiar with the process of upgrading templates. Do I need to define a function to update the template via the database? 
