### PR TITLE
Move "Drop index_is_current_revision from civicrm_activity schema" to 6.14 and add upgrade reminder message

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -21,6 +21,16 @@
  */
 class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    if ($rev === '6.14.alpha1') {
+      if (CRM_Core_DAO::singleValueQuery('SELECT MIN(id) FROM civicrm_activity WHERE is_current_revision = 0')) {
+        $docUrl = 'https://civicrm.org/redirect/activities-5.57';
+        $docAnchor = 'target="_blank" href="' . htmlentities($docUrl) . '"';
+        $preUpgradeMessage .= '<p>' . ts('Your database contains CiviCase activity revisions which have been deprecated since 5.54. As of 6.14 they will begin to appear as duplicates everywhere and you may experience issues editing or working with activities that have revisions. For further instructions see this <a %1>Lab Snippet</a>.', [1 => $docAnchor]) . '</p>';
+      }
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -44,6 +44,7 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'required' => FALSE,
       'description' => ts('JSON blob of config as appropriate for the specific integration'),
     ], 'AFTER `accepted_credit_cards`');
+    $this->addTask('Drop civicrm_activity.is_current_revision index', 'dropIndex', 'civicrm_activity', 'index_is_current_revision');
   }
 
 }

--- a/schema/Activity/Activity.entityType.php
+++ b/schema/Activity/Activity.entityType.php
@@ -44,12 +44,6 @@ return [
       ],
       'add' => '4.7',
     ],
-    'index_is_current_revision' => [
-      'fields' => [
-        'is_current_revision' => TRUE,
-      ],
-      'add' => '2.2',
-    ],
     'index_is_deleted' => [
       'fields' => [
         'is_deleted' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Activity revisions were already deprecated but will now cause problems outside of just api4/searchkit etc. This adds another upgrade message about it.

Before
----------------------------------------
While no new revisions were being created since 5.54 (with some missed spots fixed later), they were still handled and displayed as usual on most activity/case screens.

After
----------------------------------------
They'll now show as duplicates everywhere, and cause potential problems.

Technical Details
----------------------------------------
* https://github.com/civicrm/civicrm-core/pull/35015
* https://github.com/civicrm/civicrm-core/pull/35010
* https://github.com/civicrm/civicrm-core/pull/35009 (against 6.13 but now moved to 6.14 to match the other changes and to make the query in this upgrade message more efficient against large databases)

Comments
----------------------------------------
In 5.54 and 5.57 we directed people to a lab snippet with more information and options for what to do. I've updated the lab snippet slightly and if their database still contains revisions this will direct them to it again.