### PR TITLE
`Afform\Utils::getEntityWeights` dont crash for non array key type values

### DIFF
--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -37,12 +37,13 @@ class Utils {
   public static function getEntityWeights($formEntities, $entityValues) {
     $sorter = new \MJS\TopSort\Implementations\FixedArraySort();
 
+    $formEntityNames = array_keys($formEntities);
     foreach ($formEntities as $entityName => $entity) {
       $references = [];
       foreach ($entityValues[$entityName] as $record) {
         foreach ($record['fields'] as $fieldName => $fieldValue) {
           foreach ((array) $fieldValue as $value) {
-            if (!is_bool($value) && array_key_exists($value, $formEntities) && $value !== $entityName) {
+            if (in_array($value, $formEntityNames, TRUE) && $value !== $entityName) {
               $references[$value] = $value;
             }
           }


### PR DESCRIPTION
Before
----------------------------------------
- crashes if any `value` is an array on PHP 8.0+
- throws a deprecation warning if `value` is null on PHP 8.5+

After
----------------------------------------
- doesn't crash

Technical Details
----------------------------------------
Fairly sure `array_key_exists($a, $b)` is equivalent to `in_array($a, array_keys($b), TRUE)`, but without the crashing if `$a` is a type that can't be an array key.

I don't understand why the `!is_bool($value)` is there. Given the array keys of `$formEntities` are all strings, it seems redundant?
