### PR TITLE
AdminUI: manage acls: add an object-table filter

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchManageACLs.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchManageACLs.aff.html
@@ -4,5 +4,6 @@
     <p>{{:: ts('Depending on the chosen mode, each ACL either Allows or Denies permission. When multiple rules contradict each other (e.g. one rule allows and the second rule denies access to the same contacts) the rule with the highest priority takes precidence.') }}</p>
     <p><a href="https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control/" target="_blank">{{:: ts('Learn more...') }}</a></p>
   </div>
+  <af-field name="object_table" />
   <crm-search-display-table search-name="Manage_ACLs" display-name="Manage_ACLs_Table_1"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_ACLs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_ACLs.mgd.php
@@ -118,6 +118,7 @@ return [
               'sortable' => TRUE,
             ],
             [
+              'label' => E::ts('Actions'),
               'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',


### PR DESCRIPTION
Overview
----------------------------------------

On sites with many ACL rules, I find that having a filter on the object-table is really helpful.

For example, as an admin, I want to view all ACLs specific to Custom Groups/Fields, and ignore ACLs for Groups (contacts).

EDIT: I also added the "Actions" column header.

Before
----------------------------------------

<img width="3372" height="1322" alt="image" src="https://github.com/user-attachments/assets/0784b759-62ea-46f1-8628-f5be6800c239" />


After
----------------------------------------

<img width="3372" height="1322" alt="image" src="https://github.com/user-attachments/assets/b8b79725-0319-486a-b679-83d53500a89b" />

and so, for example, I can view all ACLs specific to Custom Groups:

<img width="3372" height="1322" alt="image" src="https://github.com/user-attachments/assets/49f7792e-8949-4723-bfdd-6912f26ad485" />

Comments
------------------------

I hesitated about re-ordering the columns, so that "Piority" is first, but that might be confused with "ID".

and in general I don't think we should have a column for "Enabled", and just have some other indicator (I'd have to check PriceSets, I think I did that differently)