### PR TITLE
Avoid argument type error on invalid authx bearer

### DIFF
--- a/ext/authx/Civi/Authx/CheckCredential.php
+++ b/ext/authx/Civi/Authx/CheckCredential.php
@@ -62,7 +62,7 @@ class CheckCredential extends AutoService implements EventSubscriberInterface {
   public function basicUser(CheckCredentialEvent $check): void {
     if ($check->credFormat === 'Basic') {
       [$user, $pass] = explode(':', base64_decode($check->credValue), 2);
-      if ($userId = _authx_uf()->checkPassword($user, $pass)) {
+      if ($userId = _authx_uf()->checkPassword($user, $pass ?? '')) {
         $check->accept(['userId' => $userId, 'credType' => 'pass']);
       }
     }


### PR DESCRIPTION
Authx makes call with NULL as pass argument if bearer string does not contain :. This causes PHP to crash.

Invalid requests should be 400 type errors not 500 types.

@totten 