### PR TITLE
CiviCase - Remove references to is_current_revision from activity queries

### DIFF
--- a/CRM/Activity/ActionMapping.php
+++ b/CRM/Activity/ActionMapping.php
@@ -138,7 +138,7 @@ class CRM_Activity_ActionMapping extends \Civi\ActionSchedule\MappingBase {
       $query->where("e.status_id IN (#selectedStatuss)")
         ->param('selectedStatuss', $selectedStatuses);
     }
-    $query->where('e.is_current_revision = 1 AND e.is_deleted = 0');
+    $query->where('e.is_deleted = 0');
 
     return $query;
   }

--- a/CRM/Activity/BAO/Query.php
+++ b/CRM/Activity/BAO/Query.php
@@ -361,7 +361,7 @@ class CRM_Activity_BAO_Query {
                       ON ( civicrm_activity_contact.contact_id = contact_a.id ) ";
         $from .= " $side JOIN civicrm_activity
                       ON ( civicrm_activity.id = civicrm_activity_contact.activity_id
-                      AND civicrm_activity.is_deleted = 0 AND civicrm_activity.is_current_revision = 1 )";
+                      AND civicrm_activity.is_deleted = 0 )";
         // Do not show deleted contact's activity
         // unless we are looking at deleted contacts.
         $from .= " INNER JOIN civicrm_contact

--- a/CRM/Activity/Page/AJAX.php
+++ b/CRM/Activity/Page/AJAX.php
@@ -320,9 +320,7 @@ class CRM_Activity_Page_AJAX {
     $mainActivity->copyValues($mainActVals);
     $mainActivity->id = NULL;
     $mainActivity->activity_date_time = $actDateTime;
-    // Make sure this is current revision.
-    $mainActivity->is_current_revision = TRUE;
-    $mainActivity->original_id = $mainActivity->parent_id = NULL;
+    $mainActivity->parent_id = NULL;
 
     $mainActivity->save();
     $mainActivityId = $mainActivity->id;

--- a/CRM/Activity/Tokens.php
+++ b/CRM/Activity/Tokens.php
@@ -41,10 +41,8 @@ class CRM_Activity_Tokens extends CRM_Core_EntityTokens {
       return;
     }
 
-    // The joint expression for activities needs some extra nuance to handle.
-    // Multiple revisions of the activity.
-    // Q: Could we simplify & move the extra AND clauses into `where(...)`?
-    $e->query->param('casEntityJoinExpr', 'e.id = reminder.entity_id AND e.is_current_revision = 1 AND e.is_deleted = 0');
+    // Q: Could we simplify & move the extra AND clause into `where(...)`?
+    $e->query->param('casEntityJoinExpr', 'e.id = reminder.entity_id AND e.is_deleted = 0');
     parent::alterActionScheduleQuery($e);
   }
 

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -511,7 +511,7 @@ HERESQL;
         (SELECT b.id FROM civicrm_case_activity bca
          INNER JOIN civicrm_activity b ON bca.activity_id=b.id
          WHERE b.activity_date_time <= DATE_ADD( NOW(), INTERVAL 14 DAY )
-         AND b.is_current_revision = 1 AND b.is_deleted=0 AND b.status_id = $scheduled_id
+         AND b.is_deleted=0 AND b.status_id = $scheduled_id
          AND bca.case_id = ca.case_id ORDER BY b.activity_date_time ASC LIMIT 1)) t_act
         ON t_act.case_id = civicrm_case.id
 HERESQL;
@@ -526,7 +526,7 @@ HERESQL;
         (SELECT b.id FROM civicrm_case_activity bca
          INNER JOIN civicrm_activity b ON bca.activity_id=b.id
          WHERE b.activity_date_time >= DATE_SUB( NOW(), INTERVAL 14 DAY )
-         AND b.is_current_revision = 1 AND b.is_deleted=0 AND b.status_id <> $scheduled_id
+         AND b.is_deleted=0 AND b.status_id <> $scheduled_id
          AND bca.case_id = ca.case_id ORDER BY b.activity_date_time DESC LIMIT 1)) t_act
         ON t_act.case_id = civicrm_case.id
 HERESQL;
