### PR TITLE
Performance Cache missing on hot paths in CiviCRM core causing excess…

### DIFF
--- a/CRM/Core/Module.php
+++ b/CRM/Core/Module.php
@@ -64,7 +64,7 @@ class CRM_Core_Module {
   public static function getAll($fresh = FALSE) {
     static $result;
     if ($fresh || !is_array($result)) {
-      $result = CRM_Extension_System::singleton()->getMapper()->getModules();
+      $result = CRM_Extension_System::singleton()->getMapper()->getModules($fresh);
       // pseudo-module for core
       $result[] = new CRM_Core_Module('civicrm', TRUE, ts('CiviCRM Core'));
 

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -488,15 +488,27 @@ class CRM_Extension_Mapper {
   /**
    * Get a list of all installed modules, including enabled and disabled ones
    *
+   * @param bool $fresh
+   *   Force new results?
+   *
    * @return CRM_Core_Module[]
    */
-  public function getModules() {
+  public function getModules($fresh = FALSE) {
+    if ($this->cache && !$fresh) {
+      $cached = $this->cache->get($this->cacheKey . '_modules');
+      if (is_array($cached)) {
+        return $cached;
+      }
+    }
     $result = [];
     $dao = new CRM_Core_DAO_Extension();
     $dao->type = 'module';
     $dao->find();
     while ($dao->fetch()) {
       $result[] = new CRM_Core_Module($dao->full_name, $dao->is_active, $dao->label);
+    }
+    if ($this->cache) {
+      $this->cache->set($this->cacheKey . '_modules', $result);
     }
     return $result;
   }
@@ -542,6 +554,7 @@ class CRM_Extension_Mapper {
     $this->infos = [];
     $this->moduleExtensions = NULL;
     if ($this->cache) {
+      $this->cache->delete($this->cacheKey . '_modules');
       $this->cache->delete($this->cacheKey . '_moduleFiles');
     }
     // FIXME: How can code so code wrong be so right?


### PR DESCRIPTION
Github Issue: https://lab.civicrm.org/dev/core/-/work_items/6451

## Overview

Two methods in CiviCRM core are called thousands of times per page load but query the database every call. This PR adds per-request static caching using `Civi::$statics`, the same pattern already used elsewhere in core (e.g., `CRM_Extension_Mapper::getActiveModuleFiles()`).

On a typical contact summary page with ~39 active extensions, `CRM_Extension_Mapper::getModules()` alone was executing `SELECT * FROM civicrm_extension WHERE type = 'module'` ~8,768 times per page — roughly 41% of all queries on a single page load.

## Before

Both methods hit the database on every call, with no per-request caching:

```php
// CRM/Extension/Mapper.php
public function getModules() {
    $result = [];
    $dao = new CRM_Core_DAO_Extension();
    $dao->type = 'module';
    $dao->find();
    while ($dao->fetch()) {
        $result[] = new CRM_Core_Module($dao->full_name, $dao->is_active, $dao->label);
    }
    return $result;
}

// Civi/Api4/Utils/CoreUtil.php
public static function getOptionValueFields(int|string $optionGroup, string $key = 'name'): array {
    return \CRM_Core_DAO_OptionGroup::getDbVal('option_value_fields', $optionGroup, $key)
        ?: ['name', 'label', 'description'];
}
```

Measured query count on a contact summary page: **~18,000 queries** total, of which ~8,700 were `civicrm_extension` lookups and ~700 were `option_value_fields` lookups for the same option group names.

## After

Both methods now use `Civi::$statics` for per-request caching:

```php
// CRM/Extension/Mapper.php
public function getModules() {
    if (isset(\Civi::$statics[__CLASS__]['modules'])) {
        return \Civi::$statics[__CLASS__]['modules'];
    }
    $result = [];
    $dao = new CRM_Core_DAO_Extension();
    $dao->type = 'module';
    $dao->find();
    while ($dao->fetch()) {
        $result[] = new CRM_Core_Module($dao->full_name, $dao->is_active, $dao->label);
    }
    \Civi::$statics[__CLASS__]['modules'] = $result;
    return $result;
}

// Civi/Api4/Utils/CoreUtil.php
public static function getOptionValueFields(int|string $optionGroup, string $key = 'name'): array {
    $cacheKey = $key . ':' . $optionGroup;
    if (isset(\Civi::$statics[__CLASS__]['optionValueFields'][$cacheKey])) {
        return \Civi::$statics[__CLASS__]['optionValueFields'][$cacheKey];
    }
    $result = \CRM_Core_DAO_OptionGroup::getDbVal('option_value_fields', $optionGroup, $key)
        ?: ['name', 'label', 'description'];
    \Civi::$statics[__CLASS__]['optionValueFields'][$cacheKey] = $result;
    return $result;
}
```

Reproduction / benchmark methodology:
1. Enable `CIVICRM_DEBUG_LOG_QUERY` in `civicrm.settings.php`
2. Load a single contact summary page (`civicrm/contact/view?cid=X`)
3. Count logged queries and group by normalized SQL pattern
