### PR TITLE
github action deprecation for regen

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -123,7 +123,7 @@ jobs:
           git commit -m "regenerate civicrm_generated" sql/civicrm_generated.mysql
           git remote add mine https://${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git
           git push mine
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ success() }}
         with:
           name: the_file_you_requested


### PR DESCRIPTION
Overview
----------------------------------------
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/upload-artifact@v4. [blah blah blah] For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Before
----------------------------------------
4

After
----------------------------------------
7

Technical Details
----------------------------------------
7 is bigger than 4

Comments
----------------------------------------
Sample run here showing it still works: https://github.com/demeritcowboy/civicrm-core/actions/runs/23869954944/job/69599050578#step:10:1
