### PR TITLE
dev/core#6472 SearchKit - Fix download action when columnMode is 'auto'

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -135,6 +135,15 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     $this->_apiParams['checkPermissions'] = $this->savedSearch['api_params']['checkPermissions'] = empty($this->display['acl_bypass']);
     $this->display['settings']['columns'] ??= [];
 
+    // Get auto columns
+    if ('auto' === ($this->display['settings']['columnMode'] ?? NULL)) {
+      $defaultDisplay = \Civi\Api4\SearchDisplay::getDefault(FALSE)
+        ->setSavedSearch($this->savedSearch)
+        ->setType($this->display['type'])
+        ->execute()->single();
+      $this->display['settings']['columns'] = $defaultDisplay['settings']['columns'];
+    }
+
     $this->processResult($result);
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -47,13 +47,7 @@ class Run extends AbstractRunAction {
   protected function processResult(SearchDisplayRunResult $result) {
     $entityName = $this->savedSearch['api_entity'];
     $apiParams =& $this->_apiParams;
-    if ('auto' === ($this->display['settings']['columnMode'] ?? NULL)) {
-      $defaultDisplay = \Civi\Api4\SearchDisplay::getDefault(FALSE)
-        ->setSavedSearch($this->savedSearch)
-        ->setType($this->display['type'])
-        ->execute()->single();
-      $this->display['settings']['columns'] = $defaultDisplay['settings']['columns'];
-    }
+
     $page = $index = NULL;
     $key = $this->return;
     // Pager can operate in "page" mode for traditional pager, or "scroll" mode for infinite scrolling


### PR DESCRIPTION
When using 'auto' columns, the download action wasn't working (it thought there were no columns).

This fixes it by moving the default calculation to the parent class.

Fixes dev/core#6472

backport of https://github.com/civicrm/civicrm-core/pull/35502