### PR TITLE
Don't blank activity contacts when updating activities by importing w…

### DIFF
--- a/ext/civiimport/Civi/Import/ActivityParser.php
+++ b/ext/civiimport/Civi/Import/ActivityParser.php
@@ -76,13 +76,18 @@ class ActivityParser extends ImportParser {
       if (array_keys($targetContactParams) === ['email_primary.email']) {
         $targetContactParams['contact_type'] = 'Individual';
       }
-      $activityParams['target_contact_id'] = $this->getContactID($targetContactParams, empty($targetContactParams['id']) ? NULL : (int) $targetContactParams['id'], 'TargetContact', $this->getDedupeRulesForEntity('TargetContact'));
-      $activityParams['assignee_contact_id'] = $this->getContactID($assigneeContactParams, empty($assigneeContactParams['id']) ? NULL : (int) $assigneeContactParams['id'], 'AssigneeContact', $this->getDedupeRulesForEntity('AssigneeContact'));
-
-      try {
-        $activityParams['source_contact_id'] = $this->getContactID($sourceContactParams, empty($sourceContactParams['id']) ? NULL : (int) $sourceContactParams['id'], 'SourceContact', $this->getDedupeRulesForEntity('SourceContact'));
+      if ($targetContactParams) {
+        $activityParams['target_contact_id'] = $this->getContactID($targetContactParams, empty($targetContactParams['id']) ? NULL : (int) $targetContactParams['id'], 'TargetContact', $this->getDedupeRulesForEntity('TargetContact'));
       }
-      catch (\CRM_Core_Exception $e) {
+      if ($assigneeContactParams) {
+        $activityParams['assignee_contact_id'] = $this->getContactID($assigneeContactParams, empty($assigneeContactParams['id']) ? NULL : (int) $assigneeContactParams['id'], 'AssigneeContact', $this->getDedupeRulesForEntity('AssigneeContact'));
+      }
+      if ($sourceContactParams) {
+        try {
+          $activityParams['source_contact_id'] = $this->getContactID($sourceContactParams, empty($sourceContactParams['id']) ? NULL : (int) $sourceContactParams['id'], 'SourceContact', $this->getDedupeRulesForEntity('SourceContact'));
+        }
+        catch (\CRM_Core_Exception $e) {
+        }
       }
       if (empty($activityParams['id']) && empty($activityParams['source_contact_id'])) {
         $activityParams['source_contact_id'] = \CRM_Core_Session::getLoggedInContactID();


### PR DESCRIPTION
Before
----------------------------------------
Import an activity with an ID, to update an existing activity
Do not add any target, source or assignee contact details
Target, source and assignee contacts are blanked on the existing activity

After
----------------------------------------
Activity contacts only changed if included in import data.

Comments
----------------------------------------
Removed a test case that didn't make sense (it is perfectly fine to create an activity with no target contact). Added a test to make sure we add the source contact as the logged in user when the import doesn't include a source contact.