### PR TITLE
Only get active dashlets to add on dashboard

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -185,7 +185,10 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard implements EventSubs
    */
   public static function initializeDashlets() {
     $allDashlets = (array) civicrm_api4('Dashboard', 'get', [
-      'where' => [['domain_id', '=', 'current_domain']],
+      'where' => [
+        ['domain_id', '=', 'current_domain'],
+        ['is_active', '=', TRUE],
+      ],
     ], 'name');
     $defaultDashlets = [];
     $defaults = ['blog' => 1, 'getting-started' => '0'];


### PR DESCRIPTION
Overview
----------------------------------------
When the Blog and Getting Started dashlets are disabled, users encounter a fatal error upon visiting the CiviCRM dashboard.

````
2026-05-05 11:27:40+0100  [debug] DB Error: already exists INSERT INTO `civicrm_dashboard_contact` (`dashboard_id` , `contact_id` , `column_no` , `is_active` ) VALUES ( 1 ,  123 ,  1 ,  1 )  [nativecode=1062 ** Duplicate entry '1-123' for key 'index_dashboard_id_contact_id']
````

Before
----------------------------------------
Fatal error on screen 

After
----------------------------------------
No Fatal error