### PR TITLE
dev/core#6333 : [PHP8.5] Fix BAO_Activity::getActivities to use apiv4 OR get rid of it

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -563,14 +563,45 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
   public static function getActivities($params) {
     $activities = [];
 
-    // Activity.Get API params
-    $activityParams = self::getActivityParamsForDashboardFunctions($params);
+    $activityParams['where'] = [
+      ['is_deleted', '=', 0],
+      //@todo this filter doesn't work well with apiv3
+      //  ['is_current_revision', '=', FALSE],
+      ['is_test', '=', 0],
+      ['activity_type_id', 'IN', self::filterActivityTypes($params)['IN']],
+    ];
+
+    if (!empty($params['contact_id'])) {
+      $activityParams['where'][] = [
+        'OR',
+        [
+          ['assignee_contact.contact_id', 'IN', [$params['contact_id']]],
+          ['target_contact.contact_id', 'IN', [$params['contact_id']]],
+          ['source_contact.contact_id', 'IN', [$params['contact_id']]],
+        ]
+      ];
+    }
+    if (!empty($params['activity_date_time'])) {
+      $activityParams['where'][] = ['activity_date_time', '=', $params['activity_date_time']];
+    }
+
+    if (!empty($params['activity_status_id'])) {
+      $activityParams['where'][] = ['activity_status_id', 'IN', explode(',', $params['activity_status_id'])];
+    }
+
+    $enabledComponents = self::activityComponents();
+    // @todo - this appears to be duplicating the activity api.
+    if (!in_array('CiviCase', $enabledComponents)) {
+      $activityParams['where'][] = ['case_id', 'IS NULL'];
+    }
 
     if (!empty($params['rowCount']) &&
       $params['rowCount'] > 0
     ) {
-      $activityParams['options']['limit'] = $params['rowCount'];
+      $activityParams['limit'] = $params['rowCount'];
     }
+    $activityParams['offset'] = $params['offset'] ?? 0;
+
 
     if (!empty($params['sort'])) {
       if (is_a($params['sort'], 'CRM_Utils_Sort')) {
@@ -581,31 +612,41 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       }
     }
 
-    $activityParams['options']['sort'] = empty($order) ? "activity_date_time DESC" : str_replace('activity_type ', 'activity_type_id.label ', $order);
+    $activityParams['orderBy'] = empty($order) ? ['activity_date_time' => 'DESC'] : [str_replace('activity_type ', 'activity_type_id:label ', $order) => 'ASC'];
 
-    $activityParams['return'] = [
+    $activityParams['select'] = [
       'activity_date_time',
       'source_record_id',
       'source_contact_id',
       'source_contact_name',
       'assignee_contact_id',
       'assignee_contact_name',
+      'target_contact_id',
+      'target_contact_name',
       'status_id',
       'subject',
       'activity_type_id',
-      'activity_type',
-      'case_id',
-      'campaign_id',
+      'activity_type_id:label',
+      'activity_type_id:name',
+      'activity_date_time',
     ];
+    $activityParams['join'] = [
+      ['ActivityContact AS source_contact', 'LEFT', ['id', '=', 'source_contact.activity_id'], ['source_contact.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Source')]],
+      ['ActivityContact AS assignee_contact', 'LEFT', ['id', '=', 'assignee_contact.activity_id'], ['assignee_contact.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Assignees')]],
+      ['ActivityContact AS target_contact', 'LEFT', ['id', '=', 'target_contact.activity_id'], ['target_contact.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets')]],
+    ];
+    $activityParams['groupBy'] = ['id'];
     // Q. What does the code below achieve? case_id and campaign_id are already
     // in the array, defined above, and this code adds them in again if their
     // component is enabled? @fixme remove case_id and campaign_id from the array above?
     foreach (['case_id' => 'CiviCase', 'campaign_id' => 'CiviCampaign'] as $attr => $component) {
-      if (in_array($component, self::activityComponents())) {
-        $activityParams['return'][] = $attr;
+      if (in_array($component, $enabledComponents)) {
+      //  $activityParams['select'][] = $attr;
       }
     }
-    $result = civicrm_api3('Activity', 'Get', $activityParams)['values'];
+    //print_r($activityParams);
+    $result = civicrm_api4('Activity', 'get', $activityParams)->indexBy('id')->getArrayCopy();
+    //print_r($result);
 
     $bulkActivityTypeID = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Bulk Email');
     $allCampaigns = CRM_Campaign_BAO_Campaign::getCampaigns(NULL, NULL, FALSE, FALSE, FALSE, TRUE);
@@ -624,55 +665,29 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       'campaign_id' => 'campaign_id',
       'case_id' => 'case_id',
     ];
