### PR TITLE
some dbs like big letters

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -128,7 +128,7 @@ function _civiimport_civicrm_get_import_tables(): array {
 
   // Verify the tables exist; remove any that don't.
   $tablesToVerify = array_column($importEntities, 'table_name', 'user_job_id');
-  $existingTables = CRM_Core_DAO::executeQuery('SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ("' . implode('","', $tablesToVerify) . '")')
+  $existingTables = CRM_Core_DAO::executeQuery('SELECT TABLE_NAME AS table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ("' . implode('","', $tablesToVerify) . '")')
     ->fetchMap('table_name', 'table_name');
   $existingTables = array_intersect($tablesToVerify, $existingTables);
   $importEntities = array_intersect_key($importEntities, $existingTables);


### PR DESCRIPTION
Overview
----------------------------------------
Field names are case sensitive when accessed from $dao->fieldname, i.e. while the sql doesn't care, php cares that `$dao->TABLE_NAME` is different from `$dao->table_name`

Before
----------------------------------------
I have hundreds of fails like this in another environment after https://github.com/civicrm/civicrm-core/pull/35223.

```
Undefined property: CRM_Core_DAO::$table_name

/home/runner/drupal10/vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php:133
/home/runner/drupal10/vendor/civicrm/civicrm-core/CRM/Core/DAO.php:1600
/home/runner/drupal10/vendor/civicrm/civicrm-core/ext/civiimport/civiimport.php:132
/home/runner/drupal10/vendor/civicrm/civicrm-core/ext/civiimport/civiimport.php:56
```

After
----------------------------------------
Should be good everywhere.

Technical Details
----------------------------------------
I'm not sure why the errors don't show up in jenkins. Maybe they get swallowed somewhere? Maybe different dbs return things normalized differently? Maybe pear-db adjusts sometimes and not others? I dunno but we do this `TABLE_NAME as table_name` elsewhere probably for the same reason.

Comments
----------------------------------------

