### PR TITLE
Don't auto-open entityref autocompletes in SK

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/entityRef.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/entityRef.html
@@ -3,7 +3,7 @@
   ng-model="$ctrl.value"
   crm-autocomplete="$ctrl.getFkEntity()"
   crm-autocomplete-params="{fieldName: $ctrl.input.field.entity + '.' + $ctrl.input.field.name, key: $ctrl.input.optionKey || null}"
-  auto-open="true"
+  auto-open="false"
   multi="$ctrl.isMulti()"
   static-options="$ctrl.getAutocompleteStaticOptions()"
   placeholder="{{:: ts('Select') }}"


### PR DESCRIPTION
Overview
----------------------------------------
Contribution and activity autocompletes can be slow with large databases. If an autocomplete has auto-open, it fires off a query getting all of the relevant entity with an orderby. This query can be slow if the table is large (in WMF's case, the activity and contribution tables are quite large) and that can make following queries, once you've actually added a search term, slow.

Before
----------------------------------------
Entityref autocompletes have auto-open on in SK.

After
----------------------------------------
auto-open off in SK
