### PR TITLE
Add entity ID and griditem class to Searchkit Grid display

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
@@ -1,4 +1,4 @@
-<div ng-repeat="(rowIndex, row) in $ctrl.results" class="{{ row.cssClass }}">
+<div ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}" class="crm-search-display-griditem {{ row.cssClass }}">
   <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: $ctrl.getFieldClass(colIndex, colData) }}">
     <label ng-if=":: colData.label">
       {{:: colData.label }}


### PR DESCRIPTION
Overview
----------------------------------------
This makes it much easier to do things like add custom "click" handlers for searchkit grid items.

- Add "data-entity-id" to each grid item - Let's you do things like "highlight on map" when clicked - see https://lab.civicrm.org/extensions/searchkitmaps/-/blob/main/ang/crmSearchKitMaps.js?ref_type=heads#L53
- Add a griditem class to each item - let's you target the item directly - eg.
```
document.querySelector("crm-search-display-grid").querySelectorAll('div.crm-search-display-griditem').forEach(function(item) {
      item.addEventListener('click', function() {
        console.log(this.dataset.entityId);
      });
    });
```

Before
----------------------------------------
No data entity id, no class for searchkit grid items.

After
----------------------------------------
Data entity id, class for searchkit grid items.

Technical Details
----------------------------------------
Described above

Comments
----------------------------------------
@mlutfy 
