### PR TITLE
Api4 - Decouple CiviCase activity spec from core

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -28,18 +28,6 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
   public function modifySpec(RequestSpec $spec) {
     $action = $spec->getAction();
 
-    if (\CRM_Core_Component::isEnabled('CiviCase')) {
-      $field = new FieldSpec('case_id', 'Activity', 'Integer');
-      $field->setTitle(ts('Case ID'));
-      $field->setLabel($action === 'get' ? ts('Filed on Case') : ts('File on Case'));
-      $field->setDescription(ts('CiviCase this activity belongs to.'));
-      $field->setFkEntity('Case');
-      $field->setInputType('EntityRef');
-      $field->setColumnName('id');
-      $field->setSqlRenderer(['\Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
-      $spec->addFieldSpec($field);
-    }
-
     if (in_array($action, ['create', 'update'], TRUE)) {
       // The database default '1' is problematic as the option list is user-configurable,
       // so activity type '1' doesn't necessarily exist. Best make the field required.

--- a/ext/civi_case/Civi/Api4/Event/Subscriber/CaseSchemaMapSubscriber.php
+++ b/ext/civi_case/Civi/Api4/Event/Subscriber/CaseSchemaMapSubscriber.php
@@ -8,9 +8,9 @@ use Civi\Api4\Service\Schema\Joinable\Joinable;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * @service civi.api4.activitySchema
+ * @service civi.api4.civiCaseSchema
  */
-class ActivitySchemaMapSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
+class CaseSchemaMapSubscriber extends \Civi\Core\Service\AutoService implements EventSubscriberInterface {
 
   /**
    * @return array

--- a/ext/civi_case/Civi/Api4/Service/Spec/Provider/ActivityCaseSpecProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Spec/Provider/ActivityCaseSpecProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use CRM_Case_ExtensionUtil as E;
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * @service
+ * @internal
+ */
+class ActivityCaseSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $action = $spec->getAction();
+
+    $field = new FieldSpec('case_id', 'Activity', 'Integer');
+    $field->setTitle(E::ts('Case ID'));
+    $field->setLabel($action === 'get' ? E::ts('Filed on Case') : E::ts('File on Case'));
+    $field->setDescription(E::ts('CiviCase this activity belongs to.'));
+    $field->setFkEntity('Case');
+    $field->setInputType('EntityRef');
+    $field->setColumnName('id');
+    // @see CaseSchemaMapSubscriber for the source of the join sql
+    $field->setSqlRenderer(['Civi\Api4\Service\Schema\Joiner', 'getExtraJoinSql']);
+    $spec->addFieldSpec($field);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'Activity';
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Moves some civicase-specific api code that doesn't belong in core.