### PR TITLE
SearchKit - Improve aggregation handling of DB Entity displays

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -63,6 +63,7 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
         'searchable' => 'secondary',
         'class' => SKEntity::class,
         'icon' => 'fa-search-plus',
+        'primary_key' => $display['settings']['primaryKey'] ?? [],
         'search_fields' => [],
       ];
       foreach ($display['settings']['columns'] as $column) {
@@ -106,6 +107,10 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       'attributes' => 'ENGINE=InnoDB',
       'fields' => [],
     ];
+    // Use primary keys from original table, if available
+    $primaryKeys = CoreUtil::getInfoItem($this->savedSearch['api_entity'], 'primary_key') ?? [];
+    $newSettings['primaryKey'] = [];
+    // Format columns and assign primary keys
     foreach ($newSettings['columns'] as &$column) {
       $expr = $this->getSelectExpression($column['key']);
       if (!$expr) {
@@ -113,6 +118,9 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       }
       $column['spec'] = Meta::formatFieldSpec($column, $expr);
       $table['fields'][] = $this->formatSQLSpec($column, $expr);
+      if (in_array($column['key'], $primaryKeys)) {
+        $newSettings['primaryKey'][] = $column['spec']['name'];
+      }
     }
     // Store new settings with added column spec
     $event->params['settings'] = $newSettings;

--- a/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
+++ b/ext/search_kit/Civi/Schema/SkEntityMetaProvider.php
@@ -24,6 +24,7 @@ class SkEntityMetaProvider extends SqlEntityMetadata {
       'title_plural' => $display['label'],
       'description' => $display['settings']['description'] ?? NULL,
       'table' => $display['tableName'],
+      'primary_key' => $display['settings']['primaryKey'] ?? [],
     ];
     return $displayProps[$propertyName] ?? NULL;
   }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -657,9 +657,12 @@
       if (ctrl.savedSearch.api_params.groupBy.indexOf(arg.path) > -1) {
         return false;
       }
+      const primaryKeys = searchMeta.getEntity(arg.field.entity)?.primary_key;
+      if (!primaryKeys || !primaryKeys.length) {
+        return true;
+      }
       // If the entity this column belongs to is being grouped by primary key, then also no
-      const idField = searchMeta.getEntity(arg.field.entity).primary_key[0];
-      return ctrl.savedSearch.api_params.groupBy.indexOf(arg.prefix + idField) < 0;
+      return ctrl.savedSearch.api_params.groupBy.indexOf(arg.prefix + primaryKeys[0]) < 0;
     };
 
     $scope.fieldsForGroupBy = function() {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -66,6 +66,7 @@ class EntityDisplayTest extends Api4TestBase {
         'columns' => [
           [
             'key' => 'id',
+            'name' => 'contact_id',
             'label' => 'Contact ID',
             'type' => 'field',
           ],
@@ -131,13 +132,14 @@ class EntityDisplayTest extends Api4TestBase {
     $this->assertSame('My New Entity', $info['title']);
     $this->assertSame('civicrm_sk_my_new_entity', $info['table_name']);
     $this->assertSame('secondary', $info['searchable']);
-    $this->assertSame(['id', 'first', 'last_name', 'prefix_id', 'created_date', 'modified_date'], $info['search_fields']);
+    $this->assertSame(['contact_id', 'first', 'last_name', 'prefix_id', 'created_date', 'modified_date'], $info['search_fields']);
+    $this->assertSame(['contact_id'], $info['primary_key']);
 
     $getFields = civicrm_api4('SK_MyNewEntity', 'getFields', ['loadOptions' => TRUE])->indexBy('name');
     $this->assertNotEmpty($getFields['prefix_id']['options'][1]);
-    $this->assertSame('Integer', $getFields['id']['data_type']);
-    $this->assertSame('EntityRef', $getFields['id']['input_type']);
-    $this->assertSame('Contact', $getFields['id']['fk_entity']);
+    $this->assertSame('Integer', $getFields['contact_id']['data_type']);
+    $this->assertSame('EntityRef', $getFields['contact_id']['input_type']);
+    $this->assertSame('Contact', $getFields['contact_id']['fk_entity']);
     $this->assertSame('String', $getFields['first']['data_type']);
     $this->assertSame('Text', $getFields['first']['input_type']);
     $this->assertNull($getFields['first']['fk_entity']);
@@ -542,6 +544,13 @@ class EntityDisplayTest extends Api4TestBase {
       ],
       'acl_bypass' => FALSE,
     ]);
+
+    $info = Entity::get(FALSE)
+      ->addWhere('name', '=', 'SK_TestEntityWithLongCustomFieldNameDbEntity1')
+      ->execute()->single();
+    $this->assertSame('testEntityWithLongCustomFieldName DB Entity 1', $info['title']);
+    $this->assertSame('secondary', $info['searchable']);
+    $this->assertSame(['id'], $info['primary_key']);
 
     $display = civicrm_api4('SearchDisplay', 'get', ['where' => [['name', '=', 'TestEntityWithLongCustomFieldNameDbEntity1']]])->single();
     $columnName = $display['settings']['columns'][0]['spec']['name'];


### PR DESCRIPTION
Overview
----------------------------------------
This passes through the primary key of the main entity to the db entity for better aggregation, and adds some error handling whenever SK encounters an entity with no primary key.