### PR TITLE
Removing double fieldset

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Confirm.tpl
@@ -194,9 +194,9 @@
   {/if}
 
   {if $customPre}
-    <fieldset class="label-left crm-profile-view">
+    <div class="label-left crm-profile-view">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false hideFieldset=false}
-    </fieldset>
+    </div>
   {/if}
 
   {if $pcpBlock && $pcp_display_in_roll}
@@ -290,9 +290,9 @@
   {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="confirmContribution" showPremiumSelectionFields=false preview=false}
 
   {if $customPost}
-    <fieldset class="label-left crm-profile-view">
+    <div class="label-left crm-profile-view">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}
-    </fieldset>
+    </div>
   {/if}
 
   {if $confirmText}

--- a/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/ThankYou.tpl
@@ -237,9 +237,9 @@
   {/if}
 
   {if $customPre}
-    <fieldset class="label-left crm-profile-view">
+    <div class="label-left crm-profile-view">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPre prefix=false hideFieldset=false}
-    </fieldset>
+    </div>
   {/if}
 
   {if $pcpBlock && $pcp_display_in_roll}
@@ -321,9 +321,9 @@
   {include file="CRM/Contribute/Form/Contribution/PremiumBlock.tpl" context="thankContribution" showPremiumSelectionFields=false preview=false}
 
   {if $customPost}
-    <fieldset class="label-left crm-profile-view">
+    <div class="label-left crm-profile-view">
       {include file="CRM/UF/Form/Block.tpl" fields=$customPost prefix=false hideFieldset=false}
-    </fieldset>
+    </div>
   {/if}
 
   <div id="thankyou_footer" class="contribution_thankyou_footer-section">


### PR DESCRIPTION
Overview
----------------------------------------
Remove the unnecessary fieldset in a fieldset on contribution confirmation and thank you page:

<img width="2110" height="414" alt="Capture d’écran du 2026-04-08 14-18-52" src="https://github.com/user-attachments/assets/9f6587a2-f98e-4dc9-ac30-799c9f288a50" />

Before
----------------------------------------

There is a `fieldset` container that doesn't bring any semantic value.

After
----------------------------------------

Changed to a `div`

Comments
----------------------------------------

- This remove the needs for a specific css to deal with this in case we want to add padding / border... on fieldset
- no changes in css, the classes `label-left` and `crm-profile-view` don't mind about the tag
