### PR TITLE
Failed 🔬🧪  Angular service for on-demand loading modules

### DIFF
--- a/CRM/Core/Page.php
+++ b/CRM/Core/Page.php
@@ -470,7 +470,7 @@ class CRM_Core_Page {
    * For ajax-loaded pages, this returns scripts, styles and settings as structured data
    * rather than as markup. Those resources are handled clientside by civi.crmSnippet.refresh().
    */
-  private function addAjaxResources() {
+  protected function addAjaxResources() {
     $ajaxRegion = CRM_Core_Region::instance('ajax-snippet');
     // Ensure all resources are added to the region before processing it
     $ajaxRegion->getFinalItems();

--- a/js/angular-crmResource/all.js
+++ b/js/angular-crmResource/all.js
@@ -66,6 +66,69 @@
     };
   });
 
+  const modulesPending = {};
+  angular.module('crmResource').factory('crmResourceLoader', function ($q) {
+    return {
+      // Load Angular modules dynamically
+      loadModules: function (moduleNames) {
+        // Filter out modules that are already loaded.
+        const loadedModules = CRM.angular.modules || [];
+        const modulesToLoad = moduleNames.filter(name => !loadedModules.includes(name));
+
+        // Early return if all modules are already loaded.
+        if (modulesToLoad.length === 0) {
+          return $q.resolve();
+        }
+
+        // Collect promises for modules that are already pending
+        const pendingPromises = [];
+        const newModulesToLoad = [];
+
+        modulesToLoad.forEach(name => {
+          if (modulesPending[name]) {
+            pendingPromises.push(modulesPending[name]);
+          } else {
+            newModulesToLoad.push(name);
+          }
+        });
+
+        // If all requested modules are pending, return combined promise
+        if (newModulesToLoad.length === 0) {
+          return $q.all(pendingPromises);
+        }
+
+        // Create a new promise for the modules being loaded
+        const deferred = $q.defer();
+
+        // Track all new modules with the same promise
+        newModulesToLoad.forEach(name => {
+          modulesPending[name] = deferred.promise;
+        });
+
+        const snippet = $('<div></div>');
+        const settings = {
+          url: CRM.url('civicrm/ajax/angular-modules', {modules: newModulesToLoad.join(',')}),
+        };
+
+        $(snippet).crmSnippet(settings)
+          .on('crmLoad', function () {
+            // Clean up pending tracking and resolve
+            newModulesToLoad.forEach(name => delete modulesPending[name]);
+            deferred.resolve();
+          })
+          .on('crmLoadFail', function () {
+            // Clean up pending tracking and reject
+            newModulesToLoad.forEach(name => delete modulesPending[name]);
+            deferred.reject();
+          })
+          .crmSnippet('refresh');
+
+        // Return combined promise of new and pending modules
+        return $q.all([deferred.promise, ...pendingPromises]);
+      }
+    };
+  });
+
   angular.module('crmResource').config(function($provide) {
     $provide.decorator('$templateCache', function($delegate, $http, $q, crmResource) {
       var origGet = $delegate.get;


### PR DESCRIPTION
Overview
----------------------------------------
Just thought I'd leave this here for posterity. Is it possible to lazy-load AngularJS modules on-demand? The short answer is "no".

The use-case was subsearches. Where e.g. we have a `crm-search-display-table` with a subsearch of a different type, say `crm-search-display-list` embedded in it. If `crmSearchDisplayList` module wasn't present at page-load, this code would helpfully load it for us.

It doesn't work.

In some circumstances, it is possible to lazy-load modules. In fact we already do it when we popup a new Afform. The Afform itself is a new AgularJS module that wasn't necessarily present when the page first loaded. This PR was piggybacking on that mechanism.

But the reason the popup scenario works and this one doesn't is because we bootstrap a new instance of Angular within the popup, and it initializes its compiler with all available modules (including the one we just loaded). However, any existing `<crm-angular-js>` blocks on the page with Angular *already bootstrapped* will not get the new module, because their compiler has already set up its injector with the old list of modules.

And there's not much to be done about that without ripping into the guts of AngularJS's `$compiler/injector`. Not worth it IMO.