### PR TITLE
Afform panel pane title padding: reverts regression from #34165 - /dev/core/6326

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -79,6 +79,7 @@ details.af-container.af-layout-inline > *:not(summary) {
   box-shadow: var(--crm-form-block-box-shadow, 1px 2px 8px 1px rgba(0, 0, 0, 0.3));
   position: relative;
   padding: var(--crm-form-block-padding, 5px);
+  padding-top: 50px !important; /* vs next line */
 }
 #bootstrap-theme .af-container-style-pane > .af-title {
   background-color: var(--crm-form-block-header-color, #70716b);


### PR DESCRIPTION
Overview
----------------------------------------
As described here: https://lab.civicrm.org/dev/core/-/issues/6326#note_197692

Before
----------------------------------------
Titles hidden.

After
----------------------------------------
Titles visible

Technical Details
----------------------------------------
There's a better solution to this problem then using a fixed amount of padding to offset panel body from the title; this isn't the time to figure that out, this just reverts [the line that was taken out](https://github.com/civicrm/civicrm-core/pull/34165/changes#diff-743a61c777fe9d87826bbb0085e737e21943a49de55a5ef0f185ace86f24e354L82).

NB - the `!important` is related to the next css selector, comment added to make that clear.
 
Comments
----------------------------------------
This either needs applying to 6.12 OR I figure out a better fix sooner and apply that there instead…