### PR TITLE
dev/core#6493 - respect default filter values on initial search kit run [RC]

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -154,8 +154,10 @@
         // Set up watches to refresh search results when needed.
         // And trigger the first run of the search if appropriate.
         function setUpWatches() {
-          // Kick off first run of the search if there's no search button.
-          if (!ctrl.settings.button) {
+          // Kick off first run of the search immediately if there's no search button
+          // NOTE: if there is an afFieldset it is better to wait for filters to load
+          // any default values
+          if (!ctrl.settings.button && !ctrl.afFieldset) {
             ctrl.getResultsPronto();
             // Prevent the below watchers from running the search while we're already doing it.
             ctrl.doingFirstRun = true;


### PR DESCRIPTION
Overview
----------------------------------------
RC version of https://github.com/civicrm/civicrm-core/pull/35675

I think there is probably a better long term fix for master, but this seems the safest thing in the short term.