### PR TITLE
Keep button declarations within CiviCRM scope

### DIFF
--- a/ext/riverlea/core/css/components/_buttons.css
+++ b/ext/riverlea/core/css/components/_buttons.css
@@ -34,12 +34,12 @@
 #bootstrap-theme .btn:focus,
 .crm-container .crm-button:hover,
 .crm-container .crm-button:focus,
-[type="button"]:hover,
-[type="reset"]:hover,
-[type="submit"]:hover,
-[type="button"]:focus,
-[type="reset"]:focus,
-[type="submit"]:focus {
+.crm-container [type="button"]:hover,
+.crm-container [type="reset"]:hover,
+.crm-container [type="submit"]:hover,
+.crm-container [type="button"]:focus,
+.crm-container [type="reset"]:focus,
+.crm-container [type="submit"]:focus {
   background: var(--crm-primary-hover-color);
   color: var(--crm-primary-hover-text-color);
   text-decoration: none;


### PR DESCRIPTION
Overview
----------------------------------------
In WordPress, because RiverLea is loaded on Post Types that support the CiviCRM Shortcode dialog, the TinyMCE buttons  pick up un-scoped RiverLea `:hover` and `:focus` values.

Before
----------------------------------------
TinyMCE buttons pick up RiverLea values.

<img width="913" height="337" alt="Screenshot 2026-05-09 at 13 26 19" src="https://github.com/user-attachments/assets/b17e1d91-c282-4517-815b-3462e8f9400a" />

After
----------------------------------------
TinyMCE buttons no longer affected.

<img width="911" height="412" alt="Screenshot 2026-05-09 at 13 27 55" src="https://github.com/user-attachments/assets/2b4d984d-b33d-4533-a35a-93ea4069490b" />

@vingle 