### PR TITLE
[6.14] afform - use InlineAfform.tpl for shortcodes

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -528,13 +528,16 @@ function afform_shortcode_content($content, $atts, $args, $context) {
       'where' => [['name', '=', $atts['name']]],
     ])->first();
     if ($afform) {
-      Civi::service('angularjs.loader')->addModules($afform['module_name']);
-      $content = "
-        <div class='crm-container' id='bootstrap-theme'>
-          <crm-angular-js modules='{$afform['module_name']}'>
-            <{$afform['directive_name']}></{$afform['directive_name']}>
-          </crm-angular-js>
-        </div>";
+      // NOTE: we are relying on WP to fulfill bootstrap CSS
+      \Civi::service('angularjs.loader')->addModules($afform['module_name']);
+
+      $blockMarkup = \CRM_Core_Smarty::singleton()->fetchWith('afform/InlineAfform.tpl', [
+        'block' => [
+          'module' => $afform['module_name'],
+          'directive' => $afform['directive_name'],
+        ],
+      ]);
+      $content = "<div class='crm-container'>{$blockMarkup}</div>";
     }
   }
   return $content;


### PR DESCRIPTION
RC version of https://github.com/civicrm/civicrm-core/pull/35563

The validation thing is a fairly bad bug, so would be good to backport to 6.13 if there is another point release.

CC @mattwire 