### PR TITLE
CiviReport - Prevent navigation from being selected as own parent

### DIFF
--- a/CRM/Report/Form/Instance.php
+++ b/CRM/Report/Form/Instance.php
@@ -134,6 +134,13 @@ class CRM_Report_Form_Instance {
 
     // navigation field
     $parentMenu = CRM_Core_BAO_Navigation::getNavigationList();
+    // Remove current report from the list as it cannot be a child of itself.
+    if ($instanceID) {
+      $navId = CRM_Core_DAO::getFieldValue('CRM_Report_DAO_ReportInstance', $instanceID, 'navigation_id');
+      if ($navId) {
+        CRM_Utils_Array::removeRecursive($parentMenu, ['id' => $navId]);
+      }
+    }
 
     $form->add('select2', 'parent_id', ts('Parent Menu'), $parentMenu, FALSE, ['class' => 'huge', 'placeholder' => ts('Top level')]);
 


### PR DESCRIPTION
Overview
----------------------------------------
Prevent a navigation item as being selected as the child of itself.

Technical Details
----------------------------------------
This matches the functionality in `CRM_Admin_Form_Navigation::buildQuickForm()` 