### PR TITLE
show relationship type contact types

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
@@ -86,12 +86,14 @@ return [
               'key' => 'contact_type_a:label',
               'label' => E::ts('Contact Type A'),
               'sortable' => TRUE,
+              'rewrite' => '{if \'[contact_sub_type_a:label]\'}[contact_sub_type_a:label]{else}[contact_type_a:label]{/if}',
             ],
             [
               'type' => 'field',
               'key' => 'contact_type_b:label',
               'label' => E::ts('Contact Type B'),
               'sortable' => TRUE,
+              'rewrite' => '{if \'[contact_sub_type_b:label]\'}[contact_sub_type_b:label]{else}[contact_type_b:label]{/if}',
             ],
             [
               'type' => 'field',


### PR DESCRIPTION
lab.c.o: https://lab.civicrm.org/dev/core/-/work_items/6470

Overview
----------------------------------------
The "Administer Relationship Types" screen has been replaced by SearchKit. However, the QuickForm screen, when showing what contacts could be selected for the relationship, made clear when they only applied to a particular contact subtype.  The AdminUI version doesn't.

Because AdminUI is now default on new installs, I'm putting this against the rc since it's now a regression rather than a missing feature.

To replicate:
* Go to **Administer menu » Customize Data and Screens » Relationship Types**.
* Create a new relationship that is only applicable to contact subtypes.
* Go back to **Administer menu » Customize Data and Screens » Relationship Types**.

Before
----------------------------------------
<img width="958" height="244" alt="Selection_2828" src="https://github.com/user-attachments/assets/ae596b81-06ba-4189-a90e-823d01553714" />

After
----------------------------------------
<img width="961" height="329" alt="Selection_2826" src="https://github.com/user-attachments/assets/93a1fe4e-adc9-4d4f-998b-6534dda338cd" />