### PR TITLE
Stop assigning amount to online templates

### DIFF
--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -181,7 +181,6 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
         'title' => $title,
         'isShare' => $values['is_share'] ?? NULL,
         'thankyou_title' => $values['thankyou_title'] ?? NULL,
-        'amount' => $values['amount'] ?? NULL,
         'is_pay_later' => $values['is_pay_later'] ?? FALSE,
         'receipt_date' => empty($values['receipt_date']) ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
         'pay_later_receipt' => $values['pay_later_receipt'] ?? NULL,

--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1123,7 +1123,6 @@ WHERE civicrm_event.is_active = 1
           'credit_card_exp_date' => CRM_Utils_Date::mysqlToIso(CRM_Utils_Date::format($participantParams['credit_card_exp_date'] ?? NULL)),
           'selfcancelxfer_time' => abs($values['event']['selfcancelxfer_time']),
           'selfservice_preposition' => $values['event']['selfcancelxfer_time'] < 0 ? ts('after') : ts('before'),
-          'currency' => $values['event']['currency'] ?? CRM_Core_Config::singleton()->defaultCurrency,
         ]);
 
         // CRM-13890 : NOTE wait list condition need to be given so that

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1515,6 +1515,7 @@ class CRM_Utils_Token {
           '$contributionTypeName' => 'contribution.financial_type_id:name',
           '$email' => 'contact.email_primary.email',
           '$address' => 'contribution.address_id.display',
+          '$amount' => ts('see default template for how to show this'),
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.
@@ -1566,6 +1567,7 @@ class CRM_Utils_Token {
           '$financialTypeName' => 'contribution.financial_type_id:name',
           '$contributionTypeName' => 'contribution.financial_type_id:name',
           '$address' => 'contribution.address_id.display',
+          '$amount' => ts('see default template for how to show this'),
         ],
         'contribution_offline_receipt' => [
           '$totalTaxAmount' => 'contribution.tax_amount',


### PR DESCRIPTION

Overview
----------------------------------------
Stop assigning `$amount`  to online templates

The variable is  not in any of them. Noisy deprecrations were added to event online receipts in May 2025

The other 2 didn't have noisy deprecations - but that was more reflective of how long it has been since they were actually used in them.

I added the noisy site checks for them in case.

Also, I removed a currency assign - this is always assigned by the workflow message class for all contribution related templates

Before
----------------------------------------
legacy assigns for `$amount` `$currency`


After
----------------------------------------
poof (currency still assigned elsewhere)

Technical Details
----------------------------------------

Comments
----------------------------------------
