### PR TITLE
MembershipType - Filter by domain on admin screen

### DIFF
--- a/CRM/Member/Page/MembershipType.php
+++ b/CRM/Member/Page/MembershipType.php
@@ -98,6 +98,7 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
     $this->assign('action');
     $membershipType = (array) MembershipType::get()
       ->addOrderBy('weight')
+      ->addWhere('domain_id', '=', 'current_domain')
       ->setSelect([
         'id',
         'domain_id',

--- a/schema/Member/MembershipType.entityType.php
+++ b/schema/Member/MembershipType.entityType.php
@@ -48,7 +48,7 @@ return [
       'sql_type' => 'int unsigned',
       'input_type' => 'EntityRef',
       'required' => TRUE,
-      'description' => ts('Which Domain is this match entry for'),
+      'description' => ts('Domain to which this membership type belongs.'),
       'add' => '3.0',
       'default_callback' => ['CRM_Core_BAO_Domain', 'getDomainID'],
       'input_attrs' => [


### PR DESCRIPTION
Overview
----------------------------------------
On Administer -> Membership Types, avoid showing membership types from other domains.

See [dev/core#6473](https://lab.civicrm.org/dev/core/-/work_items/6473)

Before
----------------------------------------
Admin screen shows membership types for all domains, without showing which domain they belong to.

After
----------------------------------------
Just show the relevant ones.