### PR TITLE
SearchTasks - Add support for tagging cases

### DIFF
--- a/CRM/Case/Form/Task.php
+++ b/CRM/Case/Form/Task.php
@@ -31,6 +31,13 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
   public static $entityShortname = 'case';
 
   /**
+   * @var array
+   * @deprecated Should just use $this->_entityIds or $this->_componentIds
+   * (not sure which is preferred, they're both a little quirky, but at least not as bespoke as this one)
+   */
+  public $_caseIds = NULL;
+
+  /**
    * @inheritDoc
    */
   public function setContactIDs() {
@@ -121,6 +128,10 @@ class CRM_Case_Form_Task extends CRM_Core_Form_Task {
    */
   protected function getTokenSchema(): array {
     return ['contactId', 'caseId'];
+  }
+
+  public function getDefaultEntity() {
+    return 'Case';
   }
 
 }

--- a/CRM/Case/Form/Task/AddToTag.php
+++ b/CRM/Case/Form/Task/AddToTag.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Search task to tag activities.
+ */
+class CRM_Case_Form_Task_AddToTag extends CRM_Case_Form_Task {
+
+  /**
+   * @var bool
+   */
+  public $submitOnce = TRUE;
+
+  use CRM_Core_Form_Task_TagTrait;
+
+}

--- a/CRM/Case/Form/Task/RemoveFromTag.php
+++ b/CRM/Case/Form/Task/RemoveFromTag.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+/**
+ * Search task to remove tags from activities.
+ */
+class CRM_Case_Form_Task_RemoveFromTag extends CRM_Case_Form_Task {
+
+  /**
+   * @var bool
+   */
+  public $submitOnce = TRUE;
+
+  use CRM_Core_Form_Task_TagTrait;
+
+}

--- a/CRM/Case/Task.php
+++ b/CRM/Case/Task.php
@@ -85,6 +85,16 @@ class CRM_Case_Task extends CRM_Core_Task {
           ],
           'result' => FALSE,
         ],
+        self::TAG_ADD => [
+          'title' => ts('Tag - add to cases'),
+          'class' => 'CRM_Case_Form_Task_AddToTag',
+          'result' => FALSE,
+        ],
+        self::TAG_REMOVE => [
+          'title' => ts('Tag - remove from cases'),
+          'class' => 'CRM_Case_Form_Task_RemoveFromTag',
+          'result' => FALSE,
+        ],
       ];
 
       //CRM-4418, check for delete


### PR DESCRIPTION
Overview
----------------------------------------
Add the standard add/remove tags search task to cases.

Following on from https://github.com/civicrm/civicrm-core/pull/35411 this is now super easy to add.