### PR TITLE
Add setting to use membership payment table

### DIFF
--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -121,7 +121,7 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
     if (!empty($latestMembershipLineItem['contribution_id'])) {
       $latestContributionID = $latestMembershipLineItem['contribution_id'];
     }
-    else {
+    elseif (CRM_Price_BAO_LineItem::siteHasMembershipPaymentRecordsNotReflectedInLineItems()) {
       $membershipPayments = civicrm_api3('MembershipPayment', 'get', [
         'sequential' => 1,
         'return' => ["contribution_id.receive_date", "contribution_id"],

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -352,6 +352,12 @@ WHERE li.contribution_id = %1";
   }
 
   public static function siteHasMembershipPaymentRecordsNotReflectedInLineItems(): bool {
+    if (!\Civi::settings()->get('civi_member_use_civicrm_membership_payment_table')) {
+      // This has a default of TRUE so would only be FALSE if deliberately set to FALSE.
+      // Later we will give it a default of FALSE but actively update on upgrade
+      // such that any sites that have orphan membership payment records will have it set to TRUE.
+      return FALSE;
+    }
     if (!\Civi::cache('long')->has(__FUNCTION__)) {
       \Civi::cache('long')->set(__FUNCTION__,
         (bool) CRM_Core_DAO::singleValueQuery('

--- a/ext/civi_member/settings/Member.setting.php
+++ b/ext/civi_member/settings/Member.setting.php
@@ -37,4 +37,18 @@ return [
     'help_text' => ts('If you select a default online contribution page for self-service membership renewals, a "renew" link pointing to that page will be displayed on the Contact Dashboard for memberships which were entered offline. You will need to ensure that the membership block for the selected online contribution page includes any currently available memberships.'),
     'settings_pages' => ['member' => ['weight' => 0]],
   ],
+  'member_use_civicrm_membership_payment_table' => [
+    'group_name' => 'Member Preferences',
+    'group' => 'member',
+    'name' => 'member_use_civicrm_membership_payment_table',
+    'title' => ts('Use old-style MembershipPayment records'),
+    'type' => 'Boolean',
+    'html_type' => 'toggle',
+    'default' => TRUE,
+    'add' => '6.13',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => ts('Disable this setting if you do not need to support old-style MembershipPayment records.'),
+    'settings_pages' => ['member' => ['weight' => 0]],
+  ],
 ];


### PR DESCRIPTION


Overview
----------------------------------------
Add setting to use membership payment table

This grabs the setting from https://github.com/civicrm/civicrm-core/pull/34470/changes/0a974fd9ac0e8ef1c1b60ec5014fda48cced46da


Before
---------------------------------------
 https://github.com/civicrm/civicrm-core/pull/34470 stalled on a test - wrong  data type but other work done to build on it

After
----------------------------------------
Setting pulled out from that PR - note 
- that PR needs (regardless) to be updated to use CRM_Price_BAO_LineItem::siteHasMembershipPaymentRecordsNotReflectedInLineItems() rather than checking the setting directly - allowing us to iterate on that in 1 place

Technical Details
----------------------------------------


Comments
----------------------------------------
@mattwire @ufundo 