### PR TITLE
Stop assigning event & participant groupTree to online event email

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3685,26 +3685,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     CRM_Event_BAO_Event::retrieve($eventParams, $values['event']);
 
-    // add custom fields for event
-    $eventGroupTree = CRM_Core_BAO_CustomGroup::getTree('Event', NULL, $eventID);
-
-    $eventCustomGroup = [];
-    foreach ($eventGroupTree as $key => $group) {
-      if ($key === 'info') {
-        continue;
-      }
-
-      foreach ($group['fields'] as $k => $customField) {
-        $groupLabel = $group['title'];
-        if (!empty($customField['customValue'])) {
-          foreach ($customField['customValue'] as $customFieldValues) {
-            $eventCustomGroup[$groupLabel][$customField['label']] = $customFieldValues['data'] ?? NULL;
-          }
-        }
-      }
-    }
-    $values['event']['customGroup'] = $eventCustomGroup;
-
     //get participant details
     $participantParams = [
       'id' => $participantID,
@@ -3713,25 +3693,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $values['participant'] = [];
 
     CRM_Event_BAO_Participant::getValues($participantParams, $values['participant'], $participantIds);
-    // add custom fields for event
-    $participantGroupTree = CRM_Core_BAO_CustomGroup::getTree('Participant', NULL, $participantID);
-    $participantCustomGroup = [];
-    foreach ($participantGroupTree as $key => $group) {
-      if ($key === 'info') {
-        continue;
-      }
-
-      foreach ($group['fields'] as $k => $customField) {
-        $groupLabel = $group['title'];
-        if (!empty($customField['customValue'])) {
-          foreach ($customField['customValue'] as $customFieldValues) {
-            $participantCustomGroup[$groupLabel][$customField['label']] = $customFieldValues['data'] ?? NULL;
-          }
-        }
-      }
-    }
-    $values['participant']['customGroup'] = $participantCustomGroup;
-
     $ufJoinParams = [
       'entity_table' => 'civicrm_event',
       'entity_id' => $eventID,

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1625,6 +1625,10 @@ class CRM_Utils_Token {
           '$lineItem' => '$lineItems',
           '$participant_status' => 'participant.status_id:label',
           '$billingName' => 'contribution.address_id.name',
+          '$event.customGroup' => 'no longer available / relevant, use event tokens',
+          '$participant.customGroup' => 'no longer available / relevant, use participant tokens',
+          '$custom_pre_id' => 'no longer available/relevant',
+          '$custom_post_id' => 'no longer available/relevant',
         ],
         'participant_transferred' => [
           '$location' => 'event.location',


### PR DESCRIPTION
Overview
----------------------------------------
Stop assigning event & participant groupTree to online event email

Before
----------------------------------------
We have been calculating & assigning event & participant custom fields to the online receipt - but any use of them in the template is lost in the past. Code has a lot of history & likely it made more sense once

After
----------------------------------------
Assignments removed. Notification noise added. I didn't remove the profile ids but I did add deprecation noise to flush out any dependencies

Technical Details
----------------------------------------


Comments
----------------------------------------
