### PR TITLE
Remove always empty empty

### DIFF
--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -86,10 +86,8 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
       );
     }
     if (empty($trxnId)) {
-      if (empty($trxnId['id'])) {
-        $trxn = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution->id, 'ASC', TRUE);
-        $trxnId['id'] = $trxn['financialTrxnId'];
-      }
+      $trxn = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution->id, 'ASC', TRUE);
+      $trxnId['id'] = $trxn['financialTrxnId'];
     }
     return self::create($params, NULL, $trxnId);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Is a glass empty if the glass inside the glass is empty?

Before
----------------------------------------
Empty empty.

After
----------------------------------------
Just empty.

Technical Details
----------------------------------------
The nested `if empty` check is redundant since it is always empty if the first empty is empty.

Comments
----------------------------------------
