### PR TITLE
Remove duplicate join on LineItem Contribution in SearchKit

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -340,6 +340,16 @@ class Admin {
               // Add the straight 1-1 join (but only if it's not a reference to itself, those can be done with implicit joins)
               if (!$isSelf) {
                 $alias = $entity['name'] . '_' . $targetEntityName . '_' . $keyField['name'];
+
+                // For LineItem we have contribution_id and entity_id=contribution_id when entity_table=civicrm_contribution
+                // They are the same and it is confusing to have two joins in the SearchKit UI.
+                // Aliases: LineItem_Contribution_contribution_id and LineItem_Contribution_entity_id
+                if ($alias === 'LineItem_Contribution_entity_id') {
+                  // LineItem.entity_id === LineItem.contribution_id if LineItem.entity_table='civicrm_contribution'
+                  // Don't show the duplicate join - see https://github.com/civicrm/civicrm-core/pull/35495
+                  continue;
+                }
+
                 $joins[$entity['name']][] = [
                   'label' => $entity['title'] . ' ' . ($dynamicCol ? $targetEntity['title'] : $keyField['label']),
                   'description' => '',


### PR DESCRIPTION
Overview
----------------------------------------
Per discussion in chat (https://chat.civicrm.org/civicrm/pl/wtigs1wk53bsjq3oj9rgha17tc)

LineItem entity "joins" to Contribution via `lineitem.contribution_id` and (`lineitem.entity_id==contribution_id` if `entity_table='civicrm_contribution'`).

That is confusing and unnecessary.

Solution 1: Remove the join on entity table.
Solution 2: Re-label the join on contribution ID.

Both solutions are implemented in this PR, comments please on preferred solution?

crmSearchAdmin.component.js is responsible for parsing and rendering the list of joins.

Before
----------------------------------------
Confusing

After
----------------------------------------
Not confusing.

Technical Details
----------------------------------------
In this PR I'm forcing them to be the same: https://github.com/civicrm/civicrm-core/pull/35082/changes#diff-a16d4d7449cf5f3a0616d1d282a32f27ab6d3f7d2726d076c02ad1d4d655af41R67

Effectively entity_id === contribution_id if entity_table=civicrm_contribution:

It's being forced here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Price/BAO/LineItem.php#L410 and here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/BAO/FinancialProcessor.php#L1087 and here: https://github.com/civicrm/civicrm-core/blob/master/CRM/Contribute/BAO/Contribution.php#L249

Comments
----------------------------------------
@ufundo 