### PR TITLE
Respect domain filter on multisite for various entities

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Price_Sets.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Price_Sets.mgd.php
@@ -2,53 +2,75 @@
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
 return [
-  [
-    'name' => 'SavedSearch_Administer_Price_Sets',
-    'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'name' => 'Administer_Price_Sets',
-        'label' => E::ts('Price Sets'),
-        'api_entity' => 'PriceSet',
-        'api_params' => [
+      [
+        'name' => 'SavedSearch_Administer_Price_Sets',
+        'entity' => 'SavedSearch',
+        'cleanup' => 'unused',
+        'update' => 'unmodified',
+        'params' => [
           'version' => 4,
-          'select' => [
-            'id',
-            'title',
-            'extends:label',
-            'COUNT(PriceSet_PriceField_price_set_id_01.id) AS COUNT_PriceSet_PriceField_price_set_id_01_id',
-            'GROUP_CONCAT(DISTINCT PriceSet_PriceField_price_set_id_01.label) AS GROUP_CONCAT_PriceSet_PriceField_price_set_id_01_label',
-            'is_active',
-          ],
-          'groupBy' => ['id'],
-          'where' => [
-            ['is_reserved', '=', FALSE],
-            [
-              'is_quick_config',
-              '=',
-              FALSE,
-            ],
-          ],
-          'join' => [
-            [
-              'PriceField AS PriceSet_PriceField_price_set_id_01',
-              'LEFT',
-              [
+          'values' => [
+            'name' => 'Administer_Price_Sets',
+            'label' => E::ts('Price Sets'),
+            'api_entity' => 'PriceSet',
+            'api_params' => [
+              'version' => 4,
+              'select' => [
                 'id',
-                '=',
-                'PriceSet_PriceField_price_set_id_01.price_set_id',
+                'title',
+                'extends:label',
+                'COUNT(PriceSet_PriceField_price_set_id_01.id) AS COUNT_PriceSet_PriceField_price_set_id_01_id',
+                'GROUP_CONCAT(DISTINCT PriceSet_PriceField_price_set_id_01.label) AS GROUP_CONCAT_PriceSet_PriceField_price_set_id_01_label',
+                'is_active',
               ],
+              'groupBy' => [
+                'id',
+              ],
+              'where' => [
+                [
+                  'is_reserved',
+                  '=',
+                  FALSE,
+                ],
+                [
+                  'is_quick_config',
+                  '=',
+                  FALSE,
+                ],
+                [
+                  'OR',
+                  [
+                    [
+                      'domain_id:name',
+                      '=',
+                      'current_domain',
+                    ],
+                    [
+                      'domain_id:name',
+                      'IS NULL',
+                    ],
+                  ],
+                ],
+              ],
+              'join' => [
+                [
+                  'PriceField AS PriceSet_PriceField_price_set_id_01',
+                  'LEFT',
+                  [
+                    'id',
+                    '=',
+                    'PriceSet_PriceField_price_set_id_01.price_set_id',
+                  ],
+                ],
+              ],
+              'having' => [],
             ],
           ],
-          'having' => [],
+          'match' => [
+            'name',
+          ],
         ],
       ],
-      'match' => ['name'],
-    ],
-  ],
   [
     'name' => 'SavedSearch_Administer_Price_Sets_SearchDisplay_Administer_Price_Sets',
     'entity' => 'SearchDisplay',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Membership_Type.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Membership_Type.mgd.php
@@ -36,6 +36,7 @@ return [
               '=',
               TRUE,
             ],
+            ['domain_id:name', '=', 'current_domain'],
           ],
           'groupBy' => [],
           'join' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
@@ -7,65 +7,81 @@ if (!CRM_Core_Component::isEnabled('CiviMember')) {
 }
 
 return [
-  [
-    'name' => 'SavedSearch_Contact_Summary_Memberships',
-    'entity' => 'SavedSearch',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'name' => 'Contact_Summary_Memberships',
-        'label' => E::ts('Contact Summary Memberships'),
-        'api_entity' => 'Membership',
-        'api_params' => [
+      [
+        'name' => 'SavedSearch_Contact_Summary_Memberships',
+        'entity' => 'SavedSearch',
+        'cleanup' => 'unused',
+        'update' => 'unmodified',
+        'params' => [
           'version' => 4,
-          'select' => [
-            'id',
-            'membership_type_id:label',
-            'join_date',
-            'start_date',
-            'end_date',
-            'status_id:label',
-            'source',
-            'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
-            'IF(owner_membership_id, "(' . E::ts('by relationship') . ')", owner_membership_id) AS IF_owner_membership_id_owner_membership_id',
-            'COUNT(DISTINCT Membership_Membership_owner_membership_id_01.id) AS COUNT_Membership_Membership_owner_membership_id_01_id',
-          ],
-          'orderBy' => [],
-          'where' => [],
-          'groupBy' => [
-            'id',
-            'Membership_ContributionRecur_contribution_recur_id_01.id',
-          ],
-          'join' => [
-            [
-              'ContributionRecur AS Membership_ContributionRecur_contribution_recur_id_01',
-              'LEFT',
-              [
-                'contribution_recur_id',
-                '=',
+          'values' => [
+            'name' => 'Contact_Summary_Memberships',
+            'label' => E::ts('Contact Summary Memberships'),
+            'api_entity' => 'Membership',
+            'api_params' => [
+              'version' => 4,
+              'select' => [
+                'id',
+                'membership_type_id:label',
+                'join_date',
+                'start_date',
+                'end_date',
+                'status_id:label',
+                'source',
+                'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
+                'IF(owner_membership_id, "(' . E::ts('by relationship') . ')", owner_membership_id) AS IF_owner_membership_id_owner_membership_id',
+                'COUNT(DISTINCT Membership_Membership_owner_membership_id_01.id) AS COUNT_Membership_Membership_owner_membership_id_01_id',
+                'Membership_MembershipType_membership_type_id_01.title',
+              ],
+              'orderBy' => [],
+              'where' => [
+                [
+                  'Membership_MembershipType_membership_type_id_01.domain_id:name',
+                  '=',
+                  'current_domain',
+                ],
+              ],
+              'groupBy' => [
+                'id',
                 'Membership_ContributionRecur_contribution_recur_id_01.id',
               ],
-            ],
-            [
-              'Membership AS Membership_Membership_owner_membership_id_01',
-              'LEFT',
-              [
-                'id',
-                '=',
-                'Membership_Membership_owner_membership_id_01.owner_membership_id',
+              'join' => [
+                [
+                  'ContributionRecur AS Membership_ContributionRecur_contribution_recur_id_01',
+                  'LEFT',
+                  [
+                    'contribution_recur_id',
+                    '=',
+                    'Membership_ContributionRecur_contribution_recur_id_01.id',
+                  ],
+                ],
+                [
+                  'Membership AS Membership_Membership_owner_membership_id_01',
+                  'LEFT',
+                  [
+                    'id',
+                    '=',
+                    'Membership_Membership_owner_membership_id_01.owner_membership_id',
+                  ],
+                ],
+                [
+                  'MembershipType AS Membership_MembershipType_membership_type_id_01',
+                  'LEFT',
+                  [
+                    'membership_type_id',
+                    '=',
+                    'Membership_MembershipType_membership_type_id_01.id',
+                  ],
+                ],
               ],
+              'having' => [],
             ],
           ],
-          'having' => [],
+          'match' => [
+            'name',
+          ],
         ],
       ],
-      'match' => [
-        'name',
-      ],
-    ],
-  ],
   [
     'name' => 'SavedSearch_Contact_Summary_Memberships_SearchDisplay_Contact_Summary_Memberships_Active',
     'entity' => 'SearchDisplay',
@@ -306,74 +322,74 @@ return [
       ],
     ],
   ],
-  [
-    'name' => 'SavedSearch_Contact_Summary_Memberships_SearchDisplay_Contact_Summary_Memberships_Inactive',
-    'entity' => 'SearchDisplay',
-    'cleanup' => 'unused',
-    'update' => 'unmodified',
-    'params' => [
-      'version' => 4,
-      'values' => [
-        'name' => 'Contact_Summary_Memberships_Inactive',
-        'label' => E::ts('Contact Summary Memberships Inactive'),
-        'saved_search_id.name' => 'Contact_Summary_Memberships',
-        'type' => 'table',
-        'settings' => [
-          'description' => '',
-          'sort' => [
+      [
+        'name' => 'SavedSearch_Contact_Summary_Memberships_SearchDisplay_Contact_Summary_Memberships_Inactive',
+        'entity' => 'SearchDisplay',
+        'cleanup' => 'unused',
+        'update' => 'unmodified',
+        'params' => [
+          'version' => 4,
+          'values' => [
+            'name' => 'Contact_Summary_Memberships_Inactive',
+            'label' => E::ts('Contact Summary Memberships Inactive'),
+            'saved_search_id.name' => 'Contact_Summary_Memberships',
+            'type' => 'table',
+            'settings' => [
+              'description' => '',
+              'sort' => [
             [
               'id',
               'DESC',
             ],
-          ],
-          'limit' => 0,
-          'pager' => FALSE,
-          'placeholder' => 5,
-          'columns' => [
-            [
-              'type' => 'field',
-              'key' => 'membership_type_id:label',
-              'label' => E::ts('Membership'),
-              'sortable' => TRUE,
-              'rewrite' => '[membership_type_id:label] [IF_owner_membership_id_owner_membership_id]',
-            ],
+              ],
+              'limit' => 0,
+              'pager' => FALSE,
+              'placeholder' => 5,
+              'columns' => [
+              [
+                'type' => 'field',
+                'key' => 'membership_type_id:label',
+                'label' => E::ts('Membership'),
+                'sortable' => TRUE,
+                'rewrite' => '[membership_type_id:label] [IF_owner_membership_id_owner_membership_id]',
+              ],
             [
               'type' => 'field',
               'key' => 'join_date',
               'label' => E::ts('Member Since'),
               'sortable' => TRUE,
             ],
-            [
-              'type' => 'field',
-              'key' => 'start_date',
-              'label' => E::ts('Membership Start Date'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'end_date',
-              'label' => E::ts('Membership Expiration Date'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'status_id:label',
-              'label' => E::ts('Status'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'source',
-              'label' => E::ts('Membership Source'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'field',
-              'key' => 'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
-              'label' => E::ts('Auto Renew'),
-              'sortable' => FALSE,
-              'rewrite' => '[none]',
-              'icons' => [
+              [
+                'type' => 'field',
+                'key' => 'start_date',
+                'label' => E::ts('Membership Start Date'),
+                'sortable' => TRUE,
+              ],
+              [
+                'type' => 'field',
+                'key' => 'end_date',
+                'label' => E::ts('Membership Expiration Date'),
+                'sortable' => TRUE,
+              ],
+              [
+                'type' => 'field',
+                'key' => 'status_id:label',
+                'label' => E::ts('Status'),
+                'sortable' => TRUE,
+              ],
+              [
+                'type' => 'field',
+                'key' => 'source',
+                'label' => E::ts('Membership Source'),
+                'sortable' => TRUE,
+              ],
+              [
+                'type' => 'field',
+                'key' => 'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
+                'label' => E::ts('Auto Renew'),
+                'sortable' => FALSE,
+                'rewrite' => '[none]',
+                'icons' => [
                 [
                   'icon' => 'fa-exclamation-triangle',
                   'side' => 'left',
@@ -391,14 +407,14 @@ return [
                     'IS NOT EMPTY',
                   ],
                 ],
+                ],
               ],
-            ],
-            [
-              'text' => '',
-              'style' => 'default',
-              'size' => 'btn-xs',
-              'icon' => 'fa-bars',
-              'links' => [
+              [
+                'text' => '',
+                'style' => 'default',
+                'size' => 'btn-xs',
+                'icon' => 'fa-bars',
+                'links' => [
                 [
                   'entity' => 'Membership',
                   'action' => 'view',
@@ -495,24 +511,24 @@ return [
                   'task' => '',
                   'condition' => [],
                 ],
+                ],
+                'type' => 'menu',
+                'alignment' => 'text-right',
               ],
-              'type' => 'menu',
-              'alignment' => 'text-right',
+              ],
+              'actions' => FALSE,
+              'classes' => [
+                'table',
+                'table-striped',
+                'disabled',
+              ],
+              'noResultsText' => '',
             ],
           ],
-          'actions' => FALSE,
-          'classes' => [
-            'table',
-            'table-striped',
-            'disabled',
+          'match' => [
+            'saved_search_id',
+            'name',
           ],
-          'noResultsText' => '',
         ],
       ],
-      'match' => [
-        'saved_search_id',
-        'name',
-      ],
-    ],
-  ],
 ];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse.mgd.php
@@ -249,6 +249,7 @@ return [
           'orderBy' => [],
           'where' => [
             ['sms_provider_id', 'IS EMPTY'],
+            ['domain_id:name', '=', 'current_domain'],
           ],
           'groupBy' => [
             'id',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Mail_Accounts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Mail_Accounts.mgd.php
@@ -37,7 +37,9 @@ return [
             'is_default',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [
+            ['domain_id:name', '=', 'current_domain'],
+          ],
           'groupBy' => [],
           'join' => [],
           'having' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_SMS_Provider.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_SMS_Provider.mgd.php
@@ -26,7 +26,9 @@ return [
             'api_type:label',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [
+            ['domain_id:name', '=', 'current_domain'],
+          ],
           'groupBy' => [],
           'join' => [],
           'having' => [],

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
@@ -27,7 +27,9 @@ return [
             'data',
           ],
           'orderBy' => [],
-          'where' => [],
+          'where' => [
+            ['domain_id:name', '=', 'current_domain'],
+          ],
           'groupBy' => [],
           'join' => [],
           'having' => [],


### PR DESCRIPTION
Overview
----------------------------------------

Add current_domain constraints to managed saved searches in civicrm_admin_ui ext to work better on multisite:

- Mail Accounts
- Sms Providers
- Mailings
- Contact Summary Memberships
- Priceset with option to use NULL for global price sets

This is follow up from https://github.com/civicrm/civicrm-core/pull/34828 

Before
----------------------------------------
Various screens did not account for the domain making UX confusing.

<img width="1858" height="580" alt="image" src="https://github.com/user-attachments/assets/7b1a5df9-5e2c-42a2-b09d-3d7fc32f8fdb" />


After
----------------------------------------
Respect the domain a couple examples and notes below.

**Contact Summary Membership Tab**
In some cases there have been years of odd behavior such as contact summary membership screen where it shows all membership regardless of domain and one domain could edit/delete ones not in their domain. This fixes that. 

![firefox_vrQRIP5hIC](https://github.com/user-attachments/assets/ced3477c-af2a-4041-aadb-2dfc701892bb)

**Price Sets**
Some entities are clearly to be contained in a domain but price sets have a good use case to share across many domains, to remove unnecessary repetition of creating the same price set db bloat. While other times, say event price sets only need to show in the given domain. I set the saved search here to look for current domain or NULL to accommodate this. FYI @eileenmcnaughton had the idea of NULL meaning global per this kind of scenario: https://lab.civicrm.org/extensions/multisite/-/issues/4#note_79697

> I did wonder about making domain_id optional (in the schema) with NULL or 0 meaning 'all sites' but that is a core change if so.

**I have tested on the various screens on a WP multisite.** 

Price sets is a WIP that will need follow up PR since saving does not set the domain id, you have to do it thru the API Explorer. Additionally, in a contribution page "Amounts" tab, there is no logic to consider the domain at present.

<img width="690" height="273" alt="image" src="https://github.com/user-attachments/assets/a82979ef-f324-40bf-b76b-c7e44b638721" />

Technical Details / related
----------------------------------------
I skipped the following searches for now, since they are option values.

SavedSearch_Label_Formats.mgd.php (OptionValue)
SavedSearch_Print_Page_PDF_Formats.mgd.php (OptionValue)

