### PR TITLE
Price Fields - use Number rather than Text as default input type on

### DIFF
--- a/ext/civi_contribute/Civi/Contribute/Utils/PriceFieldUtils.php
+++ b/ext/civi_contribute/Civi/Contribute/Utils/PriceFieldUtils.php
@@ -87,6 +87,12 @@ class PriceFieldUtils {
       $fullLabel = ($priceField['price_set_id.title'] === $priceField['label']) ?
         $priceField['label'] : "{$priceField['price_set_id.title']}: {$priceField['label']}";
 
+      // Price Field configuration sets Text for "Text / Numeric Quantity"
+      // but we want input_type = Number so we get clientside validation
+      // that the user has entered a numeric value
+      if ($priceField['html_type'] === 'Text') {
+        $priceField['html_type'] = 'Number';
+      }
       $fieldSpec = [
         'price_field_id' => $priceField['id'],
         'name' => $fullName,
@@ -94,7 +100,6 @@ class PriceFieldUtils {
         'frontend_label' => $priceField['label'],
         // TODO: do all price fields correspond to an amount?
         'data_type' => 'Float',
-        // TODO: check mappings
         'input_type' => $priceField['html_type'],
         'is_enter_qty' => $priceField['is_enter_qty'],
       ];


### PR DESCRIPTION
Before
----------------------------------------
- numeric Price Fields have `html_type=Text` in the DB
- no clientside validation that a numeric value is entered

After
----------------------------------------
- numeric Price Fields still have `html_type=Text` in the DB (this is baked into the config forms, and maybe the Contribution Page code)
- this is mapped to `input_type=Number` when exposing Price Fields to afform
- numeric Price Fields get clientside validation 
- you can override back to Text if you need to on an individual form, using formbuilder

Technical Details
----------------------------------------
I think it would be good to [render Number inputs using `<input type="text" inputmode="numeric">` rather than `<input type="number">`.](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/). I *think* that would allow us to localise the value separators.

But that's a general afform level change, for a different PR. 

