### PR TITLE
Riverlea - fix cache clear when editing streams

### DIFF
--- a/ext/riverlea/CRM/riverlea/BAO/RiverleaStream.php
+++ b/ext/riverlea/CRM/riverlea/BAO/RiverleaStream.php
@@ -14,8 +14,8 @@ class CRM_riverlea_BAO_RiverleaStream extends CRM_riverlea_DAO_RiverleaStream im
     }
   }
 
-  public static function self_hook_civicrm_postCommit(PostEvent $event): void {
-    \Civi::service('themes')->clear();
+  public static function self_hook_civicrm_post(PostEvent $event): void {
+    \Civi::service('themes')->clearCache();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Riverlea is supposed to clear the theme cache when Streams are edited. 

Before
----------------------------------------
- if you create a new stream, then try to activate it straight away, it's not available yet. you have to flush the cache first

After
----------------------------------------
- if you create a new stream, you can activate it straight away

Technical Details
----------------------------------------
`self_hook_civicrm_postCommit` doesn't seem to get picked up, so its never worked! (I guess is its much less noticeable on dev sites because of caching levels)
