### PR TITLE
Afform - Ensure search params from url are set immediately.

### DIFF
--- a/ext/afform/core/ang/afCore.js
+++ b/ext/afform/core/ang/afCore.js
@@ -22,7 +22,9 @@
           // Afforms do not use routing, but some forms get input from search params
           const dialog = $el.closest('.ui-dialog-content');
           if (!dialog.length) {
-            // Full-screen mode: watch search params in url
+            // Full-screen mode: use search params in url
+            $scope.routeParams = $location.search();
+            // Full-screen mode: watch changes to search params in url
             $scope.$watch(function() {return $location.search();}, function(params) {
               $scope.routeParams = params;
             });


### PR DESCRIPTION
Overview
----------------------------------------

Fixes [dev/core#6385](https://lab.civicrm.org/dev/core/-/issues/6385)

Before
----------------------------------------
In "Administer Custom Fields" clicking on fields for one group will show fields for all groups.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Now that SearchKit [loads faster](https://github.com/civicrm/civicrm-core/pull/35059) we need to ensure it gets its url search params right away.