### PR TITLE
dev/core#6482 Treat text area custom fields like other custom fields …

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataFieldView.tpl
@@ -32,7 +32,7 @@
             <div class="crm-content crm-custom-data crm-contact-reference">
               {$element.contact_ref_links|join:', '}
             </div>
-          {elseif $element.field_type eq 'File' || $element.field_type eq 'RichTextEditor' || $element.field_type === 'Link'}
+          {elseif $element.field_type eq 'File' || $element.field_type eq 'TextArea' || $element.field_type eq 'RichTextEditor' || $element.field_type === 'Link'}
             <div class="crm-content crm-custom-data">{$element.field_value|purify}</div>
           {else}
             <div class="crm-content crm-custom-data">{$element.field_value|escape}</div>

--- a/templates/CRM/Custom/Page/CustomDataView.tpl
+++ b/templates/CRM/Custom/Page/CustomDataView.tpl
@@ -69,8 +69,10 @@
                           {else}
                             {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
                               {$element.contact_ref_links|join:', '}
+                            {elseif $element.field_type eq 'File' || $element.field_type eq 'TextArea' || $element.field_type eq 'RichTextEditor' || $element.field_type === 'Link'}
+                              {$element.field_value|purify}
                             {else}
-                              {$element.field_value}
+                              {$element.field_value|escape}
                             {/if}
                           {/if}
                         {/if}
@@ -121,8 +123,10 @@
                   <div class="content">
                     {if $element.field_data_type EQ 'ContactReference' && $element.contact_ref_links}
                       {$element.contact_ref_links|join:', '}
+                    {elseif $element.field_type eq 'File' || $element.field_type eq 'TextArea' || $element.field_type eq 'RichTextEditor' || $element.field_type === 'Link'}
+                      {$element.field_value|purify}
                     {else}
-                      {if $element.field_value}{$element.field_value} {else}<br/>{/if}
+                      {if $element.field_value}{$element.field_value|escape} {else}<br/>{/if}
                     {/if}
                   </div>
                 {/if}


### PR DESCRIPTION
…with HTML tags in it and amk the CustomDataview template consistent with the Contact Page CustomDataFieldView template

Overview
----------------------------------------
This fixes an issue where the <br> tags get overescaped in a text area when displaying on a contact screen and also syncs up the two templates together

Before
----------------------------------------
Double escaping on text area fields

After
----------------------------------------
No double escaping

ping @andrew-cormick-dockery @ufundo @johntwyman @colemanw 