### PR TITLE
SearchKit - Fix task links for non-admin users.

### DIFF
--- a/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
+++ b/Civi/Api4/Generic/Traits/SavedSearchInspectorTrait.php
@@ -54,6 +54,10 @@ trait SavedSearchInspectorTrait {
    */
   private $_joinMap;
 
+  private $_savedSearchParam;
+
+  private $_displayParam;
+
   /**
    * If SavedSearch is supplied as a string, this will load it as an array
    * @param int|null $id
@@ -61,6 +65,10 @@ trait SavedSearchInspectorTrait {
    * @throws \CRM_Core_Exception
    */
   protected function loadSavedSearch(?int $id = NULL) {
+    // Stash original
+    if (!$id && is_string($this->savedSearch)) {
+      $this->_savedSearchParam = $this->savedSearch;
+    }
     if ($id || is_string($this->savedSearch)) {
       $this->savedSearch = SavedSearch::get(FALSE)
         ->addWhere($id ? 'id' : 'name', '=', $id ?: $this->savedSearch)
@@ -86,6 +94,7 @@ trait SavedSearchInspectorTrait {
   protected function loadSearchDisplay(): void {
     // Display name given
     if (is_string($this->display)) {
+      $this->_displayParam = $this->display;
       $this->display = \Civi\Api4\SearchDisplay::get(FALSE)
         ->setSelect(['*', 'type:name'])
         ->addWhere('name', '=', $this->display)
@@ -485,6 +494,14 @@ trait SavedSearchInspectorTrait {
       }
     }
     return $this->_joinMap[$joinAlias];
+  }
+
+  protected function getSavedSearchParam(): array|string {
+    return $this->_savedSearchParam ?? $this->savedSearch;
+  }
+
+  protected function getDisplayParam(): array|string|null {
+    return $this->_displayParam ?? $this->display;
   }
 
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1012,8 +1012,8 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       try {
         $this->tasks = SearchDisplay::getSearchTasks()
           ->setCheckPermissions($this->getCheckPermissions())
-          ->setSavedSearch($this->getSavedSearch())
-          ->setDisplay($this->getDisplay())
+          ->setSavedSearch($this->getSavedSearchParam())
+          ->setDisplay($this->getDisplayParam())
           ->execute()
           ->indexBy('name');
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6458](https://lab.civicrm.org/dev/core/-/work_items/6458)

Before
----------------------------------------
Non-admins cannot enable/disable relationships on the contact summary tab.

After
----------------------------------------
Functionality restored.

Technical Details
----------------------------------------
When a task is used as a link, getSearchTasks will be called. This fails due to `checkPermissionToLoadSearch()` if the search/display is already an array, so this ensures they are passed in their original form.