### PR TITLE
River: removes un-used variables

### DIFF
--- a/ext/riverlea/core/css/_dark.css
+++ b/ext/riverlea/core/css/_dark.css
@@ -40,7 +40,7 @@
   --crm-alert-success-text-color: var(--crm-success-text-color);
   --crm-alert-warning-bg-color: var(--crm-warning-color);
   --crm-alert-warning-border-color: color-mix(in srgb, var(--crm-alert-warning-bg-color) 90%,#fff 10%);
-/* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
+/* Form '--crm-form-' '--crm-input-' */
   --crm-input-description: var(--crm-c-gray-300);
 /* Tabs '--crm-tabs' */
   --crm-tabs-bg-color: var(--crm-layer2-bg-color);

--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -22,7 +22,6 @@
   --crm-c-blue-dark: #20576f;
   --crm-c-blue-darker: #133f51;
   --crm-c-purple: #4d4d69;
-  --crm-c-purple-dark: #3e3e54;
   --crm-c-green: #d6e9c6;
   --crm-c-green-light: #dfefdc;
   --crm-c-green-dark: #2e562e;
@@ -131,17 +130,13 @@
   --crm-heading-margin: var(--crm-l-medium) 0;
   --crm-heading-radius: var(--crm-l-radius);
 /* Buttons */
-  --crm-btn-box-shadow: none;
   --crm-btn-border: 0 solid transparent;
   --crm-btn-txt-transform: inherit;
-  --crm-btn-weight: inherit;
-  --crm-btn-font: inherit;
   --crm-btn-radius: 3px;
   --crm-btn-padding-block: var(--crm-l-xsmall-1); /* padding for top and bottom, one value */
   --crm-btn-padding-inline: var(--crm-l-medium-1); /* padding for left and right, one value */
   --crm-btn-small-padding: var(--crm-l-xsmall) var(--crm-l-medium);
   --crm-btn-large-padding: var(--crm-l-medium) var(--crm-l-reg);
-  --crm-btn-align: center;
   --crm-btn-height: 28px;
   --crm-btn-icon-spacing: var(--crm-l-small);
   --crm-btn-icon-size: auto;
@@ -164,23 +159,18 @@
   --crm-table-bg-color: var(--crm-paper);
   --crm-table-row-border: var(--crm-border);
   --crm-table-column-border: 0 solid transparent;
-  --crm-table-font-size: var(--crm-font-size);
   --crm-table-padding: var(--crm-l-medium);
-  --crm-table-header-border: 1px solid transparent;
   --crm-table-header-border-bottom: 2px solid var(--crm-border-color);
   --crm-table-header-bg-color: var(--crm-paper);
   --crm-table-header-color: var(--crm-text-color);
-  --crm-table-header-txt: inherit;
   --crm-table-row-bg-color: var(--crm-table-bg-color); /* don't make transparent */
   --crm-table-row-alternate-bg-color: #000; /* color for alternate row mixer */
   --crm-table-row-alternate-mix: 7%; /* 0% for no row col, 100% for all of it */
   --crm-table-row-hover-color: var(--crm-c-yellow-light);
   --crm-table-sort-color: var(--crm-c-gray-300);
-  --crm-table-sort-float: left; /* 'left', 'right' or 'none' */
   --crm-table-sort-active-color: var(--crm-link-color);
   --crm-table-compressed-width: auto;
   --crm-table-nested-padding: var(--crm-l-reg) var(--crm-l-medium);
-  --crm-table-nested-head-border: 0 solid transparent;
   --crm-table-nested-border: var(--crm-border);
   --crm-table-inset-bg-color: var(--crm-layer2-bg-color);
 /* Panels */
@@ -248,7 +238,6 @@
   --crm-form-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
   --crm-form-checkbox-list-bg-color: var(--crm-table-row-hover-color);
   --crm-input-bg-color: var(--crm-paper);
-  --crm-input-bg-image: linear-gradient(top, #eee 1%, #fff 15%);
   --crm-input-color: var(--crm-text-color);
   --crm-input-border-color: var(--crm-c-gray-400);
   --crm-input-border-radius: 3px;
@@ -270,11 +259,7 @@
   --crm-input-dropdown-icon: "\f107";
   --crm-input-radio-color: var(--crm-focus-color);
   --crm-input-select-bg-color: var(--crm-layer1-bg-color);
-  --crm-input-inline-edit-border: 0 solid transparent;
   --crm-input-inline-edit-bg-color: var(--crm-container-bg-color);
-  --crm-fieldset-border-color: var(--crm-c-gray-400);
-  --crm-fieldset-border: 1px 0 0 0;
-  --crm-fieldset-padding: var(--crm-padding-reg) var(--crm-padding-small);
   --crm-input-toggle-width: 2.75rem;
   --crm-input-toggle-height: var(--crm-l-reg-4);
   --crm-input-toggle-disabled-bg: var(--crm-inverse-bg-color);
@@ -297,7 +282,6 @@
   --crm-tab-count-color: var(--crm-info-color);
   --crm-tab-radius: var(--crm-l-radius);
   --crm-tab-border: var(--crm-border);
-  --crm-tab-border-width: 0;
   --crm-tab-active-border: 0 solid transparent;
 /* Contact dashboard */
   --crm-contact-border: var(--crm-tab-border);

--- a/ext/riverlea/streams/empty/_dark.css
+++ b/ext/riverlea/streams/empty/_dark.css
@@ -20,7 +20,7 @@
 /* Panels '--crm-panel-' */
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
 /* Alerts '--crm-alert' */
-/* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
+/* Form '--crm-form-' '--crm-input-' */
 /* Tabs '--crm-tabs' */
 /* Contact layout '--crm-contact-' */
 /* Dialog '--crm-dialog-' */

--- a/ext/riverlea/streams/hackneybrook/_dark.css
+++ b/ext/riverlea/streams/hackneybrook/_dark.css
@@ -37,14 +37,12 @@
   --crm-table-row-bg-color: var(--crm-layer1-bg-color);
   --crm-table-row-border: 1px solid var(--crm-c-gray-200);
   --crm-table-row-hover-color: var(--crm-layer2-bg-color);
-/* Panels '--crm-panel-' */
-  --crm-panel-border-col: var(--crm-c-gray-500);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
   --crm-accordion-header-bg-color: var(--crm-layer2-bg-color);
   --crm-accordion-header-bg-active-color: var(--crm-c-gray-600);
   --crm-accordion-body-border: 0;
 /* Alerts '--crm-alert' */
-/* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
+/* Form '--crm-form-' '--crm-input-' */
   --crm-input-border-color: var(--crm-c-gray-500);
   --crm-form-checkbox-list-bg-color: #665800;
 /* Tabs '--crm-tabs' */

--- a/ext/riverlea/streams/minetta/_dark.css
+++ b/ext/riverlea/streams/minetta/_dark.css
@@ -31,13 +31,11 @@
   --crm-table-outside-border: var(--crm-border);
   --crm-table-row-border: 1px solid var(--crm-c-gray-200);
   --crm-table-row-hover-color: var(--crm-c-amber);
-/* Panels '--crm-panel-' */
-  --crm-panel-border-col: var(--crm-c-gray-200);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
   --crm-accordion-header-bg-color: var(--crm-layer2-bg-color);
   --crm-accordion-header-bg-active-color: var(--crm-c-gray-600);
 /* Alerts '--crm-alert' */
-/* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
+/* Form '--crm-form-' '--crm-input-' */
   --crm-form-block-bg-color: var(--crm-layer1-bg-color);
   --crm-input-border-color: var(--crm-c-gray-200);
   --crm-input-radio-color: #38c4b4;

--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -47,7 +47,7 @@
   --crm-alert-warning-bg-color: #383124;
   --crm-alert-info-bg-color: var(--crm-c-blue-darker);
   --crm-alert-info-text-color: var(--crm-c-blue-light);
-/* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
+/* Form '--crm-form-' '--crm-input-' */
   --crm-form-block-bg-color: var(--crm-c-dkblue-02);
   --crm-input-bg-color: var(--crm-c-blue-darker);
   --crm-input-color: var(--crm-c-blue); /* text */

--- a/ext/riverlea/streams/walbrook/_dark.css
+++ b/ext/riverlea/streams/walbrook/_dark.css
@@ -33,14 +33,12 @@
 /* Tables '--crm-table-' */
   --crm-table-row-hover-color: var(--crm-alert-info-border-color);
 /* Panels '--crm-panel-' */
-  --crm-panel-border-col: var(--crm-c-gray-500);
-  --crm-panel-border: 1px;
   --crm-panel-bg-color: var(--crm-container-bg-color);
 /* Accordions '--crm-accordion-' and '--crm-accordion2-' for .crm-accrdion-light */
   --crm-accordion-header-bg-active-color: var(--crm-secondary-hover-color);
   --crm-accordion2-header-bg-active-color: var(--crm-secondary-hover-color);
 /* Alerts '--crm-alert' */
-/* Form '--crm-form-' '--crm-input-' '--crm-inline-' '--crm-fieldset-' '--crm-checkbox' */
+/* Form '--crm-form-' '--crm-input-' */
   --crm-form-block-bg-color: var(--crm-container-bg-color);
   --crm-input-border-color: var(--crm-c-gray-500);
 /* Tabs '--crm-tabs'/

--- a/ext/riverlea/streams/walbrook/_main.css
+++ b/ext/riverlea/streams/walbrook/_main.css
@@ -80,7 +80,6 @@
   --crm-table-row-hover-color: var(--crm-c-gray-200);
   --crm-table-sort-color: var(--crm-c-gray-500);
   --crm-table-nested-padding: 0 0 var(--crm-l-reg) 0;
-  --crm-table-nested-head-border: 2px solid var(--crm-c-gray-300);
   --crm-table-nested-border: 0 solid transparent;
 /* Panels */
   --crm-panel-head-margin: var(--crm-l-medium-2);
@@ -117,14 +116,12 @@
   --crm-form-block-padding: var(--crm-l-reg);
   --crm-form-block-border-radius: 0;
   --crm-input-bg-color: var(--crm-container-bg-color);
-  --crm-input-bg-image: none;
   --crm-input-border-color: #c2cfd8;
   --crm-input-border-radius: var(--crm-l-radius);
   --crm-input-box-shadow: inset 0 0 3px 0 rgba(0,0,0,.2);
   --crm-input-padding: var(--crm-l-xsmall-1) var(--crm-l-medium-1);
   --crm-input-label-weight: bold;
   --crm-input-radio-color: var(--crm-primary-color);
-  --crm-input-inline-edit-border: 1px solid var(--crm-c-gray-900);
   --crm-form-fieldset-border-color: unset;
   --crm-form-fieldset-border-width: 0;
   --crm-form-fieldset-padding: 0;


### PR DESCRIPTION
Overview
----------------------------------------
Following on from https://github.com/civicrm/civicrm-core/pull/35380 - and the Wallace [custom property inspector's checks](https://www.projectwallace.com/custom-property-inspector) - removes 26 unused variables. There's also some base colours that aren't used but am leaving these for now.

Before
----------------------------------------
Lots of css variables from early in RiverLea's development that aren't still being used anywhere.

After
----------------------------------------
They've gone.

Technical Details
----------------------------------------
Should be merged after #35380. You can double check the deletions by searching for any of the deleted variables.

Comments
----------------------------------------
Would be nice unit tests (one day) – if the CSS uses a custom property that isn't defined anywhere in Civi, or conversely sets a custom property that isn't used anywhere.