### PR TITLE
add Afform - Checkout integration

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Action/Contribution/ContinueCheckout.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Contribution/ContinueCheckout.php
@@ -16,6 +16,9 @@ class ContinueCheckout extends AbstractAction {
   protected string $token;
 
   public function _run(Result $result): void {
+    if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+      throw new \CRM_Core_Exception('You must opt in to Enable FormBuilder Contributions before using Checkout');
+    }
 
     try {
       $session = CheckoutSession::restoreFromToken($this->token);

--- a/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/ContributionCheckoutFieldsSpecProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/Spec/Provider/ContributionCheckoutFieldsSpecProvider.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Service\Spec\FieldSpec;
+
+use CRM_Contribute_ExtensionUtil as E;
+
+/**
+ * Class ContributionCheckoutFieldsSpecProvider
+ *
+ * @package Civi\Api4\Service\Spec\Provider
+ * @service
+ * @internal
+ */
+class ContributionCheckoutFieldsSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * Note: using create here doesn't block using these fields with an existing contribution
+   * on afform because afform bases field options on 'create'
+   *
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+      return FALSE;
+    }
+    return ($action === 'create' && $entity === 'Contribution');
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $this->addCheckoutOptionField($spec);
+    $this->addCheckoutParamsField($spec);
+    $this->addRecurPeriodField($spec);
+  }
+
+  /**
+   * Add selector for checkout option
+   */
+  protected function addCheckoutOptionField(RequestSpec $spec): void {
+    $checkoutOption = new FieldSpec('checkout_option', $spec->getEntity(), 'String');
+    $checkoutOption->setLabel(E::ts('Checkout Option'))
+      ->setDescription(E::ts('Checkout option to use for Contribution payment.'))
+      ->setInputType('Select')
+      ->setOptionsCallback([__CLASS__, 'getCheckoutOptions'])
+      ->setType('Extra');
+
+    $spec->addFieldSpec($checkoutOption);
+  }
+
+  /**
+   * Add pseudofield to collect additional parameters for checkout
+   */
+  protected function addCheckoutParamsField(RequestSpec $spec): void {
+    $checkoutParams = new FieldSpec('checkout_params', $spec->getEntity(), 'String');
+    $checkoutParams->setLabel(E::ts('Checkout Details'))
+      ->setInputType('CheckoutBlock')
+      ->setSerialize('JSON')
+      ->setType('Extra');
+
+    $spec->addFieldSpec($checkoutParams);
+  }
+
+  /**
+   * Add field to set if contribution should recur.
+   *
+   * NOTE: this is intended to be a flat field. In the future it could
+   * be hookable to provide custom options like Quarterly / Every 2 months / Every 35 days
+   * but given those use cases are very much the exception rather the rule,
+   * I am deliberately avoiding having period_unit and period_qty fields
+   * which cause confusion for users and developers alike
+   */
+  protected function addRecurPeriodField(RequestSpec $spec): void {
+    $recurPeriod = new FieldSpec('recur_period', $spec->getEntity(), 'String');
+    $recurPeriod->setLabel(E::ts('Recur Period'))
+      ->setInputType('Select')
+      ->setDefaultValue(NULL)
+      ->setOptions([
+        '' => E::ts('Does not recur'),
+        'monthly' => E::ts('Every month'),
+        'yearly' => E::ts('Every year'),
+      ])
+      ->setType('Extra');
+
+    $spec->addFieldSpec($recurPeriod);
+  }
+
+  public static function getCheckoutOptions(): array {
+    $fieldOptions = [];
+
+    $checkoutOptions = \Civi::service('civi.checkout')->getOptions();
+
+    foreach ($checkoutOptions as $name => $option) {
+
+      $fieldOptions[] = [
+        'id' => $name,
+        'name' => $name,
+        'label' => $option->getFrontendLabel(),
+        //'description' => $option['description'],
+        'icon' => 'fa-money',
+      ];
+    }
+
+    return $fieldOptions;
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout/Afform.php
+++ b/ext/civi_contribute/Civi/Checkout/Afform.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace Civi\Checkout;
+
+use Civi\Afform\Event\AfformSubmitEvent;
+use Civi\Afform\Event\AfformValidateEvent;
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoService;
+use CRM_Contribute_ExtensionUtil as E;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Handle afform integration with Checkout
+ *
+ * @service civi.checkout.afform
+ */
+class Afform extends AutoService implements EventSubscriberInterface {
+
+  public const NO_PAYMENT_PROCESSING = '_none_';
+
+  public function isActive(): bool {
+    return !!\Civi::settings()->get('contribute_enable_afform_contributions');
+  }
+
+  /**
+   * @return array
+   */
+  public static function getSubscribedEvents() {
+    return [
+      // add afCheckout as a dependency of forms with Contributions
+      // we must hook later to alter afform modules @see afform_civicrm_config
+      'hook_civicrm_angularModules' => ['onAlterAngularModules', -1010],
+      // provide CheckoutBlock element to FormBuilder
+      'civi.afform_admin.metadata' => ['onAfformAdminMetadata'],
+      // run validation hook from selected CheckoutOption
+      'civi.afform.validate' => ['validatePaymentFields', 0],
+      // trigger Checkout on submission
+     //  this runs *after* the Contribution is saved at 0
+      'civi.afform.submit' => ['startCheckout', -100],
+    ];
+  }
+
+  /**
+   * Validate the payment fields on the form
+   *
+   * @param \Civi\Afform\Event\AfformValidateEvent $event
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  public function validatePaymentFields(AfformValidateEvent $event) {
+    if (!$this->isActive()) {
+      return;
+    }
+
+    $contributions = array_filter($event->getFormDataModel()->getEntities(), fn ($entity) => $entity['type'] === 'Contribution');
+
+    if (!$contributions) {
+      return;
+    }
+
+    $values = $event->getSubmittedValues();
+
+    // NOTE: we only expect one Contribution, but future proofing
+    foreach ($contributions as $contribution) {
+      foreach ($values[$contribution['name']] as $contributionValues) {
+        $checkoutOption = $contributionValues['fields']['checkout_option'] ?? NULL;
+        if (!$checkoutOption) {
+          continue;
+        }
+
+        $checkoutOption = \Civi::service('civi.checkout')->getOption($checkoutOption);
+
+        // TODO: what is passed to the checkout validate?
+        // this is much harder than the actual payment - when the records are saved and
+        // we can pass the Contribution ID and the processor can get whatever info it needs
+        // using canonical api4 keys
+        // but the data structure at this point is very afform specific
+        $checkoutOption->validate($event);
+      }
+    }
+  }
+
+  /**
+   * Check if Payment Processor is configured. If it is, start CheckoutSession
+   * and add response to the afform response
+   */
+  public function startCheckout(AfformSubmitEvent $event) {
+    if (!$this->isActive()) {
+      return;
+    }
+
+    if ($event->getEntityType() !== 'Contribution') {
+      return;
+    }
+
+    // get contribution record
+    $contribution = $event->getRecords()[0]['fields'];
+
+    // check for payment processor value: if set this will trigger checkout, if not we will ignore
+    $checkoutOption = $contribution['checkout_option'] ?? NULL;
+    if (!$checkoutOption) {
+      return;
+    }
+    // get contribution ID (the record should already have been saved in CreateContribution)
+    $contributionId = $event->getEntityId(0);
+
+    $checkoutSession = new CheckoutSession($contributionId, $checkoutOption);
+
+    // get payment params passed from frontend
+    $checkoutSession->setCheckoutParams($contribution['checkout_params'] ?? []);
+
+    $this->setOnwardUrlsAndMessages($checkoutSession, $event);
+
+    // start the checkout
+    $checkoutSession->startCheckout();
+
+    $responseItems = $checkoutSession->getResponseItems();
+
+    $submitRequest = $event->getApiRequest();
+
+    foreach ($responseItems as $key => $value) {
+      $submitRequest->setResponseItem($key, $value);
+    }
+  }
+
+  /**
+   * Set onward urls for the checkout session based on afform configuration
+   *
+   * At the moment this is limited to using the Afform "redirect_url" as success
+   * page if set.
+   *
+   * For now, everything else will use the default afform checkout landing page.
+   *
+   * TODO 1: should we add form-level redirect for Fail/Cancel states (this could be
+   *   independent of checkout)
+   *
+   * TODO 2: a good default behaviour for Fail could be to resume the form state - it
+   *   may be there is just one thing you need to correct in the details you entered
+   *
+   * NOTE: we currently force https urls because at least stripe checkout requires
+   *   this - this could cause errors if SSL is not configured - we should warn about
+   *   this at a higher level (system check?)
+   */
+  private function setOnwardUrlsAndMessages(CheckoutSession $checkout, AfformSubmitEvent $event): void {
+    $afform = $event->getAfform();
+
+    $checkout->setTitle($afform['title']);
+
+    $confirmationUrl = ($afform['confirmation_type'] === 'redirect_to_url') ? $afform['redirect'] : NULL;
+    if ($confirmationUrl) {
+      $confirmationUrl = $event->getApiRequest()->replaceTokens($confirmationUrl);
+
+      $confirmationUrl = (string) \Civi::url($confirmationUrl)
+        ->setPreferFormat('absolute')
+        ->setSsl(TRUE);
+
+      $checkout->setSuccessUrl($confirmationUrl);
+      return;
+    }
+    $confirmationMessage = ($afform['confirmation_type'] === 'show_confirmation_message') ? $afform['confirmation_message'] : NULL;
+    if ($confirmationMessage) {
+      $confirmationMessage = $event->getApiRequest()->replaceTokens($confirmationMessage);
+
+      $checkout->setSuccessMessage($confirmationMessage);
+      return;
+    }
+  }
+
+  public function onAlterAngularModules(GenericHookEvent $e): void {
+    if (!$this->isActive()) {
+      return;
+    }
+
+    $checkoutOptions = \Civi::service('civi.checkout')->getOptions();
+
+    // if no checkout options configured then no need to do anything
+    if (!$checkoutOptions) {
+      return;
+    }
+
+    foreach ($checkoutOptions as $name => $option) {
+      $module = $option->getAfformModule() ?? NULL;
+      if ($module && !in_array($module, $e->angularModules['afCheckout']['requires'])) {
+        $e->angularModules['afCheckout']['requires'][] = $module;
+      }
+    }
+
+    // add afCheckout as a dependency of afAdmin so can be used in FormBuilder
+    $e->angularModules['afAdmin']['requires'][] = 'afCheckout';
+
+    // find configured afforms which use checkout and add the module dependency
+    // TODO: if/when we have a hook for afforms being saved, we should include
+    // the requirement in the .ang.php data in order to avoid computing it
+    // for every form every cache clear
+    foreach ($e->angularModules as $name => $module) {
+      if (!empty($module['_afform']) && $this->afformUsesCheckout($module['_afform'])) {
+        $e->angularModules[$name]['requires'] ??= [];
+        $e->angularModules[$name]['requires'][] = 'afCheckout';
+      }
+    }
+  }
+
+  private function afformUsesCheckout(string $afformName): bool {
+    $layout = \Civi\Api4\Afform::get(FALSE)
+      ->addWhere('name', '=', $afformName)
+      ->addSelect('layout')
+      ->setLayoutFormat('html')
+      ->execute()
+      ->first()['layout'] ?? '';
+
+    if (!\str_contains($layout, 'Contribution')) {
+      return FALSE;
+    }
+    return TRUE;
+
+    // the below is a more strictly correct check - but is more labour intensive
+    // $layout = \Civi\Api4\Afform::get(FALSE)
+    //   ->addWhere('name', '=', $afformName)
+    //   ->addSelect('layout')
+    //   ->setLayoutFormat('deep')
+    //   ->execute()
+    //   ->first()['layout'] ?? NULL;
+
+    // // unexpected but dont crash the hook
+    // if (!$layout) {
+    //   return FALSE;
+    // }
+
+    // // does the form include contributions?
+    // $formDataModel = new FormDataModel($layout);
+    // $contributions = array_filter($formDataModel->getEntities(), fn ($entity) => $entity['type'] === 'Contribution');
+
+    // return !!$contributions;
+  }
+
+  public function onAfformAdminMetadata(GenericHookEvent $e) {
+    if (!$this->isActive()) {
+      return;
+    }
+    $e->inputTypes[] = [
+      'name' => 'CheckoutBlock',
+      'label' => E::ts('Checkout Details Block'),
+      'template' => '~/afCheckout/inputType/CheckoutBlock.html',
+      'admin_template' => '~/afCheckout/inputType/CheckoutBlockAdmin.html',
+    ];
+  }
+
+  public static function getSettings(): array {
+    $checkoutOptions = \Civi::service('civi.checkout')->getOptions();
+    $testMode = \Civi::service('civi.checkout')->isTestMode();
+
+    $config = array_filter(array_map(fn ($option) => $option->getAfformSettings($testMode), $checkoutOptions));
+
+    return [
+      'checkoutOptions' => $config,
+    ];
+  }
+
+}

--- a/ext/civi_contribute/Civi/Checkout/QuickformCheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/QuickformCheckoutOptionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Civi\Checkout;
+
+/**
+ * FIXME: clarify what functions from CRM_Core_Payment are required for Quickform processing
+ */
+interface QuickformCheckoutOptionInterface {
+
+  /**
+   * Process payment
+   *
+   * @param array|PropertyBag $params
+   *
+   * @param string $component
+   *
+   * @return array
+   *   Result array (containing at least the key payment_status_id)
+   *
+   * @throws \Civi\Payment\Exception\PaymentProcessorException
+   *
+   * @see \CRM_Core_Payment
+   */
+  public function doPayment(&$params, $component = 'contribute');
+
+}

--- a/ext/civi_contribute/ang/afCheckout.ang.php
+++ b/ext/civi_contribute/ang/afCheckout.ang.php
@@ -1,0 +1,24 @@
+<?php
+
+if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+  return [];
+}
+
+// Angular module afCheckout.
+// @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+return [
+  'js' => [
+    'ang/afCheckout.js',
+    'ang/afCheckout/*.js',
+    'ang/afCheckout/*/*.js',
+  ],
+  'css' => [
+    'ang/afCheckout.css',
+  ],
+  'partials' => ['ang/afCheckout'],
+  'requires' => ['crmUi', 'crmUtil', 'ngRoute'],
+  'settingsFactory' => ['Civi\Checkout\Afform', 'getSettings'],
+  'exports' => [
+    'af-checkout-block' => 'E',
+  ],
+];

