### PR TITLE
Allow deleting SearchKit when entity doesn't exist

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -116,6 +116,8 @@
             row.permissionToEdit = false;
           }
 
+          // Implied permission that if you can edit, you should be able to delete.
+          row.permissionToDelete = row.permissionToEdit;
           // If main entity doesn't exist, no can edit
           if (!row.data['api_entity:label']) {
             row.permissionToEdit = false;
@@ -128,9 +130,6 @@
           if (!row.data.display_name) {
             row.openDisplayMenu = false;
           }
-
-          // Implied permission that if you can edit, you should be able to delete.
-          row.permissionToDelete = row.permissionToEdit;
         });
         updateAfformCounts();
       });


### PR DESCRIPTION
Overview
----------------------------------------
Today I imported a SearchKit with an entity that doesn't exist on the target system.  I couldn't delete it.

To replicate:
* Create a minimal SearchKit and save.
* Export the SearchKit.
* In the exported JSON, change the name of the entity to `Foo`.
* Delete the SearchKit.
* Import it from the JSON.
* Attempt to delete it.

Before
----------------------------------------
No **Delete** option in the links menu.

After
----------------------------------------
Delete option appears.

Technical Details
----------------------------------------
Generally speaking, `permissionToDelete` and permissionToEdit` are identical - but in this instance, we need to distinguish between the two, so we're assigning `permissionToDelete` before the two cases that should allow deleting but not editing.