### PR TITLE
Introduces theme mode change based on user control

### DIFF
--- a/ext/riverlea/Civi/Api4/Action/RiverleaStream/Render.php
+++ b/ext/riverlea/Civi/Api4/Action/RiverleaStream/Render.php
@@ -57,12 +57,6 @@ class Render extends \Civi\Api4\Generic\BasicBatchAction {
   protected function doTask($stream): array {
     $content = [];
 
-    // if dark mode is not set explicitly, we derive it
-    // based on frontend/backend settings, stream level settings, global dark mode settings
-    if (!$this->darkMode) {
-      $this->darkMode = $this->getDarkModeDefault($stream);
-    }
-
     $content[] = self::concatStreamCss($stream);
 
     switch ($this->darkMode ?? NULL) {
@@ -80,27 +74,22 @@ class Render extends \Civi\Api4\Generic\BasicBatchAction {
 
       case 'inherit':
       default:
+        $darkRules = self::concatStreamCss($stream, TRUE);
         // tell OS we are happy with light or dark for system elements
         $content[] = ":root { color-scheme: light dark; }";
+        $content[] = ":root[data-civi-color-scheme=light] { color-scheme: light; }";
+        $content[] = ":root[data-civi-color-scheme=dark] { color-scheme: dark; }";
         // add stream dark vars wrapped inside a media query
         $content[] = '@media (prefers-color-scheme: dark) {';
-        $content[] = self::concatStreamCss($stream, TRUE);
+        $content[] = str_replace(':root', ':root:not([data-civi-color-scheme=light])', $darkRules);
         $content[] = '}';
+        $content[] = str_replace(':root', ':root[data-civi-color-scheme=dark]', $darkRules);
         break;
     }
 
     return [
       'content' => implode("\n", $content),
     ];
-  }
-
-  private function getDarkModeDefault(array $stream) {
-    if ($this->isFrontend) {
-      return $stream['dark_frontend'] ?? \Civi::settings()->get('riverlea_dark_mode_frontend');
-    }
-    else {
-      return $stream['dark_backend'] ?? \Civi::settings()->get('riverlea_dark_mode_backend');
-    }
   }
 
   /**

--- a/ext/riverlea/Civi/Api4/Action/RiverleaStream/Render.php
+++ b/ext/riverlea/Civi/Api4/Action/RiverleaStream/Render.php
@@ -99,6 +99,11 @@ class Render extends \Civi\Api4\Generic\BasicBatchAction {
       return $stream['dark_frontend'] ?? \Civi::settings()->get('riverlea_dark_mode_frontend');
     }
     else {
+      // Backend requests may be overridden by user cookie
+      if (!empty($_COOKIE['riverlea_dark_mode_backend'])) {
+        $cookieVal = $_COOKIE['riverlea_dark_mode_backend'];
+        return in_array($cookieVal, ['light', 'dark', 'inherit'], TRUE) ? $cookieVal : ($stream['dark_backend'] ?? \Civi::settings()->get('riverlea_dark_mode_backend'));
+      }
       return $stream['dark_backend'] ?? \Civi::settings()->get('riverlea_dark_mode_backend');
     }
   }

--- a/ext/riverlea/Civi/Riverlea/Page/ThemeAdmin.php
+++ b/ext/riverlea/Civi/Riverlea/Page/ThemeAdmin.php
@@ -26,11 +26,14 @@ class ThemeAdmin extends \CRM_Core_Page {
 
     foreach ($themeSettings as &$setting) {
       $value = \Civi::settings()->get($setting['name']);
+      $options = $setting['options'] ?? NULL;
 
       // render option values if applicable
       // use raw value if not a valid option
-      if ($setting['options']) {
-        $valueLabel = $setting['options'][$value] ?? E::ts("%1 [unrecognised option]", [1 => $value]);
+      if (is_array($options) && $options) {
+        $values = (array) $value;
+        $valueLabels = array_map(fn ($value) => $options[$value] ?? E::ts("%1 [unrecognised option]", [1 => $value]), $values);
+        $valueLabel = implode(', ', $valueLabels) ?: '-';
       }
       else {
         $valueLabel = $value;

--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -116,6 +116,15 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
         // Variable needed by the previewer.js script.
         $bundle->addVars(E::LONG_NAME, ['resourceUrl' => E::url()]);
       }
+
+      if ($this->userControlsEnabled()) {
+        // Load the user controls
+        $bundle->addStyleFile('riverlea', 'elements/civi-riverlea-user-controls.css', ['weight' => 955]);
+        $bundle->addScriptFile('riverlea', 'elements/civi-riverlea-user-controls.js', [
+          'weight' => 960,
+          'translate' => FALSE,
+        ]);
+      }
     }
 
     if ($bundle->name === 'bootstrap3') {
@@ -177,7 +186,8 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
     $streamModified = $stream['modified_date'] ?? NULL;
 
     $isFrontend = \CRM_Utils_System::isFrontendPage();
-    $darkMode = $isFrontend ? \Civi::settings()->get('riverlea_dark_mode_frontend') : \Civi::settings()->get('riverlea_dark_mode_backend');
+
+    $darkMode = $this->getCurrentDarkMode();
 
     return [
       'stream' => $stream['name'],
@@ -185,6 +195,15 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
       'is_frontend' => $isFrontend,
       'dark_mode' => $darkMode,
     ];
+  }
+
+  public function getCurrentDarkMode(): string {
+    if ($this->userControlsEnabled()) {
+      // we need to inherit from the user controlled preference
+      return 'inherit';
+    }
+
+    return \CRM_Utils_System::isFrontendPage() ? \Civi::settings()->get('riverlea_dark_mode_frontend') : \Civi::settings()->get('riverlea_dark_mode_backend');
   }
 
   /**
@@ -223,6 +242,7 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
     $render = \Civi\Api4\RiverleaStream::render(FALSE)
       ->addWhere('name', '=', $e->params['stream'])
       ->setIsFrontend($e->params['is_frontend'])
+      ->setDarkMode($e->params['dark_mode'])
       ->execute()
       ->first();
 
@@ -262,6 +282,16 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
           ->execute();
       }
     }
+  }
+
+  /**
+   * Is the backend dark-mode toggle enabled in theme settings?
+   */
+  private function userControlsEnabled(): bool {
+    if (!\CRM_Utils_System::isFrontendPage()) {
+      return !!\Civi::settings()->get('riverlea_user_controls_backend');
+    }
+    return FALSE;
   }
 
 }

--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -116,6 +116,19 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
         // Variable needed by the previewer.js script.
         $bundle->addVars(E::LONG_NAME, ['resourceUrl' => E::url()]);
       }
