### PR TITLE
dev/core#6362 - Restrict version of brick/money more for drupal 10 and such

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "tplaner/when": "~3.1",
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
-    "brick/money": "~0.5",
+    "brick/money": ">=0.9 <0.11",
     "pear/mail_mime": "~1.10",
     "pear/db": "~1.12.2",
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4febec11d862bd75ded1d1be56356228",
+    "content-hash": "139a6fb22d498a0dbedfabbbacfd660d",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/issues/6362 and other issues

Before
----------------------------------------
brick is causing multiple problems because we allow too large a range.
See https://github.com/civicrm/civicrm-core/pull/34707#issuecomment-3856059380

After
----------------------------------------
less range

Technical Details
----------------------------------------


Comments
----------------------------------------

