### PR TITLE
PaymentProcessor - More efficient query to fetch all processors

### DIFF
--- a/CRM/Financial/BAO/PaymentProcessor.php
+++ b/CRM/Financial/BAO/PaymentProcessor.php
@@ -267,9 +267,32 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
       }
     }
 
+    $fieldsToProvide = [
+      'id',
+      'name',
+      'title',
+      'frontend_title',
+      'payment_instrument_id',
+      'payment_processor_type_id',
+      'user_name',
+      'password',
+      'signature',
+      'url_site',
+      'url_api',
+      'url_recur',
+      'url_button',
+      'subject',
+      'class_name',
+      'is_recur',
+      'billing_mode',
+      'is_test',
+      'payment_type',
+      'is_default',
+    ];
+
     $retrievalParameters = [
       'options' => ['sort' => 'is_default DESC, name', 'limit' => 0],
-      'api.payment_processor_type.getsingle' => 1,
+      'return' => array_merge($fieldsToProvide, ['payment_processor_type_id.name']),
     ];
     if (isset($isActive)) {
       // We use isset because we don't want to set the is_active parameter at all is $isActive is NULL
@@ -287,34 +310,13 @@ class CRM_Financial_BAO_PaymentProcessor extends CRM_Financial_DAO_PaymentProces
 
     $processors = civicrm_api3('payment_processor', 'get', $retrievalParameters);
     foreach ($processors['values'] as $processor) {
-      $fieldsToProvide = [
-        'id',
-        'name',
-        'title',
-        'frontend_title',
-        'payment_processor_type_id',
-        'user_name',
-        'password',
-        'signature',
-        'url_site',
-        'url_api',
-        'url_recur',
-        'url_button',
-        'subject',
-        'class_name',
-        'is_recur',
-        'billing_mode',
-        'is_test',
-        'payment_type',
-        'is_default',
-      ];
       foreach ($fieldsToProvide as $field) {
         // Prevent e-notices in processor classes when not configured.
         if (!isset($processor[$field])) {
           $processors['values'][$processor['id']][$field] = NULL;
         }
       }
-      $processors['values'][$processor['id']]['payment_processor_type'] = $processor['payment_processor_type'] = $processors['values'][$processor['id']]['api.payment_processor_type.getsingle']['name'];
+      $processors['values'][$processor['id']]['payment_processor_type'] = $processors['values'][$processor['id']]['payment_processor_type_id.name'];
       $processors['values'][$processor['id']]['object'] = Civi\Payment\System::singleton()->getByProcessor($processors['values'][$processor['id']]);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Improves performance and fixes potential crash during upgrade.

Before
----------------------------------------
Many big queries: selects all processor fields and then uses chain select to fetch all processor type fields.
Pre-upgrade, it might try to select fields that don't exist and crash.

After
----------------------------------------
Single optimized query fetches only desired fields.

Technical Details
----------------------------------------
The upshot of this change is that `$fieldsToProvide` is now exactly what will be returned, whereas before, that may have been the intention, but in practice it was just the minimum set; others would sneak in undeclared (because the Api3 call had no `return` specified so was effectively `SELECT *`).

The only risk is that some downstream callers may be relying on any of those sneaky undeclared fields, but spot-checking them, I don't see evidence of that.

Comments
-----
For me, this fixes a crash on my site after merging #35019 (FYI @ufundo). The crash doesn't present in most normal uses but IMO still worth fixing because in the event it does happen, it's pretty crippling to the whole site. One reliable way to reproduce it is to upgrade your database version to 6.14 *before* applying the patch from #35019, e.g.

- `cv api4 Domain.update +w id=1 +v version=6.13.0`
- `git checkout 668822e4~1`
- `cv up`
- `git checkout 668822e4`
- Now navigate to Search Kit and watch everything crash