### PR TITLE
`afform_payments` is defunct when upgrading to 6.14

### DIFF
--- a/extension-compatibility.json
+++ b/extension-compatibility.json
@@ -65,5 +65,9 @@
   "minifier": {
     "obsolete": "6.12",
     "force-uninstall": true
+  },
+  "afform_payments": {
+    "obsolete": "6.14",
+    "force-uninstall": true
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
The functionality previously developed in `afform_payments` has been merged into `civi_contribute` in 6.14. As such the dev extension should be uninstalled.

All the functionality in `afform_payments` is runtime services, so it should be very safe to uninstall.

Folks upgrading should be aware they will need to enable `contribute_enable_afform_contributions` to opt-in to the equivalent core functionality. It's only been early testers so far, will communicate this on Mattermost etc.

FYI @mattwire @GuillaumeSorel 
