### PR TITLE
River: fixes typo that breaks dropdown-link hover styling

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -82,7 +82,7 @@
 .crm-contribpage-links-list-inner a:is(:hover,:focus),
 .crm-event-links-list-inner ul a:is(:hover,:focus),
 .crm-participant-list-inner ul a:is(:hover,:focus),
-#crm-create-new-list ul a:is(:hover,:focus), {
+#crm-create-new-list ul a:is(:hover,:focus) {
   text-decoration: none;
   color: var(--crm-text-color);
   background-color: var(--crm-container-bg-color);


### PR DESCRIPTION
Overview
----------------------------------------
Hover styling on some dropdown menus (event edit screen, contribution edit screen) had regressed at some point. This fixes the cause. The impact isn't just style - hover state is illegible in most streams.

Before
----------------------------------------
<img width="224" height="207" alt="image" src="https://github.com/user-attachments/assets/eb29c2da-816d-4c6b-a366-4f8b2ce52a33" />

After
----------------------------------------
<img width="219" height="206" alt="image" src="https://github.com/user-attachments/assets/575d5db3-5d9d-4fee-9662-bb9e2bf61b32" />

Comments
----------------------------------------
Will apply to 6.11 too.
