### PR TITLE
riverlea - consolidate crm-input-border

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -241,6 +241,7 @@
   --crm-input-color: var(--crm-text-color);
   --crm-input-border-color: var(--crm-c-gray-400);
   --crm-input-border-radius: 3px;
+  --crm-input-border: 1px solid var(--crm-input-border-color);
   --crm-input-active-transition: border-color .15s ease-in-out 0s;
   --crm-input-box-shadow: inset 0 1px 2px 0 rgba(0,0,0,.1);
   --crm-input-padding: var(--crm-l-xsmall-1) var(--crm-l-small-2);

--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -151,7 +151,7 @@ select.crm-form-select,
   border-radius: var(--crm-input-border-radius);
   box-shadow: var(--crm-input-box-shadow);
   color: var(--crm-input-color);
-  border: 1px solid var(--crm-input-border-color);
+  border: var(--crm-input-border);
   padding: var(--crm-input-padding);
   height: var(--crm-input-height);
   width: var(--crm-input-width);
@@ -463,7 +463,7 @@ input.crm-form-checkbox) + label {
 .crm-container .select2-container-multi .select2-choices,
 .crm-container .select2-container .select2-choice {
   background: var(--crm-input-bg-color);
-  border: 1px solid var(--crm-input-border-color);
+  border: var(--crm-input-border);
   border-radius: var(--crm-input-border-radius);
   box-shadow: var(--crm-input-box-shadow);
   height: var(--crm-input-height) !important /* vs select2.min.css */;
@@ -676,7 +676,7 @@ span.crm-select-item-color {
 .select2-drop.select2-drop-active.crm-container .crm-entityref-filters select,
 .select2-drop.select2-drop-active.crm-container .crm-entityref-filters input {
   background: var(--crm-container-bg-color);
-  border: 1px solid var(--crm-input-border-color);
+  border: var(--crm-input-border);
   border-radius: var(--crm-input-border-radius);
   box-sizing: border-box;
   height: var(--crm-l-large);

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -615,7 +615,7 @@ i.crm-i.af-gui-conditional-dialog-move-icon {
   padding-inline: var(--crm-l-medium);
   width: 110px;
   margin-left: var(--crm-l-xsmall-2);
-  border: 1px solid var(--crm-input-border-color);
+  border: var(--crm-input-border);
   border-radius: 2px;
 }
 #afGuiEditor li.disabled a strong {


### PR DESCRIPTION
Before
----------------------------------------
- lots of repeated `border: 1px solid var(--crm-input-border-color);`

After
----------------------------------------
- use `--crm-input-border` 

Comments
----------------------------------------
This is a common pattern where we have vars for specific components, and then another var for the composite. This allows consumers to override just the color or the whole thing in one go; whilst maintaining consistency.
