### PR TITLE
more fix message template upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixThirteen.php
+++ b/CRM/Upgrade/Incremental/php/SixThirteen.php
@@ -31,6 +31,7 @@ class CRM_Upgrade_Incremental_php_SixThirteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Replace {$email} with "" in membership_autorenew_billing', 'updateMessageToken', 'membership_autorenew_billing', '$email', '', $rev);
     $this->addTask('Replace {$email} with "" in contribution_recurring_billing', 'updateMessageToken', 'contribution_recurring_billing', '$email', '', $rev);
+    $this->addTask('Replace "elseif !empty($email)" with "{elseif {contact.email_primary.email|boolean}}" in contribution_online_receipt', 'updateMessageToken', 'contribution_online_receipt', 'elseif !empty($email)', 'elseif {contact.email_primary.email|boolean}', $rev);
     $this->addTask('Replace {$email} with "{contact.email_primary.email}" in contribution_online_receipt', 'updateMessageToken', 'contribution_online_receipt', '$email', 'contact.email_primary.email', $rev);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
syntax error

Before
----------------------------------------
syntax error 

After
----------------------------------------


Technical Details
----------------------------------------
The elseif requires a different replacement

Comments
----------------------------------------
There is still a difficulty doing a faithful upgrade for https://github.com/civicrm/civicrm-core/pull/34734 because the lone {$email} is replaced in two different ways in the on-disk template file, and I don't see how to do such a replacement with this convenience function. But this is about the elseif replacement giving an error at runtime.