### PR TITLE
[backport] afForm - avoid hardcode call to Sweetalert#35041

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -428,6 +428,13 @@
           else {
             displayError(error.error_message, ts('There is a problem'), 'error');
           }
+
+          $element.trigger('crmFormError', {
+            afform: ctrl.getFormMeta(),
+            data: data,
+            submissionResponse: submissionResponse,
+            error: error
+          });
         });
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -369,29 +369,17 @@
         $('af-form[ng-form="' + ctrl.getFormMeta().name + '"]')
           .addClass('disabled')
           .find('button[ng-click="afform.submit()"]').prop('disabled', true);
-        displayError(errorMsg, ts('Sorry'), 'error');
-      }
-
-     function displayError(errorMsg, title, type) {
-        if (typeof Swal === 'function') {
-          Swal.fire({
-            icon: type,
-            html: errorMsg.replace("\n", '<br>')
-          });
-        }
-        else {
-          CRM.alert(errorMsg, title, type);
-        }
+        CRM.alert(errorMsg, ts('Sorry'), 'error');
       }
 
       const handleError = (error) => {
         // see: CRM/Api4/Page/AJAX.php
         if (error && error.error_code !== '1') {
-          displayError(error.error_message, ts('Please resolve these issues'), 'warning');
+          CRM.alert(error.error_message, ts('Please resolve these issues'), 'warning');
         }
         else {
           const message = error?.error_message ? error.error_message : ts('Unknown error');
-          displayError(message, ts('There is a problem'), 'error');
+          CRM.alert(message, ts('There is a problem'), 'error');
         }
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -384,6 +384,16 @@
         }
       }
 
+      const handleError = (error) => {
+        // see: CRM/Api4/Page/AJAX.php
+        if (error && error.error_code !== '1') {
+          displayError(error.error_message, ts('Please resolve these issues'), 'warning');
+        }
+        else {
+          displayError(error.error_message, ts('There is a problem'), 'error');
+        }
+      };
+
       this.submit = function () {
         // validate required fields on the form
         if (!ctrl.ngForm.$valid || !validateFileFields()) {
@@ -421,13 +431,7 @@
           status.reject();
           $element.unblock();
 
-          // see: CRM/Api4/Page/AJAX.php
-          if (error.error_code !== '1') {
-            displayError(error.error_message, ts('Please resolve these issues'), 'warning');
-          }
-          else {
-            displayError(error.error_message, ts('There is a problem'), 'error');
-          }
+          handleError(error);
 
           $element.trigger('crmFormError', {
             afform: ctrl.getFormMeta(),
@@ -466,14 +470,7 @@
         })
         .catch(function(error) {
           setDraftStatus('unsaved');
-
-          // see: CRM/Api4/Page/AJAX.php
-          if (error.error_code !== '1') {
-            displayError(error.error_message, ts('Please resolve these issues'), 'warning');
-          }
-          else {
-            displayError(error.error_message, ts('There is a problem'), 'error');
-          }
+          handleError(error);
         });
       };
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -390,7 +390,8 @@
           displayError(error.error_message, ts('Please resolve these issues'), 'warning');
         }
         else {
-          displayError(error.error_message, ts('There is a problem'), 'error');
+          const message = error?.error_message ? error.error_message : ts('Unknown error');
+          displayError(message, ts('There is a problem'), 'error');
         }
       };
 


### PR DESCRIPTION
Overview
----------------------------------------
Backport for https://github.com/civicrm/civicrm-core/pull/35041

This may not *need* a backport but would avoid having one version `6.12` with exceptional behaviour (different to 6.11 and 6.13)

_Opening again because need a separate branch_ due to divergences on 6.12/6.13