### PR TITLE
dev/core#4950 AdminUI - reenable contact summary activity tab using subsearches for…

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchTabActivity.aff.php
@@ -4,12 +4,13 @@ return [
   'type' => 'search',
   'title' => ts('Activities'),
   'description' => '',
-  // Disabled temporarily for https://lab.civicrm.org/dev/core/-/issues/4950
-  // 'placement' => ['contact_summary_tab'],
+  'placement' => ['contact_summary_tab'],
   'placement_weight' => 70,
   'icon' => 'fa-tasks',
   'permission' => [
     'access CiviCRM',
   ],
   'permission_operator' => 'AND',
+  // TODO: why is this required?
+  'requires' => ['crmSearchDisplayList'],
 ];

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Activities.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Activities.mgd.php
@@ -21,9 +21,6 @@ return [
             'subject',
             'activity_date_time',
             'status_id:label',
-            'GROUP_CONCAT(UNIQUE Activity_ActivityContact_Contact_02.sort_name) AS GROUP_CONCAT_Activity_ActivityContact_Contact_02_sort_name',
-            'GROUP_CONCAT(UNIQUE Activity_ActivityContact_Contact_03.sort_name) AS GROUP_CONCAT_Activity_ActivityContact_Contact_03_sort_name',
-            'GROUP_CONCAT(UNIQUE Activity_ActivityContact_Contact_04.sort_name) AS GROUP_CONCAT_Activity_ActivityContact_Contact_04_sort_name',
           ],
           'orderBy' => [],
           'where' => $excludeCaseActivities ? [['case_id', 'IS EMPTY']] : [],
@@ -39,51 +36,6 @@ return [
                 'id',
                 '=',
                 'Activity_ActivityContact_Contact_01.activity_id',
-              ],
-            ],
-            [
-              'Contact AS Activity_ActivityContact_Contact_02',
-              'LEFT',
-              'ActivityContact',
-              [
-                'id',
-                '=',
-                'Activity_ActivityContact_Contact_02.activity_id',
-              ],
-              [
-                'Activity_ActivityContact_Contact_02.record_type_id:name',
-                '=',
-                '"Activity Source"',
-              ],
-            ],
-            [
-              'Contact AS Activity_ActivityContact_Contact_03',
-              'LEFT',
-              'ActivityContact',
-              [
-                'id',
-                '=',
-                'Activity_ActivityContact_Contact_03.activity_id',
-              ],
-              [
-                'Activity_ActivityContact_Contact_03.record_type_id:name',
-                '=',
-                '"Activity Targets"',
-              ],
-            ],
-            [
-              'Contact AS Activity_ActivityContact_Contact_04',
-              'LEFT',
-              'ActivityContact',
-              [
-                'id',
-                '=',
-                'Activity_ActivityContact_Contact_04.activity_id',
-              ],
-              [
-                'Activity_ActivityContact_Contact_04.record_type_id:name',
-                '=',
-                '"Activity Assignees"',
               ],
             ],
           ],
@@ -115,7 +67,7 @@ return [
               'DESC',
             ],
           ],