+    //print_r($result);
 
-    if (empty($result)) {
-      $targetCount = [];
-    }
-    else {
-      $targetCount = CRM_Core_DAO::executeQuery('
-      SELECT activity_id, count(*) as target_contact_count
-      FROM civicrm_activity_contact
-      INNER JOIN civicrm_contact c ON contact_id = c.id AND c.is_deleted = 0
-      WHERE activity_id IN (' . implode(',', array_keys($result)) . ')
-      AND record_type_id = %1
-      GROUP BY activity_id', [
-        1 => [
-          CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets'),
-          'Integer',
-        ],
-      ])->fetchAll();
-    }
-    foreach ($targetCount as $activityTarget) {
-      $result[$activityTarget['activity_id']]['target_contact_count'] = $activityTarget['target_contact_count'];
-    }
     // Iterate through & do basic mappings & determine which ones we want to retrieve target count for.
     foreach ($result as $id => $activity) {
       $activities[$id] = [
         'activity_id' => $activity['id'],
         'activity_date_time' => $activity['activity_date_time'] ?? NULL,
         'subject' => $activity['subject'] ?? NULL,
-        'assignee_contact_name' => $activity['assignee_contact_sort_name'] ?? [],
         'source_contact_id' => $activity['source_contact_id'] ?? NULL,
-        'source_contact_name' => $activity['source_contact_sort_name'] ?? NULL,
+        'source_contact_name' => $activity['source_contact_name'],
       ];
-      $activities[$id]['activity_type_name'] = CRM_Core_PseudoConstant::getName('CRM_Activity_BAO_Activity', 'activity_type_id', $activity['activity_type_id']);
-      $activities[$id]['activity_type'] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $activity['activity_type_id']);
-      $activities[$id]['target_contact_count'] = $activity['target_contact_count'] ?? 0;
-      if (!empty($activity['target_contact_count'])) {
-        $displayedTarget = civicrm_api3('ActivityContact', 'get', [
-          'activity_id' => $id,
-          'check_permissions' => TRUE,
-          'options' => ['limit' => 1],
-          'record_type_id' => 'Activity Targets',
-          'return' => ['contact_id.sort_name', 'contact_id'],
-          'sequential' => 1,
-        ])['values'];
-        if (empty($displayedTarget[0])) {
-          $activities[$id]['target_contact_name'] = [];
+      $activities[$id]['activity_type_name'] = $activity['activity_type_id:name'];
+      $activities[$id]['activity_type'] = $activity['activity_type_id:label'];
+      $activities[$id]['target_contact_count'] = count($activity['target_contact_id'] ?? []);
+      foreach(['target', 'assignee'] as $recordType) {
+        $contactNames = explode(',', $activity[$recordType . '_contact_name']) ?? [];
+        $activities[$id][$recordType . '_contact_name'] = [];
+        foreach ($contactNames as $key => $contactName) {
+          $activities[$id][$recordType . '_contact_name'][$activity[$recordType . '_contact_id'][$key]] = $contactNames[$key];
         }
-        else {
-          $activities[$id]['target_contact_name'] = [$displayedTarget[0]['contact_id'] => $displayedTarget[0]['contact_id.sort_name']];
-        }
+      }
+      if (empty($activities[$id]['target_contact_count'])) {
+        $activities[$id]['target_contact_name'] = [];
       }
       if ($activities[$id]['activity_type_name'] === 'Bulk Email') {
         $bulkActivities[] = $id;
@@ -2072,7 +2087,6 @@ INNER JOIN  civicrm_option_group grp ON (grp.id = option_group_id AND grp.name =
       'is_test' => 0,
       'contact_id' => $params['contact_id'] ?? NULL,
       'activity_date_time' => $params['activity_date_time'] ?? NULL,
-      'check_permissions' => 1,
       'options' => [
         'offset' => $params['offset'] ?? 0,
       ],

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -569,23 +569,17 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
         'source_record_id',
         'source_contact_id',
         'MAX(source_contact.contact_id.sort_name) AS source_contact_name',
-        'assignee_contact_id',
-        'target_contact_id',
         'status_id',
         'subject',
         'activity_type_id',
         'activity_type_id:label',
         'activity_type_id:name',
         'activity_date_time',
-        'GROUP_CONCAT(DISTINCT target_contact_name.contact_id.sort_name) AS target_contact_names',
-        'GROUP_CONCAT(DISTINCT assignee_contact_name.contact_id.sort_name) AS assignee_contact_names',
       ],
       'join' => [
         ['ActivityContact AS source_contact', 'LEFT', ['id', '=', 'source_contact.activity_id'], ['source_contact.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Source')]],
         ['ActivityContact AS assignee_contact', 'LEFT', ['id', '=', 'assignee_contact.activity_id'], ['assignee_contact.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Assignees')]],
-        ['ActivityContact AS assignee_contact_name', 'LEFT', ['assignee_contact.activity_id', '=', 'assignee_contact_name.activity_id'], ['assignee_contact_name.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Assignees')]],
         ['ActivityContact AS target_contact', 'LEFT', ['id', '=', 'target_contact.activity_id'], ['target_contact.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets')]],
