### PR TITLE
Select2 - Revert change causing multiselect text to bleed through modal.

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -597,11 +597,6 @@ input.crm-form-checkbox) + label {
   animation-timing-function: var(--fa-animation-timing,linear);
 }
 
-/* Prevent multiselect from auto-closing when clicking on the input element – keep it in front of the select2-drop-mask */
-li.select2-search-field {
-  z-index: 9999;
-}
-
 /* Color dot for selecting e.g. tags */
 span.crm-select-item-color {
   display: inline-block;


### PR DESCRIPTION
Overview
----------------------------------------
This reverts https://github.com/civicrm/civicrm-core/pull/34786 which was a css hack that caused problems.
A better solution will go into master: #35307

See [dev/core#6421](https://lab.civicrm.org/dev/core/-/work_items/6421).