### PR TITLE
Display title instead of name for Payment processor on contribution page configuration

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/Amount.php
+++ b/CRM/Contribute/Form/ContributionPage/Amount.php
@@ -85,7 +85,7 @@ class CRM_Contribute_Form_ContributionPage_Amount extends CRM_Contribute_Form_Co
     if (!empty($paymentProcessors)) {
       foreach ($paymentProcessors as $id => $processor) {
         if ($id != 0) {
-          $paymentProcessor[$id] = $processor['name'];
+          $paymentProcessor[$id] = $processor['title'];
         }
         if (!empty($processor['is_recur'])) {
           $recurringPaymentProcessor[] = $id;


### PR DESCRIPTION
Overview
----------------------------------------
Contribution Page configuration should show title not name for payment processor

Before
----------------------------------------
Payment processor name displayed on Contribution Page configuration

After
----------------------------------------
Payment processor backend title displayed on Contribution Page configuration

Technical Details
----------------------------------------


Comments
----------------------------------------

