### PR TITLE
dev/core#6415: Remove unused arguments from crmSearchDisplayChartKit.component.js

### DIFF
--- a/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKit/crmSearchDisplayChartKit.component.js
@@ -1,4 +1,4 @@
-(function (angular, $, _, dc, d3, crossfilter) {
+(function (angular, $, _) {
   "use strict";
 
   angular.module('crmChartKit').component('crmSearchDisplayChartKit', {
@@ -17,4 +17,4 @@
     templateUrl: '~/crmChartKit/chartKitCanvas.html',
     controller: () => {}
   });
-})(angular, CRM.$, CRM._, CRM.chart_kit.dc, CRM.chart_kit.d3, CRM.chart_kit.crossfilter);
+})(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
I don't see why these would need to be here, as they aren't used just to register the component, as far as I know (as opposed to in `civi-search-display-chart-kit.js` where they are actually used).

This causes [#6415](https://lab.civicrm.org/dev/core/-/work_items/6415), where AdminUI modals for Profile Fields from Manage Contribution Page / Event don't work.

Chartkit works as expected with this change, though I'm not familiar, so I haven't tested extensively.