### PR TITLE
afForm - fixes for post-submit error handling 

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -428,6 +428,13 @@
           else {
             displayError(error.error_message, ts('There is a problem'), 'error');
           }
+
+          $element.trigger('crmFormError', {
+            afform: ctrl.getFormMeta(),
+            data: data,
+            submissionResponse: submissionResponse,
+            error: error
+          });
         });
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -384,6 +384,16 @@
         }
       }
 
+      const handleError = (error) => {
+        // see: CRM/Api4/Page/AJAX.php
+        if (error && error.error_code !== '1') {
+          displayError(error.error_message, ts('Please resolve these issues'), 'warning');
+        }
+        else {
+          displayError(error.error_message, ts('There is a problem'), 'error');
+        }
+      };
+
       this.submit = function () {
         // validate required fields on the form
         if (!ctrl.ngForm.$valid || !validateFileFields()) {
@@ -421,13 +431,7 @@
           status.reject();
           $element.unblock();
 
-          // see: CRM/Api4/Page/AJAX.php
-          if (error.error_code !== '1') {
-            displayError(error.error_message, ts('Please resolve these issues'), 'warning');
-          }
-          else {
-            displayError(error.error_message, ts('There is a problem'), 'error');
-          }
+          handleError(error);
 
           $element.trigger('crmFormError', {
             afform: ctrl.getFormMeta(),
@@ -466,14 +470,7 @@
         })
         .catch(function(error) {
           setDraftStatus('unsaved');
-
-          // see: CRM/Api4/Page/AJAX.php
-          if (error.error_code !== '1') {
-            displayError(error.error_message, ts('Please resolve these issues'), 'warning');
-          }
-          else {
-            displayError(error.error_message, ts('There is a problem'), 'error');
-          }
+          handleError(error);
         });
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -390,7 +390,8 @@
           displayError(error.error_message, ts('Please resolve these issues'), 'warning');
         }
         else {
-          displayError(error.error_message, ts('There is a problem'), 'error');
+          const message = error?.error_message ? error.error_message : ts('Unknown error');
+          displayError(message, ts('There is a problem'), 'error');
         }
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix regressions from https://github.com/civicrm/civicrm-core/pull/34309
- restore `crmFormError` trigger in `this.submit` which seems to have incidentally been removed
- handle 500 errors (where `error.error_message` is empty)

Technical Details
----------------------------------------
I've factored out the repeated logic for looking at the error code.

The issue with 500 errors is the error has no `error_message` so the JS crashes and no alert is shown.

Comments
----------------------------------------
I think the addition of `displayError` should be redundant [now that Sweetalert extension overloads CRM.alert](https://lab.civicrm.org/extensions/sweetalert#usage) - so I'd like to remove it. But I will make a separate PR on `master` for that.
