### PR TITLE
UserDashboard - Add group subscribe/unsubscribe UI

### DIFF
--- a/ext/user_dashboard/Civi/UserDashboard/DashboardAfformLayoutProvider.php
+++ b/ext/user_dashboard/Civi/UserDashboard/DashboardAfformLayoutProvider.php
@@ -11,10 +11,18 @@ class DashboardAfformLayoutProvider extends \Civi\Core\Service\AutoSubscriber {
 
   public static function getSubscribedEvents(): array {
     return [
-      'civi.afform.get' => ['addDashboardLayout', -100],
+      'civi.afform.get' => [
+        ['addDashboardLayout', -100],
+        ['addGroupSubscriptionLayout', -100],
+      ],
     ];
   }
 
+  /**
+   * Provides markup for the dashboard layout.
+   *
+   * Dynamically retrieves search displays tagged as "UserDashboard" and includes them in the generated layout.
+   */
   public function addDashboardLayout(GenericHookEvent $event) {
     if (!$event->getLayout ||
       ($event->getTypes && !in_array('search', $event->getTypes)) ||
@@ -44,6 +52,46 @@ class DashboardAfformLayoutProvider extends \Civi\Core\Service\AutoSubscriber {
   HTML;
     }
     $event->afforms[] = $afform;
+  }
+
+  /**
+   * Generates dynamic form layout for subscribing to public groups.
+   */
+  public function addGroupSubscriptionLayout(GenericHookEvent $event) {
+    if (!$event->getLayout ||
+      ($event->getTypes && !in_array('form', $event->getTypes)) ||
+      (!empty($event->getNames['name']) && !in_array('afformUpdateGroupSubscriptions', $event->getNames['name']))
+    ) {
+      return;
+    }
+    $publicGroups = civicrm_api4('Group', 'get', [
+      'checkPermissions' => FALSE,
+      'select' => ['name'],
+      'where' => [
+        ['visibility', '=', 'Public Pages'],
+        ['is_active', '=', TRUE],
+        ['is_hidden', '=', FALSE],
+      ],
+    ])->column('name');
+    $fieldsMarkup = array_reduce($publicGroups, function($fieldsMarkup, $groupName) {
+      return ltrim($fieldsMarkup) . "    <af-field name=\"$groupName\" />\n";
+    }, '');
+
+    $layout = <<<HTML
+<af-form ctrl="afform">
+  <af-entity data="{}" type="Individual" name="Individual1" label="User" actions="{create: false, update: true}" security="FBAC" autofill="user" />
+  <af-entity data="{contact_id: 'Individual1'}" actions="{create: true, update: true}" security="FBAC" type="GroupSubscription" name="GroupSubscription1" label="Groups" group-subscription="no-confirm" />
+  <fieldset af-fieldset="GroupSubscription1" class="af-container" af-title="Select Groups">
+    $fieldsMarkup
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Save</button>
+</af-form>
+HTML;
+
+    $event->afforms[] = [
+      'name' => 'afformUpdateGroupSubscriptions',
+      'layout' => $layout,
+    ];
   }
 
 }

--- a/ext/user_dashboard/ang/afformUpdateGroupSubscriptions.aff.php
+++ b/ext/user_dashboard/ang/afformUpdateGroupSubscriptions.aff.php
@@ -1,0 +1,15 @@
+<?php
+use CRM_UserDashboard_ExtensionUtil as E;
+
+return [
+  'type' => 'form',
+  'title' => E::ts('Update Group Subscriptions'),
+  'icon' => 'fa-users',
+  'server_route' => 'civicrm/user/group-subscriptions',
+  'permission' => [
+    'access Contact Dashboard',
+  ],
+  'create_submission' => TRUE,
+  'confirmation_type' => 'show_confirmation_message',
+  'confirmation_message' => E::ts('Your group subscriptions have been saved.'),
+];

--- a/ext/user_dashboard/managed/SavedSearch_UserDashboard_Groups.mgd.php
+++ b/ext/user_dashboard/managed/SavedSearch_UserDashboard_Groups.mgd.php
@@ -135,6 +135,21 @@ return [
               'Removed',
             ],
           ],
+          'columnMode' => 'custom',
+          'toolbar' => [
+            [
+              'entity' => '',
+              'text' => E::ts('Manage Group Subscriptions'),
+              'icon' => 'fa-external-link',
+              'target' => 'crm-popup',
+              'action' => '',
+              'style' => 'default',
+              'join' => '',
+              'path' => 'civicrm/user/group-subscriptions',
+              'task' => '',
+              'conditions' => [],
+            ],
+          ],
         ],
       ],
       'match' => [


### PR DESCRIPTION
Overview
----------------------------------------
Adds parity with the old user dashboard to the new extension, allowing users to join/leave public groups.

<img width="1122" height="509" alt="image" src="https://github.com/user-attachments/assets/611d7e0f-03b1-4753-9830-669513291aa0" />
