### PR TITLE
Riverlea - improve display of active / other streams

### DIFF
--- a/ext/riverlea/css/stream-list.css
+++ b/ext/riverlea/css/stream-list.css
@@ -20,6 +20,13 @@ civi-riverlea-stream-card .panel-heading {
   justify-content: space-between;
   align-items: center;
 }
+civi-riverlea-stream-card .panel-heading .civi-riverlea-stream-header-tags > * {
+  background-color: var(--crm-info-color);
+  color: var(--crm-info-text-color);
+  padding: var(--crm-l-small);
+  margin: var(--crm-l-small);
+  border-radius: var(--crm-l-radius);
+}
 civi-riverlea-stream-card .btn.btn-stream-selected {
   background-color: var(--crm-success-color);
   color: var(--crm-success-text-color);

--- a/ext/riverlea/css/stream-list.css
+++ b/ext/riverlea/css/stream-list.css
@@ -1,6 +1,5 @@
 /* CSS rules for Riverlea stream admin */
 
-
 civi-riverlea-stream-list ul {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr) );
@@ -21,21 +20,12 @@ civi-riverlea-stream-card .panel-heading {
   align-items: center;
 }
 civi-riverlea-stream-card .panel-heading .civi-riverlea-stream-header-tags > * {
-  background-color: var(--crm-info-color);
-  color: var(--crm-info-text-color);
-  padding: var(--crm-l-small);
   margin: var(--crm-l-small);
-  border-radius: var(--crm-l-radius);
-}
-civi-riverlea-stream-card .btn.btn-stream-selected {
-  background-color: var(--crm-success-color);
-  color: var(--crm-success-text-color);
 }
 civi-riverlea-stream-card .btn.btn-set-preview.btn-stream-selected {
   background-color: var(--crm-warning-color);
   color: var(--crm-warning-text-color);
 }
-
 civi-riverlea-stream-card .civi-riverlea-stream-details code {
   display: inline-block;
 }

--- a/ext/riverlea/css/stream-list.css
+++ b/ext/riverlea/css/stream-list.css
@@ -1,8 +1,9 @@
 /* CSS rules for Riverlea stream admin */
 
+
 civi-riverlea-stream-list ul {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(30rem, 1fr) );
+  grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr) );
   padding-left: 0;
   gap: 1rem;
   margin: 0;

--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -297,6 +297,7 @@
       <div class="panel panel-info">
         <div class="panel-heading">
           <h3></h3>
+          <div class="civi-riverlea-stream-header-tags"></div>
           <div class="civi-riverlea-stream-header-buttons crm-buttons"></div>
         </div>
 
@@ -323,6 +324,7 @@
 
       this.renderDetailsArea(this.querySelector('.civi-riverlea-stream-details'));
 
+      this.renderHeaderTags(this.querySelector('.civi-riverlea-stream-header-tags'));
       this.renderHeaderButtons(this.querySelector('.civi-riverlea-stream-header-buttons'));
       this.renderPanelButtons(this.querySelector('.civi-riverlea-stream-panel-buttons'));
 
@@ -371,6 +373,20 @@
       this.setFrontend = CRM.utils.createButton(ts('Set for Frontend'), 'btn-set-frontend', 'fa-shop', () => this.streamList.confirmThenUpdate('frontend', this.streamName, this.data.label));
 
       container.append(this.setPreview, this.setBackend, this.setFrontend);
