### PR TITLE
dev/core#6413 CoreForm - Prevent double-escaping field labels

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -577,10 +577,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
     }
 
     if ($type === 'checkbox') {
-      $element = $this->addElement($type, $name, CRM_Utils_String::purifyHTML($label), NULL, $attributes);
+      $element = $this->addElement($type, $name, $label, NULL, $attributes);
     }
     else {
-      $element = $this->addElement($type, $name, CRM_Utils_String::purifyHTML($label), $attributes, $extra);
+      $element = $this->addElement($type, $name, $label, $attributes, $extra);
     }
     if (HTML_QuickForm::isError($element)) {
       CRM_Core_Error::statusBounce(HTML_QuickForm::errorMessage($element));


### PR DESCRIPTION
Overview
----------------------------------------
As of https://github.com/civicrm/civicrm-packages/commit/862222a8 labels are escaped by default, making this extra escaping redundant, and causing any form labels with special characters to be double-escaped.

To reproduce, create a tagset or a custom field with a special character in the label and visit advanced search.