### PR TITLE
HTMLInputCoder - Fix latent bug when transcoding array data

### DIFF
--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -265,7 +265,7 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
    */
   public function transcode(string $field, $storedValue, string $outputFormat) {
     if (is_array($storedValue)) {
-      return array_map(fn($t) => $this->transcode('title', $t, $outputFormat), $storedValue);
+      return array_map(fn($t) => $this->transcode($field, $t, $outputFormat), $storedValue);
     }
     if ($storedValue === NULL) {
       return $storedValue;


### PR DESCRIPTION
Overview
----------------------------------------

Follow-up to #35220 (6.13-rc). The PR introduced a new helper function, `transcode(string $field, $storedValue, string $outputFormat)`. The `$storedValue` can provide one string to transcode... or it can be a list of strings.

```php
// Transcode a single string
$escapedString = transcode('title', 'Bill & Ted', 'html');

// Transcode a list of strings
$escapedStrings = transcode('title', ['Bill & Ted', 'Thelma & Louise'], 'html');
```

This fixes an issue with the second example.

Before
----------------------------------------

When `transocde()` walks through the list of strings... it re-sets the `$field` to a hard-coded field-name, `title`. That's fine if your `$field` is actually `'title'`. But this would misbehave:

```php
$escapedStrings = transcode('description', ['Bill & Ted', 'Thelma & Louise'], 'html');
```

After
----------------------------------------

Respect the given `$field`.

Technical Details
----------------------------------------

In searching for places where `transcode()` is used with an array... it is circumstantially true that they all have `$field='title'`. Hence, the bug is latent (it's unlikely that you would find a user-visible bug right now).