### PR TITLE
fix premium option to show on contribution page

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -71,7 +71,7 @@
               </div>
               {if $showPremiumSelectionFields}
                 {assign var="premium_option" value="options_"|cat:$row.id}
-                  {if array_key_exists('premium_option', $form)}
+                  {if array_key_exists($premium_option, $form)}
                     <div class="premium-full-options">
                       <p>{$form.$premium_option.html}</p>
                     </div>


### PR DESCRIPTION
Overview
----------------------------------------
The option to select premium product disapeared on contribution page

Before
----------------------------------------
Cannot see premium product options

<img width="886" height="194" alt="Screenshot 2026-04-28 at 17 04 04" src="https://github.com/user-attachments/assets/41186635-5e4a-404f-9c3d-e636bff52c24" />


After
----------------------------------------
Can see the option now

<img width="895" height="255" alt="Screenshot 2026-04-28 at 17 04 20" src="https://github.com/user-attachments/assets/925e13f7-f5ed-40d5-afea-c0a27ed52b1f" />


