### PR TITLE
API_Wrapper - Fix autoloading

### DIFF
--- a/CRM/Core/ClassLoader.php
+++ b/CRM/Core/ClassLoader.php
@@ -161,6 +161,9 @@ class CRM_Core_ClassLoader {
       // CiviCRM_API3_Exception
       require_once 'api/Exception.php';
     }
+    if ($class === 'API_Wrapper') {
+      require_once 'api/Wrapper.php';
+    }
     if (
       // Only load classes that clearly belong to CiviCRM.
       // Note: api/v3 does not use classes, but api_v3's test-suite does


### PR DESCRIPTION
Overview
----------------------------------------
This addresses (real+potential) class-loading issues for the interface `API_Wrapper`.

It specifically addresses an error mentioned in `dev-mosaico` which appears when scanning a class that implements `API_Wrapper`.

Before
----------------------------------------

`API_Wrapper` must be loaded with explicit `require_once`.

`ClassLoader` doesn't know how to find API_Wrapper.

After
----------------------------------------

`API_Wrapper` can use auto-loader.

@totten @colemanw 