### PR TITLE
dev/core#6337 Fix custom fields screen when CiviMember disabled

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1832,11 +1832,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
 
     $eventType = CRM_Core_OptionGroup::values('event_type');
     $campaignTypes = CRM_Campaign_PseudoConstant::campaignType();
-    $membershipType = \Civi\Api4\MembershipType::get(FALSE)
-      ->addWhere('is_active', '=', TRUE)
-      ->addOrderBy('weight', 'ASC')
-      ->execute()
-      ->column('title', 'id');
+    $membershipType = CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE);
     $participantRole = CRM_Core_OptionGroup::values('participant_role');
 
     asort($activityType);

--- a/CRM/Custom/Page/Group.php
+++ b/CRM/Custom/Page/Group.php
@@ -144,11 +144,7 @@ class CRM_Custom_Page_Group extends CRM_Core_Page {
 
     $subTypes['Activity'] = CRM_Core_PseudoConstant::activityType(FALSE, TRUE, FALSE, 'label', TRUE);
     $subTypes['Contribution'] = CRM_Contribute_PseudoConstant::financialType();
-    $subTypes['Membership'] = \Civi\Api4\MembershipType::get(FALSE)
-      ->addWhere('is_active', '=', TRUE)
-      ->addOrderBy('weight', 'ASC')
-      ->execute()
-      ->column('title', 'id');
+    $subTypes['Membership'] = CRM_Member_BAO_MembershipType::getMembershipTypes(FALSE);
     $subTypes['Event'] = CRM_Core_OptionGroup::values('event_type');
     $subTypes['Campaign'] = CRM_Campaign_PseudoConstant::campaignType();
     $subTypes['Participant'] = [];

--- a/CRM/Member/BAO/MembershipType.php
+++ b/CRM/Member/BAO/MembershipType.php
@@ -238,7 +238,6 @@ class CRM_Member_BAO_MembershipType extends CRM_Member_DAO_MembershipType implem
    * @return array
    */
   public static function getMembershipTypes($public = TRUE) {
-    CRM_Core_Error::deprecatedWarning('Use API4 MembershipType::Get instead');
     $membershipTypes = [];
     $membershipType = new CRM_Member_DAO_MembershipType();
     $membershipType->is_active = 1;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes broken custom fields screen when both CiviMember and AdminUI disabled.

Before
----------------------------------------
Disable CiviMember and AdminUI – the "Administer Custom Fields" screen crashes

After
----------------------------------------
Works.

Technical Details
----------------------------------------
The MembershipType api cannot be used when CiviMember is disabled.

This partially reverts 0ceba2e945dbcc261f68694bdc4647637c6a7c0a which caused the regression.

Comments
---------
Reverting is easier than another fix because this screen is getting replaced by AdminUI anyways.