### PR TITLE
check `civicrm_domain` rather than `civicrm_log` to see if upgrade is finished

### DIFF
--- a/CRM/Core/BAO/Domain.php
+++ b/CRM/Core/BAO/Domain.php
@@ -101,7 +101,7 @@ class CRM_Core_BAO_Domain extends CRM_Core_DAO_Domain {
    * @throws \CRM_Core_Exception
    */
   public static function isDBUpdateRequired() {
-    $dbVersion = self::version();
+    $dbVersion = self::version(TRUE);
     $codeVersion = CRM_Utils_System::version();
     return version_compare($dbVersion, $codeVersion) < 0;
   }

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -46,16 +46,10 @@ class CRM_Upgrade_DispatchPolicy {
       return NULL;
     }
 
-    // Have we run CRM_Upgrade_Form::doCoreFinish() for this version?
-    $codeVer = CRM_Utils_System::version();
-    $isCoreCurrent = CRM_Core_DAO::singleValueQuery('
-        SELECT count(*) as count
-        FROM civicrm_log
-        WHERE entity_table = "civicrm_domain"
-        AND data LIKE %1
-        ', [1 => ['upgrade:%->' . $codeVer, 'String']]);
+    // Are there outstanding core version upgrades?
+    $upgradeFinished = !CRM_Core_BAO_Domain::isDBUpdateRequired();
 
-    return CRM_Upgrade_DispatchPolicy::get($isCoreCurrent < 1 ? 'upgrade.main' : 'upgrade.finish');
+    return CRM_Upgrade_DispatchPolicy::get($upgradeFinished ? 'upgrade.finish' : 'upgrade.main');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing AutoServices when running `cv updb` on a newly installed database.

Before
----------------------------------------
- upgrader checks `civicrm_log` table to see if previous upgrade has finished, in order to pick `upgrade.finish` over `upgrade.main`
- if db is newly installed, or `civicrm_log` has been truncated, this falsely suggests upgrade in progress, and maintains a stricter dispatch policy
- extension AutoServices can be missing from the container - `afform_scanner` cant be found; extension hooks which should be firing aren't

After
----------------------------------------
- check `civicrm_domain` version to see if we have finished
- add passthru param to ensure we skip the cache and get up to date info
- fixes my presentation of https://lab.civicrm.org/dev/core/-/issues/4267#note_198397 and https://lab.civicrm.org/dev/core/-/issues/6320

Technical Details
----------------------------------------
There may have been a good reason to check `civicrm_log` that has been lost to the sands of time.

As @totten [notes](https://lab.civicrm.org/dev/core/-/issues/4267#note_198463) there are lots of potential upgrade paths to test.

I had no problems on a Standalone site using `cv updb` with cv @ 0.3.7
a) running `cv updb` when no core upgrade required at core 6.8
a) upgrading 6.8 => 6.11.1