### PR TITLE
SearchKit - Remove obsolete width restriction for help blocks

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -383,6 +383,6 @@ crm-search-admin-import {
   top: 1px;
   right: 0;
 }
-.crm-search-admin-relative .help-block { /* reduces help-block by width of crm-search-admin-right button */
-  width: calc(100% - 180px);
+.crm-search-admin-display-header-links {
+  margin-left: auto;
 }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -15,7 +15,6 @@
       CRM.crmSearchAdmin.displayTypes.forEach(function(type) {
         html +=
           '<div ng-switch-when="' + type.id + '">\n' +
-          '  <div class="help-block"><i class="crm-i ' + type.icon + '" role="img" aria-hidden="true"></i> ' + _.escape(type.description) + '</div>' +
           '  <search-admin-display-' + type.id + ' api-entity="$ctrl.savedSearch.api_entity" api-params="$ctrl.savedSearch.api_params" display="$ctrl.display"></search-admin-display-' + type.id + '>\n' +
           '  <hr>\n' +
           '  <button type="button" class="btn btn-{{ !$ctrl.stale ? \'success\' : $ctrl.preview ? \'warning\' : \'primary\' }}" ng-click="$ctrl.previewDisplay()" ng-disabled="!$ctrl.stale">\n' +
@@ -40,6 +39,10 @@
       this.aclBypassHelp = ts('Only users with "all CiviCRM permissions and ACLs" can disable permission checks.');
 
       this.preview = this.stale = false;
+
+      this.$onInit = function() {
+        this.displayType = CRM.crmSearchAdmin.displayTypes.find(type => type.id === this.display.type);
+      };
 
       // Extra (non-field) colum types
       this.colTypes = {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplayHeader.html
@@ -1,3 +1,15 @@
+<div class="crm-search-admin-flex-row">
+  <div class="help-block">
+    <i class="crm-i {{:: $ctrl.parent.displayType.icon }}" role="img" aria-hidden="true"></i>
+    {{:: $ctrl.parent.displayType.description }}
+  </div>
+  <div class="btn-group crm-search-admin-display-header-links" ng-if="$ctrl.parent.crmSearchAdmin.displayIsViewable($ctrl.display)">
+    <a ng-href="{{ $ctrl.parent.crmSearchAdmin.searchDisplayPath + '#/display/' + $ctrl.parent.savedSearch.name + '/' + $ctrl.display.name }}" target="_blank" class="btn btn-primary-outline" title="{{:: ts('View search display on its own page') }}">
+      <i class="crm-i fa-external-link" role="img" aria-hidden="true"></i>
+      {{:: ts('View Display') }}
+    </a>
+  </div>
+</div>
 <fieldset class="crm-search-admin-display-header">
   <div class="form-inline">
     <label for="crm-search-admin-display-label">{{:: ts('Name') }} <span class="crm-marker">*</span></label>
@@ -19,9 +31,3 @@
     <textarea class="form-control" placeholder="{{:: ts('Description (shown above)') }}" ng-model="$ctrl.display.settings.description"></textarea>
   </div>
 </fieldset>
-<div class="form-group crm-search-admin-right crm-search-admin-display-header-links" ng-if="$ctrl.display.id">
-  <a ng-href="{{ $ctrl.parent.crmSearchAdmin.searchDisplayPath + '#/display/' + $ctrl.parent.savedSearch.name + '/' + $ctrl.display.name }}" target="_blank" class="btn btn-primary-outline" title="{{:: ts('View search display on its own page') }}">
-    <i class="crm-i fa-external-link" role="img" aria-hidden="true"></i>
-    {{:: ts('View Display') }}
-  </a>
-</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a couple minor issues with the "View Display" button and help text in SearchKit.

- Consistently enforce conditional rule for both "view" buttons
- Use css flex instead of float + width guesswork which was causing a weirdly cropped with on all help text as shown in the screenshots.

Before
----------------------------------------
<img width="885" height="911" alt="Screenshot 2026-02-16 at 4 48 36 PM" src="https://github.com/user-attachments/assets/f7b88c9a-d61b-4fb0-8ba2-beac42924c92" />


After
----------------------------------------
<img width="886" height="911" alt="Screenshot 2026-02-16 at 4 49 50 PM" src="https://github.com/user-attachments/assets/3b7a1e18-ee36-4c47-8858-9dfceda56ab0" />
