### PR TITLE
Add Created/Modified Date to LineItem

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixSixteen.php
+++ b/CRM/Upgrade/Incremental/php/SixSixteen.php
@@ -29,6 +29,39 @@ class CRM_Upgrade_Incremental_php_SixSixteen extends CRM_Upgrade_Incremental_Bas
    */
   public function upgrade_6_16_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+
+    $this->addTask('Add column "LineItem.created_date"', 'alterSchemaField', 'LineItem', 'created_date', [
+      'title' => ts('Created Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the LineItem created.'),
+      'add' => '6.16',
+      'unique_name' => 'lineitem_created_date',
+      'default' => 'CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Created Date'),
+      ],
+    ]);
+    $this->addTask('Add column "LineItem.modified_date"', 'alterSchemaField', 'LineItem', 'modified_date', [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the LineItem modified.'),
+      'add' => '6.16',
+      'unique_name' => 'lineitem_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Modified Date'),
+      ],
+    ]);
   }
 
 }

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -23,6 +23,38 @@ return [
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
     ],
+    'created_date' => [
+      'title' => ts('Created Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the LineItem created.'),
+      'add' => '6.16',
+      'unique_name' => 'lineitem_created_date',
+      'default' => 'CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Created Date'),
+      ],
+    ],
+    'modified_date' => [
+      'title' => ts('Modified Date'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'readonly' => TRUE,
+      'description' => ts('When was the LineItem modified.'),
+      'add' => '6.16',
+      'unique_name' => 'lineitem_modified_date',
+      'default' => 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP',
+      'usage' => [
+        'export',
+      ],
+      'input_attrs' => [
+        'label' => ts('Modified Date'),
+      ],
+    ],
     'entity_table' => [
       'title' => ts('Line Item Entity Type'),
       'sql_type' => 'varchar(64)',


### PR DESCRIPTION
Overview
----------------------------------------
Currently there are no dates recorded on a LineItem. There is discussion here around that: https://lab.civicrm.org/dev/core/-/work_items/6282

For auditing, tracing and debugging it is very helpful to have a "created_date" on an entity. In the case of LineItems they are usually created at the same time as a Contribution. However, multiple advanced scenarios allow them to be added (and maybe removed) at a later date.

For example, an Order::Modify API (or an Order->AddLineItem) would add new lineitems at a later date. The LineItemEditor extension also adds/removes lineitems.
For these advanced scenarios there is currently no way of seeing which LineItems were added when (unless you have advanced logging enabled in which case you might be able to work it out from the advanced log tables).

Third-party API integrations also make use of "created_date" fields to help with syncronisation/timing.

~I don't think we need "modified_date" on a lineitem at this time as modifying a lineitem involves editing financial items/related entities and is not a supported flow at this time (the recommended way is probably to reverse a lineitem completely and re-add it).~
There are certain things that are ok to modify a LineItem - eg. changing the entity_id for a linked Membership/Participant record. So it does make sense to add a `modified_date` field as well.

Before
----------------------------------------
No `created_date` or `modified_date` on lineitem.

After
----------------------------------------
`created_date` and `modified_date` on lineitem.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------

