### PR TITLE
dev/core#6404 - Only show active payment processors on event fees form

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -238,6 +238,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
 
     $paymentProcessor = PaymentProcessor::get(FALSE)
       ->addWhere('is_test', '=', FALSE)
+      ->addWhere('is_active', '=', TRUE)
       ->execute()
       ->column('title', 'id');
 


### PR DESCRIPTION
Overview
----------------------------------------
Restores the old behavior of only showing active payment processors when editing the Fees tab on an event form.

Before
----------------------------------------
Before https://github.com/civicrm/civicrm-core/commit/3c86d803113862597ffeb6127aeb188bcf982c1a, the Fees tab would only show active payment processors. After that commit, it also shows disabled payment processors as options. This only occurs on the event edit form, not the public form.

After
----------------------------------------
Filter on is_active = true to again only show active payment processors.

Technical Details
----------------------------------------
The old code called `CRM_Core_PseudoConstant::get`, which would default to only including where `is_active` is TRUE in this situation.
