### PR TITLE
PriceSet System Check: display the Financial Type

### DIFF
--- a/CRM/Utils/Check/Component/PriceFields.php
+++ b/CRM/Utils/Check/Component/PriceFields.php
@@ -25,7 +25,7 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
    * @return CRM_Utils_Check_Message[]
    */
   public function checkPriceFields(): array {
-    $sql = "SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label
+    $sql = "SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label, cft.id as cft_id, cft.label as cft_label, cft.is_active as cft_is_active
       FROM civicrm_price_set ps
       INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
       INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
@@ -34,7 +34,7 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
       INNER JOIN civicrm_contribution_page cp ON cp.id = pse.entity_id AND cp.is_active = 1
       WHERE cft.id IS NULL OR cft.is_active = 0
       UNION
-      SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label
+      SELECT DISTINCT ps.title as ps_title, ps.id as ps_id, psf.label as psf_label, cft.id as cft_id, cft.label as cft_label, cft.is_active as cft_is_active
       FROM civicrm_price_set ps
       INNER JOIN civicrm_price_field psf ON psf.price_set_id = ps.id
       INNER JOIN civicrm_price_field_value pfv ON pfv.price_field_id = psf.id
@@ -48,16 +48,27 @@ class CRM_Utils_Check_Component_PriceFields extends CRM_Utils_Check_Component {
     $messages = [];
     while ($dao->fetch()) {
       $count++;
-      $url = CRM_Utils_System::url('civicrm/admin/price/field', [
-        'reset' => 1,
-        'action' => 'browse',
-        'sid' => $dao->ps_id,
-      ]);
-      $html .= "<tr><td>$dao->ps_title</td><td>$dao->psf_label</td><td><a href='$url'>" . ts('View Price Set Fields') . '</a></td></tr>';
+      // Link to edit Price Set
+      $url = CRM_Utils_System::url('civicrm/admin/price/edit', ['reset' => 1, 'action' => 'update', 'sid' => $dao->ps_id]);
+      $view_ps = "<a href='$url'>" . htmlspecialchars($dao->ps_title) . '</a>';
+      // Link to view Price Set Fields
+      $url = CRM_Utils_System::url('civicrm/admin/price/field', ['reset' => 1, 'action' => 'browse', 'sid' => $dao->ps_id]);
+      if (function_exists('civicrm_admin_ui_civicrm_config')) {
+        $url = CRM_Utils_System::url('civicrm/admin/price/field#/?sid=' . $dao->ps_id);
+      }
+      $view_psf = "<a href='$url'>" . htmlspecialchars($dao->psf_label) . '</a>';
+      // Link to view Financial Type, if any
+      $view_ft = ts('Deleted');
+      if ($dao->cft_label) {
+        $cft_status = ts('Disabled');
+        $url = CRM_Utils_System::url('civicrm/admin/financial/financialType/edit', ['reset' => 1, 'action' => 'update', 'id' => $dao->cft_id]);
+        $view_ft = "<a href='$url'>" . htmlspecialchars($dao->cft_label) . '</a> - ' . ts('Disabled');
+      }
+      $html .= '<tr><td>' . $view_ps . '</td><td>' . $view_psf . '</td><td>' . $view_ft . '</td></tr>';
     }
     if ($count > 0) {
-      $msg = '<p>' . ts('The following Price Set Fields use disabled or invalid financial types and need to be fixed if they are to still be used.') . '<p>'
-        . '<p><table><thead><tr><th>' . ts('Price Set') . '</th><th>' . ts('Price Set Field') . '</th><th>' . ts('Action') . '</th>'
+      $msg = '<p>' . ts('The following Price Set Fields use disabled or invalid financial types and need to be fixed if they are to still be used.') . ' ' . ts('You can also disable the Price Sets if they are not used anymore by any active Event or Contribution Pages.') . '<p>'
+        . '<p><table><thead><tr><th>' . ts('Price Set') . '</th><th>' . ts('Price Set Field') . '</th><th>' . ts('Financial Type') . '</th>'
         . '</tr></thead><tbody>'
         . $html
         . '</tbody></table></p>';


### PR DESCRIPTION
Overview
----------------------------------------

The Invalid Price Set system check alert has a vague and sometimes invalid call-to-action to resolve the issue.

For example, typically a Financial Type has been disabled (it's not easy to delete a Financial Type that is used by a Price Set Field).

This PR displays and links to the disabled Financial Type.

It is complementary to #35414.

Before
----------------------------------------

<img width="3306" height="546" alt="image" src="https://github.com/user-attachments/assets/4fef6672-a0f6-4e8d-8cad-8ba226c0e7ef" />

After
----------------------------------------

- Added recommendation to disable invalid Price Sets.
- Added a "Financial Type" column. If the FT has been deleted, it will show "Deleted".
- Removed the "Action" column, since it has been replaced with links to the respective Price Set, Price Set Field, and to the Financial Type
- Added support for AdminUI, otherwise the link to the Price Set Fields shows fields for all Price Sets.

<img width="3306" height="546" alt="image" src="https://github.com/user-attachments/assets/f547b8b0-d13d-4b23-82dd-186913e423d8" />

cc @shaneonabike @larssandergreen 