### PR TITLE
Api4 - New SqlView class

### DIFF
--- a/Civi/Api4/Action/GetActions.php
+++ b/Civi/Api4/Action/GetActions.php
@@ -79,18 +79,24 @@ class GetActions extends BasicGetAction {
   private function loadAction($actionName, $method = NULL) {
     try {
       if (!isset($this->_actions[$actionName]) && (!$this->_actionsToGet || in_array(strtolower($actionName), $this->_actionsToGet))) {
+        $vars = ['entity' => $this->getEntityName(), 'action' => $actionName];
+        if ($method) {
+          $methodDocs = ReflectionUtils::getCodeDocs($method, 'Method', $vars);
+          // Internal non-api function should be skipped
+          if (!empty($methodDocs['internal']) && !(is_string($methodDocs['internal']) && strtolower($methodDocs['internal']) === 'api')) {
+            return;
+          }
+        }
         $action = \Civi\API\Request::create($this->getEntityName(), $actionName, ['version' => 4]);
         $authorized = !$this->checkPermissions || \Civi::service('civi_api_kernel')->runAuthorize($this->getEntityName(), $actionName, ['version' => 4]);
         if (is_object($action) && $authorized) {
           $this->_actions[$actionName] = ['name' => $actionName];
           if ($this->_isFieldSelected('description', 'comment', 'see')) {
-            $vars = ['entity' => $this->getEntityName(), 'action' => $actionName];
             // Docblock from action class
             $actionDocs = ReflectionUtils::getCodeDocs($action->reflect(), NULL, $vars);
             unset($actionDocs['method']);
             // Docblock from action factory function in entity class. This takes precedence since most action classes are generic.
             if ($method) {
-              $methodDocs = ReflectionUtils::getCodeDocs($method, 'Method', $vars);
               // Allow method doc to inherit class doc
               if (str_contains($method->getDocComment(), '@inheritDoc') && !empty($methodDocs['comment']) && !empty($actionDocs['comment'])) {
                 $methodDocs['comment'] .= "\n\n" . $actionDocs['comment'];

--- a/Civi/Api4/Generic/AbstractEntity.php
+++ b/Civi/Api4/Generic/AbstractEntity.php
@@ -68,6 +68,7 @@ abstract class AbstractEntity implements EntityInterface {
   /**
    * Returns a list of permissions needed to access the various actions in this api.
    *
+   * @internal
    * @return array
    */
   public static function permissions() {
@@ -82,7 +83,7 @@ abstract class AbstractEntity implements EntityInterface {
   /**
    * Get entity name from called class
    *
-   * @return string
+   * @internal
    */
   public static function getEntityName(): string {
     return CoreUtil::stripNamespace(static::class);
@@ -136,6 +137,7 @@ abstract class AbstractEntity implements EntityInterface {
   /**
    * Reflection function called by Entity::get()
    *
+   * @internal
    * @see \Civi\Api4\Action\Entity\Get
    * @return array{name: string, title: string, description: string, title_plural: string, type: string, paths: array, class: string, primary_key: array, searchable: string, dao: string, label_field: string, icon: string}
    */

--- a/Civi/Api4/Generic/SqlView.php
+++ b/Civi/Api4/Generic/SqlView.php
@@ -1,0 +1,237 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic;
+
+use Civi\Api4\Event\SchemaMapBuildEvent;
+use Civi\Api4\Service\Schema\Joinable\Joinable;
+use Civi\Api4\Service\Schema\Table;
+use Civi\Api4\Utils\CoreUtil;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoServiceInterface;
+use Civi\Core\Service\AutoServiceTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Base class for SQL Views.
+ *
+ * To-date this is not used in core but is provided for extensions to use.
+ *
+ * Inheritors of this class must define viewSelect() and viewFrom() which are used to generate the View and the API.
+ * Recommended: implement the getEntityTitle() method.
+ * Optional: override the viewName() function to customize the table name of the view.
+ * Optional: class annotations can be added to customize the API:
+ * e.g. @description, @icon, @labelField, @orderBy, @searchable, @searchFields, @since.
+ *
+ * @service
+ * @internal
+ */
+abstract class SqlView extends AbstractEntity implements EventSubscriberInterface, AutoServiceInterface {
+  use AutoServiceTrait;
+
+  /**
+   * Defines the SELECT clause of the view and also the output of Api4 getFields.
+   *
+   * Return values can include anything supported by Api4 getFields, plus a "select" key which defines the SQL expression.
+   * The "name" key defines the field alias in the view, and the name of the Api4 field.
+   *
+   * If selecting an existing database column, specify "original_field" (concatenating the api entity name with the field name e.g. 'Contact.id').
+   * This allows the api to reuse the existing metadata for the field, including FKs and pseudoconstants.
+   *
+   * Example:
+   * ```php
+   * return [
+   *   // Will be rendered as `SELECT CONCAT(first_name, ' ', last_name) AS full_name`
+   *   [
+   *     'select' => 'CONCAT(civicrm_contact.first_name, " ", civicrm_contact.last_name)',
+   *     'name' => 'full_name',
+   *     'data_type' => 'String',
+   *   ],
+   *   // Using the 'original_field' key will establish a FK to civicrm_contact.
+   *   [
+   *     'select' => 'civicrm_email.email',
+   *     'name' => 'email',
+   *     'original_field' => 'Email.email',
+   *   ],
+   *   ... more columns ...
+   * ];
+   * ```
+   */
+  abstract protected static function viewSelect(): array;
+
+  /**
+   * Defines the body of the view.
+   *
+   * Should return a string containing the entire view SQL starting with the word "FROM".
+   *
+   * Example:
+   * ```php
+   * return 'FROM civicrm_contact WHERE contact_type = "Individual"';
+   * ```
+   */
+  abstract protected static function viewFrom(): string;
+
+  /**
+   * Defines the table name of the view.
+   *
+   * In most cases this does not need to be overridden; the default is civicrm_view_{entity_name}.
+   */
+  protected static function viewName(): string {
+    return 'civicrm_view_' . \CRM_Utils_String::convertStringToSnakeCase(static::getEntityName());
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return DAOGetAction
+   */
+  public static function get($checkPermissions = TRUE): DAOGetAction {
+    return (new DAOGetAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return AutocompleteAction
+   */
+  public static function autocomplete($checkPermissions = TRUE): AutocompleteAction {
+    return (new AutocompleteAction(static::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  public static function getFields($checkPermissions = TRUE): BasicGetFieldsAction {
+    return (new BasicGetFieldsAction(static::getEntityName(), __FUNCTION__, [static::class, '_getFieldsFromViewSelect']))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public static function getInfo(): array {
+    $info = parent::getInfo();
+    $info['table_name'] = static::viewName();
+    $info['primary_key'] ??= [];
+    $info['description'] ??= ts('View of %1', [1 => $info['title']]);
+    $info['dao'] = 'Civi\Core\DAO\SqlView';
+    $info['type'] = ['SqlView', 'DAOEntity'];
+    return $info;
+  }
+
+  /**
+   * @internal
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.api4.entityTypes' => '_on_civi_api4_entityTypes',
+      'api.schema_map.build' => '_on_schema_map_build',
+    ];
+  }
+
+  /**
+   * Helper for getFields.
+   */
+  public static function _getFieldsFromViewSelect(): array {
+    $fields = static::viewSelect();
+    foreach ($fields as &$field) {
+      $field['column_name'] = $field['name'];
+      $field['table_name'] = static::viewName();
+      $field['entity'] = static::getEntityName();
+      $originalDefn = self::getOriginalDefinition($field);
+      if ($originalDefn) {
+        // Fetch original options
+        if (isset($originalDefn['options_callback']) || isset($originalDefn['pseudoconstant'])) {
+          $originalDefn['pseudoconstant'] = [
+            'callback' => [static::class, '_getOptions'],
+          ];
+        }
+        // Set FK to original entity id
+        if ($originalDefn['name'] === CoreUtil::getIdFieldName($originalDefn['entity'])) {
+          $field['fk_entity'] = $originalDefn['entity'];
+          $field['fk_column'] = $originalDefn['name'];
+          $field['input_type'] = 'EntityRef';
+        }
+        $field += $originalDefn;
+      }
+      unset($field['select'], $field['options_callback']);
+    }
+    return $fields;
+  }
+
+  /**
+   * Callback rebuilds the view whenever the Api4 entityTypes cache is rebuilt.
+   *
+   * @internal
+   */
+  public static function _on_civi_api4_entityTypes(GenericHookEvent $event): void {
+    $viewName = static::viewName();
+    \CRM_Core_DAO::executeQuery("DROP VIEW IF EXISTS `$viewName`");
+    $selects = [];
+    foreach (static::viewSelect() as $field) {
+      $selects[] = "{$field['select']} AS `{$field['name']}`";
+    }
+    $select = implode(', ', $selects);
+    $from = static::viewFrom();
+    \CRM_Core_DAO::executeQuery("CREATE VIEW `$viewName` AS SELECT $select $from");
+  }
+
+  /**
+   * Callback to register FK joins for the view.
+   *
+   * This makes it possible to use implicit join syntax in Api.get.
+   *
+   * @internal
+   */
+  public static function _on_schema_map_build(SchemaMapBuildEvent $event): void {
+    $schema = $event->getSchemaMap();
+    foreach (static::_getFieldsFromViewSelect() as $field) {
+      if (isset($field['fk_entity'])) {
+        $fkTable = CoreUtil::getTableName($field['fk_entity']);
+        if ($fkTable) {
+          $table = $schema->getTableByName($field['table_name']) ?? (new Table($field['table_name']));
+          $link = new Joinable($fkTable, $field['fk_column'] ?? 'id', $field['name']);
+          $link->setBaseTable($field['table_name']);
+          $link->setJoinType(Joinable::JOIN_TYPE_ONE_TO_MANY);
+          $table->addTableLink($field['name'], $link);
+          $schema->addTable($table);
+        }
+      }
+    }
+  }
+
+  /**
+   * Fetch the original definition of a field from the entity it belongs to.
+   */
+  protected static function getOriginalDefinition(array $field, $loadOptions = FALSE): ?array {
+    if (!isset($field['original_field'])) {
+      return NULL;
+    }
+    [$originalEntity, $originalField] = explode('.', $field['original_field'], 2);
+    return civicrm_api4($originalEntity, 'getfields', [
+      'checkPermissions' => FALSE,
+      'action' => 'get',
+      'where' => [['name', '=', $originalField]],
+      'loadOptions' => $loadOptions,
+    ])->first();
+  }
+
+  /**
+   * Pseudoconstant callback.
+   */
+  public static function _getOptions($fieldName): array {
+    foreach (static::viewSelect() as $field) {
+      if ($field['name'] === $fieldName) {
+        $originalField = static::getOriginalDefinition($field, array_merge(['id'], array_keys(\CRM_Core_SelectValues::optionAttributes())));
+        return $originalField['options'] ?: [];
+      }
+    }
+    return [];
+  }
+
+}

--- a/Civi/Api4/Generic/Traits/ReadOnlyEntity.php
+++ b/Civi/Api4/Generic/Traits/ReadOnlyEntity.php
@@ -20,7 +20,7 @@ trait ReadOnlyEntity {
    * Not intended to be used outside CiviCRM core code.
    *
    * @inheritDoc
-   * @internal
+   * @internal api
    */
   public static function save($checkPermissions = TRUE) {
     return parent::save($checkPermissions);
@@ -30,7 +30,7 @@ trait ReadOnlyEntity {
    * Not intended to be used outside CiviCRM core code.
    *
    * @inheritDoc
-   * @internal
+   * @internal api
    */
   public static function create($checkPermissions = TRUE) {
     return parent::create($checkPermissions);
@@ -40,7 +40,7 @@ trait ReadOnlyEntity {
    * Not intended to be used outside CiviCRM core code.
    *
    * @inheritDoc
-   * @internal
+   * @internal api
    */
   public static function update($checkPermissions = TRUE) {
     return parent::update($checkPermissions);
@@ -50,7 +50,7 @@ trait ReadOnlyEntity {
    * Not intended to be used outside CiviCRM core code.
    *
    * @inheritDoc
-   * @internal
+   * @internal api
    */
   public static function delete($checkPermissions = TRUE) {
     return parent::delete($checkPermissions);
@@ -60,7 +60,7 @@ trait ReadOnlyEntity {
    * Not intended to be used outside CiviCRM core code.
    *
    * @inheritDoc
-   * @internal
+   * @internal api
    */
   public static function replace($checkPermissions = TRUE) {
     return parent::replace($checkPermissions);

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -43,6 +43,12 @@ class CoreUtil {
     if (!$dao && self::isContact($entityName)) {
       $dao = 'CRM_Contact_DAO_Contact';
     }
+    // Last resort (added for the sake of SqlView APIs which are not registered with AllCoreTables).
+    // Again, all this could be avoided if we could just call self::getInfoItem.
+    $className = 'Civi\Api4\\' . $entityName;
+    if (!$dao && class_exists($className)) {
+      $dao = $className::getInfo()['dao'] ?? NULL;
+    }
     return $dao ? AllCoreTables::getBAOClassName($dao) : NULL;
   }
 

--- a/Civi/Core/DAO/SqlView.php
+++ b/Civi/Core/DAO/SqlView.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Core\DAO;
+
+/**
+ * DAO stub for Api4 SqlView.
+ */
+class SqlView extends \CRM_Core_DAO {
+
+  public static function tableHasBeenAdded(): bool {
+    // Sql views don't have a real table; the view is created by `Civi\Api4\Generic\SqlView::_on_civi_api4_entityTypes`
+    return TRUE;
+  }
+
+}

--- a/Civi/Core/Service/AutoDefinition.php
+++ b/Civi/Core/Service/AutoDefinition.php
@@ -33,9 +33,10 @@ class AutoDefinition {
     $result = [];
 
     $classDoc = ReflectionUtils::parseDocBlock($class->getDocComment());
-    // AutoSubscriber is an internal service by default
-    if (is_a($className, AutoSubscriber::class, TRUE)) {
-      $classDoc += ['service' => TRUE, 'internal' => TRUE];
+    // If service defn not set, check parent classes
+    $baseClass = $class;
+    while (!isset($classDoc['service']) && $baseClass = $baseClass->getParentClass()) {
+      $classDoc += ReflectionUtils::parseDocBlock($baseClass->getDocComment());
     }
     if (!empty($classDoc['service'])) {
       $serviceName = static::pickName($classDoc, $class->getName());

--- a/Civi/Core/Service/AutoSubscriber.php
+++ b/Civi/Core/Service/AutoSubscriber.php
@@ -18,7 +18,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Child classes must implement the `getSubscribedEvents` method, and the callbacks
  * it returns will be automatically registered.
  *
- * This class implies @service @internal on all subclasses.
+ * All children of this class will inherit the following annotations
+ * which tell `AutoDefinition` to register them as internal services:
+ * @service
+ * @internal
  */
 abstract class AutoSubscriber implements AutoServiceInterface, EventSubscriberInterface {
 

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -298,7 +298,7 @@ class Admin {
   public static function getJoins(array $allowedEntities):array {
     $joins = [];
     foreach ($allowedEntities as $entity) {
-      $isVirtualEntity = (bool) array_intersect(['CustomValue', 'SavedSearch'], $entity['type']);
+      $isVirtualEntity = (bool) array_intersect(['CustomValue', 'SavedSearch', 'SqlView'], $entity['type']);
 
       // Normal DAO entities (excludes virtual entities)
       // FIXME: At this point DAO entities have enough metadata that using getReferenceColumns()

--- a/tests/phpunit/Civi/Api4/MockSqlView.php
+++ b/tests/phpunit/Civi/Api4/MockSqlView.php
@@ -2,9 +2,32 @@
 
 namespace Civi\Api4;
 
+use Civi\Api4\Event\SchemaMapBuildEvent;
+use Civi\Core\Event\GenericHookEvent;
+
 /**
+ * @since 6.14
  */
 class MockSqlView extends Generic\SqlView {
+
+  /**
+   *  Override event callback to only build this view when it's actually needed.
+   *  This prevents interference with other tests as creating a view breaks transactions.
+   */
+  public static function _on_civi_api4_entityTypes(GenericHookEvent $event): void {
+    if (!empty($GLOBALS['enableMockSqlView'])) {
+      parent::_on_civi_api4_entityTypes($event);
+    }
+  }
+
+  /**
+   * Override event callback to only schema when it's actually needed.
+   */
+  public static function _on_schema_map_build(SchemaMapBuildEvent $event): void {
+    if (!empty($GLOBALS['enableMockSqlView'])) {
+      parent::_on_schema_map_build($event);
+    }
+  }
 
   protected static function viewSelect(): array {
     return [

--- a/tests/phpunit/Civi/Api4/MockSqlView.php
+++ b/tests/phpunit/Civi/Api4/MockSqlView.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Civi\Api4;
+
+/**
+ */
+class MockSqlView extends Generic\SqlView {
+
+  protected static function viewSelect(): array {
+    return [
+      [
+        'select' => 'c.id',
+        'name' => 'contact_id',
+        'original_field' => 'Contact.id',
+      ],
+      [
+        'select' => 'CONCAT(c.first_name, " ", c.last_name)',
+        'name' => 'full_name',
+        'data_type' => 'String',
+      ],
+      [
+        'select' => 'e.email',
+        'name' => 'email',
+        'original_field' => 'Email.email',
+      ],
+      [
+        'select' => 'e.id',
+        'name' => 'email_id',
+        'data_type' => 'Integer',
+        'original_field' => 'Email.id',
+      ],
+      [
+        'select' => 'e.location_type_id',
+        'name' => 'email_location_type_id',
+        'original_field' => 'Email.location_type_id',
+      ],
+    ];
+  }
+
+  protected static function viewFrom(): string {
+    return <<<SQL
+FROM civicrm_contact c
+LEFT JOIN civicrm_email e ON e.contact_id = c.id AND e.is_primary = 1
+WHERE c.contact_type = "Individual" AND last_name LIKE "Test%"
+SQL;
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/SqlViewTest.php
+++ b/tests/phpunit/api/v4/Entity/SqlViewTest.php
@@ -21,12 +21,23 @@ namespace Civi\tests\phpunit\api\v4\Entity;
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
 use Civi\Api4\MockSqlView;
-use Civi\Test\TransactionalInterface;
 
 /**
  * @group headless
  */
-class SqlViewTest extends Api4TestBase implements TransactionalInterface {
+class SqlViewTest extends Api4TestBase {
+
+  public function setUp(): void {
+    parent::setUp();
+    // Enable mock view. See MockSqlView::_on_schema_map_build
+    $GLOBALS['enableMockSqlView'] = TRUE;
+    \Civi::cache('metadata')->clear();
+  }
+
+  public function tearDown(): void {
+    $GLOBALS['enableMockSqlView'] = FALSE;
+    parent::tearDown();
+  }
 
   /**
    * Test relationship cache tracks created relationships.

--- a/tests/phpunit/api/v4/Entity/SqlViewTest.php
+++ b/tests/phpunit/api/v4/Entity/SqlViewTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace Civi\tests\phpunit\api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Contact;
+use Civi\Api4\MockSqlView;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SqlViewTest extends Api4TestBase implements TransactionalInterface {
+
+  /**
+   * Test relationship cache tracks created relationships.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetFields(): void {
+    $fields = MockSqlView::getFields(FALSE)
+      ->setLoadOptions(TRUE)
+      ->execute()->indexBy('name');
+    $this->assertCount(5, $fields);
+    $this->assertEquals('String', $fields['full_name']['data_type']);
+    $this->assertEquals('Contact', $fields['contact_id']['fk_entity']);
+    $this->assertContains('Home', $fields['email_location_type_id']['options']);
+  }
+
+  public function testGetSqlView() {
+    $sampleData = [
+      [
+        'first_name' => 'One',
+        'last_name' => 'Tester',
+        'email_primary.email' => 'test1@example.com',
+      ],
+      [
+        'first_name' => 'Two',
+        'last_name' => 'Not Included',
+      ],
+      [
+        'first_name' => 'Three',
+        'last_name' => 'Tester',
+      ],
+    ];
+    $cid = $this->saveTestRecords('Contact', ['records' => $sampleData])->column('id');
+
+    $results = MockSqlView::get(FALSE)
+      ->addSelect('contact_id', 'full_name', 'email', 'email_location_type_id:label')
+      ->execute()->indexBy('contact_id');
+
+    $this->assertSame('One Tester', $results[$cid[0]]['full_name']);
+    $this->assertSame('Three Tester', $results[$cid[2]]['full_name']);
+    // Where clause in view excludes contact 2.
+    $this->assertArrayNotHasKey($cid[1], $results);
+
+    // Check emails
+    $this->assertSame('test1@example.com', $results[$cid[0]]['email']);
+    $this->assertNull($results[$cid[2]]['email']);
+    // Pseudoconstant ought to work
+    $defaultLocation = \CRM_Core_BAO_LocationType::getDefault()->display_name;
+    $this->assertSame($defaultLocation, $results[$cid[0]]['email_location_type_id:label']);
+    // No email address
+    $this->assertNull($results[$cid[2]]['email_location_type_id:label']);
+  }
+
+  public function testJoinViaFkFields(): void {
+    $contact = $this->createTestRecord('Contact', [
+      'first_name' => uniqid('first_'),
+      'last_name' => uniqid('Tester'),
+      'email_primary.email' => 'primary@example.com',
+      'email_billing.email' => 'billing@example.com',
+    ]);
+
+    $view = MockSqlView::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->addSelect('contact_id.display_name', 'email_id.email', 'full_name')
+      ->addJoin('Email AS explicit_email', FALSE, ['email_id', '=', 'explicit_email.id'])
+      ->addSelect('explicit_email.email');
+
+    $result = $view->execute()->single();
+
+    $this->assertSame($contact['display_name'], $result['contact_id.display_name']);
+    $this->assertSame('primary@example.com', $result['email_id.email']);
+    $this->assertSame($contact['display_name'], $result['full_name']);
+    $this->assertSame('primary@example.com', $result['explicit_email.email']);
+  }
+
+  public function testJoinFromContact(): void {
+    $sampleData = [
+      [
+        'first_name' => 'Alpha',
+        'last_name' => 'Tester',
+        'email_primary.email' => 'alpha@example.com',
+      ],
+      [
+        'first_name' => 'Beta',
+        'last_name' => 'Tester',
+      ],
+    ];
+    $contacts = $this->saveTestRecords('Contact', ['records' => $sampleData]);
+
+    $results = Contact::get(FALSE)
+      ->addWhere('id', 'IN', $contacts->column('id'))
+      ->addJoin('MockSqlView AS view', 'LEFT', ['id', '=', 'view.contact_id'])
+      ->addSelect('id', 'display_name', 'view.full_name', 'view.email')
+      ->addOrderBy('id')
+      ->execute()->indexBy('id');
+
+    $this->assertCount(2, $results);
+    $this->assertSame($results[$contacts[0]['id']]['display_name'], $results[$contacts[0]['id']]['view.full_name']);
+    $this->assertSame('alpha@example.com', $results[$contacts[0]['id']]['view.email']);
+    $this->assertSame($results[$contacts[1]['id']]['display_name'], $results[$contacts[1]['id']]['view.full_name']);
+    $this->assertNull($results[$contacts[1]['id']]['view.email']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Provides base class for SQL Views.

To-date this is not used in core but is provided for extensions to use.

Documentation: https://docs.civicrm.org/dev/en/latest/api/v4/sql-views/