### PR TITLE
Afform - Enable extra fields not tied to an entity

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -31,7 +31,7 @@
       <li role="tab" ng-class="{active: canvasTab === 'layout'}">
         <a href ng-click="canvasTab = 'layout'">
           <i class="crm-i fa-list-alt" role="img" aria-hidden="true"></i>
-          <span>{{:: ts('Form Layout') }}</span>
+          <span>{{:: ts('Layout') }}</span>
         </a>
       </li>
       <li role="tab" ng-class="{active: canvasTab === 'markup'}">

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorPalette.html
@@ -4,7 +4,13 @@
       <li role="tab" class="fluid-width-tab" ng-class="{active: selectedEntityName === null}" title="{{:: ts('Form Settings') }}">
         <a href ng-click="editor.selectEntity(null)">
           <i class="crm-i fa-gear" role="img" aria-hidden="true"></i>
-          <span>{{:: ts('Form Settings') }}</span>
+          <span>{{:: ts('Settings') }}</span>
+        </a>
+      </li>
+      <li role="tab" class="fluid-width-tab" ng-class="{active: selectedEntityName === 'extra'}" title="{{:: ts('Elements') }}">
+        <a href ng-click="editor.selectEntity('extra')">
+          <i class="crm-i fa-rectangle-list" role="img" aria-hidden="true"></i>
+          <span>{{:: ts('Elements') }}</span>
         </a>
       </li>
       <li role="tab" ng-repeat="entity in entities" class="fluid-width-tab" ng-class="{active: selectedEntityName === entity.name}" title="{{ entity.label }}">
@@ -56,6 +62,9 @@
     </ul>
   </div>
   <div class="panel-body" role="tabpanel" ng-include="'~/afGuiEditor/config-form.html'" ng-if="selectedEntityName === null"></div>
+  <div class="panel-body" role="tabpanel" ng-if="selectedEntityName === 'extra'">
+    <af-gui-elements></af-gui-elements>
+  </div>
   <div class="panel-body" role="tabpanel" ng-repeat="entity in entities" ng-if="selectedEntityName === entity.name">
     <af-gui-entity entity="entity"></af-gui-entity>
   </div>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiElements.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiElements.component.js
