### PR TITLE
dev/core#6392 Fix PriceField Text inputs

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -300,6 +300,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         $priceOptionText = self::buildPriceOptionText($customOption[$optionKey], $field->is_display_amounts, $valueFieldName);
         // This second label is then added to the form as a second form element which just carries the label and is not otherwise used.
         $elementLabelAfter = $qf->add('static', $elementName . '_label_after', $priceOptionText['label']);
+        $elementLabelAfter->setLabelEscaped();
 
         if (!empty($fieldOptions[$optionKey]['label'])) {
           //check for label.
@@ -322,6 +323,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           ),
           $useRequired && $field->is_required
         );
+        $element->setLabelEscaped();
         if ($is_pay_later) {
           $qf->add('text', 'txt-' . $elementName, $label, ['size' => '4']);
         }


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a regression with text labels.

Before
----------------------------------------

<img width="1920" height="503" alt="image" src="https://github.com/user-attachments/assets/1694b688-fe5b-4583-b7e0-21c9e05a4f86" />

After
----------------------------------------

<img width="1666" height="204" alt="image" src="https://github.com/user-attachments/assets/249c4c3b-fcb6-4019-8c09-a0bffbfd6afe" />

(from a dev site with a slightly different configuration and taxes)


<img width="1698" height="228" alt="image" src="https://github.com/user-attachments/assets/a67e2e39-d76a-4df8-a2f3-ad359c31cf1d" />


Technical Details
----------------------------------------

Requires a patch to QuickForm (https://github.com/civicrm/civicrm-packages/pull/436).


cc @seamuslee001 