### PR TITLE
Api - Remove redundant require_once from Kernel.

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -16,7 +16,6 @@ use Civi\API\Event\ExceptionEvent;
 use Civi\API\Event\ResolveEvent;
 use Civi\API\Event\RespondEvent;
 
-require_once 'api/Exception.php';
 require_once 'api/v3/utils.php';
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Removes unnecessary include of the deprecated api/Exception classes. 

Technical Details
--------

Api/Exception classes are not used in core, but any extensions using them will not break because they are still included via our autoloader (for the time being):

https://github.com/civicrm/civicrm-core/blob/08231eabb02d11868fdea64b1ade459a1f728893/CRM/Core/ClassLoader.php#L158-L163