### PR TITLE
dev/core#6411 Add in some defensive coding into createUser for WP to …

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -866,6 +866,18 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
       'role' => get_option('default_role'),
     ];
 
+    // dev/core#6411 check to see if the wordpress user has already been created via some other method
+    $user_name_check = get_user_by('login', $user_data['user_login']);
+    $email_check = get_user_by('email', $user_data['user_email']);
+    if ($user_name_check || $email_check) {
+      if ($email_check) {
+        /** @var WP_User $email_check */
+        return $email_check->ID;
+      }
+      /** @var WP_User $user_name_check */
+      return $user_name_check->ID;
+    }
+
     /*
      * The notify parameter was ignored on WordPress and default behaviour
      * was to always notify. Preserve that behaviour but allow the "notify"


### PR DESCRIPTION
…return early if the user already exists in WP

Overview
----------------------------------------
This aims to fix a recent issue where the order of the createUser call changed and that this can result in an error on a contribution page submit on WordPress if trying to create a user account at the same time

Before
----------------------------------------
Contribution not processed

After
----------------------------------------
Contribution created

ping @kcristiano @haystack @MegaphoneJon @aydun 