### PR TITLE
Afform - Prevent flash of "CiviCRM" page title as full-page form loads

### DIFF
--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -1239,6 +1239,9 @@
           crmDocumentTitle: '='
         },
         link: function(scope, $el, attrs) {
+          pageTitleHTML = attrs.initialPageTitle || 'CiviCRM';
+          documentTitle = attrs.initialDocumentTitle || 'CiviCRM';
+
           function update() {
             $timeout(function() {
               const newPageTitleHTML = $el.html().trim(),

--- a/ext/afform/core/CRM/Afform/Page/AfformBase.php
+++ b/ext/afform/core/CRM/Afform/Page/AfformBase.php
@@ -52,14 +52,16 @@ class CRM_Afform_Page_AfformBase extends CRM_Core_Page {
           ],
         ]);
       }
-      // 'CiviCRM' be replaced with Afform title via AfformBase.tpl.
-      // @see crmUi.directive(crmPageTitle)
-      CRM_Utils_System::setTitle('CiviCRM');
     }
     else {
       // Afform has no title
-      CRM_Utils_System::setTitle('');
+      $title = 'CiviCRM';
     }
+
+    // Will be passed through `crm-page-title` in AfformBase.tpl
+    // @see crmUi.directive(crmPageTitle)
+    CRM_Utils_System::setTitle($title);
+    $this->assign('afformTitle', $title);
 
     parent::run();
   }

--- a/ext/afform/core/templates/CRM/Afform/Page/AfformBase.tpl
+++ b/ext/afform/core/templates/CRM/Afform/Page/AfformBase.tpl
@@ -1,8 +1,8 @@
 <crm-angular-js modules="afformStandalone">
   <form id="bootstrap-theme" ng-controller="AfformStandalonePageCtrl">
-    {literal}
-      <h1 style="display: none" crm-page-title ng-if="afformTitle">{{ afformTitle }}</h1>
-    {/literal}
+    <h1 style="display: none" crm-page-title ng-if="afformTitle" initial-document-title="{$afformTitle}" initial-page-title="{$afformTitle}">
+      {literal}{{ afformTitle }}{/literal}
+    </h1>
     <{$directive}></{$directive}>
   </form>
 </crm-angular-js>


### PR DESCRIPTION
Overview
----------------------------------------
See discussion: https://chat.civicrm.org/civicrm/pl/xubijpwk1jbcxqtayd8i3oed3y

Before
----------------------------------------
Page title flashes "CiviCRM" before changing to form title

After
----------------------------------------
Title set immediately but can still dynamically update

Comments
----------------------------------------
You can see the dynamism in action by enabling the CiviCRM Admin UI extension and visiting Administer Custom Fields. Clicking on the "Fields" for a custom group will take you to a full-screen list of custom fields with the custom group dynamically added to the page title.
