### PR TITLE
CRM_Utils_System - Use array_pad to pad an array

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1036,10 +1036,7 @@ class CRM_Utils_System {
    */
   public static function explode($separator, $string, $limit) {
     $result = explode($separator, ($string ?? ''), $limit);
-    for ($i = count($result); $i < $limit; $i++) {
-      $result[$i] = NULL;
-    }
-    return $result;
+    return array_pad($result, $limit, NULL);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Small code refactor: instead of using a loop to pad an array, use `array_pad`, that's what it's for.