### PR TITLE
add config JSON blob to PaymentProcessor entity

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -37,6 +37,13 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'description' => ts('Controls whether file is stored in public or private directory.'),
       'default' => FALSE,
     ], 'AFTER `description`');
+    $this->addTask('Add PaymentProcessor.config', 'alterSchemaField', 'PaymentProcessor', 'config', [
+      'title' => ts('Configuration'),
+      'sql_type' => 'text',
+      'input_type' => 'Textarea',
+      'required' => FALSE,
+      'description' => ts('JSON blob of config as appropriate for the specific integration'),
+    ], 'AFTER `accepted_credit_cards`');
   }
 
 }

--- a/schema/Financial/PaymentProcessor.entityType.php
+++ b/schema/Financial/PaymentProcessor.entityType.php
@@ -261,5 +261,13 @@ return [
       'default' => NULL,
       'serialize' => CRM_Core_DAO::SERIALIZE_JSON,
     ],
+    'config' => [
+      'title' => ts('Configuration'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => ts('JSON blob of config as appropriate for the specific integration'),
+      'add' => '6.14',
+      'serialize' => CRM_Core_DAO::SERIALIZE_JSON,
+    ],
   ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
Allow storing whatever details are needed for different payment integrations in a sane way, rather than having to jerry-rig into a fixed set of core fields. Particular useful in an OAuth/CiviConnect world.



Before
----------------------------------------
- different payment integrations have completely different sets of differently shaped pegs
- lots of rigidly named square holes

After
----------------------------------------
- stash whatever you need in a JSON blob


Technical Details
---------------------------------------
I don't need separate columns for these. The `user_name` field of different payment processors isn't equivalent or comparable. It lends itself to awkward DX and awkward UI that doesn't adapt to particular contexts.

~This needs an upgrader -- I couldn't see if we can do the schemaHelper type thing to add columns for core entities?~ Thanks @colemanw 


