### PR TITLE
SearchKit - Extract condition picker to its own reusable component

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -8,53 +8,16 @@
       apiParams: '<',
       links: '<'
     },
-    require: {
-      crmSearchAdmin: '^crmSearchAdmin'
-    },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkGroup.html',
     controller: function ($scope, $element, $timeout, searchMeta) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this,
         linkProps = ['path', 'task', 'entity', 'action', 'join', 'target', 'icon', 'text', 'style', 'conditions'];
 
-      this.conditionCount = [];
-
-      ctrl.permissionOperators = [
-        {key: 'CONTAINS', value: ts('Includes')},
-        {key: '=', value: ts('Has All')},
-        {key: '!=', value: ts('Lacks All')}
-      ];
-
       this.styles = CRM.crmSearchAdmin.styles;
 
       this.getStyle = function(item) {
         return _.findWhere(this.styles, {key: item.style});
-      };
-
-      this.getField = searchMeta.getField;
-
-      this.fields = function() {
-        let selectFields = ctrl.crmSearchAdmin.getSelectFields();
-        // Use machine names not labels for option matching
-        selectFields.forEach((field) => field.id = field.id.replace(':label', ':name'));
-        let permissionField = [{
-          text: ts('Current User Permission'),
-          id: 'check user permission',
-          description: ts('Check permission of logged-in user')
-        }];
-        return {results: permissionField.concat(selectFields)};
-      };
-
-      this.addCondition = function(item, selection) {
-        item.conditions.push([selection, '=']);
-      };
-
-      this.onChangeCondition = function(item, index) {
-        if (item.conditions[index][0]) {
-          item.conditions[index][1] = '=';
-        } else {
-          item.conditions.splice(index, 1);
-        }
       };
 
       this.sortableOptions = {
@@ -67,8 +30,6 @@
           return ui;
         }
       };
-
-      this.permissions = CRM.crmSearchAdmin.permissions;
 
       $scope.pickIcon = function(index) {
         searchMeta.pickIcon().then(icon => ctrl.group[index].icon = icon);
@@ -126,14 +87,6 @@
             $select.val('');
           });
         });
-
-        // Track number of conditions per item, for use with the "Add Condition" selector
-        $scope.$watch('$ctrl.group', function() {
-          // Timeout prevents bouncy-ness in the onChange of the "Add Condition" element
-          $timeout(function() {
-            ctrl.conditionCount = _.map(ctrl.group, item => item.conditions.length);
-          });
-        }, true);
 
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -36,27 +36,7 @@
         <crm-search-admin-token-select model="item" field="text" suffix=":label"></crm-search-admin-token-select>
       </td>
       <td>
-        <div class="form-inline" ng-repeat="condition in item.conditions">
-          <input ng-model="condition[0]" crm-ui-select="{placeholder: ' ', data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition(item, $index)">
-          <div class="form-group" ng-if="condition[0] === 'check user permission'">
-            <select class="form-control crm-auto-width" crm-ui-select ng-model="condition[1]" ng-options="o.key as o.value for o in $ctrl.permissionOperators"></select>
-            <input class="form-control" crm-ui-select="{data: $ctrl.permissions, multiple: true}" ng-model="condition[2]" ng-list>
-          </div>
-          <crm-search-condition class="form-group"
-            ng-if="condition[0] && condition[0] !== 'check user permission'"
-            clause="condition"
-            field="$ctrl.getField(condition[0])"
-            offset="1"
-            option-key="'name'">
-          </crm-search-condition>
-        </div>
-        <div ng-if="item.conditions.length < 1">
-          <input class="form-control crm-auto-width" on-crm-ui-select="$ctrl.addCondition(item, selection)" crm-ui-select="{placeholder: ts('Add Condition...'), data: $ctrl.fields}">
-        </div>
-        <!-- Subsequent Add Condition button has a different placeholder to clarify that the operator is AND -->
-        <div ng-if="item.conditions.length >= 1">
-          <input class="form-control crm-auto-width" on-crm-ui-select="$ctrl.addCondition(item, selection)" crm-ui-select="{placeholder: ts('And...'), data: $ctrl.fields}">
-        </div>
+        <crm-search-conditions item="item"></crm-search-conditions>
       </td>
       <td>
         <div class="btn-group">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.component.js
@@ -1,0 +1,53 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('crmSearchConditions', {
+    bindings: {
+      item: '<',
+    },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/crmSearchAdmin/crmSearchConditions.html',
+    controller: function ($scope, searchMeta) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+
+      this.permissions = CRM.crmSearchAdmin.permissions;
+
+      this.permissionOperators = [
+        {key: 'CONTAINS', value: ts('Includes')},
+        {key: '=', value: ts('Has All')},
+        {key: '!=', value: ts('Lacks All')}
+      ];
+
+      this.getField = searchMeta.getField;
+
+      this.fields = () => {
+        let selectFields = this.crmSearchAdmin.getSelectFields();
+        // Use machine names not labels for option matching
+        selectFields.forEach((field) => field.id = field.id.replace(':label', ':name'));
+        let permissionField = [{
+          text: ts('Current User Permission'),
+          id: 'check user permission',
+          description: ts('Check permission of logged-in user')
+        }];
+        return {results: permissionField.concat(selectFields)};
+      };
+
+      this.addCondition = (selection) => {
+        this.item.conditions = this.item.conditions || [];
+        this.item.conditions.push([selection, '=']);
+      };
+
+      this.onChangeCondition = (index) => {
+        if (this.item.conditions[index][0]) {
+          this.item.conditions[index][1] = '=';
+        } else {
+          this.item.conditions.splice(index, 1);
+        }
+      };
+
+    },
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.html
@@ -1,0 +1,21 @@
+<div class="form-inline" ng-repeat="condition in $ctrl.item.conditions">
+  <input ng-model="condition[0]" crm-ui-select="{placeholder: ' ', data: $ctrl.fields}" ng-change="$ctrl.onChangeCondition($index)">
+  <div class="form-group" ng-if="condition[0] === 'check user permission'">
+    <select class="form-control crm-auto-width" crm-ui-select ng-model="condition[1]" ng-options="o.key as o.value for o in $ctrl.permissionOperators"></select>
+    <input class="form-control" crm-ui-select="{data: $ctrl.permissions, multiple: true}" ng-model="condition[2]" ng-list>
+  </div>
+  <crm-search-condition class="form-group"
+    ng-if="condition[0] && condition[0] !== 'check user permission'"
+    clause="condition"
+    field="$ctrl.getField(condition[0])"
+    offset="1"
+    option-key="'name'">
+  </crm-search-condition>
+</div>
+<div ng-if="!$ctrl.item.conditions || $ctrl.item.conditions.length &lt; 1">
+  <input class="form-control crm-auto-width" on-crm-ui-select="$ctrl.addCondition(selection)" crm-ui-select="{placeholder: ts('Add Condition...'), data: $ctrl.fields}">
+</div>
+<!-- Subsequent Add Condition button has a different placeholder to clarify that the operator is AND -->
+<div ng-if="$ctrl.item.conditions.length &gt;= 1">
+  <input class="form-control crm-auto-width" on-crm-ui-select="$ctrl.addCondition(selection)" crm-ui-select="{placeholder: ts('And...'), data: $ctrl.fields}">
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit code refactor to facilitate conditions being added to other types of fields/elements.

Technical Details
----------------------------------------
Permission picker doesn't need to be coupled to the link group.