### PR TITLE
Theme Settings (River): add icon for editable, dropdown and warning for 'advanced css'

### DIFF
--- a/ext/riverlea/css/stream-list.css
+++ b/ext/riverlea/css/stream-list.css
@@ -7,7 +7,9 @@ civi-riverlea-stream-list ul {
   gap: 1rem;
   margin: 0;
 }
-
+civi-riverlea-stream-list .civi-riverlea-stream-edit-dialog {
+  width: 100%;
+}
 civi-riverlea-stream-card {
   display: block;
 }
@@ -27,15 +29,15 @@ civi-riverlea-stream-card .btn.btn-set-preview.btn-stream-selected {
   background-color: var(--crm-warning-color);
   color: var(--crm-warning-text-color);
 }
-
 civi-riverlea-stream-card .civi-riverlea-stream-details code {
   display: inline-block;
 }
-
-civi-riverlea-stream-list .civi-riverlea-stream-edit-dialog {
-  width: 100%;
+civi-riverlea-stream-card .panel-heading .far {
+  padding-right: var(--crm-flex-gap);
 }
-
+civi-riverlea-stream-card .panel-heading:has(.btn-update) .fa-window-maximize:before {
+  content: "\f2d2";
+}
 civi-riverlea-stream-editor .civi-riverlea-stream-editor-preview-pane {
   padding: 1rem;
 }
@@ -57,13 +59,11 @@ civi-riverlea-stream-editor .civi-riverlea-stream-colors-header {
 civi-riverlea-stream-editor .civi-riverlea-stream-colors-header h3 {
   padding-left: 0;
 }
-
 civi-riverlea-stream-variable {
   display: flex;
   flex-flow: row;
   justify-content: space-between;
 }
-
 civi-riverlea-stream-variable input[type="color"] {
   width: 3rem;
 }

--- a/ext/riverlea/js/editor.js
+++ b/ext/riverlea/js/editor.js
@@ -123,12 +123,15 @@
         <fieldset class="civi-riverlea-stream-color-inputs-dark"></fieldset>
 
         <fieldset class="civi-riverlea-stream-size-inputs"></fieldset>
-        <details class="crm-accordion-settings">
-          <summary>Advanced CSS</summary>
-          <p class="description">CSS entered below may need adjusting to work with later CiviCRM versions.</p>
+        <details class="crm-accordion-settings civi-riverlea-stream-custom-inputs-container">
+          <summary></summary>
+          <p class="description"></p>
           <fieldset class="civi-riverlea-stream-custom-inputs"></fieldset>
         </details>
-      `;
+     `;
+     
+     this.editPane.querySelector('.civi-riverlea-stream-custom-inputs-container summary').innerText = ts('Advanced CSS');
+    this.editPane.querySelector('.civi-riverlea-stream-custom-inputs-container .description').innerText = ts('CSS entered below may need adjusting to work with later CiviCRM versions');
 
       this.editPane.querySelector('h2').innerText = this.data.label;
 

--- a/ext/riverlea/js/editor.js
+++ b/ext/riverlea/js/editor.js
@@ -123,7 +123,11 @@
         <fieldset class="civi-riverlea-stream-color-inputs-dark"></fieldset>
 
         <fieldset class="civi-riverlea-stream-size-inputs"></fieldset>
-        <fieldset class="civi-riverlea-stream-custom-inputs"></fieldset>
+        <details class="crm-accordion-settings">
+          <summary>Advanced CSS</summary>
+          <p class="description">CSS entered below may need adjusting to work with later CiviCRM versions.</p>
+          <fieldset class="civi-riverlea-stream-custom-inputs"></fieldset>
+        </details>
       `;
 
       this.editPane.querySelector('h2').innerText = this.data.label;

--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -297,7 +297,7 @@
       this.innerHTML = `
       <div class="panel panel-info">
         <div class="panel-heading">
-          <h3>${this.data.label}</h3>
+          <h3><i aria-hidden="true" class="far fa-window-maximize"></i>${this.data.label}</h3>
           <div class="civi-riverlea-stream-header-buttons crm-buttons"></div>
         </div>
 
@@ -373,7 +373,7 @@
     renderHeaderButtons(container) {
       const createButton = CRM.riverlea.createButton;
 
-      const cloneBtn = createButton('Clone', 'btn-clone', 'copy', () => this.streamList.clone(this.streamName).then(() => CRM.alert(ts('Stream cloned'), '', 'success')));
+      const cloneBtn = createButton('Clone', 'btn-clone', 'window-restore', () => this.streamList.clone(this.streamName).then(() => CRM.alert(ts('Stream cloned'), '', 'success')));
       container.append(cloneBtn);
 
       if (!this.data.is_reserved) {


### PR DESCRIPTION
Overview
----------------------------------------
Having spent a bit of time with the Theme Settings felt a few tweaks might help:
 - Adding an icon that's different for base themes/streams and branches/clones - so if they have the same name its clear which is the original.
 - Put the CSS behind an 'advanced CSS' settings accordion with a disclaimer. 

This third change is to make clearer that the top part of the edit screen (colour, button roundness, etc) should survive upgrades because they're using River's CSS Variables, while css entered in the custom CSS boxes might not. This isn't something that's particularly obvious or intuitive without knowing how River or the customiser works.
 
I also removed some line spaces on the css file, and moved one selector to be better grouped.
 
Before
----------------------------------------

<img width="739" height="551" alt="image" src="https://github.com/user-attachments/assets/b3954a54-c78b-4915-8118-9f285584fa22" />
<img width="787" height="448" alt="image" src="https://github.com/user-attachments/assets/8e4dbb37-0a86-4c51-8a60-c61bdebad53f" />

After
----------------------------------------
Theme listing:

<img width="603" height="584" alt="image" src="https://github.com/user-attachments/assets/fa18a5ae-9c3d-4b61-a496-541f6198436a" />

Edit screen (closed css accordion)

<img width="747" height="266" alt="image" src="https://github.com/user-attachments/assets/c7de19ea-3707-4ac6-8c1f-cbe9f30201d3" />

Edit screen (open css accordion)

<img width="742" height="449" alt="image" src="https://github.com/user-attachments/assets/afe03840-5d92-4170-a1bd-3c8d82bb96e9" />

| Walbrook | Hackney | Thames |
| ---- | ---- | ---- |
| <img width="739" height="653" alt="image" src="https://github.com/user-attachments/assets/a754df76-17ff-45bc-b354-d4e3eefe690d" /> | <img width="744" height="568" alt="image" src="https://github.com/user-attachments/assets/5550b2ca-ff11-4b86-ad05-7f724ca45755" /> | <img width="740" height="625" alt="image" src="https://github.com/user-attachments/assets/42a656cf-cb0d-464b-9434-5864b884507c" />|

Technical Details
----------------------------------------
I wasn't sure how to wrap the new description in the accordion in `{ts}` tags - so not sure if that new line will be translatable.

Comments
----------------------------------------
This followed conversations on Mattermost. 

NB: I did originally change the name from 'clone' to 'branch' because it's a bit more accurate, but it also might create misunderstandings linked to git, so have reverted for now (but the screengrabs now say 'branch' rather than 'clone' - please ignore that).

Not sure if it should be pushed forward to 6.13 to accompany the release of this.