### PR TITLE
Fix PHP 8 warning in RemoveFromGroup.tpl: use $form.group_id.value instead of $group.id

### DIFF
--- a/templates/CRM/Contact/Form/Task/RemoveFromGroup.tpl
+++ b/templates/CRM/Contact/Form/Task/RemoveFromGroup.tpl
@@ -10,7 +10,7 @@
 <div class="crm-form-block crm-block crm-contact-task-removefromgroup-form-block">
   <table class="form-layout-compressed">
     <tr class="crm-contact-task-removefromgroupform-block-group_id">
-      <td class="label">{if $group.id}{ts}Group{/ts}{else}{$form.group_id.label}{/if}</td>
+      <td class="label">{if $form.group_id.value}{ts}Group{/ts}{else}{$form.group_id.label}{/if}</td>
       <td>{$form.group_id.html}</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Summary

Fixes a PHP 8 warning triggered every time the **Remove Contacts from Group** form is loaded:

```
PHP Warning: Trying to access array offset on value of type null in
.../cache/.../file_RemoveFromGroup.tpl.php
```

## Root cause

`templates/CRM/Contact/Form/Task/RemoveFromGroup.tpl` used `{if $group.id}` to decide the label style. Under PHP 8, Smarty 5 compiles this to `getValue('group')['id']`. When `$group` is `null` (the controller never assigns it), PHP 8 throws a warning instead of silently returning `null` as PHP 7 did.

## Fix

Replace `{if $group.id}` with `{if $form.group_id.value}` — the same pattern already used in `AddToGroup.tpl`. The semantic is identical: if a group is pre-selected (value present), show the static "Group" label; otherwise show the dropdown label.

```diff
- <td class="label">{if $group.id}{ts}Group{/ts}{else}{$form.group_id.label}{/if}</td>
+ <td class="label">{if $form.group_id.value}{ts}Group{/ts}{else}{$form.group_id.label}{/if}</td>
```

No PHP controller change needed.

## Related

GitLab issue: https://lab.civicrm.org/dev/core/-/work_items/6462

## AI disclosure

This PR was developed with Claude Code assistance. All code has been reviewed as best I can. I tested the code in my local civicrm installation.