### PR TITLE
dev/core#6495 Fix regression introduced on campaign selector for contributions

### DIFF
--- a/CRM/Contribute/Selector/Search.php
+++ b/CRM/Contribute/Selector/Search.php
@@ -366,7 +366,7 @@ class CRM_Contribute_Selector_Search extends CRM_Core_Selector_Base implements C
       //carry campaign on selectors.
       // @todo - I can't find any evidence that 'carrying' the campaign on selectors actually
       // results in it being displayed anywhere so why do we do this???
-      $row['campaign'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribution_BAO_Contribution', 'campaign_id', $result->contribution_campaign_id);
+      $row['campaign'] = CRM_Core_PseudoConstant::getLabel('CRM_Contribute_BAO_Contribution', 'campaign_id', $result->contribution_campaign_id);
       $row['campaign_id'] = $result->contribution_campaign_id;
 
       // add contribution status name


### PR DESCRIPTION
Regression introduced here https://github.com/civicrm/civicrm-core/commit/b6112ac494beb22e1759c67250698d2f030f7d45



In 6.14.0 if you have CiviCampaign enabled, contribution tab does'nt load getting this error: `Class "CRM_Contribution_BAO_Contribution" not found`.

Also reproduced at smaster in 6.16.aplha1

<img width="855" height="712" alt="imatge" src="https://github.com/user-attachments/assets/a645c99f-e032-430a-8def-8cf01504fef2" />
