### PR TITLE
Create LineItems after creating Contribution record for MembershipRenewal form

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -602,6 +602,9 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         ? $this->getSubmittedValue('renewal_date')
         : date('Ymd', strtotime($membership['end_date'] . '+1 day'));
     }
+    // LineItems are created in the call to recordMembershipContribution() below
+    // Don't try to create them early when we don't have a contribution.
+    $membershipParams['skipLineItem'] = TRUE;
     $this->processMembership($membershipParams, $changeToday, $numRenewTerms, $pending);
 
     if (!empty($this->_params['record_contribution']) || $this->_mode) {


### PR DESCRIPTION
Overview
----------------------------------------
We have multiple functions that try to create LineItems. In this case the call to `processMembership()` will try to create them but we don't have a Contribution yet.
The later call to `recordMembershipContribution()` will also create the LineItems and it does have a Contribution.

So we tell the first function not to do anything with LineItems and just create/update the Membership.

Partial from https://github.com/civicrm/civicrm-core/pull/35082

Before
----------------------------------------
LineItems created before Contribution but can be created later.

After
----------------------------------------
LineItems created when Contribution is created.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------

