### PR TITLE
SearchKit - Fix excessive height of description boxes in search displays

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -179,15 +179,6 @@
   border: 0 solid transparent;
 }
 
-/* Tab: Configure Settings */
-
-.crm-search .crm-search-admin-relative textarea {
-  width: 100%;
-  min-height: 100px;
-}
-.crm-search .input-group-addon:has(.fa-calendar-times-o) {
-  width: auto;
-}
 /* Tab: display */
 
 .crm-search .crm-search-admin-relative details > fieldset {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
@@ -1,4 +1,4 @@
-<textarea class="form-control" placeholder="{{:: ts('Description (shown above default display)') }}" ng-model="$ctrl.savedSearch.description"></textarea>
+<textarea class="form-control" rows=5 placeholder="{{:: ts('Description (shown above default display)') }}" ng-model="$ctrl.savedSearch.description"></textarea>
 <div class="form-group">
   <label class="sr-only" for="expires_date">{{:: ts('Search Expiry Date') }}</label>
   <div class="input-group">


### PR DESCRIPTION
Overview
----------------------------------------
Css was commented as targeting just the "Settings" tab but it was actually affecting all tabs, forcing excessive height of textareas everywhere.

It wasn't too helpful on the settings tab either, so I just took it out.

Before
----------------------------------------
<img width="1218" height="231" alt="image" src="https://github.com/user-attachments/assets/cb726555-7d58-43b1-afd9-f7c69eeb322b" />


After
----------------------------------------
<img width="1212" height="191" alt="image" src="https://github.com/user-attachments/assets/b892dc49-53b0-4d59-a44e-e77c9ef723bc" />

