### PR TITLE
dev/core#6448 Don't show empty custom fields on workflow messages

### DIFF
--- a/Civi/WorkflowMessage/Traits/CustomFieldTrait.php
+++ b/Civi/WorkflowMessage/Traits/CustomFieldTrait.php
@@ -91,9 +91,9 @@ trait CustomFieldTrait {
     foreach ($viewableFields as $fieldSpec) {
       $fieldName = $fieldSpec['custom_group_id.name'] . '.' . $fieldSpec['name'];
       $value = str_replace('&nbsp;', '', \CRM_Core_BAO_CustomField::displayValue($entityRecord[$fieldName], $fieldSpec['id'], $entityRecord['id']));
-      // I can't see evidence we have filtered out empty strings here historically
-      // but maybe we should?
-      $fields[$fieldSpec['custom_group_id.title']][$fieldSpec['label']] = $value;
+      if ($value !== '') {
+        $fields[$fieldSpec['custom_group_id.title']][$fieldSpec['label']] = $value;
+      }
     }
     return $fields;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6448

Fulfilling the prophecy of the comment - we shouldn't include empty custom fields in workflow messages.  This is particularly important for backend event reg (and presumably contributions) because folks can have a lot of irrelevant custom fields, and we don't want donors etc. to see those.

Before
----------------------------------------
Custom fields always shown

After
----------------------------------------
Empty custom fields filtered out.