### PR TITLE
Add chainselect configuration for PriceField->PriceFieldValue on LineItem so one filters the other

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -1232,4 +1232,31 @@ WHERE li.contribution_id = %1";
     return $clauses;
   }
 
+  /**
+   * @param string $fieldName
+   * @param array $hookParams
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function getPriceFieldValueOptionsForPriceField(string $fieldName, array $hookParams): array {
+    if ($fieldName !== 'price_field_value_id') {
+      return [];
+    }
+
+    $priceFieldValueAPI = \Civi\Api4\PriceFieldValue::get()
+      ->addSelect('id', 'name', 'label')
+      ->setCheckPermissions(!empty($hookParams['check_permissions']));
+    // If we're using API4 explorer the options callback is only called once on initial load
+    //   with empty "values" so in that case we return all PriceFieldValues
+    if (!empty($hookParams['values']['price_field_id'])) {
+      // We are filtering by price_field_id (Eg. from a Formbuilder) - return valid priceFieldValues for selected
+      //   priceField.
+      $priceFieldValueAPI->addWhere('price_field_id', '=', $hookParams['values']['price_field_id']);
+    }
+
+    return $priceFieldValueAPI->execute()->getArrayCopy();
+  }
+
 }

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -129,18 +129,16 @@ return [
     'price_field_value_id' => [
       'title' => ts('Option ID'),
       'sql_type' => 'int unsigned',
-      'input_type' => 'EntityRef',
+      'input_type' => 'ChainSelect',
       'description' => ts('FK to civicrm_price_field_value'),
       'add' => '3.3',
       'default' => NULL,
       'input_attrs' => [
         'label' => ts('Option'),
+        'control_field' => 'price_field_id',
       ],
       'pseudoconstant' => [
-        'table' => 'civicrm_price_field_value',
-        'key_column' => 'id',
-        'name_column' => 'name',
-        'label_column' => 'label',
+        'callback' => ['\CRM_Price_BAO_LineItem', 'getPriceFieldValueOptionsForPriceField'],
       ],
       'entity_reference' => [
         'entity' => 'PriceFieldValue',


### PR DESCRIPTION
Overview
----------------------------------------
Adds in a callback and metadata for `LineItem` `price_field_id` and `price_field_value_id` so that when loaded eg. via FormBuilder as a field or a filter the `price_field_value_id` will be filtered by the selected `price_field_id`

Before
----------------------------------------
All `PriceFieldValue` options in the database selectable.

After
----------------------------------------
Only `PriceFieldValue` options that are for the selected `PriceField` are selectable.

Technical Details
----------------------------------------
Note code comment re. API4 explorer which doesn't support dynamic options so we load them all there.

Comments
----------------------------------------