+
+      if (!\CRM_Utils_System::isFrontendPage()) {
+        // Inject dark mode preference for backend toggle
+        $bundle->addScript(
+          'window.riverleaBackendMode = ' . json_encode($this->getBackendDarkMode()) . ';',
+          ['weight' => 950, 'translate' => FALSE]
+        );
+        // Load the dark mode toggle button
+        $bundle->addScriptFile('riverlea', 'js/modeToggle.js', [
+          'weight' => 960,
+          'translate' => FALSE,
+        ]);
+      }
     }
 
     if ($bundle->name === 'bootstrap3') {
@@ -255,6 +268,23 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
           ->execute();
       }
     }
+  }
+  /**
+   * Get the backend dark mode, respecting per-user cookie override.
+   */
+  private function getBackendDarkMode() {
+    return $this->getDarkModeSetting();
+  }
+
+  /**
+   * Determine the active dark-mode option, checking cookie first.
+   */
+  private function getDarkModeSetting() {
+    $darkModeSetting = \Civi::settings()->get('riverlea_dark_mode_backend');
+    if (!empty($_COOKIE['riverlea_dark_mode_backend'])) {
+      $darkModeSetting = $_COOKIE['riverlea_dark_mode_backend'];
+    }
+    return in_array($darkModeSetting, ['light', 'dark', 'inherit'], TRUE) ? $darkModeSetting : 'light';
   }
 
 }

--- a/ext/riverlea/elements/civi-riverlea-user-controls.css
+++ b/ext/riverlea/elements/civi-riverlea-user-controls.css
@@ -1,0 +1,81 @@
+#civicrm-menu > .civi-riverlea-user-controls-item {
+  float: right;
+  padding-left: var(--crm-padding-small);
+}
+
+civi-riverlea-user-controls {
+  display: block;
+
+  .civi-riverlea-user-controls-wrap {
+    padding-inline: var(--crm-padding-medium);
+    height: 42px;
+    display: flex;
+    align-items: center;
+  }
+
+  .civi-riverlea-color-scheme-switch {
+    position: relative;
+    width: var(--crm-l-large-1);
+    height: 28px;
+    border: 0;
+    border-radius: 100px;
+    cursor: pointer;
+    transition: background .2s ease, transform .2s ease;
+    padding: 0;
+    outline: none;
+    background: var(--crm-input-toggle-button-bg);
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, .4);
+  }
+  .crm-i {
+    position: absolute;
+    top: 2px;
+    left: 3px;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: left .2s ease, transform .2s ease, background .2s ease, color .2s ease;
+    background: var(--crm-input-toggle-button-bg);
+    color: var(--crm-text-color);
+    font-size: var(--crm-font-small-size);
+    line-height: 1;
+    margin: 0;
+  }
+  .crm-i.fa-sun {
+    color: var(--crm-c-amber);
+  }
+
+  .crm-i.fa-moon {
+    color: var(--crm-c-yellow);
+  }
+
+  .civi-riverlea-color-scheme-switch[data-mode="light"] {
+    background: var(--crm-input-toggle-disabled-bg);
+  }
+  .civi-riverlea-color-scheme-switch[data-mode="auto"] {
+    background: var(--crm-input-toggle-enabled-bg);
+  }
+  .civi-riverlea-color-scheme-switch[data-mode="auto"] .crm-i {
+    left: var(--crm-l-medium-2);
+  }
+  .civi-riverlea-color-scheme-switch[data-mode="dark"] {
+    background: var(--crm-paper);
+  }
+  .civi-riverlea-color-scheme-switch[data-mode="dark"] .crm-i {
+    left: 21px;
+    background: var(--crm-c-darkest);
+    border: 1px solid var(--crm-c-gray-800)
+  }
+  .civi-riverlea-color-scheme-switch:focus-visible {
+    box-shadow: 0 0 0 2px var(--crm-focus-color);
+  }
+
+}
+
+@media (max-width: 991px) {
+  .civi-riverlea-user-controls-item {
+    padding-left: 12px;
+  }
+}

