### PR TITLE
FormBuilder - only show nav menu option if there is a page route

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -69,7 +69,7 @@
       </label>
     </div>
 
-    <div class="form-group">
+    <div class="form-group" ng-show="!!editor.afform.server_route">
       <div class="form-inline">
         <label ng-class="{disabled: !editor.afform.server_route}">
           <input type="checkbox" ng-checked="editor.afform.server_route && editor.afform.navigation" ng-disabled="!editor.afform.server_route" ng-click="editor.toggleNavigation()">


### PR DESCRIPTION
Overview
----------------------------------------
Only show add to nav options if you set a page route (similar to frontend/backend setting)
