### PR TITLE
dev/core#6390 Do not create indexes on serialized fields and have upg…

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -200,7 +200,8 @@ class CRM_Core_BAO_SchemaHandler {
 
     // Add index if field is searchable if it does not reference a foreign key
     // (skip indexing FK fields because it would be redundant to have 2 indexes)
-    if (!empty($params['searchable']) && empty($params['fk_table_name']) && !$searchIndexExists) {
+    // Also do not add an index if it is a searlizable column
+    if (!empty($params['searchable']) && empty($params['fk_table_name']) && !$searchIndexExists && empty($params['serialize'])) {
       $indexName = $params['name'];
       if ($params['type'] === 'text' || self::getFieldLength($params['type']) > self::MAX_INDEX_LENGTH) {
         $indexName .= '(' . self::MAX_INDEX_LENGTH . ')';

--- a/CRM/Upgrade/Incremental/php/SixFifteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFifteen.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\CustomField;
+
 /**
  * Upgrade logic for the 6.15.x series.
  *
@@ -29,6 +31,23 @@ class CRM_Upgrade_Incremental_php_SixFifteen extends CRM_Upgrade_Incremental_Bas
    */
   public function upgrade_6_15_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('dev/core#6390 Remove indexes from serialied custom fields', 'removeSearchIndexForSerializedCustomFields');
+  }
+
+  public static function removeSearchIndexForSerializedCustomFields($ctx): bool {
+    $customFields = CustomField::get(FALSE)
+      ->addWhere('serialize', '!=', 0)
+      ->addWhere('is_searchable', '=', TRUE)
+      ->execute();
+    foreach ($customFields as $customField) {
+      $params = [
+        'id' => $customField['id'],
+        'is_searchable' => 0,
+        'serialize' => $customField['serialize'],
+      ];
+      CRM_Core_BAO_CustomFIeld::create($params);
+    }
+    return TRUE;
   }
 
 }


### PR DESCRIPTION
…rade step to remove any indexes currently existing in the database

Overview
----------------------------------------
This aims to stop adding indexes to serialized fields as it doesn't make much sense and in some cases can crash when importing the custom field as a manged entities

Before
----------------------------------------
Potential crash with index being created on a serialized custom field

After
----------------------------------------
issue fixed

ping @colemanw @ufundo 

If we agree that this works I can work on putting it against the RC and maybe stable as well