### PR TITLE
PHP8.5 Make wordReplacement fields required

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -75,7 +75,7 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'collate' => 'utf8_bin',
       'required' => TRUE,
     ]);
-    $this->addTask('Make WordReplacement replace word required', 'alterSchemaField', 'WordReplacement', 'replace_word', [
+    $this->addTask('Make WordReplacement "replace_word" required', 'alterSchemaField', 'WordReplacement', 'replace_word', [
       'title' => ts('Replacement Word'),
       'sql_type' => 'varchar(255)',
       'input_type' => 'Text',

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -66,7 +66,7 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
     ], 'AFTER `accepted_credit_cards`');
     $this->addTask('Drop civicrm_activity.is_current_revision index', 'dropIndex', 'civicrm_activity', 'index_is_current_revision');
 
-    $this->addTask('Make WordReplacement Find Word', 'alterSchemaField', 'WordReplacement', 'find_word', [
+    $this->addTask('Make WordReplacement "find_word" required.', 'alterSchemaField', 'WordReplacement', 'find_word', [
       'title' => ts('Replaced Word'),
       'sql_type' => 'varchar(255)',
       'input_type' => 'Text',

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -65,6 +65,24 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'description' => ts('JSON blob of config as appropriate for the specific integration'),
     ], 'AFTER `accepted_credit_cards`');
     $this->addTask('Drop civicrm_activity.is_current_revision index', 'dropIndex', 'civicrm_activity', 'index_is_current_revision');
+
+    $this->addTask('Make WordReplacement Find Word', 'alterSchemaField', 'WordReplacement', 'find_word', [
+      'title' => ts('Replaced Word'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Text',
+      'description' => ts('Word which need to be replaced'),
+      'add' => '4.4',
+      'collate' => 'utf8_bin',
+      'required' => TRUE,
+    ]);
+    $this->addTask('Make WordReplacement replace word required', 'alterSchemaField', 'WordReplacement', 'replace_word', [
+      'title' => ts('Replacement Word'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Text',
+      'description' => ts('Word which will replace the word in find'),
+      'add' => '4.4',
+      'collate' => 'utf8_bin',
+    ]);
   }
 
 }

--- a/schema/Core/WordReplacement.entityType.php
+++ b/schema/Core/WordReplacement.entityType.php
@@ -38,6 +38,7 @@ return [
       'description' => ts('Word which need to be replaced'),
       'add' => '4.4',
       'collate' => 'utf8_bin',
+      'required' => TRUE,
     ],
     'replace_word' => [
       'title' => ts('Replacement Word'),
@@ -46,6 +47,7 @@ return [
       'description' => ts('Word which will replace the word in find'),
       'add' => '4.4',
       'collate' => 'utf8_bin',
+      'required' => TRUE,
     ],
     'is_active' => [
       'title' => ts('Word Replacement is Active'),


### PR DESCRIPTION
Feels like these fields should be required ...

To fix

<img width="956" height="467" alt="image" src="https://github.com/user-attachments/assets/c12e2a57-1afa-44ed-9d20-7687afea0515" />
