### PR TITLE
Afform - Add new event callback for inputTypes

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -198,7 +198,7 @@ class AfformAdminMeta {
    *
    * @return array
    */
-  public static function getMetadata() {
+  public static function getMetadata(): array {
     $data = \Civi::cache('metadata')->get('afform_admin.metadata');
     if (!$data) {
       $entities = [
@@ -215,25 +215,6 @@ class AfformAdminMeta {
         ->execute()->indexBy('name');
       foreach ($contactAndCustom as $name => $entity) {
         $entities[$name] = self::entityToAfformMeta($entity);
-      }
-
-      // Call getFields on getFields to get input type labels
-      $inputTypeLabels = \Civi\Api4\Contact::getFields(FALSE)
-        ->setLoadOptions(TRUE)
-        ->setAction('getFields')
-        ->addWhere('name', '=', 'input_type')
-        ->execute()
-        ->column('options')[0];
-      // Scan for input types, use label from getFields if available
-      $inputTypes = [];
-      foreach (glob(__DIR__ . '/../../ang/afGuiEditor/inputType/*.html') as $file) {
-        $name = basename($file, '.html');
-        $inputTypes[] = [
-          'name' => $name,
-          'label' => $inputTypeLabels[$name] ?? _ts($name),
-          'template' => '~/af/fields/' . $name . '.html',
-          'admin_template' => '~/afGuiEditor/inputType/' . $name . '.html',
-        ];
       }
 
       // Static elements
@@ -357,7 +338,6 @@ class AfformAdminMeta {
       $data = [
         // @see afform-entity-php/mixin.php
         'entities' => &$entities,
-        'inputTypes' => &$inputTypes,
         'elements' => &$elements,
         'styles' => &$styles,
         'permissions' => &$permissions,
@@ -368,7 +348,15 @@ class AfformAdminMeta {
       \Civi::dispatcher()->dispatch('civi.afform_admin.metadata', $event);
       \Civi::cache('metadata')->set('afform_admin.metadata', $data);
     }
+    return $data;
+  }
 
+  public static function getModuleSettings(): array {
+    $data = self::getMetadata();
+    // InputTypes have their own hook and cache.
+    $inputTypes = Utils::getInputTypes();
+    // Convert to non-associative array.
+    $data['inputTypes'] = array_map(fn($inputType, $name) => $inputType + ['name' => $name], $inputTypes, array_keys($inputTypes));
     return $data;
   }
 

--- a/ext/afform/admin/ang/afGuiEditor.ang.php
+++ b/ext/afform/admin/ang/afGuiEditor.ang.php
@@ -9,7 +9,7 @@ return [
   'css' => ['ang/afGuiEditor.css'],
   'partials' => ['ang/afGuiEditor'],
   'requires' => ['crmUi', 'crmUtil', 'crmDialog', 'api4', 'crmMonaco', 'ui.sortable'],
-  'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getMetadata'],
+  'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getModuleSettings'],
   'basePages' => [],
   'exports' => [
     'af-gui-editor' => 'E',

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -4,7 +4,6 @@ namespace Civi\Afform;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Afform;
-use Civi\AfformAdmin\AfformAdminMeta;
 use Civi\Api4\Utils\CoreUtil;
 use CRM_Afform_ExtensionUtil as E;
 
@@ -275,24 +274,11 @@ class FormDataModel {
 
   /**
    * @param string $inputType name of input type
-   * @return string path to the angular template for this input type
+   * @return string|null
+   *   Path to the angular template for this input type
    */
   public static function getInputTypeTemplate(string $inputType): ?string {
-    // if afform admin is not enabled, there is no hook
-    // to add custom input types so we can just use the
-    // naive string concatenation
-    if (!class_exists('\\Civi\\AfformAdmin\\AfformAdminMeta')) {
-      return '~/af/fields/' . $inputType . '.html';
-    }
-
-    $inputTypes = AfformAdminMeta::getMetadata()['inputTypes'];
-
-    foreach ($inputTypes as $type) {
-      if ($type['name'] === $inputType) {
-        return $type['template'];
-      }
-    }
-    return NULL;
+    return Utils::getInputTypes()[$inputType]['template'] ?? NULL;
   }
 
   /**

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -150,6 +150,8 @@ class Utils {
       // but 3rd parties must specify their own template file names.
       foreach ($inputTypes as $name => &$inputType) {
         $inputType += [
+          'module' => 'af',
+          'admin_module' => 'afGuiEditor',
           'template' => "~/af/fields/$name.html",
           'admin_template' => "~/afGuiEditor/inputType/$name.html",
         ];
@@ -160,6 +162,19 @@ class Utils {
       ];
       $event = GenericHookEvent::create($data);
       \Civi::dispatcher()->dispatch('civi.afform.input_types', $event);
+
+      // If module and admin_module are not specified, infer them from template file names.
+      foreach ($inputTypes as &$inputType) {
+        if (!isset($inputType['module']) && isset($inputType['template']) && str_starts_with($inputType['template'], '~/')) {
+          [, $moduleName] = explode('/', $inputType['template']);
+          $inputType['module'] = $moduleName;
+        }
+        if (!isset($inputType['admin_module']) && isset($inputType['admin_template']) && str_starts_with($inputType['admin_template'], '~/')) {
+          [, $moduleName] = explode('/', $inputType['admin_template']);
+          $inputType['admin_module'] = $moduleName;
+        }
+      }
+
       \Civi::cache('metadata')->set('afform.input_types', $inputTypes);
     }
     return $inputTypes;

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -13,6 +13,7 @@
 namespace Civi\Afform;
 
 use Civi\Api4\Utils\FormattingUtil;
+use Civi\Core\Event\GenericHookEvent;
 use Civi\Search\Display;
 use CRM_Afform_ExtensionUtil as E;
 
@@ -83,6 +84,85 @@ class Utils {
       'REGEXP BINARY' => E::ts('Matches Pattern (case-sensitive)'),
       'NOT REGEXP BINARY' => E::ts("Doesn't Match Pattern (case-sensitive)"),
     ];
+  }
+
+  public static function getInputTypes(): array {
+    $inputTypes = \Civi::cache('metadata')->get('afform.input_types');
+    if ($inputTypes === NULL) {
+      // Note: When adding a new input type, one must also create corresponding template and admin_template files.
+      $inputTypes = [
+        'ChainSelect' => [
+          'label' => E::ts('Chain-Select'),
+        ],
+        'CheckBox' => [
+          'label' => E::ts('Checkboxes'),
+        ],
+        'Date' => [
+          'label' => E::ts('Date Picker'),
+        ],
+        'DisplayOnly' => [
+          'label' => E::ts('Display Only'),
+        ],
+        'Email' => [
+          'label' => E::ts('Email'),
+        ],
+        'EntityRef' => [
+          'label' => E::ts('Autocomplete Entity'),
+        ],
+        'File' => [
+          'label' => E::ts('File'),
+        ],
+        'Hidden' => [
+          'label' => E::ts('Hidden'),
+        ],
+        'Location' => [
+          'label' => E::ts('Address Location'),
+        ],
+        'Number' => [
+          'label' => E::ts('Number'),
+        ],
+        'Radio' => [
+          'label' => E::ts('Radio Buttons'),
+        ],
+        'Range' => [
+          'label' => E::ts('Range'),
+        ],
+        'RichTextEditor' => [
+          'label' => E::ts('Rich Text Editor'),
+        ],
+        'Select' => [
+          'label' => E::ts('Select'),
+        ],
+        'Text' => [
+          'label' => E::ts('Single-Line Text'),
+        ],
+        'TextArea' => [
+          'label' => E::ts('Multi-Line Text'),
+        ],
+        'Toggle' => [
+          'label' => E::ts('Toggle Switch'),
+        ],
+        'Url' => [
+          'label' => E::ts('URL'),
+        ],
+      ];
+      // Input types shipped with Afform all follow this template file name convention,
+      // but 3rd parties must specify their own template file names.
+      foreach ($inputTypes as $name => &$inputType) {
+        $inputType += [
+          'template' => "~/af/fields/$name.html",
+          'admin_template' => "~/afGuiEditor/inputType/$name.html",
+        ];
+      }
+      // Allow input types to be modified by event listeners
+      $data = [
+        'inputTypes' => &$inputTypes,
+      ];
+      $event = GenericHookEvent::create($data);
+      \Civi::dispatcher()->dispatch('civi.afform.input_types', $event);
+      \Civi::cache('metadata')->set('afform.input_types', $inputTypes);
+    }
+    return $inputTypes;
   }
 
   public static function shouldReconcileManaged(array $updatedAfform, array $originalAfform = []): bool {

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -185,6 +185,17 @@ function _afform_hook_civicrm_angularModules($e) {
   foreach ($afforms as $afform) {
     $e->angularModules[$afform['module_name']]['requires'] = $dependencyMapper->autoReq($afform);
   }
+
+  // Ensure Afform requires all modules that provide input types
+  foreach (\Civi\Afform\Utils::getInputTypes() as $inputType) {
+    if (isset($inputType['module']) && $inputType['module'] !== 'af' && !in_array($inputType['module'], $e->angularModules['af']['requires'])) {
+      $e->angularModules['af']['requires'][] = $inputType['module'];
+    }
+    // Require admin_module if specified
+    if (isset($inputType['admin_module'], $e->angularModules['afGuiEditor']) && $inputType['admin_module'] !== 'afGuiEditor' && !in_array($inputType['admin_module'], $e->angularModules['afGuiEditor']['requires'])) {
+      $e->angularModules['afGuiEditor']['requires'][] = $inputType['admin_module'];
+    }
+  }
 }
 
 /**

--- a/ext/civi_contribute/Civi/Checkout/Afform.php
+++ b/ext/civi_contribute/Civi/Checkout/Afform.php
@@ -27,11 +27,10 @@ class Afform extends AutoService implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      // add afCheckout as a dependency of forms with Contributions
-      // we must hook later to alter afform modules @see afform_civicrm_config
+      // add CheckoutOption modules as dependencies of afCheckout
       'hook_civicrm_angularModules' => ['onAlterAngularModules', -1010],
       // provide CheckoutBlock element to FormBuilder
-      'civi.afform_admin.metadata' => ['onAfformAdminMetadata'],
+      'civi.afform.input_types' => ['onAfformInputTypes'],
       // run validation hook from selected CheckoutOption
       'civi.afform.validate' => ['validatePaymentFields', 0],
       // trigger Checkout on submission
@@ -185,63 +184,16 @@ class Afform extends AutoService implements EventSubscriberInterface {
         $e->angularModules['afCheckout']['requires'][] = $module;
       }
     }
-
-    // add afCheckout as a dependency of afAdmin so can be used in FormBuilder
-    $e->angularModules['afAdmin']['requires'][] = 'afCheckout';
-
-    // find configured afforms which use checkout and add the module dependency
-    // TODO: if/when we have a hook for afforms being saved, we should include
-    // the requirement in the .ang.php data in order to avoid computing it
-    // for every form every cache clear
-    foreach ($e->angularModules as $name => $module) {
-      if (!empty($module['_afform']) && $this->afformUsesCheckout($module['_afform'])) {
-        $e->angularModules[$name]['requires'] ??= [];
-        $e->angularModules[$name]['requires'][] = 'afCheckout';
-      }
-    }
   }
 
-  private function afformUsesCheckout(string $afformName): bool {
-    $layout = \Civi\Api4\Afform::get(FALSE)
-      ->addWhere('name', '=', $afformName)
-      ->addSelect('layout')
-      ->setLayoutFormat('html')
-      ->execute()
-      ->first()['layout'] ?? '';
-
-    if (!\str_contains($layout, 'Contribution')) {
-      return FALSE;
-    }
-    return TRUE;
-
-    // the below is a more strictly correct check - but is more labour intensive
-    // $layout = \Civi\Api4\Afform::get(FALSE)
-    //   ->addWhere('name', '=', $afformName)
-    //   ->addSelect('layout')
-    //   ->setLayoutFormat('deep')
-    //   ->execute()
-    //   ->first()['layout'] ?? NULL;
-
-    // // unexpected but dont crash the hook
-    // if (!$layout) {
-    //   return FALSE;
-    // }
-
-    // // does the form include contributions?
-    // $formDataModel = new FormDataModel($layout);
-    // $contributions = array_filter($formDataModel->getEntities(), fn ($entity) => $entity['type'] === 'Contribution');
-
-    // return !!$contributions;
-  }
-
-  public function onAfformAdminMetadata(GenericHookEvent $e) {
+  public function onAfformInputTypes(GenericHookEvent $e) {
     if (!$this->isActive()) {
       return;
     }
-    $e->inputTypes[] = [
-      'name' => 'CheckoutBlock',
+    $e->inputTypes['CheckoutBlock'] = [
       'label' => E::ts('Checkout Details Block'),
       'template' => '~/afCheckout/inputType/CheckoutBlock.html',
+      // Todo: Split the admin stuff into a different module
       'admin_template' => '~/afCheckout/inputType/CheckoutBlockAdmin.html',
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes two problems with [3rd parties providing input types for FormBuilder](https://github.com/civicrm/civicrm-core/pull/33127):

1. It didn't work if AfformAdmin was disabled (and that extension is optional).
2. It didn't automatically load the module providing the input type.

@ufundo if you've already implemented a custom input type, sorry, this will break what you've done, but from what I can tell it's already kinda broken in the above two ways.

This is toward [FormBuilder: allow inputs not linked to CiviCRM field](https://lab.civicrm.org/dev/core/-/work_items/6215)