### PR TITLE
SearchKit - Fix counting matched results

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -79,7 +79,7 @@
             stopIncrementer();
             ctrl.progress = Math.floor(100 * ++currentBatch / totalBatches);
             processedCount += result.countFetched;
-            countMatched += (result.countMatched || result.count);
+            countMatched += ('countMatched' in result ? result.countMatched : result.count);
             // Gather all results into one super collection
             if (batchResult) {
               batchResult.push(...result);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#6315



Technical Details
----------------------------------------
`result.countMatched` is not always the same as `result.count`. Only fall back to the latter if the former doesn't exist.