### PR TITLE
EntityRef - Add Phone to "Refine Search" options

### DIFF
--- a/CRM/Contact/BAO/Contact.php
+++ b/CRM/Contact/BAO/Contact.php
@@ -3586,6 +3586,7 @@ LEFT JOIN civicrm_address ON ( civicrm_address.contact_id = civicrm_contact.id )
       ['key' => 'postal_code', 'value' => ts('Postal Code'), 'type' => 'text', 'entity' => 'Address'],
       ['key' => 'state_province', 'value' => ts('State/Province'), 'entity' => 'Address'],
       ['key' => 'country', 'value' => ts('Country'), 'entity' => 'Address'],
+      ['key' => 'phone_numeric', 'value' => ts('Phone'), 'type' => 'text', 'entity' => 'Phone'],
       ['key' => 'first_name', 'value' => ts('First Name'), 'type' => 'text', 'condition' => ['contact_type' => 'Individual']],
       ['key' => 'last_name', 'value' => ts('Last Name'), 'type' => 'text', 'condition' => ['contact_type' => 'Individual']],
       ['key' => 'nick_name', 'value' => ts('Nick Name'), 'type' => 'text', 'condition' => ['contact_type' => 'Individual']],

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -506,6 +506,10 @@ function _civicrm_api3_get_using_query_object($entity, $params, $additional_opti
     $fields = civicrm_api($entity, 'getfields', ['version' => 3, 'action' => 'get']);
     // we need to add this in as earlier in this function 'id' was unset in favour of $entity_id
     $fields['values'][$lowercase_entity . '_id'] = [];
+    // Allow search by phone_numeric for contacts.
+    if ($lowercase_entity === 'contact') {
+      $fields['values']['phone_numeric'] = [];
+    }
     $varsToFilter = ['returnProperties', 'inputParams'];
     foreach ($varsToFilter as $varToFilter) {
       if (!is_array($$varToFilter)) {


### PR DESCRIPTION
Overview
----------------------------------------
Allows refining the search by partial phone number

<img width="592" height="264" alt="image" src="https://github.com/user-attachments/assets/81ce9696-2876-4341-bcce-bdebc9a2c2a0" />

Technical Details
----------------------------------------
Note this is for the Api3-based "EntityRef" fields which are on their way out, but the feature was requested & doesn't hurt to add.

Ref: https://dev.nysenate.gov/issues/17663