### PR TITLE
Groups - Fix html escaping on group parents field

### DIFF
--- a/CRM/Group/Form/Edit.php
+++ b/CRM/Group/Form/Edit.php
@@ -350,7 +350,7 @@ WHERE  title = %1
    *   parent groups
    */
   public static function buildParentGroups(&$form) {
-    $groupNames = CRM_Core_PseudoConstant::group();
+    $groupNames = CRM_Core_PseudoConstant::group(textFormat: 'plain');
     $parentGroups = $parentGroupElements = [];
     if (isset($form->_id) && !empty($form->_groupValues['parents'])) {
       $parentGroupIds = explode(',', $form->_groupValues['parents']);


### PR DESCRIPTION
Overview
----------------------------------------
Part of https://lab.civicrm.org/dev/core/-/work_items/6400

Before
----------------------------------------
<img width="666" height="216" alt="image" src="https://github.com/user-attachments/assets/669eca2c-8848-43b6-ab7e-7b92b974f3f4" />


After
----------------------------------------
<img width="668" height="220" alt="image" src="https://github.com/user-attachments/assets/352347bc-b044-4efd-bf8a-891874b7d38b" />

