### PR TITLE
[dev/core#6317] Clean up residual plain-text message templates

### DIFF
--- a/CRM/Upgrade/Incremental/sql/6.15.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.15.alpha1.mysql.tpl
@@ -1,1 +1,9 @@
 {* file to handle db changes in 6.15.alpha1 during upgrade *}
+
+UPDATE `civicrm_msg_template` t1 INNER JOIN `civicrm_msg_template` t2 SET t1.`msg_text` = ''
+WHERE (t1.`is_reserved` = 0) 
+    AND (t2.`is_reserved` = 1)
+    AND (t1.`workflow_id` = t2.`workflow_id`)
+    AND (t1.`msg_text` = t2.`msg_text`)
+    AND (t1.`msg_text` <> '');
+UPDATE `civicrm_msg_template` SET `msg_text` = '' WHERE (`is_reserved` = 1) AND (`msg_text` <> '');


### PR DESCRIPTION
Overview
----------------------------------------
A proposed way to clean-up unwanted plain-text reserved message templates and their unedited copies. Fix for https://lab.civicrm.org/dev/core/-/work_items/6317

Before
----------------------------------------
Multiple warnings in CiviCRM status about removed or deprecated tokens in message templates. Although the HTML versions may be up to date, the plain-text versions (which have been removed) are not cleaned up by the upgrader.

After
----------------------------------------
This is a proposed one-time SQL query to clean up the old plain-text message templates.

Spurious warnings disappear.

Technical Details
----------------------------------------
This is probably in the wrong file (e.g. should be in 6.15.x) and probably not sophisticated enough, i.e. doesn't consider whether template is core vs non-core, as in `CRM_Upgrade_Incremental_MessageTemplates::updateReservedAndMaybeDefaultTemplates()`.

But it gets the ball rolling.

Comments
----------------------------------------
Actually tested by injecting into the upgrade for 6.13.1, but the SQL is the same.
