### PR TITLE
dev/core#6449 add locale to settings metadata cache key

### DIFF
--- a/Civi/Core/SettingsMetadata.php
+++ b/Civi/Core/SettingsMetadata.php
@@ -88,9 +88,10 @@ class SettingsMetadata {
     if ($domainID === NULL) {
       $domainID = \CRM_Core_Config::domainID();
     }
+    $civicrmLocale = \CRM_Core_I18n::getLocale();
 
     $cache = \Civi::cache('settings');
-    $cacheString = 'settingsMetadata_' . $domainID . '_';
+    $cacheString = 'settingsMetadata_' . $domainID . '_' . $civicrmLocale;
     $settingsMetadata = $cache->get($cacheString);
 
     if (!is_array($settingsMetadata)) {

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -108,7 +108,7 @@ class api_v3_SettingTest extends CiviUnitTestCase {
   public function testGetFieldsCaching(int $version): void {
     $this->_apiversion = $version;
     $settingsMetadata = [];
-    Civi::cache('settings')->set('settingsMetadata_' . CRM_Core_Config::domainID() . '_', $settingsMetadata);
+    Civi::cache('settings')->set('settingsMetadata_' . CRM_Core_Config::domainID() . '_' . \CRM_Core_I18n::getLocale(), $settingsMetadata);
     $result = $this->callAPISuccess('setting', 'getfields', []);
     $this->assertArrayNotHasKey('customCSSURL', $result['values']);
     $this->quickCleanup(['civicrm_cache']);


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM loads all the settings metadata during boot. However no language is set at that time so the settings metadata is loaded untranslated.

This PR fixes that and also loads all the settings metadata into memory once booted (as it seems it is loaded and used multiple times).


Before
----------------------------------------

For example opening *Administer* > *Localisation* > *Language, currency, and location* looks like this in a Dutch and a Norwegian install of CiviCRM:

<img width="1320" height="1279" alt="2026-04-28_16-27_1" src="https://github.com/user-attachments/assets/74c5a715-6c89-432d-9a4c-8acb393852a1" />

and 
<img width="1194" height="973" alt="2026-04-28_16-27" src="https://github.com/user-attachments/assets/0041eb53-fc84-42d4-bdb8-b1253f6117c4" />


After
----------------------------------------

The same screen now looks like this

<img width="1566" height="1122" alt="2026-04-29_13-30" src="https://github.com/user-attachments/assets/31b83cac-d52c-40aa-add9-b2a5431d452f" />


Technical Details
----------------------------------------

The `bootComplete` function is called after the locale has been set. And the settings are cached (in the database) based on the locale. 