### PR TITLE
WIP: Only show one row per contact in quicksearch when more than one email matches

### DIFF
--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -136,6 +136,10 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
 
       // Single filter
       if (count($filterFields) === 1) {
+        // with JOIN - group to avoid duplicate rows when contact has the same email/phone/address of different types.
+        if (!empty($apiParams['join'])) {
+          $apiParams['groupBy'] = ['id'];
+        }
         $display['settings']['searchFields'] = $filterFields;
         $savedSearch['api_params'] = $apiParams;
       }


### PR DESCRIPTION
Before
----------------------------------------
If a contact has two emails that are the same string, but different types, quicksearch will give you two rows when searching for that email (by email, not by name/email). Same for address, city, postal and phone.

After
----------------------------------------
Only one row per contact.
I suppose you could have someone who has two emails like `bobexample@gmail.com` and `bobexample@hotmail.com` and you'll only see one of those emails in the results if you search on `bobexample`, but that seems better to me than seeing both rows. Could group by email.email instead here and then we'd have two rows in that case.  

Technical Details
----------------------------------------
No significant change in performance. We are sorting by sort_name anyways, so I don't think the group by makes much difference on top of that (if we weren't sorting, then I think it would be more significant, and arguably we shouldn't be sorting and should just grab the first 11 results for performance, but that's out of scope here).