### PR TITLE
Fix saving customfields in tests with legacy API4

### DIFF
--- a/Civi/Test/Api3TestTrait.php
+++ b/Civi/Test/Api3TestTrait.php
@@ -398,10 +398,11 @@ trait Api3TestTrait {
       }
       // Convert custom field names
       if (str_starts_with($name, 'custom_') && is_numeric($name[7])) {
-        // Strictly speaking, using titles instead of names is incorrect, but it works for
-        // unit tests where names and titles are identical and saves an extra db lookup.
-        $custom[$field['groupTitle']][$field['title']] = $name;
-        $v4FieldName = $field['groupTitle'] . '.' . $field['title'];
+        $customGroups = \CRM_Core_BAO_CustomGroup::getAll(['extends' => [$field['extends']]]);
+        $customGroupDetail = $customGroups[$field['custom_group_id']];
+        $customFieldDetail = $customGroupDetail['fields'][$field['custom_field_id']];
+        $custom[$customGroupDetail['name']][$customFieldDetail['name']] = $name;
+        $v4FieldName = $customGroupDetail['name'] . '.' . $customFieldDetail['name'];
         if (isset($v3Params[$name])) {
           $v3Params[$v4FieldName] = $v3Params[$name];
           unset($v3Params[$name]);


### PR DESCRIPTION
Overview
----------------------------------------
Code was using a hack involving titles and an incorrect assumption that titles = names when they don't. Eg. a title might be "My Custom Field" and name is "my_custom_field".

Here is an example where it will break: https://github.com/civicrm/civicrm-core/pull/35082/changes/fc134bf6e391937a1ca423a51d0c98fb532faf61  - see TokenConsistencyTest.

Before
----------------------------------------
Breaks when title/name are not the same.

After
----------------------------------------
Always looks up by name.

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw I seem to remember you might have an even better way/method that converts from API3 custom field name to API4 custom field name?
