### PR TITLE
dev/core#6379 Upgrader - Fix addExtensionTask when it's the only upgrade step

### DIFF
--- a/Civi.php
+++ b/Civi.php
@@ -124,7 +124,7 @@ class Civi {
    * @see \CRM_Queue_Service
    */
   public static function queue(string $name, array $params = []): CRM_Queue_Queue {
-    $defaults = ['reset' => FALSE, 'is_persistent' => TRUE, 'status' => 'active'];
+    $defaults = ['reset' => FALSE, 'is_persistent' => TRUE, 'status' => 'active', 'type' => 'Sql'];
     $params = array_merge($defaults, $params, ['name' => $name]);
     return CRM_Queue_Service::singleton()->create($params);
   }

--- a/tests/phpunit/api/v4/Entity/QueueTest.php
+++ b/tests/phpunit/api/v4/Entity/QueueTest.php
@@ -61,7 +61,6 @@ class QueueTest extends Api4TestBase {
   public function testBasicLinearPolling(): void {
     $queueName = 'QueueTest_' . bin2hex(random_bytes(16)) . '_linear';
     $queue = \Civi::queue($queueName, [
-      'type' => 'Sql',
       'runner' => 'task',
       'error' => 'delete',
       'retry_limit' => 2,


### PR DESCRIPTION
Overview
----------------------------------------
Regression: Upgrade step `upgrade_6_12_beta1` crashes with `Failed to create queue "CRM_Upgrade". Missing field "type".`

See https://lab.civicrm.org/dev/core/-/issues/6379#note_199503

To reproduce
----------------------------------------
1. Install 6.11
2. Enable CiviGrant
3. Upgrade to 6.12+ via GUI

Technical Details
----------------------------------------
In upgrade step 6.12.beta1, the `addExtensionTask` is called as the only task. In other upgraders it's been called in tandem with other tasks, so this problem was never noticed: `addExtensionTask` invokes `Civi::queue()` without any parameters. If the queue had already been defined by another task, this wouldn't be a problem, but in this case it has to create a new queue and fails because there is no default for 'type'.

I've added the default, which seemed the least risky in a point release.