### PR TITLE
SearchKit - Add subsearch feature

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -112,3 +112,25 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-4 crm-search-display-toggle-collapse {
   left: 6rem;
 }
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-dropdown[open] summary {
+  /* match popup background */
+  background: var(--crm-container-bg-color);
+  /* show over any border/box-shadow on the popup */
+  position: relative;
+  z-index: 2;
+}
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-dropdown-body {
+  position: absolute;
+  background: var(--crm-container-bg-color);
+  z-index: 1;
+  left: var(--crm-l-medium);
+  right: var(--crm-l-medium);
+  padding: var(--crm-l-medium);
+  border-radius: var(--crm-accordion-radius);
+  box-shadow: var(--crm-shadow-popup);
+}
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-dropdown-body .crm-search-display-table {
+  max-height: 80vh;
+  overflow-x: scroll;
+  max-width: 80vw;
+}

--- a/ext/search_kit/Civi/Api4/Result/SearchDisplayRunResult.php
+++ b/ext/search_kit/Civi/Api4/Result/SearchDisplayRunResult.php
@@ -37,4 +37,10 @@ class SearchDisplayRunResult extends \Civi\Api4\Generic\Result {
    */
   public $toolbar = NULL;
 
+  /**
+   * Subsearch display metedata
+   * @var array|null
+   */
+  public $subsearch = NULL;
+
 }

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -166,7 +166,7 @@
       function getJoin(savedSearch, fullNameOrAlias) {
         let alias = _.last(fullNameOrAlias.split(' AS ')),
           path = alias,
-          baseEntity = searchEntity,
+          baseEntity = savedSearch?.api_entity || searchEntity,
           labels = [],
           join,
           result;
@@ -222,7 +222,7 @@
           field;
         // If 2 or more segments, the first might be the name of a join
         if (dotSplit.length > 1) {
-          join = getJoin(null, dotSplit[0]);
+          join = getJoin({api_entity: entityName}, dotSplit[0]);
           if (join) {
             dotSplit.shift();
             entityName = join.entity;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -69,6 +69,18 @@
             links: []
           }
         },
+        subsearch: {
+          label: ts('Embedded Subsearch'),
+          icon: 'fa-window-restore',
+          defaults: {
+            label: '',
+            rewrite: '',
+            alignment: '',
+            subsearch: {
+              filters: {}
+            }
+          }
+        },
         include: {
           label: ts('Custom Code'),
           icon: 'fa-code',
@@ -101,7 +113,7 @@
       this.addCol = function(type) {
         const col = _.cloneDeep(this.colTypes[type].defaults);
         col.type = type;
-        if (this.display.type === 'table') {
+        if (this.display.type === 'table' && !('alignment' in col)) {
           col.alignment = 'text-right';
         }
         ctrl.display.settings.columns.push(col);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
@@ -1,0 +1,117 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('crmSearchAdminSubsearch', {
+    bindings: {
+      display: '<',
+      column: '<',
+    },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/crmSearchAdmin/crmSearchAdminSubsearch.html',
+    controller: function ($scope, searchMeta, crmApi4) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+
+      this.$onInit = () => {
+        const searchName = this.column.subsearch?.search;
+        if (searchName) {
+          getSubsearchInfo(searchName).then((result) => {
+            // If search doesn't exist, it can't be used
+            if (!result.savedSearch) {
+              delete this.column.subsearch;
+            }
+          });
+        }
+        else if (this.column.subsearch) {
+          delete this.column.subsearch;
+        }
+      };
+
+      const getSubsearchField = (fieldName) => searchMeta.getField(fieldName, this.savedSearch.api_entity);
+
+      const getSubsearchInfo = (searchName) => {
+        this.searchDisplays = null;
+        const apiCalls = crmApi4({
+          searchDisplays: ['SearchDisplay', 'get', {
+            select: ['name', 'label'],
+            where: [
+              ['saved_search_id.name', '=', searchName],
+              // For now this is the only type of embedded display we support
+              ['type:name', '=', 'crm-search-display-table'],
+            ],
+          }],
+          savedSearch: ['SavedSearch', 'get', {
+            select: ['api_entity', 'api_params'],
+            where: [['name', '=', searchName]],
+          }, 0],
+        });
+        apiCalls.then((result) => {
+          this.searchDisplays = result.searchDisplays;
+          this.savedSearch = result.savedSearch;
+          // Parse fields
+          this.subsearchFields = this.savedSearch.api_params.select.reduce((fields, fieldName) => {
+            const field = getSubsearchField(fieldName);
+            if (field) {
+              fields.push({
+                id: fieldName.split(':')[0],
+                text: field.label,
+              });
+            }
+            return fields;
+          }, []);
+        });
+        return apiCalls;
+      };
+
+      this.onChangeSearch = () => {
+        const searchName = this.column.subsearch?.search;
+        if (!searchName) {
+          delete this.column.subsearch;
+          this.savedSearch = null;
+          this.searchDisplays = null;
+        } else {
+          this.column.subsearch.filters = [];
+          getSubsearchInfo(searchName).then((result) => {
+            if (result.searchDisplays.length) {
+              this.column.subsearch.display = result.searchDisplays[0].name;
+              // Set default filter
+              const baseEntity = searchMeta.getBaseEntity();
+              const baseKey = baseEntity.primary_key[0];
+              this.savedSearch.api_params.select.forEach((fieldName) => {
+                const field = getSubsearchField(fieldName);
+                if (field?.fk_entity === baseEntity.name || (field?.name === baseKey && field?.entity === baseEntity.name)) {
+                  this.column.subsearch.filters.push({
+                    subsearch_field: fieldName.split(':')[0],
+                    parent_field: baseKey,
+                  });
+                }
+              });
+              this.noIdFilterFound = !this.column.subsearch.filters.length;
+            }
+          });
+        }
+      };
+
+      this.onChangeFilter = (index) => {
+        if (!this.column.subsearch.filters[index].field) {
+          this.column.subsearch.filters.splice(index, 1);
+        }
+      };
+
+      this.addFilter = (fieldName) => {
+        this.column.subsearch.filters = this.column.subsearch.filters || [];
+        this.column.subsearch.filters.push({
+          subsearch_field: fieldName,
+          parent_field: null,
+        });
+      };
+
+      this.fieldsForFilter = () => ({
+        results: this.crmSearchAdmin.getAllFields('', ['Field', 'Custom', 'Extra']),
+      });
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.html
@@ -1,0 +1,41 @@
+<div class="form-inline">
+  <input placeholder="{{:: ts('Saved Search') }}" class="form-control" crm-autocomplete="'SavedSearch'" crm-autocomplete-params="{key: 'name', formName: 'searchAdmin', fieldName: 'subsearchSearch'}" auto-open="true" ng-model="$ctrl.column.subsearch.search" ng-change="$ctrl.onChangeSearch()">
+  <select class="form-control" ng-model="$ctrl.column.subsearch.display" ng-if="$ctrl.column.subsearch.search" ng-disabled="!$ctrl.searchDisplays">
+    <option ng-repeat="display in $ctrl.searchDisplays" value="{{:: display.name }}">{{:: display.label }}</option>
+  </select>
+</div>
+<div class="help-block bg-warning" ng-if="$ctrl.searchDisplays && !$ctrl.searchDisplays.length">
+  <i class="crm-i fa-exclamation-triangle" aria-hidden="true" role="img"></i>
+  {{:: ts('The selected saved search does not have any table displays.') }}
+</div>
+<table class="table table-condensed" ng-if="$ctrl.searchDisplays.length">
+  <thead>
+  <tr>
+    <th>{{:: ts('Filter Subsearch Display') }}</th>
+    <th>{{:: ts('With Value') }}</th>
+  </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat="filter in $ctrl.column.subsearch.filters">
+      <td>
+        <input class="form-control" ng-model="filter.subsearch_field" crm-ui-select="{data: $ctrl.subsearchFields, placeholder: ' '}" ng-change="$ctrl.onChangeFilter($index)">
+      </td>
+      <td>
+        <input class="form-control" ng-model="filter.parent_field" crm-ui-select="{data: $ctrl.fieldsForFilter, placeholder: ts('Choose field')}">
+      </td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="2">
+        <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
+               crm-ui-select="{data: $ctrl.subsearchFields, placeholder: ts('Add Filter')}"
+               on-crm-ui-select="$ctrl.addFilter(selection)" >
+      </td>
+    </tr>
+  </tfoot>
+</table>
+<div class="help-block bg-warning" ng-if="$ctrl.noIdFilterFound && !$ctrl.column.subsearch.filters.length">
+  <i class="crm-i fa-info-circle" aria-hidden="true" role="img"></i>
+  {{:: ts('No join field found. You may need to add a field to the subsearch display first.') }}
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/subsearch.html
@@ -1,0 +1,13 @@
+<div class="form-inline crm-search-admin-flex-row">
+  <label>
+    {{:: ts('Text') }}
+  </label>
+  <input class="form-control crm-flex-1" ng-model="col.rewrite" ng-model-options="{updateOn: 'blur'}">
+  <crm-search-admin-token-select model="col" field="rewrite" suffix=":label"></crm-search-admin-token-select>
+</div>
+<search-admin-icons item="col"></search-admin-icons>
+<search-admin-css-rules label="{{:: ts('Style') }}" item="col" default="col.key"></search-admin-css-rules>
+<div class="help-block">
+  {{:: ts('Choose a Saved Search + Display to embed.') }}
+</div>
+<crm-search-admin-subsearch display="$ctrl.display" column="col"></crm-search-admin-subsearch>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
@@ -1,0 +1,10 @@
+<details class="crm-search-display-subsearch-dropdown">
+  <summary ng-click="$ctrl.onToggleDropdown(colData, $event)">
+    <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
+    {{:: colData.val }}
+    <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
+  </summary>
+  <div class="crm-search-display-subsearch-dropdown-body">
+    <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
+  </div>
+</details>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -241,6 +241,17 @@
         });
       };
 
+      this.onToggleDropdown = (col, event) => {
+        col.hasBeenOpened = true;
+        const detailsElement = event.target.closest('details');
+        // If we are opening this dropdown, close any others in the same search display
+        if (!detailsElement.open) {
+          detailsElement.closest('.crm-search-display-table')
+            .querySelectorAll('details.crm-search-display-subsearch-dropdown[open]')
+            .forEach((details) => details.open = false);
+        }
+      };
+
     }
   });
 

