### PR TITLE
dev/core#6485 SearchKit - Exclude pseudo-fields in DB Entity displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/addColMenu.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/addColMenu.html
@@ -5,7 +5,7 @@
   </button>
   <ul class="dropdown-menu">
     <li ng-repeat="item in $ctrl.parent.savedSearch.api_params.select track by $index">
-      <a href ng-click="$ctrl.parent.toggleColumn(item); $event.stopPropagation()">
+      <a href ng-if="!$ctrl.isColumnAllowed || $ctrl.isColumnAllowed(item)" ng-click="$ctrl.parent.toggleColumn(item); $event.stopPropagation()">
         <i class="crm-i fa-{{ $ctrl.parent.columnExists(item) ? 'check-' : '' }}square-o" role="img" aria-hidden="true"></i>
         {{ $ctrl.parent.getFieldLabel(item) }}
       </a>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
@@ -48,7 +48,13 @@
         if (!ctrl.display.id && !ctrl.display._job) {
           ctrl.display._job = defaultJobParams();
         }
-        ctrl.parent.initColumns({label: true});
+        this.parent.initColumns({label: true});
+        this.display.settings.columns = this.display.settings.columns.filter((col) => this.isColumnAllowed(col.key));
+      };
+
+      // Do not allow pseudo-fields to be used as columns.
+      this.isColumnAllowed = (key) => {
+        return key && !CRM.crmSearchAdmin.pseudoFields.find((field) => field.name === key);
       };
 
       this.onChangeEntityPermission = function() {


### PR DESCRIPTION
Overview
----------------------------------------
[Fixes a SearchKit console error](https://lab.civicrm.org/dev/core/-/work_items/6485) when trying to add a pseudofield to an entity display.

Technical Details
----------------------------------------
Pseudo-fields are calculated at runtime and cannot be used as part of a DB entity display. (they can always be added to the subsequent search OF the DB entity, so they don't need to be part of the entity itself).