### PR TITLE
Afform - Add missing proximity search input type

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/inputType/Location.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Location.html
@@ -1,0 +1,8 @@
+<div class="form-inline">
+  <input class="form-control" type="number" readonly placeholder="{{:: ts('Distance') }}">
+  <select class="form-control crm-auto-width" readonly>
+    <option value="km">{{:: ts('Km') }}</option>
+    <option value="miles">{{:: ts('Miles') }}</option>
+  </select>
+  <input class="form-control" readonly placeholder="{{:: ts('Street, City, State, Country') }}">
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where the "Location" input type was perceived as missing by FormBuilder.

Before
----------------------------------------
<img width="660" height="375" alt="image" src="https://github.com/user-attachments/assets/b282b2b4-4020-4538-877a-fdda4478160e" />


After
----------------------------------------
<img width="658" height="366" alt="image" src="https://github.com/user-attachments/assets/081bd418-9875-4f7c-8940-80a0be21230d" />


Technical Details
----------------------------------------
Regressed when we started scanning AfformAdmin for input types, because the template existed on the front-end but not the back-end.
