### PR TITLE
REF: Switch to API4 to get balance_amount for Contribution in tests

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -3529,7 +3529,11 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    */
   protected function validatePayments($payments): void {
     foreach ($payments as $payment) {
-      $balance = CRM_Contribute_BAO_Contribution::getContributionBalance($payment['contribution_id']);
+      $balance = \Civi\Api4\Contribution::get(FALSE)
+        ->addSelect('balance_amount')
+        ->addWhere('id', '=', $payment['contribution_id'])
+        ->execute()
+        ->first()['balance_amount'];
       if ($balance < 0 && $balance + $payment['total_amount'] === 0.0) {
         // This is an overpayment situation. there are no financial items to allocate the overpayment.
         // This is a pretty rough way at guessing which payment is the overpayment - but


### PR DESCRIPTION
Overview
----------------------------------------
We've been able to get `balance_amount` from API4 Contribution for a while now. Previously there were BAO functions such as `CRM_Contribute_BAO_Contribution::getContributionBalance()` which we don't need to use any more.

Before
----------------------------------------
Using old BAO function

After
----------------------------------------
Using API4 calculated field.

Technical Details
----------------------------------------


Comments
----------------------------------------

