### PR TITLE
Standalone - Consistent naming of extension

### DIFF
--- a/ext/standaloneusers/info.xml
+++ b/ext/standaloneusers/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <extension key="standaloneusers" type="module">
   <file>standaloneusers</file>
-  <name>Standalone Users</name>
+  <name>CiviCRM Standalone Users</name>
   <description>Provides user management, roles, permissions for standalone CiviCRM.</description>
   <license>AGPL-3.0</license>
   <maintainer>


### PR DESCRIPTION
Overview
----------------------------------------
Permissions for this extension are labeled "CiviCRM Standalone Users" but the extension itself was labeled "Standalone Users", which caused the auto-generated settings permission to have a different label than the others. Let's be consistent.
