### PR TITLE
dev/core#6493 - respect default filter values on initial search kit run

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -151,8 +151,10 @@
         // Set up watches to refresh search results when needed.
         // And trigger the first run of the search if appropriate.
         function setUpWatches() {
-          // Kick off first run of the search if there's no search button.
-          if (!ctrl.settings.button) {
+          // Kick off first run of the search immediately if there's no search button
+          // NOTE: if there is an afFieldset it is better to wait for filters to load
+          // any default values
+          if (!ctrl.settings.button && !ctrl.afFieldset) {
             ctrl.getResultsPronto();
             // Prevent the below watchers from running the search while we're already doing it.
             ctrl.doingFirstRun = true;


### PR DESCRIPTION
Overview
----------------------------------------
Fix for https://lab.civicrm.org/dev/core/-/work_items/6493

Before
----------------------------------------
- default filter input values are ignored on initial load for SearchKits on a FormBuilder form

After
----------------------------------------
- default filter input values are respected

Technical Details
----------------------------------------
The existing code tries to do a quick initial run. However this seems to fire before the `af-field`s have loaded there default values.

My guess is this is due to general changes to speed up the initial run of SearchKits.  @colemanw  I remember you had some PRs to that effect recently.

This may not be the best fix in the long run, but it seemed a small safe way on stable/RC.

I was concerned that:
- nothing would trigger the initial run if there were no default values
- it might be noticeably slower to trigger the initial run

But in testing neither of these seem an issue to me.



