### PR TITLE
Afform - Improve proximity search unit selector

### DIFF
--- a/ext/afform/core/ang/af/fields/Location.html
+++ b/ext/afform/core/ang/af/fields/Location.html
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <input class="form-control" type="number" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance" placeholder="{{:: ts('Distance') }}" >
-  <select class="form-control" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance_unit">
+  <select class="form-control crm-auto-width" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance_unit">
     <option value="km">{{:: ts('Km') }}</option>
     <option value="miles">{{:: ts('Miles') }}</option>
   </select>


### PR DESCRIPTION
Overview
----------------------------------------
Auto-width keeps the dropdown from taking too much space.

Before
----------------------------------------
<img width="740" height="97" alt="image" src="https://github.com/user-attachments/assets/bef87d5f-c71e-49cb-86e2-e4f163a2a3bf" />

After
----------------------------------------
<img width="660" height="87" alt="image" src="https://github.com/user-attachments/assets/78162350-b8bc-470a-b789-01b9a33fa319" />

