### PR TITLE
dev/core#6365 Afform - dont interrupt field level validation on frontend

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -386,7 +386,27 @@
       this.submit = function () {
         // validate required fields on the form
         if (!ctrl.ngForm.$valid || !validateFileFields()) {
-          CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
+          // at this point we want the user to know to check the invalid fields
+          //
+          // the complication is the browser will natively trigger notifications
+          // for invalid fields, and focus the first one of these
+          //
+          // on the backend CRM.alert complements this by adding a global popup
+          // that does not block the user flow
+          //
+          // however on the frontend CRM.alert will trigger a popup (either our
+          // homebrew or sweetalert) which *interrupts* the browser putting focus
+          // on the invalid fields. in this case we are better off doing nothing
+          // and just letting the browser alerts do their work
+          //
+          // NOTE: if you set sweetalert to Override Everywhere it will turn the
+          // below alert into a popup on the backend too, which isn't great
+          //
+          // TODO: in the long run we should provide a way for callers of
+          // CRM.alert to specify between interrupting vs non-interrupting alerts
+          if (document.getElementById('crm-notification-container')) {
+            CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
+          }
           return;
         }
         status = CRM.status({error: ts('Not saved')});


### PR DESCRIPTION
Overview
----------------------------------------
The browser does a better job of alerting users to invalid fields on forms. Don't get in the way.

Before
----------------------------------------
- if there are invalid fields when trying to submit a form:
  a)  the browser triggers a notification on the first invalid field, and scrolls you to it, and focuses that input
  b)  `CRM.alert` is called

- on the backend CRM.alert triggers a notification area notification, which nicely complements the native browser notifications

https://github.com/user-attachments/assets/85972456-0b66-4121-8695-a8dc46f74c71

**= good :green_circle:** 

- on the frontend CRM.alert triggers our homebrew alert popup, which interrupts the native browser notifications


https://github.com/user-attachments/assets/d44b37fa-e6b4-47df-89a9-da1839e77108


**= bad :red_circle:** 

- if you have Sweetalert extension that takes over CRM.alert - the sweetalert popup is less blocking, but still not great - note how you have to close the alert and you get scrolled back down to the bottom of the form for some reason


https://github.com/user-attachments/assets/47dceda0-e0f5-4bde-88c7-71cd99304371

**= not great :yellow_circle:** 


- prior to 6.11 ( https://github.com/civicrm/civicrm-core/pull/34122 ) CRM.alert used to use `window.alert` on the frontend - this actually functionally fine (the native browser popup plays nice with the native browser field level alerts); but it looked a bit jarring

https://github.com/user-attachments/assets/d98189e6-8c70-4c24-a084-991079742af3

**= not pretty :paintbrush:** 

After
----------------------------------------
- backend as before
- on frontend, don't trigger CRM.alert - just let the browser alerts do their thing


https://github.com/user-attachments/assets/13899b24-d843-4384-ab56-677356ae6e7a

= not perfect, but I think the best short term fix



Technical Details
----------------------------------------
While there is a separate check for file field validation, I tested this too and the behaviour was the same as the demos above.

Videos above on Firefox; I tested on Chrome too and similar story.

Underlying this is current weird discrepancy where on the backend, CRM.alert behaves as **non-modal (non-blocking)**, but on the frontend it is **modal (blocking)**. Going forward I think we should add a way to distinguish blocking/non-blocking (modal/non-modal) **calls** to CRM.alert, because it really depends on the nature of the alert (not whether it is on the frontend or backend).

NOTE: you can set Sweetalert extension to override CRM.alert everywhere. That will lead to you getting the not-great behaviour on backend. This setting generally is problematic because there are lots of calls to CRM.alert which are expected to be non-modal side-of-screen, and you end up with popups all over the shop.

Comments
----------------------------------------
Would you be able to review @wmortada ?
