### PR TITLE
Show HTML message when sending Invoice

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -475,7 +475,7 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
       elseif ($component === 'contribute') {
         $email = CRM_Contact_BAO_Contact::getPrimaryEmail($contribution->contact_id);
 
-        $sendTemplateParams['tplParams'] = array_merge($tplParams, ['email_comment' => $params['email_comment']]);
+        $sendTemplateParams['tplParams'] = $tplParams;
         $sendTemplateParams['from'] = $fromEmailAddress;
         $sendTemplateParams['toEmail'] = $email;
         $sendTemplateParams['cc'] = $contributionPage ? $contributionPage['cc_receipt'] : NULL;


### PR DESCRIPTION
Overview
----------------------------------------
When a payment invoice email is sent, only the PDF attachment is included and the email body appears blank. However, when the payment is associated with an event registration, the email body correctly displays the invoice template content.

Applying the same [fix](https://github.com/civicrm/civicrm-core/commit/40bce8be4f6e64d7b4a3a5c65c361180d5fe197b) did for event

Before
----------------------------------------
Email body is blank

After
----------------------------------------
Has email body