### PR TITLE
Auto-delete empty custom group when last field is deleted

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1089,6 +1089,25 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
 
       CRM_Utils_Weight::correctDuplicateWeights('CRM_Core_DAO_CustomField');
       Civi::cache('metadata')->clear();
+
+      // If this was the last field in the group, clean up the now-empty group
+      // to prevent orphaned civicrm_custom_group records that can crash
+      // SqlTriggers::rebuild() and CRM_Logging_Schema.
+      if (!empty($event->object->custom_group_id)) {
+        $remainingFields = CRM_Core_DAO::singleValueQuery(
+          'SELECT COUNT(*) FROM civicrm_custom_field WHERE custom_group_id = %1',
+          [1 => [$event->object->custom_group_id, 'Positive']]
+        );
+        if ($remainingFields == 0) {
+          $groupExists = CRM_Core_DAO::singleValueQuery(
+            'SELECT id FROM civicrm_custom_group WHERE id = %1',
+            [1 => [$event->object->custom_group_id, 'Positive']]
+          );
+          if ($groupExists) {
+            CRM_Core_BAO_CustomGroup::deleteRecord(['id' => $event->object->custom_group_id]);
+          }
+        }
+      }
     }
   }
 

--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1582,6 +1582,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements Event
       'table_name'
     );
 
+    // Guard against missing tables (e.g. orphaned custom group records
+    // where the backing table was dropped but the group record remains).
+    if (!CRM_Core_DAO::singleValueQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %1", [1 => [$tableName, 'String']])) {
+      return TRUE;
+    }
+
     $query = "SELECT count(id) FROM {$tableName} WHERE id IS NOT NULL LIMIT 1";
     $value = CRM_Core_DAO::singleValueQuery($query);
 

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -311,6 +311,86 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $this->assertDBNull('CRM_Core_DAO_CustomField', $customGroup['id'], 'id',
       'custom_group_id', 'Database check for deleted Custom Field.'
     );
+    // Group is auto-deleted when its last field is removed, so no
+    // explicit customGroupDelete() call is needed here.
+  }
+
+  /**
+   * Test that deleting the last field in a custom group auto-deletes the group.
+   *
+   * When the last custom field in a group is deleted, the group record becomes
+   * orphaned (no fields, but table_name still set). This can crash
+   * SqlTriggers::rebuild() and CRM_Logging_Schema if the backing table is
+   * later dropped. Verify that deleting the last field cleans up the group.
+   */
+  public function testDeleteLastFieldDeletesGroup(): void {
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $customField = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'Only Field',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+    ]);
+
+    $groupId = $customGroup['id'];
+    $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $groupId, 'table_name');
+
+    // Verify the group and table exist before deletion.
+    $this->assertDBNotNull('CRM_Core_DAO_CustomGroup', $groupId, 'id', 'id',
+      'Custom group should exist before field deletion.'
+    );
+    $this->assertTrue(CRM_Core_BAO_SchemaHandler::checkIfFieldExists($tableName, 'id'),
+      'Backing table should exist before field deletion.'
+    );
+
+    // Delete the only field in the group.
+    $fieldObject = new CRM_Core_BAO_CustomField();
+    $fieldObject->id = $customField['id'];
+    $fieldObject->find(TRUE);
+    CRM_Core_BAO_CustomField::deleteField($fieldObject);
+
+    // The group record should be auto-deleted.
+    $this->assertDBNull('CRM_Core_DAO_CustomGroup', $groupId, 'id', 'id',
+      'Custom group should be auto-deleted when last field is removed.'
+    );
+
+    // The backing table should be dropped.
+    $tableExists = CRM_Core_DAO::singleValueQuery(
+      "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = %1",
+      [1 => [$tableName, 'String']]
+    );
+    $this->assertEquals(0, $tableExists, 'Backing table should be dropped when last field is removed.');
+  }
+
+  /**
+   * Test that deleting a field from a multi-field group does NOT delete the group.
+   */
+  public function testDeleteFieldFromMultiFieldGroupKeepsGroup(): void {
+    $customGroup = $this->customGroupCreate(['extends' => 'Individual']);
+    $field1 = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'Field One',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+    ]);
+    $field2 = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'Field Two',
+      'data_type' => 'String',
+      'html_type' => 'Text',
+    ]);
+
+    // Delete field1 — group should still exist because field2 remains.
+    $fieldObject = new CRM_Core_BAO_CustomField();
+    $fieldObject->id = $field1['id'];
+    $fieldObject->find(TRUE);
+    CRM_Core_BAO_CustomField::deleteField($fieldObject);
+
+    $this->assertDBNotNull('CRM_Core_DAO_CustomGroup', $customGroup['id'], 'id', 'id',
+      'Custom group should still exist when other fields remain.'
+    );
+
+    // Clean up.
     $this->customGroupDelete($customGroup['id']);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

