### PR TITLE
Afform: Fix Process.php to seed _entityIds from stored submission data (dev/core#6370)

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Process.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Process.php
@@ -43,7 +43,7 @@ class Process extends AbstractProcessor {
         }
       }
     }
-    
+
     // process and save various enities
     $this->processFormData($entityValues);
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Process.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Process.php
@@ -33,6 +33,17 @@ class Process extends AbstractProcessor {
     // preprocess submitted values
     $entityValues = $this->preprocessSubmittedValues($afformSubmissionData['data']);
 
+    // Seed _entityIds from stored submission data so prefill-resolved
+    // IDs (e.g. autofill="user") do not override the original submitter's IDs.
+    // See: https://lab.civicrm.org/dev/core/-/issues/6370
+    foreach ($afformSubmissionData['data'] as $entityName => $records) {
+      foreach ((array) $records as $index => $record) {
+        if (!empty($record['id'])) {
+          $this->_entityIds[$entityName][$index]['id'] = $record['id'];
+        }
+      }
+    }
+    
     // process and save various enities
     $this->processFormData($entityValues);
 


### PR DESCRIPTION
## Overview

Fixes a data-loss bug in `Afform::process` where calling the action to process a pending submission on a form using `autofill="user"` overwrites the **processing admin's** contact record with the submitter's field values, leaving the original submitter's contact untouched. See [dev/core#6370](https://lab.civicrm.org/dev/core/-/issues/6370).

## Before

When `Afform::process` is called by an admin to process a pending submission from a different user, the admin's own contact record is silently overwritten with the submitter's data.

**Example:**
1. A form with `manual_processing = true` has `Individual1` set to `autofill="user"`
2. Contact ID 51 (a regular user) submits the form — submission is stored as Pending
3. Admin (contact ID 2) calls `Afform::process` with the pending `submissionId`
4. **Result:** Contact 2 (admin) is updated with contact 51's name, phone, address etc. Contact 51 is untouched.
```php
// _entityIds is seeded by prefill resolving autofill="user" to the ADMIN's contact
$this->_entityIds['Individual1'][0]['id'] = 2; // wrong — should be 51
```

## After

`Afform::process` correctly writes the submitted data to the original submitter's contact record. The admin's contact is not affected.
```php
// _entityIds is now seeded from the stored submission data BEFORE processFormData runs
$this->_entityIds['Individual1'][0]['id'] = 51; // correct
```

## Technical Details

The root cause is that `Process.php::processForm()` calls `AbstractProcessor::loadEntities()` (inherited), which dispatches `civi.afform.prefill`. This causes `ContactAutofill::onAfformPrefill` to fire and resolve `autofill="user"` to the **currently logged-in contact** (the admin), seeding `_entityIds` with the admin's ID.

Subsequently:
- `preprocessSubmittedValues()` strips `id` from fields because `id` is not a declared submittable field
- `fillIdFields()` backfills `fields.id` from `_entityIds`, writing the admin's ID into the record
- `processGenericEntity()` calls `Contact::save` with the admin's ID, overwriting their contact

The stored submission data from `combineValuesAndIds` correctly contains the original submitter's entity IDs — but `Process.php` never reads these back into `_entityIds` before processing begins.

**Fix:** After `preprocessSubmittedValues()` and before `processFormData()`, seed `_entityIds` from the stored submission data so the correct submitter IDs take precedence over whatever prefill resolved for the processing admin's session:
```php
// Seed _entityIds from stored submission data so prefill-resolved
// IDs (e.g. autofill="user") do not override the original submitter's IDs.
foreach ($afformSubmissionData['data'] as $entityName => $records) {
  foreach ((array) $records as $index => $record) {
    if (!empty($record['id'])) {
      $this->_entityIds[$entityName][$index]['id'] = $record['id'];
    }
  }
}
```

This bug only manifests when all three conditions are true:
1. `manual_processing = true` on the AfForm
2. The form uses `autofill="user"` on a contact entity
3. The person processing the submission is a different CiviCRM contact than the original submitter

Normal submission flow via `Submit.php` is unaffected — `autofill="user"` works correctly there because the submitter and the logged-in user are the same person.

A related bug (the FormBuilder GUI "Process" button producing the same corruption via a different code path) is tracked separately in [dev/core#6371](https://lab.civicrm.org/dev/core/-/issues/6371).

## Comments

- This fix was identified and root-cause analysed by tracing through `ContactAutofill.php`, `AbstractProcessor.php`, and `Process.php` in a live WordPress/CiviCRM deployment
- Confirmed via live testing: calling `Afform::process` on a pending submission from contact 51 while logged in as contact 2 resulted in contact 2 being overwritten
- The fix is minimal and surgical — 7 lines inserted at the correct point in the processing chain
- Related issue dev/core#6371 (GUI Process button) will require a separate fix