### PR TITLE
River: fixes recurring membership checkbox bug when used with Price Sets /dev/core#6318

### DIFF
--- a/ext/riverlea/core/css/components/_front.css
+++ b/ext/riverlea/core/css/components/_front.css
@@ -226,6 +226,12 @@ af-form > fieldset > legend {
   padding-inline: var(--crm-f-form-padding);
   font-size: var(--crm-l-reg-1);
 }
+
+/* Price sets */
+.crm-container #allow_auto_renew {
+  grid-column: 1 / span 2;
+}
+
 /* Social share footer */
 .crm-container .crm-socialnetwork :is(h2,p.clear) {
   margin-top: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug on recurring contribution checkbox for public contribution pages, when used with price-sets (and sometimes when not used with them). As found by @webmaster-cses-org-uk in: 
https://lab.civicrm.org/dev/core/-/issues/6318

Before
----------------------------------------
Recurring checkbox is off-screen (screengrab from scrolling off-the-edge):

<img width="744" height="388" alt="image" src="https://github.com/user-attachments/assets/0fa62a5e-0827-4e64-8b97-3adf6e6916b4" />

After
----------------------------------------
Recurring checkbox is where it should be:

<img width="729" height="245" alt="image" src="https://github.com/user-attachments/assets/d0297a5c-bc28-441f-82d8-28921b3f16b8" />