### PR TITLE
Use API4 to create EntityFinancialTrxn and create in batch instead of individual queries

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Api4\EntityFinancialTrxn;
+use Civi\Api4\FinancialItem;
 use Civi\Api4\PaymentProcessor;
 
 /**
@@ -727,30 +728,35 @@ class CRM_Contribute_BAO_FinancialProcessor {
       // This is an update so original currency if none passed in.
       $params['trxnParams']['currency'] = $params['currency'] ?? $params['prevContribution']->currency;
 
-      $transactionIDs[] = $this->recordAlwaysAccountsReceivable($params['trxnParams'], $params);
+      $financialTrxnIDs[] = $this->recordAlwaysAccountsReceivable($params['trxnParams'], $params);
       $trxn = CRM_Core_BAO_FinancialTrxn::create($params['trxnParams']);
       // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
-      $params['entity_id'] = $transactionIDs[] = $trxn->id;
+      $params['entity_id'] = $financialTrxnIDs[] = $trxn->id;
 
-      $sql = "SELECT id, amount FROM civicrm_financial_item WHERE entity_id = %1 and entity_table = 'civicrm_line_item'";
-
-      $entityParams = [
+      $entityFinancialTrxnRecord = [
         'entity_table' => 'civicrm_financial_item',
       ];
       foreach ($params['line_item'] as $fieldId => $fields) {
         foreach ($fields as $fieldValueId => $lineItemDetails) {
           $this->updateFinancialItemForLineItemToPaid($lineItemDetails['id']);
-          $fparams = [
-            1 => [$lineItemDetails['id'], 'Integer'],
-          ];
-          $financialItem = CRM_Core_DAO::executeQuery($sql, $fparams);
-          while ($financialItem->fetch()) {
-            $entityParams['entity_id'] = $financialItem->id;
-            $entityParams['amount'] = $financialItem->amount;
-            foreach ($transactionIDs as $tID) {
-              $entityParams['financial_trxn_id'] = $tID;
-              CRM_Financial_BAO_FinancialItem::createEntityTrxn($entityParams);
+          $financialItems = FinancialItem::get(FALSE)
+            ->addSelect('id', 'amount')
+            ->addWhere('entity_id', '=', $lineItemDetails['id'])
+            ->addWhere('entity_table', '=', 'civicrm_line_item')
+            ->execute();
+          if ($financialItems->count() > 0) {
+            $entityFinancialTrxnRecordsToCreate = [];
+            foreach ($financialItems as $financialItem) {
+              $entityFinancialTrxnRecord['entity_id'] = $financialItem['id'];
+              $entityFinancialTrxnRecord['amount'] = $financialItem['amount'];
+              foreach ($financialTrxnIDs as $financialTrxnID) {
+                $entityFinancialTrxnRecord['financial_trxn_id'] = $financialTrxnID;
+                $entityFinancialTrxnRecordsToCreate[] = $entityFinancialTrxnRecord;
+              }
             }
+            EntityFinancialTrxn::save(FALSE)
+              ->setRecords($entityFinancialTrxnRecordsToCreate)
+              ->execute();
           }
         }
       }

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -9,6 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\EntityFinancialTrxn;
 use Civi\Api4\FinancialItem;
 
 /**
@@ -42,7 +43,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
    * @return CRM_Financial_DAO_FinancialItem
    */
   public static function add($lineItem, $contribution, $taxTrxnID = FALSE, $trxnId = NULL) {
-    $financialItemStatus = CRM_Financial_DAO_FinancialItem::buildOptions('status_id');
+    $financialItemStatus = array_column(Civi::entity('FinancialItem')->getOptions('status_id'), 'name', 'id');
     $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
     $itemStatus = NULL;
     if ($contributionStatus === 'Completed' || $contributionStatus === 'Pending refund') {
@@ -122,23 +123,27 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
     }
 
     $financialItem->save();
-    $financialtrxnIDS = $trxnIds['id'] ?? NULL;
-    if (!empty($financialtrxnIDS)) {
-      if (!is_array($financialtrxnIDS)) {
-        $financialtrxnIDS = [$financialtrxnIDS];
+    $financialTrxnIDs = $trxnIds['id'] ?? NULL;
+    if (!empty($financialTrxnIDs)) {
+      if (!is_array($financialTrxnIDs)) {
+        $financialTrxnIDs = [$financialTrxnIDs];
       }
-      foreach ($financialtrxnIDS as $tID) {
-        $entity_financial_trxn_params = [
+      $entityFinancialTrxnRecordsToCreate = [];
+      foreach ($financialTrxnIDs as $financialTrxnID) {
+        $entityFinancialTrxnRecord = [
           'entity_table' => "civicrm_financial_item",
           'entity_id' => $financialItem->id,
-          'financial_trxn_id' => $tID,
+          'financial_trxn_id' => $financialTrxnID,
           'amount' => $params['amount'],
         ];
         if (!empty($ids['entityFinancialTrxnId'])) {
-          $entity_financial_trxn_params['id'] = $ids['entityFinancialTrxnId'];
+          $entityFinancialTrxnRecord['id'] = $ids['entityFinancialTrxnId'];
         }
-        self::createEntityTrxn($entity_financial_trxn_params);
+        $entityFinancialTrxnRecordsToCreate[] = $entityFinancialTrxnRecord;
       }
+      EntityFinancialTrxn::save(FALSE)
+        ->setRecords($entityFinancialTrxnRecordsToCreate)
+        ->execute();
     }
     if (!empty($ids['id'])) {
       CRM_Utils_Hook::post('edit', 'FinancialItem', $financialItem->id, $financialItem, $params);
@@ -156,8 +161,11 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
    *   an assoc array of name/value pairs.
    *
    * @return CRM_Financial_DAO_EntityFinancialTrxn
+   *
+   * @deprecated
    */
   public static function createEntityTrxn($params) {
+    CRM_Core_Error::deprecatedWarning('Use API4 FinancialItem::Create');
     $entity_trxn = new CRM_Financial_DAO_EntityFinancialTrxn();
     $entity_trxn->copyValues($params);
     $entity_trxn->save();

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -9,6 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\EntityFinancialTrxn;
 use Civi\Api4\FinancialItem;
 
 /**
@@ -120,23 +121,27 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
     }
 
     $financialItem->save();
-    $financialtrxnIDS = $trxnIds['id'] ?? NULL;
-    if (!empty($financialtrxnIDS)) {
-      if (!is_array($financialtrxnIDS)) {
-        $financialtrxnIDS = [$financialtrxnIDS];
+    $financialTrxnIDs = $trxnIds['id'] ?? NULL;
+    if (!empty($financialTrxnIDs)) {
+      if (!is_array($financialTrxnIDs)) {
+        $financialTrxnIDs = [$financialTrxnIDs];
       }
-      foreach ($financialtrxnIDS as $tID) {
-        $entity_financial_trxn_params = [
+      $entityFinancialTrxnRecordsToCreate = [];
+      foreach ($financialTrxnIDs as $financialTrxnID) {
+        $entityFinancialTrxnRecord = [
           'entity_table' => "civicrm_financial_item",
           'entity_id' => $financialItem->id,
-          'financial_trxn_id' => $tID,
+          'financial_trxn_id' => $financialTrxnID,
           'amount' => $params['amount'],
         ];
         if (!empty($ids['entityFinancialTrxnId'])) {
-          $entity_financial_trxn_params['id'] = $ids['entityFinancialTrxnId'];
+          $entityFinancialTrxnRecord['id'] = $ids['entityFinancialTrxnId'];
         }
-        self::createEntityTrxn($entity_financial_trxn_params);
+        $entityFinancialTrxnRecordsToCreate[] = $entityFinancialTrxnRecord;
       }
+      EntityFinancialTrxn::save(FALSE)
+        ->setRecords($entityFinancialTrxnRecordsToCreate)
+        ->execute();
     }
     if (!empty($ids['id'])) {
       CRM_Utils_Hook::post('edit', 'FinancialItem', $financialItem->id, $financialItem, $params);
@@ -154,8 +159,11 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
    *   an assoc array of name/value pairs.
    *
    * @return CRM_Financial_DAO_EntityFinancialTrxn
+   *
+   * @deprecated
    */
   public static function createEntityTrxn($params) {
+    CRM_Core_Error::deprecatedWarning('Use API4 FinancialItem::Create');
     $entity_trxn = new CRM_Financial_DAO_EntityFinancialTrxn();
     $entity_trxn->copyValues($params);
     $entity_trxn->save();

--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -138,7 +138,7 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
    *
    * @throws \CRM_Core_Exception
    */
-  public function testCreateEntityTrxn(): CRM_Financial_DAO_EntityFinancialTrxn {
+  public function testCreateEntityTrxn() {
     $fParams = [
       'name' => 'Donations',
       'is_deductible' => 0,
@@ -157,8 +157,11 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
       'financial_trxn_id' => $financialTrxn->id,
       'amount' => $amount,
     ];
+    EntityFinancialTrxn::create(FALSE)
+      ->setValues($params)
+      ->execute()
+      ->first();
 
-    $entityTrxn = CRM_Financial_BAO_FinancialItem::createEntityTrxn($params);
     $entityResult = $this->assertDBNotNull(
       'CRM_Financial_DAO_EntityFinancialTrxn',
       $financialTrxn->id,
@@ -167,7 +170,6 @@ class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
       'Database check on added entity financial trxn record.'
     );
     $this->assertEquals($entityResult, $amount, 'Verify Amount for Financial Item');
-    return $entityTrxn;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This switches the creation of EntityFinancialTrxn records to use API4 and to add in bulk using "save" action instead of adding each one individually.

Before
----------------------------------------
Direct SQL queries, EntityFinancialTrxn records added separately via direct DAO in a foreach loop.

After
----------------------------------------
API4 calls. EntityFinancialTrxn records generated via foreach loop and added in bulk at the end using API4 "save" action.

Technical Details
----------------------------------------


Comments
----------------------------------------
Simplifies the code and should provide a minor performance improvement as well as getting rid of more direct SQL.