### PR TITLE
SearchKit - Ensure multi-valued tokens are formatted correctly in link

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -232,7 +232,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         if ($this->hasValue($column['label']) && (!empty($column['forceLabel']) || $this->hasValue($out['val']))) {
           $out['label'] = $this->replaceTokens($column['label'], $data, 'view');
         }
-        if (!empty($column['link'])) {
+        if (!empty($column['link']) && $this->hasValue($out['val'])) {
           $links = $this->formatFieldLinks($column, $data, $out['val']);
           if ($links) {
             $out['links'] = $links;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -535,7 +535,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   private function formatFieldLinks($column, $data, $value): array {
     $links = [];
     foreach ((array) $value as $index => $val) {
-      $link = $this->formatLink($column['link'], $data, FALSE, $val, $index);
+      // If contents of field are multi-valued, pass $index to formatLink(), otherwise NULL
+      // This tells it whether to select a single value or all values in a multivalued token
+      $link = $this->formatLink($column['link'], $data, FALSE, $val, is_array($value) ? $index : NULL);
       if ($link) {
         // Style rules get appled to each link
         if (!empty($column['cssRules'])) {
@@ -584,13 +586,13 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @param array $data
    * @param bool $allowMultiple
    * @param string|NULL $text
-   * @param int $index
+   * @param int|null $index
    * @return array|null
    * @throws \CRM_Core_Exception
    */
-  protected function formatLink(array $link, array $data, bool $allowMultiple = FALSE, ?string $text = NULL, $index = 0): ?array {
+  protected function formatLink(array $link, array $data, bool $allowMultiple = FALSE, ?string $text = NULL, ?int $index = NULL): ?array {
     $useApi = (!empty($link['entity']) && !empty($link['action']));
-    $originalData = $data;
+    // When rendering multiple links, gather multivalued token values
     if (isset($index)) {
       foreach ($data as $key => $value) {
         if (is_array($value)) {
@@ -619,8 +621,6 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     elseif (!$this->checkLinkAccess($link, $data)) {
       return NULL;
     }
-    // FIXME: We should use $originalData so button links can render tokens correctly. But
-    // this doesn't match the getLinks() behavior so is out of scope for now.
     $link['text'] = $text ?? $this->replaceTokens($link['text'], $data, 'view');
     if (!empty($link['task'])) {
       $keys = ['task', 'text', 'title', 'icon', 'style'];
@@ -630,8 +630,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       if (($link['csrf'] ?? NULL) === 'qfKey') {
         $query['qfKey'] = $this->getQfKey($link['path']);
       }
-      // We use original data so that tokens which rely on array-based columns are correctly rendered.
-      $path = $this->replaceTokens($link['path'], $originalData, 'url');
+      $path = $this->replaceTokens($link['path'], $data, 'url');
       if (!$path) {
         // Return null if `$link[path]` is empty or if any tokens do not resolve
         return NULL;
@@ -1249,7 +1248,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $dataType = $this->getSelectExpression($token['content'])['dataType'] ?? NULL;
         $val = $this->formatViewValue($token['content'], $val, $data, $dataType);
       }
-      $replacement = implode(', ', (array) $val);
+      // Convert array to string. Add space to user-facing display value.
+      $separator = $format === 'view' ? ', ' : ',';
+      $replacement = implode($separator, (array) $val);
       // A missing token in a url invalidates it
       if ($format === 'url' && $replacement === '') {
         // Required token - invalidate the whole url


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6108](https://lab.civicrm.org/dev/core/-/issues/6108)
Which regressed from [dev/core#3197](https://lab.civicrm.org/dev/core/-/issues/3197)


Technical Details
----------------------------------------
Depending on context, a token with an array value might be expected to show all values (comma separated) or just one value if the field itself is multivalued and is creating multiple links.

Originally, it always did the latter; then dev/core#3197 switched to always doing the former. This strikes a balance and figures out whether it's appropriate to do so based on the field being linked.