+    }
+
+    renderHeaderTags(container) {
+      const createTag = (label) => {
+        const tag = document.createElement('span');
+        tag.innerText = label;
+        return tag;
+      };
+      if (this.state.is_backend) {
+        container.append(createTag(ts('Backend')));
+      }
+      if (this.state.is_frontend) {
+        container.append(createTag(ts('Frontend')));
+      }
     }
 
     renderHeaderButtons(container) {

--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -378,6 +378,7 @@
     renderHeaderTags(container) {
       const createTag = (label) => {
         const tag = document.createElement('span');
+        tag.classList.add('label', 'label-success');
         tag.innerText = label;
         return tag;
       };
@@ -419,6 +420,7 @@
       const updateButtonState = (button, is_disabled) => {
         button.disabled = is_disabled;
         button.classList.toggle('btn-stream-selected', is_disabled);
+        //button.classList.toggle('bg-success', is_disabled);
       };
 
       updateButtonState(this.setPreview, this.state.is_preview);

--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -13,29 +13,30 @@
 
     connectedCallback() {
       this.innerHTML = `
-        <div class="civi-theme-selections">
-          <div class="civi-backend">
-            <h3></h3>
-            <div></div>
-          </div>
-          <div class="civi-frontend">
-            <h3></h3>
-            <div></div>
-          </div>
+        <div class="civi-themes-selected">
+          <h2></h2>
+          <ul>
+            <li class="civi-backend">
+            </li>
+            <li class="civi-frontend">
+            </li>
+          </ul>
         </div>
         <div class="civi-themes-available">
-          <h3></h3>
+          <h2></h2>
           <ul></ul>
         </div>
       `;
-      this.querySelector('.civi-backend h3').innerText = ts('Current Backend Theme');
-      this.backendSlot = this.querySelector('.civi-backend div');
+      this.querySelector('.civi-themes-selected h2').innerText = ts('Active Themes');
 
-      this.querySelector('.civi-frontend h3').innerText = ts('Current Frontend Theme');
-      this.frontendSlot = this.querySelector('.civi-frontend div');
+      //this.querySelector('.civi-backend h3').innerText = ts('Backend Theme');
+      this.backendSlot = this.querySelector('.civi-backend');
+
+      //this.querySelector('.civi-frontend h3').innerText = ts('Frontend Theme');
+      this.frontendSlot = this.querySelector('.civi-frontend');
 
       // create list for other streams
-      this.querySelector('.civi-themes-available h3').innerText = ts('Other Available Themes');
+      this.querySelector('.civi-themes-available h2').innerText = ts('Other Available Themes');
       this.ul = this.querySelector('.civi-themes-available ul');
 
       // button to create a new stream FIXME only allow cloning for now
@@ -164,12 +165,10 @@
 
         if (card.state.is_backend && card.state.is_frontend) {
           this.backendSlot.append(card);
-          this.querySelector('.civi-backend h3').innerText = ts('Current Theme (Backend + Frontend)');
           this.querySelector('.civi-frontend').hidden = true;
         }
         else if (card.state.is_backend) {
           this.backendSlot.append(card);
-          this.querySelector('.civi-backend h3').innerText = ts('Current Backend Theme');
         }
         else if (card.state.is_frontend) {
           this.frontendSlot.append(card);

--- a/ext/riverlea/templates/Civi/Riverlea/Page/ThemeAdmin.tpl
+++ b/ext/riverlea/templates/Civi/Riverlea/Page/ThemeAdmin.tpl
@@ -1,5 +1,3 @@
-<h2>{ts}Themes{/ts}</h2>
-
 <civi-riverlea-stream-list></civi-riverlea-stream-list>
 
 <h2>{ts}Additional settings{/ts}</h2>


### PR DESCRIPTION
Before
----------------------------------------
- the boxes for the selected streams at the top of the stream list are fullwidth
- on large screens they go ridiculously wide
- there are many levels of headers (including duplicated <h3>)

<img width="2177" height="634" alt="image" src="https://github.com/user-attachments/assets/2804bba7-bebb-41bd-b618-9b3da1e828b7" />




After
----------------------------------------
- boxes are the same width as the grid below
- no more duplicated <h3>
- clearer separation of Active from Others
- little tags on the card itself to indicate Frontend/Backend. this is extensible to other tags in future maybe

<img width="1409" height="925" alt="image" src="https://github.com/user-attachments/assets/4ac667a0-634e-4726-99b4-57b1b6e4691c" />


