### PR TITLE
Manage Events: move map option to Location tab and use toggles everywhere

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -157,10 +157,9 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
 
     $this->add('textarea', 'summary', ts('Event Summary'), $attributes['summary']);
     $this->add('wysiwyg', 'description', ts('Complete Description'), $attributes['event_description'] + ['preset' => 'civievent']);
-    $this->addElement('checkbox', 'is_public', ts('Display the event in public listings'));
-    $this->addElement('checkbox', 'is_share', ts('Social media sharing links'));
-    $this->addElement('checkbox', 'is_map', ts('Map to the event location'));
-    $this->addElement('checkbox', 'is_show_calendar_links', ts('Calendar links'));
+    $this->addToggle('is_public', ts('Display the event in public listings'));
+    $this->addToggle('is_share', ts('Social media sharing links'));
+    $this->addToggle('is_show_calendar_links', ts('Calendar links'));
 
     $this->add('datepicker', 'start_date', ts('Start'), [], !$this->_isTemplate, ['time' => TRUE]);
     $this->add('datepicker', 'end_date', ts('End'), [], FALSE, ['time' => TRUE]);
@@ -181,7 +180,7 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
 
     $this->add('textarea', 'event_full_text', ts('Message if Event Is Full'), $attributes['event_full_text']);
 
-    $this->addElement('checkbox', 'is_active', ts('Event is active'));
+    $this->addToggle('is_active', ts('Event is active'));
 
     $this->addFormRule(['CRM_Event_Form_ManageEvent_EventInfo', 'formRule']);
     if ($this->isSubmitted()) {
@@ -230,7 +229,6 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $params['start_date'] ??= NULL;
     $params['end_date'] ??= NULL;
     $params['has_waitlist'] ??= FALSE;
-    $params['is_map'] ??= FALSE;
     $params['is_active'] ??= FALSE;
     $params['is_public'] ??= FALSE;
     $params['is_share'] ??= FALSE;

--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -228,11 +228,9 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $this->addYesNo('is_monetary',
+    $this->addToggle('is_monetary',
       ts('Paid Event'),
-      NULL,
-      NULL,
-      ['onclick' => "return showHideByValue('is_monetary','0','event-fees','block','radio',false);"]
+      ['onclick' => "return showHideByValue('is_monetary','1','event-fees','block','checkbox',false);"]
     );
 
     //add currency element.

--- a/CRM/Event/Form/ManageEvent/Location.php
+++ b/CRM/Event/Form/ManageEvent/Location.php
@@ -150,6 +150,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
     $this->addEmailBlockNonContactFields(2);
     $this->addPhoneBlockFields(1);
     $this->addPhoneBlockFields(2);
+    $this->addToggle('is_map', ts('Show a Map'));
 
     $this->applyFilter('__ALL__', 'trim');
 
@@ -189,7 +190,7 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
       }
       $this->add('select', 'loc_event_id', ts('Use Location'), $locationEvents, FALSE, ['class' => 'crm-select2']);
     }
-    $this->addElement('advcheckbox', 'is_show_location', ts('Show Location?'));
+    $this->addToggle('is_show_location', ts('Show Location'));
     parent::buildQuickForm();
   }
 
