### PR TITLE
New SchemaHelper functions for CiviCRM 6.15 / civimix-schema@5.98

### DIFF
--- a/CRM/Upgrade/Incremental/Base.php
+++ b/CRM/Upgrade/Incremental/Base.php
@@ -419,11 +419,13 @@ class CRM_Upgrade_Incremental_Base {
       $fieldSql .= " $position";
     }
     if (CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, $fieldName)) {
-      return self::alterColumn($ctx, $tableName, $fieldName, $fieldSql, !empty($fieldSpec['localizable']));
+      self::alterColumn($ctx, $tableName, $fieldName, $fieldSql, !empty($fieldSpec['localizable']));
     }
     else {
-      return self::addColumn($ctx, $tableName, $fieldName, $fieldSql, !empty($fieldSpec['localizable']), $version, $triggerRebuild);
+      self::addColumn($ctx, $tableName, $fieldName, $fieldSql, !empty($fieldSpec['localizable']), $version, $triggerRebuild);
     }
+    Civi::schemaHelper()->createForeignKey($tableName, $fieldName, $fieldSpec);
+    return TRUE;
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixSeven.php
+++ b/CRM/Upgrade/Incremental/php/SixSeven.php
@@ -37,8 +37,8 @@ class CRM_Upgrade_Incremental_php_SixSeven extends CRM_Upgrade_Incremental_Base 
       'required' => FALSE,
       'description' => ts('Alternate FK when using translation_source instead of entity_table / entity_id'),
       'add' => '6.7.alpha1',
-      // as of 6.14 this is not picked up by EFv2 during upgrades
-      // so commenting for clarity
+      // At the time, this was not picked up by EFv2 during upgrades (fixed in SchemaHelper as of 6.15)
+      // FK manually added during SixFourteen upgrade instead.
       // 'entity_reference' => [
       //   'entity' => 'TranslationSource',
       //   'key' => 'source_key',

--- a/mixin/lib/civimix-schema@5/src/SchemaHelper.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelper.php
@@ -127,7 +127,7 @@ return new class() implements SchemaHelperInterface {
     $absolutePath = $this->getExtensionDir() . DIRECTORY_SEPARATOR . $filePath;
     $entityDefn = include $absolutePath;
     $sql = $this->arrayToSql($entityDefn);
-    \CRM_Core_DAO::executeQuery($sql, [], TRUE, NULL, FALSE, FALSE);
+    \CRM_Core_DAO::executeQuery($sql, i18nRewrite: FALSE);
     return TRUE;
   }
 
@@ -155,14 +155,18 @@ return new class() implements SchemaHelperInterface {
     else {
       $query = "ALTER TABLE `$tableName` ADD COLUMN `$fieldName` $fieldSql";
     }
-    \CRM_Core_DAO::executeQuery($query, [], TRUE, NULL, FALSE, FALSE);
+    \CRM_Core_DAO::executeQuery($query, i18nRewrite: FALSE);
+
+    // Add FK constraint if needed.
+    $this->createForeignKey($tableName, $fieldName, $fieldSpec);
+
     return TRUE;
   }
 
   public function dropSchemaField(string $entityName, string $fieldName): bool {
     if ($this->schemaFieldExists($entityName, $fieldName)) {
       $tableName = $this->getTableName($entityName);
-      \CRM_Core_DAO::executeQuery("ALTER TABLE `$tableName` DROP COLUMN `$fieldName`", [], TRUE, NULL, FALSE, FALSE);
+      \CRM_Core_DAO::executeQuery("ALTER TABLE `$tableName` DROP COLUMN `$fieldName`", i18nRewrite: FALSE);
     }
     return TRUE;
   }
