### PR TITLE
dev/core#6057 Fix partial payment handling on contribution page

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -16,6 +16,8 @@
  */
 use Civi\Api4\Contribution;
 use Civi\Api4\Membership;
+use Civi\Api4\Payment;
+use Civi\Payment\Exception\PaymentProcessorException;
 
 /**
  * form to process actions on the group aspect of Custom Data
@@ -59,6 +61,55 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   private function getSelectedProductOption(): mixed {
     return $this->getSubmittedValue('options_' . $this->getSelectedProductID());
+  }
+
+  /**
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  private function processPaymentOnExistingContribution(): array {
+    try {
+      $paymentParams = [
+        'amount' => $this->getSubmittedValue('total_amount'),
+        'contributionID' => $this->getExistingContributionID(),
+      ] + $this->getBasePaymentParams() + $this->prepareParamsForPaymentProcessor($this->getSubmittedValues());
+      $payment = Civi\Payment\System::singleton()->getById($this->getPaymentProcessorID());
+      $result = $payment->doPayment($paymentParams);
+      if ($result['payment_status'] == 'Completed') {
+        Payment::create(FALSE)
+          ->addValue('contribution_id', $this->getExistingContributionID())
+          ->addValue('total_amount', $this->getSubmittedValue('total_amount'))
+          ->addValue('payment_processor_id', $this->getPaymentProcessorID())
+          ->addValue('trxn_id', $result['trxn_id'])
+          ->addValue('fee_amount', $result['fee_amount'] ?? NULL)
+          ->addValue('card_type_id', $paymentParams['card_type_id'])
+          ->addValue('pan_truncation', $paymentParams['pan_truncation'])
+          ->execute();
+      }
+    }
+    catch (PaymentProcessorException $e) {
+      // Clean up DB as appropriate.
+      if (!empty($paymentParams['contributionID'])) {
+        CRM_Contribute_BAO_Contribution::failPayment($paymentParams['contributionID'],
+          $paymentParams['contactID'], $e->getMessage());
+      }
+      if (!empty($paymentParams['contributionRecurID'])) {
+        CRM_Contribute_BAO_ContributionRecur::deleteRecurContribution($paymentParams['contributionRecurID']);
+      }
+
+      $result['is_payment_failure'] = TRUE;
+      $result['error'] = $e;
+    }
+    return $result;
+  }
+
+  /**
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  public function isRecordPaymentOnly(): bool {
+    $isRecordPaymentOnly = $this->getSubmittedValue('total_amount') && $this->getSubmittedValue('total_amount') !== $this->getExistingContributionValue('total_amount');
+    return $isRecordPaymentOnly;
   }
 
   /**
@@ -428,6 +479,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->getMainContributionAmount();
+    $this->assign('paymentAmount', $this->getSubmittedValue('total_amount'));
     if (isset($this->_params['amount'])) {
       $this->setFormAmountFields($this->getPriceSetID());
     }
@@ -2297,8 +2349,17 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     $this->_useForMember = $this->get('useForMember');
 
+    if ($this->isRecordPaymentOnly()) {
+      // A payment is being made against an existing contribution - do not pass go
+      // Only process & record the payment. Note that if the payment === the contribution amount
+      // we go through the normal flow but ,we should consolidate on using
+      // separate handling for payment only vs full contribution (even if
+      // some bits have to be extracted to share) cos overloading this form with payment handling
+      // was one of the original sins here.
+      return $this->processPaymentOnExistingContribution();
+    }
     // store the fact that this is a membership and membership type is selected
-    if ($this->isMembershipSelected()) {
+    elseif ($this->isMembershipSelected()) {
       $this->doMembershipProcessing($contactID, $membershipParams);
     }
     else {
@@ -2434,7 +2495,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $membershipParams['amount'] = $this->getMainContributionAmount();
         $this->processMembership($membershipParams, $contactID);
       }
-      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+      catch (PaymentProcessorException $e) {
         CRM_Core_Session::singleton()->setStatus($e->getMessage());
         if ($this->getContributionID()) {
           CRM_Contribute_BAO_Contribution::failPayment($this->getContributionID(),
@@ -2640,7 +2701,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       }
       return $result;
     }
-    catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+    catch (PaymentProcessorException $e) {
       // Clean up DB as appropriate.
       if (!empty($paymentParams['contributionID'])) {
         CRM_Contribute_BAO_Contribution::failPayment($paymentParams['contributionID'],

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -50,6 +50,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     $this->assign('max_reminders', $this->_values['max_reminders'] ?? NULL);
     $this->assign('initial_reminder_day', $this->getPledgeBlockValue('initial_reminder_day'));
     $this->assignTotalAmounts();
+    $this->assign('paymentAmount', $this->getSubmittedValue('total_amount'));
     // Link (button) for users to create their own Personal Campaign page
     if ($linkText = CRM_PCP_BAO_PCP::getPcpBlockStatus($this->getContributionPageID(), 'contribute')) {
       $linkTextUrl = CRM_Utils_System::url('civicrm/contribute/campaign',

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -856,6 +856,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     $this->assign('trxn_id', $this->_params['trxn_id'] ?? NULL);
     $this->assign('amount_level', str_replace(CRM_Core_DAO::VALUE_SEPARATOR, ' ', $this->order->getAmountLevel()));
     $this->assign('amount', $this->getMainContributionAmount() > 0 ? CRM_Utils_Money::format($this->getMainContributionAmount(), NULL, NULL, TRUE) : NULL);
+    $this->assign('payment_amount', $this->getSubmittedValue('total_amount'));
 
     $isRecurEnabled = isset($this->_values['is_recur']) && !empty($this->_paymentProcessor['is_recur']);
     $this->assign('is_recur_enabled', $isRecurEnabled);
@@ -1261,8 +1262,13 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * Arguably the form should start to build $this->_params in the pre-process main page & use that array consistently throughout.
    */
   protected function setRecurringMembershipParams() {
+    if ($this->getExistingContributionID()) {
+      // Existing contribution so not adding recur.
+      return;
+    }
     $priceFieldId = array_key_first($this->_values['fee']);
     // Why is this an array in CRM_Contribute_Form_Contribution_Main::submit and a string in CRM_Contribute_Form_Contribution_Confirm::preProcess()?
+    // Preferred approach is $this->getSubmittedValue("price_{$priceFieldId}") anyway
     if (is_array($this->_params["price_{$priceFieldId}"])) {
       $priceFieldValue = array_key_first($this->_params["price_{$priceFieldId}"]);
     }
@@ -1510,6 +1516,26 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    */
   protected function getExistingContributionID(): ?int {
     return $this->_ccid ?: CRM_Utils_Request::retrieve('ccid', 'Positive', $this);
+  }
+
+  /**
+   * Get the value for a field relating to the existing contribution for which a payment is being made.
+   *
+   * @param string $fieldName
+   *
+   * @return mixed
+   * @throws \CRM_Core_Exception
+   */
+  protected function getExistingContributionValue(string $fieldName) {
+    if ($this->isDefined('ExistingContribution')) {
+      return $this->lookup('ExistingContribution', $fieldName);
+    }
+    $id = $this->getExistingContributionID();
+    if ($id) {
+      $this->define('Contribution', 'ExistingContribution', ['id' => $id]);
+      return $this->lookup('ExistingContribution', $fieldName);
+    }
+    return NULL;
   }
 
   /**

--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -26,7 +26,14 @@
 
   {include file="CRM/Contribute/Form/Contribution/MembershipBlock.tpl"}
 
-  {if $amount GTE 0 OR $minimum_fee GTE 0 OR ($isDisplayLineItems and $lineItem)}
+  {if $paymentAmount}
+    <div class="header-dark">{ts}Payment Amount{/ts}</div>
+    <div class="crm-section no-label amount_display-section">
+      <div class="content">
+        {$paymentAmount|crmMoney}
+      </div>
+    </div>
+  {elseif $amount GTE 0 OR $minimum_fee GTE 0 OR ($isDisplayLineItems and $lineItem)}
     <div class="crm-group amount_display-group">
       <div class="header-dark">
         {if !$membershipBlock AND $amount OR ($isDisplayLineItems and $lineItem)}{ts}Contribution Amount{/ts}{else}{ts}Membership Fee{/ts} {/if}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -80,7 +80,9 @@
 
       <div class="crm-section no-label amount_display-section">
         <div class="content">
-          {if $lineItem and $priceSetID}
+          {if $paymentAmount}
+            {ts}Payment Amount{/ts}: <strong>{$paymentAmount|crmMoney}</strong><br />
+          {elseif $lineItem and $priceSetID}
             {if !$amount}{assign var="amount" value=0}{/if}
             {assign var="totalAmount" value=$amount}
             {include file="CRM/Price/Page/LineItem.tpl" context="Contribution" displayLineItemFinancialType=false pricesetFieldsCount=false currencySymbol='' hookDiscount=''}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6057 Fix partial payment handling on contribution page

Before
----------------------------------------
When attempting to pay the balance on a contribution via a contribution page the amount processed is the contribution amount, not the payment amount (ie the balance)

Steps to replicate https://lab.civicrm.org/dev/core/-/issues/6057

After
----------------------------------------
The correct amount is processed

Technical Details
----------------------------------------
Part of what makes this form so awful is trying to drive different flows through the same funnel. Since this flow is thoroughly broken I have separated it out. There is some risk that something in the shared code should be done - but that pales beside us charging the wrong amount. However, to be conservative I have only pushed the broken ones (ie where the amount paid is not the full contribution total) through the new code

This is an older regression - on balance I think master is better for it

Comments
----------------------------------------
@mattwire @MegaphoneJon 