### PR TITLE
Afform Admin - caret looks weird on dropup menu

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -100,7 +100,7 @@ class AfformAdminInjector extends AutoSubscriber {
           $editMenu = <<<HTML
             <div class="btn-group crm-admin-block-context-dropdown dropup" ng-if="checkLinkPerm('{$links[0]['permission']}', {$links[0]['created_id']})">
               <button type="button" class="btn dropdown-toggle btn-sm" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <i class="crm-i fa-gear" role="img" aria-hidden="true"></i> <span class="caret"></span><span class="sr-only">{{:: ts('Configure')}}</span>
+                <i class="crm-i fa-gear" role="img" aria-hidden="true"></i> <span class="sr-only">{{:: ts('Configure')}}</span>
               </button>
               <ul class="dropdown-menu dropdown-menu-right">$linksMarkup</ul>
             </div>


### PR DESCRIPTION
Overview
----------------------------------------
The caret points down, but these menus now "drop up", which is mismatched. We don't need the caret.


Before
---------------------------------------
<img width="935" height="325" alt="image" src="https://github.com/user-attachments/assets/2a8cfa10-aac3-40b9-90a9-1f7c6cd71f16" />


After
---------------------------------------
<img width="1007" height="498" alt="image" src="https://github.com/user-attachments/assets/bfeb31f5-9579-487a-a700-b37154cae826" />


Comments
-------------------------------------
It would be nice if they droplet bit on the menu aligned more centrally, but that's fight for another day.