### PR TITLE
Drop `index_is_current_revision` from `civicrm_activity` schema

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixThirteen.php
+++ b/CRM/Upgrade/Incremental/php/SixThirteen.php
@@ -34,6 +34,7 @@ class CRM_Upgrade_Incremental_php_SixThirteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask('Replace "elseif !empty($email)" with "{elseif {contact.email_primary.email|boolean}}" in contribution_online_receipt', 'updateMessageToken', 'contribution_online_receipt', 'elseif !empty($email)', 'elseif {contact.email_primary.email|boolean}', $rev);
     $this->addTask('Replace {$email} with "{contact.email_primary.email}" in contribution_online_receipt', 'updateMessageToken', 'contribution_online_receipt', '$email', 'contact.email_primary.email', $rev);
     $this->addTask('Update quicksearch options to support non-primary search', 'updateQuicksearchOptionsPrimary');
+    $this->addTask('Drop civicrm_activity.is_current_revision index', 'dropIndex', 'civicrm_activity', 'index_is_current_revision');
   }
 
   /**

--- a/schema/Activity/Activity.entityType.php
+++ b/schema/Activity/Activity.entityType.php
@@ -44,12 +44,6 @@ return [
       ],
       'add' => '4.7',
     ],
-    'index_is_current_revision' => [
-      'fields' => [
-        'is_current_revision' => TRUE,
-      ],
-      'add' => '2.2',
-    ],
     'index_is_deleted' => [
       'fields' => [
         'is_deleted' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Column is deprecated & unused, so should not be indexed.

@demeritcowboy 