### PR TITLE
Add contribution status to context for civicrm_links hook

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -399,6 +399,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
         'cid' => (int) $result->contact_id,
         'cxt' => $this->_context,
         'financial_type_id' => $result->financial_type_id ? (int) $result->financial_type_id : NULL,
+        'contribution_status_id' => $result->contribution_status_id,
       ];
 
       if (in_array($row['contribution_status_name'], ['Partially paid', 'Pending refund']) || $isPayLater) {


### PR DESCRIPTION
Add contribution status id, to let us determine which links to show without having to make a duplicative query. It's a bit out of place since these are meant to fill the URLs, but the financial_type_id is already there...

Overview
----------------------------------------
Adds a bit more context to determine when to show links on a contribution list

Before
----------------------------------------
civicrm_links hook subscribers need to make a db query to determine contribution status, despite that information being available in the selector.

After
----------------------------------------
civicrm_links hook subscribers can read contribution status from $values with no db queries needed.
