### PR TITLE
River: restores striped table rows and selected row state

### DIFF
--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -187,7 +187,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 }
 .crm-container table.report td {
   border: var(--crm-table-row-border);
-  background-color: var(--crm-table-alternate-row);
+  background-color: var(--crm-table-row-bg-color);
 }
 .crm-container tr.columnheader-dark th {
   background-color: var(--crm-primary-color);
@@ -243,9 +243,10 @@ tbody.scrollContent:has(.alternateRow),
   background-color: var(--crm-striped-bg-color) !important;
 }
 .crm-container table.dataTable:is(.stripe,.display) tbody tr.even:not(.disabled),
+.crm-container table tr.even-row:not(.disabled),
 tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):not(.disabled) {
-  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, (--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.hover tbody tr.odd:hover,
 .crm-container table.dataTable.display tbody tr.odd:hover,
@@ -260,9 +261,9 @@ tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container table.dataTable.display tbody tr.even:hover,
 .crm-container table.row-highlight tr.even-row:hover,
 .crm-container table.row-highlight tr.even:hover,
-.crm-container .even-row.crm-row-selected,
-.crm-container .even.crm-row-selected ,
-.crm-container .even-row:hover,
+.crm-container table tr.even-row.crm-row-selected,
+.crm-container .even.crm-row-selected,
+.crm-container table tr.even-row:hover,
 .crm-container .even:hover,
 tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):hover {
@@ -360,9 +361,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table td.info,
 .crm-container .table th.info,
 .crm-container .table tr.info > td,
-.crm-container .table tr.info > th,
-.crm-container table tr.crm-row-selected,
-.crm-container table tr.crm-row-selected > td {
+.crm-container .table tr.info > th {
   background-color: var(--crm-alert-info-bg-color);
   color: var(--crm-alert-info-text-color);
 }
@@ -370,9 +369,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-hover > tbody > tr > th.info:hover,
 .crm-container .table-hover > tbody > tr.info:hover > td,
 .crm-container .table-hover > tbody > tr:hover > .info,
-.crm-container .table-hover > tbody > tr.info:hover > th,
-.crm-container table tr.crm-row-selected:hover > td,
-.crm-container table tr.crm-row-selected > td:hover {
+.crm-container .table-hover > tbody > tr.info:hover > th {
   background-color: var(--crm-alert-info-border-color);
 }
 .crm-container .table-responsive {

--- a/release-notes/6.14.0.md
+++ b/release-notes/6.14.0.md
@@ -26,6 +26,7 @@ Released May 6, 2026;
 
 - **add Afform - Checkout integration
   ([35235](https://github.com/civicrm/civicrm-core/pull/35235),
+  [35508](https://github.com/civicrm/civicrm-core/pull/35508),
   [35179](https://github.com/civicrm/civicrm-core/pull/35179) and
   [35313](https://github.com/civicrm/civicrm-core/pull/35313))**
 
@@ -142,7 +143,7 @@ Released May 6, 2026;
   Passing in specific allocations for lineItems works better, various checks on
   the amounts passed in are checked and it assumes that any unspecified
   lineItem should be allocated "0.0" of the refund/payment amount.
-  
+
 - **add config JSON blob to PaymentProcessor entity
   ([35019](https://github.com/civicrm/civicrm-core/pull/35019))**
 
@@ -218,6 +219,54 @@ Released May 6, 2026;
 ## <a name="bugs"></a>Bugs resolved
 
 ### Core CiviCRM
+
+- **Theme settings - fix when riverlea not current theme
+  ([35407](https://github.com/civicrm/civicrm-core/pull/35407))**
+
+- **Admin - Add link to delete Site From Email Address
+  ([35446](https://github.com/civicrm/civicrm-core/pull/35446))**
+
+- **SearchKit - Update row style when enabling/disabling
+  ([35448](https://github.com/civicrm/civicrm-core/pull/35448))**
+
+- **RiverLea: Missing number.png file
+  ([dev/core#6450](https://lab.civicrm.org/dev/core/-/work_items/6450):
+  [35469](https://github.com/civicrm/civicrm-core/pull/35469))**
+
+- **Tags - Fix double-escaping of separator in dropdowns
+  ([35471](https://github.com/civicrm/civicrm-core/pull/35471))**
+
+- **State/Province field does not load using secret link
+  ([dev/core#6456](https://lab.civicrm.org/dev/core/-/work_items/6456):
+  [35478](https://github.com/civicrm/civicrm-core/pull/35478))**
+
+- **Non-admins can't enable/disable relationships
+  ([dev/core#6458](https://lab.civicrm.org/dev/core/-/work_items/6458):
+  [35482](https://github.com/civicrm/civicrm-core/pull/35482))**
+
+- **AdminUI - Show relationship contact subtypes
+  ([35499](https://github.com/civicrm/civicrm-core/pull/35499))**
+
+- **SearchDisplay download returns empty CSV/Excel when downloaded from Table
+  display ([dev/core#6472](https://lab.civicrm.org/dev/core/-/work_items/6472):
+  [35502](https://github.com/civicrm/civicrm-core/pull/35502))**
+
+- **SearchKit - Fix setting column mode to auto
+  ([35501](https://github.com/civicrm/civicrm-core/pull/35501))**
+
+- **Select2 - Fix js error in quickedit links
+  ([35538](https://github.com/civicrm/civicrm-core/pull/35538))**
+
+- **[6.14] afform - use InlineAfform.tpl for shortcodes
+  ([35564](https://github.com/civicrm/civicrm-core/pull/35564))**
+
+- **select2 validation errors aren't shown - especially on FormBuilder submit
+  ([dev/core#6479](https://lab.civicrm.org/dev/core/-/work_items/6479):
+  [35573](https://github.com/civicrm/civicrm-core/pull/35573))**
+
+- **FormBuilder: Saving a draft can cause unfixable "this field is required"
+  ([dev/core#6481](https://lab.civicrm.org/dev/core/-/work_items/6481):
+  [35593](https://github.com/civicrm/civicrm-core/pull/35593))**
 
 - **Remove instances of $dao->free
   ([dev/core#562](https://lab.civicrm.org/dev/core/-/work_items/562):
@@ -517,6 +566,20 @@ Released May 6, 2026;
 
 ### CiviContribute
 
+- **fix premium option to show on contribution page
+  ([35540](https://github.com/civicrm/civicrm-core/pull/35540))**
+
+- **error viewing membership with recurring contribution
+  ([35596](https://github.com/civicrm/civicrm-core/pull/35596))**
+
+- **Disabled payment processors appear as options on event fee configuration
+  ([dev/core#6404](https://lab.civicrm.org/dev/core/-/work_items/6404):
+  [35507](https://github.com/civicrm/civicrm-core/pull/35507))**
+
+- **"Pay Later" appears unconditionally when multiple payment processor options
+  exist ([dev/core#6442](https://lab.civicrm.org/dev/core/-/work_items/6442):
+  [35475](https://github.com/civicrm/civicrm-core/pull/35475))**
+
 - **reset metadata cache when toggling FormBuilder Contributions
   ([35247](https://github.com/civicrm/civicrm-core/pull/35247))**
 
@@ -544,6 +607,12 @@ Released May 6, 2026;
 
 ### CiviEvent
 
+- **CiviEvent: for event not allowing registration more than once, when user has
+  registered and has multiple roles set, no warning that user is already
+  registered
+  ([dev/core#5540](https://lab.civicrm.org/dev/core/-/work_items/5540):
+  [35568](https://github.com/civicrm/civicrm-core/pull/35568))**
+
 - **Event Registration - Fix cleanMoneyFields to work with multi-valued prices
   ([35127](https://github.com/civicrm/civicrm-core/pull/35127))**
 
@@ -551,6 +620,10 @@ Released May 6, 2026;
   ([35254](https://github.com/civicrm/civicrm-core/pull/35254))**
 
 ### CiviMember
+
+- **Membership type names in multisite setup
+  ([dev/core#6473](https://lab.civicrm.org/dev/core/-/work_items/6473):
+  [35512](https://github.com/civicrm/civicrm-core/pull/35512))**
 
 - **CiviMember - show contributions linked by line item as well/instead of
   `civicrm_membership_payment`
@@ -593,6 +666,11 @@ Released May 6, 2026;
 
 ### WordPress Integration
 
+- **WordPress: Error when account creation enabled in profile and CiviCRM Member
+  Sync plugin is active
+  ([dev/core#6411](https://lab.civicrm.org/dev/core/-/work_items/6411):
+  [35473](https://github.com/civicrm/civicrm-core/pull/35473))**
+
 - **Formbuilder: Since 6.7. message token behaves like Login token - the user
   gets logged in after having clicked- (In 6.4. it was working ok)
   ([dev/core#6171](https://lab.civicrm.org/dev/core/-/work_items/6171):
@@ -604,6 +682,9 @@ Released May 6, 2026;
 
 ## <a name="misc"></a>Miscellany
 
+- **Bump phpoffice/phpspreadsheet from 2.4.3 to 2.4.5
+  ([35547](https://github.com/civicrm/civicrm-core/pull/35547))**
+  
 - **SearchDisplay - Extract redundant code to set column defaults
   ([35228](https://github.com/civicrm/civicrm-core/pull/35228))**
 


### PR DESCRIPTION
Overview
----------------------------------------
Following @christianwach noticing an impactful striped-row regression (https://github.com/civicrm/civicrm-core/pull/35609), this restores it to non-bootstrap striped tables. It also restores the select state to them, which was being replaced with the wrong colour variable (info bg colour rather than selected-state colour)…

Before
----------------------------------------
<img width="1716" height="318" alt="image" src="https://github.com/user-attachments/assets/ce7b54b3-f3ae-4bfa-ae3a-1e43142668d2" />

After
----------------------------------------
<img width="1180" height="314" alt="image" src="https://github.com/user-attachments/assets/b9a5d536-7af1-4e52-9e42-b75d0bca85c3" />

Notes
----------------------------------------
Part of this PR (adding `table tr`) is to increase specificity and avoid adding another `!important` declaration. This PR also includes the fix from #35609, happy to wait until that's merged then rebase.

@colemanw - SearchKit doesn't add a `crm-selected-row` class to selected classes so I've not been able to style the SearchKit selected rows. In two months when `:has` is baseline:widely then we could do it with `tr:has(input[type="checkbox"]:checked)`