### PR TITLE
dev/core#6323 - Make event registration work like it was in php7

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1520,7 +1520,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         }
         $priceFieldId = substr($valKey, 6);
         $noneOptionValueSelected = FALSE;
-        if (!$this->getPriceFieldMetaData()[$priceFieldId]['is_required'] && $value == 0) {
+        if (!$this->getPriceFieldMetaData()[$priceFieldId]['is_required'] && ($value == 0 || $value === '')) {
           $noneOptionValueSelected = TRUE;
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6323

Before
----------------------------------------
In php7, you could enter a blank value for an optional price field.
This stops working in php8 and you get an error because it thinks you need to make a selection, which is extra confusing when it's a text/quantity field.

1. Create a price set for events.
2. Create a price field. Make it text/quantity just to make this clearer. That might even be typical for an open-ended optional donation.
3. Leave it optional.
4. Make an event, and use the price set for the fees.
5. Visit the registration and leave the price field blank.
6. In php 7 this is fine. In php 8 you get a validation error on submit.

After
----------------------------------------
Like it was for 1000s of years.

Technical Details
----------------------------------------
In php 7, `"" == 0` is true.
In php 8, `"" == 0` is false.

Comments
----------------------------------------
Ahhhhhhhhhh