-        ['ActivityContact AS target_contact_name', 'LEFT', ['target_contact.activity_id', '=', 'target_contact_name.activity_id'], ['target_contact_name.record_type_id', '=', CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets')]],
       ],
       'where' => [
         ['is_deleted', '=', 0],
@@ -648,6 +642,26 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     $result = civicrm_api4('Activity', 'get', $activityParams)->indexBy('id')->getArrayCopy();
 
+    $activityContacts = civicrm_api4('ActivityContact', 'get', [
+      'select' => [
+        'activity_id',
+        'record_type_id:name',
+        'contact_id.sort_name',
+        'contact_id',
+      ],
+      'where' => [
+        ['activity_id', 'IN', array_keys($result)],
+        ['contact_id.is_deleted', '=', FALSE],
+        ['record_type_id', 'IN',
+          [
+            CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Assignees'),
+            CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_ActivityContact', 'record_type_id', 'Activity Targets'),
+          ]
+        ],
+      ],
+      'checkPermissions' => TRUE,
+    ])->getArrayCopy();
+
     if (!in_array('CiviCase', $enabledComponents) && !empty($result)) {
       $caseActivityIDsToExclude = CRM_Utils_Array::collect('activity_id', CRM_Core_DAO::executeQuery(sprintf('SELECT activity_id FROM civicrm_case_activity WHERE activity_id IN (%s)', implode(',', array_keys($result))))->fetchAll());
     }
@@ -686,29 +700,17 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
       $activities[$id]['activity_type_name'] = $activity['activity_type_id:name'];
       $activities[$id]['activity_type'] = $activity['activity_type_id:label'];
       $activities[$id]['target_contact_count'] = count($activity['target_contact_id'] ?? []);
-      foreach (['target', 'assignee'] as $recordType) {
-        $contactNames = $activity[$recordType . '_contact_names'] ?? [];
-        $activities[$id][$recordType . '_contact_name'] = [];
-        foreach ($contactNames as $key => $contactName) {
-          if ($recordType == 'target' && $key > 0) {
-            continue;
-          }
-          $activities[$id][$recordType . '_contact_name'][$activity[$recordType . '_contact_id'][$key]] = $contactNames[$key];
-        }
-      }
-      if (!empty($activities[$id]['target_contact_count']) &&
-        \Civi\Api4\ActivityContact::get(TRUE)
-          ->selectRowCount()
-          ->addWhere('activity_id', '=', $activity['id'])
-          ->addWhere('record_type_id:name', '=', 'Activity Targets')
-          ->execute()->count() == 0) {
-        $activities[$id]['target_contact_name'] = [];
-      }
+      $activities[$id]['assignee_contact_name'] = $activities[$id]['target_contact_name'] = [];
       if ($activities[$id]['activity_type_name'] === 'Bulk Email') {
         $bulkActivities[] = $id;
         // Get the total without permissions being passed but only display names after permissioning.
         $activities[$id]['recipients'] = ts('(%1 recipients)', [1 => $activities[$id]['target_contact_count']]);
       }
+    }
+
+    foreach ($activityContacts as $activityContact) {
+      $recordType = $activityContact['record_type_id:name'] == 'Activity Targets' ? 'target' : 'assignee';
+      $activities[$activityContact['activity_id']][$recordType . '_contact_name'][$activityContact['contact_id']] = $activityContact['contact_id.sort_name'];
     }
 
     // Eventually this second iteration should just handle the target contacts. It's a bit muddled at

--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -51,16 +51,6 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
 
-      $field = new FieldSpec('source_contact_name', 'Activity', 'String');
-      $field->setTitle(ts('Source Contact Name'));
-      $field->setLabel(ts('Source Contact Name'));
-      $field->setColumnName('id');
-      $field->setDescription(ts('Contact Names who created this activity.'));
-      $field->setFkEntity('Contact');
-      $field->setInputType('EntityRef');
-      $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactNames']);
-      $spec->addFieldSpec($field);
-
       $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
       $field->setTitle(ts('Target Contacts'));
       $field->setLabel(ts('With Contacts'));
@@ -76,16 +66,6 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
 
-      $field = new FieldSpec('target_contact_name', 'Activity', 'String');
-      $field->setTitle(ts('Target Contact Name'));
-      $field->setLabel(ts('Target Contact Name'));
-      $field->setColumnName('id');
-      $field->setDescription(ts('Contact Names who involved in this activity.'));
-      $field->setFkEntity('Contact');
-      $field->setInputType('EntityRef');
-      $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactNames']);
-      $spec->addFieldSpec($field);
-
       $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
       $field->setTitle(ts('Assignee Contacts'));
       $field->setLabel(ts('Assigned to'));
@@ -99,16 +79,6 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setOperators(['CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL']);
       $field->addSqlFilter([__CLASS__, 'getActivityContactFilterSql']);
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
-      $spec->addFieldSpec($field);
-
-      $field = new FieldSpec('assignee_contact_name', 'Activity', 'String');
-      $field->setTitle(ts('Assignee Contact Name'));
-      $field->setLabel(ts('Assignee Contact Name'));
-      $field->setColumnName('id');
-      $field->setDescription(ts('Contact Names assigned to this activity.'));
-      $field->setFkEntity('Contact');
-      $field->setInputType('EntityRef');
-      $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactNames']);
       $spec->addFieldSpec($field);
     }
 
