### PR TITLE
River: fixes typo that breaks dropdown-links hover styling - 6.11

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -82,7 +82,7 @@
 .crm-contribpage-links-list-inner a:is(:hover,:focus),
 .crm-event-links-list-inner ul a:is(:hover,:focus),
 .crm-participant-list-inner ul a:is(:hover,:focus),
-#crm-create-new-list ul a:is(:hover,:focus), {
+#crm-create-new-list ul a:is(:hover,:focus) {
   text-decoration: none;
   color: var(--crm-text-color);
   background-color: var(--crm-container-bg-color);


### PR DESCRIPTION
6.11 version of https://github.com/civicrm/civicrm-core/pull/34940

FTR, this would be a nice lint rule to add - no `,` followed by `{`.