### PR TITLE
River: restores striped table rows and selected row state

### DIFF
--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -187,7 +187,7 @@ tbody .crm-row-child:not(:has(~ .crm-row-child)) td {
 }
 .crm-container table.report td {
   border: var(--crm-table-row-border);
-  background-color: var(--crm-table-alternate-row);
+  background-color: var(--crm-table-row-bg-color);
 }
 .crm-container tr.columnheader-dark th {
   background-color: var(--crm-primary-color);
@@ -243,9 +243,10 @@ tbody.scrollContent:has(.alternateRow),
   background-color: var(--crm-striped-bg-color) !important;
 }
 .crm-container table.dataTable:is(.stripe,.display) tbody tr.even:not(.disabled),
+.crm-container table tr.even-row:not(.disabled),
 tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):not(.disabled) {
-  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, (--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
+  --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));
 }
 .crm-container table.dataTable.hover tbody tr.odd:hover,
 .crm-container table.dataTable.display tbody tr.odd:hover,
@@ -260,9 +261,9 @@ tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container table.dataTable.display tbody tr.even:hover,
 .crm-container table.row-highlight tr.even-row:hover,
 .crm-container table.row-highlight tr.even:hover,
-.crm-container .even-row.crm-row-selected,
-.crm-container .even.crm-row-selected ,
-.crm-container .even-row:hover,
+.crm-container table tr.even-row.crm-row-selected,
+.crm-container .even.crm-row-selected,
+.crm-container table tr.even-row:hover,
 .crm-container .even:hover,
 tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):hover {
@@ -360,9 +361,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table td.info,
 .crm-container .table th.info,
 .crm-container .table tr.info > td,
-.crm-container .table tr.info > th,
-.crm-container table tr.crm-row-selected,
-.crm-container table tr.crm-row-selected > td {
+.crm-container .table tr.info > th {
   background-color: var(--crm-alert-info-bg-color);
   color: var(--crm-alert-info-text-color);
 }
@@ -370,9 +369,7 @@ tbody.scrollContent tr.alternateRow:hover,
 .crm-container .table-hover > tbody > tr > th.info:hover,
 .crm-container .table-hover > tbody > tr.info:hover > td,
 .crm-container .table-hover > tbody > tr:hover > .info,
-.crm-container .table-hover > tbody > tr.info:hover > th,
-.crm-container table tr.crm-row-selected:hover > td,
-.crm-container table tr.crm-row-selected > td:hover {
+.crm-container .table-hover > tbody > tr.info:hover > th {
   background-color: var(--crm-alert-info-border-color);
 }
 .crm-container .table-responsive {


### PR DESCRIPTION
Overview
----------------------------------------
Following @christianwach noticing an impactful striped-row regression (https://github.com/civicrm/civicrm-core/pull/35609), this restores it to non-bootstrap striped tables. It also restores the select state to them, which was being replaced with the wrong colour variable (info bg colour rather than selected-state colour)… 6.14 version of https://github.com/civicrm/civicrm-core/pull/35612.

Before
----------------------------------------
<img width="1716" height="318" alt="image" src="https://github.com/user-attachments/assets/ce7b54b3-f3ae-4bfa-ae3a-1e43142668d2" />

After
----------------------------------------
<img width="1180" height="314" alt="image" src="https://github.com/user-attachments/assets/b9a5d536-7af1-4e52-9e42-b75d0bca85c3" />

Notes
----------------------------------------
Part of this PR (adding `table tr`) is to increase specificity and avoid adding another `!important` declaration. This PR also includes the fix from #35609, happy to wait until that's merged then rebase.

@colemanw - SearchKit doesn't add a `crm-selected-row` class to selected classes so I've not been able to style the SearchKit selected rows. In two months when `:has` is baseline:widely then we could do it with `tr:has(input[type="checkbox"]:checked)`