@@ -213,23 +183,6 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       'CRM_Activity_BAO_ActivityContact',
       'record_type_id',
       $recordTypes[$key]);
-  }
-
-  public static function renderSqlForActivityContactNames(array $field, Api4SelectQuery $query): string {
-    $contactLinkTypes = [
-      'source_contact_name' => 'Activity Source',
-      'target_contact_name' => 'Activity Targets',
-      'assignee_contact_name' => 'Activity Assignees',
-    ];
-    $recordTypeId = \CRM_Core_PseudoConstant::getKey(
-        'CRM_Activity_BAO_ActivityContact',
-        'record_type_id',
-        $contactLinkTypes[$field['name']]);
-    return "(SELECT GROUP_CONCAT(`c`.`sort_name`)
-              FROM `civicrm_activity_contact` `ac`
-              INNER JOIN `civicrm_contact` `c` ON `c`.`id` = `ac`.`contact_id`
-              WHERE `ac`.`activity_id` = {$field['sql_name']}
-              AND record_type_id = $recordTypeId)";
   }
 
 }

--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -51,6 +51,16 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
 
+      $field = new FieldSpec('source_contact_name', 'Activity', 'String');
+      $field->setTitle(ts('Source Contact Name'));
+      $field->setLabel(ts('Source Contact Name'));
+      $field->setColumnName('id');
+      $field->setDescription(ts('Contact Names who created this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactNames']);
+      $spec->addFieldSpec($field);
+
       $field = new FieldSpec('target_contact_id', 'Activity', 'Array');
       $field->setTitle(ts('Target Contacts'));
       $field->setLabel(ts('With Contacts'));
