### PR TITLE
dev/core#6442 Do not add pay later processor if is_pay_later = 0

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -495,6 +495,9 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
    * @return string
    */
   public function getPayLaterLabel(): string {
+    if (!$this->getContributionPageValue('is_pay_later')) {
+      return '';
+    }
     return (string) $this->getContributionPageValue('pay_later_text');
   }
 


### PR DESCRIPTION
The way the decision is made to render the label is convoluted but https://lab.civicrm.org/dev/core/-/work_items/6442 points out it went wrong with https://github.com/civicrm/civicrm-core/pull/35110/changes so the approach is simply to nuance that

Port of https://github.com/civicrm/civicrm-core/pull/35475 to stable