### PR TITLE
(dev/core#6251) Outbound Mail - Fix new warning. Finish conversion.

### DIFF
--- a/CRM/Admin/Form/Setting/Smtp.php
+++ b/CRM/Admin/Form/Setting/Smtp.php
@@ -84,12 +84,6 @@ class CRM_Admin_Form_Setting_Smtp extends CRM_Admin_Form_Generic {
       ['type' => 'submit']
     );
     $this->getElement('buttons')->setElements($buttons);
-
-    // When re-drawing after POST-back, ensure that values are rendered again.
-    if ($this->_submitValues && $mandatory !== NULL) {
-      $mandatoryValues = $this->convertMailingBackendToFormValues($mandatory);
-      $this->_submitValues = array_merge($this->_submitValues, $mandatoryValues);
-    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to a couple patches in January. At the time, there were two options for fixing dev/core#6251 -- the narrower (#34443) and the generalized (#34444), and they were tested separately. We initially merged the narrower (going to 6.10-rc) and then later merged the generalized (6.12-alpha).

However, the combination/revert wasn't quite complete -- it left some stray code that emits a warning in 6.12+.

Steps to Reproduce
----------------------------------------

* Open "Outbound Mail" settings
* Click "Save & Send Test Email"

Before
----------------------------------------

Warning:

<img width="870" height="184" alt="Screenshot 2026-03-06 at 6 36 46 PM" src="https://github.com/user-attachments/assets/65ee7503-65fd-4b0b-bd9b-1faa9222343d" />

After
----------------------------------------

No warning

Technical Details
----------------------------------------

There is no local variable in `CRM_Admin_Form_Setting_Smtp::buildQuickForm()` (with `$mandatory`) because the functionality was pushed-up to parent method `CRM_Core_Form::buildForm()` (with `getMandatoryValues()`).