### PR TITLE
Riverlea - Use portable resourceBase variable

### DIFF
--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -113,6 +113,8 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
     if ($bundle->name === 'coreResources') {
       if (\CRM_Core_Permission::check('administer CiviCRM')) {
         $bundle->addScriptFile('riverlea', 'js/previewer.js');
+        // Variable needed by the previewer.js script.
+        $bundle->addVars(E::LONG_NAME, ['resourceUrl' => E::url()]);
       }
     }
 

--- a/ext/riverlea/js/previewer.js
+++ b/ext/riverlea/js/previewer.js
@@ -40,7 +40,7 @@
 
     async fetchCoreDarkRules() {
       if (this.coreDarkRules) return;
-      return fetch(CRM.resourceUrls.civicrm + '/ext/riverlea/core/css/_dark.css')
+      return fetch(CRM.vars.riverlea.resourceUrl + '/core/css/_dark.css')
         .then((response) => response.text())
         .then((content) => this.coreDarkRules = content);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Improves portability of RiverLea preview code instead of relying on otherwise-unused variable.

See https://github.com/civicrm/civicrm-core/pull/35234


Technical Details
----------------------------------------
The previous code was assuming that riverlea assets are always found within the CiviCRM core directory, but that might not always be the case, e.g. with Asset Publisher, the locations of public resources can change.