### PR TITLE
Refactor is_full / freezeOptions in event registrations

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -915,10 +915,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
   /**
    * Get the array of price field value IDs on the form that 'count' as
-   * full.
-   *
-   * The criteria for full is slightly confusing as it has an exclusion around
-   * select fields if they are the default - or something...
+   * full, which will be frozen.
    *
    * @param array $field
    *
@@ -936,12 +933,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
-   * Is the option a 'full ID'.
+   * Should we disable this option because it is full?
    *
-   * It is not clear why this is different to the is_full calculation
-   * but it is used in a less narrow context, around validation.
-   *
-   * Ideally figure it out & update this doc block.
+   * We don't disable the option if the user has already selected it.
    *
    * @param array $option
    * @param array $field
@@ -950,62 +944,23 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   private function isOptionFullID(array $option, array $field) : bool {
-    $fieldId = $option['price_field_id'];
-    $currentParticipantNo = (int) substr($this->_name, 12);
-    $defaultPricefieldIds = [];
-    if (!empty($this->_values['line_items'])) {
-      foreach ($this->_values['line_items'] as $lineItem) {
-        $defaultPricefieldIds[] = $lineItem['price_field_value_id'];
-      }
-    }
-    $formattedPriceSetDefaults = [];
-    if (!empty($this->_allowConfirmation) && (isset($this->_pId) || isset($this->_additionalParticipantId))) {
-      $participantId = $this->_pId ?? $this->_additionalParticipantId;
-      $pricesetDefaults = CRM_Event_Form_EventFees::setDefaultPriceSet($participantId,
-        $this->getEventID()
-      );
-      // modify options full to respect the selected fields
-      // options on confirmation.
-      $formattedPriceSetDefaults = self::formatPriceSetParams($this, $pricesetDefaults);
-    }
-
-    //get the current price event price set options count.
-    $currentOptionsCount = $this->getPriceSetOptionCount();
-    $optId = $option['id'];
-    $count = $option['count'] ?? 0;
-    $currentTotalCount = $currentOptionsCount[$optId] ?? 0;
-    $isOptionFull = FALSE;
-    $totalCount = $currentTotalCount + $this->getUsedSeatsCount($optId);
-    if ($option['max_value'] &&
-      (($totalCount >= $option['max_value']) &&
-        (empty($this->_lineItem[$currentParticipantNo][$optId]['price_field_id']) || $this->getUsedSeatsCount($optId) >= $option['max_value']))
-    ) {
-      $isOptionFull = TRUE;
-      if ($field['html_type'] === 'Select') {
-        if (!empty($defaultPricefieldIds) && in_array($optId, $defaultPricefieldIds)) {
-          $isOptionFull = FALSE;
+    $optionFull = $this->getIsOptionFull($option);
+    if ($optionFull && $field['html_type'] === 'Select') {
+      $defaultPricefieldIds = [];
+      if (!empty($this->_values['line_items'])) {
+        foreach ($this->_values['line_items'] as $lineItem) {
+          $defaultPricefieldIds[] = $lineItem['price_field_value_id'];
         }
       }
-    }
-    //here option is not full,
-    //but we don't want to allow participant to increase
-    //seats at the time of re-walking registration.
-    if ($count &&
-      !empty($this->_allowConfirmation) &&
-      !empty($formattedPriceSetDefaults)
-    ) {
-      if (empty($formattedPriceSetDefaults["price_{$fieldId}"]) || empty($formattedPriceSetDefaults["price_{$fieldId}"][$optId])) {
-        $isOptionFull = TRUE;
+      if (in_array($option['id'], $defaultPricefieldIds)) {
+        $optionFull = FALSE;
       }
     }
-    return $isOptionFull;
+    return $optionFull;
   }
 
   /**
-   * Should this option be disabled on the basis of being full.
-   *
-   * Note there is another full calculation that is slightly different for
-   * ... reasons? When we figure out what those are we can update this.
+   * Is this option full?
    *
    * @param array $option
    *
@@ -1015,40 +970,18 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   protected function getIsOptionFull(array $option): bool {
     $isFull = FALSE;
     $currentParticipantNo = (int) substr($this->_name, 12);
-    $formattedPriceSetDefaults = [];
     $maxValue = $option['max_value'] ?? 0;
     $priceFieldValueID = $option['id'];
     //get the current price event price set options count.
     $currentOptionsCount = $this->getPriceSetOptionCount();
     $currentTotalCount = $currentOptionsCount[$priceFieldValueID] ?? 0;
-
     $totalCount = $currentTotalCount + $this->getUsedSeatsCount($priceFieldValueID);
-    if (!empty($form->_allowConfirmation) && (isset($form->_pId) || isset($form->_additionalParticipantId))) {
-      $participantId = $form->_pId ?? $form->_additionalParticipantId;
-      $pricesetDefaults = CRM_Event_Form_EventFees::setDefaultPriceSet($participantId,
-        $this->getEventID()
-      );
-      // modify options full to respect the selected fields
-      // options on confirmation.
-      $formattedPriceSetDefaults = self::formatPriceSetParams($form, $pricesetDefaults);
-    }
-    $count = $option['count'] ?? 0;
+
     if ($maxValue &&
       (($totalCount >= $maxValue) &&
         (empty($this->_lineItem[$currentParticipantNo][$priceFieldValueID]['price_field_id']) || $this->getUsedSeatsCount($priceFieldValueID) >= $maxValue))
     ) {
       $isFull = TRUE;
-    }
-    //here option is not full,
-    //but we don't want to allow participant to increase
-    //seats at the time of re-walking registration.
-    if ($count &&
-      !empty($this->_allowConfirmation) &&
-      !empty($formattedPriceSetDefaults)
-    ) {
-      if (empty($formattedPriceSetDefaults["price_{$option['price_field_id']}"]) || empty($formattedPriceSetDefaults["price_{$option['price_field_id']}"][$priceFieldValueID])) {
-        $isFull = TRUE;
-      }
     }
     return $isFull;
   }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -192,21 +192,6 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
   }
 
   /**
-   * Freeze price option if full and on front end
-   *
-   * @param $element
-   * @param $fieldOptions
-   *
-   * @return null
-   */
-  public static function freezeIfEnabled(&$element, $fieldOptions) {
-    if ((!empty($fieldOptions['is_full'])) && CRM_Utils_System::isFrontendPage()) {
-      $element->freeze();
-    }
-    return NULL;
-  }
-
-  /**
    * Get the field title.
    *
    * @param int $id
@@ -330,7 +315,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         // CRM-6902 - Add "max" option for a price set field
         if (in_array($optionKey, $freezeOptions)) {
-          self::freezeIfEnabled($element, $fieldOptions[$optionKey]);
+          if (CRM_Utils_System::isFrontendPage()) {
+            $element->freeze();
+          }
           // CRM-14696 - Improve display for sold out price set options
           $elementLabelAfter->setLabel('<span class="sold-out-option">' . $elementLabelAfter->getLabel() . '&nbsp;(' . ts('Sold out') . ')</span>');
         }
@@ -410,7 +397,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $radioElement->setTextEscaped();
           // CRM-6902 - Add "max" option for a price set field
           if (in_array($radioElement->getValue(), $freezeOptions)) {
-            self::freezeIfEnabled($radioElement, $customOption[$radioElement->getValue()]);
+            if (CRM_Utils_System::isFrontendPage()) {
+              $radioElement->freeze();
+            }
             // CRM-14696 - Improve display for sold out price set options
             $radioElement->setText('<span class="sold-out-option">' . $radioElement->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
           }
@@ -503,7 +492,9 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           }
           // CRM-6902 - Add "max" option for a price set field
           if (in_array($opId, $freezeOptions)) {
-            self::freezeIfEnabled($check[$opId], $customOption[$opId]);
+            if (CRM_Utils_System::isFrontendPage()) {
+              $check[$opId]->freeze();
+            }
             // CRM-14696 - Improve display for sold out price set options
             $check[$opId]->setText('<span class="sold-out-option">' . $check[$opId]->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
           }


### PR DESCRIPTION
Overview
----------------------------------------
No change in behaviour.
This was, as the notes indicated, kind of confusing.

Note that in order to actually freeze a form element, it had to both be in $freezeOptions and is_full, so both isOptionFullID and getIsOptionFull had to be true (except for selects, which didn't check is_full).

I have removed the code that froze price options when re-walking the form:

1. It has been non-functional for the last two years, because getIsOptionFull did not work for this as it used $form where it should have used $this.
2. I tried it out and I can't find any way by going back and forth to get the registration form to allow me to select a sold out option that is selected by another of the participants.

So I think it was fixed in some other way in the interim. The only possible change would be for selects in any case.

And it should now be clear that if isOptionFullID is true, then getIsOptionFull must also be true, so any option in $optionFullIds/$freezeOptions must be is_full, so we don't need to check it when freezing price options. 

This is an intermediate step, I can get rid of isOptionFullID entirely in the next step, but thought it was easier to understand by leaving it in for now.