### PR TITLE
dev/core#6305 Afform - Add token picker to confirmation message

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -26,25 +26,59 @@
       };
 
       this.getTokens = function() {
-        const tokens = ctrl.editor.getEntities().reduce((tokens, entity) => {
+        const allTokens = [];
+        ctrl.editor.getEntities().forEach((entity) => {
+          const entityTokens = [];
           const entityMeta = ctrl.editor.meta.entities[entity.type];
           if (entityMeta.submissionTokens) {
+            // Explicitly defined submission tokens e.g. by FormProcessor extension
             entityMeta.submissionTokens.forEach((submissionToken) => {
-              const description = submissionToken.description ?? '';
-              tokens.push({
+              entityTokens.push({
                 id: entity.name + '.0.' + submissionToken.token,
                 text: entity.label + ' ' + submissionToken.label,
-                description: description
+                description: submissionToken.description ?? '',
               });
             });
           } else {
-            tokens.push({id: entity.name + '.0.id', text: entity.label + ' ' + ts('ID')});
+            // Primary key token
+            entityTokens.push({
+              id: entity.name + '.0.id',
+              text: ts('%1 ID', {1: entity.label}),
+            });
+            // Tokens from entity data values
+            if (entity.data) {
+              Object.keys(entity.data).forEach((key) => {
+                if (entityMeta.fields[key]) {
+                  entityTokens.push({
+                    id: entity.name + '.0.' + key,
+                    text: entity.label + ' ' + entityMeta.fields[key].label,
+                  });
+                }
+              });
+            }
+            // Tokens from entity fields on the form
+            ctrl.editor.getEntityFields(entity.name).fields.forEach((field) => {
+              entityTokens.push({
+                id: entity.name + '.0.' + field.name,
+                text: entity.label + ' ' + field.label,
+              });
+            });
           }
-          return tokens;
-        }, []);
-        tokens.push({id: 'token', text: ts('Submission JWT')});
+          if (entityTokens.length) {
+            allTokens.push({
+              text: entity.label,
+              children: entityTokens,
+            });
+          }
+        });
+        allTokens.push({
+          text: ts('Form'),
+          children: [
+            {id: 'token', text: ts('Submission JWT')},
+          ],
+        });
         return {
-          results: tokens
+          results: allTokens
         };
       };
 

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -221,6 +221,7 @@
       <label for="af_config_confirmation_message">
         {{:: editor.meta.afform_fields.confirmation_message.title }}
       </label>
+      <af-gui-token-select class="pull-right" model="editor.afform" field="confirmation_message"></af-gui-token-select>
       <textarea ng-model="editor.afform.confirmation_message" class="form-control" id="af_config_confirmation_message" ng-model-options="editor.debounceMode"></textarea>
       <p class="help-block">{{:: ts("This message wil be displayed when the form is submitted.") }}</p>
     </div>

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
@@ -57,4 +57,37 @@ EOHTML;
     $this->assertSame($cid[0], $result[0]['Individual1'][0]['id']);
   }
 
+  public function testSubmitWithTokensInConfirmationMessage(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'Hello'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC"  />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="last_name" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      'confirmation_type' => 'show_confirmation_message',
+      'confirmation_message' => 'Thank you "[Individual1.0.first_name] [Individual1.0.last_name]" You are now registered as [Individual1.0.source] ID_[Individual1.0.id].',
+    ]);
+
+    // Submit with new contact
+    $submission = [
+      ['fields' => ['first_name' => 'Jane', 'last_name' => 'Doe']],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $contactId = $result[0]['Individual1'][0]['id'];
+    $expectedMessage = "Thank you \"Jane Doe\" You are now registered as Hello ID_$contactId.";
+    $this->assertSame($expectedMessage, $result[0]['message']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6305](https://lab.civicrm.org/dev/core/-/issues/6305)

Before
----------------------------------------
FormBuilder did not have a token picker for confirmation messages.

After
----------------------------------------
<img width="676" height="390" alt="image" src="https://github.com/user-attachments/assets/d6840163-2811-4ebf-8f30-a57dd80d4789" />


Technical Details
----------------------------------------
~~Also fixes a regex issue with the replaceTokens function which would previously match all of e.g. "hello[Individual1.0.first_name]" (including the word "hello") instead of just the part within the brackets.~~
Broken out to https://github.com/civicrm/civicrm-core/pull/35129

Adds tests.