### PR TITLE
Case Dashboard: use toggle, rename title, code cleanup

### DIFF
--- a/CRM/Case/Page/DashBoard.php
+++ b/CRM/Case/Page/DashBoard.php
@@ -46,25 +46,15 @@ class CRM_Case_Page_DashBoard extends CRM_Core_Page {
 
     CRM_Utils_System::setTitle(ts('CiviCase Dashboard'));
 
-    //validate access for all cases.
+    // Validate access for all cases.
     if ($allCases && !CRM_Core_Permission::check('access all cases and activities')) {
       $allCases = 0;
       CRM_Core_Session::setStatus(ts('You are not authorized to access all cases and activities.'), ts('Sorry'), 'error');
     }
     $this->assign('all', $allCases);
-    if (!$allCases) {
-      $this->assign('myCases', TRUE);
-    }
-    else {
-      $this->assign('myCases', FALSE);
-    }
+    $this->assign('myCases', !$allCases);
+    $this->assign('newClient', CRM_Core_Permission::check('add contacts') && CRM_Core_Permission::check('access all cases and activities'));
 
-    $this->assign('newClient', FALSE);
-    if (CRM_Core_Permission::check('add contacts') &&
-      CRM_Core_Permission::check('access all cases and activities')
-    ) {
-      $this->assign('newClient', TRUE);
-    }
     $summary = CRM_Case_BAO_Case::getCasesSummary($allCases);
     $upcoming = CRM_Case_BAO_Case::getCases($allCases, [], 'dashboard', TRUE);
     $recent = CRM_Case_BAO_Case::getCases($allCases, ['type' => 'recent'], 'dashboard', TRUE);

--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1928,7 +1928,8 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->addRadio($name, $label, $options, $props, NULL, $required);
 
       case 'CheckBox':
-        if ($context === 'search') {
+        // Ex: for is_deceased, but not is_deleted (usually implicit)
+        if ($context === 'search' && !in_array($name, ['case_deleted', 'is_deleted'])) {
           $this->addYesNo($name, $label, TRUE, FALSE, $props);
           return;
         }

--- a/templates/CRM/Case/Page/DashBoard.tpl
+++ b/templates/CRM/Case/Page/DashBoard.tpl
@@ -16,33 +16,21 @@
 
     {capture assign=newCaseURL}{crmURL p="civicrm/case/add" q="action=add&context=standalone&reset=1"}{/capture}
 
-    <div class="crm-submit-buttons crm-case-dashboard-buttons">
+    <div class="crm-submit-buttons crm-case-dashboard-buttons float-right">
+      {crmPermission has='access all cases and activities'}
+        <div class="crm-case-dashboard-switch-view-buttons">
+          <div class="crm-form-toggle-container">
+            <span class="crm-form-toggle-text">{ts}Show Only My Cases{/ts}</span>
+            <input name="allupcoming" {if $myCases}checked{/if} type="checkbox" class="crm-form-toggle" onClick='window.location.replace(CRM.url("civicrm/case", "reset=1&all=" + (this.checked ? "0" : "1")))' value="1">
+          </div>
+        </div>
+      {/crmPermission}
       {if $newClient and $allowToAddNewCase}
         <a href="{$newCaseURL}" class="button"><span><i class="crm-i fa-plus-circle" role="img" aria-hidden="true"></i> {ts}Add Case{/ts}</span></a>
       {/if}
       <a class="button no-popup" name="find_my_cases" href="{crmURL p="civicrm/case/search" q="reset=1&case_owner=2&force=1"}"><span><i class="crm-i fa-search" role="img" aria-hidden="true"></i> {ts}Find My Cases{/ts}</span></a>
-
-      <div class="crm-case-dashboard-switch-view-buttons">
-        {if $myCases}
-          {* check for access all cases and activities *}
-          {crmPermission has='access all cases and activities'}
-            <div><input name="allupcoming" id="allupcoming-all" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><label for="allupcoming-all">{ts}All Cases{/ts}</label></div>
-            <div><input name="allupcoming" id="allupcoming-my" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><label for="allupcoming-my">{ts}My Cases{/ts}</label></div>
-          {/crmPermission}
-        {else}
-          <div><input name="allupcoming" id="allupcoming-all" checked type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=1"}")' value="1"><label for="allupcoming-all">{ts}All Cases with Upcoming Activities{/ts}</label></div>
-          <div><input name="allupcoming" id="allupcoming-my" type="radio" class="radio" onClick='window.location.replace("{crmURL p="civicrm/case" q="reset=1&all=0"}")' value="0"><label for="allupcoming-my">{ts}My Cases with Upcoming Activities{/ts}</label></div>
-        {/if}
-      </div>
     </div>
-
-    <h3>
-      {if $myCases}
-        {ts}Summary of Involvement{/ts}
-      {else}
-        {ts}Summary of All Cases{/ts}
-      {/if}
-    </h3>
+    <h3>{ts}Case Summary{/ts}</h3>
     <table class="report">
       <tr class="columnheader">
         <th>&nbsp;</th>


### PR DESCRIPTION
Overview
----------------------------------------

A few visual changes to the CiviCase Dashboard:

- Uses a toggle for "My Cases", and simplifies the label (see "comments" below)
- Floats the buttons right, to be slightly more out of the way, and to be consistent with the Contribution dashboard (I might do the same for the Event dashboard)
- Changes the "Summary of Involvement" title to "Case Summary"
- Code cleanup

Before
----------------------------------------

<img  alt="image" src="https://github.com/user-attachments/assets/4ddacca8-9954-4f2e-93e1-6cf026c0d3fc" />

After
----------------------------------------

<img alt="image" src="https://github.com/user-attachments/assets/c63a3d37-1145-4970-a577-ca50d10d5ce2" />

Toggled shows "All Cases":

<img  alt="image" src="https://github.com/user-attachments/assets/93347f0e-c3bb-4240-b3a2-01b4988e3037" />



Comments
----------------------------------------

About the "All Cases / My Cases" vs "All upcoming cases": the old behaviour was rather confusing. When we toggle, it changes to "all cases with upcoming activities". I had simplified the label around 2021, but I hadn't noticed the confusing conditions. I could not find any reason to keep the conditions that basically duplicates the code.

I thought maybe there was a way to toggle "all cases with future activities" vs "all cases including those without upcoming", but it doesn't seem to be the case?

cc @demeritcowboy 