### PR TITLE
SchemaHelper - Add getExistingTables function

### DIFF
--- a/ext/civiimport/civiimport.php
+++ b/ext/civiimport/civiimport.php
@@ -128,8 +128,7 @@ function _civiimport_civicrm_get_import_tables(): array {
 
   // Verify the tables exist; remove any that don't.
   $tablesToVerify = array_column($importEntities, 'table_name', 'user_job_id');
-  $existingTables = CRM_Core_DAO::executeQuery('SELECT TABLE_NAME AS table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name IN ("' . implode('","', $tablesToVerify) . '")')
-    ->fetchMap('table_name', 'table_name');
+  $existingTables = Civi::schemaHelper()->getExistingTables($tablesToVerify);
   $existingTables = array_intersect($tablesToVerify, $existingTables);
   $importEntities = array_intersect_key($importEntities, $existingTables);
 

--- a/mixin/lib/civimix-schema@5/src/SchemaHelper.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelper.php
@@ -54,8 +54,25 @@ return new class() implements SchemaHelperInterface {
     return \Civi::entity($entityName)->getMeta('table');
   }
 
+  /**
+   * Check if a single table exists.
+   */
   public function tableExists(string $tableName): bool {
-    return \CRM_Core_DAO::checkTableExists($tableName);
+    $existing = $this->getExistingTables([$tableName]);
+    return count($existing) === 1;
+  }
+
+  /**
+   * Given a list of table names, return the ones that exist.
+   * @since 6.15
+   */
+  public function getExistingTables(array $tableNames): array {
+    if (empty($tableNames)) {
+      return [];
+    }
+    $escaped = implode("', '", array_map(['\CRM_Core_DAO', 'escapeString'], $tableNames));
+    $dao = \CRM_Core_DAO::executeQuery("SELECT TABLE_NAME AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN ('$escaped')");
+    return $dao->fetchMap('table_name', 'table_name');
   }
 
   /**

--- a/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelperInterface.php
@@ -35,6 +35,10 @@ namespace CiviMix\Schema;
  * @method bool tableExists(string $tableName)
  * @method bool dropTable(string $tableName)
  *
+ * [[ CiviCRM 6.15+ / civimix-schema@5.98+ ]]
+ *
+ * @method array getExistingTables(array $tableNames)
+ *
  * To see the latest implementation:
  *
  * @see ./SchemaHelper.php


### PR DESCRIPTION
Overview
----------------------------------------
Add a helper function to check if multiple tables exist, as it's generally useful and to avoid the TABLE_NAME vs table_name gotcha.

Followup to https://github.com/civicrm/civicrm-core/pull/35253