### PR TITLE
Afform - Add checkbox field option for a CheckoutOption

### DIFF
--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/checkBox.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/checkBox.html
@@ -1,0 +1,2 @@
+<label for="{{:: field.name }}">{{:: field.title }}</label>
+<input type="checkbox" id="{{:: field.name }}" name='{{:: field.name }}' ng-model="$ctrl.checkout_params[field.name]" ng-required="field.is_required" />


### PR DESCRIPTION
Overview
----------------------------------------
_Adds a checkbox field for use with a CheckoutOption fields._

Before
----------------------------------------
_Doesn't exist_

After
----------------------------------------
_Now it does_


Comments
----------------------------------------
cc: @ufundo this is so we can have a checkbox for card on file functionality. If the checkbox is checked, we can create a token to be used for future transactions. Just an example of the need, not sure what others may need it for.
