### PR TITLE
River: restores missing marker for primary phone/etc, and error colour (/core/6419)

### DIFF
--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -241,6 +241,7 @@ dl dl {
 .crm-container .status-warning,
 .crm-container .crm-error,
 .crm-container td.tasklist a:link,
+.crm-container label.error,
 #bootstrap-theme .has-error .help-block,
 #bootstrap-theme .has-error .control-label,
 #bootstrap-theme .has-error .radio,

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -98,7 +98,12 @@
   padding: var(--crm-padding-reg) 0;
 }
 .crm-container .crm-summary-row.primary .crm-label:after {
-  content: ' *'; /* marks primary contact records on contact dashboard */
+  content: '\f005';
+  font-family: 'Font Awesome 5 Free';
+  opacity: 0.5;
+  font-size: 75%;
+  position: relative;
+  top: -2px;
 }
 /* Fieldset */
 .crm-container fieldset {

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -97,6 +97,9 @@
 .crm-search-display .form-inline {
   padding: var(--crm-padding-reg) 0;
 }
+.crm-container .crm-summary-row.primary .crm-label:after {
+  content: ' *'; /* marks primary contact records on contact dashboard */
+}
 /* Fieldset */
 .crm-container fieldset {
   border: var(--crm-border);


### PR DESCRIPTION
Overview
----------------------------------------
Reported [here](https://lab.civicrm.org/dev/core/-/work_items/6419) - River lost the bold/asterisk styling used to demark records set to 'primary' in the contact dashboard. This restores them.

While debugging this, I saw the class `error` is used for inline error messages, so that's added to the 'error' colour descriptor array.

Before
----------------------------------------
'Primary' record not marked.

<img width="310" height="87" alt="image" src="https://github.com/user-attachments/assets/549fc478-f1e3-461d-9737-f11a2461c3d2" />

Error message in text colour.

<img width="647" height="40" alt="image" src="https://github.com/user-attachments/assets/ff9dedc6-e018-441e-b0c7-35dd4544db5b" />

After
----------------------------------------
'Primary' record has ~~asterisk~~ star.

<img width="2368" height="364" alt="image" src="https://github.com/user-attachments/assets/2662af3e-23d7-4061-bb6e-569f16b57764" />
<img width="150" height="34" alt="image" src="https://github.com/user-attachments/assets/ce0e8094-386a-483b-9c5f-9ce1e039325d" />

Walbrook:

<img width="1095" height="152" alt="image" src="https://github.com/user-attachments/assets/a62011eb-59a6-4784-abaa-acf3d42b27b1" />
<img width="187" height="72" alt="image" src="https://github.com/user-attachments/assets/0697e492-b26f-4f33-bd10-c7f2c3f66ddf" />

Hackney:

<img width="1025" height="94" alt="image" src="https://github.com/user-attachments/assets/ad6d1182-2195-47cb-9b69-c54489e4153c" />
<img width="163" height="46" alt="image" src="https://github.com/user-attachments/assets/95d49318-8785-40da-a266-2a2d9bc77b87" />

Thames:

<img width="1043" height="101" alt="image" src="https://github.com/user-attachments/assets/66ca8694-dccd-475a-9501-44b6ac0d355b" />
<img width="145" height="37" alt="image" src="https://github.com/user-attachments/assets/e1d93ddb-89d6-4e5f-97fa-6e60a4e03db5" />

Error message in the error message darkmode-safe red.

<img width="653" height="44" alt="image" src="https://github.com/user-attachments/assets/ed05f317-e854-4f4f-81bb-57386b4bae86" />
<img width="646" height="39" alt="image" src="https://github.com/user-attachments/assets/b79f7615-70aa-4ada-a1fd-e3d85ce87203" />

Comments
----------------------------------------
Historically Greenwich used bold to show the primary record, The Island used an asterisk. Am using an asterisk here because bold won't stand out if the label font is bold. Obviously there's a number of other ways to make the primary record stand out.

EDIT: updated to use a FontAwesome star, with an opacity following [discussion](https://lab.civicrm.org/dev/core/-/work_items/6419#note_201422) - there is some pixel positioning on this, which I don't like, but for inline icons is lighter than wrapping in a centred flex container.