### PR TITLE
Fix php8.5 use of NULL in Core/L18n

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -247,7 +247,7 @@ class CRM_Core_I18n {
   public static function getFormatLocales(): array {
     $values = CRM_Core_OptionValue::getValues(['name' => 'languages'], $optionValues, 'label', TRUE);
     $return = [];
-    $return[NULL] = ts('Inherit from language');
+    $return[''] = ts('Inherit from language');
     foreach ($values as $value) {
       $return[$value['name']] = $value['label'];
     }


### PR DESCRIPTION
@totten this one feels a bit hard to figure out cos it's in layers of resolvers - I don't know that I can get away with this change


<img width="1486" height="590" alt="image" src="https://github.com/user-attachments/assets/e8d7b115-c5b6-4e21-aa03-6d2f901ae359" />