### PR TITLE
Fulltext custom search broken since 6.13

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -146,15 +146,13 @@ class CRM_Contact_Form_Search_Custom_FullText extends CRM_Contact_Form_Search_Cu
   }
 
   public function initialize() {
-    static $initialized = FALSE;
-
-    if (!$initialized) {
-      $initialized = TRUE;
-
-      $this->buildTempTable();
-
-      $this->fillTable();
+    if (isset(\Civi::$statics[__CLASS__][__FUNCTION__]['initialized'])) {
+      return;
     }
+
+    \Civi::$statics[__CLASS__][__FUNCTION__]['initialized'] = TRUE;
+    $this->buildTempTable();
+    $this->fillTable();
   }
 
   public function buildTempTable(): void {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Membership.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText/Membership.php
@@ -99,7 +99,7 @@ INNER JOIN civicrm_membership cm ON cm.id = ct.entity_id
 LEFT JOIN  civicrm_contact c ON cm.contact_id = c.id
 LEFT JOIN  civicrm_membership_type cmt ON cmt.id = cm.membership_type_id
 LEFT JOIN  civicrm_line_item line ON line.entity_id = cm.id AND line.entity_table = 'civicrm_membership'
-LEFT JOIN  civicrm_contribution cc ON cc.id = cmp.contribution_id
+LEFT JOIN  civicrm_contribution cc ON cc.id = line.contribution_id
 LEFT JOIN  civicrm_membership_status cms ON cms.id = cm.status_id
 {$this->toLimit($limit)}
 ";

--- a/ext/legacycustomsearches/CRM/Contact/Selector/Custom.php
+++ b/ext/legacycustomsearches/CRM/Contact/Selector/Custom.php
@@ -113,7 +113,6 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
   ) {
     $this->_customSearchClass = $customSearchClass;
     $this->_formValues = $formValues;
-    $this->_includeContactIds = $includeContactIds;
 
     $ext = CRM_Extension_System::singleton()->getMapper();
 
@@ -178,6 +177,7 @@ class CRM_Contact_Selector_Custom extends CRM_Contact_Selector {
           'qs' => 'reset=1&cid=%%id%%&searchType=custom',
           'class' => 'no-popup',
           'title' => ts('Map Contact'),
+          'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::MAP),
         ];
       }
     }

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
@@ -5,7 +5,6 @@ namespace Civi\Searches;
 use Civi\Test;
 use Civi\Test\HeadlessInterface;
 use Civi\Core\HookInterface;
-use Civi\Test\TransactionalInterface;
 use CRM_Contact_Form_Search_Custom_FullText;
 use CRM_Core_Config;
 use CRM_Core_DAO;
@@ -27,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @group headless
  */
-class FullTextTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class FullTextTest extends TestCase implements HeadlessInterface, HookInterface {
 
   use Test\ContactTestTrait;
   use Test\Api3TestTrait;
@@ -41,6 +40,13 @@ class FullTextTest extends TestCase implements HeadlessInterface, HookInterface,
     return Test::headless()
       ->install(['legacycustomsearches'])
       ->apply();
+  }
+
+  public function tearDown(): void {
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_activity");
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_contribution");
+    CRM_Core_DAO::executeQuery("DELETE FROM civicrm_contact WHERE id > 2");
+    parent::tearDown();
   }
 
   /**
@@ -112,14 +118,6 @@ class FullTextTest extends TestCase implements HeadlessInterface, HookInterface,
       }
     }
     $this->assertEquals(2, $count, 'Should be exactly 2 records in the results');
-
-    // For some reason this doesn't delete them ??
-    \Civi\Api4\Contribution::delete(FALSE)
-      ->addWhere('id', '=', $contributionId)
-      ->execute();
-    \Civi\Api4\Contact::delete(FALSE)
-      ->addWhere('id', '=', $contactId)
-      ->execute();
   }
 
 }

--- a/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
+++ b/ext/legacycustomsearches/tests/phpunit/Civi/Searches/FullTextTest.php
@@ -79,4 +79,47 @@ class FullTextTest extends TestCase implements HeadlessInterface, HookInterface,
     $this->assertEmpty($count, 'ACL contacts are not removed.');
   }
 
+  public function testContribution(): void {
+    $contactId = $this->individualCreate(['first_name' => 'Aa', 'last_name' => 'Aa']);
+    $contributionId = \Civi\Api4\Contribution::create(FALSE)
+      ->setValues([
+        'contact_id' => $contactId,
+        'total_amount' => '10',
+        'financial_type_id:name' => 'Donation',
+        'source' => 'gambling debt recovery',
+        'contribution_status_id:name' => 'Completed',
+      ])->execute()->first()['id'];
+
+    $formValues = ['table' => '', 'text' => 'gambling'];
+    $fullText = new CRM_Contact_Form_Search_Custom_FullText($formValues);
+    $fullText->initialize();
+
+    $dao = CRM_Core_DAO::executeQuery('SELECT * FROM ' . $fullText->getTableName());
+    $count = 0;
+    while ($dao->fetch()) {
+      $count++;
+      if ($dao->table_name == 'Activity') {
+        $this->assertEquals($contactId, $dao->contact_id);
+        $this->assertEquals('$ 10.00 - gambling debt recovery', $dao->subject);
+      }
+      elseif ($dao->table_name == 'Contribution') {
+        $this->assertEquals($contactId, $dao->contact_id);
+        $this->assertEquals('gambling debt recovery', $dao->contribution_source);
+        $this->assertEquals('10.00', $dao->contribution_total_amount);
+      }
+      else {
+        $this->fail('Unexpected table in results: ' . $dao->table_name);
+      }
+    }
+    $this->assertEquals(2, $count, 'Should be exactly 2 records in the results');
+
+    // For some reason this doesn't delete them ??
+    \Civi\Api4\Contribution::delete(FALSE)
+      ->addWhere('id', '=', $contributionId)
+      ->execute();
+    \Civi\Api4\Contact::delete(FALSE)
+      ->addWhere('id', '=', $contactId)
+      ->execute();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Broke in 6.13 with https://github.com/civicrm/civicrm-core/commit/3e6e88ec3d863cf94926dd06e7e68f06c74de7dc

Before
----------------------------------------
DB Error::no such field

After
----------------------------------------


Technical Details
----------------------------------------
join was changed but the query still references previous table alias
The actual fix is just that one line change in Membership.php.

Comments
----------------------------------------
I'll put up the fix after the test run since I want to see how it runs here since core extension tests don't work properly outside of this environment since they don't bootstrap enough.