### PR TITLE
CRM_Core_Error - Errors in CLI should generate exit code

### DIFF
--- a/CRM/Core/Error.php
+++ b/CRM/Core/Error.php
@@ -256,7 +256,8 @@ class CRM_Core_Error extends PEAR_ErrorStack {
     // always log the backtrace to a file
     self::backtrace('backTrace', TRUE);
 
-    exit(0);
+    // If we failed in CLI context, then report the failure.
+    exit(1);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

While inspecting an upgrade bug, I tried sequencing some bash commands. For example:

```bash
composer install && cv status && cv updb
```

Or equivalently:

```bash
set -e                  ## Enable error checks
composer install
cv status
cv updb
```

This kind of scripting depends on having decent exit codes. Specifically, in POSIX, `0` means success, and any other number is a failure.

Before
----------------------------------------

If there is a bootstrap error in a middle step (e.g. `cv status`), then CiviCRM calls `exit(0)`. The error is not emitted properly to bash, and execution proceeds to other steps.


After
----------------------------------------

If there is an error in a middle step, then CiviCRM calls `exit(1)`. The script knows to stop.