### PR TITLE
River: Lighten link colour in Minetta to make them stand out better.

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -18,6 +18,7 @@
   --crm-c-gray-025: #fbfafa;
   --crm-c-blue: #bce8f1;
   --crm-c-blue-light: #e9f5fb;
+  --crm-c-blue-mid: #2c789b;
   --crm-c-blue-dark: #20576f;
   --crm-c-blue-darker: #133f51;
   --crm-c-purple: #4d4d69;
@@ -39,8 +40,8 @@
   --crm-text-light-color: #fff;
   --crm-text-dark-color: #464354;
   --crm-text-color: var(--crm-text-dark-color);
-  --crm-link-color: var(--crm-c-blue-dark);
-  --crm-link-hover-color: var(--crm-c-blue-darker);
+  --crm-link-color: var(--crm-c-blue-mid);
+  --crm-link-hover-color: var(--crm-c-blue-dark);
   --crm-focus-color: var(--crm-c-blue-dark);
   --crm-paper: var(--crm-text-light-color); /* The lightest bg in light mode */
   --crm-ink: var(--crm-c-darkest); /* The darkest foreground in light mode */


### PR DESCRIPTION
Overview
----------------------------------------
Following discussion [here](https://chat.civicrm.org/civicrm/pl/7owj9rbwijgc8gb1hmdukgqrme), the link colour in Minetta is barely distinguishable.

Before

<img width="432" height="25" alt="image" src="https://github.com/user-attachments/assets/68150fd1-3574-46b4-9d33-7434174f638b" />

<img width="1499" height="314" alt="image" src="https://github.com/user-attachments/assets/ce9cdc84-d74e-49bf-83c3-186b2ff543fc" />

After

Minetta - light
<img width="574" height="33" alt="image" src="https://github.com/user-attachments/assets/d2a93630-78f4-4613-82db-75533befb5fe" />
 <img width="1280" height="275" alt="image" src="https://github.com/user-attachments/assets/bdfcf287-173a-48b0-8c0a-ef8f49fcf815" /> 
 
 Hackney - light
 
 <img width="436" height="26" alt="image" src="https://github.com/user-attachments/assets/9393ece7-2f4d-4855-ae13-c3f2115209eb" />
<img width="1496" height="290" alt="image" src="https://github.com/user-attachments/assets/186b3a1d-125e-429d-b2d9-73d110461e71" />


NB - Minetta and Hackney Dark have their own link colour variables, as do both modes of Walbrook and Thames - so not screengrabbed.

Technical Details
----------------------------------------
Rather than lightening `--crm-c-blue-dark`- which was the variable used for links - have added a new colour variable `--crm-c-blue-mid` with the lightest shade of blue that is still WCAG AA (it was previously WCAG AAA - but as tat makes the links nearly impossible to see it's a trade off re-accessibility - sufficient contrast both with the background and other text colours).

The hover colour has also been changed to make it a little light - but still darker than the link colour.