### PR TITLE
dev/core#3448 When deleting a record, cleanup any files from custom fields

### DIFF
--- a/CRM/Core/BAO/CustomValue.php
+++ b/CRM/Core/BAO/CustomValue.php
@@ -16,11 +16,43 @@
  */
 
 use Civi\Api4\Event\AuthorizeRecordEvent;
+use Civi\Core\Event\PreEvent;
+use Civi\Core\HookInterface;
 
 /**
  * Business objects for managing custom data values.
  */
-class CRM_Core_BAO_CustomValue extends CRM_Core_DAO implements \Civi\Core\HookInterface {
+class CRM_Core_BAO_CustomValue extends CRM_Core_DAO implements HookInterface {
+
+  public static function on_hook_civicrm_pre(PreEvent $event): void {
+    if ($event->action !== 'delete' || !$event->id) {
+      return;
+    }
+    // When deleting a record, cleanup any files from custom fields
+    foreach (CRM_Core_BAO_CustomGroup::getAll(['extends' => $event->entity]) as $customGroup) {
+      $filesToDelete = [];
+      foreach ($customGroup['fields'] as $field) {
+        if ($field['data_type'] === 'File') {
+          $files = CRM_Core_DAO::executeQuery("SELECT %1 FROM %2 WHERE entity_id = %3 AND %1 IS NOT NULL", [
+            1 => [$field['column_name'], 'MysqlColumnNameOrAlias'],
+            2 => [$customGroup['table_name'], 'MysqlColumnNameOrAlias'],
+            3 => [$event->id, 'Integer'],
+          ])->fetchMap($field['column_name'], $field['column_name']);
+          foreach ($files as $fileId) {
+            $refCount = \Civi\Api4\Utils\CoreUtil::getRefCountTotal('File', $fileId);
+            if ($refCount <= 1) {
+              $filesToDelete[] = $fileId;
+            }
+          }
+        }
+      }
+      if ($filesToDelete) {
+        \Civi\Api4\File::delete(FALSE)
+          ->addWhere('id', 'IN', $filesToDelete)
+          ->execute();
+      }
+    }
+  }
 
   /**
    * Validate a value against a CustomField type.

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -291,9 +291,9 @@ class CRM_Case_BAO_CaseTest extends CiviCaseTestCase {
     $this->assertNotEquals($a, $fileA['values']['id'], 'The new file A should be a copy of the old file A not the same file.');
     $this->assertNotEquals($b, $fileB['values']['id'], 'The new file B should be a copy of the old file B not the same file.');
 
-    // delete original files
-    unlink($fileA['values']['uri']);
-    unlink($fileB['values']['uri']);
+    // Original files should have been deleted
+    $this->assertFileDoesNotExist($fileA['values']['uri']);
+    $this->assertFileDoesNotExist($fileB['values']['uri']);
 
     $new_file = \Civi\Api4\File::get(FALSE)->addWhere('id', '=', $a)->execute()->first();
     $this->assertNotEquals($filepath . '/' . $new_file['uri'], $fileA['values']['uri'], 'The new file A should not have the same uri as the old file A');

--- a/tests/phpunit/api/v4/Custom/CustomFileTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFileTest.php
@@ -142,6 +142,45 @@ class CustomFileTest extends Api4TestBase {
       ->execute();
     $this->assertCount(0, $result);
     $this->assertFileDoesNotExist($fileUri2);
+
+    // Add a new file
+    $file3 = $this->createTestRecord('File', [
+      'mime_type' => 'text/plain',
+      'file_name' => 'test123.txt',
+      'content' => 'Hello World 12345',
+    ]);
+
+    // Update contact with new file
+    Contact::update(FALSE)
+      ->addWhere('id', '=', $contact['id'])
+      ->addValue($fieldName, $file3['id'])
+      ->execute();
+
+    // Move contact to trash
+    Contact::delete(FALSE)
+      ->addWhere('id', '=', $contact['id'])
+      ->setUseTrash(TRUE)
+      ->execute();
+
+    // File should NOT have been deleted
+    $result = File::get(FALSE)
+      ->selectRowCount()
+      ->addWhere('id', '=', $file3['id'])
+      ->execute();
+    $this->assertCount(1, $result);
+
+    // Delete contact from trash
+    Contact::delete(FALSE)
+      ->addWhere('id', '=', $contact['id'])
+      ->setUseTrash(FALSE)
+      ->execute();
+
+    // File should have been deleted
+    $result = File::get(FALSE)
+      ->selectRowCount()
+      ->addWhere('id', '=', $file3['id'])
+      ->execute();
+    $this->assertCount(0, $result);
   }
 
   public function testMoveFile(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3448](https://lab.civicrm.org/dev/core/-/issues/3448)

Before
----------------------------------------
Deleting a record does not delete any uploaded files associated with that record.

After
----------------------------------------
Now it does.