### PR TITLE
php warning if relationship_type_id not in the params for relationship update

### DIFF
--- a/CRM/Contact/BAO/Relationship.php
+++ b/CRM/Contact/BAO/Relationship.php
@@ -314,7 +314,7 @@ class CRM_Contact_BAO_Relationship extends CRM_Contact_DAO_Relationship implemen
   public static function loadExistingRelationshipDetails($params) {
     if (!empty($params['contact_id_a'])
       && !empty($params['contact_id_b'])
-      && is_numeric($params['relationship_type_id'])) {
+      && is_numeric($params['relationship_type_id'] ?? NULL)) {
       return $params;
     }
     if (empty($params['id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
A bit of an edge case, but seems straightforward.

Before
----------------------------------------
1. Suppose you're doing something like flipping the A and B:
```php
Civi\Api4\Relationship::update(FALSE)
->addWhere('id', '=', $some_id)
->addValue('contact_id_a', $the_original_b)
->addValue('contact_id_b', $the_original_a)
->execute();
```
2. Gives a php warning about missing relationship_type_id.

It's an edge case since to get the warning you need to be doing something where you specify both contact_id_a AND contact_id_b but not relationship type.

After
----------------------------------------


Technical Details
----------------------------------------
no change in function - it goes on and looks up the relationship type the same as before

Comments
----------------------------------------