@@ -66,6 +76,16 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
 
+      $field = new FieldSpec('target_contact_name', 'Activity', 'String');
+      $field->setTitle(ts('Target Contact Name'));
+      $field->setLabel(ts('Target Contact Name'));
+      $field->setColumnName('id');
+      $field->setDescription(ts('Contact Names who involved in this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactNames']);
+      $spec->addFieldSpec($field);
+
       $field = new FieldSpec('assignee_contact_id', 'Activity', 'Array');
       $field->setTitle(ts('Assignee Contacts'));
       $field->setLabel(ts('Assigned to'));
@@ -79,6 +99,16 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setOperators(['CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL']);
       $field->addSqlFilter([__CLASS__, 'getActivityContactFilterSql']);
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
+      $spec->addFieldSpec($field);
+
+      $field = new FieldSpec('assignee_contact_name', 'Activity', 'String');
+      $field->setTitle(ts('Assignee Contact Name'));
+      $field->setLabel(ts('Assignee Contact Name'));
+      $field->setColumnName('id');
+      $field->setDescription(ts('Contact Names assigned to this activity.'));
+      $field->setFkEntity('Contact');
+      $field->setInputType('EntityRef');
+      $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactNames']);
       $spec->addFieldSpec($field);
     }
 
@@ -183,6 +213,23 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       'CRM_Activity_BAO_ActivityContact',
       'record_type_id',
       $recordTypes[$key]);
+  }
+
+  public static function renderSqlForActivityContactNames(array $field, Api4SelectQuery $query): string {
+    $contactLinkTypes = [
+      'source_contact_name' => 'Activity Source',
+      'target_contact_name' => 'Activity Targets',
+      'assignee_contact_name' => 'Activity Assignees',
+    ];
+    $recordTypeId = \CRM_Core_PseudoConstant::getKey(
+        'CRM_Activity_BAO_ActivityContact',
+        'record_type_id',
+        $contactLinkTypes[$field['name']]);
+    return "(SELECT GROUP_CONCAT(`c`.`sort_name`)
+              FROM `civicrm_activity_contact` `ac`
+              INNER JOIN `civicrm_contact` `c` ON `c`.`id` = `ac`.`contact_id`
+              WHERE `ac`.`activity_id` = {$field['sql_name']}
+              AND record_type_id = $recordTypeId)";
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This patch is about relying on APIv4 to fetch activities for given parameters that is later used in contact summary activity listing. 

Before
----------------------------------------
Use apiv3 to fetch activity result. 

After
----------------------------------------
Optimized and replaced apiv3 Activity.get call with APIv4 

Technical Details
----------------------------------------
There were three blockers while doing the change : 
1. On disabled CiviCase environment there are still activity types like 'Meeting' are treated as permitted activity types. These kind of activity types are not meant for only Cases. And the failures from unit tests like tests/phpunit/CRM/Activity/BAO/ActivityTest::testGetActivitiesForContactSummary are such example. So I have to use a SQL query [here](https://github.com/civicrm/civicrm-core/pull/34823/changes#diff-205800b0086e4e7f73b39a41f3aa9760637718d32ab4fc9424efc3bb0f8606faR652) to exclude those activities if not relying on case_id field column. I can't think of any other alternative.

2. To fetch target/assignee contact names unlike apiv3 Activity.get action, going with apiv4 way I need to use explict joins to bring those contact informations

3. I can't make use of getActivityParamsForDashboardFunctions() because case_id filter added by it is still useful of getActivitiesCount() that used apiv3 and due to limitation in item 1 above, that is we still can't use case_id IS NULL filter in apiv4 yet so we cannot change or use getActivityParamsForDashboardFunctions


Comments
----------------------------------------
ping @colemanw @eileenmcnaughton 