### PR TITLE
Fix test issue - if you pass in contribution_status_id it might get overridden by contribution_status_id:name if API4 is involved

### DIFF
--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -1104,14 +1104,22 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
       'payment_instrument_id' => 1,
       'non_deductible_amount' => 10.00,
       'source' => 'SSF',
-      'contribution_status_id' => 'Completed',
-      'contribution_status_id:name' => 'Completed',
       'version' => 3,
     ], $params);
+
+    // Note: Ideally default for contribution_status_id would be "Pending" but tests are expecting default=Completed.
     if ($params['version'] === 4) {
+      if (!isset($params['contribution_status_id:name']) && !isset($params['contribution_status_id'])) {
+        $params['contribution_status_id:name'] = 'Completed';
+      }
       return $this->createTestEntity('Contribution', $params, $identifier)['id'];
     }
-    return $this->callAPISuccess('Contribution', 'create', $params)['id'];
+    else {
+      if (!isset($params['contribution_status_id'])) {
+        $params['contribution_status_id'] = 'Completed';
+      }
+      return $this->callAPISuccess('Contribution', 'create', $params)['id'];
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
If you pass in `contribution_status_id` to the `contributionCreate` test helper you might get wierd results if API4 is involved because `contribution_status_id:name` is still set to "Completed".

Found via https://github.com/civicrm/civicrm-core/pull/35583

Before
----------------------------------------
Potentially mismatched test params.

After
----------------------------------------
Only set if `contribution_status_id` is not passed in.

Technical Details
----------------------------------------


Comments
----------------------------------------

