### PR TITLE
Afform - Ensure search_displays are always returned when requested

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Get.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Get.php
@@ -21,8 +21,8 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
 
     // Optimization: only fetch extra data if requested
     $getComputed = $this->_isFieldSelected('has_local', 'has_base', 'base_module');
-    $getLayout = $this->_isFieldSelected('layout');
     $getSearchDisplays = $this->_isFieldSelected('search_displays');
+    $getLayout = $getSearchDisplays || $this->_isFieldSelected('layout');
     // To optimize lookups by file/module/directive name
     $getNames = array_filter([
       'name' => $this->_itemsToGet('name'),
@@ -61,7 +61,7 @@ class Get extends \Civi\Api4\Generic\BasicGetAction {
           continue 2;
         }
       }
-      $record = $scanner->getMeta($name, $getLayout || $getSearchDisplays);
+      $record = $scanner->getMeta($name, $getLayout);
       // Skip if afform does not exist or is not of requested type(s)
       if (
         (!$record && !isset($afforms[$name])) ||


### PR DESCRIPTION
Overview
----------------------------------------
This fixes missing admin links in the User Dashboard extension.

Before
----------------------------------------
<img width="902" height="428" alt="image" src="https://github.com/user-attachments/assets/82b8bf64-de85-4ae5-a8fc-0cf9223a11c4" />


After
----------------------------------------

<img width="908" height="428" alt="Screenshot 2026-02-23 at 11 01 59 AM" src="https://github.com/user-attachments/assets/e852840c-bfdb-4993-be67-54dfb53a8fb2" />

Technical Details
----------------------------------------
Ensures hook-provided Afforms have their search displays returned as well as static ones.