### PR TITLE
Minor visual improvements to Find Event/Contributions

### DIFF
--- a/CRM/Event/Form/SearchEvent.php
+++ b/CRM/Event/Form/SearchEvent.php
@@ -52,7 +52,7 @@ class CRM_Event_Form_SearchEvent extends CRM_Core_Form {
     $this->addSelect('event_type_id', ['multiple' => TRUE, 'context' => 'search']);
 
     $searchOption = [ts('Show Current and Upcoming Events'), ts('Search All or by Date Range')];
-    $this->addRadio('eventsByDates', ts('Events by Dates'), $searchOption, ['onclick' => "return showHideByValue('eventsByDates','1','id_fromToDates','block','radio',true);"], '&nbsp;');
+    $this->addToggle('eventsByDates', ts('Show Past Events'), ['onclick' => "return showHideByValue('eventsByDates','1','id_fromToDates','block','checkbox');"]);
 
     $this->add('datepicker', 'start_date', ts('From'), [], FALSE, ['time' => FALSE]);
     $this->add('datepicker', 'end_date', ts('To'), [], FALSE, ['time' => FALSE]);

--- a/templates/CRM/Contribute/Form/SearchContribution.tpl
+++ b/templates/CRM/Contribute/Form/SearchContribution.tpl
@@ -14,7 +14,8 @@
       <div class="float-right">
         {include file="CRM/common/formButtons.tpl" location=''}
       </div>
-      <div class="advanced-search-fields form-layout" style="max-width: 90%;">
+      {* The 85% is to leave space for the Submit button (and not just in English) *}
+      <div class="advanced-search-fields form-layout" style="max-width: 85%;">
         <div class="search-field">
           {$form.title.label}
           {$form.title.html|crmAddClass:twenty}
@@ -24,7 +25,13 @@
           {$form.financial_type_id.html}
         </div>
         <div class="search-field">
-          {include file="CRM/Campaign/Form/addCampaignToSearch.tpl" campaignTrClass='' campaignTdClass=''}
+          {* Show Campaign if CiviCampaign is enabled *}
+          {if $campaignElementName}
+            <div class="search-field crm-event-searchevent-form-block-campaign_id">
+              {$form.$campaignElementName.label}<br>
+              {$form.$campaignElementName.html}
+            </div>
+          {/if}
         </div>
       </div>
     </div>

--- a/templates/CRM/Event/Form/SearchEvent.tpl
+++ b/templates/CRM/Event/Form/SearchEvent.tpl
@@ -12,44 +12,44 @@
     {ts}Find Events{/ts}
   </summary>
   <div class="crm-accordion-body">
-    <table class="form-layout">
-      <tr class="crm-event-searchevent-form-block-title">
-          <td>
-            {$form.title.label}
-            {$form.title.html|crmAddClass:twenty}
-          </td>
-          <td>
-            <label>{ts}Event Type{/ts}</label>
-            {$form.event_type_id.html}
-          </td>
-      </tr>
-      <tr>
-        <td colspan="2">
-          <div style="height: auto; vertical-align: bottom">{$form.eventsByDates.html}</div>
-        </td>
-      </tr>
-      <tr>
-       <td colspan="2">
-          <table class="form-layout-compressed" id="id_fromToDates">
-            <tr class="">
-              <td class="crm-event-searchevent-form-block-start_date">
-                {$form.start_date.label}
-                {$form.start_date.html}
-              </td>
-              <td class="crm-event-searchevent-form-block-end_date">
-                {$form.end_date.label}
-                {$form.end_date.html}
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-
-      {* campaign in event search *}
-      {include file="CRM/Campaign/Form/addCampaignToSearch.tpl"
-      campaignTrClass='crm-event-searchevent-form-block-campaign_id' campaignTdClass=''}
-      <td class="right">{include file="CRM/common/formButtons.tpl" location=''}</td>
-    </table>
+    <div class="float-right">
+      {include file="CRM/common/formButtons.tpl" location=''}
+    </div>
+    {* The 85% is to leave space for the Submit button (and not just in English) *}
+    <div class="advanced-search-fields form-layout" style="max-width: 85%;">
+      <div class="search-field crm-event-searchevent-form-block-title">
+        {$form.title.label}<br>
+        {$form.title.html|crmAddClass:twenty}
+      </div>
+      <div class="search-field">
+        {$form.event_type_id.label}<br>
+        {$form.event_type_id.html}
+      </div>
+      {* Show Campaign if CiviCampaign is enabled *}
+      {if $campaignElementName}
+        <div class="search-field crm-event-searchevent-form-block-campaign_id">
+          {$form.$campaignElementName.label}<br>
+          {$form.$campaignElementName.html}
+        </div>
+      {/if}
+    </div>
+    <div class="advanced-search-fields form-layout" style="max-width: 85%;">
+      <div class="search-field">
+        {$form.eventsByDates.label}
+        {$form.eventsByDates.html}
+      </div>
+      <div class="search-field">
+        <div id="id_fromToDates" class="advanced-search-fields form-layout">
+          <div crm-event-searchevent-form-block-start_date">
+            {$form.start_date.label}<br>
+            {$form.start_date.html}
+          </div>
+          <div crm-event-searchevent-form-block-end_date">
+            {$form.end_date.label}<br>
+            {$form.end_date.html}
+          </div>
+        </div>
+      </div>
   </div>
 </details>
 

--- a/templates/CRM/Event/Page/ManageEvent.tpl
+++ b/templates/CRM/Event/Page/ManageEvent.tpl
@@ -10,9 +10,6 @@
 {capture assign=newEventURL}{crmURL p='civicrm/event/add' q="action=add&reset=1"}{/capture}
 
 <div class="crm-block crm-content-block">
-<div class="float-right">
-  {include file="CRM/Event/Page/iCalLinks.tpl"}
-</div>
 
 <div class="action-link">
   <a accesskey="N" href="{$newEventURL}" id="newManageEvent" class="button crm-popup">
@@ -156,4 +153,8 @@
   </div>
   {/if}
 {/if}
+  <div class="float-right">
+    {include file="CRM/Event/Page/iCalLinks.tpl"}
+  </div>
+  <div class="clear"></div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

A few minor improvements to : Manage Events, Find Participants and Find Contributions.

Initially, I wanted to move this iCalendar feed link to the bottom of the "Manage Events" page, same as on the "Event Dashboard" page:

<img width="1639" height="386" alt="image" src="https://github.com/user-attachments/assets/f5fef20a-9e2d-4058-a7a3-d29bfbe05ea8" />

Then I noticed that the "Find Events" form looked funny, and was not mobile-compatible, and would be nicer with a toggle.

Before:

<img width="1642" height="751" alt="image" src="https://github.com/user-attachments/assets/5d1fbcd8-fe94-44fd-90b2-d668ec862b27" />

After:

<img width="1636" height="493" alt="image" src="https://github.com/user-attachments/assets/87e53567-73d9-4683-b748-683d28785cd8" />

.. and I noticed that "Manage Contribution Pages" had some similar issues:

Before:

<img width="1647" height="450" alt="image" src="https://github.com/user-attachments/assets/fca33ba8-b12b-4a5a-9e45-245ef529ccfd" />

After:

<img width="1647" height="450" alt="image" src="https://github.com/user-attachments/assets/c9b63e05-2476-4eff-b8c6-1d194259834c" />

Comment
------------------

CiviCRM Admin UI must be disabled to see some of these forms.