### PR TITLE
Support contributionRecur tokens in Member email task

### DIFF
--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -112,14 +112,16 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
       // checkPermissions set to false - in case form is bypassing in some way.
       $memberships = Membership::get(FALSE)
         ->addWhere('id', 'IN', $this->getIDs())
-        ->setSelect(['id', 'contact_id'])->execute();
+        ->setSelect(['id', 'contact_id', 'contribution_recur_id'])->execute();
       foreach ($memberships as $membership) {
         $this->rows[] = [
           'contact_id' => $membership['contact_id'],
           'membership_id' => $membership['id'],
+          'contribution_recur_id' => $membership['contribution_recur_id'],
           'schema' => [
             'contactId' => $membership['contact_id'],
             'membershipId' => $membership['id'],
+            'contribution_recurId' => $membership['contribution_recur_id'] ?? NULL,
           ],
         ];
       }
@@ -133,7 +135,7 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
    * @return array
    */
   public function getTokenSchema(): array {
-    return ['membershipId', 'contactId'];
+    return ['contribution_recurId', 'membershipId', 'contactId'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The Member entity has a field `contribution_recur_id` which is set if it is auto-renew / linked to a recur. So we can use that in tokens when sending emails.

Before
----------------------------------------
Not possible to use contributionRecur tokens with Member email tasks.

After
----------------------------------------
Can use contributionRecur tokens with Member email tasks.

Technical Details
----------------------------------------
Just enables it in the schema and selects the contribution_recur_id if available.

Comments
----------------------------------------
If the `contributionRecur` entity is not set the (recur) tokens will simply be replaced with an empty string. So there should be no problem if you select multiple memberships and only some have recurring contributions.
