### PR TITLE
dev/core#6339 : Cannot import 'Amount Label'

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1569,7 +1569,7 @@ class CRM_Financial_BAO_Order {
 
     $contributionValues['total_amount'] = $this->getTotalAmount();
     $contributionValues['tax_amount'] = $this->getTotalTaxAmount();
-    $contributionValues['amount_level'] = $this->getAmountLevel();
+    $contributionValues['amount_level'] = $contributionValues['amount_level'] ?? $this->getAmountLevel();
     $contributionValues['contribution_status_id:name'] = 'Pending';
     $contributionValues['line_item'] = [$this->getLineItems()];
     if ($this->getExistingContributionRecurID()) {

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -979,6 +979,27 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that amount label is imported successfully
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testImportAmountLabel(): void {
+    $contactID = $this->individualCreate();
+    $values = [
+      'Contribution.contact_id' => $contactID,
+      'Contribution.receive_date' => '2026-05-01',
+      'Contribution.payment_instrument_id' => 'EFT',
+      'Contribution.total_amount' => 10,
+      'Contribution.financial_type_id' => 'Member Dues',
+      'Contribution.contribution_status_id' => 'Failed',
+      'Contribution.amount_level' => 'REJ:56',
+    ];
+    $this->runImport($values, 'create');
+    $contribution = $this->callAPISuccessGetSingle('Contribution', ['Contribution.contact_id' => $contactID]);
+    $this->assertEquals($values['Contribution.amount_level'], $contribution['amount_level']);
+  }
+
+  /**
    * Add a random extra option value
    *
    * @param string $optionGroup


### PR DESCRIPTION
Steps to replicate
------------------
1. Go to CiviCRM >> Contribution >> Import Contribution
2. Import CSV that includes amount label columns (you can use this sample CSV [sample.csv](/uploads/fd66746886f423968d6117fa325d46fa/sample.csv))  


After
--------
Amount label value should be imported and visible in contribution view

Before
--------
Amount label is not imported and thus, not visible in contribution view. 


Technical details:
-----------------
This is a regression due to https://github.com/civicrm/civicrm-core/commit/e23e3be662010471af44b13e407c393dd52b93bd#diff-1df61486055fb855d4b4d6bd17e4c34ba8bc34439d548cbb5f067dad40d87fc5L354 change, since 6.6.0

As an alternative we can modify Order::create to allow overriding amount_level and then no changes needed in ext/civiimport/Civi/Import/ContributionParser.php and would be more centralized. Right not amount_level is a calculated field whose value is updated [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Financial/BAO/Order.php#L1122) 

Comments
----------------------------------------
ping @eileenmcnaughton @Edzelopez