### PR TITLE
Guard against orphaned custom groups in trigger rebuild and isGroupEmpty

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -1582,6 +1582,12 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements Event
       'table_name'
     );
 
+    // Guard against missing tables (e.g. orphaned custom group records
+    // where the backing table was dropped but the group record remains).
+    if (!CRM_Core_DAO::checkTableExists($tableName)) {
+      return TRUE;
+    }
+
     $query = "SELECT count(id) FROM {$tableName} WHERE id IS NOT NULL LIMIT 1";
     $value = CRM_Core_DAO::singleValueQuery($query);
 

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -300,11 +300,25 @@ class TimestampTriggers {
 
     if ($this->getCustomDataEntity()) {
       $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $this->getCustomDataEntity(), 'is_multiple' => FALSE]);
-      foreach ($customGroups as $customGroup) {
-        $relations[] = [
-          'table' => $customGroup['table_name'],
-          'column' => 'entity_id',
-        ];
+      if ($customGroups) {
+        // Batch-check which backing tables exist (single query) to guard
+        // against orphaned civicrm_custom_group records whose table was dropped.
+        $tableNames = array_column($customGroups, 'table_name');
+        $escaped = implode("', '", array_map(['\CRM_Core_DAO', 'escapeString'], $tableNames));
+        $existingTables = [];
+        $dao = \CRM_Core_DAO::executeQuery("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('$escaped')");
+        while ($dao->fetch()) {
+          $existingTables[$dao->TABLE_NAME] = TRUE;
+        }
+        foreach ($customGroups as $customGroup) {
+          if (!isset($existingTables[$customGroup['table_name']])) {
+            continue;
+          }
+          $relations[] = [
+            'table' => $customGroup['table_name'],
+            'column' => 'entity_id',
+          ];
+        }
       }
     }
 

--- a/Civi/Core/SqlTrigger/TimestampTriggers.php
+++ b/Civi/Core/SqlTrigger/TimestampTriggers.php
@@ -300,29 +300,41 @@ class TimestampTriggers {
 
     if ($this->getCustomDataEntity()) {
       $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => $this->getCustomDataEntity(), 'is_multiple' => FALSE]);
