### PR TITLE
AdminUI: contact registration tab: change column order and tweak labels

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Events.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Events.mgd.php
@@ -91,11 +91,24 @@ return [
           'placeholder' => 5,
           'columns' => [
             [
+              'type' => 'field',
+              'key' => 'register_date',
+              'label' => E::ts('Registered'),
+              'sortable' => TRUE,
+            ],
+            [
               'type' => 'html',
               'key' => 'event_id.title',
               'label' => E::ts('Event'),
               'sortable' => TRUE,
               'rewrite' => '[event_id.title]',
+            ],
+            [
+              'type' => 'html',
+              'key' => 'Participant_Event_event_id_01.start_date',
+              'label' => E::ts('Event Dates'),
+              'sortable' => TRUE,
+              'rewrite' => '[Participant_Event_event_id_01.start_date] -<br> [Participant_Event_event_id_01.end_date]',
             ],
             [
               'type' => 'field',
@@ -111,19 +124,6 @@ return [
             ],
             [
               'type' => 'field',
-              'key' => 'register_date',
-              'label' => E::ts('Registered'),
-              'sortable' => TRUE,
-            ],
-            [
-              'type' => 'html',
-              'key' => 'Participant_Event_event_id_01.start_date',
-              'label' => E::ts('Event Date(s)'),
-              'sortable' => TRUE,
-              'rewrite' => '[Participant_Event_event_id_01.start_date] -<br> [Participant_Event_event_id_01.end_date]',
-            ],
-            [
-              'type' => 'field',
               'key' => 'status_id:label',
               'label' => E::ts('Status'),
               'sortable' => TRUE,
@@ -131,11 +131,11 @@ return [
             [
               'type' => 'field',
               'key' => 'role_id:label',
-              'label' => E::ts('Participant Role'),
+              'label' => E::ts('Role'),
               'sortable' => TRUE,
             ],
             [
-              'text' => '',
+              'label' => E::ts('Actions'),
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',


### PR DESCRIPTION
Overview
----------------------------------------

Changes the default column order of the AdminUI "Contact Event Registrations" tab.

1. "Registered" is moved as the first column, since this is the default sort, and things are usually shown as "most recent  first"
2. "Participant Role" shortened to "Role" (shorter, clear enough)
3. Added the "Actions" header, to be consistent with other screens such as in #34936 - I somewhat assumed the label was there for accessibility, and I see similar designs in other software.

Before
----------------------------------------

<img width="3360" height="1154" alt="2026-02-27_09-42" src="https://github.com/user-attachments/assets/69ef0f24-266f-43c5-b002-08edcfc61f37" />


After
----------------------------------------

<img width="3348" height="1144" alt="2026-02-27_09-41" src="https://github.com/user-attachments/assets/58aae799-b8b9-4b76-8a6c-dc4a5f1b35f2" />


Comments
----------------------------------------

Theme is work-in-progress [TheIsland-on-RiverLea](https://lab.civicrm.org/extensions/theisland/-/issues/32).