### PR TITLE
add model for CheckoutSession / CheckoutOptions 

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Action/Contribution/ContinueCheckout.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Contribution/ContinueCheckout.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Civi\Api4\Action\Contribution;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Crypto\Exception\CryptoException;
+use Civi\Checkout\CheckoutSession;
+use CRM_Contribute_ExtensionUtil as E;
+
+class ContinueCheckout extends AbstractAction {
+
+  /**
+   * @var string
+   */
+  protected string $token;
+
+  public function _run(Result $result): void {
+
+    try {
+      $session = CheckoutSession::restoreFromToken($this->token);
+    }
+    catch (CryptoException $e) {
+      if (str_contains($e->getMessage(), 'Expired token')) {
+        throw new \CRM_Core_Exception(E::ts('Checkout session expired'));
+      }
+    }
+
+    // continue the checkout (may involve server side api calls, user redirects)
+    $session->continueCheckout();
+
+    // get updated token (in case relevant state has changed)
+    $result['token'] = $session->tokenise();
+    // get status key
+    $result['status'] = $session->getStatus();
+    // get title (for landing page)
+    $result['title'] = $session->getTitle();
+    // get user message
+    $result['message'] = $session->getStatusMessage();
+    // get onward url
+    $result['redirect'] = $session->getNextUrl();
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout.php
+++ b/ext/civi_contribute/Civi/Checkout.php
@@ -4,13 +4,14 @@ namespace Civi;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Core\Service\AutoService;
 use CRM_Core_Session;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 use CRM_Contribute_ExtensionUtil as E;
 
 /**
  * @service civi.checkout
  */
-class Checkout extends AutoService {
+class Checkout extends AutoService implements EventSubscriberInterface {
 
   /**
    * @var \Civi\Checkout\CheckoutOptionInterface[]
@@ -18,6 +19,15 @@ class Checkout extends AutoService {
    * Local cache of options
    */
   protected ?array $options = NULL;
+
+  public static function getSubscribedEvents(): array {
+    return [
+      // listen to our own event to add the default pay later option
+      // we add this early so an extension can replace with something
+      // more bespoke if desired
+      'civi.checkout.options' => ['addPayLaterOption', 100],
+    ];
+  }
 
   /**
    * Gather available CheckoutOptions
@@ -50,6 +60,10 @@ class Checkout extends AutoService {
   public function isTestMode(): bool {
     $session = CRM_Core_Session::singleton();
     return !!\CRM_Utils_Request::retrieve('testMode', 'Boolean', $session);
+  }
+
+  public function addPayLaterOption(GenericHookEvent $e) {
+    $e->options['pay_later'] = new Checkout\PayLater();
   }
 
 }

--- a/ext/civi_contribute/Civi/Checkout.php
+++ b/ext/civi_contribute/Civi/Checkout.php
@@ -34,6 +34,10 @@ class Checkout extends AutoService implements EventSubscriberInterface {
     ];
   }
 
+  protected function isEnabled(): bool {
+    return !!\Civi::settings()->get('contribute_enable_afform_contributions');
+  }
+
   /**
    * Gather available CheckoutOptions
    *
@@ -46,6 +50,10 @@ class Checkout extends AutoService implements EventSubscriberInterface {
    * @return \Civi\Checkout\CheckoutOptionInterface[]
    */
   public function getOptions(): array {
+    if (!$this->isEnabled()) {
+      // dont even fire the hook
+      return [];
+    }
     if (!is_array($this->options)) {
       $e = GenericHookEvent::create(['options' => []]);
       \Civi::dispatcher()->dispatch('civi.checkout.options', $e);
@@ -76,6 +84,10 @@ class Checkout extends AutoService implements EventSubscriberInterface {
    * - authentication of the specific checkout is done using JWT param
    */
   public function authorizeContinueCheckout(\Civi\API\Event\AuthorizeEvent $event) {
+    if (!$this->isEnabled()) {
+      // do nothing
+      return;
+    }
     $apiRequest = $event->getApiRequest();
     if ($apiRequest['version'] == 4) {
       if ($apiRequest['entity'] === 'Contribution' && $apiRequest['action'] === 'continueCheckout') {

--- a/ext/civi_contribute/Civi/Checkout.php
+++ b/ext/civi_contribute/Civi/Checkout.php
@@ -1,0 +1,55 @@
+<?php
+namespace Civi;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoService;
+use CRM_Core_Session;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * @service civi.checkout
+ */
+class Checkout extends AutoService {
+
+  /**
+   * @var \Civi\Checkout\CheckoutOptionInterface[]
+   *
+   * Local cache of options
+   */
+  protected ?array $options = NULL;
+
+  /**
+   * Gather available CheckoutOptions
+   *
+   * Note: currently this is a totally global list. In the future we
+   * may want to distinguish options based on frontend (e.g. afform / quickform / ?)
+   *
+   * A site builder may specify a further subset of available options on
+   * a specific options on a specific afform / contribution page etc
+   *
+   * @return \Civi\Checkout\CheckoutOptionInterface[]
+   */
+  public function getOptions(): array {
+    if (!is_array($this->options)) {
+      $e = GenericHookEvent::create(['options' => []]);
+      \Civi::dispatcher()->dispatch('civi.checkout.options', $e);
+      $this->options = $e->options;
+    }
+    return $this->options;
+  }
+
+  public function getOption(string $name): Checkout\CheckoutOptionInterface {
+    $option = $this->getOptions()[$name] ?? NULL;
+    if (!$option) {
+      throw new \CRM_Core_Exception("No CheckoutOption found with name: {$name}");
+    }
+    return $option;
+  }
+
+  public function isTestMode(): bool {
+    $session = CRM_Core_Session::singleton();
+    return !!\CRM_Utils_Request::retrieve('testMode', 'Boolean', $session);
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout.php
+++ b/ext/civi_contribute/Civi/Checkout.php
@@ -26,6 +26,11 @@ class Checkout extends AutoService implements EventSubscriberInterface {
       // we add this early so an extension can replace with something
       // more bespoke if desired
       'civi.checkout.options' => ['addPayLaterOption', 100],
+      // open access to Contribution.continueCheckout
+      // (authorization uses JWT)
+      'civi.api.authorize' => [
+        ['authorizeContinueCheckout', 100],
+      ],
     ];
   }
 
@@ -64,6 +69,22 @@ class Checkout extends AutoService implements EventSubscriberInterface {
 
   public function addPayLaterOption(GenericHookEvent $e) {
     $e->options['pay_later'] = new Checkout\PayLater();
+  }
+
+  /**
+   * Contribution.continueCheckout is open to anyone with make online contributions
+   * - authentication of the specific checkout is done using JWT param
+   */
+  public function authorizeContinueCheckout(\Civi\API\Event\AuthorizeEvent $event) {
+    $apiRequest = $event->getApiRequest();
+    if ($apiRequest['version'] == 4) {
+      if ($apiRequest['entity'] === 'Contribution' && $apiRequest['action'] === 'continueCheckout') {
+        if (\CRM_Core_Permission::check('make online contributions')) {
+          $event->authorize();
+          $event->stopPropagation();
+        }
+      }
+    }
   }
 
 }

--- a/ext/civi_contribute/Civi/Checkout/AfformCheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/AfformCheckoutOptionInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Civi\Checkout;
+
+use Civi\Afform\Event\AfformValidateEvent;
+
+/**
+ * AfformCheckoutInterface
+ */
+interface AfformCheckoutOptionInterface {
+
+  /**
+   * Respond to validation event. At this point this will be
+   * an AfformValidateEvent - but leaving open for handling other
+   * event types in future
+   *
+   * @param Civi\Afform\Event\AfformValidateEvent $event
+   */
+  public function validate(AfformValidateEvent $event): void;
+
+  /**
+   * Provide settings to afCheckout
+   *
+   * Typically this will include `template` referencing a .html partial
+   *
+   * May also include payment processor specific data - e.g. public client key
+   *
+   * @return mixed[]
+   */
+  public function getAfformSettings(bool $testMode): array;
+
+  /**
+   * @return ?string name of an angular module required to use this CheckoutOption with Afform, if any
+   */
+  public function getAfformModule(): ?string;
+
+}

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOption.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOption.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Civi\Checkout;
+
+use Civi\Core\Event\GenericHookEvent;
+
+/**
+ * Optional base class for implementing CheckoutOptionInterface
+ */
+abstract class CheckoutOption implements CheckoutOptionInterface {
+
+  abstract public function getLabel(): string;
+
+  public function getFrontendLabel(): string {
+    return $this->getLabel();
+  }
+
+  public function getPaymentMethod(): ?string {
+    return NULL;
+  }
+
+  public function getPaymentProcessorId(bool $testMode = FALSE): ?int {
+    return NULL;
+  }
+
+  public function validate(GenericHookEvent $e): void {
+    // no default validation rules
+  }
+
+  /**
+   * NOTE: this is a very naive implementation as a starting point
+   * for adapting CRM_Core_Payment implementations.
+   */
+  public function startCheckout(CheckoutSession $session): void {
+    $contributionId = $session->getContributionId();
+    $processor = $this->getQuickformProcessor($session->isTestMode());
+    $processor->doPayment(['contributionID' => $contributionId]);
+  }
+
+  public function continueCheckout(CheckoutSession $session): void {
+    // some payment processor happen in one shot, in which case
+    // this can be empty
+  }
+
+  /**
+   * By default fetch using getPaymentProcessorId. This will work well for
+   * legacy payment processors where 1 PaymentProcessor = 1 Checkout Option
+   *
+   * A new integration may offer multiple CheckoutOptions for a single
+   * PaymentProcessor record, which may return different classes here
+   */
+  public function getQuickformProcessor(bool $testMode = FALSE): ?\CRM_Core_Payment {
+    $id = $this->getPaymentProcessorId($testMode);
+    return $id ? \Civi\Payment\System::singleton()->getById($id) : NULL;
+  }
+
+  public function getAfformSettings(bool $testMode): ?array {
+    return NULL;
+  }
+
+  public function getAfformModule(): ?string {
+    return NULL;
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOption.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOption.php
@@ -2,8 +2,6 @@
 
 namespace Civi\Checkout;
 
-use Civi\Core\Event\GenericHookEvent;
-
 /**
  * Optional base class for implementing CheckoutOptionInterface
  */
@@ -21,10 +19,6 @@ abstract class CheckoutOption implements CheckoutOptionInterface {
 
   public function getPaymentProcessorId(bool $testMode = FALSE): ?int {
     return NULL;
-  }
-
-  public function validate(GenericHookEvent $e): void {
-    // no default validation rules
   }
 
   /**
@@ -45,21 +39,14 @@ abstract class CheckoutOption implements CheckoutOptionInterface {
   /**
    * By default fetch using getPaymentProcessorId. This will work well for
    * legacy payment processors where 1 PaymentProcessor = 1 Checkout Option
-   *
-   * A new integration may offer multiple CheckoutOptions for a single
-   * PaymentProcessor record, which may return different classes here
    */
-  public function getQuickformProcessor(bool $testMode = FALSE): ?\CRM_Core_Payment {
+  protected function getQuickformProcessor(bool $testMode = FALSE): ?\CRM_Core_Payment {
     $id = $this->getPaymentProcessorId($testMode);
-    return $id ? \Civi\Payment\System::singleton()->getById($id) : NULL;
-  }
-
-  public function getAfformSettings(bool $testMode): ?array {
-    return NULL;
-  }
-
-  public function getAfformModule(): ?string {
-    return NULL;
+    $connection = \Civi\Api4\PaymentProcessor::get(FALSE)->addWhere('id', '=', $id)->execute()->first();
+    if (!$connection || empty($connection['name'])) {
+      return NULL;
+    }
+    return \Civi\Payment\System::singleton()->getByName($connection['name'], $testMode);
   }
 
 }

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Civi\Checkout;
+
+/**
+ * Checkout Options represent the user-facing side of a PaymentProcessor
+ *
+ * The Stripe integration provides a good example:
+ * - the user sets up a connection to Stripe with credentials => this is saved in
+ *   PaymentProcessor record
+ * - this single Stripe PaymentProcessor record can provide multiple CheckoutOptions: for Stripe, Stripe Checkout, Stripe Embedded Checkout etc
+ *
+ * Alternative the new Paypal extension provides a CheckoutOption without having
+ * a PaymentProcessor record at all (connection details are stored in custom JSON object
+ * - though this is only a transitional step and may change in future)
+ *
+ * Finally Pay Later is a checkout option which doesn't require a PaymentProcessor record
+ * at all
+ *
+ * Methods on the Checkout Option handle the interaction between user and payment processor
+ * during a CheckoutSession.
+ *
+ * Ideally this handling is independent of the frontend form layer (quickform / afform / ...)
+ * and works off of data stored on the Contribution record (and joined entities) and
+ * whatever transient "checkout_params" the Option/PaymentProcessor needs
+ */
+interface CheckoutOptionInterface {
+
+  public function getLabel(): string;
+
+  public function getFrontendLabel(): string;
+
+  /**
+   * @return ?string name of associated Payment Method/Instrument, if any
+   */
+  public function getPaymentMethod(): ?string;
+
+  /**
+   * @return ?int id of associated PaymentProcessor record, if any
+   */
+  public function getPaymentProcessorId(bool $testMode = FALSE): ?int;
+
+  /**
+   * Respond to validation event. At this point this will be
+   * an AfformValidateEvent - but leaving open for handling other
+   * event types in future
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $event
+   */
+  public function validate(GenericHookEvent $event): void;
+
+  /**
+   * Initiate a new checkout
+   */
+  public function startCheckout(CheckoutSession $session): void;
+
+  /**
+   * Take user to the next step. May redirect or update the status of
+   * the contribution.
+   */
+  public function continueCheckout(CheckoutSession $session): void;
+
+  /**
+   * @return ?\CRM_Core_Payment Quickform Processor class, if any
+   */
+  public function getQuickformProcessor(bool $testMode = FALSE): ?\CRM_Core_Payment;
+
+  /**
+   * For CheckoutOptions that support Afform, provide the necessary details
+   *
+   * Typically this will include `template` referencing a .html partial
+   *
+   * May also include payment processor specific keys - e.g. public client key
+   *
+   * @return ?mixed[] configuration for afCheckout integration, if any
+   */
+  public function getAfformSettings(bool $testMode): ?array;
+
+  /**
+   * @return ?string name of an angular module required to use this CheckoutOption with Afform, if any
+   */
+  public function getAfformModule(): ?string;
+
+}

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
@@ -20,9 +20,10 @@ namespace Civi\Checkout;
  * Methods on the Checkout Option handle the interaction between user and payment processor
  * during a CheckoutSession.
  *
- * Ideally this handling is independent of the frontend form layer (quickform / afform / ...)
- * and works off of data stored on the Contribution record (and joined entities) and
- * whatever transient "checkout_params" the Option/PaymentProcessor needs
+ * Ideally as much handling as possible is independent of the frontend form layer (quickform / afform / ...)
+ * and works through CheckoutSession and/or data stored on the Contribution record (and joined entities)
+ *
+ * Additional optional interface AfformCheckoutOptionInterface provides functions to integrate with Afform
  */
 interface CheckoutOptionInterface {
 
@@ -38,16 +39,7 @@ interface CheckoutOptionInterface {
   /**
    * @return ?int id of associated PaymentProcessor record, if any
    */
-  public function getPaymentProcessorId(bool $testMode = FALSE): ?int;
-
-  /**
-   * Respond to validation event. At this point this will be
-   * an AfformValidateEvent - but leaving open for handling other
-   * event types in future
-   *
-   * @param \Civi\Core\Event\GenericHookEvent $event
-   */
-  public function validate(GenericHookEvent $event): void;
+  public function getPaymentProcessorId(): ?int;
 
   /**
    * Initiate a new checkout
@@ -59,26 +51,5 @@ interface CheckoutOptionInterface {
    * the contribution.
    */
   public function continueCheckout(CheckoutSession $session): void;
-
-  /**
-   * @return ?\CRM_Core_Payment Quickform Processor class, if any
-   */
-  public function getQuickformProcessor(bool $testMode = FALSE): ?\CRM_Core_Payment;
-
-  /**
-   * For CheckoutOptions that support Afform, provide the necessary details
-   *
-   * Typically this will include `template` referencing a .html partial
-   *
-   * May also include payment processor specific keys - e.g. public client key
-   *
-   * @return ?mixed[] configuration for afCheckout integration, if any
-   */
-  public function getAfformSettings(bool $testMode): ?array;
-
-  /**
-   * @return ?string name of an angular module required to use this CheckoutOption with Afform, if any
-   */
-  public function getAfformModule(): ?string;
 
 }

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
@@ -134,4 +134,21 @@ class CheckoutOptionUtils {
     }, $allFields);
   }
 
+  public static function getPaymentProcessorPairs(array $paymentProcessorTypeNames): array {
+    $all = \Civi\Api4\PaymentProcessor::get(FALSE)
+      // note the payment_processor_type_id doesn't actually matter when it comes to
+      // CheckoutOptions - as long as the credentials are valid
+      ->addWhere('payment_processor_type_id:name', 'IN', $paymentProcessorTypeNames)
+      ->addWhere('is_test', 'IN', [TRUE, FALSE])
+      ->execute();
+
+    $pairs = [];
+
+    foreach ($all as $processor) {
+      $pairs[$processor['name']][$processor['is_test'] ? 'test' : 'live'] = $processor;
+    }
+
+    return $pairs;
+  }
+
 }

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
@@ -1,0 +1,137 @@
+<?php
+
+  /*
+   +--------------------------------------------------------------------+
+   | Copyright CiviCRM LLC. All rights reserved.                        |
+   |                                                                    |
+   | This work is published under the GNU AGPLv3 license with some      |
+   | permitted exceptions and without any warranty. For full license    |
+   | and copyright information, see https://civicrm.org/licensing       |
+   +--------------------------------------------------------------------+
+   */
+
+namespace Civi\Checkout;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * Optional utils for implementing payment processor classes.
+ * Think of it like the pick-n-mix version of PropertyBag -
+ * you can use things if they are useful but you dont have to
+ */
+class CheckoutOptionUtils {
+
+  /**
+   * Map from api4 fields on the Contribution field to param names
+   * commonly used by payment processors
+   *
+   * @return array
+   */
+  public static function getLegacyKeyMap(): array {
+    return [
+      'id' => 'contributionID',
+      'contact_id' => 'contactID',
+      'total_amount' => 'amount',
+      'invoice_id' => 'invoiceID',
+      'source' => 'source',
+      'currency' => 'currency',
+      // TODO? it might be nice to use the address record on the contribution
+      // but this is not being saved at the moment. this was previously done
+      // in the Contribution quickform layer. should it be moved to Order api?
+      // or drop the duplication of contact billing address and contribution billing
+      // address
+      // 'address_id.street_address' => 'billingStreetAddress',
+      // 'address_id.city' => 'billingCity',
+      // 'address_id.postal_code' => 'billingPostalCode',
+      // 'address_id.country_id.iso_code' => 'billingCountry',
+      'contact_id.address_billing.street_address' => 'billingStreetAddress',
+      'contact_id.address_billing.city' => 'billingCity',
+      'contact_id.address_billing.postal_code' => 'billingPostalCode',
+      'contact_id.address_billing.country_id.iso_code' => 'billingCountry',
+    ];
+  }
+
+  public static function fillContributionDefaults(array $contribution): array {
+    $defaults = [
+      'description' => E::ts('CiviCRM Contribution'),
+      'source' => E::ts('CiviCRM Contribution'),
+    ];
+
+    foreach ($defaults as $key => $value) {
+      if (empty($contribution[$key])) {
+        $contribution[$key] = $value;
+      }
+    }
+
+    return $contribution;
+  }
+
+  public static function fetchRequiredParams(int $contributionId, array $api4Keys = [], array $legacyKeys = [], array $knownValues = []): array {
+    $fieldsToFetch = [];
+
+    foreach ($api4Keys as $api4Key) {
+      if (isset($knownValues[$api4Key])) {
+        continue;
+      }
+      $fieldsToFetch[] = $api4Key;
+    }
+
+    $legacyKeyMap = self::getLegacyKeyMap();
+
+    foreach ($legacyKeys as $legacyKey) {
+      $sourceFields = array_keys(array_filter($legacyKeyMap, fn ($key) => $key === $legacyKey));
+
+      if (!$sourceFields) {
+        throw new \CRM_Core_Exception("Sorry - no api4 source key is known for requested legacy key: {$legacyKey}");
+      }
+
+      $fieldsToFetch = array_merge($fieldsToFetch, $sourceFields);
+    }
+
+    $values = \Civi\Api4\Contribution::get(FALSE)
+      ->addWhere('id', '=', $contributionId)
+      ->addSelect(...$fieldsToFetch)
+      ->execute()
+      ->first();
+
+    // rekey using legacy keys if requested
+    foreach ($legacyKeys as $legacyKey) {
+      $sourceFields = array_keys(array_filter($legacyKeyMap, fn ($key) => $key === $legacyKey));
+      foreach ($sourceFields as $sourceField) {
+        // in case there are multiple source keys, take the
+        // first non-empty value
+        if ($values[$sourceField]) {
+          $values[$legacyKey] = $values[$sourceField];
+          continue;
+        }
+      }
+    }
+
+    // We need to pass the currency to the payment processor,
+    //   use the default if not passed a default from Afform
+    if (empty($values['currency'])) {
+      $values['currency'] = \CRM_Core_Config::singleton()->defaultCurrency;
+    }
+
+    return $values;
+  }
+
+  public static function fetchLineItems(int $contributionId): array {
+    $lineItems = (array) \Civi\Api4\LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionId)
+      ->addSelect('*', 'price_field_id:label', 'price_field_value_id:label')
+      ->execute();
+    return $lineItems;
+  }
+
+  public static function mapQuickformFieldMetadata(array $allFields): array {
+    return array_map(function ($field) {
+      if ($field['htmlType'] === 'select') {
+        $field['options'] = array_map(fn ($key) => ['id' => $key, 'label' => $field['attributes'][$key]], array_keys($field['attributes']));
+      }
+      unset($field['attributes'], $field['extra']);
+      return $field;
+    }, $allFields);
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -352,10 +352,13 @@ class CheckoutSession {
   public function getResponseItems(): array {
     $responseItems = $this->responseItems;
 
-    // if the payment processor doesn't set a redirect item
-    // we ensure set this key is set to suppress any standard
-    // Afform redirect
-    $responseItems['redirect'] ??= $this->getNextUrl() ?? FALSE;
+    // if redirect / message aren't set explicitly, then provide
+    // defaults to override any normal Afform redirect/message
+    $redirect = $this->getNextUrl() ?? FALSE;
+    $responseItems['redirect'] ??= $redirect;
+
+    $message = $this->getStatusMessage() ?? FALSE;
+    $responseItems['message'] ??= $message;
 
     return $responseItems;
   }

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -1,0 +1,558 @@
+<?php
+
+namespace Civi\Checkout;
+
+use Civi\Api4\Contribution;
+use Civi\Api4\Payment;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * CheckoutSession represents state of a user going through checkout.
+ *
+ * It mainly functions to store ephemeral data like:
+ * - payment processor session IDs
+ * - onward urls - where user should be sent e.g. for success/failure/cancel
+ */
+class CheckoutSession {
+
+  public const STATUS_SUCCESS = 'success';
+  public const STATUS_PENDING = 'pending';
+  public const STATUS_CANCEL = 'cancel';
+  public const STATUS_FAIL = 'fail';
+
+  protected int $contributionId;
+
+  protected string $checkoutOption;
+
+  /**
+   * @var string[]
+   * Store for urls that may be used for onward journey. Expect them
+   * to be keyed by STATUS
+   */
+  protected array $urls = [];
+
+  /**
+   * @var string[]
+   * Store for messages that may be used for onward journey. Expect them
+   * to be keyed by STATUS
+   */
+  protected array $messages = [];
+
+  /**
+   * @var string
+   * Title for the checkout session - may be shown on landing pages
+   */
+  protected string $title;
+
+  /**
+   * @var string
+   * Current status of the session. Expect to be one
+   * of the STATUS_ constants above
+   */
+  protected string $status = self::STATUS_PENDING;
+
+  /**
+   * @var mixed[]
+   * Other parameters required by the Payment Processor
+   * Might include things like payment_intent_id or
+   * card details (in PCI compliant context!)
+   */
+  protected array $checkoutParams = [];
+
+  /**
+   * @var bool
+   * Are we in test mode?
+   */
+  protected bool $testMode;
+
+  /**
+   * @var float
+   * Total amount
+   */
+  protected float $totalAmount;
+
+  /**
+   * @var float
+   * Fee amount
+   * @see createPayment
+   */
+  protected float $feeAmount = 0;
+
+  /**
+   * The trxn_id to record on the financial_trxn (payment) record
+   *
+   * @var string
+   */
+  protected string $transactionId = '';
+
+  /**
+   * The order_reference to record on the financial_trxn (payment) record
+   *
+   * @var string
+   */
+  protected string $orderReference = '';
+
+  /**
+   * @var array
+   *
+   * Keys that will be set on the Afform response.
+   *
+   * Keys should be strings, values may be strings or JSON serializable
+   * objects (like array of strings)
+   *
+   * This could be a standard key supported by the afForm
+   * controller (like `redirect`) or a custom key
+   * that is used by the Payment Processor on the client
+   * side (like `checkout_session_id` in Stripe Embedded Checkout)
+   */
+  protected array $responseItems = [];
+
+  /**
+   * @param int $contributionId
+   * @param string $checkoutOption
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function __construct(int $contributionId, string $checkoutOption) {
+    $this->contributionId = $contributionId;
+    $this->checkoutOption = $checkoutOption;
+
+    // fetch values from the contribution that should not change during the session
+    // note: do *not* fetch things like status upfront -- that may change
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
+      ->addWhere('id', '=', $this->contributionId)
+      ->addSelect('is_test', 'total_amount')
+      ->execute()
+      ->single();
+
+    $this->totalAmount = $contribution['total_amount'];
+    $this->testMode = $contribution['is_test'];
+
+    // set default messages
+    // NOTE: we use "payment" instead of checkout
+    // as checkout is weird terminology in a donation
+    // context
+    $this->title = E::ts('CiviCRM payment');
+
+    $this->messages = [
+      self::STATUS_CANCEL => E::ts('Payment cancelled.'),
+      self::STATUS_FAIL => E::ts('Payment failed'),
+      self::STATUS_SUCCESS => E::ts('Payment complete'),
+      self::STATUS_PENDING => E::ts('Confirming payment status'),
+    ];
+  }
+
+  public function getContributionId(): int {
+    return $this->contributionId;
+  }
+
+  public function getTotalAmount(): float {
+    return $this->totalAmount;
+  }
+
+  public function isTestMode(): bool {
+    return $this->testMode;
+  }
+
+  protected function getCheckoutOption(): CheckoutOptionInterface {
+    return \Civi::service('civi.checkout')->getOption($this->checkoutOption);
+  }
+
+  /**
+   * @param array $params
+   *
+   * @return $this
+   */
+  public function setCheckoutParams(array $params): CheckoutSession {
+    foreach ($params as $key => $value) {
+      $this->setCheckoutParam($key, $value);
+    }
+    return $this;
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $value
+   *
+   * @return $this
+   */
+  public function setCheckoutParam(string $key, $value): CheckoutSession {
+    $this->checkoutParams[$key] = $value;
+    return $this;
+  }
+
+  /**
+   * @return mixed[]
+   */
+  public function getCheckoutParams(): array {
+    return $this->checkoutParams;
+  }
+
+  /**
+   * @param string $key
+   *
+   * @return mixed|null
+   */
+  public function getCheckoutParam(string $key) {
+    return $this->checkoutParams[$key] ?? NULL;
+  }
+
+  /**
+   * @param string $status
+   *
+   * @return $this
+   */
+  public function setStatus(string $status): CheckoutSession {
+    $this->status = $status;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getStatus(): string {
+    return $this->status;
+  }
+
+  /**
+   * @param string $url
+   *
+   * @return $this
+   */
+  public function setSuccessUrl(string $url): CheckoutSession {
+    $this->urls['success'] = $url;
+    return $this;
+  }
+
+  /**
+   * @param string $message
+   *
+   * @return $this
+   */
+  public function setSuccessMessage(string $message): CheckoutSession {
+    $this->messages['success'] = $message;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getSuccessUrl(): string {
+    return $this->urls['success'] ?? '';
+  }
+
+  /**
+   * @param string $url
+   *
+   * @return $this
+   */
+  public function setFailUrl(string $url): CheckoutSession {
+    $this->urls['fail'] = $url;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getFailUrl(): string {
+    return $this->urls['fail'] ?? $this->urls['cancel'] ?? '';
+  }
+
+  /**
+   * @param string $url
+   *
+   * @return $this
+   */
+  public function setCancelUrl(string $url): CheckoutSession {
+    $this->urls['cancel'] = $url;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getCancelUrl(): string {
+    return $this->urls['cancel'] ?? $this->urls['fail'] ?? '';
+  }
+
+  /**
+   * @param string $url
+   *
+   * @return $this
+   */
+  public function setPendingUrl(string $url): CheckoutSession {
+    $this->urls[self::STATUS_PENDING] = $url;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getPendingUrl(): string {
+    return $this->urls[self::STATUS_PENDING] ?? '';
+  }
+
+  /**
+   * Get URL to take user to based on the current status
+   */
+  public function getNextUrl(): string {
+    $status = $this->getStatus();
+
+    return $this->urls[$status] ?? FALSE;
+  }
+
+  /**
+   * Get status message to show to user
+   */
+  public function getStatusMessage(): string {
+    $status = $this->getStatus();
+    return $this->messages[$status] ?? E::ts('Unrecognised payment status: %1', [1 => $status]);
+  }
+
+  /**
+   * Set title (for landing page)
+   */
+  public function setTitle(string $title): CheckoutSession {
+    $this->title = $title;
+    return $this;
+  }
+
+  /**
+   * Get title (for landing page)
+   */
+  public function getTitle(): string {
+    return $this->title;
+  }
+
+  /**
+   * @return string
+   */
+  public function getLandingUrl(): string {
+    return (string) \Civi::url('civicrm/checkout/continue')
+      ->setQuery(['session' => $this->tokenise()])
+      ->setPreferFormat('absolute')
+      ->setScheme('current');
+  }
+
+  /**
+   * @param string $key
+   * @param mixed $value
+   *
+   * @return $this
+   */
+  public function setResponseItem(string $key, $value): CheckoutSession {
+    $this->responseItems[$key] = $value;
+    return $this;
+  }
+
+  /**
+   * @return array
+   */
+  public function getResponseItems(): array {
+    $responseItems = $this->responseItems;
+
+    // if the payment processor doesn't set a redirect item
+    // we ensure set this key is set to suppress any standard
+    // Afform redirect
+    $responseItems['redirect'] ??= $this->getNextUrl() ?? FALSE;
+
+    return $responseItems;
+  }
+
+  /**
+   * @return array
+   */
+  public function toArray(): array {
+    return [
+      'contribution_id' => $this->contributionId,
+      'checkout_option' => $this->checkoutOption,
+      'urls' => $this->urls,
+      'messages' => $this->messages,
+      'title' => $this->title,
+      'checkout_params' => $this->getCheckoutParams(),
+      'status' => $this->getStatus(),
+    ];
+  }
+
+  /**
+   * @return string
+   */
+  public function tokenise(): string {
+    // 20 minutes
+    $expires = \CRM_Utils_Time::time() + (20 * 60);
+    $payload = [
+      'session' => $this->toArray(),
+      'exp' => $expires,
+    ];
+    return \Civi::service('crypto.jwt')->encode($payload, ['SIGN', 'WEAK_SIGN']);
+  }
+
+  /**
+   * @param string $sessionToken
+   *
+   * @return \Civi\AfformPayment\CheckoutSession
+   * @throws \CRM_Core_Exception
+   */
+  public static function restoreFromToken(string $sessionToken): CheckoutSession {
+    $payload = \Civi::service('crypto.jwt')->decode($sessionToken, ['SIGN', 'WEAK_SIGN']);
+
+    $data = $payload['session'];
+
+    $session = new CheckoutSession($data->contribution_id, $data->checkout_option);
+    $session->setCheckoutParams((array) $data->checkout_params);
+    $session->urls = (array) $data->urls;
+    $session->messages = (array) $data->messages;
+    $session->title = $data->title;
+
+    // TODO: we should probably recheck the session status after restoring from the token
+    // because the token status may be out of date - for example if:
+    // - user submits to continue a pending session, checkout is finalised server side
+    // - user submits duplicate request with the same old token, according to which the
+    // session is still pending
+    $session->status = $data->status;
+
+    return $session;
+  }
+
+  /**
+   * @return $this
+   */
+  public function startCheckout(): CheckoutSession {
+    $this->getCheckoutOption()->startCheckout($this);
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function continueCheckout(): CheckoutSession {
+    $this->getCheckoutOption()->continueCheckout($this);
+    return $this;
+  }
+
+  /**
+   * @return $this
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function pending(): CheckoutSession {
+    $this->status = self::STATUS_PENDING;
+    Contribution::update(FALSE)
+      ->addWhere('id', '=', $this->contributionId)
+      ->addWhere('contribution_status_id:name', '!=', 'Pending')
+      ->addValue('contribution_status_id:name', 'Pending')
+      ->execute();
+    return $this;
+  }
+
+  /**
+   * @return $this
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function fail(): CheckoutSession {
+    $this->status = self::STATUS_FAIL;
+    Contribution::update(FALSE)
+      ->addWhere('id', '=', $this->contributionId)
+      ->addWhere('contribution_status_id:name', '!=', 'Failed')
+      ->addValue('contribution_status_id:name', 'Failed')
+      ->execute();
+    return $this;
+  }
+
+  /**
+   * @return $this
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function cancel(): CheckoutSession {
+    $this->status = self::STATUS_CANCEL;
+    Contribution::update(FALSE)
+      ->addWhere('id', '=', $this->contributionId)
+      ->addWhere('contribution_status_id:name', '!=', 'Cancelled')
+      ->addValue('contribution_status_id:name', 'Cancelled')
+      ->execute();
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function success(): CheckoutSession {
+    $this->status = self::STATUS_SUCCESS;
+    // TODO: the checkout is successful, but we are probably still
+    // waiting for the payment to clear
+    // ideally we would be able to update the Contribution record
+    // to indicate that payment is expected but in transit
+    return $this;
+  }
+
+  public function getFeeAmount(): float {
+    return $this->feeAmount;
+  }
+
+  /**
+   * @param float $feeAmount
+   *
+   * @return $this
+   */
+  public function setFeeAmount(float $feeAmount): CheckoutSession {
+    $this->feeAmount = $feeAmount;
+    return $this;
+  }
+
+  public function getTransactionId(): string {
+    return $this->transactionId;
+  }
+
+  /**
+   * @param string $transactionId
+   *
+   * @return $this
+   */
+  public function setTransactionId(string $transactionId): CheckoutSession {
+    $this->transactionId = $transactionId;
+    return $this;
+  }
+
+  public function getOrderReference(): string {
+    return $this->orderReference;
+  }
+
+  /**
+   * @param string $orderReference
+   *
+   * @return $this
+   */
+  public function setOrderReference(string $orderReference): CheckoutSession {
+    $this->orderReference = $orderReference;
+    return $this;
+  }
+
+  /**
+   * @return int
+   *   Returns the ID of the FinancialTrxn (Payment) that was created
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function createPayment(): int {
+    if (method_exists($this->getCheckoutOption(), 'createPayment')) {
+      return $this->getCheckoutOption()->createPayment($this);
+    }
+    else {
+      return Payment::create(FALSE)
+        ->addValue('contribution_id', $this->getContributionId())
+        ->addValue('total_amount', $this->totalAmount)
+        ->addValue('fee_amount', $this->feeAmount)
+        ->addValue('payment_processor_id', $this->getCheckoutOption()->getPaymentProcessorId())
+        ->addValue('trxn_date', date('Ymd H:i:s'))
+        ->addValue('trxn_id', $this->transactionId)
+        ->addValue('order_reference', $this->orderReference)
+        ->addValue('payment_instrument_id:name', $this->getCheckoutOption()->getPaymentMethod())
+        ->execute()->first()['id'];
+    }
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout/Page/Landing.php
+++ b/ext/civi_contribute/Civi/Checkout/Page/Landing.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Civi\Checkout\Page;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * Resume checkout session, potentially after trip to the external
+ * payment processor.
+ *
+ * This endpoint may include a callback to the payment processor to
+ * check the status
+ */
+class Landing extends \CRM_Core_Page {
+
+  public function run() {
+    try {
+      $token = \CRM_Utils_Request::retrieve('session', 'String');
+      $result = \Civi\Api4\Contribution::continueCheckout(FALSE)
+        ->setToken($token)
+        ->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $result = [
+        'title' => E::ts('Error confirming payment status'),
+        'message' => $e->getMessage(),
+        'status' => 'error',
+      ];
+    }
+
+    // if redirect, redirect immediately
+    if ($result['redirect'] ?? FALSE) {
+      \CRM_Utils_System::redirect($result['redirect']);
+      return;
+    }
+
+    // otherwise set title then pass the rest to clientside renderer
+    \CRM_Utils_System::setTitle($result['title']);
+    \Civi::resources()->addScriptFile(E::SHORT_NAME, 'js/landing.js');
+    \Civi::resources()->addVars('checkout', [
+      'landingPageInitialCheck' => $result,
+    ]);
+    parent::run();
+
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout/PayLater.php
+++ b/ext/civi_contribute/Civi/Checkout/PayLater.php
@@ -2,9 +2,10 @@
 
 namespace Civi\Checkout;
 
+use Civi\Afform\Event\AfformValidateEvent;
 use CRM_Contribute_ExtensionUtil as E;
 
-class PayLater extends CheckoutOption {
+class PayLater extends CheckoutOption implements AfformCheckoutOptionInterface {
 
   public function getLabel(): string {
     return E::ts('Pay Later');
@@ -25,6 +26,14 @@ class PayLater extends CheckoutOption {
       ->execute();
 
     $session->success();
+  }
+
+  public function validate(AfformValidateEvent $event): void {
+    // no validation requirements for Pay Later
+  }
+
+  public function getAfformModule(): ?string {
+    return NULL;
   }
 
   public function getAfformSettings(bool $testMode): array {

--- a/ext/civi_contribute/Civi/Checkout/PayLater.php
+++ b/ext/civi_contribute/Civi/Checkout/PayLater.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Civi\Checkout;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+class PayLater extends CheckoutOption {
+
+  public function getLabel(): string {
+    return E::ts('Pay Later');
+  }
+
+  public function startCheckout(CheckoutSession $session): void {
+    // FIXME: Contribution.update crashes if we dont pass
+    // back the financial type id
+    $financialTypeId = \Civi\Api4\Contribution::get(FALSE)
+      ->addWhere('id', '=', $session->getContributionId())
+      ->addSelect('financial_type_id')
+      ->execute()->single()['financial_type_id'];
+
+    \Civi\Api4\Contribution::update(FALSE)
+      ->addWhere('id', '=', $session->getContributionId())
+      ->addValue('is_pay_later', TRUE)
+      ->addValue('financial_type_id', $financialTypeId)
+      ->execute();
+
+    $session->success();
+  }
+
+  public function getAfformSettings(bool $testMode): array {
+    return [
+      // TODO: add a setting to make this user configurable
+      'description' => E::ts('No payment will be taken now.'),
+    ];
+  }
+
+}

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -174,10 +174,9 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
 
     $contribution = $event->getRecords()[0]['fields'];
 
-    // TODO: enforce payment is pending? maybe Order does this. maybe
-    // you want to create a contribution with line items in
-    // another state?
-    // $contribution['contribution_status_id:name'] = 'Pending';
+    if (\Civi::service('civi.checkout')->isTestMode()) {
+      $contribution['is_test'] = TRUE;
+    }
 
     // use order to create the contribution record
     $savedContribution = \Civi\Api4\Order::create(FALSE)

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -42,6 +42,8 @@
     <mixin>mgd-php@2.0.0</mixin>
     <mixin>setting-php@1.0.0</mixin>
     <mixin>afform-entity-php@1.0.0</mixin>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Contribute</namespace>

--- a/ext/civi_contribute/js/landing.js
+++ b/ext/civi_contribute/js/landing.js
@@ -1,0 +1,45 @@
+(function (api4) {
+
+  document.addEventListener('DOMContentLoaded', () => {
+    // note: token may be updated on subsequent requests
+    let recheckCount = 0;
+
+    const setMessage = (message, showLoader) => {
+      document.querySelector('#checkoutLanding .crm-checkout-message').innerText = message;
+      document.querySelector('#checkoutLanding .crm-loading-spinner').style.display = showLoader ? null : 'none';
+    };
+
+    const recheckStatus = (token) => CRM.api4('Contribution', 'continueCheckout', {
+      token: token
+    })
+    .then((response) => handleResponse(response));
+
+    const handleResponse = (response) => {
+      if (!response.status || !response.message) {
+        setMessage(ts('Error checking payment status'), false);
+      }
+
+      if (response.redirect) {
+        window.location = response.redirect;
+        return;
+      }
+
+      if (response.status === 'pending') {
+        if (recheckCount > 3) {
+          setMessage(ts('Unable to get status'), false);
+        }
+        else {
+          setMessage(response.message, true);
+          recheckCount += 1;
+          setTimeout(() => recheckStatus(response.token), 3000);
+        }
+      }
+      else {
+        // otherwise, hide loader
+        setMessage(response.message, false);
+      }
+    };
+
+    handleResponse(CRM.vars.checkout.landingPageInitialCheck);
+  });
+})(CRM.api4);

--- a/ext/civi_contribute/templates/Civi/Checkout/Page/Landing.tpl
+++ b/ext/civi_contribute/templates/Civi/Checkout/Page/Landing.tpl
@@ -1,0 +1,4 @@
+<div id="checkoutLanding">
+  <div class="crm-checkout-message">{ts}Loading{/ts}</div>
+  <div class="crm-loading-spinner"></div>
+</div>

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/CheckoutTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/CheckoutTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Civi\Contribute;
+
+use Civi\Checkout\CheckoutOptionInterface;
+use Civi\Checkout\CheckoutSession;
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test Contribution handling in Afform
+ *
+ * @group headless
+ */
+class CheckoutTest extends TestCase implements HeadlessInterface {
+
+  protected $afformContributionSettingBackup;
+
+  protected $contactId;
+
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      // TODO: if paypal moved to civicrm-core, then include and test interaction
+      // ->install(['paypal'])
+      ->apply();
+  }
+
+  public function setUp(): void {
+    $this->afformContributionSettingBackup = \Civi::settings()->get('contribute_enable_afform_contributions');
+    \Civi::settings()->set('contribute_enable_afform_contributions', TRUE);
+
+    $this->contactId = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('first_name', 'Test')
+      ->addValue('last_name', 'Contact')
+      ->execute()
+      ->single()['id'];
+  }
+
+  public function tearDown(): void {
+    \Civi::settings()->set('contribute_enable_afform_contributions', $this->afformContributionSettingBackup);
+
+    \Civi\Api4\Contribution::delete(FALSE)
+      ->addWhere('contact_id', '=', $this->contactId)
+      ->execute();
+
+    \Civi\Api4\Contact::delete(FALSE)
+      ->addWhere('id', '=', $this->contactId)
+      ->setUseTrash(FALSE)
+      ->execute();
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testCheckoutOptionGathering(): void {
+    $options = \Civi::service('civi.checkout')->getOptions();
+
+    // we should have at least the PayLater option
+    $this->assertEquals(TRUE, !empty($options));
+
+    // the pay later option should be a checkout option interface
+    foreach ($options as $name => $option) {
+
+      // all options should have name keys
+      $this->assertEquals(TRUE, is_string($name));
+      // all options should implement CheckoutOptionInterface
+      $this->assertEquals(TRUE, is_a($option, CheckoutOptionInterface::class));
+    }
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testCheckoutSession(): void {
+    $contribution = $this->createPendingContribution();
+
+    // note: pay_later option should always be available
+    $checkoutSession = new CheckoutSession($contribution['id'], 'pay_later');
+    $checkoutSession->setSuccessUrl("https://thank.you");
+
+    // check the session is pending
+    $this->assertEquals(CheckoutSession::STATUS_PENDING, $checkoutSession->getStatus());
+
+    $checkoutSession->startCheckout();
+
+    $contribution = \Civi\Api4\Contribution::get(FALSE)
+      ->addWhere('id', '=', $contribution['id'])
+      ->addSelect('contribution_status_id:name', 'is_pay_later')
+      ->execute()
+      ->first();
+
+    // check the contribution is updated
+    $this->assertEquals('Pending', $contribution['contribution_status_id:name']);
+    $this->assertEquals(TRUE, $contribution['is_pay_later']);
+
+    // check the session is successful
+    $this->assertEquals(CheckoutSession::STATUS_SUCCESS, $checkoutSession->getStatus());
+    // check the session tells us to go to the thank you page now
+    $this->assertEquals("https://thank.you", $checkoutSession->getNextUrl());
+
+    // we should be able to tokenise the session
+    $token = $checkoutSession->tokenise();
+
+    // and then call continueCheckout api
+    $result = \Civi\Api4\Contribution::continueCheckout(FALSE)
+      ->setToken($token)
+      ->execute();
+
+    // and get the status back
+    $this->assertEquals($result['redirect'], $checkoutSession->getNextUrl());
+  }
+
+  protected function createPendingContribution(): array {
+    return \Civi\Api4\Order::create(FALSE)
+      ->setContributionValues([
+        'contact_id' => $this->contactId,
+        'financial_type_id' => 1,
+      ])
+      ->addLineItem([
+        'unit_price' => 10,
+        'qty' => 1,
+      ])
+      ->execute()
+      ->first();
+  }
+
+}

--- a/ext/civi_contribute/xml/Menu/civi_contribute.xml
+++ b/ext/civi_contribute/xml/Menu/civi_contribute.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/checkout/continue</path>
+    <page_callback>Civi\Checkout\Page\Landing</page_callback>
+    <title>CiviCRM Payment</title>
+    <access_arguments>make online contributions</access_arguments>
+    <is_public>true</is_public>
+  </item>
+</menu>


### PR DESCRIPTION
Overview
----------------------------------------
Adds new CheckoutSession / CheckoutOptions model which provide the plumbing for FormBuilder payments.

Before
----------------------------------------
- Payment Processor integrations are defined with one big class extending `CRM_Core_Payment` that defines methods for handling frontend contributions (through Quickform Contribution Pages) and also handling backoffice operations, webhooks etc
- there is a 1-1 relationship between CRM_Core_Payment objects and PaymentProcessor records. This can lead to redundancy where one account with the payment processor (such as Stripe) is used with different modes (Stripe Card Element + Stripe Checkout)
- the payment integration is geared to a one-shot server side process through the `doPayment`

After
----------------------------------------
- add CheckoutSession which provides a model for handling of more multi step payment flows, where steps may happen serverside or clientside depending on the integration
- add CheckoutOption which provides a model for frontend "checkout options" which may not correspond 1-1 to PaymentProcessor records - e.g. one connection to Stripe can provide options for Stripe Hosted Checkout and Stripe Embedded Checkout; we can provide a Pay Later checkout option which does not correspond to any PaymentProcessor record.

Technical Details
----------------------------------------
The CheckoutOptions are gathered using a hook `civi.checkout.options` which collects objects which implement CheckoutOptionInterface. This provides flexibility in how Payment integrations respond to the hook, and potentially more bespoke behaviours by supplying bespoke implementations of the interface.

There is an optional AfformCheckoutOptionInterface which includes extra functions specific to Afform. At this stage the likelihood is that all CheckoutOptions will be AfformCheckoutOptions, but there is flexibility going forward - (`QuickformCheckoutOptions` or `BackofficeCheckoutOptions` or ?)


Comments
----------------------------------------
The functionality is gated behind `contribute_enable_afform_contributions` feature flag setting for now, so everything is *opt in* for now.

Nothing calls this directly, it works in combo with:
- https://lab.civicrm.org/extensions/afform_payments/-/tree/core-checkout = remaining afform integration code
- https://lab.civicrm.org/extensions/paypal = Paypal implementation of afform integration
- https://lab.civicrm.org/ufundo/stripe/-/tree/afform-flat = Stripe implementation of afform integration

My intention is to create a follow up PR with the third and final chunk from `afform_payments`.