### PR TITLE
Form Builder - Fix warning about null values

### DIFF
--- a/ext/afform/core/Civi/Afform/StringVisitor.php
+++ b/ext/afform/core/Civi/Afform/StringVisitor.php
@@ -189,10 +189,10 @@ class StringVisitor {
   }
 
   protected function isWorthy($value): bool {
-    return !is_array($value)
+    return !empty($value)
+      && !is_array($value)
       && (!str_contains($value, '{{'))
-      && (!str_contains($value, 'ts('))
-      && !empty($value);
+      && (!str_contains($value, 'ts('));
   }
 
 }


### PR DESCRIPTION
Backport #35037 from 6.13-rc to 6.12-stable.

(The warning is very recent, from 6.11.2.)