### PR TITLE
dev/core#6396 Fix missing curency info

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -209,7 +209,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     CRM_Core_Payment_Form::mapParams(NULL, $this->getSubmittedValues(), $paymentParams, TRUE);
     $paymentParams['contributionPageID'] = $this->getContributionPageID();
     $paymentParams['campaign_id'] = $this->getCampaignID();
-    $paymentParams['currency'] = $this->getCurrency();
+    $paymentParams['currency'] = $paymentParams['currencyID'] = $this->getCurrency();
     $paymentParams['description'] = $this->getSource();
     $paymentParams['contactID'] = $this->getContactID();
     return $paymentParams;


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/issues/6396

@jusfreeman 

Before
----------------------------------------
Currency not passed to Payment processor in all expected ways. In the case of Paypal Std it potentially assumes the wrong currency

After
----------------------------------------
Expected parameters passed for currency

Technical Details
----------------------------------------
In fact on review Paypal Std should use `currency` rather than expect `currencyID` - we could fix as a follow up 
https://docs.civicrm.org/dev/en/latest/extensions/payment-processors/paymentclass/#core-parameters

Comments
----------------------------------------

