### PR TITLE
Afform - Set static title for full-page forms

### DIFF
--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -52,9 +52,7 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
           ],
         ]);
       }
-      // 'CiviCRM' be replaced with Afform title via AfformBase.tpl.
-      // @see crmUi.directive(crmPageTitle)
-      CRM_Utils_System::setTitle('CiviCRM');
+      CRM_Utils_System::setTitle($title, $afform['title']);
     }
     else {
       // Afform has no title

--- a/ext/afform/core/templates/CRM/Afform/Page/AfformBase.tpl
+++ b/ext/afform/core/templates/CRM/Afform/Page/AfformBase.tpl
@@ -1,8 +1,5 @@
 <crm-angular-js modules="afformStandalone">
   <form id="bootstrap-theme" ng-controller="AfformStandalonePageCtrl">
-    {literal}
-      <h1 style="display: none" crm-page-title ng-if="afformTitle">{{ afformTitle }}</h1>
-    {/literal}
     <{$directive}></{$directive}>
   </form>
 </crm-angular-js>


### PR DESCRIPTION


Overview
----------------------------------------
See discussion at https://chat.civicrm.org/civicrm/pl/xubijpwk1jbcxqtayd8i3oed3y

Before
----------------------------------------
Page title flashes "CiviCRM" before changing to form title

After
----------------------------------------

Title set immediately


Technical Details
----------------------------------------
The dynamism is not needed when the form is full-screen as the title will never change.