### PR TITLE
PHP8.5 fix use of null as key in SearchKit

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -374,7 +374,8 @@ class Admin {
             $keyField = $fields[$reference->getReferenceKey()] ?? NULL;
             foreach ($reference->getTargetEntities() as $dynamicValue => $targetEntityName) {
               $targetEntity = $allowedEntities[$targetEntityName] ?? NULL;
-              $baseEntity = $allowedEntities[$fields[$baseKey]['fk_entity']] ?? NULL;
+              $fkEntity = $fields[$baseKey]['fk_entity'] ?? '';
+              $baseEntity = $allowedEntities[$fkEntity] ?? NULL;
               if (!$targetEntity || !$baseEntity) {
                 continue;
               }


### PR DESCRIPTION
<img width="1486" height="590" alt="image" src="https://github.com/user-attachments/assets/2f7fc52c-8642-412a-a4b4-6930b6f61334" />
