### PR TITLE
dev/core#6451 OptionGroup - Add cached function getOptionValueFields

### DIFF
--- a/CRM/Core/BAO/OptionGroup.php
+++ b/CRM/Core/BAO/OptionGroup.php
@@ -17,6 +17,25 @@
 class CRM_Core_BAO_OptionGroup extends CRM_Core_DAO_OptionGroup implements \Civi\Core\HookInterface {
 
   /**
+   * Get the suffixes supported by a given option group.
+   */
+  public static function getOptionValueFields(string $optionGroupName): array {
+    $cache = Civi::cache('metadata');
+    $optionValueFields = $cache->get('optionValueFields');
+    if (!is_array($optionValueFields)) {
+      $optionValueFields = [];
+      // Don't cache option groups that just use the default of 'name,label,description'
+      $query = "SELECT name, option_value_fields FROM civicrm_option_group WHERE option_value_fields IS NOT NULL AND option_value_fields != 'name,label,description'";
+      $dao = CRM_Core_DAO::executeQuery($query);
+      while ($dao->fetch()) {
+        $optionValueFields[$dao->name] = explode(',', $dao->option_value_fields);
+      }
+      $cache->set('optionValueFields', $optionValueFields);
+    }
+    return $optionValueFields[$optionGroupName] ?? ['name', 'label', 'description'];
+  }
+
+  /**
    * @deprecated
    * @param array $params
    * @param array $defaults

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -386,14 +386,14 @@ class CoreUtil {
   /**
    * Get the suffixes supported by a given option group
    *
-   * @param string|int $optionGroup
-   *   OptionGroup id or name
-   * @param string $key
-   *   Is $optionGroup being passed as "id" or "name"
+   * @deprecated use \CRM_Core_BAO_OptionGroup::getSuffixes()
+   *
+   * @param string $optionGroup
+   *   OptionGroup name
    * @return array
    */
-  public static function getOptionValueFields(int|string $optionGroup, string $key = 'name'): array {
-    return \CRM_Core_DAO_OptionGroup::getDbVal('option_value_fields', $optionGroup, $key) ?: ['name', 'label', 'description'];
+  public static function getOptionValueFields(string $optionGroup): array {
+    return \CRM_Core_BAO_OptionGroup::getOptionValueFields($optionGroup);
   }
 
   /**

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -107,11 +107,7 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
     // Set default selectors (allowing for overrides)
     $field['pseudoconstant'] += ['key_column' => 'value'];
 
-    // Guard against sql errors if this (relatively new) column hasn't been added yet by the upgrader
-    if (version_compare(\CRM_Core_BAO_Domain::version(), '5.49', '>')) {
-      $optionValueFieldsStr = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $groupId, 'option_value_fields');
-    }
-    $optionValueFields = empty($optionValueFieldsStr) ? ['name', 'label', 'description'] : explode(',', $optionValueFieldsStr);
+    $optionValueFields = \CRM_Core_BAO_OptionGroup::getOptionValueFields($groupName);
     foreach ($optionValueFields as $optionValueField) {
       $field['pseudoconstant'] += ["{$optionValueField}_column" => $optionValueField];
     }


### PR DESCRIPTION
Overview
----------------------------------------
Solves one of the performance issues noted in https://lab.civicrm.org/dev/core/-/work_items/6451 by more efficiently looking up and caching `option_value_fields`.

Before
----------------------------------------
Hundreds of queries – one per field; only cached in memory so repeated on every request.

After
----------------------------------------
Single query for all fields, cached in metadata so not repeated on every page.

Technical Details
----------------------------------------
Replaces two other implementations that had weaker caching and were still resulting in hundreds of queries per page load. This reduces that number to zero.