### PR TITLE
Tasks - Prevent cross-contamination from shared variable

### DIFF
--- a/CRM/Activity/Task.php
+++ b/CRM/Activity/Task.php
@@ -25,6 +25,13 @@ class CRM_Activity_Task extends CRM_Core_Task {
   public static $objectType = 'activity';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts.
    *

--- a/CRM/Campaign/Task.php
+++ b/CRM/Campaign/Task.php
@@ -36,6 +36,13 @@ class CRM_Campaign_Task extends CRM_Core_Task {
   public static $objectType = 'campaign';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a voter / group of voters
    *

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -33,6 +33,13 @@ class CRM_Case_Task extends CRM_Core_Task {
   public static $objectType = 'case';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts
    *

--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -41,6 +41,13 @@ class CRM_Contact_Task extends CRM_Core_Task {
    */
   public static $objectType = 'contact';
 
+  /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
   public static function tasks() {
     if (!self::$_tasks) {
       self::$_tasks = [

--- a/CRM/Contribute/Task.php
+++ b/CRM/Contribute/Task.php
@@ -37,6 +37,13 @@ class CRM_Contribute_Task extends CRM_Core_Task {
   public static $objectType = 'contribution';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts
    *

--- a/CRM/Core/Task.php
+++ b/CRM/Core/Task.php
@@ -45,6 +45,8 @@ abstract class CRM_Core_Task {
   /**
    * The task array
    *
+   * Should be overridden by child classes so they don't interfere with each other.
+   *
    * @var array
    */
   public static $_tasks = [];
@@ -66,10 +68,10 @@ abstract class CRM_Core_Task {
    *            ]
    */
   public static function tasks() {
-    CRM_Utils_Hook::searchTasks(static::$objectType, self::$_tasks);
-    asort(self::$_tasks);
+    CRM_Utils_Hook::searchTasks(static::$objectType, static::$_tasks);
+    asort(static::$_tasks);
 
-    return self::$_tasks;
+    return static::$_tasks;
   }
 
   /**
@@ -83,7 +85,7 @@ abstract class CRM_Core_Task {
     static::tasks();
 
     $titles = [];
-    foreach (self::$_tasks as $id => $value) {
+    foreach (static::$_tasks as $id => $value) {
       $titles[$id] = $value['title'];
     }
 
@@ -133,7 +135,7 @@ abstract class CRM_Core_Task {
   public static function corePermissionedTaskTitles($tasks, $permission, $params) {
     // Only offer the "Update Smart Group" task if a smart group/saved search is already in play and we have edit permissions
     if (!empty($params['ssID']) && ($permission == CRM_Core_Permission::EDIT) && CRM_Core_Permission::check('edit groups')) {
-      $tasks[self::SAVE_SEARCH_UPDATE] = self::$_tasks[self::SAVE_SEARCH_UPDATE]['title'];
+      $tasks[self::SAVE_SEARCH_UPDATE] = static::$_tasks[self::SAVE_SEARCH_UPDATE]['title'];
     }
     else {
       unset($tasks[self::SAVE_SEARCH_UPDATE]);
@@ -155,13 +157,13 @@ abstract class CRM_Core_Task {
   public static function getTask($value) {
     static::tasks();
 
-    if (empty(self::$_tasks[$value])) {
+    if (empty(static::$_tasks[$value])) {
       // Children can specify a default task (eg. print), pick another if it is not valid.
-      $value = key(self::$_tasks);
+      $value = key(static::$_tasks);
     }
     return [
-      self::$_tasks[$value]['class'] ?? NULL,
-      self::$_tasks[$value]['result'] ?? NULL,
+      static::$_tasks[$value]['class'] ?? NULL,
+      static::$_tasks[$value]['result'] ?? NULL,
     ];
   }
 
@@ -220,7 +222,7 @@ abstract class CRM_Core_Task {
   public static function getTaskAndTitleByClass($className) {
     static::tasks();
 
-    foreach (self::$_tasks as $task => $value) {
+    foreach (static::$_tasks as $task => $value) {
       if ((!empty($value['url']) || $task == self::TASK_EXPORT)
           && ((is_array($value['class']) && in_array($className, $value['class']))
           || ($value['class'] == $className))) {

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -34,6 +34,13 @@ class CRM_Event_Task extends CRM_Core_Task {
   public static $objectType = 'event';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts
    *

--- a/CRM/Mailing/Task.php
+++ b/CRM/Mailing/Task.php
@@ -25,6 +25,13 @@ class CRM_Mailing_Task extends CRM_Core_Task {
   public static $objectType = 'mailing';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts.
    *

--- a/CRM/Member/Task.php
+++ b/CRM/Member/Task.php
@@ -33,6 +33,13 @@ class CRM_Member_Task extends CRM_Core_Task {
   public static $objectType = 'membership';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts
    *

--- a/CRM/Pledge/Task.php
+++ b/CRM/Pledge/Task.php
@@ -23,6 +23,13 @@ class CRM_Pledge_Task extends CRM_Core_Task {
   public static $objectType = 'pledge';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts
    *

--- a/ext/civigrant/CRM/Grant/Task.php
+++ b/ext/civigrant/CRM/Grant/Task.php
@@ -33,6 +33,13 @@ class CRM_Grant_Task extends CRM_Core_Task {
   public static $objectType = 'grant';
 
   /**
+   * Tasks for this class – overridden from parent to avoid cross-contamination with sibling classes.
+   *
+   * @var array
+   */
+  public static $_tasks = [];
+
+  /**
    * These tasks are the core set of tasks that the user can perform
    * on a contact / group of contacts
    *

--- a/tests/phpunit/CRM/Core/TaskTest.php
+++ b/tests/phpunit/CRM/Core/TaskTest.php
@@ -1,0 +1,98 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @group headless
+ */
+class CRM_Core_TaskTest extends CiviUnitTestCase {
+
+  public function testTask() {
+    CRM_Core_BAO_ConfigSetting::enableAllComponents();
+
+    $taskClasses = [
+      'CRM_Activity_Task',
+      'CRM_Campaign_Task',
+      'CRM_Case_Task',
+      'CRM_Contact_Task',
+      'CRM_Contribute_Task',
+      'CRM_Event_Task',
+      'CRM_Mailing_Task',
+      'CRM_Member_Task',
+      'CRM_Pledge_Task',
+    ];
+
+    // Call all of them to ensure they don't interfere with each other.
+    foreach ($taskClasses as $className) {
+      $tasks = $className::tasks();
+      $this->assertIsArray($tasks, "$className::tasks() should return an array");
+      $this->assertNotEmpty($tasks, "$className::tasks() should not be empty");
+    }
+
+    // Pick one example task from each class and assert something stable about it.
+    // (For some classes we assert a specific known entry; for others we assert the "Print" task shape/pattern.)
+    $examples = [
+      'CRM_Activity_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Activity_Task::TASK_SMS, $tasks);
+        $this->assertEquals('CRM_Activity_Form_Task_FileOnCase', $tasks[CRM_Activity_Task::TASK_SMS]['class']);
+      },
+
+      'CRM_Contact_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Contact_Task::GROUP_ADD, $tasks);
+        $this->assertEquals('CRM_Contact_Form_Task_AddToGroup', $tasks[CRM_Contact_Task::GROUP_ADD]['class']);
+      },
+
+      'CRM_Contribute_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Contribute_Task::TASK_EXPORT, $tasks);
+        $this->assertIsArray($tasks[CRM_Contribute_Task::TASK_EXPORT]['class']);
+        $this->assertEquals('CRM_Contribute_Export_Form_Select', $tasks[CRM_Contribute_Task::TASK_EXPORT]['class'][0]);
+      },
+
+      'CRM_Event_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Event_Task::CANCEL_REGISTRATION, $tasks);
+        $this->assertEquals('CRM_Event_Form_Task_Cancel', $tasks[CRM_Event_Task::CANCEL_REGISTRATION]['class']);
+      },
+
+      // For these, assert the shared "Print selected rows" task exists and looks like the expected Print form.
+      'CRM_Campaign_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Campaign_Task::TASK_PRINT, $tasks);
+        $this->assertIsString($tasks[CRM_Campaign_Task::TASK_PRINT]['class']);
+        $this->assertStringContainsString('_Form_Task_Print', $tasks[CRM_Campaign_Task::TASK_PRINT]['class']);
+      },
+      'CRM_Case_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Case_Task::TASK_PRINT, $tasks);
+        $this->assertIsString($tasks[CRM_Case_Task::TASK_PRINT]['class']);
+        $this->assertStringContainsString('_Form_Task_Print', $tasks[CRM_Case_Task::TASK_PRINT]['class']);
+      },
+      'CRM_Mailing_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Mailing_Task::TASK_PRINT, $tasks);
+        $this->assertIsString($tasks[CRM_Mailing_Task::TASK_PRINT]['class']);
+        $this->assertStringContainsString('_Form_Task_Print', $tasks[CRM_Mailing_Task::TASK_PRINT]['class']);
+      },
+      'CRM_Member_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Member_Task::TASK_PRINT, $tasks);
+        $this->assertIsString($tasks[CRM_Member_Task::TASK_PRINT]['class']);
+        $this->assertStringContainsString('_Form_Task_Print', $tasks[CRM_Member_Task::TASK_PRINT]['class']);
+      },
+      'CRM_Pledge_Task' => function(array $tasks): void {
+        $this->assertArrayHasKey(CRM_Pledge_Task::TASK_PRINT, $tasks);
+        $this->assertIsString($tasks[CRM_Pledge_Task::TASK_PRINT]['class']);
+        $this->assertStringContainsString('_Form_Task_Print', $tasks[CRM_Pledge_Task::TASK_PRINT]['class']);
+      },
+    ];
+
+    foreach ($examples as $className => $assertion) {
+      $tasks = $className::tasks();
+      $assertion($tasks);
+    }
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fix incorrect tasks sometimes being returned by SearchKit.

Fixes test failure in https://github.com/civicrm/civicrm-core/pull/34774

Technical Details
----------------------------------------
Isolate task definitions in each class to prevent them clobbering each other and add unit test for task consistency across classes.