### PR TITLE
dev/core#6341 Use fallback to get the account ID

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -181,22 +181,23 @@ class CRM_Contribute_BAO_FinancialProcessor {
         'Accounts Receivable Account is'
       );
     }
+    $accountID = NULL;
     if (!empty($params['payment_processor'])) {
-      return CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['payment_processor'], NULL, 'civicrm_payment_processor');
+      $accountID = CRM_Contribute_PseudoConstant::getRelationalFinancialAccount($params['payment_processor'], NULL, 'civicrm_payment_processor');
     }
     // Probably here we should check $this->updatedContribution instead of params
     // and then we would not need the next if.
-    if (!empty($params['payment_instrument_id'])) {
-      return CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($params['payment_instrument_id']);
+    if (!$accountID && !empty($params['payment_instrument_id'])) {
+      $accountID = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount($params['payment_instrument_id']);
     }
     // Probably updatedContribution makes more sense - per previous comment.
     // dev/financial#160 - If this is a contribution update, also check for an existing payment_instrument_id.
-    if ($this->getOriginalPaymentInstrumentID()) {
-      return CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount((int) $params['prevContribution']->payment_instrument_id);
+    elseif (!$accountID && $this->getOriginalPaymentInstrumentID()) {
+      $accountID = CRM_Financial_BAO_EntityFinancialAccount::getInstrumentFinancialAccount((int) $params['prevContribution']->payment_instrument_id);
     }
     $relationTypeId = key(CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name LIKE 'Asset' "));
     $queryParams = [1 => [$relationTypeId, 'Integer']];
-    return CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_financial_account WHERE is_default = 1 AND financial_account_type_id = %1", $queryParams);
+    return $accountID ?: CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_financial_account WHERE is_default = 1 AND financial_account_type_id = %1", $queryParams);
   }
 
   /**


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#6341 Use fallback to get the account ID

Before
----------------------------------------
We have an expectation that each Payment Instrument will be configured with a financial account. However, it does not seem to be enforced in the UI so we need to consider what to happen if not configured 

After
----------------------------------------
This causes it to use a fallback of the site default rather than trying to return the clearly invalid NULL

Technical Details
----------------------------------------
It feels like we should be enforcing this to be configured but that is also a larger project

Comments
----------------------------------------
@JoeMurray @seamuslee001 

