### PR TITLE
UserDashboard - Add acl_bypass to displays & cleanup search displays

### DIFF
--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Activities.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Activities.mgd.php
@@ -106,6 +106,7 @@ return [
         'label' => E::ts('Your Assigned Activities'),
         'saved_search_id.name' => 'UserDashboard_Activities',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Contributions.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Contributions.mgd.php
@@ -7,22 +7,24 @@ if (!CRM_Core_Component::isEnabled('CiviContribute')) {
 
 return [
   [
-    'name' => 'SavedSearch_UserDashboard_PCPs',
+    'name' => 'SavedSearch_UserDashboard_Contributions',
     'entity' => 'SavedSearch',
     'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'UserDashboard_PCPs',
-        'label' => E::ts('User Dashboard - PCPs'),
-        'api_entity' => 'PCP',
+        'name' => 'UserDashboard_Contributions',
+        'label' => E::ts('User Dashboard - Contributions'),
+        'api_entity' => 'Contribution',
         'api_params' => [
           'version' => 4,
           'select' => [
-            'title',
-            'status_id:label',
-            'page_id.frontend_title',
+            'total_amount',
+            'financial_type_id:label',
+            'contribution_status_id:label',
+            'receive_date',
+            'receipt_date',
           ],
           'orderBy' => [],
           'where' => [
@@ -39,17 +41,18 @@ return [
     ],
   ],
   [
-    'name' => 'SavedSearch_UserDashboard_PCPs_SearchDisplay_UserDashboard_PCPs',
+    'name' => 'SavedSearch_UserDashboard_Contributions_SearchDisplay_UserDashboard_Contributions',
     'entity' => 'SearchDisplay',
     'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'UserDashboard_PCPs',
-        'label' => E::ts('Personal Campaign Pages'),
-        'saved_search_id.name' => 'UserDashboard_PCPs',
+        'name' => 'UserDashboard_Contributions',
+        'label' => E::ts('Your Contribution(s)'),
+        'saved_search_id.name' => 'UserDashboard_Contributions',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],
@@ -62,20 +65,32 @@ return [
           'columns' => [
             [
               'type' => 'field',
-              'key' => 'title',
-              'label' => E::ts('Title'),
+              'key' => 'total_amount',
+              'label' => E::ts('Total Amount'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
-              'key' => 'status_id:label',
+              'key' => 'financial_type_id:label',
               'label' => E::ts('Type'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
-              'key' => 'page_id.frontend_title',
-              'label' => E::ts('Campaign'),
+              'key' => 'receive_date',
+              'label' => E::ts('Date'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'receipt_date',
+              'label' => E::ts('Receipt Sent'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'contribution_status_id:label',
+              'label' => E::ts('Status'),
               'sortable' => TRUE,
             ],
           ],

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Events.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Events.mgd.php
@@ -77,6 +77,13 @@ return [
               'key' => 'Participant_Event_event_id_01.title',
               'label' => E::ts('Event'),
               'sortable' => TRUE,
+              'title' => E::ts('View Event'),
+              'link' => [
+                'entity' => 'Event',
+                'action' => 'view',
+                'join' => 'Participant_Event_event_id_01',
+                'target' => '',
+              ],
             ],
             [
               'type' => 'field',

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Events.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Events.mgd.php
@@ -20,17 +20,27 @@ return [
         'api_params' => [
           'version' => 4,
           'select' => [
-            'event_id.title',
+            'Participant_Event_event_id_01.title',
             'role_id:label',
             'status_id:label',
-            'event_id.start_date',
+            'Participant_Event_event_id_01.start_date',
           ],
           'orderBy' => [],
           'where' => [
             ['contact_id', '=', 'user_contact_id'],
           ],
           'groupBy' => [],
-          'join' => [],
+          'join' => [
+            [
+              'Event AS Participant_Event_event_id_01',
+              'INNER',
+              [
+                'event_id',
+                '=',
+                'Participant_Event_event_id_01.id',
+              ],
+            ],
+          ],
           'having' => [],
         ],
       ],
@@ -51,6 +61,7 @@ return [
         'label' => E::ts('Your Event(s)'),
         'saved_search_id.name' => 'UserDashboard_Events',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],
@@ -63,13 +74,13 @@ return [
           'columns' => [
             [
               'type' => 'field',
-              'key' => 'event_id.title',
+              'key' => 'Participant_Event_event_id_01.title',
               'label' => E::ts('Event'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
-              'key' => 'event_id.start_date',
+              'key' => 'Participant_Event_event_id_01.start_date',
               'label' => E::ts('Event Date'),
               'sortable' => TRUE,
             ],

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Groups.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Groups.mgd.php
@@ -37,6 +37,11 @@ return [
               '=',
               TRUE,
             ],
+            [
+              'is_hidden',
+              '=',
+              FALSE,
+            ],
           ],
           'groupBy' => [
             'id',
@@ -45,7 +50,7 @@ return [
           'join' => [
             [
               'Contact AS Group_GroupContact_Contact_01',
-              'LEFT',
+              'INNER',
               'GroupContact',
               [
                 'id',
@@ -88,6 +93,7 @@ return [
         'label' => E::ts('Your Group(s)'),
         'saved_search_id.name' => 'UserDashboard_Groups',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Memberships.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Memberships.mgd.php
@@ -1,30 +1,30 @@
 <?php
 use CRM_UserDashboard_ExtensionUtil as E;
 
-if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+if (!CRM_Core_Component::isEnabled('CiviMember')) {
   return [];
 }
 
 return [
   [
-    'name' => 'SavedSearch_UserDashboard_Contributions',
+    'name' => 'SavedSearch_UserDashboard_Memberships',
     'entity' => 'SavedSearch',
     'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'UserDashboard_Contributions',
-        'label' => E::ts('User Dashboard - Contributions'),
-        'api_entity' => 'Contribution',
+        'name' => 'UserDashboard_Memberships',
+        'label' => E::ts('User Dashboard - Memberships'),
+        'api_entity' => 'Membership',
         'api_params' => [
           'version' => 4,
           'select' => [
-            'total_amount',
-            'financial_type_id:label',
-            'contribution_status_id:label',
-            'receive_date',
-            'receipt_date',
+            'membership_type_id:label',
+            'status_id:label',
+            'start_date',
+            'end_date',
+            'join_date',
           ],
           'orderBy' => [],
           'where' => [
@@ -41,17 +41,18 @@ return [
     ],
   ],
   [
-    'name' => 'SavedSearch_UserDashboard_Contributions_SearchDisplay_UserDashboard_Contributions',
+    'name' => 'SavedSearch_UserDashboard_Memberships_SearchDisplay_UserDashboard_Memberships',
     'entity' => 'SearchDisplay',
     'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'UserDashboard_Contributions',
-        'label' => E::ts('Your Contribution(s)'),
-        'saved_search_id.name' => 'UserDashboard_Contributions',
+        'name' => 'UserDashboard_Memberships',
+        'label' => E::ts('Your Membership(s)'),
+        'saved_search_id.name' => 'UserDashboard_Memberships',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],
@@ -64,31 +65,31 @@ return [
           'columns' => [
             [
               'type' => 'field',
-              'key' => 'total_amount',
-              'label' => E::ts('Total Amount'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'financial_type_id:label',
+              'key' => 'membership_type_id:label',
               'label' => E::ts('Type'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
-              'key' => 'receive_date',
-              'label' => E::ts('Date'),
+              'key' => 'join_date',
+              'label' => E::ts('Member Since'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
-              'key' => 'receipt_date',
-              'label' => E::ts('Receipt Sent'),
+              'key' => 'start_date',
+              'label' => E::ts('Start Date'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
-              'key' => 'contribution_status_id:label',
+              'key' => 'end_date',
+              'label' => E::ts('End Date'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'status_id:label',
               'label' => E::ts('Status'),
               'sortable' => TRUE,
             ],

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_PCPs.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_PCPs.mgd.php
@@ -1,37 +1,46 @@
 <?php
 use CRM_UserDashboard_ExtensionUtil as E;
 
-if (!CRM_Core_Component::isEnabled('CiviMember')) {
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
   return [];
 }
 
 return [
   [
-    'name' => 'SavedSearch_UserDashboard_Memberships',
+    'name' => 'SavedSearch_UserDashboard_PCPs',
     'entity' => 'SavedSearch',
     'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'UserDashboard_Memberships',
-        'label' => E::ts('User Dashboard - Memberships'),
-        'api_entity' => 'Membership',
+        'name' => 'UserDashboard_PCPs',
+        'label' => E::ts('User Dashboard - PCPs'),
+        'api_entity' => 'PCP',
         'api_params' => [
           'version' => 4,
           'select' => [
-            'membership_type_id:label',
+            'title',
             'status_id:label',
-            'start_date',
-            'end_date',
-            'join_date',
+            'PCP_ContributionPage_page_id_01.frontend_title',
           ],
           'orderBy' => [],
           'where' => [
             ['contact_id', '=', 'user_contact_id'],
           ],
           'groupBy' => [],
-          'join' => [],
+          'join' => [
+            [
+              'ContributionPage AS PCP_ContributionPage_page_id_01',
+              'LEFT',
+              [
+                'page_id',
+                '=',
+                'PCP_ContributionPage_page_id_01.id',
+              ],
+              ['page_type', '=', '\'contribute\''],
+            ],
+          ],
           'having' => [],
         ],
       ],
@@ -41,17 +50,18 @@ return [
     ],
   ],
   [
-    'name' => 'SavedSearch_UserDashboard_Memberships_SearchDisplay_UserDashboard_Memberships',
+    'name' => 'SavedSearch_UserDashboard_PCPs_SearchDisplay_UserDashboard_PCPs',
     'entity' => 'SearchDisplay',
     'cleanup' => 'always',
     'update' => 'unmodified',
     'params' => [
       'version' => 4,
       'values' => [
-        'name' => 'UserDashboard_Memberships',
-        'label' => E::ts('Your Membership(s)'),
-        'saved_search_id.name' => 'UserDashboard_Memberships',
+        'name' => 'UserDashboard_PCPs',
+        'label' => E::ts('Personal Campaign Pages'),
+        'saved_search_id.name' => 'UserDashboard_PCPs',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],
@@ -64,32 +74,20 @@ return [
           'columns' => [
             [
               'type' => 'field',
-              'key' => 'membership_type_id:label',
-              'label' => E::ts('Type'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'join_date',
-              'label' => E::ts('Member Since'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'start_date',
-              'label' => E::ts('Start Date'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'end_date',
-              'label' => E::ts('End Date'),
+              'key' => 'title',
+              'label' => E::ts('Title'),
               'sortable' => TRUE,
             ],
             [
               'type' => 'field',
               'key' => 'status_id:label',
-              'label' => E::ts('Status'),
+              'label' => E::ts('Type'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'PCP_ContributionPage_page_id_01.frontend_title',
+              'label' => E::ts('Campaign'),
               'sortable' => TRUE,
             ],
           ],

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Pledges.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Pledges.mgd.php
@@ -69,6 +69,7 @@ return [
         'label' => E::ts('Your Pledges'),
         'saved_search_id.name' => 'UserDashboard_Pledges',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Relationships.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Relationships.mgd.php
@@ -57,6 +57,7 @@ return [
         'label' => E::ts('Your Contacts / Organizations'),
         'saved_search_id.name' => 'UserDashboard_Relationships',
         'type' => 'table',
+        'acl_bypass' => TRUE,
         'settings' => [
           'description' => NULL,
           'sort' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Improve SearchDisplays in the UserDashboard extension:

- Add acl_bypass to all Dashboard displays, as these are meant to show to less-privledged users & already have appropriate filters applied.
- Rename files per civix export standard.
- Add explicit joins instead of implied joins that SK UI doesn't understand.
- Add link to view event info for parity with the old dashboard.
