### PR TITLE
(dev/core#6400) Group - Reduce systemic double-encoding of title/description

### DIFF
--- a/CRM/ACL/Form/ACL.php
+++ b/CRM/ACL/Form/ACL.php
@@ -108,7 +108,7 @@ class CRM_ACL_Form_ACL extends CRM_Admin_Form {
     $group = [
       '-1' => ts('- select group -'),
       '0' => ts('All Groups'),
-    ] + CRM_Core_PseudoConstant::group();
+    ] + CRM_Core_PseudoConstant::group(textFormat: 'plain');
 
     $customGroup = [
       '-1' => ts('- select set of custom fields -'),

--- a/CRM/Campaign/Form/Campaign.php
+++ b/CRM/Campaign/Form/Campaign.php
@@ -217,7 +217,7 @@ class CRM_Campaign_Form_Campaign extends CRM_Core_Form {
         ['class' => 'crm-select2']
       );
     }
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     //get the campaign groups.
     $this->add('select', 'includeGroups',
       ts('Include Group(s)'),

--- a/CRM/Campaign/Form/Task/Reserve.php
+++ b/CRM/Campaign/Form/Task/Reserve.php
@@ -142,7 +142,7 @@ class CRM_Campaign_Form_Task_Reserve extends CRM_Campaign_Form_Task {
     $this->addElement('text', 'ActivityType', ts('Activity Type'));
     $this->addElement('text', 'newGroupName', ts('Name for new group'));
     $this->addElement('text', 'newGroupDesc', ts('Description of new group'));
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     $hasExistingGroups = FALSE;
     if (is_array($groups) && !empty($groups)) {
       $hasExistingGroups = TRUE;

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -866,7 +866,11 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
    * @param string $spacer
    * @param bool $titleOnly
    * @param bool $public
-   *
+   * @param string $textFormat
+   *   Preferred encoding for the title/description
+   *   - 'plain' for plain text. (Ex: "Bill & Ted's >est Adventure")
+   *   - 'html' for HTML entities. (Ex: "Bill &amp; Ted's &gt;est Adventure")
+   *   - 'html-ish' for partial HTML entities (Ex: "Bill & Ted's &gt;est Adventure") [DEPRECATED]
    * @return array
    */
   public static function getGroupsHierarchy(
@@ -874,11 +878,14 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
     $parents = NULL,
     $spacer = '<span class="child-indent"></span>',
     $titleOnly = FALSE,
-    $public = FALSE
+    $public = FALSE,
+    string $textFormat = 'html-ish'
   ) {
     if (empty($groupIDs)) {
       return [];
     }
+
+    // TODO: Emit a warning if someone requests $textFormat==='html-ish'. This not a sensible format for display. (Or transmission or storage, but storage has massive inertia...)
 
     $groupIdString = '(' . implode(',', array_keys($groupIDs)) . ')';
     // <span class="child-icon"></span>
@@ -912,12 +919,13 @@ WHERE  id IN $groupIdString
     // $tree contains the child nodes based on their parent_id.
     $roots = [];
     $tree = [];
+    $codex = CRM_Utils_API_HTMLInputCoder::singleton();
     while ($dao->fetch()) {
-      $title = $dao->title;
-      $description = $dao->description;
+      $title = $codex->transcode('title', $dao->title, $textFormat);
+      $description = $codex->transcode('description', $dao->description, $textFormat);
       if ($public) {
-        $title = $dao->frontend_title;
-        $description = $dao->frontend_description;
+        $title = $codex->transcode('frontend_title', $dao->frontend_title, $textFormat);
+        $description = $codex->transcode('frontend_description', $dao->frontend_description, $textFormat);
       }
       if ($dao->parents) {
         $parentArray = explode(',', $dao->parents);

--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -249,12 +249,15 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
    *   Contact id.
    *
    * @param bool $visibility
-   *
-   *
+   * @param string $textFormat
+   *   Preferred encoding for the title
+   *   - 'plain' for plain text. (Ex: "Bill & Ted's >est Adventure")
+   *   - 'html' for HTML entities. (Ex: "Bill &amp; Ted's &gt;est Adventure")
+   *   - 'html-ish' for partial HTML entities (Ex: "Bill & Ted's &gt;est Adventure") [DEPRECATED]
    * @return array
    *   this array has key-> group id and value group title
    */
-  public static function getGroupList($contactId = 0, $visibility = FALSE) {
+  public static function getGroupList($contactId = 0, $visibility = FALSE, string $textFormat = 'html-ish') {
     $select = 'SELECT civicrm_group.id, civicrm_group.title ';
     $from = ' FROM civicrm_group ';
     $where = " WHERE civicrm_group.is_active = 1 ";
@@ -276,7 +279,7 @@ class CRM_Contact_BAO_GroupContact extends CRM_Contact_DAO_GroupContact implemen
 
     $values = [];
     while ($group->fetch()) {
-      $values[$group->id] = $group->title;
+      $values[$group->id] = CRM_Utils_API_HTMLInputCoder::singleton()->transcode('title', $group->title, $textFormat);
     }
 
     return $values;

--- a/CRM/Contact/Form/DedupeFind.php
+++ b/CRM/Contact/Form/DedupeFind.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_DedupeFind extends CRM_Admin_Form {
    */
   public function buildQuickForm(): void {
 
-    $groupList = ['' => ts('- All Contacts -')] + CRM_Core_PseudoConstant::nestedGroup();
+    $groupList = ['' => ts('- All Contacts -')] + CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     $this->add('select', 'group_id', ts('Select Group'), $groupList, FALSE, ['class' => 'crm-select2 huge']);
     $this->add('text', 'limit', ts('No of contacts to find matches for '));

--- a/CRM/Contact/Form/Edit/TagsAndGroups.php
+++ b/CRM/Contact/Form/Edit/TagsAndGroups.php
@@ -91,7 +91,7 @@ class CRM_Contact_Form_Edit_TagsAndGroups {
       }
 
       if ($groupID || !empty($group)) {
-        $groups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids, NULL, '- ', FALSE, $public);
+        $groups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids, NULL, '- ', FALSE, $public, textFormat: 'plain');
 
         $attributes['skiplabel'] = TRUE;
         $elements = [];

--- a/CRM/Contact/Form/GroupContact.php
+++ b/CRM/Contact/Form/GroupContact.php
@@ -72,7 +72,7 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
     if ($this->_context == 'user') {
       $onlyPublicGroups = CRM_Utils_Request::retrieve('onlyPublicGroups', 'Boolean', $this, FALSE);
       $ids = CRM_Core_PseudoConstant::allGroup();
-      $heirGroups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids);
+      $heirGroups = CRM_Contact_BAO_Group::getGroupsHierarchy($ids, textFormat: 'html');
 
       $allGroups = [];
       foreach ($heirGroups as $id => $group) {
@@ -84,14 +84,14 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
       }
     }
     else {
-      $allGroups = CRM_Core_PseudoConstant::group();
+      $allGroups = CRM_Core_PseudoConstant::group(textFormat: 'html');
     }
 
     // Arrange groups into hierarchical listing (child groups follow their parents and have indentation spacing in title)
-    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($allGroups, NULL, '&nbsp;&nbsp;', TRUE);
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($allGroups, NULL, '&nbsp;&nbsp;', TRUE, textFormat: 'html');
 
     // get the list of groups contact is currently in ("Added") or unsubscribed ("Removed").
-    $currentGroups = CRM_Contact_BAO_GroupContact::getGroupList($this->_contactId);
+    $currentGroups = CRM_Contact_BAO_GroupContact::getGroupList($this->_contactId, textFormat: 'html');
 
     // Remove current groups from drowdown options ($groupSelect)
     if (is_array($currentGroups)) {
@@ -114,7 +114,8 @@ class CRM_Contact_Form_GroupContact extends CRM_Core_Form {
         $msg = ts('Add to a group');
       }
       $this->assign('groupLabel', $msg);
-      $this->addField('group_id', ['class' => 'crm-action-menu fa-plus', 'placeholder' => $msg, 'options' => $groupSelect]);
+      $groupField = $this->addField('group_id', ['class' => 'crm-action-menu fa-plus', 'placeholder' => $msg, 'options' => $groupSelect]);
+      $groupField->setOptionTextEscaped(); /* Complex logic above re: spacer, so everything was built as HTML */
 
       $this->addButtons([
         [

--- a/CRM/Contact/Form/Search/Basic.php
+++ b/CRM/Contact/Form/Search/Basic.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Search_Basic extends CRM_Contact_Form_Search {
 
     // add select for groups
     // Get hierarchical listing of groups, respecting ACLs for CRM-16836.
-    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '- ', TRUE);
+    $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($this->_group, NULL, '- ', TRUE, textFormat: 'plain');
     if (!empty($searchOptions['groups'])) {
       $this->addField('group', [
         'entity' => 'group_contact',

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -41,7 +41,7 @@ class CRM_Contact_Form_Search_Criteria {
       // multiselect for groups
       if ($form->_group) {
         // Arrange groups into hierarchical listing (child groups follow their parents and have indentation spacing in title)
-        $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '- ', TRUE);
+        $groupHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($form->_group, NULL, '- ', TRUE, textFormat: 'plain');
 
         $form->add('select', 'group', ts('Groups'), $groupHierarchy, FALSE,
          ['id' => 'group', 'multiple' => 'multiple', 'class' => 'crm-select2']

--- a/CRM/Contact/Form/Task/AddToGroup.php
+++ b/CRM/Contact/Form/Task/AddToGroup.php
@@ -106,7 +106,7 @@ class CRM_Contact_Form_Task_AddToGroup extends CRM_Contact_Form_Task {
     }
 
     // add select for groups
-    $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup();
+    $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group, FALSE, ['class' => 'crm-select2 huge']);
 

--- a/CRM/Contact/Form/Task/RemoveFromGroup.php
+++ b/CRM/Contact/Form/Task/RemoveFromGroup.php
@@ -27,7 +27,7 @@ class CRM_Contact_Form_Task_RemoveFromGroup extends CRM_Contact_Form_Task {
    */
   public function buildQuickForm() {
     // add select for groups
-    $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup();
+    $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group, TRUE, ['class' => 'crm-select2 huge']);
 
     $this->setTitle(ts('Remove Contacts from Group'));

--- a/CRM/Contact/Import/Form/Preview.php
+++ b/CRM/Contact/Import/Form/Preview.php
@@ -47,7 +47,7 @@ class CRM_Contact_Import_Form_Preview extends CRM_Import_Form_Preview {
       );
     }
 
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     if (!empty($groups)) {
       $this->addElement('select', 'groups', ts('Add imported records to existing group(s)'), $groups, [

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -451,7 +451,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       return;
     }
 
-    $nestedGroup = CRM_Core_PseudoConstant::nestedGroup();
+    $nestedGroup = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     if ($nestedGroup) {
       $this->add('select', 'group', $this->getGroupLabel(), $nestedGroup, FALSE,
         [

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -231,14 +231,18 @@ class CRM_Core_Permission {
    *   Type of group(Access/Mailing).
    * @param bool $excludeHidden
    *   exclude hidden groups.
-   *
-   *
+   * @param string $textFormat
+   *   One of: 'plain', 'html', 'html-ish'
    * @return array
    *   array reference of all groups.
    */
-  public static function group($groupType, $excludeHidden = TRUE) {
+  public static function group($groupType, $excludeHidden = TRUE, string $textFormat = 'html-ish') {
     $config = CRM_Core_Config::singleton();
-    return $config->userPermissionClass->group($groupType, $excludeHidden);
+    $groups = $config->userPermissionClass->group($groupType, $excludeHidden);
+    // You might think that this could return different formats on different UFs.
+    // But no -- there is only one base implementation of `group()`, and it reads
+    // the "title" fields.
+    return CRM_Utils_API_HTMLInputCoder::singleton()->transcode('title', $groups, $textFormat);
   }
 
   /**

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -740,16 +740,16 @@ WHERE  id = %1";
    *   Type of group(Access/Mailing).
    * @param bool $excludeHidden
    *   Exclude hidden groups.
-   *
-   *
+   * @param string $textFormat
+   *   Ex: 'plain', 'html', or 'html-ish'
    * @return array
    *   array reference of all groups.
    */
-  public static function allGroup($groupType = NULL, $excludeHidden = TRUE) {
+  public static function allGroup($groupType = NULL, $excludeHidden = TRUE, string $textFormat = 'html-ish') {
     $condition = CRM_Contact_BAO_Group::groupTypeCondition($groupType, $excludeHidden);
     $values = [];
     self::populate($values, 'CRM_Contact_DAO_Group', FALSE, 'title', 'is_active', $condition);
-    return $values;
+    return CRM_Utils_API_HTMLInputCoder::singleton()->transcode('title', $values, $textFormat);
   }
 
   /**
@@ -765,13 +765,16 @@ WHERE  id = %1";
    *   Type of group(Access/Mailing).
    * @param bool $excludeHidden
    *   Exclude hidden groups.
-   *
-   *
+   * @param string $textFormat
+   *   Preferred encoding for the title
+   *   - 'plain' for plain text. (Ex: "Bill & Ted's >est Adventure")
+   *   - 'html' for HTML entities. (Ex: "Bill &amp; Ted's &gt;est Adventure")
+   *   - 'html-ish' for partial HTML entities (Ex: "Bill & Ted's &gt;est Adventure") [DEPRECATED]
    * @return array
    *   array reference of all groups.
    */
-  public static function group($groupType = NULL, $excludeHidden = TRUE) {
-    return CRM_Core_Permission::group($groupType, $excludeHidden);
+  public static function group($groupType = NULL, $excludeHidden = TRUE, string $textFormat = 'html-ish') {
+    return CRM_Core_Permission::group($groupType, $excludeHidden, $textFormat);
   }
 
   /**

--- a/CRM/Core/PseudoConstant.php
+++ b/CRM/Core/PseudoConstant.php
@@ -779,11 +779,17 @@ WHERE  id = %1";
    * @param bool $checkPermissions
    * @param string|null $groupType
    * @param bool $excludeHidden
+   * @param string $textFormat
+   *   Preferred encoding for the title/description
+   *   - 'plain' for plain text. (Ex: "Bill & Ted's >est Adventure")
+   *   - 'html' for HTML entities. (Ex: "Bill &amp; Ted's &gt;est Adventure")
+   *   - 'html-ish' for partial HTML entities (Ex: "Bill & Ted's &gt;est Adventure") [DEPRECATED]
    * @return array
    */
-  public static function nestedGroup(bool $checkPermissions = TRUE, $groupType = NULL, bool $excludeHidden = TRUE) {
+  public static function nestedGroup(bool $checkPermissions = TRUE, $groupType = NULL, bool $excludeHidden = TRUE, string $textFormat = 'html-ish') {
     $groups = $checkPermissions ? self::group($groupType, $excludeHidden) : self::allGroup($groupType, $excludeHidden);
-    return CRM_Contact_BAO_Group::getGroupsHierarchy($groups, NULL, '&nbsp;&nbsp;', TRUE);
+    $spacers = ['plain' => '- ', 'html' => '&nbsp;&nbsp;', 'html-ish' => '&nbsp;&nbsp;'];
+    return CRM_Contact_BAO_Group::getGroupsHierarchy($groups, NULL, $spacers[$textFormat], TRUE, textFormat: $textFormat);
   }
 
   /**

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1975,7 +1975,7 @@ class CRM_Report_Form extends CRM_Core_Form {
         'type' => CRM_Utils_Type::T_INT,
         'operatorType' => CRM_Report_Form::OP_MULTISELECT,
         'group' => TRUE,
-        'options' => CRM_Core_PseudoConstant::nestedGroup(),
+        'options' => CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain'),
       ],
     ];
     if (empty($this->_columns['civicrm_group']['dao'])) {

--- a/CRM/Report/Form.php
+++ b/CRM/Report/Form.php
@@ -1723,7 +1723,7 @@ class CRM_Report_Form extends CRM_Core_Form {
     ) {
       $this->addElement('select', 'groups', ts('Group'),
         ['' => ts('Add Contacts to Group')] +
-        CRM_Core_PseudoConstant::nestedGroup(),
+        CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain'),
         ['class' => 'crm-select2 crm-action-menu fa-plus huge', 'title' => ts('Add Contacts to Group')]
       );
       $this->assign('group', TRUE);

--- a/CRM/SMS/Form/Group.php
+++ b/CRM/SMS/Form/Group.php
@@ -99,7 +99,7 @@ class CRM_SMS_Form_Group extends CRM_Contact_Form_Task {
     );
 
     // Get the mailing groups.
-    $groups = CRM_Core_PseudoConstant::nestedGroup(TRUE, 'Mailing');
+    $groups = CRM_Core_PseudoConstant::nestedGroup(TRUE, 'Mailing', textFormat: 'plain');
 
     // Get the sms mailing list.
     $mailings = CRM_Mailing_PseudoConstant::completed('sms');

--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -247,4 +247,40 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
     }
   }
 
+  /**
+   * Convert a raw database value to the desired format.
+   *
+   * @param string $field
+   *   Machine-name of the field.
+   *   Ex: 'title' or 'frontend_title'
+   * @param string|string[] $storedValue
+   *   Raw value(s) from the database.
+   * @param string $outputFormat
+   *   Preferred encoding of the value.
+   *   - 'plain' for plain text. (Ex: "Bill & Ted's >est Adventure")
+   *   - 'html' for HTML entities. (Ex: "Bill &amp; Ted's &gt;est Adventure")
+   *   - 'html-ish' for partial HTML entities (Ex: "Bill & Ted's &gt;est Adventure")
+   * @return string|string[]
+   * @throws \CRM_Core_Exception
+   */
+  public function transcode(string $field, $storedValue, string $outputFormat) {
+    if (is_array($storedValue)) {
+      return array_map(fn($t) => $this->transcode('title', $t, $outputFormat), $storedValue);
+    }
+    if ($storedValue === NULL) {
+      return $storedValue;
+    }
+
+    $storageFormat = $this->isSkippedField($field) ? 'plain' : 'html-ish';
+    return match($storageFormat . ' => ' . $outputFormat) {
+      "plain => plain" => $storedValue,
+      "plain => html-ish" => $this->encodeValue($storedValue),
+      "plain => html" =>  htmlentities($storedValue),
+      "html-ish => html-ish" => $storedValue,
+      "html-ish => plain" => $this->decodeValue($storedValue),
+      "html-ish => html" => htmlentities($this->decodeValue($storedValue)),
+      default => throw new \CRM_Core_Exception("Invalid transcode operation ($storageFormat => $outputFormat)")
+    };
+  }
+
 }

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PostalMailing.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/PostalMailing.php
@@ -51,7 +51,7 @@ class CRM_Contact_Form_Search_Custom_PostalMailing extends CRM_Contact_Form_Sear
    * @param CRM_Core_Form $form
    */
   public function buildForm(&$form) {
-    $groups = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(FALSE);
+    $groups = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(FALSE, textFormat: 'plain');
     $form->addElement('select', 'group_id', ts('Group'), $groups, ['class' => 'crm-select2 huge']);
 
     /**


### PR DESCRIPTION
Overview
----------------------------------------

With QuickForm updates in v6.12.1, many dropdowns where you can choose a `Group` will present it with double-encoding.

For a complete list of affected screens, look at the commit-list. As I went through testing out screens, I noted the specific screen that was tested. (Each commit says `(dev/core#6400) re: "Some Screen Name"`. That screen had a double-encoding problem that is now fixed.)

Technical Details
----------------------------------------

This is an alternative to #35203 started by @seamuslee001 (and where I initially did some extra commits). This variant is motivated by a few factors:

1. It's actually a good thing to use HTML_QuickForm with automatic encoding of the options (instead of opting-out of that) -- this behaves more like other form-renderers. In the future, it should  be easier to swap around both data-readers (BAO, APIv3, APIv4) and form-renders (QF, JS, etc) if the data is being passed as plain-text.
2. The formatting of  a group-list turns out be rather quirky.
    * At the heart (underneath many of these screens), it's using `getGroupsHierarchy()` which can read from a mix of fields (`title` and/or `description` and/or `frontend_title` and/or `frontend_description`). Why is that complicated? Because `HTMLInputCoder::$skipFields` applies different encodings to different fields. (N.B. `description` and `frontend_description` are stored with different encodings, but `getGroupsHierarchy()` wants to treat them as interchangeable.)
    * Even if you accept the absurd thesis behind `HTMLInputCoder` (*that values should be HTML-encoded before being written to disk*)... it uses an implementation of HTML encoding that kinda sucks. I haven't noticed any bug or exploit (*I suppose whoever chose the encoding was thinking about XSS...*), but the selection of entities is weird. So if you read a `title` that was stored by `HTMLInputCoder`... you should probably re-encode with a proper HTML encoder before outputting it. (*The Red Sommelier of Fate added a note: "This bottle of irony features a natural twist of pain and a subtle hint of cruelty that is almost delicious, if you're not the one drinking it."*) 
    * At least one screen uses `addElement('select2'...)` which outputs a `text` element and some JSON. In that context, `setOptionTextEscaped()` is nonsensical. It needs to get the group-list as plain-text.

Addressing the "Group" dropdown is particularly involved because there are so many helper functions that look-up the list of groups -- and all of them output group titles (and/or descriptions).

* `CRM_Contact_BAO_Group::getGroupsHierarchy()`
* `CRM_Contact_BAO_GroupContact::getGroupList()`
* `CRM_Core_PseudoConstant::nestedGroup()`
* `CRM_Core_PseudoConstant::allGroup()`
* `CRM_Core_PseudoConstant::group()`
* `CRM_Core_Permission::group()` and its single implementation, `CRM_Core_Permission_Base::group()`

The approach in this PR -- add a new argument to each helper (`string $textFormat`) so that you can request the list of groups with particular encoding (i.e. `text` or `html` or the Sommelier's favorite `html-ish`). The helpers remain backward-compatible (in that they default to `html-ish`), but it's easy to fix the various callers.

------

I did leave a couple things out-of-scope for this PR. The PR is focused on fixing QuickForm-land. In JS-land (APIv3 Explorer, APIv4 Explorer, Search Kit), it seems that the "Group" dropdowns are usually based on `getFields` (`loadOptions`). Well, screens based on `getFields` (`loadOptions`) frequently produce double-encodings. But tackling that requires a whole different headspace... leave that for another PR...