### PR TITLE
ContributionCharts: Fix year dropdown for when the fiscal year does not start in January

### DIFF
--- a/CRM/Contribute/Form/ContributionCharts.php
+++ b/CRM/Contribute/Form/ContributionCharts.php
@@ -65,11 +65,14 @@ class CRM_Contribute_Form_ContributionCharts extends CRM_Core_Form {
 
     //take available years from database to show in drop down
     $currentYear = date('Y');
-    $years = $this->getContributionTotalsByYear() + [date('Y') => TRUE];
-    ksort($years);
-    foreach (array_keys($years) as $year) {
-      $years[$year] = $year;
+    $yearsWithTotals = $this->getContributionTotalsByYear() + [$currentYear => TRUE];
+    $years = [];
+    foreach (array_keys($yearsWithTotals) as $year) {
+      // Set fiscalYearStart as value for the select drop down
+      $years[explode("-", $year)[0] ?: $year] = $year;
     }
+    ksort($years);
+
     $this->addElement('select', 'select_year', ts('Select Year (for monthly breakdown)'), $years);
     $this->setDefaults([
       'select_year' => $this->_year ?: $currentYear,


### PR DESCRIPTION
Overview
----------------------------------------
Quick fix to "select_year" select in ContributionCharts.php. I change the value of the select options to change the fiscalYearStart - fiscalYearEnd (YYYY-YYYY) format to only the fiscalYearStart (YYYY).  The dashboard would break if your fiscal year didn't start in January.

Steps to reproduce:

- Go to: Administer > Localization > Date Formats: change the "Fiscal Year Start" to another month, such as July 01
- Then go to: Contributions > Dashboard: under the graphics, select another year.

Before
----------------------------------------

The statistics for an older year couldn't be seen and the dropdown would revert to the default value (current year).

After
----------------------------------------
Work as intended.

<img width="436" height="175" alt="image" src="https://github.com/user-attachments/assets/12ce6fd8-1a0c-4df4-9d0b-6c1a5c170c8a" />

<img width="760" height="546" alt="image" src="https://github.com/user-attachments/assets/5573c3ea-de1e-4897-81fa-deb47e809bc8" />
