### PR TITLE
Don't check permissions in getUserJob

### DIFF
--- a/Civi/UserJob/UserJobTrait.php
+++ b/Civi/UserJob/UserJobTrait.php
@@ -74,7 +74,7 @@ trait UserJobTrait {
    */
   public function getUserJob(): array {
     if (empty($this->userJob)) {
-      $this->userJob = UserJob::get()
+      $this->userJob = UserJob::get(FALSE)
         ->addSelect('*', 'search_display_id.name', 'search_display_id.saved_search_id.name')
         ->addWhere('id', '=', $this->getUserJobID())
         ->execute()


### PR DESCRIPTION
This is called from a lot of places for managed entities. I'm seeing authorization failures when running cv flush here. It feels OK to me to not check permissions here.