### PR TITLE
Standalone - Add PSR-4 wrapper for `CRM_Core_ClassLoader`

### DIFF
--- a/Civi/Core/LegacyClassLoader.php
+++ b/Civi/Core/LegacyClassLoader.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core;
+
+/**
+ * Class LegacyClassLoader
+ * @package Civi\Core
+ *
+ * This is just a PSR-4 wrapper for legacy PSR-0 classloader CRM_Core_ClassLoader
+ *
+ * It means you don't have to scrabble around to find the old classloader
+ * if you already have PSR-4 autoloading up and running
+ */
+class LegacyClassLoader {
+
+  public static function register() {
+    $coreRoot = \dirname(__DIR__, 2);
+    $classLoader = implode(DIRECTORY_SEPARATOR, [$coreRoot, 'CRM', 'Core', 'ClassLoader.php']);
+    require_once $classLoader;
+    \CRM_Core_ClassLoader::singleton()->register();
+  }
+
+}

--- a/setup/res/civicrm.standalone.php.txt
+++ b/setup/res/civicrm.standalone.php.txt
@@ -15,15 +15,13 @@ $appRootPath = __DIR__;
 
 // standard file structure with top-level private, public and extensions dirs.
 $autoLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'core', 'vendor', 'autoload.php']);
-$classLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'core', 'CRM', 'Core', 'ClassLoader.php']);
 
 # // alternative composer-style file structure:
 # $autoLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath , 'vendor', 'autoload.php']);
-# $classLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'vendor', 'civicrm', 'civicrm-core', 'CRM', 'Core', 'ClassLoader.php']);
 
+// path to settings file
 $settingsPath = implode(DIRECTORY_SEPARATOR, [__DIR__, 'private', 'civicrm.settings.php']);
 
 require_once $autoLoader;
-require_once $classLoader;
-\CRM_Core_ClassLoader::singleton()->register();
+\Civi\Core\LegacyClassLoader::register();
 \Civi\Core\SettingsManager::bootSettings($settingsPath);


### PR DESCRIPTION
Overview
----------------------------------------
Makes booting the system cleaner and easier.

Before
----------------------------------------
- `Civi`-namespaced stuff loads cleanly with composer autoloader
- you have to scrabble around to find `CRM_Core_ClassLoader` before you can load `CRM`-namespaced stuff

After
----------------------------------------
- once you have PSR-4 loading, you can use `Civi\Core\LegacyClassLoader::register();` to get `CRM` stuff
- less scrabbling around
- comes immediately to new Standalone installs (in civicrm.standalone.php)

Technical Details
----------------------------------------
Existing Standalone installs will have the old `civicrm.standalone.php` template. There's no harm in that for now.

Comments
----------------------------------------
Working on bringing similar cleanliness to Drupal

