### PR TITLE
Fix word_replacement upgrade

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -76,22 +76,20 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
     ], 'AFTER `accepted_credit_cards`');
     $this->addTask('Drop civicrm_activity.is_current_revision index', 'dropIndex', 'civicrm_activity', 'index_is_current_revision');
 
+    $bin_collation = strpos(CRM_Core_BAO_SchemaHandler::getInUseCollation(), 'utf8mb4') !== FALSE ? 'utf8mb4_bin' : 'utf8_bin';
     $this->addTask('Make WordReplacement "find_word" required.', 'alterSchemaField', 'WordReplacement', 'find_word', [
-      'title' => ts('Replaced Word'),
       'sql_type' => 'varchar(255)',
-      'input_type' => 'Text',
       'description' => ts('Word which need to be replaced'),
       'add' => '4.4',
-      'collate' => 'utf8_bin',
+      'collate' => $bin_collation,
       'required' => TRUE,
     ]);
     $this->addTask('Make WordReplacement "replace_word" required', 'alterSchemaField', 'WordReplacement', 'replace_word', [
-      'title' => ts('Replacement Word'),
       'sql_type' => 'varchar(255)',
-      'input_type' => 'Text',
       'description' => ts('Word which will replace the word in find'),
       'add' => '4.4',
-      'collate' => 'utf8_bin',
+      'collate' => $bin_collation,
+      'required' => TRUE,
     ]);
   }
 

--- a/CRM/Upgrade/Incremental/sql/6.14.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.14.alpha1.mysql.tpl
@@ -1,1 +1,5 @@
 {* file to handle db changes in 6.14.alpha1 during upgrade *}
+
+-- Should never come up but in the php file we change the column to not null, so this will avoid a crash just in case.
+UPDATE civicrm_word_replacement SET find_word = '' WHERE find_word IS NULL;
+UPDATE civicrm_word_replacement SET replace_word = '' WHERE replace_word IS NULL;

--- a/schema/Core/WordReplacement.entityType.php
+++ b/schema/Core/WordReplacement.entityType.php
@@ -1,5 +1,8 @@
 <?php
 
+// Nothing is created yet at the time we're called, so do the same thing as the civimix SqlGenerator
+$bin_collation = strpos(CRM_Core_BAO_SchemaHandler::DEFAULT_COLLATION, 'utf8mb4') !== FALSE ? 'utf8mb4_bin' : 'utf8_bin';
+
 return [
   'name' => 'WordReplacement',
   'table' => 'civicrm_word_replacement',
@@ -37,7 +40,7 @@ return [
       'input_type' => 'Text',
       'description' => ts('Word which need to be replaced'),
       'add' => '4.4',
-      'collate' => 'utf8_bin',
+      'collate' => $bin_collation,
       'required' => TRUE,
     ],
     'replace_word' => [
@@ -46,7 +49,7 @@ return [
       'input_type' => 'Text',
       'description' => ts('Word which will replace the word in find'),
       'add' => '4.4',
-      'collate' => 'utf8_bin',
+      'collate' => $bin_collation,
       'required' => TRUE,
     ],
     'is_active' => [


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/35124#discussion_r2978676964

Before
----------------------------------------
* Doesn't fully do what it says it does.
* Overwrites my mb4 with mb3.

After
----------------------------------------
Better

Technical Details
----------------------------------------


Comments
----------------------------------------
Personally I'd like replace_word to be blankable, but the UI doesn't let you regardless of the schema. So I'm not going to push for that here.