### PR TITLE
add Contribution/LineItem support to Afform

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
@@ -51,6 +51,9 @@ class PriceFieldSpecProvider extends \Civi\Core\Service\AutoService implements G
    * @inheritDoc
    */
   public function applies($entity, $action) {
+    if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+      return FALSE;
+    }
     return ($action === 'create' &&
     ($entity === 'Contribution' || in_array($entity, PriceFieldUtils::getEnabledEntities())));
   }

--- a/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/PriceFieldSpecProvider.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Contribute\Utils\PriceFieldUtils;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * Class PriceFieldSpecProvider
+ *
+ * @package Civi\Api4\Service\Spec\Provider
+ * @service
+ * @internal
+ */
+class PriceFieldSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $fields = PriceFieldUtils::getPriceFieldsForEntity($spec->getEntity());
+
+    foreach ($fields as $field) {
+      $fieldSpec = new FieldSpec($field['name'], $spec->getEntity(), $field['data_type']);
+      $fieldSpec->setLabel(E::ts("Contribution Amount: %1", [1 => $field['label']]))
+        ->setInputType($field['input_type'])
+        ->setType('Extra');
+
+      if ($field['options'] ?? NULL) {
+        $fieldSpec->setOptions($field['options']);
+      }
+
+      $spec->addFieldSpec($fieldSpec);
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return ($action === 'create' &&
+    ($entity === 'Contribution' || in_array($entity, PriceFieldUtils::getEnabledEntities())));
+  }
+
+}

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -1,0 +1,263 @@
+<?php
+namespace Civi\Contribute\Service;
+
+use Civi\Afform\Event\AfformSubmitEvent;
+use Civi\Afform\Event\AfformValidateEvent;
+use Civi\Contribute\Utils\PriceFieldUtils;
+use Civi\Core\Service\AutoService;
+use DateTime;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * @service civi.afform.create_contribution
+ */
+class CreateContribution extends AutoService implements EventSubscriberInterface {
+
+  protected bool $active = TRUE;
+
+  /**
+   * Public method to disable this service if not desired, using:
+   * \Civi::service('civi.afform.create_contribution')->setActive(FALSE);
+   *
+   * @param bool $active
+   * @return $this
+   */
+  public function setActive($active) {
+    $this->active = $active;
+    return $this;
+  }
+
+  /**
+   * Default is to run if we have a contribution record on the form
+   *
+   * Can be overridden using setActive method
+   */
+  protected function isActive($formDataModel): bool {
+    if (!$this->active) {
+      return FALSE;
+    }
+    foreach ($formDataModel->getEntities() as $formEntity) {
+      if ($formEntity['type'] === 'Contribution' && $formEntity['actions']['create']) {
+        // creating new contributions
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      'civi.afform.validate' => [
+        // TODO: this belongs in a hook to validate a form
+        // that is being saved or loaded rather than submitted
+        // but we dont have that yet - hopefully the admin will
+        // try to submit the form at least once
+        ['validateFormModel', 1000],
+        ['validateLineItems', 101],
+      ],
+      'civi.afform.submit' => [
+        // the GenericEntitySave is a no-op for Contributions
+        // this provides the equivalent functionality for new Contributions
+        // TODO: provide sensible default for existing contributions
+        ['saveNewContribution', 0],
+      ],
+    ];
+  }
+
+  public function validateFormModel(AfformValidateEvent $event) {
+    $model = $event->getFormDataModel();
+
+    // only validate forms this service cares about
+    if (!$this->isActive($model)) {
+      return;
+    }
+    // find contributions on the form
+    $contributions = array_filter($model->getEntities(), fn ($entity) => $entity['type'] === 'Contribution');
+
+    if (!$contributions) {
+      // shouldn't reach here with isActive check above
+      return;
+    }
+    if (count($contributions) > 1) {
+      $event->setError(E::ts('Handling multiple contributions on the same form is not supported'));
+      return;
+    }
+    $contribution = reset($contributions);
+    if (count(array_filter($contribution['actions'])) !== 1) {
+      $event->setError(E::ts('Contribution action should be create or update but not both.'));
+      return;
+    }
+
+    // TODO: check any entities with price fields are ordered *before* the contribution
+  }
+
+  public function validateLineItems(AfformValidateEvent $event) {
+    $dataModel = $event->getFormDataModel();
+    if (!$this->isActive($dataModel)) {
+      return;
+    }
+
+    $lineItems = $this->gatherLineItems($event, FALSE);
+
+    // TODO implement hookable validation event
+    // \Civi::log()->debug("Afform Payment Validate: " . json_encode($lineItems));
+    // $validationErrors = \Civi\Api4\Order::validate()->setLineItems($lineItems)->execute()
+    // foreach ($validationErrors as $error) {
+    //   $event->setError($error);
+    // }
+
+    // in the absence of hookable validation, provide this sensible default
+    // this catches cases when user must select one of a number of possible
+    // price fields to provide line items, but no specific price field is required
+    if (!$lineItems) {
+      $event->setError(E::ts('No line items for creating contribution'));
+      return;
+    }
+
+    $event->getApiRequest()->setResponseItem('line_items', $lineItems);
+  }
+
+  protected function gatherLineItems(AfformSubmitEvent|AfformValidateEvent $event, bool $requireLinkedEntityIds = TRUE) {
+    $dataModel = $event->getFormDataModel();
+    $allSubmittedValues = $event->getSubmittedValues();
+
+    $lineItems = [];
+
+    foreach ($dataModel->getEntities() as $entityName => $entity) {
+      $entityType = $entity['type'];
+      $priceFields = PriceFieldUtils::getPriceFieldsForEntity($entityType);
+      if (!$priceFields) {
+        continue;
+      }
+      $requireId = ($requireLinkedEntityIds && $entityType !== 'Contribution');
+      $entityIds = $requireId ? $event->getEntityIds($entityName) : NULL;
+
+      foreach ($allSubmittedValues[$entityName] as $i => $submittedValues) {
+        $values = array_merge($entity['data'], $submittedValues['fields']);
+
+        // note when validating (or preapproving) we dont need any entity IDs
+        // but when creating the contribution we need the entity IDs for saved
+        // linked records (e.g. participant ID / membership ID)
+        if ($requireId) {
+          if (empty($entityIds[$i])) {
+            // skip this record
+            \Civi::log()->debug("Skipping line items for {$entityName}.{$i} on {$event->getAfform()['name']} as no entity id found.");
+            continue;
+          }
+          $values['id'] = $entityIds[$i];
+        }
+
+        $lineItems = array_merge($lineItems, $this->getLineItemsForRecord($entityType, $values, $priceFields));
+      }
+    }
+
+    return $lineItems;
+  }
+
+  public function saveNewContribution(AfformSubmitEvent $event) {
+    if ($event->getEntityType() !== 'Contribution') {
+      return;
+    }
+    if (!$this->isActive($event->getFormDataModel())) {
+      return;
+    }
+
+    $lineItems = $this->gatherLineItems($event);
+
+    $contribution = $event->getRecords()[0]['fields'];
+
+    // TODO: enforce payment is pending? maybe Order does this. maybe
+    // you want to create a contribution with line items in
+    // another state?
+    // $contribution['contribution_status_id:name'] = 'Pending';
+
+    // use order to create the contribution record
+    $savedContribution = \Civi\Api4\Order::create(FALSE)
+      ->setContributionValues($contribution)
+      ->setLineItems($lineItems)
+      ->execute()
+      ->first();
+
+    $event->setEntityId(0, $savedContribution['id']);
+
+    if ($contribution['recur_period'] ?? NULL) {
+      $this->createContributionRecur($savedContribution['id'], $contribution['recur_period']);
+    }
+
+  }
+
+  /**
+   * Calculate line items for an individual record
+   */
+  private function getLineItemsForRecord(string $entityType, array $values, array $priceFields): array {
+    $lineItems = [];
+
+    foreach ($values as $key => $fieldValue) {
+      $priceField = array_find($priceFields, fn ($priceField) => $priceField['name'] === $key);
+      if (!$priceField) {
+        continue;
+      }
+      // $fieldValue can be scalar or array
+      foreach ((array) $fieldValue as $singleFieldValue) {
+        $lineItems[] = PriceFieldUtils::getLineItemForPriceFieldValue($entityType, $values['id'] ?? NULL, $priceField, $singleFieldValue);
+      }
+    }
+
+    return $lineItems;
+  }
+
+  /**
+   * For a recurring contribution, create a ContributionRecur record as well
+   */
+  public function createContributionRecur(int $contributionId, string $recurPeriod) {
+    // get values we need to reuse from the contribution record
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
+      ->addSelect('contact_id', 'total_amount', 'currency', 'is_test')
+      ->addWhere('id', '=', $contributionId)
+      ->execute()
+      ->single();
+
+    // unpack recurPeriod parameter
+    // TODO: provide extendable options (option group) for this
+    $recurParams = match($recurPeriod) {
+      'monthly' => [
+        'frequency_unit' => 'month',
+        'frequency_interval' => 1,
+      ],
+      'yearly' => [
+        'frequency_unit' => 'year',
+        'frequency_interval' => 1,
+      ],
+      default => throw new \CRM_Core_Exception('Unrecognised recur_period value'),
+    };
+
+    // calculate the next scheduled date
+    $nextSched = (new DateTime("+ {$recurParams['frequency_interval']} {$recurParams['frequency_unit']}"))->format('Y-m-d');
+
+    $recurRecordId = \Civi\Api4\ContributionRecur::create(FALSE)
+      ->addValue('contact_id', $contribution['contact_id'])
+      ->addValue('amount', $contribution['total_amount'])
+      ->addValue('currency', $contribution['currency'])
+      ->addValue('is_test', $contribution['is_test'])
+      ->addValue('frequency_unit', $recurParams['frequency_unit'])
+      ->addValue('frequency_interval', $recurParams['frequency_interval'])
+      ->addValue('next_sched_contribution_date', $nextSched)
+      ->execute()
+      ->single()['id'];
+
+    // attach the existing contribution to the recurring record
+    \Civi\Api4\Contribution::update(FALSE)
+      ->addWhere('id', '=', $contributionId)
+      ->addValue('contribution_recur_id', $recurRecordId)
+      ->execute();
+
+    // TODO: do we need to copy the first contribution as a template?
+    // or will it be used anyway if no template contribution exists
+  }
+
+}

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -35,6 +35,9 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
    * Can be overridden using setActive method
    */
   protected function isActive($formDataModel): bool {
+    if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+      return FALSE;
+    }
     if (!$this->active) {
       return FALSE;
     }

--- a/ext/civi_contribute/Civi/Contribute/Utils/PriceFieldUtils.php
+++ b/ext/civi_contribute/Civi/Contribute/Utils/PriceFieldUtils.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace Civi\Contribute\Utils;
+
+class PriceFieldUtils {
+
+  /**
+   * @return string[] entities for which payments are enabled
+   */
+  public static function getEnabledEntities(): array {
+    return array_keys(self::getPriceFieldSpecs());
+  }
+
+  /**
+   * Map for non-pseudoconstant `extends` field on `price_set`
+   *
+   * TODO: make extends a pseudoconstant OR use a new field on `price_field` table
+   *
+   * @return array
+   */
+  protected static function getExtendsIdToEntityMap(): array {
+    $componentToEntityMap = [
+      'CiviMember' => 'Membership',
+      'CiviContribute' => 'Contribution',
+      'CiviEvent' => 'Participant',
+    ];
+
+    $extendsIdToEntityMap = [];
+
+    foreach (\CRM_Price_BAO_PriceSet::getExtendsOptions() as $option) {
+      $component = $option['name'];
+      $entity = $componentToEntityMap[$component];
+
+      $extendsId = (int) $option['id'];
+      $extendsIdToEntityMap[$extendsId] = $entity;
+    }
+
+    return $extendsIdToEntityMap;
+  }
+
+  public static function getPriceFieldsForEntity(string $entity): array {
+    return self::getPriceFieldSpecs()[$entity] ?? [];
+  }
+
+  public static function getPriceFieldSpecs(): array {
+    if (!isset(\Civi::$statics[__CLASS__])) {
+      \Civi::$statics[__CLASS__] = self::fetchPriceFieldSpecs();
+    }
+    return \Civi::$statics[__CLASS__];
+  }
+
+  protected static function fetchPriceFieldSpecs(): array {
+    $priceFields = (array) \Civi\Api4\PriceField::get(FALSE)
+      ->addSelect('id', 'name', 'label', 'html_type', 'is_enter_qty', 'is_display_amounts')
+      // TODO: using entity extends from the parent PriceSet for now
+      // if we want to flatten to only use PriceFields, we could add
+      // an extends field to PriceField
+      // (in this case use a nice pseudoconstant straight from the outset
+      // to avoid need for getExtendsIdForEntity and allow easy extending
+      // to other (custom) entities)
+      // we also using price set name and label to create full names / labels for each field
+      // if we flatten then we should enforce unique names on PriceField
+      // and make sure labels are clear
+      ->addSelect('price_set_id.extends', 'price_set_id.name', 'price_set_id.title')
+      ->execute()
+      ->indexBy('id');
+
+    $fieldValues = (array) \Civi\Api4\PriceFieldValue::get(FALSE)
+      ->addSelect('id', 'price_field_id', 'label', 'amount')
+      ->execute();
+
+    // Add amount to each PriceFieldValue option label
+    foreach ($fieldValues as &$fieldValue) {
+      if (!empty($priceFields[$fieldValue['price_field_id']]['is_display_amounts'])) {
+        $fieldValue['label'] = $fieldValue['label'] . ' - ' . \Civi::format()->money($fieldValue['amount'], \CRM_Core_Config::singleton()->defaultCurrency);
+      }
+    }
+
+    $extendsIdToEntityMap = self::getExtendsIdToEntityMap();
+
+    $fieldSpecs = [];
+
+    foreach ($priceFields as $priceField) {
+      $fullName = "{$priceField['price_set_id.name']}.{$priceField['name']}";
+
+      // concatenate set label if not duplicate
+      $fullLabel = ($priceField['price_set_id.title'] === $priceField['label']) ?
+        $priceField['label'] : "{$priceField['price_set_id.title']}: {$priceField['label']}";
+
+      $fieldSpec = [
+        'price_field_id' => $priceField['id'],
+        'name' => $fullName,
+        'label' => $fullLabel,
+        'frontend_label' => $priceField['label'],
+        // TODO: do all price fields correspond to an amount?
+        'data_type' => 'Float',
+        // TODO: check mappings
+        'input_type' => $priceField['html_type'],
+        'is_enter_qty' => $priceField['is_enter_qty'],
+      ];
+
+      if ($fieldSpec['price_field_id'] === 1) {
+        // price_field_id = 1 is the "magic" Default Contribution Amount,
+        // the schema has options but we ignore them as user will
+        // enter amount rather than option ID
+      }
+      else {
+        $options = array_filter($fieldValues, fn($value) => ($value['price_field_id'] === $priceField['id']));
+
+        if ($options) {
+          $fieldSpec['options'] = array_column($options, 'label', 'id');
+          // note: field value will be a PriceFieldValue id rather than an amount
+          $fieldSpec['data_type'] = 'Integer';
+          if ($fieldSpec['is_enter_qty']) {
+            $fieldSpec['amount'] = reset($options)['amount'];
+          }
+        }
+      }
+
+      // add to sub array keyed by entity
+      // NOTE this allows the same field may appear multiple times on separate entities?
+      // if price_set_id.extends is multivalued... is it ever?
+      foreach ($priceField['price_set_id.extends'] ?? [] as $extendsId) {
+        $entity = $extendsIdToEntityMap[$extendsId];
+        $fieldSpec['extends'] = $entity;
+
+        // initialise sub-array for this entity if necessary
+        $fieldSpecs[$entity] ??= [];
+        $fieldSpecs[$entity][$fullName] = $fieldSpec;
+      }
+    }
+
+    return $fieldSpecs;
+  }
+
+  public static function getLineItemForPriceFieldValue(string $entityType, ?int $entityId, array $field, $fieldValue): array {
+    $entityTable = \Civi\Schema\EntityRepository::getEntity($entityType)['table'] ?? NULL;
+    $lineItem = [
+      'entity_type' => $entityType,
+      'entity_table' => $entityTable,
+      'entity_id' => $entityId,
+      'price_field_id' => $field['price_field_id'],
+      'label' => $field['label'],
+      // TODO: is this true/used? what if $entityType === 'Participant' ?
+      'participant_count' => 0,
+      // these will need to be populated per record
+      // 'field_title' => $field['label'],
+      // 'description' => E::ts('%1 ID: %2', [
+      //   1 => $entityType,
+      //   2 => $entityId,
+      // ]),
+      // 'contribution_id' => 1,
+      // 'qty' => 1,
+      // 'unit_price' => 125,
+      // 'line_total' => 125,
+      // 'participant_count' => 0,
+      // 'price_field_value_id' => 1,
+      // 'financial_type_id' => 1,
+      // 'non_deductible_amount' => 0,
+      // 'tax_amount' => 0,
+      // 'membership_num_terms' => NULL,
+    ];
+
+    // special handling for Default Contribution Amount
+    // this has one field value but the user will enter an amount
+    // rather than option id
+    if ($field['price_field_id'] === 1) {
+      $lineItem['qty'] = 1;
+      $lineItem['unit_price'] = $fieldValue;
+      // generic line item
+      $lineItem['price_field_value_id'] = 1;
+    }
+    elseif ($field['is_enter_qty'] ?? FALSE) {
+      $lineItem['qty'] = $fieldValue;
+      $lineItem['unit_price'] = $field['amount'];
+      $lineItem['price_field_value_id'] = array_keys($field['options'])[0];
+    }
+    elseif ($field['options'] ?? FALSE) {
+      if (!\array_key_exists($fieldValue, $field['options'])) {
+        throw new \CRM_Core_Exception("Invalid option ID {$fieldValue} for field ID {$field['price_field_id']}");
+      }
+      $lineItem['price_field_value_id'] = $fieldValue;
+      //$lineItem['description'] = "{$field['options'][$fieldValue]} ({$lineItem['description']})";
+    }
+    else {
+      $lineItem['qty'] = 1;
+      $lineItem['unit_price'] = $fieldValue;
+      // generic line item
+      $lineItem['price_field_value_id'] = 1;
+    }
+
+    return $lineItem;
+  }
+
+}

--- a/ext/civi_contribute/afformEntities/Contribution.php
+++ b/ext/civi_contribute/afformEntities/Contribution.php
@@ -1,4 +1,9 @@
 <?php
+
+if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+  return [];
+}
+
 return [
   'type' => 'primary',
   'defaults' => "{

--- a/ext/civi_contribute/afformEntities/Contribution.php
+++ b/ext/civi_contribute/afformEntities/Contribution.php
@@ -1,5 +1,7 @@
 <?php
 
+use CRM_Contribute_ExtensionUtil as E;
+
 if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
   return [];
 }
