### PR TITLE
Do not look up membership payments if no MembershipPayment orphans

### DIFF
--- a/Civi/Membership/OrderCompleteSubscriber.php
+++ b/Civi/Membership/OrderCompleteSubscriber.php
@@ -197,8 +197,9 @@ class OrderCompleteSubscriber extends AutoService implements EventSubscriberInte
       ->addWhere('entity_table', '=', 'civicrm_membership')
       ->addSelect('entity_id')
       ->execute()->indexBy('entity_id'));
-
-    $membershipIDs = \CRM_Member_BAO_MembershipPayment::getMembershipPaymentsWithMissingLineitems($contributionID, $membershipIDs);
+    if (\CRM_Price_BAO_LineItem::siteHasMembershipPaymentRecordsNotReflectedInLineItems()) {
+      $membershipIDs = \CRM_Member_BAO_MembershipPayment::getMembershipPaymentsWithMissingLineitems($contributionID, $membershipIDs);
+    }
 
     if (empty($membershipIDs)) {
       return [];


### PR DESCRIPTION
Overview
----------------------------------------
Do not look up membership payments if no MembershipPayment orphans

Before
----------------------------------------
The check for membership payments happens regardless of whether we already no there are no orphans

After
----------------------------------------
Check is conditional

Technical Details
----------------------------------------

Comments
----------------------------------------
