### PR TITLE
WYSIWYG: Focus when expanding a collapsed editor

### DIFF
--- a/js/wysiwyg/crm.wysiwyg.js
+++ b/js/wysiwyg/crm.wysiwyg.js
@@ -65,7 +65,9 @@
           // Stop browser from opening clicked links
           e.preventDefault();
           $(item).show().next('.replace-plain').hide();
-          CRM.wysiwyg.create(item);
+          CRM.wysiwyg.create(item).then(() => {
+            CRM.wysiwyg.focus(item);
+          });
         });
     }
   };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes minor UX issue with our collapsed wysiwyg inputs.

Before
----------------------------------------
On e.g. the Configure Event: Online Registration screen, clicking on the rich text inputs will expand but doesn't focus them. You have to click a 2nd time to focus & type.

After
----------------------------------------
1 click expands and focuses.

Technical Details
----------------------------------------
Clicking on a collapsed wysiwyg shouldn't require a 2nd mouse click to focus and type.
