### PR TITLE
dev/core#6430 SearchTask - Fix double-escaping and show tags in color

### DIFF
--- a/CRM/Activity/Form/Task/AddToTag.php
+++ b/CRM/Activity/Form/Task/AddToTag.php
@@ -22,20 +22,6 @@
 class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
 
   /**
-   * Name of the tag.
-   *
-   * @var string
-   */
-  protected $_name;
-
-  /**
-   * All the tags in the system.
-   *
-   * @var array
-   */
-  protected $_tags;
-
-  /**
    * @var bool
    */
   public $submitOnce = TRUE;
@@ -45,15 +31,11 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
    */
   public function buildQuickForm() {
     // add select for tag
-    $this->_tags = CRM_Core_BAO_Tag::getTags('civicrm_activity');
-
-    foreach ($this->_tags as $tagID => $tagName) {
-      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
-    }
+    $this->add('select2', 'tag', ts('Select Tag'), CRM_Core_BAO_Tag::getColorTags('civicrm_activity'), FALSE, ['multiple' => TRUE]);
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_activity');
 
-    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_activity');
+    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_activity', NULL, TRUE);
 
     $this->addDefaultButtons(ts('Tag Activities'));
   }
@@ -81,12 +63,12 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
    */
   public function postProcess() {
     // Get the submitted values in an array.
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->controller->exportValues();
     $activityTags = $tagList = [];
 
     // check if contact tags exists
     if (!empty($params['tag'])) {
-      $activityTags = $params['tag'];
+      $activityTags = array_flip(explode(',', $params['tag']));
     }
 
     // check if tags are selected from taglists
@@ -110,19 +92,10 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
       }
     }
 
-    $tagSets = CRM_Core_BAO_Tag::getTagsUsedFor('civicrm_activity', FALSE, TRUE);
-
-    foreach ($tagSets as $key => $value) {
-      $this->_tags[$key] = $value['name'];
-    }
-
     // merge activity and taglist tags
     $allTags = CRM_Utils_Array::crmArrayMerge($activityTags, $tagList);
 
-    $this->_name = [];
     foreach ($allTags as $key => $dnc) {
-      $this->_name[] = $this->_tags[$key];
-
       [, $added, $notAdded] = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_activityHolderIds, $key,
         'civicrm_activity', FALSE);
 
@@ -133,8 +106,9 @@ class CRM_Activity_Form_Task_AddToTag extends CRM_Activity_Form_Task {
           'plural' => '%count activities already had this tag',
         ]);
       }
+      $tagLabel = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $key, 'label');
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
+      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $tagLabel]), 'success');
     }
 
   }

--- a/CRM/Activity/Form/Task/RemoveFromTag.php
+++ b/CRM/Activity/Form/Task/RemoveFromTag.php
@@ -21,20 +21,6 @@
 class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
 
   /**
-   * Name of the tag
-   *
-   * @var string
-   */
-  protected $_name;
-
-  /**
-   * All the tags in the system
-   *
-   * @var array
-   */
-  protected $_tags;
-
-  /**
    * @var bool
    */
   public $submitOnce = TRUE;
@@ -44,13 +30,10 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
    */
   public function buildQuickForm() {
     // add select for tag
-    $this->_tags = CRM_Core_BAO_Tag::getTags('civicrm_activity');
-    foreach ($this->_tags as $tagID => $tagName) {
-      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
-    }
+    $this->add('select2', 'tag', ts('Select Tag'), CRM_Core_BAO_Tag::getColorTags(), FALSE, ['multiple' => TRUE]);
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_activity');
-    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_activity', NULL, TRUE, FALSE);
+    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_activity', NULL, TRUE);
 
     $this->addDefaultButtons(ts('Remove Tags from activities'));
   }
@@ -78,13 +61,13 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
    */
   public function postProcess() {
     //get the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->controller->exportValues();
 
     $activityTags = $tagList = [];
 
     // check if contact tags exists
     if (!empty($params['tag'])) {
-      $activityTags = $params['tag'];
+      $activityTags = array_flip(explode(',', $params['tag']));
     }
 
     // check if tags are selected from taglists
@@ -101,18 +84,11 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
         }
       }
     }
-    $tagSets = CRM_Core_BAO_Tag::getTagsUsedFor('civicrm_activity', FALSE, TRUE);
 
-    foreach ($tagSets as $key => $value) {
-      $this->_tags[$key] = $value['name'];
-    }
     // merge contact and taglist tags
     $allTags = CRM_Utils_Array::crmArrayMerge($activityTags, $tagList);
 
