### PR TITLE
Memberships Renewal for Dedupe contact when ContributionPage submitted as anonymous

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -2230,6 +2230,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
             $params[$greeting] = CRM_Contact_BAO_Contact_Utils::defaultGreeting('Individual', $greeting);
           }
         }
+      } else {
+        // We found a duplicate contact, so let's use it as the contact ID moving forward.
+        $this->_contactID = $contactID;
       }
       $contactType = NULL;
     }


### PR DESCRIPTION
Overview
----------------------------------------
_When submitting a ContributionPage that is setup for a membership and the submission is from an anonymous user, there was an issue with renewing a membership for a Contact found via a `CRM_Contact_BAO_Contact::getFirstDuplicateContact`. The Confirm page was defaulting to the `getContactID` function when locating an [existing membership](https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/Form/Contribution/Confirm.php#L136C25-L136C45) yet the contact was found through the duplicate match function._

Before
----------------------------------------
_Contribution was created for the duplicate match contact, but the membership for the contact was not found._

After
----------------------------------------
_Duplicate Contact match is used to lookup the membership and connects the Contribution with the existing membership for renewal._

Technical Details
----------------------------------------
_The default function for getting the existing membership was using the `getContactID` function which in turn would try and locate the contact as logged in or passed in through the url. But when an anonymous submission was created and a duplicate contact was matched, it wasn't using the contact found to look for an existing membership. This now sets the `_contactID` variable which the `getContactID` checks first. Now the membership can be found and matched to the Contribution so that once payment has been collected, the membership can be renewed._
