### PR TITLE
Remove membership_payment lookup

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1134,14 +1134,15 @@ AND civicrm_membership.is_test = %2";
    * @return int
    *   contribution page id
    */
-  public static function getContributionPageId($membershipID) {
+  public static function getContributionPageId(int $membershipID) {
     $query = "
 SELECT c.contribution_page_id as pageID
-  FROM civicrm_membership_payment mp, civicrm_contribution c
- WHERE mp.contribution_id = c.id
-   AND c.contribution_page_id IS NOT NULL
-   AND mp.membership_id = " . CRM_Utils_Type::escape($membershipID, 'Integer')
-      . " ORDER BY mp.id DESC";
+  FROM civicrm_line_item line
+   INNER JOIN civicrm_contribution c ON c.id = line.contribution_id
+    AND entity_table = 'civicrm_membership'
+ WHERE c.contribution_page_id IS NOT NULL
+   AND line.entity_id = " . CRM_Utils_Type::escape($membershipID, 'Integer')
+      . " ORDER BY line.id DESC";
 
     return CRM_Core_DAO::singleValueQuery($query);
   }


### PR DESCRIPTION

Overview
----------------------------------------
Remove membership_payment lookup

Before
----------------------------------------
User Dashboard lookup for contribution page for membership uses deprecated membership_payment table

After
----------------------------------------
Uses line item table

Technical Details
----------------------------------------
This is one which is less likely to be used legacy data so we don't need to handle data hygeine issues like we do with (e.g) reports

Comments
----------------------------------------
