### PR TITLE
Remove lookup on always-empty _values['line_items']

### DIFF
--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -223,10 +223,8 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     }
 
     // do the amount validations.
-    //skip for update mode since amount is freeze, CRM-6052
-    if (empty($values['total_amount']) &&
-        empty($self->_values['line_items'])
-      ) {
+    // This empty check is probably always true & a hangover from shared code.
+    if (empty($values['total_amount'])) {
       $priceSetId = $values['priceSetId'] ?? NULL;
       if ($priceSetId) {
         CRM_Price_BAO_PriceField::priceSetValidation($priceSetId, $values, $errorMsg, TRUE);


### PR DESCRIPTION
Overview
----------------------------------------
Remove lookup on always-empty _values['line_items']

Before
----------------------------------------
The lookup is there but it's always true

After
----------------------------------------
Poof

Technical Details
----------------------------------------
This value is populated by the parent form (don't get me started on why it should not inherit from that form) but the parent form calls a function that will always leave the `line_items` empty when there is no participant ID (this form is to add participant records to contacts so that will always be the case)

Comments
----------------------------------------
