### PR TITLE
dev/core#6496 Fix issue where using a 'membership' price set but not …

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -722,6 +722,12 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     if ($this->isFormSupportsNonMembershipContributions()) {
       return (int) $this->getContributionPageValue('financial_type_id');
     }
+    // If even tho we have a membership price set no membership has been selected
+    // so use the Contribution Page value
+    // see dev/core#6496
+    if (empty($this->getFirstSelectedMembershipType())) {
+      return (int) $this->getContributionPageValue('financial_type_id');
+    }
     return (int) $this->getFirstSelectedMembershipType()['financial_type_id'];
   }
 


### PR DESCRIPTION
…requiring membership signup might lead to a DB constraint violation because no financial type is returned from getFinancialTypeID()

Overview
----------------------------------------
This fixes an issue where getFirstSelectedMembershipType might return an empty array causing the function to return 0 and cause a DB constraint violantion when creating a contribution on a contribution page

Before
----------------------------------------
DB error triggerd

After
----------------------------------------
No Db error triggered and contribution created

ping @ufundo @eileenmcnaughton