### PR TITLE
dev/core#6491 inherited memberships not applied if similar one exists from another owner/primary.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -184,7 +184,14 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
    * @throws \CRM_Core_Exception
    */
   protected function getExistingMembership(int $membershipTypeID): array|false {
-    $contactID = $this->_membershipContactID ?: $this->getContactID();
+    $contactID = $this->getSubmittedValue('onbehalfof_id') ?: $this->getContactID();
+    if (!empty($this->_membershipContactID) && $contactID !== $this->_membershipContactID) {
+      // We don't really expect this to be true anymore - perhaps we should add logging to confirm this.
+      // the $this->_membershipContactID property is probably on it's way out.
+      if (!$this->getSubmittedValue('onbehalfof_id')) {
+        $contactID = $this->_membershipContactID;
+      }
+    }
 
     // Find dedupe ContactId when anonymous form submission.
     if (empty($contactID)) {

--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1775,19 +1775,15 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
    * @throws \CRM_Core_Exception
    */
   protected static function hasExistingInheritedMembership($params) {
-    $currentMemberships = \Civi\Api4\Membership::get(FALSE)
+    $membershipGet = \Civi\Api4\Membership::get(FALSE)
       ->addJoin('MembershipStatus AS membership_status', 'LEFT')
       ->addWhere('membership_status.is_current_member', '=', TRUE)
-      ->addWhere('contact_id', '=', $params['contact_id'])
-      ->execute();
+      ->addWhere('contact_id', '=', $params['contact_id']);
+    if (!empty($params['owner_membership_id'])) {
+      $membershipGet->addWhere('owner_membership_id', '=', $params['owner_membership_id']);
+    }
+    $currentMemberships = $membershipGet->execute();
     foreach ($currentMemberships as $membership) {
-      if (!empty($membership['owner_membership_id'])
-        && $membership['membership_type_id'] === $params['membership_type_id']
-        && (int) $params['owner_membership_id'] !== (int) $membership['owner_membership_id']
-      ) {
-        // Inheriting it from another contact, don't update here.
-        return TRUE;
-      }
       if (self::matchesRequiredMembership($params, $membership)) {
         return TRUE;
       }


### PR DESCRIPTION
port https://github.com/civicrm/civicrm-core/pull/35621 - but I made changes to the contact ID retrieval per discussion on that PR (confirmed it worked via UI test)