### PR TITLE
Contribution Page ignores "Someone Else" when trying to update a membership

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -426,7 +426,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     parent::preProcess();
     $this->_ccid = $this->getExistingContributionID();
 
-    $this->_params = $this->controller->exportValues('Main');
     $this->_params['ip_address'] = CRM_Utils_System::ipAddress();
     $this->_params['amount'] = $this->getMainContributionAmount();
     if (isset($this->_params['amount'])) {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -390,6 +390,8 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    * @throws \Exception
    */
   public function preProcess() {
+    // Get form field values.
+    $this->_params = $this->controller->exportValues('Main');
 
     // current contribution page id
     $this->getContributionPageID();

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2375,12 +2375,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @throws \CRM_Core_Exception
    */
   public function getRequestedContactID(): ?int {
-    if (isset($this->_params) && !empty($this->_params['select_contact_id'])) {
-      return (int) $this->_params['select_contact_id'];
-    }
-    if (isset($this->_params, $this->_params[0]) && !empty($this->_params[0]['select_contact_id'])) {
-      // Event form stores as an indexed array, contribution form not so much...
-      return (int) $this->_params[0]['select_contact_id'];
+    if ($this->getSubmittedValue('select_contact_id')) {
+      return (int) $this->getSubmittedValue('select_contact_id');
     }
     $urlContactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
     return is_numeric($urlContactID) ? (int) $urlContactID : NULL;

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1623,6 +1623,64 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test renewing an existing membership when using the "Someone else"
+   * option on the ContributionPage.
+   */
+  public function testSubmitSomeoneElseMembershipRenewal(): void {
+    // Create and log in a contact "logged_in"
+    $this->createLoggedInUser();
+    // Create a another contact called "member"
+    $this->individualCreate([], 'member');
+    $this->restoreMembershipTypes();
+    $membershipTypes = \CRM_Member_BAO_MembershipType::getAllMembershipTypes();
+    // Make sure the MembershipType ids are set as restoreMembershipTypes just uses Api4 to create the types.
+    if (!empty($membershipTypes)) {
+      foreach ($membershipTypes as $membershipType) {
+        $name = strtolower($membershipType['name']);
+        if (empty($this->ids['MembershipType'][$name])) {
+          $this->ids['MembershipType'][$name] = $membershipType['id'];
+        }
+      }
+    }
+    $this->contributionPageQuickConfigCreate([], [], FALSE, TRUE, TRUE, TRUE, 'existingMemberPage');
+    $year = (int) (CRM_Utils_Time::date('Y')) - 1;
+    // Create original membership for member contact.
+    $original_membership = Membership::create(FALSE)
+      ->addValue('membership_type_id:name', 'Student')
+      ->addValue('contact_id', $this->ids['Contact']['member'])
+      ->addValue('start_date', $year . '-01-01')
+      ->addValue('join_date', $year . '-01-01')
+      ->addValue('end_date', $year . '-12-31')
+      ->execute()
+      ->first();
+    $this->createPriceSetWithPage();
+    // Submit the form as the logged_in contact, but renewal should be for member contact.
+    $this->submitOnlineContributionForm([
+      'contact_id' => $this->ids['Contact']['logged_in'],
+      'select_contact_id' => $this->ids['Contact']['member'],
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['contribution_amount'] => -1,
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_student'],
+      'id' => $this->getContributionPageID('existingMemberPage'),
+      'credit_card_exp_date' => [
+        'M' => 9,
+        'Y' => (int) (CRM_Utils_Time::date('Y')) + 1,
+      ],
+    ] + $this->getBillingSubmitValues(),
+    $this->getContributionPageID('existingMemberPage'), ['cid' => $this->ids['Contact']['logged_in']]);
+
+    $this->callAPISuccessGetSingle('Contribution', [
+      'contact_id' => $this->ids['Contact']['member'],
+    ]);
+    $membership = Membership::get(FALSE)
+      ->addWhere('contact_id', '=', $this->ids['Contact']['member'])
+      ->execute()
+      ->first();
+    // Make sure that the end data has changed since payment succeeded.
+    $this->assertGreaterThan($original_membership['end_date'], $membership['end_date']);
+  }
+
+  /**
    * Test form submission zero dollars with basic price set.
    */
   public function testSubmitZeroDollar(): void {


### PR DESCRIPTION
Overview
----------------------------------------
_When the ContributionBase is checking for the 'select_contact_id' from the `_params` variable, the `_params` variables hasn't been set. This change forces the `_params` to be set before anything is checked._

Before
----------------------------------------
When choosing the "Not _Current Contact_, or want to do this for a different person" option on the ContributionPage, it is setting the `cid` to 0. Then when the form is being processed, the `cid` value is being used as the `_params` variable hasn't been set and in the [`getRequestedContactID`](https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/Form.php#L2377), it tries to check for the 'select_contact_id' for the someone else, but the `_params` variable is empty.

After
----------------------------------------
_Changed the ContributionBase->preProcess to initialize the `_params` variable first before attempting to do any processing for the page. This makes sure that the "someone else" selection is used for the contactID._

Technical Details
----------------------------------------
_This seems like a potential regression, but I haven't had a chance to dig back enough to see where the change was. There has been a lot of changes to  the Contribution section in the past few months. I am also not sure if this may need to be moved to the `CRM_Core_Form` or if is needs to be added somewhere else to make sure the `select_contact_id` is set and present in the `_params` variable when it is part of the submission._

cc: @eileenmcnaughton 