### PR TITLE
Managed - Ensure managed record is deleted when record doesn't exist

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -444,7 +444,11 @@ class CRM_Core_ManagedEntities {
         // FIXME: This extra counting should be unnecessary, because getRefCount only returns values if count > 0
         $total = 0;
         foreach ($getRefCount as $refCount) {
-          $total += $refCount['count'];
+          // For now, getRefCount includes references from the Log table...
+          // TODO: that's probably something we should consider excluding from refCounts!
+          if ($refCount['name'] !== 'Log') {
+            $total += $refCount['count'];
+          }
         }
 
         $doDelete = ($total == 0);

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -320,8 +320,17 @@ class CoreUtil {
    * @return array{name: string, type: string, count: int, table: string|null, key: string|null}[]
    */
   public static function getRefCount(string $entityName, $entityId): array {
-    $entity = \Civi::entity($entityName);
     $idField = self::getIdFieldName($entityName);
+    // If entity doesn't exist there are no refs to count
+    $exists = civicrm_api4($entityName, 'get', [
+      'checkPermissions' => FALSE,
+      'select' => [$idField],
+      'where' => [[$idField, '=', $entityId]],
+    ])->countFetched();
+    if (!$exists) {
+      return [];
+    }
+    $entity = \Civi::entity($entityName);
     return $entity->getReferenceCounts([$idField => $entityId]);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Does a better job of cleaning up 'unused' managed records.

Technical Details
--------

When `CRM_Core_ManagedEntities::removeStaleEntity` calls `CoreUtil::getRefCount`, it should return empty if the record doesn't exist.

This prevents false-positive from getRefCount - if an entity doesn't exist, there can't be any real references to it and the row in the managed table ought to be cleaned up.

Also, exclude references from the Log table, which shouldn't count.