### PR TITLE
remove deprecated alias SettingsManager::useDefaults

### DIFF
--- a/Civi/Core/SettingsManager.php
+++ b/Civi/Core/SettingsManager.php
@@ -139,16 +139,6 @@ class SettingsManager {
   }
 
   /**
-   * Maintained as public alias of bootComplete for compatibility
-   *
-   * @deprecated
-   * @return SettingsManager
-   */
-  public function useDefaults() {
-    return $this->bootComplete();
-  }
-
-  /**
    * (Re)load database values for all existing settings bags
    *
    * @return SettingsManager


### PR DESCRIPTION
Overview
----------------------------------------
Deprecated a year ago and unlikely to have downstream callers.