@@ -1,0 +1,124 @@
+// https://civicrm.org/licensing
+(function (angular, $, _) {
+  "use strict";
+
+  angular.module('afGuiEditor').component('afGuiElements', {
+    templateUrl: '~/afGuiEditor/afGuiElements.html',
+    require: {editor: '^^afGuiEditor'},
+    controller: function ($scope, $timeout, afGui, formatForSelect2) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
+      const ctrl = this;
+      $scope.controls = {
+        fieldSearch: '',
+      };
+      $scope.fieldList = [];
+      $scope.fieldTitles = [];
+      $scope.blockList = [];
+      $scope.blockTitles = [];
+      $scope.elementList = [];
+      $scope.elementTitles = [];
+
+      this.$onInit = function() {
+        this.buildPaletteLists();
+      };
+
+      this.buildPaletteLists = () => {
+        const search = $scope.controls.fieldSearch ? $scope.controls.fieldSearch.toLowerCase() : null;
+        buildFieldList(search);
+        buildBlockList(search);
+        buildElementList(search);
+      };
+
+      const buildFieldList = (search) => {
+        $scope.fieldList.length = 0;
+        $scope.fieldTitles.length = 0;
+
+        // Fields can only be added to a submission form
+        if (this.editor.getFormType() !== 'form') {
+          return;
+        }
+
+        const extraFormFields = afGui.findRecursive(this.editor.afform.layout['#children'],
+          (node) => node['#tag'] === 'af-field' && !node.name,
+          (node) => node.defn.name
+        );
+
+        function addExtraField(field) {
+          const tag = {
+            "#tag": "af-field",
+            defn: _.cloneDeep(field.extra_defn),
+          };
+          tag.defn.label = ts('Extra %1', {1: field.label});
+          tag.defn.input_type = field.name;
+
+          // Make a unique name not already in use on the form
+          const name = field.name.toLowerCase();
+          let count = 1;
+          while ((name + count) in extraFormFields) {
+            ++count;
+          }
+          tag.defn.name = name + count;
+
+          $scope.fieldList.push(tag);
+          $scope.fieldTitles.push(field.label);
+        }
+
+        afGui.meta.inputTypes
+          .filter((field) => field.extra_defn && (!search || field.label.toLowerCase().includes(search)))
+          .forEach(field => addExtraField(field));
+      };
+
+      const buildElementList = (search) => {
+        $scope.elementList.length = 0;
+        $scope.elementTitles.length = 0;
+        const formType = this.editor.getFormType();
+        Object.entries(afGui.meta.elements).forEach(([name, element]) => {
+          if (
+            (!element.afform_type || element.afform_type.includes(formType)) &&
+            name !== 'fieldset' && // Only shown on afGuiEntity tab
+            (!search || name.includes(search) || element.title.toLowerCase().includes(search))) {
+            const node = _.cloneDeep(element.element);
+            $scope.elementList.push(node);
+            $scope.elementTitles.push(element.title);
+          }
+        });
+      };
+
+      function buildBlockList(search) {
+        $scope.blockList.length = 0;
+        $scope.blockTitles.length = 0;
+        Object.entries(afGui.meta.blocks).forEach(([directive, block]) => {
+          if ((!search || directive.includes(search) || block.name.toLowerCase().includes(search) || block.title.toLowerCase().includes(search)) &&
+            // A block of type "*" applies to everything.
+            block.entity_type === '*' && !block.join_entity &&
+            // Prevent recursion
+            block.name !== ctrl.editor.getAfform().name
+          ) {
+            const item = {"#tag": directive};
+            $scope.blockList.push(item);
+            $scope.blockTitles.push(block.title);
+          }
+        });
+      }
+
+      // This gets called from jquery-ui so we have to manually apply changes to scope
+      $scope.buildPaletteLists = () => {
+        $timeout(() => {
+          $scope.$apply(() => {
+            ctrl.buildPaletteLists();
+          });
+        });
+      };
+
+      this.addValue = function(fieldName) {
+        if (fieldName) {
+          if (!ctrl.entity.data) {
+            ctrl.entity.data = {};
+          }
+          ctrl.entity.data[fieldName] = '';
+        }
+      };
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/admin/ang/afGuiEditor/afGuiElements.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiElements.html
@@ -1,0 +1,38 @@
+<form class="" ng-if="!$ctrl.entity.loading">
+  <div class="alert alert-warning" ng-if=":: $ctrl.editor.getFormType() === 'form'">
+    {{:: ts('Note: Extra fields are submitted with the form, but not saved to the CiviCRM database.')}}
+  </div>
+  <fieldset class="af-gui-entity-palette">
+    <legend class="form-inline">
+      {{:: ts('Add:') }}
+      <input ng-model="controls.fieldSearch" ng-change="$ctrl.buildPaletteLists()" class="form-control" type="search" placeholder="&#x1f50d;" title="{{:: ts('Search fields') }}" />
+    </legend>
+    <div class="af-gui-entity-palette-select-list">
+      <div ng-if="elementList.length">
+        <label>{{:: ts('Elements') }}</label>
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="elementList">
+          <div ng-repeat="element in elementList" >
+            <div class="af-gui-palette-item">{{:: elementTitles[$index] }}</div>
+          </div>
+        </div>
+      </div>
+      <div ng-if="blockList.length">
+        <label>{{:: ts('Blocks') }}</label>
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="blockList">
+          <div ng-repeat="block in blockList">
+            <div class="af-gui-palette-item">{{:: blockTitles[$index] }}</div>
+          </div>
+        </div>
+      </div>
+      <div ng-if="fieldList.length">
+        <label>{{ ts('Extra Fields') }}</label>
+        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="fieldList">
+          <div ng-repeat="field in fieldList">
+            <div class="af-gui-palette-item">{{:: fieldTitles[$index] }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</form>
+

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -93,8 +93,8 @@
         $scope.blockTitles.length = 0;
         Object.entries(afGui.meta.blocks).forEach(([directive, block]) => {
           if ((!search || directive.includes(search) || block.name.toLowerCase().includes(search) || block.title.toLowerCase().includes(search)) &&
-            // A block of type "*" applies to everything. A block of type "Contact" also applies to "Individual", "Organization" & "Household".
-            (block.entity_type === '*' || block.entity_type === ctrl.entity.type || (block.entity_type === 'Contact' && ['Individual', 'Household', 'Organization'].includes(ctrl.entity.type))) &&
+            // A block of type "Contact" also applies to "Individual", "Organization" & "Household".
+            (block.entity_type === ctrl.entity.type || (block.entity_type === 'Contact' && ['Individual', 'Household', 'Organization'].includes(ctrl.entity.type))) &&
             // Prevent recursion
             block.name !== ctrl.editor.getAfform().name
           ) {
@@ -122,24 +122,21 @@
         });
       }
 
+      // The only entity-specific element is `fieldset`. All others go in the Form Elements tab.
       function buildElementList(search) {
         $scope.elementList.length = 0;
         $scope.elementTitles.length = 0;
-        Object.entries(afGui.meta.elements).forEach(([name, element]) => {
-          if (
-            (!element.afform_type || element.afform_type.includes('form')) &&
-            (!search || name.includes(search) || element.title.toLowerCase().includes(search))) {
-            const node = _.cloneDeep(element.element);
-            if (name === 'fieldset') {
-              if (!ctrl.editor.allowEntityConfig) {
-                return;
-              }
-              node['af-fieldset'] = ctrl.entity.name;
-            }
-            $scope.elementList.push(node);
-            $scope.elementTitles.push(name === 'fieldset' ? ts('Fieldset for %1', {1: ctrl.entity.label}) : element.title);
-          }
-        });
+
+        const fieldsetTitle = ts('Fieldset for %1', {1: ctrl.entity.label});
+        if (
+          ctrl.editor.allowEntityConfig &&
+          (!search || fieldsetTitle.toLowerCase().includes(search))
+        ) {
+          const fieldsetElement = _.cloneDeep(afGui.meta.elements.fieldset.element);
+          fieldsetElement['af-fieldset'] = ctrl.entity.name;
+          $scope.elementList.push(fieldsetElement);
+          $scope.elementTitles.push(fieldsetTitle);
+        }
       }
 
       // This gets called from jquery-ui so we have to manually apply changes to scope

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -17,8 +17,6 @@
       $scope.calcFieldTitles = [];
       $scope.blockList = [];
       $scope.blockTitles = [];
-      $scope.elementList = [];
-      $scope.elementTitles = [];
 
       $scope.getField = afGui.getField;
 
@@ -32,7 +30,6 @@
         buildCalcFieldList(search);
         buildFieldList(search);
         buildBlockList(search);
-        buildElementList(search);
       };
 
       // Gets the name of the entity a field belongs to
@@ -115,21 +112,6 @@
             }
           }, []);
         }
