### PR TITLE
Bump select2 version to 3.5-civicrm-1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -271,7 +271,7 @@
         "ignore": [".*", "*.log", "*.md", "component.json", "package.json", "node_modules"]
       },
       "select2": {
-        "url": "https://github.com/colemanw/select2/archive/v3.5-civicrm-1.3.zip"
+        "url": "https://github.com/colemanw/select2/archive/v3.5-civicrm-1.4.zip"
       },
       "js-yaml": {
         "url": "https://github.com/nodeca/js-yaml/archive/3.13.1.zip",


### PR DESCRIPTION
Overview
----------------------------------------
Includes fix from https://github.com/colemanw/select2/pull/8

This is a better fix for https://dev.nysenate.gov/issues/17663