### PR TITLE
Afform - Improve SearchDisplay tag detection

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -3,6 +3,7 @@
 namespace Civi\AfformAdmin;
 
 use Civi\Afform\Placement\PlacementUtils;
+use Civi\Afform\Utils;
 use Civi\Api4\Afform;
 use Civi\Api4\Entity;
 use Civi\Api4\Utils\CoreUtil;
@@ -350,6 +351,8 @@ class AfformAdminMeta {
       $dateRanges = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
       $dateRanges = array_merge([['id' => '{}', 'label' => E::ts('Choose Date Range')]], $dateRanges);
 
+      $searchDisplayTags = Utils::getSearchDisplayTags();
+
       // Allow data to be modified by event listeners
       $data = [
         // @see afform-entity-php/mixin.php
@@ -359,6 +362,7 @@ class AfformAdminMeta {
         'styles' => &$styles,
         'permissions' => &$permissions,
         'dateRanges' => &$dateRanges,
+        'searchDisplayTags' => &$searchDisplayTags,
       ];
       $event = GenericHookEvent::create($data);
       \Civi::dispatcher()->dispatch('civi.afform_admin.metadata', $event);

--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\Afform;
 
+use Civi\Afform\Utils;
 use Civi\AfformAdmin\AfformAdminMeta;
 use Civi\Api4\Afform;
 use Civi\Api4\AfformBehavior;
@@ -178,8 +179,8 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
         $displayTags[] = ['search-name' => $searchName, 'display-name' => $displayName];
       }
       else {
-        foreach (\Civi\Search\Display::getDisplayTypes(['name']) as $displayType) {
-          $displayTags = array_merge($displayTags, \CRM_Utils_Array::findAll($info['definition']['layout'], ['#tag' => $displayType['name']]));
+        foreach (Utils::getSearchDisplayTags() as $displayType) {
+          $displayTags = array_merge($displayTags, \CRM_Utils_Array::findAll($info['definition']['layout'], ['#tag' => $displayType]));
         }
       }
       foreach ($displayTags as $displayTag) {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -581,7 +581,7 @@
         const searchFieldsets = afGui.findRecursive(editor.afform.layout, {'af-fieldset': ''});
         return searchFieldsets.reduce((searchDisplays, fieldset) => {
           const displayElement = afGui.findRecursive(fieldset['#children'], (item) => {
-            return item['search-name'] && item['#tag'] && item['#tag'].indexOf('crm-search-display-') === 0;
+            return item['search-name'] && item['#tag'] && afGui.meta.searchDisplayTags.includes(item['#tag']);
           })[0];
           if (displayElement) {
             searchDisplays[displayElement['search-name'] + (displayElement['display-name'] ? '.' + displayElement['display-name'] : '')] = {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -70,7 +70,7 @@
 
       $scope.getSearchKey = function(node) {
         const searchDisplays = afGui.findRecursive(node['#children'], (item) =>
-          item['#tag'] && item['#tag'].indexOf('crm-search-display-') === 0 && item['search-name']
+          item['#tag'] && afGui.meta.searchDisplayTags.includes(item['#tag']) && item['search-name']
         );
         if (searchDisplays && searchDisplays.length) {
           return searchDisplays[0]['search-name'] + (searchDisplays[0]['display-name'] ? '.' + searchDisplays[0]['display-name'] : '');
@@ -376,10 +376,10 @@
         if (node['#tag'] && node['#tag'] in afGui.meta.blocks) {
           return 'container';
         }
-        if (node['#tag'] && (node['#tag'].slice(0, 19) === 'crm-search-display-')) {
+        if (node['#tag'] && afGui.meta.searchDisplayTags.includes(node['#tag'])) {
           return 'searchDisplay';
         }
-        if (node['#tag'] && _.includes(genericElements, node['#tag'])) {
+        if (node['#tag'] && genericElements.includes(node['#tag'])) {
           return 'generic';
         }
         const classes = afGui.splitClass(node['class']);

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.component.js
@@ -77,7 +77,7 @@
 
       // When opening the menu, fetch search displays to show in the `af-gui-tab-count` select
       this.getSearchDisplays = function(tabIndex) {
-        const displayTags = afGui.getFormElements(this.node['#children'][tabIndex]['#children'], (item) => (item['#tag'] && item['#tag'].startsWith('crm-search-display-') && item['search-name']));
+        const displayTags = afGui.getFormElements(this.node['#children'][tabIndex]['#children'], (item) => (item['#tag'] && afGui.meta.searchDisplayTags.includes(item['#tag']) && item['search-name']));
         this.searchDisplays[tabIndex] = displayTags.map(item => {
           return {
             tag: item,

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -346,13 +346,14 @@ class FormDataModel {
    *
    * @param array $node
    */
-  public function findSearchDisplay($node) {
-    foreach (\Civi\Search\Display::getDisplayTypes(['name']) as $displayType) {
-      foreach (AHQ::getTags($node, $displayType['name']) as $display) {
+  public function findSearchDisplay(array $node): ?string {
+    foreach (Utils::getSearchDisplayTags() as $displayType) {
+      foreach (AHQ::getTags($node, $displayType) as $display) {
         $this->searchDisplays[$display['display-name']]['searchName'] = $display['search-name'];
         return $display['display-name'];
       }
     }
+    return NULL;
   }
 
   /**
@@ -366,14 +367,14 @@ class FormDataModel {
   /**
    * @return array{type: string, fields: array, joins: array, security: string, actions: array}
    */
-  public function getEntity($entityName) {
+  public function getEntity(string $entityName): ?array {
     return $this->entities[$entityName] ?? NULL;
   }
 
   /**
    * @return array{fields: array, searchName: string}
    */
-  public function getSearchDisplay($displayName) {
+  public function getSearchDisplay(string $displayName): ?array {
     return $this->searchDisplays[$displayName] ?? NULL;
   }
 

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -13,6 +13,7 @@
 namespace Civi\Afform;
 
 use Civi\Api4\Utils\FormattingUtil;
+use Civi\Search\Display;
 use CRM_Afform_ExtensionUtil as E;
 
 /**
@@ -149,6 +150,12 @@ class Utils {
 
       self::saveTranslations($form, $html);
     }
+  }
+
+  public static function getSearchDisplayTags(): array {
+    $displayTags = array_column(Display::getDisplayTypes(['name'], TRUE), 'name');
+    $displayTags[] = 'crm-search-display';
+    return $displayTags;
   }
 
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1814,6 +1814,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       // If not found, check if this is a subsearch embedded within another display
       if (!$afform['searchDisplay']) {
         $displayTags = array_column(Display::getDisplayTypes(['name']), 'name');
+        $displayTags[] = 'crm-search-display';
         $displays = \CRM_Utils_Array::findAll(
           $afform['layout'],
          fn($element) => isset($element['#tag']) && in_array($element['#tag'], $displayTags, TRUE)


### PR DESCRIPTION
Overview
----------------------------------------
Gets Afform Gui Editor working with the new [generic search display tags](https://github.com/civicrm/civicrm-core/commit/fa5407b8e9a71b49a77a3a965890cc978c541be1).

Technical Details
----------------------------------------
This fixes compatibility with the new generic `<crm-search-display>` tag, and any future display types that may follow a different naming convention.