### PR TITLE
Riverlea - Remove firefox-only width property

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -396,9 +396,6 @@
   right: 0;
   left: unset;
 }
-.crm-container .dropdown-menu li input {
-  width: -moz-available;
-}
 @media (min-width: 768px) {
   .crm-container .navbar-right .dropdown-menu {
     right: 0;


### PR DESCRIPTION


Overview
----------------------------------------
Thanks to @angelajackson07 for raising this issue: this removes a css rule that was messing up the display of checkboxes and radios in FireFox.

Before
------
<img width="1613" height="987" alt="Screenshot from 2026-04-10 14-13-24" src="https://github.com/user-attachments/assets/f2e9b766-f074-4de9-b5b2-4e7e839b69b9" />

After
-----
<img width="1613" height="987" alt="Screenshot from 2026-04-10 14-14-45" src="https://github.com/user-attachments/assets/1d734277-7196-44da-a0b9-b84aa340a230" />