### PR TITLE
Reduce Priceset Alerts to only active Pricesets

### DIFF
--- a/CRM/Utils/Check/Component/PriceFields.php
+++ b/CRM/Utils/Check/Component/PriceFields.php
@@ -32,7 +32,7 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
       LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
       INNER JOIN civicrm_price_set_entity pse ON entity_table = 'civicrm_contribution_page' AND ps.id = pse.price_set_id
       INNER JOIN civicrm_contribution_page cp ON cp.id = pse.entity_id AND cp.is_active = 1
-      WHERE cft.id IS NULL OR cft.is_active = 0
+      WHERE (cft.id IS NULL OR cft.is_active = 0) AND ps.is_active = 1
       UNION
       SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label
       FROM civicrm_price_set ps
@@ -41,7 +41,7 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
       LEFT JOIN civicrm_financial_type cft ON cft.id = pfv.financial_type_id
       INNER JOIN civicrm_price_set_entity pse ON entity_table = 'civicrm_event' AND ps.id = pse.price_set_id
       INNER JOIN civicrm_event ce ON ce.id = pse.entity_id AND ce.is_active = 1
-      WHERE cft.id IS NULL OR cft.is_active = 0";
+      WHERE (cft.id IS NULL OR cft.is_active = 0) AND ps.is_active = 1";
     $dao = CRM_Core_DAO::executeQuery($sql);
     $count = 0;
     $html = '';


### PR DESCRIPTION
Overview
----------------------------------------
Invalid Priceset Alerts are fantastic but I think it can be sometime overwhelming for the average user. to correct. In several situations, the people I work with simple disable the Priceset because they can't really delete it since it's associated to purchases, but they still get warnings about it.

Before
----------------------------------------

Lots of warnings about Pricesets that are disabled (still have issues but are clearly not being used)

After
----------------------------------------

Only warnings about Pricesets that are actively being used and should probably get warnings for.
