### PR TITLE
Add condition to where clause for current domain

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Scheduled_Jobs.mgd.php
@@ -30,7 +30,9 @@ return [
             'api_action',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [
+            ['domain_id:name', '=', 'current_domain'],
+          ],
           'groupBy' => [],
           'join' => [],
           'having' => [],


### PR DESCRIPTION
Overview
----------------------------------------
On multisite, limit scheduled jobs to their domain only.

Before
----------------------------------------
Was showing all of them on all sites.

<img width="1899" height="4546" alt="image" src="https://github.com/user-attachments/assets/358077fd-4752-4094-bc9c-b34671ea469a" />


After
----------------------------------------
Only the current domain

<img width="1841" height="454" alt="image" src="https://github.com/user-attachments/assets/5427b410-ab0e-4ca9-a1a6-a3cc042e91b6" />

Comments
----------------------------------------
Spare a thought for multisite with regard to other screens, I did not scan others yet.
