### PR TITLE
hook_postCommit - Enable alias. Allow dispatching to self_* listeners.

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -487,6 +487,7 @@ class Container {
     $dispatcher->addListener('hook_civicrm_pre', $aliasEvent('hook_civicrm_pre', 'entity'), 100);
     $dispatcher->addListener('civi.dao.preDelete', ['\CRM_Core_BAO_EntityTag', 'preDeleteOtherEntity']);
     $dispatcher->addListener('hook_civicrm_post', $aliasEvent('hook_civicrm_post', 'entity'), 100);
+    $dispatcher->addListener('hook_civicrm_postCommit', $aliasEvent('hook_civicrm_postCommit', 'entity'), 100);
     $dispatcher->addListener('hook_civicrm_post::Activity', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_post::Case', ['\Civi\CCase\Events', 'fireCaseChange']);
     $dispatcher->addListener('hook_civicrm_caseChange', ['\Civi\CCase\Events', 'delegateToXmlListeners']);


### PR DESCRIPTION
Overview
----------------------------------------

`hook_postCommit` is the friendly, less transactional brother of `hook_post`.  Improve `hook_postCommit` to have better parity with `hook_post`.

Follow-up to @ufundo's comment [here](https://github.com/civicrm/civicrm-core/pull/35232/changes#r3000608883).

Before
----------------------------------------

* `hook_pre` supports aliased events (`hook_pre::Entity`) and `self_*()` listeners in BAO
* `hook_post` supports aliased events (`hook_post::Entity`) and `self_*()` listeners in BAO
* `hook_postCommit` does not.

After
----------------------------------------

* `hook_pre` supports aliased events (`hook_pre::Entity`) and `self_*()` listeners in BAO
* `hook_post` supports aliased events (`hook_post::Entity`) and `self_*()` listeners in BAO
* `hook_postCommit` supports aliased events (`hook_postCommit::Entity`) and `self_*()` listeners in BAO
