### PR TITLE
Tags - Fix double-escaping of separator in dropdowns

### DIFF
--- a/CRM/Contact/Form/Search.php
+++ b/CRM/Contact/Form/Search.php
@@ -516,7 +516,7 @@ class CRM_Contact_Form_Search extends CRM_Core_Form_Search {
 
     $this->_group = CRM_Core_PseudoConstant::group();
 
-    $this->_tag = CRM_Core_BAO_Tag::getTags();
+    $this->_tag = CRM_Core_BAO_Tag::getTags(separator: '- ');
     $this->_done = FALSE;
 
     /*

--- a/CRM/Contact/Form/Search/Criteria.php
+++ b/CRM/Contact/Form/Search/Criteria.php
@@ -60,7 +60,7 @@ class CRM_Contact_Form_Search_Criteria {
     $form->addOptionalQuickFormElement('all_tag_types');
     if ($form->_searchOptions['tags']) {
       // multiselect for categories
-      $contactTags = CRM_Core_BAO_Tag::getTags();
+      $contactTags = CRM_Core_BAO_Tag::getTags(separator: '- ');
 
       if ($contactTags) {
         $form->add('select', 'contact_tags', ts('Tag'), $contactTags, FALSE,

--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -427,7 +427,7 @@ AND       CEF.entity_id    = %2";
     $form->assign('numAttachments', $numAttachments);
 
     CRM_Core_BAO_Tag::getTags('civicrm_file', $tags, NULL,
-      '&nbsp;&nbsp;', TRUE);
+      '- ', TRUE);
 
     // get tagset info
     $parentNames = CRM_Core_BAO_Tag::getTagSet('civicrm_file');

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -463,7 +463,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
       $this->searchFieldMetadata['Contact']['group'] = ['name' => 'group', 'type' => CRM_Utils_Type::T_INT, 'is_pseudofield' => TRUE, 'html' => ['type' => 'Select']];
     }
 
-    $contactTags = CRM_Core_BAO_Tag::getTags();
+    $contactTags = CRM_Core_BAO_Tag::getTags(separator: '- ');
     if ($contactTags) {
       $this->add('select', 'contact_tags', $this->getTagLabel(), $contactTags, FALSE,
         [


### PR DESCRIPTION
Overview
----------------------------------------
- Fixes [dev/core#6430](https://lab.civicrm.org/dev/core/-/work_items/6430)
- Backports https://github.com/civicrm/civicrm-core/pull/35471

Before
---------
<img width="342" height="284" alt="image" src="https://github.com/user-attachments/assets/1ec1d83b-3108-46aa-bcac-8417a6cec030" />


After
-------
<img width="273" height="276" alt="image" src="https://github.com/user-attachments/assets/8d760f95-1b11-4747-a2f0-d6441744d19e" />