-      }
-
-      function buildElementList(search) {
-        $scope.elementList.length = 0;
-        $scope.elementTitles.length = 0;
-        _.each(afGui.meta.elements, function(element, name) {
-          if (
-            (!element.afform_type || element.afform_type.includes('search')) &&
-            (!search || name.includes(search) || element.title.toLowerCase().includes(search))
-          ) {
-            const node = _.cloneDeep(element.element);
-            $scope.elementList.push(node);
-            $scope.elementTitles.push(element.title);
-          }
-        });
       }
 
       // This gets called from jquery-ui so we have to manually apply changes to scope

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.html
@@ -1,6 +1,6 @@
 <div class="af-gui-columns crm-flex-box">
   <fieldset class="af-gui-entity-values">
-    <legend>{{:: ts('Filters:') }}</legend>
+    <legend>{{:: ts('Hidden Filters:') }}</legend>
     <div class="form-inline" ng-repeat="filter in $ctrl.filters">
       <input class="form-control" ng-model="filter.name" ng-change="$ctrl.onChangeFilter($index)" crm-ui-select="{data: $ctrl.getFilterFields, placeholder: ' '}" />
       <div class="input-group">
@@ -37,18 +37,10 @@
 
   <fieldset class="af-gui-entity-palette">
     <legend class="form-inline">
-      {{:: ts('Add:') }}
+      {{:: ts('Form Filters:') }}
       <input ng-model="controls.fieldSearch" ng-change="$ctrl.buildPaletteLists()" class="form-control" type="search" placeholder="&#x1f50d;" title="{{:: ts('Search fields') }}" />
     </legend>
     <div class="af-gui-entity-palette-select-list">
