### PR TITLE
Use lineItem look up when generating invoices

### DIFF
--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -14,6 +14,8 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\LineItem;
+use Civi\Api4\Participant;
 
 /**
  * This class provides the functionality to email a group of
@@ -311,37 +313,33 @@ AND    {$this->_componentClause}";
    */
   private static function getDetails($contributionIDs) {
     if (empty($contributionIDs)) {
+      CRM_Core_Error::deprecatedWarning('calling this function with no IDs is deprecated');
       return [];
     }
-    $query = "
-SELECT    c.id              as contribution_id,
-          c.contact_id      as contact_id     ,
-          mp.membership_id  as membership_id  ,
-          pp.participant_id as participant_id ,
-          p.event_id        as event_id
-FROM      civicrm_contribution c
-LEFT JOIN civicrm_membership_payment  mp ON mp.contribution_id = c.id
-LEFT JOIN civicrm_participant_payment pp ON pp.contribution_id = c.id
-LEFT JOIN civicrm_participant         p  ON pp.participant_id  = p.id
-WHERE     c.id IN ( $contributionIDs )";
 
     $rows = [];
-    $dao = CRM_Core_DAO::executeQuery($query);
+    $lines = LineItem::get(FALSE)
+      ->addWhere('contribution_id', 'IN', explode(',', $contributionIDs))
+      ->addSelect('*', 'contribution_id.contact_id')
+      ->execute();
 
-    while ($dao->fetch()) {
-      $rows[$dao->contribution_id]['component'] = $dao->participant_id ? 'event' : 'contribute';
-      $rows[$dao->contribution_id]['contact'] = $dao->contact_id;
-      if ($dao->membership_id) {
-        if (!array_key_exists('membership', $rows[$dao->contribution_id])) {
-          $rows[$dao->contribution_id]['membership'] = [];
-        }
-        $rows[$dao->contribution_id]['membership'][] = $dao->membership_id;
+    foreach ($lines as $line) {
+      $rows[$line['contribution_id']] = $rows[$line['contribution_id']] ?? [] + [
+        'component' => 'contribute',
+        'contact' => $line['contribution_id.contact_id'],
+        'membership' => NULL,
+        'participant' => NULL,
+        'event' => NULL,
+      ];
+      if ($line['entity_table'] == 'civicrm_participant') {
+        $rows[$line['contribution_id']]['participant'] = $line['entity_id'];
+        $rows[$line['contribution_id']]['event'] = Participant::get(FALSE)
+          ->addWhere('id', '=', $line['entity_id'])
+          ->addSelect('event_id')
+          ->execute()->single()['event_id'];
       }
-      if ($dao->participant_id) {
-        $rows[$dao->contribution_id]['participant'] = $dao->participant_id;
-      }
-      if ($dao->event_id) {
-        $rows[$dao->contribution_id]['event'] = $dao->event_id;
+      if ($line['entity_table'] == 'civicrm_membership') {
+        $rows[$line['contribution_id']]['membership'] = $line['entity_id'];
       }
     }
     return $rows;


### PR DESCRIPTION
Overview
----------------------------------------
Use lineItem look up when generating invoices

Before
----------------------------------------
Still using legacy membership_payment & participant_payment

After
----------------------------------------
Using line items

Technical Details
----------------------------------------
@mattwire @ufundo I think we can be more aggressive here & just replace. Although there are rumoured to be sites with data issues meaning that not all have line items for memberships all discussion I've heard is around older contributions & edge cases - and that most sites are accurately creating them in the now. That means that we need to be pretty careful with
- search
- reporting
- things that affect data flow - ie don't introduce fatal errors

But I think we can rely on sites having good data a bit more here as the impact is low (mostly selection of from details for the email when receipting, possibly completely unused on the PDF side ) and PDFs and invoices are generally generated for newer invoices with some supervision

Comments
----------------------------------------
