### PR TITLE
dev/core#6407 Do not double escape the shared address label

### DIFF
--- a/CRM/Contact/Form/Edit/Address.php
+++ b/CRM/Contact/Form/Edit/Address.php
@@ -158,8 +158,10 @@ class CRM_Contact_Form_Edit_Address {
 
       // do we want to update employer for shared address
       $employer_label = '<span class="addrel-employer">' . ts('Set this organization as current employer') . '</span>';
+      $form->assign('employer_label', $employer_label);
       $household_label = '<span class="addrel-household">' . ts('Create a household member relationship with this contact') . '</span>';
-      $form->addElement('checkbox', "address[$blockId][add_relationship]", NULL, $employer_label . $household_label);
+      $form->assign('household_label', $household_label);
+      $form->addElement('checkbox', "address[$blockId][add_relationship]", NULL, '');
     }
   }
 

--- a/templates/CRM/Contact/Form/ShareAddress.tpl
+++ b/templates/CRM/Contact/Form/ShareAddress.tpl
@@ -16,7 +16,7 @@
       {$form.address.$blockId.master_contact_id.html}
       <div class="shared-address-add-relationship" style="display: none;">
         {$form.address.$blockId.add_relationship.html}
-        {$form.address.$blockId.add_relationship.label}
+        <label for="address[{$blockId}][add_relationship]">{$employer_label}{$household_label}</label>
         <span class="employer">{help id="add_relationship" file="CRM/Contact/Form/Contact" title=$form.address.$blockId.add_relationship.textLabel}</span>
       </div>
       <div class="shared-address-list">


### PR DESCRIPTION
Overview
----------------------------------------
Shared Address label is double escaped

Before
----------------------------------------
Shared Address label is broken

After
----------------------------------------
Shared address label is correct

ping @totten @demeritcowboy 