### PR TITLE
Minor cleanup around changeFeeSelections

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1388,14 +1388,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $contributionID = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($this->getMembershipID());
 
       // get price fields of chosen price-set
-      $priceSetDetails = CRM_Utils_Array::value(
-        $this->_priceSetId,
-        CRM_Price_BAO_PriceSet::getSetDetail(
-          $this->_priceSetId,
-          TRUE,
-          TRUE
-        )
-      );
+      $priceSetDetails = CRM_Price_BAO_PriceSet::getSetDetail($this->_priceSetId, TRUE, TRUE)[$this->_priceSetId] ?? NULL;
 
       // add price field information in $inputParams
       self::addPriceFieldByMembershipType($inputParams, $priceSetDetails['fields'], $this->getMembership()['membership_type_id']);

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -554,7 +554,7 @@ WHERE li.contribution_id = %1";
   }
 
   /**
-   * Function to update related contribution of a entity and
+   * Function to update related contribution of an entity and
    *  add/update/cancel financial records
    *
    * @param array $params
@@ -579,7 +579,7 @@ WHERE li.contribution_id = %1";
       $order->setForm($form);
     }
     unset($params);
-    $feeAmount = $updatedAmount = $order->getTotalAmount();
+    $feeAmount = $order->getTotalAmount();
     $taxAmount = $order->getTotalTaxAmount();
     $submittedLineItems = $order->getLineItems();
     $entityTable = 'civicrm_' . $entity;
@@ -602,13 +602,13 @@ WHERE li.contribution_id = %1";
     }
 
     // update line item with changed line total and other information
-    $totalParticipant = $participantCount = 0;
+    $totalParticipant = 0;
     $amountLevel = [];
     if (!empty($requiredChanges['line_items_to_update'])) {
-      foreach ($requiredChanges['line_items_to_update'] as $priceFieldValueID => $value) {
-        $amountLevel[] = $value['label'] . ' - ' . (float) $value['qty'];
-        if ($entity == 'participant' && isset($value['participant_count'])) {
-          $totalParticipant += $value['participant_count'];
+      foreach ($requiredChanges['line_items_to_update'] as $priceFieldValueID => $priceFieldValue) {
+        $amountLevel[] = $priceFieldValue['label'] . ' - ' . (float) $priceFieldValue['qty'];
+        if ($entity == 'participant' && isset($priceFieldValue['participant_count'])) {
+          $totalParticipant += $priceFieldValue['participant_count'];
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused variables. Rename variables for clarity. Remove use of deprecated `CRM_Utils_Array::value()`

Partial from https://github.com/civicrm/civicrm-core/pull/35525

Before
----------------------------------------
Less clean

After
----------------------------------------
More clean

Technical Details
----------------------------------------


Comments
----------------------------------------
