### PR TITLE
Mark nonprimaryquicksearch & secondaryquicksearch as obsolete

### DIFF
--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -1,4 +1,14 @@
 {
+  "nonprimaryquicksearch": {
+    "obsolete": "6.13",
+    "disable": true,
+    "uninstall": true
+  },
+  "secondaryquicksearch": {
+    "obsolete": "6.13",
+    "disable": true,
+    "uninstall": true
+  },
   "hotfix_extup": {
     "obsolete": "6.1",
     "force-uninstall": true


### PR DESCRIPTION
Overview
----------------------------------------
Extensions are now redundant with core and may interfere with core functionality.

Per https://github.com/civicrm/civicrm-core/pull/34790#issuecomment-3970207577