### PR TITLE
dev/core#6493 - fix respecting filter input default values on SearchKit first load

### DIFF
--- a/ext/chart_kit/js/components/civi-search-display.js
+++ b/ext/chart_kit/js/components/civi-search-display.js
@@ -103,6 +103,10 @@
     }
 
     getResultsSoon() {
+      // if this the first ever run, promote it to a pronto
+      if (!this.hasRun) {
+        return this.getResultsPronto();
+      }
       clearTimeout(this.nextRun);
       this.nextRun = setTimeout(() => this.runSearch(), 600);
     }
@@ -279,6 +283,8 @@
 
     // Call SearchDisplay.run and update this.results and this.rowCount
     runSearch(apiCalls, statusParams, editedRow) {
+      // mark that we have done the initial run
+      this.hasRun = true;
       // TODO: unwind use of ctrl
       const ctrl = this;
       const requestId = ++this._runCount;

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -59,14 +59,26 @@
 
         ctrl.onInitialize.forEach(callback => callback.call(ctrl, $scope, $element));
 
-        // _.debounce used here to trigger the initial search immediately but prevent subsequent launches within 300ms
-        this.getResultsPronto = _.debounce(ctrl.runSearch, 300, {leading: true, trailing: false});
-        // _.debounce used here to schedule a search if nothing else happens for 600ms: useful for auto-searching on typing
-        this.getResultsSoon = _.debounce(function() {
-          $scope.$apply(function() {
-            ctrl.runSearch();
-          });
-        }, 600);
+        // trigger the initial search immediately but prevent subsequent launches within 300ms
+        this.getResultsPronto = () => {
+          if (this.justRun) {
+            // if just run, dont run again
+            return;
+          }
+          this.runSearch();
+          this.justRun = true;
+          setTimeout(() => this.justRun = false, 300);
+        };
+
+        // schedule a search if nothing else happens for 600ms: useful for auto-searching on typing
+        this.getResultsSoon = () => {
+          // if this the first ever run, promote it to a pronto
+          if (!this.hasRun) {
+            return this.getResultsPronto();
+          }
+          clearTimeout(this.nextRun);
+          this.nextRun = setTimeout(() => $scope.$apply(() => this.runSearch()), 600);
+        };
 
         // Update totalCount variable if used.
         // Integrations can pass in `total-count="somevar" to keep track of the number of results returned
@@ -162,8 +174,9 @@
         }
 
         // If the search display is visible, go ahead & run it
+        // (though use timeout to ensure all filters etc have loaded)
         if ($element.is(':visible')) {
-          setUpWatches();
+          $timeout(() => setUpWatches());
         }
         // Wait until display is visible
         else {
@@ -243,6 +256,9 @@
 
       // Call SearchDisplay.run and update ctrl.results and ctrl.rowCount
       runSearch: function(apiCalls, statusParams, editedRow) {
+        // mark that we have done the initial run
+        this.hasRun = true;
+
         const ctrl = this;
         const requestId = ++this._runCount;
         const apiParams = this.getApiParams();

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -107,7 +107,7 @@
           ctrl.page = 1;
           ctrl.rowCount = null;
           ctrl.onChangeFilters.forEach(callback => callback.call(ctrl));
-          if (!ctrl.settings.button && !ctrl.doingFirstRun) {
+          if (!ctrl.settings.button) {
             ctrl.getResultsSoon();
           }
         }
@@ -115,7 +115,7 @@
         function onChangePageSize() {
           ctrl.page = 1;
           // Only refresh if search has already been run
-          if (ctrl.results && !ctrl.doingFirstRun) {
+          if (ctrl.results) {
             ctrl.getResultsSoon();
           }
         }
@@ -149,15 +149,9 @@
         }
 
         // Set up watches to refresh search results when needed.
-        // And trigger the first run of the search if appropriate.
+        // Because `angular.$watch` runs immediately as well as on subsequent changes,
+        // this also kicks off the first run of the search (if there's no search button).
         function setUpWatches() {
-          // Kick off first run of the search if there's no search button.
-          if (!ctrl.settings.button) {
-            ctrl.getResultsPronto();
-            // Prevent the below watchers from running the search while we're already doing it.
-            ctrl.doingFirstRun = true;
-            $timeout(() => ctrl.doingFirstRun = false, 1000);
-          }
           if (ctrl.afFieldset) {
             $scope.$watch(ctrl.afFieldset.getFilterValues, onChangeFilters, true);
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/work_items/6392 by reverting https://github.com/civicrm/civicrm-core/commit/ceac80894c7c9349d09573a6da17a553a8a747d1 which introduces it, and then using a slightly different approach to get those 600ms back.

@colemanw 