### PR TITLE
Afform - More efficient search display tag retrieval

### DIFF
--- a/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
+++ b/ext/afform/admin/Civi/Api4/Action/Afform/LoadAdminData.php
@@ -173,15 +173,15 @@ class LoadAdminData extends \Civi\Api4\Generic\AbstractAction {
 
     if ($info['definition']['type'] === 'search') {
       $getFieldsMode = 'get';
-      $displayTags = [];
       if ($newForm) {
         [$searchName, $displayName] = array_pad(explode('.', $this->entity ?? ''), 2, '');
-        $displayTags[] = ['search-name' => $searchName, 'display-name' => $displayName];
+        $displayTags = [
+          ['search-name' => $searchName, 'display-name' => $displayName],
+        ];
       }
       else {
-        foreach (Utils::getSearchDisplayTags() as $displayType) {
-          $displayTags = array_merge($displayTags, \CRM_Utils_Array::findAll($info['definition']['layout'], ['#tag' => $displayType]));
-        }
+        $displayTypes = Utils::getSearchDisplayTags();
+        $displayTags = \CRM_Utils_Array::findAll($info['definition']['layout'], fn($el) => in_array($el['#tag'] ?? '', $displayTypes));
       }
       foreach ($displayTags as $displayTag) {
         if (isset($displayTag['display-name']) && strlen($displayTag['display-name'])) {

--- a/ext/afform/core/Civi/Afform/AHQ.php
+++ b/ext/afform/core/Civi/Afform/AHQ.php
@@ -29,19 +29,21 @@ class AHQ {
    *
    * @param array|string $element
    *   The ArrayHtml representation of a document/fragment.
-   * @param string $tagName
+   * @param string|array $tagNames
+   *   One or more tags to match, e.g. 'af-entity' or ['af-entity', 'af-repeat']
    * @return array
    */
-  public static function getTags($element, $tagName) {
+  public static function getTags($element, string|array $tagNames) {
     if (!is_array($element) || !isset($element['#tag'])) {
       return [];
     }
     $results = [];
-    if ($element['#tag'] == $tagName) {
+    $tagNames = (array) $tagNames;
+    if (in_array($element['#tag'], $tagNames)) {
       $results[] = self::getProps($element);
     }
     foreach ($element['#children'] ?? [] as $child) {
-      $results = array_merge($results, self::getTags($child, $tagName));
+      $results = array_merge($results, self::getTags($child, $tagNames));
     }
     return $results;
   }

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -347,11 +347,9 @@ class FormDataModel {
    * @param array $node
    */
   public function findSearchDisplay(array $node): ?string {
-    foreach (Utils::getSearchDisplayTags() as $displayType) {
-      foreach (AHQ::getTags($node, $displayType) as $display) {
-        $this->searchDisplays[$display['display-name']]['searchName'] = $display['search-name'];
-        return $display['display-name'];
-      }
+    foreach (AHQ::getTags($node, Utils::getSearchDisplayTags()) as $display) {
+      $this->searchDisplays[$display['display-name']]['searchName'] = $display['search-name'];
+      return $display['display-name'];
     }
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Performance tweak to FormBuilder when loading search forms.

Technical Details
-----------
Instead of searching the entire document tree once per search display, search it for every display in one go.