### PR TITLE
SearchKit - add display_type option for subsearches

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplayTable.css
@@ -134,3 +134,6 @@ table.crm-sticky-header > thead > tr {
   overflow-x: scroll;
   max-width: 80vw;
 }
+#bootstrap-theme .crm-search-display-table .crm-search-display-subsearch-accordion {
+  min-width: 10rem;
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -589,7 +589,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         // this gives us a full key for settings in the result - see addSubsearchDisplaySettings
         'search_and_display' => "{$column['subsearch']['search']}.{$column['subsearch']['display']}",
         'filters' => [],
-        'display_type' => $column['subsearch']['display_type'] ?: 'dropdown',
+        'subsearch_mode' => $column['subsearch']['subsearch_mode'] ?? 'dropdown',
       ],
     ];
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -589,6 +589,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         // this gives us a full key for settings in the result - see addSubsearchDisplaySettings
         'search_and_display' => "{$column['subsearch']['search']}.{$column['subsearch']['display']}",
         'filters' => [],
+        'display_type' => $column['subsearch']['display_type'] ?: 'dropdown',
       ],
     ];
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -77,7 +77,8 @@
             rewrite: '',
             alignment: '',
             subsearch: {
-              filters: {}
+              filters: {},
+              display_type: 'dropdown'
             }
           }
         },

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -77,8 +77,8 @@
             rewrite: '',
             alignment: '',
             subsearch: {
-              filters: {},
-              display_type: 'dropdown'
+              filters: [],
+              subsearch_mode: 'dropdown'
             }
           }
         },

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
@@ -40,7 +40,7 @@
             ],
           }],
           savedSearch: ['SavedSearch', 'get', {
-            select: ['api_entity', 'api_params'],
+            select: ['label', 'api_entity', 'api_params'],
             where: [['name', '=', searchName]],
           }, 0],
         });
