### PR TITLE
Add workflow name to token context

### DIFF
--- a/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
+++ b/Civi/WorkflowMessage/Traits/ReflectiveWorkflowTrait.php
@@ -112,12 +112,14 @@ trait ReflectiveWorkflowTrait {
    * @see \Civi\WorkflowMessage\WorkflowMessageInterface::export()
    */
   public function export(?string $format = NULL): ?array {
+    $values = [];
     switch ($format) {
+      case 'tokenContext':
+        $values += ['workflow' => $this->getWorkflowName()];
       case 'modelProps':
       case 'envelope':
-      case 'tokenContext':
       case 'tplParams':
-        $values = $this->_extras[$format] ?? [];
+        $values += $this->_extras[$format] ?? [];
         $fieldsByFormat = $this->getFieldsByFormat($format);
         foreach ($fieldsByFormat as $key => $field) {
           /** @var \Civi\WorkflowMessage\FieldSpec $field */


### PR DESCRIPTION
If you have a TokenValueEvent subscriber, you might like to know which workflow you are rendering tokens for.