### PR TITLE
Select2 - Prevent multiselect dropdown from auto-closing when clicking input

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -596,6 +596,11 @@ input.crm-form-checkbox) + label {
   animation-timing-function: var(--fa-animation-timing,linear);
 }
 
+/* Prevent multiselect from auto-closing when clicking on the input element – keep it in front of the select2-drop-mask */
+li.select2-search-field {
+  z-index: 9999;
+}
+
 /* Color dot for selecting e.g. tags */
 span.crm-select-item-color {
   display: inline-block;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a UI annoyance with Select2 widgets

Before
----------------------------------------
1. Go to create a "New Activity"
2. Open the "With Contact" select2
3. Click on the "Refine Search" dropdown. You don't have to select anything
4. Click to type something in the autocomplete input
5. Instead of letting you type, the select2 widget closes, you have to click a second time to open it again

After
----------------------------------------
Clicking on the input does not close the select2.

Technical Details
----------------------------------------
Keep it in front of the select2-drop-mask to allow the input to be clicked on.

Ref: https://dev.nysenate.gov/issues/17663