### PR TITLE
SearchKit - Prevent aggregation issues when augmenting select clause

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1571,9 +1571,14 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $field = $clause['fields'][$fieldAlias];
         if (!empty($field['input_attrs']['control_field']) && strpos($fieldAlias, ':')) {
           $prefix = substr($fieldAlias, 0, strrpos($fieldAlias, $field['name']));
-          // Don't need to add the field if a suffixed version already exists
-          if (!$this->getSelectExpression($prefix . $field['input_attrs']['control_field'] . ':label')) {
-            $this->addSelectExpression($prefix . $field['input_attrs']['control_field']);
+          $controlField = $prefix . $field['input_attrs']['control_field'];
+          if (
+            // Don't need to add the field if a suffixed version already exists
+            !array_intersect(array_keys($this->getSelectClause()), ["$controlField:label", "$controlField:name"]) &&
+            // Don't add if it would cause aggregation problems
+            !$this->canAggregate($controlField)
+          ) {
+            $this->addSelectExpression($controlField);
           }
         }
       }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3455,4 +3455,71 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals([$cids[0], $cids[1]], $result->column('key'));
   }
 
+  public function testGroupByCaseStatus(): void {
+    $cases = $this->saveTestRecords('Case', [
+      'records' => [
+        ['status_id:name' => 'Open'],
+        ['status_id:name' => 'Open'],
+        ['status_id:name' => 'Closed'],
+      ],
+    ]);
+    $caseIds = $cases->column('id');
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Case',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'COUNT(id) AS COUNT_id',
+            'status_id:label',
+          ],
+          'orderBy' => [],
+          'where' => [
+            ['id', 'IN', $caseIds],
+          ],
+          'groupBy' => [
+            'status_id',
+          ],
+          'join' => [],
+          'having' => [],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'testDisplay',
+        'settings' => [
+          'actions' => TRUE,
+          'pager' => [],
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'status_id:label',
+              'label' => 'Status',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'COUNT_id',
+              'label' => 'Count',
+              'sortable' => TRUE,
+            ],
+          ],
+          'sort' => [
+            ['status_id:label', 'ASC'],
+          ],
+        ],
+      ],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(2, $result);
+
+    $data = array_column($result->column('data'), 'COUNT_id', 'status_id:label');
+    $this->assertEquals(1, $data['Resolved']);
+    $this->assertEquals(2, $data['Ongoing']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Prevents a fatal error with the following search. Adds test.

<img width="1146" height="637" alt="image" src="https://github.com/user-attachments/assets/159e67da-eec6-423d-bdd4-69f1cb3c9b88" />
