### PR TITLE
(dev/core#6394) Upgrader - Fix "hook_permission" error when removing "minifier".

### DIFF
--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -64,7 +64,6 @@
   },
   "minifier": {
     "obsolete": "6.12",
-    "disable": true,
-    "uninstall": true
+    "force-uninstall": true
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------

With the recent #35138, the upgrader is supposed to disable the `minifier` extension. This tends to fail on systems which have `minifier`, but it eventually works (*which can create an optical-illusion during testing*).

To make this more reliable, use `force-uninstall` instead of `disable`/`uninstall`.

See: https://lab.civicrm.org/dev/core/-/issues/6394. ping @colemanw @MegaphoneJon @mattwire 

Technical Details
----------------------------------------

I haven't looked closely at `minifier`. From the name/scope, it _sounds_ like a stateless extension where you don't need any special uninstall logic. But if it does need detailed uninstall logic, then... this will get more interesting...