### PR TITLE
REF: Refactor Order->save(), set Contribution.receive_date=ContributionRecur.start_date

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -31,6 +31,7 @@ use Civi\Api4\PriceSet;
  * may change.
  *
  * @internal
+ *
  */
 class CRM_Financial_BAO_Order {
 
@@ -867,7 +868,7 @@ class CRM_Financial_BAO_Order {
    *
    * @throws \CRM_Core_Exception
    */
-  public function getLineItems():array {
+  public function getLineItems(): array {
     if (empty($this->lineItems)) {
       $this->lineItems = $this->calculateLineItems();
     }
@@ -1570,49 +1571,27 @@ class CRM_Financial_BAO_Order {
    *
    * @return void
    */
-  public function setContributionRecur(array $contributionRecurValues) {
+  public function setContributionRecurValues(array $contributionRecurValues) {
     $this->contributionRecurValues = $contributionRecurValues;
   }
 
   /**
    * @param array $contributionValues
    *
-   * @return \Civi\Api4\Generic\Result
-   *
-   * @internal Access through apiv4 Order api only. Signature subject to change.
-   *
-   * @throws \CRM_Core_Exception
+   * @return void
    */
-  public function save(array $contributionValues): Result {
+  public function setContributionValues(array $contributionValues) {
     $this->contributionValues = $contributionValues;
-    $this->saveContributionRecur();
-    foreach ($this->getLineItems() as $index => $lineItem) {
-      // Save entities first, so we can get the Entity ID.
-      if ($lineItem['entity_table'] !== 'civicrm_contribution') {
-        $this->setLineItemValue('entity_id', $this->saveLineItemEntity($lineItem), $index);
-      }
-    }
-
-    $contributionValues['total_amount'] = $this->getTotalAmount();
-    $contributionValues['tax_amount'] = $this->getTotalTaxAmount();
-    $contributionValues['amount_level'] = $contributionValues['amount_level'] ?? $this->getAmountLevel();
-    $contributionValues['contribution_status_id:name'] = 'Pending';
-    $contributionValues['line_item'] = [$this->getLineItems()];
-    if ($this->getExistingContributionRecurID()) {
-      $contributionValues['contribution_recur_id'] = $this->getExistingContributionRecurID();
-    }
-    return Contribution::create(FALSE)
-      ->setValues($contributionValues)->execute();
   }
 
   /**
-   * This will create a ContributionRecur if (at least) frequency_unit is set in $this->contributionRecurValues
+   *  Calculate additional/automatic/required parameters for ContributionRecur
    *
    * @return void
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
    */
-  private function saveContributionRecur(): void {
+  private function calculateContributionRecurValues() {
     if (!$this->getExistingContributionRecurID()) {
       if (empty($this->contributionRecurValues)) {
         // We are not creating a ContributionRecur. That is ok.
@@ -1639,8 +1618,89 @@ class CRM_Financial_BAO_Order {
         ->single();
       $this->setExistingContributionRecurID($contributionRecur['id']);
     }
+  }
 
-    $this->setExistingContributionRecurID($this->getExistingContributionRecurID());
+  /**
+   * Calculate additional/automatic/required parameters for Contribution
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   */
+  private function calculateContributionValues() {
+    $this->contributionValues['total_amount'] = $this->getTotalAmount();
+    $this->contributionValues['tax_amount'] = $this->getTotalTaxAmount();
+    $this->contributionValues['amount_level'] = $this->contributionValues['amount_level'] ?? $this->getAmountLevel();
+    $this->contributionValues['contribution_status_id:name'] = 'Pending';
+    if ($this->getExistingContributionRecurID()) {
+      $this->contributionValues['contribution_recur_id'] = $this->getExistingContributionRecurID();
+    }
+    // If we specify a future start_date for recur, the Contribution should also use that date (unless overridden)
+    // @todo: Maybe we should also make it a template contribution?
+    if (isset($this->contributionRecurValues['start_date']) && !isset($this->contributionValues['receive_date'])) {
+      $this->contributionValues['receive_date'] = $this->contributionRecurValues['start_date'];
+    }
+  }
+
+  /**
+   * @return $this
+   *
+   * @internal Access through apiv4 Order api only. Signature subject to change.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function validate(): CRM_Financial_BAO_Order {
+    // First we calculate remaining parameters for Contribution/ContributionRecur
+    $this->calculateContributionRecurValues();
+    $this->calculateContributionValues();
+    // Then we get/calculate the lineitems - they won't have related entity IDs Membership/Participant etc. for new records.
+    $this->getLineItems();
+    return $this;
+  }
+
+  /**
+   * @return array
+   *
+   * @internal Access through apiv4 Order api only. Signature subject to change.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function save(): Result {
+    // Now we must save/create a ContributionRecur before we create related entity IDs because ContributionRecurID is
+    //   linked to some related entities, eg. Membership.
+    $this->saveContributionRecur();
+    foreach ($this->getLineItems() as $index => $lineItem) {
+      // Save entities first, so we can get the Entity ID.
+      if ($lineItem['entity_table'] !== 'civicrm_contribution') {
+        $this->setLineItemValue('entity_id', $this->saveLineItemEntity($lineItem), $index);
+      }
+    }
+    $this->contributionValues['line_item'] = [$this->getLineItems()];
+
+    return Contribution::create(FALSE)
+      ->setValues($this->contributionValues)->execute();
+  }
+
+  /**
+   * This will create a ContributionRecur if (at least) frequency_unit is set in $this->contributionRecurValues
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  private function saveContributionRecur(): void {
+    if (!$this->getExistingContributionRecurID()) {
+      if (empty($this->contributionRecurValues)) {
+        // We are not creating a ContributionRecur. That is ok.
+        return;
+      }
+
+      $contributionRecur = ContributionRecur::create(FALSE)
+        ->setValues($this->contributionRecurValues)
+        ->execute()
+        ->single();
+      $this->setExistingContributionRecurID($contributionRecur['id']);
+    }
   }
 
   /**

--- a/Civi/Api4/Action/Order/Create.php
+++ b/Civi/Api4/Action/Order/Create.php
@@ -105,8 +105,9 @@ class Create extends AbstractAction {
       $this->formatWriteValues($lineItem, 'LineItem', 'create');
       $order->setLineItem($lineItem, $index);
     }
-    $order->setContributionRecur($this->getContributionRecurValues());
-    $result[] = $order->save($this->getContributionValues())->first();
+    $order->setContributionRecurValues($this->getContributionRecurValues());
+    $order->setContributionValues($this->getContributionValues());
+    $result[] = $order->validate()->save()->first();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This refactors Order->save() (only used by API4 Order::create) to make it more modular and separate functionality into separate functions - reason: prepare for a "validate" step/event.

Also sets `Contribution.receive_date` = `ContributionRecur.start_date` if `receive_date` is not specified but `start_date` is. This is what you'd expect to happen but was omitted when I added support for recurring contributions in Order API. Basically if you set a future start date you're expecting the first contribution to be taken on that date unless you specify otherwise. Without this you end up with a Contribution with todays date.

Note: https://github.com/civicrm/civicrm-core/pull/35524 builds on this and adds in events.

Before
----------------------------------------
Described above

After
----------------------------------------
Described above

Technical Details
----------------------------------------
Previously we had functions that did two things: calculate parameters and save the entity. Eg. `saveContributionRecur` becomes `calculateContributionRecurValues` and `saveContributionRecur`.

Comments
----------------------------------------
The only functional change in this PR is the default receive_date = start_date.