When the last custom field in a custom group is deleted (via UI or API), `CRM_Core_BAO_CustomField::deleteField()` removes the field but leaves the parent `civicrm_custom_group` record orphaned — `is_active=1`, `table_name` still pointing to a backing table with no custom columns. If that backing table is later dropped (e.g. by logging schema reconciliation or upgrade cleanup), `SqlTriggers::rebuild()` crashes with MySQL error 1146 ("Table doesn't exist"), potentially taking the site offline.

This PR auto-deletes the empty custom group when the last field is removed, and hardens `isGroupEmpty()` against pre-existing orphaned groups.

Before
----------------------------------------

1. Create a custom group with one field
2. Delete the field via **Administer > Custom Data > [Group] > delete field**
3. The `civicrm_custom_group` record remains with `is_active=1` and `table_name` still set, but zero fields
4. Run `drush civicrm-sql-rebuild-triggers` — if the backing table was dropped by another process, this crashes:

```
nativecode=1146 — Table 'civicrm_value_example_123' doesn't exist
```

`CustomGroup::isGroupEmpty()` is also vulnerable — it runs `SELECT count(id) FROM {$tableName}` directly, which crashes on a missing table.

After
----------------------------------------

1. Create a custom group with one field
2. Delete the field — the now-empty group is automatically cleaned up (backing table dropped, `civicrm_custom_group` record deleted)
3. `SqlTriggers::rebuild()` runs cleanly — no orphaned references
4. `isGroupEmpty()` checks `INFORMATION_SCHEMA.TABLES` before querying, so pre-existing orphaned groups return `TRUE` instead of crashing

Groups with remaining fields are unaffected — only the "last field deleted" case triggers cleanup.

Technical Details
----------------------------------------

**`CRM/Core/BAO/CustomField.php`** — In `self_hook_civicrm_post()`, after a field delete, count remaining fields in the group. If zero, delete the group via `CRM_Core_BAO_CustomGroup::deleteRecord()`. This goes through the proper BAO path — table drop, record deletion, cache clearing, and hooks — consistent with how API3/API4 already handle group deletion. A guard check confirms the group still exists before calling `deleteRecord()`, making this safe when invoked from `deleteGroup($force=TRUE)` which deletes multiple fields sequentially.

**`CRM/Core/BAO/CustomGroup.php`** — In `isGroupEmpty()`, check `INFORMATION_SCHEMA.TABLES` for table existence before querying the backing table. If the table is missing, return `TRUE` (the group is effectively empty). This hardens against pre-existing orphaned groups that were created before this fix.

**`tests/phpunit/CRM/Core/BAO/CustomFieldTest.php`** — Updated `testDeleteCustomField` to remove the now-unnecessary `customGroupDelete()` call, since the group is auto-deleted when its last field is removed.

Comments
----------------------------------------

Three tests cover the new behaviour:
- `testDeleteLastFieldDeletesGroup` — verifies last-field deletion auto-deletes the group and drops the backing table
- `testDeleteFieldFromMultiFieldGroupKeepsGroup` — verifies non-last-field deletion preserves the group
- `testDeleteCustomField` (existing, updated) — confirms field deletion still works; no longer calls `customGroupDelete()` since the group is already cleaned up