### PR TITLE
PHP8.5 fix use of NULL pdfLetter

### DIFF
--- a/CRM/Contribute/Form/Task/PDFLetter.php
+++ b/CRM/Contribute/Form/Task/PDFLetter.php
@@ -196,7 +196,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
         $contributionIDs["{$result->contact_id}-{$result->contribution_id}"] = $result->contribution_id;
       }
     }
-    [$contributions, $contacts] = $this->buildContributionArray($groupBy, $contributionIDs, $returnProperties, $messageToken, $separator, $this->isQueryIncludesSoftCredits());
+    [$contributions, $contacts] = $this->buildContributionArray((string) $groupBy, $contributionIDs, $returnProperties, $messageToken, $separator, $this->isQueryIncludesSoftCredits());
     $html = [];
     $contactHtml = $emailedHtml = [];
     foreach ($contributions as $contributionId => $contribution) {
@@ -310,7 +310,7 @@ class CRM_Contribute_Form_Task_PDFLetter extends CRM_Contribute_Form_Task {
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public function buildContributionArray($groupBy, $contributionIDs, $returnProperties, $messageToken, $separator, $isIncludeSoftCredits) {
+  public function buildContributionArray(string $groupBy, $contributionIDs, $returnProperties, $messageToken, $separator, $isIncludeSoftCredits) {
     $contributions = $contacts = [];
     foreach ($contributionIDs as $item => $contributionId) {
       $contribution = CRM_Contribute_BAO_Contribution::getContributionTokenValues($contributionId, $messageToken)['values'][$contributionId];


### PR DESCRIPTION
<img width="1232" height="233" alt="image" src="https://github.com/user-attachments/assets/fbe7a4a7-2f9e-473f-bac2-2acfc3bf1b6f" />

CRM_Contribute_Form_Task_PDFLetterCommonTest::testPostProcess
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-0/web/core/CRM/Contribute/Form/Task/PDFLetter.php:335
/home/homer/buildkit/build/build-0/web/core/CRM/Contribute/Form/Task/PDFLetter.php:199
/home/homer/buildkit/build/build-0/web/core/tests/phpunit/CRM/Contribute/Form/Task/PDFLetterCommonTest.php:216
/home/homer/buildkit/build/build-0/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552