### PR TITLE
Ensure scheduled_date is always set when submitting a mailing

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -440,6 +440,8 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing implements \Civi\C
    * @param \CRM_Mailing_DAO_Mailing $mailing
    */
   protected static function doSubmitActions(array $params, CRM_Mailing_DAO_Mailing $mailing): void {
+    $params = self::ensureScheduledDate($params);
+
     // Create parent job if not yet created.
     // Condition on the existence of a scheduled date.
     if (!empty($params['scheduled_date']) && $params['scheduled_date'] !== 'null' && empty($params['_skip_evil_bao_auto_schedule_'])) {
@@ -471,6 +473,26 @@ class CRM_Mailing_BAO_Mailing extends CRM_Mailing_DAO_Mailing implements \Civi\C
       }
       self::getRecipients($mailing->id);
     }
+  }
+
+  /**
+   * Ensure scheduled_date is set when scheduled_id is present.
+   *
+   * A mailing with scheduled_id but no scheduled_date is an invalid state
+   * that prevents the mail scheduler from ever sending it. This guards
+   * against edge cases where scheduled_date is lost in the pipeline.
+   *
+   * @param array $params
+   * @return array
+   */
+  private static function ensureScheduledDate(array $params): array {
+    if (!empty($params['scheduled_id']) && (empty($params['scheduled_date']) || $params['scheduled_date'] === 'null')) {
+      Civi::log()->warning('Mailing: scheduled_id is set but scheduled_date is missing for mailing {id}. Defaulting to now.', [
+        'id' => $params['id'] ?? 'unknown',
+      ]);
+      $params['scheduled_date'] = CRM_Utils_Date::currentDBDate();
+    }
+    return $params;
   }
 
   /**
@@ -986,6 +1008,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     }
     // CRM-20892 Unset Modifed Date here so that MySQL can correctly set an updated modfied date.
     unset($params['modified_date']);
+    $params = self::ensureScheduledDate($params);
 
     $result = static::writeRecord($params);
 


### PR DESCRIPTION
## Overview

Adds a defensive guard to prevent mailings from silently disappearing when `scheduled_date` is lost during the mailing submit pipeline, leaving `scheduled_id` set but `scheduled_date` as NULL.

## Before

When a mailing is submitted via `Mailing.submit`, it is possible for `scheduled_date` to end up NULL in the database while `scheduled_id` and `approval_date` are correctly set. This causes the mail scheduler to never pick up the mailing, and it disappears from both the Scheduled and Draft mailing lists. This has been observed in production across multiple sites using the Mosaico editor.

## After

A private `ensureScheduledDate()` method in `CRM_Mailing_BAO_Mailing` guards against the invalid state. If `scheduled_id` is present but `scheduled_date` is missing or `'null'`, it defaults to `CRM_Utils_Date::currentDBDate()` and logs a warning. The method is called from both `add()` (before `writeRecord()`) and `doSubmitActions()`.

## Technical Details

- Added `ensureScheduledDate()` private static method in `CRM/Mailing/BAO/Mailing.php` that validates `scheduled_date` is set when `scheduled_id` is present, defaulting to now with a warning log.
- Called from `add()` before `writeRecord()` — catches the invalid state right before DB write.
- Called from `doSubmitActions()` — catches the invalid state before job scheduling.
- No changes to `api/v3/Mailing.php` — the BAO layer handles it centrally.

## Comments

This was reported by multiple production sites. DB logs confirm `scheduled_date=NULL` being written at submit time while `scheduled_id` and `approval_date` are correctly set. The issue is intermittent and has not been reproduced locally, but the defensive guard is valid regardless of the root cause — a mailing with `scheduled_id` but no `scheduled_date` is an invalid state that should never exist.