--- a/ext/search_kit/css/crmSearchDisplayTable.css
+++ b/ext/search_kit/css/crmSearchDisplayTable.css
@@ -97,3 +97,23 @@ table.crm-sticky-header > thead > tr {
 #bootstrap-theme .crm-search-display-table .crm-hierarchical-depth-4 crm-search-display-toggle-collapse {
   left: 120px;
 }
+
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-dropdown summary {
+  padding: 1rem;
+  border-radius: var(--crm-l-radius);
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
+}
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-dropdown[open] summary {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-dropdown-body {
+  position: absolute;
+  background: var(--crm-container-bg-color);
+  z-index: 1;
+  left: 1rem;
+  right: 1rem;
+  padding: 1rem;
+  border-radius: var(--crm-l-radius);
+}


### PR DESCRIPTION
Overview
----------------------------------------
New feature allows a nested display-within-a-display. Useful for e.g. contributions + line items, or cases + activities.

<img width="746" height="938" alt="image" src="https://github.com/user-attachments/assets/c2ade2af-870c-463c-b2e1-ef83f4f22b09" />

Notes
---------

**Previous Drafts:**
- https://github.com/civicrm/civicrm-core/pull/34730
- https://github.com/civicrm/civicrm-core/pull/34741

@ufundo what's changed from your PR is:

- Renamed everything from 'nested' to 'subsearch'
- Added tokenizable text + support for icons and styles
- Removed the mousein/mouseout auto-open as it was a bit chaotic
- Cleanup unused stuff from 1st PR
- Lint & cleanup some POC code from 2nd PR
- Still limited to table displays for now.
