### PR TITLE
AfformValidateEvent: setError->addError and add method setErrors

### DIFF
--- a/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
@@ -10,9 +10,9 @@ class AfformValidateEvent extends AfformBaseEvent {
   /**
    * @var array
    */
-  private $errors = [];
+  private array $errors = [];
 
-  private $entityFieldDefn = [];
+  private array $entityFieldDefn = [];
 
   /**
    * AfformValidateEvent constructor.
@@ -26,13 +26,44 @@ class AfformValidateEvent extends AfformBaseEvent {
   }
 
   /**
+   * Alias for addError()
+   *
    * @param string $errorMsg
+   *
+   * @return void
+   *
+   * @deprecated
    */
-  public function setError(string $errorMsg) {
+  public function setError(string $errorMsg): void {
+    \CRM_Core_Error::deprecatedFunctionWarning('addError');
     $this->errors[] = $errorMsg;
   }
 
   /**
+   * Add an error
+   *
+   * @param string $errorMsg
+   *
+   * @return void
+   */
+  public function addError(string $errorMsg): void {
+    $this->errors[] = $errorMsg;
+  }
+
+  /**
+   * Replace all existing errors with the specified array
+   *
+   * @param array $errors
+   *
+   * @return void
+   */
+  public function setErrors(array $errors): void {
+    $this->errors = $errors;
+  }
+
+  /**
+   * Get all errors that have been set by other callers
+   *
    * @return array
    */
   public function getErrors(): array {

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -143,7 +143,7 @@ class Submit extends AbstractProcessor {
           $fieldDefn = $event->getEntityFieldDefn($afEntityName, $fieldName);
           $error = self::getFieldInputError($event, $fieldName, $fieldDefn, $attributes, $values['fields'][$fieldName] ?? NULL);
           if ($error) {
-            $event->setError($error);
+            $event->addError($error);
           }
         }
         foreach ($afEntity['joins'] ?? [] as $joinEntity => $join) {
@@ -152,7 +152,7 @@ class Submit extends AbstractProcessor {
               $fieldDefn = $event->getEntityFieldDefn($afEntityName, $fieldName, $joinEntity);
               $error = self::getFieldInputError($event, $fieldName, $fieldDefn, $attributes, $joinValues[$fieldName] ?? NULL);
               if ($error) {
-                $event->setError($error);
+                $event->addError($error);
               }
             }
           }
@@ -229,7 +229,7 @@ class Submit extends AbstractProcessor {
         foreach ($entity['fields'] as $fieldName => $attributes) {
           $error = self::getEntityRefError($formName, $entityName, $entity['type'], $fieldName, $attributes, $values['fields'][$fieldName] ?? NULL);
           if ($error) {
-            $event->setError($error);
+            $event->addError($error);
           }
         }
         foreach ($entity['joins'] ?? [] as $joinEntity => $join) {
@@ -237,7 +237,7 @@ class Submit extends AbstractProcessor {
             foreach ($join['fields'] ?? [] as $fieldName => $attributes) {
               $error = self::getEntityRefError($formName, $entityName . '+' . $joinEntity, $joinEntity, $fieldName, $attributes, $joinValues[$fieldName] ?? NULL);
               if ($error) {
-                $event->setError($error);
+                $event->addError($error);
               }
             }
           }

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -87,12 +87,12 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
       return;
     }
     if (count($contributions) > 1) {
-      $event->setError(E::ts('Handling multiple contributions on the same form is not supported'));
+      $event->addError(E::ts('Handling multiple contributions on the same form is not supported'));
       return;
     }
     $contribution = reset($contributions);
     if (count(array_filter($contribution['actions'])) !== 1) {
-      $event->setError(E::ts('Contribution action should be create or update but not both.'));
+      $event->addError(E::ts('Contribution action should be create or update but not both.'));
       return;
     }
 
@@ -118,7 +118,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
     // this catches cases when user must select one of a number of possible
     // price fields to provide line items, but no specific price field is required
     if (!$lineItems) {
-      $event->setError(E::ts('No line items for creating contribution'));
+      $event->addError(E::ts('No line items for creating contribution'));
       return;
     }
 

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/TestCheckoutOption.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/TestCheckoutOption.php
@@ -24,7 +24,7 @@ class TestCheckoutOption extends CheckoutOption implements AfformCheckoutOptionI
     $currency = $submittedValues['Contribution1'][0]['fields']['currency'];
 
     if ($currency === 'USD' && $contributionAmount > 10) {
-      $e->setError('No payments over 10 USD');
+      $e->addError('No payments over 10 USD');
     }
   }
 

--- a/ext/recaptcha/Civi/AfformReCaptcha2.php
+++ b/ext/recaptcha/Civi/AfformReCaptcha2.php
@@ -58,7 +58,7 @@ class AfformReCaptcha2 extends AutoService implements EventSubscriberInterface {
     if (AHQ::getTags($layout, 'crm-recaptcha2')) {
       $response = $event->getApiRequest()->getValues()['extra']['recaptcha2'] ?? NULL;
       if (!isset($response) || !\CRM_Utils_ReCAPTCHA::checkResponse($response)) {
-        $event->setError(E::ts('Please go back and complete the CAPTCHA at the bottom of this form.'));
+        $event->addError(E::ts('Please go back and complete the CAPTCHA at the bottom of this form.'));
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
- Change `setError()` to `addError()` - more logical name for what it's actually doing. setError could imply that it will be the only error.
- Add a `setErrors()` method. This allows you to override / replace all errors set by core / other extensions.

Inspired by comment by @seamuslee001 here: https://github.com/civicrm/civicrm-core/pull/35524#discussion_r3192089504

Before
----------------------------------------
Less flexible ability to set validation errors for forms.

After
----------------------------------------
More flexible, clearer.

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw @ufundo ?
