### PR TITLE
[NFC] Show messages in tests when statusBouncing

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1458,7 +1458,12 @@ class CRM_Utils_System {
   public static function civiExit($status = 0, $testParameters = []) {
 
     if (CIVICRM_UF === 'UnitTests') {
-      throw new CRM_Core_Exception_PrematureExitException('civiExit called', $testParameters);
+      // When statusBouncing, it's helpful to see the status messages.
+      // It would make sense to add them to testParameters instead of appending
+      // to the message, but I don't see where they get output anywhere?
+      $bounceMessages = CRM_Core_Session::singleton()->getStatus();
+      $bounceMessages = empty($bounceMessages) ? '' : ("\n" . print_r($bounceMessages, TRUE));
+      throw new CRM_Core_Exception_PrematureExitException('civiExit called' . $bounceMessages, $testParameters);
     }
     if ($status > 0) {
       http_response_code(500);


### PR DESCRIPTION
Overview
----------------------------------------
When statusBounce is called the test exits but the messages that would have been in the popup bubble get lost and you don't know what the bounce was about.

Before
----------------------------------------
When statusBounce is called the test exits but the messages that would have been in the popup bubble get lost and you don't know what the bounce was about.

After
----------------------------------------
Messages

Technical Details
----------------------------------------


Comments
----------------------------------------
e.g. help diagnose https://test.civicrm.org/job/CiviCRM-Ext-Matrix/6379/BKPROF=min,BUILDTYPE=normal,CIVIVER=master,EXTKEY=com.iatspayments.civicrm,label=bknix-tmp/testReport/(root)/CRM_Iats_ContributioniATSTest/testIATSSWIPEBackend/