### PR TITLE
dev/core#6428 AfformCheckout - properly suppress afCheckout and dependencies if not enabled

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/Afform.php
+++ b/ext/civi_contribute/Civi/Checkout/Afform.php
@@ -169,6 +169,17 @@ class Afform extends AutoService implements EventSubscriberInterface {
 
   public function onAlterAngularModules(GenericHookEvent $e): void {
     if (!$this->isActive()) {
+      // if afform contributions is disabled we de-register afCheckout
+      unset($e->angularModules['afCheckout']);
+
+      // also deregister any modules which depend on it (which will come from integrations, e.g. afStripe, afPaypal)
+      // NOTE: if another module registers a dependency on afStripe it might crash. we dont expect that to happen
+      // and in the long run this should be removed, so not worth handling that case
+      foreach ($e->angularModules as $name => $module) {
+        if (in_array('afCheckout', $module['requires'] ?? [])) {
+          unset($e->angularModules[$name]);
+        }
+      }
       return;
     }
 

--- a/ext/civi_contribute/ang/afCheckout.ang.php
+++ b/ext/civi_contribute/ang/afCheckout.ang.php
@@ -1,9 +1,5 @@
 <?php
 
-if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
-  return [];
-}
-
 // Angular module afCheckout.
 // @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
 return [


### PR DESCRIPTION
Before
----------------------------------------
- status page crash if FormBuilder Contributions not enabled
- the attempt to not register `afCheckout` if disabled wasn't working properly
- could also crash if an integration module declared an explicit dependency

After
----------------------------------------
- more fully suppress when FormBuilder Contributions not enabled
- no crash

Technical Details
----------------------------------------
Trying to return an empty array in `.ang.php` doesn't work - a module is still declared by `ang-php` mixin. It's just broken.

This is different to `.mgd.php` and feels like a gotcha, which might be nice to fix. I couldn't see an easy route to do so for the RC however.

It could still crash if there was a transitive angular module dependency, ie something depended on `afStripe`. But nothing does now, and I don't really see a reason anything should in the future. We don't expect this setting to be in place forever so I don't think it's necessary to handle that case.

Comments
----------------------------------------
The other fix was to enable FormBuilder Contributions...
