### PR TITLE
Riverlea - add margin between status text and buttons

### DIFF
--- a/ang/crmStatusPage/StatusPage.html
+++ b/ang/crmStatusPage/StatusPage.html
@@ -30,7 +30,7 @@
           href="javascript:void(0)"
           >
         </a>
-        <div ng-if="status.actions" class="crm-status-item-actions">
+        <div ng-if="status.actions" class="crm-buttons crm-status-item-actions">
           <button type="button" ng-repeat="action in status.actions" ng-click="doAction(action)">
             <i class="crm-i {{:: action.icon }}" ng-if="action.icon" role="img" aria-hidden="true"></i>
             {{:: action.title }}

--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -85,3 +85,6 @@
 .status-debug-information {
   font-size: var(--crm-font-small-size);
 }
+#crm-status-list .crm-status-item .crm-buttons {
+  margin-top: var(--crm-flex-gap, 0.5rem);
+}

--- a/ext/riverlea/core/ang/crmStatusPage.css
+++ b/ext/riverlea/core/ang/crmStatusPage.css
@@ -63,7 +63,6 @@
   right: 0;
   width: calc(1.5 * var(--crm-dropdown-width));
   margin: 0;
-  padding: 0;
   z-index: 99;
   background: var(--crm-dropdown-bg-color);
   padding: var(--crm-dropdown-padding);


### PR DESCRIPTION
Before
----------------------------------------
- no margin
<img width="628" height="195" alt="image" src="https://github.com/user-attachments/assets/6ac45bf3-23ec-4225-af50-aaf00ae6c058" />


After
----------------------------------------
- some margin

<img width="816" height="497" alt="image" src="https://github.com/user-attachments/assets/4cb9d093-ece3-468c-a240-77c16c357d15" />


Technical Details
----------------------------------------
We still have separate version of `crmStatusPage.css` for Riverlea / non-RL. I will make a follow up PR to merge them.

Comments
----------------------------------------
It's quite a small amount of margin. I also tried `--crm-l-reg` but it was then too much margin :shrug: 