### PR TITLE
Fix Filter Fields for entities without <entity>_type_id

### DIFF
--- a/ext/afform/core/Civi/Afform/Placement/PlacementUtils.php
+++ b/ext/afform/core/Civi/Afform/Placement/PlacementUtils.php
@@ -113,7 +113,7 @@ class PlacementUtils {
     }
     // All other filters, e.g. activity_type
     $filterField = self::getEntityTypeFilterFields($entityName)[0] ?? NULL;
-    if (\Civi::entity($entityName)->getField($filterField)) {
+    if ($filterField && \Civi::entity($entityName)->getField($filterField)) {
       $options = \Civi::entity($entityName)->getOptions($filterField);
       return \CRM_Utils_Array::formatForSelect2($options, 'label', 'name');
     }


### PR DESCRIPTION
Overview
----------------------------------------
You should be able to embed a SearchKit afform within Smarty and [pass it filters](https://docs.civicrm.org/dev/en/latest/afform/embedding/#passing-data-to-an-afform-embedded-in-a-smarty-page-to-filter-a-search-table).  However, if you try to implement this in the FormBuilder admin UI, you get an error if the entity doesn't have a field like `<entity>_type_id` (e.g. `case_type_id`, `activity_type_id`.

To replicate:
* Add a new option value to the Afform Placement option group that uses `Participant` for its `grouping`.  Or, for testing purposes, just change the grouping on one record, e.g. `UPDATE civicrm_option_value SET grouping = 'Participant' WHERE name = 'event_manage_tab';`

Before
----------------------------------------
```
TypeError: "Civi\Schema\EntityProvider::getField(): Argument #1 ($fieldName) must be of type string, null given, called in /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/afform/core/Civi/Afform/Placement/PlacementUtils.php on line 116" in /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Schema/EntityProvider.php on line 92

#0 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/afform/core/Civi/Afform/Placement/PlacementUtils.php(116): Civi\Schema\EntityProvider->getField()
#1 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php(409): Civi\Afform\Placement\PlacementUtils::getEntityTypeFilterOptions()
#2 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php(50): Civi\AfformAdmin\AfformAdminMeta::getPlacementFilterOptions()
#3 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/Civi/Angular/AngularLoader.php(150): Civi\AfformAdmin\AfformAdminMeta::getAdminSettings()
#4 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Core/Resources/CollectionTrait.php(394): Civi\Angular\AngularLoader->Civi\Angular\{closure}()
#5 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Core/Region.php(151): CRM_Core_Region->getSettings()
#6 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm/CRM/Core/Region.php(166): CRM_Core_Region->{closure}()
#7 /home/jon/local/mysite/web/wp-content/plugins/civicrm/civicrm.php(1221): CRM_Core_Region->render()
```
After
----------------------------------------
No error.

Comments
----------------------------------------
The `return NULL` at the bottom of this function suggests this was the intent all along, but you can't pass `NULL` to a filter field.
