### PR TITLE
dev/core#6495 Fix mis-spelled class name for CRM_Contribute_BAO_Contribution

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -366,7 +366,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
       //carry campaign on selectors.
       // @todo - I can't find any evidence that 'carrying' the campaign on selectors actually
       // results in it being displayed anywhere so why do we do this???
-      $row['campaign'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribution_BAO_Contribution', 'campaign_id', $result->contribution_campaign_id);
+      $row['campaign'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'campaign_id', $result->contribution_campaign_id);
       $row['campaign_id'] = $result->contribution_campaign_id;
 
       // add contribution status name


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an error introduced with PR #35258 when accessing contributions that are associated with a campaign.

Before
----------------------------------------
When there is at least one contribution with an associated campaign, the error message 'Class "CRM_Contribution_BAO_Contribution" not found' shows when you try to access the Contribution overview screen. This happens with the contribution search screen, too.

After
----------------------------------------
No error is shown.

Comments
----------------------------------------
We stumbled upon this when we updated to 6.14, and it would be great to have this fix in 6.14.1. It seems weird that this didn't come up during automated testing.