### PR TITLE
SearchKit lists display: add entity ID and listitem class

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayListItems.html
@@ -1,4 +1,4 @@
-<li ng-repeat="(rowIndex, row) in $ctrl.results" class="{{ row.cssClass }}">
+<li ng-repeat="(rowIndex, row) in $ctrl.results" data-entity-id="{{:: row.key }}" class="crm-search-display-listitem {{ row.cssClass }}">
   <div ng-repeat="(colIndex, colData) in row.columns" title="{{:: colData.title }}" class="{{:: $ctrl.getFieldClass(colIndex, colData) }}">
     <label ng-if=":: colData.label">
       {{:: colData.label }}


### PR DESCRIPTION
Overview
----------------------------------------

Applies the same pattern as #35330 used for grid items (and tables) to searchkit lists.

Example usage:

```
document.querySelector("crm-search-display-list").querySelectorAll('div.crm-search-display-listitem').forEach(function(item) {
      item.addEventListener('click', function() {
        console.log(this.dataset.entityId);
      });
    });
```

cc @mattwire 