### PR TITLE
Stop assigning no-longer-in-shipped-templates 'address' variable

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2261,18 +2261,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
    * @throws \CRM_Core_Exception
    */
   public function _gatherMessageValues($values, ?int $eventID, ?int $participantID) {
-    // set display address of contributor
-    if ($this->address_id) {
-      $addressDetails = CRM_Core_BAO_Address::getValues(['id' => $this->address_id], FALSE, 'id');
-      $addressDetails = reset($addressDetails);
-    }
-    // Else we assign the billing address of the contribution contact.
-    else {
-      $addressDetails = (array) CRM_Core_BAO_Address::getValues(['contact_id' => $this->contact_id, 'is_billing' => 1]);
-      $addressDetails = reset($addressDetails);
-    }
-    $values['address'] = $addressDetails['display'] ?? '';
-
     if (!$eventID) {
       //get soft contributions
       $softContributions = CRM_Contribute_BAO_ContributionSoft::getSoftContribution($this->id, TRUE);
@@ -2384,7 +2372,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     $template->assign('receipt_text', $values['receipt_text'] ?? NULL);
     $template->assign('is_monetary', 1);
     $template->assign('is_recur', !empty($this->contribution_recur_id));
-    $template->assign('address', CRM_Utils_Address::format($input));
 
     if ($this->_component === 'event') {
       $template->assign('event', $values['event']);

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -155,7 +155,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
     if (!empty($values['is_email_receipt']) || !empty($values['onbehalf_dupe_alert']) ||
       $returnMessageText
     ) {
-      $template = CRM_Core_Smarty::singleton();
 
       if (!array_key_exists('related_contact', $values)) {
         [$displayName, $email] = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID, FALSE, CRM_Core_BAO_LocationType::getBilling());
@@ -188,13 +187,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'pay_later_receipt' => $values['pay_later_receipt'] ?? NULL,
         'contributionStatus' => $values['contribution_status'] ?? NULL,
       ];
-
-      // address required during receipt processing (pdf and email receipt)
-      $displayAddress = $values['address'] ?? NULL;
-      if ($displayAddress) {
-        $tplParams['address'] = $displayAddress;
-      }
-
       // CRM-6976
       $originalCCReceipt = $values['cc_receipt'] ?? NULL;
 

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1152,12 +1152,6 @@ WHERE civicrm_event.is_active = 1
           ],
         ];
 
-        // address required during receipt processing (pdf and email receipt)
-        $displayAddress = $values['address'] ?? NULL;
-        if ($displayAddress) {
-          $sendTemplateParams['tplParams']['address'] = $displayAddress;
-        }
-
         if ($returnMessageText) {
           [$sent, $subject, $message, $html] = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
           return [

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1514,6 +1514,7 @@ class CRM_Utils_Token {
           '$financialTypeName' => 'contribution.financial_type_id:name',
           '$contributionTypeName' => 'contribution.financial_type_id:name',
           '$email' => 'contact.email_primary.email',
+          '$address' => 'contribution.address_id.display',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1564,6 +1565,7 @@ class CRM_Utils_Token {
           '$financialTypeId' => 'contribution.financial_type_id',
           '$financialTypeName' => 'contribution.financial_type_id:name',
           '$contributionTypeName' => 'contribution.financial_type_id:name',
+          '$address' => 'contribution.address_id.display',
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',
@@ -1630,6 +1632,7 @@ class CRM_Utils_Token {
           '$participant.customGroup' => 'no longer available / relevant, use participant tokens',
           '$custom_pre_id' => 'no longer available/relevant',
           '$custom_post_id' => 'no longer available/relevant',
+          '$address' => 'contribution.address_id.display',
         ],
         'participant_transferred' => [
           '$location' => 'event.location',

--- a/tests/phpunit/CRM/PCP/BAO/PCPTest.php
+++ b/tests/phpunit/CRM/PCP/BAO/PCPTest.php
@@ -241,7 +241,6 @@ class CRM_PCP_BAO_PCPTest extends CiviUnitTestCase {
       'receipt_from_name' => 'CiviCRM Fundraising Dept.',
       'receipt_from_email' => 'donationFake@civicrm.org',
       'contribution_status' => 'Completed',
-      'address' => "Giver {$contact_contributor}\n123 Main St.\n",
       'softContributions' => NULL,
       'title' => 'Contribution',
       'is_pay_later' => '0',

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2040,7 +2040,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
       'street_address' => 'is billing st',
       'contact_id' => $this->_params['contact_id'],
     ]);
-    $params = array_merge($this->_params, ['contribution_status_id' => 2]);
+    $params = array_merge($this->_params, ['contribution_status_id' => 2, 'address_id' => $address['id']]);
     $contribution = $this->callAPISuccess('contribution', 'create', $params);
     $this->callAPISuccess('contribution', 'completetransaction', [
       'id' => $contribution['id'],

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -75,7 +75,7 @@
   {if !empty($isBillingAddressRequiredForPayLater)}
   isBillingAddressRequiredForPayLater:::{$isBillingAddressRequiredForPayLater}
   {/if}
-  address:::{$address}
+  address:::{contribution.address_id.display}
   {if !empty($credit_card_type)}
   credit_card_type:::{$credit_card_type}
   credit_card_number:::{$credit_card_number}


### PR DESCRIPTION
Overview
----------------------------------------
Stop assigning no-longer-in-shipped-templates 'address' variable

Before
----------------------------------------
Variable appears to be available as an input but is creating a lot of complexity for something that was replaced by tokens a while back

After
----------------------------------------
No longer assigned, any sites using it should see a status check

Technical Details
----------------------------------------

Comments
----------------------------------------
