### PR TITLE
dev/core#6347 Status Page: Fix link to filter scheduled jobs

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -785,7 +785,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         'options' => ['sort' => "id desc", 'limit' => 1],
       ])['values'][0]['description'] ?? NULL;
       if (!empty($lastExecutionMessage) && str_contains($lastExecutionMessage, 'Failure')) {
-        $viewLogURL = CRM_Utils_System::url('civicrm/admin/joblog', "jid={$job['id']}&reset=1");
+        $viewLogURL = CRM_Utils_System::url("civicrm/admin/joblog#?job_id={$job['id']}");
         $html .= '<tr>
           <td>' . $job['name'] . ' </td>
           <td>' . $lastExecutionMessage . '</td>


### PR DESCRIPTION
Issue
---
See dev/core#6347
On the CiviCRM System Status page (civicrm/a#/status), the link "View Job Log" doesn't properly filter the job log by the failing job id.

Before
---
The link would display all the scheduled jobs (no filter applied).

After
---
The link filters properly.

Comments
---
Fixes https://lab.civicrm.org/dev/core/-/issues/6347
Modeled on PR #27628