### PR TITLE
Fix report export parameter checks

### DIFF
--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -3700,10 +3700,10 @@ class CRM_Report_Form extends CRM_Core_Form {
       // @todo all http vars should be extracted in the preProcess
       // - not randomly in the class
       if (!$pageId && !empty($_POST)) {
-        if (isset($_POST['PagerBottomButton']) && isset($_POST['crmPID_B'])) {
+        if (isset($_POST['PagerBottomButton'], $_POST['crmPID_B'])) {
           $pageId = max((int) $_POST['crmPID_B'], 1);
         }
-        elseif (isset($_POST['PagerTopButton']) && isset($_POST['crmPID'])) {
+        elseif (isset($_POST['PagerTopButton'], $_POST['crmPID'])) {
           $pageId = max((int) $_POST['crmPID'], 1);
         }
         unset($_POST['crmPID_B'], $_POST['crmPID']);

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -2303,7 +2303,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     $relative, $from, $to, $type = NULL, $fromTime = NULL, $toTime = NULL
   ) {
     $clauses = [];
-    if (array_key_exists($relative, $this->getOperationPair(CRM_Report_Form::OP_DATE))) {
+    if (array_key_exists($relative ?? '', $this->getOperationPair(CRM_Report_Form::OP_DATE))) {
       $sqlOP = $this->getSQLOperator($relative);
       return "( {$fieldName} {$sqlOP} )";
     }
@@ -3039,10 +3039,10 @@ class CRM_Report_Form extends CRM_Core_Form {
     ) {
       $existingParams = $this->_params;
       $this->setParams($this->_formValues);
-      if (!empty($existingParams['task'])) {
+      if (array_key_exists('task', $existingParams)) {
         $this->_params['task'] = $existingParams['task'];
       }
-      if (isset($existingParams['output'])) {
+      if (array_key_exists('output', $existingParams)) {
         $this->_params['output'] = $existingParams['output'];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Pull request for reports export fix discussed here: https://lab.civicrm.org/dev/core/-/issues/6328#note_198003

Before
----------------------------------------
Fix report export for non-admins (undefined "fields" key)
#### Problem
When exporting reports (e.g. CSV) as a non-admin, CiviCRM can trigger PHP notices and broken export, especially for reports that use multiple custom field groups:
Warning: Undefined array key "fields" in CRM/Report/Form.php (in alterCustomDataDisplay())
Warning: foreach() argument must be of type array|object, null given
Admins are unaffected; the issue appears mainly for users without “administer Reports” or “access Report Criteria”.

#### Cause
Missing _params['fields']. Code assumes it exists and attempts to iterate over it.

An existing fallback fills params from the saved report instance (_formValues) when fields is missing. It only runs when empty($this->_params['task']). On Export, the form submits with task = 'report_instance.csv' (or similar), so the fallback was skipped, _params['fields'] stayed empty, and the bug appeared.

After
----------------------------------------
1. Return early when _params['fields'] is missing
2. Run the _formValues fallback whenever _params['fields'] is empty (and _formValues exist), instead of only when 'task' is empty.
3. After applying fallback, restore task and output from the current request, so export still runs correctly.
4. CSV files export successfully for non-admin users.