### PR TITLE
Groups - Fix smarty warning on "New Group" form

### DIFF
--- a/templates/CRM/Group/Form/Edit.tpl
+++ b/templates/CRM/Group/Form/Edit.tpl
@@ -75,7 +75,7 @@
       <td>{$form.is_active.html}</td>
     </tr>
 
-   {if $group.created_by}
+   {if !empty($group.created_by)}
       <tr class="crm-group-form-block-created">
         <td class="label">{ts}Created By{/ts}</td>
         <td>{$group.created_by}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes smarty warning.

Before
----------------------------------------
<img width="1080" height="916" alt="image" src="https://github.com/user-attachments/assets/8049cade-e937-415a-a271-b2d99a10a455" />


After
----------------------------------------
<img width="1079" height="748" alt="image" src="https://github.com/user-attachments/assets/404e1ee3-f040-4b17-9d4d-bb824563a78c" />
