### PR TITLE
Riverlea - fix pay later table styling + duplicate border declaration

### DIFF
--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -163,7 +163,6 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 
 /* Advance search compressed table */
 #search-status table.form-layout-compressed {
-  border: 0;
   background: var(--crm-container-bg-color);
   width: 100%;
   border: 0;
@@ -226,8 +225,8 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 /* Pay later table (nested inside another table) */
 
 .crm-container table#payLater table#payLaterOptions.form-layout {
-  border: var(--c-crm-table-nested-border);
-  background: var(--crm-c-table-bg-color);
+  border: var(--crm-table-nested-border);
+  background: var(--crm-table-bg-color);
 }
 
 /* Striped rows */


### PR DESCRIPTION
Overview
----------------------------------------
Couple of invalid vars and a duplicated `border: 0;` rule