### PR TITLE
NFC: Update validateContactID comment

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -521,7 +521,7 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   }
 
   /**
-   * Validate that a passed in contact ID is for an existing, not-deleted contact.
+   * Validate that a passed in contact ID is of the given contact type.
    *
    * @param int $contactID
    * @param string|null $contactType


### PR DESCRIPTION
This function doesn't validate that the contact isn't deleted (nor should it), nor does it even check if a contact ID exists unless you pass in a contact type as well.