### PR TITLE
SearchKit - Ensure all viewable display types are loaded

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay.module.js
+++ b/ext/search_kit/ang/crmSearchDisplay.module.js
@@ -1,7 +1,7 @@
 (function(angular, $, _) {
   "use strict";
 
-  // Note: We're not using CRM.angRequires here to avoid circular dependencies with search display types. See crmSearchDisplay.ang.php
-  angular.module('crmSearchDisplay', ['api4', 'ngSanitize']);
+  // This will include all viewable display types. See Civi\Search\AngularDependencyInjector.
+  angular.module('crmSearchDisplay', CRM.angRequires('crmSearchDisplay'));
 
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes Subsearch displays not showing when they are a different type than the parent display (e.g. a List embedded in a Table).

Technical Details
----------------------------------------
I had tried to avoid doing this in fa5407b8 but it didn't work.

Apparently it's not enough to just load the javascript, you have to require the modules for AngularJS to load them.

Technically this creates a circular dependency where e.g. crmSearchDisply and crmSearchDisplayTable both require each other. But it doesn't seem to be a problem because they both get loaded, so the dependency is met.