### PR TITLE
CiviCase - Standardize delete api & hooks

### DIFF
--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -50,6 +50,19 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
     return $result;
   }
 
+  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $e) {
+    $moveToTrash = $e->action === 'edit' && !empty($e->params['is_deleted']) && !self::getDbVal('is_deleted', $e->id);
+    // When trashing or deleting a case, do the same to the activities
+    if ($moveToTrash || $e->action === 'delete') {
+      $activities = self::getCaseActivityDates($e->id);
+      if ($activities) {
+        foreach ($activities as $value) {
+          CRM_Activity_BAO_Activity::deleteActivity($value, $moveToTrash);
+        }
+      }
+    }
+  }
+
   /**
    * @param \Civi\Core\Event\PostEvent $e
    */
@@ -57,6 +70,12 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
     // FIXME: The EventScanner ought to skip over disabled components when registering HookInterface
     if (!CRM_Core_Component::isEnabled('CiviCase')) {
       return;
+    }
+    // After deleting or moving case to trash, disable case relationships
+    if ($e->entity === 'Case' &&
+      (($e->action === 'edit' && !empty($e->params['is_deleted'])) || $e->action === 'delete')
+    ) {
+      self::enableDisableCaseRelationships($e->id, FALSE);
     }
     if ($e->entity === 'Activity' && in_array($e->action, ['create', 'edit'])) {
       /** @var CRM_Activity_DAO_Activity $activity */
@@ -217,8 +236,7 @@ WHERE civicrm_case.id = %1";
   }
 
   /**
-   * Delete the record that are associated with this case.
-   * record are deleted from case
+   * @deprecated
    *
    * @param int $caseId
    *   Id of the case to delete.
@@ -226,43 +244,20 @@ WHERE civicrm_case.id = %1";
    * @param bool $moveToTrash
    *
    * @return bool
-   *   is successful
+   * @throws \CRM_Core_Exception
    */
   public static function deleteCase($caseId, $moveToTrash = FALSE) {
-    CRM_Utils_Hook::pre('delete', 'Case', $caseId);
-
-    //delete activities
-    $activities = self::getCaseActivityDates($caseId);
-    if ($activities) {
-      foreach ($activities as $value) {
-        CRM_Activity_BAO_Activity::deleteActivity($value, $moveToTrash);
-      }
-    }
-
     if (!$moveToTrash) {
       $transaction = new CRM_Core_Transaction();
-    }
-    $case = new CRM_Case_DAO_Case();
-    $case->id = $caseId;
-    if (!$moveToTrash) {
-      $result = $case->delete();
+      self::deleteRecord(['id' => $caseId]);
       $transaction->commit();
     }
     else {
-      $result = $case->is_deleted = 1;
-      $case->save();
+      $updateParams = ['id' => $caseId, 'is_deleted' => 1];
+      self::create($updateParams);
     }
 
-    if ($result) {
-      // CRM-7364, disable relationships
-      self::enableDisableCaseRelationships($caseId, FALSE);
-
-      CRM_Utils_Hook::post('delete', 'Case', $caseId, $case);
-
-      return TRUE;
-    }
-
-    return FALSE;
+    return TRUE;
   }
 
   /**

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -236,7 +236,7 @@ WHERE civicrm_case.id = %1";
   }
 
   /**
-   * @deprecated
+   * Deletes a case or moves it to the trash.
    *
    * @param int $caseId
    *   Id of the case to delete.

--- a/CRM/Case/BAO/Case.php
+++ b/CRM/Case/BAO/Case.php
@@ -16,11 +16,12 @@
  */
 
 use Civi\Api4\Activity;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * This class contains the functions for Case Management.
  */
-class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInterface {
+class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements EventSubscriberInterface {
 
   /**
    * Static field for all the case information that we can potentially export.
@@ -28,6 +29,13 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
    * @var array
    */
   public static $_exportableFields = NULL;
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_civicrm_pre' => ['_on_hook_civicrm_pre', -200],
+      'hook_civicrm_post' => ['_on_hook_civicrm_post', 200],
+    ];
+  }
 
   /**
    * Create a case object.
@@ -50,7 +58,10 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
     return $result;
   }
 
-  public static function self_hook_civicrm_pre(\Civi\Core\Event\PreEvent $e) {
+  public static function _on_hook_civicrm_pre(\Civi\Core\Event\PreEvent $e) {
+    if ($e->entity !== 'Case') {
+      return;
+    }
     $moveToTrash = $e->action === 'edit' && !empty($e->params['is_deleted']) && !self::getDbVal('is_deleted', $e->id);
     // When trashing or deleting a case, do the same to the activities
     if ($moveToTrash || $e->action === 'delete') {
@@ -66,7 +77,7 @@ class CRM_Case_BAO_Case extends CRM_Case_DAO_Case implements \Civi\Core\HookInte
   /**
    * @param \Civi\Core\Event\PostEvent $e
    */
