### PR TITLE
Optionally show spaces remaining in price sets on front end registration

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -935,7 +935,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       }
     }
     foreach ($field['options'] ?? [] as $option) {
-      if ($this->getIsOptionFull($option) &&
+      if ($this->getIsOptionFullAndSpacesRemaining($option)['is_full'] &&
         !(in_array($option['id'], $selectedSelectPriceFieldIds))
       ) {
         $optionFullIds[$option['id']] = $option['id'];
@@ -945,31 +945,34 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
-   * Is this option full?
+   * Is this option full and how many spaces are remaining?
    *
-   * Excluding the current participant's saved options.
+   * Both is_full and spaces_remaining exclude the current participant's
+   * saved options when re-walking the registration.
    *
    * @param array $option
    *
-   * @return bool
+   * @return array ['is_full' => bool, 'spaces_remaining' => int|NULL] (NULL for no max)
    * @throws \CRM_Core_Exception
    */
-  protected function getIsOptionFull(array $option): bool {
+  protected function getIsOptionFullAndSpacesRemaining(array $option): array {
     $maxValue = $option['max_value'] ?? 0;
     if (!$maxValue) {
-      return FALSE;
+      return ['is_full' => FALSE, 'spaces_remaining' => NULL];
     }
     $currentTotalCount = $this->getPriceSetOptionCount()[$option['id']] ?? 0;
     $usedSeatsCount = $this->getUsedSeatsCount($option['id']);
     $totalCount = $currentTotalCount + $usedSeatsCount;
-
     $currentParticipantNo = (int) substr($this->_name, 12);
+    // If the participant has selected this option, we want to show the space including their selection on re-walk, same as initial.
+    $currentlySelected = $this->_lineItem[$currentParticipantNo][$option['id']]['qty'] ?? 0;
+
     if ($usedSeatsCount >= $maxValue ||
-        ($totalCount >= $maxValue && empty($this->_lineItem[$currentParticipantNo][$option['id']]['price_field_id']))
-      ) {
-      return TRUE;
+      ($totalCount >= $maxValue && !$currentlySelected)
+    ) {
+      return ['is_full' => TRUE, 'spaces_remaining' => $maxValue - $totalCount + $currentlySelected];
     }
-    return FALSE;
+    return ['is_full' => FALSE, 'spaces_remaining' => $maxValue - $totalCount + $currentlySelected];
   }
 
   /**
@@ -1952,7 +1955,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
             $isRequire = FALSE;
           }
           foreach ($options as $option) {
-            $options[$option['id']]['is_full'] = $this->getIsOptionFull($option);
+            $options[$option['id']] += $this->getIsOptionFullAndSpacesRemaining($option);
           }
           if (!empty($options)) {
             //build the element.

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -296,7 +296,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
             break;
           }
           else {
-            if ($values['is_default'] && !$this->getIsOptionFull($values)) {
+            if ($values['is_default'] && !$this->getIsOptionFullAndSpacesRemaining($values)['is_full']) {
               if ($val['html_type'] === 'CheckBox') {
                 $this->_defaults["price_{$key}"][$keys] = 1;
               }

--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -316,13 +316,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         }
 
         // CRM-6902 - Add "max" option for a price set field
-        if (in_array($optionKey, $freezeOptions)) {
-          if (CRM_Utils_System::isFrontendPage()) {
-            $element->freeze();
-          }
-          // CRM-14696 - Improve display for sold out price set options
-          $elementLabelAfter->setLabel('<span class="sold-out-option">' . $elementLabelAfter->getLabel() . '&nbsp;(' . ts('Sold out') . ')</span>');
+        if (in_array($optionKey, $freezeOptions) && CRM_Utils_System::isFrontendPage()) {
+          $element->freeze();
         }
+        $elementLabelAfter->setLabel(self::applyFullOrSpacesRemainingLabel($elementLabelAfter->getLabel(), $optionKey, $customOption, $field, $freezeOptions));
 
         //CRM-10117
         if ($isQuickConfig) {
@@ -396,15 +393,13 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
 
         $element = &$qf->addRadio($elementName, $label, $choice, [], NULL, FALSE, $choiceAttrs);
         foreach ($element->getElements() as $radioElement) {
-          $radioElement->setTextEscaped();
+          $optionKey = $radioElement->getValue();
           // CRM-6902 - Add "max" option for a price set field
-          if (in_array($radioElement->getValue(), $freezeOptions)) {
-            if (CRM_Utils_System::isFrontendPage()) {
-              $radioElement->freeze();
-            }
-            // CRM-14696 - Improve display for sold out price set options
-            $radioElement->setText('<span class="sold-out-option">' . $radioElement->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
+          if (in_array($optionKey, $freezeOptions) && CRM_Utils_System::isFrontendPage()) {
+            $radioElement->freeze();
           }
+          $radioElement->setText(self::applyFullOrSpacesRemainingLabel($radioElement->getText(), $optionKey, $customOption, $field, $freezeOptions));
+          $radioElement->setTextEscaped();
         }
 
         // make contribution field required for quick config when membership block is enabled
@@ -428,17 +423,14 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
           $priceOptionText['label'] = strip_tags($priceOptionText['label']);
           $priceVal[$opt['id']] = $priceOptionText['priceVal'];
 
+          $priceOptionText['label'] = self::applyFullOrSpacesRemainingLabel($priceOptionText['label'], $opt['id'], $customOption, $field, $freezeOptions);
           if (!in_array($opt['id'], $freezeOptions)) {
             $allowedOptions[] = $opt['id'];
           }
           // CRM-14696 - Improve display for sold out price set options
-          else {
-            if (CRM_Utils_System::isFrontendPage()) {
-              $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
-            }
-            $priceOptionText['label'] = $priceOptionText['label'] . ' (' . ts('Sold out') . ')';
+          elseif (CRM_Utils_System::isFrontendPage()) {
+            $opt['id'] = 'crm_disabled_opt-' . $opt['id'];
           }
-
           $selectOption[$opt['id']] = $priceOptionText['label'];
 
           if ($is_pay_later) {
@@ -493,13 +485,10 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
             $qf->addGroup($txtcheck, 'txt-' . $elementName, $label);
           }
           // CRM-6902 - Add "max" option for a price set field
-          if (in_array($opId, $freezeOptions)) {
-            if (CRM_Utils_System::isFrontendPage()) {
-              $check[$opId]->freeze();
-            }
-            // CRM-14696 - Improve display for sold out price set options
-            $check[$opId]->setText('<span class="sold-out-option">' . $check[$opId]->getText() . '&nbsp;(' . ts('Sold out') . ')</span>');
+          if (in_array($opId, $freezeOptions) && CRM_Utils_System::isFrontendPage()) {
+            $check[$opId]->freeze();
           }
+          $check[$opId]->setText(self::applyFullOrSpacesRemainingLabel($check[$opId]->getText(), $opId, $customOption, $field, $freezeOptions));
           $check[$opId]->setTextEscaped();
         }
         $element = &$qf->addGroup($check, $elementName, $label);
@@ -512,6 +501,37 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
     if (isset($qf->_online) && $qf->_online) {
       $element->freeze();
     }
+  }
+
+  /**
+   * Append sold-out or spaces-remaining text to a price option label.
+   *
+   * Sold-out and spaces-remaining are mutually exclusive: if the option is
+   * frozen (sold out) the sold-out text is appended; otherwise, if the field
+   * has show_remaining enabled, the number of spaces remaining is appended.
+   *
+   * @param string $label
+   * @param string $optionKey
+   * @param array $customOption
+   * @param \CRM_Price_DAO_PriceField $field
+   * @param array $freezeOptions
+   *
+   * @return string
+   */
+  private static function applyFullOrSpacesRemainingLabel($label, $optionKey, $customOption, $field, $freezeOptions): string {
+    if (in_array($optionKey, $freezeOptions)) {
+      if ($field->html_type === 'Select') {
+        return $label . ' (' . ts('Sold out') . ')';
+      }
+      return '<span class="sold-out-option">' . $label . '&nbsp;(' . ts('Sold out') . ')</span>';
+    }
+    if ($field->show_remaining) {
+      $spacesRemaining = $customOption[$optionKey]['spaces_remaining'] ?? NULL;
+      if ($spacesRemaining && $spacesRemaining >= 0) {
+        return $label . '&nbsp;' . ts('(%1 left)', [1 => $spacesRemaining]);
+      }
+    }
+    return $label;
   }
 
   /**

--- a/CRM/Price/BAO/PriceSet.php
+++ b/CRM/Price/BAO/PriceSet.php
@@ -427,6 +427,7 @@ WHERE     cpf.price_set_id = %1";
       'help_post',
       'weight',
       'is_display_amounts',
+      'show_remaining',
       'options_per_line',
       'is_active',
       'active_on',

--- a/CRM/Price/Form/Field.php
+++ b/CRM/Price/Form/Field.php
@@ -304,6 +304,10 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
     // is_display_amounts
     $this->add('checkbox', 'is_display_amounts', ts('Display Amount?'));
 
+    if ($this->extendsEvent()) {
+      // show_remaining
+      $this->add('checkbox', 'show_remaining', ts('Show spaces remaining?'));
+    }
     // weight
     $this->add('number', 'weight', ts('Order'), CRM_Core_DAO::getAttribute('CRM_Price_DAO_PriceField', 'weight'), TRUE);
     $this->addRule('weight', ts('is a numeric field'), 'numeric');
@@ -641,6 +645,7 @@ class CRM_Price_Form_Field extends CRM_Core_Form {
 
     $params['is_display_amounts'] ??= FALSE;
     $params['is_required'] ??= FALSE;
+    $params['show_remaining'] ??= FALSE;
     $params['is_active'] ??= FALSE;
     $params['financial_type_id'] ??= FALSE;
     $params['visibility_id'] ??= FALSE;

--- a/CRM/Upgrade/Incremental/php/SixFifteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFifteen.php
@@ -29,6 +29,14 @@ class CRM_Upgrade_Incremental_php_SixFifteen extends CRM_Upgrade_Incremental_Bas
    */
   public function upgrade_6_15_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add PriceField.show_remaining', 'alterSchemaField', 'PriceField', 'show_remaining', [
+      'title' => ts('Show spaces remaining?'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Show how many spaces are remaining on front end'),
+      'default' => FALSE,
+    ], 'AFTER `is_display_amounts`');
   }
 
 }

--- a/schema/Price/PriceField.entityType.php
+++ b/schema/Price/PriceField.entityType.php
@@ -138,6 +138,15 @@ return [
       'description' => ts('Should the price be displayed next to the label for each option?'),
       'default' => TRUE,
     ],
+    'show_remaining' => [
+      'title' => ts('Show spaces remaining?'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Show how many spaces are remaining on front end'),
+      'add' => '6.15',
+      'default' => FALSE,
+    ],
     'options_per_line' => [
       'title' => ts('Price Field Options per Row'),
       'sql_type' => 'int unsigned',

--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -147,6 +147,12 @@
       {/if}
       </td>
     </tr>
+    {if array_key_exists('show_remaining', $form)}
+      <tr class="crm-price-field-form-block-show_remaining">
+      <td class="label">{$form.show_remaining.label} {help id="id-show_remaining" file="CRM/Price/Page/Field.hlp"}</td>
+      <td>{$form.show_remaining.html}</td>
+    </tr>
+    {/if}
     <tr class="crm-price-field-form-block-weight">
       <td class="label">{$form.weight.label}</td>
       <td>{$form.weight.html|crmAddClass:two}


### PR DESCRIPTION
Overview
----------------------------------------
If you offer an event registration with a price set and limits for each option, your registrants might run into a problem.
Suppose Bob is registering all four members of his family for an event. He wants everyone to attend the same workshop. The workshop has a limit of 8 registrants, but 5 spaces have already been claimed and so there are only 3 left. Bob registers himself and two additional participants for the workshop and then when he gets to little Bobby Junior's registration, he can't select the same workshop, because it is now sold out. Bob has to go back through all the registrants and try another option, which it might also turn out doesn't have enough space for his whole family. Bob is frustrated and writes an annoyed email or maybe he just gives up entirely.

If we could show Bob how many spaces are available in specific options right from the start, he could make appropriate selections with that knowledge and choose a workshop with space for his whole family.

That's what this PR does:

- Admins can choose to show remaining spaces for a price field.
- If the show remaining spaces option is enabled for a price field and the price option has a max, the number of spaces remaining is shown on the front end.
- When re-walking the registration, the user will always see the number of spaces remaining excluding the selection for the current participant (so if the option will be sold out once we include the current participant, then it will show `(1 left)`. This is consistent with how the spaces remaining are shown to users when first selecting options, to avoid confusion. Otherwise, when re-walking, the spaces remaining will account for all of the participants in the registration.
- If an option is sold out, it will continue to show `(sold out)` and won't show spaces remaining.
- Nothing changes from current behaviour unless an admin enables spaces_remaining for a price field.
- This is currently only shown on the front end, but it wouldn't be a huge project to also show it on the backend (though obviously it is less necessary there as you can only register or edit one participant at a time).

<img width="453" height="341" alt="image" src="https://github.com/user-attachments/assets/03c62a68-1b46-4bf4-9541-ce2793ce645c" />

Comments
----------------------------------------
The first commit is separately #35324.
The signature of `isOptionFullID()` has changed, but I have confirmed it does not appear anywhere else in universe.