### PR TITLE
dev/core#6424 Fix regression matching membership on renewals

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -188,7 +188,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     // Find dedupe ContactId when anonymous form submission.
     if (empty($contactID)) {
-      $contactID = $this->getDedupeContact($this->getSubmittedValues());
+      $contactID = $this->getDedupeContact();
     }
 
     // CRM-7297 - allow membership type to be changed during renewal so long as the parent org of new membershipType
@@ -227,19 +227,18 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
   /**
    * Get the (dedupe) contact from the params submitted in the form.
    *
-   * @param array $params
-   *
    * @return int|null
    */
-  private function getDedupeContact(array $params): ?int {
-    if (!empty($params['onbehalf'])) {
-      unset($params['onbehalf']);
+  private function getDedupeContact(): ?int {
+    $submittedValues = $this->getSubmittedValues();
+    if (!empty($submittedValues['onbehalf'])) {
+      unset($submittedValues['onbehalf']);
     }
-    if (!empty($params['honor'])) {
-      unset($params['honor']);
+    if (!empty($submittedValues['honor'])) {
+      unset($submittedValues['honor']);
     }
 
-    return CRM_Contact_BAO_Contact::getFirstDuplicateContact($params, 'Individual', 'Unsupervised', [], FALSE);
+    return CRM_Contact_BAO_Contact::getFirstDuplicateContact($submittedValues, 'Individual', 'Unsupervised', [], FALSE);
   }
 
   /**
@@ -2290,7 +2289,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     if (empty($contactID)) {
-      $contactID = $this->getDedupeContact($params);
+      $contactID = $this->getDedupeContact();
 
       // Fetch default greeting id's if creating a contact
       if (!$contactID) {

--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -185,6 +185,12 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    */
   protected function getExistingMembership(int $membershipTypeID): array|false {
     $contactID = $this->_membershipContactID ?: $this->getContactID();
+
+    // Find dedupe ContactId when anonymous form submission.
+    if (empty($contactID)) {
+      $contactID = $this->getDedupeContact($this->getSubmittedValues());
+    }
+
     // CRM-7297 - allow membership type to be changed during renewal so long as the parent org of new membershipType
     // is the same as the parent org of an existing membership of the contact
     return CRM_Member_BAO_Membership::getContactMembership($contactID, $membershipTypeID,
@@ -216,6 +222,24 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     // If there is no processor we are using the pay-later manual pseudo-processor.
     // (note it might make sense to make this a row in the processor table in the db).
     return $this->_paymentProcessor['id'] ?? 0;
+  }
+
+  /**
+   * Get the (dedupe) contact from the params submitted in the form.
+   *
+   * @param array $params
+   *
+   * @return int|null
+   */
+  private function getDedupeContact(array $params): ?int {
+    if (!empty($params['onbehalf'])) {
+      unset($params['onbehalf']);
+    }
+    if (!empty($params['honor'])) {
+      unset($params['honor']);
+    }
+
+    return CRM_Contact_BAO_Contact::getFirstDuplicateContact($params, 'Individual', 'Unsupervised', [], FALSE);
   }
 
   /**
@@ -2266,15 +2290,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
 
     if (empty($contactID)) {
-      $dupeParams = $params;
-      if (!empty($dupeParams['onbehalf'])) {
-        unset($dupeParams['onbehalf']);
-      }
-      if (!empty($dupeParams['honor'])) {
-        unset($dupeParams['honor']);
-      }
-
-      $contactID = CRM_Contact_BAO_Contact::getFirstDuplicateContact($dupeParams, 'Individual', 'Unsupervised', [], FALSE);
+      $contactID = $this->getDedupeContact($params);
 
       // Fetch default greeting id's if creating a contact
       if (!$contactID) {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -756,6 +756,11 @@ INNER JOIN  civicrm_membership_type type ON ( type.id = membership.membership_ty
    * @throws \CRM_Core_Exception
    */
   public static function getContactMembership($contactID, $memType, $isTest, $membershipId = NULL, $onlySameParentOrg = FALSE) {
+    // $contactID needs to be set.
+    if (!$contactID) {
+      return FALSE;
+    }
+
     //check for owner membership id, if it exists update that membership instead: CRM-15992
     if ($membershipId) {
       CRM_Core_Error::deprecatedWarning('passing in membership ID is deprecated');

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1478,7 +1478,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       'start_date' => $year . '-01-02',
       'join_date' => $year . '-01-02',
       'end_date' => $year . '-12-31',
-    ] , 'other_member');
+    ], 'other_member');
     $original_membership = Membership::create(FALSE)
       ->addValue('membership_type_id:name', 'Student')
       ->addValue('contact_id', $this->ids['Contact']['member'])
@@ -1540,12 +1540,10 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $items = $this->setupMembershipContributionPage(FALSE);
     $original_membership = $items['original_membership'];
     $this->submitOnlineContributionForm([
-        'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
-        'price_' . $this->ids['PriceField']['contribution_amount'] => -1,
-        'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_student'],
-      ] + $this->getBillingSubmitValues(),
-      $this->getContributionPageID('existingMemberPage')
-    );
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['contribution_amount'] => -1,
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_student'],
+    ] + $this->getBillingSubmitValues(), $this->getContributionPageID('existingMemberPage'));
     // Make sure the other membership was not renewed.
     $otherMembership = Membership::get(FALSE)
       ->addWhere('contact_id', '=', $this->ids['Contact']['member_other'])

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1452,9 +1452,12 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
    * Basic setup for membership tests.
    * @return array
    */
