### PR TITLE
[REF] Create new methods to get Joomla user and current user

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -111,17 +111,10 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     $ufName = CRM_Utils_Type::escape($ufName, 'String');
 
     $values = [];
-    if (version_compare(JVERSION, '4.0', 'lt')) {
-      $user = JUser::getInstance($ufID);
-    }
-    else {
-      $factoryClassName = $this->factoryClassName();
-      $user = $factoryClassName::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById($ufID);
-    }
-
     $values['email'] = $ufName;
-    $user->bind($values);
 
+    $user = $this->getJoomlaUserById($ufID);
+    $user->bind($values);
     $user->save();
   }
 
@@ -544,7 +537,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    * @return bool
    */
   public function loadUser($username, $password = NULL) {
-    $factoryClassName = self::factoryClassName();
+    $factoryClassName = $this->factoryClassName();
     if (version_compare(JVERSION, '4.0', 'lt')) {
       $uid = JUserHelper::getUserId($username);
     }
@@ -573,12 +566,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
 
     // Save details in Joomla session
-    if (version_compare(JVERSION, '4.0.0', 'ge')) {
-      $user = $factoryClassName::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById($uid);
-    }
-    else {
-      $user = $factoryClassName::getUser($uid);
-    }
+    $user = $this->getJoomlaUserById($uid);
     $jsession = $factoryClassName::getApplication()->getSession();
     $jsession->set('user', $user);
 
@@ -653,6 +641,11 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     }
   }
 
+  /**
+   * Return and define the current Joomla! version (JVERSION) if not already defined.
+   * @param string $joomlaBase Base path to Joomla! installation.
+   * @return string
+   */
   public function getJVersion($joomlaBase) {
     // Files may be in different places depending on Joomla version
     if (!defined('JVERSION')) {
@@ -670,8 +663,51 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       $jversion = new $class();
       define('JVERSION', $jversion->getShortVersion());
     }
+    return JVERSION;
   }
 
