### PR TITLE
Authenticator - Conditionally ignore "Basic" authentication (Variant B) 

### DIFF
--- a/ext/authx/Civi/Authx/Authenticator.php
+++ b/ext/authx/Civi/Authx/Authenticator.php
@@ -41,7 +41,12 @@ class Authenticator extends AutoService implements HookInterface {
     }
 
     if (!empty($_SERVER['HTTP_AUTHORIZATION']) && !empty(\Civi::settings()->get('authx_header_cred'))) {
-      return $this->auth($e, ['flow' => 'header', 'cred' => $_SERVER['HTTP_AUTHORIZATION'], 'siteKey' => $siteKey]);
+      try {
+        return $this->auth($e, ['flow' => 'header', 'cred' => $_SERVER['HTTP_AUTHORIZATION'], 'siteKey' => $siteKey]);
+      }
+      catch (IgnoreCredentialException $e) {
+        // HTTP `Authorization:` can be dirty. Try other things...
+      }
     }
 
     if (!empty($params['_authx'])) {

--- a/ext/authx/Civi/Authx/IgnoreCredentialException.php
+++ b/ext/authx/Civi/Authx/IgnoreCredentialException.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Authx;
+
+/**
+ * You start evaluating a credential. It's not exactly valid or invalid -- but you realize that
+ * the credential is so nonsensical that we can neither accept it nor reject it.
+ */
+class IgnoreCredentialException extends AuthxException {
+
+}

--- a/ext/authx/Civi/Authx/IgnoreImprovisedFirewall.php
+++ b/ext/authx/Civi/Authx/IgnoreImprovisedFirewall.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Authx;
+
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service authx.ignore_improvised_proxy
+ */
+class IgnoreImprovisedFirewall extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.authx.checkPolicy' => ['onCheckPolicy', -500],
+    ];
+  }
+
+  public function onCheckPolicy(CheckPolicyEvent $event) {
+    if (
+      // The request uses the standard HTTP Authorization header...
+      $event->target->flow === 'header'
+
+      // And the request includes a password...
+      && preg_match('/^(Basic|Digest) /', $event->target->cred)
+
+      // But the system-policy doesn't allow passwords...
+      && !in_array('pass', $event->policy['allowCreds'])
+    ) {
+      // So... this header is probably irrelevant noise...
+      throw new IgnoreCredentialException('Received password via HTTP Authorization, but passwords are not enabled for HTTP Authorization.');
+    }
+  }
+
+}

--- a/ext/authx/authx.php
+++ b/ext/authx/authx.php
@@ -107,13 +107,6 @@ function authx_civicrm_install() {
  */
 function authx_civicrm_enable() {
   _authx_civix_civicrm_enable();
-  // If the system is already using HTTP `Authorization:` headers before installation/re-activation, then
-  // it's probably an extra/independent layer of security.
-  // Only activate support for `Authorization:` if this looks like a clean/amenable environment.
-  // @link https://github.com/civicrm/civicrm-core/pull/22837
-  if (empty($_SERVER['HTTP_AUTHORIZATION']) && NULL === Civi::settings()->getExplicit('authx_header_cred')) {
-    Civi::settings()->set('authx_header_cred', ['jwt', 'api_key']);
-  }
 }
 
 /**

--- a/ext/authx/settings/authx.setting.php
+++ b/ext/authx/settings/authx.setting.php
@@ -101,7 +101,7 @@ $_authx_settings = function() {
   $s['authx_legacyrest_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_legacyrest_user']['default'] = 'require';
   $s['authx_param_cred']['default'] = ['jwt', 'api_key'];
-  $s['authx_header_cred']['default'] = []; /* @see \authx_civicrm_install() */
+  $s['authx_header_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_xheader_cred']['default'] = ['jwt', 'api_key'];
   $s['authx_pipe_cred']['default'] = ['jwt', 'api_key'];
 


### PR DESCRIPTION
Overview
----------------------------------------

Alternative to #34829, #34843. Description: TODO

This variant is more complicated than the others, but it should be better in that:

1. It doesn't hard-code the list of credential-types into the top-level file.
2. It respects the policy hook (`civi.authx.checkPolicy`)
3. It re-enables default support `Authorization: Bearer XYZ` in all configurations.
4. If you synchronize configurations between a production system (with no firewall) and a staging system (with firewall), then you don't need to change the settings.