### PR TITLE
Support JSON_EXTRACT in API4 & SearchKit

### DIFF
--- a/Civi/Api4/Query/SqlFunctionJSON_EXTRACT.php
+++ b/Civi/Api4/Query/SqlFunctionJSON_EXTRACT.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Query;
+
+/**
+ * SQL Function: JSON_EXTRACT
+ */
+class SqlFunctionJSON_EXTRACT extends SqlFunction {
+
+  public $supportsExpansion = FALSE;
+
+  protected static $category = self::CATEGORY_STRING;
+
+  protected static function params(): array {
+    return [
+      [
+        'max_expr' => 1,
+        'must_be' => ['SqlField', 'SqlFunction', 'SqlEquation'],
+        'optional' => FALSE,
+      ],
+      [
+        'label' => ts('Path'),
+        'max_expr' => 1,
+        'must_be' => ['SqlString'],
+        'optional' => FALSE,
+      ],
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public static function getTitle(): string {
+    return ts('JSON extract');
+  }
+
+  /**
+   * @return string
+   */
+  public static function getDescription(): string {
+    return ts('Extracts values from a JSON field.');
+  }
+
+  public function getSqlFunctionName(): string {
+    return 'JSON_EXTRACT';
+  }
+
+  public function render(Api4Query $query, bool $includeAlias = FALSE): string {
+    $output = '';
+    $field = $this->args[0]['expr'][0]->render($query);
+    $path = $this->args[1]['expr'][0]->render($query);
+    if (!preg_match('/[\'"]?\$/', $path)) {
+      $path = "'$." . $path . "'";
+    }
+
+    $output .= "{$field}, {$path}";
+
+    $renderedExpression = $this->renderExpression($output);
+    $alias = ($includeAlias ? " AS `{$this->getAlias()}`" : '');
+    return sprintf("JSON_UNQUOTE(%s)%s", $renderedExpression, $alias);
+  }
+
+  /**
+   * Returns the alias to use for SELECT AS.
+   *
+   * @return string
+   */
+  public function getAlias(): string {
+    return $this->alias ?? \CRM_Utils_String::munge(trim($this->expr, ' ()'), '_', 256);
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -199,10 +199,23 @@
         ctrl.writeExpr();
       };
 
+      function safeStringAlias(value) {
+        const MAX_LEN = 20;
+        const cleaned = value
+          .toLowerCase()
+          .replace(/['"]/g, '')        // remove quotes
+          .replace(/[^a-z0-9]+/g, '_') // replace unsafe chars
+          .replace(/^_+|_+$/g, '');    // trim underscores
+
+        const short = cleaned.slice(0, MAX_LEN);
+        return `${short}_${hash}`;
+      }
+
       // Make a sql-friendly alias for this expression
       function makeAlias() {
         const args = ctrl.args
-          .filter(arg => arg.value && (arg.type === 'field' || arg.type === 'number'))
+          .filter(arg => arg.value && (arg.type === 'field' || arg.type === 'number' || arg.type === 'string'))
+          .map(arg => arg.type === 'string' ? safeStringAlias(arg.value) : arg.value)
           .map(arg => arg.value);
         return (ctrl.fnName + '_' + args.join('_')).replace(/[.:]/g, '_');
       }

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -572,4 +572,69 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount(2, $result);
   }
 
+  public function testJsonExtract(): void {
+    \Civi\Api4\CustomGroup::create(FALSE)
+      ->addValue('name', 'json_test')
+      ->addValue('title', 'Json test')
+      ->addChain('json_object', \Civi\Api4\CustomField::create(FALSE)
+        ->addValue('html_type', 'Text')
+        ->addValue('name', 'json_object')
+        ->addValue('label', 'Json test object field')
+        ->addValue('custom_group_id', '$id')
+      )
+      ->addChain('json_array', \Civi\Api4\CustomField::create(FALSE)
+        ->addValue('html_type', 'Text')
+        ->addValue('name', 'json_array')
+        ->addValue('label', 'Json test array field')
+        ->addValue('custom_group_id', '$id')
+      )
+      ->execute();
+
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      [
+        'first_name' => 'abc',
+        'last_name' => $lastName,
+        'json_test.json_object' => json_encode(['a' => 1, 'b' => 'one', 'Contact Country' => 'United Kingdon']),
+        'json_test.json_array' => json_encode([1, 2, 3]),
+      ],
+      [
+        'first_name' => 'def',
+        'last_name' => $lastName,
+        'json_test.json_object' => json_encode(['a' => 2, 'b' => 'two', 'Contact Country' => 'United States']),
+        'json_test.json_array' => json_encode([4, 15, 9]),
+      ],
+    ];
+    Contact::save(FALSE)
+      ->setRecords($sampleData)
+      ->execute();
+
+    // Test JSON_EXTRACT in select
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $lastName)
+      ->addSelect('JSON_EXTRACT(json_test.json_object, "$.a") AS a')
+      ->addSelect('JSON_EXTRACT(json_test.json_object, "$.b") AS b')
+      ->addSelect('JSON_EXTRACT(json_test.json_object, "Contact Country") AS country')
+      ->addSelect('JSON_EXTRACT(json_test.json_array, "$[0]") AS first_element')
+      ->addSelect('JSON_EXTRACT(json_test.json_array, "$[1]") AS second_element')
+      ->addSelect('JSON_EXTRACT(json_test.json_array, "$[2]") AS third_element')
+      ->addOrderBy('id')
+      ->execute();
+
+    $this->assertCount(2, $result);
+    $this->assertEquals(1, $result[0]['a']);
+    $this->assertEquals('one', $result[0]['b']);
+    $this->assertEquals('United Kingdon', $result[0]['country']);
+    $this->assertEquals(1, $result[0]['first_element']);
+    $this->assertEquals(2, $result[0]['second_element']);
+    $this->assertEquals(3, $result[0]['third_element']);
+
+    $this->assertEquals(2, $result[1]['a']);
+    $this->assertEquals('two', $result[1]['b']);
+    $this->assertEquals('United States', $result[1]['country']);
+    $this->assertEquals(4, $result[1]['first_element']);
+    $this->assertEquals(15, $result[1]['second_element']);
+    $this->assertEquals(9, $result[1]['third_element']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Support `JSON_EXTRACT` in SearchKit.

See https://dev.mysql.com/doc/refman/8.4/en/json-search-functions.html.

Before
----------------------------------------
Whilst the number of SQL functions that SearchKit supports is impressive, it doesn't support `JSON_EXTRACT`.

After
----------------------------------------
Now it does (with the odd caveat - see details below).

This screenshot demonstrates the functionality:

<img width="1713" height="574" alt="Screenshot 2026-03-05 at 17 25 55" src="https://github.com/user-attachments/assets/f9009c68-03af-4110-a0f3-51aa8f8637af" />

In that example, we are syncing data from WooCommerce (using a slightly modified version of https://github.com/mecachisenros/woocommerce_civicrm), and storing some custom fields as JSON. You will see one column shows the JSON payload.

I am then using the new `JSON_EXTRACT` function to extract two specific keys.

For country I am using `$.Country` which is technically the right mySQL syntax.

For `Dietary Requirements` you can see I am skipping the `$`; Whilst that's technically invalid, I added this as a little Civi magic to make the $. implied if it's not specified. I think this makes the UX clearer for users who might not be familiar with the `JSON_EXTRACT` function.

There are various reasons why someone might be storing JSON, and I know of a few extensions in Civi-land that do store bits of data as JSON (often the results of third-party API calls where the response format might not be known with 100% certainty).

Technical Details
----------------------------------------

1. I noticed that using quote marks in the `SqlString` field were not saved correctly; they were over-escaped, and ultimately stopped the SQL running correctly. I see this as a separate (related) issue but it does mean that you can't enter a value like `$."Dietary Requirements"` (this is another reason I made the `$.` implied if missing)

2. I think people using this new function are going to want to use it multiple times per report. Therefore, I updated the `makeAlias` function to make the alias unique across multiple `JSON_EXTRACT` uses on the same column.