-          'limit' => 50,
+          'limit' => 20,
           'pager' => [
             'hide_single' => TRUE,
             'show_count' => TRUE,
@@ -156,39 +108,63 @@ return [
               'editable' => TRUE,
             ],
             [
-              'type' => 'field',
-              'key' => 'GROUP_CONCAT_Activity_ActivityContact_Contact_02_sort_name',
+              'type' => 'subsearch',
               'label' => ts('Added By'),
               'sortable' => TRUE,
-              'link' => [
-                'entity' => 'Contact',
-                'action' => 'view',
-                'join' => 'Activity_ActivityContact_Contact_02',
-                'target' => '_blank',
+              'subsearch' => [
+                'search' => 'Contact_Summary_ActivityContacts',
+                'display' => 'Contact_Summary_ActivityContacts',
+                'subsearch_mode' => 'inline',
+                'filters' => [
+                  [
+                    'subsearch_field' => 'Contact_ActivityContact_Activity_01.id',
+                    'parent_field' => 'id',
+                  ],
+                  [
+                    'subsearch_field' => 'Contact_ActivityContact_Activity_01.record_type_id:name',
+                    'value' => 'Activity Source',
+                  ],
+                ],
               ],
             ],
             [
-              'type' => 'field',
-              'key' => 'GROUP_CONCAT_Activity_ActivityContact_Contact_03_sort_name',
+              'type' => 'subsearch',
               'label' => ts('With'),
               'sortable' => TRUE,
-              'link' => [
-                'entity' => 'Contact',
-                'action' => 'view',
-                'join' => 'Activity_ActivityContact_Contact_03',
-                'target' => '_blank',
+              'subsearch' => [
+                'search' => 'Contact_Summary_ActivityContacts',
+                'display' => 'Contact_Summary_ActivityContacts',
+                'subsearch_mode' => 'inline',
+                'filters' => [
+                  [
+                    'subsearch_field' => 'Contact_ActivityContact_Activity_01.id',
+                    'parent_field' => 'id',
+                  ],
+                  [
+                    'subsearch_field' => 'Contact_ActivityContact_Activity_01.record_type_id:name',
+                    'value' => 'Activity Targets',
+                  ],
+                ],
               ],
             ],
             [
-              'type' => 'field',
-              'key' => 'GROUP_CONCAT_Activity_ActivityContact_Contact_04_sort_name',
+              'type' => 'subsearch',
               'label' => ts('Assigned'),
               'sortable' => TRUE,
-              'link' => [
-                'entity' => 'Contact',
-                'action' => 'view',
-                'join' => 'Activity_ActivityContact_Contact_04',
-                'target' => '_blank',
+              'subsearch' => [
+                'search' => 'Contact_Summary_ActivityContacts',
+                'display' => 'Contact_Summary_ActivityContacts',
+                'subsearch_mode' => 'inline',
+                'filters' => [
+                  [
+                    'subsearch_field' => 'Contact_ActivityContact_Activity_01.id',
+                    'parent_field' => 'id',
+                  ],
+                  [
+                    'subsearch_field' => 'Contact_ActivityContact_Activity_01.record_type_id:name',
+                    'value' => 'Activity Assignees',
+                  ],
+                ],
               ],
             ],
             [

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_ActivityContacts.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_ActivityContacts.mgd.php
@@ -1,0 +1,94 @@
+<?php
+
+return [
+  [
+    'name' => 'SavedSearch_Contact_Summary_ActivityContacts',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Contact_Summary_ActivityContacts',
+        'label' => ts('Contact Summary Activities Tab - Activity Contacts'),
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'sort_name',
+            'display_name',
+            'Contact_ActivityContact_Activity_01.record_type_id:name',
+            'Contact_ActivityContact_Activity_01.id',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'join' => [
+            [
+              'Activity AS Contact_ActivityContact_Activity_01',
+              'INNER',
+              'ActivityContact',
+              [
+                'id',
+                '=',
+                'Contact_ActivityContact_Activity_01.contact_id',
+              ],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Contact_Summary_ActivityContacts_SearchDisplay_Contact_Summary_ActivityContacts',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Contact_Summary_ActivityContacts',
+        'label' => ts('Contact Summary Activities Tab - Activity Contacts'),
+        'saved_search_id.name' => 'Contact_Summary_ActivityContacts',
+        'type' => 'list',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [
+            [
+              'sort_name',
+              'DESC',
+            ],
+          ],
+          'limit' => 3,
+          'pager' => [
+            'hide_single' => TRUE,
+            //'show_count' => TRUE,
+            'expose_limit' => TRUE,
+          ],
+          'placeholder' => 1,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'display_name',
+              //'label' => ts(''),
+             // 'label' => FALSE,
+              'sortable' => TRUE,
+            ],
+          ],
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'toolbar' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+        'saved_search_id',
+      ],
+    ],
+  ],
+];

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -596,7 +596,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     ];
 
     foreach ($column['subsearch']['filters'] as $filterSetting) {
-      $out['subsearch']['filters'][$filterSetting['subsearch_field']] = $data[$filterSetting['parent_field']] ?? NULL;
+      // use hardcoded value or value from column data or null
+      $value = $filterSetting['value'] ?? $data[$filterSetting['parent_field']] ?? NULL;
+      $out['subsearch']['filters'][$filterSetting['subsearch_field']] = $value;
     }
 
     return $out;


### PR DESCRIPTION
… activity contacts

Overview
----------------------------------------
Wondering if subsearches can help with performance problems on this screen.

Before
----------------------------------------
- lots of group bys

After
----------------------------------------
- lots of follow up requests
- the original list loading wont be blocked, and then the activity contacts will be filled in 
- hopefully each individual query is small enough to not block up the whole db

Technical Details
----------------------------------------
Uses subsearches in place of the group bys for finding the contacts for each row in an activity.

Adds the ability to pass a raw value filter in the subsearch config (needs config UI support).

Not sure why I couldn't seem to use list search without adding the `crmSearchDisplayList` dependency.

Comments
----------------------------------------
Might be just replacing one performance problem with another. The subsearches could be collapsed and only run when user looks at them -- but this does feel like a screen where you expect to be able to scan all of the rows without having to go into each one.


