### PR TITLE
EventInfo: convert waitlist checkbox to a toggle

### DIFF
--- a/CRM/Event/Form/ManageEvent/EventInfo.php
+++ b/CRM/Event/Form/ManageEvent/EventInfo.php
@@ -165,14 +165,14 @@ class CRM_Event_Form_ManageEvent_EventInfo extends CRM_Event_Form_ManageEvent {
     $this->add('datepicker', 'end_date', ts('End'), [], FALSE, ['time' => TRUE]);
 
     $this->add('number', 'max_participants', ts('Max Number of Participants'),
-      ['onchange' => "if (this.value != '') {cj('#id-waitlist').show(); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','radio',false); showHideByValue('has_waitlist','0','id-event_full','table-row','radio',true); return;} else {cj('#id-event_full, #id-waitlist, #id-waitlist-text').hide(); return;}"]
+      ['onchange' => "if (this.value != '') {cj('#id-waitlist').show(); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','checkbox',false); showHideByValue('has_waitlist','0','id-event_full','table-row','checkbox',true); return;} else {cj('#id-event_full, #id-waitlist, #id-waitlist-text').hide(); return;}"]
     );
     $this->addRule('max_participants', ts('Max participants should be a positive number'), 'positiveInteger');
 
     $participantStatuses = CRM_Event_PseudoConstant::participantStatus();
     $waitlist = 0;
     if (in_array('On waitlist', $participantStatuses) and in_array('Pending from waitlist', $participantStatuses)) {
-      $this->addElement('checkbox', 'has_waitlist', ts('Offer a Waitlist?'), NULL, ['onclick' => "showHideByValue('has_waitlist','0','id-event_full','table-row','radio',true); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','radio',false);"]);
+      $this->addToggle('has_waitlist', ts('Offer a Waitlist'), ['onclick' => "showHideByValue('has_waitlist','0','id-event_full','table-row','checkbox',true); showHideByValue('has_waitlist','0','id-waitlist-text','table-row','checkbox',false);"]);
       $this->add('textarea', 'waitlist_text', ts('Waitlist Message'), $attributes['waitlist_text']);
       $waitlist = 1;
     }

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
@@ -51,7 +51,7 @@
 <p>{if $params.waitlist}
   {ts}You may allow users to join a waitlist when the event is full (by checking the box below).{/ts}
 {else}
-  {ts}You may allow users to join a waitlist when the event is full. To enable this feature you must first enable the Participant Statuses used by the waitlist work-flow (click the wrench icon, or navigate to Administer » CiviEvent » Participant Statuses). Then reload this form and check 'Offer a Waitlist?'.{/ts}
+  {ts}You may allow users to join a waitlist when the event is full. To enable this feature you must first enable the Participant Statuses used by the waitlist work-flow (click the wrench icon, or navigate to Administer » CiviEvent » Participant Statuses). Then reload this form and check 'Offer a Waitlist'.{/ts}
 {/if}</p>
 <p>{ts}Otherwise, the registration link is hidden and the &quot;Event Full Message&quot' is displayed when the maximum number of registrations is reached. Only participants with status types marked as 'counted' are included when checking if the event is full.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.tpl
@@ -74,8 +74,8 @@
     </tr>
     <tr id="id-waitlist" class="crm-event-manage-eventinfo-form-block-has_waitlist">
       {if $waitlist}
-        <td class="label">{$form.has_waitlist.label}</td>
-        <td>{$form.has_waitlist.html} {help id="has_waitlist"}</td>
+        <td class="label">{$form.has_waitlist.label} {help id="has_waitlist"}</td>
+        <td>{$form.has_waitlist.html}</td>
       {/if}
     </tr>
     <tr id="id-event_full" class="crm-event-manage-eventinfo-form-block-event_full_text">


### PR DESCRIPTION
Overview
----------------------------------------

Converts the "Offer a Waitlist" checkbox to a toggle, same as the rest of those options on that page. Related to #34895

Also renamed the label to remove the "?", same as other labels (with apologies to translators, I think it's worth it).

Before
----------------------------------------

<img width="2400" height="656" alt="image" src="https://github.com/user-attachments/assets/713ad1cd-6137-49dc-bb10-2a113e19e4f9" />


After
----------------------------------------

<img width="2400" height="656" alt="image" src="https://github.com/user-attachments/assets/91c4f1c9-81ed-4d2f-adba-0d371caf93bf" />

