### PR TITLE
Fix Multi-Record Custom Field Autocomplete

### DIFF
--- a/Civi/Api4/Service/Autocomplete/CustomValueAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/CustomValueAutocompleteProvider.php
@@ -36,7 +36,7 @@ class CustomValueAutocompleteProvider extends \Civi\Core\Service\AutoService imp
     // Custom groups could contain any fields & we have no idea what's in them
     // but this is just the default display and can be overridden.
     // Our best guess for a "title" is the first text field in the group
-    $titleField = \Civi\Api4\CustomValue::getFields('Multi_Stuff', FALSE)
+    $titleField = \Civi\Api4\CustomValue::getFields($customGroupName, FALSE)
       ->addWhere('data_type', '=', 'String')
       ->addWhere('input_type', '=', 'Text')
       ->execute()->first()['name'] ?? NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Autocomplete for multi-record custom fields was causing an error (see stacktrace below). It appears to be a simple fix by removing a hardcoded string and using an existing variable. I experienced this issue on CiviCRM 6.11.0 and 6.12.0. I can confirm this patch allows the autocomplete to function correctly and not error out.

It would be great to write some tests for this class. I'm a new contributor and would need some more time and direction to make that happen. 

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
[Stacktrace](https://github.com/user-attachments/files/25881662/CiviCRM.bug.txt)

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
