### PR TITLE
dev/core#5820 - Advanced Search by Entity Reference

### DIFF
--- a/CRM/Core/BAO/CustomQuery.php
+++ b/CRM/Core/BAO/CustomQuery.php
@@ -278,6 +278,7 @@ class CRM_Core_BAO_CustomQuery {
             break;
 
           case 'Int':
+          case 'EntityReference':
             $this->_where[$grouping][] = CRM_Contact_BAO_Query::buildClause($fieldName, $op, $value, 'Integer');
             $this->_qill[$grouping][] = ts('%1 %2 %3', [1 => $field['label'], 2 => $qillOp, 3 => $qillValue]);
             break;

--- a/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomQueryTest.php
@@ -483,6 +483,35 @@ class CRM_Core_BAO_CustomQueryTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test filtering by a custom field of type EntityReference.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSearchEntityReferenceCustomField(): void {
+    $ids = $this->entityCustomGroupWithSingleFieldCreate(__FUNCTION__, 'ContactTestTest');
+    $entityRefField = $this->customFieldCreate([
+      'custom_group_id' => $ids['custom_group_id'],
+      'label' => 'Entity reference field',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      'default_value' => NULL,
+    ]);
+    $entityRefFieldName = 'custom_' . $entityRefField['id'];
+    $contactId = $this->individualCreate();
+
+    $formValues = [$entityRefFieldName => $contactId];
+    $params = CRM_Contact_BAO_Query::convertFormValues($formValues);
+    $queryObj = new CRM_Contact_BAO_Query($params);
+    $queryObj->query();
+
+    $this->assertNotEmpty($queryObj->_where[0], 'EntityReference custom field should produce a WHERE clause');
+    $this->assertStringContainsString('= ' . $contactId, $queryObj->_where[0][0]);
+    $this->assertNotEmpty($queryObj->_qill[0], 'EntityReference custom field should produce a qill entry');
+    $this->assertStringContainsString('Entity reference field', $queryObj->_qill[0][0]);
+  }
+
+  /**
    * Test search builder style query including custom address fields.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
## Overview

Fixes [dev/core#5820](https://lab.civicrm.org/dev/core/-/work_items/5820)

## Problem

Custom fields of `data_type = 'EntityReference'` are silently ignored when
used as search criteria in Advanced Search (`civicrm/contact/search/advanced`).
The search form renders the autocomplete widget correctly and the value is
submitted, but no WHERE clause is generated, so the filter has no effect.

## Root Cause

`CRM_Core_BAO_CustomQuery::where()` uses a `switch ($field['data_type'])` to
build the SQL WHERE clause for each custom field criterion. The switch handles:

  String, StateProvince, Country, ContactReference, Int, Boolean,
  Link, Memo, Money, Float, Date, File

`EntityReference` was introduced later and was never added to this switch.
Because no `case 'EntityReference':` branch exists, the data type falls
through the switch without producing a WHERE clause, causing the filter to
be silently ignored.

## Fix

`EntityReference` stores integer primary-key IDs (confirmed by its type
mappings in `CRM_Core_BAO_CustomField`: `'EntityReference' => 'Integer'`
and `'EntityReference' => CRM_Utils_Type::T_INT`). It is never serialized.
Adding it as a fall-through to the existing `Int` case is the minimal,
correct fix.

## Affected versions

Reproduced on CiviCRM 6.13.0. The `EntityReference` data type was introduced
in CiviCRM 5.40-ish and `CustomQuery::where()` was never updated accordingly.

## Comments

I have notes back to CiviCRM 5.75.0 (July 2024) noting this bug.
Got copilot to investigate and fix and write the unit test.

✅ I tested this patch on dev and live environments. 
✅ Currently it works on a live environment running Drupal 10.6.6 and CiviCRM 6.13.1.
ℹ️ The unit test has not been tested locally as I'm setup for site building not core development