### PR TITLE
add `civi.afform.save` event when saving Afforms

### DIFF
--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -5,6 +5,7 @@ namespace Civi\Api4\Utils;
 use Civi\Afform\StringVisitor;
 use Civi\Api4\TranslationSource;
 use Civi\Afform\Utils;
+use Civi\Core\Event\GenericHookEvent;
 
 /**
  * Class AfformSaveTrait.
@@ -31,8 +32,13 @@ trait AfformSaveTrait {
       $item['created_id'] = \CRM_Core_Session::getLoggedInContactID();
     }
 
-    // FIXME validate all field data.
     $item = _afform_fields_filter($item);
+
+    // listeners can validate field data
+    // FIXME: add core listeners to do essential validation?
+    // FIXME: move everything below this into appropriately weighted listeners so
+    // other listeners can hook in wherever they like in the process?
+    \Civi::dispatcher()->dispatch('civi.afform.save', GenericHookEvent::create(['record' => $item]));
 
     // Create or update aff.html.
     if (isset($item['layout'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Dispatch event when saving afforms. Allows listeners to validate configuration.

Before
----------------------------------------
- FIXME for validating Afforms on save

After
----------------------------------------
- a very basic event is dispatched prior to saving the changes to disk
- listeners can validate the record before it is saved (and throw an Exception if something is wrong)
- I guess listeners could also amend the record? I'm not sure whether this would be a good idea in practice

Technical Details
----------------------------------------
Maybe the event should be more structured?

I think a common pattern might be for listeners to call `$model = new FormDataModel($e->record['layout']);` to parse the layout. We could do this before creating the event. However, if listeners alter the layout of the original record then the two parameters might get out of sync - so I think it's safest to just pass the record.