### PR TITLE
River: moves most of .label- utility classes from #Bootstrap to core

### DIFF
--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -3369,23 +3369,8 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
   padding: 9px 14px;
 }
 
-/* Labels */
+/* Labels - not moved to .crm-container to avoid clash with other use of .label */
 
-#bootstrap-theme .label-primary,
-#bootstrap-theme .label-warning,
-#bootstrap-theme .label-success,
-#bootstrap-theme .label-default,
-#bootstrap-theme .label-info,
-#bootstrap-theme .label-danger {
-  display: inline;
-  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
-  font-weight: normal;
-  color: var(--crm-text-light-color);
-  text-align: center;
-  white-space: nowrap;
-  vertical-align: baseline;
-  border-radius: var(--crm-l-radius);
-}
 #bootstrap-theme .label:empty {
   display: none;
 }
@@ -3397,54 +3382,6 @@ fieldset[disabled] #bootstrap-theme .navbar-inverse .btn-link:focus {
 #bootstrap-theme a.label:focus {
   text-decoration: none;
   cursor: var(--crm-link-hover-cursor);
-}
-#bootstrap-theme .label-default {
-  background: var(--crm-c-darkest);
-  color: var(--crm-text-light-color);
-}
-#bootstrap-theme .label-default[href]:hover,
-#bootstrap-theme .label-default[href]:focus {
-  background: color-mix(in srgb, var(--crm-c-darkest) 87.5%, #fff 12.5%);
-}
-#bootstrap-theme .label-primary {
-  background: var(--crm-primary-color);
-  color: var(--crm-primary-text-color);
-}
-#bootstrap-theme .label-primary[href]:hover,
-#bootstrap-theme .label-primary[href]:focus {
-  background: var(--crm-primary-hover-color);
-}
-#bootstrap-theme .label-success {
-  background: var(--crm-success-color);
-  color: var(--crm-success-text-color);
-}
-#bootstrap-theme .label-success[href]:hover,
-#bootstrap-theme .label-success[href]:focus {
-  background: color-mix(in srgb, var(--crm-success-color) 87.5%, #000 12.5%);
-}
-#bootstrap-theme .label-info {
-  background: var(--crm-info-color);
-  color: var(--crm-info-text-color);
-}
-#bootstrap-theme .label-info[href]:hover,
-#bootstrap-theme .label-info[href]:focus {
-  background: color-mix(in srgb, var(--crm-info-color) 87.5%, #000 12.5%);
-}
-#bootstrap-theme .label-warning {
-  background: var(--crm-warning-color);
-  color: var(--crm-warning-text-color);
-}
-#bootstrap-theme .label-warning[href]:hover,
-#bootstrap-theme .label-warning[href]:focus {
-  background: color-mix(in srgb, var(--crm-warning-color) 87.5%, #000 12.5%);
-}
-#bootstrap-theme .label-danger {
-  background: var(--crm-danger-color);
-  color: var(--crm-danger-text-color);
-}
-#bootstrap-theme .label-danger[href]:hover,
-#bootstrap-theme .label-danger[href]:focus {
-  background: color-mix(in srgb, var(--crm-danger-color) 87.5%, #000 12.5%);
 }
 #bootstrap-theme .label i.crm-i {
   color: inherit; /* resets icons inside labels to use the label text colour */

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -220,7 +220,7 @@ table.advmultiselect {
   box-shadow: none;
   border-radius: var(--crm-l-radius);
 }
-.crm-container .panel-body:before, #bootstrap-theme .panel-body:after {
+.crm-container .panel-body:before, .crm-container .panel-body:after {
   display: table;
   content: " ";
 }
