### PR TITLE
Only use membership_payment table in membership detail report if site requires it

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -347,6 +347,20 @@ WHERE li.contribution_id = %1";
     return TRUE;
   }
 
+  public static function siteHasMembershipPaymentRecordsNotReflectedInLineItems(): bool {
+    if (!\Civi::cache('long')->has(__FUNCTION__)) {
+      \Civi::cache('long')->set(__FUNCTION__,
+        (bool) CRM_Core_DAO::singleValueQuery('
+        SELECT p.id FROM civicrm_membership_payment p LEFT JOIN civicrm_line_item line
+          ON line.contribution_id = p.contribution_id AND line.entity_id = p.membership_id
+          AND line.entity_table = "civicrm_membership"
+          WHERE line.id IS NULL LIMIT 1
+        ')
+      );
+    }
+    return \Civi::cache('long')->get(__FUNCTION__);
+  }
+
   /**
    * Process price set and line items.
    *


### PR DESCRIPTION
Overview
----------------------------------------
Only use membership_payment table in membership detail report if site requires it

Before
----------------------------------------
MembershipPayments are deprecated but the member detail report still required them. @ufundo & @mattwire have both recently done work towards removing the requirement

After
----------------------------------------
 This removes the requirement in the membership_detail report, but still handles it if required. It adds an extra query to check - but that query is cached and it will be possible to turn that query off once @ufundo's PR is merged
 
Technical Details
----------------------------------------

Comments
----------------------------------------