-      <div ng-if="elementList.length">
-        <label>{{:: ts('Elements') }}</label>
-        <div ui-sortable="$ctrl.editor.getSortableOptions()" ui-sortable-update="buildPaletteLists" ng-model="elementList">
-          <div ng-repeat="element in elementList" >
-            <div class="af-gui-palette-item">{{:: elementTitles[$index] }}</div>
-          </div>
-        </div>
-      </div>
       <div ng-if="blockList.length">
         <label>{{:: ts('Blocks') }}</label>
         <div ui-sortable="$ctrl.editor.getSortableOptions($ctrl.editor.getSelectedEntityName())" ui-sortable-update="buildPaletteLists" ng-model="blockList">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -1,4 +1,4 @@
-<li ng-if="!$ctrl.fieldDefn.input_attrs || !$ctrl.fieldDefn.input_attrs.autofill">
+<li ng-if="$ctrl.node.name && (!$ctrl.fieldDefn.input_attrs || !$ctrl.fieldDefn.input_attrs.autofill)">
   <div ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown">
     <label>{{:: ts('Type:') }}</label>
     <select class="form-control" ng-model="getSet('input_type')" ng-model-options="{getterSetter: true}" title="{{:: ts('Field type') }}">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -68,7 +68,7 @@
         if (ctrl.fieldDefn.operators && ctrl.fieldDefn.operators.length) {
           this.searchOperators = _.pick(this.searchOperators, ctrl.fieldDefn.operators);
         }
