### PR TITLE
Translation.source_key - ensure FK exists and collation matches target

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -92,6 +92,7 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'required' => TRUE,
     ]);
     $this->addTask('Replace TranslationSource "index_source_key" with "UI_source_key"', 'replaceTranslationSourceIndex');
+    $this->addTask('Ensure TranslationSource.source_key foreign key constraint exists', 'ensureTranslationSourceForeignKey');
   }
 
   /**
@@ -100,6 +101,45 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
   public static function replaceTranslationSourceIndex() {
     \CRM_Core_BAO_SchemaHandler::createMissingIndices(CRM_Core_BAO_SchemaHandler::getMissingIndices(FALSE, ['civicrm_translation_source']));
     \CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_translation_source', 'index_source_key');
+    return TRUE;
+  }
+
+  /**
+   * Constraint likely not have been created in 6.7 upgrader -
+   * may also have collation issues
+   */
+  public static function ensureTranslationSourceForeignKey($ctx) {
+    // drop any existing constraint so we can update collations
+    CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_translation', 'FK_civicrm_translation_source_key');
+
+    // ensure matching character sets + collations on the two fields
+    // Q: why do we use ascii rather than standard utf8?
+    $sqlType = 'char(22) CHARACTER SET ascii COLLATE ascii_general_ci';
+
+    self::alterSchemaField($ctx, 'Translation', 'source_key', [
+      'title' => ts('Source Key'),
+      'input_type' => 'Text',
+      'sql_type' => $sqlType,
+      'required' => FALSE,
+      'description' => ts('Alternate FK when using translation_source instead of entity_table / entity_id'),
+    ]);
+
+    self::alterSchemaField($ctx, 'TranslationSource', 'source_key', [
+      'title' => ts('Source Key'),
+      'sql_type' => $sqlType,
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('hash(source)'),
+    ]);
+
+    $sql = CRM_Core_BAO_SchemaHandler::buildForeignKeySQL([
+      'fk_table_name' => 'civicrm_translation_source',
+      'fk_field_name' => 'source_key',
+      'name' => 'source_key',
+      'fk_attributes' => ' ON DELETE CASCADE',
+    ], "\n", " ADD ", 'civicrm_translation');
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_translation " . $sql, [], TRUE, NULL, FALSE, FALSE);
+
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -132,6 +132,13 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
       'description' => ts('hash(source)'),
     ]);
 
+    self::alterSchemaField($ctx, 'TranslationSource', 'context_key', [
+      'title' => ts('Context Key'),
+      'sql_type' => $sqlType,
+      'required' => TRUE,
+      'description' => ts('hash(entity_name,entity_id,entity_field,entity)'),
+    ]);
+
     $sql = CRM_Core_BAO_SchemaHandler::buildForeignKeySQL([
       'fk_table_name' => 'civicrm_translation_source',
       'fk_field_name' => 'source_key',

--- a/CRM/Upgrade/Incremental/php/SixSeven.php
+++ b/CRM/Upgrade/Incremental/php/SixSeven.php
@@ -37,11 +37,13 @@ class CRM_Upgrade_Incremental_php_SixSeven extends CRM_Upgrade_Incremental_Base 
       'required' => FALSE,
       'description' => ts('Alternate FK when using translation_source instead of entity_table / entity_id'),
       'add' => '6.7.alpha1',
-      'entity_reference' => [
-        'entity' => 'TranslationSource',
-        'key' => 'source_key',
-        'on_delete' => 'CASCADE',
-      ],
+      // as of 6.14 this is not picked up by EFv2 during upgrades
+      // so commenting for clarity
+      // 'entity_reference' => [
+      //   'entity' => 'TranslationSource',
+      //   'key' => 'source_key',
+      //   'on_delete' => 'CASCADE',
+      // ],
     ]);
     $this->addTask(ts('Create index %1', [1 => 'civicrm_translation.index_source_key']), 'addIndex', 'civicrm_translation', 'source_key');
     $this->addTask('Update localization menu item', 'updateLocalizationMenuItem');

--- a/schema/Core/Translation.entityType.php
+++ b/schema/Core/Translation.entityType.php
@@ -111,7 +111,9 @@ return [
     'source_key' => [
       'title' => ts('Source Key'),
       'input_type' => 'Text',
-      'sql_type' => 'char(22) CHARACTER SET ascii',
+      // NOTE: set to match TranslationSource.source_key
+      // Q: why is this character set / collation preferred over standard uf8?
+      'sql_type' => 'char(22) CHARACTER SET ascii COLLATE ascii_general_ci',
       'required' => FALSE,
       'description' => ts('Alternate FK when using translation_source instead of entity_table / entity_id'),
       'add' => '6.7.alpha1',

--- a/schema/Core/TranslationSource.entityType.php
+++ b/schema/Core/TranslationSource.entityType.php
@@ -82,7 +82,9 @@ return [
     ],
     'source_key' => [
       'title' => ts('Source Key'),
-      'sql_type' => 'char(22) CHARACTER SET ascii',
+      // NOTE: set to match Translation.source_key
+      // Q: why is this character set / collation preferred over standard uf8?
+      'sql_type' => 'char(22) CHARACTER SET ascii COLLATE ascii_general_ci',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('hash(source)'),

--- a/schema/Core/TranslationSource.entityType.php
+++ b/schema/Core/TranslationSource.entityType.php
@@ -67,7 +67,9 @@ return [
     ],
     'context_key' => [
       'title' => ts('Context Key'),
-      'sql_type' => 'char(22) CHARACTER SET ascii',
+      // NOTE: set to match source_key
+      // Q: why is this character set / collation preferred over standard uf8?
+      'sql_type' => 'char(22) CHARACTER SET ascii COLLATE ascii_general_ci',
       'required' => TRUE,
       'description' => ts('hash(entity_name,entity_id,entity_field,entity)'),
       'add' => '6.7.alpha1',


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/33756

Ensure the foreign key from Translation.source_key => TranslationSource.source_key is actually created. To do so, ensure collations match.

Before
----------------------------------------
- foreign key exists on fresh installs > 6.7
- no foreign key created on upgrade
- inconsistent collations on these fields in the wild

After
----------------------------------------
- foreign key for all
- consistent collation for all

Technical Details
----------------------------------------
I'm not sure of the rationale behind using `ascii` character set here, but I think it follows that we need `ascii_general_ci` collation. This needs to be matched on both fields to ensure we can create the key.
