### PR TITLE
SearchKit - Simplify using crmSearchDisplay component.

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplay.component.js
@@ -11,7 +11,7 @@
       settings: '<',
       filters: '<',
     },
-    template: function($element) {
+    template: () => {
       let html = '';
       const displayTypes = CRM.crmSearchDisplay.viewableDisplayTypes;
       Object.entries(displayTypes).forEach(([type, directive]) => {
@@ -19,7 +19,36 @@
       });
       return html;
     },
-    controller: function($scope, $element) {
+    controller: function($scope, crmApi4) {
+
+      this.$onInit = () => {
+        // Load display settings if not supplied by e.g. AfformSearchMetadataInjector
+        if (!this.settings || !this.apiEntity || !this.type) {
+          const apiCalls = {
+            search: ['SavedSearch', 'get', {
+              select: ['id', 'name', 'api_entity'],
+              where: [['name', '=', this.search]],
+            }, 0],
+          };
+          if (this.display) {
+            apiCalls.display = ['SearchDisplay', 'get', {
+              select: ['type', 'settings'],
+              where: [['name', '=', this.display], ['saved_search_id.name', '=', this.search]],
+            }, 0];
+          } else {
+            apiCalls.display = ['SearchDisplay', 'getDefault', {
+              select: ['type', 'settings'],
+              savedSearch: this.search,
+            }, 0];
+          }
+          crmApi4(apiCalls).then((result) => {
+            this.apiEntity = result.search.api_entity;
+            this.settings = result.display.settings;
+            this.type = result.display.type;
+          });
+        }
+      };
+
     }
 
   });

--- a/ext/search_kit/ang/crmSearchPage.module.js
+++ b/ext/search_kit/ang/crmSearchPage.module.js
@@ -9,47 +9,38 @@
       $routeProvider.when('/display/:savedSearchName/:displayName?', {
         controller: 'crmSearchPageDisplay',
         templateUrl: '~/crmSearchPage/crmSearchPage.html',
-        resolve: {
-          // Load saved search display
-          info: function($route, crmApi4) {
-            const params = $route.current.params;
-            const apiCalls = {
-              search: ['SavedSearch', 'get', {
-                select: ['id', 'name', 'api_entity'],
-                where: [['name', '=', params.savedSearchName]],
-                chain: {
-                  checkAccess: ['SavedSearch', 'checkAccess', {action: 'update', values: {id: '$id'}}, 0],
-                },
-              }, 0],
-            };
-            if (params.displayName) {
-              apiCalls.display = ['SearchDisplay', 'get', {
-                where: [['name', '=', params.displayName], ['saved_search_id.name', '=', params.savedSearchName]],
-              }, 0];
-            } else {
-              apiCalls.display = ['SearchDisplay', 'getDefault', {
-                savedSearch: params.savedSearchName,
-              }, 0];
-            }
-            return crmApi4(apiCalls);
-          }
-        }
       });
     })
 
     // Controller for displaying a search
-    .controller('crmSearchPageDisplay', function($scope, $location, info) {
+    .controller('crmSearchPageDisplay', function($scope, $location, $route, $timeout, crmApi4) {
       const ctrl = $scope.$ctrl = this;
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
-      this.display = info.display;
-      this.searchName = info.search.name;
-      this.apiEntity = info.search.api_entity;
-      // Format edit link if user has access
-      this.editLink = info.search.checkAccess.access ? CRM.url('civicrm/admin/search#/edit/' + info.search.id) : false;
 
-      $scope.$watch(function() {return $location.search();}, function(params) {
-        ctrl.filters = params;
-      });
+      const routeParams = $route.current.params;
+
+      // The crmSearchDisplay component will take care of loading & running the search.
+      this.searchName = routeParams.savedSearchName;
+      this.displayName = routeParams.displayName;
+
+      // Check access for edit link. Defer via $timeout because this is lower priority than the search itself.
+      $timeout(() => {
+        crmApi4('SavedSearch', 'get', {
+          select: ['id'],
+          where: [['name', '=', this.searchName]],
+          chain: {
+            checkAccess: ['SavedSearch', 'checkAccess', {action: 'update', values: {id: '$id'}}, 0],
+          },
+        }, 0)
+          .then((result) => {
+            // Format edit link if user has access
+            if (result.checkAccess?.access) {
+              this.editLink = CRM.url('civicrm/admin/search#/edit/' + result.id);
+            }
+          });
+      }, 500);
+
+      $scope.$watch(() => $location.search(), (params) => this.filters = params);
     });
 
 })(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchPage/crmSearchPage.html
+++ b/ext/search_kit/ang/crmSearchPage/crmSearchPage.html
@@ -3,5 +3,5 @@
   <div class="pull-right btn-group" ng-if="$ctrl.editLink">
     <a class="btn btn-sm" ng-href="{{:: $ctrl.editLink }}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i> {{:: ts("Edit Search") }}</a>
   </div>
-  <crm-search-display type="{{:: $ctrl.display.type }}" api-entity="{{:: $ctrl.apiEntity }}" search="$ctrl.searchName" display="$ctrl.display.name" settings="$ctrl.display.settings" filters="$ctrl.filters"></crm-search-display>
+  <crm-search-display search="$ctrl.searchName" display="$ctrl.displayName" filters="$ctrl.filters"></crm-search-display>
 </form>


### PR DESCRIPTION
Overview
----------------------------------------
Improves developer experience, makes it easier to embed SearchKit displays anywhere.

Before
----------------------------------------
All settings metadata needed to be pre-loaded to run a search display. This was handled by `Civi\Api4\Action\SearchDisplay\GetMarkup` or `Civi\Search\AfformSearchMetadataInjector::preprocess`.

After
----------------------------------------

The only required parameter is the name of the search, and the name of the display if using one:

```html
<crm-search-display search="'myCoolSavedSearch'" display="'myGreatDisplay'">
```

Or if using the default display, this is all that's needed:

```html
<crm-search-display search="'myCoolSavedSearch'">
```

Technical Details
----------------------------------------
Basically takes the logic from `crmSearchPage.module.js` and moves it over to `crmSearchDisplay.component.js` for better reusability.

This allows crmSearchDisplay to be used by itself without any reliance on `AfformSearchMetadataInjector`.

Comments
---------
This was a dream of yours @ufundo.

Note this only works on the backend. Frontend users still won't have access to `SearchDisplay.get` api.