### PR TITLE
Don't load export preview data unnecessarily

### DIFF
--- a/CRM/Export/Form/Map.php
+++ b/CRM/Export/Form/Map.php
@@ -53,11 +53,17 @@ class CRM_Export_Form_Map extends CRM_Core_Form {
     $mappingTypeId = $this->get('mappingTypeId');
     $mappings = civicrm_api3('Mapping', 'get', ['return' => ['name', 'description'], 'mapping_type_id' => $mappingTypeId, 'options' => ['limit' => 0]]);
 
+    // No need to generate preview data if we're going back to step 2 or actually downloading the file.
+    $previewData = [];
+    if ($this->_flagSubmitted === FALSE) {
+      $previewData = $this->getPreviewData();
+    }
+
     Civi::resources()->addVars('exportUi', [
       'fields' => CRM_Export_Utils::getExportFields($this->get('exportMode')),
       'contact_types' => array_values($contactTypes),
       'location_type_id' => CRM_Utils_Array::makeNonAssociative(CRM_Core_BAO_Address::buildOptions('location_type_id'), 'id', 'text'),
-      'preview_data' => $this->getPreviewData(),
+      'preview_data' => $previewData,
       'mapping_id' => $this->_mappingId,
       'mapping_description' => $mappings['values'][$this->_mappingId]['description'] ?? '',
       'mapping_type_id' => $mappingTypeId,


### PR DESCRIPTION
Overview
----------------------------------------
While troubleshooting a bigger issue, I realized that the export preview data is loaded (which appears export step 3, "Select Fields to Export") gets built any time you go back to step 2, or download the CSV.  That can be a pretty heavy query, so let's not.

To replicate - fire up XDebug, place a breakpoint on `CRM_Export_BAO_ExportProcessor::getPreviewData()`. Do an export, and also go back to step 2.

Before
----------------------------------------
Preview is built when entering and leaving step 3, including downloading the CSV.

After
----------------------------------------
Preview data is built no more often than necessary.