### PR TITLE
Api3 - Mark MembershipPayment as deprecated in the Explorer.

### DIFF
--- a/api/v3/MembershipPayment.php
+++ b/api/v3/MembershipPayment.php
@@ -10,7 +10,7 @@
  */
 
 /**
- * This api exposes CiviCRM membership contribution link.
+ * @deprecated API – Use the LineItem API instead.
  *
  * @package CiviCRM_APIv3
  */
@@ -61,4 +61,8 @@ function _civicrm_api3_membership_payment_create_spec(&$params) {
  */
 function civicrm_api3_membership_payment_get($params) {
   return _civicrm_api3_basic_get('CRM_Member_DAO_MembershipPayment', $params);
+}
+
+function _civicrm_api3_membership_payment_deprecation() {
+  return "Use the LineItem API instead.";
 }


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/civicrm/civicrm-core/pull/35002 – shows the deprecation in the API Explorer.

<img width="2092" height="722" alt="image" src="https://github.com/user-attachments/assets/af12d5ab-b067-4495-b149-98b57cad7ed9" />

@eileenmcnaughton 