### PR TITLE
dev/core#6400 SearchKit - Fix over-escaping of group names

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
@@ -200,10 +200,11 @@ class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Gene
    * @return array
    */
   public static function getGroupList($field, $values, $returnFormat, $checkPermissions) {
-    $groups = $checkPermissions ? \CRM_Core_PseudoConstant::group() : \CRM_Core_PseudoConstant::allGroup(NULL, FALSE);
+    $groups = $checkPermissions ? \CRM_Core_PseudoConstant::group(textFormat: 'plain') : \CRM_Core_PseudoConstant::allGroup(NULL, FALSE, 'plain');
     $options = \CRM_Utils_Array::makeNonAssociative($groups, 'id', 'label');
     if ($options && is_array($returnFormat) && in_array('name', $returnFormat)) {
       $groupIndex = array_flip(array_keys($groups));
+      // The pseudoconstant functions don't include names; we have to fetch them separately
       $dao = \CRM_Core_DAO::executeQuery('SELECT id, name FROM civicrm_group WHERE id IN (%1)', [
         1 => [implode(',', array_keys($groups)), 'CommaSeparatedIntegers'],
       ]);


### PR DESCRIPTION
Overview
----------------------------------------
Fixes over-escaped html in the "In Groups" searchKit contact filter.

See https://lab.civicrm.org/dev/core/-/work_items/6400

Before
----------------------------------------
<img width="677" height="176" alt="image" src="https://github.com/user-attachments/assets/f65382c4-8397-44a2-bd02-8caafbd0aaba" />


After
----------------------------------------
<img width="677"  alt="image" src="https://github.com/user-attachments/assets/14fe6b66-a76f-46f0-ae77-d6e5fda888a2" />

