### PR TITLE
AdminUI - Specific page for draft mailing

### DIFF
--- a/ext/civicrm_admin_ui/ang/afsearchMailingBrowseDraft.aff.html
+++ b/ext/civicrm_admin_ui/ang/afsearchMailingBrowseDraft.aff.html
@@ -1,0 +1,8 @@
+<div af-fieldset="">
+  <div class="af-container af-layout-inline">
+    <af-field name="name" />
+    <af-field name="created_date" defn="{input_type: 'Select', search_range: true}" />
+    <af-field name="created_id.display_name,scheduled_id.display_name" defn="{label: 'Created by', input_attrs: {}, input_type: 'Text'}" />
+  </div>
+  <crm-search-display-table search-name="Draft_Mailings_Browse" display-name="Draft_Mailings_Table"></crm-search-display-table>
+</div>

--- a/ext/civicrm_admin_ui/ang/afsearchMailingBrowseDraft.aff.php
+++ b/ext/civicrm_admin_ui/ang/afsearchMailingBrowseDraft.aff.php
@@ -1,0 +1,11 @@
+<?php
+
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+return [
+  'type' => 'search',
+  'title' => E::ts('Mailings Draft'),
+  'server_route' => 'civicrm/mailing/draft',
+  'permission' => ['access CiviMail', 'create mailings', 'schedule mailings'],
+  'permission_operator' => 'OR',
+];

