### PR TITLE
Civi\Test - loadSnapshot() should work with varied `DEFINER`s

### DIFF
--- a/Civi/Test/Schema.php
+++ b/Civi/Test/Schema.php
@@ -138,15 +138,27 @@ class Schema {
   public function loadSnapshot(string $file) {
     $dsn = \Civi\Test::dsn();
     $defaultsFile = $this->createMysqlDefaultsFile($dsn);
+
+    $pipeline = [];
+
     if (preg_match(';sql.bz2$;', $file)) {
-      $cmd = sprintf('bzip2 -d -c %s | mysql --defaults-file=%s %s', escapeshellarg($file), escapeshellarg($defaultsFile), escapeshellarg($dsn['database']));
+      $pipeline[] = sprintf('bzip2 -d -c %s', escapeshellarg($file));
     }
     elseif (preg_match(';sql.gz$;', $file)) {
-      $cmd = sprintf('gzip -d -c %s | mysql --defaults-file=%s %s', escapeshellarg($file), escapeshellarg($defaultsFile), escapeshellarg($dsn['database']));
+      $pipeline[] = sprintf('gzip -d -c %s ', escapeshellarg($file));
     }
     else {
-      $cmd = sprintf('cat %s | mysql --defaults-file=%s %s', escapeshellarg($file), escapeshellarg($defaultsFile), escapeshellarg($dsn['database']));
+      $pipeline[] = sprintf('cat %s', escapeshellarg($file));
     }
+
+    // Rewrite the "DEFINER". This regex is fine because we're handling
+    // test snapshots and because the new definer comes from a trusted source.
+    // Hypothetically, for untrusted snapshots, you might want something better.
+    $definer = $this->getEscapedDefiner();
+    $pipeline[] = sprintf('sed %s', escapeshellarg('s/DEFINER=`[^`]*`@`[^`]*`/DEFINER=' . $definer . '/g'));
+
+    $pipeline[] = sprintf('mysql --defaults-file=%s %s', escapeshellarg($defaultsFile), escapeshellarg($dsn['database']));
+    $cmd = implode(' | ', $pipeline);
     ProcessHelper::runOk($cmd);
     return $this;
   }
@@ -174,6 +186,15 @@ class Schema {
       }
     }
     return $file;
+  }
+
+  protected function getEscapedDefiner(): string {
+    $pdo = \Civi\Test::pdo();
+    $definer = $pdo->query('SELECT user()')->fetchColumn();
+    [$user, $host] = explode('@', $definer);
+    $user = trim($user, '`');
+    $host = trim($host, '`');
+    return "`{$user}`@`{$host}`";
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

The recent update to `civicrm-upgrade-test` (https://github.com/civicrm/civicrm-buildkit/pull/1031) brought in some new test snapshots. Some of these snapshots need a little extra filter to work consistently across different test-systems.

Before
----------------------------------------

The `upgrade` tests fail on unrelated PRs.

After
----------------------------------------

Well, one hopes the tests will pass.

Technical Details
----------------------------------------

The issue specifically affects multilingual snapshots, because they rely on triggers. The triggers have `DEFINER`s that need to be adapted to match the local test environment.