### PR TITLE
SearchKit - Move admin edit link to the bottom and style dropups

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -98,11 +98,11 @@ class AfformAdminInjector extends AutoSubscriber {
             HTML;
           }
           $editMenu = <<<HTML
-            <div class="pull-right btn-group af-admin-edit-form-link" ng-if="checkLinkPerm('{$links[0]['permission']}', {$links[0]['created_id']})">
+            <div class="btn-group crm-admin-block-context-dropdown dropup" ng-if="checkLinkPerm('{$links[0]['permission']}', {$links[0]['created_id']})">
               <button type="button" class="btn dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <i class="crm-i fa-gear" role="img" aria-hidden="true"></i> <span class="caret"></span><span class="sr-only">{{:: ts('Configure')}}</span>
               </button>
-              <ul class="dropdown-menu">$linksMarkup</ul>
+              <ul class="dropdown-menu dropdown-menu-right">$linksMarkup</ul>
             </div>
           HTML;
           // Append link to end of afform markup so it has the highest z-index and is clickable.

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -93,36 +93,6 @@ details.af-container.af-layout-inline > *:not(summary) {
   margin-top: 0;
 }
 
-/* Admin edit links */
-#bootstrap-theme .afform-directive:has(> .af-admin-edit-form-link) .crm-search-display {
-  padding-top: 0.5rem;
-}
-#bootstrap-theme .afform-directive .af-admin-edit-form-link {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-}
-#bootstrap-theme .af-admin-edit-form-link > button {
-  background: transparent;
-  color: var(--crm-text-color, black);
-  border-radius: 2rem;
-  height: inherit;
-  padding: 0 !important;
-  border: 0;
-  opacity: 0.6;
-}
-#bootstrap-theme .af-admin-edit-form-link.open button,
-#bootstrap-theme .af-admin-edit-form-link button:hover,
-#bootstrap-theme .af-admin-edit-form-link button:focus {
-  background: transparent;
-  color: var(--crm-text-color, black);
-  opacity: 1;
-  box-shadow: none !important; /* vs dropdown-toggle */
-}
-#bootstrap-theme .af-admin-edit-form-link > button .crm-i {
-  padding: 0;
-  border: 0;
-}
 /* Fieldset */
 
 fieldset.af-container.af-layout-inline {

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -100,7 +100,7 @@ details.af-container.af-layout-inline > *:not(summary) {
 #bootstrap-theme .afform-directive .af-admin-edit-form-link {
   position: absolute;
   right: 0;
-  top: 0;
+  bottom: 0;
 }
 #bootstrap-theme .af-admin-edit-form-link > button {
   background: transparent;

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -133,6 +133,13 @@
   right: var(--crm-l-reg);
   left: auto;
 }
+.crm-container .btn-group.dropup .dropdown-menu-right::before,
+.crm-container .btn-group.pull-right.dropup .dropdown-menu::before {
+  top: auto;
+  bottom: -5px;
+  border-top: 5px solid var(--crm-dropdown-bg-color);
+  border-bottom: none;
+}
 .crm-container .btn-slide ul.panel li {
   padding: var(--crm-dropdown-padding);
   list-style: none;
@@ -150,6 +157,30 @@
 .crm-container .btn-slide ul.panel li a:focus {
   color: var(--crm-dropdown-hover-text-color);
   background-color: var(--crm-dropdown-hover-bg-color);
+}
+
+/* Admin dropdown links for editing a content block (e.g. an Afform or a Search Display) */
+#bootstrap-theme .crm-admin-block-context-dropdown {
+  position: absolute;
+  right: 0;
+  bottom: 1rem;
+}
+#bootstrap-theme .crm-admin-block-context-dropdown > button {
+  background: transparent;
+  color: var(--crm-text-color, black);
+  border-radius: 2rem;
+  height: inherit;
+  padding: 0 !important;
+  border: 0;
+  opacity: 0.6;
+}
+#bootstrap-theme .crm-admin-block-context-dropdown.open button,
+#bootstrap-theme .crm-admin-block-context-dropdown button:hover,
+#bootstrap-theme .crm-admin-block-context-dropdown button:focus {
+  background: transparent;
+  color: var(--crm-text-color, black);
+  opacity: 1;
+  box-shadow: none !important; /* vs dropdown-toggle */
 }
 
 /* Tooltip - contact dashboard/contact search */
@@ -353,13 +384,8 @@
   right: 0;
   left: auto;
 }
-.crm-container .dropup .caret,
-.crm-container .navbar-fixed-bottom .dropdown .caret {
-  content: "";
-  border-top: 0;
-  border-bottom: 4px dashed;
-}
 .crm-container .dropup .dropdown-menu,
