### PR TITLE
Contribution Autocomplete: Don't search by total_amount

### DIFF
--- a/Civi/Api4/Service/Autocomplete/ContributionAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContributionAutocompleteProvider.php
@@ -58,6 +58,7 @@ class ContributionAutocompleteProvider extends \Civi\Core\Service\AutoService im
       return;
     }
     $e->display['settings'] = [
+      'searchFields' => ['id', 'contact_id.sort_name'],
       'sort' => [
         ['contact_id.sort_name', 'ASC'],
         ['total_amount', 'ASC'],


### PR DESCRIPTION
I can't imagine you'd often want to search a contribution autocomplete by the donation amount. The total_amount LIKE 'NNN%' query generated can be slow when you have many contributions.

This was being added because it was part of the rewrite on the first column in the SearchDisplay, so probably not because someone specifically wanted it.