### PR TITLE
Set default location type for new email, etc blocks on contact summary

### DIFF
--- a/CRM/Contact/Form/Inline.php
+++ b/CRM/Contact/Form/Inline.php
@@ -136,6 +136,32 @@ abstract class CRM_Contact_Form_Inline extends CRM_Core_Form {
   }
 
   /**
+   * Build default values for a repeated block inline form (email, phone, im, openid, website).
+   *
+   * Populates defaults from existing values and sets the default location type id on hidden empty blocks.
+   *
+   * @param array $blocks Existing saved blocks, keyed 1-n.
+   * @param string $key Field key (e.g. 'email', 'phone').
+   * @param int $blockCount Total number of blocks to fill.
+   * @param int $defaultLocationTypeId Default location type ID for hidden empty blocks.
+   *
+   * @return array
+   */
+  protected function setBlockDefaultValues(array $blocks, string $key, int $blockCount, int $defaultLocationTypeId): array {
+    $defaults = [];
+    foreach ($blocks as $id => $value) {
+      $defaults[$key][$id] = $value;
+    }
+    $defaultTypeKey = ($key === 'website') ? 'website_type_id' : 'location_type_id';
+    for ($i = 1; $i <= $blockCount; $i++) {
+      if (empty($defaults[$key][$i])) {
+        $defaults[$key][$i][$defaultTypeKey] = $defaultLocationTypeId;
+      }
+    }
+    return $defaults;
+  }
+
+  /**
    * Add entry to log table.
    */
   protected function log() {

--- a/CRM/Contact/Form/Inline/Email.php
+++ b/CRM/Contact/Form/Inline/Email.php
@@ -141,18 +141,7 @@ class CRM_Contact_Form_Inline_Email extends CRM_Contact_Form_Inline {
    * @return array
    */
   public function setDefaultValues() {
-    $defaults = [];
-    if (!empty($this->_emails)) {
-      foreach ($this->_emails as $id => $value) {
-        $defaults['email'][$id] = $value;
-      }
-    }
-    else {
-      // get the default location type
-      $defaults['email'][1]['location_type_id'] = CRM_Core_BAO_LocationType::getDefault()->id;
-    }
-
-    return $defaults;
+    return $this->setBlockDefaultValues($this->_emails, 'email', $this->_blockCount, CRM_Core_BAO_LocationType::getDefault()->id);
   }
 
   /**

--- a/CRM/Contact/Form/Inline/IM.php
+++ b/CRM/Contact/Form/Inline/IM.php
@@ -127,18 +127,7 @@ class CRM_Contact_Form_Inline_IM extends CRM_Contact_Form_Inline {
    * @return array
    */
   public function setDefaultValues(): array {
-    $defaults = [];
-    if (!empty($this->_ims)) {
-      foreach ($this->_ims as $id => $value) {
-        $defaults['im'][$id] = $value;
-      }
-    }
-    else {
-      // get the default location type
-      $locationType = CRM_Core_BAO_LocationType::getDefault();
-      $defaults['im'][1]['location_type_id'] = $locationType->id;
-    }
-    return $defaults;
+    return $this->setBlockDefaultValues($this->_ims, 'im', $this->_blockCount, CRM_Core_BAO_LocationType::getDefault()->id);
   }
 
   /**

--- a/CRM/Contact/Form/Inline/OpenID.php
+++ b/CRM/Contact/Form/Inline/OpenID.php
@@ -126,19 +126,8 @@ class CRM_Contact_Form_Inline_OpenID extends CRM_Contact_Form_Inline {
    *
    * @return array
    */
-  public function setDefaultValues() {
-    $defaults = [];
-    if (!empty($this->_openids)) {
-      foreach ($this->_openids as $id => $value) {
-        $defaults['openid'][$id] = $value;
-      }
-    }
-    else {
-      // get the default location type
-      $locationType = CRM_Core_BAO_LocationType::getDefault();
-      $defaults['openid'][1]['location_type_id'] = $locationType->id;
-    }
-    return $defaults;
+  public function setDefaultValues(): array {
+    return $this->setBlockDefaultValues($this->_openids, 'openid', $this->_blockCount, CRM_Core_BAO_LocationType::getDefault()->id);
   }
 
   /**

--- a/CRM/Contact/Form/Inline/Phone.php
+++ b/CRM/Contact/Form/Inline/Phone.php
@@ -120,18 +120,7 @@ class CRM_Contact_Form_Inline_Phone extends CRM_Contact_Form_Inline {
    * @return array
    */
   public function setDefaultValues(): array {
-    $defaults = [];
-    if (!empty($this->_phones)) {
-      foreach ($this->_phones as $id => $value) {
-        $defaults['phone'][$id] = $value;
-      }
-    }
-    else {
-      // get the default location type
-      $locationType = CRM_Core_BAO_LocationType::getDefault();
-      $defaults['phone'][1]['location_type_id'] = $locationType->id;
-    }
-    return $defaults;
+    return $this->setBlockDefaultValues($this->_phones, 'phone', $this->_blockCount, CRM_Core_BAO_LocationType::getDefault()->id);
   }
 
   /**

--- a/CRM/Contact/Form/Inline/Website.php
+++ b/CRM/Contact/Form/Inline/Website.php
@@ -83,19 +83,8 @@ class CRM_Contact_Form_Inline_Website extends CRM_Contact_Form_Inline {
    * @return array
    */
   public function setDefaultValues() {
-    $defaults = [];
-    if (!empty($this->_websites)) {
-      foreach ($this->_websites as $id => $value) {
-        $defaults['website'][$id] = $value;
-      }
-    }
-    else {
-      // set the default website type
-      $defaults['website'][1]['website_type_id'] = key(CRM_Core_OptionGroup::values('website_type',
-        FALSE, FALSE, FALSE, ' AND is_default = 1'
-      ));
-    }
-    return $defaults;
+    $defaultType = key(CRM_Core_OptionGroup::values('website_type', FALSE, FALSE, FALSE, ' AND is_default = 1'));
+    return $this->setBlockDefaultValues($this->_websites, 'website', $this->_blockCount, $defaultType);
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
When adding a new email, phone, IM, OpenID or website on the contact summary, when there is already an existing email, etc, the new location type or website type is not set to the default.

After
----------------------------------------
Default is set as expected.