### PR TITLE
Theme Settings: puts css under advanced, adds clone icon, a few of css tidies

### DIFF
--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -526,6 +526,9 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 .crm-container .label-danger[href]:focus {
   background: color-mix(in srgb, var(--crm-danger-color) 87.5%, var(--crm-ink) 12.5%);
 }
+.crm-container span.label + span.label {
+  margin-left: var(--crm-flex-gap);
+}
 
 /* Background regions */
 

--- a/ext/riverlea/css/stream-list.css
+++ b/ext/riverlea/css/stream-list.css
@@ -4,10 +4,13 @@ civi-riverlea-stream-list ul {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(30rem, 1fr) );
   padding-left: 0;
-  gap: 1rem;
+  gap: var(--crm-padding-reg, 1rem);
   margin: 0;
+  list-style: none;
 }
-
+civi-riverlea-stream-list .civi-riverlea-stream-edit-dialog {
+  width: 100%;
+}
 civi-riverlea-stream-card {
   display: block;
 }
@@ -19,9 +22,6 @@ civi-riverlea-stream-card .panel-heading {
   justify-content: space-between;
   align-items: center;
 }
-civi-riverlea-stream-card .panel-heading .civi-riverlea-stream-header-tags > * {
-  margin: var(--crm-l-small);
-}
 civi-riverlea-stream-card .btn.btn-set-preview.btn-stream-selected {
   background-color: var(--crm-warning-color);
   color: var(--crm-warning-text-color);
@@ -29,13 +29,14 @@ civi-riverlea-stream-card .btn.btn-set-preview.btn-stream-selected {
 civi-riverlea-stream-card .civi-riverlea-stream-details code {
   display: inline-block;
 }
-
-civi-riverlea-stream-list .civi-riverlea-stream-edit-dialog {
-  width: 100%;
+civi-riverlea-stream-card .panel-heading .far {
+  padding-right: var(--crm-flex-gap);
 }
-
+civi-riverlea-stream-card .panel-heading:has(.btn-update) .fa-window-maximize:before {
+  content: "\f2d2";
+}
 civi-riverlea-stream-editor .civi-riverlea-stream-editor-preview-pane {
-  padding: 1rem;
+  padding: var(--crm-padding-reg);
 }
 civi-riverlea-stream-editor iframe {
   width: 100%;
@@ -55,19 +56,17 @@ civi-riverlea-stream-editor .civi-riverlea-stream-colors-header {
 civi-riverlea-stream-editor .civi-riverlea-stream-colors-header h3 {
   padding-left: 0;
 }
-
 civi-riverlea-stream-variable {
   display: flex;
   flex-flow: row;
   justify-content: space-between;
 }
-
 civi-riverlea-stream-variable input[type="color"] {
   width: 3rem;
 }
 civi-riverlea-stream-variable .input-group {
   display: flex;
   flex-flow: row nowrap;
-  gap: 0.5rem;
+  gap: var(--crm-flex-gap);
   align-items: center;
 }

--- a/ext/riverlea/js/editor.js
+++ b/ext/riverlea/js/editor.js
@@ -123,12 +123,17 @@
         <fieldset class="civi-riverlea-stream-color-inputs-dark"></fieldset>
 
         <fieldset class="civi-riverlea-stream-size-inputs"></fieldset>
-        <fieldset class="civi-riverlea-stream-custom-inputs"></fieldset>
+        <details class="crm-accordion-settings civi-riverlea-stream-custom-inputs-container">
+          <summary></summary>
+          <p class="description"></p>
+          <fieldset class="civi-riverlea-stream-custom-inputs"></fieldset>
+        </details>
       `;
 
-      this.editPane.querySelector('h2').innerText = this.data.label;
-
-      this.editPane.querySelector('.civi-riverlea-stream-colors-header h3').innerText = ts('Colors');
+    this.editPane.querySelector('.civi-riverlea-stream-custom-inputs-container summary').innerText = ts('Advanced CSS');
+    this.editPane.querySelector('.civi-riverlea-stream-custom-inputs-container .description').innerText = ts('CSS entered below may need adjusting to work with later CiviCRM versions');
+    this.editPane.querySelector('h2').innerText = this.data.label;
+    this.editPane.querySelector('.civi-riverlea-stream-colors-header h3').innerText = ts('Colors');
 
       // render dark mode switcher
       const darkModeToggle = this.editPane.querySelector('.civi-riverlea-stream-dark-toggle input');

--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -294,7 +294,7 @@
       this.innerHTML = `
       <div class="panel panel-info">
         <div class="panel-heading">
-          <h3></h3>
+          <h3><i role="img" aria-hidden="true" class="crm-i fa-window-maximize"></i><span></span></h3>
           <div class="civi-riverlea-stream-header-tags"></div>
           <div class="civi-riverlea-stream-header-buttons crm-buttons"></div>
         </div>
@@ -313,7 +313,7 @@
       </div>
       `;
 
-      this.querySelector('h3').innerText = this.data.label;
+      this.querySelector('h3 span').innerText = this.data.label;
       if (this.data.description) {
         this.querySelector('.panel-body p').innerText = this.data.description;
       }


### PR DESCRIPTION
This replaces https://github.com/civicrm/civicrm-core/pull/35034 - which had conflicts. Main features:
 - the CSS boxes in the stream edit screen are put behind 'Advanced CSS' with a warning.
 - an icon is prepended to the headers of each stream and clone, which differs for clones, adding another way to spot which streams are editable
 - removes list-style to make the non-RiverLea rendered output look a bit neater
 - adds spacing when two labels are together
 - tidies spacing on the css file, puts in a few variables where it fits and move a selector around for grouping.

NB: this PR no longer changes the name from 'clone' to 'merge'

| Before  | After | 
|---|---|
| Advanced CSS: <img width="787" height="448" alt="image" src="https://github.com/user-attachments/assets/a5d426b6-2a04-4a75-baba-2ac9c584332b" /> | <img width="747" height="266" alt="image" src="https://github.com/user-attachments/assets/c5feedbb-2b36-4165-b193-2919634065b6" />  |
| | <img width="742" height="449" alt="image" src="https://github.com/user-attachments/assets/235c0451-42fc-40cf-a480-03bba463361e" />
| Headers:  <img width="921" height="439" alt="image" src="https://github.com/user-attachments/assets/fe4274f6-5392-4278-a651-4975f5900094" /> |  <img width="964" height="554" alt="image" src="https://github.com/user-attachments/assets/13c76a63-6e9e-4dc4-a963-27654f98f8cd" /> |
| Greenwich rendering: <img width="1353" height="351" alt="image" src="https://github.com/user-attachments/assets/4b4845e4-1743-42f0-9dc7-23420122eb82" /> | <img width="1342" height="348" alt="image" src="https://github.com/user-attachments/assets/166fa783-7363-4bcb-bc63-e55f7677fb86" /> |
| Adds label spacing (in river core): <img width="923" height="125" alt="image" src="https://github.com/user-attachments/assets/4412ab50-3e91-4de9-ad5d-a5c71f3ee943" />  | <img width="925" height="113" alt="image" src="https://github.com/user-attachments/assets/cddef394-ac8b-47a3-90f6-f55c84ebde97" /> |

Comments
----------------------------------------
Casual use of the custom css boxes is the sort of thing one developer might do while another, who doesn't know Civi has this new feature, isn't able to figure out what's happening – it could also break on upgrade. Short of removing the function, hiding it a little, with an extra warning, should improve informed used.

This PR introduces two new icons - that aren't being used for their intended font-awesome purpose. As they are set via CSS, they also aren't using an `aria-label` for accessibility, and instead are hidden to screen readers. For me the icons are self-explanatory and help with recognising the original streams – the left looks a bit like a screen with menubar, the right looks like a copy of that. Am sure there could be other metaphors (branches, etc), this seems simple, and better than nothing

<img width="1096" height="131" alt="image" src="https://github.com/user-attachments/assets/677056f4-ce29-4c60-8d84-35e51983a47e" />
