### PR TITLE
SearchKit - Fix double-call of onInitialize

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -59,9 +59,6 @@
           });
         }
 
-        _.each(ctrl.onInitialize, function(callback) {
-          callback.call(ctrl, $scope, $element);
-        });
         ctrl.onInitialize.forEach(callback => callback.call(ctrl, $scope, $element));
 
         // _.debounce used here to trigger the initial search immediately but prevent subsequent launches within 300ms


### PR DESCRIPTION
Overview
----------------------------------------
Fixes duplicative function call in SearchKit.

This was probably a mistake made during merge-conflict resolution.
