### PR TITLE
dev/core#6441

### DIFF
--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -360,6 +360,9 @@ class AutocompleteAction extends AbstractAction {
       $this->searchFields = $searchFields;
     }
 
+    // ensure there is no duplicates
+    $this->searchFields = array_values(array_unique($this->searchFields));
+
     // Set searchField if not passed in
     $this->searchField = $this->searchField ?: $this->searchFields[0];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix infinite loop in some custom AutocompleteAction.

See https://lab.civicrm.org/dev/core/-/work_items/6441

Before
----------------------------------------
When displaying `id` as an information in a custom autocomplete, and doing a search that yiedl no result, there is an infinite loop.

After
----------------------------------------
Remove the possibility of an infinite loop

Technical Details
----------------------------------------
The code `AutocompleteAction::getNextSearchField()` assumes that there is no duplicates in `searchFields` but it's never enforced. Now, we enforce the unicity.