### PR TITLE
Use mysql no api3 to check for membership_payment

### DIFF
--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -223,12 +223,11 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
    * @throws \CRM_Core_Exception
    * @internal
    */
-  public static function legacyMembershipPaymentCreateIfNotExist(int $membershipID, int $contributionID, bool $isSkipLineItem = FALSE) {
-    $membershipPayment = civicrm_api3('MembershipPayment', 'get', [
-      'membership_id' => $membershipID,
-      'contribution_id' => $contributionID,
-    ]);
-    if (empty($membershipPayment['count'])) {
+  public static function legacyMembershipPaymentCreateIfNotExist(int $membershipID, int $contributionID, bool $isSkipLineItem = FALSE): void {
+    if (!CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_membership_payment WHERE membership_id = %1 AND contribution_id = %2', [
+      1 => [$membershipID, 'Integer'],
+      2 => [$contributionID, 'Integer'],
+    ])) {
       self::legacyMembershipPaymentCreate($membershipID, $contributionID, $isSkipLineItem);
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
Use mysql no api3 to check for membership_payment

Before
----------------------------------------
Use of apiv3 MembershipPayment

After
----------------------------------------
Use of sql

Technical Details
----------------------------------------
@mattwire I think we want to move towards noisy deprecation of the MembershipPayment `get` api to discourage use of it - avoiding it in this function will help with that

Comments
----------------------------------------
- Also - I think it would probably be better as a private function on the `LineItem` BAO (ie the only caller)

