### PR TITLE
SearchKit - Allow ActivityContact to be searched directly

### DIFF
--- a/Civi/Api4/ActivityContact.php
+++ b/Civi/Api4/ActivityContact.php
@@ -18,7 +18,7 @@ namespace Civi\Api4;
  * The record_type_id field determines the contact's role in the activity (source, target, or assignee).
  * @ui_join_filters record_type_id
  *
- * @searchable bridge
+ * @searchable secondary
  * @see \Civi\Api4\Activity
  * @since 5.19
  * @package Civi\Api4


### PR DESCRIPTION
Overview
----------------------------------------
Sometimes it's more efficient to build a search based on activity contacts if you don't need to join on both Activity and Contact.

<img width="1060" height="674" alt="image" src="https://github.com/user-attachments/assets/4e561d2e-c899-468b-b341-d88b4a0b7555" />
