### PR TITLE
Api4 - Fix fatal error with PSR16_STRICT mode

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -251,7 +251,7 @@ class BasicGetFieldsAction extends BasicGetAction {
     $reflector = \Civi\Core\Resolver::singleton()->getReflector($field['pseudoconstant']['callback']);
     // we need to stringify the callback itself - depends on why
     $callbackName = match ($reflector::class) {
-      'ReflectionMethod' => "{$reflector->class}::{$reflector->name}",
+      'ReflectionMethod' => \CRM_Utils_String::munge($reflector->class) . ".$reflector->name",
       default => NULL,
     };
     // if we dont know how to stringify the callback then we cant cache


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6353](https://lab.civicrm.org/dev/core/-/issues/6353)

Before
----------------------------------------
Fatal error when navigating to FormBuilder

After
----------------------------------------
Fixed

Notes
--------
We really need to enable `CIVICRM_PSR16_STRICT` on Jenkins to catch this sorta thing.