### PR TITLE
Adding filters to Pricesets listing

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchAdministerPriceSets.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdministerPriceSets.aff.html
@@ -1,3 +1,8 @@
 <div af-fieldset="">
+  <div class="af-container af-layout-cols">
+    <af-field name="title" defn="{label: 'Title', input_attrs: {}, required: false}" />
+    <af-field name="is_active" defn="{input_type: 'Toggle', label: 'Is Enabled?', afform_default: true}" />
+    <af-field name="extends" defn="{input_type: 'Select', input_attrs: {multiple: true}, required: false, label: 'Used for'}" />
+  </div>
   <crm-search-display-table search-name="Administer_Price_Sets" display-name="Administer_Price_Sets"></crm-search-display-table>
 </div>

--- a/ext/civicrm_admin_ui/ang/afsearchAdministerPriceSets.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchAdministerPriceSets.aff.html
@@ -1,7 +1,7 @@
 <div af-fieldset="">
   <div class="af-container af-layout-cols">
     <af-field name="title" defn="{label: 'Title', input_attrs: {}, required: false}" />
-    <af-field name="is_active" defn="{input_type: 'Toggle', label: 'Is Enabled?', afform_default: true}" />
+    <af-field name="is_active" defn="{input_type: 'Radio', label: 'Is Enabled?', afform_default: true}" />
     <af-field name="extends" defn="{input_type: 'Select', input_attrs: {multiple: true}, required: false, label: 'Used for'}" />
   </div>
   <crm-search-display-table search-name="Administer_Price_Sets" display-name="Administer_Price_Sets"></crm-search-display-table>


### PR DESCRIPTION
Overview
----------------------------------------
Give the people more fitlers!

Before
----------------------------------------

<img width="1175" height="864" alt="PricesetOrig" src="https://github.com/user-attachments/assets/9fd89337-a565-4e0c-99ed-1031d69b91bd" />


After
----------------------------------------
<img width="1175" height="864" alt="PricesetDisabled" src="https://github.com/user-attachments/assets/4f2ce519-4a0c-43c4-9775-532e87c6cb9e" />
<img width="1175" height="864" alt="PricesetEnabled" src="https://github.com/user-attachments/assets/89f92242-b1e5-43fb-b4f6-df43665f4885" />



Comments
----------------------------------------

I set it to default to hide in active filters because I figure it reduces the noise a bit for finding what you are actively using.