### PR TITLE
dev/core#6491 inherited memberships not applied if similar one exists from another owner/primary

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -184,7 +184,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @throws \CRM_Core_Exception
    */
   protected function getExistingMembership(int $membershipTypeID): array|false {
-    $contactID = $this->_membershipContactID ?: $this->getContactID();
+    $contactID = ($this->_params['onbehalfof_id'] ?? NULL) ?: $this->_membershipContactID ?: $this->getContactID();
 
     // Find dedupe ContactId when anonymous form submission.
     if (empty($contactID)) {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1775,19 +1775,15 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    * @throws \CRM_Core_Exception
    */
   protected static function hasExistingInheritedMembership($params) {
-    $currentMemberships = \Civi\Api4\Membership::get(FALSE)
+    $membershipGet = \Civi\Api4\Membership::get(FALSE)
       ->addJoin('MembershipStatus AS membership_status', 'LEFT')
       ->addWhere('membership_status.is_current_member', '=', TRUE)
-      ->addWhere('contact_id', '=', $params['contact_id'])
-      ->execute();
+      ->addWhere('contact_id', '=', $params['contact_id']);
+    if (!empty($params['owner_membership_id'])) {
+      $membershipGet->addWhere('owner_membership_id', '=', $params['owner_membership_id']);
+    }
+    $currentMemberships = $membershipGet->execute();
     foreach ($currentMemberships as $membership) {
-      if (!empty($membership['owner_membership_id'])
-        && $membership['membership_type_id'] === $params['membership_type_id']
-        && (int) $params['owner_membership_id'] !== (int) $membership['owner_membership_id']
-      ) {
-        // Inheriting it from another contact, don't update here.
-        return TRUE;
-      }
       if (self::matchesRequiredMembership($params, $membership)) {
         return TRUE;
       }


### PR DESCRIPTION
Overview
----------------------------------------
As described in issue https://lab.civicrm.org/dev/core/-/work_items/6491 :

On submission of a contribution form for membership on behalf of an organization, the organization's membership is not created if a related contact already has a similar membership inherited from another organization.

Before
----------------------------------------
Reference "repro" in https://lab.civicrm.org/dev/core/-/work_items/6491

When the form is submitted, the contribution is recorded, but no membership is created for the organization.

After
----------------------------------------

The membership is created for the organization, and it's properly inherited by related contacts.

Technical Details
----------------------------------------

Comments
----------------------------------------

