### PR TITLE
use core error styling for standalone errors

### DIFF
--- a/ext/standaloneusers/css/standalone.css
+++ b/ext/standaloneusers/css/standalone.css
@@ -66,18 +66,3 @@ div.crm-container .standalone-auth-form input[type=text] {
   place-self: end;
   margin-right: 0; /* override civicrm.css's 6px */
 }
-
-/* moved here from menubar-standalone.css
-TODO: can these be removed, or at least made to use Riverlea vars? */
-.standalone-errors {
-  background: #ffe8e4;
-  color: #422;
-  padding: 1rem;
-  margin-bottom: 1rem;
-}
-.standalone-errors code {
-  color: #004e81;
-}
-.standalone-errors .backtrace {
-  font-size: 0.825rem;
-}

--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -57,7 +57,7 @@
 
     {* This has to come at the bottom because the variable may not be populated until some of the templates evaluated inline above get evaluated. *}
     {if $standaloneErrors}
-      <div class="standalone-errors">
+      <div class="status error standalone-errors">
         <ul>{$standaloneErrors}</ul>
       </div>
       <script type="text/javascript">


### PR DESCRIPTION
Overview
----------------------------------------
Fixed styles break in Riverlea dark mode

Before
----------------------------------------

<img width="1007" height="428" alt="image" src="https://github.com/user-attachments/assets/f9834e8b-b65b-46b0-b3fa-6f32c31d5f4a" />


After
----------------------------------------

<img width="1008" height="310" alt="image" src="https://github.com/user-attachments/assets/325ecd01-c1d5-4b05-a1ac-27bc2c4c240c" />




Technical Details
----------------------------------------
`.status.error` works in RL and pre-RL


Comments
----------------------------------------
_Anything else you would like the reviewer to note_
