### PR TITLE
CustomField - Fix unit test to not hardcode IDs

### DIFF
--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -1016,7 +1016,7 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
       'extends' => 'Individual',
       'title' => 'my bulk group',
     ]);
-    CustomField::save(FALSE)->setRecords([
+    $customFields = CustomField::save(FALSE)->setRecords([
       [
         'label' => 'Test',
         'data_type' => 'String',
@@ -1034,13 +1034,18 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
       'custom_group_id' => $customGroup['id'],
       'is_active' => 1,
       'is_searchable' => 1,
-    ])->execute();
+    ])->execute()->indexBy('label');
+    $this->assertCount(2, $customFields);
+
+    $testLink = $customFields['test_link']['column_name'];
+    $this->assertEquals('test_link_' . $customFields['test_link']['id'], $testLink);
+
     $dao = CRM_Core_DAO::executeQuery(('SHOW CREATE TABLE ' . $customGroup['values'][$customGroup['id']]['table_name']));
     $dao->fetch();
     $collation = \CRM_Core_BAO_SchemaHandler::getInUseCollation();
-    $this->assertStringContainsString('`test_link_2` varchar(2047) COLLATE ' . $collation . ' DEFAULT NULL', $dao->Create_Table);
+    $this->assertStringContainsString("`$testLink` varchar(2047) COLLATE $collation DEFAULT NULL", $dao->Create_Table);
     $this->assertStringContainsString('KEY `index_my_text` (`my_text`)', $dao->Create_Table);
-    $this->assertStringContainsString('KEY `index_test_link_2` (`test_link_2`(512))', $dao->Create_Table);
+    $this->assertStringContainsString("KEY `index_$testLink` (`$testLink`(512))", $dao->Create_Table);
     $characterSet = stripos($collation, 'utf8mb4') !== FALSE ? 'utf8mb4' : 'utf8';
     $this->assertStringContainsString("ENGINE=InnoDB DEFAULT CHARSET={$characterSet} COLLATE={$collation}", $dao->Create_Table);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Addresses a test failure from https://github.com/civicrm/civicrm-core/pull/35302