### PR TITLE
Fix "Unrecognized Angular module crmSearchDisplayChartKit"

### DIFF
--- a/ext/search_kit/Civi/Search/AngularDependencyInjector.php
+++ b/ext/search_kit/Civi/Search/AngularDependencyInjector.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Civi\Search;
+
+use Civi\Core\Service\AutoSubscriber;
+
+class AngularDependencyInjector extends AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      // Late listener, so that all modules are present before adding dependencies.
+      'hook_civicrm_angularModules' => ['onAngularModules', -999],
+    ];
+  }
+
+  /**
+   * Generate dynamic list of dependencies for the `crmSearchDisplay` module.
+   *
+   * It must require all the modules that provide a viewable search display type.
+   */
+  public function onAngularModules($e) {
+    if (!isset($e->angularModules['crmSearchDisplay'])) {
+      // This shouldn't happen. Condition probably isn't needed.
+      return;
+    }
+    foreach (\Civi\Search\Display::getDisplayTypes(['id', 'name'], TRUE) as $displayType) {
+      foreach ($e->angularModules as $name => $module) {
+        if (isset($module['exports'][$displayType['name']])) {
+          $requires[] = $name;
+        }
+      }
+    }
+    if (isset($requires)) {
+      $e->angularModules['crmSearchDisplay']['requires'] = array_unique(array_merge($e->angularModules['crmSearchDisplay']['requires'], $requires));
+    }
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchDisplay.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplay.ang.php
@@ -1,14 +1,5 @@
 <?php
 // Search Display base module - provides search display wrapper and base services.
-
-// Generate dynamic list of dependencies
-// To prevent circular dependencies in Anguar, only these two are declared clientside.
-$requires = ['api4', 'ngSanitize'];
-// Add all viewable display type Angular modules
-foreach (\Civi\Search\Display::getDisplayTypes(['id', 'name'], TRUE) as $displayType) {
-  $requires[] = CRM_Utils_String::convertStringToCamel($displayType['name'], FALSE);
-}
-
 return [
   'js' => [
     'ang/crmSearchDisplay.module.js',
@@ -22,7 +13,8 @@ return [
     'css/crmSearchDisplay.css',
   ],
   'basePages' => [],
-  'requires' => $requires,
+  // Search display types are added by Civi\Search\AngularDependencyInjector
+  'requires' => ['api4', 'ngSanitize'],
   'exports' => [
     'crm-search-display' => 'E',
   ],


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression from fa5407b8e which naively assumed all search displays have the same name as their module; this makes use of the `exports` so that names don't have to match.

Before
----------------------------------------
Every page with a search display fails to load, says this:

<img width="2230" height="222" alt="image" src="https://github.com/user-attachments/assets/fbdbe639-9755-401a-88dd-3d643e4fa5bb" />


After
----------------------------------------
Works.