### PR TITLE
Fix Payment allocations test API version setting

### DIFF
--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -532,9 +532,6 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
    * @dataProvider getPaymentLineItemAllocations
    */
   public function testCreatePaymentLineItemsAllocations($paymentLineItemData): void {
-    // We set API version for Payment::create so we can test with v3 and v4 (parameters are similar)
-    $params['version'] = $paymentLineItemData['api_version'];
-
     $contribution = $this->createPartiallyPaidParticipantOrder();
     $lineItems = $this->callAPISuccess('LineItem', 'get', ['contribution_id' => $contribution['id']])['values'];
 
@@ -542,6 +539,8 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
     $params = [
       'contribution_id' => $contribution['id'],
       'total_amount' => 50,
+      // We set API version for Payment::create so we can test with v3 and v4 (parameters are similar)
+      'version' => $paymentLineItemData['api_version'],
     ];
     $amounts = $paymentLineItemData['amounts1'];
     foreach ($lineItems as $id => $ignore) {


### PR DESCRIPTION
Overview
----------------------------------------
The `testCreatePaymentLineItemsAllocations` was not testing API4 because params were immediately overwritten.

Before
----------------------------------------
Testing API3 twice.

After
----------------------------------------
Testing API3 and API4 as intended.

Technical Details
----------------------------------------


Comments
----------------------------------------

