### PR TITLE
Fix PHPDoc: use fully-qualified class name for TokenRow

### DIFF
--- a/Civi/Token/Event/TokenValueEvent.php
+++ b/Civi/Token/Event/TokenValueEvent.php
@@ -37,7 +37,7 @@ namespace Civi\Token\Event;
 class TokenValueEvent extends TokenEvent {
 
   /**
-   * @return \Traversable<TokenRow>
+   * @return \Traversable<\Civi\Token\TokenRow>
    */
   public function getRows() {
     return $this->tokenProcessor->getRows();


### PR DESCRIPTION
The previous annotation resolved to Civi\Token\Event\TokenRow, which does not exist.

```
  /**
   * @return \Traversable<TokenRow>
   */
  public function getRows() {
```

Explicitly reference Civi\Token\TokenRow so static analysis works correctly.