### PR TITLE
Discard HEAD Request For URL Tracking

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -35,16 +35,19 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
     if (!$url_id) {
       CRM_Utils_System::sendInvalidRequestResponse(ts("Missing input parameters"));
     }
-    $queue = Civi::queue('civicrm.mailing.event.queue', [
-      'type' => 'Sql',
-      'reset' => FALSE,
-      'error' => 'abort',
-    ]);
-    $queue->createItem(new CRM_Queue_Task(
-      ['CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen', 'queuedTrack'],
-      [$queue_id, $url_id, date('YmdHis')],
-      'Processing tracked url open for queue (#' . $queue_id . '), url (#' . $url_id . ')'
-    ));
+    $isHead = ($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'HEAD';
+    if (!$isHead) {
+      $queue = Civi::queue('civicrm.mailing.event.queue', [
+        'type'  => 'Sql',
+        'reset' => FALSE,
+        'error' => 'abort',
+      ]);
+      $queue->createItem(new CRM_Queue_Task(
+        ['CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen', 'queuedTrack'],
+        [$queue_id, $url_id, date('YmdHis')],
+        'Processing tracked url open for queue (#' . $queue_id . '), url (#' . $url_id . ')'
+      ));
+    }
     $url = trim(CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track(NULL, $url_id));
     $query_string = $this->extractPassthroughParameters();
 


### PR DESCRIPTION
Overview
----------------------------------------
HEAD requests make up a significant portion of all click-tracking traffic, which are email security scanners and link previewers (e.g. Microsoft SafeLinks) and not real human clicks and should not be counted as url clicks, this PR improves the click through url count by ignoring HEAD requests for click through tracxking.
