### PR TITLE
Don't pass parameters by reference

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -2067,7 +2067,7 @@ WHERE {$whereClause}";
    * @return CRM_Contribute_BAO_Contribution
    * @throws \CRM_Core_Exception
    */
-  public static function recordMembershipContribution(&$params) {
+  public static function recordMembershipContribution($params) {
     $contributionParams = [];
     $config = CRM_Core_Config::singleton();
     $contributionParams['currency'] = $config->defaultCurrency;
@@ -2139,9 +2139,6 @@ WHERE {$whereClause}";
         CRM_Contribute_BAO_ContributionSoft::add($contributionSoftParams);
       }
     }
-
-    // store contribution id
-    $params['contribution_id'] = $contribution->id;
 
     return $contribution;
   }

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1302,7 +1302,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       }
       $params['lineItems'] = $lineItem;
       if (!empty($formValues['record_contribution'])) {
-        CRM_Member_BAO_Membership::recordMembershipContribution($params);
+        $params['contribution_id'] = CRM_Member_BAO_Membership::recordMembershipContribution($params)->id;
       }
     }
 

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -628,10 +628,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
         }
       }
       $this->_params['contact_id'] = $this->_contactID;
-      //recordMembershipContribution receives params as a reference & adds one variable. This is
-      // not a great pattern & ideally it would not receive as a reference. We assign our params as a
-      // temporary variable to avoid e-notice & to make it clear to future refactorer that
-      // this function is NOT reliant on that var being set
       $temporaryParams = array_merge($this->_params, [
         'membership_id' => $membershipParams['id'],
         'contribution_recur_id' => $contributionRecurID,

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -1758,6 +1758,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'receive_date' => '2020-08-08',
     ];
     $contribution1 = CRM_Member_BAO_Membership::recordMembershipContribution($contributionParams);
+    $contributionParams['contribution_id'] = $contribution1->id;
 
     // 2nd Payment
     $contributionParams = [


### PR DESCRIPTION
Overview
----------------------------------------
Per comment, we only set one parameter so retrieve it via return values instead.

