### PR TITLE
SearchKit - Fix undefined error in `addEntityJoins` function

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -400,7 +400,7 @@
       const existingJoins = getExistingJoins();
 
       function addEntityJoins(entity, stack, baseEntity) {
-        return Object.values(CRM.crmSearchAdmin.joins[entity]).reduce((joinEntities, join) => {
+        return Object.values(CRM.crmSearchAdmin.joins[entity] || {}).reduce((joinEntities, join) => {
           let num = 0;
           if (
             // Exclude joins that singly point back to the original entity


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug introduced in fac47d1 – creating/editing a search for entities with no joins will show a console error.