### PR TITLE
River: removes excess padding on dropdown inputs

### DIFF
--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -288,6 +288,7 @@
 #bootstrap-theme .dropdown-menu li .form-inline,
 #bootstrap-theme .dropdown-menu li .form-inline a:not(.select2-choice) {
   color: var(--crm-dropdown-color);
+  padding: 0;
 }
 .crm-container .dropdown-menu > li {
   border-radius: var(--crm-l-radius);


### PR DESCRIPTION
Overview
----------------------------------------
Inputs on Bootstrap dropdowns are wrapped in .form-inline which has block padding on it. This resets that to zero.

Before
----------------------------------------
<img width="311" height="190" alt="image" src="https://github.com/user-attachments/assets/cb5f8f44-6868-4ea0-b337-f3a44db5dc4e" />

<img width="232" height="165" alt="image" src="https://github.com/user-attachments/assets/7b9f70f6-9928-43d7-ab82-e48dab762895" />

After
----------------------------------------
<img width="302" height="104" alt="image" src="https://github.com/user-attachments/assets/38e2aa13-aa3d-4fec-9275-d4d93c3d7a99" />

<img width="227" height="130" alt="image" src="https://github.com/user-attachments/assets/804d9a34-ca73-4d3b-8e2f-21e12f05aed9" />