### PR TITLE
[Draft] pass custom fields to civi.dao.preInsert/preUpdate when copying records

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -1947,8 +1947,6 @@ LIKE %1
         break;
       }
 
-      $newObject = new $daoName();
-
       $fields = $object->fields();
       $fieldsToPrefix = [];
       $fieldsToSuffix = [];
@@ -1964,6 +1962,7 @@ LIKE %1
       }
 
       $localizableFields = FALSE;
+      $record = [];
       foreach ($fields as $name => $value) {
         if ($name === 'id' || $value['name'] === 'id') {
           // copy everything but the id!
@@ -1972,33 +1971,42 @@ LIKE %1
 
         $dbName = $value['name'];
         $type = CRM_Utils_Type::typeToString($value['type']);
-        $newObject->$dbName = $object->$dbName;
+        $record[$dbName] = $object->$dbName;
         if (isset($fieldsToPrefix[$dbName])) {
-          $newObject->$dbName = $fieldsToPrefix[$dbName] . $newObject->$dbName;
+          $record[$dbName] = $fieldsToPrefix[$dbName] . $record[$dbName];
         }
         if (isset($fieldsToSuffix[$dbName])) {
-          $newObject->$dbName .= $fieldsToSuffix[$dbName];
+          $record[$dbName] .= $fieldsToSuffix[$dbName];
         }
         if (isset($fieldsToReplace[$dbName])) {
-          $newObject->$dbName = $fieldsToReplace[$dbName];
+          $record[$dbName] = $fieldsToReplace[$dbName];
         }
 
         if ($type === 'Timestamp' || $type === 'Date') {
-          $newObject->$dbName = CRM_Utils_Date::isoToMysql($newObject->$dbName);
+          $record[$dbName] = CRM_Utils_Date::isoToMysql($record[$dbName]);
         }
 
         if (!empty($value['localizable'])) {
           $localizableFields = TRUE;
         }
-
-        if ($newData) {
-          $newObject->copyValues($newData);
-        }
+      }
+      if ($newData) {
+        $record = array_merge($record, $newData);
       }
       if (!empty($fields['name'])) {
+        // `makeNameFromLabel()` isn't static, so we need to create an instance to use it.
+        $newObject = new $daoName();
+        $newObject->copyValues($record);
         $newObject->makeNameFromLabel();
+        $record['name'] = $newObject->name;
       }
-      $newObject->save();
+      if (!$blockCopyofCustomValues) {
+        $customParams = self::buildCustomFieldCopyParams($daoName, $object->id);
+        if ($customParams) {
+          $record['custom'] = CRM_Core_BAO_CustomField::postProcess($customParams, NULL, CRM_Core_DAO_AllCoreTables::getEntityNameForClass($daoName));
+        }
+      }
+      $newObject = $daoName::writeRecord($record);
 
       // ensure we copy all localized fields as well
       if (CRM_Core_I18n::isMultilingual() && $localizableFields) {
@@ -2018,9 +2026,11 @@ LIKE %1
       }
 
       if (!$blockCopyofCustomValues) {
-        $newObject->copyCustomFields($object->id, $newObject->id);
+        // Custom field values are stored via writeRecord() above. Copy only the
+        // activity file attachments that are tracked outside the custom field tables.
+        $tableName = CRM_Core_DAO_AllCoreTables::getTableForClass($daoName);
+        CRM_Core_BAO_File::copyEntityFile($tableName, $object->id, $tableName, $newObject->id);
       }
-      CRM_Utils_Hook::post('create', CRM_Core_DAO_AllCoreTables::getEntityNameForClass($daoName), $newObject->id, $newObject);
     }
 
     return $newObject;


### PR DESCRIPTION
Overview
----------------------------------------
#33005 saves custom data before emitting `civi.dao.postInsert/postUpdate` events for reasons enumerated there.  But this doesn't apply to `CRM_Core_DAO::copyGeneric()`.  This modifies `copyGeneric()` to do so. I'm also going through `writeRecord()` since it's a more correct approach than DIYing it in `copyGeneric()` - for instance, `copyGeneric()` has a `post` but no `pre` hook.

Before
----------------------------------------
Copying a record doesn't pass custom data to `civi.dao.postInsert/postUpdate` or `hook_civicrm_pre`.

After
----------------------------------------
Does.

Comments
----------------------------------------
This relies on https://github.com/civicrm/civicrm-core/pull/35339 and shouldn't be evaluated until that's merged.