-    $this->_name = [];
     foreach ($allTags as $key => $dnc) {
-      $this->_name[] = $this->_tags[$key];
-
       [, $removed, $notRemoved] = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_activityHolderIds,
         $key, 'civicrm_activity', FALSE);
 
@@ -128,8 +104,9 @@ class CRM_Activity_Form_Task_RemoveFromTag extends CRM_Activity_Form_Task {
           'plural' => '%count activities already did not have this tag',
         ]);
       }
+      $tagLabel = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $key, 'label');
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
+      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $tagLabel]), 'success');
     }
   }
 

--- a/CRM/Contact/Form/Task/AddToTag.php
+++ b/CRM/Contact/Form/Task/AddToTag.php
@@ -25,32 +25,14 @@
 class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
 
   /**
-   * Name of the tag.
-   *
-   * @var string
-   */
-  protected $_name;
-
-  /**
-   * All the tags in the system.
-   *
-   * @var array
-   */
-  protected $_tags;
-
-  /**
    * Build the form object.
    */
   public function buildQuickForm() {
     // add select for tag
-    $this->_tags = CRM_Core_BAO_Tag::getTags();
-
-    foreach ($this->_tags as $tagID => $tagName) {
-      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
-    }
+    $this->add('select2', 'tag', ts('Select Tag'), CRM_Core_BAO_Tag::getColorTags(), FALSE, ['multiple' => TRUE]);
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');
-    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_contact');
+    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_contact', NULL, TRUE);
 
     $this->addDefaultButtons(ts('Tag Contacts'));
   }
@@ -78,12 +60,12 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
    */
   public function postProcess() {
     //get the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->controller->exportValues();
     $contactTags = $tagList = [];
 
     // check if contact tags exists
     if (!empty($params['tag'])) {
-      $contactTags = $params['tag'];
+      $contactTags = array_flip(explode(',', $params['tag']));
     }
 
     // check if tags are selected from taglists
@@ -107,17 +89,11 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
       }
     }
 
-    $tagSets = CRM_Core_BAO_Tag::getTagsUsedFor('civicrm_contact', FALSE, TRUE);
-
-    foreach ($tagSets as $key => $value) {
-      $this->_tags[$key] = $value['name'];
-    }
-
     // merge contact and taglist tags
     $allTags = CRM_Utils_Array::crmArrayMerge($contactTags, $tagList);
 
     foreach ($allTags as $key => $dnc) {
-      list($total, $added, $notAdded) = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_contactIds, $key,
+      [, $added, $notAdded] = CRM_Core_BAO_EntityTag::addEntitiesToTag($this->_contactIds, $key,
         'civicrm_contact', FALSE);
 
       $status = [ts('%count contact tagged', ['count' => $added, 'plural' => '%count contacts tagged'])];
@@ -127,8 +103,9 @@ class CRM_Contact_Form_Task_AddToTag extends CRM_Contact_Form_Task {
           'plural' => '%count contacts already had this tag',
         ]);
       }
+      $tagLabel = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $key, 'label');
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
+      CRM_Core_Session::setStatus($status, ts("Added Tag <em>%1</em>", [1 => $tagLabel]), 'success');
     }
 
   }

--- a/CRM/Contact/Form/Task/RemoveFromTag.php
+++ b/CRM/Contact/Form/Task/RemoveFromTag.php
@@ -21,31 +21,14 @@
 class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
 
   /**
-   * Name of the tag.
-   *
-   * @var string
-   */
-  protected $_name;
-
-  /**
-   * All the tags in the system.
-   *
-   * @var array
-   */
-  protected $_tags;
-
-  /**
    * Build the form object.
    */
   public function buildQuickForm() {
     // add select for tag
-    $this->_tags = CRM_Core_BAO_Tag::getTags();
-    foreach ($this->_tags as $tagID => $tagName) {
-      $this->addElement('checkbox', "tag[$tagID]", NULL, $tagName);
-    }
+    $this->add('select2', 'tag', ts('Select Tag'), CRM_Core_BAO_Tag::getColorTags(), FALSE, ['multiple' => TRUE]);
 
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_contact');
-    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_contact', NULL, TRUE, FALSE);
+    CRM_Core_Form_Tag::buildQuickForm($this, $parentNames, 'civicrm_contact', NULL, TRUE);
 
     $this->addDefaultButtons(ts('Remove Tags from Contacts'));
   }
