### PR TITLE
Rely on parent to load Payment processor

### DIFF
--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -38,17 +38,8 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
       }
     }
 
-    if ($this->_coid) {
-      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'info');
-      $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->_coid, 'contribute', 'obj');
-    }
-
     if ($this->getMembershipID()) {
-      $this->_paymentProcessor = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->getMembershipID(), 'membership', 'info');
-      $this->_paymentProcessor['object'] = CRM_Financial_BAO_PaymentProcessor::getProcessorForEntity($this->getMembershipID(), 'membership', 'obj');
-      $membershipTypes = CRM_Member_PseudoConstant::membershipType();
-      $membershipTypeId = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_Membership', $this->getMembershipID(), 'membership_type_id');
-      $this->assign('membershipType', $membershipTypes[$membershipTypeId] ?? NULL);
+      $this->assign('membershipType', $this->getMembershipValue('membership_type_id:name'));
       $this->_mode = 'auto_renew';
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Rely on parent to load Payment processor

Before
----------------------------------------
`UpdateBilling` loads the payment processor - but this would already be set because it calls `parent::preProcess()` first which calls `setPaymentProcessor` - https://github.com/civicrm/civicrm-core/blob/85b6447a0a32b93876f1def8b80c29e55917d640/CRM/Contribute/Form/ContributionRecur.php#L140-L154

That `getContributionRecurID()` considers the membership ID & contribution ID if contribution recur ID is not provided

https://github.com/civicrm/civicrm-core/blob/85b6447a0a32b93876f1def8b80c29e55917d640/CRM/Contribute/Form/ContributionRecur.php#L191-L203

After
----------------------------------------
removed

Technical Details
----------------------------------------
@mattwire can you check my logic here?

Comments
----------------------------------------

