### PR TITLE
(PHP 8.5) Hush deprecation notice re: MYSQL_ATTR_USE_BUFFERED_QUERY

### DIFF
--- a/Civi/Test.php
+++ b/Civi/Test.php
@@ -84,10 +84,12 @@ class Test {
       $dsninfo = self::dsn();
       $host = $dsninfo['hostspec'];
       $port = @$dsninfo['port'];
+      // PHP 8.4 introduced Pdo\Mysql constants, and PHP 8.5 strongly prefers the new constants. But they're invalid on PHP 8.1-8.3.
+      $bufferedQuery = defined('Pdo\Mysql::ATTR_USE_BUFFERED_QUERY') ? \Pdo\Mysql::ATTR_USE_BUFFERED_QUERY : PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
       try {
         self::$singletons['pdo'] = new PDO("mysql:host={$host}" . ($port ? ";port=$port" : ""),
           $dsninfo['username'], $dsninfo['password'],
-          [PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE]
+          [$bufferedQuery => TRUE]
         );
       }
       catch (PDOException $e) {


### PR DESCRIPTION
Overview
----------------------------------------

The warning says this:

```
Deprecated: Constant PDO::MYSQL_ATTR_USE_BUFFERED_QUERY is deprecated since 8.5, 
use Pdo\Mysql::ATTR_USE_BUFFERED_QUERY instead 
in /home/totten/bknix/build/dev/web/core/Civi/Test.php on line 90
```

It's going to be a few years before we can use the new constant straight-up. In the mean time, there's no point seeing the warning.