### PR TITLE
dev/core#6320 CRM_Core_Permission - use non-static cache for permissions list

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -597,7 +597,11 @@ class CRM_Core_Permission {
    * @throws RuntimeException
    */
   public static function basicPermissions($includeDisabled = FALSE, $returnAssociative = FALSE): array {
-    $permissions = Civi::$statics[__CLASS__][__FUNCTION__] ??= self::assembleBasicPermissions();
+    $permissions = Civi::cache('metadata')->get('basicPermissionsList');
+    if (!is_array($permissions)) {
+      $permissions = self::assembleBasicPermissions();
+      Civi::cache('metadata')->set('basicPermissionsList', $permissions);
+    }
     if (!$includeDisabled) {
       $permissions = array_filter($permissions, fn($permission) => empty($permission['disabled']));
     }


### PR DESCRIPTION
Overview
----------------------------------------
Avoid staleness during long running processes like upgrade.

Before
----------------------------------------
- `basicPermissions` uses a static cache
- stale list can persist during upgrade, causing bugs like https://lab.civicrm.org/dev/core/-/issues/6320

After
----------------------------------------
- `basicPermissions` uses a normal cache
- it should get reset appropriately during upgrades and similar

Technical Details
----------------------------------------
I've used the `metadata` cache because this is metadata about which permissions exist. I just need one that is cleared in `Rebuilder`.

Comments
----------------------------------------
Still to test on the affected site, but interested in what Jenkins thinks.
