### PR TITLE
Partial reversion of #34684 to resolve dev/core#6429

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -422,6 +422,11 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       // fields to be saved for new activity.
       foreach ($params as $key => $value) {
         $match = [];
+        // for autocomplete transfer hidden value instead of label
+        if ($params[$key] && isset($params[$key . '_id'])) {
+          $params[$key] = $params[$key . '_id'];
+          unset($params[$key . '_id']);
+        }
         if (preg_match('/^(custom_\d+_)(\d+)$/', $key, $match)) {
           $params[$match[1] . '-1'] = $params[$key];
           unset($params[$key]);

--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -406,6 +406,18 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
       $oldActivity = civicrm_api3('Activity', 'getsingle', ['id' => $this->_activityId]);
       $params = array_merge($oldActivity, $params);
 
+      // Here we have oldActivity with keys <custom_[custom_field_id]>
+      //  where custom_field_id is [0-9]+
+      // In $params custom we have keys with
+      //   custom_<custom_value_table_id>_<custom_field_id>
+      //
+      // For contact reference fields Activity.getSingle returns
+      // two rows ($params['custom_<field_id>'] and
+      //   $params['custom_<field_id>_id']
+      // Where the '_id' value has the int and without doesn't
+      // We want to keep the integer representation here otherwise
+      // we get a type error
+
       // unset custom fields-id from params since we want custom
       // fields to be saved for new activity.
       foreach ($params as $key => $value) {


### PR DESCRIPTION
Resolves [dev/core#6429](https://lab.civicrm.org/dev/core/-/work_items/6429)

In #34684 we removed handing from the postProcess that correctly copies over the 'custom_[custom_field_id]_id' instead of custom_[custom_field_id]

Without this we hit errors when we have a Contact Reference field populated on a CiviCRM Activity on a Case we are supposed to have an int but we have a string.

Overview
----------------------------------------

Code was removed. Editing Activities on Cases broke if there was a custom field of type contact reference.

Before
----------------------------------------

Fewer lines of code.

After
----------------------------------------

More lines of code... :(

Technical Details
----------------------------------------

Potentially instead of using api3 to get the existing parameters we should use API4 then handle however it treats the contact field.


Comments
----------------------------------------

Details on how to replicate this are in the linked issue.
