### PR TITLE
Afform - Update "Not Saved" text to match already-translated strings

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -409,7 +409,7 @@
           }
           return;
         }
-        status = CRM.status({error: ts('Not saved')});
+        status = CRM.status({error: ts('Not Saved')});
         $element.block();
         if (cancelDraftWatcher) {
           cancelDraftWatcher();


### PR DESCRIPTION
Overview
----------------------------------------
The string "Not Saved" is already translated in CiviCRM core, but "Not saved" wasn't.
