### PR TITLE
dev/core#6400 Flag Group selects as already escaped

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -125,7 +125,8 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
       '0' => ts('All Events'),
     ] + CRM_Event_PseudoConstant::event(NULL, FALSE, "is_template = 0");
 
-    $this->add('select', 'group_id', ts('Group'), $group);
+    $groupElement = $this->add('select', 'group_id', ts('Group'), $group);
+    $groupElement->setOptionTextEscaped();
     $this->add('select', 'custom_group_id', ts('Custom Data'), $customGroup);
     $this->add('select', 'uf_group_id', ts('Profile'), $ufGroup);
     $this->add('select', 'event_id', ts('Event'), $event);

--- a/CRM/Contact/Form/DedupeFind.php
+++ b/CRM/Contact/Form/DedupeFind.php
@@ -51,7 +51,8 @@ class CRM_Contact_Form_DedupeFind extends CRM_Admin_Form {
 
     $groupList = ['' => ts('- All Contacts -')] + CRM_Core_PseudoConstant::nestedGroup();
 
-    $this->add('select', 'group_id', ts('Select Group'), $groupList, FALSE, ['class' => 'crm-select2 huge']);
+    $groupElement = $this->add('select', 'group_id', ts('Select Group'), $groupList, FALSE, ['class' => 'crm-select2 huge']);
+    $groupElement->setOptionTextEscaped();
     $this->add('text', 'limit', ts('No of contacts to find matches for '));
 
     // To improve usability for smaller sites, we don't show the limit field unless a default limit has been set.

--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -114,7 +114,8 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
         $msg = ts('Add to a group');
       }
       $this->assign('groupLabel', $msg);
-      $this->addField('group_id', ['class' => 'crm-action-menu fa-plus', 'placeholder' => $msg, 'options' => $groupSelect]);
+      $groupSelect = $this->addField('group_id', ['class' => 'crm-action-menu fa-plus', 'placeholder' => $msg, 'options' => $groupSelect]);
+      $groupSelect->setOptionTextEscaped();
 
       $this->addButtons([
         [

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -51,12 +51,13 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
     $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '- ', TRUE);
     if (!empty($searchOptions['groups'])) {
-      $this->addField('group', [
+      $field = $this->addField('group', [
         'entity' => 'group_contact',
         'label' => ts('in'),
         'placeholder' => ts('- any group -'),
         'options' => $groupHierarchy,
       ]);
+      $field->setOptionTextEscaped();
     }
 
     if (!empty($searchOptions['tags'])) {

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -45,7 +45,7 @@ class CRM_Contact_Form_Search_Criteria {
 
         $form->add('select', 'group', ts('Groups'), $groupHierarchy, FALSE,
          ['id' => 'group', 'multiple' => 'multiple', 'class' => 'crm-select2']
-        );
+        )->setOptionTextEscaped();
         $groupOptions = CRM_Core_BAO_OptionValue::getOptionValuesAssocArrayFromName('group_type');
         $form->add('select', 'group_type', ts('Group Types'), $groupOptions, FALSE,
           ['id' => 'group_type', 'multiple' => 'multiple', 'class' => 'crm-select2']

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -109,6 +109,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup();
 
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group, FALSE, ['class' => 'crm-select2 huge']);
+    $groupElement->setOptionTextEscaped();
 
     $this->_title = $group[$this->_id];
 

--- a/CRM/Contact/Form/Task/RemoveFromGroup.php
+++ b/CRM/Contact/Form/Task/RemoveFromGroup.php
@@ -29,6 +29,7 @@ class CRM_Contact_Form_Task_RemoveFromGroup extends CRM_Contact_Form_Task {
     // add select for groups
     $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup();
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group, TRUE, ['class' => 'crm-select2 huge']);
+    $groupElement->setOptionTextEscaped();
 
     $this->setTitle(ts('Remove Contacts from Group'));
     $this->addDefaultButtons(ts('Remove from Group'));

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -53,7 +53,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       $this->addElement('select', 'groups', ts('Add imported records to existing group(s)'), $groups, [
         'multiple' => 'multiple',
         'class' => 'crm-select2',
-      ]);
+      ])->setOptionTextEscaped();
     }
 
     //display new tag

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -459,7 +459,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
           'multiple' => 'multiple',
           'class' => 'crm-select2',
         ]
-      );
+      )->setOptionTextEscaped();
       $this->searchFieldMetadata['Contact']['group'] = ['name' => 'group', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'html' => ['type' => 'Select']];
     }
 

--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -107,6 +107,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
     $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::group();
 
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group);
+    $groupElement->setOptionTextEscaped();
 
     $this->_title = $group[$this->_id];
 

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -52,7 +52,8 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
    */
   public function buildForm(&$form) {
     $groups = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(FALSE);
-    $form->addElement('select', 'group_id', ts('Group'), $groups, ['class' => 'crm-select2 huge']);
+    $groupElement = $form->addElement('select', 'group_id', ts('Group'), $groups, ['class' => 'crm-select2 huge']);
+    $groupElement->setOptionTextEscaped();
 
     /**
      * if you are using the standard template, this array tells the template what elements


### PR DESCRIPTION
Overview
----------------------------------------
This flags groups selects as already escaped so that we do not double escape group titles / the code flagging a group is a child group

Before
----------------------------------------
Group Titles overescaped

After
----------------------------------------
Group titles display right

ping @totten @mlutfy 