### PR TITLE
Only delete related memberships of contacts with a relationship configured in the membership type

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -644,7 +644,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    * Delete related memberships.
    *
    * @param int $ownerMembershipId
-   * @param int $contactId
+   * @param int|null $contactId
    *
    * @return void
    */

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1285,7 +1285,15 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
 
     //lets cleanup related membership if any.
     if (empty($relatedContacts)) {
-      self::deleteRelatedMemberships($membership->id);
+      if (Civi::settings()->get('disable_related_membership_logic') ?? FALSE) {
+        // Only delete memberships of contacts with a relationship configured in the membership type.
+        foreach (array_keys($allRelatedContacts) as $relatedContactId) {
+          self::deleteRelatedMemberships($membership->id, $relatedContactId);
+        }
+      }
+      else {
+        self::deleteRelatedMemberships($membership->id);
+      }
     }
     else {
       // Edit the params array

--- a/CRM/Member/Form/MembershipView.php
+++ b/CRM/Member/Form/MembershipView.php
@@ -219,7 +219,8 @@ class CRM_Member_Form_MembershipView extends CRM_Core_Form {
         );
 
         // To display relationship type in view membership page
-        $sql = "
+        if (is_array($membershipType['relationship_type_id']) && [] !== $membershipType['relationship_type_id']) {
+          $sql = "
 SELECT relationship_type_id,
   CASE
   WHEN  contact_id_a = {$values['owner_contact_id']} AND contact_id_b = {$values['contact_id']} THEN 'b_a'
@@ -227,20 +228,21 @@ SELECT relationship_type_id,
 END AS 'relType'
   FROM civicrm_relationship
  WHERE relationship_type_id IN (" . implode(',', $membershipType['relationship_type_id']) . ")";
-        $dao = CRM_Core_DAO::executeQuery($sql);
-        $values['relationship'] = NULL;
-        while ($dao->fetch()) {
-          $typeId = $dao->relationship_type_id;
-          $direction = $dao->relType;
-          if ($direction && $typeId) {
-            if ($values['relationship']) {
-              $values['relationship'] .= ',';
+          $dao = CRM_Core_DAO::executeQuery($sql);
+          $values['relationship'] = NULL;
+          while ($dao->fetch()) {
+            $typeId = $dao->relationship_type_id;
+            $direction = $dao->relType;
+            if ($direction && $typeId) {
+              if ($values['relationship']) {
+                $values['relationship'] .= ',';
+              }
+              $values['relationship'] .= CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType',
+                $typeId,
+                "name_$direction",
+                'id'
+              );
             }
-            $values['relationship'] .= CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_RelationshipType',
-              $typeId,
-              "name_$direction",
-              'id'
-            );
           }
         }
       }

--- a/ext/civi_member/settings/Member.setting.php
+++ b/ext/civi_member/settings/Member.setting.php
@@ -51,4 +51,18 @@ return [
     'help_text' => ts('Disable this setting if you do not need to support old-style MembershipPayment records.'),
     'settings_pages' => ['member' => ['weight' => 0]],
   ],
+  'disable_related_membership_logic' => [
+    'group_name' => 'Member Preferences',
+    'group' => 'member',
+    'name' => 'disable_related_membership_logic',
+    'type' => 'Boolean',
+    'html_type' => 'checkbox',
+    'default' => NULL,
+    'add' => '6.13',
+    'title' => ts('Disable related membership logic'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => ts('If set, dissable processing of related memberships of unrelated contacts or contacts related through relationship types not configured in the membership type. Otherwise, those related memberships might get deleted or updated when the parent membership is being updated.'),
+    'settings_pages' => ['member' => ['weight' => 0]],
+  ],
 ];

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -126,6 +126,53 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test to not delete related membership when type of parent membership is changed which does not have relation type
+   * associated with disabled related membership logic setting.
+   */
+  public function testNotDeleteRelatedMembershipsOnParentTypeChanged(): void {
+
+    $contactId = $this->individualCreate();
+    $membershipOrganizationId = $this->organizationCreate();
+    $organizationId = $this->organizationCreate();
+    Civi::settings()->set('disable_related_membership_logic', TRUE);
+
+    // Create relationship between organization and individual contact
+    $this->createTestEntity('Relationship', [
+      // Employer of relationship
+      'relationship_type_id:name' => 'Employee of',
+      'contact_id_a' => $contactId,
+      'contact_id_b' => $organizationId,
+      'is_active' => 1,
+    ]);
+
+    // Create two membership types one with relationship and one without.
+    $membershipTypeWithRelationship = $this->createMembershipType($membershipOrganizationId, TRUE);
+    $membershipTypeWithoutRelationship = $this->createMembershipType($membershipOrganizationId);
+
+    // Creating membership of organisation
+    $membership = $this->createTestEntity('Membership', [
+      'membership_type_id' => $membershipTypeWithRelationship["id"],
+      'contact_id'         => $organizationId,
+      'status_id:name'          => 'test status',
+    ], 'first');
+
+    // Check count of related memberships. It should be one for individual contact.
+    $relatedMembershipsCount = $this->getRelatedMembershipsCount($this->ids['Membership']['first']);
+    $this->assertEquals(1, $relatedMembershipsCount, 'Related membership count should be 1.');
+
+    // Update membership by changing it's type. New membership type is without relationship.
+    $membership["membership_type_id"] = $membershipTypeWithoutRelationship["id"];
+    Membership::update()
+      ->setValues($membership)
+      ->execute();
+
+    // Check count of related memberships again. It should still be one as we changed the membership type, but the
+    // setting for disabling delete logic is on.
+    $relatedMembershipsCount = $this->getRelatedMembershipsCount($membership["id"]);
+    $this->assertEquals(1, $relatedMembershipsCount, 'Related membership count should be 1.');
+  }
+
+  /**
    */
   public function testGetValues(): void {
     //        $this->markTestSkipped( 'causes mysterious exit, needs fixing!' );


### PR DESCRIPTION
Overview
----------------------------------------
*systopia-reference: 33742*

Related memberships (with `owner_membership_id`) can be controlled by relationships of types configured per membership type. When editing a parent membership, related memberships are being updated or deleted, depending on the relationship status. However, deleting related memberships does not check for whether they belong to contacts that are actually related via a relevant relationship. When no matching active relationship exists, all memberships referencing the currently processed parent membership are being deleted.

When using the `owner_membership_id` attribute for derived memberships without the relationship functionality provided by Core, this leads to deleting *all* related memberships whenever a parent membership is being updated.

When using only the core method of deriving memberships using the relationship type configuration option per membership type, nothing should change with this PR.

So this PR just adds an explicit condition that was not considered necessary because of `owner_membership_id` not being used differently.

Before
----------------------------------------
All memberships referencing the updated membership in `owner_membership_id` are being deleted.

After
----------------------------------------
Only related memberships for contacts with a relevant relationship (of a type configured in the membership type) are being deleted.

This is configurable per membership type (new setting *Disable processing related memberships*) if some process relies on cleaning up related memberships as it works currently, so this should be fully backwards-compatible.

Technical Details
----------------------------------------
Can this be made more performant with an `IN(…)` condition instead of looping through relevant contacts?

Comments
----------------------------------------
I couldn't find any hint about `owner_membership_id` being considered to be exclusively used by the relationships configured per membership type. If this is considered debatable, please let me know.