@@ -72,6 +72,10 @@
           this.column.subsearch.filters = [];
           getSubsearchInfo(searchName).then((result) => {
             if (result.searchDisplays.length) {
+              // Set default label
+              this.column.label = this.column.label || result.savedSearch.label;
+              this.column.rewrite = this.column.rewrite || result.savedSearch.label;
+
               this.column.subsearch.display = result.searchDisplays[0].name;
               // Set default filter
               const baseEntity = searchMeta.getBaseEntity();

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
@@ -19,12 +19,10 @@
           getSubsearchInfo(searchName).then((result) => {
             // If search doesn't exist, it can't be used
             if (!result.savedSearch) {
-              delete this.column.subsearch;
+              delete this.column.subsearch.search;
+              delete this.column.subsearch.display;
             }
           });
-        }
-        else if (this.column.subsearch) {
-          delete this.column.subsearch;
         }
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/subsearch.html
@@ -7,20 +7,20 @@
 </div>
 <search-admin-icons item="col"></search-admin-icons>
 <search-admin-css-rules label="{{:: ts('Style') }}" item="col" default="col.key"></search-admin-css-rules>
+<div class="form-inline">
+  <label>
+    {{:: ts('Subsearch Display Mode') }}
+  </label>
+  <select class="form-control" ng-model="col.subsearch.subsearch_mode">
+    <option value="dropdown">{{:: ts('Dropdown (Full-Width)') }}</option>
+    <option value="collapsed">{{:: ts('Inline (Collapsed)') }}</option>
+    <option value="inline">{{:: ts('Inline (Open)') }}</option>
+  </select>
+</div>
+<p ng-if="col.subsearch.subsearch_mode === 'inline'" class="status status-notice">
+  {{:: ts('Note: Inline (Open) Subsearches could cause high server load, as they all run simultaneously. You will probably want to limit the number of results in both the parent and child searches, or switch to Inline (Collapsed) mode.') }}
+</p>
 <div class="help-block">
   {{:: ts('Choose a Saved Search + Display to embed.') }}
 </div>
 <crm-search-admin-subsearch display="$ctrl.display" column="col"></crm-search-admin-subsearch>
-<div class="form-inline">
-  <label>
-    {{:: ts('Subsearch Display') }}
-  </label>
-  <select class="form-control crm-flex-1" ng-model="col.subsearch.display_type">
-    <option value="dropdown">{{:: ts('Dropdown') }}</option>
-    <option value="accordion">{{:: ts('Accordion') }}</option>
-    <option value="inline">{{:: ts('Inline') }}</option>
-  </select>
-  <span ng-if="col.subsearch.display_type === 'inline'" class="status status-notice">
-    {{:: ts('Note: Inline Subsearches have the potential to generate high server load. You will probably want to limit the number of results in both the parent and child searches.') }}
-  </span>
-</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/subsearch.html
@@ -11,3 +11,16 @@
   {{:: ts('Choose a Saved Search + Display to embed.') }}
 </div>
 <crm-search-admin-subsearch display="$ctrl.display" column="col"></crm-search-admin-subsearch>
+<div class="form-inline">
+  <label>
+    {{:: ts('Subsearch Display') }}
+  </label>
+  <select class="form-control crm-flex-1" ng-model="col.subsearch.display_type">
+    <option value="dropdown">{{:: ts('Dropdown') }}</option>
+    <option value="accordion">{{:: ts('Accordion') }}</option>
+    <option value="inline">{{:: ts('Inline') }}</option>
+  </select>
+  <span ng-if="col.subsearch.display_type === 'inline'" class="status status-notice">
+    {{:: ts('Note: Inline Subsearches have the potential to generate high server load. You will probably want to limit the number of results in both the parent and child searches.') }}
+  </span>
+</div>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
@@ -1,4 +1,4 @@
-<details ng-if="colData.subsearch.display_type === 'dropdown'" class="crm-search-display-subsearch-dropdown">
+<details ng-if="colData.subsearch.subsearch_mode === 'dropdown'" class="crm-search-display-subsearch-dropdown">
   <summary ng-click="$ctrl.onToggleDisclosure(colData, $event)">
     <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
     {{:: colData.val }}
@@ -8,7 +8,7 @@
     <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
   </div>
 </details>
-<details ng-if="colData.subsearch.display_type === 'accordion'" class="crm-search-display-subsearch-accordion">
+<details ng-if="colData.subsearch.subsearch_mode === 'collapsed'" class="crm-search-display-subsearch-accordion">
   <summary ng-click="$ctrl.onToggleDisclosure(colData, $event)">
     <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
     {{:: colData.val }}
@@ -18,7 +18,7 @@
     <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
   </div>
 </details>
-<div ng-if="colData.subsearch.display_type === 'inline'" class="crm-search-display-subsearch-inline">
+<div ng-if="colData.subsearch.subsearch_mode === 'inline'" class="crm-search-display-subsearch-inline">
   <div class="crm-search-display-subsearch-inline-header">
     <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
     {{:: colData.val }}

--- a/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
@@ -1,5 +1,5 @@
-<details class="crm-search-display-subsearch-dropdown">
-  <summary ng-click="$ctrl.onToggleDropdown(colData, $event)">
+<details ng-if="colData.subsearch.display_type === 'dropdown'" class="crm-search-display-subsearch-dropdown">
+  <summary ng-click="$ctrl.onToggleDisclosure(colData, $event)">
     <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
     {{:: colData.val }}
     <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
@@ -8,3 +8,21 @@
     <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
   </div>
 </details>
+<details ng-if="colData.subsearch.display_type === 'accordion'" class="crm-search-display-subsearch-accordion">
+  <summary ng-click="$ctrl.onToggleDisclosure(colData, $event)">
+    <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
+    {{:: colData.val }}
+    <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
+  </summary>
+  <div class="crm-accordion-body crm-search-display-subsearch-accordion-body">
+    <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
+  </div>
+</details>
+<div ng-if="colData.subsearch.display_type === 'inline'" class="crm-search-display-subsearch-inline">
+  <div class="crm-search-display-subsearch-inline-header">
+    <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
+    {{:: colData.val }}
+    <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
+  </div>
+  <crm-search-display-table search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
+</div>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -243,9 +243,9 @@
 
       this.onToggleDisclosure = (col, event) => {
         col.hasBeenOpened = true;
-        const detailsElement = event.target.closest('details');
-        // If we are opening this dropdown, close any others in the same search display
-        if (!detailsElement.open) {
+        const detailsElement = event.target.closest('details.crm-search-display-subsearch-dropdown');
+        // If we are opening a dropdown, close any others in the same search display
+        if (detailsElement && !detailsElement.open) {
           detailsElement.closest('.crm-search-display-table')
             .querySelectorAll('details.crm-search-display-subsearch-dropdown[open]')
             .forEach((details) => details.open = false);

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -241,7 +241,7 @@
         });
       };
 
-      this.onToggleDropdown = (col, event) => {
+      this.onToggleDisclosure = (col, event) => {
         col.hasBeenOpened = true;
         const detailsElement = event.target.closest('details');
         // If we are opening this dropdown, close any others in the same search display


### PR DESCRIPTION
Overview
----------------------------------------
Allow showing subsearches in dropdown, regular accordion, or directly inline.

Before
----------------------------------------
- subsearches are always in dropdowns

After
----------------------------------------
- three options for subsearch display
  - `dropdown` is default, as before
  - `accordion` renders an openable accordion - allows e.g. opening multiple rows for comparison, whilst maintaining the lazy loading
  - `inline` loads all the subsearches immediately - some performance cost but can be very useful when combined with pagination


Technical Details
----------------------------------------
The regular accordion uses the `crm-accordion-body` utility class to style with themes.

The only additional styling is a rule with a minimal `min-width` for the unopened accordion, to reduce the amount of layout shift when the accordion is opened. (In practice you might want a wider min-width, but it depends on your subsearch. This can also be achieved with a long title).

I added a UI notice about potential performance implications of using Inline searches.

