### PR TITLE
Afform - Fix "Store Values" in search display filters

### DIFF
--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -77,7 +77,7 @@
         };
 
         this.$onInit = function() {
-          $scope.$watch(ctrl.getFieldData, function(newVal, oldVal) {
+          $scope.$watch(ctrl.getFieldData, (newVal, oldVal) => {
             $element[0].dispatchEvent(new Event('crmFormChangeFilters'));
             if (this.storeValues) {
               if (typeof newVal === 'object' && typeof oldVal === 'object' && Object.keys(newVal).length) {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6338](https://lab.civicrm.org/dev/core/-/issues/6338)


Before
----------------------------------------
"Remember Filters" does not work.

After
----------------------------------------
Functionality restored.

Technical Details
----------------------------------------
Regressed with 682ae66 which rearranged the function so that `this` to no longer references the main directive object, causing `this.storeValues` to always return `undefined`. Changing to an arrow function allows `this` binding to pass-thru.