--- a/ext/riverlea/elements/civi-riverlea-user-controls.js
+++ b/ext/riverlea/elements/civi-riverlea-user-controls.js
@@ -1,0 +1,111 @@
+(function () {
+
+  class CiviRiverleaUserControls extends HTMLElement {
+
+     /* jshint ignore:start */
+    static MODES = {
+      light: {
+        label: ts('Light'),
+        icon: 'fa-sun',
+        next: 'dark',
+      },
+      dark: {
+        label: ts('Dark'),
+        icon: 'fa-moon',
+        next: 'auto',
+      },
+      auto: {
+        label: ts('Auto'),
+        icon: 'fa-circle-half-stroke',
+        next: 'light',
+      }
+    };
+    /* jshint ignore:end */
+
+    connectedCallback() {
+      this.render();
+      this.loadMode();
+      this.querySelector('button').addEventListener('click', () => this.nextMode());
+    }
+
+    render() {
+      this.innerHTML = `
+        <span class="civi-riverlea-user-controls-wrap">
+          <button type="button" role="switch" class="civi-riverlea-color-scheme-switch">
+            <i class="crm-i" role="img" aria-disabled="true"></i>
+          </button>
+        </span>
+      `;
+    }
+
+    nextMode() {
+      this.setMode(CiviRiverleaUserControls.MODES[this.mode].next);
+    }
+
+    setMode(mode) {
+      this.mode = mode;
+
+      document.querySelector(':root').dataset.civiColorScheme = this.mode;
+
+      this.renderMode();
+
+      this.saveMode();
+    }
+
+    renderMode() {
+      const details = CiviRiverleaUserControls.MODES[this.mode];
+
+      // swap the icon class
+      this.querySelector('.crm-i').classList.remove('fa-sun', 'fa-moon', 'fa-circle-half-stroke');
+      this.querySelector('.crm-i').classList.add(details.icon);
+
+      const button = this.querySelector('button');
+      button.dataset.mode = this.mode;
+      const description = ts('Backend theme mode: %1. Click to switch', {1: details.label});
+      button.title = description;
+      //redundant?
+      button.setAttribute('aria-label', description);
+
+    }
+
+    saveMode() {
+      window.localStorage.setItem('civi-riverlea-user-controls-color-scheme', this.mode);
+    }
+
+    loadMode() {
+      const saved = window.localStorage.getItem('civi-riverlea-user-controls-color-scheme');
+      this.setMode(saved ? saved : 'auto');
+    }
+  }
+
+  customElements.define('civi-riverlea-user-controls', CiviRiverleaUserControls);
+
+  function appendWrappedControl(container) {
+    const wrapper = document.createElement('li');
+    wrapper.className = 'civi-riverlea-user-controls-item';
+
+    const controls = document.createElement('civi-riverlea-user-controls');
+    wrapper.append(controls);
+
+    container.append(wrapper);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const menu = document.getElementById('civicrm-menu');
+    if (menu) {
+      appendWrappedControl(menu);
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      const menu = document.getElementById('civicrm-menu');
+      if (menu) {
+    appendWrappedControl(menu);
+
+        observer.disconnect();
+      }
+    });
+    observer.observe(document.body, {childList: true, subtree: true});
+  });
+
+})();

