### PR TITLE
ChartKit - add integer scale type

### DIFF
--- a/ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
@@ -246,27 +246,34 @@
         return this.searchColumns.find((searchColumn) => (searchColumn.key === key));
       };
 
-      this.getColumnSourceDataType = (col) => {
+      this.getColumnDataType = (col) => {
         const details = this.getSearchColumn(col.key);
         return details ? details.dataType : null;
-      };
-
-      this.getColumnSourceDataTypeIsDate = (col) => {
-        const dataType = this.getColumnSourceDataType(col);
-        return dataType && ['Date', 'Time', 'Timestamp'].includes(dataType);
       };
 
       this.getColumnScaleTypeOptions = (col) => {
         let options = this.getAxisScaleTypeOptions(col.axis);
 
-        // date is only valid if the column type is date
-        if (this.getColumnSourceDataTypeIsDate(col)) {
-          options = options.filter((item) => ['date', 'categorical'].includes(item));
-        } else if (this.getColumnSourceDataType(col) === 'String') {
-          options = options.filter((item) => item === 'categorical');
-        } else {
-          options = options.filter((item) => item !== 'date');
+        switch (this.getColumnDataType(col)) {
+          case 'Date':
+          case 'Time':
+          case 'Timestamp':
+            options = ['date', 'categorical'].filter((item) => options.includes(item));
+            break;
+
+          case 'Integer':
+            options = ['integer', 'numeric', 'categorical'].filter((item) => options.includes(item));
+            break;
+
+          case 'String':
+            options = options.filter((item) => item === 'categorical');
+            break;
+
+          default:
+            // exclude date if data type is not one of those above
+            options = options.filter((item) => item !== 'date');
         }
+
         // this is a bit hacky, but if option groups can be categorical, they
         // probably should be
         if (col.key && col.key.includes(':label') && options.includes('categorical')) {
@@ -276,7 +283,7 @@
       };
 
       this.getColumnDatePrecisionOptions = (col) => {
-        if (this.getColumnSourceDataTypeIsDate(col)) {
+        if (['Date', 'Time', 'Timestamp'].includes(this.getColumnDataType(col))) {
           return chartKitColumnOptions.datePrecision.map((option) => option.key);
         }
         return [];
@@ -306,19 +313,24 @@
       this.getColumnDataLabelFormatterOptions = (col) => {
         const options = this.getAxisDataLabelFormatterOptions(col.axis);
 
-        // categorical will often be rendered to string, which
-        // dont like being formatted
-        if (col.scaleType === 'categorical') {
-          return ['none', 'round', 'formatMoney'];
-        }
-        // default to money for money columns
-        if (col.sourceDataType === 'Money') {
+        // default to money formatting for money columns
+        if (this.getColumnDataType(col) === 'Money') {
           return ['formatMoney', 'round', 'none'];
         }
 
-        if (col.scaleType === 'date') {
-          // TODO support fancy date formatting?
-          return ['none'];
+        switch (col.scaleType) {
+          case 'categorical':
+            // categorical will often be rendered to string, which
+            // dont like being formatted
+            return ['none', 'round', 'formatMoney'];
+
+          case 'integer':
+            // formatters generally dont make sense for integer scales
+            return ['none'];
+
+          case 'date':
+            // TODO support fancy date formatting?
+            return ['none'];
         }
 
         return options;

--- a/ext/chart_kit/js/chartKitColumnOptions.js
+++ b/ext/chart_kit/js/chartKitColumnOptions.js
@@ -95,7 +95,11 @@
     scaleType: [
       {
         key: 'numeric',
-        label: ts('Numeric'),
+        label: ts('Continuous'),
+      },
+      {
+        key: 'integer',
+        label: ts('Whole Number'),
       },
       {
         key: 'categorical',

--- a/ext/chart_kit/js/components/civi-search-display-chart-kit.js
+++ b/ext/chart_kit/js/components/civi-search-display-chart-kit.js
@@ -331,11 +331,19 @@
           // timescale
           this.chart.x(d3.scaleTime().domain([min, max]).nice());
           break;
+
         case 'categorical':
           this.chart
             .x(d3.scaleBand().domain(xDomainValues))
             .xUnits(dc.units.ordinal);
           break;
+
+        case 'integer':
+          this.chart
+            .x(d3.scaleBand().domain(d3.range(min, max + 1)))
+            .xUnits(dc.units.ordinal);
+          break;
+
         default:
           // regular linear scale
           this.chart.x(d3.scaleLinear().domain([min, max]).nice());

--- a/ext/chart_kit/js/typeBackends/chartKitComposite.js
+++ b/ext/chart_kit/js/typeBackends/chartKitComposite.js
@@ -15,7 +15,7 @@
       'x': {
         label: ts('X-Axis'),
         // prefer date/categorical
-        scaleTypes: ['date', 'numeric', 'categorical'],
+        scaleTypes: ['date', 'numeric', 'categorical', 'integer'],
         reduceTypes: [],
         isDimension: true,
       },

--- a/ext/chart_kit/js/typeBackends/chartKitSeries.js
+++ b/ext/chart_kit/js/typeBackends/chartKitSeries.js
@@ -14,7 +14,7 @@
     getAxes: () => ({
       'x': {
         label: ts('X-Axis'),
-        scaleTypes: ['date', 'numeric', 'categorical'],
+        scaleTypes: ['date', 'numeric', 'categorical', 'integer'],
         reduceTypes: [],
         isDimension: true,
       },

--- a/ext/chart_kit/js/typeBackends/chartKitStack.js
+++ b/ext/chart_kit/js/typeBackends/chartKitStack.js
@@ -11,7 +11,7 @@
     getAxes: () => ({
       'x': {
         label: ts('X-Axis'),
-        scaleTypes: ['date', 'numeric', 'categorical'],
+        scaleTypes: ['date', 'numeric', 'categorical', 'integer'],
         reduceTypes: [],
         isDimension: true,
       },

--- a/ext/civigrant/managed/SavedSearch_CiviGrant_Dashboard_Graph.mgd.php
+++ b/ext/civigrant/managed/SavedSearch_CiviGrant_Dashboard_Graph.mgd.php
@@ -58,7 +58,7 @@ return [
               'name' => 'x_0',
               'label' => E::ts('Year'),
               'sourceDataType' => 'Integer',
-              'scaleType' => 'categorical',
+              'scaleType' => 'integer',
               'datePrecision' => NULL,
               'reduceType' => 'list',
               'seriesType' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
Better option for when the x-axis takes integer values.


Before
----------------------------------------
 Two bad options for charts like amount by year on CiviGrant dashboard
 - "Numeric" spaces bars a bit oddly, and sometimes renders non-sensical decimal point ticks
<img width="835" height="354" alt="image" src="https://github.com/user-attachments/assets/651d5db8-f21d-4725-85a3-770e4192b4ef" />
 

 - "Categorical" misses out values without any data
 
<img width="969" height="426" alt="image" src="https://github.com/user-attachments/assets/b0942a49-f604-482b-a38e-e0d61edc8d54" />



After
----------------------------------------
- "Whole number" does just what you want:

<img width="795" height="423" alt="image" src="https://github.com/user-attachments/assets/8353cf3a-83a4-49c9-8566-375a1e568bf4" />


Comments
----------------------------------------
The new type should be the default when it makes sense. The relevant CiviGrant chart is updated to use it.
