### PR TITLE
Move "Drop `index_is_current_revision` from `civicrm_activity` schema" from 6.13 to 6.14

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixThirteen.php
+++ b/CRM/Upgrade/Incremental/php/SixThirteen.php
@@ -34,7 +34,6 @@ class CRM_Upgrade_Incremental_php_SixThirteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask('Replace "elseif !empty($email)" with "{elseif {contact.email_primary.email|boolean}}" in contribution_online_receipt', 'updateMessageToken', 'contribution_online_receipt', 'elseif !empty($email)', 'elseif {contact.email_primary.email|boolean}', $rev);
     $this->addTask('Replace {$email} with "{contact.email_primary.email}" in contribution_online_receipt', 'updateMessageToken', 'contribution_online_receipt', '$email', 'contact.email_primary.email', $rev);
     $this->addTask('Update quicksearch options to support non-primary search', 'updateQuicksearchOptionsPrimary');
-    $this->addTask('Drop civicrm_activity.is_current_revision index', 'dropIndex', 'civicrm_activity', 'index_is_current_revision');
   }
 
   /**

--- a/schema/Activity/Activity.entityType.php
+++ b/schema/Activity/Activity.entityType.php
@@ -44,6 +44,12 @@ return [
       ],
       'add' => '4.7',
     ],
+    'index_is_current_revision' => [
+      'fields' => [
+        'is_current_revision' => TRUE,
+      ],
+      'add' => '2.2',
+    ],
     'index_is_deleted' => [
       'fields' => [
         'is_deleted' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
@colemanw I'm going to add an upgrade message for the activity revisions and it will work better if the index is still there, so I'll redo this in 6.14.

In any case it makes general sense for this to be in the same version as the other code changes.

Reverts https://github.com/civicrm/civicrm-core/pull/35009

Comments
------------
For anyone who's already run the upgrade for 6.13 or installed a fresh 6.13 without the index, it won't make any difference if the upgrade step runs again in 6.14. If the database has tons of activities, the preupgrade message may run slowly but we're talking about someone doing it with the RC or master so it wouldn't be a live site.