### PR TITLE
Formbuilder - allow tokens in field default values

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -21,8 +21,31 @@
         });
       };
 
-      this.insertToken = function(key) {
-        ctrl.model[ctrl.field] = (ctrl.model[ctrl.field] || '') + '[' + key + ']';
+      this.insertToken = (key) => {
+        const token = '[' + key + ']';
+        let value = getModelValue();
+        if (value.length) {
+          value += ' ';
+        }
+        value += token;
+        setModelValue(value);
+      };
+
+      const getModelValue = () => {
+        // If using getter/setter factory
+        if (typeof this.model === 'function') {
+          return this.model(this.field)() || '';
+        }
+        return this.model[this.field] || '';
+      };
+
+      const setModelValue = (value) => {
+        // If using getter/setter factory
+        if (typeof this.model === 'function') {
+          this.model(this.field)(value);
+        } else {
+          this.model[this.field] = value;
+        }
       };
 
       this.getTokens = function() {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiTokenSelect.js
@@ -4,7 +4,8 @@
   angular.module('afGuiEditor').component('afGuiTokenSelect', {
     bindings: {
       model: '<',
-      field: '@'
+      field: '@',
+      noSubmissionTokens: '@',
     },
     require: {
       editor: '^afGuiEditor'
@@ -53,7 +54,7 @@
         ctrl.editor.getEntities().forEach((entity) => {
           const entityTokens = [];
           const entityMeta = ctrl.editor.meta.entities[entity.type];
-          if (entityMeta.submissionTokens) {
+          if (entityMeta.submissionTokens && !ctrl.noSubmissionTokens) {
             // Explicitly defined submission tokens e.g. by FormProcessor extension
             entityMeta.submissionTokens.forEach((submissionToken) => {
               entityTokens.push({
@@ -62,12 +63,14 @@
                 description: submissionToken.description ?? '',
               });
             });
-          } else {
+          } else if (!entityMeta.submissionTokens) {
             // Primary key token
-            entityTokens.push({
-              id: entity.name + '.0.id',
-              text: ts('%1 ID', {1: entity.label}),
-            });
+            if (!ctrl.noSubmissionTokens) {
+              entityTokens.push({
+                id: entity.name + '.0.id',
+                text: ts('%1 ID', {1: entity.label}),
+              });
+            }
             // Tokens from entity data values
             if (entity.data) {
               Object.keys(entity.data).forEach((key) => {
@@ -94,12 +97,14 @@
             });
           }
         });
-        allTokens.push({
-          text: ts('Form'),
-          children: [
-            {id: 'token', text: ts('Submission JWT')},
-          ],
-        });
+        if (!ctrl.noSubmissionTokens) {
+          allTokens.push({
+            text: ts('Form'),
+            children: [
+              {id: 'token', text: ts('Submission JWT')},
+            ],
+          });
+        }
         return {
           results: allTokens
         };

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -111,7 +111,7 @@
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
     <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" op="$ctrl.isSearch() ? (getSetOperator() || 'IN') : null">
   </form>
-  <af-gui-token-select class="input-group-addon" model="getSet" field="afform_default" ng-if="$ctrl.allowTokensInDefault()"></af-gui-token-select>
+  <af-gui-token-select class="input-group-addon" model="getSet" field="afform_default" ng-if="$ctrl.allowTokensInDefault()" no-submission-tokens="true"></af-gui-token-select>
 </li>
 <li>
   <a href ng-click="toggleLabel(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show field label') }}">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -111,7 +111,7 @@
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
     <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" op="$ctrl.isSearch() ? (getSetOperator() || 'IN') : null">
   </form>
-  <af-gui-token-select class="input-group-addon" model="$ctrl.fieldDefn" field="afform_default" ng-if="$ctrl.allowTokensInDefault()"></af-gui-token-select>
+  <af-gui-token-select class="input-group-addon" model="getSet" field="afform_default" ng-if="$ctrl.allowTokensInDefault()"></af-gui-token-select>
 </li>
 <li>
   <a href ng-click="toggleLabel(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show field label') }}">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField-menu.html
@@ -111,6 +111,7 @@
   <form ng-click="$event.stopPropagation()" class="af-gui-field-select-in-dropdown form-inline">
     <input class="form-control" af-gui-field-value="$ctrl.fieldDefn" ng-model="getSet('afform_default')" ng-model-options="{getterSetter: true}" op="$ctrl.isSearch() ? (getSetOperator() || 'IN') : null">
   </form>
+  <af-gui-token-select class="input-group-addon" model="$ctrl.fieldDefn" field="afform_default" ng-if="$ctrl.allowTokensInDefault()"></af-gui-token-select>
 </li>
 <li>
   <a href ng-click="toggleLabel(); $event.stopPropagation(); $event.target.blur();" title="{{:: ts('Show field label') }}">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -381,6 +381,8 @@
         return ctrl.hasDefaultValue && ctrl.getDefn().data_type !== 'Boolean' && ctrl.defaultDateType() === 'fixed';
       };
 
+      this.allowTokensInDefault = () => ['Text', 'TextArea', 'Hidden', 'DisplayOnly'].includes(this.fieldDefn.input_type);
+
       this.defaultDateType = function(newValue) {
         if (arguments.length) {
           if (newValue === 'relative') {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -381,7 +381,7 @@
         return ctrl.hasDefaultValue && ctrl.getDefn().data_type !== 'Boolean' && ctrl.defaultDateType() === 'fixed';
       };
 
-      this.allowTokensInDefault = () => ['Text', 'TextArea', 'Hidden', 'DisplayOnly'].includes(this.fieldDefn.input_type);
+      this.allowTokensInDefault = () => this.editor.getFormType() === 'form' && ['Text', 'TextArea', 'Hidden', 'DisplayOnly'].includes(this.fieldDefn.input_type);
 
       this.defaultDateType = function(newValue) {
         if (arguments.length) {

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -92,6 +92,17 @@
           }, true);
         }
 
+        // check for tokens in the default value
+        if (this.defn.afform_default) {
+          const tokens = this.afForm.identifyTokens(this.defn.afform_default);
+          if (tokens.length) {
+            $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
+              const calculatedValue = this.afForm.replaceTokens(this.defn.afform_default);
+              setValue(calculatedValue);
+            });
+          }
+        }
+
         // ChainSelect - watch control field & reload options as needed
         if (this.defn.input_type === 'ChainSelect' && this.defn.input_attrs.control_field) {
           const controlField = namePrefix + this.defn.input_attrs.control_field;

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -96,7 +96,12 @@
         if (this.defn.afform_default) {
           const tokens = this.afForm.identifyTokens(this.defn.afform_default);
           if (tokens.length) {
-            $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
+            const calculateValueWatcher = $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
+              if ($element[0].querySelector('.ng-touched')) {
+                // user has touched this input, stop calculating
+                calculateValueWatcher();
+                return;
+              }
               const calculatedValue = this.afForm.replaceTokens(this.defn.afform_default);
               setValue(calculatedValue);
             });

--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -93,19 +93,17 @@
         }
 
         // check for tokens in the default value
-        if (this.defn.afform_default) {
-          const tokens = this.afForm.identifyTokens(this.defn.afform_default);
-          if (tokens.length) {
-            const calculateValueWatcher = $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
-              if ($element[0].querySelector('.ng-touched')) {
-                // user has touched this input, stop calculating
-                calculateValueWatcher();
-                return;
-              }
-              const calculatedValue = this.afForm.replaceTokens(this.defn.afform_default);
-              setValue(calculatedValue);
-            });
-          }
+        const tokens = this.afForm.identifyTokens(this.defn.afform_default);
+        if (tokens && tokens.length) {
+          const calculateValueWatcher = $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
+            if ($element[0].querySelector('.ng-touched')) {
+              // user has touched this input, stop calculating
+              calculateValueWatcher();
+              return;
+            }
+            const calculatedValue = this.afForm.replaceTokens(this.defn.afform_default);
+            setValue(calculatedValue);
+          });
         }
 
         // ChainSelect - watch control field & reload options as needed
@@ -213,7 +211,12 @@
           }
           // Set default value based on field defn
           else if ('afform_default' in ctrl.defn) {
-            setValue(ctrl.defn.afform_default);
+            if (ctrl.afForm.identifyTokens(ctrl.defn.afform_default)) {
+              setValue(ctrl.afForm.replaceTokens(ctrl.defn.afform_default));
+            }
+            else {
+              setValue(ctrl.defn.afform_default);
+            }
           }
 
           if (ctrl.defn.search_range) {

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -535,6 +535,29 @@
         return data.extra;
       };
 
+      // these tokens matching/replacing functions should match
+      // the serverside implementation in AbstractProcessor::replaceTokens
+      this.identifyTokens = (message) => message?.match(/\[[a-zA-Z0-9_]+\.[0-9]+\.[^\]]+\]/g);
+
+      this.getTokenValues = (tokens) => {
+        const values = {};
+
+        tokens.forEach((token) => {
+          const parts = token.slice(1, -1).split('.');
+          values[token] = data[parts[0]][parts[1]].fields[parts.slice(2).join('.')];
+          values[token] = (values[token] === undefined) ? '' : values[token];
+        });
+
+        return values;
+      };
+
+      this.replaceTokens = (message) => {
+        const tokens = this.identifyTokens(message);
+        const tokenValues = this.getTokenValues(tokens);
+        tokens.forEach((token) => message = message.replace(token, tokenValues[token]));
+        return message;
+      };
+
     }
   });
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------
Allow using tokens for other field values in a field default value.

