### PR TITLE
Remove unused variable causing php warnings.

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomData.tpl
+++ b/templates/CRM/Contact/Page/View/CustomData.tpl
@@ -8,7 +8,6 @@
  +--------------------------------------------------------------------+
 *}
 {* template for custom data *}
-{assign var="customDataGroupName" value=$customDataGroup.name}
 {strip}
   {if $displayStyle neq 'tableOriented' and ($action eq 16 or $action eq 4)} {* Browse or View actions *}
     {assign var="customGroupDisplayDone" value=1}


### PR DESCRIPTION
Overview
----------------------------------------
Fix php8 warning.



Technical Details
----------------------------------------
This is orphaned dead code — `$customDataGroup` is never set by any PHP in CiviCRM, and `$customDataGroupName` is never consumed by any template. In PHP 8.x, accessing `null['name']` raises `Warning: Trying to access array offset on null`.