@@ -538,7 +538,6 @@ HERESQL;
           ON civicrm_case.id = ca4.case_id
         LEFT JOIN civicrm_activity t_act
           ON t_act.id = ca4.activity_id
-          AND t_act.is_current_revision = 1
 HERESQL;
     }
 
@@ -1000,8 +999,7 @@ SELECT civicrm_case.id, case_status.label AS case_status, status_id, civicrm_cas
               AND ov.name = 'Scheduled'";
 
     $where = '
-            WHERE cca.case_id= %1
-              AND ca.is_current_revision = 1';
+            WHERE cca.case_id= %1';
 
     if (!empty($params['source_contact_id'])) {
       $where .= "
@@ -1677,7 +1675,6 @@ HERESQL;
     if ($latestDate) {
       if (!empty($criteriaParams['activity_type_id'])) {
         $where .= " AND ca.activity_type_id    = " . CRM_Utils_Type::escape($criteriaParams['activity_type_id'], 'Integer');
-        $where .= " AND ca.is_current_revision = 1";
         $groupBy .= " GROUP BY ca.activity_type_id, ca.id";
       }
 

--- a/CRM/Case/BAO/Query.php
+++ b/CRM/Case/BAO/Query.php
@@ -534,8 +534,7 @@ case_relation_type.id = case_relationship.relationship_type_id )";
 
       case 'case_activity':
         $from .= " INNER JOIN civicrm_case_activity ON civicrm_case_activity.case_id = civicrm_case.id ";
-        $from .= " INNER JOIN civicrm_activity case_activity ON ( civicrm_case_activity.activity_id = case_activity.id
-                                                                AND case_activity.is_current_revision = 1 )";
+        $from .= " INNER JOIN civicrm_activity case_activity ON ( civicrm_case_activity.activity_id = case_activity.id )";
         break;
 
       case 'civicrm_case_tag':

--- a/CRM/Case/Form/CaseView.php
+++ b/CRM/Case/Form/CaseView.php
@@ -568,8 +568,6 @@ class CRM_Case_Form_CaseView extends CRM_Core_Form implements CRM_Case_Form_Case
       ->addWhere('case_id', '=', $form->_caseID)
       // we want to include deleted too since the filter can search for deleted
       ->addWhere('activity_id.is_deleted', 'IN', [0, 1])
-      // technically correct, but this might end up excluding some deleted ones depending on how they got deleted
-      // ->addWhere('activity_id.is_current_revision', '=', 1)
       ->addSelect('activity_id.activity_type_id', 'activity_id.activity_type_id:label')
       ->addGroupBy('activity_id.activity_type_id')
       // this creates strange SQL - if it is too slow could sort in php instead

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -361,7 +361,6 @@ INNER JOIN civicrm_case_activity ca on ca.activity_id = a.id
 WHERE  t.contact_id = %1
 AND    t.record_type_id = $targetID
 AND    a.is_auto = 1
-AND    a.is_current_revision = 1
 AND    ca.case_id = %2
 ";
     $sqlParams = [1 => [$params['clientID'], 'Integer'], 2 => [$params['caseID'], 'Integer']];
@@ -436,7 +435,6 @@ AND        a.is_deleted = 0
         'activity_type_id' => $activityTypeID,
         'source_contact_id' => $params['creatorID'],
         'is_auto' => FALSE,
-        'is_current_revision' => 1,
         'subject' => !empty($params['subject']) ? $params['subject'] : $activityTypeName,
         'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', $statusName),
         'target_contact_id' => $client,
@@ -452,7 +450,6 @@ AND        a.is_deleted = 0
         'activity_type_id' => $activityTypeID,
         'source_contact_id' => $params['creatorID'],
         'is_auto' => TRUE,
-        'is_current_revision' => 1,
         'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', $statusName),
         'target_contact_id' => $client,
         'weight' => $orderVal,

--- a/CRM/Case/XMLProcessor/Report.php
+++ b/CRM/Case/XMLProcessor/Report.php
@@ -173,8 +173,7 @@ SELECT a.*, c.id as caseID
 FROM   civicrm_activity a,
        civicrm_case     c,
        civicrm_case_activity ac
