### PR TITLE
Fix using REGEXP on numbers in API4 Explorer

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1346,6 +1346,7 @@ apiCalls.${results} = [${jsCall}];
             op = field.serialize || dataType === 'Array' ? 'IN' : '=';
           }
           multi = ['IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN'].includes(op);
+          let regexp = op.includes('REGEXP');
           // IS NULL, IS EMPTY, etc.
           if (op.includes('IS ')) {
             $el.hide();
@@ -1378,7 +1379,7 @@ apiCalls.${results} = [${jsCall}];
                 {id: 'false', text: ts('No')}
               ]});
             }
-          } else if (dataType === 'Integer' && !multi) {
+          } else if (dataType === 'Integer' && !multi && !regexp) {
             $el.attr('type', 'number');
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Currently, if you attempt to use REGEXP in API Explorer on an integer, a blank value will be passed.

To replicate:
* Go to `https://smaster.demo.civicrm.org/civicrm/api4#/explorer/Address/get?where=%5B%5B%22id%22,%22REGEXP%22,%22%22%5D%5D
* In the `id REGEXP` value, put in `133`.
* Note that the code generators show the 133.
* Change it to `(133|134)`.
* Note that the code generators blank out the value as soon as a non-digit is entered.  Executing the command also doesn't work.

Before
----------------------------------------
Can't enter a REGEXP value in API4 Explorer.

After
----------------------------------------
Can.