### PR TITLE
Riverlea - fix broken .columnheader-dark

### DIFF
--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -191,8 +191,8 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
   background-color: var(--crm-table-alternate-row);
 }
 .crm-container tr.columnheader-dark th {
-  background-color: var(--crm-c-dark-bg-color);
-  color: var(--crm-text-light-color);
+  background-color: var(--crm-primary-color);
+  color: var(--crm-primary-text-color);
 }
 
 /* Batch entry table */


### PR DESCRIPTION
Overview
----------------------------------------
Rule is using a variable which no longer exists.

Before
----------------------------------------
<img width="1371" height="663" alt="image" src="https://github.com/user-attachments/assets/97596418-bee6-40e5-af6d-9c8bd138009e" />


After
----------------------------------------
Use theme primary color:

Minetta
<img width="1449" height="597" alt="image" src="https://github.com/user-attachments/assets/d646ac9c-bbae-4041-8063-34124f6409bf" />

Hackney
<img width="1493" height="627" alt="image" src="https://github.com/user-attachments/assets/6b181167-bbb7-4575-b1e6-2de609017ee9" />

Walbrook
<img width="1254" height="605" alt="image" src="https://github.com/user-attachments/assets/3f115fa3-c7ee-44f9-bf01-e24896ace60a" />

Thames
<img width="1489" height="634" alt="image" src="https://github.com/user-attachments/assets/488578ea-aeb7-4187-9f37-a143406c888c" />





Technical Details
----------------------------------------
Using primary will not necessarily be "dark" as per the classname.

But we want to move to using primary/secondary/info/warning/danger etc for emphasis colours as the html <=> theme contract. "Dark" is hard to be sure about across themes/dark mode etc