### PR TITLE
Allow additional participant profiles to be unset in Manage Event

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -833,45 +833,16 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
       $ufAdd = [];
       $wtAdd = 2;
 
-      if (array_key_exists('additional_custom_pre_id', $params)) {
-        if (empty($params['additional_custom_pre_id'])) {
-          $ufAdd[1] = $params['custom_pre_id'];
-          $wtAdd = 1;
-        }
-        elseif (($params['additional_custom_pre_id'] ?? NULL) == 'none') {
-        }
-        else {
-          $ufAdd[1] = $params['additional_custom_pre_id'];
-          $wtAdd = 1;
-        }
+      if (!empty($params['additional_custom_pre_id'])) {
+        $ufAdd[1] = $params['additional_custom_pre_id'];
+        $wtAdd = 1;
       }
 
-      if (array_key_exists('additional_custom_post_id', $params)) {
-        if (empty($params['additional_custom_post_id'])) {
-          $ufAdd[2] = $params['custom_post_id'];
-        }
-        elseif (($params['additional_custom_post_id'] ?? NULL) == 'none') {
-        }
-        else {
-          $ufAdd[2] = $params['additional_custom_post_id'];
-        }
+      if (!empty($params['additional_custom_post_id'])) {
+        $ufAdd[2] = $params['additional_custom_post_id'];
       }
 
-      if (!empty($params['additional_custom_post_id_multiple'])) {
-        $additionalPostMultiple = [];
-        foreach ($params['additional_custom_post_id_multiple'] as $key => $value) {
-          if (is_null($value) && !empty($params['custom_post_id'])) {
-            $additionalPostMultiple[$key] = $params['custom_post_id'];
-          }
-          elseif ($value == 'none') {
-            continue;
-          }
-          elseif ($value) {
-            $additionalPostMultiple[$key] = $value;
-          }
-        }
-        $ufAdd = array_merge($ufAdd, $additionalPostMultiple);
-      }
+      $ufAdd = array_merge($ufAdd, array_filter($params['additional_custom_post_id_multiple'] ?? []));
 
       $ufAdd = array_values($ufAdd);
       if (!empty($ufAdd)) {


### PR DESCRIPTION
Before
----------------------------------------
In Manage Event - Online Registration, if you leave any of the profile selects empty for additional participants, the value is copied from the primary participant profiles on save. This prevents not having a profile for an additional participant, for example if you wanted to have an additional profile for the primary participant but not show it for the additional participant.

After
----------------------------------------
Profiles are saved exactly as indicated.

Technical Details
----------------------------------------
I think what happened here is we used to have regular selects for these profiles and they had `none` options. But now that these are Select2s, there is no none option and so it has become impossible to leave them unset if the corresponding primary participant profile is set.
