### PR TITLE
River: Resets toggle padding for front-end

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -230,6 +230,7 @@ select.crm-error {
     border: 2px solid var(--crm-input-toggle-disabled-bg);
     background-color: var(--crm-input-toggle-disabled-bg);
     transition: 0.1s;
+    padding: 0;
   }
 
   & input[type="checkbox"].crm-form-toggle::before {


### PR DESCRIPTION
Overview
----------------------------------------
River front-end sets input padding [quite broadly](https://github.com/civicrm/civicrm-core/blob/master/ext/riverlea/core/css/components/_front.css#L147) – which impacts front-end display of the newish toggle element. This resets the toggle padding to zero, as it is in the backend by default.

Before
----------------------------------------
Oof

<img width="428" height="245" alt="image" src="https://github.com/user-attachments/assets/2acc0509-2f4d-4353-ac80-eecfd8d4cdcc" />

After
----------------------------------------
Ahh

<img width="463" height="200" alt="image" src="https://github.com/user-attachments/assets/38499d32-ad5e-4db6-bba4-141a7473badc" />

Technical Details
----------------------------------------
All River Streams are impacted by this bug and fix. Another way to fix this would be to increase specificity around [_front.css#L147](https://github.com/civicrm/civicrm-core/blob/master/ext/riverlea/core/css/components/_front.css#L147) but that would require more testing.