### PR TITLE
Settings - Handle file uploads on settings form

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -46,6 +46,8 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
     $this->_settings = array_filter($allSettings, function ($setting) use ($filter) {
       return !empty($setting['settings_pages'][$filter]);
     });
+    // Add CSS for File CRUD form elements
+    Civi::resources()->addStyleFile('civicrm', 'css/admin.css');
   }
 
   /**

--- a/CRM/Admin/Form/SettingTrait.php
+++ b/CRM/Admin/Form/SettingTrait.php
@@ -263,8 +263,43 @@ trait CRM_Admin_Form_SettingTrait {
       else {
         $this->$add($settingName, $props['title'], $options);
       }
+      if (($props['html_type'] ?? '') === 'file') {
+        $this->addExistingFileElement($settingName, $props);
+      }
     }
     return isset($quickFormType);
+  }
+
+  /**
+   * Adds extra markup needed to display an existing file.
+   */
+  public function addExistingFileElement(string $settingName, array &$props) {
+    $settingValue = Civi::settings()->get($settingName);
+    if ($settingValue) {
+      $file = \Civi\Api4\File::get(FALSE)
+        ->addWhere('id', '=', $settingValue)
+        ->addSelect('file_name', 'icon')
+        ->execute()->first();
+    }
+    // Add form element to show existing file and allow deleting it
+    if (isset($file)) {
+      $this->add('checkbox', "delete_file_$settingName");
+      $title = htmlspecialchars(ts('Delete file'));
+      $fileName = htmlspecialchars($file['file_name']);
+      $markup = <<<HTML
+<div class="crm-file-upload-wrapper">
+  <label class="crm-delete-file" title="$title">
+    <span class="sr-only">$title</span>
+    <input type="checkbox" name="delete_file_$settingName" >
+    <span>
+      <i class="crm-i {$file['icon']}" role="img" aria-hidden="true"></i>
+      $fileName
+    </span>
+    <i class="crm-i delete-icon" role="img" aria-hidden="true"></i>
+  </label>
+HTML;
+      $props['wrapper_element'] = [$markup, '</div>'];
+    }
   }
 
   /**
@@ -350,6 +385,7 @@ trait CRM_Admin_Form_SettingTrait {
       $settingMetaData = $this->getSettingMetadata($setting);
       $settings[$setting] = self::formatSettingValue($settingMetaData, $settingValue);
     }
+    $this->handleFileUploads($settings, $params);
     Setting::set(FALSE)->setValues($settings)->execute();
   }
 
@@ -374,6 +410,42 @@ trait CRM_Admin_Form_SettingTrait {
       }
     }
     return $settingValue;
+  }
+
+  protected function handleFileUploads(array &$settings, $params) {
+    foreach ($this->getSettingsMetaData() as $settingName => $settingMetaData) {
+      if ($settingMetaData['type'] === 'File') {
+        $upload = $this->_submitFiles[$settingName] ?? NULL;
+        $fileWasUploaded = !empty($upload['tmp_name']) && !empty($upload['name']) && !empty($upload['type']);
+        $deleteFileOption = $params["delete_file_$settingName"] ?? FALSE;
+
+        $existingSetting = Civi::settings()->get($settingName);
+        if ($existingSetting) {
+          $existingFile = \Civi\Api4\File::get(FALSE)
+            ->addSelect('id')
+            ->addWhere('id', '=', $existingSetting)
+            ->execute()->first()['id'] ?? NULL;
+        }
+
+        if ($deleteFileOption && $existingFile) {
+          \Civi\Api4\File::delete(FALSE)
+            ->addWhere('id', '=', $existingFile)
+            ->execute();
+          $settings[$settingName] = NULL;
+        }
+
+        // Only accept a replacement file if the user opted to delete the old one.
+        if ($fileWasUploaded && ($deleteFileOption || !$existingFile)) {
+          $savedFile = \Civi\Api4\File::create(FALSE)
+            ->addValue('file_name', $upload['name'])
+            ->addValue('move_file', $upload['tmp_name'])
+            ->addValue('mime_type', $upload['type'])
+            ->addValue('is_public', $settingMetaData['file_is_public'] ?? FALSE)
+            ->execute()->single();
+          $settings[$settingName] = $savedFile['id'];
+        }
+      }
+    }
   }
 
   /**

--- a/css/admin.css
+++ b/css/admin.css
@@ -85,3 +85,17 @@
     font-weight: bold;
   }
 }
+
+/* File CRUD form elements */
+/* Currently only used on CRM_Admin_Form_Generic */
+.crm-container label.crm-delete-file {
+  display: block;
+  cursor: pointer;
+}
+label.crm-delete-file input[type=checkbox],
+label.crm-delete-file:has(input[type=checkbox]:not(:checked)) + input[type=file] {
+  display: none;
+}
+label.crm-delete-file input[type=checkbox]:checked + span {
+  text-decoration: line-through;
+}

--- a/ext/riverlea/core/css/admin.css
+++ b/ext/riverlea/core/css/admin.css
@@ -141,3 +141,17 @@
     font-weight: bold;
   }
 }
+
+/* File CRUD form elements */
+/* Currently only used on CRM_Admin_Form_Generic */
+.crm-container label.crm-delete-file {
+  display: block;
+  cursor: pointer;
+}
+label.crm-delete-file input[type=checkbox],
+label.crm-delete-file:has(input[type=checkbox]:not(:checked)) + input[type=file] {
+  display: none;
+}
+label.crm-delete-file input[type=checkbox]:checked + span {
+  text-decoration: line-through;
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds functionality to the generic settings form to enable file uploads.

<img width="1212" height="208" alt="image" src="https://github.com/user-attachments/assets/0e3b8390-cc08-4a11-91ce-2f62ee4b630d" />


Before
--------
In theory, a setting could be a file, but no UI support.

After
------
A setting can be a file and the settings form handles CRUD.
