### PR TITLE
Fold legacyMembership process back into main function in Batch Entry

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -778,9 +778,77 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
             'start_date' => $value['membership_start_date'] ?? NULL,
           ];
 
-          $membership = $this->legacyProcessMembership(
-            $value['custom'], $formDates
-          );
+          $changeToday = NULL;
+          $numRenewTerms = 1;
+          $format = '%Y%m%d';
+          $ids = [];
+          $isPayLater = NULL;
+          $memParams = $this->getCurrentRowMembershipParams();
+          $currentMembership = $this->getCurrentMembership();
+
+          // Now Renew the membership
+          if (!$currentMembership['is_current_member']) {
+            // membership is not CURRENT
+
+            // CRM-7297 Membership Upsell - calculate dates based on new membership type
+            $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($currentMembership['id'],
+              $changeToday,
+              $this->getCurrentRowMembershipTypeID(),
+              $numRenewTerms
+            );
+
+            foreach (['start_date', 'end_date'] as $dateType) {
+              $memParams[$dateType] = $memParams[$dateType] ?: ($dates[$dateType] ?? NULL);
+            }
+
+            $ids['membership'] = $currentMembership['id'];
+
+            //set the log start date.
+            $memParams['log_start_date'] = CRM_Utils_Date::customFormat($dates['log_start_date'], $format);
+          }
+          else {
+
+            // CURRENT Membership
+            $membership = new CRM_Member_DAO_Membership();
+            $membership->id = $currentMembership['id'];
+            $membership->find(TRUE);
+            // CRM-7297 Membership Upsell - calculate dates based on new membership type
+            $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership->id,
+              $changeToday,
+              $this->getCurrentRowMembershipTypeID(),
+              $numRenewTerms
+            );
+
+            // Insert renewed dates for CURRENT membership
+            $memParams['join_date'] = CRM_Utils_Date::isoToMysql($membership->join_date);
+            $memParams['start_date'] = $formDates['start_date'] ?? CRM_Utils_Date::isoToMysql($membership->start_date);
+            $memParams['end_date'] = $formDates['end_date'] ?? NULL;
+            if (empty($memParams['end_date'])) {
+              $memParams['end_date'] = $dates['end_date'] ?? NULL;
+            }
+
+            //set the log start date.
+            $memParams['log_start_date'] = CRM_Utils_Date::customFormat($dates['log_start_date'], $format);
+
+            if (!empty($currentMembership['id'])) {
+              $ids['membership'] = $currentMembership['id'];
+            }
+            $memParams['membership_activity_status'] = $isPayLater ? 'Scheduled' : 'Completed';
+          }
+
+          //since we are renewing,
+          //make status override false.
+          $memParams['is_override'] = FALSE;
+          $memParams['custom'] = $value['custom'];
+          // Load all line items & process all in membership. Don't do in contribution.
+          // Relevant tests in api_v3_ContributionPageTest.
+          // @todo stop passing $ids (membership and userId may be set by this point)
+          // $ids['membership'] is the "current membership ID"
+          $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
+
+          // not sure why this statement is here, seems quite odd :( - Lobo: 12/26/2010
+          // related to: http://forum.civicrm.org/index.php/topic,11416.msg49072.html#msg49072
+          $membership->find(TRUE);
 
           // make contribution entry
           $contrbutionParams = array_merge($value, ['membership_id' => $membership->id]);
@@ -920,90 +988,6 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
     CRM_Contact_BAO_Contact::createProfileContact($value, $this->_fields,
       $value['contact_id']
     );
-  }
-
-  /**
-   * @param $customFieldsFormatted
-   * @param array $formDates
-   *
-   * @return CRM_Member_BAO_Membership
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function legacyProcessMembership($customFieldsFormatted, $formDates = []): CRM_Member_DAO_Membership {
-    $changeToday = NULL;
-    $numRenewTerms = 1;
-    $format = '%Y%m%d';
-    $ids = [];
-    $isPayLater = NULL;
-    $memParams = $this->getCurrentRowMembershipParams();
-    $currentMembership = $this->getCurrentMembership();
-
-    // Now Renew the membership
-    if (!$currentMembership['is_current_member']) {
-      // membership is not CURRENT
-
-      // CRM-7297 Membership Upsell - calculate dates based on new membership type
-      $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($currentMembership['id'],
-        $changeToday,
-        $this->getCurrentRowMembershipTypeID(),
-        $numRenewTerms
-      );
-
-      foreach (['start_date', 'end_date'] as $dateType) {
-        $memParams[$dateType] = $memParams[$dateType] ?: ($dates[$dateType] ?? NULL);
-      }
-
-      $ids['membership'] = $currentMembership['id'];
-
-      //set the log start date.
-      $memParams['log_start_date'] = CRM_Utils_Date::customFormat($dates['log_start_date'], $format);
-    }
-    else {
-
-      // CURRENT Membership
-      $membership = new CRM_Member_DAO_Membership();
-      $membership->id = $currentMembership['id'];
-      $membership->find(TRUE);
-      // CRM-7297 Membership Upsell - calculate dates based on new membership type
-      $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership->id,
-        $changeToday,
-        $this->getCurrentRowMembershipTypeID(),
-        $numRenewTerms
-      );
-
-      // Insert renewed dates for CURRENT membership
-      $memParams['join_date'] = CRM_Utils_Date::isoToMysql($membership->join_date);
-      $memParams['start_date'] = $formDates['start_date'] ?? CRM_Utils_Date::isoToMysql($membership->start_date);
-      $memParams['end_date'] = $formDates['end_date'] ?? NULL;
-      if (empty($memParams['end_date'])) {
-        $memParams['end_date'] = $dates['end_date'] ?? NULL;
-      }
-
-      //set the log start date.
-      $memParams['log_start_date'] = CRM_Utils_Date::customFormat($dates['log_start_date'], $format);
-
-      if (!empty($currentMembership['id'])) {
-        $ids['membership'] = $currentMembership['id'];
-      }
-      $memParams['membership_activity_status'] = $isPayLater ? 'Scheduled' : 'Completed';
-    }
-
-    //since we are renewing,
-    //make status override false.
-    $memParams['is_override'] = FALSE;
-    $memParams['custom'] = $customFieldsFormatted;
-    // Load all line items & process all in membership. Don't do in contribution.
-    // Relevant tests in api_v3_ContributionPageTest.
-    // @todo stop passing $ids (membership and userId may be set by this point)
-    // $ids['membership'] is the "current membership ID"
-    $membership = CRM_Member_BAO_Membership::create($memParams, $ids);
-
-    // not sure why this statement is here, seems quite odd :( - Lobo: 12/26/2010
-    // related to: http://forum.civicrm.org/index.php/topic,11416.msg49072.html#msg49072
-    $membership->find(TRUE);
-
-    return $membership;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fold legacyMembership process back into main function in Batch Entry

Before
----------------------------------------
in separate function

After
----------------------------------------
folded back in

Technical Details
----------------------------------------
@mattwire both the approach you were looking at here (leaning into the `skipLineItems` magic) and the one I was expecting to be the path forwards (switching to order api - getting rid of the rest of the silliness) work better with the function folded back in - this is just that - no changes at all to the code being copied (even though I agree with you about getting rid of that `find()` I went for a straight copy.

Note that with this fixed the `$ids` would only be passed from apiv3 - I was expecting to copy a bunch of functionality from `BAO_Create` to the apiv3 at that point & noisily deprecate it in the `BAO_Create`

Comments
----------------------------------------
