### PR TITLE
System Status - Consolidate upgrade notices

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -831,7 +831,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         'fa-plug'
       );
       $message->addAction(
-        ts('Run Upgrades'),
+        ts('Run upgrades'),
         ts('Run extension upgrades now?'),
         'href',
         ['path' => 'civicrm/admin/extensions/upgrade', 'query' => ['reset' => 1, 'destination' => CRM_Utils_System::url('civicrm/a/#/status')]]
@@ -873,7 +873,6 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
   public function checkDbVersion() {
     $messages = [];
     $dbVersion = CRM_Core_BAO_Domain::version();
-    $upgradeUrl = CRM_Utils_System::url("civicrm/upgrade", "reset=1");
 
     if (!$dbVersion) {
       // if db.ver missing
@@ -896,24 +895,28 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
     }
     elseif (stripos($dbVersion, 'upgrade')) {
       // if db.ver indicates a partially upgraded db
-      $messages[] = new CRM_Utils_Check_Message(
+      $message = new CRM_Utils_Check_Message(
         __FUNCTION__,
-        ts('Database check failed - the database looks to have been partially upgraded. You must reload the database with the backup and try the <a href=\'%1\'>upgrade process</a> again.', [1 => $upgradeUrl]),
+        ts('Database check failed - the database looks to have been partially upgraded. You must reload the database with the backup and try the upgrade process again.'),
         ts('Database Partially Upgraded'),
         \Psr\Log\LogLevel::ALERT,
         'fa-database'
       );
+      $message->addAction(ts('Re-try upgrades'), NULL, 'href', ['path' => 'civicrm/upgrade', 'query' => 'reset=1']);
+      $messages[] = $message;
     }
     else {
       // if db.ver < code.ver, time to upgrade
       if (CRM_Core_BAO_Domain::isDBUpdateRequired()) {
-        $messages[] = new CRM_Utils_Check_Message(
+        $message = new CRM_Utils_Check_Message(
           __FUNCTION__,
-          ts('New codebase version detected. You must visit <a href=\'%1\'>upgrade screen</a> to upgrade the database.', [1 => $upgradeUrl]),
+          ts('New codebase version detected. Please run updates for the database.'),
           ts('Database Upgrade Required'),
           \Psr\Log\LogLevel::ALERT,
           'fa-database'
         );
+        $message->addAction(ts('Run upgrades'), NULL, 'href', ['path' => 'civicrm/upgrade', 'query' => 'reset=1']);
+        $messages[] = $message;
       }
 
       // if db.ver > code.ver, sth really wrong

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -820,7 +820,9 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
    * @return CRM_Utils_Check_Message[]
    */
   public function checkExtensionUpgrades() {
-    if (CRM_Extension_Upgrades::hasPending()) {
+    // Note: The system-DB-upgrade is a super-set of the extension-DB-upgrade. If that's
+    // being displayed, then we don't need to show the extension-DB-upgrade.
+    if (!CRM_Core_BAO_Domain::isDBUpdateRequired() && CRM_Extension_Upgrades::hasPending()) {
       $message = new CRM_Utils_Check_Message(
         __FUNCTION__,
         ts('Extension upgrades should be run as soon as possible.'),


### PR DESCRIPTION
Overview
----------------------------------------

The "System Status" shows two alerts for applying database-upgrades.

While there are edge-case distinctions in what they do, it's neither good nor necessary to show both alerts at the same time.

Steps to Reproduce
----------------------------------------

* Install an older version of CivicCM
* Get the code for a new version of CiviCRM (without running upgrader)
* Browse to the "System Status"

Before
----------------------------------------

You see two alerts -- one for the system-DB-upgrade and one for the extension-DB-upgrade.

<img width="705" height="339" alt="Screenshot 2026-02-27 at 2 38 40 PM" src="https://github.com/user-attachments/assets/704cb7fa-bddf-49ef-9065-ad23f874a4f3" />

You should click the first link, because it is more general. It will run both low-level DB updates and (*now-a-days*) extension DB updates. So clicking that will do the job of both.

You should not click the second link. It is likely to fail, because the extensions depend on having low-level services. Of course, this second link is much more prominent -- and so that's what you'll want to click. 💣 

After
----------------------------------------

It only shows the first message, and the action-link is more apparent:

<img width="579" height="238" alt="Screenshot 2026-02-27 at 3 21 44 PM" src="https://github.com/user-attachments/assets/03973476-bd7a-4c13-ac29-59bce20e0d0c" />

The system upgrade includes the extension upgrade, so you don't need to do anything afterward.

Of course... a week later... you might download a newer extension. And then you'll see one message:

<img width="570" height="236" alt="Screenshot 2026-02-27 at 3 22 10 PM" src="https://github.com/user-attachments/assets/b4a7eaea-1542-43ed-bd81-2be1d07730f8" />

In either case, we only show one message, and it's the appropriate one.

Comments
----------------------------------------

There are differences between the two links:

* The system-DB-upgrade includes a preflight screen with additional warnings/notices (e.g. extra steps you should do manually; or breaking-changes that will affect your system). So it is heavier. And if there are no low-level updates, then it won't do anything.
* The extension-DB-upgrade goes straight to the action list.

It might make sense to further unify the screens/mechanisms. That's a much longer project. This PR is a simple cleanup.