### PR TITLE
dev/core#6429 - Alternate to 35349 to solve problem with contact reference on case activity edit

### DIFF
--- a/CRM/Case/Form/Activity.php
+++ b/CRM/Case/Form/Activity.php
@@ -402,21 +402,8 @@ class CRM_Case_Form_Activity extends CRM_Activity_Form_Activity {
 
     // format activity custom data
     if ($this->_activityId) {
-      // retrieve and include the custom data of old Activity
-      $oldActivity = civicrm_api3('Activity', 'getsingle', ['id' => $this->_activityId]);
-      $params = array_merge($oldActivity, $params);
-
-      // unset custom fields-id from params since we want custom
-      // fields to be saved for new activity.
-      foreach ($params as $key => $value) {
-        $match = [];
-        if (preg_match('/^(custom_\d+_)(\d+)$/', $key, $match)) {
-          $params[$match[1] . '-1'] = $params[$key];
-          unset($params[$key]);
-        }
-      }
+      $params['id'] = $this->_activityId;
     }
-
     $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params,
       $this->_activityId,
       'Activity'


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6429

Before
----------------------------------------
crash on edit case activity if have contact ref custom field

After
----------------------------------------


Technical Details
----------------------------------------
In this alternate we instead remove code that was for activity revisions which no longer are used.

Because we no longer retrieve ALL the old data, some things are missing from the array, but the way forms work and BAO_Activity::create work we don't need all the old data, just the form submitted data. All we need to do is set the activity id when it's an edit.

For example is_star is missing from the array, but it doesn't matter it survives whatever value it was from before the edit (that particular field is only used in the civicase extension).
Or is_auto, but that's an oddball since on form create or edit it should always become 0 anyway. It's only ever 1 when initially populated by the timeline.

target_contact and other fields all still seem to work.

Comments
----------------------------------------
@stesi561 