@@ -489,6 +489,72 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 }
 .crm-status-box-outer.status-error .crm-status-box-inner {
   background: var(--crm-danger-color);
+}
+
+/* Labels */
+
+.crm-container .label-primary,
+.crm-container .label-warning,
+.crm-container .label-success,
+.crm-container .label-default,
+.crm-container .label-info,
+.crm-container .label-danger {
+  display: inline;
+  padding: var(--crm-btn-padding-block) var(--crm-btn-padding-inline);
+  font-weight: normal;
+  color: var(--crm-text-light-color);
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: var(--crm-l-radius);
+}
+.crm-container .label-default {
+  background: var(--crm-c-darkest);
+  color: var(--crm-text-light-color);
+}
+.crm-container .label-default[href]:hover,
+.crm-container .label-default[href]:focus {
+  background: color-mix(in srgb, var(--crm-c-darkest) 87.5%, var(--crm-paper) 12.5%);
+}
+.crm-container .label-primary {
+  background: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
+}
+.crm-container .label-primary[href]:hover,
+.crm-container .label-primary[href]:focus {
+  background: var(--crm-primary-hover-color);
+}
+.crm-container .label-success {
+  background: var(--crm-success-color);
+  color: var(--crm-success-text-color);
+}
+.crm-container .label-success[href]:hover,
+.crm-container .label-success[href]:focus {
+  background: color-mix(in srgb, var(--crm-success-color) 87.5%, var(--crm-ink) 12.5%);
+}
+.crm-container .label-info {
+  background: var(--crm-info-color);
+  color: var(--crm-info-text-color);
+}
+.crm-container .label-info[href]:hover,
+.crm-container .label-info[href]:focus {
+  background: color-mix(in srgb, var(--crm-info-color) 87.5%, var(--crm-ink) 12.5%);
+}
+.crm-container .label-warning {
+  background: var(--crm-warning-color);
+  color: var(--crm-warning-text-color);
+}
+.crm-container .label-warning[href]:hover,
+.crm-container .label-warning[href]:focus {
+  background: color-mix(in srgb, var(--crm-warning-color) 87.5%, var(--crm-ink) 12.5%);
+}
+.crm-container .label-danger {
+  background: var(--crm-danger-color);
+  color: var(--crm-danger-text-color);
+}
+.crm-container .label-danger[href]:hover,
+.crm-container .label-danger[href]:focus {
+  background: color-mix(in srgb, var(--crm-danger-color) 87.5%, var(--crm-ink) 12.5%);
 }
 
 /* Background regions */


### PR DESCRIPTION
Overview
----------------------------------------
In Bootstrap3 there are useful utility classes to create tags or labels, that look like buttons but without click activity. This PR moves to Civi core to allow for use with the `#bootstrap-theme` wrapper, following discussion here: https://github.com/civicrm/civicrm-core/pull/35025

Before
----------------------------------------
Label styling needs to be wrapped in `#bootstrap-theme`.

After
----------------------------------------
It doesn't.

Technical Details
----------------------------------------
There's a little complexity here in that `.label` was used across Civi before Bootstrap and is still used. As a result, the CSS that defines *only* `.label` are kept within the bootstrap.css file with the `#bootstrap-theme` prefix so that they are only applied intentionally (in the exact same way they are currently applied). But the `.label-info/default/primary/warning/danger/success` classes now should work anywhere in Civi, without the `#bootstrap-theme` wrapper 

Comments
----------------------------------------
This PR lowers the specificity of these label colours. So if label was defined inside another region with bg/foreground colours defined, this PR could change the appearance there. But I can't think of any examples - the nearest is SearchKit tables but that uses `bg-emphasis-color` and `btn-emphasis-color` but not label.

Sidenote, while making this change I also fixed something [that had got missed here](https://github.com/civicrm/civicrm-core/compare/master...vingle:civicrm-core:bootstrap-theme-move?expand=1#diff-9d7f6e4ddd8fe0f8f564fcc7f898438d649af38d2ebd023a707b41c505c79662R223), and chanced instances of `#000` in the hover color mix to `--crm-ink` - which has the effect of darkening the hover in light mode, and lightening the hover in dark mode.