@@ -10,9 +12,20 @@ return [
     data: {
       contact_id: 'user_contact_id',
       financial_type_id: 1
+    },
+    actions: {
+      create: true,
+      update: false,
     }
   }",
   'boilerplate' => [
+    [
+      '#tag' => 'af-field',
+      'name' => 'default_contribution_amount.contribution_amount',
+      'defn' => [
+        'label' => E::ts('Contribution Amount'),
+      ],
+    ],
     [
       '#tag' => 'af-field',
       'name' => 'source',

--- a/ext/civi_contribute/afformEntities/Contribution.php
+++ b/ext/civi_contribute/afformEntities/Contribution.php
@@ -1,0 +1,16 @@
+<?php
+return [
+  'type' => 'primary',
+  'defaults' => "{
+    data: {
+      contact_id: 'user_contact_id',
+      financial_type_id: 1
+    }
+  }",
+  'boilerplate' => [
+    [
+      '#tag' => 'af-field',
+      'name' => 'source',
+    ],
+  ],
+];

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -41,6 +41,7 @@
     <mixin>scan-classes@1.0.0</mixin>
     <mixin>mgd-php@2.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
+    <mixin>afform-entity-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Contribute</namespace>

--- a/ext/civi_contribute/settings/Contribute.setting.php
+++ b/ext/civi_contribute/settings/Contribute.setting.php
@@ -210,4 +210,18 @@ return [
     'help_text' => ts('Enabling this setting will update related contribution of membership(s) except if the membership is paid for with a recurring contribution.'),
     'settings_pages' => ['contribute' => ['weight' => 20]],
   ],
+  'contribute_enable_afform_contributions' => [
+    'group_name' => 'Contribute Preferences',
+    'group' => 'contribute',
+    'name' => 'contribute_enable_afform_contributions',
+    'type' => 'Boolean',
+    'html_type' => 'toggle',
+    'default' => FALSE,
+    'add' => '6.14',
+    'title' => ts('Enable Contributions in FormBuilder'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => ts('Enable Contributions and Price Fields in FormBuilder.'),
+    'settings_pages' => ['contribute' => ['weight' => 100]],
+  ],
 ];

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Civi\Contribute;
+
+use Civi\Api4\Afform;
+use Civi\Contribute\Utils\PriceFieldUtils;
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test Contribution handling in Afform
+ *
+ * @group headless
+ */
+class AfformContributionTest extends TestCase implements HeadlessInterface {
+
+  protected int $eventId;
+  protected int $inPersonPriceFieldValueId;
+
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->install(['civi_event', 'org.civicrm.afform'])
+      ->apply();
+  }
+
+  public function setUp(): void {
+    \Civi::settings()->set('contribute_enable_afform_contributions', TRUE);
+
+    \Civi\Api4\PriceSet::save(FALSE)
+      ->addRecord([
+        // participant
+        'extends' => [1],
+        'name' => 'participant_fields',
+        'title' => 'Participant Options',
+      ])
+      ->addRecord([
+         // contribution
+        'extends' => [2],
+        'name' => 'donation_options',
+        'title' => 'Donation Options',
+      ])
+      ->execute();
+
+    $fields = \Civi\Api4\PriceField::save(FALSE)
+      ->addRecord([
+        'name' => 'ticket_option',
+        'label' => 'Ticket Option',
+        'html_type' => 'Radio',
+        'price_set_id:name' => 'participant_fields',
+      ])
+      ->addRecord([
+        'name' => 'additional_donation',
+        'label' => 'Additional Donation',
+        'html_type' => 'Text',
+        'price_set_id:name' => 'donation_options',
+      ])
+      ->execute();
+
+    $priceFieldValues = \Civi\Api4\PriceFieldValue::save(FALSE)
+      ->addRecord([
+        'name' => 'in_person',
+        'label' => 'In person',
+        'amount' => 10,
+        'price_field_id' => $fields[0]['id'],
+        'financial_type_id:name' => 'Event Fee',
+      ])
+      ->addRecord([
+        'name' => 'online',
+        'label' => 'Online',
+        'amount' => 5,
+        'price_field_id' => $fields[0]['id'],
+        'financial_type_id:name' => 'Event Fee',
+      ])
+      ->execute();
+
+    $event = \Civi\Api4\Event::save(FALSE)
+      ->addRecord([
+        'title' => 'Test event',
+        'event_type_id' => 1,
+        'start_date' => 'now',
+      ])
+      ->execute()->single();
+
+    $this->eventId = $event['id'];
+
+    $this->inPersonPriceFieldValueId = $priceFieldValues[0]['id'];
+
+    // reset the price field cache
+    // TODO: this should probably be included in post hook
+    unset(\Civi::$statics[PriceFieldUtils::class]);
+
+    $layout = <<<HTML
+    <af-form ctrl="afform">
+      <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="FBAC" />
+      <af-entity type="Participant" name="Participant1" label="Participant 1" data="{contact_id: 'Individual1'}" actions="{create: true, update: true}" security="FBAC" />
+      <af-entity type="Contribution" name="Contribution1" label="Contribution 1" data="{contact_id: 'Individual1', financial_type_id: 1}" actions="{create: true, update: false}" security="FBAC" />
+      <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+        <div class="af-container">
+          <af-field name="first_name" />
+          <af-field name="last_name" />
+        </div>
+      </fieldset>
+      <fieldset af-fieldset="Participant1" class="af-container" af-title="Participant 1">
+        <div class="af-container">
+          <!-- standard field for participant -->
+          <af-field name="event_id" defn="{required: true}" />
+          <!-- price field for participant -->
+          <af-field name="participant_fields.ticket_option" />
+        </div>
+      </fieldset>
+      <fieldset af-fieldset="Contribution1" class="af-container" af-title="Contribution 1">
+        <div class="af-container">
+          <!-- standard field for Contribution -->
+          <af-field name="source" />
+          <!-- price field for Contribution -->
+          <af-field name="donation_options.additional_donation" />
+        </div>
+      </fieldset>
+    </af-form>
+    HTML;
+
+    Afform::save(FALSE)
+      ->addRecord([
+        'name' => 'testAfformContribution',
+        'layout' => $layout,
+      ])
+      ->setLayoutFormat('html')
+      ->execute();
+
+  }
+
+  public function tearDown(): void {
+    \Civi\Api4\PriceFieldValue::delete(FALSE)
+      ->addWhere('name', 'IN', ['in_person', 'online'])
+      //->addWhere('id', '>', 0)
+      ->execute();
+
+    \Civi\Api4\PriceField::delete(FALSE)
+      ->addWhere('name', 'IN', ['ticket_option', 'additional_donation'])
+      //->addWhere('id', '>', 0)
+      ->execute();
+
+    \Civi\Api4\PriceSet::delete(FALSE)
+      ->addWhere('name', 'IN', ['participant_fields', 'donation_options'])
+      //->addWhere('id', '>', 0)
+      ->execute();
+
+    // \Civi\Api4\Afform::delete(FALSE)->addWhere('name', '=', 'testAfformContribution')->execute();
+
+    \Civi\Api4\Event::delete(FALSE)->addWhere('title', '=', 'Test event')->execute();
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testContributionCreate(): void {
+    $response = Afform::submit(FALSE)
+      ->setName('testAfformContribution')
+      ->setValues([
+        'Individual1' => [
+          [
+            'fields' => [
+              'first_name' => 'Test',
+              'last_name' => 'Contact',
+            ],
+          ],
+        ],
+        'Participant1' => [
+          [
+            'fields' => [
+              'event_id' => $this->eventId,
+              'participant_fields.ticket_option' => $this->inPersonPriceFieldValueId,
+            ],
+          ],
+        ],
+        'Contribution1' => [
+          [
+            'fields' => [
+              'source' => 'testContributionCreate',
+              // free text input
+              'donation_options.additional_donation' => 5,
+            ],
+          ],
+        ],
+      ])
+      ->execute();
+
+    // check a valid contribution ID
+    $contributionId = $response->single()['Contribution1'][0]['id'];
+    $this->assertEquals(TRUE, $contributionId > 0);
+
+    // check a valid participant ID
+    $participantId = $response->single()['Participant1'][0]['id'];
+    $this->assertEquals(TRUE, $participantId > 0);
+
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
+      ->addWhere('id', '=', $contributionId)
+      ->execute()
+      ->single();
+
+    // check expected amount
+    $this->assertEquals(15, $contribution['total_amount']);
+
+    // get line items
+    $lineItems = \Civi\Api4\LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionId)
+      ->execute();
+
+    // should have 2 line items
+    $this->assertEquals(2, $lineItems->count());
+
+    // should have 1 participant line item
+    $participantLineItems = array_filter((array) $lineItems, fn ($lineItem) => $lineItem['entity_table'] === 'civicrm_participant');
+    $this->assertEquals(1, count($participantLineItems));
+
+    // should be linked to the participant
+    $participantLineItem = array_values($participantLineItems)[0];
+    $this->assertEquals($participantId, $participantLineItem['entity_id']);
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testValidateLineItems(): void {
+    try {
+      $response = Afform::submit(FALSE)
+        ->setName('testAfformContribution')
+        ->setValues([
+          'Individual1' => [
+            [
+              'fields' => [
+                'first_name' => 'Test',
+                'last_name' => 'Contact',
+              ],
+            ],
+          ],
+          'Participant1' => [
+            [
+              'fields' => [
+                'event_id' => $this->eventId,
+                // 'participant_fields.ticket_option' => $this->inPersonPriceFieldValueId,
+              ],
+            ],
+          ],
+          'Contribution1' => [
+            [
+              'fields' => [
+                'source' => 'testContributionCreate',
+                // 'donation_options.additional_donation' => 5,
+              ],
+            ],
+          ],
+        ])
+        ->execute();
+
+      $this->fail('Afform::submit should have failed');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertEquals(TRUE, \str_contains($e->getMessage(), 'No line items'));
+    }
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds Contribution/LineItem handling in the CiviContribute extension. 

This is pulled from https://lab.civicrm.org/extensions/afform_payments . This half of the extension has more or less stabilised in the last few months. 

NOTE: this does not add payment processing. That is to follow.

Before
----------------------------------------
- no Contributions in FormBuilder

After
----------------------------------------
- Contribution entity can be added in FormBuilder
- Price Fields can be added to entities in FormBuilder
  - this works a bit like Custom Fields - configured Price Fields are available to add to the form
  - any combination of Price Fields can be added (Price Sets are basically ignored, except for determining the entity a Field belongs to)
  - these are then used to generate the Line Items for the Contribution when it is saved
- handling is currently only for new Contributions

Technical Details
----------------------------------------
When submitting an afform, the Contribution saving is handled slightly exceptionally to other Afform entities. In particular:
- saving is done using "Order" api (rather than `Contribution.save`)
- most Contribution values are taken from the Contribution record (as per a normal Afform entity)
- LineItems are gathered from PriceFields on the form. These may be on the Contribution, or on related entities (like Membership or Participant).

~Relies on https://github.com/civicrm/civicrm-core/pull/35043 and https://github.com/civicrm/civicrm-core/pull/35044 for enabling validation in FormBuilder (because there are some constraints when adding Contribution; these would ideally be added clientside as well, but that is trickier, and the more important thing is to validate serverside).~ Have returned to a "validate on submit" for now, which is suboptimal but avoids blocking on https://github.com/civicrm/civicrm-core/pull/35043


Comments
----------------------------------------
Merging into `civi_contribute` means the code is in the place it belongs in the long term, and doesn't have to be juggled between extensions.

The new functionality is gated with a "feature flag" setting which defaults to `FALSE` for now, so it is opt in on the CiviContribute Component Settings page for now, but can be updated to `TRUE` if and when this is totally stable.