### PR TITLE
Allow CiviMail admins to preview mailings by numeric ID when hash_mailing_url is enabled

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -105,9 +105,14 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
         $this->_mailing->id = $this->_mailingID;
         // if mailing is present and associated hash is present
         // while 'hash' is not been used for mailing view : throw 'permissionDenied'
+        // Allow numeric ID access for authenticated users with CiviMail
+        // admin permissions, since they can already enumerate all mailings
+        // via the API. The hash requirement only protects against anonymous
+        // enumeration of public-facing "view in browser" links.
         if ($this->_mailing->find() &&
           CRM_Core_DAO::getFieldValue('CRM_Mailing_BAO_Mailing', $this->_mailingID, 'hash', 'id') &&
-          !$allowID
+          !$allowID &&
+          !CRM_Core_Permission::check([['administer CiviCRM', 'approve mailings', 'access CiviMail']])
         ) {
           CRM_Utils_System::permissionDenied();
           return NULL;

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1994,3 +1994,7 @@
 
 - github      : MundMBo
   name        : Marvin Müller
+
+- github      : PassionateBytes
+  name        : Paul Bütof
+  organization: Passionate Bytes Solutions

--- a/tests/phpunit/CRM/Mailing/Page/ViewTest.php
+++ b/tests/phpunit/CRM/Mailing/Page/ViewTest.php
@@ -17,6 +17,11 @@ use Civi\Api4\Email;
  */
 class CRM_Mailing_Page_ViewTest extends CiviUnitTestCase {
 
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_group', 'civicrm_group_contact', 'civicrm_mailing', 'civicrm_mailing_group', 'civicrm_mailing_recipients', 'civicrm_mailing_event_queue']);
+    parent::tearDown();
+  }
+
   /**
    * Test that numeric ID access is denied for unprivileged users
    * when hash_mailing_url is enabled.

--- a/tests/phpunit/CRM/Mailing/Page/ViewTest.php
+++ b/tests/phpunit/CRM/Mailing/Page/ViewTest.php
@@ -17,6 +17,47 @@ use Civi\Api4\Email;
  */
 class CRM_Mailing_Page_ViewTest extends CiviUnitTestCase {
 
+  /**
+   * Test that numeric ID access is denied for unprivileged users
+   * when hash_mailing_url is enabled.
+   */
+  public function testHashNumericIdDeniedWithoutPermission(): void {
+    Civi::settings()->set('hash_mailing_url', 1);
+    $this->setupMailing();
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_mailing SET hash = %1 WHERE id = %2", [
+      1 => ['109002430016e903', 'String'],
+      2 => [$this->ids['Mailing']['default'], 'Positive'],
+    ]);
+    $this->setPermissions(['view public CiviMail content']);
+    $_REQUEST['id'] = (string) $this->ids['Mailing']['default'];
+    $page = new CRM_Mailing_Page_View('View Mailing');
+    $this->expectException(CRM_Core_Exception::class);
+    $page->run();
+  }
+
+  /**
+   * Test that numeric ID access is allowed for users with access CiviMail
+   * when hash_mailing_url is enabled.
+   */
+  public function testHashNumericIdAllowedWithCiviMailPermission(): void {
+    Civi::settings()->set('hash_mailing_url', 1);
+    $this->setupMailing();
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_mailing SET hash = %1 WHERE id = %2", [
+      1 => ['109002430016e903', 'String'],
+      2 => [$this->ids['Mailing']['default'], 'Positive'],
+    ]);
+    $this->setPermissions(['access CiviCRM', 'access CiviMail']);
+    $_REQUEST['id'] = (string) $this->ids['Mailing']['default'];
+    $page = new CRM_Mailing_Page_View('View Mailing');
+    try {
+      $page->run();
+      $this->fail('Page Run should cause a PrematureExitException to occur');
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      // Page rendered successfully — expected for admin users.
+    }
+  }
+
   public function testHashNumericMailingView(): void {
     Civi::settings()->set('hash_mailing_url', 1);
     $this->setupMailing();


### PR DESCRIPTION
Overview
----------------------------------------
When `hash_mailing_url` is enabled, clicking the **Preview** button on the sent mailings listing page (`civicrm/mailing`) returns a 403 Permission Denied for all users, including administrators.

The entity schema defines the preview path as `civicrm/mailing/view?id=[id]` (numeric ID), but `CRM_Mailing_Page_View::run()` rejects numeric ID access when `hash_mailing_url` is enabled and a hash exists — which is always, since hashes are generated on every mailing creation regardless of the setting.

Before
----------------------------------------
1. Enable `hash_mailing_url` (Administer → CiviMail → CiviMail Component Settings)
2. Navigate to the sent mailings listing (`civicrm/mailing`)
3. Click **Preview** in the context menu of any mailing
4. **Result:** 403 Permission Denied

This affects all users, including those with `administer CiviCRM` or `access CiviMail` permissions.

After
----------------------------------------
Users with `administer CiviCRM`, `approve mailings`, or `access CiviMail` permissions can preview mailings by numeric ID. Anonymous and unprivileged users are still blocked from numeric ID access, preserving the anti-enumeration protection.

Technical Details
----------------------------------------
The `hash_mailing_url` setting is designed to prevent anonymous enumeration of public-facing "view in browser" links. However, authenticated users with CiviMail admin permissions can already enumerate all mailings via the API, so the hash restriction provides no additional security for them.

The fix adds a permission check to the existing guard in `CRM_Mailing_Page_View::run()` (lines 108-114). The permission set (`administer CiviCRM`, `approve mailings`, `access CiviMail`) matches the existing `checkPermission()` method on the same page for consistency.

The SearchKit mailing listing constructs the preview URL via the entity schema path definition in `schema/Mailing/Mailing.entityType.php` (`'preview' => 'civicrm/mailing/view?id=[id]&reset=1'`), which always uses the numeric ID. Changing the schema to conditionally use `[hash]` was considered but rejected as it would couple static schema metadata to a runtime setting and introduce caching concerns.

Two new tests are added:
- `testHashNumericIdDeniedWithoutPermission` — verifies unprivileged users are still blocked
- `testHashNumericIdAllowedWithCiviMailPermission` — verifies admin users can preview by numeric ID

Comments
----------------------------------------
This was discovered on a CiviCRM 6.10.2 Standalone deployment. A GitLab issue will be filed at lab.civicrm.org.