### PR TITLE
allow cc and bcc in flexmailer

### DIFF
--- a/ext/flexmailer/src/Listener/DefaultSender.php
+++ b/ext/flexmailer/src/Listener/DefaultSender.php
@@ -66,7 +66,18 @@ class DefaultSender extends AutoService {
       }
 
       $headers = $message->headers();
-      $result = $mailer->send($headers['To'], $headers, $message->get());
+
+      $to = $headers['To'];
+
+      if (!empty($headers['Cc'])) {
+        $to .= ',' . $headers['Cc'];
+      }
+
+      if (!empty($headers['Bcc'])) {
+        $to .= ',' . $headers['Bcc'];
+      }
+
+      $result = $mailer->send($to, $headers, $message->get());
 
       if ($job_date) {
         unset($errorScope);

--- a/ext/flexmailer/src/MailParams.php
+++ b/ext/flexmailer/src/MailParams.php
@@ -60,6 +60,16 @@ class MailParams {
     unset($mailParams['toEmail']);
     $mailParams['To'] = "$toName <$toEmail>";
 
+    if (!empty($mailParams['cc'])) {
+      $mailParams['Cc'] = $mailParams['cc'];
+      unset($mailParams['cc']);
+    }
+
+    if (!empty($mailParams['bcc'])) {
+      $mailParams['Bcc'] = $mailParams['bcc'];
+      unset($mailParams['bcc']);
+    }
+
     // 2. Apply the other fields.
     foreach ($mailParams as $key => $value) {
       if (empty($value)) {


### PR DESCRIPTION
Overview
----------------------------------------
When adding cc or bcc addresses using the hook hook_civicrm_alterMailParams, they will be correctly processed if it's a transactional mail. However, if it's a mass mailing, cc and bcc addresses are ignored.

Before
----------------------------------------
flexmailer does not process cc and bcc addresses.

After
----------------------------------------
flexmailer processes cc and bcc addresses.

Technical Details
----------------------------------------
The flexmailer extension contained no code to process cc and bcc, unlike CRM_Utils_Mail. Now it does.

Comments
----------------------------------------
See also the new extension I am developing: https://github.com/AlainBenbassat/carboncopy
