### PR TITLE
dev/core#6348 - UI/helptext - Add data-help-id HTML attribute to support document queries

### DIFF
--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -72,6 +72,9 @@ function smarty_function_help($params, $smarty) {
     $class .= " {$params['class']}";
   }
 
+  // reasonably reliable data attribute (data-help-id) to support document queries
+  $dataHelpId = htmlspecialchars($params['id'], ENT_QUOTES);
+
   // Escape for html
   $title = htmlspecialchars(ts('%1 Help', [1 => $helpTextTitle]));
   // Escape for html and js
@@ -83,5 +86,5 @@ function smarty_function_help($params, $smarty) {
     $param = is_bool($param) || is_numeric($param) ? (int) $param : (string) $param;
   }
   $helpTextParams = htmlspecialchars(json_encode($params), ENT_QUOTES);
-  return '<a class="' . $class . '" title="' . $title . '" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $helpTextTitle . ', ' . $helpTextParams . '); return false;\'>&nbsp;</a>';
+  return '<a class="' . $class . '" title="' . $title . '" data-help-id="'.$dataHelpId.'" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $helpTextTitle . ', ' . $helpTextParams . '); return false;\'>&nbsp;</a>';
 }

--- a/CRM/Core/Smarty/plugins/function.help.php
+++ b/CRM/Core/Smarty/plugins/function.help.php
@@ -86,5 +86,5 @@ function smarty_function_help($params, $smarty) {
     $param = is_bool($param) || is_numeric($param) ? (int) $param : (string) $param;
   }
   $helpTextParams = htmlspecialchars(json_encode($params), ENT_QUOTES);
-  return '<a class="' . $class . '" title="' . $title . '" data-help-id="'.$dataHelpId.'" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $helpTextTitle . ', ' . $helpTextParams . '); return false;\'>&nbsp;</a>';
+  return '<a class="' . $class . '" title="' . $title . '" data-help-id="' . $dataHelpId . '" aria-label="' . $title . '" href="#" onclick=\'CRM.help(' . $helpTextTitle . ', ' . $helpTextParams . '); return false;\'>&nbsp;</a>';
 }


### PR DESCRIPTION
This PR adds an HTML attribute, data-help-id, to Help Text pop-up links. It sets data-help-id to the ID used to identify the help message in .hlp files. This will improve support for targeting specific help text icons in javascript, css. 

One use case for this is hiding or removing specific help icons from a form. 