### PR TITLE
Show group-related custom fields when you add a participant to a group

### DIFF
--- a/CRM/Event/Form/Task/AddToGroup.php
+++ b/CRM/Event/Form/Task/AddToGroup.php
@@ -55,6 +55,8 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
     parent::setContactIDs();
     $this->_context = $this->get('context');
     $this->_id = $this->get('amtgID');
+
+    CRM_Custom_Form_CustomData::preProcess($this, NULL, NULL, 1, 'Group', $this->_id);
   }
 
   /**
@@ -104,7 +106,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
     }
 
     // add select for groups
-    $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::group();
+    $group = ['' => ts('- select group -')] + CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     $groupElement = $this->add('select', 'group_id', ts('Select Group'), $group);
 
@@ -124,6 +126,8 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
     }
     else {
       $this->setTitle(ts('Add Contacts to A Group'));
+      //build custom data
+      CRM_Custom_Form_CustomData::buildQuickForm($this);
     }
 
     $this->addDefaultButtons(ts('Add to Group'));
@@ -144,6 +148,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
     }
 
     $defaults['group_option'] = 0;
+    $defaults += CRM_Custom_Form_CustomData::setDefaultValues($this);
     return $defaults;
   }
 
@@ -202,6 +207,7 @@ class CRM_Event_Form_Task_AddToGroup extends CRM_Event_Form_Task {
         $groupParams['group_type'] = '';
       }
       $groupParams['is_active'] = 1;
+      $groupParams['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $this->_id, 'Group');
 
       $createdGroup = CRM_Contact_BAO_Group::writeRecord($groupParams);
       $groupID = $createdGroup->id;

--- a/templates/CRM/Event/Form/Task/AddToGroup.tpl
+++ b/templates/CRM/Event/Form/Task/AddToGroup.tpl
@@ -39,6 +39,9 @@
                     <td>{$form.group_type.html}</td>
                 </tr>
                 {/if}
+                <tr>
+                  <td colspan=2>{include file="CRM/Custom/Form/CustomData.tpl"}</td>
+                </tr>
                 </table>
             </td>
         </tr>


### PR DESCRIPTION
Overview
----------------------------------------
When you add contacts to a group, you see the custom fields linked to groups.
When you add participants to a group, you get an almost identical screen but the group-related custom fields are missing.
This PR brings consistency in the add-to-group screen.

Before
----------------------------------------
No group-related custom fields are shown when you add a participant to a group.

After
----------------------------------------
The group-related custom fields are shown when you add a participant to a group. Just like when you add contacts to a group.

Comments
----------------------------------------
You can easily test this by installing the extension [Temporary Groups](https://lab.civicrm.org/extensions/temporarygroups).
