### PR TITLE
Reduce repeated require_once calls for CPU performance improvement

### DIFF
--- a/Civi/API/Api3SelectQuery.php
+++ b/Civi/API/Api3SelectQuery.php
@@ -10,6 +10,8 @@
  */
 namespace Civi\API;
 
+require_once 'api/v3/Generic.php';
+
 /**
  */
 class Api3SelectQuery extends SelectQuery {
@@ -129,7 +131,6 @@ class Api3SelectQuery extends SelectQuery {
    * @inheritDoc
    */
   protected function getFields() {
-    require_once 'api/v3/Generic.php';
     // Call this function directly instead of using the api wrapper to force unique field names off
     $apiSpec = \civicrm_api3_generic_getfields([
       'entity' => $this->entity,

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -16,6 +16,9 @@ use Civi\API\Event\ExceptionEvent;
 use Civi\API\Event\ResolveEvent;
 use Civi\API\Event\RespondEvent;
 
+require_once 'api/Exception.php';
+require_once 'api/v3/utils.php';
+
 /**
  * @package Civi
  * @copyright CiviCRM LLC https://civicrm.org/licensing
@@ -175,11 +178,9 @@ class Kernel {
    * @throws \CRM_Core_Exception
    */
   public function boot($apiRequest) {
-    require_once 'api/Exception.php';
     // the create error function loads some functions from utils
     // so this require is also needed for apiv4 until such time as
     // we alter create error.
-    require_once 'api/v3/utils.php';
     switch ($apiRequest['version']) {
       case 3:
         if (!is_array($apiRequest['params'])) {
@@ -414,7 +415,6 @@ class Kernel {
       }
     }
 
-    require_once "api/v3/utils.php";
     $data = \civicrm_api3_create_error($msg, $data);
 
     if (isset($apiRequest['params']) && is_array($apiRequest['params']) && !empty($apiRequest['params']['api.has_parent'])) {

--- a/Civi/API/Provider/MagicFunctionProvider.php
+++ b/Civi/API/Provider/MagicFunctionProvider.php
@@ -14,6 +14,8 @@ namespace Civi\API\Provider;
 use Civi\API\Events;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+require_once 'api/v3/Generic.php';
+
 /**
  * This class manages the loading of API's using strict file+function naming
  * conventions.
@@ -217,7 +219,6 @@ class MagicFunctionProvider implements EventSubscriberInterface, ProviderInterfa
     }
 
     // Determine if there is a generic implementation of the action
-    require_once 'api/v3/Generic.php';
     # $genericFunction = 'civicrm_api3_generic_' . $apiRequest['action'];
     $genericFunction = $this->getFunctionName('generic', $apiRequest['action'], $apiRequest['version']);
     $genericFiles = [

--- a/api/v3/CustomSearch.php
+++ b/api/v3/CustomSearch.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+require_once 'api/v3/OptionValue.php';
+
 /**
  * This api exposes CiviCRM custom search.
  *
@@ -24,7 +26,6 @@
  *   API result array
  */
 function civicrm_api3_custom_search_get($params) {
-  require_once 'api/v3/OptionValue.php';
   $params['option_group_id'] = CRM_Core_DAO::getFieldValue(
     'CRM_Core_DAO_OptionGroup', 'custom_search', 'id', 'name'
   );
@@ -40,7 +41,6 @@ function civicrm_api3_custom_search_get($params) {
  *   API result array
  */
 function civicrm_api3_custom_search_create($params) {
-  require_once 'api/v3/OptionValue.php';
   $params['option_group_id'] = CRM_Core_DAO::getFieldValue(
     'CRM_Core_DAO_OptionGroup', 'custom_search', 'id', 'name'
   );
@@ -60,7 +60,6 @@ function civicrm_api3_custom_search_create($params) {
  *   Array of parameters determined by getfields.
  */
 function _civicrm_api3_custom_search_create_spec(&$params) {
-  require_once 'api/v3/OptionValue.php';
   _civicrm_api3_option_value_create_spec($params);
   $params['option_group_id']['api.default'] = CRM_Core_DAO::getFieldValue(
     'CRM_Core_DAO_OptionGroup', 'custom_search', 'id', 'name'
@@ -77,6 +76,5 @@ function _civicrm_api3_custom_search_create_spec(&$params) {
  *   API result array
  */
 function civicrm_api3_custom_search_delete($params) {
-  require_once 'api/v3/OptionValue.php';
   return civicrm_api3_option_value_delete($params);
 }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+require_once 'CRM/Core/ClassLoader.php';
+
 /**
  * CiviCRM APIv3 utility functions.
  *
@@ -19,7 +21,6 @@
  * Initialize CiviCRM - should be run at the start of each API function.
  */
 function _civicrm_api3_initialize() {
-  require_once 'CRM/Core/ClassLoader.php';
   CRM_Core_ClassLoader::singleton()->register();
   CRM_Core_Config::singleton();
 }


### PR DESCRIPTION
## Reduce repeated `require_once` calls in API execution paths

### Problem

During profiling of API-heavy requests, we identified repeated `require_once` calls inside frequently executed functions and methods across APIv3 and API kernel code.

Examples included:

* `require_once 'api/v3/Generic.php';`
* `require_once 'api/v3/utils.php';`
* `require_once 'api/v3/OptionValue.php';`
* `require_once 'CRM/Core/ClassLoader.php';`

Although PHP prevents duplicate loading, each repeated `require_once` still triggers include-path resolution and filesystem checks.

In high-volume API execution, this results in unnecessary filesystem activity and additional CPU overhead.

### Root Cause

Several core API functions were loading dependencies inside hot execution paths, including:

* `Api3SelectQuery::getFields()`
* `Kernel::boot()`
* `MagicFunctionProvider::invoke()`
* `civicrm_api3_custom_search_*()`
* `_civicrm_api3_initialize()`

These functions may execute many times within a single request or across batch operations.

### Fix

Move repeated `require_once` statements to top-level file scope so dependencies are loaded once during initial file load instead of during runtime execution.

This patch:

* Removes repeated runtime `require_once` calls
* Loads dependencies once at file initialization
* Keeps behavior unchanged while reducing include-path lookups

### Expected Impact

Before:

* Repeated include resolution during API execution
* Additional filesystem lookups and CPU usage

After:

* Single dependency load during file initialization
* Reduced filesystem overhead in API-intensive workloads

This optimization improves CPU efficiency and reduces unnecessary filesystem activity during repeated API operations.

---

**I have submitted similar changes to** "pear/Mail" as well: https://github.com/pear/Mail/pull/37. It may take some time for the PR to be merged. In the meantime, can we use a Composer patch until the changes are merged upstream?

### Root Cause

`include_once` is executed repeatedly during email processing, especially inside loops handling headers and recipients.

For bulk mailings, this creates a significant filesystem overhead:

* Thousands of unnecessary `lstat()` calls
* Increased CPU usage during mail processing
* Compounded impact when multiple mail jobs run in parallel

### Fix

Move:

```php
require_once 'Mail/RFC822.php';
```

to the top-level scope of `vendor/pear/mail/Mail.php`, and remove the repeated `include_once` calls from:

* `prepareHeaders()`
* `parseRecipients()`

### Expected Impact

Before:

* Repeated include-path traversal per email
* for mailing of ~60,000+ receipent, ~60,000+ filesystem lookups for mail jobs

After:

* Single lookup at class load time
* No repeated include resolution during mail processing

This significantly reduces filesystem overhead and lowers CPU consumption during bulk email operations.
 
 
 ---
 
 
 ## Impact Analysis

### Before (current state, sending 5,000 emails): (we have **12+** extension)

 - Email 1: include_once → searches 12+ extension dirs → finds file → 12+ lstat() calls
 - Email 2-5000: include_once → still searches 12+ dirs to verify → 12+ lstat() calls each
 - Total: ~60,000 filesystem lookups

### After fix (same 5,000 emails):
- Class load: require_once 'Mail/RFC822.php' at top → searches once → 1 lookup
- Email 1-5000: Skip include, use cached class → 0 lookups per email
- Total: ~1 filesystem lookup

