### PR TITLE
afForm - avoid hardcode call to Sweetalert

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -369,29 +369,17 @@
         $('af-form[ng-form="' + ctrl.getFormMeta().name + '"]')
           .addClass('disabled')
           .find('button[ng-click="afform.submit()"]').prop('disabled', true);
-        displayError(errorMsg, ts('Sorry'), 'error');
-      }
-
-     function displayError(errorMsg, title, type) {
-        if (typeof Swal === 'function') {
-          Swal.fire({
-            icon: type,
-            html: errorMsg.replace("\n", '<br>')
-          });
-        }
-        else {
-          CRM.alert(errorMsg, title, type);
-        }
+        CRM.alert(errorMsg, ts('Sorry'), 'error');
       }
 
       const handleError = (error) => {
         // see: CRM/Api4/Page/AJAX.php
         if (error && error.error_code !== '1') {
-          displayError(error.error_message, ts('Please resolve these issues'), 'warning');
+          CRM.alert(error.error_message, ts('Please resolve these issues'), 'warning');
         }
         else {
           const message = error?.error_message ? error.error_message : ts('Unknown error');
-          displayError(message, ts('There is a problem'), 'error');
+          CRM.alert(message, ts('There is a problem'), 'error');
         }
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Use CRM.alert - and let the Sweetalert integration take care of passing that to Sweetalert if appropriate.

Follow up to https://github.com/civicrm/civicrm-core/pull/35039

Before
----------------------------------------
- hardcoded callout to Sweetalert


After
----------------------------------------
- use CRM.alert
- Sweetalert integration will pass that to Sweetalert according to user config https://lab.civicrm.org/extensions/sweetalert#usage

Technical Details
----------------------------------------
If a site is not using the latest version of Sweetalert integration, or loads Sweetalert at CMS level, then they might miss out. Given the change was only released in 6.12 I don't think anyone should be relying to heavily on either of these yet - and I'd recommend they get the latest Sweetalert integration.

In the long run I think this is important to:
- avoid unscalable chain of "if alert library A, do A; if alert library B, do B"
- ensure the burden for translating CRM.alert params into Sweetalert is shouldered by the Sweetalert integration. E.g. if Sweetalert params change in a future version; or if something considered a valid `type` by CRM.alert does not correspond to a valid `icon` in Sweetalert.

Comments
--------------------------------------
cc @shaneonabike is this reasonable? It looks like the sweetalerting was added a bit incidentally in https://github.com/civicrm/civicrm-core/pull/34309