@@ -224,6 +225,12 @@ class CRM_Event_Form_ManageEvent_Location extends CRM_Event_Form_ManageEvent {
   public function postProcess() {
     $params = $this->exportValues();
     $deleteOldBlock = FALSE;
+
+    // This property is on the event itself, not the location
+    // It was previously on the EventInfo
+    $params['id'] = $this->getEventID();
+    $params['is_map'] ??= FALSE;
+    $event = CRM_Event_BAO_Event::create($params);
 
     // If 'Use existing location' is selected.
     if (($params['location_option'] ?? NULL) == 2) {

--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -214,16 +214,14 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $this->applyFilter('__ALL__', 'trim');
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
 
-    $this->addElement('checkbox',
-      'is_online_registration',
+    $this->addToggle('is_online_registration',
       ts('Allow Online Registration'),
-      NULL,
       [
         'onclick' => "return showHideByValue('is_online_registration'," .
         "''," .
         "'registration_blocks'," .
         "'block'," .
-        "'radio'," .
+        "'checkbox'," .
         "false );",
       ]
     );
@@ -245,19 +243,13 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       $ruleFields[$key] = ucwords(str_replace('_', ' ', $fields));
     }
 
-    $this->addElement('checkbox',
-      'is_multiple_registrations',
-      ts('Register multiple participants?')
-    );
+    $this->addToggle('is_multiple_registrations', ts('Register multiple participants?'));
 
     // CRM-17745: Make maximum additional participants configurable
     $numericOptions = CRM_Core_SelectValues::getNumericOptions(1, 9);
     $this->add('select', 'max_additional_participants', ts('Maximum additional participants'), $numericOptions, FALSE, ['class' => 'required']);
 
-    $this->addElement('checkbox',
-      'allow_same_participant_emails',
-      ts('Allow same email and multiple registrations?')
-    );
+    $this->addToggle('allow_same_participant_emails', ts('Allow same email and multiple registrations?'));
     $this->assign('ruleFields', json_encode($ruleFields));
 
     $dedupeRules = [
@@ -268,18 +260,16 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
 
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     if (in_array('Awaiting approval', $participantStatuses) and in_array('Pending from approval', $participantStatuses) and in_array('Rejected', $participantStatuses)) {
-      $this->addElement('checkbox',
-        'requires_approval',
+      $this->addToggle('requires_approval',
         ts('Require participant approval?'),
-        NULL,
-        ['onclick' => "return showHideByValue('requires_approval', '', 'id-approval-text', 'table-row', 'radio', false);"]
+        ['onclick' => "return showHideByValue('requires_approval', '', 'id-approval-text', 'table-row', 'checkbox', false);"]
       );
       $this->add('textarea', 'approval_req_text', ts('Approval message'), $attributes['approval_req_text']);
     }
 
     $this->add('text', 'expiration_time', ts('Pending participant expiration (hours)'));
     $this->addRule('expiration_time', ts('Please enter the number of hours (as an integer).'), 'integer');
-    $this->addField('allow_selfcancelxfer', ['label' => ts('Allow self-service cancellation or transfer?'), 'type' => 'advcheckbox']);
+    $this->addToggle('allow_selfcancelxfer', ts('Allow self-service cancellation or transfer?'));
     $this->add('text', 'selfcancelxfer_time', ts('Cancellation or transfer time limit (hours)'));
     $this->addRule('selfcancelxfer_time', ts('Please enter the number of hours (as an integer).'), 'integer');
     self::buildRegistrationBlock($this);
@@ -378,7 +368,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    */
   public function buildConfirmationBlock(&$form) {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
-    $form->addYesNo('is_confirm_enabled', ts('Use a confirmation screen?'), NULL, NULL, ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
+    $form->addToggle('is_confirm_enabled', ts('Use a confirmation screen?'), ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
     $form->add('text', 'confirm_title', ts('Title'), $attributes['confirm_title']);
     $form->add('wysiwyg', 'confirm_text', ts('Introductory Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
     $form->add('wysiwyg', 'confirm_footer_text', ts('Footer Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
@@ -392,7 +382,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
   public function buildMailBlock(&$form) {
     $form->registerRule('emailList', 'callback', 'emailList', 'CRM_Utils_Rule');
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
-    $form->addYesNo('is_email_confirm', ts('Send a confirmation email'), NULL, NULL, ['onclick' => "return showHideByValue('is_email_confirm','','confirmEmail','block','radio',false);"]);
+    $form->addToggle('is_email_confirm', ts('Send a confirmation email'), ['onclick' => "return showHideByValue('is_email_confirm','','confirmEmail','block','checkbox',false);"]);
     $form->add('wysiwyg', 'confirm_email_text', ts('Text'), $attributes['confirm_email_text']);
     $form->add('text', 'cc_confirm', ts('CC Confirmation To'), CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event', 'cc_confirm'));
     $form->addRule('cc_confirm', ts('Please enter a valid list of comma delimited email addresses'), 'emailList');

--- a/js/Common.js
+++ b/js/Common.js
@@ -125,27 +125,45 @@ function showHideByValue(trigger_field_id, trigger_value, target_element_id, tar
         }
       }
     }
-
   }
-  else {
-    if (field_type == 'radio') {
-      target = target_element_id.split("|");
-      for (j = 0; j < target.length; j++) {
-        if (cj('[name="' + trigger_field_id + '"]:first').is(':checked')) {
-          if (invert) {
-            cj('#' + target[j]).hide();
-          }
-          else {
-            cj('#' + target[j]).show();
-          }
+  else if (field_type == 'radio') {
+    target = target_element_id.split("|");
+    for (j = 0; j < target.length; j++) {
+      if (cj('[name="' + trigger_field_id + '"]:first').is(':checked')) {
+        if (invert) {
+          cj('#' + target[j]).hide();
         }
         else {
-          if (invert) {
-            cj('#' + target[j]).show();
-          }
-          else {
-            cj('#' + target[j]).hide();
-          }
+          cj('#' + target[j]).show();
+        }
+      }
+      else {
+        if (invert) {
+          cj('#' + target[j]).show();
+        }
+        else {
+          cj('#' + target[j]).hide();
+        }
+      }
+    }
+  }
+  else if (field_type == 'checkbox') {
+    target = target_element_id.split("|");
+    for (j = 0; j < target.length; j++) {
+      if (cj('#' + trigger_field_id).is(':checked')) {
+        if (invert) {
+          cj('#' + target[j]).hide();
+        }
+        else {
+          cj('#' + target[j]).show();
+        }
+      }
+      else {
+        if (invert) {
+          cj('#' + target[j]).show();
+        }
+        else {
+          cj('#' + target[j]).hide();
         }
       }
     }

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
@@ -72,12 +72,6 @@
 {/htxt}
 
 
-{htxt id='is_map'}
-{capture assign=mapURL}{crmURL p='civicrm/admin/setting/mapping' q="reset=1"}{/capture} 
-{ts 1=$mapURL}Include map presenting event location on event information page? (A map provider must be configured under <a href='%1'>Administer > System Settings > Mapping and Geocoding</a>){/ts}
-{/htxt}
-
-
 {htxt id='is_show_calendar_links'}
 {ts}Displays links to download an iCal file with the event information, as well as a link to add to Google Calendar. The links will be displayed on the event information page, as well as on the thank-you page and in the email receipt.{/ts}
 {/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -80,7 +80,7 @@
     </tr>
     <tr id="id-event_full" class="crm-event-manage-eventinfo-form-block-event_full_text">
       <td class="label">{$form.event_full_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='event_full_text' id=$eventID}{/if}
-        <br />{help id="event_full_text"}&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <br />{help id="event_full_text"}</td>
       <td>{$form.event_full_text.html}</td>
     </tr>
     <tr id="id-waitlist-text" class="crm-event-manage-eventinfo-form-block-waitlist_text">
@@ -90,28 +90,24 @@
       {/if}
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-is_active">
-      <td>&nbsp;</td>
-      <td>{$form.is_active.html} {$form.is_active.label} {help id="is_active"}</td>
+      <td class="label">{$form.is_active.label} {help id="is_active"}</td>
+      <td>{$form.is_active.html}</td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-is_public">
-      <td>&nbsp;</td>
-      <td>{$form.is_public.html} {$form.is_public.label} {help id="is_public"}</td>
+      <td class="label">{$form.is_public.label} {help id="is_public"}</td>
+      <td>{$form.is_public.html}</td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-separator">
       <td>&nbsp;</td>
       <td>{ts}Display event information:{/ts}</td>
     </tr>
-    <tr class="crm-event-manage-eventinfo-form-block-is_map">
-      <td>&nbsp;</td>
-      <td>{$form.is_map.html} {$form.is_map.label} {help id="is_map"}</td>
-    </tr>
     <tr class="crm-event-manage-eventinfo-form-block-is_show_calendar_links">
-      <td>&nbsp;</td>
-      <td>{$form.is_show_calendar_links.html} {$form.is_show_calendar_links.label} {help id="is_show_calendar_links"}</td>
+      <td class="label">{$form.is_show_calendar_links.label} {help id="is_show_calendar_links"}</td>
+      <td>{$form.is_show_calendar_links.html}</td>
     </tr>
     <tr class="crm-event-manage-eventinfo-form-block-is_share">
-      <td>&nbsp;</td>
-      <td>{$form.is_share.html} {$form.is_share.label} {help id="is_share"}
+      <td class="label">{$form.is_share.label} {help id="is_share"}</td>
+      <td>{$form.is_share.html}</td>
     </tr>
 
     {if $eventID AND !$isTemplate}

--- a/templates/CRM/Event/Form/ManageEvent/Location.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/Location.hlp
@@ -20,3 +20,7 @@
   {ts}Note that if 'Show Location' is not set a map will not be shown, regardless of the setting of 'Include Map to Event Location'.{/ts}
 {/htxt}
 
+{htxt id='is_map'}
+{capture assign=mapURL}{crmURL p='civicrm/admin/setting/mapping' q="reset=1"}{/capture}
+{ts 1=$mapURL}Include map presenting event location on event information page? (A map provider must be configured under <a href='%1'>Administer > System Settings > Mapping and Geocoding</a>){/ts}
+{/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/Location.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Location.tpl
@@ -16,7 +16,7 @@
   {if $locEvents}
     <table class="form-layout-compressed">
       <tr id="optionType" class="crm-event-manage-location-form-block-location_option">
-        <td class="labels">
+        <td class="label">
           {$form.location_option.label}
         </td>
         {foreach from=$form.location_option key=key item =item}
@@ -26,7 +26,7 @@
         {/foreach}
       </tr>
       <tr id="existingLoc" class="crm-event-manage-location-form-block-loc_event_id">
-        <td class="labels">
+        <td class="label">
           {$form.loc_event_id.label}
         </td>
         <td class="value" colspan="2">
@@ -38,12 +38,16 @@
         </td>
       </tr>
       <tr class="crm-event-manage-location-form-block-is_show_location">
-        <td class="labels">
+        <td class="label">
           {$form.is_show_location.label} {help id="is_show_location"}
         </td>
         <td class="values">
           {$form.is_show_location.html}
         </td>
+      </tr>
+      <tr class="crm-event-manage-location-form-block-is_map">
+        <td class="label">{$form.is_map.label} {help id="is_map"}</td>
+        <td>{$form.is_map.html}</td>
       </tr>
     </table>
   {/if}

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {if $addProfileBottomAdd OR $addProfileBottom}
-  <td scope="row" class="label" width="20%">
+  <td class="label">
     {if $addProfileBottomAdd}{$form.additional_custom_post_id_multiple[$profileBottomNumAdd].label}
     {else}{$form.custom_post_id_multiple[$profileBottomNum].label}{/if}</td>
   <td>
@@ -39,60 +39,58 @@
 <table class="form-layout-compressed">
 
   <tr class="crm-event-manage-registration-form-block-registration_link_text">
-    <td scope="row" class="label"
-        width="20%">{$form.registration_link_text.label} <span class="crm-marker">*</span>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='registration_link_text' id=$eventID}{/if}</td>
+    <td class="label">{$form.registration_link_text.label} <span class="crm-marker">*</span>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='registration_link_text' id=$eventID}{/if}</td>
     <td>{$form.registration_link_text.html} {help id="link_text"}</td>
   </tr>
   {if !$isTemplate}
     <tr class="crm-event-manage-registration-form-block-registration_start_date">
-      <td scope="row" class="label" width="20%">{$form.registration_start_date.label}</td>
+      <td class="label">{$form.registration_start_date.label}</td>
       <td>{$form.registration_start_date.html}</td>
     </tr>
     <tr class="crm-event-manage-registration-form-block-registration_end_date">
-      <td scope="row" class="label" width="20%">{$form.registration_end_date.label}</td>
+      <td class="label">{$form.registration_end_date.label}</td>
       <td>{$form.registration_end_date.html}</td>
     </tr>
   {/if}
   <tr class="crm-event-manage-registration-form-block-is_multiple_registrations">
-    <td scope="row" class="label" width="20%">{$form.is_multiple_registrations.label}</td>
-    <td>{$form.is_multiple_registrations.html} {help id="is_multiple_registrations"}</td>
+    <td class="label">{$form.is_multiple_registrations.label} {help id="is_multiple_registrations"}</td>
+    <td>{$form.is_multiple_registrations.html}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-maximum_additional_participants" id="id-max-additional-participants">
-    <td scope="row" class="label" width="20%">{$form.max_additional_participants.label}</td>
-    <td>{$form.max_additional_participants.html} {help id="max_additional_participants"}</td>
+    <td class="label">{$form.max_additional_participants.label} {help id="max_additional_participants"}</td>
+    <td>{$form.max_additional_participants.html}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-allow_same_participant_emails">
-    <td scope="row" class="label" width="20%">{$form.allow_same_participant_emails.label}</td>
-    <td>{$form.allow_same_participant_emails.html} {help id="allow_same_participant_emails"}</td>
+    <td class="label">{$form.allow_same_participant_emails.label} {help id="allow_same_participant_emails"}</td>
+    <td>{$form.allow_same_participant_emails.html}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-dedupe_rule_group_id">
-    <td scope="row" class="label" width="20%">{$form.dedupe_rule_group_id.label}</td>
-    <td>{$form.dedupe_rule_group_id.html} {help id="dedupe_rule_group_id"}</td>
+    <td class="label">{$form.dedupe_rule_group_id.label} {help id="dedupe_rule_group_id"}</td>
+    <td>{$form.dedupe_rule_group_id.html}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-requires_approval">
     {if !empty($form.requires_approval)}
-      <td scope="row" class="label" width="20%">{$form.requires_approval.label}</td>
-      <td>{$form.requires_approval.html} {help id="requires_approval"}</td>
+      <td class="label">{$form.requires_approval.label} {help id="requires_approval"}</td>
+      <td>{$form.requires_approval.html}</td>
     {/if}
   </tr>
   <tr id="id-approval-text" class="crm-event-manage-registration-form-block-approval_req_text">
     {if !empty($form.approval_req_text)}
-      <td scope="row" class="label"
-          width="20%">{$form.approval_req_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='approval_req_text' id=$eventID}{/if}</td>
+      <td class="label">{$form.approval_req_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='approval_req_text' id=$eventID}{/if}</td>
       <td>{$form.approval_req_text.html}</td>
     {/if}
   </tr>
   <tr class="crm-event-manage-registration-form-block-expiration_time">
-    <td scope="row" class="label" width="20%">{$form.expiration_time.label}</td>
-    <td>{$form.expiration_time.html|crmAddClass:four} {help id="expiration_time"}</td>
+    <td class="label">{$form.expiration_time.label} {help id="expiration_time"}</td>
+    <td>{$form.expiration_time.html|crmAddClass:four}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-selfcancelxfer">
-    <td scope="row" class="label" width="20%">{$form.allow_selfcancelxfer.label}</td>
-    <td>{$form.allow_selfcancelxfer.html} {help id="allow_selfcancelxfer"}</td>
+    <td class="label">{$form.allow_selfcancelxfer.label} {help id="allow_selfcancelxfer"}</td>
+    <td>{$form.allow_selfcancelxfer.html}</td>
   </tr>
   <tr class="crm-event-manage-registration-form-block-selfcancelxfer_time">
-    <td scope="row" class="label" width="20%">{$form.selfcancelxfer_time.label}</td>
-    <td>{$form.selfcancelxfer_time.html|crmAddClass:four} {help id="selfcancelxfer_time"}</td>
+    <td class="label">{$form.selfcancelxfer_time.label} {help id="selfcancelxfer_time"}</td>
+    <td>{$form.selfcancelxfer_time.html|crmAddClass:four}</td>
   </tr>
 </table>
 <div class="spacer"></div>
@@ -103,13 +101,11 @@
   <div id="registration_screen" class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-intro_text">
-        <td scope="row" class="label"
-            width="20%">{$form.intro_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='intro_text' id=$eventID}{/if}</td>
+        <td class="label">{$form.intro_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='intro_text' id=$eventID}{/if}</td>
         <td>{$form.intro_text.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-footer_text">
-        <td scope="row" class="label"
-            width="20%">{$form.footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='footer_text' id=$eventID}{/if}</td>
+        <td class="label">{$form.footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='footer_text' id=$eventID}{/if}</td>
         <td>{$form.footer_text.html}</td>
       </tr>
     </table>
@@ -153,13 +149,13 @@
     </table>
     <table class="form-layout-compressed">
       <tr id="additional_profile_pre" class="crm-event-manage-registration-form-block-additional_custom_pre_id">
-        <td scope="row" class="label" width="20%">{$form.additional_custom_pre_id.label}</td>
+        <td class="label">{$form.additional_custom_pre_id.label}</td>
         <td>{$form.additional_custom_pre_id.html}
           <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
         </td>
       </tr>
       <tr id="additional_profile_post" class="crm-event-manage-registration-form-block-additional_custom_post_id">
-        <td scope="row" class="label" width="20%">{$form.additional_custom_post_id.label}</td>
+        <td class="label">{$form.additional_custom_post_id.label}</td>
         <td>{$form.additional_custom_post_id.html}
           <a href="#" class="crm-button crm-popup">{icon icon="fa-list-alt"}{/icon} {ts}Fields{/ts}</a>
           <p class='profile_bottom_add_link_main{if $profilePostMultipleAdd} hiddenElement{/if}'><a href="#" class="crm-hover-button crm-button-add-profile"><i class="crm-i fa-plus-circle" role="img" aria-hidden="true"></i> {ts}add another profile{/ts}</a></p>
@@ -196,25 +192,23 @@
   <div class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_confirm_enabled">
-        <td scope="row" class="label" width="20%">{$form.is_confirm_enabled.label}</td>
+        <td class="label">{$form.is_confirm_enabled.label}</td>
         <td>{$form.is_confirm_enabled.html}</td>
       </tr>
     </table>
     <table class="form-layout-compressed" id="confirm_screen_settings">
       <tr class="crm-event-manage-registration-form-block-confirm_title">
-        <td scope="row" class="label" width="20%">{$form.confirm_title.label} <span
+        <td class="label">{$form.confirm_title.label} <span
             class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_title' id=$eventID}{/if}
         </td>
         <td>{$form.confirm_title.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-confirm_text">
-        <td scope="row" class="label"
-            width="20%">{$form.confirm_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_text' id=$eventID}{/if}</td>
+        <td class="label">{$form.confirm_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_text' id=$eventID}{/if}</td>
         <td>{$form.confirm_text.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-confirm_footer_text">
-        <td scope="row" class="label"
-            width="20%">{$form.confirm_footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_footer_text' id=$eventID}{/if}</td>
+        <td class="label">{$form.confirm_footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_footer_text' id=$eventID}{/if}</td>
         <td>{$form.confirm_footer_text.html}</td>
       </tr>
     </table>
@@ -227,18 +221,15 @@
   <div class="crm-accordion-body">
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-confirm_thankyou_title">
-        <td scope="row" class="label" width="20%">{$form.thankyou_title.label} <span
-            class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_title' id=$eventID}{/if}
-        </td>
+        <td class="label">{$form.thankyou_title.label} <span class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_title' id=$eventID}{/if}</td>
         <td>{$form.thankyou_title.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-confirm_thankyou_text">
-        <td scope="row" class="label" width="20%">{$form.thankyou_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_text' id=$eventID}{/if}</td>
+        <td class="label">{$form.thankyou_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_text' id=$eventID}{/if}</td>
         <td>{$form.thankyou_text.html}</td>
       </tr>
       <tr class="crm-event-manage-registration-form-block-confirm_thankyou_footer_text">
-        <td scope="row" class="label"
-            width="20%">{$form.thankyou_footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_footer_text' id=$eventID}{/if}</td>
+        <td class="label">{$form.thankyou_footer_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='thankyou_footer_text' id=$eventID}{/if}</td>
         <td>{$form.thankyou_footer_text.html}</td>
       </tr>
     </table>
@@ -251,36 +242,32 @@
   <div class="crm-accordion-wrapper">
     <table class="form-layout-compressed">
       <tr class="crm-event-manage-registration-form-block-is_email_confirm">
-        <td scope="row" class="label" width="20%">{$form.is_email_confirm.label} {help id="is_email_confirm"}</td>
+        <td class="label">{$form.is_email_confirm.label} {help id="is_email_confirm"}</td>
         <td>{$form.is_email_confirm.html}</td>
       </tr>
     </table>
     <div id="confirmEmail">
       <table class="form-layout-compressed">
         <tr class="crm-event-manage-registration-form-block-confirm_email_text">
-          <td scope="row" class="label"
-              width="20%">{$form.confirm_email_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_email_text' id=$eventID}{/if}</td>
+          <td class="label">{$form.confirm_email_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_email_text' id=$eventID}{/if}</td>
           <td>{$form.confirm_email_text.html}<br/>
-            <span
-              class="description">{ts}Additional message or instructions to include in confirmation email.{/ts}</span>
+            <span class="description">{ts}Additional message or instructions to include in confirmation email.{/ts}</span>
           </td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-confirm_from_name">
-          <td scope="row" class="label" width="20%">{$form.confirm_from_name.label} <span
-              class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_from_name' id=$eventID}{/if}
-          </td>
+          <td class="label">{$form.confirm_from_name.label} <span class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_from_name' id=$eventID}{/if}</td>
           <td>{$form.confirm_from_name.html}</td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-confirm_from_email">
-          <td scope="row" class="label" width="20%">{$form.confirm_from_email.label} <span class="crm-marker">*</span></td>
+          <td class="label">{$form.confirm_from_email.label} <span class="crm-marker">*</span></td>
           <td>{$form.confirm_from_email.html}</td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-cc_confirm">
-          <td scope="row" class="label" width="20%">{$form.cc_confirm.label} {help id="cc_confirm"}</td>
+          <td class="label">{$form.cc_confirm.label} {help id="cc_confirm"}</td>
           <td>{$form.cc_confirm.html}</td>
         </tr>
         <tr class="crm-event-manage-registration-form-block-bcc_confirm">
-          <td scope="row" class="label" width="20%">{$form.bcc_confirm.label} {help id="bcc_confirm"}</td>
+          <td class="label">{$form.bcc_confirm.label} {help id="bcc_confirm"}</td>
           <td>{$form.bcc_confirm.html}</td>
         </tr>
       </table>
@@ -292,41 +279,6 @@
   <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
-  {include file="CRM/common/showHide.tpl"}
-{include file="CRM/common/showHideByFieldValue.tpl"
-trigger_field_id    ="is_online_registration"
-trigger_value       =""
-target_element_id   ="registration_blocks"
-target_element_type ="block"
-field_type          ="radio"
-invert              = 0
-}
-{include file="CRM/common/showHideByFieldValue.tpl"
-trigger_field_id    ="is_confirm_enabled"
-trigger_value       =""
-target_element_id   ="confirm_screen_settings"
-target_element_type ="block"
-field_type          ="radio"
-invert              = 0
-}
-{include file="CRM/common/showHideByFieldValue.tpl"
-trigger_field_id    ="is_email_confirm"
-trigger_value       =""
-target_element_id   ="confirmEmail"
-target_element_type ="block"
-field_type          ="radio"
-invert              = 0
-}
-{if !empty($form.requires_approval)}
-{include file="CRM/common/showHideByFieldValue.tpl"
-    trigger_field_id    ="requires_approval"
-    trigger_value       =""
-    target_element_id   ="id-approval-text"
-    target_element_type ="table-row"
-    field_type          ="radio"
-    invert              = 0
-}
-{/if}
 
 {*include profile link function*}
 {include file="CRM/common/buildProfileLink.tpl"}


### PR DESCRIPTION
Overview
----------------------------------------

On the Manage Event forms, move the "Show Map" setting under the Location tab.

It makes more sense to have it next to the "Show Location" checkbox.

Before
----------------------------------------

The option is under the Event info:

<img width="3002" height="974" alt="image" src="https://github.com/user-attachments/assets/352ba385-cbd2-4ae4-adfa-afd70ccb8710" />

After
----------------------------------------

Now under Event Location:

<img width="1950" height="866" alt="image" src="https://github.com/user-attachments/assets/21bd4a34-1e33-4b28-9b4d-014e499f8155" />

And toggles on various things, instead of checkboxes:

<img width="2190" height="910" alt="image" src="https://github.com/user-attachments/assets/68979cb1-66c4-41e7-9a76-94b5e32691ae" />

Comments
-------------------

I also moved a few help texts, so that they are always after the label. When the label is long, it's a bit awkward because the help icon is on a separate line. This is (in my opinion) a separate RiverLea issue. It was already a problem before. This PR makes it slightly more obvious.

In `Registration.tpl`, I also did cleanup: removed many `width=20%` and `scope=row` markup that was unusual. Also removed some unnecessary `showHide.tpl` includes.