### PR TITLE
fix #6366 find dedupe contact in buildQuickForm()

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -137,7 +137,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // Find dedupe ContactId when anonymous form submission. 
     if (empty($contactID)) {
-      $contactID = $this->getDedupeContact($this->_params);
+      $contactID = $this->getDedupeContact($this->getSubmittedValues());
     }
 
     // CRM-7297 - allow membership type to be changed during renewal so long as the parent org of new membershipType

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -134,6 +134,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   protected function getExistingMembership(int $membershipTypeID): array|false {
     $contactID = $this->_membershipContactID ?: $this->getContactID();
+
+    // Find dedupe ContactId when anonymous form submission. 
+    if (empty($contactID)) {
+      $contactID = $this->getDedupeContact($this->_params);
+    }
+
     // CRM-7297 - allow membership type to be changed during renewal so long as the parent org of new membershipType
     // is the same as the parent org of an existing membership of the contact
     return CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,
@@ -165,6 +171,25 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // If there is no processor we are using the pay-later manual pseudo-processor.
     // (note it might make sense to make this a row in the processor table in the db).
     return $this->_paymentProcessor['id'] ?? 0;
+  }
+
+
+  /**
+   * Get the (dedupe) contact from the params submitted in the form.
+   *
+   * @param array $params
+   *
+   * @return int
+   */
+  private function getDedupeContact(array $params): int {
+      if (!empty($params['onbehalf'])) {
+        unset($params['onbehalf']);
+      }
+      if (!empty($params['honor'])) {
+        unset($params['honor']);
+      }
+
+      return CRM_Contact_BAO_Contact::getFirstDuplicateContact($params, 'Individual', 'Unsupervised', [], FALSE);
   }
 
   /**
@@ -2213,15 +2238,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     if (empty($contactID)) {
-      $dupeParams = $params;
-      if (!empty($dupeParams['onbehalf'])) {
-        unset($dupeParams['onbehalf']);
-      }
-      if (!empty($dupeParams['honor'])) {
-        unset($dupeParams['honor']);
-      }
-
-      $contactID = CRM_Contact_BAO_Contact::getFirstDuplicateContact($dupeParams, 'Individual', 'Unsupervised', [], FALSE);
+      $contactID = $this->getDedupeContact($params);
 
       // Fetch default greeting id's if creating a contact
       if (!$contactID) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -179,9 +179,9 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    *
    * @param array $params
    *
-   * @return int
+   * @return int|null
    */
-  private function getDedupeContact(array $params): int {
+  private function getDedupeContact(array $params): ?int {
       if (!empty($params['onbehalf'])) {
         unset($params['onbehalf']);
       }

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -135,7 +135,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   protected function getExistingMembership(int $membershipTypeID): array|false {
     $contactID = $this->_membershipContactID ?: $this->getContactID();
 
-    // Find dedupe ContactId when anonymous form submission. 
+    // Find dedupe ContactId when anonymous form submission.
     if (empty($contactID)) {
       $contactID = $this->getDedupeContact($this->getSubmittedValues());
     }
@@ -173,7 +173,6 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     return $this->_paymentProcessor['id'] ?? 0;
   }
 
-
   /**
    * Get the (dedupe) contact from the params submitted in the form.
    *
@@ -182,14 +181,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @return int|null
    */
   private function getDedupeContact(array $params): ?int {
-      if (!empty($params['onbehalf'])) {
-        unset($params['onbehalf']);
-      }
-      if (!empty($params['honor'])) {
-        unset($params['honor']);
-      }
+    if (!empty($params['onbehalf'])) {
+      unset($params['onbehalf']);
+    }
+    if (!empty($params['honor'])) {
+      unset($params['honor']);
+    }
 
-      return CRM_Contact_BAO_Contact::getFirstDuplicateContact($params, 'Individual', 'Unsupervised', [], FALSE);
+    return CRM_Contact_BAO_Contact::getFirstDuplicateContact($params, 'Individual', 'Unsupervised', [], FALSE);
   }
 
   /**

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -756,6 +756,11 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    * @throws \CRM_Core_Exception
    */
   public static function getContactMembership($contactID, $memType, $isTest, $membershipId = NULL, $onlySameParentOrg = FALSE) {
+    // $contactID needs to be set.
+    if (!$contactID) {
+      return false;
+    }
+
     //check for owner membership id, if it exists update that membership instead: CRM-15992
     if ($membershipId) {
       CRM_Core_Error::deprecatedWarning('passing in membership ID is deprecated');

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -758,7 +758,7 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
   public static function getContactMembership($contactID, $memType, $isTest, $membershipId = NULL, $onlySameParentOrg = FALSE) {
     // $contactID needs to be set.
     if (!$contactID) {
-      return false;
+      return FALSE;
     }
 
     //check for owner membership id, if it exists update that membership instead: CRM-15992


### PR DESCRIPTION
Overview
----------------------------------------
Problem is, that when a membership contribution page is filled anonymously (logged out) and the contact is matched by contact matching. Then the existing ContactMembership does not work.

For more details see: https://lab.civicrm.org/dev/core/-/issues/6366#note_199389

The fix was to run contact matching also in [buildQuickForm()](https://github.com/civicrm/civicrm-core/blob/629fedd428ebd0beb94d79de666d5742ccb64671/CRM/Contribute/Form/Contribution/Confirm.php#L621)
Therefore the logic from [processFormSubmission()](https://github.com/civicrm/civicrm-core/blob/629fedd428ebd0beb94d79de666d5742ccb64671/CRM/Contribute/Form/Contribution/Confirm.php#L2216) to an own function getDedupeContact()

This also adds a check to `CRM_Member_BAO_Membership::getContactMembership()` that false is returned when no contactID is given. One could think about if this should even throw an exception. 