### PR TITLE
Use API4 for Membership::create in tests

### DIFF
--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -740,7 +740,7 @@ contribution_recur.payment_instrument_id:name :Check
     if (!isset($this->ids['Membership'][0])) {
       $this->ids['Membership'][0] = $this->contactMembershipCreate([
         'contact_id' => $this->getContactID(),
-        $this->getCustomFieldName('text') => 'my field',
+        $this->getCustomFieldName('text', 4) => 'my field',
       ]);
     }
     return $this->ids['Membership'][0];

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -741,6 +741,8 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       }
     }
 
+    // Set API version to 4 to avoid legacy financial processing in BAO_Membership::create
+    $params['version'] = 4;
     $result = $this->callAPISuccess('Membership', 'create', $params);
     return $result['id'];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Use API4 Membership::create in tests instead of API3.

Two reasons:
- Move off legacy API
- Stop doing a load of legacy financial processing that is wrong / not required - ie. see https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/BAO/Membership.php#L309

Before
----------------------------------------
API3 create.

After
----------------------------------------
API4 create.

Technical Details
----------------------------------------
Switches the tests over to use API4 Membership::create. All tests still pass.

Comments
----------------------------------------

