### PR TITLE
Symfony 8 - adding array return type declaration to getSubscribedEvents declarations

### DIFF
--- a/CRM/Core/BAO/RecurringEntity.php
+++ b/CRM/Core/BAO/RecurringEntity.php
@@ -99,7 +99,7 @@ class CRM_Core_BAO_RecurringEntity extends CRM_Core_DAO_RecurringEntity implemen
   const MODE_NEXT_ALL_ENTITY = 2;
   const MODE_ALL_ENTITY_IN_SERIES = 3;
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.dao.postInsert' => 'triggerInsert',
       'civi.dao.postUpdate' => 'triggerUpdate',

--- a/CRM/Mailing/Service/ListUnsubscribe.php
+++ b/CRM/Mailing/Service/ListUnsubscribe.php
@@ -25,7 +25,7 @@ class CRM_Mailing_Service_ListUnsubscribe extends \Civi\Core\Service\AutoService
     ];
   }
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&hook_civicrm_alterMailParams' => ['alterMailParams', 1000],
     ];

--- a/CRM/Queue/TaskHandler.php
+++ b/CRM/Queue/TaskHandler.php
@@ -31,7 +31,7 @@ class CRM_Queue_TaskHandler extends AutoService implements EventSubscriberInterf
    */
   const TYPE_NAME = 'task';
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&hook_civicrm_queueRun_' . static::TYPE_NAME => 'runBatch',
     ];

--- a/Civi/API/Provider/AdhocProvider.php
+++ b/Civi/API/Provider/AdhocProvider.php
@@ -22,7 +22,7 @@ class AdhocProvider implements EventSubscriberInterface, ProviderInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     // Using a high priority allows adhoc implementations
     // to override standard implementations -- which is
     // handy for testing/mocking.

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -23,7 +23,7 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.resolve' => [
         ['onApiResolve', Events::W_MIDDLE],

--- a/Civi/API/Provider/ReflectionProvider.php
+++ b/Civi/API/Provider/ReflectionProvider.php
@@ -22,7 +22,7 @@ class ReflectionProvider implements EventSubscriberInterface, ProviderInterface 
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.resolve' => [
         // TODO decide if we really want to override others

