### PR TITLE
CiviMail - Hide "Back to CiviMail" link when report is in a popup

### DIFF
--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -118,6 +118,10 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
       $backUrl = CRM_Utils_System::url('civicrm/mailing', 'reset=1');
       $backUrlTitle = ts('Back to CiviMail');
     }
+    // Hide back button in modal dialog context
+    if (CRM_Core_Resources::isAjaxMode()) {
+      $backUrl = NULL;
+    }
     $this->assign('backUrl', $backUrl);
     $this->assign('backUrlTitle', $backUrlTitle);
     // We use this variable to alter the Mailing Report layout

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -224,6 +224,8 @@
 {/if}
 </table>
 </fieldset>
-<div class="action-link">
+{if $backUrl}
+  <div class="action-link">
     <a href="{$backUrl}" ><i class="crm-i fa-chevron-left" role="img" aria-hidden="true"></i> {$backUrlTitle}</a>
-</div>
+  </div>
+{/if}


### PR DESCRIPTION
Overview
----------------------------------------
When viewing a CiviMail report, there's no need for a "Back to CiviMail" link if viewed in a popup; you can just close the popup rather than clicking the link and losing your place when the page refreshes.

Before
----------------------------------------
<img width="989" height="700" alt="Screenshot 2026-02-13 at 2 03 57 PM" src="https://github.com/user-attachments/assets/f407627e-5b64-4de7-aa4b-36f2b3ae34f1" />


After
----------------------------------------

<img width="993" height="702" alt="Screenshot 2026-02-13 at 2 03 14 PM" src="https://github.com/user-attachments/assets/fd70abd3-32b1-44d9-a8d4-f7e27babdd75" />