### PR TITLE
Fix scheduled_date being nullified after mailing submit

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -987,6 +987,20 @@ ORDER BY   civicrm_email.is_bulkmail DESC
     // CRM-20892 Unset Modifed Date here so that MySQL can correctly set an updated modfied date.
     unset($params['modified_date']);
 
+    // Prevent scheduled_date from being nullified on updates.
+    // The crmMailingMgr JS service calls Mailing.create for save/preview
+    // operations, passing scheduled_id (from the mailing model) but deleting
+    // scheduled_date (to avoid re-triggering scheduling). When writeRecord
+    // processes the update, the orphaned scheduled_id without scheduled_date
+    // causes the valid scheduled_date to be overwritten with NULL in the DB.
+    if (!empty($id) && !empty($params['scheduled_id'])
+      && array_key_exists('scheduled_date', $params)
+      && (empty($params['scheduled_date']) || $params['scheduled_date'] === 'null')
+    ) {
+      \Civi::log()->warning('Mailing: prevented scheduled_date from being nullified for mailing ' . $id . ', scheduled_id=' . $params['scheduled_id']);
+      unset($params['scheduled_date']);
+    }
+
     $result = static::writeRecord($params);
 
     // CRM-20892 Re find record after saing so we can set the updated modified date in the result.

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -300,6 +300,7 @@
           }
         });
         delete params.scheduled_date;
+        delete params.scheduled_id;
         delete params.recipients; // the content was merged in
         return qApi('Mailing', 'create', params).then(function (recipResult) {
           // changes rolled back, so we don't care about updating mailing
@@ -333,6 +334,7 @@
             crmMailingCache.put('mailing-' + mailing.id + '-recipient-params', params.recipients);
           }
           delete params.scheduled_date;
+          delete params.scheduled_id;
           delete params.recipients; // the content was merged in
           recipientCount = qApi('Mailing', 'create', params).then(function (recipResult) {
             // changes rolled back, so we don't care about updating mailing
@@ -364,7 +366,10 @@
         // WORKAROUND: Mailing.create (aka CRM_Mailing_BAO_Mailing::create()) interprets scheduled_date
         // as an *intent* to schedule and creates tertiary records. Saving a draft with a scheduled_date
         // is therefore not allowed. Remove this after fixing Mailing.create's contract.
+        // Also delete scheduled_id to prevent writeRecord from nullifying
+        // scheduled_date in the database when it processes the orphaned field.
         delete params.scheduled_date;
+        delete params.scheduled_id;
 
         delete params.jobs;
 
@@ -417,7 +422,10 @@
         // WORKAROUND: Mailing.create (aka CRM_Mailing_BAO_Mailing::create()) interprets scheduled_date
         // as an *intent* to schedule and creates tertiary records. Saving a draft with a scheduled_date
         // is therefore not allowed. Remove this after fixing Mailing.create's contract.
+        // Also delete scheduled_id to prevent writeRecord from nullifying
+        // scheduled_date in the database when it processes the orphaned field.
         delete params.scheduled_date;
+        delete params.scheduled_id;
 
         delete params.jobs;
 


### PR DESCRIPTION
## Overview

Fixes scheduled mailings having their scheduled time overwritten after submission. The crmMailingMgr JS service deletes scheduled_date before calling Mailing.create for save/preview/test operations (to avoid re-triggering scheduling) but leaves scheduled_id in params, causing writeRecord to nullify scheduled_date in the database.

## Before

After submitting a mailing with a scheduled date, subsequent Mailing.create calls from the frontend (save, preview recipients, send test) pass scheduled_id without scheduled_date. This causes writeRecord to overwrite the correct scheduled_date with NULL, making the mailing either disappear from the scheduler or send at the wrong time.

## After

Two fixes:

1. **Frontend (root cause):** delete params.scheduled_id added alongside delete params.scheduled_date in all 4 places in crmMailingMgr service, so the create call no longer passes orphaned scheduling fields.

2. **Backend (defensive guard):** In BAO::add(), if an update has scheduled_id set but scheduled_date is explicitly empty/null, unset it from params so writeRecord preserves the existing DB value.

## Technical Details

**Frontend fix** in ext/civi_mail/ang/crmMailing/services.js:

Added delete params.scheduled_id in:
- previewRecipients() - tentative save to get recipient list
- previewRecipientCount() - tentative save to get recipient count
- save() - draft save
- sendTest() - save before sending test email

**Backend fix** in CRM/Mailing/BAO/Mailing.php:

Guard in add() before writeRecord():
- If update (has id) AND scheduled_id is present AND scheduled_date is explicitly empty/null
- Unset scheduled_date from params so writeRecord skips the field
- Logs a warning when triggered

## How to reproduce

1. Create a mailing (Mosaico or Traditional)
2. Schedule it for later today (e.g. select today's date with a future time)
3. Submit the mailing
4. Check the scheduled_date in the database - it will be the current time/null instead of the chosen time
