### PR TITLE
use membership title not machine name on backend

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -415,7 +415,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         $selOrgMemType[$memberOfContactId][0] = ts('- select -');
       }
       if (empty($selOrgMemType[$memberOfContactId][$key])) {
-        $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
+        $selOrgMemType[$memberOfContactId][$key] = $values['title'] ?? NULL;
       }
 
       $totalAmount = $values['minimum_fee'] ?? 0;


### PR DESCRIPTION
Overview
----------------------------------------
When adding a membership on the backend, the machine names are used, not the titles.

To replicate:
* Create a new membership type with spaces.
* Add a membership on the back end.
* Go to select your membership type.

Before
----------------------------------------
`Name_with_spaces`.

After
----------------------------------------
`Name with spaces`.

Comments
----------------------------------------
There's a similar issue with payment processor selection for contribution pages but I'll leave that out of scope here.
