### PR TITLE
dev/core#6426 - Switch Navigation select to use select2.

### DIFF
--- a/CRM/Admin/Form/Navigation.php
+++ b/CRM/Admin/Form/Navigation.php
@@ -93,14 +93,10 @@ class CRM_Admin_Form_Navigation extends CRM_Admin_Form {
       $parentMenu = CRM_Core_BAO_Navigation::getNavigationList();
 
       if (isset($this->_id)) {
-        unset($parentMenu[$this->_id]);
+        CRM_Utils_Array::removeRecursive($parentMenu, ['id' => $this->_id]);
       }
 
-      // also unset home.
-      $homeMenuId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Home', 'id', 'name');
-      unset($parentMenu[$homeMenuId]);
-
-      $this->add('select', 'parent_id', ts('Parent'), ['' => ts('Top level')] + $parentMenu, FALSE, ['class' => 'crm-select2 huge']);
+      $this->add('select2', 'parent_id', ts('Parent'), $parentMenu, FALSE, ['class' => 'huge', 'placeholder' => ts('Top level')]);
     }
   }
 

--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Navigation;
+
 /**
  *
  * @package CRM
@@ -154,85 +156,49 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
    *   returns associated array
    */
   public static function getNavigationList() {
-    $cacheKeyString = "navigationList_" . CRM_Core_Config::domainID();
-    $whereClause = '';
-
-    $config = CRM_Core_Config::singleton();
+    $cacheKeyString = "navigationList_" . CRM_Core_Config::domainID() . Civi::settings()->get('lcMessages');
 
     // check if we can retrieve from database cache
     $navigations = Civi::cache('navigation')->get($cacheKeyString);
 
     if (!$navigations) {
-      $domainID = CRM_Core_Config::domainID();
-      $query = "
-SELECT id, label, parent_id, weight, is_active, name
-FROM civicrm_navigation WHERE domain_id = $domainID
-ORDER BY weight";
-      $result = CRM_Core_DAO::executeQuery($query);
+      $results = Navigation::get(FALSE)
+        ->addSelect('id', 'label', 'icon', 'parent_id', 'icon')
+        ->addWhere('domain_id', '=', 'current_domain')
+        ->addWhere('is_active', '=', TRUE)
+        ->addWhere('name', '!=', 'Home')
+        ->addOrderBy('weight')
+        ->execute();
 
-      $pidGroups = [];
-      while ($result->fetch()) {
-        $pidGroups[$result->parent_id ?? ''][$result->label ?? ''] = $result->id;
+      // Build a translated array indexed by id
+      $i18n = CRM_Core_I18n::singleton();
+      $lookup = [];
+      foreach ($results as $item) {
+        $lookup[$item['id']] = [
+          'id' => $item['id'],
+          'label' => $i18n->crm_translate($item['label']),
+          'icon' => $item['icon'],
+        ];
       }
 
-      foreach ($pidGroups[''] as $label => $val) {
-        $pidGroups[''][$label] = self::_getNavigationValue($val, $pidGroups);
+      // Build the nested structure
+      foreach ($results as $item) {
+        if ($item['parent_id'] && isset($lookup[$item['parent_id']])) {
+          $lookup[$item['parent_id']]['children'][] = &$lookup[$item['id']];
+        }
       }
 
+      // Extract only top-level items (parent_id is NULL)
       $navigations = [];
-      self::_getNavigationLabel($pidGroups[''], $navigations);
+      foreach ($results as $item) {
+        if (!$item['parent_id']) {
+          $navigations[] = $lookup[$item['id']];
+        }
+      }
 
       Civi::cache('navigation')->set($cacheKeyString, $navigations);
     }
     return $navigations;
-  }
-
-  /**
-   * Helper function for getNavigationList().
-   *
-   * @param array $list
-   *   Menu info.
-   * @param array $navigations
-   *   Navigation menus.
-   * @param string $separator
-   *   Menu separator.
-   */
-  public static function _getNavigationLabel($list, &$navigations, $separator = '') {
-    $i18n = CRM_Core_I18n::singleton();
-    foreach ($list as $label => $val) {
-      if ($label == 'navigation_id') {
-        continue;
-      }
-      $translatedLabel = $i18n->crm_translate($label, ['context' => 'menu']);
-      $navigations[is_array($val) ? $val['navigation_id'] : $val] = "{$separator}{$translatedLabel}";
-      if (is_array($val)) {
-        self::_getNavigationLabel($val, $navigations, $separator . '&nbsp;&nbsp;&nbsp;&nbsp;');
-      }
-    }
-  }
-
-  /**
-   * Helper function for getNavigationList().
-   *
-   * @param string $val
-   *   Menu name.
-   * @param array $pidGroups
-   *   Parent menus.
-   *
-   * @return array
-   */
-  public static function _getNavigationValue($val, &$pidGroups) {
-    if (array_key_exists($val, $pidGroups)) {
-      $list = ['navigation_id' => $val];
-      foreach ($pidGroups[$val] as $label => $id) {
-        $list[$label] = self::_getNavigationValue($id, $pidGroups);
-      }
-      unset($pidGroups[$val]);
-      return $list;
-    }
-    else {
-      return $val;
-    }
   }
 
   /**
@@ -897,7 +863,7 @@ ORDER BY weight";
     $childCount = 0;
     $parentIds = [$id];
     while ($parentIds) {
-      $parentIds = \Civi\Api4\Navigation::get(FALSE)
+      $parentIds = Navigation::get(FALSE)
         ->addWhere('parent_id', 'IN', $parentIds)
         ->addSelect('id')
         ->execute()->column('id');

--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -135,7 +135,7 @@ class CRM_Report_Form_Instance {
     // navigation field
     $parentMenu = CRM_Core_BAO_Navigation::getNavigationList();
 
-    $form->add('select', 'parent_id', ts('Parent Menu'), ['' => ts('- select -')] + $parentMenu);
+    $form->add('select2', 'parent_id', ts('Parent Menu'), $parentMenu, FALSE, ['class' => 'huge', 'placeholder' => ts('Top level')]);
 
     // For now we only providing drilldown for one primary detail report only. In future this could be multiple reports
     foreach ($form->_drilldownReport as $reportUrl => $drillLabel) {

--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -144,6 +144,50 @@ class CRM_Utils_Array {
   }
 
   /**
+   * Recursively removes items from a given array that match the predicate
+   *
+   * @param array|null $collection
+   * @param array|callable|string $predicate
+   */
+  public static function removeRecursive(&$collection, $predicate): void {
+    if (!is_array($collection)) {
+      return;
+    }
+
+    foreach ($collection as $key => &$item) {
+      if (is_array($item)) {
+        if (self::matchesPredicate($item, $predicate)) {
+          unset($collection[$key]);
+        }
+        else {
+          foreach ($item as &$children) {
+            self::removeRecursive($children, $predicate);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Helper function to check if an item matches a predicate.
+   *
+   * @param array $item
+   * @param array|callable|string $predicate
+   * @return bool
+   */
+  private static function matchesPredicate(array $item, $predicate): bool {
+    if (is_callable($predicate)) {
+      return $predicate($item);
+    }
+    elseif (is_array($predicate)) {
+      return count(array_intersect_assoc($item, $predicate)) === count($predicate);
+    }
+    else {
+      return array_key_exists($predicate, $item);
+    }
+  }
+
+  /**
    * Wraps and slightly changes the behavior of PHP's array_search().
    *
    * This function reproduces the behavior of array_search() from PHP prior to

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -554,4 +554,64 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals($expected, $sorted);
   }
 
+  public function testRemoveRecursive(): void {
+    $data = [
+      ['name' => 'Alice', 'age' => 31, 'active' => TRUE],
+      ['name' => 'Bob', 'age' => 25, 'active' => FALSE],
+      ['name' => 'Charlie', 'age' => 35, 'active' => TRUE],
+      ['name' => 'David', 'age' => 28, 'active' => FALSE],
+      [
+        'name' => 'Eve',
+        'age' => 30,
+        'active' => TRUE,
+        'children' => [
+          ['name' => 'Billy', 'age' => 3, 'active' => TRUE],
+          ['name' => 'Jilly', 'age' => 5, 'active' => FALSE],
+        ],
+      ],
+    ];
+
+    // Test removing by active status
+    $dataClone = $data;
+    CRM_Utils_Array::removeRecursive($dataClone, ['active' => FALSE]);
+    $this->assertCount(3, $dataClone);
+    $this->assertEquals('Alice', $dataClone[0]['name']);
+    $this->assertEquals('Charlie', $dataClone[2]['name']);
+    $this->assertCount(1, $dataClone[4]['children']);
+
+    // Test removing by age greater than 30
+    $dataClone = $data;
+    CRM_Utils_Array::removeRecursive($dataClone, fn($item) => $item['age'] > 30);
+    $this->assertCount(3, $dataClone);
+    $this->assertEquals('Bob', $dataClone[1]['name']);
+    $this->assertEquals('David', $dataClone[3]['name']);
+    $this->assertCount(2, $dataClone[4]['children']);
+
+    // Test removing with no matches
+    $dataClone = $data;
+    CRM_Utils_Array::removeRecursive($dataClone, fn($item) => $item['age'] > 100);
+    $this->assertCount(5, $dataClone);
+    $this->assertEquals($data, $dataClone);
+
+    // Test removing with all matches
+    $dataClone = $data;
+    CRM_Utils_Array::removeRecursive($dataClone, 'name');
+    $this->assertCount(0, $dataClone);
+    $this->assertEquals([], $dataClone);
+
+    // Test with empty array
+    $emptyData = [];
+    CRM_Utils_Array::removeRecursive($emptyData, 'name');
+    $this->assertEquals([], $emptyData);
+
+    // Test removing by children key
+    $dataClone = $data;
+    CRM_Utils_Array::removeRecursive($dataClone, 'children');
+    $this->assertCount(4, $dataClone);
+    $this->assertEquals('Alice', $dataClone[0]['name']);
+    $this->assertEquals('Bob', $dataClone[1]['name']);
+    $this->assertEquals('Charlie', $dataClone[2]['name']);
+    $this->assertEquals('David', $dataClone[3]['name']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [the regression](https://lab.civicrm.org/dev/core/-/work_items/6426) and spruces up the dropdown to take advantage of select2 with icons, etc.

Before
-----

<img width="842" height="470" alt="image" src="https://github.com/user-attachments/assets/723cd114-3847-494e-a515-8fddb3bcbd43" />


<img width="770" height="524" alt="image" src="https://github.com/user-attachments/assets/b9b5e351-2602-4adf-8cf7-0fdbc34e2937" />


After
-----
<img width="925" height="470" alt="image" src="https://github.com/user-attachments/assets/bec3328c-cb0d-4c39-9dfb-0cb9339ff58a" />

<img width="769" height="541" alt="image" src="https://github.com/user-attachments/assets/1204dfbe-ca6b-4e49-ad79-3c4b246c2973" />


Technical Details
----------------------------------------
This patch is bigger than the usual regression fix but it's doing it The Right Way® with unit tests, and it only affects 2 dropdowns on 2 forms.