### PR TITLE
SearchKit edit-in-place: add support for TextArea ("Note" type)

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplay/crmSearchDisplayEditable.component.js
@@ -48,7 +48,7 @@
           if (e.key === 'Escape') {
             $scope.$apply(() => ctrl.cancel());
           }
-          else if (e.key === 'Enter') {
+          else if (e.key === 'Enter' && e.target.type !== 'textarea') {
             $scope.$apply(() => ctrl.save());
           }
         });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -172,6 +172,10 @@
           return '~/crmSearchTasks/crmSearchInput/email.html';
         }
 
+        if (field.input_type === 'TextArea') {
+          return '~/crmSearchTasks/crmSearchInput/textArea.html';
+        }
+
         return '~/crmSearchTasks/crmSearchInput/text.html';
       };
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/textArea.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/textArea.html
@@ -1,0 +1,6 @@
+<div class="form-group" ng-if="!$ctrl.isMulti()" >
+  <textarea class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.input.field.nullable || $ctrl.input.field.required"></textarea>
+</div>
+<div class="form-group" ng-if="$ctrl.isMulti()" >
+  <input class="form-control" ng-model="$ctrl.value" id="{{:: $ctrl.labelId }}" ng-required="!$ctrl.input.field.nullable || $ctrl.input.field.required" crm-ui-select="{multiple: true, tags: [], tokenSeparators: [','], formatNoMatches: ''}" ng-list>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
In SearchDisplays, when "Note" type fields have "In-place edit" enabled, use a `textarea` widget to edit them.

Before
----------------------------------------
"Note" type fields were edited-in-place using a single-line text input, which stripped all newlines out of the text.

After
----------------------------------------
`textarea` — multiple lines; line breaks can be entered and are preserved.

Comments
----------------------------------------
This takes care of the edit side of things; #35362 took care of a display issue.
