### PR TITLE
FormBuilder: Saving a draft can cause unfixable "this field is required"

### DIFF
--- a/ext/afform/core/ang/af/afJoin.directive.js
+++ b/ext/afform/core/ang/af/afJoin.directive.js
@@ -41,7 +41,7 @@
           };
           this.getFieldData = function() {
             const data = this.getData();
-            if (!data[this.offset]) {
+            if (!data[this.offset] || (Array.isArray(data[this.offset]) && !data[this.offset].length)) {
               data[this.offset] = {};
             }
             return data[this.offset];


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/work_items/6481.

Before
----------------------------------------
"This field is required" (from server-side validation, after client-side validation passes).

After
----------------------------------------
No error.

Technical Details
----------------------------------------
When you save a draft with no email, it saves in the database like this:

```
{"extra":[],"Individual1":[{"fields":{"first_name":"fds","last_name":"ff"},"joins":{"Email":[[]]}}]}
```

If you fill in the email and submit, it looks like this:
```
{"extra":[],"Individual1":[{"fields":{"first_name":"cvv","last_name":"vc"},"joins":{"Email":[{"email":"d@o.org"}]}}]}
```

Note that in the first, the email value is `[[]]`.  In the second, it's `[{values}]`.  The array-in-an-array, not object-in-an-array, causes the issue. However, there's a race condition, so the bug only manifests if the prefill finishes before <waves hands vaguely>.