### PR TITLE
dev/core#6284 Afform - Update field values as route changes

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -150,30 +150,39 @@
         // Wait for parent controllers to initialize
         $timeout(function() {
           initializeValue(true);
+          $scope.$watch('$parent.routeParams', setValueFromRouteParams);
         });
 
-        function initializeValue(firstLoad) {
+        // Sets field value dynamically based on route parameters
+        // Note: routeParams might come from the url, or they could be passed via a modal popup
+        function setValueFromRouteParams(routeParams) {
+          if (!routeParams) {
+            return;
+          }
           // Unique field name = entity_name index . join . field_name
-          const entityName = ctrl.afFieldset.getName(),
-            joinEntity = ctrl.afJoin ? ctrl.afJoin.entity : null,
-            urlArgs = $scope.$parent.routeParams;
+          const entityName = ctrl.afFieldset.getName();
+          const joinEntity = ctrl.afJoin ? ctrl.afJoin.entity : null;
           let uniquePrefix = '';
           if (entityName) {
             const index = ctrl.getEntityIndex();
             uniquePrefix = entityName + (index ? index + 1 : '') + (joinEntity ? '.' + joinEntity : '') + '.';
           }
           // Set default value from url with uniquePrefix + fieldName
-          if (urlArgs && ((uniquePrefix + ctrl.fieldName) in urlArgs)) {
-            setValue(urlArgs[uniquePrefix + ctrl.fieldName]);
+          if ((uniquePrefix + ctrl.fieldName) in routeParams) {
+            setValue(routeParams[uniquePrefix + ctrl.fieldName]);
           }
           // Set default value from url with fieldName only
-          else if (urlArgs && (ctrl.fieldName in urlArgs)) {
-            setValue(urlArgs[ctrl.fieldName]);
+          else if (ctrl.fieldName in routeParams) {
+            setValue(routeParams[ctrl.fieldName]);
           }
-          else if (urlArgs && urlArgs._s) {
+          else if (routeParams._s) {
             setValue(ctrl.afFieldset.getSearchParamSetFieldValue(ctrl.fieldName));
           }
-          else if (firstLoad && ctrl.afFieldset.getStoredValue(ctrl.fieldName) !== undefined) {
+        }
+
+        function initializeValue(firstLoad) {
+          // Set default value if specified. Note that setValueFromUrl() will override this.
+          if (firstLoad && ctrl.afFieldset.getStoredValue(ctrl.fieldName) !== undefined) {
             setValue(ctrl.afFieldset.getStoredValue(ctrl.fieldName));
           }
           // Set default value based on field defn


### PR DESCRIPTION
Overview
----------------------------------------
Especially important for search forms – when the url changes the filters should update. 

Fixes [dev/core#6284](https://lab.civicrm.org/dev/core/-/issues/6284)

Before
----------------------------------------
This is apparent when clicking the different links to mailing searches in the menubar:

With AdminUI extension enabled, click in the menubar to "Draft Mailings". Once that loads, go in the menubar again and click on "Sent Mailings" or "Archived Mailings". Nothing happens.

After
----------------------------------------
Clicking between e.g. Draft and Sent mailings now updates in real-time instead of requiring a page refresh.

Ref: https://dev.nysenate.gov/issues/17867
