### PR TITLE
MembershipType - Add domain to name index; prevent upgrade crash

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -476,11 +476,16 @@ ADD UNIQUE INDEX `unique_entity_id` ( `entity_id` )";
    *
    * @param string $tableName
    * @param string $indexName
+   *
+   * @return bool
+   *   TRUE if the index was dropped, FALSE otherwise.
    */
-  public static function dropIndexIfExists($tableName, $indexName) {
+  public static function dropIndexIfExists($tableName, $indexName): bool {
     if (self::checkIfIndexExists($tableName, $indexName)) {
       CRM_Core_DAO::executeQuery("DROP INDEX $indexName ON $tableName");
+      return TRUE;
     }
+    return FALSE;
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixEleven.php
+++ b/CRM/Upgrade/Incremental/php/SixEleven.php
@@ -29,7 +29,6 @@ class CRM_Upgrade_Incremental_php_SixEleven extends CRM_Upgrade_Incremental_Base
    */
   public function upgrade_6_11_alpha1($rev): void {
     $this->addTask('Add Membership title and frontend_title columns', 'addMembershipTitleColumns');
-    $this->addTask(ts('Create index %1', [1 => 'civicrm_membership_type.UI_name']), 'addIndex', 'civicrm_membership_type', [['name']], 'UI');
 
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Set preferred language to default if undefined', 'setPreferredLanguageToDefaultIfNull');

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -95,6 +95,10 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask('Ensure TranslationSource.source_key foreign key constraint exists', 'ensureTranslationSourceForeignKey');
   }
 
+  public function upgrade_6_14_beta1($rev): void {
+    $this->addTask('Add unique index to MembershipType on name + domain_id', 'addMembershipTypeIndex');
+  }
+
   /**
    * @see https://lab.civicrm.org/dev/core/-/issues/6143
    */
@@ -147,6 +151,34 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
     ], "\n", " ADD ", 'civicrm_translation');
     CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_translation " . $sql, [], TRUE, NULL, FALSE, FALSE);
 
+    return TRUE;
+  }
+
+  public static function addMembershipTypeIndex(): bool {
+    $oldIndexExists = \CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_membership_type', 'UI_name');
+    $newIndexExists = \CRM_Core_BAO_SchemaHandler::checkIfIndexExists('civicrm_membership_type', 'UI_name_domain_id');
+    if ($newIndexExists) {
+      // Upgrade has already run, nothing to do.
+      return TRUE;
+    }
+    if (!$oldIndexExists) {
+      // If we didn't already have a unique index, ensure all membership types in the same domain have a unique name
+      CRM_Core_DAO::executeQuery('
+        UPDATE civicrm_membership_type m1, civicrm_membership_type m2
+        SET m1.name = CONCAT(m1.name, "_", m1.id)
+        WHERE m1.name = m2.name AND m1.id > m2.id
+        AND m1.domain_id = m2.domain_id',
+        i18nRewrite: FALSE);
+    }
+    \CRM_Core_BAO_SchemaHandler::createMissingIndices([
+      'civicrm_membership_type' => [
+        [
+          'name' => 'UI_name_domain_id',
+          'unique' => TRUE,
+          'field' => ['name', 'domain_id'],
+        ],
+      ],
+    ]);
     return TRUE;
   }
 

--- a/schema/Member/MembershipType.entityType.php
+++ b/schema/Member/MembershipType.entityType.php
@@ -24,12 +24,13 @@ return [
       ],
       'add' => '3.3',
     ],
-    'UI_name' => [
+    'UI_name_domain_id' => [
       'fields' => [
         'name' => TRUE,
+        'domain_id' => TRUE,
       ],
       'unique' => TRUE,
-      'add' => '6.11',
+      'add' => '6.14',
     ],
   ],
   'getFields' => fn() => [


### PR DESCRIPTION
Overview
----------------------------------------
Solves a potential upgrader crash and cross-domain name conflict with membership types.

Fixes [dev/core#6473](https://lab.civicrm.org/dev/core/-/work_items/6473)


Before
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/34160 added a unique index to name, but did not take domain into account. Also, the upgrader took no precautions when adding the index – two membership types with the same name would crash the upgrade.

After
----------------------------------------
Unique index added to name+domain_id, upgrader improved.
