### PR TITLE
(dev/core#6394) Upgrader - Fix "hook_permission" error when removing "minifier"

### DIFF
--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -54,7 +54,6 @@
   },
   "minifier": {
     "obsolete": "6.12",
-    "disable": true,
-    "uninstall": true
+    "force-uninstall": true
   }
 }


### PR DESCRIPTION
Backport #35160 from 6.13-rc to 6.12-stable.