### PR TITLE
Fix stale membership_type_id overriding price set selections on membership form

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -93,7 +93,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   public static function getSelectedMemberships($priceSet, $params) {
     $memTypeSelected = [];
     $priceFieldIDS = self::getPriceFieldIDs($params, $priceSet);
-    if (isset($params['membership_type_id']) && !empty($params['membership_type_id'][1])) {
+    if (isset($params['membership_type_id']) && !empty($params['membership_type_id'][1]) && empty($params['price_set_id'])) {
       $memTypeSelected = [$params['membership_type_id'][1] => $params['membership_type_id'][1]];
     }
     else {


### PR DESCRIPTION
Overview
----------------------------------------
When a non-quick-config price set is selected on the back-office membership form, creating a membership fails with `DB Error: constraint violation` because `membership_type_id` is missing from the INSERT. This happens because a stale `membership_type_id` value from the org/type selector overrides the price set selections.

Before
----------------------------------------
1. Go to a contact's membership tab → Add Membership
2. Select a non-quick-config price set from the "Choose price set" dropdown
3. Select membership options from the price set fields
4. Submit
5. Result: `DB Error: constraint violation` — membership is not created

After
----------------------------------------
The same steps now correctly create memberships for all selected price set options.

Technical Details
----------------------------------------
The membership form has two selection modes: an org/type dropdown (`membership_type_id[0]`/`membership_type_id[1]`) and a price set selector. When switching to a price set, JavaScript sets `membership_type_id[1]` to `0`, but a stale value can remain if the user previously browsed membership types.

`getSelectedMemberships()` checks `membership_type_id[1]` first:
```php
if (isset($params['membership_type_id']) && !empty($params['membership_type_id'][1])) {
    $memTypeSelected = [$params['membership_type_id'][1] => ...];
}
```

When `membership_type_id[1]` has a stale value (e.g. `52`), only that single type is returned — all price set selections are ignored. `getMembershipParameters()` then only sets `membership_type_id` for type 52, but the form tries to create memberships for all types from the price set line items, resulting in INSERTs without `membership_type_id`.

The fix adds `&& empty($params['price_set_id'])` so that when a price set is active, membership types are always derived from the price field selections instead.

Comments
----------------------------------------
Tested on a site with a non-quick-config membership price set containing 9 fields (Select and CheckBox types) covering 60+ membership types. Verified that all combinations work correctly after the fix.