--- a/Civi/API/Provider/StaticProvider.php
+++ b/Civi/API/Provider/StaticProvider.php
@@ -27,7 +27,7 @@ class StaticProvider extends AdhocProvider {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.resolve' => [
         ['onApiResolve', Events::W_MIDDLE],

--- a/Civi/API/Subscriber/APIv3SchemaAdapter.php
+++ b/Civi/API/Subscriber/APIv3SchemaAdapter.php
@@ -23,7 +23,7 @@ class APIv3SchemaAdapter implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => [
         ['onApiPrepare', Events::W_MIDDLE],

--- a/Civi/API/Subscriber/ChainSubscriber.php
+++ b/Civi/API/Subscriber/ChainSubscriber.php
@@ -38,7 +38,7 @@ class ChainSubscriber implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents():array {
     return [
       'civi.api.respond' => ['onApiRespond', Events::W_EARLY],
     ];

--- a/Civi/API/Subscriber/DebugSubscriber.php
+++ b/Civi/API/Subscriber/DebugSubscriber.php
@@ -51,7 +51,7 @@ class DebugSubscriber implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => ['onApiPrepare', 999],
       'civi.api.respond' => ['onApiRespond', -999],

--- a/Civi/API/Subscriber/DynamicFKAuthorization.php
+++ b/Civi/API/Subscriber/DynamicFKAuthorization.php
@@ -40,7 +40,7 @@ class DynamicFKAuthorization implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_EARLY],

--- a/Civi/API/Subscriber/I18nSubscriber.php
+++ b/Civi/API/Subscriber/I18nSubscriber.php
@@ -32,7 +32,7 @@ class I18nSubscriber implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => ['onApiPrepare', Events::W_MIDDLE],
       'civi.api.respond' => ['onApiRespond', Events::W_LATE],

--- a/Civi/API/Subscriber/PermissionCheck.php
+++ b/Civi/API/Subscriber/PermissionCheck.php
@@ -24,7 +24,7 @@ class PermissionCheck implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.authorize' => [
         ['onApiAuthorize', Events::W_LATE],

--- a/Civi/API/Subscriber/SiteEmailLegacyOptionValueAdapter.php
+++ b/Civi/API/Subscriber/SiteEmailLegacyOptionValueAdapter.php
@@ -28,7 +28,7 @@ class SiteEmailLegacyOptionValueAdapter extends AutoSubscriber {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => [
         ['onApiPrepare', 2000],

--- a/Civi/API/Subscriber/TransactionSubscriber.php
+++ b/Civi/API/Subscriber/TransactionSubscriber.php
@@ -32,7 +32,7 @@ class TransactionSubscriber implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => ['onApiPrepare', Events::W_EARLY],
       'civi.api.respond' => ['onApiRespond', Events::W_MIDDLE],

--- a/Civi/API/Subscriber/WhitelistSubscriber.php
+++ b/Civi/API/Subscriber/WhitelistSubscriber.php
@@ -28,7 +28,7 @@ class WhitelistSubscriber implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.authorize' => ['onApiAuthorize', Events::W_EARLY],
       'civi.api.respond' => ['onApiRespond', Events::W_MIDDLE],

--- a/Civi/API/Subscriber/WrapperAdapter.php
+++ b/Civi/API/Subscriber/WrapperAdapter.php
@@ -24,7 +24,7 @@ class WrapperAdapter implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => ['onApiPrepare', Events::W_MIDDLE],
       'civi.api.respond' => ['onApiRespond', Events::W_EARLY * 2],

--- a/Civi/Core/MetadataFlush.php
+++ b/Civi/Core/MetadataFlush.php
@@ -16,7 +16,7 @@ namespace Civi\Core;
  */
 class MetadataFlush extends Service\AutoSubscriber {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.cache.metadata.clear' => 'onClearMetadata',
     ];

--- a/Civi/Esm/BasicLoaderTrait.php
+++ b/Civi/Esm/BasicLoaderTrait.php
@@ -30,7 +30,7 @@ trait BasicLoaderTrait {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&civi.esm.useModule' => 'onUseModule',
       '&civi.region.render' => 'onRegionRender',

--- a/Civi/I18n/TranslationAfformProvider.php
+++ b/Civi/I18n/TranslationAfformProvider.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TranslationAfformProvider extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.get' => 'getTranslationAfforms',
     ];

--- a/Civi/Managed/MultisiteManaged.php
+++ b/Civi/Managed/MultisiteManaged.php
@@ -17,7 +17,7 @@ class MultisiteManaged extends AutoService implements EventSubscriberInterface {
   private $entities = [];
   private $domains;
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&hook_civicrm_managed' => ['generateDomainEntities', -1000],
     ];

--- a/Civi/Token/AbstractTokenSubscriber.php
+++ b/Civi/Token/AbstractTokenSubscriber.php
@@ -39,7 +39,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 abstract class AbstractTokenSubscriber implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.token.list' => 'registerTokens',
       'civi.token.eval' => 'evaluateTokens',

--- a/Civi/Token/ImpliedContextSubscriber.php
+++ b/Civi/Token/ImpliedContextSubscriber.php
@@ -14,7 +14,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ImpliedContextSubscriber implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.token.list' => ['onRegisterTokens', 1000],
       'civi.token.eval' => ['onEvaluateTokens', 1000],

--- a/Civi/Visual/Bundle.php
+++ b/Civi/Visual/Bundle.php
@@ -36,7 +36,7 @@ class Bundle extends CRM_Core_Resources_Bundle implements EventSubscriberInterfa
 
   protected $initialized;
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'hook_civicrm_buildAsset' => [['buildAssetJs', 0], ['buildAssetCss', 0]],
     ];

--- a/Civi/WorkflowMessage/TestBanner.php
+++ b/Civi/WorkflowMessage/TestBanner.php
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TestBanner extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&hook_civicrm_alterMailContent' => ['onAlterMailContent', -1000],
     ];

--- a/ext/afform/core/Civi/Afform/Behavior/ActivityAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ActivityAutofill.php
@@ -16,7 +16,7 @@ class ActivityAutofill extends AbstractBehavior implements EventSubscriberInterf
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.prefill' => ['onAfformPrefill', 99],
       '&civi.afform.createToken' => ['onCreateToken', 99],

--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -18,7 +18,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.sort.prefill' => 'onAfformSortPrefill',
       'civi.afform.prefill' => ['onAfformPrefill', 99],

--- a/ext/afform/core/Civi/Afform/Behavior/ContactDedupe.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactDedupe.php
@@ -16,7 +16,7 @@ class ContactDedupe extends AbstractBehavior implements EventSubscriberInterface
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.submit' => ['onAfformSubmit', 101],
     ];

--- a/ext/afform/core/Civi/Afform/Behavior/EventAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/EventAutofill.php
@@ -16,7 +16,7 @@ class EventAutofill extends AbstractBehavior implements EventSubscriberInterface
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.prefill' => ['onAfformPrefill', 99],
       '&civi.afform.createToken' => ['onCreateToken', 99],

--- a/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
+++ b/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
@@ -17,7 +17,7 @@ class GroupSubscription extends AbstractBehavior implements EventSubscriberInter
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.sort.prefill' => 'onAfformSortPrefill',
       'civi.afform.prefill' => ['onAfformPrefill', 99],

--- a/ext/afform/core/Civi/Afform/Behavior/ParticipantAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ParticipantAutofill.php
@@ -16,7 +16,7 @@ class ParticipantAutofill extends AbstractBehavior implements EventSubscriberInt
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.prefill' => ['onAfformPrefill', 99],
       '&civi.afform.createToken' => ['onCreateToken', 99],

--- a/ext/afform/core/Civi/Afform/Translator.php
+++ b/ext/afform/core/Civi/Afform/Translator.php
@@ -14,7 +14,7 @@ class Translator extends AutoService implements EventSubscriberInterface {
   /**
    *
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&hook_civicrm_alterAngular' => 'translateAfform',
     ];

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAccessSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAccessSubscriber.php
@@ -27,7 +27,7 @@ class AfformAccessSubscriber extends AutoService implements EventSubscriberInter
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api4.authorizeRecord::Afform' => ['onApiAuthorizeRecord', 500],
     ];

--- a/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
+++ b/ext/afform/core/Civi/Api4/Subscriber/AfformAutocompleteSubscriber.php
@@ -29,7 +29,7 @@ class AfformAutocompleteSubscriber extends AutoService implements EventSubscribe
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.prepare' => ['onApiPrepare', 200],
     ];

--- a/ext/chart_kit/Civi/ChartKit/Bundle.php
+++ b/ext/chart_kit/Civi/ChartKit/Bundle.php
@@ -36,7 +36,7 @@ class Bundle extends CRM_Core_Resources_Bundle implements EventSubscriberInterfa
 
   protected $initialized;
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'hook_civicrm_buildAsset' => [['buildAssetJs', 0], ['buildAssetCss', 0]],
     ];

--- a/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
+++ b/ext/civi_case/Civi/Afform/Behavior/CaseAutofill.php
@@ -16,7 +16,7 @@ class CaseAutofill extends AbstractBehavior implements EventSubscriberInterface 
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.prefill' => ['onAfformPrefill', 99],
       '&civi.afform.createToken' => ['onCreateToken', 99],

--- a/ext/civi_case/Civi/Afform/Behavior/ContactAutofillBasedOnCase.php
+++ b/ext/civi_case/Civi/Afform/Behavior/ContactAutofillBasedOnCase.php
@@ -19,7 +19,7 @@ class ContactAutofillBasedOnCase extends AutoService implements EventSubscriberI
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.respond' => 'onAfformGetBehaviors',
       'hook_civicrm_buildAsset' => 'onBuildAsset',

--- a/ext/civi_contribute/Civi/Checkout/Afform.php
+++ b/ext/civi_contribute/Civi/Checkout/Afform.php
@@ -25,7 +25,7 @@ class Afform extends AutoService implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       // add CheckoutOption modules as dependencies of afCheckout
       'hook_civicrm_angularModules' => ['onAlterAngularModules', -1010],

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -53,7 +53,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform.validate' => [
         // TODO: this belongs in a hook to validate a form

--- a/ext/civi_report/Civi/Api4/Event/Subscriber/ClassicReportGetter.php
+++ b/ext/civi_report/Civi/Api4/Event/Subscriber/ClassicReportGetter.php
@@ -18,7 +18,7 @@ use Civi\Core\Service\AutoSubscriber;
  */
 class ClassicReportGetter extends AutoSubscriber {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api4.report.get' => 'onGetReports',
     ];

--- a/ext/civicrm_admin_ui/Civi/Api4/Event/Subscriber/CustomGroupEntityLinks.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Event/Subscriber/CustomGroupEntityLinks.php
@@ -19,7 +19,7 @@ class CustomGroupEntityLinks extends \Civi\Core\Service\AutoSubscriber {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api4.entityTypes' => ['addCustomGroupLinks', \Civi\API\Events::W_LATE],
     ];

--- a/ext/iframe/Civi/Iframe/Iframe.php
+++ b/ext/iframe/Civi/Iframe/Iframe.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Iframe extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return ['&civi.url.render.iframe' => 'onRenderUrl'];
   }
 

--- a/ext/oauth-client/Civi/OAuth/CiviConnectProviders.php
+++ b/ext/oauth-client/Civi/OAuth/CiviConnectProviders.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class CiviConnectProviders extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&hook_civicrm_oauthProviders' => ['hook_civicrm_oauthProviders', -1000],
       '&hook_civicrm_initiators::PaymentProcessor' => ['pickDefaultPaymentInitiators', -1000],

--- a/ext/oembed/Civi/Oembed/OembedDiscovery.php
+++ b/ext/oembed/Civi/Oembed/OembedDiscovery.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class OembedDiscovery extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&civi.invoke.auth' => ['onInvoke', 100],
     ];

