### PR TITLE
SearchKit - Fix setting column mode to auto

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -55,9 +55,12 @@
       };
 
       this.setColumnMode = (value) => {
+        if (value === 'auto') {
+          delete this.display.settings.columns;
+        }
         // if not using auto columns we need to run initColumns to initialise defaults
         // and populate or validate this.settings.columns
-        if (value !== 'auto') {
+        else {
           this.parent.initColumns({label: true, sortable: true});
         }
         this.display.settings.columnMode = value;


### PR DESCRIPTION
Overview
----------------------------------------
When setting column mode to 'auto', the columns were not being cleared and were interfering with the running of the search display.
