### PR TITLE
dev/core#6351 - Fix show/hide for activity assignee notification activity types on display prefs admin page

### DIFF
--- a/templates/CRM/Admin/Form/Preferences/Display.tpl
+++ b/templates/CRM/Admin/Form/Preferences/Display.tpl
@@ -35,8 +35,8 @@
         }
 
         // show/hide activity types based on checkbox value
-        $('.crm-setting-form-block-do_not_notify_assignees_for').toggle($('#activity_assignee_notification_activity_assignee_notification').is(":checked"));
-        $('#activity_assignee_notification_activity_assignee_notification').click(function() {
+        $('.crm-setting-form-block-do_not_notify_assignees_for').toggle($('#activity_assignee_notification').is(":checked"));
+        $('#activity_assignee_notification').click(function() {
           $('.crm-setting-form-block-do_not_notify_assignees_for').toggle($(this).is(":checked"));
         });
 


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6351

Before
----------------------------------------
At admin - customize - display prefs, toggle the checkbox for notifying assignee activities. It's supposed to show/hide another field for which activity types.

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

