### PR TITLE
Fix exporting primary and non-primary location fields when search includes location type.

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -1268,13 +1268,7 @@ class CRM_Contact_BAO_Query {
                 case 'civicrm_im':
                 case 'civicrm_openid':
 
-                  $this->_tables[$tName] = "\nLEFT JOIN $tableName `$tName` ON contact_a.id = `$tName`.contact_id";
-                  if ($tableName != 'civicrm_phone') {
-                    $this->_tables[$tName] .= " AND `$tName`.$lCond";
-                  }
-                  elseif (is_numeric($name)) {
-                    $this->_select[$tName] = "IF (`$tName`.is_primary = $name, `$tName`.phone, NULL) as `$tName`";
-                  }
+                  $this->_tables[$tName] = "\nLEFT JOIN $tableName `$tName` ON contact_a.id = `$tName`.contact_id AND `$tName`.$lCond";
 
                   // this special case to add phone type
                   if ($cond) {

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -782,11 +782,7 @@ class CRM_Export_BAO_ExportProcessor {
     $returnProperties = $this->getReturnProperties();
     $params = array_merge($params, $this->getWhereParams());
 
-    $query = new CRM_Contact_BAO_Query($params, $returnProperties, NULL,
-      FALSE, FALSE, $this->getQueryMode(),
-      FALSE, TRUE, TRUE, NULL, $this->getQueryOperator(),
-      NULL, TRUE
-    );
+    [$query, $usePrimaryAlias] = $this->buildExportQuery($params, $returnProperties);
 
     //sort by state
     //CRM-15301
@@ -809,15 +805,16 @@ class CRM_Export_BAO_ExportProcessor {
     }
 
     if ($this->isPostalableOnly) {
+      $addrTable = $usePrimaryAlias ? '`1-address`' : 'civicrm_address';
       if (array_key_exists('street_address', $returnProperties)) {
-        $addressWhere = " civicrm_address.street_address <> ''";
+        $addressWhere = " {$addrTable}.street_address <> ''";
         if (array_key_exists('supplemental_address_1', $returnProperties)) {
           // We need this to be an OR rather than AND on the street_address so, hack it in.
           $addressOptions = CRM_Core_BAO_Setting::valueOptions(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME,
             'address_options', TRUE, NULL, TRUE
           );
           if (!empty($addressOptions['supplemental_address_1'])) {
-            $addressWhere .= " OR civicrm_address.supplemental_address_1 <> ''";
+            $addressWhere .= " OR {$addrTable}.supplemental_address_1 <> ''";
           }
         }
         $whereClauses['address'] = '(' . $addressWhere . ')';
@@ -2473,6 +2470,104 @@ LEFT JOIN civicrm_option_value contribution_status ON (civicrm_contribution.cont
     }
 
     return $paymentDetails;
+  }
+
+  /**
+   * $returnProperties places fields that can have a location type in
+   * a second-level array - unless they're primary fields, then they
+   * remain at the top level. That's fine so long as CRM_Contact_BAO_Query::_primaryLocation
+   * remains with its TRUE default. But if in Advanced Search a user specifies a location type,
+   * primaryLocation is set to FALSE, the join doesn't filter on `is_primary`, and we get incorrect data.
+   * To avoid this, we move all location-having fields into a location[1] entry so they get
+   * explicit is_primary = 1 in their joins.
+   *
+   * This breaks the mapping when we return to runQuery(), so we also have to remap our query
+   * results back to the original fields.
+   *
+   * @return array [CRM_Contact_BAO_Query $query, bool $usePrimaryAlias]
+   */
+  private function buildExportQuery(array $params, array $returnProperties): array {
+    $queryReturnProperties = $returnProperties;
+    $usePrimaryAlias = FALSE;
+    $locationFieldNames = array_diff(
+      CRM_Contact_BAO_Query::$_locationSpecificFields,
+      ['location_type']
+    );
+    foreach ($locationFieldNames as $field) {
+      if (isset($returnProperties[$field])) {
+        $queryReturnProperties['location'][1][$field] = $returnProperties[$field];
+        unset($queryReturnProperties[$field]);
+        $usePrimaryAlias = TRUE;
+      }
+    }
+
+    $query = new CRM_Contact_BAO_Query($params, $queryReturnProperties, NULL,
+      FALSE, FALSE, $this->getQueryMode(),
+      FALSE, TRUE, TRUE, NULL, $this->getQueryOperator(),
+      NULL, TRUE
+    );
+
+    if ($usePrimaryAlias) {
+      $this->remapPrimaryLocationQueryFields($query);
+    }
+
+    return [$query, $usePrimaryAlias];
+  }
+
+  /**
+   * If we remapped field names in buildExportQuery(), we undo that
+   * so the query matches the expected structure.
+   *
+   * @param CRM_Contact_BAO_Query $query
+   */
+  private function remapPrimaryLocationQueryFields(CRM_Contact_BAO_Query $query): void {
+    // addHierarchicalElements unconditionally adds a location_type JOIN
+    // and SELECT for every location index. For our synthetic location[1]
+    // (primary), this JOIN causes duplicate rows when primary phone and
+    // primary address have different location types. Remove it.
+    unset($query->_select['1-location_type_id'], $query->_select['1-location_type']);
+    unset($query->_element['1-location_type_id'], $query->_element['1-location_type']);
+    unset($query->_tables['1-location_type']);
+    unset($query->_whereTables['1-location_type']);
+    // _fromClause was already built from _tables during construction,
+    // so we must rebuild it after modifying _tables.
+    $query->_fromClause = CRM_Contact_BAO_Query::fromClause(
+      $query->_tables, NULL, NULL,
+      $query->_primaryLocation, $query->_mode, NULL, $query->_onlyDeleted
+    );
+
+    foreach (array_keys($query->_select) as $key) {
+      if (str_starts_with($key, '1-')) {
+        $newKey = substr($key, 2);
+        $query->_select[$newKey] = str_replace("as `$key`", "as `$newKey`", $query->_select[$key]);
+        unset($query->_select[$key]);
+      }
+    }
+
+    foreach (array_keys($query->_element) as $key) {
+      if (str_starts_with($key, '1-')) {
+        $newKey = substr($key, 2);
+        $query->_element[$newKey] = $query->_element[$key];
+        unset($query->_element[$key]);
+      }
+    }
+
+    // This is necessary for state, country etc.
+    foreach (array_keys($query->_pseudoConstantsSelect) as $key) {
+      if (!str_starts_with($key, '1-')) {
+        continue;
+      }
+      $entry = $query->_pseudoConstantsSelect[$key];
+      $newKey = substr($key, 2);
+      if (isset($entry['idCol']) && str_starts_with($entry['idCol'], '1-')) {
+        $entry['idCol'] = substr($entry['idCol'], 2);
+      }
+      if (isset($entry['element']) && str_starts_with($entry['element'], '1-')) {
+        $entry['element'] = substr($entry['element'], 2);
+      }
+      $query->_pseudoConstantsSelect[$newKey] = $entry;
+      unset($query->_pseudoConstantsSelect[$key]);
+    }
   }
 
 }

--- a/tests/phpunit/CRM/Contact/BAO/QueryTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/QueryTest.php
@@ -486,6 +486,55 @@ class CRM_Contact_BAO_QueryTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that phone at Primary and phone at a named location return
+   * distinct values (the primary phone should not bleed into the
+   * location-specific column).
+   *
+   * Regression test for CRM-14585.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPhoneAtMultipleLocationsReturnsDistinctValues(): void {
+    $contactID = $this->individualCreate();
+
+    $this->callAPISuccess('Phone', 'create', [
+      'contact_id' => $contactID,
+      'location_type_id' => 'Home',
+      'phone' => '111-PRIMARY',
+      'phone_type_id' => 1,
+      'is_primary' => 1,
+    ]);
+
+    $this->callAPISuccess('Phone', 'create', [
+      'contact_id' => $contactID,
+      'location_type_id' => 'Work',
+      'phone' => '222-WORK',
+      'phone_type_id' => 1,
+      'is_primary' => 0,
+    ]);
+
+    $returnProperties = [
+      'sort_name' => 1,
+      'location' => [
+        1 => ['phone-1' => 1],
+        'Work' => ['phone-1' => 1],
+      ],
+    ];
+
+    $queryObj = new CRM_Contact_BAO_Query(
+      [['contact_id', '=', $contactID, 0, 0]],
+      $returnProperties
+    );
+    [$select, $from, $where] = $queryObj->query();
+    $dao = CRM_Core_DAO::executeQuery("$select $from $where");
+    $this->assertTrue($dao->fetch());
+
+    $this->assertEquals('111-PRIMARY', $dao->{'1-phone-1'}, 'Primary phone should show primary number');
+    $this->assertNotEquals('111-PRIMARY', $dao->{'Work-phone-1'}, 'Work phone should not show primary number');
+    $this->assertEquals('222-WORK', $dao->{'Work-phone-1'}, 'Work phone should show work number');
+  }
+
+  /**
    * Check that we get a successful result querying for home address.
    * CRM-14263 search builder failure with search profile & address in criteria
    *

--- a/tests/phpunit/CRM/Export/BAO/ExportProcessorTest.php
+++ b/tests/phpunit/CRM/Export/BAO/ExportProcessorTest.php
@@ -1,0 +1,322 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Export_BAO_ExportProcessorTest extends CiviUnitTestCase {
+
+  /**
+   * @var \CRM_Export_BAO_ExportProcessor
+   */
+  protected $processor;
+
+  /**
+   * @var \League\Csv\Reader
+   */
+  protected $csv;
+
+  protected $contactID;
+
+  protected $locationTypeID;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->locationTypeID = $this->locationTypeCreate([
+      'name' => 'Secondary',
+      'display_name' => 'Secondary',
+    ]);
+    $this->contactID = $this->individualCreate();
+  }
+
+  public function tearDown(): void {
+    $this->quickCleanup([
+      'civicrm_contact',
+      'civicrm_email',
+      'civicrm_phone',
+      'civicrm_address',
+    ]);
+    if ($this->processor && $this->processor->getTemporaryTable()) {
+      CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS ' . $this->processor->getTemporaryTable());
+    }
+    if ($this->locationTypeID) {
+      $this->locationTypeDelete($this->locationTypeID);
+    }
+    parent::tearDown();
+  }
+
+  /**
+   * Test that top-level address fields (including pseudoconstants like
+   * state_province/country) export primary address data even when a
+   * location-type WHERE filter disables _primaryLocation on the query.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
+   */
+  public function testTopLevelAddressFieldsUsePrimaryWhenLocationFilterPresent(): void {
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => 'Home',
+      'street_address' => '123 Primary St',
+      'city' => 'Primary City',
+      'postal_code' => '11111',
+      'state_province_id' => 1004,
+      'country_id' => 1228,
+      'is_primary' => 1,
+    ]);
+
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => $this->locationTypeID,
+      'street_address' => '456 Secondary Ave',
+      'city' => 'Secondary City',
+      'postal_code' => '22222',
+      'state_province_id' => 1021,
+      'country_id' => 1228,
+      'is_primary' => 0,
+    ]);
+
+    $selectedFields = [
+      ['contact_type' => 'Individual', 'name' => 'street_address'],
+      ['contact_type' => 'Individual', 'name' => 'city'],
+      ['contact_type' => 'Individual', 'name' => 'postal_code'],
+      ['contact_type' => 'Individual', 'name' => 'state_province'],
+      ['contact_type' => 'Individual', 'name' => 'country'],
+      ['contact_type' => 'Individual', 'name' => 'street_address', 'location_type_id' => $this->locationTypeID],
+      ['contact_type' => 'Individual', 'name' => 'city', 'location_type_id' => $this->locationTypeID],
+      ['contact_type' => 'Individual', 'name' => 'postal_code', 'location_type_id' => $this->locationTypeID],
+      ['contact_type' => 'Individual', 'name' => 'state_province', 'location_type_id' => $this->locationTypeID],
+    ];
+
+    $this->doExportTest([
+      'fields' => $selectedFields,
+      'params' => [['location_type', '=', [$this->locationTypeID], 0, 0]],
+    ]);
+
+    $row = $this->csv->nth(0);
+    $this->assertEquals('123 Primary St', $row['Street Address']);
+    $this->assertEquals('Primary City', $row['City']);
+    $this->assertEquals('11111', $row['Postal Code']);
+    $this->assertEquals('CA', $row['State']);
+    $this->assertEquals('United States', $row['Country']);
+    $this->assertEquals('456 Secondary Ave', $row['Secondary-Street Address']);
+    $this->assertEquals('Secondary City', $row['Secondary-City']);
+    $this->assertEquals('22222', $row['Secondary-Postal Code']);
+    $this->assertEquals('MI', $row['Secondary-State']);
+  }
+
+  /**
+   * Test that top-level email fields export primary email data even when
+   * a location-type WHERE filter disables _primaryLocation on the query.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
+   */
+  public function testTopLevelEmailFieldUsePrimaryWhenLocationFilterPresent(): void {
+    // Address at the secondary location type is needed so the
+    // location_type WHERE filter matches this contact.
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => $this->locationTypeID,
+      'street_address' => '1 Test St',
+      'is_primary' => 0,
+    ]);
+
+    $this->callAPISuccess('Email', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => 'Home',
+      'email' => 'primary@example.com',
+      'is_primary' => 1,
+    ]);
+
+    $this->callAPISuccess('Email', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => $this->locationTypeID,
+      'email' => 'secondary@example.com',
+      'is_primary' => 0,
+    ]);
+
+    $selectedFields = [
+      ['contact_type' => 'Individual', 'name' => 'email'],
+      ['contact_type' => 'Individual', 'name' => 'email', 'location_type_id' => $this->locationTypeID],
+    ];
+
+    $this->doExportTest([
+      'fields' => $selectedFields,
+      'params' => [['location_type', '=', [$this->locationTypeID], 0, 0]],
+    ]);
+
+    $row = $this->csv->nth(0);
+    $this->assertEquals('primary@example.com', $row['Email']);
+    $this->assertEquals('secondary@example.com', $row['Secondary-Email']);
+  }
+
+  /**
+   * Test that the primary phone JOIN includes is_primary = 1 when
+   * a location type filter moves phone into addHierarchicalElements.
+   *
+   * Without this fix, the phone JOIN is unfiltered, producing
+   * duplicate rows for contacts with multiple phones.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testTopLevelPhoneFieldUsePrimaryWhenLocationFilterPresent(): void {
+    $selectedFields = [
+      ['contact_type' => 'Individual', 'name' => 'phone'],
+    ];
+    $processor = $this->createExportProcessor($selectedFields, [['location_type', '=', [$this->locationTypeID], 0, 0]]);
+    [, $queryString] = $processor->runQuery([], '');
+    $this->assertMatchesRegularExpression(
+      '/LEFT JOIN civicrm_phone.*is_primary = 1/',
+      $queryString,
+      'Phone JOIN should filter on is_primary'
+    );
+  }
+
+  /**
+   * Test that exporting primary phone + primary address doesn't produce
+   * duplicate rows when they have different location types.
+   *
+   * addHierarchicalElements creates a location_type JOIN with OR conditions
+   * for both phone and address. When those have different location_type_ids,
+   * the JOIN matches multiple location_type rows, duplicating the contact.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
+   */
+  public function testNoDuplicateRowsWhenPrimaryPhoneAndAddressHaveDifferentLocationTypes(): void {
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => 'Work',
+      'street_address' => '100 Work St',
+      'is_primary' => 1,
+    ]);
+
+    $this->callAPISuccess('Phone', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => 'Home',
+      'phone' => '555-1234',
+      'is_primary' => 1,
+    ]);
+
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => $this->locationTypeID,
+      'street_address' => '200 Secondary Ave',
+      'is_primary' => 0,
+    ]);
+
+    $selectedFields = [
+      ['contact_type' => 'Individual', 'name' => 'street_address'],
+      ['contact_type' => 'Individual', 'name' => 'phone'],
+      ['contact_type' => 'Individual', 'name' => 'street_address', 'location_type_id' => $this->locationTypeID],
+    ];
+
+    $this->doExportTest([
+      'fields' => $selectedFields,
+      'params' => [['location_type', '=', [$this->locationTypeID], 0, 0]],
+    ]);
+
+    $this->assertCount(1, $this->csv);
+    $row = $this->csv->nth(0);
+    $this->assertEquals('100 Work St', $row['Street Address']);
+    $this->assertEquals('555-1234', $row['Phone']);
+    $this->assertEquals('200 Secondary Ave', $row['Secondary-Street Address']);
+  }
+
+  /**
+   * Test that top-level address fields still work correctly when no
+   * location-specific fields are requested (regression check).
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \League\Csv\Exception
+   */
+  public function testTopLevelAddressFieldsAloneStillWork(): void {
+    $this->callAPISuccess('Address', 'create', [
+      'contact_id' => $this->contactID,
+      'location_type_id' => 'Home',
+      'street_address' => '789 Only St',
+      'city' => 'Only City',
+      'is_primary' => 1,
+    ]);
+
+    $selectedFields = [
+      ['contact_type' => 'Individual', 'name' => 'street_address'],
+      ['contact_type' => 'Individual', 'name' => 'city'],
+    ];
+
+    $this->doExportTest(['fields' => $selectedFields]);
+
+    $row = $this->csv->nth(0);
+    $this->assertEquals('789 Only St', $row['Street Address']);
+    $this->assertEquals('Only City', $row['City']);
+  }
+
+  /**
+   * Run the export and capture CSV output.
+   *
+   * @param array $params
+   *
+   * @throws \CRM_Core_Exception
+   */
+  protected function doExportTest(array $params): void {
+    $fields = $params['fields'] ?? [];
+    $fieldDefaults = ['contact_type' => 'Individual', 'phone_type_id' => NULL, 'location_type_id' => NULL];
+    foreach ($fields as $key => $field) {
+      $fields[$key] = array_merge($fieldDefaults, $field);
+    }
+    $this->startCapturingOutput();
+    try {
+      $ids = $params['ids'] ?? [$this->contactID];
+      $defaultClause = empty($ids) ? NULL : 'contact_a.id IN (' . implode(',', $ids) . ')';
+      CRM_Export_BAO_Export::exportComponents(
+        $params['selectAll'] ?? !$fields,
+        $ids,
+        $params['params'] ?? [],
+        $params['order'] ?? NULL,
+        $fields,
+        NULL,
+        CRM_Export_Form_Select::CONTACT_EXPORT,
+        $params['componentClause'] ?? $defaultClause,
+        NULL,
+        FALSE,
+        FALSE,
+        []
+      );
+    }
+    catch (CRM_Core_Exception_PrematureExitException $e) {
+      $this->processor = $e->errorData['processor'];
+      $this->csv = $this->captureOutputToCSV();
+      return;
+    }
+    $this->fail('We expected a premature exit exception');
+  }
+
+  /**
+   * Create an ExportProcessor with the given fields and params.
+   *
+   * @param array $selectedFields
+   * @param array $params
+   *
+   * @return \CRM_Export_BAO_ExportProcessor
+   */
+  protected function createExportProcessor(array $selectedFields, array $params = []): CRM_Export_BAO_ExportProcessor {
+    $fieldDefaults = ['contact_type' => 'Individual', 'phone_type_id' => NULL, 'location_type_id' => NULL];
+    foreach ($selectedFields as $key => $field) {
+      $selectedFields[$key] = array_merge($fieldDefaults, $field);
+    }
+    $processor = new CRM_Export_BAO_ExportProcessor(
+      CRM_Export_Form_Select::CONTACT_EXPORT,
+      $selectedFields,
+      'AND',
+      FALSE,
+      FALSE,
+      FALSE,
+      []
+    );
+    $ids = [$this->contactID];
+    $processor->setComponentClause('contact_a.id IN (' . implode(',', $ids) . ')');
+    $processor->setIds($ids);
+    return $processor;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This is a variation of core#464 and core#1725.  When filtering Advanced Search by a location type, an export can return incorrect data for location-having fields (address, email, phone).

To replicate:
* Have a contact with two addresses.  First add one with location type "Other", then add one with location type "Home".  Set "Home" as primary.
* In Advanced Search, use "Address Location" to filter on contacts with a location type of "Other". 
* Export your contact.  Select both "Street Adress - Primary" and "Street Address - Other" as fields.
* In the CSV, the primary address will be replaced by the Other address.

Before
----------------------------------------
Incorrect data exported.

After
----------------------------------------
Correct data exported.

Technical Details
----------------------------------------
The export processor builds the `$returnProperties` with primary location-having fields at the top level of the array, and fields with a location type specified in a second-level array.  When building the query in `CRM_Contact_BAO_Query`,  `_primaryLocation` defaults to `TRUE`, and the join that handles top-level fields includes `AND is_primary = 1` as a result.

However - if the Advanced Search specifies a location type, then `_primaryLocation` gets set to `FALSE`, the join doesn't filter on `is_primary`, and you get incorrect results.

To handle this, we wrap instantiating the query in a helper function.  It places primary fields in a second-level array before building the query, forcing them to have `is_primary = 1`.  Once the query is returned, we undo the remapping everywhere it matters.

Comments
----------------------------------------
Would this have been easier to do in `CRM_Contact_BAO_Query`?  Maybe, but a) that's a lot riskier, b) it's a lot harder if Eileen chops off my head for touching `primaryLocationOnly`.  This limits the fix to the only place it matters.

AI disclosure - Claude wrote 90% of the test file.