### PR TITLE
Add support for xLabelAngle to avoid overlapping X-axis labels in charts

### DIFF
--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -37,7 +37,7 @@ class CRM_Utils_Chart {
 
     // based on number of bar count adjust angle for xLabelAngle
     // if xLabelAngle is not set
-    if (!isset($params['xLabelAngle'])) {
+    if (empty($params['xLabelAngle'])) {
       $count = count($params['values']);
       $output['xLabelAngle'] = match (TRUE) {
         $count > 20 => 80,

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -40,10 +40,9 @@ class CRM_Utils_Chart {
     if (empty($params['xLabelAngle'])) {
       $count = count($params['values']);
       $output['xLabelAngle'] = match (TRUE) {
-        $count > 20 => 80,
-        $count > 16 => 60,
-        $count > 12 => 35,
-        $count > 6 => 20,
+        $count > 20 => 70,
+        $count > 16 => 45,
+        $count > 12 => 20,
         default => 0,
       };
     }

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -34,6 +34,24 @@ class CRM_Utils_Chart {
     if (empty($output)) {
       return NULL;
     }
+
+    // based on number of bar count adjust angle for xLabelAngle
+    // if xLabelAngle is already set and less than equal 20, then based on
+    // count of bars adjust angle for xLabelAngle
+    if (empty($params['xLabelAngle']) || ($params['xLabelAngle'] <= 20)) {
+      $count = count($params['values']);
+      $output['xLabelAngle'] = match (TRUE) {
+        $count > 20 => 80,
+        $count > 16 => 60,
+        $count > 12 => 35,
+        $count > 6 => 20,
+        default => 0,
+      };
+    }
+    else {
+      $output['xLabelAngle'] = $params['xLabelAngle'];
+    }
+
     $output['type'] = 'barchart';
     // Default title
     $output += ['title' => ts('Bar Chart')];

--- a/CRM/Utils/Chart.php
+++ b/CRM/Utils/Chart.php
@@ -36,9 +36,8 @@ class CRM_Utils_Chart {
     }
 
     // based on number of bar count adjust angle for xLabelAngle
-    // if xLabelAngle is already set and less than equal 20, then based on
-    // count of bars adjust angle for xLabelAngle
-    if (empty($params['xLabelAngle']) || ($params['xLabelAngle'] <= 20)) {
+    // if xLabelAngle is not set
+    if (!isset($params['xLabelAngle'])) {
       $count = count($params['values']);
       $output['xLabelAngle'] = match (TRUE) {
         $count > 20 => 80,

--- a/js/crm.visual.createChart.js
+++ b/js/crm.visual.createChart.js
@@ -92,6 +92,8 @@
       dataDimension = ndx.dimension(d => d.label);
       dataGroup = dataDimension.group().reduceSum(d => d.value);
       var ordinals = data.values[0].map(d => d.label);
+      const xLabelAngle = data.xLabelAngle || 0;
+      const bottomMargin = xLabelAngle ? Math.max(70, xLabelAngle) : 30;
 
       if (data.type === 'barchart') {
         chart = dc.barChart(chartNode)
@@ -102,7 +104,7 @@
           .gap(4) // px
           .x(d3.scale.ordinal(ordinals).domain(ordinals))
           .xUnits(dc.units.ordinal)
-          .margins({top: 10, right: 30, bottom: 30, left: 90})
+          .margins({top: 10, right: 30, bottom: bottomMargin, left: 90})
           .elasticY(true)
           .renderLabel(false)
           .renderHorizontalGridLines(true)
@@ -131,6 +133,15 @@
       div.appendChild(links);
 
       dc.renderAll();
+      if (xLabelAngle) {
+        chart.selectAll('g.x text')
+          .style('text-anchor', 'end')
+          .attr('dx', '-0.5em')
+          .attr('dy', '0.15em')
+          .attr('transform', function() {
+            return 'rotate(-' + xLabelAngle + ')';
+          });
+      }
     };
   })(CRM.$, CRM._, CRM.visual.d3, CRM.visual.dc, CRM.visual.crossfilter);
 


### PR DESCRIPTION
Overview
----------------------------------------
Add support for `xLabelAngle` to avoid overlapping X-axis labels in charts.

Before
----------------------------------------
X-axis labels did not have supporting JavaScript code to apply label rotation, causing labels to overlap when there were many bars.
<img width="1467" height="531" alt="chart_before" src="https://github.com/user-attachments/assets/b7f7fe49-503f-4086-ab3d-250ffd091ae5" />


After
----------------------------------------
X-axis labels now support rotation using `xLabelAngle`, improving readability for charts with many labels.
<img width="1455" height="505" alt="chart_after" src="https://github.com/user-attachments/assets/15fb8cc0-34d1-44a9-a1c0-06e334ee304a" />


Technical Details
----------------------------------------

* Added JavaScript support for applying `xLabelAngle` to X-axis labels.
* Dynamically adjusts the bottom chart margin based on the label angle.
* Added automatic angle calculation in PHP based on the number of bars when `xLabelAngle` is not explicitly set (or is less than or equal to 20).
* This helps prevent label collisions and improves chart readability for larger datasets.