### PR TITLE
dev/core#6302 Fix redirect bug on SendEmail button

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -70,14 +70,6 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       $this->_componentClause = " civicrm_contribution.id IN ( $id ) ";
       $this->_single = TRUE;
       $this->assign('totalSelectedContributions', 1);
-
-      // set the redirection after actions
-      $contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, FALSE);
-      $url = CRM_Utils_System::url('civicrm/contact/view/contribution',
-        "action=view&reset=1&id={$id}&cid={$contactId}&context=contribution&selectedChild=contribute"
-      );
-
-      CRM_Core_Session::singleton()->pushUserContext($url);
     }
     else {
       parent::preProcess();

--- a/CRM/Contribute/Form/Task/TaskTrait.php
+++ b/CRM/Contribute/Form/Task/TaskTrait.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\Contribution;
 
 /**
  * This class provides shared contribution task functionality.
@@ -109,6 +110,11 @@ trait CRM_Contribute_Form_Task_TaskTrait {
     return $this->ids;
   }
 
+  protected function getContributionID(): ?int {
+    $id = (int) CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    return $id ?: NULL;
+  }
+
   /**
    * @return array|bool|string[]
    * @throws \CRM_Core_Exception
@@ -119,7 +125,12 @@ trait CRM_Contribute_Form_Task_TaskTrait {
     if (!$this->controller instanceof CRM_Contact_Controller_Search && $this->controller->get('id')) {
       return explode(',', $this->controller->get('id'));
     }
-    $ids = $this->getSelectedIDs($this->getSearchFormValues());
+    if ($this->getContributionID()) {
+      $ids = [$this->getContributionID()];
+    }
+    else {
+      $ids = $this->getSelectedIDs($this->getSearchFormValues());
+    }
     if (!$ids) {
       $result = $this->getSearchQueryResults();
       while ($result->fetch()) {
@@ -147,6 +158,25 @@ trait CRM_Contribute_Form_Task_TaskTrait {
    */
   public function isSingle() {
     return count($this->getIDs()) === 1;
+  }
+
+  public function setNextUrl(string $pathPart) {
+    if ($this->getContributionID()) {
+      // set the redirection after actions
+      $url = CRM_Utils_System::url('civicrm/contact/view/contribution', [
+        'action' => 'view',
+        'reset' => 1,
+        'id' => $this->getContributionID(),
+        'cid' => Contribution::get()->addWhere('id', '=', $this->getContributionID())->addSelect('contact_id')->execute()->first()['contact_id'],
+        'context' => 'contribution',
+        'selectedChild' => 'contribute',
+      ]);
+
+      CRM_Core_Session::singleton()->pushUserContext($url);
+    }
+    else {
+      parent::setNextUrl('contribute');
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6302 Fix redirect bug on SendEmail button

Before
----------------------------------------
When using the Send Receipt form a contribution tab it has no idea where to send the browser and it winds up on an empty search with an invalid session method

<img width="1136" height="533" alt="image" src="https://github.com/user-attachments/assets/0e0ef9d0-493a-432d-890d-1dd5ac1635df" />


After
----------------------------------------
The context is set to the contribution - I used the destination url from the existing button search task that works in this context which lands on 'view' - which was not my first choice but I think any bike-shedding could be down the track. 

Technical Details
----------------------------------------

Comments
----------------------------------------
