### PR TITLE
SearchKit/FormBuilder (and edit contact) and move wrenches and gears to the bottom

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -100,7 +100,7 @@ details.af-container.af-layout-inline > *:not(summary) {
 #bootstrap-theme .afform-directive .af-admin-edit-form-link {
   position: absolute;
   right: 0;
-  top: 0;
+  bottom: 0;
 }
 #bootstrap-theme .af-admin-edit-form-link > button {
   background: transparent;

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -15,10 +15,7 @@
     {include file="CRM/Contact/Form/Edit/Lock.tpl"}
   {/if}
   <div class="crm-form-block crm-search-form-block">
-    {crmPermission has='administer CiviCRM'}
-      <a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts escape='htmlattribute'}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" role="img" aria-hidden="true"></i></a>
-    {/crmPermission}
-    <span style="float:right;"><a href="#expand" id="expand">{ts}Expand all tabs{/ts}</a></span>
+    <span class="float-right"><a href="#expand" id="expand">{ts}Expand all tabs{/ts}</a></span>
     <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="top"}
     </div>
@@ -90,6 +87,9 @@
     <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
+    {crmPermission has='administer CiviCRM'}
+      <span class="float-right"><a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts escape='htmlattribute'}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" role="img" aria-hidden="true"></i></a></span>
+    {/crmPermission}
   </div>
   {literal}
 


### PR DESCRIPTION
Overview
----------------------------------------

Moves the "edit" gears and wrenches to the bottom of the screen.

For most people, they are distracting. They feel like a Drupal-ism. I was hesitating to hide them completely in TheIsland, I figured this was a better compromise.

This applies to both backend screens, as well as public forms.

Before
----------------------------------------

Contact relationships:

<img width="3362" height="1648" alt="2026-03-08_13-53" src="https://github.com/user-attachments/assets/a5c5ec9d-a33f-442e-b0e3-fba2316b2201" />

Edit Contact:

<img width="3358" height="804" alt="2026-03-08_13-53_1" src="https://github.com/user-attachments/assets/85c47560-3d1b-43fe-8f99-97f344e83ac7" />

After
----------------------------------------

<img width="3344" height="1918" alt="2026-03-08_13-52" src="https://github.com/user-attachments/assets/a6f7f56e-cc75-44cf-8f56-90557226d88f" />

Edit Contact:

<img width="3346" height="836" alt="2026-03-08_13-56" src="https://github.com/user-attachments/assets/d3097977-2144-421c-9ec5-358cddd3a108" />

Comments
----------------------------------------

I would do the same for Event Info pages, even if that might annoy some people, but I do it for many clients sites, because the icons like a bug more than a feature.


cc @colemanw 