@@ -73,13 +56,13 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
    */
   public function postProcess() {
     //get the submitted values in an array
-    $params = $this->controller->exportValues($this->_name);
+    $params = $this->controller->exportValues();
 
     $contactTags = $tagList = [];
 
     // check if contact tags exists
     if (!empty($params['tag'])) {
-      $contactTags = $params['tag'];
+      $contactTags = array_flip(explode(',', $params['tag']));
     }
 
     // check if tags are selected from taglists
@@ -90,22 +73,18 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
             $tagList[$val] = 1;
           }
           else {
-            list($label, $tagID) = explode(',', $val);
+            [, $tagID] = explode(',', $val);
             $tagList[$tagID] = 1;
           }
         }
       }
     }
-    $tagSets = CRM_Core_BAO_Tag::getTagsUsedFor('civicrm_contact', FALSE, TRUE);
 
-    foreach ($tagSets as $key => $value) {
-      $this->_tags[$key] = $value['name'];
-    }
     // merge contact and taglist tags
     $allTags = CRM_Utils_Array::crmArrayMerge($contactTags, $tagList);
 
     foreach ($allTags as $key => $dnc) {
-      list($total, $removed, $notRemoved) = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_contactIds, $key,
+      [, $removed, $notRemoved] = CRM_Core_BAO_EntityTag::removeEntitiesFromTag($this->_contactIds, $key,
         'civicrm_contact', FALSE);
 
       $status = [
@@ -120,8 +99,9 @@ class CRM_Contact_Form_Task_RemoveFromTag extends CRM_Contact_Form_Task {
           'plural' => '%count contacts already did not have this tag',
         ]);
       }
+      $tagLabel = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Tag', $key, 'label');
       $status = '<ul><li>' . implode('</li><li>', $status) . '</li></ul>';
-      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $this->_tags[$key]]), 'success');
+      CRM_Core_Session::setStatus($status, ts("Removed Tag <em>%1</em>", [1 => $tagLabel]), 'success');
     }
   }
 

--- a/templates/CRM/Activity/Form/Task/AddToTag.tpl
+++ b/templates/CRM/Activity/Form/Task/AddToTag.tpl
@@ -14,13 +14,8 @@
 <table class="form-layout-compressed">
     <tr class="crm-activity-task-addtotag-form-block-tag">
         <td>
-            <div class="listing-box">
-            {foreach from=$form.tag item="tag_val"}
-                <div class="{cycle values="odd-row,even-row"}">
-                {$tag_val.html}
-                </div>
-            {/foreach}
-            </div>
+          {$form.tag.label}
+          {$form.tag.html}
         </td>
     </tr>
     <tr>

--- a/templates/CRM/Activity/Form/Task/RemoveFromTag.tpl
+++ b/templates/CRM/Activity/Form/Task/RemoveFromTag.tpl
@@ -13,12 +13,8 @@
 <table class="form-layout-compressed">
     <tr class="crm-activity-task-removefromtag-form-block-tag">
         <td>
-            <div class="listing-box">
-            {foreach from=$form.tag item="tag_val"}
-                <div class="{cycle values="odd-row,even-row"}">
-                {$tag_val.html}
-            {/foreach}
-            </div>
+          {$form.tag.label}
+          {$form.tag.html}
         </td>
     </tr>
     <tr>

--- a/templates/CRM/Contact/Form/Task/AddToTag.tpl
+++ b/templates/CRM/Contact/Form/Task/AddToTag.tpl
@@ -12,13 +12,8 @@
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-addtotag-form-block-tag">
         <td>
-            <div class="listing-box">
-            {foreach from=$form.tag item="tag_val"}
-                <div class="{cycle values="odd-row,even-row"}">
-                {$tag_val.html}
-                </div>
-            {/foreach}
-            </div>
+          {$form.tag.label}
+          {$form.tag.html}
         </td>
     </tr>
     <tr>

--- a/templates/CRM/Contact/Form/Task/RemoveFromTag.tpl
+++ b/templates/CRM/Contact/Form/Task/RemoveFromTag.tpl
@@ -15,13 +15,8 @@
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-removefromtag-form-block-tag">
       <td>
-        <div class="listing-box">
-        {foreach from=$form.tag item="tag_val"}
-           <div class="{cycle values="odd-row,even-row"}">
-             {$tag_val.html}
-          </div>
-        {/foreach}
-        </div>
+        {$form.tag.label}
+        {$form.tag.html}
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Overview
----------------------------------------
This fixes 4 forms that were affected by double-html escaping.

Removes some unnecessary code in the process.

See [dev/core#6430](https://lab.civicrm.org/dev/core/-/work_items/6430)

Comments
----------------------------------------
The code in these 4 forms is annoyingly redundant. They were obviously a copy-paste job originally, but even more annoyingly they now diverge in small ways for no reason. I made a few tweaks to get them more conformant with each other so we can turn their common code into a trait.