### PR TITLE
Fix issue #6460 importing contact state field as part of contribution import

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -822,6 +822,10 @@
 
 - github      : jaomalley
 
+- github      : jasonhildebrand
+  name        : Jason Hildebrand
+  organization: PeaceWorks Technology Solutions
+
 - github      : javiya-rupal
   name        : Rupal Javiya
 

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -19,6 +19,7 @@ use Civi\Api4\DedupeRuleGroup;
 use Civi\Api4\Email;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Phone;
+use Civi\Api4\StateProvince;
 use Civi\Core\Event\GenericHookEvent;
 
 /**
@@ -538,7 +539,56 @@ abstract class ImportParser extends \CRM_Import_Parser {
       }
       $params[$entity][$this->getFieldMetadata($mappedField['name'])['name']] = $this->getTransformedFieldValue($mappedField['name'], $fieldValue);
     }
+
+    // Some option-values (notably state/province abbreviations like "ON") can be ambiguous
+    // until we know the country. Resolve these using the primary address country where possible.
+    $this->resolvePrimaryAddressStateProvince($params);
+
     return $this->removeEmptyValues($params);
+  }
+
+  /**
+   * Resolve Contact-like `address_primary.state_province_id` values using `address_primary.country_id`.
+   *
+   * The base parser may return the raw string for ambiguous values (e.g. "ON").
+   * Contact Import has a later disambiguation pass once the country is known; we do a similar thing here.
+   */
+  protected function resolvePrimaryAddressStateProvince(array &$params): void {
+    foreach (array_keys($params) as $entityName) {
+      if (!is_array($params[$entityName])) {
+        continue;
+      }
+      if (!array_key_exists('address_primary.state_province_id', $params[$entityName])) {
+        continue;
+      }
+
+      $state = $params[$entityName]['address_primary.state_province_id'];
+      if ($state === NULL || $state === '' || is_numeric($state) || $state === 'invalid_import_value') {
+        continue;
+      }
+      $state = trim((string) $state);
+      if ($state === '') {
+        continue;
+      }
+      $countryID = $params[$entityName]['address_primary.country_id'] ?? NULL;
+      if (!is_numeric($countryID)) {
+        continue;
+      }
+
+      // Try looking up first by abbreviation, then by full province/state name.
+      foreach (['abbreviation', 'name'] as $field) {
+        $match = StateProvince::get(FALSE)
+          ->addSelect('id')
+          ->addWhere('country_id', '=', (int) $countryID)
+          ->addWhere($field, '=', $state)
+          ->setLimit(2)
+          ->execute();
+        if (count($match) === 1) {
+          $params[$entityName]['address_primary.state_province_id'] = (int) $match->first()['id'];
+          break;
+        }
+      }
+    }
   }
 
   /**

--- a/ext/civiimport/tests/phpunit/StateProvinceResolutionTest.php
+++ b/ext/civiimport/tests/phpunit/StateProvinceResolutionTest.php
@@ -1,0 +1,192 @@
+<?php
+
+use Civi\Api4\Country;
+use Civi\Api4\StateProvince;
+use Civi\Api4\UserJob;
+use Civi\Import\ContributionParser;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group headless
+ */
+class StateProvinceResolutionTest extends TestCase implements HeadlessInterface, TransactionalInterface {
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return \Civi\Test::headless()
+      ->install('org.civicrm.search_kit')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testResolvesAmbiguousStateProvinceAbbreviationWithCountry(): void {
+    $canadaID = $this->getCountryIdByIso('CA');
+    $abbr = 'ON';
+    $expectedStateID = $this->getStateProvinceIdByCountryAndAbbr($canadaID, $abbr);
+
+    $userJobID = $this->createContributionImportUserJob([
+      ['name' => 'Contact.address_primary.state_province_id'],
+      ['name' => 'Contact.address_primary.country_id'],
+    ], 2);
+
+    $parser = new ContributionParser();
+    $parser->setUserJobID($userJobID);
+    $parser->init();
+
+    // Map state before country to reproduce the ambiguity.
+    $mapped = $parser->getMappedRow([$abbr, $canadaID]);
+    $this->assertSame($canadaID, (int) $mapped['Contact']['address_primary.country_id']);
+    $this->assertSame($expectedStateID, (int) $mapped['Contact']['address_primary.state_province_id']);
+  }
+
+  public function testResolvesStateProvinceValuesWhenOptionsNotPreloaded(): void {
+    $canadaID = $this->getCountryIdByIso('CA');
+
+    // Even seemingly-unambiguous values (like "BC") generally cannot be resolved by
+    // the base option-value transformer because `state_province_id` is a chain-select
+    // whose options depend on country and are not preloaded.
+    $bcID = $this->getStateProvinceIdByCountryAndAbbr($canadaID, 'BC');
+
+    $userJobID = $this->createContributionImportUserJob([
+      ['name' => 'Contact.address_primary.state_province_id'],
+      ['name' => 'Contact.address_primary.country_id'],
+    ], 2);
+
+    $parser = new ContributionParser();
+    $parser->setUserJobID($userJobID);
+    $parser->init();
+
+    // Abbreviation.
+    $mapped = $parser->getMappedRow(['BC', $canadaID]);
+    $this->assertSame($bcID, (int) $mapped['Contact']['address_primary.state_province_id']);
+
+    // Full name.
+    $mapped = $parser->getMappedRow(['British Columbia', $canadaID]);
+    $this->assertSame($bcID, (int) $mapped['Contact']['address_primary.state_province_id']);
+  }
+
+  public function testAcceptsNumericStateProvinceId(): void {
+    $canadaID = $this->getCountryIdByIso('CA');
+    $bcID = $this->getStateProvinceIdByCountryAndAbbr($canadaID, 'BC');
+
+    $userJobID = $this->createContributionImportUserJob([
+      ['name' => 'Contact.address_primary.state_province_id'],
+      ['name' => 'Contact.address_primary.country_id'],
+    ], 2);
+
+    $parser = new ContributionParser();
+    $parser->setUserJobID($userJobID);
+    $parser->init();
+
+    $mapped = $parser->getMappedRow([$bcID, $canadaID]);
+    $this->assertSame($bcID, (int) $mapped['Contact']['address_primary.state_province_id']);
+  }
+
+  public function testResolvesAmbiguousStateProvinceNameWithCountry(): void {
+    $canadaID = $this->getCountryIdByIso('CA');
+    $usaID = $this->getCountryIdByIso('US');
+    $name = 'Test Province Shared Name ' . uniqid('', TRUE);
+
+    $caStateID = $this->createStateProvince($canadaID, $name, $this->randomAbbr());
+    $this->createStateProvince($usaID, $name, $this->randomAbbr());
+
+    $userJobID = $this->createContributionImportUserJob([
+      ['name' => 'Contact.address_primary.state_province_id'],
+      ['name' => 'Contact.address_primary.country_id'],
+    ], 2);
+
+    $parser = new ContributionParser();
+    $parser->setUserJobID($userJobID);
+    $parser->init();
+
+    $mapped = $parser->getMappedRow([$name, $canadaID]);
+    $this->assertSame($canadaID, (int) $mapped['Contact']['address_primary.country_id']);
+    $this->assertSame($caStateID, (int) $mapped['Contact']['address_primary.state_province_id']);
+  }
+
+  public function testDoesNotResolveStateProvinceWithoutCountry(): void {
+    $canadaID = $this->getCountryIdByIso('CA');
+    $abbr = 'ON';
+
+    $userJobID = $this->createContributionImportUserJob([
+      ['name' => 'Contact.address_primary.state_province_id'],
+      ['name' => 'Contact.address_primary.country_id'],
+    ], 2);
+
+    $parser = new ContributionParser();
+    $parser->setUserJobID($userJobID);
+    $parser->init();
+
+    // Leave country blank; the resolver should not run.
+    $mapped = $parser->getMappedRow([$abbr, '']);
+    $this->assertSame($abbr, $mapped['Contact']['address_primary.state_province_id']);
+  }
+
+  private function getCountryIdByIso(string $isoCode): int {
+    return (int) Country::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('iso_code', '=', $isoCode)
+      ->execute()
+      ->single()['id'];
+  }
+
+  private function createStateProvince(int $countryID, string $name, string $abbr): int {
+    return (int) StateProvince::create(FALSE)
+      ->setValues([
+        'country_id' => $countryID,
+        'name' => $name,
+        'abbreviation' => $abbr,
+        'is_active' => TRUE,
+      ])
+      ->execute()
+      ->first()['id'];
+  }
+
+  private function getStateProvinceIdByCountryAndAbbr(int $countryID, string $abbr): int {
+    return (int) StateProvince::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('country_id', '=', $countryID)
+      ->addWhere('abbreviation', '=', $abbr)
+      ->execute()
+      ->single()['id'];
+  }
+
+  private function createContributionImportUserJob(array $importMappings, int $numberOfColumns): int {
+    $userJob = UserJob::create(FALSE)->setValues([
+      'job_type' => 'contribution_import',
+      'status_id:name' => 'draft',
+      'metadata' => [
+        'DataSource' => [
+          'number_of_columns' => $numberOfColumns,
+        ],
+        'submitted_values' => [
+          'contactType' => 'Individual',
+          'dataSource' => 'CRM_Import_DataSource_CSV',
+        ],
+        'import_mappings' => $importMappings,
+        'entity_configuration' => [
+          'Contribution' => ['action' => 'create'],
+          'Contact' => [
+            'action' => 'save',
+            'contact_type' => 'Individual',
+            'dedupe_rule' => ['IndividualUnsupervised'],
+          ],
+        ],
+        'import_options' => [
+          'date_format' => CRM_Utils_Date::DATE_yyyy_mm_dd,
+        ],
+        'bundled_actions' => [],
+      ],
+    ])->execute()->first();
+
+    return (int) $userJob['id'];
+  }
+
+  private function randomAbbr(): string {
+    // 4 chars max.
+    return substr(strtoupper(bin2hex(random_bytes(2))), 0, 4);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes https://lab.civicrm.org/dev/core/-/work_items/6460

Before
----------------------------------------
Previously, when using contribution import, the system failed to set the state field, unless a numerical ID was given in the import file.

After
----------------------------------------
The state field is resolved and set as expected.  There are no UI changes.

Technical Details
----------------------------------------
The contribution import did not correctly resolve state/province values.  This is now done using lookup, taking the country into account because the same abbreviation can be used in multiple countries.

This PR adds 5 new test cases to cover various scenarios related to this issue. 

Comments
----------------------------------------
AI was used to develop the fix and implement the test cases.  I have manually reviewed it all and made several adjustments to improve consistency with the existing codebase.
