### PR TITLE
afform - Fix Boolean CheckBox filter resetting to inactive-only on uncheck

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -456,6 +456,14 @@
         const currentVal = $scope.dataProvider.getFieldData()[ctrl.fieldName];
         // Setter
         if (arguments.length) {
+          // A single Boolean CheckBox transitioning from checked (true) to unchecked in a
+          // search filter context means "remove filter" (null), not "filter for false".
+          const isUserUnchecking = val === false && currentVal === true;
+          const isSingleBooleanCheckbox = ctrl.defn.input_type === 'CheckBox' && !ctrl.isMultiple();
+          const isSearchFilterContext = !ctrl.afFieldset.afFormCtrl && !ctrl.search_operator;
+          if (isUserUnchecking && isSingleBooleanCheckbox && isSearchFilterContext) {
+            val = null;
+          }
           if (ctrl.search_operator) {
             if (typeof currentVal !== 'object') {
               $scope.dataProvider.getFieldData()[ctrl.fieldName] = {};


### PR DESCRIPTION
## Overview

In SearchKit searches embedded via Afform, checking and then unchecking a Boolean CheckBox filter (e.g. "Is relationship enabled") incorrectly narrows results to show only inactive records instead of restoring the unfiltered view.

## Before

1. Page load (no filter) → all results shown (active + inactive) ✓

<img width="1676" height="945" alt="01-initial-7-results" src="https://github.com/user-attachments/assets/ae6d3894-3bca-4ee4-bb90-4e82d002ae6b" />

2. Check "Is relationship enabled" → active-only results ✓
<img width="1676" height="945" alt="02-checked-4-results" src="https://github.com/user-attachments/assets/b8dcebe4-18e2-455a-b530-64c660ea09dc" />

3. Uncheck → **inactive-only results** ✗ (should show all again)
.
<img width="1676" height="945" alt="03-bug-unchecked-2-results" src="https://github.com/user-attachments/assets/d18577a7-9465-4e2d-89ea-bee94e3747e8" />


## After

1. Page load → all results ✓
2. Check → active-only ✓
3. Uncheck → **all results restored, filter cleared** ✓


<img width="1676" height="945" alt="04-fixed-unchecked-7-results" src="https://github.com/user-attachments/assets/f8fa6dbb-d94e-4256-869f-7a820d032585" />

## Technical Details

**Root cause — two-layer chain:**

1. Angular's `ng-model` with `getterSetter: true` calls `getSetValue(false)` when the user unchecks the box.
2. `getAfformFilters()` in `searchDisplayBaseTrait.service.js` passes any `typeof val === 'boolean'` as an active filter. So `false` reaches the API as `is_active=0`. The initial `null` state is correctly excluded.

**The fix** — in `getSetValue` within `ext/afform/core/ang/af/afField.component.js`:

When a single Boolean CheckBox transitions from `true` to `false` in a search-filter context, coerce the value to `null` so the filter is removed rather than inverted.

```javascript
const isUserUnchecking = val === false && currentVal === true;
const isSingleBooleanCheckbox = ctrl.defn.input_type === 'CheckBox' && !ctrl.isMultiple();
const isSearchFilterContext = !ctrl.afFieldset.afFormCtrl && !ctrl.search_operator;
if (isUserUnchecking && isSingleBooleanCheckbox && isSearchFilterContext) {
  val = null;
}
```

**Why each guard is needed:**

| Guard | Reason |
|-------|--------|
| `currentVal === true` | Distinguishes user uncheck from programmatic `false` set by URL params (`?is_active=0`) or `afform_default: false`, which arrive while `currentVal` is still `undefined` |
| `input_type === 'CheckBox' && !isMultiple()` | Single Boolean checkbox only — multi-value checkbox lists use `checklist-model`, not `getSetValue` |
| `!ctrl.afFieldset.afFormCtrl` | Limits fix to search-filter fieldsets. In save forms `false` must persist — `null` would silently skip writing to the database |
| `!ctrl.search_operator` | Field stores value directly; operator-keyed fields follow a different code path |

## Testing

| Scenario | Result |
|----------|--------|
| Page load, no filter | All results ✓ |
| Check boolean filter | Filtered results ✓ |
| Uncheck boolean filter | All results restored ✓ |
| URL param `?is_active=0` on load | Guard does not fire, filter remains active ✓ |
| `afform_default: false` | Guard does not fire, filter remains active ✓ |
| `afform_default: true` → user unchecks | Guard fires, filter cleared ✓ |
| Boolean checkbox on a save form (e.g. `do_not_email`) | `afFormCtrl` present, guard skipped, `false` written to DB ✓ |

Related: #34172 (addressed empty filter values at the downstream layer but left `getSetValue` untouched)