### PR TITLE
Set API4 version correctly when calling API4::Update

### DIFF
--- a/Civi/Api4/Generic/Traits/DAOActionTrait.php
+++ b/Civi/Api4/Generic/Traits/DAOActionTrait.php
@@ -221,6 +221,10 @@ trait DAOActionTrait {
     // Use BAO create or add method if not deprecated
     if ($method && !ReflectionUtils::isMethodDeprecated($baoName, $method)) {
       foreach ($items as $item) {
+        // If we get here through API4 update version is not set.
+        // Methods such as CRM_Member_BAO_Membership::create() check if
+        //   version is 4 and change behaviour if so. Make sure it is set.
+        $item['version'] ??= 4;
         $saved[] = $baoName::$method($item);
       }
     }

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -109,6 +109,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'contact_id'         => $organizationId,
       'status_id:name'          => 'test status',
     ], 'first');
+    unset($membership['version']);
 
     // Check count of related memberships. It should be one for individual contact.
     $relatedMembershipsCount = $this->getRelatedMembershipsCount($this->ids['Membership']['first']);
@@ -821,6 +822,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     // Update membership by changing its status.
     $otherStatusID = $this->membershipStatusCreate('another status ' . random_int(1, 1000));
     $membership["status_id"] = $otherStatusID;
+    $membership['version'] = 3;
     $this->callAPISuccess("Membership", "create", $membership);
 
     // Assert nothing has changed.


### PR DESCRIPTION
Overview
----------------------------------------
This is a bit obscure...

If you call an API4 update function the API version does not get set correctly. But I'm not sure if it should actually be getting passed through at all because we shouldn't care once we get to the BAO.

However, for `CRM_Member_BAO_Membership::create()` we specifically check if `$params['version'] !== 4` and completely skip a bunch of financial processing if it is set to 4. See https://github.com/civicrm/civicrm-core/blob/master/CRM/Member/BAO/Membership.php#L309

Partial from https://github.com/civicrm/civicrm-core/pull/35082

This is the "fix" I came up with for 35082. But I'm wondering if we might be better switching it around and explicitly setting version = 3 when coming from API3 and not setting / using it at all when coming via any other route.

Before
----------------------------------------
Membership create BAO will process stuff meant for API3 if `version` is not set to 4.

After
----------------------------------------
Version is set.

Technical Details
----------------------------------------


Comments
----------------------------------------
@demeritcowboy any thoughts? I could do with a second opinion on this one, but think it might be cleaner to do as an API3 hack rather than how I've done it here.
