### PR TITLE
Ensure that Contribution Page field is show as selected even if the c…

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1931,9 +1931,15 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       );
     }
 
+    $contributionPages = [];
+    $entityContributionPage = Civi::entity('Contribution')->getOptions('contribution_page_id', [], TRUE);
+    foreach ($entityContributionPage as $contributionPage) {
+      $contributionPages[$contributionPage['id']] = $contributionPage['label'];
+    }
+
     $form->add('select', 'contribution_page_id',
       ts('Contribution Page'),
-      ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::contributionPage(),
+      ['' => ts('- select -')] + $contributionPages,
       FALSE,
       ['class' => 'crm-select2']
     );


### PR DESCRIPTION
…ontribution page is disabled

Overview
----------------------------------------
This fixes an issue where if you are editing a contribution that was associated with a disabled contribution page that the contribution page field doesn't show as filled in correctly. 

Before
----------------------------------------
Create Contribution for a contribution page
Disable contribution Page
Edit contribution created and notice in the additional details section contribution page field is not filled out

After
----------------------------------------
Create Contribution for a contribution page
Disable contribution Page
Edit contribution created and notice in the additional details section contribution page field is filled out

Technical Details
----------------------------------------
This replaces a deprecated method for getting options with using the Civi::entity()

ping @colemanw @demeritcowboy @eileenmcnaughton @mattwire 