### PR TITLE
[PHP8.5] fix misuse of NULL - getLinks

### DIFF
--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -185,7 +185,7 @@ class GetLinks extends BasicGetAction {
   }
 
   private function getAllowedEntityActions(string $entityName): array {
-    $uid = \CRM_Core_Session::getLoggedInContactID();
+    $uid = (int) \CRM_Core_Session::getLoggedInContactID();
     if (!isset(\Civi::$statics[__CLASS__]['actions'][$entityName][$uid])) {
       $permissions = new Result();
       // Bypass the api wrapper, we don't want lack of permission for 'getActions' action to get in the way

--- a/tests/phpunit/CRM/Activity/Form/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Form/ActivityTest.php
@@ -321,10 +321,8 @@ class CRM_Activity_Form_ActivityTest extends CiviUnitTestCase {
 
   /**
    * Test that inbound email is still treated properly if you change the label.
-   * I'm not crazy about the strategy used in this test but I can't see another
+   * I'm not crazy about the strategy used in this test, but I can't see another
    * way to do it.
-   *
-   * @throws \CRM_Core_Exception
    */
   public function testInboundEmailDisplaysWithLineBreaks(): void {
     // Change label


### PR DESCRIPTION
`$uid` is only used in the function so casting to int doesn't have any flow on

<img width="1232" height="233" alt="image" src="https://github.com/user-attachments/assets/e42e8a30-c6bd-4383-b75f-d2c2a3a5de20" />
