### PR TITLE
PHP8.5 OpenID Use inner join to avoid adding empty array to NULL key

### DIFF
--- a/CRM/Core/BAO/OpenID.php
+++ b/CRM/Core/BAO/OpenID.php
@@ -89,7 +89,7 @@ SELECT civicrm_openid.openid, civicrm_location_type.name as locationType, civicr
 civicrm_openid.allowed_to_login as allowed_to_login, civicrm_openid.id as openid_id,
 civicrm_openid.location_type_id as locationTypeId
 FROM      civicrm_contact
-LEFT JOIN civicrm_openid ON ( civicrm_openid.contact_id = civicrm_contact.id )
+INNER JOIN civicrm_openid ON ( civicrm_openid.contact_id = civicrm_contact.id )
 LEFT JOIN civicrm_location_type ON ( civicrm_openid.location_type_id = civicrm_location_type.id )
 WHERE
   civicrm_contact.id = %1


### PR DESCRIPTION
Overview
----------------------------------------
PHP8.5 OpenID Use inner join to avoid adding empty array to NULL key

Before
----------------------------------------
CRM_Core_BAO_LocationTest::testLocBlockgetValues
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-0/web/core/CRM/Core/BAO/OpenID.php:117
/home/homer/buildkit/build/build-0/web/core/CRM/Core/BAO/Block.php:166
/home/homer/buildkit/build/build-0/web/core/CRM/Core/BAO/Block.php:204
/home/homer/buildkit/build/build-0/web/core/CRM/Core/BAO/Location.php:49
/home/homer/buildkit/build/build-0/web/core/tests/phpunit/CRM/Core/BAO/LocationTest.php:243
/home/homer/buildkit/build/build-0/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552


After
----------------------------------------
gone

Technical Details
----------------------------------------
occurs when there is no open ID - seems silly to enter the result->fetch() loop when no Open ID records exist

Comments
----------------------------------------
