### PR TITLE
avoid blank translation

### DIFF
--- a/CRM/Core/xml/Menu/Admin.xml
+++ b/CRM/Core/xml/Menu/Admin.xml
@@ -454,7 +454,6 @@
      <path>civicrm/admin/extensions</path>
      <title>Manage Extensions</title>
      <page_callback>CRM_Admin_Page_Extensions</page_callback>
-     <desc></desc>
      <access_arguments>administer CiviCRM system</access_arguments>
      <adminGroup>System Settings</adminGroup>
      <weight>120</weight>


### PR DESCRIPTION
Overview
----------------------------------------
https://chat.civicrm.org/civicrm/pl/zetcsmrnjibiidb6qyiqkcb5qw

Before
----------------------------------------
I believe it's the cause of e.g. this: https://lab.civicrm.org/dev/translation/-/blob/c99966f9f9a97fb5dccea4b40503a4098859bc67/po/nb_NO/menu.po#L1607

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

