### PR TITLE
Start converting CompleteOrder to API4

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2932,13 +2932,20 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       }
     }
 
-    $contributionParams['id'] = $contributionID;
-    $contributionParams['is_post_payment_create'] = $isPostPaymentCreate;
-
-    $contributionResult = civicrm_api3('Contribution', 'create', $contributionParams);
+    if ($isPostPaymentCreate) {
+      $contributionResult = \Civi\Api4\Contribution::update(FALSE)
+        ->setValues($contributionParams)
+        ->addWhere('id', '=', $contributionID)
+        ->execute()
+        ->first();
+    }
+    else {
+      $contributionParams['id'] = $contributionID;
+      $contributionResult = civicrm_api3('Contribution', 'create', $contributionParams);
+    }
 
     $transaction->commit();
-    \Civi::log()->info("Contribution {$contributionParams['id']} updated successfully");
+    \Civi::log()->info("Contribution {$contributionID} updated successfully");
 
     $contributionSoft = ContributionSoft::get(FALSE)
       ->addWhere('contribution_id', '=', $contributionID)
@@ -2955,10 +2962,10 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
           'id' => $contributionID,
           'payment_processor_id' => $paymentProcessorId,
         ]);
-        \Civi::log()->info("Contribution {$contributionParams['id']} Receipt sent");
+        \Civi::log()->info("Contribution {$contributionID} Receipt sent");
       }
       catch (Exception $e) {
-        \Civi::log()->warning("Contribution {$contributionParams['id']} Failed to send receipt: " . $e->getMessage());
+        \Civi::log()->warning("Contribution {$contributionID} Failed to send receipt: " . $e->getMessage());
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
If we already created payment we can skip all the logic in API3 Contribution::create and use API4.
Keep using API3 if we didn't create a payment yet so it can fiddle around with lineitems etc.

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
