### PR TITLE
Wordpress CreateUser micro-optimisation

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -867,13 +867,14 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
     ];
 
     // dev/core#6411 check to see if the wordpress user has already been created via some other method
-    $user_name_check = get_user_by('login', $user_data['user_login']);
     $email_check = get_user_by('email', $user_data['user_email']);
-    if ($user_name_check || $email_check) {
-      if ($email_check) {
-        /** @var WP_User $email_check */
-        return $email_check->ID;
-      }
+    if ($email_check) {
+      /** @var WP_User $email_check */
+      return $email_check->ID;
+    }
+
+    $user_name_check = get_user_by('login', $user_data['user_login']);
+    if ($user_name_check) {
       /** @var WP_User $user_name_check */
       return $user_name_check->ID;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Only `call get_user_by('login', ...)` if `get_user_by('email', ...)` fails 

Before
----------------------------------------
`get_user_by` is called twice every time.


After
----------------------------------------
`get_user_by` is only called twice if the user is not found by email.

Technical Details
----------------------------------------
This is a fairly straight-forward micro-optimisation.

Comments
----------------------------------------
This was discussed briefly in #35473
