### PR TITLE
Api4 Explorer - Make localization optional

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -87,6 +87,10 @@
         name: 'php',
         label: ts('View as PHP')
       },
+      {
+        name: 'php_ts',
+        label: ts('PHP + Localization')
+      },
     ];
     this.authxEnabled = CRM.vars.api4.authxEnabled;
 
@@ -1008,11 +1012,15 @@
           break;
 
         case 'php':
-          // Fields marked 'localizable' in the schema should get wrapped in ts() for the php format
+          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2)) + ';', 'php', 1));
+          break;
+
+        case 'php_ts':
+          // Fields marked 'localizable' in the schema should get wrapped in ts() for the php_ts format
           let localizable = _.pluck(_.filter(_.findWhere(getEntity().actions, {name: $scope.action}).fields, {localizable: true}), 'name') || [];
           // More field names that probably should be translated
           localizable = _.union(localizable, ['label', 'title', 'description', 'text']);
-          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2, localizable)) + ';', 'php', 1));
+          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2, localizable)) + ';', 'php_ts', 1));
           break;
       }
     };

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminExport.component.js
@@ -18,7 +18,7 @@
       ];
 
       this.$onInit = function() {
-        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php&cleanup=always&id=' + ctrl.savedSearch.id);
+        this.apiExplorerLink = CRM.url('civicrm/api4#/explorer/SavedSearch/export?_format=php_ts&cleanup=always&id=' + ctrl.savedSearch.id);
         this.simpleLink = CRM.url('civicrm/admin/search#/create/' + ctrl.savedSearch.api_entity + '?params=' + encodeURI(angular.toJson(ctrl.savedSearch.api_params)));
 
         const apiCalls = [


### PR DESCRIPTION
Overview
----------------------------------------
The php output format can be confusing when we always insert `E::ts()`. This makes it optional.

<img width="660" height="242" alt="image" src="https://github.com/user-attachments/assets/d3939837-befb-4a89-b836-38e8f923f5bf" />

