### PR TITLE
Allow files to be public

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -50,6 +50,22 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File implements \Civi\Core\HookInte
         $event->params['created_id'] = CRM_Core_Session::getLoggedInContactID();
       }
     }
+    // When updating is_public, move the file to public/private directory.
+    if ($event->action === 'edit' && isset($event->params['is_public'])) {
+      $wasPublic = self::getDbVal('is_public', $event->params['id']);
+      $isPublic = (bool) $event->params['is_public'];
+      if ($wasPublic !== $isPublic) {
+        $privateDir = CRM_Core_Config::singleton()->customFileUploadDir;
+        $publicDir = CRM_Core_Config::singleton()->imageUploadDir;
+        $oldUri = self::getDbVal('uri', $event->params['id']);
+        $newUri = $event->params['uri'] ?? $oldUri;
+        $oldPath = ($wasPublic ? $publicDir : $privateDir) . "/$oldUri";
+        $newPath = ($isPublic ? $publicDir : $privateDir) . "/$newUri";
+        if (file_exists($oldPath)) {
+          rename($oldPath, $newPath);
+        }
+      }
+    }
   }
 
   /**
@@ -772,8 +788,16 @@ HEREDOC;
   }
 
   public static function getFileUrl(int $fileId, string $cmsEnd = 'current', ?string $flags = NULL): \Civi\Core\Url {
-    $fileHash = self::generateFileHash(NULL, $fileId);
-    return Civi::url("$cmsEnd://civicrm/file?reset=1&id=$fileId&fcs=$fileHash", $flags);
+    $isPublic = self::getDbVal('is_public', $fileId);
+    if ($isPublic) {
+      $uri = self::getDbVal('uri', $fileId);
+      $path = Civi::settings()->get('imageUploadURL');
+      return Civi::url("$path/$uri", $flags);
+    }
+    else {
+      $fileHash = self::generateFileHash(NULL, $fileId);
+      return Civi::url("$cmsEnd://civicrm/file?reset=1&id=$fileId&fcs=$fileHash", $flags);
+    }
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -29,6 +29,14 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
    */
   public function upgrade_6_14_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add File.is_public', 'alterSchemaField', 'File', 'is_public', [
+      'title' => ts('File Is Public'),
+      'sql_type' => 'boolean',
+      'input_type' => 'Toggle',
+      'required' => TRUE,
+      'description' => ts('Controls whether file is stored in public or private directory.'),
+      'default' => FALSE,
+    ], 'AFTER `description`');
   }
 
 }

--- a/Civi/Api4/Action/File/FileSaveTrait.php
+++ b/Civi/Api4/Action/File/FileSaveTrait.php
@@ -42,7 +42,9 @@ trait FileSaveTrait {
 
   private function getFilePath(array $file) {
     $uri = $file['uri'] ?? \CRM_Core_DAO_File::getDbVal('uri', $file['id']);
-    return \CRM_Core_Config::singleton()->customFileUploadDir . $uri;
+    $isPublic = $file['is_public'] ?? (isset($file['id']) ? \CRM_Core_DAO_File::getDbVal('is_public', $file['id']) : FALSE);
+    $settingName = $isPublic ? 'imageUploadDir' : 'customFileUploadDir';
+    return \CRM_Core_Config::singleton()->$settingName . $uri;
   }
 
   private function makeFileUri($fileName) {

--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -194,7 +194,8 @@ trait DAOActionTrait {
         $result[] = $this->baoToArray($dao, $items[$index]);
       }
       \CRM_Utils_API_HTMLInputCoder::singleton()->decodeRows($result);
-      FormattingUtil::formatOutputValues($result, $this->entityFields());
+      $coreFields = array_filter($this->entityFields(), fn($field) => $field['type'] === 'Field');
+      FormattingUtil::formatOutputValues($result, $coreFields);
     }
     else {
       $result = $this->reloadResults($daos, $this->reload);

--- a/Civi/Api4/Service/Spec/Provider/FileGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FileGetSpecProvider.php
@@ -67,7 +67,7 @@ class FileGetSpecProvider extends \Civi\Core\Service\AutoService implements Gene
     $field = new FieldSpec('content', $spec->getEntity(), 'String');
     $field->setLabel(ts('Content'))
       ->setTitle(ts('Content'))
-      ->setColumnName('uri')
+      ->setColumnName('id')
       ->setDescription(ts('Contents of file'))
       ->setType('Extra')
       ->addOutputFormatter([__CLASS__, 'formatFileContent']);
@@ -95,16 +95,21 @@ class FileGetSpecProvider extends \Civi\Core\Service\AutoService implements Gene
     }
   }
 
