### PR TITLE
ChartKit - Remove deprecated empty 'settings' from ang module

### DIFF
--- a/ext/chart_kit/ang/crmChartKit.ang.php
+++ b/ext/chart_kit/ang/crmChartKit.ang.php
@@ -23,5 +23,4 @@ return [
   'exports' => [
     'crm-search-display-chart-kit' => 'E',
   ],
-  'settings' => [],
 ];


### PR DESCRIPTION
Overview
----------------------------------------
This key is deprecated and should not be present.

Comments
----------------------------------------
FYI @ufundo we have a unit test to check this key is not present, but I guess it doesn't run on core extensions so didn't catch this one:
https://github.com/civicrm/civicrm-core/blob/fb78575099d10e359e2f2308e8ed3e47267e3da4/tests/phpunit/Civi/Angular/ManagerTest.php#L81