### PR TITLE
dev/core#6393 Purify instead of escape in contact summery overlay

### DIFF
--- a/templates/CRM/Profile/Page/Overlay.tpl
+++ b/templates/CRM/Profile/Page/Overlay.tpl
@@ -30,7 +30,7 @@
             {$field.label}
         </div>
         <div class="content">
-          {$field.value|escape}
+          {$field.value|purify}
         </div>
         <div class="clear"></div>
       </div>


### PR DESCRIPTION
Before
----------------------------------------
Email field value, which includes HTML, breaks display.

After
----------------------------------------
Fixed.