### PR TITLE
Queue: add retry to getStatuses so that new queues do not fail

### DIFF
--- a/CRM/Queue/BAO/Queue.php
+++ b/CRM/Queue/BAO/Queue.php
@@ -70,6 +70,8 @@ class CRM_Queue_BAO_Queue extends CRM_Queue_DAO_Queue implements \Civi\Core\Hook
       // This is more suitable if the queue is a closed batch of interdependent tasks.
       // For linear queues (`Sql`), this will stop any new task-runs. For parallel queues (`SqlParallel`),
       // it will also stop new task-runs, but on-going tasks must wind-down on their own.
+      'retry' => ts('Retry after the retry interval'),
+      // ^^ When a task fails, retry after retry_interval until retry_limit
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes, for example:

```
$queue = \Civi::queue(self::QUEUE_NAME, [
  'type' => 'Sql',
  'runner' => 'task',
  'error' => 'retry',
  'retry_limit' => 10,
  'retry_interval' => 30,
]);
```

Failed tasks will restart after 30 seconds, with up to 10 retries.

Otherwise the above code fails with `Invalid error mode "error"`.

Technical Details
----------------------------------------

The `error` parameter is somewhat documented here: https://docs.civicrm.org/dev/en/latest/framework/queues/#1-creating-a-queue

Related doc PR: https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1281