### PR TITLE
Riverlea - fix rendering stream descriptions

### DIFF
--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -317,7 +317,7 @@
 
       this.querySelector('h3').innerText = this.data.label;
       if (this.data.description) {
-        this.querySelector('.panel-body p').innerText = this.description;
+        this.querySelector('.panel-body p').innerText = this.data.description;
       }
 
       this.querySelector('.panel-body details summary').innerText = ts('More info');


### PR DESCRIPTION
Overview
----------------------------------------
Fix all stream descriptions rendering as "undefined" :facepalm: 

<img width="358" height="187" alt="image" src="https://github.com/user-attachments/assets/4de259a8-e3fc-4a75-a238-bdabcf466209" />
