### PR TITLE
Emit permission denied to invalid mailing view requests

### DIFF
--- a/CRM/Mailing/Page/View.php
+++ b/CRM/Mailing/Page/View.php
@@ -65,7 +65,15 @@ class CRM_Mailing_Page_View extends CRM_Core_Page {
     if (empty($id) || is_array($id)) {
       $print = TRUE;
     }
-    $this->getMailingID($id);
+    try {
+      $this->getMailingID($id);
+    }
+    catch (CRM_Core_Exception $e) {
+      // The view mailing URL is frequently hit by spammers.
+      Civi::log()->notice("Invalid mailing view URL requested.", ['request_url' => $_SERVER['REQUEST_URI'] ?? '']);
+      // Exit with permission denied.
+      CRM_Utils_System::permissionDenied();
+    }
 
     // Retrieve contact ID and checksum from the URL
     $cs = CRM_Utils_Request::retrieve('cs', 'String');


### PR DESCRIPTION
The public mailing view URL is frequently hit by hackers.

Currently this results in Civi crashing, emitting http 500 responses and logging a load of unwanted traces in the private logs.

This PR softens this to returning permission denied, and a simple one line log at 'notice' level.

(I believe invalid requests should result in 4xx errors not 5xx errors/fatals. In part because I want fatal to be a "bad thing" that I can investigate, and I don't want to be bothered by irrelevant fatals in the logs.)