### PR TITLE
Add API4 ContributionRecur::cancelSubscription

### DIFF
--- a/Civi/Api4/Action/ContributionRecur/CancelSubscription.php
+++ b/Civi/Api4/Action/ContributionRecur/CancelSubscription.php
@@ -1,0 +1,83 @@
+<?php
+namespace Civi\Api4\Action\ContributionRecur;
+
+use Civi\Api4\ContributionRecur;
+use Civi\Api4\Generic\BasicBatchAction;
+
+/**
+ * This API Action cancels the contributionRecur and payment processor subscription.
+ *
+ */
+class CancelSubscription extends BasicBatchAction {
+
+  /**
+   * If the payment processor supports optional notification (cancelRecurringNotifyOptional)
+   *   then setting this to FALSE will update the recurring contribution in CiviCRM but NOT
+   *   notify the payment provider.
+   *
+   * @var bool
+   */
+  protected bool $notifyPaymentProcessor = TRUE;
+
+  /**
+   * Optional cancellation reason
+   *
+   * @var string
+   */
+  protected string $cancelReason = '';
+
+  /**
+   * @inheritDoc
+   */
+  public function doTask($item) {
+    try {
+      if (empty($item['payment_processor_id'])) {
+        $message = ts('No payment processor for recurring contribution ID: %1', [1 => $item['id']]);
+      }
+      else {
+        $paymentProcessor = \Civi\Payment\System::singleton()->getById($item['payment_processor_id']);
+        if (!$paymentProcessor->supports('cancelRecurring')) {
+          $message = ts('Payment processor does not support cancelling recurring contribution');
+        }
+        else {
+          $propertyBag = new \Civi\Payment\PropertyBag();
+          $propertyBag->setContributionRecurID($item['id']);
+          $propertyBag->setRecurProcessorID($item['processor_id']);
+          if ($paymentProcessor->supports('cancelRecurringNotifyOptional') && !$this->notifyPaymentProcessor) {
+            $propertyBag->setIsNotifyProcessorOnCancelRecur(FALSE);
+          }
+          else {
+            $propertyBag->setIsNotifyProcessorOnCancelRecur(TRUE);
+          }
+          $message = $paymentProcessor->doCancelRecurring($propertyBag)['message'] ?? '';
+        }
+      }
+    }
+    catch (\Throwable $t) {
+      \Civi::log()->error(ts('Error cancelling recurring contribution ID: %1. Error: %2', [1 => $item['id'], 2 => $t->getMessage()]));
+    }
+
+    // Now update the actual recurring Contribution
+    ContributionRecur::update(FALSE)
+      ->addWhere('id', '=', $item['id'])
+      ->setValues([
+        'contribution_status_id:name' => 'Cancelled',
+        'processor_message' => $message ?? NULL,
+        'cancel_reason' => $this->cancelReason,
+        'cancel_date' => 'now',
+      ])->execute();
+    return [
+      'id' => $item['id'],
+      'message' => $message ?? NULL,
+    ];
+  }
+
+  protected function getSelect() {
+    return [
+      'id',
+      'payment_processor_id',
+      'processor_id',
+    ];
+  }
+
+}

--- a/ext/civi_contribute/Civi/Api4/ContributionRecur.php
+++ b/ext/civi_contribute/Civi/Api4/ContributionRecur.php
@@ -11,6 +11,7 @@
 namespace Civi\Api4;
 
 use Civi\Api4\Action\ContributionRecur\UpdateAmountOnRecur;
