### PR TITLE
SearchKit - Allow subsearch of different types

### DIFF
--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformGetTest.php
@@ -128,10 +128,20 @@ HTML;
   }
 
   public function testGetSearchDisplays() {
+    $exampleLayout = <<<AFFORM
+<div>
+  <crm-search-display-grid search-name="foo" display-name="foo-bar" />
+  <div>
+    <crm-search-display type="list"  search-name="genericTag" />
+  </div>
+</div>
+< crm-search-display-table search-name='foo' display-name = 'bar-food' >
+AFFORM;
+
     Afform::create()
       ->addValue('name', $this->formName)
       ->addValue('title', 'Test Form')
-      ->addValue('layout', '<div><crm-search-display-grid search-name="foo" display-name="foo-bar" /></div>< crm-search-display-table search-name=\'foo\' display-name = \'bar-food\' >')
+      ->addValue('layout', $exampleLayout)
       ->setLayoutFormat('html')
       ->execute();
 
@@ -141,7 +151,7 @@ HTML;
       ->addWhere('search_displays', 'CONTAINS', 'foo.foo-bar')
       ->execute()->single();
 
-    $this->assertEquals(['foo.foo-bar', 'foo.bar-food'], $result['search_displays']);
+    $this->assertEquals(['foo.foo-bar', 'genericTag', 'foo.bar-food'], $result['search_displays']);
   }
 
   public function testGetLayoutWithLegacyContactTypeConversion() {

--- a/ext/chart_kit/ang/crmChartKit.ang.php
+++ b/ext/chart_kit/ang/crmChartKit.ang.php
@@ -18,7 +18,7 @@ return [
     'ui.bootstrap',
     'crmSearchDisplay',
   ],
-  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
+  'basePages' => [],
   'bundles' => ['bootstrap3', 'chart_kit'],
   'exports' => [
     'crm-search-display-chart-kit' => 'E',

--- a/ext/civi_campaign/ang/afsearchCampaignDashboard.aff.html
+++ b/ext/civi_campaign/ang/afsearchCampaignDashboard.aff.html
@@ -6,7 +6,7 @@
         <af-field name="campaign_type_id" defn="{input_attrs: {multiple: true, placeholder: 'Filter by type'}, label: false}" />
         <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: 'Filter by status'}, label: false}" />
       </fieldset>
