### PR TITLE
(dev/core#6379) Upgrader - Fix "missing type" error. Track queue metadata.

### DIFF
--- a/CRM/Queue/Queue.php
+++ b/CRM/Queue/Queue.php
@@ -151,6 +151,20 @@ abstract class CRM_Queue_Queue {
   }
 
   /**
+   * Remove the contents and all metadata about the queue.
+   *
+   * @return void
+   * @throws \Civi\Core\Exception\DBQueryException
+   */
+  public function destroyQueue(): void {
+    $this->deleteQueue();
+    // If there is a persistent description of the queue, then drop it.
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_queue WHERE name = %1', [
+      1 => [$this->getName(), 'String'],
+    ]);
+  }
+
+  /**
    * Add a new item to the queue.
    *
    * @param mixed $data

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -899,6 +899,14 @@ SET    version = '$version'
    * @return bool
    */
   public static function doFinish(): bool {
+    $queue = Civi::queue(CRM_Upgrade_Form::QUEUE_NAME);
+    if ($queue->numberOfItems() > 0) {
+      throw new \CRM_Core_Exception("Error: Upgrade completed, but there are tasks remaining in the upgrade-queue.");
+    }
+    else {
+      $queue->destroyQueue();
+    }
+
     $session = CRM_Core_Session::singleton();
     $session->reset('keep_login');
     return TRUE;

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -485,7 +485,7 @@ SET    version = '$version'
    * @param string $postUpgradeMessageFile
    *   path of a modifiable file which lists the post-upgrade messages.
    *
-   * @return CRM_Queue_Service
+   * @return CRM_Queue_Queue
    */
   public static function buildQueue($currentVer, $latestVer, $postUpgradeMessageFile) {
     $upgrade = new CRM_Upgrade_Form();

--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -494,10 +494,17 @@ SET    version = '$version'
     if (!CRM_Queue_BAO_QueueItem::findCreateTable()) {
       throw new CRM_Core_Exception(ts('Failed to find or create queueing table'));
     }
-    $queue = CRM_Queue_Service::singleton()->create([
-      'name' => self::QUEUE_NAME,
+    $queue = Civi::queue(self::QUEUE_NAME, [
       'type' => 'Sql',
       'reset' => TRUE,
+
+      // Make it easy for upgrade-tasks to lookup `Civi::queue($name)`.
+      'is_persistent' => TRUE,
+
+      // Ensure that background workers (eg `coworker`) don't pick our tasks.
+      'runner' => NULL,
+      // NOTE: The "runner" column really should've been two columns. If we fix the schema,
+      // then this would become (say) "agent=>browser" and "content_type=>task".
     ]);
 
     $task = new CRM_Queue_Task(

--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -141,10 +141,7 @@ class CRM_Upgrade_Incremental_Base {
    * @param string $funcName
    */
   protected function addTask($title, $funcName) {
-    $queue = CRM_Queue_Service::singleton()->load([
-      'type' => 'Sql',
-      'name' => CRM_Upgrade_Form::QUEUE_NAME,
-    ]);
+    $queue = Civi::queue(CRM_Upgrade_Form::QUEUE_NAME);
 
     $args = func_get_args();
     $title = array_shift($args);
@@ -178,10 +175,7 @@ class CRM_Upgrade_Incremental_Base {
       return;
     }
 
-    $queue = CRM_Queue_Service::singleton()->load([
-      'type' => 'Sql',
-      'name' => CRM_Upgrade_Form::QUEUE_NAME,
-    ]);
+    $queue = Civi::queue(CRM_Upgrade_Form::QUEUE_NAME);
     foreach (CRM_Upgrade_Snapshot::createTasks('civicrm', $this->getMajorMinor(), $name, $select) as $task) {
       $queue->createItem($task, ['weight' => -1]);
     }


### PR DESCRIPTION
Overview
----------------------------------------

Updates the mechanics of the upgrade-queue to record some metadata about the queue (such as its `type`). This fixes an error (`Missing field "type"`) that occurs in certain upgrade scenarios.

Addresses https://lab.civicrm.org/dev/core/-/issues/6379. Builds on @colemanw's analysis in the #35097 draft (but with a different implementation).

Steps to reproduce
----------------------------------------

1. Install 6.11
2. Enable CiviGrant
3. Upgrade to 6.12+ via GUI

Before
----------------------------------------

The upgrade-queue is "non-persistent". This is an older style, where we don't store any metadata about the queue.

The upgrade fails because it cannot find metadata:

<img width="921" height="987" alt="Screenshot 2026-03-13 at 5 00 47 PM" src="https://github.com/user-attachments/assets/fd785bcf-205b-489c-b894-cb419ab98470" />

Under the hood, the logic uses a mix of older and newer notations:

* Older-style: `CRM_Queue_Service::singleton()->load([...specs...])`
* Newer-style: `Civi::queue(name)`

(The notations use very similar code-paths, but that the older-style expects you pass-in the specifications for the queue. In the newer style, you only need to give the name -- but it might fail if the specifications aren't stored.)

After
----------------------------------------

The upgrade-queue is "persistent". There is metadata in `civicrm_queue` table.

The upgrade scenario works.

The upgrader consistently uses the newer notation (`Civi::queue(...)`).


