### PR TITLE
(dev/core#6356) civiimport - Fix pre-upgrade crash 

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -84,6 +84,9 @@ function _civiimport_civicrm_get_import_tables(): array {
   if (isset(Civi::$statics['civiimport_tables'])) {
     return Civi::$statics['civiimport_tables'];
   }
+  if (CRM_Core_BAO_Domain::isDBUpdateRequired() && !\CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_user_job', 'search_display_id')) {
+    return [];
+  }
   // label may not exist yet as a field in the table, e.g. if the upgrade
   // hasn't run yet. If so, then always use '' as label.
   $labelField = CRM_Core_BAO_Domain::isDBVersionAtLeast('6.8.alpha1') ? '`user_job`.`label`, ' : "'' AS `label`, ";


### PR DESCRIPTION
Overview
----------------------------------------

This fixes a pre-upgrade crash for systems that use `civiimport`. The crash can be observed when upgrading (say) 6.0=>6.11.

Details: https://lab.civicrm.org/dev/core/-/issues/6356

Before
----------------------------------------

Random operations fail because `_civiimport_civicrm_get_import_tables()` issues an invalid SQL query. The full error is in Gitlab, but it concludes with:

```
[nativecode=1054 ** Unknown column 'user_job.search_display_id' in 'on clause']"]
```

The column `search_display_id` doesn't exist in the original/starting schema (6.0).

After
----------------------------------------

Skip the failing query.

Comments
----------------------------------------

* I don't really know all the use-cases/data-flows involving `civiimport`'s dynamic-entities, so I don't know how sensible the patch really is. (Skipping metadata for entities might have general risks, but the specific risk depends on the actual usage.)  I pinged @eileenmcnaughton and @larssandergreen
[on Mattermost](https://chat.civicrm.org/civicrm/pl/gshh157rhjga7fx8eeq5cdir5a), and Lars thought it would be OK to skip. So who I am to argue against the simple fix...

* The test in #34945 reproduces the failure. I've included the test in this PR (which should now show it passing; it passes locally).

* I'm playing a little bit of billiards - there's a ball bouncing around between this PR and [34930](https://github.com/civicrm/civicrm-core/pull/34930). In 6 months, future upgrades might have trouble (because of the caching underneath `isDBUpdateRequired()`). But today, this works. And if we also tackle `#34930` with [this adjustment](https://github.com/civicrm/civicrm-core/pull/34930#discussion_r2866765988), then the future upgrades should also be OK. So we converge in a better place. 🤞 