### PR TITLE
fix PHP warnings when custom group is empty

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1392,6 +1392,7 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements \Civi
       $formattedGroupTree[$key]['extends_entity_column_value'] = $value['extends_entity_column_value'] ?? NULL;
       $formattedGroupTree[$key]['subtype'] = $value['subtype'] ?? NULL;
       $formattedGroupTree[$key]['max_multiple'] = $value['max_multiple'] ?? NULL;
+      $formattedGroupTree[$key]['fields'] = $value['fields'] ?? [];
 
       // Properties that might have been filtered out but which
       // should be present to avoid smarty e-notices.


### PR DESCRIPTION
Overview
----------------------------------------
When you have a custom field group with no fields, you get PHP warnings.

To replicate:
* Create a new custom field group for activities, with no fields.
* Open the "New Activity" screen.

Before
----------------------------------------
```
Warning: Undefined array key "fields" in CRM_Core_BAO_CustomGroup::buildQuickForm() (line 1192 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/BAO/CustomGroup.php).
Warning: foreach() argument must be of type array|object, null given in CRM_Core_BAO_CustomGroup::buildQuickForm() (line 1192 of /home/jon/local/civicrm-buildkit/build/dmaster/web/sites/all/modules/civicrm/CRM/Core/BAO/CustomGroup.php).
Warning: Undefined array key "fields" in content_699bca77ea4c18_19785756() (line 74 of /home/jon/local/civicrm-buildkit/app/private/dmaster/default/civicrm/templates_c/en_US/c3/d5/56/c3d556b6afd9baf898f173f5fe8e177722320f17_0.file_CustomData.tpl.php).
```

After
----------------------------------------
No warnings.

Comments
----------------------------------------
I spent quite a bit of time figuring out how to replace `getTree()` in `CRM_Custom_Form_CustomDataByType::preProcess()` - but much of the functionality that got Frankensteined into `getTree()` that `getAll()` does away with is relevant to this particular call to `getTree()`.
