### PR TITLE
Afform translation: add support for multi-locale (not just multi-lingual)

### DIFF
--- a/Civi/I18n/TranslationAfformProvider.php
+++ b/Civi/I18n/TranslationAfformProvider.php
@@ -26,7 +26,9 @@ class TranslationAfformProvider extends AutoService implements EventSubscriberIn
    * @throws \CRM_Core_Exception
    */
   public static function getTranslationAfforms($event): void {
-    if (!\CRM_Core_I18n::isMultilingual()) {
+    $locales = \CRM_Core_I18n::uiLanguages();
+
+    if (count($locales) <= 1) {
       return;
     }
 
@@ -41,21 +43,18 @@ class TranslationAfformProvider extends AutoService implements EventSubscriberIn
       return;
     }
 
-    $languages = \CRM_Core_I18n::languages();
-    $locales = \CRM_Core_I18n::getMultilingual();
-
     // if forcing translation source, we don't want to offer the translation to default locale
     $force_translation_source_locale = \Civi::settings()->get('force_translation_source_locale') ?? TRUE;
     if ($force_translation_source_locale) {
       $defaultLocale = \Civi::settings()->get('lcMessages');
-      $locales = array_diff($locales, [$defaultLocale]);
+      unset($locales[$defaultLocale]);
     }
-    foreach ($locales as $index => $langCode) {
+    foreach ($locales as $langCode => $langLabel) {
       $name = 'afsearchTranslation' . $langCode;
       $afforms[$name] = [
         'name' => $name,
         'type' => 'search',
-        'title' => ts('Translations to %1', [1 => $languages[$langCode]]),
+        'title' => ts('Translations to %1', [1 => $langLabel]),
         'description' => NULL,
         'placement' => [],
         'placement_filters' => [],

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -388,19 +388,19 @@ class AfformAdminMeta {
 
   private static function getLocales(): array {
     $options = [];
-    if (\CRM_Core_I18n::isMultiLingual()) {
-      $languages = \CRM_Core_I18n::languages();
-      $locales = \CRM_Core_I18n::getMultilingual();
-
+    $locales = \CRM_Core_I18n::uiLanguages();
+    if (count($locales) > 1) {
       if (\Civi::settings()->get('force_translation_source_locale') ?? TRUE) {
         $defaultLocale = \Civi::settings()->get('lcMessages');
-        $locales = [$defaultLocale];
+        $langLabel = $locales[$defaultLocale];
+        $locales = [];
+        $locales[$defaultLocale] = $langLabel;
       }
 
-      foreach ($locales as $index => $locale) {
+      foreach ($locales as $langCode => $langLabel) {
         $options[] = [
-          'id' => $locale,
-          'text' => $languages[$locale],
+          'id' => $langCode,
+          'text' => $langLabel,
         ];
       }
     }

--- a/managed/translation/SavedSearch_Translation.mgd.php
+++ b/managed/translation/SavedSearch_Translation.mgd.php
@@ -1,11 +1,11 @@
 <?php
-if (!\CRM_Core_I18n::isMultilingual()) {
-  return [];
-}
-$items = [];
 
-$languages = \CRM_Core_I18n::languages();
-$locales = \CRM_Core_I18n::getMultilingual();
+$items = [];
+$locales = \CRM_Core_I18n::uiLanguages();
+
+if (count($locales) <= 1) {
+  return $items;
+}
 
 // if forcing translation source, we don't want to offer the translation to default locale
 $force_translation_source_locale = \Civi::settings()->get('force_translation_source_locale') ?? TRUE;
@@ -14,7 +14,7 @@ if ($force_translation_source_locale) {
   $locales = array_diff($locales, [$defaultLocale]);
 }
 
-foreach ($locales as $index => $langCode) {
+foreach ($locales as $langCode => $langLabel) {
   $items[] = [
     'name' => "SavedSearch_Translation_$langCode",
     'entity' => 'SavedSearch',
@@ -24,7 +24,7 @@ foreach ($locales as $index => $langCode) {
       'version' => 4,
       'values' => [
         'name' => "Translations_$langCode",
-        'label' => ts('Translations for %1', [1 => $languages[$langCode]]),
+        'label' => ts('Translations for %1', [1 => $langLabel]),
         'form_values' => [
           'join' => [
             'TranslationSource_Translation_source_key_01' => 'Translated Strings',
@@ -77,7 +77,7 @@ foreach ($locales as $index => $langCode) {
       'version' => 4,
       'values' => [
         'name' => "Translations_Table_$langCode",
-        'label' => ts('Translations for %1', [1 => $languages[$langCode]]),
+        'label' => ts('Translations for %1', [1 => $langLabel]),
         'saved_search_id.name' => "Translations_$langCode",
         'type' => 'table',
         'settings' => [
@@ -157,7 +157,7 @@ foreach ($locales as $index => $langCode) {
       'values' => [
         'name' => 'afsearchTranslation' . $langCode,
         'parent_id.name' => 'Localization',
-        'label' => ts('Translations to %1', [1 => $languages[$langCode]]),
+        'label' => ts('Translations to %1', [1 => $langLabel]),
         'permission' => ['translate CiviCRM'],
         'permission_operator' => 'AND',
         'weight' => 5,


### PR DESCRIPTION
Overview
----------------------------------------

Enables the FormBuilder (afform) translation interfaces if there are multiple locales enabled (not just multi-lingual).

To reproduce:

- Go to Administer > Localization > Languages
- Add another language

Example:

<img width="1724" height="908" alt="image" src="https://github.com/user-attachments/assets/94ea11ba-3f07-4063-a461-098f39ff4dfb" />

Before
----------------------------------------

No translation menu items under Administer > Localization.

After
----------------------------------------

Menus are there and working:

<img width="2312" height="760" alt="image" src="https://github.com/user-attachments/assets/2c5d4236-47d1-4b8d-989f-ea387fed3981" />

Technical Details
----------------------------------------

I'm not 100% sure about the difference between i18n functions/settings.

Comments
----------------------------------------

Works for me.