### PR TITLE
Clean money fields in API4

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -146,6 +146,11 @@ class FormattingUtil {
       case 'Date':
         $value = self::formatDateValue('Ymd', $value, $operator, $index);
         break;
+
+      case 'Money':
+        if (isset($value) && $value !== '') {
+          $value = \CRM_Utils_Rule::cleanMoney($value);
+        }
     }
 
     $hic = \CRM_Utils_API_HTMLInputCoder::singleton();


### PR DESCRIPTION
Overview
----------------------------------------
If you submit a money field with anything but a digit or period, e.g. a currency symbol or thousands separator, API4 will either record the value as zero or crash, depending on the entity.

Replication steps are available at https://lab.civicrm.org/dev/core/-/work_items/6116 - but this has added urgency with the upcoming release of FormBuilder contribution integration, since this will surface quite quickly there. 


Before
----------------------------------------
Submitting a non-custom money field with anything but a digit or period results in 0 being recorded.

After
----------------------------------------
Amount submits correctly.

Comments
----------------------------------------
This alone is NOT sufficient to fix a contribution FormBuilder field (my use case is grants).  That's because the fields aren't formatted for the line item. I'll submit a different lab.c.o ticket for that.
