### PR TITLE
Fix Contribution Transfer During Contact Merge

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -377,7 +377,8 @@ class CRM_Dedupe_Merger {
 INNER JOIN  civicrm_pledge_payment payment ON ( payment.contribution_id = contribution.id )
 INNER JOIN  civicrm_pledge pledge ON ( pledge.id = payment.pledge_id )
        SET  contribution.contact_id = $mainContactId
-     WHERE  pledge.contact_id = $otherContactId";
+     WHERE  pledge.contact_id = $otherContactId
+       AND  contribution.contact_id = $otherContactId";
         break;
 
       case 'civicrm_membership':
@@ -386,7 +387,8 @@ INNER JOIN  civicrm_pledge pledge ON ( pledge.id = payment.pledge_id )
 INNER JOIN  civicrm_line_item line ON ( line.contribution_id = contribution.id AND line.entity_table = 'civicrm_membership')
 INNER JOIN  civicrm_membership membership ON ( membership.id = line.entity_id )
        SET  contribution.contact_id = $mainContactId
-     WHERE  membership.contact_id = $otherContactId";
+     WHERE  membership.contact_id = $otherContactId
+       AND  contribution.contact_id = $otherContactId";
         break;
 
       case 'civicrm_participant':
@@ -395,7 +397,8 @@ INNER JOIN  civicrm_membership membership ON ( membership.id = line.entity_id )
 INNER JOIN  civicrm_line_item line ON ( line.contribution_id = contribution.id AND line.entity_table = 'civicrm_participant')
 INNER JOIN  civicrm_participant participant ON ( participant.id = line.entity_id )
        SET  contribution.contact_id = $mainContactId
-     WHERE  participant.contact_id = $otherContactId";
+     WHERE  participant.contact_id = $otherContactId
+       AND  contribution.contact_id = $otherContactId";
         break;
     }
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1842,4 +1842,151 @@ WHERE
     return $contact2;
   }
 
+  /**
+   * The generated SQL must include the payer-equality clause for every supported payment table.
+   *
+   * @dataProvider paymentSqlTableProvider
+   */
+  public function testPaymentSqlIncludesPayerEqualityClause(string $tableName): void {
+    $sqls = CRM_Dedupe_Merger::paymentSql($tableName, 1001, 2002);
+
+    $this->assertCount(1, $sqls, "paymentSql() should produce exactly one SQL for {$tableName}");
+    $this->assertStringContainsString(
+      'contribution.contact_id = 2002',
+      $sqls[0],
+      "paymentSql() for {$tableName} must restrict the rewrite to contributions paid by the deleted contact."
+    );
+  }
+
+  public function paymentSqlTableProvider(): array {
+    return [
+      'pledge'      => ['civicrm_pledge'],
+      'membership'  => ['civicrm_membership'],
+      'participant' => ['civicrm_participant'],
+    ];
+  }
+
+  /**
+   * Event-fee contribution paid by a third party.
+   */
+  public function testParticipantContributionStaysWithThirdPartyPayer(): void {
+    [$mainId, $otherId] = $this->createMergePair();
+    $employerId = $this->organizationCreate(['organization_name' => 'Acme Employer']);
+    $participantId = $this->participantCreate(['contact_id' => $otherId]);
+    $contributionId = $this->createParticipantContribution($employerId, $participantId);
+
+    $this->runPaymentSql('civicrm_participant', $mainId, $otherId);
+
+    $this->assertEquals($employerId, $this->getContributionContactId($contributionId));
+  }
+
+  /**
+   * Membership-fee contribution paid by a third-party.
+   */
+  public function testMembershipContributionStaysWithThirdPartyPayer(): void {
+    [$mainId, $otherId] = $this->createMergePair();
+    $thirdPartyId = $this->individualCreate([], 'parent');
+    $membershipId = $this->contactMembershipCreate(['contact_id' => $otherId]);
+    $contributionId = $this->createMembershipContribution($thirdPartyId, $membershipId);
+
+    $this->runPaymentSql('civicrm_membership', $mainId, $otherId);
+
+    $this->assertEquals($thirdPartyId, $this->getContributionContactId($contributionId));
+  }
+
+  /**
+   * Pledge-payment contribution paid by a third-party.
+   */
+  public function testPledgeContributionStaysWithThirdPartyPayer(): void {
+    [$mainId, $otherId] = $this->createMergePair();
+    $thirdPartyId = $this->individualCreate([], 'sibling');
+    $pledgeId = $this->pledgeCreate(['contact_id' => $otherId]);
+    $contributionId = $this->createPledgeContribution($thirdPartyId, $pledgeId);
+
+    $this->runPaymentSql('civicrm_pledge', $mainId, $otherId);
+
+    $this->assertEquals($thirdPartyId, $this->getContributionContactId($contributionId));
+  }
+
+  /**
+   * Returns [mainId, otherId] – two fresh individuals to use for a merge.
+   */
+  private function createMergePair(): array {
+    return [
+      $this->individualCreate([], 'main'),
+      $this->individualCreate([], 'other'),
+    ];
+  }
+
+  /**
+   * Executes the SQL produced by paymentSql() for the given table. Mirrors
+   * what CRM_Dedupe_Merger::moveContactBelongings() does for the same table
+   * during a real merge, but stays focused on just the function under test.
+   */
+  private function runPaymentSql(string $tableName, int $mainId, int $otherId): void {
+    foreach (CRM_Dedupe_Merger::paymentSql($tableName, $mainId, $otherId) as $sql) {
+      CRM_Core_DAO::executeQuery($sql);
+    }
+  }
+
+  /**
+   * Returns the current contact_id of the given contribution.
+   */
+  private function getContributionContactId(int $contributionId): int {
+    return (int) CRM_Core_DAO::singleValueQuery(
+      'SELECT contact_id FROM civicrm_contribution WHERE id = %1',
+      [1 => [$contributionId, 'Integer']]
+    );
+  }
+
+  /**
+   * Creates a contribution belonging to $payerId and links it to the given
+   * participant via civicrm_participant_payment.
+   */
+  private function createParticipantContribution(int $payerId, int $participantId): int {
+    $contributionId = $this->contributionCreate([
+      'contact_id'        => $payerId,
+      'financial_type_id' => 'Event Fee',
+    ]);
+    $this->callAPISuccess('ParticipantPayment', 'create', [
+      'contribution_id' => $contributionId,
+      'participant_id'  => $participantId,
+    ]);
+    return $contributionId;
+  }
+
+  /**
+   * Creates a contribution belonging to $payerId and links it to the given
+   * membership via civicrm_membership_payment.
+   */
+  private function createMembershipContribution(int $payerId, int $membershipId): int {
+    $contributionId = $this->contributionCreate([
+      'contact_id'        => $payerId,
+      'financial_type_id' => 'Member Dues',
+    ]);
+    $this->callAPISuccess('MembershipPayment', 'create', [
+      'contribution_id' => $contributionId,
+      'membership_id'   => $membershipId,
+    ]);
+    return $contributionId;
+  }
+
+  /**
+   * Creates a contribution belonging to $payerId.
+   */
+  private function createPledgeContribution(int $payerId, int $pledgeId): int {
+    $contributionId = $this->contributionCreate([
+      'contact_id'        => $payerId,
+      'financial_type_id' => 'Donation',
+    ]);
+    CRM_Core_DAO::executeQuery(
+      'UPDATE civicrm_pledge_payment SET contribution_id = %1 WHERE pledge_id = %2 ORDER BY id LIMIT 1',
+      [
+        1 => [$contributionId, 'Integer'],
+        2 => [$pledgeId, 'Integer'],
+      ]
+    );
+    return $contributionId;
+  }
+
 }


