### PR TITLE
Contact Relationship (and notes): rename Row Actions and move help text

### DIFF
--- a/ang/afform/afsearchTabRel.aff.html
+++ b/ang/afform/afsearchTabRel.aff.html
@@ -1,8 +1,8 @@
 <div af-fieldset="">
   <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Active" filters="{near_contact_id: options.contact_id, is_current: true}"></crm-search-display-table>
   <h3>{{:: ts('Inactive Relationships') }}</h3>
-  <div class="help">{{:: ts('These relationships are Disabled OR have a past End Date.') }}</div>
   <crm-search-display-table search-name="Contact_Summary_Relationships" display-name="Contact_Summary_Relationships_Inactive" filters="{near_contact_id: options.contact_id, is_current: false}"></crm-search-display-table>
+  <div class="help">{{:: ts('Inactive relationships are disabled or have a past end date.') }}</div>
   <div class="help">
     <strong>{{:: ts('Permissioned Relationships:') }}</strong>
     <i class="crm-i fa-eye" role="img" aria-hidden="true"></i> {{:: ts('This contact can be viewed by the other.') }}

--- a/managed/contactSummary/SavedSearch_Contact_Summary_Notes.mgd.php
+++ b/managed/contactSummary/SavedSearch_Contact_Summary_Notes.mgd.php
@@ -142,7 +142,7 @@ return [
             ],
             [
               'size' => 'btn-xs',
-              'label' => ts('Row Actions'),
+              'label' => ts('Actions'),
               'label_hidden' => TRUE,
               'links' => [
                 [

--- a/managed/contactSummary/SavedSearch_Contact_Summary_Relationships.mgd.php
+++ b/managed/contactSummary/SavedSearch_Contact_Summary_Relationships.mgd.php
@@ -240,7 +240,7 @@ return [
               'icon' => 'fa-bars',
               'links' => $links,
               'type' => 'menu',
-              'label' => ts('Row Actions'),
+              'label' => ts('Actions'),
               'label_hidden' => TRUE,
               'alignment' => 'text-right',
             ],
@@ -392,7 +392,7 @@ return [
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',
-              'label' => ts('Row Actions'),
+              'label' => ts('Actions'),
               'label_hidden' => TRUE,
               'links' => [
                 [


### PR DESCRIPTION
Overview
----------------------------------------

Minor changes to the Contact relationships and notes tabs.

1. Rename "Row Actions" to "Actions"
2. same, for the inactive relationships
3. Move the help text below the table, so that all help texts are in the same place, and not too distracting.
4. Change the help text to avoid "This OR That"

The "Row Actions" was also changed on the Notes tab.

Before
----------------------------------------

<img width="3380" height="1924" alt="2026-02-27_09-26" src="https://github.com/user-attachments/assets/a31b3ace-9e7b-4fb5-bb87-6722650562c8" />


After
----------------------------------------

<img width="3374" height="1888" alt="2026-02-27_09-21" src="https://github.com/user-attachments/assets/1fa2bcf2-cdd8-413d-b305-cbc07af07d66" />

Comments
----------------------------------------

Theme is work-in-progress [TheIsland-on-RiverLea](https://lab.civicrm.org/extensions/theisland/-/issues/32).