### PR TITLE
Backport to 6.14: CiviEvent: fix participant registration check with multiple roles assigned to participant

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -825,7 +825,7 @@ WHERE  civicrm_participant.id = {$participantId}
     }
 
     if ([] !== $filterRoleIds) {
-      $query->addWhere('role_id', 'IN', $filterRoleIds);
+      $query->addWhere('role_id', 'CONTAINS ONE OF', $filterRoleIds);
     }
 
     if (!$includeTest) {


### PR DESCRIPTION
Backport to 6.14 of #35560 

[ Rest below copied from that PR. ]

Fix for issue [dev/core#5540](https://lab.civicrm.org/dev/core/-/work_items/5540).

Overview
----------------------------------------
[ From the Overview in [dev/core#5540](https://lab.civicrm.org/dev/core/-/work_items/5540).]
CiviEvent event set to only allow each email address to register once. Add an additional role, e.g., Host or Speaker. Then, when going to the registration page for that event, that user no longer sees the notice that they've already registered and the system allows a second registration.

Now, when a participant has multiple roles and they try to register for an event that only allows them to register once, they'll be notified.

Before
----------------------------------------
When a participant with multiple roles attempts to register, they are allowed to and not notified they've already registered.

After
----------------------------------------
Participant with multiple roles, e.g., Attendee and Speaker, receives notice that they've already registered.

Technical Details
----------------------------------------
role_id uses SERIALIZE_SEPARATOR_TRIMMED, so IN doesn't work
API4 Query has CONTAINS ONE OF do the proper thing for serialized data.

Comments
----------------------------------------
Long standing bug. Probably multiple years, but haven't walked through all the history. Recent refactoring simply reproduced the already broken implementation when multiple roles existed.
