### PR TITLE
SearchKit - Fill in missing default column values when editing a search

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -356,18 +356,24 @@
       };
 
       // Helper function to sort active from hidden columns and initialize each column with defaults
-      this.initColumns = function(defaults) {
+      this.initColumns = (defaults) => {
         initDefaults = defaults;
-        if (!ctrl.display.settings.columns) {
-          ctrl.display.settings.columns = _.transform(ctrl.savedSearch.api_params.select, function(columns, fieldExpr) {
+        if (!this.display.settings.columns) {
+          this.display.settings.columns = _.transform(this.savedSearch.api_params.select, function(columns, fieldExpr) {
             columns.push(searchMeta.fieldToColumn(fieldExpr, defaults));
           });
         } else {
-          let activeColumns = ctrl.display.settings.columns.map(col => col.key);
+          let activeColumns = this.display.settings.columns.map(col => col.key);
           // Delete any column that is no longer in the search
           activeColumns.reverse().forEach((key, index) => {
-            if (key && !ctrl.getExprFromSelect(key)) {
-              ctrl.removeCol(activeColumns.length - 1 - index);
+            if (key && !this.getExprFromSelect(key)) {
+              this.removeCol(activeColumns.length - 1 - index);
+            }
+          });
+          // Fill in any missing default values from columns
+          this.display.settings.columns.forEach((col, index) => {
+            if (col.type && this.colTypes[col.type]?.defaults) {
+              this.display.settings.columns[index] = _.merge({}, this.colTypes[col.type].defaults, col);
             }
           });
         }


### PR DESCRIPTION
Overview
----------------------------------------
When we add new config options, they will appear to be missing when editing older searches, even if they're not required it still doesn't look right.

Before
----------------------------------------
Edit the "Contact Summary Cases" search display.
Notice that the option for "Subsearch Display Mode" appears to be missing:

<img width="400" height="98" alt="image" src="https://github.com/user-attachments/assets/76b158e7-391b-4697-b586-bf140c68f34b" />


After
----------------------------------------
The default is populated:

<img width="400" height="96" alt="image" src="https://github.com/user-attachments/assets/58b708c7-28d5-41dd-901c-ca61a988866d" />
