### PR TITLE
Standaloneusers - enable adding Custom Fields to Users

### DIFF
--- a/ext/standaloneusers/managed/OptionValue_cg_extend_objects_User.mgd.php
+++ b/ext/standaloneusers/managed/OptionValue_cg_extend_objects_User.mgd.php
@@ -1,0 +1,29 @@
+<?php
+
+use CRM_Standaloneusers_ExtensionUtil as E;
+
+// Adds User to the list of entities for which custom fields can be created.
+return [
+  [
+    'name' => 'cg_extend_objects:Users',
+    'entity' => 'OptionValue',
+    'cleanup' => 'always',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'cg_extend_objects',
+        'label' => E::ts('User'),
+        'value' => 'User',
+        'name' => 'civicrm_uf_match',
+        'icon' => 'fa-user',
+        'is_reserved' => TRUE,
+        'is_active' => TRUE,
+      ],
+      'match' => [
+        'name',
+        'option_group_id',
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Add User to the list of entities which Custom Fields can be created for on Standalone.

Before
----------------------------------------
- No custom fields for users

After
----------------------------------------
- Can create custom groups/fields on User entity
- Can write to those fields, and values are written to the db
- Read isn't working :thinking: 

Technical Details
----------------------------------------
I'm not sure why read isn't working. I'm suspicious of a) some custom handling in the BAO; b) the reuse of `civicrm_uf_match` for both UfMatch and User entities. Needs more digging.

Comments
----------------------------------------
I can't see how this would be a security concern, but would appreciate other eyes on this angle.
