### PR TITLE
Fix UpdateSubscription line item check

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -477,12 +477,14 @@ LEFT  JOIN civicrm_line_item line  ON ( line.contribution_id = con.id AND line.e
    * @param int $id
    * @param array $inputOverrides
    *   Parameters that should be overridden. Add unit tests if using parameters other than total_amount & financial_type_id.
+   * @param bool $isFlattenLineItems
+   *   Flatten line items by getting rid of extra price-set-id layer
    *
    * @return array
    *
    * @throws \CRM_Core_Exception
    */
-  public static function getTemplateContribution(int $id, array $inputOverrides = []): array {
+  public static function getTemplateContribution(int $id, array $inputOverrides = [], bool $isFlattenLineItems = FALSE): array {
     $recurringContribution = ContributionRecur::get(FALSE)
       ->addWhere('id', '=', $id)
       ->setSelect(['is_test', 'financial_type_id', 'amount', 'campaign_id'])
@@ -539,7 +541,7 @@ LEFT  JOIN civicrm_line_item line  ON ( line.contribution_id = con.id AND line.e
       // Line items aren't always written to a contribution, for mystery reasons.
       // Checking for their existence prevents $order->getPriceSetID returning NULL.
       if ($lineItems) {
-        $result['line_item'][$order->getPriceSetID()] = $lineItems;
+        $result['line_item'] = $isFlattenLineItems ? $lineItems : [$order->getPriceSetID() => $lineItems];
       }
       // If the template contribution was made on-behalf then add the
       // relevant values to ensure the activity reflects that.

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -128,14 +128,14 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
   /**
    * Actually build the components of the form.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     // CRM-16398: If current recurring contribution got > 1 lineitems then make amount field readonly
     $amtAttr = ['size' => 20];
-    $lineItems = CRM_Price_BAO_LineItem::getLineItemsByContributionID($this->getContributionID());
-    if (count($lineItems) > 1) {
+    $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getContributionRecurID(), [], TRUE);
+    if ($templateContribution && count($templateContribution['line_item']) > 1) {
       $amtAttr += ['readonly' => TRUE];
     }
-    $amountField = $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,
+    $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,
       TRUE, 'currency', $this->getSubscriptionDetails()->currency, TRUE
     );
 


### PR DESCRIPTION


Overview
----------------------------------------
Fix UpdateSubscription line item check

I hit this in our test trying to deprecate calling BAO_LineItem::getLineItems without entity_id but it turned out that the way this is working it was trying to look up line items for the contribution (to check the count) but the property it was looking at was only populated in the ?maybe never true? situation where the contribution id is in the url (as coid). I swapped instead to use the function to getTemplateContribution as it seemed more appropriate.

I also adapted getTemplateContribution to allow a flatter line item array to be returned as I have been trying to get away from the more onerous, unnessessarily nested array

Before
----------------------------------------
the line item check generally does not retrieve line items because it has no contribution ID

If it DID find multiple line items then the amount box here would be read only

<img width="1031" height="387" alt="image" src="https://github.com/user-attachments/assets/844914da-e5c1-410c-ac4d-d1c2ad2094e4" />


After
----------------------------------------
looks up appropriate template contribution instead

Technical Details
----------------------------------------

Comments
----------------------------------------
