### PR TITLE
Advanced Search - Hide proximity radius if using zip code range.

### DIFF
--- a/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
+++ b/templates/CRM/Contact/Form/Search/Criteria/Location.tpl
@@ -114,9 +114,9 @@
               $('#postal-code-range-toggle').change(function() {
                 if ($(this).is(':checked')) {
                   $('.postal_code_range-wrapper').show();
-                  $('.postal_code-wrapper').hide().find('input').val('');
+                  $('.postal_code-wrapper, .prox_distance-wrapper').hide().find('input').val('');
                 } else {
-                  $('.postal_code-wrapper').show();
+                  $('.postal_code-wrapper, .prox_distance-wrapper').show();
                   $('.postal_code_range-wrapper').hide().find('input').val('');
                 }
               });
@@ -128,7 +128,7 @@
           </script>
         {/if}
         {if !empty($form.prox_distance.html)}
-          <div class="crm-field-wrapper">
+          <div class="crm-field-wrapper prox_distance-wrapper">
             {$form.prox_distance.label}<br />
             {$form.prox_distance.html}&nbsp;{$form.prox_distance_unit.html}
           </div>


### PR DESCRIPTION
Overview
----------------------------------------
Improves the Advanced Search UI by hiding "Find contacts within" selector when using "Postal Code Range".

<img width="508" height="156" alt="image" src="https://github.com/user-attachments/assets/a80fa5b9-ca45-43fa-b676-8b60439f824b" />

<img width="498" height="162" alt="image" src="https://github.com/user-attachments/assets/2a4f814d-9ae8-4d34-a93c-c71dd9b45945" />



Technical Details
----------------------------------------
Zip code range is incompatible with "Find Contacts Within" radius search. The reason is that a range of zip codes cannot be resolved to a single point on a map from which we can draw a radius.