### PR TITLE
Make mail Content-Transfer-Encoding configurable

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -379,7 +379,7 @@ class CRM_Utils_Mail {
     $headers['Subject'] = $params['subject'] ?? NULL;
     $headers['Content-Type'] = $htmlMessage ? 'multipart/mixed; charset=utf-8' : 'text/plain; charset=utf-8';
     $headers['Content-Disposition'] = 'inline';
-    $headers['Content-Transfer-Encoding'] = '8bit';
+    $headers['Content-Transfer-Encoding'] = self::getContentTransferEncoding();
     $headers['Return-Path'] = $params['returnPath'] ?? $defaultReturnPath;
 
     // CRM-11295: Omit reply-to headers if empty; this avoids issues with overzealous mailservers
@@ -538,20 +538,52 @@ class CRM_Utils_Mail {
    * @return mixed
    */
   public static function setMimeParams($message, $params = NULL) {
-    static $mimeParams = NULL;
+    // Keyed by encoding: the setting can change within a process (e.g. tests).
+    static $mimeParams = [];
     if (!$params) {
-      if (!$mimeParams) {
-        $mimeParams = [
-          'text_encoding' => '8bit',
-          'html_encoding' => '8bit',
+      $encoding = self::getContentTransferEncoding();
+      if (!isset($mimeParams[$encoding])) {
+        $mimeParams[$encoding] = [
+          'text_encoding' => $encoding,
+          'html_encoding' => $encoding,
           'head_charset' => 'utf-8',
           'text_charset' => 'utf-8',
           'html_charset' => 'utf-8',
         ];
       }
-      $params = $mimeParams;
+      $params = $mimeParams[$encoding];
     }
     return $message->get($params);
+  }
+
+  /**
+   * Content-Transfer-Encoding to use for outgoing mail bodies.
+   *
+   * Falls back to the historical default if the setting is unavailable (e.g.
+   * during installation) or holds an unrecognised value.
+   *
+   * @return string
+   */
+  public static function getContentTransferEncoding(): string {
+    try {
+      $encoding = (string) Civi::settings()->get('mail_content_transfer_encoding');
+    }
+    catch (\Throwable $e) {
+      return '8bit';
+    }
+    return isset(self::getContentTransferEncodings()[$encoding]) ? $encoding : '8bit';
+  }
+
+  /**
+   * Options for the `mail_content_transfer_encoding` setting.
+   *
+   * @return array
+   */
+  public static function getContentTransferEncodings(): array {
+    return [
+      '8bit' => ts('8bit'),
+      'quoted-printable' => ts('quoted-printable'),
+    ];
   }
 
   /**

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -2037,3 +2037,7 @@
 - github      : yf-zhou
   name        : Yifei Zhou
   organization: JMA Consulting
+
+- github      : jfilter
+  name        : Johannes Filter
+  organization: civico GmbH

--- a/settings/Mailing.setting.php
+++ b/settings/Mailing.setting.php
@@ -119,4 +119,25 @@ return [
     ],
     'settings_pages' => ['smtp' => ['section' => 'default', 'weight' => 350]],
   ],
+  'mail_content_transfer_encoding' => [
+    'group_name' => 'Mailing Preferences',
+    'group' => 'mailing',
+    'name' => 'mail_content_transfer_encoding',
+    'type' => 'String',
+    'quick_form_type' => 'Select',
+    'html_type' => 'Select',
+    'default' => '8bit',
+    'title' => ts('Content-Transfer-Encoding'),
+    'add' => '6.18',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'pseudoconstant' => [
+      'callback' => 'CRM_Utils_Mail::getContentTransferEncodings',
+    ],
+    'help_text' => [
+      ts('Transfer encoding used for the body of outgoing email.'),
+      ts('Some SMTP relay services re-process 8bit message bodies and misinterpret UTF-8 as Latin-1, which shows up as double-encoded characters (for example "ü" arriving as "Ã¼"). Switching to quoted-printable makes the body 7-bit safe and avoids that. Other delivery paths, notably some local qmail setups, have been reported to work better with 8bit, so the default is left unchanged.'),
+    ],
+    'settings_pages' => ['smtp' => ['section' => 'default', 'weight' => 360]],
+  ],
 ];

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -91,6 +91,47 @@ class CRM_Utils_MailTest extends CiviUnitTestCase {
   }
 
   /**
+   * The default is unchanged, so existing installs keep sending 8bit.
+   */
+  public function testContentTransferEncodingDefaultsTo8bit(): void {
+    $this->assertEquals('8bit', CRM_Utils_Mail::getContentTransferEncoding());
+  }
+
+  /**
+   * An unrecognised value must not leak into the message headers.
+   */
+  public function testContentTransferEncodingFallsBackOnUnknownValue(): void {
+    Civi::settings()->set('mail_content_transfer_encoding', 'base64');
+    $this->assertEquals('8bit', CRM_Utils_Mail::getContentTransferEncoding());
+  }
+
+  /**
+   * The setting must reach both the header and the MIME body encoding.
+   *
+   * @dataProvider contentTransferEncodings
+   */
+  public function testContentTransferEncodingIsApplied(string $encoding): void {
+    Civi::settings()->set('mail_content_transfer_encoding', $encoding);
+    $mailHelper = new CiviMailUtils($this);
+    $params = [
+      'toEmail' => 'a@example.com',
+      'from' => 'b@example.com',
+      'subject' => 'hey',
+      'text' => 'Grüße aus München',
+    ];
+    CRM_Utils_Mail::send($params);
+
+    $message = $mailHelper->getMostRecentEmail();
+    $this->assertStringContainsString('Content-Transfer-Encoding: ' . $encoding, $message);
+    // Whatever the wire encoding, the text must survive decoding intact.
+    $this->assertStringContainsString('Grüße aus München', quoted_printable_decode($message));
+  }
+
+  public static function contentTransferEncodings(): array {
+    return [['8bit'], ['quoted-printable']];
+  }
+
+  /**
    * Mimic exception in mailer class.
    *
    * @throws \PEAR_Exception


### PR DESCRIPTION
## Summary

Revised following @totten's review. Rather than changing the default outright, this introduces the configuration option he suggested:

> Introduce a configuration option for content-encoding. (Phase-in a change of default -- with a way for particular systems to back out to 8bit.)

**The default is unchanged (`8bit`)**, so this PR is purely additive and cannot regress any existing install — including the qmail setups discussed below. Sites affected by relay re-encoding can switch to `quoted-printable` themselves; flipping the default becomes a separate, evidence-led decision.

## The problem this makes fixable

SMTP relay services (Mailjet, Amazon SES, SendGrid) may re-encode `8bit` message bodies, interpreting UTF-8 bytes as Latin-1. This causes double-encoding (mojibake) for non-ASCII characters — German umlauts arrive as `Ã¼`, `Ã¤`, `Ã`.

Confirmed on Mailjet SMTP relay with CiviCRM 6.11 (both CiviMail bulk sends and transactional mail); the database content, `mb_internal_encoding` and CiviCRM's own mail log were all correct UTF-8, and only the delivered message was broken. Switching to `quoted-printable` fixed it.

Supporting references: AWS SES documentation warns that "8-bit-encoded content might not appear correctly when it arrives in recipients' inboxes"; RFC 6152 requires relays to either convert `8bit` to a 7-bit encoding or reject; the Drupal SMTP module has the same report ([#3035346](https://www.drupal.org/project/smtp/issues/3035346)).

## Changes

- New setting `mail_content_transfer_encoding` (`settings/Mailing.setting.php`), a select of `8bit` / `quoted-printable`, on the SMTP settings page. Default `8bit`.
- `CRM_Utils_Mail::getContentTransferEncoding()` reads it, with a fallback to `8bit` if the setting is unavailable (e.g. during installation) or holds an unrecognised value, so a bad value can never reach the headers.
- `CRM_Utils_Mail::getContentTransferEncodings()` provides the options (also the setting's pseudoconstant callback).
- The three previously hardcoded places now use it: the `Content-Transfer-Encoding` header in `setEmailHeaders()`, and `text_encoding` / `html_encoding` in `setMimeParams()`. The static cache in `setMimeParams()` is now keyed by encoding so a runtime change takes effect.

Dropped from the previous revision: the test-helper changes in `Civi/Test/FormTrait.php` and `CiviMailUtils`, and the `JobProcessMailingTest` expectation. They are unnecessary while the default is `8bit`, and decoding unconditionally could corrupt a genuinely 8bit body. They belong with a default change.

## Verification

`OK (4 tests, 26 assertions)` — new tests in `tests/phpunit/CRM/Utils/MailTest.php` cover the default, the fallback on an unrecognised value, and that each setting reaches both the header and the MIME body encoding, with the non-ASCII text surviving a round trip.

Observed wire format on a CiviCRM 6.16.1 Standalone install, same message body each time:

```
Setting: 8bit
  Content-Transfer-Encoding: 8bit
  Body: Grüße aus München

Setting: quoted-printable
  Content-Transfer-Encoding: quoted-printable
  Body: Gr=C3=BC=C3=9Fe aus M=C3=BCnchen
```

## On the qmail data-point

@elisseck offered to re-test qmail with different scenarios — that offer is still open and would be very welcome. With this PR merged, that test becomes a one-setting change rather than a patch, which should make it easier to run in isolation.

Nothing in this PR asks anyone to accept `quoted-printable`; it only makes the choice reachable.


