### PR TITLE
Catch Connection e.g. HTTP Timeout errors in geocoding

### DIFF
--- a/CRM/Utils/Geocode/Google.php
+++ b/CRM/Utils/Geocode/Google.php
@@ -147,7 +147,7 @@ class CRM_Utils_Geocode_Google {
     try {
       $request = $client->request('GET', $query, ['timeout' => \Civi::settings()->get('http_timeout')]);
     }
-    catch (GuzzleHttp\Exception\ClientException $e) {
+    catch (GuzzleHttp\Exception\ClientException | GuzzleHttp\Exception\ConnectException $e) {
       CRM_Core_Error::debug_var('Geocoding failed.  Message from Guzzle:', $e->getMessage());
       $coords['geo_code_error'] = $e->getMessage();
       return $coords;


### PR DESCRIPTION
Overview
----------------------------------------
On a client site that uses Google Geocoding from core occasionally there has been errors like `cURL error 28: Operation timed out after 5000 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)` when geocoding addresses

As per the Guzzle docs these throw a ConnectException not a ClientException https://docs.guzzlephp.org/en/latest/quickstart.html#exceptions and the same in 6.5 https://docs.guzzlephp.org/en/6.5/quickstart.html#exceptions 

Before
----------------------------------------
Geocoding class only catches Client errors not Connect Errors

After
----------------------------------------
Both sets of errors are caught

ping @eileenmcnaughton @mattwire @demeritcowboy 