### PR TITLE
Fix another place to use line items to get linked memberships

### DIFF
--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -112,8 +112,6 @@ class api_v3_ContributionRecurTest extends CiviUnitTestCase {
 
   /**
    * Test that we can cancel a contribution and add a cancel_reason via the api.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testContributionRecurCancel(): void {
     $result = $this->callAPISuccess($this->_entity, 'create', $this->params);


### PR DESCRIPTION
Overview
----------------------------------------
Fix another place to use line items to get linked memberships

Before
----------------------------------------
Look up based on membership payment


After
----------------------------------------
Only uses membership payment if line items are not reliable

Technical Details
----------------------------------------


Comments
----------------------------------------
