### PR TITLE
[NFC] setStatus is a static function

### DIFF
--- a/CRM/Contact/Form/Contact.php
+++ b/CRM/Contact/Form/Contact.php
@@ -1098,10 +1098,10 @@ class CRM_Contact_Form_Contact extends CRM_Core_Form {
       $message .= "<br />$parseStatusMsg";
     }
 
-    $session = CRM_Core_Session::singleton();
-    $session->setStatus($message, ts('Contact Saved'), 'success');
+    CRM_Core_Session::setStatus($message, ts('Contact Saved'), 'success');
 
     // add the recently viewed contact
+    $session = CRM_Core_Session::singleton();
     $recentOther = [];
     if (($session->get('userID') == $contact->id) ||
       CRM_Contact_BAO_Contact_Permission::allow($contact->id, CRM_Core_Permission::EDIT)

--- a/CRM/Contact/Form/Task/Delete.php
+++ b/CRM/Contact/Form/Task/Delete.php
@@ -212,11 +212,11 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
     foreach ($this->_contactIds as $cid) {
       $name = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $cid, 'display_name');
       if (CRM_Contact_BAO_Contact::checkDomainContact($cid)) {
-        $session->setStatus(ts("'%1' cannot be deleted because the information is used for special system purposes.", [1 => $name]), 'Cannot Delete Domain Contact', 'error');
+        CRM_Core_Session::setStatus(ts("'%1' cannot be deleted because the information is used for special system purposes.", [1 => $name]), ts('Cannot Delete Domain Contact'), 'error');
         continue;
       }
       if ($currentUserId == $cid) {
-        $session->setStatus(ts("You are currently logged in as '%1'. You cannot delete yourself.", [1 => $name]), 'Unable To Delete', 'error');
+        CRM_Core_Session::setStatus(ts("You are currently logged in as '%1'. You cannot delete yourself.", [1 => $name]), ts('Unable To Delete'), 'error');
         continue;
       }
       if (CRM_Contact_BAO_Contact::deleteContact($cid, FALSE, $this->_skipUndelete)) {
@@ -243,7 +243,7 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
           'count' => $deleted,
         ]);
       }
-      $session->setStatus($status, $title, 'success');
+      CRM_Core_Session::setStatus($status, $title, 'success');
     }
     // Alert user of any failures
     if ($not_deleted) {
@@ -255,12 +255,12 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
       $ufmatch->contact_id = $cid;
       $ufmatch->domain_id = CRM_Core_Config::domainID();
       if ($ufmatch->find(TRUE)) {
-        $status = ts('The contact has a CMS account. You will need to delete it before you can delete this contact.');
+        $status = ts('The contact has a user account. You will need to delete it before you can delete this contact.');
       }
       else {
         $status = ts('The contact might be the Membership Organization of a Membership Type. You will need to edit the Membership Type and change the Membership Organization before you can delete this contact.');
       }
-      $session->setStatus('<ul><li>' . implode('</li><li>', $not_deleted) . '</li></ul>' . $status, $title, 'error');
+      CRM_Core_Session::setStatus('<ul><li>' . implode('</li><li>', $not_deleted) . '</li></ul>' . $status, $title, 'error');
     }
     if (isset($this->_sharedAddressMessage) && $this->_sharedAddressMessage['count'] > 0) {
       if (count($this->_sharedAddressMessage['contactList']) == 1) {
@@ -271,7 +271,7 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
       }
       $message .= '<ul><li>' . implode('</li><li>', $this->_sharedAddressMessage['contactList']) . '</li></ul>';
 
-      $session->setStatus($message, ts('Shared Addresses Owner Deleted'), 'info', ['expires' => 30000]);
+      CRM_Core_Session::setStatus($message, ts('Shared Addresses Owner Deleted'), 'info', ['expires' => 30000]);
 
       $this->set('sharedAddressMessage', NULL);
     }
@@ -283,7 +283,6 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
    * Set the url for the contact to be redirected to.
    */
   protected function setRedirection() {
-
     $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'basic');
     $urlParams = 'force=1';
     $urlString = "civicrm/contact/search/$context";

--- a/CRM/Contribute/Form/UpdateBilling.php
+++ b/CRM/Contribute/Form/UpdateBilling.php
@@ -333,7 +333,7 @@ class CRM_Contribute_Form_UpdateBilling extends CRM_Contribute_Form_Contribution
     $session = CRM_Core_Session::singleton();
     $userID = $session->get('userID');
     if ($userID && $status) {
-      $session->setStatus($status, $msgTitle, $msgType);
+      CRM_Core_Session::setStatus($status, $msgTitle, $msgType);
     }
     elseif (!$userID) {
       if ($status) {

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -906,12 +906,9 @@ AND    option_group_id = %2";
     // reset the cache
     Civi::cache('fields')->flush();
 
-    $msg = '<p>' . ts("Custom field '%1' has been saved.", [1 => $customField->label]) . '</p>';
-
     $buttonName = $this->controller->getButtonName();
     $session = CRM_Core_Session::singleton();
     if ($buttonName == $this->getButtonName('next', 'new')) {
-      $msg .= '<p>' . ts("Ready to add another.") . '</p>';
       $session->replaceUserContext(CRM_Utils_System::url('civicrm/admin/custom/group/field/add',
         'reset=1&gid=' . $this->_gid
       ));
@@ -919,7 +916,8 @@ AND    option_group_id = %2";
     else {
       $session->replaceUserContext(CRM_Utils_System::url("civicrm/admin/custom/group/fields#/?gid=$this->_gid"));
     }
-    $session->setStatus($msg, ts('Saved'), 'success');
+
+    CRM_Core_Session::setStatus(ts("Custom field '%1' has been saved.", [1 => $customField->label]), ts('Saved'), 'success');
 
     // Add data when in ajax contect
     $this->ajaxResponse['customField'] = $customField->toArray();

--- a/CRM/Pledge/Page/Tab.php
+++ b/CRM/Pledge/Page/Tab.php
@@ -118,8 +118,7 @@ class CRM_Pledge_Page_Tab extends CRM_Core_Page {
     }
     elseif ($this->_action & CRM_Core_Action::DETACH) {
       CRM_Pledge_BAO_Pledge::cancel($this->_id);
-      $session = CRM_Core_Session::singleton();
-      $session->setStatus(ts('Pledge has been Cancelled and all scheduled (not completed) payments have been cancelled.<br />'));
+      CRM_Core_Session::setStatus(ts('Pledge has been cancelled and all scheduled (not completed) payments have been cancelled.'));
       CRM_Utils_System::redirect($session->popUserContext());
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------

Converts non-static calls to `CRM_Core_Session::setStatus` to static calls.

There are a few left, but I couldn't easily test them.  

Also minor tweaks to fix some translations, or remove some formatting in certain places.