### PR TITLE
Dedupe - Return success from AJAX callback

### DIFF
--- a/CRM/Contact/Page/AJAX.php
+++ b/CRM/Contact/Page/AJAX.php
@@ -919,7 +919,7 @@ LIMIT {$rowCount}
     $sql = "UPDATE civicrm_prevnext_cache SET is_selected = %1 WHERE {$whereClause} AND cachekey LIKE %3";
     CRM_Core_DAO::executeQuery($sql, $params);
 
-    CRM_Utils_System::civiExit();
+    CRM_Utils_System::sendJSONResponse(['status' => 'success']);
   }
 
   /**


### PR DESCRIPTION

Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/work_items/6412

Before
----------------------------------------
"Request Failed" dialog when selecting duplicates.

After
----------------------------------------
No error message.

Technical Details
----------------------------------------
`CRM/Contact/Page/AJAX.php` — `toggleDedupeSelect()` performs a successful UPDATE on civicrm_prevnext_cache but calls `CRM_Utils_System::civiExit()` without returning any response body. CiviCRM's JavaScript interprets the empty 200 response as a failure and displays a "Request Failed — Unable to complete the request" dialog on every checkbox interaction on the Find Duplicates / Merge Contacts screen.