### PR TITLE
SearchKit - Make loading 600ms faster

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -109,7 +109,7 @@
           ctrl.page = 1;
           ctrl.rowCount = null;
           ctrl.onChangeFilters.forEach(callback => callback.call(ctrl));
-          if (!ctrl.settings.button) {
+          if (!ctrl.settings.button && !ctrl.doingFirstRun) {
             ctrl.getResultsSoon();
           }
         }
@@ -117,7 +117,7 @@
         function onChangePageSize() {
           ctrl.page = 1;
           // Only refresh if search has already been run
-          if (ctrl.results) {
+          if (ctrl.results && !ctrl.doingFirstRun) {
             ctrl.getResultsSoon();
           }
         }
@@ -151,9 +151,15 @@
         }
 
         // Set up watches to refresh search results when needed.
-        // Because `angular.$watch` runs immediately as well as on subsequent changes,
-        // this also kicks off the first run of the search (if there's no search button).
+        // And trigger the first run of the search if appropriate.
         function setUpWatches() {
+          // Kick off first run of the search if there's no search button.
+          if (!ctrl.settings.button) {
+            ctrl.getResultsPronto();
+            // Prevent the below watchers from running the search while we're already doing it.
+            ctrl.doingFirstRun = true;
+            $timeout(() => ctrl.doingFirstRun = false, 1000);
+          }
           if (ctrl.afFieldset) {
             $scope.$watch(ctrl.afFieldset.getFilterValues, onChangeFilters, true);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Ensures the initial run of a search display starts without delay.

This restores the snappiness from https://github.com/civicrm/civicrm-core/pull/25408 which got lost somewhere along the way.

Thanks to @artfulrobot for the initial fix, and apologies if I'm the one who mucked it up. There's been a lot of refactoring lately.
