### PR TITLE
Show (Sold out) on full options on New Event Registration

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2046,6 +2046,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
     //build the priceset fields.
     // This is probably not required now - normally loaded from event ....
     $this->add('hidden', 'priceSetId', $this->getPriceSetID());
+    $recordedOptionsCount = CRM_Event_BAO_Participant::priceSetOptionsCount($this->getEventID());
 
     foreach ($this->getPriceFieldMetaData() as $field) {
       // public AND admin visibility fields are included for back-office registration and back-office change selections
@@ -2061,7 +2062,18 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
         continue;
       }
 
+      $optionFullIds = [];
+      foreach ($options as $option) {
+        if (isset($recordedOptionsCount[$option['id']]) && ($recordedOptionsCount[$option['id']] >= $option['max_value'])) {
+          $optionFullIds[$option['id']] = $option['id'];
+        }
+      }
+
       //soft suppress required rule when option is full.
+      if (!empty($optionFullIds) && (count($options) == count($optionFullIds))) {
+        $isRequire = FALSE;
+      }
+
       if (!empty($options)) {
         //build the element.
         CRM_Price_BAO_PriceField::addQuickFormElement($this,
@@ -2070,7 +2082,8 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
           FALSE,
           $isRequire,
           NULL,
-          $options
+          $options,
+          $optionFullIds
         );
       }
     }


### PR DESCRIPTION
Before
----------------------------------------
Sold out options are not shown as sold out on this form.
<img width="814" height="684" alt="image" src="https://github.com/user-attachments/assets/371b6717-a8c2-415a-add8-75ab7cd7e58a" />

After
----------------------------------------
Sold out options are marked as sold out.
<img width="1124" height="750" alt="image" src="https://github.com/user-attachments/assets/8f9537ad-178b-4eec-ab0f-db115385035e" />

Comments
----------------------------------------
Follow up to #33254. This makes it so the new event registration and edit participant forms show sold out in the same way (and behave in the same way with the previous PR).

Repost of #33572.