### PR TITLE
Gender in profiles: avoid nbsp space - fixes spaces when using River as a frontend theme

### DIFF
--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -1892,7 +1892,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     elseif (in_array($fieldName, ['gender_id', 'communication_style_id'])) {
       $options = [];
       $pseudoValues = CRM_Contact_DAO_Contact::buildOptions($fieldName);
-      $form->addRadio($name, ts('%1', [1 => $title]), $pseudoValues, ['allowClear' => !$required], NULL, $required);
+      $form->addRadio($name, ts('%1', [1 => $title]), $pseudoValues, ['allowClear' => !$required], '', $required);
     }
     elseif ($fieldName === 'prefix_id' || $fieldName === 'suffix_id') {
       $form->addSelect($name, [


### PR DESCRIPTION
Overview
----------------------------------------

When the gender field is included in a public profile (ex: membership page), there is a "nbsp" space added, which then behaves oddly with when River is used as a public theme.

Before
----------------------------------------

Very space:

<img width="1494" height="586" alt="image" src="https://github.com/user-attachments/assets/49848c29-f996-430a-ba6a-fa4279368817" />

After
----------------------------------------

Less space:

<img width="1494" height="586" alt="image" src="https://github.com/user-attachments/assets/33b9f812-1feb-4e09-aaac-bb9f4536a81d" />

Comments
----------------------------------------

- Ignoring the "clear" link for now, because it's more of a River issue (?).
- The separator should always be "" instead of "nbsp", but I could not figure out where it's from. I poked around QuickForm as well.

cc @vingle I suspect/hope you won't object to the "nbsp" removals, but checking just in case!