### PR DESCRIPTION
## Overview

When two contacts are merged, `civicrm_contribution.contact_id` is currently rewritten to the surviving contact for **every** contribution attached to the deleted contact's participants, memberships, or pledges — regardless of who originally paid. This silently destroys the link between the contribution and its real payer whenever a third party (employer organisation, parent, sibling, friend, anonymous benefactor, etc.) paid on behalf of the contact being merged.

This PR scopes that rewrite to contributions actually paid by the contact being deleted. Third-party-paid contributions now stay attached to their original payer after the merge.

## Before

In `CRM_Dedupe_Merger::paymentSql()`, each of the three `UPDATE` statements (pledge / membership / participant variants) had a `WHERE` clause that filtered only on the bridge entity's `contact_id`:

```sql
UPDATE IGNORE civicrm_contribution contribution
  INNER JOIN civicrm_participant_payment payment ON payment.contribution_id = contribution.id
  INNER JOIN civicrm_participant participant      ON participant.id = payment.participant_id
SET   contribution.contact_id = $mainContactId
WHERE participant.contact_id = $otherContactId
```

Because the `WHERE` only checked who the *participant* was — never who the *payer* was — every contribution attached to the deleted contact's participation got rewritten to the surviving contact, even when that contribution had originally been paid by a different contact entirely.

## After

`paymentSql()` adds `AND contribution.contact_id = $otherContactId` to each WHERE` clause:

```sql
UPDATE IGNORE civicrm_contribution contribution
  INNER JOIN civicrm_participant_payment payment ON payment.contribution_id = contribution.id
  INNER JOIN civicrm_participant participant      ON participant.id = payment.participant_id
SET   contribution.contact_id = $mainContactId
WHERE participant.contact_id  = $otherContactId
  AND contribution.contact_id = $otherContactId
```

Behaviour matrix for the participant case (membership and pledge are
identical in shape):

| participant.contact_id | contribution.contact_id | New WHERE matches? | Result                                |
|------------------------|-------------------------|--------------------|---------------------------------------|
| `otherId`              | `otherId`               | yes                | rewritten to `mainId` (unchanged)     |
| `otherId`              | C (employer org)        | no                 | stays with C ✅ (was incorrectly moved)|
| `otherId`              | parent / sibling / friend | no              | stays with original payer ✅           |
| someone else           | anything                | no                 | not handled by `paymentSql()` (already correct under the bridge filter) |
| `otherId`              | `mainId`                | no                 | left alone (no double-application)    |
