### PR TITLE
allow public access to StateProvince.get

### DIFF
--- a/Civi/Api4/StateProvince.php
+++ b/Civi/Api4/StateProvince.php
@@ -19,4 +19,13 @@ namespace Civi\Api4;
  */
 class StateProvince extends Generic\DAOEntity {
 
+  public static function permissions(): array {
+    $permissions = parent::permissions();
+
+    // there's nothing secret about the list of StateProvinces
+    $permissions['get'] = ['*always allow*'];
+
+    return $permissions;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Api4 version of existing endpoint `civicrm/ajax/jqState`.

Before
----------------------------------------
- `civicrm/ajax/jqState` provides StateProvince records for QuickForm chain selects
- the same data is available through Api4, but it is restricted by `access CiviCRM` permission

After
----------------------------------------
- `get`ting the same data through Api4 is publicly accessible

Comments
----------------------------------------
It's much nicer for new things not to build on the old endpoint, and to be able to fetch with `CRM.api4` and `crmApi4` with sane parameters.

This is helpful in AfformPayments https://lab.civicrm.org/extensions/afform_payments/-/merge_requests/13
