### PR TITLE
SearchKit - Prefetch default columns

### DIFF
--- a/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
+++ b/ext/search_kit/Civi/Search/AfformSearchMetadataInjector.php
@@ -58,6 +58,15 @@ class AfformSearchMetadataInjector {
             catch (\CRM_Core_Exception $e) {
               return;
             }
+            // Fetch auto columns
+            if (isset($displayName) && ($display['settings']['columnMode'] ?? '') === 'auto') {
+              $defaultSettings = \Civi\Api4\SearchDisplay::getDefault(FALSE)
+                ->setSavedSearch($searchName)
+                ->setType($display['type'])
+                ->addSelect('settings')
+                ->execute()->first()['settings'];
+              $display['settings']['columns'] = $defaultSettings['columns'];
+            }
             // Note: Should be kept in-sync with \Civi\Api4\Action\SearchDisplay\GetMarkup::doTask
             pq($component)->attr('settings', htmlspecialchars(\CRM_Utils_JS::encode($display['settings'] ?? []), ENT_COMPAT));
             pq($component)->attr('api-entity', htmlspecialchars($savedSearch['api_entity'], ENT_COMPAT));

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -31,12 +31,12 @@
           this.placeholders.push({});
         }
 
-        if (this.settings.columnMode === 'auto') {
+        // This will ony be true if running the search outside of an Afform.
+        // Within an Afform, default columns will be set by AfformSearchMetadataInjector.
+        if (this.settings.columnMode === 'auto' && (!this.settings.columns || !this.settings.columns.length)) {
           // start with no columns in case we run before
           // we've fetched the right ones
           this.columns = [];
-          // TODO: default permission is access CiviCRM
-          // need to tweak permissions for frontend forms
           crmApi4('SearchDisplay', 'getDefault', {
             savedSearch: this.search
           })


### PR DESCRIPTION
Overview
----------------------------------------
This makes search display loading faster and avoids permission issues with FBAC.

Fixes https://lab.civicrm.org/dev/core/-/issues/6399
