### PR TITLE
afform - reset ngForm to clean after successful submit

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -320,6 +320,9 @@
         const metaData = ctrl.getFormMeta(),
           dialog = $element.closest('.ui-dialog-content');
 
+        // reset form to clean
+        ctrl.ngForm.$setPristine();
+
         $element.trigger('crmFormSuccess', {
           afform: metaData,
           data: data,


### PR DESCRIPTION
Before
----------------------------------------
- ngForm.$dirty tells you when user has edited the form
- not reset after submitting the form

After
----------------------------------------
- ngForm.$dirty tells you when user has edited the form
- gets reset after successful submission of the form

Technical Details
----------------------------------------
There may be other places where afform and ngForm dont quite keep state in sync, but this is the major one I can see.