-  public function setupMembershipContributionPage(): array {
-    $this->createLoggedInUser();
-    $this->individualCreate([], 'member');
+  public function setupMembershipContributionPage($isLoggedIn = TRUE): array {
+    if ($isLoggedIn) {
+      $this->createLoggedInUser();
+    }
+    $this->individualCreate([], 'member_other');
+    $this->individualCreate(['first_name' => 'Dave', 'last_name' => 'Wong', 'email_primary.email' => 'dave@example.com'], 'member');
     $this->restoreMembershipTypes();
     $membershipTypes = \CRM_Member_BAO_MembershipType::getAllMembershipTypes();
     // Make sure the MembershipType ids are set as restoreMembershipTypes just uses Api4 to create the types.
@@ -1468,6 +1471,14 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     }
     $this->contributionPageQuickConfigCreate([], [], FALSE, TRUE, TRUE, TRUE, 'existingMemberPage');
     $year = (int) (CRM_Utils_Time::date('Y')) - 1;
+    // Create a membership against another contact to check it is not 'stolen'.
+    $this->createTestEntity('Membership', [
+      'membership_type_id:name' => 'Student',
+      'contact_id' => $this->ids['Contact']['member_other'],
+      'start_date' => $year . '-01-02',
+      'join_date' => $year . '-01-02',
+      'end_date' => $year . '-12-31',
+    ] , 'other_member');
     $original_membership = Membership::create(FALSE)
       ->addValue('membership_type_id:name', 'Student')
       ->addValue('contact_id', $this->ids['Contact']['member'])
@@ -1518,6 +1529,35 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $expectedDate = date('Y-m-d', strtotime($original_membership['end_date']));
     // Make sure that the end data hasn't changed since payment failed.
     $this->assertEquals($expectedDate, $membership['end_date']);
+  }
+
+  /**
+   * Test to make sure that a membership renewal finds the membership on the contact to renew.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSubmitMembershipRenewalSuccessMatchCorrectContact() : void {
+    $items = $this->setupMembershipContributionPage(FALSE);
+    $original_membership = $items['original_membership'];
+    $this->submitOnlineContributionForm([
+        'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+        'price_' . $this->ids['PriceField']['contribution_amount'] => -1,
+        'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_student'],
+      ] + $this->getBillingSubmitValues(),
+      $this->getContributionPageID('existingMemberPage')
+    );
+    // Make sure the other membership was not renewed.
+    $otherMembership = Membership::get(FALSE)
+      ->addWhere('contact_id', '=', $this->ids['Contact']['member_other'])
+      ->execute()
+      ->first();
+    $this->assertEquals(strtotime($original_membership['end_date']), strtotime($otherMembership['end_date']));
+    $membership = Membership::get(FALSE)
+      ->addWhere('contact_id', '=', $this->ids['Contact']['member'])
+      ->execute()
+      ->first();
+    // Make sure that the right membership was renewed.
+    $this->assertGreaterThan(strtotime($original_membership['end_date']), strtotime($membership['end_date']));
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6424 Fix regression matching membership on renewals - this is a port of https://github.com/civicrm/civicrm-core/pull/35081 with a test added & a minor tweak to get the params consistently - I have a further tweak but will do that on master

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
