### PR TITLE
dev/core#6369 Fix incorrect paylater text

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -492,6 +492,13 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   }
 
   /**
+   * @return string
+   */
+  public function getPayLaterLabel(): string {
+    return (string) $this->getContributionPageValue('pay_later_text');
+  }
+
+  /**
    * Build the price set form.
    *
    * @return void


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6369 Fix incorrect paylater text

Before
----------------------------------------
Says pay later - not the assigned text

After
----------------------------------------
<img width="970" height="108" alt="image" src="https://github.com/user-attachments/assets/97836ba9-66f5-4dea-8eda-a15db8a077e0" />


Technical Details
----------------------------------------
@andyburnsco 

Comments
----------------------------------------
