### PR TITLE
Remove unused CRM.resourceUrls variable

### DIFF
--- a/Civi/Angular/AngularLoader.php
+++ b/Civi/Angular/AngularLoader.php
@@ -161,7 +161,6 @@ class AngularLoader {
       }
       // TODO optimization; client-side caching
       return array_merge($settingsByModule, ['permissions' => $permissions], [
-        'resourceUrls' => \CRM_Extension_System::singleton()->getMapper()->getActiveModuleUrls(),
         'angular' => [
           'modules' => $allModules,
           'requires' => $angular->getResources($moduleNames, 'requires', 'requires'),

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -15,9 +15,6 @@ describe('crmCaseType', function() {
   var scope;
 
   beforeEach(function() {
-    CRM.resourceUrls = {
-      'civicrm': ''
-    };
     module('crmCaseType');
     module('crmJsonComparator');
     inject(function(crmJsonComparator) {


### PR DESCRIPTION
Overview
----------------------------------------
Make CiviCRM more efficient by removing unused variable.

Technical Details
----------------------------------------
We were just wasting CPU and bandwidth sending this huge unused array to the client on every request.
