### PR TITLE
SearchKit - Fix no results for unpermissioned users

### DIFF
--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -187,7 +187,11 @@ class GetLinks extends BasicGetAction {
   private function getAllowedEntityActions(string $entityName): array {
     $uid = \CRM_Core_Session::getLoggedInContactID();
     if (!isset(\Civi::$statics[__CLASS__]['actions'][$entityName][$uid])) {
-      \Civi::$statics[__CLASS__]['actions'][$entityName][$uid] = civicrm_api4($entityName, 'getActions', ['checkPermissions' => TRUE])->column('name');
+      $permissions = new Result();
+      // Bypass the api wrapper, we don't want lack of permission for 'getActions' action to get in the way
+      Request::create($entityName, 'getActions', ['version' => 4, 'checkPermissions' => TRUE])
+        ->_run($permissions);
+      \Civi::$statics[__CLASS__]['actions'][$entityName][$uid] = $permissions->column('name');
     }
     return \Civi::$statics[__CLASS__]['actions'][$entityName][$uid];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Even when a search display has permissions bypassed, they still need to be checked for the links and actions.

This prevents an error caused by unpermissioned users not having enough permission to check their permissions.