### PR TITLE
When import shows two contacts exist that match imported data, provide link to merge

### DIFF
--- a/CRM/Contact/Import/Parser/Contact.php
+++ b/CRM/Contact/Import/Parser/Contact.php
@@ -513,8 +513,12 @@ class CRM_Contact_Import_Parser_Contact extends CRM_Import_Parser {
       if (count($possibleMatches) === 1) {
         return array_key_last($possibleMatches);
       }
-      if (count($possibleMatches) > 1) {
-        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts: ') . implode(',', array_keys($possibleMatches)), CRM_Import_Parser::ERROR);
+      if (count($possibleMatches) === 2) {
+        $mergeUrl = \CRM_Utils_System::url('civicrm/contact/merge', ['reset' => 1, 'action' => 'update', 'cid' => array_key_first($possibleMatches), 'oid' => array_key_last($possibleMatches)]);
+        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts:') . ' ' . implode(', ', array_keys($possibleMatches)) . '<br /><a href="' . $mergeUrl . '" target="_blank">' . ts('Merge contacts') . '</a>', CRM_Import_Parser::ERROR);
+      }
+      if (count($possibleMatches) > 2) {
+        throw new CRM_Core_Exception(ts('Record duplicates multiple contacts:') . ' ' . implode(', ', array_keys($possibleMatches)), CRM_Import_Parser::ERROR);
       }
       return NULL;
     }

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -574,8 +574,12 @@ abstract class ImportParser extends \CRM_Import_Parser {
       if (count($possibleMatches) === 1) {
         $contactID = array_key_first($possibleMatches);
       }
-      elseif (count($possibleMatches) > 1) {
-        throw new \CRM_Core_Exception(ts('Record duplicates multiple contacts:') . ' ' . implode(',', $possibleMatches));
+      elseif (count($possibleMatches) === 2) {
+        $mergeUrl = \CRM_Utils_System::url('civicrm/contact/merge', ['reset' => 1, 'action' => 'update', 'cid' => array_key_first($possibleMatches), 'oid' => array_key_last($possibleMatches)]);
+        throw new \CRM_Core_Exception(ts('Record duplicates multiple contacts:') . ' ' . implode(', ', $possibleMatches) . '<br /><a href="' . $mergeUrl . '" target="_blank">' . ts('Merge contacts') . '</a>');
+      }
+      elseif (count($possibleMatches) > 2) {
+        throw new \CRM_Core_Exception(ts('Record duplicates multiple contacts:') . ' ' . implode(', ', $possibleMatches));
       }
       elseif (!in_array($action, ['create', 'ignore', 'save'], TRUE)) {
         throw new \CRM_Core_Exception(ts('No matching %1 found', [1 => $entity]));

--- a/ext/civiimport/managed/ImportSearches.mgd.php
+++ b/ext/civiimport/managed/ImportSearches.mgd.php
@@ -53,7 +53,7 @@ foreach ($importEntities as $importEntity) {
   $columns = [];
   foreach ($fields as $field) {
     $columns[] = [
-      'type' => 'field',
+      'type' => $field['name'] === '_status_message' ? 'html' : 'field',
       'key' => $field['name'],
       'dataType' => $field['data_type'] ?? 'String',
       'label' => $field['title'] ?? $field['label'],


### PR DESCRIPTION
Just showing the contact ids is not that useful, but if we provide a link to merge them then the user can immediately open it and see if they are in fact dupes and merge them if needed.

<img width="657" height="201" alt="image" src="https://github.com/user-attachments/assets/3aba154a-a0c0-4bc7-bcb5-355af5cb8058" />

Would be nice to also cover the case where there are 3+ matches (maybe a link to an afform that shows them), but that's lower priority.

Also put a space between the ids and make the string for the two versions the same. This makes the _status_message field in the import searchdisplay HTML, but that seems fine to me in general.

