### PR TITLE
Select2 - Fix indentation for nested Select2

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -688,18 +688,21 @@ span.crm-select-item-color {
 }
 .crm-container .select2-results .select2-result-label {
   font-size: var(--crm-input-font-size);
-  padding: var(--crm-l-small) var(--crm-l-medium);
+  padding-top: var(--crm-l-small);
+  padding-bottom: var(--crm-l-small);
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .crm-container .select2-results > li .select2-result-label {
-  padding: 0;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 .select2-results li.select2-result-with-children > .select2-result-label {
   font-weight: bold;
   background: var(--crm-layer2-bg-color);
-  padding: var(--crm-l-small);
+  padding-top: var(--crm-l-small);
+  padding-bottom: var(--crm-l-small);
 }
 .crm-container .crm-select2-row-description p {
   font-weight: normal;


### PR DESCRIPTION
Overview
----------------------------------------
Hierarchical select2 results are supposed to be indented, but [the select2.css padding](https://github.com/colemanw/select2/blob/stable/3.5/select2.css#L386-L392) was being overridden by Riverlea.

This removes the left/right padding overrides.

Before
----------------------------------------
You can see this for example in FormBuilder. Create a new submission form, type anything in the "Page Route" and then click "Add to Navigation Menu":

<img width="468" height="484" alt="image" src="https://github.com/user-attachments/assets/e6a9eaff-ad68-4d85-b3aa-19f521669c1a" />


After
----------------------------------------
<img width="468" height="484" alt="image" src="https://github.com/user-attachments/assets/be732285-9aa0-42df-ae31-e42612544f02" />


Technical Details
----------------------------------------
@vingle if you really hate the 20px, 40px, etc in select2.css we could copy it into Riverlea & redo in rems?