### PR TITLE
Fix dev/core#6325: User Dashboard: Membership "renew" link not showin…

### DIFF
--- a/CRM/Member/Page/UserDashboard.php
+++ b/CRM/Member/Page/UserDashboard.php
@@ -82,7 +82,7 @@ class CRM_Member_Page_UserDashboard extends CRM_Contact_Page_View_UserDashBoard 
    */
   public function buildMemberLinks(&$members, $isActiveMembers = FALSE) {
     if (!empty($members)) {
-      $statuses = ($isActiveMembers) ? ['Current', 'New', 'Cancelled', 'Deceased', 'Pending'] : ['Expired'];
+      $statuses = ($isActiveMembers) ? ['Current', 'New', 'Cancelled', 'Deceased', 'Pending'] : ['Expired', 'Grace'];
       foreach ($members as $id => &$member) {
 
         // Is this recurring membership?


### PR DESCRIPTION
…g for 'Grace' status

Overview
----------------------------------------
As in issue: https://lab.civicrm.org/dev/core/-/issues/6325

Before
----------------------------------------
'Grace' status precludes display of membership "Renew" link on user dashboard.

After
----------------------------------------
'Grace' status **does not** preclude display of "Renew" link.
