### PR TITLE
SearchKit - Improve view/edit links for case activities

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -2255,13 +2255,15 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
    * @return array
    */
   public static function getViewOnlyActivityTypeIDs() {
-    $viewOnlyActivities = [
-      'Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'),
-    ];
-    if (!self::checkEditInboundEmailsPermissions()) {
-      $viewOnlyActivities['Inbound Email'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email');
+    if (!isset(Civi::$statics[__METHOD__])) {
+      Civi::$statics[__METHOD__] = [
+        'Email' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Email'),
+      ];
+      if (!self::checkEditInboundEmailsPermissions()) {
+        Civi::$statics[__METHOD__]['Inbound Email'] = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Inbound Email');
+      }
     }
-    return $viewOnlyActivities;
+    return Civi::$statics[__METHOD__];
   }
 
   /**

--- a/CRM/Case/Form/ActivityView.php
+++ b/CRM/Case/Form/ActivityView.php
@@ -24,10 +24,13 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
    * Process the view.
    */
   public function preProcess() {
-    $contactID = CRM_Utils_Request::retrieve('cid', 'Integer', $this, TRUE);
     $activityID = CRM_Utils_Request::retrieve('aid', 'Integer', $this, TRUE);
     $revs = CRM_Utils_Request::retrieve('revs', 'Boolean');
-    $caseID = CRM_Utils_Request::retrieve('caseID', 'Boolean');
+    $caseID = CRM_Utils_Request::retrieve('caseID', 'Integer');
+    if (!isset($caseID)) {
+      $caseID = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseActivity', $activityID, 'case_id', 'activity_id');
+    }
+    $contactID = CRM_Utils_Request::retrieve('cid', 'Integer', $this) ?: CRM_Case_BAO_Case::getCaseClients($caseID)[0];
     $activitySubject = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity',
       $activityID,
       'subject'
@@ -114,10 +117,6 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
     }
     else {
       $recentContactId = $contactID;
-    }
-
-    if (!isset($caseID)) {
-      $caseID = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseActivity', $activityID, 'case_id', 'activity_id');
     }
 
     $url = CRM_Utils_System::url('civicrm/case/activity/view',

--- a/Civi/Api4/Service/Links/ActivityLinksProvider.php
+++ b/Civi/Api4/Service/Links/ActivityLinksProvider.php
@@ -57,19 +57,25 @@ class ActivityLinksProvider extends \Civi\Core\Service\AutoSubscriber {
           array_splice($links, $addLinkIndex, 1, $addLinks);
         }
       }
-      // With an activity type provided, alter path of edit links appropriately
-      $activityType = $request->getValue('activity_type_id:name');
-      $activityId = $request->getValue('id');
-      // Lookup activity type from id
-      if (!$activityType && $activityId) {
-        $activityTypeId = \CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityId, 'activity_type_id');
-        $activityType = \CRM_Core_PseudoConstant::getName('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeId);
-      }
-      if ($activityType) {
-        $viewOnlyTypes = \CRM_Activity_BAO_Activity::getViewOnlyActivityTypeIDs($request->getCheckPermissions());
-        // Remove edit & delete links for "view only" types
-        if (isset($viewOnlyTypes[$activityType])) {
-          unset($links[$editLinkIndex], $links[$deleteLinkIndex]);
+      // Alter edit & delete links based on activity type
+      // NOTE: CiviCase also alters links, @see CaseLinksProvider
+      if (isset($editLinkIndex) || isset($deleteLinkIndex)) {
+        $activityType = $request->getValue('activity_type_id:name');
+        $activityId = $request->getValue('id');
+        // Lookup activity type from id
+        if (!$activityType && $activityId) {
+          $activityTypeId = \CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityId, 'activity_type_id');
+          $activityType = \CRM_Core_PseudoConstant::getName('CRM_Activity_DAO_Activity', 'activity_type_id', $activityTypeId);
+        }
+        if ($activityType) {
+          $viewOnlyTypes = \CRM_Activity_BAO_Activity::getViewOnlyActivityTypeIDs();
+          // Remove edit & delete links for "view only" types
+          if (isset($viewOnlyTypes[$activityType], $editLinkIndex)) {
+            unset($links[$editLinkIndex]);
+          }
+          if (isset($viewOnlyTypes[$activityType], $deleteLinkIndex)) {
+            unset($links[$deleteLinkIndex]);
+          }
         }
       }
       $e->getResponse()->exchangeArray(array_values($links));

--- a/ext/civi_case/Civi/Api4/Service/Links/CaseLinksProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Links/CaseLinksProvider.php
@@ -12,7 +12,6 @@
 namespace Civi\Api4\Service\Links;
 
 use Civi\API\Event\RespondEvent;
-use Civi\Api4\Utils\CoreUtil;
 use Civi\Core\Event\GenericHookEvent;
 
 /**
@@ -56,39 +55,46 @@ class CaseLinksProvider extends \Civi\Core\Service\AutoSubscriber {
     $request = $e->getApiRequest();
     if ($request['version'] == 4 && $request->getEntityName() === 'Activity' && is_a($request, '\Civi\Api4\Action\GetLinks')) {
       $activityId = $request->getValue('id');
-      $caseId = $request->getValue('case_id');
-      if (!$caseId && $activityId) {
-        $caseId = \CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseActivity', 'case_id', $activityId, 'activity_id');
+      $values = $request->getValues();
+      // These are the most common ways case_id might come through a SK query
+      if (array_key_exists('case_id', $values) || array_key_exists('Activity_CaseActivity_Case_01.id', $values)) {
+        $caseId = $values['case_id'] ?? $values['Activity_CaseActivity_Case_01.id'];
       }
-      if (!$caseId) {
-        return;
+      // If case id not present in query, look it up.
+      elseif ($activityId) {
+        $caseId = \CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseActivity', $activityId, 'case_id', 'activity_id');
       }
       $links = (array) $e->getResponse();
+      if (!isset($caseId)) {
+        return;
+      }
       $viewLinkIndex = self::getActionIndex($links, 'view');
       $editLinkIndex = self::getActionIndex($links, 'update');
       $deleteLinkIndex = self::getActionIndex($links, 'delete');
-      // Add link to manage case
-      $links[] = [
-        'ui_action' => 'advanced',
-        'api_action' => 'update',
-        'api_values' => NULL,
-        'entity' => 'Case',
-        'path' => "civicrm/contact/view/case?reset=1&id=$caseId&action=view",
-        'text' => ts('Manage Case'),
-        'icon' => CoreUtil::getInfoItem('Case', 'icon'),
-        'weight' => 80,
-        'target' => NULL,
-      ];
+
       $idToken = $activityId ?: '[id]';
       // Change view/edit/delete links to the CiviCase version
-      if (isset($links[$viewLinkIndex]['path'])) {
+      if (isset($viewLinkIndex, $links[$viewLinkIndex]['path'])) {
         $links[$viewLinkIndex]['path'] = "civicrm/case/activity/view?reset=1&caseid=$caseId&aid=$idToken";
       }
-      if (isset($links[$editLinkIndex]['path'])) {
+      if (isset($editLinkIndex, $links[$editLinkIndex]['path'])) {
         $links[$editLinkIndex]['path'] = "civicrm/case/activity?reset=1&caseid=$caseId&id=$idToken&action=update";
       }
-      if (isset($links[$deleteLinkIndex]['path'])) {
+      if (isset($deleteLinkIndex, $links[$deleteLinkIndex]['path'])) {
         $links[$deleteLinkIndex]['path'] = "civicrm/case/activity?reset=1&caseid=$caseId&id=$idToken&action=delete";
+      }
+      // Suppress links for special case activity types
+      $activityTypeId = $request->getValue('activity_type_id');
+      // Lookup activity type from id
+      if (!$activityTypeId && $request->getValue('id')) {
+        $activityTypeId = \CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $request->getValue('id'), 'activity_type_id');
+      }
+      if ($activityTypeId) {
+        foreach (['view' => $viewLinkIndex, 'edit' => $editLinkIndex, 'delete' => $deleteLinkIndex] as $caseAction => $linkIndex) {
+          if (isset($linkIndex, $links[$linkIndex]['path']) && !\CRM_Case_BAO_Case::isActionAllowedForActivityType($activityTypeId, $caseAction)) {
+            unset($links[$linkIndex]);
+          }
+        }
       }
       $e->getResponse()->exchangeArray(array_values($links));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Ensures non-case & case activities all get their proper links with the same per-activity-type filters as the regular CiviCase UI.

Gets us closer to being able to replace the CiviCase activity listing with SearchKit.

Comments
-----------
Activity/Case link handling was added in https://github.com/civicrm/civicrm-core/pull/27973 but lacked a unit test & was partially broken. Works much better now.