### PR TITLE
Remove redundant symfony/polyfill-php81 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,6 @@
     "civicrm/composer-compile-lib": "~0.6 || ~1.0",
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18 || ^2",
-    "symfony/polyfill-php80": "^1.0",
     "symfony/polyfill-php82": "^1.0",
     "symfony/polyfill-php83": "^1.0",
     "symfony/polyfill-php84": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,6 @@
     "ezyang/htmlpurifier": "^4.13",
     "phpoffice/phpspreadsheet": "^1.18 || ^2",
     "symfony/polyfill-php80": "^1.0",
-    "symfony/polyfill-php81": "^1.0",
     "symfony/polyfill-php82": "^1.0",
     "symfony/polyfill-php83": "^1.0",
     "symfony/polyfill-php84": "^1.0",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php81`, but also `php: ^8.1.2`, so the polyfill requirement doesn't seem necessary anymore?