-        this.isMultiFieldFilter = ctrl.node.name.includes(',');
+        this.isMultiFieldFilter = ctrl.node.name?.includes(',');
       };
 
       this.getFkEntity = function() {
@@ -113,11 +113,15 @@
 
       // Returns the original field definition from metadata
       this.getDefn = function() {
-        let defn = afGui.getField(ctrl.container.getFieldEntityType(ctrl.getFieldName()), ctrl.getFieldName());
-        // Calc fields are specific to a search display, not part of the schema
-        if (!defn && ctrl.container.getSearchDisplay()) {
-          const searchDisplay = ctrl.container.getSearchDisplay();
-          defn = _.findWhere(searchDisplay.calc_fields, {name: ctrl.getFieldName()});
+        const fieldName = ctrl.getFieldName();
+        let defn;
+        if (fieldName) {
+          defn = afGui.getField(ctrl.container.getFieldEntityType(fieldName), fieldName);
+          // Calc fields are specific to a search display, not part of the schema
+          if (!defn && ctrl.container.getSearchDisplay()) {
+            const searchDisplay = ctrl.container.getSearchDisplay();
+            defn = _.findWhere(searchDisplay.calc_fields, {name: fieldName});
+          }
         }
         defn = defn || {
           label: ts('Untitled'),
@@ -131,15 +135,21 @@
 
       this.getFieldName = function() {
         // Search filters can contain multiple field names joined by a comma. Return the first as the primary.
-        return ctrl.node.name.split(',')[0];
+        return ctrl.node.name?.split(',')[0];
       };
 
       // Get the api entity this field belongs to
       this.getEntity = function() {
-        return afGui.getEntity(ctrl.container.getFieldEntityType(ctrl.getFieldName()));
+        const fieldName = ctrl.getFieldName();
+        return fieldName ? afGui.getEntity(ctrl.container.getFieldEntityType(fieldName)) : null;
       };
 
       $scope.getOriginalLabel = function() {
+        // Generic (non-entity) field
+        if (!ctrl.node.name) {
+          const genericField = afGui.meta.inputTypes.find((field) => field.name === ctrl.node.defn?.input_type);
+          return genericField ? ts('Extra %1', {1: genericField.label}) : ts('Extra Field');
+        }
         // Use afform entity if available (e.g. "Individual1")
         if (ctrl.container.getEntityName()) {
           return ctrl.editor.getEntity(ctrl.container.getEntityName()).label + ': ' + ctrl.getDefn().label;

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -43,8 +43,13 @@ class AfformMetadataInjector {
         }
 
         // Each field can be nested within a fieldset, a join or a block
+        /** @var \DOMElement $afField */
         foreach (pq('af-field', $doc) as $afField) {
-          /** @var \DOMElement $afField */
+          if ($afField->getAttribute('name') === '') {
+            // "extra" fields have no associated entity
+            self::fillExtraFieldMetadata($afField);
+            continue;
+          }
           $action = 'create';
           $joinName = pq($afField)->parents('[af-join]')->attr('af-join');
           if ($joinName) {
@@ -94,6 +99,16 @@ class AfformMetadataInjector {
     return NULL;
   }
 
+  private static function getFieldDefn(\DOMElement $afField): ?array {
+    $existingFieldDefn = trim(pq($afField)->attr('defn') ?: '');
+    if ($existingFieldDefn && $existingFieldDefn[0] != '{') {
+      // If it's not an object, can't parse it.
+      return NULL;
+    }
+
+    return $existingFieldDefn ? \CRM_Utils_JS::getRawProps($existingFieldDefn) : [];
+  }
+
   /**
    * Merge a field's definition with whatever's already in the markup
    *
@@ -107,14 +122,13 @@ class AfformMetadataInjector {
     // Defaults for attributes not in spec
     $fieldInfo['search_range'] = FALSE;
 
-    $existingFieldDefn = trim(pq($afField)->attr('defn') ?: '');
-    if ($existingFieldDefn && $existingFieldDefn[0] != '{') {
-      // If it's not an object, don't mess with it.
+    // Get field defn from afform markup
+    $fieldDefn = self::getFieldDefn($afField);
+    if (!is_array($fieldDefn)) {
+      // If it's not an array, don't mess with it.
       return;
     }
 
-    // Get field defn from afform markup
-    $fieldDefn = $existingFieldDefn ? \CRM_Utils_JS::getRawProps($existingFieldDefn) : [];
     // Uses input type set on the form if specified (else falls back to the input type in the field spec)
     $inputType = !empty($fieldDefn['input_type']) ? \CRM_Utils_JS::decode($fieldDefn['input_type']) : ($fieldInfo['input_type'] ?? 'Text');
     // On a search form, search_range will present a pair of fields (or possibly 3 fields for date select + range)
@@ -248,6 +262,13 @@ class AfformMetadataInjector {
     if ($fieldInfo) {
       self::setFieldMetadata($afField, $fieldInfo);
     }
+  }
+
+  public static function fillExtraFieldMetadata(\DOMElement $afField) {
+    $fieldDefn = self::getFieldDefn($afField);
+    $inputType = \CRM_Utils_JS::decode($fieldDefn['input_type']);
+    $typeInfo = Utils::getInputTypes()[$inputType];
+    self::setFieldMetadata($afField, $typeInfo['extra_defn']);
   }
 
   private static function getFormEntities(\phpQueryObject $doc) {

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -105,6 +105,9 @@ class Utils {
         ],
         'Email' => [
           'label' => E::ts('Email'),
+          'extra_defn' => [
+            'data_type' => 'String',
+          ],
         ],
         'EntityRef' => [
           'label' => E::ts('Autocomplete Entity'),
@@ -120,6 +123,9 @@ class Utils {
         ],
         'Number' => [
           'label' => E::ts('Number'),
+          'extra_defn' => [
+            'data_type' => 'Integer',
+          ],
         ],
         'Radio' => [
           'label' => E::ts('Radio Buttons'),
@@ -135,15 +141,27 @@ class Utils {
         ],
         'Text' => [
           'label' => E::ts('Single-Line Text'),
+          'extra_defn' => [
+            'data_type' => 'String',
+          ],
         ],
         'TextArea' => [
           'label' => E::ts('Multi-Line Text'),
+          'extra_defn' => [
+            'data_type' => 'String',
+          ],
         ],
         'Toggle' => [
           'label' => E::ts('Toggle Switch'),
+          'extra_defn' => [
+            'data_type' => 'Boolean',
+          ],
         ],
         'Url' => [
           'label' => E::ts('URL'),
+          'extra_defn' => [
+            'data_type' => 'String',
+          ],
         ],
       ];
       // Input types shipped with Afform all follow this template file name convention,

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -635,6 +635,9 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
           $item = array_merge(($val ?? []), $idData);
           $combined[$name][$idx] = $item;
         }
+        else {
+          $combined[$name][$idx] = $val;
+        }
       }
     }
     return $combined;

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -3,7 +3,8 @@
   // Example usage: <div af-fieldset="myModel"><af-field name="do_not_email" /></div>
   angular.module('af').component('afField', {
     require: {
-      afFieldset: '^^afFieldset',
+      afForm: '?^^afForm',
+      afFieldset: '?^^afFieldset',
       afJoin: '?^^afJoin',
       afRepeatItem: '?^^afRepeatItem'
     },
@@ -19,13 +20,22 @@
       let namePrefix = '';
       // Either defn.options or chain select options loaded on-the-fly
       let fieldOptions = null;
+      // "extra" fields do not belong to any entity.
+      let isExtra = false;
 
       // Attributes for each of the low & high date fields when using search_range
       this.inputAttrs = [];
 
       this.$onInit = () => {
-        const closestController = $($element).closest('[af-fieldset],[af-join],[af-repeat-item]');
-        $scope.dataProvider = closestController.is('[af-repeat-item]') ? this.afRepeatItem : this.afJoin || this.afFieldset;
+        // "extra" fields initially have no fieldName
+        if (!this.fieldName) {
+          isExtra = true;
+          $scope.dataProvider = this.afForm;
+          this.fieldName = this.defn.name;
+        } else {
+          const closestController = $($element).closest('[af-fieldset],[af-join],[af-repeat-item]');
+          $scope.dataProvider = closestController.is('[af-repeat-item]') ? this.afRepeatItem : this.afJoin || this.afFieldset;
+        }
         $scope.fieldId = _.kebabCase(this.fieldName) + '-' + afFieldId++;
 
         $element.addClass('af-field-type-' + _.kebabCase(this.defn.input_type));
@@ -160,10 +170,10 @@
             return;
           }
           // Unique field name = entity_name index . join . field_name
-          const entityName = ctrl.afFieldset.getName();
-          const joinEntity = ctrl.afJoin ? ctrl.afJoin.entity : null;
+          const entityName = ctrl.afFieldset?.getName();
+          const joinEntity = ctrl.afJoin?.entity;
           let uniquePrefix = '';
-          if (entityName) {
+          if (!isExtra && entityName) {
             const index = ctrl.getEntityIndex();
             uniquePrefix = entityName + (index ? index + 1 : '') + (joinEntity ? '.' + joinEntity : '') + '.';
           }
@@ -175,14 +185,14 @@
           else if (ctrl.fieldName in routeParams) {
             setValue(routeParams[ctrl.fieldName]);
           }
-          else if (routeParams._s) {
+          else if (!isExtra && routeParams._s) {
             setValue(ctrl.afFieldset.getSearchParamSetFieldValue(ctrl.fieldName));
           }
         }
 
         function initializeValue(firstLoad) {
           // Set default value if specified. Note that setValueFromUrl() will override this.
-          if (firstLoad && ctrl.afFieldset.getStoredValue(ctrl.fieldName) !== undefined) {
+          if (firstLoad && ctrl.afFieldset?.getStoredValue(ctrl.fieldName) !== undefined) {
             setValue(ctrl.afFieldset.getStoredValue(ctrl.fieldName));
           }
           // Set default value based on field defn
@@ -312,7 +322,7 @@
       };
 
       ctrl.isReadonly = function() {
-        if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill && !ctrl.afJoin) {
+        if (!isExtra && ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill && !ctrl.afJoin) {
           return ctrl.afFieldset.getEntity().actions[ctrl.defn.input_attrs.autofill] === false;
         }
         // TODO: Not actually used, but could be used if we wanted to render displayOnly
@@ -392,9 +402,9 @@
       };
 
       ctrl.getAutocompleteParams = function() {
-        let fieldName = ctrl.afFieldset.getName();
+        let fieldName = isExtra ? 'extra' : ctrl.afFieldset.getName();
         // Append join name which will be unpacked by AfformAutocompleteSubscriber::processAfformAutocomplete
-        if (ctrl.afJoin) {
+        if (!isExtra && ctrl.afJoin) {
           fieldName += '+' + ctrl.afJoin.entity;
         }
         fieldName += ':' + ctrl.fieldName;

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -527,6 +527,11 @@
         });
       }
 
+      // Used by "extra" afFields that have no entity.
+      this.getFieldData = () => {
+        return data.extra;
+      };
+
     }
   });
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Extra inputs can be added anywhere and they are stored in the Submission.extra values.

This adds a new Elements tab to formBuilder and moves all generic elements into that tab as well, since it was confusing to have them on the entity-specific tabs.

See https://lab.civicrm.org/dev/core/-/work_items/6215

<img width="1081" height="832" alt="image" src="https://github.com/user-attachments/assets/8d2ec692-f68a-4f19-8335-39edbe2232aa" />

