### PR TITLE
Change Add/Edit Financial Account to use EntityFormTrait

### DIFF
--- a/CRM/Core/Form/EntityFormTrait.php
+++ b/CRM/Core/Form/EntityFormTrait.php
@@ -47,6 +47,7 @@ trait CRM_Core_Form_EntityFormTrait {
    * Fields may have keys
    *  - name (required to show in tpl from the array)
    *  - description (optional, will appear below the field)
+   *  - label (optional, will be used instead of the default field label)
    *  - not-auto-addable - this class will not attempt to add the field using addField.
    *    (this will be automatically set if the field does not have html in it's metadata
    *    or is not a core field on the form's entity).
@@ -349,7 +350,9 @@ trait CRM_Core_Form_EntityFormTrait {
   protected function addEntityFieldsToTemplate() {
     foreach ($this->getEntityFields() as $fieldSpec) {
       if (empty($fieldSpec['not-auto-addable'])) {
-        $element = $this->addField($fieldSpec['name'], [], $fieldSpec['required'] ?? FALSE, FALSE);
+        $props = [];
+        $props['label'] = $fieldSpec['label'] ?? NULL;
+        $element = $this->addField($fieldSpec['name'], $props, $fieldSpec['required'] ?? FALSE, FALSE);
         if (!empty($fieldSpec['is_freeze'])) {
           $element->freeze();
         }

--- a/CRM/Financial/Form/FinancialAccount.php
+++ b/CRM/Financial/Form/FinancialAccount.php
@@ -66,61 +66,86 @@ class CRM_Financial_Form_FinancialAccount extends CRM_Contribute_Form {
   }
 
   /**
+   * Set entity fields to be assigned to the form.
+   */
+  protected function setEntityFields() {
+    $this->entityFields = [
+      'label' => [
+        'name' => 'label',
+        'required' => TRUE,
+        'label' => ts('Label'),
+      ],
+      'description' => [
+        'name' => 'description',
+        'label' => ts('Description'),
+      ],
+      'contact_id' => [
+        'name' => 'contact_id',
+        'description' => ts('Use this field to indicate the organization that owns this account.'),
+        'help' => ['id' => 'contact_id'],
+        'label' => ts('Owner'),
+      ],
+      'financial_account_type_id' => [
+        'name' => 'financial_account_type_id',
+        'required' => TRUE,
+      ],
+      'accounting_code' => [
+        'name' => 'accounting_code',
+        'description' => ts('Enter the corresponding account code used in your accounting system. This code will be available for contribution export, and included in accounting batch exports.'),
+      ],
+      'account_type_code' => [
+        'name' => 'account_type_code',
+        'description' => ts('Enter an account type code for this account. Account type codes are required for QuickBooks integration and will be included in all accounting batch exports.'),
+        'help' => ['id' => 'account_type_code'],
+      ],
+      'is_deductible' => [
+        'name' => 'is_deductible',
+        'description' => ts('Are transactions of this type tax-deductible?'),
+        'label' => ts('Tax-Deductible?'),
+      ],
+      'is_active' => ['name' => 'is_active'],
+      'is_tax' => [
+        'name' => 'is_tax',
+        'label' => ts('Is Tax?'),
+      ],
+      'tax_rate' => [
+        'name' => 'tax_rate',
+        'description' => ts('The default rate used to calculate the taxes collected into this account (e.g. for tax rate of 8.27%, enter 8.27).'),
+        'label' => ts('Tax Rate'),
+      ],
+      'is_default' => [
+        'name' => 'is_default',
+        'description' => ts('If selected, this account will be used as the default for any financial transactions that do not have a specific financial account assigned. Note: only one financial account can be set as the default.'),
+      ],
+    ];
+  }
+
+  /**
    * Build the form object.
    */
   public function buildQuickForm() {
-    parent::buildQuickForm();
-
-    if ($this->_action & CRM_Core_Action::DELETE) {
-      return;
-    }
-    if ($this->isSubmitted()) {
-      $this->addCustomDataFieldsToForm('FinancialAccount');
-    }
-
-    $this->applyFilter('__ALL__', 'trim');
-    $attributes = CRM_Core_DAO::getAttribute('CRM_Financial_DAO_FinancialAccount');
-    $this->add('text', 'label', ts('Label'), $attributes['label'], TRUE);
-    $this->addRule('label', ts('A financial type with this label already exists. Please select another label.'),
-      'objectExists', ['CRM_Financial_DAO_FinancialAccount', $this->_id]);
-
-    $this->add('text', 'description', ts('Description'), $attributes['description']);
-    $this->add('text', 'accounting_code', ts('Accounting Code'), $attributes['accounting_code']);
-    $elementAccounting = $this->add('text', 'account_type_code', ts('Account Type Code'), $attributes['account_type_code']);
-    $this->addEntityRef('contact_id', ts('Owner'), [
-      'api' => ['params' => ['contact_type' => 'Organization']],
-      'create' => TRUE,
-    ]);
-    $this->add('text', 'tax_rate', ts('Tax Rate'), $attributes['tax_rate']);
-    $this->add('checkbox', 'is_deductible', ts('Tax-Deductible?'));
-    $elementActive = $this->add('checkbox', 'is_active', ts('Enabled?'));
-    $this->add('checkbox', 'is_tax', ts('Is Tax?'));
-
-    $element = $this->add('checkbox', 'is_default', ts('Default?'));
     // CRM-12470 freeze is default if is_default is set
     if ($this->_id && CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $this->_id, 'is_default')) {
-      $element->freeze();
+      $this->entityFields['is_default']['is_freeze'] = TRUE;
     }
 
-    $financialAccountType = CRM_Financial_DAO_FinancialAccount::buildOptions('financial_account_type_id');
-    if (!empty($financialAccountType)) {
-      $element = $this->add('select', 'financial_account_type_id', ts('Financial Account Type'),
-        ['' => ts('- select -')] + $financialAccountType, TRUE, ['class' => 'crm-select2 huge']);
-      if ($this->_isARFlag) {
-        $element->freeze();
-        $elementAccounting->freeze();
-        $elementActive->freeze();
-      }
-      elseif ($this->_id && CRM_Financial_BAO_FinancialAccount::validateFinancialAccount($this->_id)) {
-        $element->freeze();
-      }
+    if ($this->_isARFlag) {
+      $this->entityFields['financial_account_type_id']['is_freeze'] = TRUE;
+      $this->entityFields['account_type_code']['is_freeze'] = TRUE;
+      $this->entityFields['is_active']['is_freeze'] = TRUE;
+    }
+    elseif ($this->_id && CRM_Financial_BAO_FinancialAccount::validateFinancialAccount($this->_id)) {
+      $this->entityFields['financial_account_type_id']['is_freeze'] = TRUE;
     }
 
     if ($this->_action == CRM_Core_Action::UPDATE &&
       CRM_Core_DAO::getFieldValue('CRM_Financial_DAO_FinancialAccount', $this->_id, 'is_reserved')
     ) {
-      $this->freeze(['description', 'is_active']);
+      $this->entityFields['is_active']['is_freeze'] = TRUE;
     }
+    $this->buildQuickEntityForm();
+    $this->addRule('label', ts('A financial type with this label already exists. Please select another label.'),
+      'objectExists', ['CRM_Financial_DAO_FinancialAccount', $this->_id]);
     $this->addFormRule(['CRM_Financial_Form_FinancialAccount', 'formRule'], $this);
   }
 

--- a/schema/Financial/FinancialAccount.entityType.php
+++ b/schema/Financial/FinancialAccount.entityType.php
@@ -159,7 +159,7 @@ return [
     'tax_rate' => [
       'title' => ts('Financial Account Tax Rate'),
       'sql_type' => 'decimal(10,8)',
-      'input_type' => NULL,
+      'input_type' => 'Text',
       'description' => ts('The percentage of the total_amount that is due for this tax.'),
       'add' => '4.3',
     ],

--- a/templates/CRM/Financial/Form/FinancialAccount.tpl
+++ b/templates/CRM/Financial/Form/FinancialAccount.tpl
@@ -14,68 +14,6 @@
     {icon icon="fa-info-circle"}{/icon}
     {ts}WARNING: You cannot delete a {$delName} Financial Account if it is currently used by any Financial Types. Consider disabling this option instead.{/ts} {ts}Deleting a financial type cannot be undone.{/ts} {ts}Do you want to continue?{/ts}
   </div>
-{else}
-  <table class="form-layout-compressed">
-    <tr class="crm-contribution-form-block-label">
-      <td class="label">{$form.label.label}</td>
-      <td class="html-adjust">{$form.label.html}</td>
-    </tr>
-    <tr class="crm-contribution-form-block-description">
-      <td class="label">{$form.description.label}</td>
-      <td class="html-adjust">{$form.description.html}</td>
-    </tr>
-    <tr class="crm-contribution-form-block-organisation_name">
-      <td class="label">{$form.contact_id.label}&nbsp;{help id="contact_id" file="CRM/Financial/Form/FinancialAccount.hlp"}</td>
-      <td class="html-adjust">{$form.contact_id.html}<br />
-        <span class="description">{ts}Use this field to indicate the organization that owns this account.{/ts}</span>
-      </td>
-    </tr>
-    <tr class="crm-contribution-form-block-financial_account_type_id">
-      <td class="label">{$form.financial_account_type_id.label}</td>
-      <td class="html-adjust">{$form.financial_account_type_id.html}</td>
-    </tr>
-    <tr class="crm-contribution-form-block-accounting_code">
-      <td class="label">{$form.accounting_code.label}</td>
-      <td class="html-adjust">{$form.accounting_code.html}<br />
-        <span class="description">{ts}Enter the corresponding account code used in your accounting system. This code will be available for contribution export, and included in accounting batch exports.{/ts}</span>
-      </td>
-    </tr>
-    <tr class="crm-contribution-form-block-account_type_code">
-      <td class="label">{$form.account_type_code.label}&nbsp;{help id="account_type_code" file="CRM/Financial/Form/FinancialAccount.hlp"}</td>
-      <td class="html-adjust">{$form.account_type_code.html}<br />
-        <span class="description">{ts}Enter an account type code for this account. Account type codes are required for QuickBooks integration and will be included in all accounting batch exports.{/ts}</span>
-      </td>
-    </tr>
-    <tr class="crm-contribution-form-block-is_deductible">
-      <td class="label">{$form.is_deductible.label}</td>
-      <td class="html-adjust">{$form.is_deductible.html}<br />
-        <span class="description">{ts}Are monies received into this account tax-deductible?{/ts}</span>
-      </td>
-    </tr>
-    <tr class="crm-contribution-form-block-is_active">
-      <td class="label">{$form.is_active.label}</td>
-      <td class="html-adjust">{$form.is_active.html}</td>
-    </tr>
-    <tr class="crm-contribution-form-block-is_tax">
-      <td class="label">{$form.is_tax.label}</td>
-      <td class="html-adjust">{$form.is_tax.html}<br />
-        <span class="description">{ts}Does this account hold taxes collected?{/ts}</span>
-      </td>
-    </tr>
-    <tr class="crm-contribution-form-block-tax_rate">
-      <td class="label">{$form.tax_rate.label}</td>
-      <td class="html-adjust">{$form.tax_rate.html}<br />
-        <span class="description">{ts}The default rate used to calculate the taxes collected into this account (e.g. for tax rate of 8.27%, enter 8.27).{/ts}</span>
-      </td>
-    </tr>
-    <tr class="crm-contribution-form-block-is_default">
-      <td class="label">{$form.is_default.label}</td>
-      <td class="html-adjust">{$form.is_default.html}<br />
-        <span class="description">{ts}Is this account to be used as the default account for its financial account type when associating financial accounts with financial types?{/ts}</span>
-      </td>
-    </tr>
-  </table>
-  {include file="CRM/common/customDataBlock.tpl" groupID='' customDataType='FinancialAccount' customDataSubType=false cid=false}
 {/if}
-<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="botttom"}</div>
+{include file="CRM/Core/Form/EntityForm.tpl"}
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
The Financial Account label isn't translatable from within CiviCRM.  So I converted this form to use EntityFormTrait so that it will.

Before
----------------------------------------
Hard-coded template, no translation.

After
----------------------------------------
Template is EntityFormTrait-based.

Technical Details
----------------------------------------
I added the ability to pass a label into EntityFormTrait.  I separated that into its own commit to be reviewed separately.  That this didn't exist previously suggests that maybe this fields need different labels in the schema instead?  By making it a separate commit (but not PR) folks have context to evaluate if that's the right approach.

Comments
----------------------------------------
The "Owner" field no longer allows creating a new organization on the fly. That seems fine and maybe preferable. Otherwise this should be functionally identical.
