### PR TITLE
dev/core#6207 Afform - Prevent corrupting js variables in field defn

### DIFF
--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -87,11 +87,19 @@ class StringVisitor {
     $defnSelectors = \CRM_Utils_JS::getDefnSelectors();
     $doc->find('af-field[defn]')->each(
       function (\DOMElement $item) use ($defnSelectors, $callback) {
-        $defn = \CRM_Utils_JS::decode($item->getAttribute('defn'));
-        foreach ($defnSelectors as $selector) {
-          $this->defnLookupTranslate($defn, $selector, $callback);
+        $rawDefn = $item->getAttribute('defn');
+        if ($rawDefn) {
+          try {
+            $defn = \CRM_Utils_JS::getRawProps($item->getAttribute('defn'));
+            foreach ($defnSelectors as $selector) {
+              $this->defnLookupTranslate($defn, $selector, $callback);
+            }
+            $item->setAttribute('defn', \CRM_Utils_JS::writeObject($defn));
+          }
+          catch (\Exception $e) {
+            // Could not parse json, skip
+          }
         }
-        $item->setAttribute('defn', \CRM_Utils_JS::encode($defn));
       }
     );
 
@@ -108,28 +116,50 @@ class StringVisitor {
   }
 
   /**
-   * Helper to translate defn data recursively
+   * Recursively traverses a definition array and applies a translation callback function.
+   *
+   * @param array $defn
+   *   Raw definition as returned by \CRM_Utils_JS::getRawProps().
+   * @param string $selector
+   *   A dot-delimited string representing the path within the array to locate the target value(s).
+   *   Supports wildcard (*) to iterate over arrays of objects.
+   * @param callable $callback
+   *   function(string $value, string $context): string
+   * @return void
    */
-  protected function defnLookupTranslate(&$defn, $selector, $callback) {
+  protected function defnLookupTranslate(array &$defn, string $selector, callable $callback): void {
     $subsels = explode('.', $selector);
     if (count($subsels) == 1) {
-      if (isset($defn[$selector]) && $this->isWorthy($defn[$selector])) {
-        $defn[$selector] = $callback($defn[$selector], 'defn');
+      if (isset($defn[$selector])) {
+        $value = \CRM_Utils_JS::decode($defn[$selector] ?? 'null');
+        if ($this->isWorthy($value)) {
+          $defn[$selector] = \CRM_Utils_JS::encode($callback($value, 'defn'));
+        }
       }
     }
     elseif (count($subsels) > 1) {
       // go deeper in the defn array
       $parentSel = $subsels[0];
       unset($subsels[0]);
-      // we use '*' to indicate that this is an array of objects so we can loop on the array
-      if (isset($subsels[1]) && $subsels[1] == '*' && !empty($defn[$parentSel])) {
-        unset($subsels[1]);
-        foreach ($defn[$parentSel] as &$subDefn) {
-          $this->defnLookupTranslate($subDefn, implode('.', $subsels), $callback);
+      try {
+        $parentValues = \CRM_Utils_JS::getRawProps($defn[$parentSel]);
+        // we use '*' to indicate that this is an array of objects so we can loop on the array
+        if (isset($subsels[1]) && $subsels[1] == '*' && !empty($defn[$parentSel])) {
+          unset($subsels[1]);
+          foreach ($parentValues as &$subDefn) {
+            $subValues = \CRM_Utils_JS::getRawProps($subDefn);
+            $this->defnLookupTranslate($subValues, implode('.', $subsels), $callback);
+            $subDefn = \CRM_Utils_JS::writeObject($subValues);
+          }
+          $defn[$parentSel] = \CRM_Utils_JS::writeObject($parentValues);
         }
+        elseif (isset($defn[$parentSel])) {
+          $this->defnLookupTranslate($parentValues, implode('.', $subsels), $callback);
+        }
+        $defn[$parentSel] = \CRM_Utils_JS::writeObject($parentValues);
       }
-      elseif (isset($defn[$parentSel])) {
-        $this->defnLookupTranslate($defn[$parentSel], implode('.', $subsels), $callback);
+      catch (\Exception $e) {
+        // Could not parse json, skip
       }
     }
   }

--- a/ext/afform/mock/ang/translate/tTranslatedDefn.aff.html
+++ b/ext/afform/mock/ang/translate/tTranslatedDefn.aff.html
@@ -3,7 +3,7 @@
   <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
     <div class="af-container">
       <div class="af-container af-layout-inline">
-        <af-field name="first_name" defn="{input_attrs: {placeholder: '(Your given name)'}, label: 'Given Name'}" />
+        <af-field name="first_name" defn="{afform_default: options.search_query, input_attrs: {placeholder: '(Your given name)'}, label: 'Given Name'}" />
       </div>
     </div>
   </fieldset>

--- a/ext/afform/mock/ang/translate/tTranslatedDefn.rendered.html
+++ b/ext/afform/mock/ang/translate/tTranslatedDefn.rendered.html
@@ -3,7 +3,7 @@
   <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
     <div class="af-container">
       <div class="af-container af-layout-inline">
-        <af-field name="first_name" defn="{input_attrs: {placeholder: '(Your given name)', size: '30', label: 'Prénom'}, label: 'Given Name', required: false, name: 'first_name', data_type: 'String', serialize: null, fk_entity: null, dfk_entities: null, options: false, input_type: 'Text', help_pre: null, help_post: null, search_range: false, template: '~/af/fields/Text.html'}"></af-field>
+        <af-field name="first_name" defn="{afform_default: options.search_query, input_attrs: {placeholder: '(Your given name)', size: '30', label: 'Prénom'}, label: 'Given Name', required: false, name: 'first_name', data_type: 'String', serialize: null, fk_entity: null, dfk_entities: null, options: false, input_type: 'Text', help_pre: null, help_post: null, search_range: false, template: '~/af/fields/Text.html'}"></af-field>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6207](https://lab.civicrm.org/dev/core/-/issues/6207)

Regression caused by translating afform strings and decoding/re-encoding `defn` objects. Instead of trying to decode everything, leave properties alone that don't need translation.

See https://github.com/civicrm/civicrm-core/pull/32859 for the original change that caused this issue.