### PR TITLE
(dev/core#6379) Upgrader - Fix "missing type" error.  Use helper.

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -40,6 +40,19 @@ class CRM_Upgrade_Incremental_Base {
     return $this->majorMinor;
   }
 
+  protected function getQueue(): CRM_Queue_Queue {
+    // It would be prettier to call `Civi::queue(CRM_Upgrade_Form::QUEUE_NAME)`,
+    // but... that works best if you have persistent metadata in `civicrm_queue`.
+    // Alas, that table only exists in 5.47+, but the upgrader may start with
+    // schema as old as 4.7.
+
+    // So for now, we need to give the metadata explicitly.
+    return CRM_Queue_Service::singleton()->load([
+      'type' => 'Sql',
+      'name' => CRM_Upgrade_Form::QUEUE_NAME,
+    ]);
+  }
+
   /**
    * Get a list of revisions (PATCH releases) related to this class.
    *
@@ -141,10 +154,7 @@ class CRM_Upgrade_Incremental_Base {
    * @param string $funcName
    */
   protected function addTask($title, $funcName) {
-    $queue = CRM_Queue_Service::singleton()->load([
-      'type' => 'Sql',
-      'name' => CRM_Upgrade_Form::QUEUE_NAME,
-    ]);
+    $queue = $this->getQueue();
 
     $args = func_get_args();
     $title = array_shift($args);
@@ -178,10 +188,7 @@ class CRM_Upgrade_Incremental_Base {
       return;
     }
 
-    $queue = CRM_Queue_Service::singleton()->load([
-      'type' => 'Sql',
-      'name' => CRM_Upgrade_Form::QUEUE_NAME,
-    ]);
+    $queue = $this->getQueue();
     foreach (CRM_Upgrade_Snapshot::createTasks('civicrm', $this->getMajorMinor(), $name, $select) as $task) {
       $queue->createItem($task, ['weight' => -1]);
     }
@@ -205,7 +212,7 @@ class CRM_Upgrade_Incremental_Base {
    *   have previously been enabled.
    */
   protected function addExtensionTask(string $title, array $keys, int $weight = 2000): void {
-    Civi::queue(CRM_Upgrade_Form::QUEUE_NAME)->createItem(
+    $this->getQueue()->createItem(
       new CRM_Queue_Task([static::CLASS, 'enableExtension'], [$keys], $title),
       ['weight' => $weight]
     );
@@ -221,7 +228,7 @@ class CRM_Upgrade_Incremental_Base {
    * @param int $weight
    */
   protected function addUninstallTask(string $title, array $keys, int $weight = 1000): void {
-    Civi::queue(CRM_Upgrade_Form::QUEUE_NAME)->createItem(
+    $this->getQueue()->createItem(
       new CRM_Queue_Task([static::CLASS, 'uninstallExtension'], [$keys], $title),
       ['weight' => $weight]
     );

--- a/CRM/Upgrade/Incremental/php/FiveSeventyNine.php
+++ b/CRM/Upgrade/Incremental/php/FiveSeventyNine.php
@@ -63,7 +63,7 @@ class CRM_Upgrade_Incremental_php_FiveSeventyNine extends CRM_Upgrade_Incrementa
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Update "Website Type" options', 'updateWebsiteType');
 
-    Civi::queue(CRM_Upgrade_Form::QUEUE_NAME)->createItem(
+    $this->getQueue()->createItem(
       new CRM_Queue_Task([static::CLASS, 'checkEnableLoginTokens']),
       ['weight' => 2001]
     );


### PR DESCRIPTION
Overview
----------------------------------------

Updates the mechanics of the upgrade-queue to ensure that the `$queue` object is fetched in a consistent manner. This fixes an error (`Missing field "type"`) that occurs in certain upgrade scenarios.

Addresses https://lab.civicrm.org/dev/core/-/issues/6379. Builds on @colemanw's analysis in the #35097 draft (but with a different implementation). Alternative to #35101.

Steps to reproduce
----------------------------------------

1. Install 6.11
2. Enable CiviGrant
3. Upgrade to 6.12+ via GUI

Before
----------------------------------------

Under the hood, the logic uses a mix of older and newer notations:

* Older-style: `CRM_Queue_Service::singleton()->load([...specs...])`
* Newer-style: `Civi::queue(name)`

The newer-style was mainly intended for use with *persistent* queues. However, at the time when the upgrade-queue is built, there may be no place to store persistent queue metadata. (The `civicrm_queue` table doesn't exist in the start-schema from v4.7.) Consequently, `Civi::queue(name)` may be inadequate.

For CiviGrant upgrade scenario, it fails:

<img width="921" height="987" alt="Screenshot 2026-03-13 at 5 00 47 PM" src="https://github.com/user-attachments/assets/fd785bcf-205b-489c-b894-cb419ab98470" />

After
----------------------------------------

The base class `CRM_Upgrade_Incremental_Base` has a helper `getQueue()` to lookup the upgrade-queue. This implementation does not rely on `civicrm_queue` for persistence.

The upgrade scenario works.
