### PR TITLE
Afform editor - catch error on save

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -741,6 +741,11 @@
               refreshMenubar();
             }
             setLastSaved();
+          })
+          .catch((error) => {
+            const message = error?.error_message ? error.error_message : ts('Unknown error');
+            CRM.alert(message, ts('Save failed'), 'error');
+            $scope.saving = false;
           });
       };
 


### PR DESCRIPTION
Before
----------------------------------------
- If something goes wrong serverside when saving afform, the button hangs on `Saving...` indefinitely

After
----------------------------------------
- If something goes wrong serverside when saving afform, an alert is shown and you can try again


Comments
----------------------------------------
Particularly helpful if you throw an error when listening to https://github.com/civicrm/civicrm-core/pull/35043