--- a/ext/riverlea/js/modeToggle.js
+++ b/ext/riverlea/js/modeToggle.js
@@ -1,0 +1,220 @@
+(function () {
+  var COOKIE_NAME = 'riverlea_dark_mode_backend';
+  var COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+  var MODES = ['light', 'dark', 'inherit'];
+  var MODE_LABELS = {
+    light: 'Light',
+    dark: 'Dark',
+    inherit: 'Auto'
+  };
+  var MODE_ICONS = {
+    light: '☀',
+    dark: '🌙',
+    inherit: '◐'
+  };
+
+  function normalizeMode(mode) {
+    return MODES.indexOf(mode) !== -1 ? mode : 'light';
+  }
+
+  function getCookie(name) {
+    var cookieParts = document.cookie ? document.cookie.split('; ') : [];
+    for (var i = 0; i < cookieParts.length; i += 1) {
+      var part = cookieParts[i];
+      if (part.indexOf(name + '=') === 0) {
+        return decodeURIComponent(part.substring(name.length + 1));
+      }
+    }
+    return null;
+  }
+
+  function setCookieMode(mode) {
+    document.cookie = COOKIE_NAME + '=' + encodeURIComponent(mode)
+      + '; path=/'
+      + '; max-age=' + COOKIE_MAX_AGE
+      + '; SameSite=Lax';
+  }
+
+  function getNextMode(currentMode) {
+    var index = MODES.indexOf(normalizeMode(currentMode));
+    return MODES[(index + 1) % MODES.length];
+  }
+
+  function getModeLabel(mode) {
+    return MODE_LABELS[normalizeMode(mode)];
+  }
+
+  function getModeIcon(mode) {
+    return MODE_ICONS[normalizeMode(mode)];
+  }
+
+  function getCurrentMode() {
+    return normalizeMode(getCookie(COOKIE_NAME) || window.riverleaBackendMode || 'light');
+  }
+
+  function ensureStyles() {
+    if (document.getElementById('riverlea-mode-toggle-style')) {
+      return;
+    }
+
+    var style = document.createElement('style');
+    style.id = 'riverlea-mode-toggle-style';
+    style.textContent = ''
+      + '.riverlea-mode-toggle-item{display:flex;align-items:center;list-style:none;}'
+      + '#civicrm-menu > .riverlea-mode-toggle-item{float:right;position:relative;z-index:500;padding:0 6px;height:42px;justify-content:center;}'
+      + '#crm-menubar-toggle-position + .riverlea-mode-toggle-item{padding-left:4px;}'
+      + '.riverlea-mode-toggle-wrap{display:inline-flex;align-items:center;height:100%;}'
+      + '.riverlea-mode-switch{position:relative;width:58px;height:30px;border:0;border-radius:999px;cursor:pointer;transition:background .2s ease,box-shadow .2s ease,transform .2s ease;padding:0;outline:none;}'
+      + '.riverlea-mode-switch .riverlea-mode-thumb{position:absolute;top:2px;left:2px;width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:13px;transition:left .2s ease,transform .2s ease,background .2s ease,color .2s ease;}'
+      + '.riverlea-mode-switch[data-mode="light"]{background:#c9c9cf;box-shadow:inset 0 1px 3px rgba(0,0,0,.25);}'
+      + '.riverlea-mode-switch[data-mode="light"] .riverlea-mode-thumb{left:2px;background:#ececef;color:#4b4b4b;}'
+      + '.riverlea-mode-switch[data-mode="inherit"]{background:linear-gradient(90deg,#c9c9cf 0%,#23262c 100%);box-shadow:inset 0 1px 4px rgba(0,0,0,.35);}'
+      + '.riverlea-mode-switch[data-mode="inherit"] .riverlea-mode-thumb{left:16px;background:#d5d5da;color:#2f3033;}'
+      + '.riverlea-mode-switch[data-mode="dark"]{background:#1f2227;box-shadow:inset 0 1px 5px rgba(255,255,255,.08),inset 0 -1px 6px rgba(0,0,0,.45);}'
+      + '.riverlea-mode-switch[data-mode="dark"] .riverlea-mode-thumb{left:30px;background:#5a5d64;color:#f3f3f4;}'
+      + '.riverlea-mode-switch:focus-visible{box-shadow:0 0 0 2px #4c9ffe;}'
+      + '@media (max-width: 991px){'
+      + '#civicrm-menu > .riverlea-mode-toggle-item{float:none;clear:both;display:block;height:auto;padding:8px 12px;}'
+      + '#crm-menubar-toggle-position + .riverlea-mode-toggle-item{padding-left:12px;}'
+      + '.riverlea-mode-toggle-wrap{display:flex;justify-content:flex-end;align-items:center;width:100%;height:auto;}'
+      + '.riverlea-mode-switch{width:52px;height:28px;}'
+      + '.riverlea-mode-switch .riverlea-mode-thumb{width:24px;height:24px;font-size:12px;}'
+      + '.riverlea-mode-switch[data-mode="inherit"] .riverlea-mode-thumb{left:14px;}'
+      + '.riverlea-mode-switch[data-mode="dark"] .riverlea-mode-thumb{left:26px;}'
+      + '}';
+
+    document.head.appendChild(style);
+  }
+
+  function isVisible(element) {
+    if (!element) {
+      return false;
+    }
+
+    var rect = element.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  }
+
+  function getToolbarContainer() {
+    var menu = document.querySelector('#civicrm-menu');
+    if (!isVisible(menu)) {
+      return null;
+    }
+    return menu;
+  }
+
+  function updateSwitchState(button, mode) {
+    var normalizedMode = normalizeMode(mode);
+    button.setAttribute('data-mode', normalizedMode);
+    button.setAttribute('aria-checked', normalizedMode === 'dark' ? 'true' : 'false');
+    button.setAttribute('aria-label', 'Backend theme mode: ' + getModeLabel(normalizedMode) + '. Click to switch.');
+    button.title = 'Backend theme mode: ' + getModeLabel(normalizedMode) + ' (click to switch)';
+    button.querySelector('.riverlea-mode-thumb').textContent = getModeIcon(normalizedMode);
+  }
+
+  function createToggleButton(mode) {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'riverlea-mode-switch';
+    button.setAttribute('role', 'switch');
+
+    var thumb = document.createElement('span');
+    thumb.className = 'riverlea-mode-thumb';
+    button.appendChild(thumb);
+
+    updateSwitchState(button, mode);
+
+    button.addEventListener('click', function () {
+      var currentMode = getCurrentMode();
+      var nextMode = getNextMode(currentMode);
+      setCookieMode(nextMode);
+      window.location.reload();
+    });
+
+    return button;
+  }
+
+  function placeNextToMenuPositionToggle(container, wrapper) {
+    var menuPositionToggle = container.querySelector('#crm-menubar-toggle-position');
+    if (menuPositionToggle && menuPositionToggle.parentNode === container) {
+      menuPositionToggle.insertAdjacentElement('afterend', wrapper);
+      return true;
+    }
+
+    container.appendChild(wrapper);
+    return false;
+  }
+
+  function watchForMenuPositionToggle(container) {
+    if (container._riverleaToggleObserver) {
+      return;
+    }
+
+    var observer = new MutationObserver(function () {
+      var wrapper = document.getElementById('riverlea-mode-toggle');
+      if (!wrapper || wrapper.parentNode !== container) {
+        return;
+      }
+
+      if (placeNextToMenuPositionToggle(container, wrapper)) {
+        observer.disconnect();
+        container._riverleaToggleObserver = null;
+      }
+    });
+
+    observer.observe(container, {childList: true, subtree: false});
+    container._riverleaToggleObserver = observer;
+  }
+
+  function mount() {
+    if (document.getElementById('riverlea-mode-toggle')) {
+      return true;
+    }
+
+    var container = getToolbarContainer();
+    if (!container) {
+      return false;
+    }
+
+    ensureStyles();
+
+    var wrapperTag = container.tagName === 'UL' ? 'li' : 'div';
+    var wrapper = document.createElement(wrapperTag);
+    wrapper.id = 'riverlea-mode-toggle';
+    wrapper.className = 'riverlea-mode-toggle-item';
+
+    var innerWrap = document.createElement('span');
+    innerWrap.className = 'riverlea-mode-toggle-wrap';
+
+    var currentMode = getCurrentMode();
+    innerWrap.appendChild(createToggleButton(currentMode));
+    wrapper.appendChild(innerWrap);
+
+    var placedBesideToggle = placeNextToMenuPositionToggle(container, wrapper);
+    if (!placedBesideToggle) {
+      watchForMenuPositionToggle(container);
+    }
+    return true;
+  }
+
+  function mountWithRetry(attempt) {
+    if (mount()) {
+      return;
+    }
+    if (attempt >= 40) {
+      return;
+    }
+    window.setTimeout(function () {
+      mountWithRetry(attempt + 1);
+    }, 100);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () {
+      mountWithRetry(0);
+    });
+  }
+  else {
+    mountWithRetry(0);
+  }
+})();

