### PR TITLE
dev/core#6404 Only show active payment processors on event fes form

### DIFF
--- a/CRM/Event/Form/ManageEvent/Fee.php
+++ b/CRM/Event/Form/ManageEvent/Fee.php
@@ -238,6 +238,7 @@ class CRM_Event_Form_ManageEvent_Fee extends CRM_Event_Form_ManageEvent {
 
     $paymentProcessor = PaymentProcessor::get(FALSE)
       ->addWhere('is_test', '=', FALSE)
+      ->addWhere('is_active', '=', TRUE)
       ->execute()
       ->column('title', 'id');
 


### PR DESCRIPTION
Overview
----------------------------------------
backport of https://github.com/civicrm/civicrm-core/pull/35507
