### PR TITLE
dev/core#6397 Api4 - Ensure CONTAINS operator works with id fields.

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -526,7 +526,7 @@ abstract class Api4Query {
       $sqlClause = \CRM_Core_DAO::createSQLFilter($fieldAlias, [$operator => $value]);
     }
 
-    if ($original_operator === "NOT CONTAINS") {
+    if ($original_operator === "NOT CONTAINS" && ($field['nullable'] ?? TRUE) !== FALSE) {
       // For a "NOT CONTAINS", this adds an "OR IS NULL" clause - we want to know that a particular value is not present and don't care whether it has any other value
       return "(($sqlClause) OR $fieldAlias IS NULL)";
     }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -123,7 +123,7 @@ class FormattingUtil {
     // Special handling for 'current_user' and user lookups
     $exactMatch = [NULL, '=', '!=', '<>', 'IN', 'NOT IN', 'CONTAINS', 'NOT CONTAINS'];
     if (is_string($fk) && CoreUtil::isContact($fk) && in_array($operator, $exactMatch, TRUE)) {
-      $value = self::resolveContactID($fieldSpec['name'], $value);
+      $value = self::resolveContactID($fieldSpec['name'], $value) ?? $value;
     }
 
     switch ($fieldSpec['data_type'] ?? NULL) {

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -107,6 +107,47 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $this->assertTrue(!empty($limit1->single()['sort_name']));
   }
 
+  public function testGetByIdWithContainsOperator(): void {
+    $cid = $this->createTestRecord('Contact')['id'];
+
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('id', 'CONTAINS', (string) $cid)
+      ->execute();
+    $this->assertContains($cid, $result->column('id'));
+
+    // String or not string – shouldn't matter.
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('id', 'CONTAINS', $cid)
+      ->execute();
+    $this->assertContains($cid, $result->column('id'));
+
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('id', 'NOT CONTAINS', (string) $cid)
+      ->setDebug(TRUE)
+      ->execute();
+    $this->assertNotContains($cid, $result->column('id'));
+    // Verify the sql uses LIKE '%{$cid}%'
+    $this->assertStringContainsString("%$cid%", $result->debug['sql'][0]);
+    // The sql should not include an IS NULL clause
+    $this->assertStringNotContainsStringIgnoringCase('IS NULL', $result->debug['sql'][0]);
+
+    // This is a really strange request; it could never possibly return any results.
+    // But let's at least ensure it composes valid SQL.
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('id', 'CONTAINS', 'Robert "Bob" O\'Connor')
+      ->setDebug(TRUE)
+      ->execute();
+    $this->assertCount(0, $result);
+    // Verify the sql uses LIKE
+    $this->assertStringContainsString('LIKE "%Robert \\"Bob\\" O\\\'Connor%"', $result->debug['sql'][0]);
+    // The sql should not include an IS NULL clause
+    $this->assertStringNotContainsStringIgnoringCase('IS NULL', $result->debug['sql'][0]);
+  }
+
   /**
    * Test a lack of fatal errors when the where contains an emoji.
    *


### PR DESCRIPTION


Overview
----------------------------------------
Ensures a string can be used with the CONTAINS operator, even with an id field. 

Fixes [dev/core#6397](https://lab.civicrm.org/dev/core/-/issues/6397)

Comments
------
This is pretty edge-case stuff, but at least now it has a test.