### PR TITLE
dev/core#6352 Fix failure to respect receipt_update = false on send receipt

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -3096,11 +3096,12 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
     $values['contribution_status'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
     $return = $contribution->composeMessageArray($input, $ids, $values, $returnMessageText);
-    if ((!isset($input['receipt_update']) || $input['receipt_update']) && empty($contribution->receipt_date)) {
-      civicrm_api3('Contribution', 'create', [
-        'receipt_date' => 'now',
-        'id' => $contribution->id,
-      ]);
+
+    if ($input['receipt_update'] && empty($contribution->receipt_date)) {
+      Contribution::update(FALSE)
+        ->addWhere('id', '=', $contributionID)
+        ->addValue('receipt_date', 'now')
+        ->execute();
     }
     return $return;
   }

--- a/CRM/Contribute/Form/Task/PDF.php
+++ b/CRM/Contribute/Form/Task/PDF.php
@@ -211,7 +211,7 @@ AND    {$this->_componentClause}";
       $input['net_amount'] = $contribution->net_amount;
       $input['trxn_id'] = $contribution->trxn_id;
       $input['trxn_date'] = $contribution->trxn_date ?? NULL;
-      $input['receipt_update'] = $params['receipt_update'];
+      $input['receipt_update'] = (bool) ($params['receipt_update'] ?? FALSE);
       $input['contribution_status_id'] = $contribution->contribution_status_id;
       $input['payment_processor_id'] = empty($contribution->trxn_id) ? NULL :
         CRM_Core_DAO::singleValueQuery("SELECT payment_processor_id

--- a/api/v3/Contribution.php
+++ b/api/v3/Contribution.php
@@ -394,6 +394,7 @@ function civicrm_api3_contribution_sendconfirmation($params) {
     'payment_processor_id',
   ];
   $input = array_intersect_key($params, array_flip($allowedParams));
+  $input['receipt_update'] = (bool) ($params['receipt_update'] ?? TRUE);
   $input['modelProps'] = [
     // Pass through legacy receipt_text.
     'userEnteredText' => $params['receipt_text'] ?? NULL,


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#6352 Fix failure to respect receipt_update = false on send receipt

Before
----------------------------------------
When submitting the form to sent an email receipt the `receipt_date` is updated even if the option to updated it is deselected

After
----------------------------------------
The option is respected

Technical Details
----------------------------------------
@demeritcowboy reported this as a regression - I'm not sure that it is but even if not it is a reasonable fix for the rc in that I didn't find any universe callers calling the function directly & it was clearly incorrect on that form


The code was passing through NULL from the form layer which was being treated as ... "I didn't bother to specify so go ahead"

This updates it such that both callers explicitly specify (and would cause a notice if they do not) and removes the squishiness.

Comments
----------------------------------------
This will require some love on upmerge