### PR TITLE
dev/core#6271 Never skip Confirm page if is should have payment on it

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -885,7 +885,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         // The concept of contributeMode is deprecated - but still needs removal from the message templates.
         $this->set('contributeMode', 'notify');
       }
-      if (empty($this->_values['event']['is_confirm_enabled']) && empty($params['additional_participants'])) {
+      if ($this->isSkipConfirmPage()) {
         $this->skipToThankYouPage();
       }
     }
@@ -1023,6 +1023,16 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
       return TRUE;
     }
     return $this->isEventFull() || $this->_requireApproval;
+  }
+
+  /**
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function isSkipConfirmPage(): bool {
+    return !$this->getEventValue('is_confirm_enabled')
+      && !$this->getSubmittedValue('additional_participants')
+      && !$this->isShowPaymentOnConfirm();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The setting to move the payment presentation off the thank you page requires a confirm page but we can wind up with no  confirm page per https://lab.civicrm.org/dev/core/-/issues/6271 because of the newly exposed field on the event entity - this ensures the setting over-rides the per-event config

Before
----------------------------------------
Error if setting `'event_show_payment_on_confirm'` applies to the event AND the `is_confirm_enabled` is set to 0

After
----------------------------------------
setting overrides the per-event config

Technical Details
----------------------------------------
This is still confusing to site admins - but should get us past the immediate regression

Comments
----------------------------------------