+use Civi\Api4\Action\ContributionRecur\CancelSubscription;
 
 /**
  * ContributionRecur entity.
@@ -27,6 +28,16 @@ class ContributionRecur extends Generic\DAOEntity {
    */
   public static function updateAmountOnRecur($checkPermissions = TRUE) {
     return (new UpdateAmountOnRecur(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   *
+   * @return \Civi\Api4\Action\ContributionRecur\CancelSubscription
+   */
+  public static function cancelSubscription($checkPermissions = TRUE) {
+    return (new CancelSubscription(static::getEntityName(), __FUNCTION__))
       ->setCheckPermissions($checkPermissions);
   }
 

--- a/tests/phpunit/api/v4/Action/ContributionRecurCancelTest.php
+++ b/tests/phpunit/api/v4/Action/ContributionRecurCancelTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use Civi\Api4\FinancialType;
+use Civi\Api4\OptionValue;
+use Civi\Api4\Order;
+use Civi\Api4\Payment;
+use Civi\Api4\ContributionRecur;
+
+/**
+ * Test API4 ContributionRecur::updateAmountOnRecur
+ *
+ * @group headless
+ */
+class ContributionRecurCancelTest extends \CiviUnitTestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->createFixture();
+    $this->createOrder();
+  }
+
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    $this->contactDelete($this->ids['Contact']['EmberRecur']);
+    parent::tearDown();
+  }
+
+  /**
+   * @var array
+   * contactID => recurID
+   */
+  protected array $recurs;
+
+  /**
+   * Populates properties: $this->recurs.
+   */
+  protected function createFixture(): void {
+    $this->individualCreate(['first_name' => 'Ember', 'last_name' => 'Recur'], 'EmberRecur');
+
+    $recur = [
+      'currency' => 'USD',
+      'contribution_status_id:name' => 'In Progress',
+      'financial_type_id:name' => 'Donation',
+      'contact_id' => $this->ids['Contact']['EmberRecur'],
+      'amount' => 2,
+    ];
+    $this->recurs = ContributionRecur::save(FALSE)
+      ->addRecord($recur)
+      ->execute()
+      ->indexBy('contact_id')
+      ->column('id');
+  }
+
+  private function createOrder() {
+    $financialTypeID = FinancialType::get(FALSE)
+      ->addWhere('name', '=', 'Donation')
+      ->execute()
+      ->first()['id'];
+    $paymentInstrumentID = OptionValue::get(FALSE)
+      ->addWhere('option_group_id:name', '=', 'payment_instrument')
+      ->execute()
+      ->first()['value'];
+
+    foreach ($this->recurs as $contactID => $recurID) {
+      $recur = ContributionRecur::get(FALSE)
+        ->addWhere('id', '=', $recurID)
+        ->execute()
+        ->first();
+
+      $orderBAO = new \CRM_Financial_BAO_Order();
+
+      $orderAPI = Order::create(FALSE)
+        ->setContributionValues([
+          'receive_date' => date('YmdHis'),
+          // trxn_date is necessary for membership date calcs.
+          'trxn_date' => date('YmdHis'),
+          'trxn_id' => 'testtrxnid' . $recur['id'],
+          'total_amount' => $recur['amount'],
+          'contact_id' => $contactID,
+          'payment_instrument_id' => $paymentInstrumentID,
+          'currency' => 'USD',
+          'financial_type_id' => $financialTypeID,
+          'is_email_receipt' => FALSE,
+          'is_test' => FALSE,
+          'contribution_recur_id' => $recurID,
+          'contribution_status_id' => 'Pending',
+          'contribution_source' => 'my test description',
+        ]);
+
+      $lineItem = [
+        'line_total' => $recur['amount'],
+        'unit_price' => $recur['amount'],
+        'price_field_id' => $orderBAO->getDefaultPriceFieldID(),
+        'price_field_value_id' => $orderBAO->getDefaultPriceFieldValueID(),
+        'financial_type_id' => $financialTypeID,
+        'qty' => 1,
+      ];
+
+      $orderAPI->addLineItem($lineItem);
+      $contributionID = $orderAPI->execute()->single()['id'];
+
+      Payment::create(FALSE)
+        ->addValue('contribution_id', $contributionID)
+        ->addValue('total_amount', $recur['amount'])
+        ->addValue('is_send_contribution_notification', FALSE)
+        ->addValue('trxn_date', date('YmdHis'))
+        ->execute();
+    }
+  }
+
+  /**
+   * Test that cancelSubscription updates the recur correctly.
+   */
+  public function testCancelNoNotify(): void {
+    $preContributionRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContributionRecur);
+    $this->assertEmpty($preContributionRecur['cancel_date']);
+
+    // Call cancelSubscription
+    ContributionRecur::cancelSubscription(FALSE)
+      ->setNotifyPaymentProcessor(FALSE)
+      ->setCancelReason('I want to cancel')
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+
+    $updatedRecur = ContributionRecur::get(FALSE)
+      ->addSelect('cancel_date', 'cancel_reason', 'contribution_status_id:name')
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+
+    $this->assertEquals('Cancelled', $updatedRecur['contribution_status_id:name']);
+    $this->assertEquals('I want to cancel', $updatedRecur['cancel_reason']);
+    $this->assertNotEmpty($updatedRecur['cancel_date']);
+  }
+
+  /**
+   * Test that cancelSubscription updates the recur correctly.
+   */
+  public function testCancelNotify(): void {
+    $preContributionRecur = ContributionRecur::get(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertNotEmpty($preContributionRecur);
+    $this->assertEmpty($preContributionRecur['cancel_date']);
+
+    $paymentProcessorID = $this->dummyProcessorCreate()->getID();
+    ContributionRecur::update(FALSE)
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->addValue('payment_processor_id', $paymentProcessorID)
+      ->addValue('processor_id', 'test-processor-id')
+      ->execute();
+
+    // Call cancelSubscription
+    $result = ContributionRecur::cancelSubscription(FALSE)
+      ->setNotifyPaymentProcessor(TRUE)
+      ->setCancelReason('I want to cancel')
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+    $this->assertEquals('Recurring contribution cancelled', $result['message']);
+
+    $updatedRecur = ContributionRecur::get(FALSE)
+      ->addSelect('cancel_date', 'cancel_reason', 'contribution_status_id:name', 'processor_id')
+      ->addWhere('id', '=', $this->recurs[$this->ids['Contact']['EmberRecur']])
+      ->execute()
+      ->first();
+
+    $this->assertEquals('Cancelled', $updatedRecur['contribution_status_id:name']);
+    $this->assertEquals('I want to cancel', $updatedRecur['cancel_reason']);
+    $this->assertNotEmpty($updatedRecur['cancel_date']);
+    $this->assertEquals('test-processor-id', $updatedRecur['processor_id']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Accepts `cancelReason` and `notifyPaymentProcessor` parameter.

Accepts standard `where` clause to select recurring contributions.
You can cancel multiple recurring contributions at the same time
if multiple are returned by the `where` clause.

This cancels a recurring contribution and, depending on the `notifyPaymentProcessor` parameter, cancels the linked subscription at the payment provider.

Before
----------------------------------------
No way to cancel a subscription without using a form or custom code with the payment processor (ie. to call `doCancelRecurring()` function.

After
----------------------------------------
API to cancel a recurring contribution (and notify the payment processor using the `doCancelRecurring()` method.

Technical Details
----------------------------------------
This allows for "cancel subscription" functionality to be made available much more easily, eg. as a batch action, in custom code etc. and could replace the code in the cancel subscription form.

Comments
----------------------------------------

