### PR TITLE
MailingTest - You shall not pass! 🧙‍♂️

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1710,43 +1710,39 @@ ORDER BY   civicrm_email.is_bulkmail DESC
 
     $mailingIDs = [];
 
-    // get permissioned query clause
-    $groupBao = new CRM_Contact_BAO_Group();
-    $permissionClauses = $groupBao->addSelectWhereClause()['id'] ?? [];
-    // No need to run query if 0 groups are allowed
-    if (!in_array('IN (0)', $permissionClauses)) {
-      $permissionClause = '';
-      if ($permissionClauses) {
-        $permissionClause = 'AND g.entity_id ' . implode(' AND g.entity_id ', $permissionClauses);
-      }
-      $domain_id = CRM_Core_Config::domainID();
+    $viewGroups = CRM_ACL_API::group(CRM_Core_Permission::VIEW, NULL, 'civicrm_group', NULL);
+    $editGroups = CRM_ACL_API::group(CRM_Core_Permission::EDIT, NULL, 'civicrm_group', NULL);
+    $allowedGroups = array_unique(array_merge($viewGroups, $editGroups));
 
-      // get all the mailings that are in this subset of groups
-      $query = "
+    $groupsIn = !empty($allowedGroups) ? implode(',', $allowedGroups) : '0';
+    $permissionClause = "AND g.entity_id IN ($groupsIn)";
+    $domain_id = CRM_Core_Config::domainID();
+
+    // get all the mailings that are in this subset of groups
+    $query = "
 SELECT    DISTINCT( m.id ) as id
   FROM    civicrm_mailing m
 LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
  WHERE ( ( g.entity_table like 'civicrm_group%' $permissionClause )
     OR   ( g.entity_table IS NULL AND g.entity_id IS NULL AND m.domain_id = $domain_id ) )
 ";
-      $dao = CRM_Core_DAO::executeQuery($query);
+    $dao = CRM_Core_DAO::executeQuery($query);
 
-      $mailingIDs = [];
-      while ($dao->fetch()) {
-        $mailingIDs[] = $dao->id;
-      }
-      //CRM-18181 Get all mailings that use the mailings found earlier as receipients
-      if (!empty($mailingIDs)) {
-        $mailings = implode(',', $mailingIDs);
-        $mailingQuery = "
-           SELECT DISTINCT ( m.id ) as id
-           FROM civicrm_mailing m
-           LEFT JOIN civicrm_mailing_group g ON g.mailing_id = m.id
-           WHERE g.entity_table like 'civicrm_mailing%' AND g.entity_id IN ($mailings)";
-        $mailingDao = CRM_Core_DAO::executeQuery($mailingQuery);
-        while ($mailingDao->fetch()) {
-          $mailingIDs[] = $mailingDao->id;
-        }
+    $mailingIDs = [];
+    while ($dao->fetch()) {
+      $mailingIDs[] = $dao->id;
+    }
+    //CRM-18181 Get all mailings that use the mailings found earlier as receipients
+    if (!empty($mailingIDs)) {
+      $mailings = implode(',', $mailingIDs);
+      $mailingQuery = "
+         SELECT DISTINCT ( m.id ) as id
+         FROM civicrm_mailing m
+         LEFT JOIN civicrm_mailing_group g ON g.mailing_id = m.id
+         WHERE g.entity_table like 'civicrm_mailing%' AND g.entity_id IN ($mailings)";
+      $mailingDao = CRM_Core_DAO::executeQuery($mailingQuery);
+      while ($mailingDao->fetch()) {
+        $mailingIDs[] = $mailingDao->id;
       }
     }
 

--- a/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
+++ b/tests/phpunit/CRM/Mailing/BAO/MailingTest.php
@@ -167,6 +167,11 @@ class CRM_Mailing_BAO_MailingTest extends CiviUnitTestCase {
    * Test verify that a disabled mailing group doesn't prevent access to the mailing generated with the group.
    */
   public function testGetMailingDisabledGroup(): void {
+    // Create extra groups to auto-increment the id a bit;
+    // we don't want the test to accidentally pass just because the id of every entity happens to be the same
+    $this->groupCreate(['name' => uniqid(), 'title' => uniqid()]);
+    $this->groupCreate(['name' => uniqid(), 'title' => uniqid()]);
+
     $this->prepareForACLs();
     $this->createLoggedInUser();
     // create hook to build ACL where clause which choses $this->allowedContactId as the only contact to be considered as mail recipient


### PR DESCRIPTION
Overview
----------------------------------------
This test accidentally passed even though it wasn't actually working. Now it properly fails.

https://github.com/civicrm/civicrm-core/pull/12259 added the test with the belief that it was fixing access to disabled groups. However, I don't think the fix actually worked. A bug in the test made it pass when it shouldn't:

1. The issue of disabled groups being excluded from the ACL clause was not actually fixed. You can see here where an `is_active` filter is still unconditionally applied to the list fetched by `CRM_Core_Permission_Base::group()`:
https://github.com/civicrm/civicrm-core/blob/02a8412f0bdba5673fa4215f5912a28c0b15c703/CRM/Core/PseudoConstant.php#L751
2. The test masked this issue because it created a very unrealistic scenario: there's only a single row in the `civicrm_group` table, and it's disabled. That means this condition is TRUE (when in a realistic database, it wouldn't be): https://github.com/civicrm/civicrm-core/blob/e13644d19ef4ee6399ecf6c168bb2701701d6d03/tests/phpunit/CRM/Mailing/BAO/MailingTest.php#L241
3. When I simply add a few other rows to the `civicrm_group` table, the unrealistic loophole is closed and the test fails.