--- a/ext/riverlea/js/modeToggle.js
+++ b/ext/riverlea/js/modeToggle.js
@@ -29,10 +29,12 @@
   }
 
   function setCookieMode(mode) {
-    document.cookie = COOKIE_NAME + '=' + encodeURIComponent(mode)
-      + '; path=/'
-      + '; max-age=' + COOKIE_MAX_AGE
-      + '; SameSite=Lax';
+    document.cookie = [
+      COOKIE_NAME + '=' + encodeURIComponent(mode),
+      'path=/',
+      'max-age=' + COOKIE_MAX_AGE,
+      'SameSite=Lax'
+    ].join('; ');
   }
 
   function getNextMode(currentMode) {
@@ -59,29 +61,30 @@
 
     var style = document.createElement('style');
     style.id = 'riverlea-mode-toggle-style';
-    style.textContent = ''
-      + '.riverlea-mode-toggle-item{display:flex;align-items:center;list-style:none;}'
-      + '#civicrm-menu > .riverlea-mode-toggle-item{float:right;position:relative;z-index:500;padding:0 6px;height:42px;justify-content:center;}'
-      + '#crm-menubar-toggle-position + .riverlea-mode-toggle-item{padding-left:4px;}'
-      + '.riverlea-mode-toggle-wrap{display:inline-flex;align-items:center;height:100%;}'
-      + '.riverlea-mode-switch{position:relative;width:58px;height:30px;border:0;border-radius:999px;cursor:pointer;transition:background .2s ease,box-shadow .2s ease,transform .2s ease;padding:0;outline:none;}'
-      + '.riverlea-mode-switch .riverlea-mode-thumb{position:absolute;top:2px;left:2px;width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:13px;transition:left .2s ease,transform .2s ease,background .2s ease,color .2s ease;}'
-      + '.riverlea-mode-switch[data-mode="light"]{background:#c9c9cf;box-shadow:inset 0 1px 3px rgba(0,0,0,.25);}'
-      + '.riverlea-mode-switch[data-mode="light"] .riverlea-mode-thumb{left:2px;background:#ececef;color:#4b4b4b;}'
-      + '.riverlea-mode-switch[data-mode="inherit"]{background:linear-gradient(90deg,#c9c9cf 0%,#23262c 100%);box-shadow:inset 0 1px 4px rgba(0,0,0,.35);}'
-      + '.riverlea-mode-switch[data-mode="inherit"] .riverlea-mode-thumb{left:16px;background:#d5d5da;color:#2f3033;}'
-      + '.riverlea-mode-switch[data-mode="dark"]{background:#1f2227;box-shadow:inset 0 1px 5px rgba(255,255,255,.08),inset 0 -1px 6px rgba(0,0,0,.45);}'
-      + '.riverlea-mode-switch[data-mode="dark"] .riverlea-mode-thumb{left:30px;background:#5a5d64;color:#f3f3f4;}'
-      + '.riverlea-mode-switch:focus-visible{box-shadow:0 0 0 2px #4c9ffe;}'
-      + '@media (max-width: 991px){'
-      + '#civicrm-menu > .riverlea-mode-toggle-item{float:none;clear:both;display:block;height:auto;padding:8px 12px;}'
-      + '#crm-menubar-toggle-position + .riverlea-mode-toggle-item{padding-left:12px;}'
-      + '.riverlea-mode-toggle-wrap{display:flex;justify-content:flex-end;align-items:center;width:100%;height:auto;}'
-      + '.riverlea-mode-switch{width:52px;height:28px;}'
-      + '.riverlea-mode-switch .riverlea-mode-thumb{width:24px;height:24px;font-size:12px;}'
-      + '.riverlea-mode-switch[data-mode="inherit"] .riverlea-mode-thumb{left:14px;}'
-      + '.riverlea-mode-switch[data-mode="dark"] .riverlea-mode-thumb{left:26px;}'
-      + '}';
+    style.textContent = [
+      '.riverlea-mode-toggle-item{display:flex;align-items:center;list-style:none;}',
+      '#civicrm-menu > .riverlea-mode-toggle-item{float:right;position:relative;z-index:500;padding:0 6px;height:42px;justify-content:center;}',
+      '#crm-menubar-toggle-position + .riverlea-mode-toggle-item{padding-left:4px;}',
+      '.riverlea-mode-toggle-wrap{display:inline-flex;align-items:center;height:100%;}',
+      '.riverlea-mode-switch{position:relative;width:58px;height:30px;border:0;border-radius:999px;cursor:pointer;transition:background .2s ease,box-shadow .2s ease,transform .2s ease;padding:0;outline:none;}',
+      '.riverlea-mode-switch .riverlea-mode-thumb{position:absolute;top:2px;left:2px;width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:13px;transition:left .2s ease,transform .2s ease,background .2s ease,color .2s ease;}',
+      '.riverlea-mode-switch[data-mode="light"]{background:#c9c9cf;box-shadow:inset 0 1px 3px rgba(0,0,0,.25);}',
+      '.riverlea-mode-switch[data-mode="light"] .riverlea-mode-thumb{left:2px;background:#ececef;color:#4b4b4b;}',
+      '.riverlea-mode-switch[data-mode="inherit"]{background:linear-gradient(90deg,#c9c9cf 0%,#23262c 100%);box-shadow:inset 0 1px 4px rgba(0,0,0,.35);}',
+      '.riverlea-mode-switch[data-mode="inherit"] .riverlea-mode-thumb{left:16px;background:#d5d5da;color:#2f3033;}',
+      '.riverlea-mode-switch[data-mode="dark"]{background:#1f2227;box-shadow:inset 0 1px 5px rgba(255,255,255,.08),inset 0 -1px 6px rgba(0,0,0,.45);}',
+      '.riverlea-mode-switch[data-mode="dark"] .riverlea-mode-thumb{left:30px;background:#5a5d64;color:#f3f3f4;}',
+      '.riverlea-mode-switch:focus-visible{box-shadow:0 0 0 2px #4c9ffe;}',
+      '@media (max-width: 991px){',
+      '#civicrm-menu > .riverlea-mode-toggle-item{float:none;clear:both;display:block;height:auto;padding:8px 12px;}',
+      '#crm-menubar-toggle-position + .riverlea-mode-toggle-item{padding-left:12px;}',
+      '.riverlea-mode-toggle-wrap{display:flex;justify-content:flex-end;align-items:center;width:100%;height:auto;}',
+      '.riverlea-mode-switch{width:52px;height:28px;}',
+      '.riverlea-mode-switch .riverlea-mode-thumb{width:24px;height:24px;font-size:12px;}',
+      '.riverlea-mode-switch[data-mode="inherit"] .riverlea-mode-thumb{left:14px;}',
+      '.riverlea-mode-switch[data-mode="dark"] .riverlea-mode-thumb{left:26px;}',
+      '}'
+    ].join('');
 
     document.head.appendChild(style);
   }

