### PR TITLE
CiviGrant - Fix missing charts on dashboard

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwelve.php
+++ b/CRM/Upgrade/Incremental/php/SixTwelve.php
@@ -51,4 +51,17 @@ class CRM_Upgrade_Incremental_php_SixTwelve extends CRM_Upgrade_Incremental_Base
     }
   }
 
+  /**
+   * Upgrade step; adds tasks including 'runSql'.
+   *
+   * @param string $rev
+   *   The version number matching this function name
+   */
+  public function upgrade_6_12_beta1($rev): void {
+    $manager = CRM_Extension_System::singleton()->getManager();
+    if ($manager->isEnabled('civigrant')) {
+      $this->addExtensionTask('Enable ChartKit extension', ['chart_kit']);
+    }
+  }
+
 }

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -32,6 +32,7 @@
   <requires>
     <ext>org.civicrm.afform</ext>
     <ext>org.civicrm.search_kit</ext>
+    <ext>chart_kit</ext>
   </requires>
   <classloader>
     <psr0 prefix="CRM_" path="."/>


### PR DESCRIPTION
Overview
----------------------------------------
With [the new dashboard](https://github.com/civicrm/civicrm-core/pull/34419), CiviGrant depends on ChartKit, but the dependency wasn't declared. This adds it.
