### PR TITLE
Explicitly set API4 version for Membership BAO

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -306,6 +306,7 @@ class CRM_Member_BAO_Membership extends CRM_Member_DAO_Membership {
     // unavailable through apiv3.
     // once we are rid of direct calls to the BAO::create from core
     // we will deprecate this stuff into the v3 api.
+    // API4 doesn't pass in "version" - we explicitly pass it in for API4 Membership - see MembershipSaveTrait
     if (($params['version'] ?? 0) !== 4) {
       if (isset($ids['membership'])) {
         $latestContributionID = CRM_Member_BAO_MembershipPayment::getLatestContributionIDFromLineitemAndFallbackToMembershipPayment($membership->id);

--- a/ext/civi_member/Civi/Api4/Action/Membership/Create.php
+++ b/ext/civi_member/Civi/Api4/Action/Membership/Create.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Membership;
+
+/**
+ * @inheritDoc
+ */
+class Create extends \Civi\Api4\Generic\DAOCreateAction {
+  use MembershipSaveTrait;
+
+}

--- a/ext/civi_member/Civi/Api4/Action/Membership/MembershipSaveTrait.php
+++ b/ext/civi_member/Civi/Api4/Action/Membership/MembershipSaveTrait.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Membership;
+
+/**
+ * Code shared by Membership create/update/save actions
+ */
+trait MembershipSaveTrait {
+
+  /**
+   * @inheritDoc
+   */
+  protected function write(array $items) {
+    foreach ($items as &$item) {
+      // Required by Membership BAO so we can deprecate lineItem processing.
+      // ie. API4 does less than direct BAO::create or API3.
+      // See https://github.com/civicrm/civicrm-core/pull/35628
+      $item['version'] = 4;
+    }
+    return parent::write($items);
+  }
+
+}

--- a/ext/civi_member/Civi/Api4/Action/Membership/Save.php
+++ b/ext/civi_member/Civi/Api4/Action/Membership/Save.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Membership;
+
+/**
+ * @inheritDoc
+ */
+class Save extends \Civi\Api4\Generic\DAOSaveAction {
+  use MembershipSaveTrait;
+
+}

--- a/ext/civi_member/Civi/Api4/Action/Membership/Update.php
+++ b/ext/civi_member/Civi/Api4/Action/Membership/Update.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Membership;
+
+/**
+ * @inheritDoc
+ */
+class Update extends \Civi\Api4\Generic\DAOUpdateAction {
+  use MembershipSaveTrait;
+
+}

--- a/ext/civi_member/Civi/Api4/Membership.php
+++ b/ext/civi_member/Civi/Api4/Membership.php
@@ -20,4 +20,31 @@ namespace Civi\Api4;
  */
 class Membership extends Generic\DAOEntity {
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Contribution\Create
+   */
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\Membership\Create(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Membership\Save
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\Membership\Save(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Membership\Update
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\Membership\Update(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -821,6 +821,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     // Update membership by changing its status.
     $otherStatusID = $this->membershipStatusCreate('another status ' . random_int(1, 1000));
     $membership["status_id"] = $otherStatusID;
+    $membership['version'] = 3;
     $this->callAPISuccess("Membership", "create", $membership);
 
     // Assert nothing has changed.


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/35624

Explicitly set version for Membership API calls.

Before
----------------------------------------
API version check in BAO Membership::create not working reliably.

After
----------------------------------------
API version check in BAO Membership::create working reliably.

Technical Details
----------------------------------------
Added a MembershipSaveTrait and explicitly passing in version=4 for Membership BAO only.

Comments
----------------------------------------
@colemanw @demeritcowboy 
