### PR TITLE
AdminUI: Don't show "Cancel Auto-renewal" menu option if inapplicable

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
@@ -29,9 +29,10 @@ return [
             'status_id:label',
             'source',
             'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
-            'IF(owner_membership_id, "(by relationship)", owner_membership_id) AS IF_owner_membership_id_owner_membership_id',
+            'IF(owner_membership_id, "(' . E::ts('by relationship') . ')", owner_membership_id) AS IF_owner_membership_id_owner_membership_id',
             'COUNT(DISTINCT Membership_Membership_owner_membership_id_01.id) AS COUNT_Membership_Membership_owner_membership_id_01_id',
-            'Membership_MembershipType_membership_type_id_01.title',
+            'GROUP_CONCAT(DISTINCT Membership_MembershipType_membership_type_id_01.title) AS GROUP_CONCAT_Membership_MembershipType_membership_type_id_01_title',
+            'Membership_ContributionRecur_contribution_recur_id_01.contribution_status_id:name',
           ],
           'orderBy' => [],
           'where' => [
@@ -93,7 +94,7 @@ return [
         'saved_search_id.name' => 'Contact_Summary_Memberships',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(''),
+          'description' => '',
           'sort' => [
             ['id', 'DESC'],
           ],
@@ -171,7 +172,7 @@ return [
               'sortable' => TRUE,
             ],
             [
-              'text' => E::ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',
@@ -187,6 +188,7 @@ return [
                   'path' => '',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -199,6 +201,7 @@ return [
                   'action' => 'view',
                   'join' => 'owner_membership_id',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
                 [
                   'entity' => 'Membership',
@@ -211,6 +214,7 @@ return [
                   'path' => '',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -223,6 +227,7 @@ return [
                   'action' => 'renew',
                   'join' => '',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -235,6 +240,7 @@ return [
                   'action' => 'followup',
                   'join' => '',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
                 [
                   'entity' => 'Membership',
@@ -247,6 +253,7 @@ return [
                   'path' => '',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -259,6 +266,18 @@ return [
                   'action' => 'cancelrecur',
                   'join' => '',
                   'target' => 'crm-popup',
+                  'conditions' => [
+                    [
+                      'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
+                      '=',
+                      TRUE,
+                    ],
+                    [
+                      'Membership_ContributionRecur_contribution_recur_id_01.contribution_status_id:name',
+                      '!=',
+                      'Cancelled',
+                    ],
+                  ],
                 ],
                 [
                   'path' => '',
@@ -271,6 +290,7 @@ return [
                   'action' => 'changebilling',
                   'join' => '',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
               ],
               'type' => 'menu',
@@ -292,6 +312,7 @@ return [
               'path' => 'civicrm/contact/view/membership?reset=1&action=add&cid=[contact_id]&context=membership',
               'task' => '',
               'condition' => [],
+              'conditions' => [],
             ],
             [
               'path' => 'civicrm/contact/view/membership?reset=1&action=add&cid=[contact_id]&context=membership&mode=live',
@@ -304,8 +325,10 @@ return [
               'action' => '',
               'join' => '',
               'target' => 'crm-popup',
+              'conditions' => [],
             ],
           ],
+          'columnMode' => 'custom',
         ],
       ],
       'match' => [
@@ -327,7 +350,7 @@ return [
         'saved_search_id.name' => 'Contact_Summary_Memberships',
         'type' => 'table',
         'settings' => [
-          'description' => E::ts(''),
+          'description' => '',
           'sort' => [
             ['id', 'DESC'],
           ],
@@ -399,7 +422,7 @@ return [
               ],
             ],
             [
-              'text' => E::ts(''),
+              'text' => '',
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',
@@ -415,6 +438,7 @@ return [
                   'path' => '',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -427,6 +451,7 @@ return [
                   'action' => 'view',
                   'join' => 'owner_membership_id',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
                 [
                   'entity' => 'Membership',
@@ -439,6 +464,7 @@ return [
                   'path' => '',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -451,6 +477,7 @@ return [
                   'action' => 'renew',
                   'join' => '',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -463,6 +490,7 @@ return [
                   'action' => 'followup',
                   'join' => '',
                   'target' => 'crm-popup',
+                  'conditions' => [],
                 ],
                 [
                   'entity' => 'Membership',
@@ -475,6 +503,7 @@ return [
                   'path' => '',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
                 [
                   'path' => '',
@@ -487,6 +516,18 @@ return [
                   'style' => 'default',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [
+                    [
+                      'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
+                      '=',
+                      TRUE,
+                    ],
+                    [
+                      'Membership_ContributionRecur_contribution_recur_id_01.contribution_status_id:name',
+                      '!=',
+                      'Cancelled',
+                    ],
+                  ],
                 ],
                 [
                   'path' => '',
@@ -499,6 +540,7 @@ return [
                   'style' => 'default',
                   'task' => '',
                   'condition' => [],
+                  'conditions' => [],
                 ],
               ],
               'type' => 'menu',
@@ -508,6 +550,7 @@ return [
           'actions' => FALSE,
           'classes' => ['table', 'table-striped', 'disabled'],
           'noResultsText' => '',
+          'columnMode' => 'custom',
         ],
       ],
       'match' => [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Memberships.mgd.php
@@ -7,81 +7,79 @@ if (!CRM_Core_Component::isEnabled('CiviMember')) {
 }
 
 return [
-      [
-        'name' => 'SavedSearch_Contact_Summary_Memberships',
-        'entity' => 'SavedSearch',
-        'cleanup' => 'unused',
-        'update' => 'unmodified',
-        'params' => [
+  [
+    'name' => 'SavedSearch_Contact_Summary_Memberships',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Contact_Summary_Memberships',
+        'label' => E::ts('Contact Summary Memberships'),
+        'api_entity' => 'Membership',
+        'api_params' => [
           'version' => 4,
-          'values' => [
-            'name' => 'Contact_Summary_Memberships',
-            'label' => E::ts('Contact Summary Memberships'),
-            'api_entity' => 'Membership',
-            'api_params' => [
-              'version' => 4,
-              'select' => [
-                'id',
-                'membership_type_id:label',
-                'join_date',
-                'start_date',
-                'end_date',
-                'status_id:label',
-                'source',
-                'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
-                'IF(owner_membership_id, "(' . E::ts('by relationship') . ')", owner_membership_id) AS IF_owner_membership_id_owner_membership_id',
-                'COUNT(DISTINCT Membership_Membership_owner_membership_id_01.id) AS COUNT_Membership_Membership_owner_membership_id_01_id',
-                'Membership_MembershipType_membership_type_id_01.title',
-              ],
-              'orderBy' => [],
-              'where' => [
-                [
-                  'Membership_MembershipType_membership_type_id_01.domain_id:name',
-                  '=',
-                  'current_domain',
-                ],
-              ],
-              'groupBy' => [
-                'id',
-                'Membership_ContributionRecur_contribution_recur_id_01.id',
-              ],
-              'join' => [
-                [
-                  'ContributionRecur AS Membership_ContributionRecur_contribution_recur_id_01',
-                  'LEFT',
-                  [
-                    'contribution_recur_id',
-                    '=',
-                    'Membership_ContributionRecur_contribution_recur_id_01.id',
-                  ],
-                ],
-                [
-                  'Membership AS Membership_Membership_owner_membership_id_01',
-                  'LEFT',
-                  [
-                    'id',
-                    '=',
-                    'Membership_Membership_owner_membership_id_01.owner_membership_id',
-                  ],
-                ],
-                [
-                  'MembershipType AS Membership_MembershipType_membership_type_id_01',
-                  'LEFT',
-                  [
-                    'membership_type_id',
-                    '=',
-                    'Membership_MembershipType_membership_type_id_01.id',
-                  ],
-                ],
-              ],
-              'having' => [],
+          'select' => [
+            'id',
+            'membership_type_id:label',
+            'join_date',
+            'start_date',
+            'end_date',
+            'status_id:label',
+            'source',
+            'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
+            'IF(owner_membership_id, "(by relationship)", owner_membership_id) AS IF_owner_membership_id_owner_membership_id',
+            'COUNT(DISTINCT Membership_Membership_owner_membership_id_01.id) AS COUNT_Membership_Membership_owner_membership_id_01_id',
+            'Membership_MembershipType_membership_type_id_01.title',
+          ],
+          'orderBy' => [],
+          'where' => [
+            [
+              'Membership_MembershipType_membership_type_id_01.domain_id:name',
+              '=',
+              'current_domain',
             ],
           ],
-          'match' => [
-            'name',
+          'groupBy' => [
+            'id',
+            'Membership_ContributionRecur_contribution_recur_id_01.id',
           ],
+          'join' => [
+            [
+              'ContributionRecur AS Membership_ContributionRecur_contribution_recur_id_01',
+              'LEFT',
+              [
+                'contribution_recur_id',
+                '=',
+                'Membership_ContributionRecur_contribution_recur_id_01.id',
+              ],
+            ],
+            [
+              'Membership AS Membership_Membership_owner_membership_id_01',
+              'LEFT',
+              [
+                'id',
+                '=',
+                'Membership_Membership_owner_membership_id_01.owner_membership_id',
+              ],
+            ],
+            [
+              'MembershipType AS Membership_MembershipType_membership_type_id_01',
+              'LEFT',
+              [
+                'membership_type_id',
+                '=',
+                'Membership_MembershipType_membership_type_id_01.id',
+              ],
+            ],
+          ],
+          'having' => [],
         ],
       ],
+      'match' => ['name'],
+    ],
+  ],
   [
     'name' => 'SavedSearch_Contact_Summary_Memberships_SearchDisplay_Contact_Summary_Memberships_Active',
     'entity' => 'SearchDisplay',
@@ -95,12 +93,9 @@ return [
         'saved_search_id.name' => 'Contact_Summary_Memberships',
         'type' => 'table',
         'settings' => [
-          'description' => '',
+          'description' => E::ts(''),
           'sort' => [
-            [
-              'id',
-              'DESC',
-            ],
+            ['id', 'DESC'],
           ],
           'limit' => 0,
           'pager' => FALSE,
@@ -176,7 +171,7 @@ return [
               'sortable' => TRUE,
             ],
             [
-              'text' => '',
+              'text' => E::ts(''),
               'style' => 'default',
               'size' => 'btn-xs',
               'icon' => 'fa-bars',
@@ -283,10 +278,7 @@ return [
             ],
           ],
           'actions' => FALSE,
-          'classes' => [
-            'table',
-            'table-striped',
-          ],
+          'classes' => ['table', 'table-striped'],
           'noResultsText' => 'No memberships have been recorded for this contact.',
           'toolbar' => [
             [
@@ -322,74 +314,71 @@ return [
       ],
     ],
   ],
-      [
-        'name' => 'SavedSearch_Contact_Summary_Memberships_SearchDisplay_Contact_Summary_Memberships_Inactive',
-        'entity' => 'SearchDisplay',
-        'cleanup' => 'unused',
-        'update' => 'unmodified',
-        'params' => [
-          'version' => 4,
-          'values' => [
-            'name' => 'Contact_Summary_Memberships_Inactive',
-            'label' => E::ts('Contact Summary Memberships Inactive'),
-            'saved_search_id.name' => 'Contact_Summary_Memberships',
-            'type' => 'table',
-            'settings' => [
-              'description' => '',
-              'sort' => [
+  [
+    'name' => 'SavedSearch_Contact_Summary_Memberships_SearchDisplay_Contact_Summary_Memberships_Inactive',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Contact_Summary_Memberships_Inactive',
+        'label' => E::ts('Contact Summary Memberships Inactive'),
+        'saved_search_id.name' => 'Contact_Summary_Memberships',
+        'type' => 'table',
+        'settings' => [
+          'description' => E::ts(''),
+          'sort' => [
+            ['id', 'DESC'],
+          ],
+          'limit' => 0,
+          'pager' => FALSE,
+          'placeholder' => 5,
+          'columns' => [
             [
-              'id',
-              'DESC',
+              'type' => 'field',
+              'key' => 'membership_type_id:label',
+              'label' => E::ts('Membership'),
+              'sortable' => TRUE,
+              'rewrite' => '[membership_type_id:label] [IF_owner_membership_id_owner_membership_id]',
             ],
-              ],
-              'limit' => 0,
-              'pager' => FALSE,
-              'placeholder' => 5,
-              'columns' => [
-              [
-                'type' => 'field',
-                'key' => 'membership_type_id:label',
-                'label' => E::ts('Membership'),
-                'sortable' => TRUE,
-                'rewrite' => '[membership_type_id:label] [IF_owner_membership_id_owner_membership_id]',
-              ],
             [
               'type' => 'field',
               'key' => 'join_date',
               'label' => E::ts('Member Since'),
               'sortable' => TRUE,
             ],
-              [
-                'type' => 'field',
-                'key' => 'start_date',
-                'label' => E::ts('Membership Start Date'),
-                'sortable' => TRUE,
-              ],
-              [
-                'type' => 'field',
-                'key' => 'end_date',
-                'label' => E::ts('Membership Expiration Date'),
-                'sortable' => TRUE,
-              ],
-              [
-                'type' => 'field',
-                'key' => 'status_id:label',
-                'label' => E::ts('Status'),
-                'sortable' => TRUE,
-              ],
-              [
-                'type' => 'field',
-                'key' => 'source',
-                'label' => E::ts('Membership Source'),
-                'sortable' => TRUE,
-              ],
-              [
-                'type' => 'field',
-                'key' => 'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
-                'label' => E::ts('Auto Renew'),
-                'sortable' => FALSE,
-                'rewrite' => '[none]',
-                'icons' => [
+            [
+              'type' => 'field',
+              'key' => 'start_date',
+              'label' => E::ts('Membership Start Date'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'end_date',
+              'label' => E::ts('Membership Expiration Date'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'status_id:label',
+              'label' => E::ts('Status'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'source',
+              'label' => E::ts('Membership Source'),
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'Membership_ContributionRecur_contribution_recur_id_01.auto_renew',
+              'label' => E::ts('Auto Renew'),
+              'sortable' => FALSE,
+              'rewrite' => '[none]',
+              'icons' => [
                 [
                   'icon' => 'fa-exclamation-triangle',
                   'side' => 'left',
@@ -407,14 +396,14 @@ return [
                     'IS NOT EMPTY',
                   ],
                 ],
-                ],
               ],
-              [
-                'text' => '',
-                'style' => 'default',
-                'size' => 'btn-xs',
-                'icon' => 'fa-bars',
-                'links' => [
+            ],
+            [
+              'text' => E::ts(''),
+              'style' => 'default',
+              'size' => 'btn-xs',
+              'icon' => 'fa-bars',
+              'links' => [
                 [
                   'entity' => 'Membership',
                   'action' => 'view',
@@ -511,24 +500,20 @@ return [
                   'task' => '',
                   'condition' => [],
                 ],
-                ],
-                'type' => 'menu',
-                'alignment' => 'text-right',
               ],
-              ],
-              'actions' => FALSE,
-              'classes' => [
-                'table',
-                'table-striped',
-                'disabled',
-              ],
-              'noResultsText' => '',
+              'type' => 'menu',
+              'alignment' => 'text-right',
             ],
           ],
-          'match' => [
-            'saved_search_id',
-            'name',
-          ],
+          'actions' => FALSE,
+          'classes' => ['table', 'table-striped', 'disabled'],
+          'noResultsText' => '',
         ],
       ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
The menu next to each membership on a contact's Membership tab has an option "Cancel Auto-renewal".  This appears unconditionally.  Clicking it when no auto-renewal exists causes an error.

This removes the option on Admin UI when there's no recurring contribution associated with the membership, or it's already been cancelled.

This problem also exists in the QuickForm version but I'm leaving that out of scope.

Before
----------------------------------------
<img width="569" height="468" alt="Selection_2772" src="https://github.com/user-attachments/assets/34ef19ce-9ea9-4770-85b8-3b323698d642" />

After
----------------------------------------
<img width="539" height="439" alt="Selection_2773" src="https://github.com/user-attachments/assets/2d16ab9a-dbbf-4cce-8e49-c0880284b046" />


Technical Details
----------------------------------------
This PR looks big because the export format for these forms has changed since the last export.  I separated a pure re-export from the actual change to make it clearer, though it still put a bunch of `conditions: []` lines in the fixed version.