### PR TITLE
FormBuilder - use toggle for frontend / backend setting

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -62,10 +62,14 @@
       <input ng-model="editor.afform.server_route" name="server_route" class="form-control" id="af_config_form_server_route" pattern="^civicrm\/[\-0-9a-zA-Z\/_]+$" onfocus="this.value = this.value || 'civicrm/'" onblur="if (this.value === 'civicrm/') this.value = ''" title="{{:: ts('Path must begin with &quot;civicrm/&quot;') }}" placeholder="{{:: ts('None') }}" ng-model-options="editor.debounceMode" ng-required="!!editor.placementRequiresServerRoute()">
     </div>
 
-    <div class="form-group" ng-if="!!editor.afform.server_route">
+    <div class="form-group" ng-show="!!editor.afform.server_route">
       <label>
-        <input type="checkbox" ng-model="editor.afform.is_public">
-        {{:: ts('Accessible on front-end of website') }}
+        {{:: ts('Frontend or backend?') }}
+        <div class="crm-form-toggle-container">
+          <input type="checkbox" class="crm-form-toggle" ng-model="editor.afform.is_public">
+          <span class="crm-form-toggle-text crm-form-toggle-text-off">{{:: ts('Backend') }}</span>
+          <span class="crm-form-toggle-text crm-form-toggle-text-on">{{:: ts('Frontend') }}</span>
+        </div>
       </label>
     </div>
 

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -114,11 +114,11 @@
 }
 
 /* Edit palette (left side) */
-#afGuiEditor-palette input,
+#afGuiEditor-palette input:not(.crm-form-toggle),
 #afGuiEditor-palette textarea {
   width: 100%;
 }
-#afGuiEditor-palette input[type="checkbox"],
+#afGuiEditor-palette input[type="checkbox"]:not(.crm-form-toggle),
 #afGuiEditor-palette input[type="radio"] {
   width: 1rem;
   height: 1rem;


### PR DESCRIPTION
Overview
----------------------------------------
Another attempt to update my least favourite FormBuilder setting

Before
----------------------------------------
- "accessible on front-end of website" checkbox
<img width="526" height="197" alt="image" src="https://github.com/user-attachments/assets/40902964-a352-4e5c-9847-95c77065a815" />


After
----------------------------------------
- toggle between "frontend" and "backend"
<img width="587" height="263" alt="image" src="https://github.com/user-attachments/assets/318dd596-f904-4776-a35d-18f5617926dd" />

Comments
----------------------------------------
In [previous discussion](https://github.com/civicrm/civicrm-core/pull/34014) there was little agreement on what this setting meant, or how to explain it. I think it's unfortunate that it seems like an optional extra - it's not clear that "accessible on frontend" means not "backend" and vice versa.

So I think this more explicit toggle might be clearer (even if the subtleties of frontend vs backend will still be mysterious to most users)