https://lab.civicrm.org/dev/core/-/work_items/6308

Tokens are the same as currently exist for the confirmation message, e.g. `[Individual1.0.first_name]`

You can compose them, e.g. `Donation from [Individual1.0.first_name]`

They will be auto-updated as changes are made to the other fields.

If the user edits the field manually, it will stop updating and leave the users value.

https://github.com/user-attachments/assets/0904882c-16ce-4547-943f-2e0990088b99



Technical Details
----------------------------------------
It implements a JS version of the token replacement, which we previously. This should be kept in sync with `AbstractProcessor::replaceTokens`` as far as possible.

Some tokens will not be available clientside - e.g. entity IDs prior to creation, any tokens added in serverside hooks. 

Issues
------------------
The token picker looks to me to be updating the right property ( `ctrl.fieldDefn.afform_default`) but it doesn't update the input on the screen; or get saved. (You can still use tokens by typing them in manually)

Ideally the token picker for this field would be limited to the clientside available tokens, but I'm not sure it's easy to determine which are ok. I suggest this is non-blocking. 

I wasn't sure what to do when the referenced fields have no value - you could:
- leave the unreplaced tag `[Individual1.0.first_name]` - but that's ugly and scary for normal form users
- leave a placeholder like `(empty)`
- empty string => this is what I've gone for