### PR TITLE
dev/core#6362 - backport - Restrict version of brick/money more for drupal 10 and such

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
     "tplaner/when": "~3.1",
     "xkerman/restricted-unserialize": "~1.1",
     "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
-    "brick/money": "~0.5",
+    "brick/money": ">=0.7 <0.11",
     "pear/mail_mime": "~1.10",
     "pear/db": "~1.12.2",
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0e1d1cd102df655f70fffec0e336d7a",
+    "content-hash": "cc160de8016dbe9397862651285d3d5c",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",


### PR DESCRIPTION
Overview
----------------------------------------
backport https://github.com/civicrm/civicrm-core/pull/34993

Note slightly different range since the locked version is older for 6.11