### PR TITLE
CustomField - Mark column_name readonly

### DIFF
--- a/schema/Core/CustomField.entityType.php
+++ b/schema/Core/CustomField.entityType.php
@@ -267,6 +267,7 @@ return [
       'input_type' => 'Text',
       'description' => ts('Name of the column that holds the values for this field.'),
       'add' => '2.0',
+      'readonly' => TRUE,
     ],
     'option_group_id' => [
       'title' => ts('Field Option Group ID'),


### PR DESCRIPTION
Overview
----------------------------------------
Add missing metadata.

Technical Details
----------------------------------------
This field should never be updated, certainly not by the user. Adding this flag prevents it from being output by `civix export`.

Note this is consistent with 
https://github.com/civicrm/civicrm-core/blob/cdf6956241079d72a97ec763995414ce084e6f77/schema/Core/CustomGroup.entityType.php#L184-L188