### PR TITLE
Fix sending of contribution receipts to prioritise line items when looking for related entities

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -17,6 +17,7 @@ use Civi\Api4\ContributionRecur;
 use Civi\Api4\EntityFinancialTrxn;
 use Civi\Api4\LineItem;
 use Civi\Api4\ContributionSoft;
+use Civi\Api4\Participant;
 use Civi\Api4\PaymentProcessor;
 use Civi\Core\Event\PreEvent;
 use Civi\Core\Event\PostEvent;
@@ -1745,13 +1746,14 @@ LEFT JOIN  civicrm_contribution contribution ON ( componentPayment.contribution_
   /**
    * Returns all contribution related object ids.
    *
-   * @deprecated since 6.2 will be removed when core callers fully removed.
+   * @deprecated since 6.2 will be around 6.20.
    *
    * @param $contributionId
    *
    * @return array
    */
   public static function getComponentDetails($contributionId) {
+    CRM_Core_Error::deprecatedFunctionWarning('api4');
     $componentDetails = $pledgePayment = [];
     if (!$contributionId) {
       return $componentDetails;
@@ -2086,8 +2088,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   - is_recur - should this be treated as recurring (not sure why you
    *   wouldn't just check presence of recur object but maintaining legacy
    *   approach to be careful)
-   * @param array $ids
-   *   IDs of related objects.
    * @param array $values
    *   Any values that may have already been compiled by calling process.
    *   This is augmented by values 'gathered' by gatherMessageValues
@@ -2100,8 +2100,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    *   messages
    * @throws \CRM_Core_Exception
    */
-  public function composeMessageArray($input, $ids, $values = [], $returnMessageText = TRUE) {
-    $ids = array_merge(self::getComponentDetails($this->id), $ids);
+  public function composeMessageArray($input, $values = [], $returnMessageText = TRUE) {
     $contributionID = (int) $this->id;
 
     $contribution = Contribution::get(FALSE)
@@ -2109,9 +2108,49 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       ->addSelect('*', 'contribution_recur_id.payment_processor_id')
       ->execute()->single();
     $contactID = $contribution['contact_id'];
+    $eventID = NULL;
+    $participantID = NULL;
+    $membershipIDs = [];
+    $lineItems = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->addWhere('entity_table', '!=', 'civicrm_contribution')
+      ->execute();
+    foreach ($lineItems as $lineItem) {
+      if ($lineItem['entity_table'] === 'civicrm_participant') {
+        $participant = Participant::get(FALSE)
+          ->addWhere('id', '=', $lineItem['entity_id'])
+          ->addSelect('registered_by_id')->execute()->first();
+        $participantID = $participant['registered_by_id'] ?: $participant['id'];
+      }
+      if ($lineItem['entity_table'] === 'civicrm_membership') {
+        $membershipIDs[] = $lineItem['entity_id'];
+      }
+    }
+    // The intent is to only do this extra look up if the proposed setting permits.
+    if (empty($membershipIDs)) {
+      $membershipPayments = civicrm_api3('MembershipPayment', 'get', ['contribution_id' => $contributionID])['values'];
+      foreach ($membershipPayments as $payment) {
+        \Civi::log('data_integrity', 'Line item linkage missing for membership ' . $payment['membership_id'] . ' and contribution ' . $contributionID);
+        $membershipIDs[] = $payment['membership_id'];
+      }
+    }
 
-    if (!empty($ids['event'])) {
+    if (!$participantID) {
+      $participantPayments = civicrm_api3('ParticipantPayment', 'get', ['contribution_id' => $contributionID])['values'];
+      foreach ($participantPayments as $payment) {
+        $participant = Participant::get(FALSE)
+          ->addWhere('id', '=', $lineItem['entity_id'])
+          ->addSelect('registered_by_id')->execute()->first();
+        $participantID = $participant['registered_by_id'] ?: $participant['id'];
+        \Civi::log('data_integrity', 'Line item linkage missing for participant ' . $payment['participant_id'] . ' and contribution ' . $contributionID);
+      }
+    }
+
+    if ($participantID) {
       $this->_component = 'event';
+      $eventID = Participant::get(FALSE)
+        ->addWhere('id', '=', $participantID)
+        ->execute()->first()['event_id'];
     }
     else {
       $this->_component = 'contribute';
@@ -2125,47 +2164,22 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
 
     $paymentProcessorID = $input['payment_processor_id'] ?? $contribution['contribution_recur_id.payment_processor_id'];
 
-    // These are probably no longer accessed from anywhere
-    $query = "
-      SELECT membership_id
-      FROM   civicrm_membership_payment
-      WHERE  contribution_id = %1 ";
-    $params = [1 => [$this->id, 'Integer']];
-    $ids['membership'] = (array) ($ids['membership'] ?? []);
-
-    $dao = CRM_Core_DAO::executeQuery($query, $params);
-    while ($dao->fetch()) {
-      if ($dao->membership_id && !in_array($dao->membership_id, $ids['membership'])) {
-        $ids['membership'][$dao->membership_id] = $dao->membership_id;
-      }
-    }
-
-    if (array_key_exists('membership', $ids) && is_array($ids['membership'])) {
-      foreach ($ids['membership'] as $id) {
-        if (!empty($id)) {
-          $membership = new CRM_Member_BAO_Membership();
-          $membership->id = $id;
-          if (!$membership->find(TRUE)) {
-            throw new Exception("Could not find membership record: $id");
-          }
-          $membership->join_date = CRM_Utils_Date::isoToMysql($membership->join_date);
-          $membership->start_date = CRM_Utils_Date::isoToMysql($membership->start_date);
-          $membership->end_date = CRM_Utils_Date::isoToMysql($membership->end_date);
-          $this->_relatedObjects['membership'][$membership->id . '_' . $membership->membership_type_id] = $membership;
-
+    foreach ($membershipIDs as $id) {
+      if (!empty($id)) {
+        $membership = new CRM_Member_BAO_Membership();
+        $membership->id = $id;
+        if (!$membership->find(TRUE)) {
+          throw new Exception("Could not find membership record: $id");
         }
+        $membership->join_date = CRM_Utils_Date::isoToMysql($membership->join_date);
+        $membership->start_date = CRM_Utils_Date::isoToMysql($membership->start_date);
+        $membership->end_date = CRM_Utils_Date::isoToMysql($membership->end_date);
+        $this->_relatedObjects['membership'][$membership->id . '_' . $membership->membership_type_id] = $membership;
+
       }
     }
 
-    $eventID = isset($ids['event']) ? (int) $ids['event'] : NULL;
-    $participantID = isset($ids['participant']) ? (int) $ids['participant'] : NULL;
-    // not sure whether it is possible for this not to be an array - load related contacts loads an array but this code was expecting a string
-    // the addition of the casting is in case it could get here & be a string. Added in 4.6 - maybe remove later? This AuthorizeNetIPN & PaypalIPN tests hit this
-    // line having loaded an array
-    $membershipIDs = !empty($ids['membership']) ? (array) $ids['membership'] : NULL;
-    unset($ids);
-
-    if ($eventID) {
+    if ($participantID) {
       $participant = new CRM_Event_BAO_Participant();
       $participant->id = $participantID;
       if ($participantID &&
@@ -2212,7 +2226,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       $template->assign('updateSubscriptionUrl', $paymentObject->subscriptionURL($entityID, $entity, 'update'));
     }
 
-    if ($eventID) {
+    if ($participantID) {
       $eventParams = ['id' => $eventID];
       $values['event'] = [];
 
@@ -3083,7 +3097,7 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       [$values['receipt_from_name'], $values['receipt_from_email']] = self::generateFromEmailAndName($input, $contribution);
     }
     $values['contribution_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
-    $return = $contribution->composeMessageArray($input, $ids, $values, $returnMessageText);
+    $return = $contribution->composeMessageArray($input, $values, $returnMessageText);
     if ((!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {
       civicrm_api3('Contribution', 'create', [
         'receipt_date' => 'now',

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -180,21 +180,13 @@ AND    {$this->_componentClause}";
 
     unset($elements);
     foreach ($elementDetails as $contribID => $detail) {
-      $input = $ids = [];
+      $input = [];
 
       if (in_array($detail['contact'], $excludedContactIDs)) {
         continue;
       }
       // @todo - CRM_Contribute_BAO_Contribution::sendMail re-does pretty much everything between here & when we call it.
       $input['component'] = $detail['component'];
-
-      $ids['contact'] = $detail['contact'];
-      $ids['contribution'] = $contribID;
-      $ids['contributionRecur'] = NULL;
-      $ids['contributionPage'] = NULL;
-      $ids['membership'] = $detail['membership'] ?? NULL;
-      $ids['participant'] = $detail['participant'] ?? NULL;
-      $ids['event'] = $detail['event'] ?? NULL;
 
       $contribution = new CRM_Contribute_BAO_Contribution();
       $contribution->id = $contribID;
@@ -232,7 +224,7 @@ AND    {$this->_componentClause}";
         $input['receipt_from_name'] = str_replace('"', '', $fromDetails[0]);
       }
 
-      $mail = CRM_Contribute_BAO_Contribution::sendMail($input, $ids, $contribID, $isCreatePDF);
+      $mail = CRM_Contribute_BAO_Contribution::sendMail($input, [], $contribID, $isCreatePDF);
 
       if (!empty($mail['html'])) {
         $message[] = $mail['html'];

--- a/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/BaseIPNTest.php
@@ -99,7 +99,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids);
+    $msg = $contribution->composeMessageArray($this->input);
     $this->assertIsArray($msg, 'Message returned as an array in line');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('General', $msg['html']);
@@ -116,7 +116,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids);
+    $msg = $contribution->composeMessageArray($this->input);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('General', $msg['html']);
 
@@ -129,7 +129,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->input['invoiceID'] = 'abc';
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids);
+    $msg = $contribution->composeMessageArray($this->input);
     $this->assertEquals('Dr. Donald Duck II', $msg['to']);
     $this->assertStringContainsString('Fowl', $msg['html']);
   }
@@ -143,7 +143,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpMembershipObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids);
+    $msg = $contribution->composeMessageArray($this->input);
     $this->assertIsArray($msg, 'Message not returned as an array');
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('General', $msg['html']);
@@ -156,7 +156,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->setUpParticipantObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids);
+    $msg = $contribution->composeMessageArray($this->input);
     $this->assertEquals('Mr. Anthony Anderson II', $msg['to']);
     $this->assertStringContainsString('Thank you for your registration', $msg['html']);
   }
@@ -196,7 +196,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $mut = new CiviMailUtils($this, TRUE);
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $contribution->composeMessageArray($this->input, $this->ids);
+    $contribution->composeMessageArray($this->input);
     $mut->assertMailLogEmpty('no mail should have been send as event set to no confirm');
     $mut->stop();
   }
@@ -210,7 +210,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $this->_setUpPledgeObjects();
     $contribution = new CRM_Contribute_BAO_Contribution();
     $contribution->id = $this->_contributionId;
-    $msg = $contribution->composeMessageArray($this->input, $this->ids);
+    $msg = $contribution->composeMessageArray($this->input);
     $this->assertStringContainsString('Contribution Information', $msg['html']);
   }
 
@@ -285,7 +285,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
     $contribution->id = $this->_contributionId;
     $contribution->find(TRUE);
     $this->objects = ['contribution' => $contribution];
-    $this->ids['membership'] = (int) $order['values'][$order['id']]['line_item'][0]['entity_id'];
+    $this->ids['Membership']['id'] = (int) $order['values'][$order['id']]['line_item'][0]['entity_id'];
 
     $this->input = [
       'component' => 'contribute',
@@ -293,7 +293,7 @@ class CRM_Core_Payment_BaseIPNTest extends CiviUnitTestCase {
       'invoiceID' => 'c8acb91e080ad7bd8a2adc119c192885',
       'contactID' => $this->_contactId,
       'contributionID' => $this->_contributionId,
-      'membershipID' => $this->ids['membership'],
+      'membershipID' => $this->ids['Membership']['id'],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix sending of contribution receipts to prioritise line items when looking for related entities

Before
----------------------------------------
The way related entities are loaded in this function has long been mysterious - in part because this code has a lot of history & we have moved more & more work away from this function. If membership_payments are missing the function does not load from line items - even though line items should be the primary source & membership payments on their way out

After
----------------------------------------
Loads from line items by preference. There is a fall back to membership payment which will be able to be disabled using this setting - https://github.com/civicrm/civicrm-core/pull/34470 (less look ups)

It will log where there is a data issue. This is most wonky, least intrusive form of alerting about these - someone would need to be looking at log output to notice - and that sort of person would hopefully have the skills to resolve. In addition logging when they happen at this point means that it is most likely to get logged in NEW ones are being created - which is perhaps a bit more concerning than the legacy ones.

Technical Details
----------------------------------------

Comments
----------------------------------------
