### PR TITLE
SearchKit - Update row style when enabling/disabling

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -384,7 +384,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @param int|null $index
    * @return array
    */
-  protected function getCssStyles(array $styleRules, array $data, ?int $index = NULL) {
+  protected function getCssStyles(array $styleRules, array $data, ?int $index = NULL): array {
     $classes = [];
     foreach ($styleRules as $clause) {
       $cssClass = $clause[0] ?? '';

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
@@ -72,6 +72,8 @@
           const row = this.results[rowIndex];
           // Preserve hierarchical info like _descendents and _depth which isn't returned by the refresh
           _.defaults(result[0].data, row.data);
+          // Ensure cssClass gets updated
+          delete (row.cssClass);
           // Note that extend() will preserve top-level items like 'collapsed' while replacing columns and data
           angular.extend(row, result[0]);
         }

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGridItems.html
@@ -1,4 +1,4 @@
-<div ng-repeat="(rowIndex, row) in $ctrl.results" class="{{:: row.cssClass }}">
+<div ng-repeat="(rowIndex, row) in $ctrl.results" class="{{ row.cssClass }}">
   <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: $ctrl.getFieldClass(colIndex, colData) }}">
     <label ng-if=":: colData.label">
       {{:: colData.label }}

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
@@ -1,4 +1,4 @@
-<li ng-repeat="(rowIndex, row) in $ctrl.results" class="{{:: row.cssClass }}">
+<li ng-repeat="(rowIndex, row) in $ctrl.results" class="{{ row.cssClass }}">
   <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: $ctrl.getFieldClass(colIndex, colData) }}">
     <label ng-if=":: colData.label">
       {{:: colData.label }}

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -155,7 +155,7 @@
       };
 
       this.getRowClass = function (row) {
-        let cssClass = row.cssClass || '';
+        let cssClass = '';
         if (ctrl.settings.hierarchical) {
           cssClass += ' crm-hierarchical-row crm-hierarchical-depth-' + row.data._depth;
           if (row.data._depth) {
@@ -228,7 +228,7 @@
         });
         this.toggleColumns();
       };
-      
+
       this.clearColumnToggles = () => {
         this.columns.forEach((col, index) => {
           this.columns[index].enabled = false;

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -1,5 +1,5 @@
 <tr ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}" ng-if="!row.hidden">
-  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: $ctrl.getRowClass(row) }}">
+  <td ng-if=":: $ctrl.hasExtraFirstColumn()" class="crm-search-ctrl-column {{:: $ctrl.getRowClass(row) }} {{ row.cssClass }}">
     <span ng-if=":: $ctrl.settings.draggable" class="crm-draggable" title="{{:: ts('Drag to reposition') }}">
       <i class="crm-i fa-arrows-v" role="img" aria-hidden="true"></i>
     </span>
@@ -16,7 +16,7 @@
       </button>
     </div>
   </td>
-  <td ng-repeat="(colIndex, colData) in row.columns track by $index" ng-if="$ctrl.columns[colIndex].enabled" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }}" data-field-name="{{:: $ctrl.columns[colIndex].key }}">
+  <td ng-repeat="(colIndex, colData) in row.columns track by $index" ng-if="$ctrl.columns[colIndex].enabled" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }} {{ row.cssClass }}" data-field-name="{{:: $ctrl.columns[colIndex].key }}">
   </td>
 </tr>
 <tr ng-if="$ctrl.rowCount === 0">

--- a/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTreeBranch.html
+++ b/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTreeBranch.html
@@ -1,6 +1,6 @@
 <ul ng-if="!$ctrl.settings.draggable" class="crm-search-display-tree-branch">
-  <li ng-repeat="row in $branch.items" class="{{:: row.cssClass }}" ng-class="{'crm-search-display-tree-branch-collapsed': row.collapsed}" ng-include="'~/crmSearchDisplayTree/crmSearchDisplayTreeLeaf.html'"></li>
+  <li ng-repeat="row in $branch.items" class="{{ row.cssClass }}" ng-class="{'crm-search-display-tree-branch-collapsed': row.collapsed}" ng-include="'~/crmSearchDisplayTree/crmSearchDisplayTreeLeaf.html'"></li>
 </ul>
 <ul ng-if="$ctrl.settings.draggable" class="crm-search-display-tree-branch" ui-sortable="$branch.draggableOptions" ng-model="$branch.items">
-  <li ng-repeat="row in $branch.items" class="{{:: row.cssClass }}" ng-class="{'crm-search-display-tree-branch-collapsed': row.collapsed}" ng-include="'~/crmSearchDisplayTree/crmSearchDisplayTreeLeaf.html'"></li>
+  <li ng-repeat="row in $branch.items" class="{{ row.cssClass }}" ng-class="{'crm-search-display-tree-branch-collapsed': row.collapsed}" ng-include="'~/crmSearchDisplayTree/crmSearchDisplayTreeLeaf.html'"></li>
 </ul>


### PR DESCRIPTION


Overview
----------------------------------------
In admin UI it's a common pattern to include an enable/disable toggle for each row, e.g. for a list of custom fields.

The button worked, but didn't appear to because the css class in the row wasn't getting updated.

Now fixed:

<img width="1136" height="608" alt="image" src="https://github.com/user-attachments/assets/1eb6073c-7108-4e37-86bb-cf5133eafa12" />

Comments
------
Marking as a regression because I'm sure this worked before.