### PR TITLE
SearchKit admin - fix adding custom display columns after reload

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -35,25 +35,29 @@
         ctrl.sortableEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'SortableEntity');
         ctrl.hierarchicalEntity = _.includes(searchMeta.getEntity(ctrl.apiEntity).type, 'HierarchicalEntity');
 
-        // set columnMode if unset
-        if (!ctrl.display.settings.columnMode) {
-          // if we already have columns defined, this is loading a display
-          // created before columnMode => so use `custom` to preserve existing
-          // behaviour
+        if (ctrl.display.settings.columnMode) {
+          // calling the setter seems redundant, but will run initColumns if needed
+          this.setColumnMode(ctrl.display.settings.columnMode);
+        }
+        else {
+          // determine the column mode to use:
+          // - for new displays is the default is `auto`
+          // - EXCEPT if we already have columns defined, this is reloading a display
+          // created before columnMode existed => use `custom` to preserve
+          // existing behaviour
           if (ctrl.display.settings.columns) {
-            ctrl.display.settings.columnMode = 'custom';
+            this.setColumnMode('custom');
           }
-          // otherwise the default for new displays is `auto`
           else {
-            ctrl.display.settings.columnMode = 'auto';
+            this.setColumnMode('auto');
           }
         }
       };
 
       this.setColumnMode = (value) => {
-        // if switching from auto columns and no columns already exist then
-        // initialise with all the columns to start
-        if (value !== 'auto' && !(this.display.settings.columns && this.display.settings.columns.length)) {
+        // if not using auto columns we need to run initColumns to initialise defaults
+        // and populate or validate this.settings.columns
+        if (value !== 'auto') {
           this.parent.initColumns({label: true, sortable: true});
         }
         this.display.settings.columnMode = value;


### PR DESCRIPTION
Overview
----------------------------------------
We need to re-run `initColumns` even if we already have columns. 

Before
----------------------------------------
- `initColumns` is only run if there are no columns to start with
- there's a bug:
  - create a search display
  - switch to custom columns
  - save and reload the page
  - try to add more columns
  - you can't

After
----------------------------------------
- `initColumns` is always run when using custom columns
- bug is fixed


Comments
----------------------------------------
I'd mistaken the purpose of `initColumns` as purely populating the columns array and missed the bit about setting defaults and removing duff columns.


