### PR TITLE
add small translations in message in Event Participant.php

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -2070,8 +2070,8 @@ WHERE    civicrm_participant.contact_id = {$contactID} AND
         if ($timenow > $cancelDeadline) {
           $details['eligible'] = FALSE;
           // Change the language of the status message based on whether the waitlist time limit is positive or negative.
-          $afterOrPrior = $time_limit <= 0 ? 'after' : 'prior to';
-          $moreOrLess = $time_limit <= 0 ? 'more' : 'fewer';
+          $afterOrPrior = $time_limit <= 0 ? ts('after') : ts('prior to');
+          $moreOrLess = $time_limit <= 0 ? ts('more') : ts('fewer');
           $details['ineligible_message'] = ts("Registration for this event cannot be cancelled or transferred %1 than %2 hours %3 the event's start time. Contact the event organizer if you have questions.",
           [1 => $moreOrLess, 2 => $cancelHours, 3 => $afterOrPrior]);
 


### PR DESCRIPTION
Overview
----------------------------------------

The problem is that the after, prior to, more and fewer are not translated in a message beeing shown when a participant wants to cancel an event too late. 
In german it looks like this: 
<img width="860" height="111" alt="Bildschirmfoto 2026-03-03 um 09 39 53" src="https://github.com/user-attachments/assets/a6842d93-17e5-4014-af09-0246a3280f8a" />


Solution is to add these small words to the translation. They need to be added in transifex or by hand.