### PR TITLE
Deprecate meaningless function call

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -157,6 +157,10 @@ WHERE li.contribution_id = %1";
    *   Array of line items
    */
   public static function getLineItems($entityId, $entity = 'participant', $isQuick = FALSE, $isQtyZero = TRUE, $relatedEntity = FALSE) {
+    if (!$entityId || !$entity) {
+      CRM_Core_Error::deprecatedWarning('calling without entityId or entity is deprecated');
+      return [];
+    }
     $selectClause = '
       SELECT li.id,
       li.label,
@@ -201,10 +205,6 @@ WHERE li.contribution_id = %1";
     }
 
     $lineItems = [];
-
-    if (!$entityId || !$entity) {
-      return $lineItems;
-    }
 
     $params = [
       1 => [$entityId, 'Integer'],


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate meaningless function call

Before
----------------------------------------
entityId & entity not required but function quietly returns an empty array

After
----------------------------------------
function noisy returns an empty array

Technical Details
----------------------------------------

Comments
----------------------------------------
