### PR TITLE
Switch Batch Entry to v4 Order api

### DIFF
--- a/CRM/Batch/Form/Entry.php
+++ b/CRM/Batch/Form/Entry.php
@@ -17,6 +17,8 @@
 
 use Civi\API\EntityLookupTrait;
 use Civi\Api4\Contribution;
+use Civi\Api4\LineItem;
+use Civi\Api4\Order;
 
 /**
  * This class provides the functionality for batch entry for contributions/memberships.
@@ -846,18 +848,23 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
           $this->setCurrentRowMembershipID($membership->id);
         }
         else {
-          $createdOrder = civicrm_api3('Order', 'create', [
-            'line_items' => $order->getLineItemForV3OrderApi(),
-            'receive_date' => $this->currentRow['receive_date'],
-            'check_number' => $this->currentRow['check_number'] ?? '',
-            'contact_id' => $this->getCurrentRowContactID(),
-            'batch_id' => $this->_batchId,
-            'financial_type_id' => $this->currentRow['financial_type_id'],
-            'payment_instrument_id' => $this->currentRow['payment_instrument_id'],
-          ]);
+          $createdOrder = Order::create(FALSE)
+            ->setLineItems($order->getLineItemsForV4OrderApi())
+            ->setContributionValues([
+              'receive_date' => $this->currentRow['receive_date'],
+              'check_number' => $this->currentRow['check_number'] ?? '',
+              'contact_id' => $this->getCurrentRowContactID(),
+              'batch_id' => $this->_batchId,
+              'financial_type_id' => $this->currentRow['financial_type_id'],
+              'payment_instrument_id' => $this->currentRow['payment_instrument_id'],
+            ])->execute()->single();
           $this->currentRowContributionID = $createdOrder['id'];
 
-          $this->setCurrentRowMembershipID($createdOrder['values'][$this->getCurrentRowContributionID()]['line_item'][0]['entity_id']);
+          $this->setCurrentRowMembershipID(LineItem::get(FALSE)
+            ->addWhere('contribution_id', '=', $createdOrder['id'])
+            ->addWhere('entity_table', '=', 'civicrm_membership')
+            ->execute()->first()['entity_id']);
+
           if ($this->getCurrentRowPaymentStatus() === 'Completed') {
             civicrm_api3('Payment', 'create', [
               'total_amount' => $order->getTotalAmount() + $order->getTotalTaxAmount(),
@@ -1064,7 +1071,7 @@ class CRM_Batch_Form_Entry extends CRM_Core_Form {
    * @throws \CRM_Core_Exception
    */
   private function getCurrentRowMembershipParams(): array {
-    return array_merge($this->getCurrentRowCustomParams(), [
+    return array_merge($this->getCurrentRowCustomParams(4), [
       'start_date' => $this->currentRow['membership_start_date'] ?? NULL,
       'end_date' => $this->currentRow['membership_end_date'] ?? NULL,
       'join_date' => $this->currentRow['membership_join_date'] ?? NULL,

--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1451,6 +1451,26 @@ class CRM_Financial_BAO_Order {
   }
 
   /**
+   * Get the constructed line items formatted for the v3 Order api.
+   *
+   * @return array
+   *
+   * @internal core tested code only.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getLineItemsForV4OrderApi(): array {
+    $lineItems = [];
+    foreach ($this->getLineItems() as $key => $line) {
+      foreach ($this->entityParameters[$key] as $fieldName => $entityParameter) {
+        $line['entity_id.' . $fieldName] = $entityParameter;
+      }
+      $lineItems[] = $line;
+    }
+    return $lineItems;
+  }
+
+  /**
    * @return array
    * @throws \CRM_Core_Exception
    * @throws \Civi\API\Exception\UnauthorizedException
@@ -1680,14 +1700,7 @@ class CRM_Financial_BAO_Order {
         if (empty($statusIDKey) || empty($entityValues[$statusIDKey])) {
           // For the Membership entity, we didn't pass in a value for "status" so we are going to calculate membership status
           //   from membership dates and membership type.
-          $entityValues['status_id'] = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate(
-            $entityValues['start_date'] ?? NULL,
-            $entityValues['end_date'] ?? NULL,
-            $entityValues['join_date'] ?? NULL,
-            $this->contributionValues['receive_date'],
-            TRUE,
-            $entityValues['membership_type_id']
-          )['id'];
+          $entityValues['status_id:name'] = 'Pending';
         }
       }
     }

--- a/tests/phpunit/CRM/Batch/Form/EntryTest.php
+++ b/tests/phpunit/CRM/Batch/Form/EntryTest.php
@@ -195,10 +195,10 @@ class CRM_Batch_Form_EntryTest extends CiviUnitTestCase {
     $this->assertEquals(date('Y-m-d', strtotime('last day of December 2013')), $memberships[2]['end_date']);
     $this->assertEquals('2013-12-01', $memberships[3]['end_date']);
 
-    //check start dates #1 should default to 1 Jan this year, #2 should be as entered
+    //check start dates #1 should default to 1 Jan this year, #2 should be as entered, 3 is from receive_date
     $this->assertEquals(date('Y-m-d', strtotime('07/22/2013')), $memberships[1]['join_date']);
     $this->assertEquals(date('Y-m-d', strtotime('07/03/2013')), $memberships[2]['join_date']);
-    $this->assertEquals(date('Y-m-d'), $memberships[3]['join_date']);
+    $this->assertEquals('2013-07-17', $memberships[3]['join_date']);
     $memberships = $this->callAPISuccess('Contribution', 'get', ['return' => ['total_amount', 'trxn_id']]);
     $this->assertEquals(3, $memberships['count']);
     foreach ($memberships['values'] as $key => $contribution) {


### PR DESCRIPTION


Overview
----------------------------------------
Switch Batch Entry to v4 Order api

Test cover in CRM_Batch_Form_EntryTest:testProcessMembership

Before
----------------------------------------
Uses apiv3

After
----------------------------------------
V4

Technical Details
----------------------------------------
- The test exposed 2 differences with apiv3 order - where the status is not set & id is set apiv3 sets the status to Pending whereas v4 sets it to (e.g.) "new" - I fixed the apiv4 behaviour to match v3 as more correct IMHO.
- When the join_date is not set the v3 api set it to 'today' whereas v4 set it based on the receive_date. The v3 behaviour was rather nonsensical.

Comments
----------------------------------------
