### PR TITLE
dev/core#6381: Add contactID and currency to payment parameters for membership contribution transactions

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -211,6 +211,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     $paymentParams['campaign_id'] = $this->getCampaignID();
     $paymentParams['currency'] = $this->getCurrency();
     $paymentParams['description'] = $this->getSource();
+    $paymentParams['contactID'] = $this->getContactID();
     return $paymentParams;
   }
 
@@ -1721,7 +1722,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       // be performed yet, so do it now.
       if (!$this->isSeparatePaymentSelected()) {
         $paymentParams['amount'] = $this->getMainContributionAmount();
-        $paymentParams += $this->getBasePaymentParams();
+        $paymentParams['currency'] = $this->getCurrency();
+        $paymentParams = $this->getBasePaymentParams() + $paymentParams;
         $paymentActionResult = $payment->doPayment($paymentParams);
         $paymentResults[] = ['contribution_id' => $paymentResult['contribution']->id, 'result' => $paymentActionResult];
       }


### PR DESCRIPTION
Ref: https://lab.civicrm.org/dev/core/-/issues/6381. Kudos entirely to @eileenmcnaughton. 

Before
----------------------------------------
Membership contribution fails, currency and contact id is set

After
----------------------------------------
Succeeds

@mattwire 