### PR TITLE
PHP 8.5 fix for phpunit-crm-4 failures

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwo.php
+++ b/CRM/Upgrade/Incremental/php/SixTwo.php
@@ -156,7 +156,7 @@ class CRM_Upgrade_Incremental_php_SixTwo extends CRM_Upgrade_Incremental_Base {
       $fieldsToConvert[$key] = self::getConvertedName($key, $entity);
       // Convert the field.
       CRM_Core_DAO::executeQuery(' UPDATE civicrm_mapping_field SET name = %1 WHERE id = %2', [
-        1 => [$fieldsToConvert[$mappingFields->name], 'String'],
+        1 => [$fieldsToConvert[$key], 'String'],
         2 => [$mappingFields->id, 'Integer'],
       ]);
     }

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -650,13 +650,13 @@ class CRM_Utils_Array {
         if ($keyvalue !== NULL && isset($node[$keyvalue]) && !is_array($node[$keyvalue])) {
           $node[$keyvalue] = [];
         }
-        $node = &$node[$keyvalue];
+        $node = &$node[$keyvalue ?? ''];
       }
       if (is_array($record)) {
-        $node[$record[$final_key]] = $record;
+        $node[($record[$final_key] ?? '')] = $record;
       }
       else {
-        $node[$record->{$final_key}] = $record;
+        $node[($record->{$final_key} ?? '')] = $record;
       }
     }
     return $result;

--- a/tests/phpunit/CRM/Utils/FileTest.php
+++ b/tests/phpunit/CRM/Utils/FileTest.php
@@ -688,8 +688,8 @@ class CRM_Utils_FileTest extends CiviUnitTestCase {
 
     $expectPrefix = $isRelative ? '' : $CRM . '/';
 
-    $expectFiles['Contact/BAO/Contact.php'] = [0 => FALSE, 1 => FALSE, 2 => TRUE, 3 => TRUE, NULL => TRUE];
-    $expectFiles['Contact/Import/Parser/Contact.php'] = [0 => FALSE, 1 => FALSE, 2 => FALSE, 3 => TRUE, NULL => TRUE];
+    $expectFiles['Contact/BAO/Contact.php'] = [0 => FALSE, 1 => FALSE, 2 => TRUE, 3 => TRUE, '' => TRUE];
+    $expectFiles['Contact/Import/Parser/Contact.php'] = [0 => FALSE, 1 => FALSE, 2 => FALSE, 3 => TRUE, '' => TRUE];
 
     foreach ($expectFiles as $expectFile => $expectMatches) {
       $actualMatches = [];


### PR DESCRIPTION
Fixes

```
CRM_Upgrade_Incremental_php_SixTwoTest::testUpdateContributionUserJobs
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-5/web/core/CRM/Upgrade/Incremental/php/SixTwo.php:159
/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CRM/Upgrade/Incremental/php/SixTwoTest.php:232
/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```
```
CRM_Utils_ArrayTest::testIndexArray
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-5/web/core/CRM/Utils/Array.php:653
/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CRM/Utils/ArrayTest.php:83
/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```
```
CRM_Utils_FileTest::testFindFilesDepth with data set "TRUE" (true)
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CRM/Utils/FileTest.php:691
/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4018
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```

ping @eileenmcnaughton @colemanw 