### PR TITLE
River: restores missing number image in FormBuilder /dev/core/6450

### DIFF
--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -437,9 +437,9 @@ af-gui-container > .af-gui-bar,
   color: var(--crm-text-color);
 }
 #afGuiEditor .af-gui-field-input-type-number input[type=text].form-control {
-  background-image: url('../images/number.png');
+  background-image: url('data:image/svg+xml,<svg fill="%23000000" width="30px" height="30px" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg"><path d="M 18.179688 16.47 L 19.24 17.54 L 15 21.78 L 10.76 17.54 L 11.82 16.47 L 15 19.66 Z M 15 10.34 L 18.18 13.53 L 19.24 12.46 L 15 8.22 L 10.76 12.46 L 11.82 13.53 Z M 15 10.34"/></svg>');
   background-repeat: no-repeat;
-  background-position: center right 6px;
+  background-position: center right;
 }
 #afGuiEditor .af-gui-field-input input.crm-form-date {
   width: 140px;


### PR DESCRIPTION
Overview
----------------------------------------
As reported https://lab.civicrm.org/dev/core/-/work_items/6450 - River has a missing image which causes NGINX errors. This restores it with an svg image…

Before
----------------------------------------
Greenwich:
<img width="319" height="89" alt="image" src="https://github.com/user-attachments/assets/1c897f9d-47f2-48bc-bff2-c691dc7b57f3" />

RiverLea
<img width="304" height="93" alt="image" src="https://github.com/user-attachments/assets/99133552-f8be-4fa6-9826-b030f39b4917" />

After
----------------------------------------
RiverLea
<img width="313" height="108" alt="image" src="https://github.com/user-attachments/assets/9fbcc213-692c-4a6b-8173-eb3d656b7310" />

Darkmode isn't great:
<img width="230" height="44" alt="image" src="https://github.com/user-attachments/assets/61af7c87-6d91-407d-8691-ef521f8f8008" />

Technical Details
----------------------------------------
Dark-mode not supported. But this isn't a realistic rendering of a number input, just an indicator, restored to avoid a missing file error.