### PR TITLE
Update user job status and expiration when importing rows manually

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -61,21 +61,35 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
   public static function hook_civicrm_queueStatus(CRM_Queue_Queue $queue, string $status): void {
     $userJobId = static::findUserJobId($queue->getName());
     if ($userJobId && $status === 'completed') {
-      $userJob = UserJob::get(FALSE)
-        ->addWhere('id', '=', $userJobId)->execute()->first();
-      $newStatus = 'completed';
-      $dataSource = $userJob['metadata']['submitted_values']['dataSource'] ?? NULL;
-      if ($dataSource) {
-        /* @var \CRM_Import_DataSource $dataSource */
-        $dataSource = new $dataSource();
-        $dataSource->setUserJobID($userJobId);
-        if ($dataSource->getRowCount(['new'])) {
-          $newStatus = 'incomplete';
-        }
-        elseif ($dataSource->getRowCount(['unimported'])) {
-          $newStatus = 'complete_with_errors';
-        }
+      self::updateUserJobStatus($userJobId);
+    }
+  }
+
+  /**
+   * Update the status of an import user job, based on the status of its rows.
+   *
+   * @param int $userJobId
+   * @throws \CRM_Core_Exception
+   */
+  public static function updateUserJobStatus($userJobId): void {
+    $userJob = UserJob::get(FALSE)
+      ->addWhere('id', '=', $userJobId)
+      ->addSelect('status_id:name', 'id', 'metadata')
+      ->execute()->first();
+    $newStatus = 'completed';
+    $dataSource = $userJob['metadata']['submitted_values']['dataSource'] ?? NULL;
+    if ($dataSource) {
+      /* @var \CRM_Import_DataSource $dataSource */
+      $dataSource = new $dataSource();
+      $dataSource->setUserJobID($userJobId);
+      if ($dataSource->getRowCount(['new'])) {
+        $newStatus = 'incomplete';
       }
+      elseif ($dataSource->getRowCount(['unimported'])) {
+        $newStatus = 'complete_with_errors';
+      }
+    }
+    if ($newStatus !== $userJob['status_id:name']) {
       UserJob::update(FALSE)
         ->addWhere('id', '=', $userJobId)
         ->addValue('status_id:name', $newStatus)

--- a/ext/civiimport/Civi/Api4/Import/Import.php
+++ b/ext/civiimport/Civi/Api4/Import/Import.php
@@ -34,6 +34,7 @@ class Import extends DAOGetAction {
       $parser->import($row);
     }
     $parser->doPostImportActions();
+    \CRM_Core_BAO_UserJob::updateUserJobStatus($userJobID);
 
     // Re-fetch the validated result with updated messages.
     $this->where = $where;


### PR DESCRIPTION
Overview
----------------------------------------
If your import user job ends up incomplete or complete with errors, you might be able to fix the problems by manually importing the relevant rows (or by making changes and then manually importing) from the Import Job SearchDisplay.

Before
----------------------------------------
User Job status and expiration date aren't updated.

After
----------------------------------------
They are updated.