### PR TITLE
Resources - Allow CoreResources bundle to contain markup

### DIFF
--- a/CRM/Core/Resources/Bundle.php
+++ b/CRM/Core/Resources/Bundle.php
@@ -40,7 +40,7 @@ class CRM_Core_Resources_Bundle implements CRM_Core_Resources_CollectionInterfac
 
     $typeAliases = [
       '*all*' => ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl', 'markup', 'template', 'callback'],
-      '*default*' => ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl'],
+      '*default*' => ['script', 'scriptFile', 'scriptUrl', 'settings', 'style', 'styleFile', 'styleUrl', 'markup'],
       '*style*' => ['style', 'styleFile', 'styleUrl'],
       '*script*' => ['script', 'scriptFile', 'scriptUrl'],
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Allows Standalone to add favicon markup to the header.

Technical Details
----------------------------------------
In working on https://github.com/civicrm/civicrm-core/pull/33452, the neatest way to add the favicon tag to the html-header seems to be adding it to the CoreResources bundle. Conceptually, the favicon is a core resource, and this allows it to sit behind the same cache. However, for some reason that bundle is restricted from adding markup. Is there a reason?

Once the restriction is lifted, this works fine:

```php
function standaloneusers_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
  if ($bundle->name === 'coreResources') {
    // Add favicon
    $bundle->addMarkup('<link rel="icon" href... />', [
      'region' => 'html-header',
    ]);
  }
}
```

@totten