@@ -170,6 +174,58 @@ return new class() implements SchemaHelperInterface {
   public function dropTable(string $tableName): bool {
     \CRM_Core_BAO_SchemaHandler::dropTable($tableName);
     return TRUE;
+  }
+
+  public function indexExists(string $tableName, string $indexName): bool {
+    $result = \CRM_Core_DAO::executeQuery(
+      "SHOW INDEX FROM %1 WHERE key_name = %2 AND seq_in_index = 1",
+      [
+        1 => [$tableName, 'MysqlColumnNameOrAlias'],
+        2 => [$indexName, 'String'],
+      ],
+      i18nRewrite: FALSE
+    );
+    return $result->fetch();
+  }
+
+  public function createIndex(string $tableName, string $indexName, array $indexDef): bool {
+    if (!$this->indexExists($tableName, $indexName)) {
+      $indexSql = $this->getSqlGenerator()->generateIndexSql($indexName, $indexDef);
+      \CRM_Core_DAO::executeQuery("ALTER TABLE `$tableName` ADD $indexSql", i18nRewrite: FALSE);
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  public function dropIndex(string $tableName, string $indexName): bool {
+    if ($this->indexExists($tableName, $indexName)) {
+      \CRM_Core_DAO::executeQuery(
+        "ALTER TABLE %1 DROP INDEX %2",
+        [
+          1 => [$tableName, 'MysqlColumnNameOrAlias'],
+          2 => [$indexName, 'MysqlColumnNameOrAlias'],
+        ],
+        i18nRewrite: FALSE
+      );
+      return TRUE;
+    }
+    return FALSE;
+  }
+
+  public function foreignKeyExists(string $tableName, string $foreignKeyName): bool {
+    return \CRM_Core_BAO_SchemaHandler::checkFKExists($tableName, $foreignKeyName);
+  }
+
+  public function createForeignKey(string $tableName, string $fieldName, array $fieldSpec): bool {
+    [$fkName, $constraint] = $this->getSqlGenerator()->getFieldConstraint($tableName, $fieldName, $fieldSpec);
+    if ($fkName && !$this->foreignKeyExists($tableName, $fkName)) {
+      \CRM_Core_DAO::executeQuery("ALTER TABLE `$tableName` ADD $constraint", i18nRewrite: FALSE);
+    }
+    return TRUE;
+  }
+
+  public function dropForeignKey(string $tableName, string $foreignKeyName): bool {
+    return \CRM_Core_BAO_SchemaHandler::safeRemoveFK($tableName, $foreignKeyName);
   }
 
   /**
@@ -191,6 +247,10 @@ return new class() implements SchemaHelperInterface {
     return $system->getMapper()->keyToBasePath($this->key);
   }
 
+  /**
+   * @return object
+   * @see SqlGenerator.php
+   */
   private function getSqlGenerator() {
     if ($this->sqlGenerator === NULL) {
       $gen = require __DIR__ . '/SqlGenerator.php';

--- a/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
@@ -38,9 +38,14 @@ namespace CiviMix\Schema;
  * [[ CiviCRM 6.15+ / civimix-schema@5.98+ ]]
  *
  * @method array getExistingTables(array $tableNames)
+ * @method bool indexExists(string $tableName, string $indexName)
+ * @method bool dropIndex(string $tableName, string $indexName)
+ * @method bool createIndex(string $tableName, string $indexName, array $indexDef)
+ * @method bool foreignKeyExists(string $tableName, string $foreignKeyName)
+ * @method bool dropForeignKey(string $tableName, string $foreignKeyName)
+ * @method bool createForeignKey(string $tableName, string $fieldName, array $fieldSpec)
  *
  * To see the latest implementation:
- *
  * @see ./SchemaHelper.php
  */
 interface SchemaHelperInterface {

--- a/mixin/lib/civimix-schema@5/src/SqlGenerator.php
+++ b/mixin/lib/civimix-schema@5/src/SqlGenerator.php
@@ -122,21 +122,26 @@ return new class() {
     }
     $indices = isset($entity['getIndices']) ? $entity['getIndices']() : [];
     foreach ($indices as $indexName => $index) {
-      $indexFields = [];
-      foreach ($index['fields'] as $fieldName => $length) {
-        $indexFields[] = "`$fieldName`" . (is_int($length) ? "($length)" : '');
-      }
-      $definition[] = (!empty($index['unique']) ? 'UNIQUE ' : '') . "INDEX `$indexName`(" . implode(', ', $indexFields) . ')';
+      $definition[] = $this->generateIndexSql($indexName, $index);
     }
     return $definition;
   }
 
+  public function generateIndexSql(string $indexName, array $index) {
+    $indexFields = [];
+    foreach ($index['fields'] as $fieldName => $length) {
+      $indexFields[] = "`$fieldName`" . (is_int($length) ? "($length)" : '');
+    }
+    return (!empty($index['unique']) ? 'UNIQUE ' : '') . "INDEX `$indexName`(" . implode(', ', $indexFields) . ')';
+  }
+
   private function generateConstraintsSql(array $entity): string {
-    $constraints = $this->getTableConstraints($entity);
     $sql = '';
-    if ($constraints) {
-      $sql .= "ALTER TABLE `{$entity['table']}`\n  ";
-      $sql .= 'ADD ' . implode(",\n  ADD ", $constraints) . ";\n";
+    foreach ($this->getTableConstraints($entity) as $fkName => $constraint) {
+      $sql .= ($sql ? "," : '') . "\n  ADD $constraint";
+    }
+    if ($sql) {
+      $sql = "ALTER TABLE `{$entity['table']}`$sql;\n";
     }
     return $sql;
   }
@@ -144,20 +149,29 @@ return new class() {
   private function getTableConstraints(array $entity): array {
     $constraints = [];
     foreach ($entity['getFields']() as $fieldName => $field) {
-      // `entity_reference.fk` defaults to TRUE if not set. If FALSE, do not add constraint.
-      if (!empty($field['entity_reference']['entity']) && ($field['entity_reference']['fk'] ?? TRUE)) {
-        $fkName = \CRM_Core_BAO_SchemaHandler::getIndexName($entity['table'], $fieldName);
+      [$fkName, $constraint] = $this->getFieldConstraint($entity['table'], $fieldName, $field);
+      if ($constraint) {
         // Make sure the FK does not already exist...
-        CRM_Core_BAO_SchemaHandler::safeRemoveFK($entity['table'], 'FK_' . $fkName);
-        $constraint = "CONSTRAINT `FK_$fkName` FOREIGN KEY (`$fieldName`)" .
-          " REFERENCES `" . $this->getTableForEntity($field['entity_reference']['entity']) . "`(`{$field['entity_reference']['key']}`)";
-        if (!empty($field['entity_reference']['on_delete'])) {
-          $constraint .= " ON DELETE {$field['entity_reference']['on_delete']}";
-        }
-        $constraints[] = $constraint;
+        // TODO: This function is supposed to generate code not alter the database. Find a better place for this guard.
+        \CRM_Core_BAO_SchemaHandler::safeRemoveFK($entity['table'], $fkName);
+        $constraints[$fkName] = $constraint;
       }
     }
     return $constraints;
+  }
+
+  public function getFieldConstraint(string $tableName, string $fieldName, array $field): array {
+    $fkName = $constraint = NULL;
+    // `entity_reference.fk` defaults to TRUE if not set. If FALSE, do not add constraint.
+    if (!empty($field['entity_reference']['entity']) && ($field['entity_reference']['fk'] ?? TRUE)) {
+      $fkName = 'FK_' . \CRM_Core_BAO_SchemaHandler::getIndexName($tableName, $fieldName);
+      $constraint = "CONSTRAINT `$fkName` FOREIGN KEY (`$fieldName`)" .
+        " REFERENCES `" . $this->getTableForEntity($field['entity_reference']['entity']) . "`(`{$field['entity_reference']['key']}`)";
+      if (!empty($field['entity_reference']['on_delete'])) {
+        $constraint .= " ON DELETE {$field['entity_reference']['on_delete']}";
+      }
+    }
+    return [$fkName, $constraint];
   }
 
   public static function generateFieldSql(array $field): string {

--- a/tests/phpunit/Civi/Schema/SchemaHelperTest.php
+++ b/tests/phpunit/Civi/Schema/SchemaHelperTest.php
@@ -16,4 +16,57 @@ class SchemaHelperTest extends \CiviUnitTestCase {
     $this->assertFalse(\Civi::schemaHelper()->tableExists('civicrm_false_nothing'));
   }
 
+  public function testForeignKeyExists(): void {
+    $this->assertTrue(\Civi::schemaHelper()->foreignKeyExists('civicrm_activity', 'FK_civicrm_activity_parent_id'));
+    $this->assertFalse(\Civi::schemaHelper()->foreignKeyExists('civicrm_activity', 'FK_civicrm_false_nothing'));
+  }
+
+  public function testIndexExists(): void {
+    $this->assertTrue(\Civi::schemaHelper()->indexExists('civicrm_activity', 'index_status_id'));
+    $this->assertFalse(\Civi::schemaHelper()->indexExists('civicrm_activity', 'index_false_nothing'));
+  }
+
+  public function testAlterSchemaFieldWithForiegnKey(): void {
+    \Civi::schemaHelper()->dropForeignKey('civicrm_activity', 'FK_civicrm_activity_parent_id');
+
+    $this->assertFalse(\Civi::schemaHelper()->foreignKeyExists('civicrm_activity', 'FK_civicrm_activity_parent_id'));
+
+    \Civi::schemaHelper()->alterSchemaField('Activity', 'parent_id', [
+      'title' => 'Parent Activity ID',
+      'sql_type' => 'int unsigned',
+      'readonly' => TRUE,
+      'description' => 'Column altered by test.',
+      'entity_reference' => [
+        'entity' => 'Activity',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ]);
+
+    $this->assertTrue(\Civi::schemaHelper()->foreignKeyExists('civicrm_activity', 'FK_civicrm_activity_parent_id'));
+
+    $result = \CRM_Core_DAO::executeQuery(
+      "SELECT COLUMN_COMMENT FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = 'civicrm_activity'
+       AND COLUMN_NAME = 'parent_id'"
+    );
+    $result->fetch();
+    $this->assertEquals('Column altered by test.', $result->COLUMN_COMMENT);
+  }
+
+  public function testDropAndAddIndex(): void {
+    \Civi::schemaHelper()->dropIndex('civicrm_activity', 'index_status_id');
+
+    $this->assertFalse(\Civi::schemaHelper()->indexExists('civicrm_activity', 'index_status_id'));
+
+    \Civi::schemaHelper()->createIndex('civicrm_activity', 'index_status_id', [
+      'fields' => [
+        'status_id' => TRUE,
+      ],
+    ]);
+
+    $this->assertTrue(\Civi::schemaHelper()->indexExists('civicrm_activity', 'index_status_id'));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This rounds out the set of SchemaHelper functions with the ability to add/drop indices and foreign keys.

It also [fixes the oversight](https://github.com/civicrm/civicrm-core/blob/a8076192def4926b3c06d3eb6ed5cedeabedae6b/CRM/Upgrade/Incremental/php/SixSeven.php#L40-L41) that `entity_reference` declarations did not create a foreign key in the alterSchemaField() function.

This is targeted for 6.15 & will require a port to `civix`.