### PR TITLE
RiverLea: exclude checkbox and radio inputs from dropdown -moz-available width rule

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -396,7 +396,7 @@
   right: 0;
   left: unset;
 }
-.crm-container .dropdown-menu li input {
+.crm-container .dropdown-menu li input:not([type="checkbox"]):not([type="radio"]) {
   width: -moz-available;
 }
 @media (min-width: 768px) {


### PR DESCRIPTION
## Overview

Fixes `dev/core#6434`

In Firefox, checkboxes in the SearchKit header dropdown were rendering at full width inside the dropdown item, which caused the label text beside them not to display correctly.

This PR narrows a RiverLea dropdown input width rule so it no longer applies to checkboxes and radio buttons.

## Before

RiverLea applied the following rule to all inputs inside dropdown menu list items:

```css
.crm-container .dropdown-menu li input {
  width: -moz-available;
}
```

In Firefox, this caused checkbox inputs in SearchKit dropdowns to stretch across the available width, hiding or displacing the label text.

<img width="1613" height="987" alt="Screenshot from 2026-04-10 14-13-24" src="https://github.com/user-attachments/assets/f2e9b766-f074-4de9-b5b2-4e7e839b69b9" />

## After

The rule now excludes checkboxes and radio buttons:

```css
.crm-container .dropdown-menu li input:not([type="checkbox"]):not([type="radio"]) {
  width: -moz-available;
}
```

This keeps the existing Firefox width behaviour for other dropdown inputs, while allowing checkboxes and radios to render at their normal width.

<img width="1613" height="987" alt="Screenshot from 2026-04-10 14-14-45" src="https://github.com/user-attachments/assets/1d734277-7196-44da-a0b9-b84aa340a230" />

## Technical Details

The issue appears to come from Firefox-specific handling of `width: -moz-available`.

Because the original selector targeted all `input` elements inside dropdown list items, checkbox inputs in SearchKit dropdowns inherited that width and expanded unexpectedly.

This change fixes the root cause by narrowing the selector, rather than adding a second override rule for checkboxes.

## Comments

Reproduced on:

* CiviCRM 6.10.1
* CiviCRM 6.12.2

Browser:

* Firefox

A local CSS workaround was tested successfully before making this change.

