### PR TITLE
reset metadata cache when toggling FormBuilder Contributions

### DIFF
--- a/ext/civi_contribute/civi_contribute.php
+++ b/ext/civi_contribute/civi_contribute.php
@@ -1,3 +1,7 @@
 <?php
 
 require_once 'civi_contribute.civix.php';
+
+function _civi_contribute_afform_clear() {
+  \Civi::cache('metadata')->clear();
+}

--- a/ext/civi_contribute/settings/Contribute.setting.php
+++ b/ext/civi_contribute/settings/Contribute.setting.php
@@ -223,5 +223,6 @@ return [
     'is_contact' => 0,
     'help_text' => ts('Enable Contributions and Price Fields in FormBuilder.'),
     'settings_pages' => ['contribute' => ['weight' => 100]],
+    'on_change' => ['_civi_contribute_afform_clear'],
   ],
 ];


### PR DESCRIPTION
Before
----------------------------------------
- FormBuilder Contributions is gated behind a setting. 
- after changing the setting, you have to flush the cache for the changes to take effect in the UI


After
----------------------------------------
- changes propogate immediately when you change the setting



Comments
----------------------------------------
Should fix the issue you saw this evening @GuillaumeSorel 