-WHERE  a.is_current_revision = 1
-AND    a.is_deleted =0
+WHERE  a.is_deleted = 0
 AND    a.activity_type_id IN ( $activityTypeIDs )
 AND    c.id = ac.case_id
 AND    a.id = ac.activity_id

--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -3268,7 +3268,7 @@ WHERE  $smartGroupClause
             ON ( civicrm_activity_contact.contact_id = contact_a.id AND civicrm_activity_contact.record_type_id = {$targetID} )
             LEFT JOIN civicrm_activity
             ON ( civicrm_activity.id = civicrm_activity_contact.activity_id
-            AND civicrm_activity.is_deleted = 0 AND civicrm_activity.is_current_revision = 1 )
+            AND civicrm_activity.is_deleted = 0 )
             LEFT JOIN civicrm_entity_tag as {$etActTable} ON ( {$etActTable}.entity_table = 'civicrm_activity' AND {$etActTable}.entity_id = civicrm_activity.id )
             LEFT JOIN civicrm_tag {$tActTable} ON ( {$etActTable}.tag_id = {$tActTable}.id  )";
 
@@ -3355,7 +3355,7 @@ WHERE  $smartGroupClause
             ON ( civicrm_activity_contact.contact_id = contact_a.id AND civicrm_activity_contact.record_type_id = {$targetID} )
             LEFT JOIN civicrm_activity
             ON ( civicrm_activity.id = civicrm_activity_contact.activity_id
-            AND civicrm_activity.is_deleted = 0 AND civicrm_activity.is_current_revision = 1 )
+            AND civicrm_activity.is_deleted = 0 )
             LEFT JOIN civicrm_entity_tag as {$etActTable} ON ( {$etActTable}.entity_table = 'civicrm_activity' AND {$etActTable}.entity_id = civicrm_activity.id ) ";
 
       // CRM-10338

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2391,7 +2391,6 @@ WHERE {$whereClause}";
           'priority_id' => 2,
           'activity_date_time' => CRM_Utils_Time::date('Y-m-d H:i:s'),
           'is_auto' => 0,
-          'is_current_revision' => 1,
           'is_deleted' => 0,
         ];
         civicrm_api3('activity', 'create', $activityParam);