--- a/ext/civi_contribute/ang/afCheckout.css
+++ b/ext/civi_contribute/ang/afCheckout.css
@@ -1,0 +1,9 @@
+.form-group.af-checkout-field {
+  display: flex;
+  flex-flow: column;
+  align-items: flex-start;
+}
+
+.af-checkout-field .af-checkout-field-date > * {
+  max-width: 6rem;
+}

--- a/ext/civi_contribute/ang/afCheckout.js
+++ b/ext/civi_contribute/ang/afCheckout.js
@@ -1,0 +1,4 @@
+(function(angular, $, _) {
+  // Declare a list of dependencies.
+  angular.module('afCheckout', CRM.angRequires('afCheckout'));
+})(angular, CRM.$, CRM._);

--- a/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
+++ b/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
@@ -1,0 +1,151 @@
+(function(angular, $, _) {
+  // Example usage: <af-form><af-entity name="Donation" type="Contribution" /> ... <fieldset af-fieldset="Donation"> <af-checkout></af-checkout> ... </fieldset></af-form>
+  angular.module('afCheckout').component('afCheckoutBlock', {
+    require: {
+      // TODO: this might be neater if we bound to the afField controller
+      // and used it setValue method. but a) setValues isn't exposed method from the afField controller
+      // and b) we need to get `afform_payment_processor` field value from the afFieldset anyway
+      // so jump straight to fieldset for now (requires Contribution isn't a join, which it definitely shouldn't be)
+      afFieldset: '^^afFieldset',
+      afForm: '^^afForm',
+    },
+    templateUrl: '~/afCheckout/afCheckoutBlock.html',
+    controller: function($scope, $element, crmApi4) {
+
+      const ts = $scope.ts = CRM.ts('afform_payments');
+
+      this.checkout_params = {};
+
+      // from settings factory
+      // @see \Civi\AfformPayment\AngularManager::getSettings
+      const options = CRM.afCheckout.checkoutOptions;
+
+      this.getCheckoutOptionKey = () => {
+        return this.getContributionValue('checkout_option');
+      };
+
+      this.getContributionValue = (key) => {
+        if (!this.afFieldset) {
+          return null;
+        }
+        // first check for an input on the form
+        const fieldData = this.afFieldset.getFieldData();
+        if (fieldData && fieldData[key]) {
+          return fieldData[key];
+        }
+        // then check for a fixed processor in the form entity data
+        const entity = this.afFieldset.getEntity();
+        if (entity && entity.data && entity.data[key]) {
+          return entity.data[key];
+        }
+        return null;
+      };
+
+      this.getCheckoutOption = () => {
+        const key = this.getCheckoutOptionKey();
+        if (!key || !options[key]) {
+          return {};
+        }
+        return options[key];
+      };
+
+      this.getCheckoutOptionLabel = () => {
+        const meta = this.getCheckoutOption();
+        return meta.label ?? null;
+      };
+
+      this.getCheckoutOptionDescription = () => {
+        const meta = this.getCheckoutOption();
+        return meta.description ?? null;
+      };
+
+      this.getCheckoutOptionTemplate = () => {
+        const meta = this.getCheckoutOption();
+        return meta.template ?? null;
+      };
+
+      this.getCheckoutOptionFields = () => {
+        const meta = this.getCheckoutOption();
+        return meta.fields ?? null;
+      };
+
+      /**
+       * NOTE: This function is a horrible hack for handling
+       * billing state/province fields from quickform payment processor
+       * meta. This would be much better handled as proper afform
+       * Address entities.
+       *
+       * TODO: move to a separate component
+       * and then hopefully this can be ripped out before too long.
+       */
+
+      this.stateProvinceOptions = {};
+
+      this.getChainSelectEmptyOptionLabel = (fieldName) => {
+        if (fieldName.indexOf('billing_state_province_id-') !== 0) {
+          return '- invalid chain select -';
+        }
+        const controlField = fieldName.replace('billing_state_province_id-', 'billing_country_id-');
+        const controlValue = this.checkout_params[controlField];
+        if (!controlValue || !controlValue.length || !this.stateProvinceOptions[controlValue]) {
+          return ts('- select country first -');
+        }
+        if (!this.stateProvinceOptions[controlValue].length) {
+          return ts('- please wait -');
+        }
+        return ts('- select -');
+      };
+
+      this.getLegacyBillingStateProvinceOptions = (fieldName) => {
+        if (fieldName.indexOf('billing_state_province_id-') !== 0) {
+          console.error("Unrecognised chain select field");
+          return [{id: '', label: ts('- please wait -')}];
+        }
+        const controlField = fieldName.replace('billing_state_province_id-', 'billing_country_id-');
+        // ensure both field values are initialised as empty strings
+        // to show '- select -'s properly
+//        if (!this.checkout_params[fieldName]) {
+//          this.checkout_params[fieldName] = '';
+//        }
+//        if (!this.checkout_params[controlField]) {
+//          this.checkout_params[controlField] = '';
+//        }
+        const controlValue = this.checkout_params[controlField];
+        if (controlValue && controlValue.length && !this.stateProvinceOptions[controlValue]) {
+          // initialising here prevents triggering multiple fetches
+          this.stateProvinceOptions[controlValue] = [];
+          this.fetchLegacyStateProvinceOptions(controlValue);
+        }
+        return this.stateProvinceOptions[controlValue];
+      };
+
+      this.fetchLegacyStateProvinceOptions = (controlValue) => crmApi4('StateProvince', 'get', {
+          where: [["country_id", "=", controlValue]],
+        })
+        // reshape for select options
+        .then((result) => result.map((record) => ({
+          id: record.id,
+          label: record.name
+        })))
+        .then((options) => this.stateProvinceOptions[controlValue] = options);
+
+
+      this.exportParamValues = () => {
+        // this is a quick way to check the data provider is ready
+        if (!this.getCheckoutOptionKey()) {
+          return;
+        }
+        this.afFieldset.getData()[0].fields.checkout_params = this.checkout_params;
+      };
+
+      this.checkParamValues = () => this.checkout_params;
+
+      this.$onInit = () => {
+        // reset params if payment processor changes
+        $scope.$watch(this.getCheckoutOptionKey, () => this.checkout_params = {});
+        // pass value changes up to the afFieldset data provider
+        $scope.$watch(this.checkParamValues, () => this.exportParamValues(), true);
+      };
+    }
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.html
+++ b/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.html
@@ -1,0 +1,7 @@
+<span ng-if="$ctrl.getCheckoutOptionDescription()">{{ $ctrl.getCheckoutOptionDescription() }}</span>
+<div ng-include="$ctrl.getCheckoutOptionTemplate()"></div>
+<div
+  ng-repeat="field in $ctrl.getCheckoutOptionFields()"
+  ng-include="'~/afCheckout/checkoutFields/' + field.htmlType + '.html'"
+  class="form-group af-checkout-field af-checkout-field_{{:: field.name }}"
+  ></div>

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/chainSelect.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/chainSelect.html
@@ -1,0 +1,5 @@
+<label>{{:: field.title }}</label>
+<select name='field.name' ng-model="$ctrl.checkout_params[field.name]" ng-required="field.is_required">
+  <option value="">{{ $ctrl.getChainSelectEmptyOptionLabel(field.name) }}</option>
+  <option ng-repeat="option in $ctrl.getLegacyBillingStateProvinceOptions(field.name)" value="{{ option.id }}">{{ option.label }}</option>
+</select>

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/date.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/date.html
@@ -1,0 +1,5 @@
+<label>{{:: field.title }}</label>
+<div class="crm-flex-box af-checkout-field-date">
+  <input type="number" name='month' placeholder="MM" ng-model="$ctrl.checkout_params[field.name].M" ng-required="field.is_required">
+  <input type="number" name='year' placeholder="YY" ng-model="$ctrl.checkout_params[field.name].Y" ng-required="field.is_required">
+</div>

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/select.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/select.html
@@ -1,0 +1,4 @@
+<label>{{:: field.title }}</label>
+<select name='field.name' ng-model="$ctrl.checkout_params[field.name]" ng-required="field.is_required">
+  <option ng-repeat="option in field.options" value="{{:: option.id }}">{{:: option.label }}</option>
+</select>

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/text.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/text.html
@@ -1,0 +1,2 @@
+<label>{{:: field.title }}</label>
+<input type="text" name='{{:: field.name }}' ng-model="$ctrl.checkout_params[field.name]" ng-required="field.is_required" />

--- a/ext/civi_contribute/ang/afCheckout/inputType/CheckoutBlock.html
+++ b/ext/civi_contribute/ang/afCheckout/inputType/CheckoutBlock.html
@@ -1,0 +1,1 @@
+<af-checkout-block></af-checkout-block>

--- a/ext/civi_contribute/ang/afCheckout/inputType/CheckoutBlockAdmin.html
+++ b/ext/civi_contribute/ang/afCheckout/inputType/CheckoutBlockAdmin.html
@@ -1,0 +1,5 @@
+<div class="form-inline">
+  <p>
+    {{:: ts('Payment details will be shown here depending on the selected Checkout Option. For payment to be taken you must either set a Checkout Option value on the Contribution or add a user input to select one.') }}
+  </p>
+</div>

--- a/ext/civi_contribute/ang/afformNewDonation.aff.html
+++ b/ext/civi_contribute/ang/afformNewDonation.aff.html
@@ -1,0 +1,18 @@
+<af-form ctrl="afform">
+  <af-entity data="{source: 'New Donation'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: false}" security="FBAC" contact-dedupe="Individual.Supervised" />
+  <af-entity data="{contact_id: 'Individual1', checkout_option: 'pay_later', financial_type_id: 1}" type="Contribution" name="Contribution1" label="Contribution 1" actions="{create: true, update: false}" security="FBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Your details">
+    <div actions="{update: true, delete: true}" class="af-container">
+      <af-field name="first_name" />
+      <af-field name="last_name" />
+      <div af-join="Email" actions="{update: true, delete: true}" data="{is_primary: true}">
+        <af-field name="email" />
+      </div>
+    </div>
+  </fieldset>
+  <fieldset af-fieldset="Contribution1" class="af-container" af-title="Your donation">
+    <af-field name="default_contribution_amount.contribution_amount" defn="{label: 'Contribution Amount', input_attrs: {}, required: true}" />
+    <af-field name="checkout_params" defn="{label: false}" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>

--- a/ext/civi_contribute/ang/afformNewDonation.aff.php
+++ b/ext/civi_contribute/ang/afformNewDonation.aff.php
@@ -1,0 +1,24 @@
+<?php
+use CRM_Contribute_ExtensionUtil as E;
+
+if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
+  return [];
+}
+
+return [
+  'type' => 'form',
+  'title' => E::ts('New Donation'),
+  'description' => E::ts('A basic donation form for your site. To use this form, change the Submission status to Open and pick a Checkout Option on the Contribution record.'),
+  'icon' => 'fa-list-alt',
+  'server_route' => 'civicrm/donate',
+  'is_public' => TRUE,
+  'permission' => [
+    'make online contributions',
+  ],
+  // disable submissions out of the box - the admin
+  // should save an override of this form to enable
+  'submit_enabled' => FALSE,
+  'create_submission' => TRUE,
+  'confirmation_type' => 'show_confirmation_message',
+  'confirmation_message' => E::ts('Thank you for your support!'),
+];

--- a/ext/civi_contribute/info.xml
+++ b/ext/civi_contribute/info.xml
@@ -44,6 +44,7 @@
     <mixin>afform-entity-php@1.0.0</mixin>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>smarty@1.0.3</mixin>
+    <mixin>ang-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Contribute</namespace>

--- a/ext/civi_contribute/settings/Contribute.setting.php
+++ b/ext/civi_contribute/settings/Contribute.setting.php
@@ -221,8 +221,8 @@ return [
     'title' => ts('Enable Contributions in FormBuilder'),
     'is_domain' => 1,
     'is_contact' => 0,
-    'help_text' => ts('Enable Contributions and Price Fields in FormBuilder.'),
-    'settings_pages' => ['contribute' => ['weight' => 100]],
+    'help_text' => ts('Enable Contributions, Price Fields and Payments in FormBuilder.'),
+    'settings_pages' => ['contribute' => ['weight' => -200]],
     'on_change' => ['_civi_contribute_afform_clear'],
   ],
 ];

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformCheckoutTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformCheckoutTest.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace Civi\Contribute;
+
+use Civi\Api4\Afform;
+use Civi\Checkout\CheckoutSession;
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test Afform - Checkout integration
+ *
+ * @group headless
+ */
+class AfformCheckoutTest extends TestCase implements HeadlessInterface {
+
+  protected $afformContributionSettingBackup;
+
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->install(['org.civicrm.afform'])
+      ->apply();
+  }
+
+  public function setUp(): void {
+    $this->afformContributionSettingBackup = \Civi::settings()->get('contribute_enable_afform_contributions');
+    \Civi::settings()->set('contribute_enable_afform_contributions', TRUE);
+
+    // add a listener with our test checkout option
+    // (payment integrations should do similar with a real CheckoutOptionInterface implemenation)
+    \Civi::dispatcher()->addListener('civi.checkout.options', function ($e) {
+      $e->options['test_checkout_option'] = new TestCheckoutOption();
+    });
+
+    $layout = <<<HTML
+    <af-form ctrl="afform">
+      <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="FBAC" />
+      <af-entity type="Contribution" name="Contribution1" label="Contribution 1" data="{contact_id: 'Individual1', financial_type_id: 1, currency: 'USD'}" actions="{create: true, update: false}" security="FBAC" />
+      <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+        <div class="af-container">
+          <af-field name="first_name" />
+          <af-field name="last_name" />
+        </div>
+      </fieldset>
+      <fieldset af-fieldset="Contribution1" class="af-container" af-title="Contribution 1">
+        <div class="af-container">
+          <!-- standard field for Contribution -->
+          <af-field name="source" />
+          <!-- price field for Contribution -->
+          <af-field name="default_contribution_amount.contribution_amount" />
+          <af-field name="checkout_option" />
+        </div>
+      </fieldset>
+    </af-form>
+    HTML;
+
+    Afform::save(FALSE)
+      ->addRecord([
+        'name' => 'testAfformCheckout',
+        'layout' => $layout,
+        'title' => 'Afform Checkout Test',
+      ])
+      ->setLayoutFormat('html')
+      ->execute();
+
+  }
+
+  public function tearDown(): void {
+    // \Civi\Api4\Afform::delete(FALSE)->addWhere('name', '=', 'testAfformCheckout')->execute();
+
+    \Civi::settings()->set('contribute_enable_afform_contributions', $this->afformContributionSettingBackup);
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testStartCheckout(): void {
+    $response = Afform::submit(FALSE)
+      ->setName('testAfformCheckout')
+      ->setValues([
+        'Individual1' => [
+          [
+            'fields' => [
+              'first_name' => 'Test',
+              'last_name' => 'Contact',
+            ],
+          ],
+        ],
+        'Contribution1' => [
+          [
+            'fields' => [
+              'source' => 'testContributionCreate',
+              // free text input
+              'default_contribution_amount.contribution_amount' => 5,
+              'checkout_option' => 'test_checkout_option',
+            ],
+          ],
+        ],
+      ])
+      ->execute()
+      ->single();
+
+    // our test CheckoutOption just spits back
+    $token = $response['test_session_token'];
+
+    // should be able to restore the CheckoutSession from the token
+    $session = CheckoutSession::restoreFromToken($token);
+
+    // we set the pending url in startCheckout
+    // the session should be pending so that should be our nextUrl
+    $nextUrl = $session->getNextUrl();
+    $this->assertEquals(TRUE, \str_starts_with($nextUrl, 'https://now.go.to'));
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testCheckoutOptionValidate(): void {
+    try {
+      $response = Afform::submit(FALSE)
+        ->setName('testAfformCheckout')
+        ->setValues([
+          'Individual1' => [
+            [
+              'fields' => [
+                'first_name' => 'Test',
+                'last_name' => 'Contact',
+              ],
+            ],
+          ],
+          'Contribution1' => [
+            [
+              'fields' => [
+                'source' => 'testContributionCreate',
+                'default_contribution_amount.contribution_amount' => 50,
+                'checkout_option' => 'test_checkout_option',
+              ],
+            ],
+          ],
+        ])
+        ->execute();
+
+      $this->fail('Afform::validate should have failed');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertEquals(TRUE, \str_contains($e->getMessage(), 'No payments over 10 USD'));
+    }
+
+  }
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function testInvalidCheckoutOption(): void {
+    try {
+      $response = Afform::submit(FALSE)
+        ->setName('testAfformCheckout')
+        ->setValues([
+          'Individual1' => [
+            [
+              'fields' => [
+                'first_name' => 'Test',
+                'last_name' => 'Contact',
+              ],
+            ],
+          ],
+          'Contribution1' => [
+            [
+              'fields' => [
+                'source' => 'testContributionCreate',
+                'default_contribution_amount.contribution_amount' => 5,
+                'checkout_option' => 'invalid_checkout_option',
+              ],
+            ],
+          ],
+        ])
+        ->execute();
+
+      $this->fail('Afform::submit should have failed because we passed an invalid checkout option');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertEquals(TRUE, \str_contains($e->getMessage(), 'No CheckoutOption found with name: invalid_checkout_option'));
+    }
+
+  }
+
+}

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AfformContributionTest extends TestCase implements HeadlessInterface {
 
+  protected $afformContributionSettingBackup;
   protected int $eventId;
   protected int $inPersonPriceFieldValueId;
 
@@ -162,6 +163,8 @@ class AfformContributionTest extends TestCase implements HeadlessInterface {
     // \Civi\Api4\Afform::delete(FALSE)->addWhere('name', '=', 'testAfformContribution')->execute();
 
     \Civi\Api4\Event::delete(FALSE)->addWhere('title', '=', 'Test event')->execute();
+
+    \Civi::settings()->set('contribute_enable_afform_contributions', $this->afformContributionSettingBackup);
   }
 
   /**

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/TestCheckoutOption.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/TestCheckoutOption.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Civi\Contribute;
+
+use Civi\Checkout\AfformCheckoutOptionInterface;
+use Civi\Checkout\CheckoutOption;
+use Civi\Checkout\CheckoutSession;
+
+class TestCheckoutOption extends CheckoutOption implements AfformCheckoutOptionInterface {
+
+  public function getLabel(): string {
+    return 'TEST';
+  }
+
+  public function startCheckout(CheckoutSession $session): void {
+    $session->setPendingUrl("https://now.go.to/{$session->getContributionId()}");
+    $session->setResponseItem('test_session_token', $session->tokenise());
+  }
+
+  public function validate($e): void {
+    $submittedValues = $e->getSubmittedValues();
+
+    $contributionAmount = $submittedValues['Contribution1'][0]['fields']['default_contribution_amount.contribution_amount'];
+    $currency = $submittedValues['Contribution1'][0]['fields']['currency'];
+
+    if ($currency === 'USD' && $contributionAmount > 10) {
+      $e->setError('No payments over 10 USD');
+    }
+  }
+
+  public function getAfformModule(): ?string {
+    return NULL;
+  }
+
+  public function getAfformSettings(bool $testMode): array {
+    return [];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds the final piece for FormBuilder Payments - integration between Afform and the Checkout model.

As before, the new functionality resides in `civi_contribute`, gated behind "Enable FormBuilder Payments" setting. This makes it opt-in initially, but gives an easy path to normalisation over time.


Before
----------------------------------------
- no payments in FormBuilder

After
---------------------------------------
- adds CheckoutOption field to Contribution entity on an afform, which allows to select an available Checkout Option. The field can fixed as an admin, or exposed as a user input field on the form itself

- adds CheckoutBlock pseudo-field to Contribution entity on an afform - this provides a pseudo-field which collects any checkout specific parameters. individual CheckoutOptions can render additional content in this space (e.g. additional fields, scripts etc) and or add custom angular handling (see e.g. afPaypal or afStripe modules)

- adds a default, minimally configured form `afformNewDonation` at `civicrm/donate` which provides a starting point for site builders to quickly set up a donation page; or clone/edit to create a more custom form

- `afCheckout` angular module is added as a dependency to forms with a Contribution on them. Any custom modules CheckoutOptions are in turn included as dependencies of `afCheckout`


Comments
-----------------------------
Follows on from:
- https://github.com/civicrm/civicrm-core/pull/35046
- https://github.com/civicrm/civicrm-core/pull/35179 

After this is merged, https://lab.civicrm.org/extensions/afform_payments will become redundant. 
