### PR TITLE
River: Adds Contribution Page Premiums CSS

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -110,7 +110,8 @@
   --crm-l-radius: 0.25rem;
   --crm-padding-reg: var(--crm-l-reg);
   --crm-padding-small: var(--crm-l-small);
-  --crm-padding-inset: var(--crm-l-medium);
+  --crm-padding-medium: var(--crm-l-medium);
+  --crm-padding-inset: var(--crm-padding-medium);
   --crm-page-padding: var(--crm-l-large-1); /* Margin left/right */
   --crm-flex-gap: var(--crm-l-medium);
 /* Type */
@@ -118,6 +119,7 @@
   --crm-font: unset;
   --crm-font-size: var(--crm-l-reg);
   --crm-font-small-size: var(--crm-l-medium-2);
+  --crm-font-medium-size: var(--crm-l-reg-2);
   --crm-font-line-height: 1.5;
   --crm-link-decoration: none;
   --crm-link-decoration-hover: underline;

--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -226,13 +226,95 @@ af-form > fieldset > legend {
   padding-inline: var(--crm-f-form-padding);
   font-size: var(--crm-l-reg-1);
 }
+
+/* Premiums */
+.crm-container.crm-public #premiums-listings {
+  width: max(450px, 60%);
+  display: flex;
+  flex-flow: column nowrap;
+  gap: var(--crm-flex-gap);
+  margin-top: var(--crm-l-medium);
+}
+.crm-container.crm-public #premiums-listings .premium-short {
+  background-color: var(--crm-layer1-bg-color);
+  border: var(--crm-border);
+  border-radius: var(--crm-l-radius);
+  padding: var(--crm-padding-medium);
+  cursor: pointer;
+}
+.crm-container.crm-public #premiums-listings .premium-short:hover {
+  border-color: var(--crm-primary-color);
+}
+.crm-container.crm-public #premiums-listings .premium-short-thumbnail {
+  float: left;
+  width: var(--crm-l-large-1);
+}
+.crm-container.crm-public #premiums-listings .premium-short-thumbnail img {
+  width: var(--crm-l-large-1);
+}
+.crm-container.crm-public #premiums-listings .premium-short-content {
+  font-size: var(--crm-font-medium-size);
+  padding: var(--crm-padding-regular);
+  font-weight: bold;
+  text-align: center;
+}
+.crm-container.crm-public #premiums-listings .premium-full {
+  display: none;
+  border: var(--crm-border);
+  border-color: var(--crm-alert-success-border-color);
+  border-radius: var(--crm-l-radius);
+  background-color: var(--crm-alert-success-bg-color);
+  color: var(--crm-alert-success-text-color);
+  padding: var(--crm-padding-medium);
+}
+.crm-container.crm-public #premiums-listings .premium-full .premium-full-image {
+  float: left;
+  padding-right: var(--crm-padding-medium);
+}
+.crm-container.crm-public #premiums-listings .premium-full .premium-full-image img {
+  width: 200px;
+}
+.crm-container.crm-public #premiums-listings .premium-full .premium-full-title {
+  text-align: center;
+  font-size: var(--crm-font-medium-size);
+  font-weight: bold;
+}
+.crm-container.crm-public #premiums-listings .premium-full .premium-full-min {
+  font-size: var(--crm-font-small-size);
+  font-style: italic;
+}
+.crm-container.crm-public #premiums-listings .premium.premium-no_thanks .premium-short {
+  text-align: center;
+  font-size: var(--crm-font-medium-size);
+  padding: var(--crm-padding-medium);
+}
+.crm-container.crm-public #premiums-listings .premium.premium-no_thanks .premium-full {
+  text-align: center;
+  font-size: var(--crm-font-medium-size);
+  font-weight: bold;
+  padding: var(--crm-padding-medium);
+}
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-short,
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full .premium-full-image {
+  opacity: 0.7;
+}
+.crm-container.crm-public #premiums-listings .premium .premium-full-disabled {
+  display: none;
+}
+.crm-container.crm-public #premiums-listings .premium.premium-disabled .premium-full-disabled {
+  display: block;
+  color: var(--crm-danger-ink-color);
+  text-align: center;
+  font-weight: bold;
+  line-height: 2;
+}
+
 /* Social share footer */
 .crm-container .crm-socialnetwork :is(h2,p.clear) {
   margin-top: 0;
 }
 
 /* Empowered by logo */
-
 .crm-public-footer {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Overview
----------------------------------------
This CSS was never [ported from civicrm.css](https://github.com/civicrm/civicrm-core/blob/f3232d92559136b1603d9abffaaf9d093d6910e2/css/civicrm.css#L3820-L3917) meaning any front-end Contribution page with Premiums using River will be mis-formatted.

Before
----------------------------------------
| Greenwich | Minetta |
|---|---|
| <img width="859" height="662" alt="image" src="https://github.com/user-attachments/assets/0fff785a-b37f-4381-993b-f3e6839728c7" /> | <img width="742" height="719" alt="image" src="https://github.com/user-attachments/assets/06d0b6a7-74e3-44df-8dfb-ef4e845f5681" /> |

After
----------------------------------------
| Light | Dark | 
|---|---|
| <img width="841" height="683" alt="image" src="https://github.com/user-attachments/assets/7afa30ce-8bbb-40d3-b2e4-099501aeb939" /> | <img width="841" height="677" alt="image" src="https://github.com/user-attachments/assets/94a0bc2f-2166-40c2-96c6-3b2240dead75" /> |
| <img width="874" height="695" alt="image" src="https://github.com/user-attachments/assets/9d3e25d0-e231-4d35-86a7-2563d9beda49" /> | <img width="870" height="692" alt="image" src="https://github.com/user-attachments/assets/4dc4903b-2790-4d4a-8736-2e9075161062" /> | 
| <img width="584" height="674" alt="image" src="https://github.com/user-attachments/assets/68817b13-ab56-464c-8d56-7c96bcf1074b" /> | <img width="526" height="675" alt="image" src="https://github.com/user-attachments/assets/27d63bc2-67ec-450b-9cfc-328c415c4aef" /> | 
| <img width="733" height="684" alt="image" src="https://github.com/user-attachments/assets/9329e836-2873-45c4-a432-8621b89050c6" /> | <img width="727" height="693" alt="image" src="https://github.com/user-attachments/assets/d313ef1b-b6c1-4f8d-86de-45d594794092" /> |

Technical Details
----------------------------------------
Two new utility variables are added as sizes closes to these were referred to in the old CSS multiple times and would be useful in other places:
- `--crm-font-medium-size: var(--crm-l-reg-2);` (1.25rem or 20px)
- `--crm-padding-medium: var(--crm-l-medium);` (0.5rem or 8px)

If this was being written from scratch, the CSS would be differrent. Instead it's working with the existing markup and JS. It needs to handle a few behavrious:
 - toggle show/hide two diferrent regions for each premium
 - add an opacity to premiums where not enough money has been contributed yet. For a11y reasons this has been scaled back to just the title, and it's more subtle to keep a AA WCAG contrast ratio for this font-size. The opacity is applied to the image, but not the other text, for legibility.
 
Comments
----------------------------------------
This only impacts River streams - and impacts all of them light/dark. However it fixes something currently completely broken/unstyled. Originally PR'd [here](https://github.com/civicrm/civicrm-core/pull/34946).