### PR TITLE
(dev/core#5814) Email - Improve Qmail compatibility. Consistent line-wrappings.

### DIFF
--- a/CRM/Mailing/BAO/Spool.php
+++ b/CRM/Mailing/BAO/Spool.php
@@ -16,6 +16,8 @@
  */
 class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
 
+  public $sep = "\n";
+
   /**
    * Store Mails into Spool table.
    *
@@ -41,7 +43,7 @@ class CRM_Mailing_BAO_Spool extends CRM_Mailing_DAO_Spool {
     foreach ($headers as $name => $value) {
       $headerStr[] = "$name: $value";
     }
-    $headerStr = implode("\n", $headerStr);
+    $headerStr = implode($this->sep, $headerStr);
 
     if (is_null($job_id)) {
       // This is not a bulk mailing. Create a dummy job for it.

--- a/CRM/Mailing/Event/BAO/MailingEventReply.php
+++ b/CRM/Mailing/Event/BAO/MailingEventReply.php
@@ -142,7 +142,7 @@ class CRM_Mailing_Event_BAO_MailingEventReply extends CRM_Mailing_Event_DAO_Mail
     else {
       $fromName = empty($eq->display_name) ? $eq->email : "{$eq->display_name} ({$eq->email})";
 
-      $message = new Mail_mime();
+      $message = new Mail_mime(CRM_Utils_Mail::pickDefaultEol());
 
       $headers = [
         'Subject' => "Re: {$mailing->subject}",

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -134,6 +134,32 @@ class CRM_Utils_Mail {
   }
 
   /**
+   * When creating a `Mail_mime` payload for use with a `Mail_*` transport,
+   * they need to agree about the end-of-line character. (Otherwise, you
+   * see mix of EOLs on header-lines -- esp re: header-wrapping.)
+   *
+   * Use pickDefaultsEol() to make a consistent choice.
+   *
+   * Aside: IMHO, the concept of a "default EOL" is fundamentally flawed.
+   * If we swap-in external transports, or if we allow multiple outbound
+   * routes, then this makes it hard to mix-and-match the payloads+transports.
+   *
+   * But for the moment, we need them to match, and we have a legacy of
+   * system-configurations that depend on particular quirks in the drivers.
+   *
+   * @internal
+   * @return string
+   */
+  public static function pickDefaultEol(): string {
+    $mailer = \Civi::service('pear_mail');
+    if ($mailer instanceof CRM_Utils_Mail_FilteredPearMailer) {
+      $mailer = $mailer->getDelegate();
+    }
+    // In core, all mailers should have a "$sep". But in contrib, it hasn't been guaranteed.
+    return property_exists($mailer, 'sep') ? $mailer->sep : "\r\n";
+  }
+
+  /**
    * Wrapper function to send mail in CiviCRM. Hooks are called from this function. The input parameter
    * is an associateive array which holds the values of field needed to send an email. Note that these
    * parameters are case-sensitive. The Parameters are:

--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -419,7 +419,7 @@ class CRM_Utils_Mail {
       $headers['Reply-To'] = $headers['From'];
     }
 
-    $msg = new Mail_mime();
+    $msg = new Mail_mime(static::pickDefaultEol());
     if ($textMessage) {
       $msg->setTxtBody($textMessage);
     }

--- a/CRM/Utils/Mail/FilteredPearMailer.php
+++ b/CRM/Utils/Mail/FilteredPearMailer.php
@@ -102,6 +102,13 @@ class CRM_Utils_Mail_FilteredPearMailer extends Mail {
     return $this->_driver;
   }
 
+  /**
+   * @return \Mail
+   */
+  public function getDelegate() {
+    return $this->_delegate;
+  }
+
   public function &__get($name) {
     return $this->_delegate->{$name};
   }

--- a/ext/flexmailer/src/MailParams.php
+++ b/ext/flexmailer/src/MailParams.php
@@ -45,7 +45,7 @@ class MailParams {
     // pass through as email headers, but there are several special-cases
     // (e.g. 'toName', 'toEmail', 'text', 'html', 'attachments', 'headers').
 
-    $message = new \Mail_mime();
+    $message = new \Mail_mime(\CRM_Utils_Mail::pickDefaultEol());
 
     // 1. Consolidate: 'toName' and 'toEmail' should be 'To'.
     $toName = trim($mailParams['toName']);

--- a/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/CancelSubscriptionTest.php
@@ -48,7 +48,7 @@ class CRM_Contribute_Form_CancelSubscriptionTest extends CiviUnitTestCase {
       'MIME-Version: 1.0',
       'From: "Bob" <bob@example.org>',
       'To: Anthony Anderson <anthony_anderson@civicrm.org>',
-      "Subject: Recurring Contribution Cancellation Notification - Mr. Anthony\r\n Anderson II",
+      "Subject: Recurring Contribution Cancellation Notification - Mr. Anthony\n Anderson II",
       'Return-Path: bob@example.org',
       'Dear Anthony,',
       'Your recurring contribution of $10.00, every 1 month has been cancelled as requested',


### PR DESCRIPTION
Overview
--------

Follow-up to [dev/core#5814](https://lab.civicrm.org/dev/core/-/issues/5814) (aka #33064, #33078). Those improved line-endings in some ways, but regressed in another way -- in particular, the regression presents as a rendering problem when using chain with Mosaico (Versafix) + Qmail (local MTA) + Outlook.com (MUA).

This should fix quirks that present when using Versafix + Qmail. (*The MUA is a less important factor. Outlook.com is notable for presenting the quirks badly, but it's not the only one.*)

There is an extremely [long discussion on Mattermost](https://chat.civicrm.org/civicrm/plgd55oz1acpgf8mnwebwqxe76sw) with several more people (@Stoob @elisseck @aydun)  working to sort-out the relevant variables.

I believe the problem stems from a mismatch with the "end of line" (EOL) policy. Some transports (SMTP, sendmail) require particular endings, but this requirement is not nicely encapsulated within the transport-driver. Rather, PEAR Mail requires that you explicitly link-up the EOL policy of the transport/driver and the content/payload (`Mail_mime`).

Before and After
------

Let's focus on 3 mechanisms which have built-in support in CiviCRM -- and see how they behave with old+new code.

| Civi Option                   | "mail()"             | "Sendmail"           | "SMTP"
|-------------------------------|----------------------|----------------------|---------------------
| __Civi Default?__                 | Yes                  | No                   | No
| __Synopsis__                      | Local MTA (mostly) <br> Remote MTA (Windows)            | Local MTA            | Remote MTA
| __Transport/Driver__              | `\Mail_mail`         | `\Mail_sendmail`     | `Mail_smtp`
| __Configuration__                 | `php.ini`            | `civicrm_settings`   | `civicrm_settings`
| &nbsp;                        |                      |                      |
| __Nominal EOL__                   | CRLF                 | LF                   | CRLF
| &nbsp;                        |                      |                      |
| __Actual EOL__ (CiviCRM <=6.4)    | Mixed (Mostly CRLF; some LF) | Pure LF              | Mixed (Mostly CRLF; some LF)
| __Actual EOL__ (CiviCRM 6.5-6.11) | Pure CRLF            | Mixed (Mostly LF; some CRLF) | Pure CRLF
| __Actual EOL__ (CiviCRM with PR)  | Pure CRLF            | Pure LF              | Pure CRLF

The re-aligned policy of EOL characters should fix compatibility with more delivery systems.

Technical Details
-----------------

* For SMTP and MIME, the RFCs specify CRLF. SMTP servers may be forgiving, but some strictly require RFC compliance -- and reject messages with mixed content. Therefore, CiviCRM 6.4 had issues with some SMTP servers. 
* For local MTAs, it depends on the implementation/endpoint.
    * Exim and Postfix seem to accept either CRLF or LF.
    * However, qmail reportedly implements a mandatory string-substitution (LF => CRLF) which is only sensible with LF inputs. (If you send CRLF to qmail, then it would output CRCRLF -- which is a very strange encoding.)
    * Therefore, Civi 6.5 had issues with qmail.
* The manifestation of the problem depends on how many new-lines appear in the headers+content of your original message. This (in turn) depends on your HTML templates and HTML editor.
    * Mosaico-Versafix is good for reproducing the problem because it has multiple blank lines.
    * However, you should expect other content to be liable to this. (In `text/html` and `text/plain` documents, it's perfectly acceptable to have multiple blank lines.)
* The manifestation of the problem depends on how each party in the SMTP-relay-process adapts to noise (CRCRLF). It leads to funny situations.
    * Example:  The same email on the same account can render differently in two MUAs, as when `icloud.com` looks fine but `Mail.app` looks terrible.
