### PR TITLE
dev/core#6479 afform - add validation alert for select2 inputs

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -386,6 +386,11 @@
       this.submit = function () {
         // validate required fields on the form
         if (!ctrl.ngForm.$valid || !validateFileFields()) {
+          // check whether its missing required or just invalid
+          const firstInvalidInput = $element[0].closest('af-form').querySelector('.ng-invalid');
+          const isRequired = firstInvalidInput.classList.contains('ng-invalid-required');
+          const message = isRequired ? ts('Please fill all required fields.') : ts('Please check all answers are valid.');
+
           // at this point we want the user to know to check the invalid fields
           //
           // the complication is the browser will natively trigger notifications
@@ -404,8 +409,18 @@
           //
           // TODO: in the long run we should provide a way for callers of
           // CRM.alert to specify between interrupting vs non-interrupting alerts
+
           if (document.getElementById('crm-notification-container')) {
-            CRM.alert(ts('Please fill all required fields.'), ts('Form Error'));
+            CRM.alert(message, ts('Form Error'));
+          }
+          else {
+            // catch case on the frontend where the invalid element is hidden
+            // (and its native validation along with it)
+            if (firstInvalidInput.classList.contains('select2-container')) {
+              firstInvalidInput.scrollIntoView();
+              firstInvalidInput.focus();
+              CRM.alert(message, ts('Form Error'));
+            }
           }
           return;
         }


### PR DESCRIPTION
Overview
----------------------------------------
We have switched to native HTML5 errors for validating afform inputs. But for `select2` inputs these are hidden.

Before
----------------------------------------
- hidden native validation error for `select2` fields
- CRM form error always says "Fill required fields" even if the validation error is something else (e.g. invalid email in an email input)

After
----------------------------------------
- add a CRM validation error for `select2` fields
- CRM form error distinguishes between missing required fields, and invalid entries

Technical Details
----------------------------------------
It's inelegant having this exceptional case. But I do think it's still better to use the native errors where we can, because they are so much more informative - e.g. "Please enter a number/email" and responsive with input scroll/focus. (If we upgrade `select2`, this should be a fairly easy place to adopt updates, which might make this redundant.)

Comments
----------------------------------------
As an aside, I checked the case where you have 'Hidden' input on the form that is required. That doesn't trigger any error, or prevent form submission. I don't think it ever has. 

I think it would be really good to add some highlight styling for `.ng-invalid` elements.
