### PR TITLE
Searchkit - Add clear button to the pick columns

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -228,6 +228,13 @@
         });
         this.toggleColumns();
       };
+      
+      this.clearColumnToggles = () => {
+        this.columns.forEach((col, index) => {
+          this.columns[index].enabled = false;
+        });
+        this.toggleColumns();
+      };
 
       /**
        * Keep track of which columns we have fetched each

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -16,8 +16,11 @@
             >
             {{:: $ctrl.getColumnToggleLabel(col) }}
         </label>
-        <button type="button" class="btn btn-secondary" ng-click="$ctrl.resetColumnToggles()">
-          {{:: ts('Select All') }}
+        <button type="button" title="{{:: ts('Select All') }}" class="btn btn-secondary" ng-click="$ctrl.resetColumnToggles()">
+          {{:: ts('All') }}
+        </button>
+        <button type="button" title="{{:: ts('Select None') }}" class="btn btn-secondary" ng-click="$ctrl.clearColumnToggles()">
+          {{:: ts('None') }}
         </button>
       </div>
     </details>


### PR DESCRIPTION

I receive some feedback about new feature "Pick columns" on SearchKit demanding a button to "deselect all" columns.

<img width="743" height="210" alt="image" src="https://github.com/user-attachments/assets/b62e4c10-7c72-40e2-bb98-1657da8ec086" />