### PR TITLE
PHP 8.5 notice fixes in tests

### DIFF
--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -684,7 +684,7 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
     $depthResults[1] = CRM_Utils_File::findFiles($CRM, 'Contact.php', $isRelative, 1);
     $depthResults[2] = CRM_Utils_File::findFiles($CRM, 'Contact.php', $isRelative, 2);
     $depthResults[3] = CRM_Utils_File::findFiles($CRM, 'Contact.php', $isRelative, 3);
-    $depthResults[NULL] = CRM_Utils_File::findFiles($CRM, 'Contact.php', $isRelative);
+    $depthResults[''] = CRM_Utils_File::findFiles($CRM, 'Contact.php', $isRelative);
 
     $expectPrefix = $isRelative ? '' : $CRM . '/';
 

--- a/tests/phpunit/CRM/Utils/StringTest.php
+++ b/tests/phpunit/CRM/Utils/StringTest.php
@@ -43,7 +43,6 @@ class CRM_Utils_StringTest extends CiviUnitTestCase {
   public function testStripPathChars(): void {
     $testSet = [
       '' => '',
-      NULL => NULL,
       'civicrm' => 'civicrm',
       'civicrm/dashboard' => 'civicrm/dashboard',
       'civicrm/contribute/transact' => 'civicrm/contribute/transact',


### PR DESCRIPTION
Fixes : 
```
 CRM_Utils_FileTest::testFindFilesDepth with data set "TRUE" (true)
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-1/web/core/tests/phpunit/CRM/Utils/FileTest.php:687
/home/homer/buildkit/build/build-1/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```

```
CRM_Utils_StringTest::testStripPathChars
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-1/web/core/tests/phpunit/CRM/Utils/StringTest.php:45
/home/homer/buildkit/build/build-1/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```


Comments
----------------------------------------
ping @colemanw @eileenmcnaughton 