### PR TITLE
StatusCheck - Collapse list of up-to-date extensions

### DIFF
--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -713,12 +713,12 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
         $message = ts('1 extension is up-to-date:', ['plural' => '%count extensions are up-to-date:', 'count' => count($okextensions)]);
       }
       else {
-        $message = ts('All extensions are up-to-date:');
+        $message = ts('All %1 installed extensions are up-to-date:', [1 => count($okextensions)]);
       }
       natcasesort($okextensions);
       $messages[] = new CRM_Utils_Check_Message(
         __FUNCTION__ . 'Ok',
-        $message . '<ul><li>' . implode('</li><li>', $okextensions) . '</li></ul>',
+        "<details><summary>$message</summary><ul><li>" . implode('</li><li>', $okextensions) . '</li></ul></details>',
         ts('Extensions'),
         \Psr\Log\LogLevel::INFO,
         'fa-plug'


### PR DESCRIPTION
Overview
----------------------------------------
The list of extensions can be quite long. This provides a more compact view.

Before
----------------------------------------
<img width="799" height="639" alt="image" src="https://github.com/user-attachments/assets/333236f7-ad3b-4d01-b9f4-cc3b7e195dd4" />

After
----------------------------------------
<img width="798" height="117" alt="image" src="https://github.com/user-attachments/assets/8f256593-f9d4-407a-aa47-5a241ace4b14" />