+.crm-container .dropup .btn.dropdown-toggle + .dropdown-menu,
 .crm-container .navbar-fixed-bottom .dropdown .dropdown-menu {
   top: auto;
   bottom: 100%;

--- a/ext/riverlea/core/css/components/_tabs.css
+++ b/ext/riverlea/core/css/components/_tabs.css
@@ -142,6 +142,10 @@
   border: var(--crm-contact-panel-border);
   border-radius: var(--crm-contact-panel-radius);
 }
+#mainTabContainer .crm-contact-tabs-list ~ .ui-tabs-panel .afform-directive {
+  /* Allow the crm-admin-block-context-dropdown widget to go all the way to the bottom of the tab */
+  position: initial;
+}
 .crm-contact-page #mainTabContainer .crm-contact-tabs-list li {
   background: var(--crm-contact-tab-bg-color);
   margin: var(--crm-contact-tab-hang);

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -2,6 +2,11 @@
    Forked on 19 July 24. Called on SearchKit pages
    Status: merged */
 
+form.crm-search-display-page {
+  /* For positioning the .crm-admin-block-context-dropdown button */
+  position: relative;
+}
+
 /* Sortable headers */
 .crm-search-display th.crm-sortable-col {
   cursor: var(--crm-link-hover-cursor);

--- a/ext/search_kit/ang/crmSearchPage/crmSearchPage.html
+++ b/ext/search_kit/ang/crmSearchPage/crmSearchPage.html
@@ -1,7 +1,17 @@
 <h1 crm-page-title>{{:: $ctrl.display.label }}</h1>
-<form id="bootstrap-theme">
-  <div class="pull-right btn-group" ng-if="$ctrl.editLink">
-    <a class="btn btn-sm" ng-href="{{:: $ctrl.editLink }}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i> {{:: ts("Edit Search") }}</a>
-  </div>
+<form id="bootstrap-theme" class="crm-search-display-page">
   <crm-search-display search="$ctrl.searchName" display="$ctrl.displayName" filters="$ctrl.filters"></crm-search-display>
+  <!-- Admin Edit Link -->
+  <div class="btn-group dropup crm-admin-block-context-dropdown" ng-if="$ctrl.editLink">
+    <button type="button" class="btn dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <i class="crm-i fa-gear" role="img" aria-hidden="true"></i>
+      <span class="sr-only">{{:: ts('Configure')}}</span>
+      <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-right">
+      <li>
+        <a ng-href="{{:: $ctrl.editLink }}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i> {{:: ts("Edit in SearchKit") }}</a>
+      </li>
+    </ul>
+  </div>
 </form>

--- a/templates/CRM/Contact/Form/Contact.tpl
+++ b/templates/CRM/Contact/Form/Contact.tpl
@@ -15,10 +15,7 @@
     {include file="CRM/Contact/Form/Edit/Lock.tpl"}
   {/if}
   <div class="crm-form-block crm-search-form-block">
-    {crmPermission has='administer CiviCRM'}
-      <a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts escape='htmlattribute'}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" role="img" aria-hidden="true"></i></a>
-    {/crmPermission}
-    <span style="float:right;"><a href="#expand" id="expand">{ts}Expand all tabs{/ts}</a></span>
+    <span class="float-right"><a href="#expand" id="expand">{ts}Expand all tabs{/ts}</a></span>
     <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="top"}
     </div>
@@ -90,6 +87,9 @@
     <div class="crm-submit-buttons">
     {include file="CRM/common/formButtons.tpl" location="bottom"}
     </div>
+    {crmPermission has='administer CiviCRM'}
+      <span class="float-right"><a href='{crmURL p="civicrm/admin/setting/preferences/display" q="reset=1"}' title="{ts escape='htmlattribute'}Click here to configure the panes.{/ts}"><i class="crm-i fa-wrench" role="img" aria-hidden="true"></i></a></span>
+    {/crmPermission}
   </div>
   {literal}
 


### PR DESCRIPTION
Overview
----------------------------------------
Moves all SearchKit and FormBuilder admin links to the bottom. Fixes Riverlea styling of "dropup" menus.

### In a Popup

<img width="1129" height="795" alt="image" src="https://github.com/user-attachments/assets/7d4d8278-38dd-47cc-86fb-58ac79bde31f" />

### On an Afform

<img width="1221" height="854" alt="image" src="https://github.com/user-attachments/assets/456db3d6-0adb-49bb-b4a4-72e7dbe4412e" />

### In a tab

<img width="1342" height="547" alt="image" src="https://github.com/user-attachments/assets/2aede179-e408-4dd3-ab34-bd56b817ca37" />

### On the standalone "View Results" page

<img width="958" height="416" alt="image" src="https://github.com/user-attachments/assets/054837c5-d2b2-4c42-b8f6-39de9e46a233" />
