### PR TITLE
Fix FinancialAccount lookup

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -659,7 +659,7 @@ class CRM_Financial_BAO_Payment {
   protected static function createFinancialItem(array $lineItem, string $trxn_date, int $contactID, string $currency): array {
     $financialAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
       $lineItem['financial_type_id'],
-      'Income Account Is'
+      'Income Account is'
     );
 
     FinancialItem::create(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
If we hit this lookup we get NULL instead of the correct financial account because `Is` !== `is` unless you `LIKE`.

I hit this when working on test failures for https://github.com/civicrm/civicrm-core/pull/35082 - I don't think the function is hit very often or we'd have seen more errors with FinancialItem having financial_account_id = NULL.

Before
----------------------------------------
Returns NULL

After
----------------------------------------
Returns financial_account_id

Technical Details
----------------------------------------
Most places seem to lookup with the SQL "LIKE" operator which is case-insensitive. But this does not so returns NULL instead of the expected financial account.

Comments
----------------------------------------

