### PR TITLE
Only add required fields to SK task modal when creating

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskFieldsTrait.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskFieldsTrait.js
@@ -41,11 +41,13 @@
         apiResult.then((results) => {
           ctrl.fields.push(... results.getFields);
           paths = results.entityInfo.paths;
-          results.getFields.forEach(field => {
-            if (field.required && !field.default_value) {
-              this.addField(field.name);
-            }
-          });
+          if (getFieldsParams.action === 'create') {
+            results.getFields.forEach(field => {
+              if (field.required && !field.default_value) {
+                this.addField(field.name);
+              }
+            });
+          }
         });
         return apiResult;
       },


### PR DESCRIPTION
Before
----------------------------------------
Required fields are added for all actions, e.g. when updating, which you don't want as you would just select the fields you want to change.

After
----------------------------------------
Only added when creating.