### PR TITLE
dev/core#6447 support sending yourself a test email from Message Admin

### DIFF
--- a/ext/message_admin/CRM/MessageAdmin/Settings.php
+++ b/ext/message_admin/CRM/MessageAdmin/Settings.php
@@ -16,9 +16,21 @@ class CRM_MessageAdmin_Settings {
       ->execute()
       ->single()['params']['language']['options'];
 
+    // sending test emails using EmailMessage.create requires
+    // a) the postbox extension to be enabled
+    // b) the user has administer CiviCRM permissions
+    // note: status = installed actually means enabled :/
+    $sendTestEnabled = \CRM_Core_Permission::check('administer CiviCRM')
+      && (bool) \Civi\Api4\Extension::get(FALSE)
+        ->addWhere('key', '=', 'postbox')
+        ->addWhere('status:name', '=', 'installed')
+        ->execute()
+        ->first();
+
     return [
       'allLanguages' => CRM_Utils_Array::subset($allLangsIdx, $usableLangs),
       'uiLanguages' => CRM_Core_I18n::uiLanguages(),
+      'sendTestEnabled' => $sendTestEnabled,
     ];
   }
 

--- a/ext/message_admin/ang/crmMsgadm/Preview.html
+++ b/ext/message_admin/ang/crmMsgadm/Preview.html
@@ -13,6 +13,10 @@
         </div>
         <div class="navbar-form navbar-right">
           <div class="form-group">
+            <button class="crm-button" ng-click="$ctrl.sendTest.send()" ng-if="!$ctrl.loading && $ctrl.sendTest">
+              <i class="crm-i fa-paper-plane" role="img" aria-disabled="true"></i>
+              {{:: ts('Send test') }}
+            </button>
             <button crm-icon="fa-times" type="button" class="btn btn-default" ng-click="previewMsgDlg.close()">
               {{::ts('Close')}}
             </button>

--- a/ext/message_admin/ang/crmMsgadm/Preview.js
+++ b/ext/message_admin/ang/crmMsgadm/Preview.js
@@ -110,6 +110,22 @@
     $scope.$watch('$ctrl.formatId', update);
     $scope.$watch('$ctrl.exampleId', update);
     update();
+
+    this.sendTest = CRM.crmMsgadm.sendTestEnabled ? {
+      send: () => {
+        const subject = this.preview.subject;
+        const body = this.preview.html;
+        return crmStatus({start: ts('Sending...'), success: ts('Sent')}, crmApi4('EmailMessage', 'create', {
+          values: {
+            // TODO: enable selecting other contacts to receive test?
+            to_contact_id: 'user_contact_id',
+            subject: subject,
+            body: body,
+          }
+        }));
+      }
+    } : null;
+
   });
 
 })(angular, CRM.$, CRM._);


### PR DESCRIPTION
Overview
----------------------------------------

Approach to https://lab.civicrm.org/dev/core/-/work_items/6447 that uses Outbound Message https://lab.civicrm.org/extensions/outbound_message

Before
----------------------------------------
- preview message templates in the UI, but not an email client

After
----------------------------------------
- preview message templates in the UI, then send yourself a test email to preview in email client

Technical Details
----------------------------------------
Relies on `outbound_message`. Should we bring this into core? Has other potential uses - such as FormBuilder confirmation messages.

Comments
----------------------------------------
Limited to sending to current logged in user - is this sufficient or is there a need to send to other contacts / arbitrary emails?

CC @eileenmcnaughton @larssandergreen 
