### PR TITLE
Don't check permissions for Entity::getfields when saving a related entity via Order API

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1639,7 +1639,7 @@ class CRM_Financial_BAO_Order {
     if (empty($entityValues['id'])) {
       // Not an update, include any relevant values (e.g. contact_id) from the contribution
       // entity values if not present already in EntityFields.
-      $fields = (array) civicrm_api4($entity, 'getfields')->indexBy('name');
+      $fields = (array) civicrm_api4($entity, 'getfields', ['checkPermissions' => FALSE])->indexBy('name');
       $carryOverFields = array_intersect_key($this->contributionValues, $fields);
       if ($entity === 'Participant') {
         $carryOverFields += array_filter(['fee_amount' => $lineItem['unit_price'], 'fee_level' => $lineItem['label']]);


### PR DESCRIPTION
Overview
----------------------------------------
When using Order API (or Order BAO) and saving related entities (ie. Participant / Membership) we do a call to Entity::getfields to filter the list of provided fields by the fields for that entity.
The "save" action already has checkPermissions = FALSE.

There is no need to check permissions on the getFields call here and in fact it causes problems if you are calling the Order API as a restricted / anonymous user.

Found while developing anonymous support for ShoppingCart. Where the form submission creates a contact and then "submits" via Order::Create API to create a contribution / lineitems / entities for that new contact.

Before
----------------------------------------
Cannot create related entities if user does not have permissions to call Entity::getfields

After
----------------------------------------
Can create related entities if user does not have permissions to call Entity::getfields

Technical Details
----------------------------------------


Comments
----------------------------------------

