### PR TITLE
Bootstrap3 Everywhere

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -383,6 +383,8 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
       $this->addBundle('coreResources');
       $this->addCoreStyles($region);
       if (!CRM_Core_Config::isUpgradeMode()) {
+        // Needed by all UIs that incorporate SearchKit, etc
+        $this->addBundle('bootstrap3');
         // This ensures that if a popup link requires AngularJS, it will always be available.
         // Additional Ang modules required by popups will be loaded on-the-fly by Civi\Angular\AngularLoader
         Civi::service('angularjs.loader')->addModules(['crmResource']);


### PR DESCRIPTION
Overview
----------------------------------------
This is a heavy-handed but probably necessary solution to the problem of BS3 not always being loaded when needed. Consider:

- Navigate to the "Manage Event: Profiles" screen
- Click to edit profile fields
- The popup appears, but BS3 styles are not present so the UI appears broken

Fixes [dev/core#6345](https://lab.civicrm.org/dev/core/-/issues/6345)