-  public static function on_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
+  public static function _on_hook_civicrm_post(\Civi\Core\Event\PostEvent $e): void {
     // FIXME: The EventScanner ought to skip over disabled components when registering HookInterface
     if (!CRM_Core_Component::isEnabled('CiviCase')) {
       return;

--- a/ext/civi_case/Civi/Api4/Action/CiviCase/Delete.php
+++ b/ext/civi_case/Civi/Api4/Action/CiviCase/Delete.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\CiviCase;
+
+/**
+ * @inheritDoc
+ * @method $this setUseTrash(bool $useTrash) Pass TRUE to move Case to trash instead of deleting
+ * @method bool getUseTrash()
+ */
+class Delete extends \Civi\Api4\Generic\DAODeleteAction {
+
+  /**
+   * Should $ENTITY be moved to the trash instead of permanently deleted?
+   * @var bool
+   */
+  protected $useTrash = FALSE;
+
+  /**
+   * @param $items
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function deleteObjects($items) {
+    foreach ($items as $item) {
+      \CRM_Case_BAO_Case::deleteCase($item['id'], $this->useTrash);
+      $ids[] = ['id' => $item['id']];
+    }
+    return $ids;
+  }
+
+}

--- a/ext/civi_case/Civi/Api4/CiviCase.php
+++ b/ext/civi_case/Civi/Api4/CiviCase.php
@@ -59,4 +59,13 @@ class CiviCase extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\CiviCase\Delete
+   */
+  public static function delete($checkPermissions = TRUE) {
+    return (new Action\CiviCase\Delete('Case', __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -373,4 +373,44 @@ class CaseTest extends Api4TestBase {
     $this->assertEquals(['A' => $case1, 'B' => $case1, 'C' => $case1, 'D' => $case1], $result);
   }
 
+  public function testCaseSoftDelete(): void {
+    // Create a case with a relationship and activity
+    $case = $this->createTestRecord('Case');
+
+    $activity = $this->createTestRecord('Activity', [
+      'case_id' => $case['id'],
+      'subject' => 'Test Activity',
+    ]);
+
+    // Get the relationship created with the case
+    $relationships = Relationship::get(FALSE)
+      ->addWhere('case_id', '=', $case['id'])
+      ->execute();
+    $relationshipId = $relationships[0]['id'];
+
+    // Delete the case with useTrash = TRUE
+    CiviCase::delete(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->setUseTrash(TRUE)
+      ->execute();
+
+    // Assert the case still exists but is_deleted = TRUE
+    $deletedCase = CiviCase::get(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->execute()->single();
+    $this->assertTrue($deletedCase['is_deleted']);
+
+    // Assert the activity still exists but is_deleted = TRUE
+    $deletedActivity = Activity::get(FALSE)
+      ->addWhere('id', '=', $activity['id'])
+      ->execute()->single();
+    $this->assertTrue($deletedActivity['is_deleted']);
+
+    // Assert the relationship still exists but is_active = FALSE
+    $deletedRelationship = Relationship::get(FALSE)
+      ->addWhere('id', '=', $relationshipId)
+      ->execute()->single();
+    $this->assertFalse($deletedRelationship['is_active']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Makes CiviCase delete functions more standard.

Before
----------------------------------------
Bespoke method used to delete case. Hook subscibers had no way to tell if op was 'delete' or 'move to trash'. No way to properly move a case to trash via the API.

After
----------------------------------------
Standard methods used. Hook called as 'edit' when moving to trash, which is consistent with other entities. API method added.


Comments
----------------------------------------
This partly unblocks https://github.com/civicrm/civicrm-core/pull/34994

But we need to do something similar for Activities and that's even more of a pain.