### PR TITLE
Log error and continue when running individual tasks for BasicBatchAction

### DIFF
--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -92,7 +92,12 @@ class BasicBatchAction extends AbstractBatchAction {
    */
   protected function processBatch(Result $result, array $items) {
     foreach ($items as $item) {
-      $result[] = $this->doTask($item);
+      try {
+        $result[] = $this->doTask($item);
+      }
+      catch (\Throwable $t) {
+        \Civi::log()->error('Failed to run ' . $this->getEntityName() . '::' . $this->getActionName() . ' for item: ' . $item['id'] . '. Error: ' . $t->getMessage());
+      }
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
With BasicBatchAction there is no validation of items before we start processing. If one of the items in the batch fails the user receives a message saying that the whole batch failed. In reality, all the items up to the failed item succeeded but nothing after the failed item was run.

This changes that to catch errors from individual items. So the whole batch will be run, failed items will be logged and you can compare `ctrl.ids.length` with `result.count` in your JS onSuccess handler to give basic feedback to the user.

Before
----------------------------------------
No way for the user to know that some worked and which one it failed on.

After
----------------------------------------
User knows that most of them worked. Can check logs to see which ones actually failed.

Technical Details
----------------------------------------
Just wraps doTask() in a try/catch.

Comments
----------------------------------------
- It would be nice to add in a "validate" step before calling `doTask()` so we could perform validation (eg. params, eg. check if all items are valid. etc).
- It would be nice if we could return a more helpful error to the user. Eg. the IDs of the failed items.

See https://lab.civicrm.org/partners/mjw/migratepaypaltostripe/-/commit/57d9de2a0221e643bc3ce4f9558c8a728c3c7862 for an example of how this could be used.

