### PR TITLE
Fix event profile selector to allow new profiles without module mapping

### DIFF
--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -734,10 +734,6 @@
       if (_.isEmpty(this.get('group_type'))) {
         return true;
       }
-      if (usedByFilter && _.isEmpty(this.get('module'))) {
-        return false;
-      }
-
       var actualTypes = CRM.UF.parseTypeList(this.get('group_type'));
       var validTypes = CRM.UF.parseTypeList(validTypesExpr);
 
@@ -749,7 +745,7 @@
       });
 
       // CRM-16915 - filter with usedBy module if specified.
-      if (usedByFilter && this.get('module') != usedByFilter) {
+      if (usedByFilter && !_.isEmpty(this.get('module')) && this.get('module') != usedByFilter) {
         allMatched = false;
       }
       //CRM-15427 allow all subtypes


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes profile selection in Event Registration configuration for users who have manage event profiles but not administer CiviCRM. In the affected flow, newly created profiles may be missing from the dropdowns (for example, “Profile for Additional Participants”) until an admin maps the profile to an event once.

Before
----------------------------------------
For users with manage event profiles (without admin rights), profile filtering in checkGroupType() excluded profiles with no module mapping. This caused newly created profiles to be hidden from event registration profile selectors until a UFJoin/module mapping existed.

After
----------------------------------------
Profiles without a module mapping are no longer excluded by default.
Module filtering is applied only when module is present.

Comments
----------------------------------------
Reproduced in 6.5.0 and confirmed code path is still present in 6.11.1 and masterr branch.