--- a/ext/civicrm_admin_ui/civicrm_admin_ui.php
+++ b/ext/civicrm_admin_ui/civicrm_admin_ui.php
@@ -118,7 +118,7 @@ function _civicrm_admin_ui_alter_mailing_navigation(&$navigationItems) {
         $navigationItem['attributes']['url'] = 'civicrm/mailing#?is_archived=0&status=Scheduled,Running,Complete,Paused,Canceled';
       }
       if (str_starts_with($navigationItem['attributes']['url'], 'civicrm/mailing/browse/unscheduled')) {
-        $navigationItem['attributes']['url'] = 'civicrm/mailing#?is_archived=0&status=Draft';
+        $navigationItem['attributes']['url'] = 'civicrm/mailing/draft';
       }
       if (str_starts_with($navigationItem['attributes']['url'], 'civicrm/mailing/browse/archived')) {
         $navigationItem['attributes']['url'] = 'civicrm/mailing#?is_archived=1';

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse_Draft.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Browse_Draft.mgd.php
@@ -1,0 +1,289 @@
+<?php
+
+use CRM_CivicrmAdminUi_ExtensionUtil as E;
+
+if (!CRM_Core_Component::isEnabled('CiviMail')) {
+  return [];
+}
+
+$select = [
+  'id',
+  'name',
+  'language:label',
+  'created_id.display_name',
+  'created_date',
+  'scheduled_id.display_name',
+  'status:label',
+];
+
+$columns = [
+  [
+    'type' => 'field',
+    'key' => 'name',
+    'label' => E::ts('Mailing Name'),
+    'sortable' => TRUE,
+    'icons' => [],
+  ],
+  [
+    'type' => 'field',
+    'key' => 'status:label',
+    'label' => E::ts('Status'),
+    'sortable' => TRUE,
+    'icons' => [],
+    'cssRules' => [],
+  ],
+];
+
+// language only if multilingual
+if (CRM_Core_I18n::isMultilingual()) {
+  $columns[] = [
+    'type' => 'field',
+    'key' => 'language:label',
+    'label' => E::ts('Language'),
+    'sortable' => TRUE,
+  ];
+}
+
+$columns = array_merge($columns, [
+  [
+    'type' => 'field',
+    'key' => 'created_id.display_name',
+    'label' => E::ts('Created By'),
+    'sortable' => TRUE,
+  ],
+  [
+    'type' => 'field',
+    'key' => 'created_date',
+    'label' => E::ts('Created Date'),
+    'sortable' => TRUE,
+  ],
+]);
+
+// campaign only if component is enabled
+if (CRM_Core_Component::isEnabled('CiviCampaign')) {
+  $select[] = 'campaign_id:label';
+  $columns[] = [
+    'type' => 'field',
+    'key' => 'campaign_id:label',
+    'label' => E::ts('Campaign'),
+    'sortable' => TRUE,
+  ];
+}
+
+$columns = array_merge($columns, [
+  [
+    'text' => '',
+    'type' => 'menu',
+    'alignment' => 'text-right',
+    'style' => 'default',
+    'size' => 'btn-xs',
+    'icon' => 'fa-bars',
+    'links' => [
+      [
+        'entity' => 'Mailing',
+        'action' => 'update',
+        'join' => '',
+        'target' => '',
+        'icon' => 'fa-pencil',
+        'text' => E::ts('Continue'),
+        'style' => 'default',
+        'path' => '',
+      ],
+      [
+        'icon' => 'fa-clone',
+        'text' => E::ts('Copy'),
+        'style' => 'default',
+        'condition' => [
+          'status:name',
+          'NOT IN',
+          ['Paused', 'Scheduled', 'Running'],
+        ],
+        'entity' => 'Mailing',
+        'action' => 'copy',
+        'join' => '',
+        'target' => '',
+      ],
+      [
+        'path' => 'civicrm/mailing/action?action=reopen&mid=[id]&reset=1',
+        'icon' => 'fa-play',
+        'text' => E::ts('Resume'),
+        'style' => 'default',
+        'condition' => [
+          'status:name',
+          '=',
+          'Paused',
+        ],
+        'entity' => '',
+        'action' => '',
+        'join' => '',
+        'target' => 'crm-popup',
+      ],
+      [
+        'path' => 'civicrm/mailing/action?action=disable&mid=[id]&reset=1',
+        'icon' => 'fa-ban',
+        'text' => E::ts('Cancel'),
+        'style' => 'default',
+        'condition' => [
+          'status:name',
+          'IN',
+          ['Scheduled', 'Running'],
+        ],
+        'entity' => '',
+        'action' => '',
+        'join' => '',
+        'target' => 'crm-popup',
+      ],
+      [
+        'entity' => 'Mailing',
+        'action' => 'preview',
+        'join' => '',
+        'target' => 'crm-popup',
+        'icon' => 'fa-eye',
+        'text' => E::ts('Preview Mailing'),
+        'style' => 'default',
+        'path' => '',
+        'condition' => [],
+      ],
+      [
+        'path' => 'civicrm/mailing/action?action=disable&mid=[id]&reset=1',
+        'icon' => 'fa-ban',
+        'text' => E::ts('Cancel'),
+        'style' => 'default',
+        'condition' => [
+          'status:name',
+          '=',
+          'Paused',
+        ],
+        'entity' => '',
+        'action' => '',
+        'join' => '',
+        'target' => 'crm-popup',
+      ],
+      [
+        'entity' => 'Mailing',
+        'task' => 'delete',
+        'join' => '',
+        'target' => 'crm-popup',
+        'icon' => 'fa-trash',
+        'text' => E::ts('Delete'),
+        'style' => 'danger',
+        'condition' => [],
+      ],
+    ],
+  ],
+]);
+
+return [
+  [
+    'name' => 'SavedSearch_Draft_Mailings_Browse',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Draft_Mailings_Browse',
+        'label' => E::ts('Draft Mailings'),
+        'api_entity' => 'Mailing',
+        'api_params' => [
+          'version' => 4,
+          'select' => $select,
+          'orderBy' => [],
+          'where' => [
+            ['sms_provider_id', 'IS EMPTY'],
+            ['domain_id:name', '=', 'current_domain'],
+            ['status:name', '=', 'Draft'],
+          ],
+          'groupBy' => [
+            'id',
+          ],
+          'join' => [
+            [
+              'MailingJob AS Mailing_MailingJob_mailing_id_01',
+              'LEFT',
+              ['id', '=', 'Mailing_MailingJob_mailing_id_01.mailing_id'],
+              ["Mailing_MailingJob_mailing_id_01.is_test", "=", FALSE],
+            ],
+          ],
+          'having' => [],
+        ],
+        'description' => NULL,
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Draft_Mailings_Browse_SearchDisplay_Mailings_Table',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Draft_Mailings_Table',
+        'label' => E::ts('Draft Mailings'),
+        'saved_search_id.name' => 'Draft_Mailings_Browse',
+        'type' => 'table',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [
+            [
+              'created_date',
+              'DESC',
+            ],
+          ],
+          'limit' => 50,
+          'pager' => [
+            'show_count' => FALSE,
+            'expose_limit' => FALSE,
+            'hide_single' => TRUE,
+          ],
+          'placeholder' => 5,
+          'columns' => $columns,
+          'actions' => TRUE,
+          'classes' => [
+            'table',
+            'table-striped',
+          ],
+          'cssRules' => [
+            [
+              'bg-warning',
+              'status:name',
+              '=',
+              'Paused',
+            ],
+            [
+              'disabled',
+              'status:name',
+              '=',
+              'Canceled',
+            ],
+            [
+              'bg-success',
+              'status:name',
+              'IN',
+              ['Scheduled', 'Running'],
+            ],
+          ],
+          'toolbar' => [
+            [
+              'entity' => 'Mailing',
+              'action' => 'add',
+              'text' => E::ts('Add Mailing'),
+              'icon' => 'fa-plus',
+              'style' => 'primary',
+              'target' => '',
+            ],
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ],
+      'match' => [
+        'name',
+        'saved_search_id',
+      ],
+    ],
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Create a separate page for draft mailing

Before
----------------------------------------
A few issues:
- if we already are in a mailing page and want to see the other page, that doesn't refresh (same url)
- draft mailing are sorted by scheduled date which makes no sense in this context
- columns Scheduled, Started, Completed are not useful for draft mailing

After
----------------------------------------

<img width="1066" height="233" alt="Screenshot 2026-04-29 at 17-36-38 Mailings Draft CRM Ville en Vert" src="https://github.com/user-attachments/assets/8b1052e0-cb07-443a-a88b-ee2a4e194aeb" />

