### PR TITLE
PHPUnit - Consistently set CIVICRM_TEST in all core extension tests

### DIFF
--- a/ext/afform/admin/tests/phpunit/bootstrap.php
+++ b/ext/afform/admin/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/afform/core/tests/phpunit/bootstrap.php
+++ b/ext/afform/core/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/afform/mock/tests/phpunit/bootstrap.php
+++ b/ext/afform/mock/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/authx/tests/phpunit/bootstrap.php
+++ b/ext/authx/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/civi_contribute/tests/phpunit/bootstrap.php
+++ b/ext/civi_contribute/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/civi_report/tests/phpunit/bootstrap.php
+++ b/ext/civi_report/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/civicrm_admin_ui/tests/phpunit/bootstrap.php
+++ b/ext/civicrm_admin_ui/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/civigrant/tests/phpunit/bootstrap.php
+++ b/ext/civigrant/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/civiimport/tests/phpunit/bootstrap.php
+++ b/ext/civiimport/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/contributioncancelactions/tests/phpunit/bootstrap.php
+++ b/ext/contributioncancelactions/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/elavon/tests/phpunit/bootstrap.php
+++ b/ext/elavon/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/financialacls/tests/phpunit/bootstrap.php
+++ b/ext/financialacls/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/iframe/tests/phpunit/bootstrap.php
+++ b/ext/iframe/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/legacycustomsearches/tests/phpunit/bootstrap.php
+++ b/ext/legacycustomsearches/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/legacydedupefinder/tests/phpunit/bootstrap.php
+++ b/ext/legacydedupefinder/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/oembed/tests/phpunit/bootstrap.php
+++ b/ext/oembed/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/payflowpro/tests/phpunit/bootstrap.php
+++ b/ext/payflowpro/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/scheduled_communications/tests/phpunit/bootstrap.php
+++ b/ext/scheduled_communications/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));

--- a/ext/search_kit/tests/phpunit/bootstrap.php
+++ b/ext/search_kit/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable

--- a/ext/sequentialcreditnotes/tests/phpunit/bootstrap.php
+++ b/ext/sequentialcreditnotes/tests/phpunit/bootstrap.php
@@ -1,6 +1,8 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
+
 // phpcs:ignore
 eval(cv('php:boot --level=classloader', 'phpcode'));
 

--- a/ext/standaloneusers/tests/phpunit/bootstrap.php
+++ b/ext/standaloneusers/tests/phpunit/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 ini_set('memory_limit', '2G');
+define('CIVICRM_TEST', 1);
 
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));


### PR DESCRIPTION
Overview
----------------------------------------

This flag is meant to indicate that you are running in a test-environment. For example, when testing, it `CIVICRM_PSR16_STRICT` is supposed to forced-on. But this depends on having `CIVICRM_TEST`.

Before
----------------------------------------

The core tests set `CIVICRM_TEST`, and a couple core-exts do, but most core-exts don't.

After
----------------------------------------

Everywhere! Everywhere! Tests are everywhere!