### PR TITLE
SearchKit - Fix defaults for tally setting

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -181,6 +181,9 @@ class Run extends AbstractRunAction {
         $select[] = $sqlFnClass::renderExpression(implode(' ', $fnArgs)) . " `$tallyKey`";
       }
     }
+    if (!$select) {
+      return [];
+    }
     $query = 'SELECT ' . implode(', ', $select) . "\nFROM (" . $sql . ")\n`api_query`";
     $dao = \CRM_Core_DAO::executeQuery($query);
     $dao->fetch();

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -59,6 +59,9 @@
         // and populate or validate this.settings.columns
         if (value !== 'auto') {
           this.parent.initColumns({label: true, sortable: true});
+          if (this.display.settings.tally) {
+            this.setTallyDefaults();
+          }
         }
         this.display.settings.columnMode = value;
       };
@@ -93,20 +96,24 @@
         }
       };
 
-      this.toggleTally = function() {
-        if (ctrl.display.settings.tally) {
-          delete ctrl.display.settings.tally;
-          ctrl.display.settings.columns.forEach((col) => delete col.tally);
+      this.toggleTally = () => {
+        if (this.display.settings.tally) {
+          delete this.display.settings.tally;
+          this.display.settings.columns.forEach((col) => delete col.tally);
         } else {
-          ctrl.display.settings.tally = {label: ts('Total')};
-          ctrl.display.settings.columns.forEach(function(col) {
-            if (col.type === 'field') {
-              col.tally = {
-                fn: searchMeta.getDefaultAggregateFn(searchMeta.parseExpr(ctrl.parent.getExprFromSelect(col.key)), ctrl.apiParams)
-              };
-            }
-          });
+          this.display.settings.tally = {label: ts('Total')};
+          this.setTallyDefaults();
         }
+      };
+
+      this.setTallyDefaults = () => {
+        this.display.settings.columns?.forEach((col) => {
+          if (col.type === 'field') {
+            col.tally = {
+              fn: searchMeta.getDefaultAggregateFn(searchMeta.parseExpr(this.parent.getExprFromSelect(col.key)), this.apiParams)
+            };
+          }
+        });
       };
 
       this.getTallyFunctions = function() {


### PR DESCRIPTION


Overview
----------------------------------------
Fixes [dev/core#6420](https://lab.civicrm.org/dev/core/-/work_items/6420)

The new "column mode" setting gives tallies the appearance of being broken because the default columns do not have any tally settings. This fixes the error, and ensures defaults are set when switching column mode to "Custom" but the default columns still don't work with the tally – you need to use custom columns for that.