### PR TITLE
Default times to end in :00

### DIFF
--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -46,6 +46,7 @@
           .timeEntry({
             spinnerImage: '',
             useMouseWheel: false,
+            defaultTime: new Date(new Date().setMinutes(0)),
             show24Hours: settings.time === true || settings.time === undefined ? CRM.config.timeIs24Hr : settings.time == '24'
           });
         if (!placeholder) {


### PR DESCRIPTION
Overview
----------------------------------------
It's bothered me for about 15 years that if it's 4:27 and you go to enter a default time for an event, it will auto-fill the minutes with "27".  The sensible default is "00".

To replicate, go to "New Event" (or anywhere that has a time field that isn't pre-filled) and try to enter a time.

Before
----------------------------------------
The current time affects the default time for an event.

After
----------------------------------------
The current time is irrelevant.
