### PR TITLE
Show frontend profile title for addt participants in event receipt

### DIFF
--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -320,7 +320,7 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
         foreach ($profile['fields'] as $participantIndex => $fields) {
           $profiles['profile'][$participantIndex][$profile['id']] = $profile['fields'][$participantIndex];
         }
-        $profiles['title'][$profile['id']] = $profile['title'];
+        $profiles['title'][$profile['id']] = $profile['frontend_title'];
       }
     }
     return $profiles;


### PR DESCRIPTION
Before
----------------------------------------
The profile title for additional participants, only in the email sent to the primary registrant, is the backend title instead of the public frontend_title (frontend title is used for the primary participant and in the email that goes directly to the additional participant).

After
----------------------------------------
frontend_title is used throughout.

Comments
----------------------------------------
The code path here is weird in that we set the profile titles in Event.php and then later use the values from getProfilesAdditionalParticipants instead, but that's a problem for another day.