### PR TITLE
[NFC] Fix flaky testBridgeJoinRelationshipContactActivity

### DIFF
--- a/tests/phpunit/api/v4/Action/FkJoinTest.php
+++ b/tests/phpunit/api/v4/Action/FkJoinTest.php
@@ -367,6 +367,7 @@ class FkJoinTest extends Api4TestBase implements TransactionalInterface {
       ->addJoin('Contact AS rel', 'LEFT', 'RelationshipCache', ['rel.far_contact_id', '=', 'contact.id'], ['rel.near_relation:name', '=', '"Child of"'])
       ->addWhere('contact.id', 'IN', [$cid1, $cid2, $cid3])
       ->addOrderBy('id')
+      ->addOrderBy('rel.id')
       ->execute();
     $this->assertCount(5, $result);
     $this->assertEquals($cid1, $result[0]['contact.id']);


### PR DESCRIPTION
Overview
----------------------------------------
Flaky test

Before
----------------------------------------
Order of results not guaranteed

After
----------------------------------------
Order more ordered.

Technical Details
----------------------------------------
The first contact has two children. When you call for them they don't always come in the same order.

Comments
----------------------------------------
I'm not 100% sure this is the cause, but forcing a reverse order for `rel.id` makes it fail similar to the fails we see in jenkins.
