### PR TITLE
fix af-markup throwing errors on search forms because no af-form parent

### DIFF
--- a/ext/afform/core/ang/af/afMarkup.element.js
+++ b/ext/afform/core/ang/af/afMarkup.element.js
@@ -9,9 +9,6 @@
 
     connectedCallback() {
       this.afForm = this.closest('af-form');
-      if (!this.afForm) {
-        throw new Error('af-markup should be placed within an af-form');
-      }
       // setTimeout ensures child elements can access parent af-form during render
       setTimeout(() => this.render());
     }
@@ -22,7 +19,11 @@
 
     render() {
       let markup = this.markup;
-      markup = this.replaceTokensWithElements(markup);
+      if (this.afForm) {
+        // at time of writing, token replacement is only supported
+        // inside af-form (*not* search forms)
+        markup = this.replaceTokensWithElements(markup);
+      }
       this.innerHTML = markup;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Similar to https://github.com/civicrm/civicrm-core/pull/35677 - `af-markup` had a hard requirement on `af-form` which caused errors on search forms.

Token replacement currently sits in `afForm` controller, so we can't support on search forms currently. 

TODO: hide token picker in FormBuilder UI for search forms until this is supported.