### PR TITLE
CiviCase - Deprecate & stop using revision functions

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -1587,92 +1587,19 @@ WHERE entity_id =%1 AND entity_table = %2";
   }
 
   /**
-   * Get all prior activities of currently viewed activity.
-   *
-   * @param int $activityID
-   *   Current activity id.
-   * @param bool $onlyPriorRevisions
-   *
-   * @return array
-   *   prior activities info.
-   * @throws \CRM_Core_Exception
+   * @deprecated unused function
    */
   public static function getPriorAcitivities($activityID, $onlyPriorRevisions = FALSE) {
-    static $priorActivities = [];
-
-    $activityID = CRM_Utils_Type::escape($activityID, 'Integer');
-    $index = $activityID . '_' . (int) $onlyPriorRevisions;
-
-    if (!array_key_exists($index, $priorActivities)) {
-      $priorActivities[$index] = [];
-
-      $originalID = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity',
-        $activityID,
-        'original_id'
-      );
-      if (!$originalID) {
-        $originalID = $activityID;
-      }
-      if ($originalID) {
-        $query = "
-SELECT c.display_name as name, cl.modified_date as date, ca.id as activityID
-FROM civicrm_log cl, civicrm_contact c, civicrm_activity ca
-WHERE (ca.id = %1 OR ca.original_id = %1)
-AND cl.entity_table = 'civicrm_activity'
-AND cl.entity_id    = ca.id
-AND cl.modified_id  = c.id
-";
-        if ($onlyPriorRevisions) {
-          $query .= " AND ca.id < {$activityID}";
-        }
-        $query .= " ORDER BY ca.id DESC";
-
-        $params = [1 => [$originalID, 'Integer']];
-        $dao = CRM_Core_DAO::executeQuery($query, $params);
-
-        while ($dao->fetch()) {
-          $priorActivities[$index][$dao->activityID]['id'] = $dao->activityID;
-          $priorActivities[$index][$dao->activityID]['name'] = $dao->name;
-          $priorActivities[$index][$dao->activityID]['date'] = $dao->date;
-        }
-      }
-    }
-    return $priorActivities[$index];
+    CRM_Core_Error::deprecatedFunctionWarning('none; activity revisions are unsupported');
+    return [];
   }
 
   /**
-   * Find the latest revision of a given activity.
-   *
-   * @param int $activityID
-   *   Prior activity id.
-   *
-   * @return int
-   *   current activity id.
-   *
-   * @throws \CRM_Core_Exception
+   * @deprecated unused function
    */
   public static function getLatestActivityId($activityID) {
-    static $latestActivityIds = [];
-
-    $activityID = CRM_Utils_Type::escape($activityID, 'Integer');
-
-    if (!array_key_exists($activityID, $latestActivityIds)) {
-      $latestActivityIds[$activityID] = [];
-
-      $originalID = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity',
-        $activityID,
-        'original_id'
-      );
-      if ($originalID) {
-        $activityID = $originalID;
-      }
-      $params = [1 => [$activityID, 'Integer']];
-      $query = 'SELECT id from civicrm_activity where original_id = %1 and is_current_revision = 1';
-
-      $latestActivityIds[$activityID] = CRM_Core_DAO::singleValueQuery($query, $params);
-    }
-
-    return $latestActivityIds[$activityID];
+    CRM_Core_Error::deprecatedFunctionWarning('none; activity revisions are unsupported');
+    return $activityID;
   }
 
   /**

--- a/CRM/Case/Form/ActivityView.php
+++ b/CRM/Case/Form/ActivityView.php
@@ -25,7 +25,6 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
    */
   public function preProcess() {
     $activityID = CRM_Utils_Request::retrieve('aid', 'Integer', $this, TRUE);
-    $revs = CRM_Utils_Request::retrieve('revs', 'Boolean');
     $caseID = CRM_Utils_Request::retrieve('caseID', 'Integer');
     if (!isset($caseID)) {
       $caseID = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseActivity', $activityID, 'case_id', 'activity_id');
@@ -75,36 +74,8 @@ class CRM_Case_Form_ActivityView extends CRM_Core_Form {
 
     $this->assign('report', $report);
 
-    $latestRevisionID = CRM_Activity_BAO_Activity::getLatestActivityId($activityID);
-
-    $viewPriorActivities = [];
-    $priorActivities = CRM_Activity_BAO_Activity::getPriorAcitivities($activityID);
-    foreach ($priorActivities as $activityId => $activityValues) {
-      if (CRM_Case_BAO_Case::checkPermission($activityId, 'view', NULL, $contactID)) {
-        $viewPriorActivities[$activityId] = $activityValues;
-      }
-    }
-
-    if ($revs) {
-      $this->setTitle(ts('Activity Revision History'));
-      $this->assign('revs', $revs);
-      $this->assign('result', $viewPriorActivities);
-      $this->assign('subject', $activitySubject);
-      $this->assign('latestRevisionID', $latestRevisionID);
-    }
-    else {
-      $this->assign('revs', 0);
-      if (count($viewPriorActivities) > 1) {
-        $this->assign('activityID', $activityID);
-      }
-
-      if ($latestRevisionID != $activityID) {
-        $this->assign('latestRevisionID', $latestRevisionID);
-      }
-    }
-
     $parentID = CRM_Activity_BAO_Activity::getParentActivity($activityID);
-    $this->assign('parentID', $parentID ?? NULL);
+    $this->assign('parentID', $parentID);
 
     //viewing activity should get diplayed in recent list.CRM-4670
     $activityTypeID = CRM_Core_DAO::getFieldValue('CRM_Activity_DAO_Activity', $activityID, 'activity_type_id');

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -368,12 +368,7 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
 
     $this->_activityId = CRM_Utils_Request::retrieve('aid', 'Positive', $this, FALSE, 0, 'GET');
-    if (is_numeric($this->_activityId)) {
-      $latestRevisionId = CRM_Activity_BAO_Activity::getLatestActivityId($this->_activityId);
-      if ($latestRevisionId) {
-        $this->_activityId = $latestRevisionId;
-      }
-    }
+
     $this->_isContactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileType($this->_gid);
 
     //get values for ufGroupName and dupe update.

--- a/CRM/Profile/Page/Dynamic.php
+++ b/CRM/Profile/Page/Dynamic.php
@@ -150,12 +150,7 @@ class CRM_Profile_Page_Dynamic extends CRM_Core_Page {
     }
 
     $this->_activityId = CRM_Utils_Request::retrieve('aid', 'Positive', $this, FALSE, 0, 'GET');
-    if (is_numeric($this->_activityId)) {
-      $latestRevisionId = CRM_Activity_BAO_Activity::getLatestActivityId($this->_activityId);
-      if ($latestRevisionId) {
-        $this->_activityId = $latestRevisionId;
-      }
-    }
+
     $this->_isContactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileType($this->_gid);
   }
 

--- a/templates/CRM/Case/Form/ActivityView.tpl
+++ b/templates/CRM/Case/Form/ActivityView.tpl
@@ -9,58 +9,37 @@
 *}
 {* View Case Activities *}
 <div class="crm-block crm-content-block crm-case-activity-view-block">
-  {if $revs}
-    {strip}
-      <table class="crm-info-panel">
-        <tr class="columnheader">
-          <th>{ts}Created By{/ts}</th>
-          <th>{ts}Created On{/ts}</th>
-          <th>&nbsp;</th>
+  {if $report}
+    <table class="crm-info-panel" id="crm-activity-view-table">
+      {foreach from=$report.fields item=row name=report}
+        <tr class="crm-case-activity-view-{$row.label}">
+          <td class="label">{$row.label}</td>
+          {if $smarty.foreach.report.first AND ( $activityID OR $parentID )} {* Add a cell to first row with links to Prompted by (parent) as appropriate *}
+            <td>{$row.value}</td>
+            <td style="padding-right: 50px; text-align: right; font-size: .9em;">
+              {if $parentID}<a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid=$parentID"}"><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Prompted by{/ts}</a>{/if}
+            </td>
+          {else}
+            <td colspan="2">
+              {if $row.label eq 'Details'}{$row.value|crmStripAlternatives|nl2brIfNotHTML|purify}{elseif $row.type eq 'Date'}{$row.value|crmDate}{else}{$row.value}{/if}</td>
+          {/if}
         </tr>
-        {foreach from=$result item=row}
-          <tr {if $row.id EQ $latestRevisionID}style="font-weight: bold;"{/if}>
-            <td class="crm-case-activityview-form-block-name">{$row.name}</td>
-            <td class="crm-case-activityview-form-block-date">{$row.date|crmDate}</td>
-            <td class="crm-case-activityview-form-block-{$row.id}"><a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid="}{$row.id}" title="{ts escape='htmlattribute'}View this revision of the activity record.{/ts}">{if $row.id != $latestRevisionID}{ts}View{/ts}{else}{ts}View (Current Revision){/ts}{/if}</a></td>
+      {/foreach}
+      {* Display custom field data for the activity. *}
+      {if $report.customGroups}
+        {foreach from=$report.customGroups item=customGroup key=groupTitle name=custom}
+          <tr class="crm-case-activityview-form-block-groupTitle form-layout">
+            <td colspan="3">{$groupTitle}</td>
           </tr>
-        {/foreach}
-      </table>
-    {/strip}
-  {else}
-    {if $report}
-      <table class="crm-info-panel" id="crm-activity-view-table">
-        {foreach from=$report.fields item=row name=report}
-          <tr class="crm-case-activity-view-{$row.label}">
-            <td class="label">{$row.label}</td>
-            {if $smarty.foreach.report.first AND ( $activityID OR $parentID OR $latestRevisionID )} {* Add a cell to first row with links to prior revision listing and Prompted by (parent) as appropriate *}
-              <td>{$row.value}</td>
-              <td style="padding-right: 50px; text-align: right; font-size: .9em;">
-                {if $activityID}<a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid=$activityID&revs=1"}"><i class="crm-i fa-history" role="img" aria-hidden="true"></i> {ts}List all revisions{/ts}</a>{if !$latestRevisionID}<br />{ts}(this is the current revision){/ts}{/if}<br />{/if}
-                {if $latestRevisionID}<a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid=$latestRevisionID"}"><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}View current revision{/ts}</a><br /><span style="color: red;">{ts}(this is not the current revision){/ts}</span><br />{/if}
-                {if $parentID}<a class="open-inline-noreturn" href="{crmURL p='civicrm/case/activity/view' h=0 q="cid=$contactID&aid=$parentID"}"><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Prompted by{/ts}</a>{/if}
-              </td>
-            {else}
-              <td colspan="2">
-                {if $row.label eq 'Details'}{$row.value|crmStripAlternatives|nl2brIfNotHTML|purify}{elseif $row.type eq 'Date'}{$row.value|crmDate}{else}{$row.value}{/if}</td>
-            {/if}
-          </tr>
-        {/foreach}
-        {* Display custom field data for the activity. *}
-        {if $report.customGroups}
-          {foreach from=$report.customGroups item=customGroup key=groupTitle name=custom}
-            <tr class="crm-case-activityview-form-block-groupTitle form-layout">
-              <td colspan="3">{$groupTitle}</td>
+          {foreach from=$customGroup item=customField name=fields}
+            <tr{if ! $smarty.foreach.fields.last} style="border-bottom: 1px solid #F6F6F6;"{/if}>
+              <td class="label">{$customField.label}</td>
+              <td>{$customField.value}</td>
             </tr>
-            {foreach from=$customGroup item=customField name=fields}
-              <tr{if ! $smarty.foreach.fields.last} style="border-bottom: 1px solid #F6F6F6;"{/if}>
-                <td class="label">{$customField.label}</td>
-                <td>{$customField.value}</td>
-              </tr>
-            {/foreach}
           {/foreach}
-        {/if}
-      </table>
-    {/if}
+        {/foreach}
+      {/if}
+    </table>
   {/if}
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom" linkButtons=$actionLinks}</div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
CIviCase activity revisions are no longer used. This deprecates and stops using some related functions.

Technical Details
----------------------------------------
- Deleted code handling activity revisions in activity views and profiles.
- Deprecated unused functions: `getPriorAcitivities` and `getLatestActivityId`.
- Simplified templates and logic by removing revision-related elements.

Comments
-----
Diff isn't so big when you [ignore whitespace changes](https://github.com/civicrm/civicrm-core/pull/35010/changes?w=1).

@demeritcowboy 