### PR TITLE
Api3 - Remove unnecessary version check

### DIFF
--- a/api/v3/CustomField.php
+++ b/api/v3/CustomField.php
@@ -134,7 +134,7 @@ function civicrm_api3_custom_field_delete($params) {
  */
 function civicrm_api3_custom_field_get($params) {
   // Legacy handling for serialize property
-  $handleLegacy = (($params['legacy_html_type'] ?? !isset($params['serialize'])) && CRM_Core_BAO_Domain::isDBVersionAtLeast('5.27.alpha1'));
+  $handleLegacy = ($params['legacy_html_type'] ?? !isset($params['serialize']));
   if ($handleLegacy && !empty($params['return'])) {
     if (!is_array($params['return'])) {
       $params['return'] = explode(',', str_replace(' ', '', $params['return']));


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused legacy version check.

Technical Details
----------------------------------------
MINIMUM_UPGRADABLE_VERSION = '5.51' so this will always be true.