### PR TITLE
RiverLea - Fix Api4 Explorer layout

### DIFF
--- a/ext/riverlea/core/css/api4-explorer.css
+++ b/ext/riverlea/core/css/api4-explorer.css
@@ -7,10 +7,6 @@
   margin-bottom: var(--crm-padding-reg);
   min-height: 500px;
 }
-.api4-explorer-row .explorer-params-panel,
-.api4-explorer-row .explorer-code-panel {
-  flex: 2;
-}
 .api4-explorer-row > .panel {
   margin: 0;
   background: var(--crm-panel-bg-color);


### PR DESCRIPTION
Overview
----------------------------------------
Stop forcing width of panels in Api4 Explorer

Before
----------------------------------------
Code panel is too wide, result panel is too narrow.

<img width="3252" height="1844" alt="image" src="https://github.com/user-attachments/assets/feff68c5-d53d-41e2-b615-8f20bafc534e" />


After
----------------------------------------
<img width="3250" height="1834" alt="image" src="https://github.com/user-attachments/assets/28a53eab-d830-4792-ac4f-be9fab2015d4" />


Technical Details
----------------------------------------
The relative flex width is already set by the classes in the markup, no need to override it in Riverlea.
FYI @vingle 