### PR TITLE
Merge missing "show linebreaks" css rule from searchkit ext into riverlea

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -28,6 +28,10 @@
   font-size: var(--crm-font-size);
 }
 
+.crm-search-display .crm-search-field-show-linebreaks .crm-search-field-value {
+  white-space: pre-line;
+}
+
 /* Loading placeholders */
 .crm-search-loading-placeholder {
   height: 2em;


### PR DESCRIPTION
Overview
----------------------------------------
Most of the styles from [ext/search_kit/css/crmSearchDisplay.css](https://github.com/civicrm/civicrm-core/blob/master/ext/search_kit/css/crmSearchDisplay.css) seem to have been merged into [ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css](https://github.com/civicrm/civicrm-core/blob/master/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css), which takes precedence. However, this one was missing, so line breaks weren't being respected in plain text fields even if you set them to be shown in your SearchDisplay.

Before
----------------------------------------
<img width="586" height="181" alt="Screenshot 2026-04-11 at 14 52 33" src="https://github.com/user-attachments/assets/af2e8402-6273-4f3f-bb58-63bb7bd9cefa" />

After
-----------------
<img width="586" height="177" alt="Screenshot 2026-04-11 at 15 00 38" src="https://github.com/user-attachments/assets/663d68a9-12ed-4721-afbb-b616344d47f7" />

Comments
----------------------------------------
Since ext/search_kit/css/crmSearchDisplay.css no longer gets loaded, should it be removed to reduce confusion? @vingle 