### PR TITLE
allow creating related records from SearchKit

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -33,7 +33,7 @@
       const EST_BATCH_TIME = 5;
 
       this.$onInit = function() {
-        if (ctrl.action === 'create') {
+        if (ctrl.action === 'create' && !ctrl.idField) {
           ctrl.ids = [0];
         }
         totalBatches = Math.ceil(ctrl.ids.length / BATCH_SIZE);
@@ -53,7 +53,8 @@
           ctrl.last = ctrl.ids.length;
         }
         const params = _.cloneDeep(ctrl.params);
-        if (ctrl.action === 'save') {
+        if (ctrl.action === 'save' || (ctrl.action === 'create' && ctrl.idField)) {
+          actionName = 'save';
           let originalRecords = params.records || [{}];
           // If "values" were passed instead of "records"
           if ('values' in params) {


### PR DESCRIPTION
Overview
----------------------------------------
I saw that 6.13+ supports creating SearchKit links that [take action on a different entity](https://docs.civicrm.org/dev/en/latest/searchkit/tasks/#taking-action-on-a-different-entity).  However, this fails if the API action you want to use is `create`.

Before
----------------------------------------
Can't use `create` in a searchKitTask hook.

After
----------------------------------------
Can.

Technical Details
----------------------------------------
Before this PR, it's assumed that any `create` action was on the same entity as the record being viewed.  So the `id` isn't helpful because you can't pass an id to a created record. Additionally, the way that SearchKit passes the ID is in an array element named `records` - which `save` supports but `create` does not.

This PR takes advantage of the similarity between the `create` and `save` APIs - if you use `create` with an `idField`, it's converted to a `save`.

Comments
----------------------------------------
I considered just adding a note in the docs that `create` wasn't supported, just use `save` - which is what I'd have done if I valued my time more.  But it seems arbitrary to support all API actions except one here.