### PR TITLE
make CRM_Core_Payment::getAllFields public

### DIFF
--- a/CRM/Core/Payment.php
+++ b/CRM/Core/Payment.php
@@ -810,7 +810,7 @@ abstract class CRM_Core_Payment {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function getAllFields() {
+  public function getAllFields() {
     $paymentFields = array_intersect_key($this->getPaymentFormFieldsMetadata(), array_flip($this->getPaymentFormFields()));
     $billingFields = array_intersect_key($this->getBillingAddressFieldsMetadata(), array_flip($this->getBillingAddressFields()));
     return array_merge($paymentFields, $billingFields);


### PR DESCRIPTION
Overview
----------------------------------------
This function is just a helper which combines a few other public methods. It's useful for FormBuilder payments to make this public too.


Technical Details
---------------------------------------
To check: do any subclasses override this method? If so this will cause problems if they have declared it protected.
