### PR TITLE
Civi::fs() - Add helper to work with local files more easily

### DIFF
--- a/CRM/Activity/BAO/ICalendar.php
+++ b/CRM/Activity/BAO/ICalendar.php
@@ -61,7 +61,7 @@ class CRM_Activity_BAO_ICalendar {
     if (Civi::settings()->get('activity_assignee_notification_ics')) {
       $this->icsfile = tempnam(CRM_Core_Config::singleton()->customFileUploadDir, 'ics');
       if ($this->icsfile !== FALSE) {
-        rename($this->icsfile, $this->icsfile . '.ics');
+        Civi::fs()->rename($this->icsfile, $this->icsfile . '.ics');
         $this->icsfile .= '.ics';
         $icsFileName = basename($this->icsfile);
 

--- a/CRM/Extension/ClassLoader.php
+++ b/CRM/Extension/ClassLoader.php
@@ -87,7 +87,7 @@ class CRM_Extension_ClassLoader {
     else {
       $this->loader = $this->buildClassLoader();
       $ser = serialize($this->loader);
-      (new Symfony\Component\Filesystem\Filesystem())->dumpFile($file,
+      Civi::fs()->dumpFile($file,
         sprintf("<?php\nreturn unserialize(%s);", var_export($ser, 1))
       );
     }

--- a/CRM/Mailing/MailStore/Localdir.php
+++ b/CRM/Mailing/MailStore/Localdir.php
@@ -137,9 +137,7 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
       print "moving $file to ignored folder\n";
     }
     $target = $this->_ignored . DIRECTORY_SEPARATOR . basename($file);
-    if (!rename($file, $target)) {
-      throw new Exception("Could not rename $file to $target");
-    }
+    Civi::fs()->rename($file, $target, TRUE);
   }
 
   /**
@@ -155,9 +153,7 @@ class CRM_Mailing_MailStore_Localdir extends CRM_Mailing_MailStore {
       print "moving $file to processed folder\n";
     }
     $target = $this->_processed . DIRECTORY_SEPARATOR . basename($file);
-    if (!rename($file, $target)) {
-      throw new Exception("Could not rename $file to $target");
-    }
+    Civi::fs()->rename($file, $target, TRUE);
   }
 
 }

--- a/CRM/Mailing/MailStore/Maildir.php
+++ b/CRM/Mailing/MailStore/Maildir.php
@@ -117,9 +117,7 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
       print "moving $file to ignored folder\n";
     }
     $target = $this->_ignored . DIRECTORY_SEPARATOR . basename($file);
-    if (!rename($file, $target)) {
-      throw new Exception("Could not rename $file to $target");
-    }
+    Civi::fs()->rename($file, $target, TRUE);
   }
 
   /**
@@ -135,9 +133,7 @@ class CRM_Mailing_MailStore_Maildir extends CRM_Mailing_MailStore {
       print "moving $file to processed folder\n";
     }
     $target = $this->_processed . DIRECTORY_SEPARATOR . basename($file);
-    if (!rename($file, $target)) {
-      throw new Exception("Could not rename $file to $target");
-    }
+    Civi::fs()->rename($file, $target, TRUE);
   }
 
 }

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -745,8 +745,8 @@ HTACCESS;
    */
   public static function tempdir($prefix = 'tmp-') {
     $fileName = self::tempnam($prefix);
-    unlink($fileName);
-    mkdir($fileName, 0700);
+    Civi::fs()->remove($fileName);
+    Civi::fs()->mkdir($fileName, 0700);
     return $fileName . '/';
   }
 

--- a/CRM/Utils/File.php
+++ b/CRM/Utils/File.php
@@ -660,17 +660,10 @@ HTACCESS;
    *
    * @return bool
    *   TRUE if absolute. FALSE if relative.
+   * @deprecated
    */
   public static function isAbsolute($path) {
-    if (substr($path, 0, 1) === DIRECTORY_SEPARATOR) {
-      return TRUE;
-    }
-    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-      if (preg_match('!^[a-zA-Z]:[/\\\\]!', $path)) {
-        return TRUE;
-      }
-    }
-    return FALSE;
+    return Civi::fs()->isAbsolutePath($path);
   }
 
   /**

--- a/Civi.php
+++ b/Civi.php
@@ -139,6 +139,35 @@ class Civi {
   }
 
   /**
+   * Get helper for working with local filesystem data.
+   *
+   * Example usage:
+   *
+   *    Civi::fs()->rename("old_item", "new_item");
+   *
+   * In general, most basic file-operations ("rename", "touch", "chown") appear
+   * in both PHP stdlib and the `Filesystem` object. The key differences:
+   *
+   * - In PHP stdlib, functions return boolean (success/failure). All file-operations
+   *   should be explicitly guarded. (Otherwise, errors will be ignored.)
+   * - In `Filesystem`, functions emit IOException if there's any problem. You have
+   *   the option to try-catch, but the implicit-default is to bubble-up errors.
+   * - `Filesystem` adds extra logic for common gotchas. For example, when writing a file,
+   *   it will auto-create parent-folder and perform an atomic file-write.
+   * - In `Filesystem`, many operations accept list of files. (Ex: `chmod(['one.txt', 'two.txt'], 0755)).
+   *
+   * TIP: If switching between PHP stdlib <=> Filesystem, pay attention to how it will
+   * affect error-handling.
+   *
+   * @return \Symfony\Component\Filesystem\Filesystem
+   * @since 6.13.beta1
+   */
+  public static function fs(): \Symfony\Component\Filesystem\Filesystem {
+    Civi::$statics['symfony_filesystem'] ??= new \Symfony\Component\Filesystem\Filesystem();
+    return Civi::$statics['symfony_filesystem'];
+  }
+
+  /**
    * Initiate a bidirectional pipe for exchanging a series of multiple API requests.
    *
    * @param string $negotiationFlags

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -206,7 +206,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
     $path = \Civi::paths()->getPath('[civicrm.private]/');
     $bare_filename = 'afile' . time() . '.php';
     $file = "$path/$bare_filename";
-    file_put_contents($file, '<?php');
+    Civi::fs()->dumpFile($file, '<?php');
 
     // A file that doesn't exist shouldn't be includable.
     $this->assertFalse(CRM_Utils_File::isIncludable('invisiblefile.php'));
@@ -221,9 +221,9 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
 
     // Set permissions to 0, then it shouldn't be includable even if in path.
     if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-      chmod($file, 0);
+      Civi::fs()->chmod($file, 0);
       $this->assertFalse(CRM_Utils_File::isIncludable($bare_filename));
-      chmod($file, 0644);
+      Civi::fs()->chmod($file, 0644);
     }
 
     ini_set('include_path', $old_include_path);
@@ -429,7 +429,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
       return "Failed to make isDirTest/ok";
     }
 
-    file_put_contents("{$a_dir}/isDirTest/ok/ok.txt", 'Hello World!');
+    Civi::fs()->dumpFile("{$a_dir}/isDirTest/ok/ok.txt", 'Hello World!');
     // hmm the "bad" isn't going to work the same way php's own tests work. We
     // need to find a directory outside both cms_root and the sys temp dir.
     // Let's just use some known unix files that always exist instead.
@@ -475,7 +475,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
     $tmpSrc = implode("\n", $lines);
 
     $outFile = tempnam(sys_get_temp_dir(), 'test-script-') . '.php';
-    file_put_contents($outFile, $tmpSrc);
+    Civi::fs()->dumpFile($outFile, $tmpSrc);
 
     try {
       $cmd = 'cv ev -v ' . escapeshellarg("return require \"$outFile\";");
@@ -733,21 +733,16 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
   public function testCleanDir(): void {
     $a_dir = sys_get_temp_dir() . '/testCleanDir';
     system('rm -rf ' . escapeshellarg($a_dir));
-    mkdir("$a_dir");
-    mkdir("$a_dir/clean");
-    mkdir("$a_dir/clean/sub1");
-    touch("$a_dir/clean/file1");
-    touch("$a_dir/clean/sub1/file2");
-    symlink("nonexistent", "$a_dir/clean/link1");
-    symlink("../external1", "$a_dir/clean/link2");
-    symlink("../external2", "$a_dir/clean/link3");
+    Civi::fs()->mkdir(["$a_dir/clean/sub1"]);
+    Civi::fs()->touch(["$a_dir/clean/file1", "$a_dir/clean/sub1/file2"]);
+    Civi::fs()->symlink("nonexistent", "$a_dir/clean/link1");
+    Civi::fs()->symlink("../external1", "$a_dir/clean/link2");
+    Civi::fs()->symlink("../external2", "$a_dir/clean/link3");
     if (function_exists('posix_mkfifo')) {
       posix_mkfifo("$a_dir/clean/fifo1", 0644);
     }
-    touch("$a_dir/externalfile1");
-    mkdir("$a_dir/externaldir1");
-    touch("$a_dir/externaldir1/file1");
-    mkdir("$a_dir/externaldir1/sub1");
+    Civi::fs()->mkdir("$a_dir/externaldir1/sub1");
+    Civi::fs()->touch(["$a_dir/externalfile1", "$a_dir/externaldir1/file1"]);
 
     CRM_Utils_File::cleanDir("$a_dir/clean", FALSE, FALSE);
     if (getenv('DEBUG')) {
@@ -771,12 +766,9 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
   public function testCleanDir_TopLink(): void {
     $a_dir = sys_get_temp_dir() . '/testCleanDir';
     system('rm -rf ' . escapeshellarg($a_dir));
-    mkdir("$a_dir");
-
-    mkdir("$a_dir/externaldir1");
-    touch("$a_dir/externaldir1/file1");
-    mkdir("$a_dir/externaldir1/sub1");
-    symlink("$a_dir/externaldir1", "$a_dir/my_dir");
+    Civi::fs()->mkdir(["$a_dir/externaldir1/sub1"]);
+    Civi::fs()->touch("$a_dir/externaldir1/file1");
+    Civi::fs()->symlink("$a_dir/externaldir1", "$a_dir/my_dir");
 
     $this->assertThat("$a_dir/my_dir", $this->directoryExists());
     $this->assertThat("$a_dir/my_dir/file1", $this->fileExists());


### PR DESCRIPTION
Overview
----------------------------------------

The Symfony `Filesystem` provides helpers for working with local files.  Many of the helpers are similar to eponymous functions from PHP standard library (`chown()`, `mkdir()`, `rename()`, etc), but they're just a little easier to work with. For example:

* In `Filesystem`, all functions throw exceptions, so you don't need to explicitly check for errors.
* Where sensible, most functions accept a list of files. So you can call `chown()`, `mkdir()`, etc with an array.

With this patch, you can access the Symfony `Filesystem` helpers via `Civi::fs()`, as in:

```php
Civi::fs()->mkdir("foo/bar");
Civi::fs()->mkdir(["first", "second"]);
```

Technical Details
----------------------------------------

In this branch, I also swapped several calls to the standard library to demonstrate. Note that one should *not* do a blind search-replace to batch-convert. The examples illustrate a few distinct adjustments:

* In `CRM/Mailing/MailStore/`, it had boilerplate (`throw new Exception(...)`). By calling `Civi::fs()`, we can drop this boilerplate, and it will still emit very similar `IOException` (*which extends `Exception`*).
* In `ICalendar.php`, it's fixing a bug. The old call to `rename()`  was suspiciously unguarded. If the rename doesn't work, then that operation logically fails.
* In `FileTest.php`, it's using less code because the new helper supports array operations. (And it's also giving a clearer exception if any of those steps fail.)