### PR TITLE
SearchKit - Fix error logging to handle missing display properties

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -122,7 +122,7 @@ class Run extends AbstractRunAction {
       $apiResult = civicrm_api4($entityName, 'get', $apiParams, $index);
     }
     catch (\Throwable $e) {
-      \Civi::log()->error("SearchDisplay.Run error: " . get_class($e) . ": {$entityName}.get: [display_id] " . $this->display['id'] . ' [saved_search_id] ' . $this->display['saved_search_id'] . ' [label] ' . $this->display['label'] . ' [error] ' . $e->getMessage());
+      \Civi::log()->error("SearchDisplay.Run error: " . get_class($e) . ": {$entityName}.get: [display_id] " . ($this->display['id'] ?? 'null') . ' [saved_search_id] ' . ($this->display['saved_search_id'] ?? 'null') . ' [label] ' . ($this->display['label'] ?? '') . ' [error] ' . $e->getMessage());
       throw $e;
     }
     // Copy over meta properties to this result


### PR DESCRIPTION
Overview
----------------------------------------
Fixes error logging when the search display doesn't have an ID.

This happens in preview mode when running an unsaved display.