### PR TITLE
Fix SK actions displayed as buttons

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTasksMenu.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTasksMenu.component.js
@@ -13,6 +13,9 @@
         ctrl = this;
 
       this.$onInit = function() {
+        if (ctrl.displayMode === 'buttons') {
+          ctrl.taskManager.getMetadata();
+        }
         // When a row is selected for bulk actions, load the actions menu
         let unwatchIDs = $scope.$watch('$ctrl.ids.length', function (idsLength) {
           if (idsLength) {


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit actions can no longer be displayed as buttons.  

I don't know when this regressed - I suspect a long time ago, but I also suspect I'm gonna be asked to put this against the rc, so I committed it such that it could go either way.

Before
----------------------------------------
<img width="530" height="738" alt="Selection_003" src="https://github.com/user-attachments/assets/461477d1-6303-4584-b7a2-d1db3379d20b" />


After
----------------------------------------
<img width="527" height="748" alt="Selection_002" src="https://github.com/user-attachments/assets/493a656d-4759-4942-ac4c-ec46454295b4" />

Comments
----------------------------------------
Maybe `getMetaData()` should fire unconditionally during `$onInit`?