### PR TITLE
Don't require activity fields if importing with id

### DIFF
--- a/CRM/Activity/Import/Form/MapField.php
+++ b/CRM/Activity/Import/Form/MapField.php
@@ -57,6 +57,9 @@ class CRM_Activity_Import_Form_MapField extends CRM_CiviImport_Form_MapField {
    * return array|null
    */
   protected function validateRequiredFields(array $importKeys): ?array {
+    if (in_array('Activity.id', $importKeys, TRUE)) {
+      return [];
+    }
     $errors = [];
     $requiredFields = [
       'Activity.activity_date_time' => ts('Activity Date'),


### PR DESCRIPTION
Before
----------------------------------------
Activity subject, date and type are required when importing to update existing activities by ID.

After
----------------------------------------
No required fields if importing Activity ID.