### PR TITLE
Fix Manage Event toggles initial show-hide state

### DIFF
--- a/CRM/Event/Form/ManageEvent/Registration.php
+++ b/CRM/Event/Form/ManageEvent/Registration.php
@@ -217,12 +217,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
     $this->addToggle('is_online_registration',
       ts('Allow Online Registration'),
       [
-        'onclick' => "return showHideByValue('is_online_registration'," .
-        "''," .
-        "'registration_blocks'," .
-        "'block'," .
-        "'checkbox'," .
-        "false );",
+        'onclick' => "return showHideByValue('is_online_registration','','registration_blocks','block','checkbox',false);",
       ]
     );
 
@@ -368,7 +363,7 @@ class CRM_Event_Form_ManageEvent_Registration extends CRM_Event_Form_ManageEvent
    */
   public function buildConfirmationBlock(&$form) {
     $attributes = CRM_Core_DAO::getAttribute('CRM_Event_DAO_Event');
-    $form->addToggle('is_confirm_enabled', ts('Use a confirmation screen?'), ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','radio',false);"]);
+    $form->addToggle('is_confirm_enabled', ts('Use a confirmation screen?'), ['onclick' => "return showHideByValue('is_confirm_enabled','','confirm_screen_settings','block','checkbox',false);"]);
     $form->add('text', 'confirm_title', ts('Title'), $attributes['confirm_title']);
     $form->add('wysiwyg', 'confirm_text', ts('Introductory Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);
     $form->add('wysiwyg', 'confirm_footer_text', ts('Footer Text'), $attributes['confirm_text'] + ['class' => 'collapsed', 'preset' => 'civievent']);

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -280,6 +280,43 @@
     {include file="CRM/common/formButtons.tpl" location="bottom"}
   </div>
 
+{* Required for the initial form load *}
+{include file="CRM/common/showHide.tpl"}
+{include file="CRM/common/showHideByFieldValue.tpl"
+  trigger_field_id    ="is_online_registration"
+  trigger_value       =""
+  target_element_id   ="registration_blocks"
+  target_element_type ="block"
+  field_type          ="checkbox"
+  invert              = 0
+}
+{include file="CRM/common/showHideByFieldValue.tpl"
+  trigger_field_id    ="is_confirm_enabled"
+  trigger_value       =""
+  target_element_id   ="confirm_screen_settings"
+  target_element_type ="block"
+  field_type          ="checkbox"
+  invert              = 0
+}
+{include file="CRM/common/showHideByFieldValue.tpl"
+  trigger_field_id    ="is_email_confirm"
+  trigger_value       =""
+  target_element_id   ="confirmEmail"
+  target_element_type ="block"
+  field_type          ="checkbox"
+  invert              = 0
+}
+{if !empty($form.requires_approval)}
+{include file="CRM/common/showHideByFieldValue.tpl"
+  trigger_field_id    ="requires_approval"
+  trigger_value       =""
+  target_element_id   ="id-approval-text"
+  target_element_type ="table-row"
+  field_type          ="radio"
+  invert              = 0
+}
+{/if}
+
 {*include profile link function*}
 {include file="CRM/common/buildProfileLink.tpl"}
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes a non-released regression found on Manage Event toggles: https://lab.civicrm.org/dev/core/-/work_items/6418 reported by @samuelsov 

Before
----------------------------------------

- "is online reg" toggle sometimes displays the online reg blocks even if the toggle is off
- "show confirmation screen" toggle did not work

After
----------------------------------------

Fixed

Comments
----------------------------------------

The `showHide` tpl code had been removed in #34895 because it seemed redundant. However, the widgets were only setting `onclick` event, and the rest of the code manages the "on load" (I still feel there is some redundancy, but I was in a rush and it makes little sense to me).