### PR TITLE
EFv2 Failed attempt to cache entity list

### DIFF
--- a/Civi/Schema/EntityRepository.php
+++ b/Civi/Schema/EntityRepository.php
@@ -16,19 +16,12 @@ namespace Civi\Schema;
  */
 class EntityRepository {
 
-  private static $entities;
-
-  private static $tableIndex;
-
-  private static $classIndex;
-
   /**
    * @internal
    * @return array
    */
   public static function getEntities(): array {
-    self::loadAll();
-    return self::$entities;
+    return self::getEntityMetadata()['entities'];
   }
 
   /**
@@ -36,13 +29,12 @@ class EntityRepository {
    * @return array{name: string, table: string, class: string, module: string, getInfo: callable, getPaths: callable, getIndices: callable, getFields: callable, metaProvider: callable, storageProvider: callable}
    */
   public static function getEntity(string $entityName): ?array {
-    self::loadAll();
-    return self::$entities[$entityName] ?? NULL;
+    return self::getEntities()[$entityName] ?? NULL;
   }
 
   public static function entityExists(string $entityName): bool {
-    self::loadAll();
-    return isset(self::$entities[$entityName]);
+    $entities = self::getEntities();
+    return isset($entities[$entityName]);
   }
 
   /**
@@ -50,13 +42,12 @@ class EntityRepository {
    * @return array
    */
   public static function getTableIndex(): array {
-    self::loadAll();
-    return self::$tableIndex;
+    return self::getEntityMetadata()['tables'];
   }
 
   public static function tableExists(string $tableName): bool {
-    self::loadAll();
-    return isset(self::$tableIndex[$tableName]);
+    $tableIndex = self::getTableIndex();
+    return isset($tableIndex[$tableName]);
   }
 
   /**
@@ -64,24 +55,34 @@ class EntityRepository {
    * @return array
    */
   public static function getClassIndex(): array {
-    self::loadAll();
-    return self::$classIndex;
+    return self::getEntityMetadata()['classes'];
   }
 
   public static function flush(): void {
-    self::$entities = NULL;
+    \Civi::cache('metadata')->delete('schema.entities');
   }
 
-  private static function loadAll(): void {
-    if (self::$entities !== NULL) {
-      return;
+  private static function getEntityMetadata(): array {
+    // Cannot use cache in pre-boot phase.
+    if (!\Civi\Core\Container::isContainerBooted()) {
+      return self::loadEntityTypes();
     }
-    $entityTypes = self::loadCoreEntities();
-    // Extensions should be online when we're called.
-    \CRM_Utils_Hook::entityTypes($entityTypes);
-    self::$entities = array_column($entityTypes, NULL, 'name');
-    self::$tableIndex = array_column(array_filter($entityTypes, fn($entityType) => !empty($entityType['table'])), 'name', 'table');
-    self::$classIndex = array_column(array_filter($entityTypes, fn($entityType) => !empty($entityType['class'])), 'name', 'class');
+    $entityMeta = \Civi::cache('metadata')->get('schema.entities');
+    if (!$entityMeta) {
+      $entityMeta = self::loadEntityTypes();
+      \Civi::cache('metadata')->set('schema.entities', $entityMeta);
+    }
+    return $entityMeta;
+  }
+
+  private static function loadEntityTypes(): array {
+    $entities = self::loadCoreEntities();
+    \CRM_Utils_Hook::entityTypes($entities);
+    return [
+      'entities' => array_column($entities, NULL, 'name'),
+      'tables' => array_column(array_filter($entities, fn($entityType) => !empty($entityType['table'])), 'name', 'table'),
+      'classes' => array_column(array_filter($entities, fn($entityType) => !empty($entityType['class'])), 'name', 'class'),
+    ];
   }
 
   private static function loadCoreEntities(): array {


### PR DESCRIPTION
Overview
----------------------------------------
Following on conversation with @larssandergreen and @ufundo (cc @eileenmcnaughton & @totten) this is how we *would* go about caching the list of Entities...

Before
----------------------------------------
`hook_civicrm_entityTypes` is called once at the beginning of every page/ajax request. It can be slow, esp with a large list of `civiimport` entities.

After
----------------------------------------
Called once when rebuilding the container, then cached.

Technical Details
----------------------------------------
It doesn't work for one reason: the `entityType` declarations contain anonymous functions, so you get:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/a290f770-57bb-48ee-8a41-425619b1e909" />

In hindsight, I guess that wasn't a very good idea after all to put those anonymous functions into the `.entityType.php` files.

Live-n-learn. Maybe we need an EFv3 to move them to named functions so they'll be cacheable.