### PR TITLE
Fix striped table rows declaration

### DIFF
--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -245,7 +245,7 @@ tbody.scrollContent:has(.alternateRow),
 .crm-container table.dataTable:is(.stripe,.display) tbody tr.even:not(.disabled),
 tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):not(.disabled) {
-  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, (--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.hover tbody tr.odd:hover,
 .crm-container table.dataTable.display tbody tr.odd:hover,


### PR DESCRIPTION
Overview
----------------------------------------
Missing `var` causes declaration to fail.

Before
----------------------------------------
All (or most, I haven't been through all TBF) striped tables have no stripes.

After
----------------------------------------
Some striped tables get their stripes back.

Comments
----------------------------------------
Striped tables in general seem not to be striped since #33802 AFAICT.