### PR TITLE
Simplify display of price set details in event receipts

### DIFF
--- a/xml/templates/message_templates/event_offline_receipt_html.tpl
+++ b/xml/templates/message_templates/event_offline_receipt_html.tpl
@@ -9,8 +9,6 @@
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
 {capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
-{capture assign=tdfirstStyle}style="width: 180px; padding-bottom: 15px;"{/capture}
-{capture assign=tdStyle}style="width: 100px;"{/capture}
 {capture assign=participantTotalStyle}style="margin: 0.5em 0 0.5em;padding: 0.5em;background-color: #999999;font-weight: bold;color: #FAFAFA;border-radius: 2px;"{/capture}
 
   <!-- BEGIN HEADER -->
@@ -159,6 +157,7 @@
         </th>
       </tr>
         {if $isShowLineItems}
+          {$isShowTax = $isShowTax && {contribution.tax_amount|boolean}}
           {foreach from=$participants key=index item=currentParticipant}
             {if $isPrimary || {participant.id} === $currentParticipant.id}
               {if $isPrimary && ($participants|@count > 1)} {* Header for multi participant registration cases. *}
@@ -170,41 +169,48 @@
               {/if}
               <tr>
                 <td colspan="2" {$valueStyle}>
-                  <table>
-                    <tr>
-                      <th>{ts}Item{/ts}</th>
-                      <th>{ts}Qty{/ts}</th>
-                      <th>{ts}Each{/ts}</th>
-                      {if $isShowTax && {contribution.tax_amount|boolean}}
-                        <th>{ts}Subtotal{/ts}</th>
-                        <th>{ts}Tax Rate{/ts}</th>
-                        <th>{ts}Tax Amount{/ts}</th>
-                      {/if}
-                      <th>{ts}Total{/ts}</th>
+                  <table style="width: 100%;">
+                    {* Don't show the table headers if we only have title and price *}
+                    {if $isShowLineSubtotal || $isShowTax}
+                      <tr>
+                        <th>{ts}Item{/ts}</th>
+                        {if $isShowLineSubtotal}
+                          <th>{ts}Qty{/ts}</th>
+                        {/if}
+                        <th>{ts}Each{/ts}</th>
+                        {if $isShowTax}
+                          <th>{ts}Subtotal{/ts}</th>
+                          <th>{ts}Tax Rate{/ts}</th>
+                          <th>{ts}Tax Amount{/ts}</th>
+                        {/if}
+                        <th>{ts}Total{/ts}</th>
                         {if $isShowParticipantCount}
                           <th>{ts}Total Participants{/ts}</th>
                         {/if}
-                    </tr>
+                      </tr>
+                    {/if}
                     {foreach from=$currentParticipant.line_items item=line}
                       <tr>
-                        <td {$tdfirstStyle}>{$line.title}</td>
-                        <td {$tdStyle} align="middle">{$line.qty}</td>
-                        <td {$tdStyle}>{$line.unit_price|crmMoney:$currency}</td>
-                          {if $isShowTax && {contribution.tax_amount|boolean}}
-                            <td>{$line.line_total|crmMoney:$currency}</td>
-                            {if $line.tax_rate || $line.tax_amount != ""}
-                              <td>{$line.tax_rate|string_format:"%.2f"}%</td>
-                              <td>{$line.tax_amount|crmMoney:$currency}</td>
-                            {else}
-                              <td></td>
-                              <td></td>
-                            {/if}
+                        <td>{$line.title}</td>
+                        {if $isShowLineSubtotal}
+                          <td>{$line.qty}</td>
+                        {/if}
+                        {if $isShowLineSubtotal || $isShowTax}
+                          <td>{$line.unit_price|crmMoney:$currency}</td>
+                        {/if}
+                        {if $isShowTax}
+                          <td>{$line.line_total|crmMoney:$currency}</td>
+                          {if $line.tax_rate || $line.tax_amount != ""}
+                            <td>{$line.tax_rate|string_format:"%.2f"}%</td>
+                            <td>{$line.tax_amount|crmMoney:$currency}</td>
+                          {else}
+                            <td></td>
+                            <td></td>
                           {/if}
-                        <td {$tdStyle}>
-                            {$line.line_total_inclusive|crmMoney:$currency}
-                        </td>
+                        {/if}
+                        <td>{$line.line_total_inclusive|crmMoney:$currency}</td>
                         {if $isShowParticipantCount}
-                          <td {$tdStyle}>{$line.participant_count}</td>
+                          <td>{$line.participant_count}</td>
                         {/if}
                       </tr>
                     {/foreach}

--- a/xml/templates/message_templates/event_online_receipt_html.tpl
+++ b/xml/templates/message_templates/event_online_receipt_html.tpl
@@ -9,8 +9,6 @@
 {capture assign=headerStyle}colspan="2" style="text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;"{/capture}
 {capture assign=labelStyle}style="padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;"{/capture}
 {capture assign=valueStyle}style="padding: 4px; border-bottom: 1px solid #999;"{/capture}
-{capture assign=tdfirstStyle}style="width: 180px; padding-bottom: 15px;"{/capture}
-{capture assign=tdStyle}style="width: 100px;"{/capture}
 {capture assign=participantTotalStyle}style="margin: 0.5em 0 0.5em;padding: 0.5em;background-color: #999999;font-weight: bold;color: #FAFAFA;border-radius: 2px;"{/capture}
 
   <!-- BEGIN HEADER -->
@@ -174,6 +172,7 @@
             </th>
           </tr>
             {if $isShowLineItems}
+              {$isShowTax = $isShowTax && {contribution.tax_amount|boolean}}
               {foreach from=$participants key=index item=currentParticipant}
                 {if $isPrimary || {participant.id} === $currentParticipant.id}
                   {if $isPrimary && ($participants|@count > 1)} {* Header for multi participant registration cases. *}
@@ -185,27 +184,36 @@
                   {/if}
                   <tr>
                     <td colspan="2" {$valueStyle}>
-                      <table>
-                        <tr>
-                          <th>{ts}Item{/ts}</th>
-                          <th>{ts}Qty{/ts}</th>
-                          <th>{ts}Each{/ts}</th>
-                          {if $isShowTax && {contribution.tax_amount|boolean}}
-                              <th>{ts}Subtotal{/ts}</th>
-                              <th>{ts}Tax Rate{/ts}</th>
-                              <th>{ts}Tax Amount{/ts}</th>
+                      <table style="width: 100%;">
+                        {* Don't show the table headers if we only have title and price *}
+                        {if $isShowLineSubtotal || $isShowTax}
+                          <tr>
+                            <th>{ts}Item{/ts}</th>
+                            {if $isShowLineSubtotal}
+                              <th>{ts}Qty{/ts}</th>
                             {/if}
-                          <th>{ts}Total{/ts}</th>
-                          {if $isShowParticipantCount}
-                            <th>{ts}Total Participants{/ts}</th>
-                          {/if}
-                        </tr>
+                            <th>{ts}Each{/ts}</th>
+                            {if $isShowTax}
+                                <th>{ts}Subtotal{/ts}</th>
+                                <th>{ts}Tax Rate{/ts}</th>
+                                <th>{ts}Tax Amount{/ts}</th>
+                              {/if}
+                            <th>{ts}Total{/ts}</th>
+                            {if $isShowParticipantCount}
+                              <th>{ts}Total Participants{/ts}</th>
+                            {/if}
+                          </tr>
+                        {/if}
                         {foreach from=$currentParticipant.line_items item=line}
                           <tr>
-                            <td {$tdfirstStyle}>{$line.title}</td>
-                            <td {$tdStyle} align="middle">{$line.qty}</td>
-                            <td {$tdStyle}>{$line.unit_price|crmMoney:$currency}</td>
-                            {if $isShowTax && {contribution.tax_amount|boolean}}
+                            <td>{$line.title}</td>
+                            {if $isShowLineSubtotal}
+                              <td>{$line.qty}</td>
+                            {/if}
+                            {if $isShowLineSubtotal || $isShowTax}
+                              <td>{$line.unit_price|crmMoney:$currency}</td>
+                            {/if}
+                            {if $isShowTax}
                               <td>{$line.line_total|crmMoney:$currency}</td>
                               {if $line.tax_rate || $line.tax_amount != ""}
                                 <td>{$line.tax_rate|string_format:"%.2f"}%</td>
@@ -215,11 +223,9 @@
                                 <td></td>
                               {/if}
                             {/if}
-                            <td {$tdStyle}>
-                              {$line.line_total_inclusive|crmMoney:$currency}
-                            </td>
+                            <td>{$line.line_total_inclusive|crmMoney:$currency}</td>
                             {if $isShowParticipantCount}
-                              <td {$tdStyle}>{$line.participant_count}</td>
+                              <td>{$line.participant_count}</td>
                             {/if}
                           </tr>
                         {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
The price set selections table in the email receipt for event registrations can be more complex than needed when registrants are selecting options where the quantity is always 1.

Before
----------------------------------------
Complex when it doesn't need to be. Strange formatting mis-aligns horizontally and fixed column width cause line breaks with longer option titles.
<img width="697" height="274" alt="image" src="https://github.com/user-attachments/assets/f4a18644-7ecc-4f01-9424-10bc1828e6f4" />


After
----------------------------------------
Simplify display when we don't need to show tax or quantities. Remove the header row in this case as well, as item and price are immediately understandable without a header. Let the email client figure out the column widths.

With a quantities = 1
<img width="696" height="156" alt="image" src="https://github.com/user-attachments/assets/916ee6b5-7299-431d-b1a8-ce19f3348e04" />

With one quantity > 1
<img width="699" height="183" alt="image" src="https://github.com/user-attachments/assets/47f2bc9d-63ed-47f5-9c38-5cae4f3525f9" />

With tax
<img width="700" height="291" alt="image" src="https://github.com/user-attachments/assets/4722402b-a789-45ff-aa70-2513eed4edd8" />

Comments
----------------------------------------
We don't have the td styles in the contribution receipts, so this makes these more consistent with those.