### PR TITLE
Authx: do not enable authx_header_cred by default - conflicts with HTTP Basic Auth

### DIFF
--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -107,13 +107,6 @@ function authx_civicrm_install() {
  */
 function authx_civicrm_enable() {
   _authx_civix_civicrm_enable();
-  // If the system is already using HTTP `Authorization:` headers before installation/re-activation, then
-  // it's probably an extra/independent layer of security.
-  // Only activate support for `Authorization:` if this looks like a clean/amenable environment.
-  // @link https://github.com/civicrm/civicrm-core/pull/22837
-  if (empty($_SERVER['HTTP_AUTHORIZATION']) && NULL === Civi::settings()->getExplicit('authx_header_cred')) {
-    Civi::settings()->set('authx_header_cred', ['jwt', 'api_key']);
-  }
 }
 
 /**

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -101,7 +101,7 @@ $_authx_settings = function() {
   $s['authx_legacyrest_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_legacyrest_user']['default'] = 'require';
   $s['authx_param_cred']['default'] = ['jwt', 'api_key'];
-  $s['authx_header_cred']['default'] = []; /* @see \authx_civicrm_install() */
+  $s['authx_header_cred']['default'] = [];
   $s['authx_xheader_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_pipe_cred']['default'] = ['jwt', 'api_key'];
 


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #22837: authx header cred authentication causes an access denied error to CiviCRM if the site uses HTTP Basic Auth, which is common on dev sites (and I've seen some clients use it to hide their CRM).

I'm curious to see the tests run.

Before
----------------------------------------

Default CiviCRM config enables `authx_header_cred`.

After
----------------------------------------

Disabled by default

Technical Details
----------------------------------------

It's not clear to me who uses this. By having it enabled by default, I assumed that some CiviCRM Core parts used this. However, I see mentions on the chat that people systematically turn it off on their production site.

Comments
----------------------------------------

sysadmin channel: https://chat.civicrm.org/civicrm/pl/xboxd6mg33gafcifygxjiyrfrw