### PR TITLE
php8.5 Upgrading zetacomponents/base (1.9.4 => 1.9.5)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6030,16 +6030,16 @@
         },
         {
             "name": "zetacomponents/base",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zetacomponents/Base.git",
-                "reference": "b6ae5f6177f6e51c5fc3514800e1c3fb076ec4be"
+                "reference": "f91dd2f04280741de7125350a8c47b6673fc8537"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zetacomponents/Base/zipball/b6ae5f6177f6e51c5fc3514800e1c3fb076ec4be",
-                "reference": "b6ae5f6177f6e51c5fc3514800e1c3fb076ec4be",
+                "url": "https://api.github.com/repos/zetacomponents/Base/zipball/f91dd2f04280741de7125350a8c47b6673fc8537",
+                "reference": "f91dd2f04280741de7125350a8c47b6673fc8537",
                 "shasum": ""
             },
             "require-dev": {
@@ -6094,9 +6094,9 @@
             "homepage": "https://github.com/zetacomponents",
             "support": {
                 "issues": "https://github.com/zetacomponents/Base/issues",
-                "source": "https://github.com/zetacomponents/Base/tree/1.9.4"
+                "source": "https://github.com/zetacomponents/Base/tree/1.9.5"
             },
-            "time": "2022-11-30T16:16:25+00:00"
+            "time": "2025-11-12T16:37:32+00:00"
         },
         {
             "name": "zetacomponents/mail",


### PR DESCRIPTION
Overview
----------------------------------------
php8.5 Upgrading zetacomponents/base (1.9.4 => 1.9.5)

Before
----------------------------------------
1.9.4

After
----------------------------------------
1.9.5

Technical Details
----------------------------------------
Just gets us to the latest lock-file supported version - I don't think it solves the php8.5 issue

Comments
----------------------------------------

