### PR TITLE
Upgrader - Show correct version for MySQL 8.0 requirement

### DIFF
--- a/CRM/Upgrade/Incremental/General.php
+++ b/CRM/Upgrade/Incremental/General.php
@@ -46,6 +46,9 @@ class CRM_Upgrade_Incremental_General {
    * The minimum recommended MySQL version.
    *
    * A site running an earlier version will be encouraged to upgrade.
+   *
+   * NOTE: When changing this, also update the target CiviCRM version in self::setPreUpgradeMessage
+   * (parm 4 of the 2nd message in that function).
    */
   const MIN_RECOMMENDED_MYSQL_VER = '8.0';
 
@@ -58,6 +61,9 @@ class CRM_Upgrade_Incremental_General {
    * The minimum recommended MariaDB version.
    *
    * A site running an earlier version will be encouraged to upgrade.
+   *
+   * NOTE: When changing this, also update the target CiviCRM version in self::setPreUpgradeMessage
+   * (parm 4 of the 2nd message in that function).
    */
   const MIN_RECOMMENDED_MARIADB_VER = '10.4';
 
@@ -93,7 +99,7 @@ class CRM_Upgrade_Incremental_General {
         1 => $latestVer,
         2 => self::MIN_RECOMMENDED_MYSQL_VER . '+',
         3 => self::MIN_RECOMMENDED_MARIADB_VER . '+',
-        4 => '5.34' . '+',
+        4 => '6.23' . '+',
         5 => CRM_Utils_SQL::getDatabaseVersion(),
       ]);
       $preUpgradeMessage .= '</p>';


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [nonsensical upgrade message](https://github.com/civicrm/civicrm-core/pull/35100#issuecomment-4412427534).

Before
-----

> This system uses MySQL/MariaDB v5.7.39. You may proceed with the upgrade, and CiviCRM v6.14.0 will continue working normally. However, CiviCRM **v5.34+** will require MySQL v8.0+ or MariaDB v10.4+.

After
-----
> This system uses MySQL/MariaDB v5.7.39. You may proceed with the upgrade, and CiviCRM v6.14.0 will continue working normally. However, CiviCRM **v6.23+** will require MySQL v8.0+ or MariaDB v10.4+.

Technical Details
----------------------------------------
The target CiviCRM version hadn't been updated since the last time we bumped the MySQL requirement.

This required picking a new target version for MySql 8. Typically, we do the next ESR + 1, so that the ESR is the last release to support the old version.

But our next ESR is coming up very soon, so I picked the one after that: ESR 6.22 will be in Jan 2027 so this targets 6.23.
