### PR TITLE
Api4 - Allow calling checkAccess with name instead of id.

### DIFF
--- a/Civi/Api4/Generic/CheckAccessAction.php
+++ b/Civi/Api4/Generic/CheckAccessAction.php
@@ -42,14 +42,37 @@ class CheckAccessAction extends AbstractAction {
    * @param \Civi\Api4\Generic\Result $result
    */
   public function _run(Result $result) {
+    $entityName = $this->getEntityName();
+    $idField = CoreUtil::getIdFieldName($entityName);
+    $record = $this->values;
+
+    // Attempt to look up record by name if id is not supplied.
+    if (!isset($record[$idField]) && isset($record['name'])) {
+      try {
+        $record[$idField] = civicrm_api4($entityName, 'get', [
+          'checkPermissions' => FALSE,
+          'select' => [$idField],
+          'where' => [['name', '=', $record['name']]],
+        ])->single()[$idField];
+      }
+      catch (\CRM_Core_Exception $e) {
+      }
+    }
+
     // Prevent circular checks
     if ($this->action === 'checkAccess') {
       $granted = TRUE;
     }
     else {
-      $granted = CoreUtil::checkAccessDelegated($this->getEntityName(), $this->action, $this->values, \CRM_Core_Session::getLoggedInContactID() ?: 0);
+      $granted = CoreUtil::checkAccessDelegated($entityName, $this->action, $record, \CRM_Core_Session::getLoggedInContactID() ?: 0);
     }
-    $result->exchangeArray([['access' => $granted]]);
+    $result->exchangeArray([
+      [
+        'access' => $granted,
+        // Only return id if access was granted.
+        $idField => isset($record[$idField]) && $granted ? $record[$idField] : NULL,
+      ],
+    ]);
   }
 
   /**

--- a/ext/search_kit/ang/crmSearchPage.module.js
+++ b/ext/search_kit/ang/crmSearchPage.module.js
@@ -25,19 +25,15 @@
 
       // Check access for edit link. Defer via $timeout because this is lower priority than the search itself.
       $timeout(() => {
-        crmApi4('SavedSearch', 'get', {
-          select: ['id'],
-          where: [['name', '=', this.searchName]],
-          chain: {
-            checkAccess: ['SavedSearch', 'checkAccess', {action: 'update', values: {id: '$id'}}, 0],
-          },
-        }, 0)
-          .then((result) => {
-            // Format edit link if user has access
-            if (result.checkAccess?.access) {
-              this.editLink = CRM.url('civicrm/admin/search#/edit/' + result.id);
-            }
-          });
+        crmApi4('SavedSearch', 'checkAccess', {
+          action: 'update',
+          values: {name: this.searchName},
+        }, 0).then((result) => {
+          // Format edit link if user has access
+          if (result?.access) {
+            this.editLink = CRM.url('civicrm/admin/search#/edit/' + result.id);
+          }
+        });
       }, 500);
 
       $scope.$watch(() => $location.search(), (params) => this.filters = params);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -998,8 +998,31 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       ->addValue('label', 'Test Display')
       ->execute();
 
+    $checkAccess = SavedSearch::checkAccess()
+      ->addValue('name', $searchName)
+      ->setAction('update')
+      ->execute()->single();
+    $this->assertTrue($checkAccess['access']);
+    $this->assertSame($search['id'], $checkAccess['id']);
+
+    $checkAccess = SearchDisplay::checkAccess()
+      ->addValue('name', $displayName)
+      ->setAction('update')
+      ->execute()->single();
+    $this->assertTrue($checkAccess['access']);
+    $this->assertSame($search['display'][0]['id'], $checkAccess['id']);
+
     $config->userPermissionClass->permissions = ['administer CiviCRM'];
+
     // Ordinary admin may not edit display because it has acl_bypass
+
+    $checkAccess = SearchDisplay::checkAccess()
+      ->addValue('name', $displayName)
+      ->setAction('update')
+      ->execute()->single();
+    $this->assertFalse($checkAccess['access']);
+    $this->assertNull($checkAccess['id']);
+
     $error = NULL;
     try {
       SearchDisplay::update()->addWhere('name', '=', $displayName)
@@ -1024,6 +1047,14 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertStringContainsString('failed', $error);
 
     // Ordinary admin may not edit the search because the display has acl_bypass
+
+    $checkAccess = SavedSearch::checkAccess()
+      ->addValue('name', $searchName)
+      ->setAction('update')
+      ->execute()->single();
+    $this->assertFalse($checkAccess['access']);
+    $this->assertNull($checkAccess['id']);
+
     $error = NULL;
     try {
       SavedSearch::update()->addWhere('name', '=', $searchName)


### PR DESCRIPTION
Overview
----------------------------------------
Improves the Api4 CheckAccess action.

Technical Details
----------------------------------------
Simplifies things on the caller side when given an entity name.