### PR TITLE
Fix add membership when civi_contribute is disabled

### DIFF
--- a/CRM/Member/BAO/MembershipPayment.php
+++ b/CRM/Member/BAO/MembershipPayment.php
@@ -111,6 +111,10 @@ class CRM_Member_BAO_MembershipPayment extends CRM_Member_DAO_MembershipPayment 
    * @internal
    */
   public static function getLatestContributionIDFromLineitemAndFallbackToMembershipPayment(int $membershipID) {
+    if (!class_exists('\Civi\Api4\LineItem')) {
+      // civi_contribute is not enabled
+      return NULL;
+    }
     $latestMembershipLineItem = LineItem::get(FALSE)
       ->addSelect('contribution_id')
       ->addWhere('entity_table', '=', 'civicrm_membership')


### PR DESCRIPTION
Overview
----------------------------------------
Following https://github.com/civicrm/civicrm-core/pull/35416 you can't create memberships is civi_contribute is disabled.

This fixes that.

Before
----------------------------------------
Can't create memberships

After
----------------------------------------
Can create memberships

Technical Details
----------------------------------------
Checks if class \Civi\Api4\LineItem exists before trying to use it.

Comments
----------------------------------------
@demeritcowboy 
