### PR TITLE
Add symfony_mailer core extension to replace PEAR Mail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@
 !/ext/user_dashboard
 !/ext/tellafriend
 !/ext/riverlea
+!/ext/symfony_mailer
 backdrop/
 bower_components
 CRM/Case/xml/configuration

--- a/ext/symfony_mailer/Civi/SymfonyMailer/FlexSender.php
+++ b/ext/symfony_mailer/Civi/SymfonyMailer/FlexSender.php
@@ -1,0 +1,195 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\SymfonyMailer;
+
+use Civi\Core\Service\AutoService;
+use Civi\FlexMailer\Event\SendBatchEvent;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+
+/**
+ * FlexMailer send listener that bypasses PEAR Mail_mime entirely.
+ *
+ * Builds Symfony Email objects directly from mailParams and sends
+ * via the Symfony transport. Runs at priority -1000, ahead of
+ * DefaultSender at -2000.
+ *
+ * @service civi_symfony_mailer_flex_sender
+ */
+class FlexSender extends AutoService {
+
+  const BULK_MAIL_INSERT_COUNT = 10;
+
+  public function onSend(SendBatchEvent $e): void {
+    $mailerService = \Civi::service('pear_mail');
+    if (!($mailerService instanceof SymfonyMailerAdapter)) {
+      return;
+    }
+
+    $e->stopPropagation();
+
+    $transport = $mailerService->getTransport();
+    $job = $e->getJob();
+    $mailing = $e->getMailing();
+    $job_date = \CRM_Utils_Date::isoToMysql($job->scheduled_date);
+
+    $targetParams = $deliveredParams = [];
+    $count = 0;
+    static $smtpConnectionErrors = 0;
+    $retryBatch = FALSE;
+
+    foreach ($e->getTasks() as $key => $task) {
+      /** @var \Civi\FlexMailer\FlexMailerTask $task */
+      if (!$task->hasContent()) {
+        continue;
+      }
+
+      $params = $task->getMailParams();
+      if (!empty($params['abortMailSend'])) {
+        continue;
+      }
+
+      $sent = FALSE;
+      try {
+        $email = MailParamsConverter::fromMailParams($params);
+
+        if ($job_date) {
+          $errorScope = \CRM_Core_TemporaryErrorScope::ignoreException();
+        }
+
+        $transport->send($email);
+        $sent = TRUE;
+
+        if ($job_date) {
+          unset($errorScope);
+        }
+      }
+      catch (TransportExceptionInterface $ex) {
+        if ($job_date) {
+          unset($errorScope);
+        }
+
+        if ($this->isTemporaryError($ex)) {
+          $smtpConnectionErrors++;
+          if ($smtpConnectionErrors <= 5) {
+            if ($transport instanceof EsmtpTransport) {
+              $transport->stop();
+            }
+            $retryBatch = TRUE;
+            unset($email, $params);
+            $task->setMailParams([]);
+            continue;
+          }
+
+          $job->writeToDB($deliveredParams, $targetParams, $mailing, $job_date);
+          \CRM_Core_Error::debug_log_message("Too many SMTP Socket Errors. Exiting");
+          \CRM_Utils_System::civiExit();
+        }
+        else {
+          $this->recordBounce($job, $task, $ex->getMessage());
+        }
+      }
+
+      unset($email, $params);
+      $task->setMailParams([]);
+
+      if (!$sent) {
+        continue;
+      }
+
+      $deliveredParams[] = $task->getEventQueueId();
+      $targetParams[] = $task->getContactId();
+
+      $count++;
+      if ($count % self::BULK_MAIL_INSERT_COUNT == 0) {
+        $job->writeToDB($deliveredParams, $targetParams, $mailing, $job_date);
+        $count = 0;
+
+        $status = \CRM_Core_DAO::getFieldValue(
+          'CRM_Mailing_DAO_MailingJob',
+          $job->id,
+          'status',
+          'id',
+          TRUE
+        );
+        if ($status != 'Running') {
+          $e->setCompleted(FALSE);
+          return;
+        }
+      }
+
+      if ($smtpConnectionErrors > 0) {
+        $smtpConnectionErrors--;
+      }
+
+      $mailThrottleTime = \CRM_Core_Config::singleton()->mailThrottleTime;
+      if (!empty($mailThrottleTime)) {
+        usleep((int) $mailThrottleTime);
+      }
+    }
+
+    $completed = $job->writeToDB(
+      $deliveredParams,
+      $targetParams,
+      $mailing,
+      $job_date
+    );
+    if ($retryBatch) {
+      $completed = FALSE;
+    }
+    $e->setCompleted($completed);
+  }
+
+  private function isTemporaryError(TransportExceptionInterface $e): bool {
+    $message = $e->getMessage();
+    $code = preg_match('/ \(code: (.+), response: /', $message, $matches) ? $matches[1] : '';
+
+    if (str_contains($message, 'Failed to write to socket')
+      || str_contains($message, 'Connection could not be established')
+      || str_contains($message, 'Connection reset by peer')) {
+      return TRUE;
+    }
+
+    // 5xx = permanent failure.
+    if (isset($code[0]) && $code[0] === '5') {
+      return FALSE;
+    }
+
+    if ($code === '450' && \Civi::settings()->get('smtp_450_is_permanent')) {
+      if (str_contains($message, '4.1.2')) {
+        return FALSE;
+      }
+    }
+
+    if (str_contains($message, 'Failed to set sender')
+      || str_contains($message, 'Failed to add recipient')
+      || str_contains($message, 'Failed to send data')) {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+  private function recordBounce($job, $task, string $errorMessage): void {
+    $params = [
+      'event_queue_id' => $task->getEventQueueId(),
+      'job_id' => $job->id,
+      'hash' => $task->getHash(),
+    ];
+    $params = array_merge($params,
+      \CRM_Mailing_BAO_BouncePattern::match($errorMessage)
+    );
+    \CRM_Mailing_Event_BAO_MailingEventBounce::recordBounce($params);
+  }
+
+}

--- a/ext/symfony_mailer/Civi/SymfonyMailer/MailParamsConverter.php
+++ b/ext/symfony_mailer/Civi/SymfonyMailer/MailParamsConverter.php
@@ -1,0 +1,190 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\SymfonyMailer;
+
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+class MailParamsConverter {
+
+  /**
+   * Keys consumed from $mailParams that are not email headers.
+   */
+  private const NON_HEADER_KEYS = [
+    'toName', 'toEmail', 'text', 'html', 'attachments', 'headers',
+    'job_id', 'abortMailSend',
+  ];
+
+  /**
+   * Build a Symfony Email from FlexMailer's $mailParams array.
+   *
+   * Used by FlexSender to bypass Mail_mime entirely.
+   */
+  public static function fromMailParams(array $params): Email {
+    $email = new Email();
+
+    $toName = trim($params['toName'] ?? '');
+    $toEmail = trim($params['toEmail'] ?? '');
+    if ($toName && $toName !== $toEmail && !str_contains($toName, '@')) {
+      $email->to(new Address($toEmail, $toName));
+    }
+    else {
+      $email->to($toEmail);
+    }
+
+    if (!empty($params['From'])) {
+      $email->from(Address::create($params['From']));
+    }
+    if (!empty($params['Subject'])) {
+      $email->subject($params['Subject']);
+    }
+    if (!empty($params['text'])) {
+      $email->text($params['text']);
+    }
+    if (!empty($params['html'])) {
+      $email->html($params['html']);
+    }
+    if (!empty($params['Reply-To'])) {
+      $email->replyTo(Address::create($params['Reply-To']));
+    }
+    if (!empty($params['Return-Path'])) {
+      $email->returnPath(Address::create($params['Return-Path']));
+    }
+    if (!empty($params['Cc'])) {
+      foreach (self::parseAddressList($params['Cc']) as $addr) {
+        $email->addCc($addr);
+      }
+    }
+    if (!empty($params['Bcc'])) {
+      foreach (self::parseAddressList($params['Bcc']) as $addr) {
+        $email->addBcc($addr);
+      }
+    }
+
+    if (!empty($params['attachments'])) {
+      foreach ($params['attachments'] as $attach) {
+        $email->attachFromPath(
+          $attach['fullPath'],
+          $attach['cleanName'] ?? NULL,
+          $attach['mime_type'] ?? NULL
+        );
+      }
+    }
+
+    if (!empty($params['Message-ID'])) {
+      $msgId = trim($params['Message-ID'], '<>');
+      $email->getHeaders()->remove('Message-ID');
+      $email->getHeaders()->addIdHeader('Message-ID', $msgId);
+    }
+
+    // Apply remaining string values as custom headers.
+    $skip = array_flip(self::NON_HEADER_KEYS);
+    $standardHeaders = ['From', 'Subject', 'Reply-To', 'Return-Path', 'Cc', 'Bcc', 'To', 'Message-ID'];
+    $skip += array_flip($standardHeaders);
+    foreach ($params as $key => $value) {
+      if (isset($skip[$key]) || $value === NULL || $value === '') {
+        continue;
+      }
+      if (is_string($value)) {
+        $email->getHeaders()->addTextHeader($key, $value);
+      }
+    }
+
+    return $email;
+  }
+
+  /**
+   * Build a Symfony Email from the $originalValues passed by CRM_Utils_Mail::send().
+   *
+   * This is the single-email path (non-FlexMailer).
+   */
+  public static function fromOriginalValues(array $headers, array $originalValues): Email {
+    $email = new Email();
+
+    if (!empty($headers['To'])) {
+      $email->to(Address::create($headers['To']));
+    }
+    if (!empty($headers['From'])) {
+      $email->from(Address::create($headers['From']));
+    }
+    if (!empty($headers['Subject'])) {
+      $email->subject($headers['Subject']);
+    }
+    if (!empty($originalValues['text'])) {
+      $email->text($originalValues['text']);
+    }
+    if (!empty($originalValues['html'])) {
+      $email->html($originalValues['html']);
+    }
+    if (!empty($headers['Reply-To'])) {
+      $email->replyTo(Address::create($headers['Reply-To']));
+    }
+    if (!empty($headers['Return-Path'])) {
+      $email->returnPath(Address::create($headers['Return-Path']));
+    }
+    if (!empty($headers['Return-Path'])) {
+      $email->returnPath(Address::create($headers['Return-Path']));
+    }
+    if (!empty($headers['Cc'])) {
+      foreach (self::parseAddressList($headers['Cc']) as $addr) {
+        $email->addCc($addr);
+      }
+    }
+    if (!empty($originalValues['bcc'])) {
+      foreach (self::parseAddressList($originalValues['bcc']) as $addr) {
+        $email->addBcc($addr);
+      }
+    }
+
+    if (!empty($originalValues['attachments'])) {
+      foreach ($originalValues['attachments'] as $attach) {
+        $email->attachFromPath(
+          $attach['fullPath'],
+          $attach['cleanName'] ?? NULL,
+          $attach['mime_type'] ?? NULL
+        );
+      }
+    }
+
+    if (!empty($headers['Message-ID'])) {
+      $msgId = trim($headers['Message-ID'], '<>');
+      $email->getHeaders()->remove('Message-ID');
+      $email->getHeaders()->addIdHeader('Message-ID', $msgId);
+    }
+
+    // Pass through remaining headers.
+    $skip = ['To', 'From', 'Subject', 'Reply-To', 'Return-Path', 'Cc', 'Bcc',
+      'Content-Type', 'Content-Disposition', 'Content-Transfer-Encoding', 'Message-ID'];
+    $skip = array_flip($skip);
+    foreach ($headers as $key => $value) {
+      if (isset($skip[$key]) || $value === NULL || $value === '') {
+        continue;
+      }
+      if (is_string($value)) {
+        $email->getHeaders()->addTextHeader($key, $value);
+      }
+    }
+
+    return $email;
+  }
+
+  /**
+   * @return \Symfony\Component\Mime\Address[]
+   */
+  private static function parseAddressList(string $list): array {
+    return array_map(
+      fn(string $addr) => Address::create(trim($addr)),
+      explode(',', $list)
+    );
+  }
+
+}

--- a/ext/symfony_mailer/Civi/SymfonyMailer/SymfonyMailerAdapter.php
+++ b/ext/symfony_mailer/Civi/SymfonyMailer/SymfonyMailerAdapter.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\SymfonyMailer;
+
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+
+/**
+ * Wraps a Symfony transport behind the send($recipients, $headers, $body)
+ * interface that CiviCRM's FilteredPearMailer exposes.
+ *
+ * This allows CRM_Utils_Mail::send() and other callers of the pear_mail
+ * service to send via Symfony without any code changes.
+ */
+class SymfonyMailerAdapter {
+
+  private TransportInterface $transport;
+  private string $driver;
+
+  /**
+   * Exposed for CRM_Utils_Mail::pickDefaultEol() compatibility.
+   * Symfony uses RFC 5322 \r\n natively.
+   */
+  public string $sep = "\r\n";
+
+  public function __construct(TransportInterface $transport, string $driver) {
+    $this->transport = $transport;
+    $this->driver = $driver;
+  }
+
+  /**
+   * Send an email, matching the FilteredPearMailer::send() signature.
+   *
+   * @param string|array $recipients
+   * @param array $headers
+   * @param string $body
+   * @param array $originalValues
+   *   Structured data from CRM_Utils_Mail::send() (html, text, attachments, bcc).
+   * @return true
+   * @throws \Exception
+   */
+  public function send($recipients, $headers, $body, array $originalValues = []) {
+    if ($this->logIfNeeded($recipients, $headers, $body)) {
+      return TRUE;
+    }
+
+    try {
+      if (!empty($originalValues['html']) || !empty($originalValues['text'])) {
+        $email = MailParamsConverter::fromOriginalValues($headers, $originalValues);
+      }
+      else {
+        // Degraded path: raw MIME body from Mail_mime (when FlexSender is not active).
+        $rawMessage = '';
+        foreach ($headers as $key => $value) {
+          $rawMessage .= "$key: $value\r\n";
+        }
+        $rawMessage .= "\r\n" . $body;
+        $email = new \Symfony\Component\Mime\RawMessage($rawMessage);
+      }
+      $this->transport->send($email);
+    }
+    catch (TransportExceptionInterface $e) {
+      throw new \Exception($e->getMessage(), (int) $e->getCode(), $e);
+    }
+
+    return TRUE;
+  }
+
+  public function disconnect(): bool {
+    if ($this->transport instanceof EsmtpTransport) {
+      $this->transport->stop();
+    }
+    return TRUE;
+  }
+
+  public function getDriver(): string {
+    return $this->driver;
+  }
+
+  public function getTransport(): TransportInterface {
+    return $this->transport;
+  }
+
+  private function logIfNeeded($recipients, $headers, $body): bool {
+    if (!defined('CIVICRM_MAIL_LOG')) {
+      return FALSE;
+    }
+    \CRM_Utils_Mail_Logger::filter($this, $recipients, $headers, $body);
+    return !defined('CIVICRM_MAIL_LOG_AND_SEND');
+  }
+
+}

--- a/ext/symfony_mailer/Civi/SymfonyMailer/TransportFactory.php
+++ b/ext/symfony_mailer/Civi/SymfonyMailer/TransportFactory.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\SymfonyMailer;
+
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+
+class TransportFactory {
+
+  /**
+   * Build a Symfony transport from CiviCRM's mailing_backend settings.
+   *
+   * @return \Symfony\Component\Mailer\Transport\TransportInterface|null
+   *   NULL when the outbound option is spool/mock (not a real transport).
+   */
+  public static function createFromSettings(): ?TransportInterface {
+    $settings = \Civi::settings()->get('mailing_backend');
+    $option = (int) $settings['outBound_option'];
+
+    return match ($option) {
+      \CRM_Mailing_Config::OUTBOUND_OPTION_SMTP => self::createSmtp($settings),
+      \CRM_Mailing_Config::OUTBOUND_OPTION_SENDMAIL => self::createSendmail($settings),
+      \CRM_Mailing_Config::OUTBOUND_OPTION_MAIL => Transport::fromDsn('native://default'),
+      default => NULL,
+    };
+  }
+
+  private static function createSmtp(array $settings): EsmtpTransport {
+    $host = $settings['smtpServer'] ?: 'localhost';
+    $port = (int) ($settings['smtpPort'] ?: 25);
+    $tls = ($port === 465);
+
+    $transport = new EsmtpTransport($host, $port, $tls);
+    $transport->setTimeout(30);
+
+    if (!empty($settings['smtpAuth'])) {
+      $transport->setUsername($settings['smtpUsername']);
+      $password = \Civi::service('crypto.token')->decrypt($settings['smtpPassword']);
+      $transport->setPassword($password);
+    }
+
+    $localhost = $_SERVER['SERVER_NAME']
+      ?? parse_url(CIVICRM_UF_BASEURL)['host']
+      ?? 'localhost';
+    $transport->setLocalDomain($localhost);
+
+    return $transport;
+  }
+
+  private static function createSendmail(array $settings): SendmailTransport {
+    $command = ($settings['sendmail_path'] ?? '/usr/sbin/sendmail')
+      . ' ' . ($settings['sendmail_args'] ?? '-bs');
+    return new SendmailTransport($command);
+  }
+
+}

--- a/ext/symfony_mailer/composer.json
+++ b/ext/symfony_mailer/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "civicrm/symfony-mailer",
+  "description": "Symfony Mailer transport for CiviCRM",
+  "license": "AGPL-3.0-or-later",
+  "require": {
+    "symfony/mailer": "~6.4 || ~7.0"
+  }
+}

--- a/ext/symfony_mailer/info.xml
+++ b/ext/symfony_mailer/info.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<extension key="symfony_mailer" type="module">
+  <file>symfony_mailer</file>
+  <name>Symfony Mailer</name>
+  <description>Replaces PEAR Mail with Symfony Mailer for outbound email delivery</description>
+  <license>AGPL-3.0</license>
+  <maintainer>
+    <author>CiviCRM</author>
+    <email>info@civicrm.org</email>
+  </maintainer>
+  <urls>
+    <url desc="Chat">https://chat.civicrm.org/civicrm/channels/dev</url>
+    <url desc="Issues">https://lab.civicrm.org/dev/core/-/issues</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
+  <develStage>alpha</develStage>
+  <compatibility>
+    <ver>[civicrm.majorVersion]</ver>
+  </compatibility>
+  <php_compatibility>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <requires>
+    <ext>org.civicrm.flexmailer</ext>
+  </requires>
+  <classloader>
+    <psr4 prefix="Civi\SymfonyMailer\" path="Civi/SymfonyMailer"/>
+  </classloader>
+  <mixins>
+    <mixin>scan-classes@1.0.0</mixin>
+  </mixins>
+  <civix>
+    <namespace>CRM/SymfonyMailer</namespace>
+    <format>25.10.2</format>
+  </civix>
+</extension>

--- a/ext/symfony_mailer/symfony_mailer.php
+++ b/ext/symfony_mailer/symfony_mailer.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\FlexMailer\FlexMailer as FM;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Implements hook_civicrm_alterMailer().
+ *
+ * Replace the PEAR Mail transport with a Symfony Mailer adapter.
+ */
+function symfony_mailer_civicrm_alterMailer(&$mailer, string $driver, array $params): void {
+  if (in_array($driver, ['CRM_Mailing_BAO_Spool', 'mock'], TRUE)) {
+    return;
+  }
+  try {
+    $transport = \Civi\SymfonyMailer\TransportFactory::createFromSettings();
+    if ($transport === NULL) {
+      return;
+    }
+    $mailer = new \Civi\SymfonyMailer\SymfonyMailerAdapter($transport, $driver);
+  }
+  catch (\Exception $e) {
+    \Civi::log()->error('symfony_mailer: failed to initialize transport: ' . $e->getMessage());
+  }
+}
+
+/**
+ * Implements hook_civicrm_container().
+ *
+ * Register the FlexMailer send listener that bypasses Mail_mime.
+ */
+function symfony_mailer_civicrm_container(ContainerBuilder $container): void {
+  $container->register('civi_symfony_mailer_flex_sender', 'Civi\SymfonyMailer\FlexSender')
+    ->setPublic(TRUE);
+  $container->findDefinition('dispatcher')->addMethodCall(
+    'addListenerService',
+    [FM::EVENT_SEND, ['civi_symfony_mailer_flex_sender', 'onSend'], -1000]
+  );
+}


### PR DESCRIPTION
## Overview

New opt-in core extension (`ext/symfony_mailer/`) that replaces PEAR Mail with [Symfony Mailer](https://symfony.com/doc/current/mailer.html) for outbound email delivery. This is the first step toward removing the legacy PEAR Mail dependency from CiviCRM core (ref: [dev/core#2159](https://lab.civicrm.org/dev/core/-/issues/2159)).

The extension builds on the `$originalValues` integration point added in PR #31842.

## Before

All outbound email uses PEAR `Mail_smtp`/`Mail_sendmail`/`Mail_mail` for transport and `Mail_mime` for MIME message construction. These packages are in minimal-maintenance mode:

- `pear/mail` v2.0 — last release Jan 2024
- `pear/mail_mime` v1.10 — README warns "unmaintained"
- `pear/net_smtp` v1.12 — last release Jan 2022

CiviCRM patches all three via composer-patches for RFC compliance. Error handling uses `PEAR_Error` return values instead of exceptions. FlexMailer's `DefaultSender` creates `Mail_mime` objects per email, contributing to memory overhead in bulk sends.

## After

When enabled, the extension replaces PEAR at two levels:

**Single emails** (`CRM_Utils_Mail::send()`): A `SymfonyMailerAdapter` wraps a Symfony transport behind the existing `send($recipients, $headers, $body)` interface. It reconstructs `Symfony\Component\Mime\Email` objects from the `$originalValues` data (html, text, attachments, bcc) rather than re-parsing the pre-rendered MIME body.

**Bulk emails** (FlexMailer): A `FlexSender` listener on `civi.flexmailer.send` (priority -1000, ahead of DefaultSender at -2000) bypasses `Mail_mime` entirely. It builds `Symfony\Component\Mime\Email` objects directly from `FlexMailerTask::getMailParams()` and sends via the Symfony transport.

When the extension is **disabled**, PEAR Mail continues unchanged — zero behavioral impact.

## What Symfony Mailer brings

- **Active maintenance**: Symfony Mailer is the industry standard PHP mail library, actively maintained by the Symfony project with regular releases
- **Native SMTP connection persistence**: `EsmtpTransport` keeps connections open across `send()` calls by default — no `'persist' => TRUE` workaround
- **Exception-based error handling**: Replaces `PEAR_Error` return values with typed `TransportExceptionInterface` exceptions
- **Built-in failover**: Architecture supports `FailoverTransport` for multiple SMTP servers (future enhancement)
- **Modern MIME construction**: `Symfony\Component\Mime\Email` has no static state or cached encoding tables — lighter per-message memory footprint than `Mail_mime`
- **RFC 5322 compliance**: Native `\r\n` line endings, proper header encoding, header injection protection
- **TLS/STARTTLS negotiation**: Automatic TLS handling based on port — no manual configuration
- **Ecosystem alignment**: Matches what Laravel, Drupal, TYPO3, and most modern PHP frameworks use

## Technical Details

### Extension structure

```
ext/symfony_mailer/
├── info.xml                           # Extension metadata
├── composer.json                      # Requires symfony/mailer ~6.4 || ~7.0
├── symfony_mailer.php                 # Hook implementations
└── Civi/SymfonyMailer/
    ├── TransportFactory.php           # Builds transport from mailing_backend settings
    ├── SymfonyMailerAdapter.php        # Wraps transport behind FilteredPearMailer interface
    ├── MailParamsConverter.php         # Converts mailParams/originalValues → Symfony Email
    └── FlexSender.php                 # FlexMailer send listener (bypasses Mail_mime)
```

### Hook integration

- `hook_civicrm_alterMailer`: Replaces `$mailer` with `SymfonyMailerAdapter`. Skips spool and mock drivers.
- `hook_civicrm_container`: Registers `FlexSender` as a `civi.flexmailer.send` listener at priority -1000.

### Compatibility

- `pickDefaultEol()`: The adapter exposes `public $sep = "\r\n"` for backward compatibility.
- `CIVICRM_MAIL_LOG`: Handled by calling `CRM_Utils_Mail_Logger::filter()` from the adapter.
- `$mailer->disconnect()`: Mapped to `EsmtpTransport::stop()`.

## Comments

This follows the same adoption path as FlexMailer itself: ship as an opt-in extension in `ext/`, let sites enable it when ready, then make it default in a future release.

Related work:
- [dev/core#2159](https://lab.civicrm.org/dev/core/-/issues/2159) — Proposal to replace PEAR mailer classes
- PR #31842 — Added `$originalValues` support for alternate mailers
- [eileenmcnaughton/symfony_mailer](https://github.com/eileenmcnaughton/symfony_mailer) — Earlier proof-of-concept