### PR TITLE
Form Builder - Fix warning about null values

### DIFF
--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -189,10 +189,10 @@ class StringVisitor {
   }
 
   protected function isWorthy($value): bool {
-    return !is_array($value)
+    return !empty($value)
+      && !is_array($value)
       && (!str_contains($value, '{{'))
-      && (!str_contains($value, 'ts('))
-      && !empty($value);
+      && (!str_contains($value, 'ts('));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

Fix a recent warning involving Afform's `StringVisitor::isWorthy()`.

The cause of the warning isn't exactly new -- the logic quirk probably goes back to sometime in 2025. But I think the warning presents in more scenarios after the recent 7126557d1d12398f888146214c3e87622abd3705 (where there's a new fallback to a null value circa L134-135). In any case, the fix is pretty minor.

Before
----------------------------------------

I've been intermittently seeing warnings like this:

```
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /Users/totten/bknix/build/build-0/web/core/ext/afform/core/Civi/Afform/StringVisitor.php:193
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /Users/totten/bknix/build/build-0/web/core/ext/afform/core/Civi/Afform/StringVisitor.php:194
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /Users/totten/bknix/build/build-0/web/core/ext/afform/core/Civi/Afform/StringVisitor.php:193
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /Users/totten/bknix/build/build-0/web/core/ext/afform/core/Civi/Afform/StringVisitor.php:194
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /Users/totten/bknix/build/build-0/web/core/ext/afform/core/Civi/Afform/StringVisitor.php:193
[PHP Deprecation] str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated at /Users/totten/bknix/build/build-0/web/core/ext/afform/core/Civi/Afform/StringVisitor.php:194
```

It was reproducible in the context of this [cv test failure](https://test.civicrm.org/job/CiviCRM-Cv-Test/2206/testReport/(root)/Civi_Cv_Command_AngularHtmlListCommandTest/testGetRegex/), although that particular issue is incidental.

After
----------------------------------------

Warning should go away.

Technical Details
----------------------------------------

This just changes the order of conditions for `isWorthy()` -- promoting the `!empty($value)` condition to the start.

(If you know that `empty($value)`, then there's no need to check `str_contains($value, '{{')`.)