### PR TITLE
Save preferred_language from contact summary

### DIFF
--- a/CRM/Contact/Form/Inline/CommunicationPreferences.php
+++ b/CRM/Contact/Form/Inline/CommunicationPreferences.php
@@ -63,6 +63,7 @@ class CRM_Contact_Form_Inline_CommunicationPreferences extends CRM_Contact_Form_
   public function postProcess(): void {
     $params = [
       'preferred_communication_method' => array_keys($this->getSubmittedValue('preferred_communication_method') ?? []),
+      'preferred_language' => $this->getSubmittedValue('preferred_language'),
       'is_opt_out' => (bool) $this->getSubmittedValue('is_opt_out'),
       'id' => $this->getContactID(),
       'communication_style_id' => $this->getSubmittedValue('communication_style_id'),


### PR DESCRIPTION
Before
----------------------------------------
On the contact summary, open the Privacy section, change the language and save. Change is not saved.

After
----------------------------------------
Change is saved.

Comments
----------------------------------------
Looks like this issue is rc only, see #32838