### PR TITLE
UtilsArray - Refactor findAll to use shared function

### DIFF
--- a/CRM/Utils/Array.php
+++ b/CRM/Utils/Array.php
@@ -109,51 +109,71 @@ class CRM_Utils_Array {
   }
 
   /**
-   * Recursively searches through a given array for all matches
+   * Non-recursive search, returns all arrays within $collection that match $predicate
    *
-   * @param array|null $collection
-   * @param array|callable|string $predicate
+   * Index keys are preserved.
+   * For recursive search, @see self::findAll
+   *
+   * @param array $collection
+   * @param callable|array|string $predicate
    * @return array
    */
-  public static function findAll($collection, $predicate) {
+  public static function filter(array $collection, callable|array|string $predicate): array {
     $results = [];
-    $search = function($collection) use (&$search, &$results, $predicate) {
-      if (is_array($collection)) {
-        if (is_callable($predicate)) {
-          if ($predicate($collection)) {
-            $results[] = $collection;
-          }
-        }
-        elseif (is_array($predicate)) {
-          if (count(array_intersect_assoc($collection, $predicate)) === count($predicate)) {
-            $results[] = $collection;
-          }
+    foreach ($collection as $key => $item) {
+      if (is_array($item) && self::matchesPredicate($item, $predicate)) {
+        $results[$key] = $item;
+      }
+    }
+    return $results;
+  }
+
+  /**
+   * Non-recursive search, returns the first array within $collection matching $predicate
+   *
+   * @param array $collection
+   * @param callable|array|string $predicate
+   * @return array|null
+   */
+  public static function find(array $collection, callable|array|string $predicate): ?array {
+    foreach ($collection as $item) {
+      if (is_array($item) && self::matchesPredicate($item, $predicate)) {
+        return $item;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Recursively searches through a given array for all matching arrays.
+   *
+   * @param array $collection
+   * @param callable|array|string $predicate
+   * @return array
+   */
+  public static function findAll(array $collection, callable|array|string $predicate): array {
+    $results = [];
+
+    foreach ($collection as $item) {
+      if (is_array($item)) {
+        if (self::matchesPredicate($item, $predicate)) {
+          $results[] = $item;
         }
         else {
-          if (array_key_exists($predicate, $collection)) {
-            $results[] = $collection;
-          }
-        }
-        foreach ($collection as $item) {
-          $search($item);
+          $results = array_merge($results, self::findAll($item, $predicate));
         }
       }
-    };
-    $search($collection);
+    }
     return $results;
   }
 
   /**
    * Recursively removes items from a given array that match the predicate
    *
-   * @param array|null $collection
-   * @param array|callable|string $predicate
+   * @param array $collection
+   * @param callable|array|string $predicate
    */
-  public static function removeRecursive(&$collection, $predicate): void {
-    if (!is_array($collection)) {
-      return;
-    }
-
+  public static function removeRecursive(array &$collection, callable|array|string $predicate): void {
     foreach ($collection as $key => &$item) {
       if (is_array($item)) {
         if (self::matchesPredicate($item, $predicate)) {
@@ -161,7 +181,9 @@ class CRM_Utils_Array {
         }
         else {
           foreach ($item as &$children) {
-            self::removeRecursive($children, $predicate);
+            if (is_array($children)) {
+              self::removeRecursive($children, $predicate);
+            }
           }
         }
       }
@@ -172,10 +194,10 @@ class CRM_Utils_Array {
    * Helper function to check if an item matches a predicate.
    *
    * @param array $item
-   * @param array|callable|string $predicate
+   * @param callable|array|string $predicate
    * @return bool
    */
-  private static function matchesPredicate(array $item, $predicate): bool {
+  private static function matchesPredicate(array $item, callable|array|string $predicate): bool {
     if (is_callable($predicate)) {
       return $predicate($item);
     }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -234,7 +234,7 @@ class CoreUtil {
       return [
         'extends' => [$entityName],
         'column' => 'id',
-        'grouping' => ($customGroupExtends[$entityName]['grouping'] ?: array_column(\CRM_Utils_Array::findAll($extendsSubGroups, ['extends' => $entityName]), 'grouping', 'id')) ?: NULL,
+        'grouping' => ($customGroupExtends[$entityName]['grouping'] ?: array_column(\CRM_Utils_Array::filter($extendsSubGroups, ['extends' => $entityName]), 'grouping', 'id')) ?: NULL,
       ];
     }
     return NULL;

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -31,121 +31,127 @@ class AdminTest extends Api4TestBase {
     $joins = Admin::getJoins($allowedEntities);
     $this->assertNotEmpty($joins);
 
-    $groupContactJoins = \CRM_Utils_Array::findAll($joins['Group'], [
+    $groupContactJoins = \CRM_Utils_Array::filter($joins['Group'], [
       'entity' => 'Contact',
       'bridge' => 'GroupContact',
       'alias' => 'Group_GroupContact_Contact',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $groupContactJoins);
+    $groupContactJoin = reset($groupContactJoins);
     $this->assertEquals(
       ['GroupContact', ['id', '=', 'Group_GroupContact_Contact.group_id']],
-      $groupContactJoins[0]['conditions']
+      $groupContactJoin['conditions']
     );
     $this->assertEquals(
       [['Group_GroupContact_Contact.status:name', '=', '"Added"']],
-      $groupContactJoins[0]['defaults']
+      $groupContactJoin['defaults']
     );
 
-    $relationshipJoins = \CRM_Utils_Array::findAll($joins['Contact'], [
+    $relationshipJoins = \CRM_Utils_Array::filter($joins['Contact'], [
       'entity' => 'Contact',
       'bridge' => 'RelationshipCache',
       'alias' => 'Contact_RelationshipCache_Contact',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $relationshipJoins);
+    $relationshipJoin = reset($relationshipJoins);
     $this->assertEquals(
       ['RelationshipCache', ['id', '=', 'Contact_RelationshipCache_Contact.far_contact_id']],
-      $relationshipJoins[0]['conditions']
+      $relationshipJoin['conditions']
     );
     $this->assertEquals(
       [['Contact_RelationshipCache_Contact.near_relation:name', '=', '"Child of"']],
-      $relationshipJoins[0]['defaults']
+      $relationshipJoin['defaults']
     );
 
     $relationshipCacheJoins = $joins['RelationshipCache'];
     $this->assertCount(4, $relationshipCacheJoins);
     $this->assertEquals(['RelationshipType', 'Contact', 'Contact', 'Case'], array_column($relationshipCacheJoins, 'entity'));
 
-    $eventParticipantJoins = \CRM_Utils_Array::findAll($joins['Event'], [
+    $eventParticipantJoins = \CRM_Utils_Array::filter($joins['Event'], [
       'entity' => 'Participant',
       'alias' => 'Event_Participant_event_id',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $eventParticipantJoins);
-    $this->assertNull($eventParticipantJoins[0]['bridge'] ?? NULL);
+    $eventParticipantJoin = reset($eventParticipantJoins);
+    $this->assertNull($eventParticipantJoin['bridge'] ?? NULL);
     $this->assertEquals(
       [['id', '=', 'Event_Participant_event_id.event_id']],
-      $eventParticipantJoins[0]['conditions']
+      $eventParticipantJoin['conditions']
     );
 
-    $tagActivityJoins = \CRM_Utils_Array::findAll($joins['Tag'], [
+    $tagActivityJoins = \CRM_Utils_Array::filter($joins['Tag'], [
       'entity' => 'Activity',
       'bridge' => 'EntityTag',
       'alias' => 'Tag_EntityTag_Activity',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $tagActivityJoins);
+    $tagActivityJoin = reset($tagActivityJoins);
     $this->assertEquals(
       ['EntityTag', ['id', '=', 'Tag_EntityTag_Activity.tag_id']],
-      $tagActivityJoins[0]['conditions']
+      $tagActivityJoin['conditions']
     );
 
-    $activityTagJoins = \CRM_Utils_Array::findAll($joins['Activity'], [
+    $activityTagJoins = \CRM_Utils_Array::filter($joins['Activity'], [
       'entity' => 'Tag',
       'bridge' => 'EntityTag',
       'alias' => 'Activity_EntityTag_Tag',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $activityTagJoins);
+    $activityTagJoin = reset($activityTagJoins);
     $this->assertEquals(
       ['EntityTag', ['id', '=', 'Activity_EntityTag_Tag.entity_id'], ['Activity_EntityTag_Tag.entity_table', '=', "'civicrm_activity'"]],
-      $activityTagJoins[0]['conditions']
+      $activityTagJoin['conditions']
     );
 
     // Ensure joins exist btw custom group & custom fields
-    $customGroupToField = \CRM_Utils_Array::findAll($joins['CustomGroup'], [
+    $customGroupToField = \CRM_Utils_Array::filter($joins['CustomGroup'], [
       'entity' => 'CustomField',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $customGroupToField);
-    $customFieldToGroup = \CRM_Utils_Array::findAll($joins['CustomField'], [
+    $customFieldToGroup = \CRM_Utils_Array::filter($joins['CustomField'], [
       'entity' => 'CustomGroup',
       'multi' => FALSE,
     ]);
     $this->assertCount(1, $customFieldToGroup);
 
     // Ensure joins btw option group and option value
-    $optionGroupToValue = \CRM_Utils_Array::findAll($joins['OptionGroup'], [
+    $optionGroupToValue = \CRM_Utils_Array::filter($joins['OptionGroup'], [
       'entity' => 'OptionValue',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $optionGroupToValue);
-    $optionValueToGroup = \CRM_Utils_Array::findAll($joins['OptionValue'], [
+    $optionValueToGroup = \CRM_Utils_Array::filter($joins['OptionValue'], [
       'entity' => 'OptionGroup',
       'multi' => FALSE,
     ]);
     $this->assertCount(1, $optionValueToGroup);
 
     // Location joins
-    $addressJoins = \CRM_Utils_Array::findAll($joins['Individual'], [
+    $addressJoins = \CRM_Utils_Array::filter($joins['Individual'], [
       'entity' => 'Address',
       'multi' => TRUE,
     ]);
     $this->assertCount(1, $addressJoins);
+    $addressJoin = reset($addressJoins);
     $this->assertEquals(
       [['id', '=', 'Contact_Address_contact_id.contact_id']],
-      $addressJoins[0]['conditions']
+      $addressJoin['conditions']
     );
     $this->assertEquals(
       [['Contact_Address_contact_id.is_primary', '=', TRUE]],
-      $addressJoins[0]['defaults']
+      $addressJoin['defaults']
     );
 
     // LocBlock joins
-    $locBlockAddress = \CRM_Utils_Array::findAll($joins['LocBlock'], [
+    $locBlockAddress = array_values(\CRM_Utils_Array::filter($joins['LocBlock'], [
       'entity' => 'Address',
-    ]);
+    ]));
     $this->assertCount(2, $locBlockAddress);
     $this->assertEquals(
       [['address_id', '=', 'LocBlock_Address_address_id.id']],
@@ -174,10 +180,11 @@ class AdminTest extends Api4TestBase {
     $allowedEntities = Admin::getSchema();
     $joins = Admin::getJoins($allowedEntities);
 
-    $entityRefJoin = \CRM_Utils_Array::findAll($joins['Contact'], ['alias' => 'Contact_Contact_favorite_nephew']);
-    $this->assertCount(1, $entityRefJoin);
-    $this->assertEquals([['EntityRefFields.favorite_nephew', '=', 'Contact_Contact_favorite_nephew.id']], $entityRefJoin[0]['conditions']);
-    $this->assertStringContainsString('Favorite Nephew', $entityRefJoin[0]['label']);
+    $entityRefJoins = \CRM_Utils_Array::filter($joins['Contact'], ['alias' => 'Contact_Contact_favorite_nephew']);
+    $this->assertCount(1, $entityRefJoins);
+    $entityRefJoin = reset($entityRefJoins);
+    $this->assertEquals([['EntityRefFields.favorite_nephew', '=', 'Contact_Contact_favorite_nephew.id']], $entityRefJoin['conditions']);
+    $this->assertStringContainsString('Favorite Nephew', $entityRefJoin['label']);
   }
 
   public function testMultiRecordCustomGetJoins(): void {
@@ -198,23 +205,27 @@ class AdminTest extends Api4TestBase {
     $allowedEntities = Admin::getSchema();
     $joins = Admin::getJoins($allowedEntities);
 
-    $entityRefJoin = \CRM_Utils_Array::findAll($joins['Custom_MultiRecordActivity'], ['alias' => 'Custom_MultiRecordActivity_Group_ref_group']);
-    $this->assertCount(1, $entityRefJoin);
-    $this->assertEquals([['ref_group', '=', 'Custom_MultiRecordActivity_Group_ref_group.id']], $entityRefJoin[0]['conditions']);
+    $entityRefJoins = \CRM_Utils_Array::filter($joins['Custom_MultiRecordActivity'], ['alias' => 'Custom_MultiRecordActivity_Group_ref_group']);
+    $this->assertCount(1, $entityRefJoins);
+    $entityRefJoin = reset($entityRefJoins);
+    $this->assertEquals([['ref_group', '=', 'Custom_MultiRecordActivity_Group_ref_group.id']], $entityRefJoin['conditions']);
 
-    $reverseJoin = \CRM_Utils_Array::findAll($joins['Group'], ['alias' => 'Group_Custom_MultiRecordActivity_ref_group']);
-    $this->assertCount(1, $reverseJoin);
-    $this->assertEquals([['id', '=', 'Group_Custom_MultiRecordActivity_ref_group.ref_group']], $reverseJoin[0]['conditions']);
+    $reverseJoins = \CRM_Utils_Array::filter($joins['Group'], ['alias' => 'Group_Custom_MultiRecordActivity_ref_group']);
+    $this->assertCount(1, $reverseJoins);
+    $reverseJoin = reset($reverseJoins);
+    $this->assertEquals([['id', '=', 'Group_Custom_MultiRecordActivity_ref_group.ref_group']], $reverseJoin['conditions']);
 
-    $activityToCustomJoin = \CRM_Utils_Array::findAll($joins['Activity'], ['alias' => 'Activity_Custom_MultiRecordActivity_entity_id']);
-    $this->assertCount(1, $activityToCustomJoin);
-    $this->assertEquals([['id', '=', 'Activity_Custom_MultiRecordActivity_entity_id.entity_id']], $activityToCustomJoin[0]['conditions']);
-    $this->assertEquals('Multiple Things', $activityToCustomJoin[0]['label']);
+    $activityToCustomJoins = \CRM_Utils_Array::filter($joins['Activity'], ['alias' => 'Activity_Custom_MultiRecordActivity_entity_id']);
+    $this->assertCount(1, $activityToCustomJoins);
+    $activityToCustomJoin = reset($activityToCustomJoins);
+    $this->assertEquals([['id', '=', 'Activity_Custom_MultiRecordActivity_entity_id.entity_id']], $activityToCustomJoin['conditions']);
+    $this->assertEquals('Multiple Things', $activityToCustomJoin['label']);
 
-    $customToActivityJoin = \CRM_Utils_Array::findAll($joins['Custom_MultiRecordActivity'], ['alias' => 'Custom_MultiRecordActivity_Activity_entity_id']);
-    $this->assertCount(1, $customToActivityJoin);
-    $this->assertEquals([['entity_id', '=', 'Custom_MultiRecordActivity_Activity_entity_id.id']], $customToActivityJoin[0]['conditions']);
-    $this->assertEquals('Multiple Things Activity', $customToActivityJoin[0]['label']);
+    $customToActivityJoins = \CRM_Utils_Array::filter($joins['Custom_MultiRecordActivity'], ['alias' => 'Custom_MultiRecordActivity_Activity_entity_id']);
+    $this->assertCount(1, $customToActivityJoins);
+    $customToActivityJoin = reset($customToActivityJoins);
+    $this->assertEquals([['entity_id', '=', 'Custom_MultiRecordActivity_Activity_entity_id.id']], $customToActivityJoin['conditions']);
+    $this->assertEquals('Multiple Things Activity', $customToActivityJoin['label']);
   }
 
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -299,9 +299,9 @@ class EntityDisplayTest extends Api4TestBase {
     $this->assertEquals($expected, array_column($joinsFromEntity, 'alias'));
 
     // Check reverse-joins
-    $eventJoin = \CRM_Utils_Array::findAll($joins['Event'], ['entity' => 'SK_MyNewEntityWithJoin']);
+    $eventJoin = \CRM_Utils_Array::filter($joins['Event'], ['entity' => 'SK_MyNewEntityWithJoin']);
     $this->assertCount(1, $eventJoin);
-    $this->assertSame('Event_SK_MyNewEntityWithJoin_Contact_Participant_contact_id_01_event_id', $eventJoin[0]['alias']);
+    $this->assertSame('Event_SK_MyNewEntityWithJoin_Contact_Participant_contact_id_01_event_id', reset($eventJoin)['alias']);
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/ArrayTest.php
+++ b/tests/phpunit/CRM/Utils/ArrayTest.php
@@ -554,6 +554,89 @@ class CRM_Utils_ArrayTest extends CiviUnitTestCase {
     $this->assertEquals($expected, $sorted);
   }
 
+  public function testFilter(): void {
+    $data = [
+      'alice' => ['name' => 'Alice', 'age' => 30, 'active' => TRUE],
+      'bob' => ['name' => 'Bob', 'age' => 25, 'active' => FALSE],
+      'charlie' => ['name' => 'Charlie', 'age' => 35, 'active' => TRUE],
+      'david' => ['name' => 'David', 'age' => 28, 'active' => FALSE],
+    ];
+
+    $filtered = CRM_Utils_Array::filter($data, ['active' => TRUE]);
+    $this->assertCount(2, $filtered);
+    $this->assertArrayHasKey('alice', $filtered);
+    $this->assertArrayHasKey('charlie', $filtered);
+
+    $noResults = CRM_Utils_Array::filter($data, ['xyz' => TRUE]);
+    $this->assertCount(0, $noResults);
+  }
+
+  public function testFind(): void {
+    $data = [
+      ['name' => 'Alice', 'age' => 30, 'active' => TRUE],
+      ['name' => 'Bob', 'age' => 25, 'active' => FALSE],
+      ['name' => 'Charlie', 'age' => 35, 'active' => TRUE],
+      ['name' => 'David', 'age' => 28, 'active' => FALSE],
+    ];
+    $this->assertTrue((bool) CRM_Utils_Array::find($data, ['name' => 'Alice', 'age' => 30]));
+    $this->assertNull(CRM_Utils_Array::find($data, ['name' => 'Alice', 'age' => 31]));
+
+    $this->assertTrue((bool) CRM_Utils_Array::find($data, 'name'));
+    $this->assertNull(CRM_Utils_Array::find($data, 'xyz'));
+  }
+
+  public function testFindAll(): void {
+    $data = [
+      ['name' => 'Alice', 'age' => 30, 'active' => TRUE],
+      ['name' => 'Bob', 'age' => 25, 'active' => FALSE],
+      ['name' => 'Charlie', 'age' => 35, 'active' => TRUE],
+      ['name' => 'David', 'age' => 28, 'active' => FALSE, 'children' => []],
+      [
+        'name' => 'Eve',
+        'age' => 25,
+        'active' => FALSE,
+        'children' => [
+          ['name' => 'Billy', 'age' => 3, 'active' => TRUE],
+          ['name' => 'Jilly', 'age' => 5, 'active' => FALSE],
+        ],
+        'parent' => ['name' => 'Walter', 'age' => 55, 'active' => TRUE],
+      ],
+    ];
+
+    // Test filtering by active status
+    $activeUsers = CRM_Utils_Array::findAll($data, ['active' => TRUE]);
+    $this->assertCount(4, $activeUsers);
+    $this->assertEquals('Alice', $activeUsers[0]['name']);
+    $this->assertEquals('Charlie', $activeUsers[1]['name']);
+    $this->assertEquals('Billy', $activeUsers[2]['name']);
+    $this->assertEquals('Walter', $activeUsers[3]['name']);
+
+    // Test filtering by age greater than 28
+    $olderUsers = CRM_Utils_Array::findAll($data, fn($item) => ($item['age'] ?? 0) > 28);
+    $this->assertCount(3, $olderUsers);
+    $this->assertEquals('Alice', $olderUsers[0]['name']);
+    $this->assertEquals('Charlie', $olderUsers[1]['name']);
+    $this->assertEquals('Walter', $olderUsers[2]['name']);
+
+    // Test filtering with no matches
+    $noMatches = CRM_Utils_Array::findAll($data, fn($item) => ($item['age'] ?? 0) > 100);
+    $this->assertCount(0, $noMatches);
+    $this->assertEquals([], $noMatches);
+
+    // Test filtering with all matches
+    $allMatches = CRM_Utils_Array::findAll($data, 'name');
+    $this->assertCount(5, $allMatches);
+
+    // Test with empty array
+    $emptyResult = CRM_Utils_Array::findAll([], 'name');
+    $this->assertEquals([], $emptyResult);
+
+    $childrenKeyExists = CRM_Utils_Array::findAll($data, 'children');
+    $this->assertCount(2, $childrenKeyExists);
+    $this->assertEquals('David', $childrenKeyExists[0]['name']);
+    $this->assertEquals('Eve', $childrenKeyExists[1]['name']);
+  }
+
   public function testRemoveRecursive(): void {
     $data = [
       ['name' => 'Alice', 'age' => 31, 'active' => TRUE],

--- a/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
+++ b/tests/phpunit/api/v4/Entity/ManagedEntityTest.php
@@ -659,9 +659,9 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     ];
     $managedRecords = [];
     \CRM_Utils_Hook::managed($managedRecords, ['unit.test.fake.ext']);
-    $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
+    $result = \CRM_Utils_Array::filter($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
     $this->assertCount(1, $result);
-    $this->assertSame(['name'], $result[0]['params']['match']);
+    $this->assertSame(['name'], reset($result)['params']['match']);
 
     Domain::create(FALSE)
       ->addValue('name', 'Another domain')
@@ -678,15 +678,15 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     \CRM_Utils_Hook::managed($managedRecords, ['unit.test.fake.ext']);
 
     // Base entity should not have been renamed
-    $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
+    $result = \CRM_Utils_Array::filter($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
     $this->assertCount(1, $result);
-    $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
+    $this->assertSame(['name', 'domain_id'], reset($result)['params']['match']);
 
     // New item should have been inserted for extra domains
     foreach (array_slice($allDomains->column('id'), 1) as $domain) {
-      $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains_' . $domain]);
+      $result = \CRM_Utils_Array::filter($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains_' . $domain]);
       $this->assertCount(1, $result);
-      $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
+      $this->assertSame(['name', 'domain_id'], reset($result)['params']['match']);
     }
 
     // Now we test Domain 1 NOT multisite enabled (ie. "global")
@@ -697,15 +697,15 @@ class ManagedEntityTest extends TestCase implements HeadlessInterface, Transacti
     \CRM_Utils_Hook::managed($managedRecords, ['unit.test.fake.ext']);
 
     // Base entity should not have been renamed
-    $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
+    $result = \CRM_Utils_Array::filter($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains']);
     $this->assertCount(1, $result);
-    $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
+    $this->assertSame(['name', 'domain_id'], reset($result)['params']['match']);
 
     // New item should have been inserted for extra domains
     foreach (array_slice($allDomains->column('id'), 1) as $domain) {
-      $result = \CRM_Utils_Array::findAll($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains_' . $domain]);
+      $result = \CRM_Utils_Array::filter($managedRecords, ['module' => 'unit.test.fake.ext', 'name' => 'Navigation_Test_Domains_' . $domain]);
       $this->assertCount(1, $result);
-      $this->assertSame(['name', 'domain_id'], $result[0]['params']['match']);
+      $this->assertSame(['name', 'domain_id'], reset($result)['params']['match']);
     }
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
Splits findAll into 3 functions, since the recursion isn't always helpful, now there's a non-recursive version (filter) and a version that just returns the first match.

Share the matcher function with removeRecursive for simplicity and consistency. Add tests.