### PR TITLE
fix finding missing indices function

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -457,7 +457,7 @@ ADD UNIQUE INDEX `unique_entity_id` ( `entity_id` )";
     $indexes = [];
     foreach ($tables as $table) {
       $query = "SHOW INDEX FROM $table";
-      $dao = CRM_Core_DAO::executeQuery($query);
+      $dao = CRM_Core_DAO::executeQuery($query, i18nRewrite: FALSE);
 
       $tableIndexes = [];
       while ($dao->fetch()) {


### PR DESCRIPTION
Overview
----------------------------------------
The API3 call `System.getmissingindices` is broken on multilingual installs.

Before
----------------------------------------
Returns a bunch of indices that exist.

After
----------------------------------------
Reports accurately.

Technical Details
----------------------------------------
By default, `CRM_Core_DAO::executeQuery()` rewrites the table names on multilingual installs.  But the rewritten tables (e.g. `civicrm_batch_en_US`) are views, so they don't have the indices, we have to check the base table (`civicrm_batch`).

Comments
----------------------------------------
This technically is a regression but from, like, 2 years ago.  Was too lazy until now to track it down.