-      if ($customGroups) {
-        // Batch-check which backing tables exist (single query) to guard
-        // against orphaned civicrm_custom_group records whose table was dropped.
-        $tableNames = array_column($customGroups, 'table_name');
-        $escaped = implode("', '", array_map(['\CRM_Core_DAO', 'escapeString'], $tableNames));
-        $existingTables = [];
-        $dao = \CRM_Core_DAO::executeQuery("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('$escaped')");
-        while ($dao->fetch()) {
-          $existingTables[$dao->TABLE_NAME] = TRUE;
+      $tableNames = array_column($customGroups, 'table_name');
+      $existingTables = self::getExistingTables($tableNames);
+      foreach ($customGroups as $customGroup) {
+        if (!isset($existingTables[$customGroup['table_name']])) {
+          continue;
         }
-        foreach ($customGroups as $customGroup) {
-          if (!isset($existingTables[$customGroup['table_name']])) {
-            continue;
-          }
-          $relations[] = [
-            'table' => $customGroup['table_name'],
-            'column' => 'entity_id',
-          ];
-        }
+        $relations[] = [
+          'table' => $customGroup['table_name'],
+          'column' => 'entity_id',
+        ];
       }
     }
 
     return $relations;
+  }
+
+  /**
+   * Check which of the given tables actually exist in the database.
+   *
+   * @param string[] $tableNames
+   *   List of table names to check.
+   * @return array
+   *   Keyed by table name, value is TRUE for each table that exists.
+   */
+  private static function getExistingTables(array $tableNames): array {
+    if (empty($tableNames)) {
+      return [];
+    }
+    $escaped = implode("', '", array_map(['\CRM_Core_DAO', 'escapeString'], $tableNames));
+    $existingTables = [];
+    $dao = \CRM_Core_DAO::executeQuery("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('$escaped')");
+    while ($dao->fetch()) {
+      $existingTables[$dao->TABLE_NAME] = TRUE;
+    }
+    return $existingTables;
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomGroupTest.php
@@ -545,6 +545,64 @@ class CRM_Core_BAO_CustomGroupTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test isGroupEmpty() returns TRUE when the backing table is missing.
+   *
+   * When a custom group's backing table has been dropped (e.g. by logging
+   * schema reconciliation) but the civicrm_custom_group record remains,
+   * isGroupEmpty() should return TRUE instead of crashing with error 1146.
+   */
+  public function testIsGroupEmptyWithMissingTable(): void {
+    $customGroup = $this->customGroupCreate([
+      'title' => 'Test Missing Table Group',
+      'extends' => 'Individual',
+    ]);
+    $groupId = $customGroup['id'];
+    $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $groupId, 'table_name');
+
+    // Drop the backing table to simulate an orphaned group.
+    CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS $tableName");
+
+    // isGroupEmpty() should return TRUE, not crash.
+    $this->assertTrue(CRM_Core_BAO_CustomGroup::isGroupEmpty($groupId));
+
+    // Clean up via API — deleteRecord() uses DROP TABLE IF EXISTS so it
+    // handles the missing backing table gracefully.
+    $this->customGroupDelete($groupId);
+  }
+
+  /**
+   * Test that trigger rebuild does not crash with an orphaned custom group.
+   *
+   * When a custom group's backing table has been dropped but the
+   * civicrm_custom_group record remains, SqlTriggers::rebuild() should
+   * complete without error.
+   */
+  public function testTriggerRebuildWithOrphanedCustomGroup(): void {
+    $customGroup = $this->customGroupCreate([
+      'title' => 'Test Orphaned Trigger Group',
+      'extends' => 'Contact',
+    ]);
+    $groupId = $customGroup['id'];
+    $tableName = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $groupId, 'table_name');
+
+    // Drop the backing table to simulate an orphaned group.
+    CRM_Core_DAO::executeQuery("DROP TABLE IF EXISTS $tableName");
+
+    // Trigger rebuild should not crash.
+    try {
+      \Civi::service('sql_triggers')->rebuild();
+      $this->addToAssertionCount(1);
+    }
+    catch (\Exception $e) {
+      $this->fail('Trigger rebuild should not crash with orphaned custom group: ' . $e->getMessage());
+    }
+
+    // Clean up via API — deleteRecord() uses DROP TABLE IF EXISTS so it
+    // handles the missing backing table gracefully.
+    $this->customGroupDelete($groupId);
+  }
+
+  /**
    * Test getGroupTitles()
    */
   public function testGetGroupTitles(): void {


### PR DESCRIPTION
Overview
----------------------------------------

When a custom field is deleted via `deleteField()`, the parent `civicrm_custom_group` record is left intact even if no fields remain. If the backing `civicrm_value_*` table is subsequently dropped (e.g. by logging schema reconciliation or upgrade cleanup), `SqlTriggers::rebuild()` crashes with MySQL error 1146 ("Table doesn't exist").

This PR adds defensive guards so that orphaned custom group records with missing backing tables do not crash trigger rebuilds or `isGroupEmpty()`.

Before
----------------------------------------

1. Create a custom group with one field
2. Delete the field — the `civicrm_custom_group` record remains orphaned
3. The backing table gets dropped by another process (e.g. logging schema reconciliation)
4. Run `drush civicrm-sql-rebuild-triggers` — crashes:

```
nativecode=1146 — Table 'civicrm_value_example_123' doesn't exist
```

The crash occurs in `TimestampTriggers::getAllRelations()` which queries `civicrm_custom_group` via `CustomGroup::getAll()` and feeds the orphaned table name to `generateTimestampTriggers()`. `SqlTriggers::createTriggers()` then fails trying to create a trigger on the non-existent table.

`CustomGroup::isGroupEmpty()` is also vulnerable — it queries the backing table directly with no existence check.

After
----------------------------------------

1. Same scenario — orphaned group, missing backing table
2. `SqlTriggers::rebuild()` runs cleanly — `TimestampTriggers::getAllRelations()` skips custom groups whose backing table no longer exists
3. `isGroupEmpty()` returns `TRUE` instead of crashing when the backing table is missing

No behaviour change for non-orphaned groups.

Technical Details
----------------------------------------

**`Civi/Core/SqlTrigger/TimestampTriggers.php`** — In `getAllRelations()`, check `INFORMATION_SCHEMA.TABLES` before adding a custom group table to the relations list. Skip groups whose backing table no longer exists.

**`CRM/Core/BAO/CustomGroup.php`** — In `isGroupEmpty()`, check `INFORMATION_SCHEMA.TABLES` before querying the backing table. If the table is missing, return `TRUE` (the group is effectively empty).

Comments
----------------------------------------

This is a defensive fix only — it does not change deletion behaviour or auto-delete orphaned groups. A separate discussion about whether `deleteField()` should clean up empty groups can happen independently.