### PR TITLE
Settings - Remove reference to old unused `checksumTimeout`

### DIFF
--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -408,7 +408,6 @@ class CRM_Core_BAO_ConfigSetting {
       'localeCustomStrings',
       'autocompleteContactSearch',
       'autocompleteContactReference',
-      'checksumTimeout',
       'checksum_timeout',
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Following on from 92a8de7296 this removes the last reference to `checksumTimeout` which is actually named `checksum_timeout`.

Before
----------------------------------------
There is no setting called `checksumTimeout`.

After
----------------------------------------
Still no setting called `checksumTimeout`.

Technical Details
----------------------------------------
According to notes in 92a8de7296 there never was a setting with that name; it was just mis-named on the admin form.

I've confirmed there are no references to `checksumTimeout` in `universe`, and that Api3, Api4, `$config` and `Civi::settings()` all refer to it by the correct name: `checksum_timeout`.