--- a/ext/riverlea/settings/riverlea.setting.php
+++ b/ext/riverlea/settings/riverlea.setting.php
@@ -10,7 +10,7 @@ return [
     'default' => 'light',
     'html_type' => 'select',
     'add' => 1.0,
-    'title' => E::ts('Backend Dark Mode Control'),
+    'title' => E::ts('Backend Dark Mode Setting'),
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => E::ts('Control whether and how dark mode can be activated (for supported Riverlea themes only).'),
@@ -23,6 +23,25 @@ return [
       'theme' => ['weight' => 110],
     ],
   ],
+  'riverlea_user_controls_backend' => [
+    'name' => 'riverlea_user_controls_backend',
+    'group' => 'riverlea',
+    'type' => 'Array',
+    'default' => [],
+    'html_type' => 'checkboxes',
+    'title' => E::ts('Backend User Controls'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => E::ts('Enable users to tweak the theme to their preferences.'),
+    'options' => [
+      // TODO: add other controls
+      'dark-mode' => E::ts('Dark-mode'),
+      //'font-size' => E::ts('Font size'),
+    ],
+    'settings_pages' => [
+      'theme' => ['weight' => 210],
+    ],
+  ],
   'riverlea_dark_mode_frontend' => [
     'name' => 'riverlea_dark_mode_frontend',
     'group' => 'riverlea',
@@ -30,7 +49,7 @@ return [
     'default' => 'light',
     'html_type' => 'select',
     'add' => 1.0,
-    'title' => E::ts('Frontend Dark Mode Control'),
+    'title' => E::ts('Frontend Dark Mode Setting'),
     'is_domain' => 1,
     'is_contact' => 0,
     'help_text' => E::ts('Control whether and how dark mode can be activated (for supported Riverlea themes only).'),


### PR DESCRIPTION
This is the PR is based on CiviCRM 6.13.1. As described on https://lab.civicrm.org/extensions/riverlea/-/work_items/160 , in detail:

## Summary

Riverlea already supports backend dark mode through theme settings and dark-mode stream variants, but there was no built-in per-user UI in the CiviCRM backend menu to switch between:

- `light`
- `dark`
- `inherit`

This implementation adds a small toggle control to the backend menubar. The control stores the selected mode in a cookie, and Riverlea uses that cookie to override the backend dark-mode setting for the current user.

## Problem Statement

The Riverlea theme already exposes backend dark mode as a setting, but the setting is global and not easy for individual users to switch on demand while browsing the backend.

The missing pieces were:

- a visible toggle in the backend menubar
- JavaScript to cycle through the available dark-mode values
- server-side support for reading a per-user override from a cookie

## Current Behavior

When the user is on a backend page:

1. Riverlea injects `window.riverleaBackendMode` into the page.
2. Riverlea loads `js/modeToggle.js` into the backend resource bundle.
3. The script mounts a toggle into `#civicrm-menu`.
4. Clicking the toggle cycles the mode in this order:
   - `light`
   - `dark`
   - `inherit`
   - back to `light`
5. The selected mode is stored in the `riverlea_dark_mode_backend` cookie.
6. The page reloads.
7. Riverlea reads the cookie on the server side and uses it as the effective backend dark-mode value.

The toggle is backend-only and is not intended for frontend pages.

## Files Involved

### 1. `ext/riverlea/Civi/Riverlea/StyleLoader.php`

This file wires the feature into Riverlea's backend asset loading.

Relevant changes:

- adds an inline script in the `coreResources` bundle:
  - `window.riverleaBackendMode = ...`
- adds the backend script file:
  - `js/modeToggle.js`
- adds helper methods to resolve the effective backend dark-mode value:
  - `getBackendDarkMode()`
  - `getDarkModeSetting()`

The helper methods:

- start with `riverlea_dark_mode_backend` from settings
- override it with `$_COOKIE['riverlea_dark_mode_backend']` when present
- validate the value strictly against:
  - `light`
  - `dark`
  - `inherit`

### 2. `ext/riverlea/Civi/Api4/Action/RiverleaStream/Render.php`

This file is responsible for determining which dark-mode variant should be used when Riverlea renders stream CSS.

Relevant change:

- `getDarkModeDefault()` now checks the backend cookie before falling back to the stream/global backend setting

This is what makes the user's menubar choice actually affect the generated backend styling.

### 3. `ext/riverlea/js/modeToggle.js`

This file provides the client-side behavior.

Responsibilities:

- reads the current mode from:
  - `riverlea_dark_mode_backend` cookie, or
  - `window.riverleaBackendMode`
- injects a small switch control into the backend menubar
- stores the selected mode in a cookie
- reloads the page after each change
- injects its own minimal CSS for the control
- includes responsive handling so the control works in both desktop and mobile menu layouts

## Data Flow

The feature currently works like this:

1. PHP determines the effective backend mode.
2. PHP exposes that value to JavaScript as `window.riverleaBackendMode`.
3. JavaScript mounts the switch into `#civicrm-menu`.
4. User clicks the switch.
5. JavaScript writes `riverlea_dark_mode_backend=<mode>` as a cookie.
6. JavaScript reloads the page.
7. PHP reads the cookie on the next request.
8. Riverlea stream rendering uses the cookie-backed value.

## Cookie Contract

Cookie name:

- `riverlea_dark_mode_backend`

Allowed values:

- `light`
- `dark`
- `inherit`

Cookie lifetime:

- one year (`max-age=31536000`)

## UI Notes

The current implementation uses a custom switch UI injected from JavaScript rather than relying on an existing Riverlea template.

Important details:

- the control mounts next to `#crm-menubar-toggle-position` when available
- if that control is not yet present, a `MutationObserver` waits for it and repositions the switch later
- the script injects its own CSS to avoid requiring an additional stylesheet change
- mobile-specific adjustments are included so the switch does not overlap or float incorrectly in the collapsed menu

## Why This Was Needed

The Riverlea theme already had the backend theme infrastructure, but not the user-facing interaction to switch modes quickly. The feature is therefore mostly an integration layer between:

- existing Riverlea theme settings
- existing dark stream support
- a new backend menubar control
- a cookie-based per-user override

## Constraints and Tradeoffs

### Cookie-based override

The implementation is intentionally lightweight and does not introduce a new persisted user preference entity or schema.

Pros:

- simple to implement
- no schema changes
- per-browser / per-user behavior works immediately

Cons:

- preference is browser-specific, not account-specific across devices
- state is not visible in CiviCRM settings UI

### Injected CSS inside JavaScript

The switch styles are currently injected directly from `modeToggle.js`.

Pros:

- easy to ship as one feature without editing additional CSS build inputs
- keeps the feature self-contained

Cons:

- less maintainable than a dedicated stylesheet
- visual behavior is harder to tune from normal theme CSS

## Reproduction / Testing

Suggested checks:

1. Enable Riverlea in the backend.
2. Visit a backend page.
3. Confirm the switch appears in the menubar.
4. Click the switch repeatedly and verify it cycles through:
   - light
   - dark
   - inherit
5. Confirm the page reloads after each click.
6. Confirm the visual theme changes accordingly.
7. Inspect browser cookies and verify `riverlea_dark_mode_backend` is written.
8. Repeat the test on a narrow/mobile viewport and confirm the switch remains usable and aligned.

---

## Screenshots

### Mode "Auto" -> Inherits the preconfigured mode in the theme settings

<img width="1868" height="258" alt="image" src="https://github.com/user-attachments/assets/c0916ed3-1ac2-4bf5-a376-9c9f9621eaa4" />

#### Mode "Light"

<img width="1868" height="405" alt="image" src="https://github.com/user-attachments/assets/91064a76-edfa-4f84-b18d-7e426c5937b3" />

#### Mode "Dark"

<img width="1873" height="199" alt="image" src="https://github.com/user-attachments/assets/a5afa92a-5a6d-4e3d-8aa5-dceb8d804db0" />

---

This feature was funded by [IUCN](https://iucn.org/)