### PR TITLE
Fix membership form using wrong price set during submission

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -562,6 +562,13 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    */
   public function getPriceSetID(): int {
     $this->_priceSetId = $this->isAjaxOverLoadMode() ? CRM_Utils_Request::retrieve('priceSetId', 'Integer') : ($this->getSubmittedValue('price_set_id') ?? NULL);
+    // During form submission, getSubmittedValue('price_set_id') may return
+    // NULL if the field has not yet been registered on the form via add().
+    // Fall back to the raw POST value to ensure non-quick-config price sets
+    // selected by the user are respected.
+    if (!$this->_priceSetId && !empty($_POST['price_set_id'])) {
+      $this->_priceSetId = (int) $_POST['price_set_id'];
+    }
     if (!$this->_priceSetId) {
       $priceSet = CRM_Price_BAO_PriceSet::getDefaultPriceSet('membership');
       $priceSet = reset($priceSet);


### PR DESCRIPTION
Overview
----------------------------------------
When a non-quick-config price set is selected on the back-office membership form (Add Membership), submitting the form results in a `DB Error: constraint violation` because `membership_type_id` is missing from the INSERT into `civicrm_membership`. This happens because `getPriceSetID()` silently falls back to the default quick-config price set instead of using the one selected by the user.

Before
----------------------------------------
1. Create a non-quick-config price set extending CiviMember with membership type options
2. Go to a contact's membership tab → Add Membership
3. Select the custom price set from the "Choose price set" dropdown
4. Select a membership option and submit
5. Result: `DB Error: constraint violation` — the membership is not created

After
----------------------------------------
The same steps now correctly create the membership using the selected price set. The user's price set selection is preserved during form submission.

Technical Details
----------------------------------------
`CRM_Member_Form::getPriceSetID()` uses `getSubmittedValue('price_set_id')` to retrieve the selected price set. However, this returns `NULL` when the form field has not yet been registered via `add()` at the time `getPriceSetID()` is first called (e.g. during `initializeOrder()` → `getOrder()`).

When the price set ID is null, the method falls back to the default quick-config membership price set. This causes:

1. `getSelectedMemberships()` searches for submitted `price_*` fields in the wrong price set's field list — finds nothing
2. `_memTypeSelected` is empty
3. `getMembershipParameters()` creates entries with dates (from Order line items) but without `membership_type_id` (only set when iterating `_memTypeSelected`)
4. `CRM_Member_BAO_Membership::create()` is called without `membership_type_id`
5. The INSERT fails with FK constraint violation on `FK_civicrm_membership_membership_type_id`

The fix adds a fallback to `$_POST['price_set_id']` before defaulting to the default price set, ensuring the user's price set selection is respected during form submission.

Comments
----------------------------------------
This bug was introduced in commit `e6e6891a30` (Feb 2024, "Fix BackOffice Membership forms getPriceSetID() to be standard"). The partial fix in `3398d70c69` (Apr 2024, dev/core#5147) addressed AJAX rendering but did not fix the form submission path.