+  /**
+   * Get the current logged-in Joomla! user, or guest (id = 0) if not logged in.
+   * @return Joomla! User object.
+   */
+  public function getCurrentJoomlaUser() {
+    // If logged in, the Joomla! method returns the current User object
+    // If not logged in, it may return NULL or the guest User object (id = 0, guest = 1)
+    $factoryClassName = $this->factoryClassName();
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $user = $factoryClassName::getApplication()->getIdentity();
+    }
+    else {
+      $user = $factoryClassName::getUser();
+    }
+    // Fall back to guest user if we got NULL (see notes above)
+    return $user ?? $this->getJoomlaUserById(0);
+  }
+
+  /**
+   * Get a Joomla! user by id.
+   * @param int $userId The user id (0 = guest).
+   * @return Joomla! User object.
+   */
+  public function getJoomlaUserById(int $userId) {
+    // The Joomla! method only accepts int or int-coercible $userId (it will not accept NULL)
+    // If $userId == 0, it returns the guest User object (id = 0, guest = 1)
+    // If $userId != 0 and exists, it returns the registered User object (id = $userId, guest = 0)
+    // If $userId != 0 and does not exist, it returns an invalid User object (id = NULL, guest = 1)
+    $factoryClassName = $this->factoryClassName();
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $user = $factoryClassName::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById($userId);
+    }
+    else {
+      $user = $factoryClassName::getUser($userId);
+    }
+    return $user;
+  }
+
+  /**
+   * Get the Joomla! document.
+   * @return Document object.
+   */
   protected function getJoomlaDocument() {
     $factoryClassName = $this->factoryClassName();
     $document = $factoryClassName::getApplication()->getDocument();
@@ -723,14 +759,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function isUserLoggedIn() {
-    $factoryClassName = $this->factoryClassName();
-    if (version_compare(JVERSION, '4.0', 'lt')) {
-      $user = $factoryClassName::getUser();
-    }
-    else {
-      $user = $factoryClassName::getApplication()->getIdentity();
-    }
-    return isset($user) && !$user->guest;
+    $user = $this->getCurrentJoomlaUser();
+    return (empty($user->id) || !empty($user->guest)) ? FALSE : TRUE;
   }
 
   /**
@@ -760,27 +790,15 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function getLoggedInUfID() {
-    $factoryClassName = $this->factoryClassName();
-    if (version_compare(JVERSION, '4.0', 'lt')) {
-      $user = $factoryClassName::getUser();
-    }
-    else {
-      $user = $factoryClassName::getApplication()->getIdentity();
-    }
-    return (empty($user) || $user->guest) ? NULL : $user->id;
+    $user = $this->getCurrentJoomlaUser();
+    return $this->getUserIDFromUserObject($user);
   }
 
   /**
    * @inheritDoc
    */
   public function getLoggedInUniqueIdentifier() {
-    $factoryClassName = $this->factoryClassName();
-    if (version_compare(JVERSION, '4.0', 'lt')) {
-      $user = $factoryClassName::getUser();
-    }
-    else {
-      $user = $factoryClassName::getApplication()->getIdentity();
-    }
+    $user = $this->getCurrentJoomlaUser();
     return $this->getUniqueIdentifierFromUserObject($user);
   }
 
@@ -789,13 +807,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function getUser($contactID) {
     $user_details = parent::getUser($contactID);
-    $factoryClassName = $this->factoryClassName();
-    if (version_compare(JVERSION, '4.0.0', 'ge')) {
-      $user = $factoryClassName::getContainer()->get(\Joomla\CMS\User\UserFactoryInterface::class)->loadUserById($user_details['id']);
-    }
-    else {
-      $user = $factoryClassName::getUser($user_details['id']);
-    }
+    $user = $this->getJoomlaUserById($user_details['id']);
     $user_details['name'] = $user->name;
     return $user_details;
   }
@@ -804,14 +816,20 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function getUserIDFromUserObject($user) {
-    return !empty($user->id) ? $user->id : NULL;
+    // See notes in getJoomlaUserById() about possible combinations of $user->guest and $user->id
+    if (!empty($user->guest)) {
+      return 0;
+    }
+    else {
+      return $user->id ?? NULL;
+    }
   }
 
   /**
    * @inheritDoc
    */
   public function getUniqueIdentifierFromUserObject($user) {
-    return (empty($user) || $user->guest) ? NULL : $user->email;
+    return (empty($user->email) || !empty($user->guest)) ? NULL : $user->email;
   }
 
   /**
@@ -957,25 +975,25 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
    */
   public function getUserRecordUrl($contactID) {
     $uid = CRM_Core_BAO_UFMatch::getUFId($contactID);
-    $factoryClassName = $this->factoryClassName();
     // if logged in user has user edit access, then allow link to other users joomla profile
     // always allow access to the user's own profile
     if (
-        $factoryClassName::getApplication()->getIdentity()?->authorise('core.edit', 'com_users') ||
+        $this->getCurrentJoomlaUser()->authorise('core.edit', 'com_users') ||
         (CRM_Core_Session::singleton()->get('userID') == $contactID)
     ) {
       return CRM_Core_Config::singleton()->userFrameworkBaseURL . "index.php?option=com_users&view=user&task=user.edit&id=" . $uid;
     }
+    return NULL;
   }
 
   /**
    * @inheritDoc
    */
   public function checkPermissionAddUser() {
-    $factoryClassName = $this->factoryClassName();
-    if ($factoryClassName::getApplication()->getIdentity()?->authorise('core.create', 'com_users')) {
+    if ($this->getCurrentJoomlaUser()->authorise('core.create', 'com_users')) {
       return TRUE;
     }
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This PR factors out two new methods in CRM_Utils_System_Joomla:

- `getCurrentJoomlaUser()`
- `getJoomlaUserById(int $userId)`

This is in support of #35314 to reduce code duplication, and helps us move towards J6 tidy-up.

Before
----------------------------------------
The Joomla methods `getIdentity()` and `loadUserById()` were called in many (8) places.

After
----------------------------------------
Now each is called in one place only. Fallback to guest user if `getIdentity()` returns `NULL` is handled in one place, as is support for multiple Joomla versions.

Technical Details
----------------------------------------
This PR includes a few incidental corrections to the code where issues were spotted, e.g. returns from functions missing.

There is only one (low-/no-impact) functional change, which is to return `0` instead of `NULL` when there is a guest user passed to `getUserIDFromUserObject()`. This is considered more correct, and brings this module into line with the equivalent methods in Standalone and Drupal8.

Comments
----------------------------------------
Informally tested by applying changes to J5.4.5 and Civi 6.13.1, with no observed difference in behaviour.