### PR TITLE
mark minifier as obsolete

### DIFF
--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -61,5 +61,10 @@
     "obsolete": "5.81",
     "disable": true,
     "uninstall": true
+  },
+  "minifier": {
+    "obsolete": "6.12",
+    "disable": true,
+    "uninstall": true
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
@mattwire has a minifier extension, but he's deprecated it because it can cause issues.  There's one particular issue where the SearchKit admin screen [stops working when ChartKit is enabled](https://lab.civicrm.org/extensions/minifier/-/issues/9).

Given that Stripe/Authnet require Payment Shared, and Payment Shared has a status check recommending people install minifier, AND 6.12 force-enabled ChartKit, I suspect that with today's security release, a bunch of people are going to hit this bug.

Before
----------------------------------------
Minifier is not marked obsolete.

After
----------------------------------------
Minifier is marked obsolete.
