### PR TITLE
Fix contributor key for Brienne

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -281,11 +281,7 @@
   organization: Non Profit Tech Advisor
 
 - github      : briennek
-  organization: Civil Justice, Inc.
   name        : Brienne K.
-
-- github      : briennekordis
-  name        : Brienne Kordis
   organization: Megaphone Technology Consulting
 
 - github      : brucew2013


### PR DESCRIPTION
Overview
----------------------------------------
I think this was a mistake that came about when Brienne changed her Github username.  I assume that caused a script to flag her old contributions as unrelated to anyone in the contributor key.  The "Civil Justice" job is unrelated to CiviCRM, this was a privacy-motivated name change.
