### PR TITLE
Correctly indicate spaces remaining for price set text fields when validating for additional participants

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -1507,7 +1507,8 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $optionsCountDetails = $priceSetDetails['optionsCountDetails']['fields'];
     }
 
-    $optionMaxValues = $fieldSelected = [];
+    $optionMaxValues = $optionWithoutCurrentValues = $fieldSelected = [];
+    $currentParticipantNo = (int) substr($this->_name, 12);
     foreach ($params as $pNum => $values) {
       if (!is_array($values) || $values == 'skip') {
         continue;
@@ -1543,15 +1544,12 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
           else {
             $currentMaxValue = 1;
           }
-
           if (isset($optionsCountDetails[$priceFieldId], $optionsCountDetails[$priceFieldId]['options'][$optId])) {
             $currentMaxValue = $optionsCountDetails[$priceFieldId]['options'][$optId] * $optVal;
           }
-          if (empty($optionMaxValues)) {
-            $optionMaxValues[$priceFieldId][$optId] = $currentMaxValue;
-          }
-          else {
-            $optionMaxValues[$priceFieldId][$optId] = $currentMaxValue + ($optionMaxValues[$priceFieldId][$optId] ?? 0);
+          $optionMaxValues[$priceFieldId][$optId] = $currentMaxValue + ($optionMaxValues[$priceFieldId][$optId] ?? 0);
+          if ($pNum !== $currentParticipantNo) {
+            $optionWithoutCurrentValues[$priceFieldId][$optId] = $currentMaxValue + ($optionWithoutCurrentValues[$priceFieldId][$optId] ?? 0);
           }
           $soldOutPnum[$optId] = $pNum;
         }
@@ -1559,7 +1557,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
 
       //validate for price field selection.
       if (empty($fieldSelected[$pNum])) {
-        $errors[$pNum]['_qf_default'] = ts('SELECT at least one OPTION FROM EVENT Fee(s).');
+        $errors[$pNum]['_qf_default'] = ts('Select at least one option.');
       }
     }
 
@@ -1569,18 +1567,19 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         $optMax = $optionsMaxValueDetails[$fieldId]['options'][$optId];
         $opDbCount = $this->getUsedSeatsCount($optId);
         $total += $opDbCount;
+        $totalWithoutCurrent = $opDbCount + ($optionWithoutCurrentValues[$fieldId][$optId] ?? 0);
         if ($optMax && ($total > $optMax)) {
-          if ($opDbCount && ($opDbCount >= $optMax)) {
+          if ($totalWithoutCurrent && ($totalWithoutCurrent >= $optMax)) {
             $errors[$soldOutPnum[$optId]]["price_{$fieldId}"]
               = ts('Sorry, this option is currently sold out.');
           }
-          elseif (($optMax - $opDbCount) == 1) {
+          elseif (($optMax - $totalWithoutCurrent) == 1) {
             $errors[$soldOutPnum[$optId]]["price_{$fieldId}"]
-              = ts('Sorry, currently only a single space is available for this option.', [1 => ($optMax - $opDbCount)]);
+              = ts('Sorry, currently only a single space is available for this option.');
           }
           else {
             $errors[$soldOutPnum[$optId]]["price_{$fieldId}"]
-              = ts('Sorry, currently only %1 spaces are available for this option.', [1 => ($optMax - $opDbCount)]);
+              = ts('Sorry, currently only %1 spaces are available for this option.', [1 => ($optMax - $totalWithoutCurrent)]);
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:

1. Set up an event registration with a price set which includes a text field with a max value.
2. Register two participants for the event from the public form.
3. Select max - 1 for the first participant and any value greater than 1 for the additional participant.

Before
----------------------------------------
Validation error indicates the wrong number of spaces still available.

After
----------------------------------------
Correct number of spaces still available indicated in error.

Technical Details
----------------------------------------
The logic here did not account for earlier participants in the same registration, only participants already recorded in the DB. Now it does.
Longer term, I think this could be refactored to use `getPriceSetOptionCount()` but for today, this fixes the bug, even if it is kind of long winded.