### PR TITLE
dev/core#5928 Fix missing subtotals on membership report summary with roll up

### DIFF
--- a/CRM/Report/Form/Member/Summary.php
+++ b/CRM/Report/Form/Member/Summary.php
@@ -238,7 +238,6 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
 
             // only include statistics columns if set
             if (!empty($field['statistics'])) {
-              $this->_statFields[] = 'civicrm_membership_member_count';
               foreach ($field['statistics'] as $stat => $label) {
                 switch (strtolower($stat)) {
                   case 'sum':
@@ -323,6 +322,8 @@ class CRM_Report_Form_Member_Summary extends CRM_Report_Form {
     if (is_array($this->_params['group_bys']) &&
       !empty($this->_params['group_bys'])
     ) {
+      // This is our 'always use with group by' stat field for this report.
+      $this->_statFields[] = 'civicrm_membership_member_count';
       foreach ($this->_columns as $table) {
         if (array_key_exists('group_bys', $table)) {
           foreach ($table['group_bys'] as $fieldName => $field) {
@@ -607,15 +608,14 @@ GROUP BY    {$this->_aliases['civicrm_contribution']}.currency
       if (array_key_exists('civicrm_membership_join_date_subtotal', $row) &&
         !$row['civicrm_membership_join_date_subtotal']
       ) {
-        $this->fixSubTotalDisplay($rows[$rowNum], $this->_statFields);
+        $rows[$rowNum]['civicrm_membership_join_date_start'] = ts('Subtotal');
         $entryFound = TRUE;
       }
       elseif (array_key_exists('civicrm_membership_join_date_subtotal', $row) &&
         $row['civicrm_membership_join_date_subtotal'] &&
         !$row['civicrm_membership_membership_type_id']
       ) {
-        $this->fixSubTotalDisplay($rows[$rowNum], $this->_statFields, FALSE);
-        $rows[$rowNum]['civicrm_membership_membership_type_id'] = '<b>' . ts('Subtotal') . '</b>';
+        $rows[$rowNum]['civicrm_membership_membership_type_id'] = ts('Subtotal');
         $entryFound = TRUE;
       }
 

--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -98,7 +98,18 @@
                   {assign var=fieldLink value=$field|cat:"_link"}
                   {assign var=fieldHover value=$field|cat:"_hover"}
                   {assign var=fieldClass value=$field|cat:"_class"}
-                  <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif array_key_exists($field, $row) && $row.$field eq 'Subtotal'} report-label{/if}">
+                  {assign var=fieldValue value=''}
+                  {assign var=isDateSubtotalField value=''}
+                  {assign var=firstCharacterOfField value=''}
+                  {if array_key_exists($field, $row)}
+                    {assign var=fieldValue value=$row[$field]}
+                  {/if}
+                  {if $fieldValue && !is_array($fieldValue)}
+                    {assign var=firstCharacterOfField value=$fieldValue|substr:0:1}
+                    {assign var=isDateSubtotalField value=!is_numeric($firstCharacterOfField) && ($header.type & 4 || $header.type & 256)}
+                  {/if}
+
+                  <td class="crm-report-{$field}{if $header.type eq 1024 OR $header.type eq 1 OR $header.type eq 512} report-contents-right{elseif ($isDateSubtotalField || $fieldValue eq 'Subtotal')} report-label{/if}">
                       {if array_key_exists($fieldLink, $row) && $row.$fieldLink}
                           <a href="{$row.$fieldLink}"
                              {if array_key_exists($fieldHover, $row)}title="{$row.$fieldHover|escape}"{/if}
@@ -110,7 +121,9 @@
                           {foreach from=$row.$field item=fieldrow key=fieldid}
                               <div class="crm-report-{$field}-row-{$fieldid}">{$fieldrow}</div>
                           {/foreach}
-                      {elseif array_key_exists($field, $row) && $row.$field eq 'Subtotal'}
+                      {elseif $isDateSubtotalField}
+                        {$row.$field}
+                      {elseif array_key_exists($field, $row)}
                           {$row.$field}
                       {elseif $header.type & 4 OR $header.type & 256}
                           {if $header.group_by eq 'MONTH' or $header.group_by eq 'QUARTER'}


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#5928 Fix missing subtotals on membership report summary with roll up

Before
----------------------------------------
Per https://lab.civicrm.org/dev/core/-/issues/5928  - the membership count is missing for the subtotal & grand total rows

<img width="1083" height="626" alt="image" src="https://github.com/user-attachments/assets/9f97dc43-1ce0-4bee-b70d-a29255555f93" />


After
----------------------------------------
<img width="732" height="626" alt="image" src="https://github.com/user-attachments/assets/6c3609dc-9f5b-464f-9395-b2bac4154e00" />

With 2 layers of grouping

<img width="732" height="683" alt="image" src="https://github.com/user-attachments/assets/d23a08e5-40e6-4d16-90ac-f373d882dbbd" />

And the version that was working still does

<img width="737" height="775" alt="image" src="https://github.com/user-attachments/assets/2b07af6e-408e-4fa4-b9c0-3a5d996bdeae" />


Technical Details
----------------------------------------
This was reported as a regression but I don't think it is

I fell down a bit of a rabbit hole because I realised the template formatted would only work if the field was 'Subtotal' in English so I added some checks to see if the field value actually started with a number (when it's a date field). It's hard to figure out how to avoid getting sucked into the vortex here but hopefully this is an OK balance

Comments
----------------------------------------