--- a/ext/recaptcha/Civi/AfformReCaptcha2.php
+++ b/ext/recaptcha/Civi/AfformReCaptcha2.php
@@ -19,7 +19,7 @@ class AfformReCaptcha2 extends AutoService implements EventSubscriberInterface {
   /**
    * @return array
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.afform_admin.metadata' => ['onAfformGetMetadata'],
       'hook_civicrm_alterAngular' => ['alterAngular'],

--- a/ext/riverlea/Civi/Riverlea/StyleLoader.php
+++ b/ext/riverlea/Civi/Riverlea/StyleLoader.php
@@ -39,7 +39,7 @@ class StyleLoader extends AutoService implements \Symfony\Component\EventDispatc
     '_fixes.css',
   ];
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'hook_civicrm_themes' => ['onGetThemes', 0],
       'hook_civicrm_alterBundle' => ['alterBundles', 0],

--- a/setup/plugins/installDatabase/InstallSchema.civi-setup.php
+++ b/setup/plugins/installDatabase/InstallSchema.civi-setup.php
@@ -11,7 +11,7 @@ if (!defined('CIVI_SETUP')) {
 
 class InstallSchemaPlugin implements \Symfony\Component\EventDispatcher\EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.setup.checkRequirements' => [
         ['checkXmlFiles', 0],


### PR DESCRIPTION
Overview
----------------------------------------
Working on Symfony 8 / Drupal 12 / PHP 8.5 compatibility

Many implementions of getSubscribedEvents() lack the matching return type declaration.
Which causes errors like:
```
PHP Fatal error:  Declaration of InstallSchemaPlugin::getSubscribedEvents() must be compatible with Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents(): array
```

Before
----------------------------------------
Error on install with Drupal 12 among other places

After
----------------------------------------
Error resolved.

