### PR TITLE
Fix fatal type error on authx with invalid cred.

### DIFF
--- a/ext/authx/Civi/Authx/CheckCredentialEvent.php
+++ b/ext/authx/Civi/Authx/CheckCredentialEvent.php
@@ -67,7 +67,7 @@ class CheckCredentialEvent extends \Civi\Core\Event\GenericHookEvent {
    *   For stateful HTTP session or CLI pipe, that's a wildcard.
    */
   public function __construct(string $cred, string $requestPath) {
-    [$this->credFormat, $this->credValue] = explode(' ', $cred, 2);
+    [$this->credFormat, $this->credValue] = explode(' ', "$cred ", 2);
     $this->requestPath = $requestPath;
   }
 


### PR DESCRIPTION
This is the same pattern of problem as https://github.com/civicrm/civicrm-core/pull/35221 (use of `explode` with an assumption that the separator exists in the input when it might not).


@ufundo 
