### PR TITLE
Support Member searchKitTasks (email)

### DIFF
--- a/CRM/Contact/Form/Task/EmailTrait.php
+++ b/CRM/Contact/Form/Task/EmailTrait.php
@@ -780,7 +780,7 @@ trait CRM_Contact_Form_Task_EmailTrait {
           'msg_html' => $html,
           'msg_subject' => $this->getSubject(),
         ],
-        'tokenContext' => array_merge(['schema' => $this->getTokenSchema()], ($values['schema'] ?? [])),
+        'tokenContext' => array_merge(['schema' => array_keys($values['schema'] ?? [])], ($values['schema'] ?? [])),
         'contactId' => $contactId,
         'disableSmarty' => !CRM_Utils_Constant::value('CIVICRM_MAIL_SMARTY'),
       ]);

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -74,6 +74,7 @@ class CRM_Member_Task extends CRM_Core_Task {
             ->get('simple_mail_limit'),
         ]),
         'class' => 'CRM_Member_Form_Task_Email',
+        'url' => 'civicrm/member/task/email',
         'result' => TRUE,
         'permissions' => ['edit memberships'],
         // Transitional key. May change.

--- a/CRM/Member/xml/Menu/Member.xml
+++ b/CRM/Member/xml/Menu/Member.xml
@@ -90,4 +90,9 @@
     <page_callback>CRM_Member_Form_MembershipType</page_callback>
     <access_arguments>access CiviMember,administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/member/task/email</path>
+    <title>Email a Member</title>
+    <page_callback>CRM_Member_Form_Task_Email</page_callback>
+  </item>
 </menu>

--- a/ext/civi_member/Civi/Api4/Service/MembershipTasksProvider.php
+++ b/ext/civi_member/Civi/Api4/Service/MembershipTasksProvider.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service;
+
+use CRM_Member_ExtensionUtil as E;
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * @service
+ * @internal
+ */
+class MembershipTasksProvider extends \Civi\Core\Service\AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_civicrm_searchKitTasks' => 'addMembershipTasks',
+    ];
+  }
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public function addMembershipTasks(GenericHookEvent $event): void {
+    foreach (\CRM_Member_Task::tasks() as $id => $task) {
+      if (!empty($task['url'])) {
+        $path = explode('?', $task['url'], 2)[0];
+        $menu = \CRM_Core_Menu::get($path);
+        $key = $menu ? \CRM_Core_Key::get($menu['page_callback'], TRUE) : '';
+
+        $event->tasks['Membership']['membership.' . $id] = [
+          'title' => $task['title'],
+          'icon' => $task['icon'] ?? 'fa-gear',
+          'crmPopup' => [
+            'path' => "'{$task['url']}'",
+            'query' => "{reset: 1}",
+            'data' => "{ids: ids.join(','), qfKey: '$key'}",
+            'mode' => $task['mode'] ?? 'back',
+          ],
+        ];
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This adds support for Member searchkitTasks. Currently just adds in email action.

Before
----------------------------------------
No support for existing member tasks/actions

After
----------------------------------------
Support for existing member tasks/action.

Technical Details
----------------------------------------
Adds in URL and allows passing ids via URL. Enables searchkitTasks subscriber for members

Comments
----------------------------------------