-  public static function formatFileContent(&$uri) {
+  public static function formatFileContent(&$content, $file) {
+    // Virtual field fetches the id and expects it to be transformed into file contents by this function
+    $fileId = $content;
+    $uri = $file['uri'] ?? ($fileId ? \CRM_Core_DAO_File::getDbVal('is_public', $fileId) : NULL);
     if ($uri && is_string($uri)) {
-      $dir = \CRM_Core_Config::singleton()->customFileUploadDir;
+      $isPublic = $file['is_public'] ?? \CRM_Core_DAO_File::getDbVal('is_public', $fileId);
+      $settingName = $isPublic ? 'imageUploadDir' : 'customFileUploadDir';
+      $dir = \CRM_Core_Config::singleton()->$settingName;
       $path = $dir . DIRECTORY_SEPARATOR . $uri;
       if (file_exists($path)) {
-        $uri = file_get_contents($path);
+        $content = file_get_contents($path);
         return;
       }
     }
-    $uri = NULL;
+    $content = NULL;
   }
 
   /**

--- a/schema/Core/File.entityType.php
+++ b/schema/Core/File.entityType.php
@@ -61,6 +61,15 @@ return [
       'description' => ts('Additional descriptive text regarding this attachment (optional).'),
       'add' => '1.5',
     ],
+    'is_public' => [
+      'title' => ts('File Is Public'),
+      'sql_type' => 'boolean',
+      'input_type' => 'Toggle',
+      'required' => TRUE,
+      'description' => ts('Controls whether file is stored in public or private directory.'),
+      'add' => '6.14',
+      'default' => FALSE,
+    ],
     'upload_date' => [
       'title' => ts('File Upload Date'),
       'sql_type' => 'datetime',

--- a/tests/phpunit/api/v4/Entity/FileTest.php
+++ b/tests/phpunit/api/v4/Entity/FileTest.php
@@ -56,10 +56,14 @@ class FileTest extends Api4TestBase {
 
     $this->assertFileDoesNotExist($originalFile);
 
-    // Hmm, the API has no way to read the content of the saved file! We'll fudge it...
-    $newFile = \CRM_Core_Config::singleton()->customFileUploadDir . $create['uri'];
-    $this->assertFileExists($newFile);
-    $this->assertEquals($originalContent, file_get_contents($newFile));
+    // Get content of new file with api
+    $getResult = \Civi\Api4\File::get(FALSE)
+      ->addSelect('uri', 'url', 'content')
+      ->addWhere('id', '=', $create['id'])
+      ->execute()->single();
+    $this->assertEquals($originalContent, $getResult['content']);
+    // Assert the url does not contain the file name
+    $this->assertStringNotContainsString('test456', $getResult['url']);
   }
 
   /**
@@ -84,6 +88,55 @@ class FileTest extends Api4TestBase {
       $this->assertTrue(str_contains($e->getMessage(), 'only allowed in trusted operation'), 'Exception should relate to permission check');
       $this->assertFileExists($originalFile, 'If creation is rejected, then file should still exist.');
     }
+  }
+
+  public function testPublicPrivateFiles(): void {
+    $fileContent = 'File Content ' . rand();
+
+    // Create file with is_public = TRUE
+    $create = \Civi\Api4\File::create(FALSE)
+      ->setValues([
+        'mime_type' => 'text/plain',
+        'file_name' => 'public_test.txt',
+        'is_public' => TRUE,
+        'content' => $fileContent,
+      ])->execute()->single();
+
+    // Assert file is in the public directory
+    $publicFile = \CRM_Core_Config::singleton()->imageUploadDir . '/' . $create['uri'];
+    $this->assertFileExists($publicFile);
+    $this->assertEquals($fileContent, file_get_contents($publicFile));
+
+    // Assert we can get contents via API
+    $getResult = \Civi\Api4\File::get(FALSE)
+      ->addSelect('uri', 'url', 'content')
+      ->addWhere('id', '=', $create['id'])
+      ->execute()->single();
+    $this->assertEquals($create['uri'], $getResult['uri']);
+    $this->assertEquals($fileContent, $getResult['content']);
+    // Assert the url contains the file name (it's public)
+    $this->assertStringContainsString($getResult['uri'], $getResult['url']);
+
+    // Update file to is_public = FALSE
+    \Civi\Api4\File::update(FALSE)
+      ->addValue('is_public', FALSE)
+      ->addWhere('id', '=', $create['id'])
+      ->execute();
+
+    // Assert file has been moved to private directory
+    $this->assertFileDoesNotExist($publicFile);
+    $privateFile = \CRM_Core_Config::singleton()->customFileUploadDir . '/' . $create['uri'];
+    $this->assertFileExists($privateFile);
+    $this->assertEquals($fileContent, file_get_contents($privateFile));
+
+    // Get content of moved file with api
+    $getResult = \Civi\Api4\File::get(FALSE)
+      ->addSelect('uri', 'url', 'content')
+      ->addWhere('id', '=', $create['id'])
+      ->execute()->single();
+    $this->assertEquals($fileContent, $getResult['content']);
+    // Assert the url does not contain the file name (it's private)
+    $this->assertStringNotContainsString($getResult['uri'], $getResult['url']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows tracking files in a public directory, which helps to unblock https://github.com/civicrm/civicrm-core/pull/33452 for a custom favicon and site logo for Standalone.


Technical Details
----------------------------------------
To-date, all files tracked in `civicrm_file` are stored in a private directory. This adds a new flag to make that optional. Now files can be uploaded to a public directory. The big difference is that with public files, the api will return a URL that directly links to the file, rather than a secure link that checks permissions.

Notes
--------
This should have no impact on existing files, or any future files uploaded, unless the `is_public` flag is specifically set (which no code does yet since it didn't exist till now).