### PR TITLE
Add prefetched entity data to TokenRow context

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -469,6 +469,11 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       'select' => $select,
       'where' => [['id', 'IN', $entityIDs]],
     ], 'id');
+    if ($result) {
+      foreach ($e->getRows() as $row) {
+        $row->context($this->entity, $result[$row->context[$this->getEntityIDField()]]);
+      }
+    }
     return $result;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
If you have a TokenValueEvent subscriber, you might like to be able to access context data for additional entities. However, only the contact data is available in the TokenRow context.

Before
----------------------------------------
Prefetched data is not added to TokenRow context.

After
----------------------------------------
Data is added to TokenRow context.

Comments
----------------------------------------
This also makes the availability of data for additional entities consistent between real workflow message flows and example data provided in message template preview. Otherwise, if you want to add a token in a subscriber, you have to handle the two cases separately to make the preview work the same as the real thing.