### PR TITLE
Theme settings - fix when riverlea not current theme

### DIFF
--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -71,10 +71,8 @@
     fetchSettingState() {
       this.settingState = {};
 
-      if (CRM?.riverlea.previewSession) {
-        const previewSession = CRM.riverlea.previewSession();
-        this.settingState.preview = previewSession ? previewSession.selected : null;
-      }
+      const previewSession = CRM.riverlea?.previewSession();
+      this.settingState.preview = previewSession ? previewSession.selected : null;
 
       return CRM.api4('Setting', 'get', { select: ['theme_backend', 'theme_frontend'] })
         .then((results) => results.forEach((record) => {


### PR DESCRIPTION
Before
----------------------------------------
- Riverlea Theme Settings page crashes if you haven't switched to a Riverlea theme yet
- you can't use it to switch to a Riverlea theme

After
----------------------------------------
- Riverlea Theme Settings loads even if you haven't switched to a Riverlea theme yet
- it doesn't look pretty, but it's functional
- you can use it to switch to a Riverlea theme
- you can't use the previewer (as per the existing status message warning)

Technical Details
----------------------------------------
I think this was attempted before, but `CRM?.riverlea.previewSession` is a fallback for no CRM object; we want `CRM.riverlea?.previewSession` as a fallback for no `CRM.riverlea` object