--- a/CRM/Report/Form/Activity.php
+++ b/CRM/Report/Form/Activity.php
@@ -588,8 +588,7 @@ class CRM_Report_Form_Activity extends CRM_Report_Form {
    */
   public function where($recordType = NULL) {
     $this->_where = " WHERE {$this->_aliases['civicrm_activity']}.is_test = 0 AND
-                                {$this->_aliases['civicrm_activity']}.is_deleted = 0 AND
-                                {$this->_aliases['civicrm_activity']}.is_current_revision = 1";
+                                {$this->_aliases['civicrm_activity']}.is_deleted = 0";
 
     $clauses = [];
     foreach ($this->_columns as $tableName => $table) {

--- a/CRM/Report/Form/ActivitySummary.php
+++ b/CRM/Report/Form/ActivitySummary.php
@@ -354,8 +354,7 @@ class CRM_Report_Form_ActivitySummary extends CRM_Report_Form {
     }
     $this->_where = " WHERE {$optionGroupClause}
                             {$this->_aliases['civicrm_activity']}.is_test = 0 AND
-                            {$this->_aliases['civicrm_activity']}.is_deleted = 0 AND
-                            {$this->_aliases['civicrm_activity']}.is_current_revision = 1";
+                            {$this->_aliases['civicrm_activity']}.is_deleted = 0";
 
     $clauses = [];
     foreach ($this->_columns as $tableName => $table) {

--- a/CRM/Report/Form/Case/Demographics.php
+++ b/CRM/Report/Form/Case/Demographics.php
@@ -346,7 +346,6 @@ where (cg.extends='Contact' OR cg.extends='Individual' OR cg.extends_entity_colu
 
     $clauses[] = "(({$this->_aliases['civicrm_case']}.is_deleted = 0) OR ({$this->_aliases['civicrm_case']}.is_deleted Is Null))";
     $clauses[] = "(({$this->_aliases['civicrm_activity']}.is_deleted = 0) OR ({$this->_aliases['civicrm_activity']}.is_deleted Is Null))";
-    $clauses[] = "(({$this->_aliases['civicrm_activity']}.is_current_revision = 1) OR ({$this->_aliases['civicrm_activity']}.is_deleted Is Null))";
 
     $this->_where = "WHERE " . implode(' AND ', $clauses);
   }

--- a/CRM/Report/Form/Case/TimeSpent.php
+++ b/CRM/Report/Form/Case/TimeSpent.php
@@ -254,9 +254,9 @@ class CRM_Report_Form_Case_TimeSpent extends CRM_Report_Form {
   }
 
   public function where() {
-    $this->_where = " WHERE {$this->_aliases['civicrm_activity']}.is_current_revision = 1 AND
-                                {$this->_aliases['civicrm_activity']}.is_deleted = 0 AND
-                                {$this->_aliases['civicrm_activity']}.is_test = 0";
+    $this->_where = " WHERE
+                      {$this->_aliases['civicrm_activity']}.is_deleted = 0 AND
+                      {$this->_aliases['civicrm_activity']}.is_test = 0";
     $clauses = [];
     foreach ($this->_columns as $tableName => $table) {
       if (array_key_exists('filters', $table)) {

--- a/Civi/CCase/Analyzer.php
+++ b/Civi/CCase/Analyzer.php
@@ -113,7 +113,6 @@ class Analyzer {
         foreach ($case['activities'] as $actId) {
           $result = civicrm_api3('Activity', 'get', [
             'id' => $actId,
-            'is_current_revision' => 1,
           ]);
           $activities = array_merge($activities, $result['values']);
         }

--- a/api/v3/Activity.php
+++ b/api/v3/Activity.php
@@ -686,7 +686,6 @@ function _civicrm_api3_activity_getlist_params(&$request) {
   $request['params']['return'] = array_unique(array_merge($fieldsToReturn, $request['extra']));
   $request['params']['options']['sort'] = 'activity_date_time DESC';
   $request['params'] += [
-    'is_current_revision' => 1,
     'is_deleted' => 0,
   ];
 }

--- a/api/v3/Case.php
+++ b/api/v3/Case.php
@@ -316,10 +316,6 @@ function civicrm_api3_case_get($params, $sql = NULL) {
       throw new CRM_Core_Exception('Invalid parameter: activity_id. Must provide a numeric value.');
     }
     $activityId = $params['activity_id'];
-    $originalId = CRM_Core_DAO::getFieldValue('CRM_Activity_BAO_Activity', $activityId, 'original_id');
-    if ($originalId) {
-      $activityId .= ',' . $originalId;
-    }
     $sql
       ->join('civicrm_case_activity', 'INNER JOIN civicrm_case_activity ON civicrm_case_activity.case_id = a.id')
       ->where("civicrm_case_activity.activity_id IN ($activityId)");

--- a/tests/phpunit/CRM/Case/BAO/CaseTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTest.php
@@ -1227,7 +1227,7 @@ class CRM_Case_BAO_CaseTest extends CiviCaseTestCase {
         FROM civicrm_case_activity ca
         INNER JOIN civicrm_activity a ON ca.activity_id = a.id
         WHERE a.subject = %1
-        AND a.is_deleted = 0 AND a.is_current_revision = 1', $queryParams)
+        AND a.is_deleted = 0', $queryParams)
     );
   }
 

--- a/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
+++ b/tests/phpunit/CRM/Core/BAO/ActionScheduleTest.php
@@ -108,7 +108,6 @@ class CRM_Core_BAO_ActionScheduleTest extends CiviUnitTestCase {
       'status_id' => 1,
       'activity_type_id' => 2,
       'activity_date_time' => '20120615100000',
-      'is_current_revision' => 1,
       'is_deleted' => 0,
       'subject' => 'Phone call',
       'details' => 'A phone call about a bear',


### PR DESCRIPTION
Overview
----------------------------------------
Column is no longer used and does not need to be queried.

Comments
----------------------------------------
@demeritcowboy unless we've done it already, this should maybe be coupled with an upgrade step to `DELETE FROM civicrm_activity WHERE is_current_revision = 0`.
