### PR TITLE
SearchKit - Bypass ACLs for entity displays and require super-admin permission

### DIFF
--- a/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/BAO/SearchDisplay.php
@@ -69,8 +69,9 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay implemen
         return;
       }
       if (in_array($e->getActionName(), ['create', 'update'], TRUE)) {
-        // Do not allow acl_bypass to be set to TRUE
-        if (!empty($record['acl_bypass'])) {
+        $displayType = $record['type'] ?? CRM_Core_DAO::getFieldValue(__CLASS__, $record['id'], 'type');
+        // Do not allow acl_bypass to be set to TRUE; do not allow edits to an entity display.
+        if (!empty($record['acl_bypass']) || $displayType === 'entity') {
           $e->setAuthorized(FALSE);
         }
         // Do not allow edits to an existing record with acl_bypass = TRUE
@@ -83,7 +84,7 @@ class CRM_Search_BAO_SearchDisplay extends CRM_Search_DAO_SearchDisplay implemen
     // Ensure only super-admins may update SavedSearches linked to displays with `acl_bypass`
     if ($recordType === 'SavedSearch' && $e->getActionName() === 'update' && !CRM_Core_Permission::check('all CiviCRM permissions and ACLs', $userCID)) {
       $id = (int) $e->getRecord()['id'];
-      $sql = "SELECT COUNT(id) FROM civicrm_search_display WHERE acl_bypass = 1 AND saved_search_id = $id";
+      $sql = "SELECT COUNT(id) FROM civicrm_search_display WHERE (acl_bypass = 1 OR type = 'entity') AND saved_search_id = $id";
       if (CRM_Core_DAO::singleValueQuery($sql)) {
         $e->setAuthorized(FALSE);
       }

--- a/ext/search_kit/Civi/Search/SKEntityGenerator.php
+++ b/ext/search_kit/Civi/Search/SKEntityGenerator.php
@@ -45,6 +45,11 @@ class SKEntityGenerator {
     }
     $apiParams['select'] = $select;
     $api = Request::create($realEntity, 'get', $apiParams);
+
+    // Note: entity display queries run without permission checks.
+    // Therefore, only super-admins are allowed to create them.
+    $api->setCheckPermissions(FALSE);
+
     $query = new Api4SelectQuery($api);
     $query->forceSelectId = FALSE;
     $sql = $query->getSql();

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -38,6 +38,12 @@
     this.afformAdminEnabled = CRM.checkPerm('manage own afform') &&
       'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
     this.displayTypes = Object.fromEntries(CRM.crmSearchAdmin.displayTypes.map(type => [type.id, type]));
+
+    // Only super admins are allowed to create entity displays
+    if (!CRM.checkPerm('all CiviCRM permissions and ACLs')) {
+      delete this.displayTypes.entity;
+    }
+
     this.searchDisplayPath = CRM.url('civicrm/search');
     this.afformPath = CRM.url('civicrm/admin/afform');
     this.debug = {};

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.component.js
@@ -32,6 +32,8 @@
             sort: ctrl.parent.getDefaultSort()
           };
         }
+        // Entity displays always bypass ACLs
+        ctrl.display.acl_bypass = true;
         if (ctrl.display.id && !ctrl.display._job) {
           crmApi4({
             ref: ['SK_' + ctrl.display.name, 'getRefreshDate', {}, 0],

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -56,12 +56,12 @@ class EntityDisplayTest extends Api4TestBase {
       ],
     ]);
 
-    $display = SearchDisplay::create(FALSE)
-      ->addValue('saved_search_id', $savedSearch['id'])
-      ->addValue('type', 'entity')
-      ->addValue('label', 'My New Entity')
-      ->addValue('name', 'MyNewEntity')
-      ->addValue('settings', [
+    $displaySettings = [
+      'saved_search_id' => $savedSearch['id'],
+      'type' => 'entity',
+      'label' => 'My New Entity',
+      'name' => 'MyNewEntity',
+      'settings' => [
         'data_mode' => $dataMode,
         'columns' => [
           [
@@ -100,7 +100,28 @@ class EntityDisplayTest extends Api4TestBase {
         'sort' => [
           ['first_name', 'ASC'],
         ],
-      ])
+      ],
+    ];
+
+    // Ensure only super-admins can create this display
+    $config = \CRM_Core_Config::singleton();
+    $config->userPermissionClass->permissions = ['administer search_kit'];
+
+    try {
+      $display = SearchDisplay::create()
+        ->setValues($displaySettings)
+        ->execute();
+    }
+    catch (UnauthorizedException $e) {
+      $message = $e->getMessage();
+    }
+
+    $this->assertStringContainsString('ACL check failed', $message);
+
+    $config->userPermissionClass->permissions = ['all CiviCRM permissions and ACLs'];
+
+    $display = SearchDisplay::create()
+      ->setValues($displaySettings)
       ->execute()->first();
 
     $expectTypes = ['table' => 'BASE TABLE', 'view' => 'VIEW'];


### PR DESCRIPTION
Overview
----------------------------------------
Prevents a crash when rebuilding a SearchKit entity display from a cron job or when run by a less-permissioned user. Ensures consistent results of entity displays regardless of logged-in user.


Technical Details
----------
Entity displays are tables/views built from a query. They should always return the same results regardless of the logged-in user, therefore those user ACLs should not be part of the query.

This switches such displays to always bypass permission checks. And like any other display with `acl_bypass`, they now require the super-admin permission to create or edit such displays. This prevents any unwanted access by less-permissioned users.