### PR TITLE
Set display name to primary email address not last email address

### DIFF
--- a/CRM/Core/BAO/Email.php
+++ b/CRM/Core/BAO/Email.php
@@ -82,6 +82,8 @@ WHERE  contact_id = {$event->params['contact_id']}
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
     $email = $event->object;
+    // CRM_Core_DAO::copyValues() sets is_primary to 'null' if not set
+    $email->is_primary = ($email->is_primary === 'null') ? NULL : $email->is_primary;
     if ($event->action !== 'delete' && !empty($email->is_primary) && !empty($email->contact_id)) {
       // update the UF user email if that has changed
       CRM_Core_BAO_UFMatch::updateUFName($email->contact_id);


### PR DESCRIPTION
Before
----------------------------------------
Edit contact emails from contact summary for a contact without a name. Add an additional email or just save if there are already multiples. The display name is set to the last of the emails, not the primary one.

After
----------------------------------------
Set to primary email.
