### PR TITLE
add void return type to process() method for objects implementing CompilerPassInterface

### DIFF
--- a/Civi/Core/Compiler/AutoServiceScannerPass.php
+++ b/Civi/Core/Compiler/AutoServiceScannerPass.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AutoServiceScannerPass implements CompilerPassInterface {
 
-  public function process(ContainerBuilder $container) {
+  public function process(ContainerBuilder $container): void {
     $autoServices = ClassScanner::get(['interface' => AutoServiceInterface::class]);
     foreach ($autoServices as $autoService) {
       $autoService::buildContainer($container);

--- a/Civi/Core/Compiler/EventScannerPass.php
+++ b/Civi/Core/Compiler/EventScannerPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class EventScannerPass implements CompilerPassInterface {
 
-  public function process(ContainerBuilder $container) {
+  public function process(ContainerBuilder $container): void {
     $dispatcher = $container->getDefinition('dispatcher');
     $subscribers = $container->findTaggedServiceIds('event_subscriber');
 

--- a/Civi/Core/Compiler/SpecProviderPass.php
+++ b/Civi/Core/Compiler/SpecProviderPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class SpecProviderPass implements CompilerPassInterface {
 
-  public function process(ContainerBuilder $container) {
+  public function process(ContainerBuilder $container): void {
     $providers = $container->findTaggedServiceIds('spec_provider');
     $gatherer = $container->getDefinition('spec_gatherer');
 

--- a/ext/iframe/lib/IframeDrupalKernel.php
+++ b/ext/iframe/lib/IframeDrupalKernel.php
@@ -21,7 +21,7 @@ class IframeDrupalKernel extends DrupalKernel {
     $container = parent::getContainerBuilder();
     $container->addCompilerPass(new class implements CompilerPassInterface {
 
-      public function process(ContainerBuilder $container) {
+      public function process(ContainerBuilder $container): void {
         $container->findDefinition('session_configuration')
           ->setClass(IframeSessionConfiguration::class);
       }


### PR DESCRIPTION
Overview
----------------------------------------

Working on Symfony 8 / Drupal 12 / PHP 8.5 compatibility

Objects implementing ContainerPassInterface have process() methods without specifying void return type.
Causes error:
```
Fatal error: Declaration of Civi\Core\Compiler\AutoServiceScannerPass::process(Symfony\Component\DependencyInjection\ContainerBuilder $container) must be compatible with Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process(Symfony\Component\DependencyInjection\ContainerBuilder $container): void in /var/www/web/drupal12-proto/vendor/civicrm/civicrm-core/Civi/Core/Compiler/AutoServiceScannerPass.php on line 18
```

Before
----------------------------------------
Error on install

After
----------------------------------------
CiviCRM installs successfully. And works!!

Technical Details
----------------------------------------
Coupled with https://github.com/civicrm/civicrm-core/pull/35569

