### PR TITLE
Add implicit FK field for primary membership's contact ID in SearchKit

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -284,6 +284,19 @@ class Admin {
             }
           }
         }
+        // Contact ID of primary membership.
+        if ($entity['name'] === 'Membership') {
+          $ownerMembershipField = \CRM_Utils_Array::findAll($schema['Membership']['fields'], ['name' => 'owner_membership_id'])[0];
+          $newField = \CRM_Utils_Array::findAll($schema['Membership']['fields'], ['name' => 'contact_id'])[0];
+          $newField['name'] = 'owner_membership_id.contact_id';
+          $newField['label'] = ($ownerMembershipField['input_attrs']['label'] ?? $ownerMembershipField['label']) . ' ' . $newField['label'];
+          array_splice(
+            $entity['fields'],
+            array_search('owner_membership_id', array_column($entity['fields'], 'name')) + 1,
+            0,
+            [$newField]
+          );
+        }
       }
     }
     return array_values($schema);


### PR DESCRIPTION
Overview
----------------------------------------
Adds a field for the parent membership's contact ID for `Membership` entities in *SearchKit*. A potential use case would be displaying primary and secondary memberships in a single display on the contact summary where you would filter by the primary member's contact ID.

*systopia-reference: 33744*

Before
----------------------------------------
Joining parent memberships can only add secondary memberships to primary memberships in a *SearchKit* query, leaving the user unable to select the primary member's contact ID (or any other field). The problem had been described in the chat previously by @masetto, see https://chat.civicrm.org/civicrm/pl/uop6dgrjgpds7n53ugd3dc8ige.

After
----------------------------------------
There is a new field in *SearchKit* for displaying the primary member's `contact_id`.

Technical Details
----------------------------------------
This follows the example set by adding useful address fields for contacts in #23972, although I'm not sure `\Civi\Search\Admin::addImplicitFKFields()` is a good place for additions like these. Maybe subscribing to an event for adding FK fields would be better.

Comments
----------------------------------------
Adding just one field of the joined entity rather than the possibility to explicitly join the primary member contact for retrieving any contact field is a quick solution, but the join on `owner_membership_id` would have to be reversed so that you could join primary memberships from secondary ones instead of the other way around.