-      <crm-search-display-table search-name="Administer_Campaigns" display-name="Campaigns_Table" total-count="$parent.count"></crm-search-display-table>
+      <crm-search-display search-name="Administer_Campaigns" display-name="Campaigns_Table" total-count="$parent.count"></crm-search-display>
     </div>
   </af-tab>
   <af-tab title="Surveys">

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1781,7 +1781,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         }
         $displays = \CRM_Utils_Array::findAll(
           $fieldset,
-          ['#tag' => $this->display['type:name'], 'search-name' => $this->savedSearch['name'], 'display-name' => $this->display['name']]
+          ['search-name' => $this->savedSearch['name'], 'display-name' => $this->display['name']]
         );
         if (!$displays) {
           continue;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -265,15 +265,14 @@ class Run extends AbstractRunAction {
       $displayName = $col['subsearch']['display'] ?? NULL;
       if ($searchName && $displayName) {
         $searchDisplay = SearchDisplay::get(FALSE)
-          ->addSelect('settings', 'saved_search_id.api_entity')
+          ->addSelect('settings', 'saved_search_id.api_entity', 'type')
           ->addWhere('name', '=', $displayName)
           ->addWhere('saved_search_id.name', '=', $searchName)
           ->execute()->first();
         if ($searchDisplay) {
           $result->subsearch ??= [];
           $result->subsearch["{$searchName}.{$displayName}"] = [
-            // Passing 'type' to support non-table displays might be nice but would add complexity
-            // 'type' => $searchDisplay['type:name'],
+            'type' => $searchDisplay['type'],
             'api_entity' => $searchDisplay['saved_search_id.api_entity'],
             'settings' => $searchDisplay['settings'],
           ];

--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -28,51 +28,57 @@ class AfformSearchMetadataInjector {
   public static function preprocess($e) {
     $changeSet = \Civi\Angular\ChangeSet::create('searchSettings')
       ->alterHtml(';\\.aff\\.html$;', function($doc, $path) {
+        // Display-type-specific tags e.g. `crm-search-display-table`
         $displayTags = array_column(\Civi\Search\Display::getDisplayTypes(['name']), 'name');
+        // Include generic tag
+        $displayTags[] = 'crm-search-display';
 
-        if ($displayTags) {
-          foreach (pq(implode(',', $displayTags), $doc) as $component) {
-            $searchName = pq($component)->attr('search-name');
-            $displayName = pq($component)->attr('display-name');
-            if ($searchName) {
-              // Fetch search display if name is provided
-              if (is_string($displayName) && strlen($displayName)) {
-                $searchDisplayGet = \Civi\Api4\SearchDisplay::get(FALSE)
-                  ->addWhere('name', '=', $displayName)
-                  ->addWhere('saved_search_id.name', '=', $searchName);
-              }
-              // Fall-back to the default display
-              else {
-                $displayName = NULL;
-                $searchDisplayGet = \Civi\Api4\SearchDisplay::getDefault(FALSE)
-                  ->setSavedSearch($searchName);
-              }
-              try {
-                $display = $searchDisplayGet
-                  ->addSelect('settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
-                  ->execute()->single();
-                $savedSearch = \CRM_Utils_Array::filterByPrefix($display, 'saved_search_id.');
-              }
-              catch (\CRM_Core_Exception $e) {
-                return;
-              }
-              // Note: Should be kept in-sync with \Civi\Api4\Action\SearchDisplay\GetMarkup::doTask
-              pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
-              pq($component)->attr('api-entity', htmlspecialchars($savedSearch['api_entity'], ENT_COMPAT));
-              pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT));
-              pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName), ENT_COMPAT));
+        foreach (pq(implode(',', $displayTags), $doc) as $component) {
+          $searchName = pq($component)->attr('search-name');
+          $displayName = pq($component)->attr('display-name');
+          if ($searchName) {
+            // Fetch search display if name is provided
+            if (is_string($displayName) && strlen($displayName)) {
+              $searchDisplayGet = \Civi\Api4\SearchDisplay::get(FALSE)
+                ->addWhere('name', '=', $displayName)
+                ->addWhere('saved_search_id.name', '=', $searchName);
+            }
+            // Fall-back to the default display
+            else {
+              $displayName = NULL;
+              $searchDisplayGet = \Civi\Api4\SearchDisplay::getDefault(FALSE)
+                ->setSavedSearch($searchName);
+            }
+            try {
+              $display = $searchDisplayGet
+                ->addSelect('type', 'settings', 'saved_search_id.api_entity', 'saved_search_id.api_params')
+                ->execute()->single();
+              $savedSearch = \CRM_Utils_Array::filterByPrefix($display, 'saved_search_id.');
+            }
+            catch (\CRM_Core_Exception $e) {
+              return;
+            }
+            // Note: Should be kept in-sync with \Civi\Api4\Action\SearchDisplay\GetMarkup::doTask
+            pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
+            pq($component)->attr('api-entity', htmlspecialchars($savedSearch['api_entity'], ENT_COMPAT));
+            pq($component)->attr('search', htmlspecialchars(\CRM_Utils_JS::encode($searchName), ENT_COMPAT));
+            pq($component)->attr('display', htmlspecialchars(\CRM_Utils_JS::encode($displayName), ENT_COMPAT));
 
-              // Add entity names to the fieldset so that afform can populate field metadata
-              $fieldset = pq($component)->parents('[af-fieldset]');
-              if ($fieldset->length) {
-                $entityList = FormDataModel::getSearchEntities($savedSearch);
-                $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList), ENT_COMPAT));
-                // Add field metadata for aggregate fields because they are not in the schema.
-                // Normal entity fields will be handled by AfformMetadataInjector
-                foreach (Meta::getCalcFields($savedSearch['api_entity'], $savedSearch['api_params']) as $fieldInfo) {
-                  foreach (pq("af-field[name='{$fieldInfo['name']}']", $doc) as $afField) {
-                    \Civi\Afform\AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
-                  }
+            // Add `type` if not included with a generic tag
+            if (pq($component)->is('crm-search-display') && pq($component)->attr('type') === NULL) {
+              pq($component)->attr('type', htmlspecialchars($display['type'], ENT_COMPAT));
+            }
+
+            // Add entity names to the fieldset so that afform can populate field metadata
+            $fieldset = pq($component)->parents('[af-fieldset]');
+            if ($fieldset->length) {
+              $entityList = FormDataModel::getSearchEntities($savedSearch);
+              $fieldset->attr('api-entities', htmlspecialchars(\CRM_Utils_JS::encode($entityList), ENT_COMPAT));
+              // Add field metadata for aggregate fields because they are not in the schema.
+              // Normal entity fields will be handled by AfformMetadataInjector
+              foreach (Meta::getCalcFields($savedSearch['api_entity'], $savedSearch['api_params']) as $fieldInfo) {
+                foreach (pq("af-field[name='{$fieldInfo['name']}']", $doc) as $afField) {
+                  \Civi\Afform\AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
                 }
               }
             }

--- a/ext/search_kit/Civi/Search/Display.php
+++ b/ext/search_kit/Civi/Search/Display.php
@@ -22,18 +22,6 @@ class Display {
   /**
    * @return array
    */
-  public static function getPartials($moduleName, $module) {
-    $partials = [];
-    foreach (self::getDisplayTypes(['id', 'name']) as $type) {
-      $partials["~/$moduleName/displayType/{$type['id']}.html"] =
-        '<' . $type['name'] . ' api-entity="{{:: $ctrl.apiEntity }}" search="$ctrl.searchName" display="$ctrl.display.name" settings="$ctrl.display.settings" filters="$ctrl.filters"></' . $type['name'] . '>';
-    }
-    return $partials;
-  }
-
-  /**
-   * @return array
-   */
   public static function getDisplayTypes(array $props, bool $onlyViewable = FALSE): array {
     try {
       if ($onlyViewable && !in_array('grouping', $props)) {

--- a/ext/search_kit/ang/crmSearchAdmin.ang.php
+++ b/ext/search_kit/ang/crmSearchAdmin.ang.php
@@ -15,7 +15,7 @@ return [
   ],
   'bundles' => ['bootstrap3'],
   'basePages' => ['civicrm/admin/search'],
-  'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'api4', 'crmSearchTasks', 'crmRouteBinder', 'crmDialog', 'md5'],
+  'requires' => ['crmUi', 'crmUtil', 'ngRoute', 'ui.sortable', 'ui.bootstrap', 'crmSearchDisplay', 'crmSearchTasks', 'crmRouteBinder', 'crmDialog', 'md5'],
   'settingsFactory' => ['\Civi\Search\Admin', 'getAdminSettings'],
   'permissions' => [
     // Note the super permission "all CiviCRM permissions and ACLs" is used in the JS layer to determine if users can create search displays that bypass ACLs

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
@@ -35,8 +35,8 @@
             select: ['name', 'label'],
             where: [
               ['saved_search_id.name', '=', searchName],
-              // For now this is the only type of embedded display we support
-              ['type:name', '=', 'crm-search-display-table'],
+              // Include all viewable display types
+              ['type', 'IN', Object.keys(CRM.crmSearchDisplay.viewableDisplayTypes)],
             ],
           }],
           savedSearch: ['SavedSearch', 'get', {

--- a/ext/search_kit/ang/crmSearchDisplay.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplay.ang.php
@@ -1,5 +1,14 @@
 <?php
-// Search Display base module - provides services used commonly by search display implementations.
+// Search Display base module - provides search display wrapper and base services.
+
+// Generate dynamic list of dependencies
+// To prevent circular dependencies in Anguar, only these two are declared clientside.
+$requires = ['api4', 'ngSanitize'];
+// Add all viewable display type Angular modules
+foreach (\Civi\Search\Display::getDisplayTypes(['id', 'name'], TRUE) as $displayType) {
+  $requires[] = CRM_Utils_String::convertStringToCamel($displayType['name'], FALSE);
+}
+
 return [
   'js' => [
     'ang/crmSearchDisplay.module.js',
@@ -13,8 +22,9 @@ return [
     'css/crmSearchDisplay.css',
   ],
   'basePages' => [],
-  'requires' => ['api4', 'ngSanitize'],
+  'requires' => $requires,
   'exports' => [
-    'crm-search-display-table' => 'E',
+    'crm-search-display' => 'E',
   ],
+  'settingsFactory' => ['\Civi\Search\Display', 'getModuleSettings'],
 ];

--- a/ext/search_kit/ang/crmSearchDisplay.module.js
+++ b/ext/search_kit/ang/crmSearchDisplay.module.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
   "use strict";
 
-  // Declare module
-  angular.module('crmSearchDisplay', CRM.angRequires('crmSearchDisplay'));
+  // Note: We're not using CRM.angRequires here to avoid circular dependencies with search display types. See crmSearchDisplay.ang.php
+  angular.module('crmSearchDisplay', ['api4', 'ngSanitize']);
 
 })(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/subsearch.html
@@ -5,7 +5,7 @@
     <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
   </summary>
   <div class="crm-search-display-subsearch-dropdown-body">
-    <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
+    <crm-search-display type="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].type }}" ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display>
   </div>
 </details>
 <details ng-if="colData.subsearch.subsearch_mode === 'collapsed'" class="crm-search-display-subsearch-accordion">
@@ -15,7 +15,7 @@
     <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
   </summary>
   <div class="crm-accordion-body crm-search-display-subsearch-accordion-body">
-    <crm-search-display-table ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
+    <crm-search-display type="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].type }}" ng-if="colData.hasBeenOpened" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display>
   </div>
 </details>
 <div ng-if="colData.subsearch.subsearch_mode === 'inline'" class="crm-search-display-subsearch-inline">
@@ -24,5 +24,5 @@
     {{:: colData.val }}
     <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
   </div>
-  <crm-search-display-table search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display-table>
+  <crm-search-display type="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].type }}" search="colData.subsearch.search" display="colData.subsearch.display" api-entity="{{:: $ctrl.results.subsearch[colData.subsearch.search_and_display].api_entity }}" settings="$ctrl.results.subsearch[colData.subsearch.search_and_display].settings" filters="colData.subsearch.filters"></crm-search-display>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplay.component.js
@@ -1,0 +1,27 @@
+(function(angular, $, _) {
+  "use strict";
+
+  // Generic wrapper to render any display type
+  angular.module('crmSearchDisplay').component('crmSearchDisplay', {
+    bindings: {
+      type: '@',
+      apiEntity: '@',
+      search: '<',
+      display: '<',
+      settings: '<',
+      filters: '<',
+    },
+    template: function($element) {
+      let html = '';
+      const displayTypes = CRM.crmSearchDisplay.viewableDisplayTypes;
+      Object.entries(displayTypes).forEach(([type, directive]) => {
+        html += `<${directive} ng-if="$ctrl.type === '${type}'" api-entity="{{:: $ctrl.apiEntity }}" search="$ctrl.search" display="$ctrl.display" settings="$ctrl.settings" filters="$ctrl.filters"></${directive}>`;
+      });
+      return html;
+    },
+    controller: function($scope, $element) {
+    }
+
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchDisplayBatch.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayBatch.ang.php
@@ -9,7 +9,7 @@ return [
     'ang/crmSearchDisplayBatch',
   ],
   'css' => [],
-  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
+  'basePages' => [],
   'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap', 'crmSearchTasks'],
   'bundles' => ['bootstrap3'],
   'permissions' => ['administer queues'],

--- a/ext/search_kit/ang/crmSearchDisplayGrid.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayGrid.ang.php
@@ -11,7 +11,7 @@ return [
   'css' => [
     'css/crmSearchDisplayGrid.css',
   ],
-  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
+  'basePages' => [],
   'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap', 'crmSearchTasks'],
   'bundles' => ['bootstrap3'],
   'exports' => [

--- a/ext/search_kit/ang/crmSearchDisplayList.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayList.ang.php
@@ -8,7 +8,7 @@ return [
   'partials' => [
     'ang/crmSearchDisplayList',
   ],
-  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
+  'basePages' => [],
   'requires' => ['crmSearchDisplay', 'crmUi', 'ui.bootstrap', 'crmSearchTasks'],
   'bundles' => ['bootstrap3'],
   'exports' => [

--- a/ext/search_kit/ang/crmSearchDisplayTable.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayTable.ang.php
@@ -11,7 +11,7 @@ return [
   'css' => [
     'css/crmSearchDisplayTable.css',
   ],
-  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
+  'basePages' => [],
   'requires' => ['crmSearchDisplay', 'crmUi', 'crmSearchTasks', 'ui.bootstrap', 'ui.sortable'],
   'bundles' => ['bootstrap3'],
   'exports' => [

--- a/ext/search_kit/ang/crmSearchDisplayTree.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayTree.ang.php
@@ -11,7 +11,7 @@ return [
   'css' => [
     'css/crmSearchDisplayTree.css',
   ],
-  'basePages' => ['civicrm/search', 'civicrm/admin/search'],
+  'basePages' => [],
   'requires' => ['crmSearchDisplay', 'crmUi', 'crmSearchTasks', 'ui.bootstrap', 'ui.sortable'],
   'bundles' => ['bootstrap3'],
   'exports' => [

--- a/ext/search_kit/ang/crmSearchPage.ang.php
+++ b/ext/search_kit/ang/crmSearchPage.ang.php
@@ -6,7 +6,9 @@ return [
     'ang/crmSearchPage/*.js',
     'ang/crmSearchPage/*/*.js',
   ],
+  'partials' => [
+    'ang/crmSearchPage',
+  ],
   'basePages' => ['civicrm/search'],
-  'requires' => ['ngRoute', 'api4', 'crmUi'],
-  'partialsCallback' => ['\Civi\Search\Display', 'getPartials'],
+  'requires' => ['ngRoute', 'api4', 'crmUi', 'crmSearchDisplay'],
 ];

--- a/ext/search_kit/ang/crmSearchPage.module.js
+++ b/ext/search_kit/ang/crmSearchPage.module.js
@@ -8,16 +8,7 @@
       // Load & render a SearchDisplay
       $routeProvider.when('/display/:savedSearchName/:displayName?', {
         controller: 'crmSearchPageDisplay',
-        template: '<h1 crm-page-title>{{:: $ctrl.display.label }}</h1>\n' +
-          '<form id="bootstrap-theme">' +
-          // Edit link for authorized users
-          '  <div class="pull-right btn-group" ng-if="$ctrl.editLink">' +
-          '    <a class="btn btn-sm" ng-href="{{:: $ctrl.editLink }}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i> {{:: ts("Edit Search") }}</a>' +
-          '  </div>' +
-          // Dynamic template generates the directive for each display type
-          // @see \Civi\Search\Display::getPartials()
-          '  <div ng-include="\'~/crmSearchPage/displayType/\' + $ctrl.display.type + \'.html\'"></div>' +
-          '</form>',
+        templateUrl: '~/crmSearchPage/crmSearchPage.html',
         resolve: {
           // Load saved search display
           info: function($route, crmApi4) {

--- a/ext/search_kit/ang/crmSearchPage/crmSearchPage.html
+++ b/ext/search_kit/ang/crmSearchPage/crmSearchPage.html
@@ -1,0 +1,7 @@
+<h1 crm-page-title>{{:: $ctrl.display.label }}</h1>
+<form id="bootstrap-theme">
+  <div class="pull-right btn-group" ng-if="$ctrl.editLink">
+    <a class="btn btn-sm" ng-href="{{:: $ctrl.editLink }}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i> {{:: ts("Edit Search") }}</a>
+  </div>
+  <crm-search-display type="{{:: $ctrl.display.type }}" api-entity="{{:: $ctrl.apiEntity }}" search="$ctrl.searchName" display="$ctrl.display.name" settings="$ctrl.display.settings" filters="$ctrl.filters"></crm-search-display>
+</form>


### PR DESCRIPTION
Overview
----------------------------------------
Enables Subsearches on any search display of any other type of search display.

Technical Details
----------
I [gave up on lazy-loading](https://github.com/civicrm/civicrm-core/pull/34852) search display modules. So this adds a new `crm-search-display` wrapper directive which pre-loads *all* viewable search displays as dependencies.