### PR TITLE
Delete Contacts confirmation: tweak language

### DIFF
--- a/CRM/Activity/Form/Task/Delete.php
+++ b/CRM/Activity/Form/Task/Delete.php
@@ -46,6 +46,7 @@ class CRM_Activity_Form_Task_Delete extends CRM_Activity_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
+    CRM_Utils_System::setTitle(ts('Delete Activities'));
     $this->addDefaultButtons(ts('Delete Activities'), 'done');
   }
 

--- a/CRM/Contact/Form/Task/Delete.php
+++ b/CRM/Contact/Form/Task/Delete.php
@@ -148,7 +148,12 @@ class CRM_Contact_Form_Task_Delete extends CRM_Contact_Form_Task {
    * Build the form object.
    */
   public function buildQuickForm() {
-    $label = $this->_restore ? ts('Restore Contact(s)') : ts('Delete Contact(s)');
+    // Title and primary button label
+    $label = ts('Delete Contact', ['plural' => 'Delete Contacts', 'count' => count($this->_contactIds)]);
+    if ($this->_restore) {
+      $label = ts('Restore Contact', ['plural' => 'Restore Contacts', 'count' => count($this->_contactIds)]);
+    }
+    CRM_Utils_System::setTitle($label);
 
     if ($this->_single) {
       // also fix the user context stack in case the user hits cancel

--- a/CRM/Contribute/Form/Task/Delete.php
+++ b/CRM/Contribute/Form/Task/Delete.php
@@ -48,6 +48,7 @@ class CRM_Contribute_Form_Task_Delete extends CRM_Contribute_Form_Task {
    * @throws \CRM_Core_Exception
    */
   public function buildQuickForm(): void {
+    CRM_Utils_System::setTitle(ts('Delete Contributions'));
     $count = 0;
     $this->assign('rows');
     foreach ($this->_contributionIds as $key => $id) {

--- a/templates/CRM/Activity/Form/Task/Delete.tpl
+++ b/templates/CRM/Activity/Form/Task/Delete.tpl
@@ -7,12 +7,12 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Confirmation of Activity deletes  *}
+{* Confirm Activity deletion *}
 <div class="crm-block crm-form-block crm-activity_delete-form-block">
   <div class="messages status no-popup">
     {icon icon="fa-info-circle"}{/icon}
-     <p>{ts}Are you sure you want to delete the selected Activities?{/ts}</p>
-     <p>{include file="CRM/Activity/Form/Task.tpl"}</p>
+    {ts}Are you sure you want to delete the selected Activities?{/ts}
+    <p>{include file="CRM/Activity/Form/Task.tpl"}</p>
   </div>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
 </div>

--- a/templates/CRM/Contact/Form/Task.tpl
+++ b/templates/CRM/Contact/Form/Task.tpl
@@ -18,7 +18,6 @@
         <th class="contact_details">{ts}Name{/ts}</th>
       </tr>
       </thead>
-
       <tbody>
         {foreach from=$value item='row'}
         <tr class="{cycle values="odd-row,even-row"}">
@@ -28,7 +27,7 @@
       </tbody>
     </table>
   </div>
-</div><br />
+</div>
 <a href="#" id="popup-button" title="{ts escape='htmlattribute'}View Selected Contacts{/ts}">{ts}View Selected Contacts{/ts}</a>
 {/if}
 

--- a/templates/CRM/Contact/Form/Task/Delete.tpl
+++ b/templates/CRM/Contact/Form/Task/Delete.tpl
@@ -7,20 +7,20 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Confirmation of contact deletes  *}
+{* Confirm contact deletion *}
 <div class="crm-block crm-form-block crm-contact-task-delete-form-block">
-<div class="messages status no-popup">
-  {icon icon="fa-info-circle"}{/icon}
-      {if $restore}
-    {ts}Are you sure you want to restore the selected contact(s)? The contact(s) and all related data will be fully restored.{/ts}
-      {elseif $trash}
-        {ts}Are you sure you want to delete the selected contact(s)?{/ts} {ts}The contact(s) and all related data will be moved to trash and only users with the relevant permission will be able to restore it.{/ts}
-      {else}
-        {ts}Are you sure you want to delete the selected contact(s)?{/ts} {ts}The contact(s) and all related data will be permanently removed.{/ts} {ts}This action cannot be undone.{/ts}
-      {/if}
+  <div class="messages status no-popup">
+    {icon icon="fa-info-circle"}{/icon}
+    {if $restore}
+      {ts}Are you sure you want to restore the selected contacts? The contacts and all related data will be fully restored.{/ts}
+    {elseif $trash}
+      {ts}The contacts and all related data will be moved to trash. Only users with the relevant permission will be able to restore it.{/ts}
+      {ts}Are you sure you want to delete the selected contacts?{/ts}
+    {else}
+      {ts}The contacts and all related data will be permanently removed.{/ts}
+      {ts}Are you sure you want to delete the selected contacts?{/ts} {ts}This action cannot be undone.{/ts}
+    {/if}
   </div>
-
-
-    <h3>{include file="CRM/Contact/Form/Task.tpl"}</h3>
+  <p>{include file="CRM/Contact/Form/Task.tpl"}</p>
   <div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location=''}</div>
 </div>

--- a/templates/CRM/Contribute/Form/Task/Delete.tpl
+++ b/templates/CRM/Contribute/Form/Task/Delete.tpl
@@ -7,13 +7,15 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Confirmation of contribution deletes  *}
-<div class="messages status no-popup">
+{* Confirm contribution deletion *}
+<div class="crm-block crm-form-block crm-contribution-task-delete-form-block">
+  <div class="messages status no-popup">
     {icon icon="fa-info-circle"}{/icon}
-        <p>{ts}Are you sure you want to delete the selected contributions? This delete operation cannot be undone and will delete all transactions and activity associated with these contributions.{/ts}</p>
-        <p>{include file="CRM/Contribute/Form/Task.tpl"}</p>
-</div>
-<p>
-<div class="form-item">
- {$form.buttons.html}
+    {ts}This delete operation cannot be undone and will delete all transactions and activity associated with these contributions.{/ts} {ts}This action cannot be undone.{/ts}
+    {ts}Are you sure you want to delete the selected contributions?{/ts}
+    <p>{include file="CRM/Contribute/Form/Task.tpl"}</p>
+  </div>
+  <div class="form-item">
+   {$form.buttons.html}
+  </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

Clarify the language around the "delete contact" task.

Ex:

- Find Contacts (classic UI, not searchkit)
- Select some contacts
- Action > Delete Contact

Changes:

- The title of the page is the action being done ("Delete Contacts" instead of "Find Contacts")
- The help text focuses on the consequences first, to make sure users read the more important bits
- Removes "(s)"

Before
----------------------------------------

<img width="3386" height="856" alt="2026-03-06_11-13" src="https://github.com/user-attachments/assets/d5d73acc-bc90-4486-b574-7782389e7a77" />


After
----------------------------------------

<img width="3372" height="766" alt="2026-03-06_11-12_1" src="https://github.com/user-attachments/assets/34e019c9-7b3b-4022-906b-2654445da112" />

Plural:

<img width="3376" height="776" alt="2026-03-06_11-12" src="https://github.com/user-attachments/assets/373ae602-98b4-4327-bc0d-5a0dd8595b98" />

Comments
----------------------------------------

Based on a discussion with  @vingle on the chat.

About the title: some other actions already do this, ex:

<img width="3380" height="880" alt="image" src="https://github.com/user-attachments/assets/1f1647e2-9bd2-4b5f-984f-0d044b6ad2d6" />
