### PR TITLE
composer.json - Apply PHP 8.x patches for xkerman/restricted-unserialize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
     "league/oauth2-client": "^2.8",
     "league/oauth2-google": "^4.0",
     "tplaner/when": "~3.1",
-    "xkerman/restricted-unserialize": "~1.1",
+    "xkerman/restricted-unserialize": "~1.1.12",
     "typo3/phar-stream-wrapper": "^3.0 || ^4.0",
     "brick/money": ">=0.9 <0.11",
     "pear/mail_mime": "~1.10",
@@ -304,6 +304,9 @@
       },
       "pear/net_smtp": {
         "Add in CiviCRM custom error message for CRM-8744": "https://download.civicrm.org/patches/ee02d81d09432e524b249c9d874c9756b88924df8f5a8d69b19e8b4d6f532327/error-msg.patch"
+      },
+      "xkerman/restricted-unserialize": {
+        "Fix warnings on PHP 8.4 and PHP 8.5": "https://download.civicrm.org/patches/1f01239f400e9aff4e59c2e744fc73bdfb48c6c3b0e93665851b7be763b2716b/php84-php85.patch"
       },
       "zetacomponents/mail": {
         "CiviCRM Custom Patches for ZetaCompoents mail": "https://download.civicrm.org/patches/6e4bd36dd432a1e62830b0c757a3bac9645ea1cfc551db39798a88c06d66aaf3/100-filename.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "139a6fb22d498a0dbedfabbbacfd660d",
+    "content-hash": "59c746676f061974d5f78dca6012a8e7",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -6202,5 +6202,5 @@
     "platform-overrides": {
         "php": "8.1.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tools/patches/raw/xkerman/restricted-unserialize/php84-php85.patch
+++ b/tools/patches/raw/xkerman/restricted-unserialize/php84-php85.patch
@@ -1,0 +1,46 @@
+From 9fcbd035d113a0482b517fc311b0af91ca3e2df8 Mon Sep 17 00:00:00 2001
+From: Tim Otten <totten@civicrm.org>
+Date: Mon, 9 Mar 2026 20:36:44 -0700
+Subject: [PATCH 1/2] Fix PHP 8.4 deprecation
+
+Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /Users/totten/src/restricted-unserialize/test/TestCase.php on line 16
+---
+ test/TestCase.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/TestCase.php b/test/TestCase.php
+index b779b6a..a2d1f9f 100644
+--- a/test/TestCase.php
++++ b/test/TestCase.php
+@@ -13,7 +13,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
+     public function __call($name, $arguments)
+     {
+         if ($name !== 'expectException') {
+-            throw new \BadMethodCallException("undefined method: ${name}");
++            throw new \BadMethodCallException("undefined method: {$name}");
+         }
+ 
+         $exception = $arguments[0];
+
+From c1758c45800d636098cea0be0e9d41cff59a17ee Mon Sep 17 00:00:00 2001
+From: Tim Otten <totten@civicrm.org>
+Date: Mon, 9 Mar 2026 20:38:59 -0700
+Subject: [PATCH 2/2] Fix PHP 8.5 deprecation
+
+Deprecated: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in /Users/totten/src/restricted-unserialize/src/BooleanHandler.php on line 22
+---
+ src/BooleanHandler.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/BooleanHandler.php b/src/BooleanHandler.php
+index 049eec3..0db97a9 100644
+--- a/src/BooleanHandler.php
++++ b/src/BooleanHandler.php
+@@ -19,6 +19,6 @@ class BooleanHandler implements HandlerInterface
+      */
+     public function handle(Source $source, $args)
+     {
+-        return array((boolean)$args, $source);
++        return array((bool)$args, $source);
+     }
+ }

--- a/tools/patches/raw/xkerman/restricted-unserialize/php84-php85.txt
+++ b/tools/patches/raw/xkerman/restricted-unserialize/php84-php85.txt
@@ -1,0 +1,1 @@
+Fix warnings on PHP 8.4 and PHP 8.5


### PR DESCRIPTION
Overview
----------------------------------------

When running `cv` test-suite with `civicrm-core` on php85, I see some failures related to `xkerman/restricted-unserialize`. These relate to new warnings.

Comments
----------------------------------------

I've also sent the patch upstream (https://github.com/xKerman/restricted-unserialize/pull/146). However, the project hasn't been updated in a few years, so I'm not certain when/if they'll take a look.

To reduce the chance of raciness between upstream+here, I've also tightened the version-constraint to match the patch.