### PR TITLE
Add SMS batch action for event participants

### DIFF
--- a/CRM/Event/Form/Task/SMS.php
+++ b/CRM/Event/Form/Task/SMS.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * This class provides the functionality to SMS a group of event participants.
+ */
+class CRM_Event_Form_Task_SMS extends CRM_Event_Form_Task {
+  use CRM_Contact_Form_Task_SMSTrait;
+
+  /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess(): void {
+    $this->bounceOnNoActiveProviders();
+    parent::preProcess();
+    $this->assign('single', FALSE);
+    $this->assign('isAdmin', CRM_Core_Permission::check('administer CiviCRM'));
+  }
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm(): void {
+    $this->assign('suppressForm', FALSE);
+    $this->buildSmsForm();
+  }
+
+}

--- a/CRM/Event/Task.php
+++ b/CRM/Event/Task.php
@@ -125,6 +125,15 @@ class CRM_Event_Task extends CRM_Core_Task {
         ],
       ];
 
+      $providersCount = CRM_SMS_BAO_SmsProvider::activeProviderCount();
+      if ($providersCount && CRM_Core_Permission::check('send SMS')) {
+        self::$_tasks[self::TASK_SMS] = [
+          'title' => ts('SMS - schedule/send'),
+          'class' => 'CRM_Event_Form_Task_SMS',
+          'result' => TRUE,
+        ];
+      }
+
       //CRM-4418, check for delete
       if (!CRM_Core_Permission::check('delete in CiviEvent')) {
         unset(self::$_tasks[self::TASK_DELETE]);
@@ -165,6 +174,9 @@ class CRM_Event_Task extends CRM_Core_Task {
       //CRM-4418,
       if (CRM_Core_Permission::check('delete in CiviEvent')) {
         $tasks[self::TASK_DELETE] = self::tasks()[self::TASK_DELETE]['title'];
+      }
+      if (!empty(self::tasks()[self::TASK_SMS])) {
+        $tasks[self::TASK_SMS] = self::tasks()[self::TASK_SMS]['title'];
       }
     }
 

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1980,7 +1980,7 @@ LEFT JOIN civicrm_mailing_group g ON g.mailing_id   = m.id
     $className = CRM_Utils_System::getClassName($form);
 
     if ($className != 'CRM_SMS_Form_Upload' && $className != 'CRM_Contact_Form_Task_SMS' &&
-      $className != 'CRM_Contact_Form_Task_SMS'
+      $className != 'CRM_Event_Form_Task_SMS'
     ) {
       $form->add('wysiwyg', 'html_message',
         strstr($className, 'PDF') ? ts('Document Body') : ts('HTML Format'),

--- a/templates/CRM/Event/Form/Task/SMS.tpl
+++ b/templates/CRM/Event/Form/Task/SMS.tpl
@@ -1,0 +1,48 @@
+{*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+*}
+<div class="crm-block crm-form-block crm-contactSMS-form-block">
+{if $suppressedSms > 0}
+  <div class="status">
+    <p>{ts count=$suppressedSms plural='SMS will NOT be sent to %count contacts who have no mobile phone number, who are set to Do not SMS, or who are deceased.'}SMS will NOT be sent to %count contact who has no mobile phone number, who is set to Do not SMS, or who is deceased.{/ts}</p>
+  </div>
+{/if}
+
+<table class="form-layout-compressed">
+  <tr class="crm-contactProvider-form-block-Provider">
+    <td class="label">{$form.sms_provider_id.label}</td>
+    <td>{$form.sms_provider_id.html}</td>
+  </tr>
+  <tr class="crm-contactsms-form-block-recipient">
+    <td class="label">{$form.to.label}</td>
+    <td>{$form.to.html}</td>
+  </tr>
+  <tr>
+    <td class="label">{$form.activity_subject.label}</td>
+    <td class="value">{$form.activity_subject.html}</td>
+  </tr>
+  {if array_key_exists('SMStemplate', $form)}
+    <tr class="crm-contactPhone-form-block-template">
+      <td class="label">{$form.SMStemplate.label}</td>
+      <td>{$form.SMStemplate.html}</td>
+    </tr>
+  {/if}
+</table>
+
+{include file="CRM/Contact/Form/Task/SMSCommon.tpl"}
+{include file="CRM/Mailing/Form/InsertTokens.tpl"}
+
+<div class="spacer"> </div>
+
+{if $suppressedSms > 0}
+  {ts count=$suppressedSms plural='SMS will NOT be sent to %count contacts.'}SMS will NOT be sent to %count contact.{/ts}
+{/if}
+
+<div class="crm-submit-buttons">{include file="CRM/common/formButtons.tpl" location="bottom"}</div>
+</div>

--- a/templates/CRM/Mailing/Form/InsertTokens.tpl
+++ b/templates/CRM/Mailing/Form/InsertTokens.tpl
@@ -25,7 +25,7 @@ var isMailing    = false;
   text_message = "mailing_format";
   isMailing = false;
   {/literal}
-{elseif $form.formClass eq 'CRM_Contact_Form_Task_SMS'}
+{elseif $form.formClass eq 'CRM_Contact_Form_Task_SMS' or $form.formClass eq 'CRM_Event_Form_Task_SMS'}
   {literal}
     prefix = "SMS";
     text_message = "sms_text_message";


### PR DESCRIPTION
CRM_Event_Task never registered TASK_SMS, so the "SMS - schedule/send"                                                                                                                                                               
  action was absent from the participant search Actions menu despite being                                                                                                                                                             
  available in the contact context.                                                                                                                                                                                                    
  
  - Add TASK_SMS to CRM_Event_Task::tasks() with the same SMS provider and permission guard used in CRM_Contact_Task                                                                                                                   
  - Add TASK_SMS to the non-editor fallback list in permissionedTaskTitles()                                                                                                                                                         
  - Add CRM_Event_Form_Task_SMS using CRM_Contact_Form_Task_SMSTrait, following the same pattern as CRM_Event_Form_Task_Email                                                                                                          
  - Add templates/CRM/Event/Form/Task/SMS.tpl                                                                                                                                                                                          
  
  Overview                                                                                                                                                                                                                             
  ----------------------------------------                                                                                                                                                                                           
  Adds "SMS - schedule/send" to the Actions menu on the Find Participants
  screen, bringing it in line with Find Contacts. When at least one SMS                                                                                                                                                                
  provider is active and the user has the `send SMS` permission, participants                                                                                                                                                          
  can now be bulk-SMS'd directly from the event participant search results                                                                                                                                                             
  without leaving CiviEvent.                                                                                                                                                                                                           
                                                                                                                                                                                                                                     
  Also fixes a pre-existing typo in CRM_Mailing_BAO_Mailing::commonCompose()                                                                                                                                                           
  where CRM_Contact_Form_Task_SMS appeared twice in the class-name guard                                                                                                                                                             
  (the second occurrence should have been CRM_SMS_Form_Upload), and extends                                                                                                                                                            
  the same guard in InsertTokens.tpl to cover the new form class.                                                                                                                                                                      
                                                                                                                                                                                                                                       
  Before                                                                                                                                                                                                                               
  ----------------------------------------                           
  The Actions dropdown on civicrm/event/search contained no SMS option.
  Users who needed to bulk-SMS participants had to export the list, switch                                                                                                                                                             
  to Find Contacts, and reconstruct their selection there.                                                                                                                                                                             
                                                                                                                                                                                                                                       
  After                                                                                                                                                                                                                                
  ----------------------------------------                                                                                                                                                                                             
  "SMS - schedule/send" appears in the Actions dropdown on the participant
  search results page whenever an active SMS provider exists and the current
  user has the `send SMS` permission — consistent with the contact search                                                                                                                                                              
  Actions menu.
                                                                                                                                                                                                                                       
  Technical Details                                                  
  ----------------------------------------
  CRM_Event_Form_Task_SMS follows the same structure as CRM_Event_Form_Task_Email:
  it extends CRM_Event_Form_Task and pulls in CRM_Contact_Form_Task_SMSTrait,                                                                                                                                                          
  which supplies buildSmsForm(), postProcessSms(), sendSMS(), and getPhones().                                                                                                                                                         
  The template is a direct copy of CRM/Contact/Form/Task/SMS.tpl — no changes                                                                                                                                                          
  were needed.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                       
  CRM_Mailing_BAO_Mailing::commonCompose() contains a guard that switches
  label rendering between email and SMS mode by checking the calling form's                                                                                                                                                            
  class name. CRM_Contact_Form_Task_SMS was listed twice (the second entry                                                                                                                                                             
  was presumably meant to be CRM_SMS_Form_Upload). This is corrected here,                                                                                                                                                             
  with CRM_Event_Form_Task_SMS added as the third SMS class. The same class                                                                                                                                                            
  name is added to the parallel check in InsertTokens.tpl so the token                                                                                                                                                                 
  selector widget enters SMS mode correctly.                                                                                                                                                                                           
                                                                                                                                                                                                                                       
  Comments                                                                                                                                                                                                                             
  ----------------------------------------                           
  The CRM_Contact_Form_Task_SMSTrait was clearly designed for reuse — this
  PR exercises that reuse for the first time outside the contact context.                                                                                                                                                              
  If there are other task contexts (e.g. contributions, memberships) where                                                                                                                                                             
  SMS would be useful, the same four-line form class pattern applies.     