### PR TITLE
dev/core#6423 Skip import validation of large files

### DIFF
--- a/CRM/Contact/Import/Form/MapField.php
+++ b/CRM/Contact/Import/Form/MapField.php
@@ -420,7 +420,16 @@ class CRM_Contact_Import_Form_MapField extends CRM_Import_Form_MapField {
 
     $parser = new CRM_Contact_Import_Parser_Contact();
     $parser->setUserJobID($this->getUserJobID());
-    $parser->validate();
+
+    // Running validation can be slow - skip for large import files to stop hanging requests and timeouts.
+    $numberRows = $parser->getRowCount();
+    $largeFile = CRM_Utils_Constant::value('CIVICRM_IMPORT_LARGE_FILE', 10000);
+    if ($numberRows < $largeFile) {
+      $parser->validate();
+    } else {
+      $this->updateUserJobMetadata('validation_skipped', TRUE);
+    }
+
   }
 
   /**

--- a/CRM/Import/Form/MapField.php
+++ b/CRM/Import/Form/MapField.php
@@ -92,7 +92,15 @@ abstract class CRM_Import_Form_MapField extends CRM_Import_Forms {
     $this->updateUserJobMetadata('submitted_values', $this->getSubmittedValues());
     $parser = $this->getParser();
     $parser->init();
-    $parser->validate();
+
+    $numberRows = $parser->getRowCount();
+    $largeFile = CRM_Utils_Constant::value('CIVICRM_IMPORT_LARGE_FILE', 10000);
+    if ($numberRows < $largeFile) {
+      $parser->validate();
+    } else {
+      $this->updateUserJobMetadata('validation_skipped', TRUE);
+    }
+
   }
 
   /**

--- a/CRM/Import/Form/Preview.php
+++ b/CRM/Import/Form/Preview.php
@@ -66,9 +66,21 @@ abstract class CRM_Import_Form_Preview extends CRM_Import_Forms {
    * @throws \CRM_Core_Exception
    */
   protected function assignPreviewVariables(): void {
+    $jobMetadata = $this->getUserJob()['metadata'];
+    $validationSkipped = $jobMetadata['validation_skipped'] ?? FALSE;
+
     $this->assign('downloadErrorRecordsUrl', $this->getDownloadURL(CRM_Import_Parser::ERROR));
-    $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
-    $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
+    $this->assign('validationSkipped', $validationSkipped);
+    if ($validationSkipped) {
+      $largeFile = CRM_Utils_Constant::value('CIVICRM_IMPORT_LARGE_FILE', 10000);
+      $this->assign('largeFileSize', CRM_Utils_Number::formatLocaleNumeric($largeFile));
+      $this->assign('invalidRowCount', FALSE);
+      $this->assign('validRowCount', FALSE);
+    } else{
+      $this->assign('invalidRowCount', $this->getRowCount(CRM_Import_Parser::ERROR));
+      $this->assign('validRowCount', $this->getRowCount(CRM_Import_Parser::VALID));
+    }
+
     $this->assign('totalRowCount', $this->getRowCount([]));
     $this->assign('mapper', $this->getMappedFieldLabels());
     $this->assign('dataValues', $this->getDataRows([], 2));

--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -1011,6 +1011,17 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
+   * Get the count of rows in the data source
+   *
+   * @param array $statuses
+   * @return int
+   */
+  public function getRowCount($statuses = []) {
+    $dataSource = $this->getDataSourceObject();
+    return $dataSource->getRowCount($statuses);
+  }
+
+  /**
    * Validate the import file, updating the import table with results.
    *
    * @throws \CRM_Core_Exception

--- a/ext/civiimport/CRM/CiviImport/Form/Preview.php
+++ b/ext/civiimport/CRM/CiviImport/Form/Preview.php
@@ -14,7 +14,15 @@ class CRM_CiviImport_Form_Preview extends CRM_Import_Form_Preview {
   public function preProcess(): void {
     $parser = $this->getParser();
     $parser->init();
-    $parser->validate();
+
+    $numberRows = $parser->getRowCount();
+    $largeFile = CRM_Utils_Constant::value('CIVICRM_IMPORT_LARGE_FILE', 10000);
+    if ($numberRows < $largeFile) {
+      $parser->validate();
+    } else {
+      $this->updateUserJobMetadata('validation_skipped', TRUE);
+    }
+
     parent::preProcess();
     $this->assign('isOpenResultsInNewTab', TRUE);
     $this->assign('downloadErrorRecordsUrl', CRM_Utils_System::url('civicrm/search', '', TRUE, '/display/Import_' . $this->getUserJobID() . '/Import_' . $this->getUserJobID() . '?_status=ERROR', FALSE));

--- a/ext/civiimport/templates/CRM/Import/Preview.tpl
+++ b/ext/civiimport/templates/CRM/Import/Preview.tpl
@@ -27,6 +27,12 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
   </div>
 
+  {if $validationSkipped}
+    <div class="alert alert-warning">
+      <p>{ts 1=$largeFileSize}Validation has been skipped as you are importing a large file (greater than %1 rows). We recommend you manually check that the file you are importing is correct. You can import regardless, and validation will be happen during the import (any invalid rows will not be imported).{/ts}</p>
+    </div>
+  {/if}
+
   {* Summary Preview (record counts) *}
   <table id="preview-counts" class="report">
     <tr><td class="label crm-grid-cell">{ts}Total Rows{/ts}</td>
@@ -47,10 +53,12 @@
       </tr>
     {/if}
 
-    <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
-      <td class="data">{$validRowCount}</td>
-      <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
-    </tr>
+    {if $validRowCount}
+      <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
+        <td class="data">{$validRowCount}</td>
+        <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
+      </tr>
+    {/if}
   </table>
 
 

--- a/templates/CRM/Activity/Import/Form/Preview.tpl
+++ b/templates/CRM/Activity/Import/Form/Preview.tpl
@@ -28,6 +28,12 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
 
+ {if $validationSkipped}
+    <div class="alert alert-warning">
+      <p>{ts 1=$largeFileSize}Validation has been skipped as you are importing a large file (greater than %1 rows). We recommend you manually check that the file you are importing is correct. You can import regardless, and validation will be happen during the import (any invalid rows will not be imported).{/ts}</p>
+    </div>
+  {/if}
+
  {* Summary Preview (record counts) *}
  <table id="preview-counts" class="report">
     <tr><td class="label crm-grid-cell">{ts}Total Rows{/ts}</td>
@@ -46,10 +52,12 @@
     </tr>
     {/if}
 
-    <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
-        <td class="data">{$validRowCount}</td>
-        <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
-    </tr>
+    {if $validRowCount}
+      <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
+          <td class="data">{$validRowCount}</td>
+          <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
+      </tr>
+    {/if}
  </table>
  <br />
 

--- a/templates/CRM/Contact/Import/Form/Preview.tpl
+++ b/templates/CRM/Contact/Import/Form/Preview.tpl
@@ -27,6 +27,12 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
 </div>
 
+{if $validationSkipped}
+  <div class="alert alert-warning">
+    <p>{ts 1=$largeFileSize}Validation has been skipped as you are importing a large file (greater than %1 rows). We recommend you manually check that the file you are importing is correct. You can import regardless, and validation will be happen during the import (any invalid rows will not be imported).{/ts}</p>
+  </div>
+{/if}
+
 <div id="preview-info">
  {* Summary Preview (record counts) *}
  <table id="preview-counts" class="report">
@@ -44,11 +50,13 @@
       </tr>
     {/if}
 
-    <tr>
-    <td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
-        <td class="data">{$validRowCount}</td>
-        <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
-    </tr>
+    {if $validRowCount}
+      <tr>
+        <td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
+          <td class="data">{$validRowCount}</td>
+          <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
+      </tr>
+    {/if}
  </table>
 
  {* Table for mapping preview *}

--- a/templates/CRM/Event/Import/Form/Preview.tpl
+++ b/templates/CRM/Event/Import/Form/Preview.tpl
@@ -28,6 +28,12 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
 
+ {if $validationSkipped}
+  <div class="alert alert-warning">
+    <p>{ts 1=$largeFileSize}Validation has been skipped as you are importing a large file (greater than %1 rows). We recommend you manually check that the file you are importing is correct. You can import regardless, and validation will be happen during the import (any invalid rows will not be imported).{/ts}</p>
+  </div>
+{/if}
+
 <div class="crm-submit-buttons">
      {include file="CRM/common/formButtons.tpl" location="top"}
 </div>
@@ -47,10 +53,12 @@
     </tr>
     {/if}
 
-    <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
-        <td class="data">{$validRowCount}</td>
-        <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
-    </tr>
+    {if $validRowCount}
+      <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
+          <td class="data">{$validRowCount}</td>
+          <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
+      </tr>
+    {/if}
  </table>
 
 

--- a/templates/CRM/Member/Import/Form/Preview.tpl
+++ b/templates/CRM/Member/Import/Form/Preview.tpl
@@ -28,6 +28,12 @@
     <p>{ts}Click 'Import Now' if you are ready to proceed.{/ts}</p>
  </div>
 
+  {if $validationSkipped}
+    <div class="alert alert-warning">
+      <p>{ts 1=$largeFileSize}Validation has been skipped as you are importing a large file (greater than %1 rows). We recommend you manually check that the file you are importing is correct. You can import regardless, and validation will be happen during the import (any invalid rows will not be imported).{/ts}</p>
+    </div>
+  {/if}
+
  {* Summary Preview (record counts) *}
  <table id="preview-counts" class="report">
     <tr><td class="label crm-grid-cell">{ts}Total Rows{/ts}</td>
@@ -46,10 +52,13 @@
     </tr>
     {/if}
 
-    <tr><td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
-        <td class="data">{$validRowCount}</td>
-        <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
-    </tr>
+    <{if $validRowCount}
+      <tr>
+        <td class="label crm-grid-cell">{ts}Valid Rows{/ts}</td>
+          <td class="data">{$validRowCount}</td>
+          <td class="explanation">{ts}Total rows to be imported.{/ts}</td>
+      </tr>
+    {/if}
  </table>
 
 


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6423 Skip import validation for large files.

Before
----------------------------------------
It is common for web servers to have request timeouts set (default 60 seconds on Apache, and limited to a max of 100 seconds on Cloudflare). Prior to this change, importing large files was very difficult as the timeout would usually be hit.

After
----------------------------------------
Validation is not performed on the import preview screen for large files (files with more than 10,000 rows). Validation is still performed during the actual import (which is batched, and so does not hit the request timeouts), and errors will be presented to the user at the final summary screen. For small files there is no change to the current behaviour.

Technical Details
----------------------------------------
 - The number of rows considered to be a "large file" is configurable with `CIVICRM_IMPORT_LARGE_FILE`. The number 10,000 is pretty arbitrary, and I'm more than happy to adjust the default! 
 
 - We did consider adding a hook on `CIVICRM_IMPORT_LARGE_FILE` too, but figured a `const` would probably be enough for most cases.
 
 - There is some precedent for setting fairly arbitrary "large" limits. The `CIVICRM_UPGRADE_SNAPSHOT` `auto` policy comes to mind.
 
 - `validate()` does an `UPDATE` database query for every single row, which is where a lot of the inefficiency comes from. We did originally look at refactoring this to do the writes in batches, but that introduces a reasonably high risk of backwards compatibility issues for custom parsers (fairly likely given the [documentation around that](https://docs.civicrm.org/dev/en/latest/framework/import/)). Having said that, it might still be worth looking at if the validation logic can be improved alongside this change.

Comments
----------------------------------------
Kudos to @karlM-BM who worked on this alongside me.