### PR TITLE
fix permission check for private reports

### DIFF
--- a/CRM/Report/BAO/ReportInstance.php
+++ b/CRM/Report/BAO/ReportInstance.php
@@ -261,7 +261,7 @@ class CRM_Report_BAO_ReportInstance extends CRM_Report_DAO_ReportInstance implem
    */
   public static function contactCanAdministerReport($instance_id) {
     if (self::reportIsPrivate($instance_id)) {
-      if (self::contactIsOwner($instance_id) || CRM_Core_Permission::check('access all private reports')) {
+      if (self::contactIsOwner($instance_id) || CRM_Core_Permission::check('administer private reports')) {
         return TRUE;
       }
     }

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -760,7 +760,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     if ($this->_id &&
       (CRM_Report_BAO_ReportInstance::reportIsPrivate($this->_id) &&
       !CRM_Report_BAO_ReportInstance::contactIsOwner($this->_id))) {
-      if (!CRM_Core_Permission::check('access all private reports')) {
+      if (!CRM_Core_Permission::check('administer private reports')) {
         $this->_instanceForm = FALSE;
         $this->assign('criteriaForm', FALSE);
       }


### PR DESCRIPTION
Overview
----------------------------------------
If a report is marked private, it may be impossible to edit it because of a mis-named permission.

Before
----------------------------------------

If a report is marked private, the user is checked against the permission "access all private reports" - however, that permission does not exist.

After
----------------------------------------

The proper permission name is "administer private reports". Once the reference to the non-existent permission name is changed, it works as expected.

Comments
----------------------------------------

Wow. Maybe we should revisit the use of private reports? I didn't even know that existed. It seems that this bug has been in place for 10 years without anyone noticing?

As far as I can tell, the permission "access all private reports" was introduced in 2016 in commit 0f8c6e5846791d886139a66ee88259e84f0d5b4b but then immediately renamed in 92991cafdd5a35b4907f9bdb1d9d648c80cfb113. But, when it was renamed one reference to it remained (which is being fixed in this PR).