### PR TITLE
Add "load" event when a searchDisplay has (re-)loaded it's data on the screen so third-party integrations can trigger actions.

### DIFF
--- a/ext/chart_kit/js/components/civi-search-display.js
+++ b/ext/chart_kit/js/components/civi-search-display.js
@@ -184,6 +184,9 @@
         });
       }
 
+      // Trigger an event when the searchDisplay has completely (re-)loaded
+      this.onPostRun.push(() => this.dispatchEvent(new Event('load')));
+
       // NOTE: @see searchDisplayBaseTrait setUpWatches
       // here we reimplement with events
 

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -148,6 +148,9 @@
           });
         }
 
+        // Trigger an event when the searchDisplay has completely (re-)loaded
+        this.onPostRun.push(() => $element[0].dispatchEvent(new Event('load')));
+
         // Set up watches to refresh search results when needed.
         // And trigger the first run of the search if appropriate.
         function setUpWatches() {


### PR DESCRIPTION
Overview
----------------------------------------
Adds a "load" event which can be used by third-party integrations to do things when the search display has loaded. For example add a click handler to each table row to highlight on a map - see https://lab.civicrm.org/extensions/searchkitmaps/-/blob/main/docs/index.md?ref_type=heads#advanced-features-requires-additional-configuration-for-formbuilder

Example:
```
CRM.$('crm-search-display-table').on('load', function(event) { console.log(event.target.getAttribute('display-name'));});
```

Before
----------------------------------------
You have to use something like jQuery ajaxSuccess and filter by URL.

After
----------------------------------------
Use the event directly and target the searchdisplay directly.

Technical Details
----------------------------------------


Comments
----------------------------------------
@ufundo per our discussion here https://chat.civicrm.org/civicrm/pl/ipdbf1er5bdcmpy3ucnqen3fee


