### PR TITLE
[6.13 backport] afform - use InlineAfform.tpl for shortcode markup

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -528,13 +528,16 @@ function afform_shortcode_content($content, $atts, $args, $context) {
       'where' => [['name', '=', $atts['name']]],
     ])->first();
     if ($afform) {
-      Civi::service('angularjs.loader')->addModules($afform['module_name']);
-      $content = "
-        <div class='crm-container' id='bootstrap-theme'>
-          <crm-angular-js modules='{$afform['module_name']}'>
-            <{$afform['directive_name']}></{$afform['directive_name']}>
-          </crm-angular-js>
-        </div>";
+      // NOTE: we are relying on WP to fulfill bootstrap CSS
+      \Civi::service('angularjs.loader')->addModules($afform['module_name']);
+
+      $blockMarkup = \CRM_Core_Smarty::singleton()->fetchWith('afform/InlineAfform.tpl', [
+        'block' => [
+          'module' => $afform['module_name'],
+          'directive' => $afform['directive_name'],
+        ],
+      ]);
+      $content = "<div class='crm-container'>{$blockMarkup}</div>";
     }
   }
   return $content;


### PR DESCRIPTION
Overview
----------------------------------------
ensures consistent markup, including <form> wrapper

Before
----------------------------------------
- different template for Afform rendered in Civi vs shortcode
- no wrapping <form> element = native input validation doesn't fire
- listeners to refresh search kit results on form submission don't fire

After
----------------------------------------
- consistent markup
- shortcodes work like other afforms

Technical Details
----------------------------------------
There may be a little performance cost for firing up Smarty - it should be pretty small and feels well worth it to me to maintain consistency. (If we think "we don't need smarty for this", then we should use pure PHP rendering everywhere.)

Switching to the block template opens the possibility of adding an options param to the shortcode, which could be very useful for devs doing any kind of non-trivial integration.

