### PR TITLE
Afform - Fix token matching

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -878,7 +878,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    */
   public function replaceTokens(string $text): string {
     $matches = [];
-    preg_match_all('/[[a-zA-Z0-9_]{1,}\.[0-9]{1,}\.[^]]+]/', $text, $matches);
+    preg_match_all('/\[[a-zA-Z0-9_]+\.[0-9]+\.[^]]+]/', $text, $matches);
 
     foreach ($matches[0] as $match) {
       // strip [ ] and split on .


### PR DESCRIPTION
Overview
----------------------------------------
Fixes token matching in FormBuilder when a token is next to letters.

Regressed with #33911

Before
----------------------------------------
A token like `hello[Individual1.0.first_name]` will fail because the regex will also match the word "hello" instead of just the token.

After
----------------------------------------
Fixed.

Comments
---------
A unit test for this is included with https://github.com/civicrm/civicrm-core/pull/35128. This just backports the fix.