### PR TITLE
QuickSearch - Ensure settings updates are reflected in menu

### DIFF
--- a/CRM/Core/BAO/Navigation.php
+++ b/CRM/Core/BAO/Navigation.php
@@ -432,6 +432,15 @@ class CRM_Core_BAO_Navigation extends CRM_Core_DAO_Navigation {
   }
 
   /**
+   * Lightweight cache flush for just the navigation menu.
+   *
+   * Note: This function must never take any arguments, as it's called from an `on_change` settings callback.
+   */
+  public static function flushCache(): void {
+    Civi::cache('navigation')->flush();
+  }
+
+  /**
    * Reset navigation for all contacts or a specified contact.
    *
    * @param int $contactID

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -217,6 +217,9 @@ return [
     'is_contact' => 0,
     'help_text' => ts("Which fields can be searched on in the menubar quicksearch box?"),
     'settings_pages' => ['search' => ['section' => 'autocomplete', 'weight' => 90]],
+    'on_change' => [
+      ['CRM_Core_BAO_Navigation', 'flushCache'],
+    ],
   ],
   'autocomplete_displays' => [
     'group_name' => 'Search Preferences',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the need for a manual cache flush after updating the QuickSearch Options

Before
----------------------------------------
Go to Search Preferences and update some QuickSearch Options. The change isn't reflected until you clear caches yourself.

See [shouldiblamecaching.com](https://shouldiblamecach.ing/)

After
----------------------------------------
Now it is.