### PR TITLE
Groups - Fixes performance issue with search pages

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -1243,24 +1243,48 @@ WHERE {$whereClause}";
    * @param array $parentArray
    *   Array of group Ids.
    *
-   * @return int
+   * @return int|null
+   *   The first active parent group ID, or NULL if none are active.
    */
-  public static function filterActiveGroups($parentArray) {
-    if (count($parentArray) >= 1) {
-      $result = civicrm_api3('Group', 'get', [
-        'id' => ['IN' => $parentArray],
-        'is_active' => TRUE,
-        'return' => 'id',
-      ]);
-      $activeParentGroupIDs = CRM_Utils_Array::collect('id', $result['values']);
-      foreach ($parentArray as $key => $groupID) {
-        if (!array_key_exists($groupID, $activeParentGroupIDs)) {
-          unset($parentArray[$key]);
-        }
+  public static function filterActiveGroups($parentArray): ?int {
+    if (!isset(Civi::$statics[__METHOD__])) {
+      Civi::$statics[__METHOD__] = [];
+    }
+    $activeGroupCache = &Civi::$statics[__METHOD__];
+
+    if (count($parentArray) < 1) {
+      return NULL;
+    }
+
+    $parentArray = array_map('intval', $parentArray);
+    $missingIDs = [];
+    foreach ($parentArray as $groupID) {
+      if (!array_key_exists($groupID, $activeGroupCache)) {
+        $missingIDs[$groupID] = $groupID;
       }
     }
 
-    return reset($parentArray);
+    if ($missingIDs) {
+      $result = Group::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('id', 'IN', array_values($missingIDs))
+        ->addWhere('is_active', '=', TRUE)
+        ->execute();
+
+      $activeParentGroupIDs = $result->column('id', 'id');
+
+      foreach ($missingIDs as $groupID) {
+        $activeGroupCache[$groupID] = !empty($activeParentGroupIDs[$groupID]);
+      }
+    }
+
+    foreach ($parentArray as $groupID) {
+      if (!empty($activeGroupCache[$groupID])) {
+        return $groupID;
+      }
+    }
+
+    return NULL;
   }
 
   /**

--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -376,6 +376,7 @@ class CRM_Contact_BAO_Group extends CRM_Contact_DAO_Group implements HookInterfa
    * @return bool
    */
   public static function setIsActive($id, $isActive) {
+    unset(Civi::$statics[__CLASS__ . '::filterActiveGroups']);
     return CRM_Core_DAO::setFieldValue('CRM_Contact_DAO_Group', $id, 'is_active', $isActive);
   }
 
@@ -1316,6 +1317,7 @@ WHERE {$whereClause}";
    * @param \Civi\Core\Event\PostEvent $event
    */
   public static function self_hook_civicrm_post(\Civi\Core\Event\PostEvent $event) {
+    unset(Civi::$statics[__CLASS__ . '::filterActiveGroups']);
     /** @var CRM_Contact_DAO_Group $group */
     $group = $event->object;
     if (in_array($event->action, ['create', 'edit'])) {

--- a/tests/phpunit/CRM/Contact/BAO/GroupTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupTest.php
@@ -98,8 +98,10 @@ class CRM_Contact_BAO_GroupTest extends CiviUnitTestCase {
     $this->assertEquals('&nbsp;&nbsp;Child Group C', $groupsHierarchy[$group3->id]);
 
     // Disable parent group A and ensure that child group C is not present as both of its parent groups are disabled
-    $group1->is_active = 0;
-    $group1->save();
+    CRM_Contact_BAO_Group::writeRecord([
+      'id' => $group1->id,
+      'is_active' => 0,
+    ]);
     $groupsHierarchy = CRM_Contact_BAO_Group::getGroupsHierarchy($params, NULL, '&nbsp;&nbsp;', TRUE);
     $this->assertFalse(array_key_exists($group3->id, $groupsHierarchy));
   }


### PR DESCRIPTION
This is the PR referenced on https://lab.civicrm.org/dev/core/-/work_items/6474

For consistency, I'll repeat here the details

## Summary

Group hierarchy building is slow on larger datasets because parent activity checks are repeated many times during one request.  
That behaviour can be seen on the Search > Search contacts page and also on the loading time of the actual contact search.

## Environment

* CiviCRM 6.13.1 without groups/ACLs in place
* CiviCRM 6.4.2 with 960 groups + basic ACLs (2 rules)
* Profiling done with xhprof, testing/performance checking without it

## Actual behavior

* getGroupsHierarchy repeatedly calls filterActiveGroups while iterating groups.
* filterActiveGroups performs API lookups for parent IDs that were already checked earlier in the same request.
* This creates N+1-like overhead and dominates wall time.

## Expected behavior

* Parent active-status checks should be reused within a request.
* Hierarchy output should remain functionally the same while avoiding repeated API calls.

## Hot path

* getGroupsHierarchy: https://github.com/civicrm/civicrm-core/blob/6.13/CRM/Contact/BAO/Group.php#L876
* loop call site: https://github.com/civicrm/civicrm-core/blob/6.13/CRM/Contact/BAO/Group.php#L932
* filter method: [Group.php:1239](https://github.com/civicrm/civicrm-core/blob/6.13/CRM/Contact/BAO/Group.php#L932)

## Suggested fix direction

* Keep existing function contract.
* Add request-level caching of active parent ID checks in filterActiveGroups (or precompute active set once in getGroupsHierarchy).
* Preserve existing visibility/ACL behavior expectations.

## What we did to rework that part

What we changed with our patch

1. Added request-level caching inside filterActiveGroups.
   * The function now keeps an in-memory map of group IDs it has already checked during the current request.
   * If the same group ID appears again later, it does not query CiviCRM again.
2. We batched only the missing IDs.
   * Instead of re-checking the full parent list every time, the function first detects which IDs are not already in cache.
   * Only those unknown IDs are queried.
3. We preserved the function’s purpose.
   * The function still returns the first eligible parent from the original input order.
   * It still filters out disabled parents.
   * In the version we tested, it also explicitly excluded hidden groups.
4. We modernized the lookup path.
   * The original implementation used an APIv3 Group.get call.
   * The patched version switched that lookup to APIv4 Group::get

## Some numbers

On CiviCRM 6.4.2 with 960 groups and ACLs, 3 times test, before the patch:

* Search > Search contacts page -> 10.6s-10.8s (DOM content)
* Performing of a search with empty search terms -> 18.3s-18.9s

Same instance, after the patch (again, 3 times tested):

* Search > Search contacts page -> 3.5s-5.6s (DOM content)
* Performing of a search with empty search terms -> 3.5s-5.8s