### PR TITLE
ChartKit - more consistent loading indicator

### DIFF
--- a/ext/chart_kit/js/components/civi-search-display-chart-kit.js
+++ b/ext/chart_kit/js/components/civi-search-display-chart-kit.js
@@ -26,7 +26,7 @@
         if (!this.chartType) {
           return;
         }
-        this.renderSpinner();
+        this.toggleLoading(true);
       });
 
       this.onPostRun.push(() => {
@@ -53,12 +53,8 @@
       return (this._settings && this._settings.format) ? this._settings.format.title : null;
     }
 
-    renderSpinner() {
-      this.chartContainer.innerHTML = '<div class="crm-loading-spinner"></div>';
-    }
-
-    toggleBlur(blur = true) {
-      this.style.filter = blur ? 'blur(1px)' : null;
+    toggleLoading(loading = true) {
+      this.chartContainer?.classList.toggle('crm-search-loading-placeholder', loading);
     }
 
     renderContainer() {
@@ -127,7 +123,7 @@
     }
 
     reloadSoon() {
-      this.toggleBlur(true);
+      this.toggleLoading(true);
       clearTimeout(this.nextReload);
       this.nextReload = setTimeout(() => this.reload(), 500);
     }
@@ -142,7 +138,7 @@
         this.loadSettings();
       }
       catch (e) {
-        this.toggleBlur(false);
+        this.toggleLoading(false);
         this.chartContainer.innerText = e.message;
         // if error loading settings, go no further
         return;
@@ -163,7 +159,8 @@
     // into at different points
     renderChart() {
       if (this.results.length === 0) {
-        // show a no results type thing
+        // show a no results message
+        this.toggleLoading(false);
         this.chartContainer.innerText = ts('Search returned no results.');
         return;
       }
@@ -190,7 +187,7 @@
       // run the dc render
       this.chart.render();
       this.renderDownloadLinks();
-      this.toggleBlur(false);
+      this.toggleLoading(false);
     }
 
     loadSettings() {
@@ -600,8 +597,8 @@
 
     setContainerStyles() {
       const formatSettings = this._settings.format ? this._settings.format : {};
-      this.chartContainer.style.height = formatSettings.height;
-      this.chartContainer.style.width = formatSettings.width;
+      this.chartContainer.style.height = formatSettings.height ? `${formatSettings.height}px` : null;
+      this.chartContainer.style.width = formatSettings.width ? `${formatSettings.width}px` : null;
       this.chartContainer.style.margin = formatSettings.padding ? formatSettings.padding.inner : null;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Use `crm-search-loading-placeholder`.

Before
----------------------------------------
- `renderSpinner` when doing fetch from server
- `toggleBlur` when just re-rendering clientside
- chart element container changes size during the render process, causing layout shifts

After
----------------------------------------
- user `toggleLoading` everywhere, which uses pre-existing `crm-search-loading-placeholder` which gives a pulsing blur best of both (and consistent with other search kit loading indication)
- chart element container size set at the start, so less layout shifting

Technical Details
----------------------------------------
I think I added the spinner previously because the container size setting was broken, so something was needed to ensure the container didn't collapse to nothing. Fixing that means `crm-search-loading-placeholder` works well.
