### PR TITLE
Standalone - Add helper to initialize CRM_Core_ClassLoader via __DIR__

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -84,3 +84,18 @@ function _ts(...$args) {
   $f = 'ts';
   return $f(...$args);
 }
+
+/**
+ * Register specialized classloader(s) for CiviCRM.
+ *
+ * This is similar to calling `CRM_Core_ClassLoader::singleton()->register()`, but
+ * this helper is easier to use. It only works if your environment has preloaded
+ * the rules from `civicrm-core:composer.json` (as on, say, Drupal 10).
+ *
+ * @return void
+ */
+function civicrm_classloader_register(): void {
+  $classLoader = implode(DIRECTORY_SEPARATOR, [__DIR__, 'CRM', 'Core', 'ClassLoader.php']);
+  require_once $classLoader;
+  \CRM_Core_ClassLoader::singleton()->register();
+}

--- a/setup/res/civicrm.standalone.php.txt
+++ b/setup/res/civicrm.standalone.php.txt
@@ -15,15 +15,12 @@ $appRootPath = __DIR__;
 
 // standard file structure with top-level private, public and extensions dirs.
 $autoLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'core', 'vendor', 'autoload.php']);
-$classLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'core', 'CRM', 'Core', 'ClassLoader.php']);
 
 # // alternative composer-style file structure:
 # $autoLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath , 'vendor', 'autoload.php']);
-# $classLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'vendor', 'civicrm', 'civicrm-core', 'CRM', 'Core', 'ClassLoader.php']);
 
 $settingsPath = implode(DIRECTORY_SEPARATOR, [__DIR__, 'private', 'civicrm.settings.php']);
 
 require_once $autoLoader;
-require_once $classLoader;
-\CRM_Core_ClassLoader::singleton()->register();
+civicrm_classloader_register();
 \Civi\Core\SettingsManager::bootSettings($settingsPath);


### PR DESCRIPTION
Overview
----------------------------------------

This is a variation on ufundo's PR #35098.  Carry-forward the idea to make `civicrm.standalone.php` a bit cleaner.  As in #35098, this leverages the fact that composer's autoloader can already find `civicrm-core` resources (and provide us with a suitable `__DIR__`). This just uses an internal API name that's a bit cleaner.

Before
----------------------------------------

For systems that load `{$site}/vendor/autoload.php` as their first autoloader,  setting up `CRM_Core_ClassLoader` requires some...

```
$in[c]a(n);
ta(ti)->ons();
```

After
----------------------------------------

For systems that load `{$site}/vendor/autoload.php` as their first autoloader, use simpler...

```
incantation();
```
