### PR TITLE
Add class definition, handle NULL return from doRefund(), allow passing currency to API4 PaymentProcessor::refund

### DIFF
--- a/Civi/Api4/Action/PaymentProcessor/Refund.php
+++ b/Civi/Api4/Action/PaymentProcessor/Refund.php
@@ -34,6 +34,13 @@ class Refund extends \Civi\Api4\Generic\AbstractAction {
   protected float $amountToRefund;
 
   /**
+   * The currency of the amount to refund (Optional)
+   *
+   * @var string
+   */
+  protected string $currency = '';
+
+  /**
    * The payment processor transaction ID
    * Required by most payment processors
    *
@@ -60,8 +67,12 @@ class Refund extends \Civi\Api4\Generic\AbstractAction {
     }
     $refundParams['amount'] = $this->amountToRefund;
     $refundParams['trxn_id'] = $this->transactionID;
+    // With a trxn_id we often don't need currency at all. But some payment processors use it for formatting the requested amount etc.
+    if (!empty($this->currency)) {
+      $refundParams['currency'] = $this->currency;
+    }
 
-    $result->exchangeArray($processor->doRefund($refundParams));
+    $result->exchangeArray($processor->doRefund($refundParams) ?? []);
     return $result;
   }
 

--- a/ext/civi_contribute/Civi/Api4/PaymentProcessor.php
+++ b/ext/civi_contribute/Civi/Api4/PaymentProcessor.php
@@ -20,4 +20,14 @@ namespace Civi\Api4;
  */
 class PaymentProcessor extends Generic\DAOEntity {
 
+  /**
+   * @param bool $checkPermissions
+   *
+   * @return Action\PaymentProcessor\Refund
+   */
+  public static function refund(bool $checkPermissions = TRUE): Action\PaymentProcessor\Refund {
+    return (new Action\PaymentProcessor\Refund(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

- Add class definition (mainly for class discovery in IDE eg. PHPStorm)
- Handle NULL return from doRefund() - eg. default implementation in Dummy payment processor returns NULL/void.
- Allow passing currency to API4 PaymentProcessor::refund. API3 supported it and some paymentprocesssors use it if available (eg. for formatting amounts). We should be able to pass the parameter.

Before
----------------------------------------
See above. Limitations.

After
----------------------------------------
See above, less limitations.

Technical Details
----------------------------------------


Comments
----------------------------------------
This API was only recently added. Changes are backwards compatible.
