### PR TITLE
FlexMailer - Fix memory leak in bulk mailing send loop

### DIFF
--- a/ext/flexmailer/src/FlexMailer.php
+++ b/ext/flexmailer/src/FlexMailer.php
@@ -157,7 +157,14 @@ class FlexMailer {
     $walkBatches = $this->fireWalkBatches(function ($tasks) use ($flexMailer) {
       $flexMailer->fireComposeBatch($tasks);
       $sendBatch = $flexMailer->fireSendBatch($tasks);
-      return $sendBatch->getCompleted();
+      $completed = $sendBatch->getCompleted();
+      // Free batch data to prevent memory growth across large mailings.
+      unset($sendBatch);
+      foreach ($tasks as $key => $task) {
+        $tasks[$key] = NULL;
+      }
+      gc_collect_cycles();
+      return $completed;
     });
 
     return $walkBatches->getCompleted();

--- a/ext/flexmailer/src/Listener/DefaultSender.php
+++ b/ext/flexmailer/src/Listener/DefaultSender.php
@@ -66,7 +66,7 @@ class DefaultSender extends AutoService {
       }
 
       $headers = $message->headers();
-      $result = $mailer->send($headers['To'], $message->headers(), $message->get());
+      $result = $mailer->send($headers['To'], $headers, $message->get());
 
       if ($job_date) {
         unset($errorScope);
@@ -87,6 +87,8 @@ class DefaultSender extends AutoService {
           if ($smtpConnectionErrors <= 5) {
             $mailer->disconnect();
             $retryBatch = TRUE;
+            unset($result, $message, $params, $headers);
+            $task->setMailParams([]);
             continue;
           }
 
@@ -129,7 +131,8 @@ class DefaultSender extends AutoService {
         }
       }
 
-      unset($result);
+      unset($result, $message, $params, $headers);
+      $task->setMailParams([]);
 
       // seems like a successful delivery or bounce, lets decrement error count
       // only if we have smtp connection errors


### PR DESCRIPTION
## Overview

Fix memory accumulation in `DefaultSender::onSend()` that causes `cv cron` to OOM when processing large bulk mailings (35K+ recipients). Each email leaks ~12-14MB of memory because per-email objects are never freed within the send loop.

## Before

During bulk mailing delivery, the send loop in `DefaultSender` creates a `Mail_mime` object per email (via `convertMailParamsToMime`) but only calls `unset($result)` at the end of each iteration. The `$message` (Mail_mime with full MIME body), `$params` (rendered HTML/text), and `$headers` (encoded headers array) all persist until the next iteration overwrites them — or until `onSend()` returns for the last email. Combined with `FlexMailerTask::$mailParams` holding the full rendered email for every task in the batch simultaneously, memory grows linearly with batch size.

With `mailerBatchLimit=125` and Mosaico templates, the process exhausts PHP's 1200M `memory_limit` at around 75-100 emails and OOMs.

Additionally, `$message->headers()` is called twice per email — once to extract the `To` header and once to pass to `$mailer->send()` — performing redundant MIME header encoding.

## After

- Per-email objects (`$message`, `$params`, `$headers`) are freed immediately after each send via `unset()`
- `$task->setMailParams([])` releases the rendered HTML/text from the task object after delivery (no code reads `mailParams` post-send)
- The already-computed `$headers` variable is reused instead of calling `$message->headers()` a second time
- On the SMTP retry path (`continue` at the temporary error branch), objects are also freed before continuing — the task will be re-created from the database on the next batch walk
- Between batches, task references are nulled and `gc_collect_cycles()` is called to collect any circular references from third-party compose/send listeners

## Technical Details

**Memory lifecycle traced through the pipeline:**

The walk callback in `FlexMailer::run()` calls `fireComposeBatch($tasks)` then `fireSendBatch($tasks)` sequentially. During compose, `DefaultComposer` creates a `TokenProcessor` that evaluates tokens for all tasks and stores rendered HTML/text in each task's `$mailParams`. During send, `DefaultSender` iterates the same tasks, converts each to `Mail_mime`, and sends via SMTP.

Before this fix, all tasks retained their full `$mailParams` (rendered HTML + text + headers) for the entire send loop duration. After this fix, each task's params are cleared immediately after successful delivery or bounce recording.

**Why `gc_collect_cycles()` between batches:** While the core FlexMailer objects do not create circular references (confirmed by code tracing — `TokenRow` objects are ephemeral facades, not stored), third-party extensions registering `civi.flexmailer.compose` or `civi.flexmailer.send` listeners may create cycles. The explicit GC call is a safety net that adds negligible overhead (no-op when no cycles exist).

**Paths verified safe for cleanup:**
- Success path: `$task->getEventQueueId()` and `$task->getContactId()` are read before cleanup
- Bounce path: `recordBounce()` reads `eventQueueId`, `hash` from the task (not from `mailParams`) before cleanup
- Retry path (`continue` at line 94): task will be re-created by `DefaultBatcher` from the database on the next walk iteration
- Early return (job stopped, line 131): local variables freed by stack unwinding; remaining tasks freed by batch-level cleanup in `FlexMailer::run()`

## Comments

This addresses the most impactful memory issue in the FlexMailer pipeline. A broader performance audit identified additional optimization opportunities that could be addressed in follow-up PRs:

- `CRM_Contact_Tokens::onEvaluate()` uses N+1 per-contact `Contact::get()` calls instead of the batched `prefetch()` pattern from the parent `CRM_Core_EntityTokens` class
- `MailingJob::writeToDB()` re-queries `$activityID` on every call (could be cached as a static variable)
- `BULK_MAIL_INSERT_COUNT = 10` triggers `writeToDB` (3-5 SQL queries + API3 call) very frequently — raising to 50+ would reduce overhead significantly
- Missing `job_id` index on `civicrm_mailing_event_queue` causes full table scans in `DefaultBatcher::findPendingTasks()`