### PR TITLE
Add `postbox` for sending emails with Api4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@
 !/ext/user_dashboard
 !/ext/tellafriend
 !/ext/riverlea
+!/ext/postbox
 backdrop/
 bower_components
 CRM/Case/xml/configuration

--- a/Civi/Queue/ShutdownWorker.php
+++ b/Civi/Queue/ShutdownWorker.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Civi\Queue;
+
+/**
+ * Shutdown worker uses register_shutdown_function to work
+ * on a queue for some time after a given request has returned to the client
+ * (so we can do long running tasks without slowing user interaction)
+ */
+class ShutdownWorker {
+
+  protected static bool $registered = FALSE;
+
+  /**
+   * @var array
+   * Queues to work on shutdown:
+   *   queueName => seconds to work on it
+   */
+  protected static array $queues = [];
+
+  /**
+   * Add a given queue to the list of queues to process on shutdown, and register
+   * the handler if it hasn't done already
+   *
+   * UNLESS:
+   * - background processing is paused using the `queue_paused` setting
+   * - fastcgi_finish_request is not available (e.g. in CLI context) - this
+   *   is required for async handling
+   */
+  public static function register(string $queueName, int $seconds = 30) {
+    if (\Civi::settings()->get('queue_paused')) {
+      return;
+    }
+    if (!\function_exists('fastcgi_finish_request')) {
+      return;
+    }
+    self::$queues[$queueName] = $seconds;
+
+    if (!self::$registered) {
+      register_shutdown_function([self::class, 'workQueues']);
+      self::$registered = TRUE;
+    }
+  }
+
+  public static function workQueues() {
+    // finish the client request
+    \session_write_close();
+    \fastcgi_finish_request();
+
+    foreach (self::$queues as $queueName => $seconds) {
+      self::workOnQueue($queueName, $seconds);
+    }
+  }
+
+  protected static function workOnQueue(string $queueName, int $seconds): void {
+    $runner = new \CRM_Queue_Runner([
+      'title' => ts("Shutdown Worker for {$queueName}"),
+      'queue' => \Civi::queue($queueName),
+      'errorMode' => \CRM_Queue_Runner::ERROR_CONTINUE,
+    ]);
+
+    // work for specified number of seconds post shutdown
+    $timeout = time() + $seconds;
+
+    while (time() < $timeout) {
+      $result = $runner->runNext(FALSE);
+      if (!$result['is_continue']) {
+        return;
+      }
+    }
+  }
+
+}

--- a/ext/postbox/CRM/Postbox/BAO/EmailMessage.php
+++ b/ext/postbox/CRM/Postbox/BAO/EmailMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+use Civi\Core\Event\PostEvent;
+use Civi\Core\Event\PreEvent;
+use Civi\Core\HookInterface;
+use CRM_Postbox_ExtensionUtil as E;
+
+class CRM_Postbox_BAO_EmailMessage extends CRM_Postbox_DAO_EmailMessage implements HookInterface {
+
+  public static function self_hook_civicrm_pre(PreEvent $e): void {
+    if ($e->action === 'create') {
+      $e->params['created_id'] = \CRM_Core_Session::getLoggedInContactID();
+    }
+  }
+
+  public static function self_hook_civicrm_post(PostEvent $e): void {
+    if ($e->action !== 'create') {
+      return;
+    }
+
+    $dispatcher = \Civi::service('civi.postbox.dispatcher');
+
+    $dispatcher->queueNewMessage($e->id);
+    $dispatcher->registerShutdownDispatcher();
+  }
+
+}

--- a/ext/postbox/CRM/Postbox/DAO/EmailMessage.php
+++ b/ext/postbox/CRM/Postbox/DAO/EmailMessage.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * DAOs provide an OOP-style facade for reading and writing database records.
+ *
+ * DAOs are a primary source for metadata in older versions of CiviCRM (<5.74)
+ * and are required for some subsystems (such as APIv3).
+ *
+ * This stub provides compatibility. It is not intended to be modified in a
+ * substantive way. Property annotations may be added, but are not required.
+ */
+class CRM_Postbox_DAO_EmailMessage extends CRM_Postbox_DAO_Base {
+
+}

--- a/ext/postbox/CRM/Postbox/Upgrader.php
+++ b/ext/postbox/CRM/Postbox/Upgrader.php
@@ -1,0 +1,10 @@
+<?php
+
+use CRM_Postbox_ExtensionUtil as E;
+
+/**
+ * Collection of upgrade steps.
+ */
+class CRM_Postbox_Upgrader extends \CRM_Extension_Upgrader_Base {
+
+}

--- a/ext/postbox/Civi/Api4/Action/EmailMessage/Send.php
+++ b/ext/postbox/Civi/Api4/Action/EmailMessage/Send.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Civi\Api4\Action\EmailMessage;
+
+/**
+ * Send an unsent email message record
+ */
+class Send extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected function getSelect(): array {
+    return [
+      'id',
+      'date_sent',
+      'subject',
+      'body',
+      'from_site_email_address_id.email',
+      'from_site_email_address_id.display_name',
+      //'from_email',
+      //'from_name',
+      'to_contact_id',
+      "to_contact_id.display_name",
+      "to_contact_id.email_primary.email",
+      "to_contact_id.email_primary.on_hold",
+      "to_contact_id.do_not_email",
+      "to_contact_id.is_deceased",
+      "to_contact_id.is_deleted",
+      'location_type',
+      'extra',
+    ];
+  }
+
+  /**
+   * @param array $record
+   * @return array
+   */
+  protected function doTask($record): array {
+    if ($record['date_sent']) {
+      \Civi::log()->debug("Unable to send EmailMessage {$record['id']} - already sent!");
+      return [
+        'status' => 'sent',
+        'message' => 'Already sent!',
+      ];
+    }
+
+    try {
+      $this->sendMessage($record);
+    }
+    catch (\CRM_Core_Exception $e) {
+      $error = $e->getMessage();
+
+      \Civi\Api4\EmailMessage::update(FALSE)
+        ->addWhere('id', '=', $record['id'])
+        ->addValue('error_message', $error)
+        ->execute();
+      return [
+        'status' => 'error',
+        'message' => $error,
+      ];
+    }
+
+    \Civi\Api4\EmailMessage::update(FALSE)
+      ->addWhere('id', '=', $record['id'])
+      ->addValue('date_sent', 'now')
+      ->execute();
+
+    return [
+      'status' => 'sent',
+    ];
+  }
+
+  private function renderFromAddress(array $record) {
+    // preserve non-null values passed to from_name / from_email
+    // $fromName = $record['from_name'] ?: $record['from_site_email_address_id.display_name'];
+    // $fromEmail = $record['from_email'] ?: $record['from_site_email_address_id.email'];
+
+    $fromName = $record['from_site_email_address_id.display_name'];
+    $fromEmail = $record['from_site_email_address_id.email'];
+
+    if (!$fromName || !$fromEmail) {
+      $default = \Civi\Api4\SiteEmailAddress::get(FALSE)
+        ->addWhere('is_default', '=', TRUE)
+        ->execute()
+        ->single();
+
+      $fromName = $fromName ?: $default['display_name'];
+      $fromEmail = $fromEmail ?: $default['email'];
+
+      if (!$fromName || !$fromEmail) {
+        throw new \CRM_Core_Exception("Could not determine from name or email");
+      }
+    }
+
+    return '"' . $fromName . '" <' . $fromEmail . '>';
+  }
+
+  private function renderRecipient(array $contactRecord, ?string $locationType = NULL): array {
+    if ($contactRecord["do_not_email"] || $contactRecord["is_deceased"] || $contactRecord["is_deleted"]) {
+      throw new \CRM_Core_Exception("Recipient is deceased, deleted, or has opted out from all mailings");
+    }
+
+    $name = $contactRecord["display_name"];
+    $email = $contactRecord["email_primary.email"];
+    $onHold = $contactRecord["email_primary.on_hold"];
+
+    // check for location type specific email
+    if ($locationType) {
+      $locationEmail = \Civi\Api4\Email::get(FALSE)
+        ->addSelect('email')
+        ->addWhere('location_type_id:name', '=', $locationType)
+        ->addWhere('contact_id', '=', $contactRecord["id"])
+        ->addWhere('on_hold', '=', FALSE)
+        ->addOrderBy('id', 'DESC')
+        ->execute()
+        ->first()['email'] ?? NULL;
+
+      if ($locationEmail) {
+        $email = $locationEmail;
+        // we only fetched not on hold emails
+        $onHold = FALSE;
+      }
+      else {
+        \Civi::log('postbox')->debug("Postbox: No active email address for {$contactRecord['id']} with location type {$locationType}. Falling back to primary email.");
+      }
+    }
+
+    if (!$email || $onHold) {
+      throw new \CRM_Core_Exception("Recipient email is blank or on hold so not sending.");
+    }
+
+    return [
+      'id' => $contactRecord['id'],
+      'email' => $email,
+      'name' => ($name !== '') ? $name : $email,
+    ];
+  }
+
+  private function renderMessage(array $record): array {
+    $message = [
+      'subject' => $record['subject'],
+      'html' => $record['body'],
+      'text' => \CRM_Utils_String::htmlToText($record['body']),
+    ];
+    // render the &amp; entities in text mode, so that the links work
+    $message['text'] = str_replace('&amp;', '&', $message['text']);
+    return $message;
+  }
+
+  /**
+   * Attempt to send email for a given record
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function sendMessage(array $record): void {
+
+    $fromAddress = $this->renderFromAddress($record);
+
+    // remove join prefix from to contact record details
+    $toContactRecord = [
+      'id' => $record['to_contact_id'],
+      'display_name' => $record["to_contact_id.display_name"],
+      'email_primary.email' => $record["to_contact_id.email_primary.email"],
+      'email_primary.on_hold' => $record["to_contact_id.email_primary.on_hold"],
+      'do_not_email' => $record["to_contact_id.do_not_email"],
+      'is_deceased' => $record["to_contact_id.is_deceased"],
+      'is_deleted' => $record["to_contact_id.is_deleted"],
+    ];
+
+    $recipient = $this->renderRecipient($toContactRecord, $record['location_type']);
+    $message = $this->renderMessage($record);
+
+    // set up the parameters for CRM_Utils_Mail::send
+    $mailParams = [
+      // from details
+      'groupName' => 'Postbox',
+      'from' => $fromAddress,
+      // recipient details
+      'contactId' => $recipient['id'],
+      'toName' => $recipient['name'],
+      'toEmail' => $recipient['email'],
+      // message content
+      'subject' => $message['subject'],
+      'html' => $message['html'],
+      'text' => $message['text'],
+    ];
+
+    // TODO: support additional contacts in cc / bcc
+    // if (!empty($record['extra']) && !empty($record['extra']['cc_contacts'])) {
+    //   $mailParams['cc'] = $record['cc_id.email_primary.email'];
+    // }
+
+    // Try to send the email.
+    $result = \CRM_Utils_Mail::send($mailParams);
+
+    // Falsey return from CRM_Utils_Mail indicates an error
+    if (!$result) {
+      throw new \CRM_Core_Exception("Error sending email to {$recipient['name']} <{$recipient['email']}>");
+    }
+  }
+
+}

--- a/ext/postbox/Civi/Api4/EmailMessage.php
+++ b/ext/postbox/Civi/Api4/EmailMessage.php
@@ -1,0 +1,13 @@
+<?php
+namespace Civi\Api4;
+
+/**
+ * EmailMessage entity.
+ *
+ * Provided by the postbox extension.
+ *
+ * @package Civi\Api4
+ */
+class EmailMessage extends Generic\DAOEntity {
+
+}

--- a/ext/postbox/Civi/Postbox/Dispatcher.php
+++ b/ext/postbox/Civi/Postbox/Dispatcher.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Civi\Postbox;
+
+use Civi\Core\Service\AutoService;
+
+use CRM_Postbox_ExtensionUtil as E;
+
+/**
+ * Coordinate sending messages using a Queue
+ *
+ * @service civi.postbox.dispatcher
+ */
+class Dispatcher extends AutoService {
+
+  public const QUEUE_NAME = 'postbox_dispatch';
+
+  /**
+   * Register shutdown worker to dispatch anything in the queue
+   */
+  public function registerShutdownDispatcher(): void {
+    if (\Civi::settings()->get('postbox_shutdown_dispatcher')) {
+      \Civi\Queue\ShutdownWorker::register(self::QUEUE_NAME);
+    }
+  }
+
+  public function getQueue(): \CRM_Queue_Queue {
+    return \Civi::queue(self::QUEUE_NAME, [
+      'type'  => 'SqlParallel',
+      'reset' => FALSE,
+      'error' => 'delete',
+      'runner' => 'task',
+      'retry_limit' => 3,
+      'retry_interval' => 10,
+    ]);
+  }
+
+  /**
+   * When a message is created, add a queue task to send it
+   *
+   * @todo queuing messages individually is highly parellisable but maybe
+   * inefficient when reloading data - could we create tasks for batches of
+   * unsent messages?
+   */
+  public function queueNewMessage(int $messageId): void {
+    $this->getQueue()->createItem(new \CRM_Queue_Task(
+      // callback
+      [self::class, 'sendMessageFromQueue'],
+      // arguments
+      [$messageId],
+      // title
+      "Send EmailMessage {$messageId}"
+    ));
+  }
+
+  /**
+   * Send a message from the queue
+   */
+  public static function sendMessageFromQueue(\CRM_Queue_TaskContext $ctx, int $messageId) {
+    $send = \Civi\Api4\EmailMessage::send(FALSE)
+      ->addWhere('id', '=', $messageId)
+      ->addWhere('error_message', 'IS EMPTY')
+      ->addWhere('date_sent', 'IS EMPTY')
+      ->execute()
+      ->single();
+
+    if ($send['status'] === 'error') {
+      \Civi::log()->error($send['message']);
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}

--- a/ext/postbox/README.md
+++ b/ext/postbox/README.md
@@ -1,0 +1,51 @@
+# Postbox
+This extension provides a new way to send messages from CiviCRM. It may be particularly useful for generating automated messages, e.g. with a CiviRules action.
+
+It owes a lot to the Email Api3 extension, though is updated to Api4.
+
+Key aims:
+- leverage Api4 to provide a familiar interface to developers, and be usable anywhere Api4 is
+- provide observability with Api4 (create a SearchKit to see emails in the queue, and emails that have been sent)
+- send asynchronously, dont block e.g. user form submission with the actual sending - just put it in a queue to send as soon as possible
+
+At the moment the first type of message we support is an EmailMessage.
+
+You can queue an email by creating a new EmailMessage:
+
+```
+
+\Civi\Api4\EmailMessage::create(FALSE)
+  ->addValue('to_contact_id', $contactId)
+  ->addValue('subject', 'Test Email')
+  ->addValue('body', 'Test content')
+  ->addValue('from_site_email_address_id', 3)
+  ->execute();
+
+```
+
+You can send a specific message with the Send action:
+
+```
+\Civi\Api4\EmailMessage::send(FALSE)
+  ->addWhere('id', '=', $messageId)
+  ->execute();
+```
+
+But you generally shouldn't generally need to do that because unsent messages will be sent automatically by a shutdown worker.
+
+
+## Thoughts
+
+- There's nothing really email specific about using the shutdown worker to process the queue - this should be generalisable, and could be specified when creating the queue.
+- Previously we enabled setting arbitrary From Name / Email address. This has been restricted for now for security considerations
+  - If using arbitrary from_email from_name it will be sensitive to whether this an allowed sender from the sites SMTP gateway. How could we validate this? (Wildcard SiteEmailAddress records?)
+- Send is currently always automated, as soon as possible. Maybe some messages have lower priority or should be deferred.
+- Send is currently one-time per message. Maybe sometimes you want to force resending a message that was already sent (though maybe then you should copy the original message record, to maintain the log?)
+- It would be nice to send messages other than email. But that introduces complexity:
+  - The shape of message content is different. It would be good if we could translate (ie to send an sms use our html=>text processor and put the subject line at the top, if provided). If you know you want to send SMS you shouldnt put too much clever HTML in the body..)
+  - The message recipient options are different. Contact IDs are good for this. But CC/BCC are email specific.
+  - Message channel might be a two-way negotiation: Alice want to send Bob an email. But Bob has said they want to receive all their messages by Signal.
+  - Maybe you want to receive messages by email AND in-app notification. A single entity works well for multi-channel sending.
+- It would be nice to specify more recipients in more ways. But that introduces lots of complexity.
+- It could be nice to send messages with MessageTemplates and Tokens. But we already have lots of codepaths for that.
+- If you send templated messages, do you want to save the final rendered content of every message to the database? Maybe sometimes you do, sometimes you don't. Maybe this could be a setting (site-wide, per email, per message template?).

--- a/ext/postbox/info.xml
+++ b/ext/postbox/info.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<extension key="postbox" type="module">
+  <file>postbox</file>
+  <name>Postbox</name>
+  <description>Core tooling for transactional messages. At the moment this means emails.</description>
+  <license>AGPL-3.0</license>
+  <authors>
+    <author>
+      <name>Ben</name>
+      <email>ben@civicrm.org</email>
+      <role>Maintainer</role>
+    </author>
+  </authors>
+  <urls>
+    <url desc="Documentation">https://docs.civicrm.org/dev/en/latest/framework/queues/</url>
+    <url desc="Chat">https://chat.civicrm.org/civicrm/channels/dev</url>
+    <url desc="Issues">https://lab.civicrm.org/dev/core/-/issues</url>
+    <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
+  </urls>
+  <releaseDate>[civicrm.releaseDate]</releaseDate>
+  <version>[civicrm.version]</version>
+  <develStage>beta</develStage>
+  <compatibility>
+    <ver>[civicrm.majorVersion]</ver>
+  </compatibility>
+  <php_compatibility>
+    <ver>8.0</ver>
+    <ver>8.1</ver>
+    <ver>8.2</ver>
+    <ver>8.3</ver>
+    <ver>8.4</ver>
+  </php_compatibility>
+  <smarty_compatibility>
+    <ver>5</ver>
+  </smarty_compatibility>
+  <comments>Click on the chat link above to discuss development, report problems or ask questions.</comments>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
+  <mixins>
+    <mixin>mgd-php@1.0.0</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
+    <mixin>smarty@1.0.3</mixin>
+    <mixin>entity-types-php@2.0.0</mixin>
+    <mixin>afform-entity-php@1.0.0</mixin>
+  </mixins>
+  <upgrader>CiviMix\Schema\Postbox\AutomaticUpgrader</upgrader>
+</extension>

--- a/ext/postbox/postbox.civix.php
+++ b/ext/postbox/postbox.civix.php
@@ -1,0 +1,235 @@
+<?php
+
+// AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Postbox_ExtensionUtil {
+  const SHORT_NAME = 'postbox';
+  const LONG_NAME = 'postbox';
+  const CLASS_PREFIX = 'CRM_Postbox';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []): string {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL): string {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+  /**
+   * @return \CiviMix\Schema\SchemaHelperInterface
+   */
+  public static function schema() {
+    if (!isset($GLOBALS['CiviMixSchema'])) {
+      pathload()->loadPackage('civimix-schema@5', TRUE);
+    }
+    return $GLOBALS['CiviMixSchema']->getHelper(static::LONG_NAME);
+  }
+
+}
+
+use CRM_Postbox_ExtensionUtil as E;
+
+spl_autoload_register('_postbox_civix_class_loader', TRUE, TRUE);
+
+function _postbox_civix_class_loader($class) {
+  if ($class === 'CRM_Postbox_DAO_Base') {
+    if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
+      class_alias('CRM_Core_DAO_Base', 'CRM_Postbox_DAO_Base');
+      // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+    }
+    else {
+      $realClass = 'CiviMix\\Schema\\Postbox\\DAO';
+      class_alias($realClass, $class);
+      // ^^ Abstract names -- discourage IDE's from picking up on this association.
+    }
+    return;
+  }
+
+  // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
+  if (strpos($class, 'CiviMix\\Schema\\Postbox\\') === 0) {
+    // civimix-schema@5 is designed for backported use in download/activation workflows,
+    // where new revisions may become dynamically available.
+    pathload()->loadPackage('civimix-schema@5', TRUE);
+    CiviMix\Schema\loadClass($class);
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
+ */
+function _postbox_civix_civicrm_config($config = NULL) {
+  static $configured = FALSE;
+  if ($configured) {
+    return;
+  }
+  $configured = TRUE;
+
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
+  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
+  set_include_path($include_path);
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function _postbox_civix_civicrm_install() {
+  _postbox_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function _postbox_civix_civicrm_enable(): void {
+  _postbox_civix_civicrm_config();
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
+}
+
+/**
+ * Inserts a navigation menu item at a given place in the hierarchy.
+ *
+ * @param array $menu - menu hierarchy
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
+ */
+function _postbox_civix_insert_navigation_menu(&$menu, $path, $item) {
+  // If we are done going down the path, insert menu
+  if (empty($path)) {
+    $menu[] = [
+      'attributes' => array_merge([
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
+      ], $item),
+    ];
+    return TRUE;
+  }
+  else {
+    // Find an recurse into the next level down
+    $found = FALSE;
+    $path = explode('/', $path);
+    $first = array_shift($path);
+    foreach ($menu as $key => &$entry) {
+      if ($entry['attributes']['name'] == $first) {
+        if (!isset($entry['child'])) {
+          $entry['child'] = [];
+        }
+        $found = _postbox_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
+      }
+    }
+    return $found;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_navigationMenu().
+ */
+function _postbox_civix_navigationMenu(&$nodes) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
+    _postbox_civix_fixNavigationMenu($nodes);
+  }
+}
+
+/**
+ * Given a navigation menu, generate navIDs for any items which are
+ * missing them.
+ */
+function _postbox_civix_fixNavigationMenu(&$nodes) {
+  $maxNavID = 1;
+  array_walk_recursive($nodes, function($item, $key) use (&$maxNavID) {
+    if ($key === 'navID') {
+      $maxNavID = max($maxNavID, $item);
+    }
+  });
+  _postbox_civix_fixNavigationMenuItems($nodes, $maxNavID, NULL);
+}
+
+function _postbox_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) {
+  $origKeys = array_keys($nodes);
+  foreach ($origKeys as $origKey) {
+    if (!isset($nodes[$origKey]['attributes']['parentID']) && $parentID !== NULL) {
+      $nodes[$origKey]['attributes']['parentID'] = $parentID;
+    }
+    // If no navID, then assign navID and fix key.
+    if (!isset($nodes[$origKey]['attributes']['navID'])) {
+      $newKey = ++$maxNavID;
+      $nodes[$origKey]['attributes']['navID'] = $newKey;
+      $nodes[$newKey] = $nodes[$origKey];
+      unset($nodes[$origKey]);
+      $origKey = $newKey;
+    }
+    if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
+      _postbox_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
+    }
+  }
+}

--- a/ext/postbox/postbox.php
+++ b/ext/postbox/postbox.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once 'postbox.civix.php';
+
+use CRM_Postbox_ExtensionUtil as E;
+
+/**
+ * Implements hook_civicrm_config().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config/
+ */
+function postbox_civicrm_config(&$config): void {
+  _postbox_civix_civicrm_config($config);
+}
+
+/**
+ * Implements hook_civicrm_install().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
+ */
+function postbox_civicrm_install(): void {
+  _postbox_civix_civicrm_install();
+}
+
+/**
+ * Implements hook_civicrm_enable().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
+ */
+function postbox_civicrm_enable(): void {
+  _postbox_civix_civicrm_enable();
+}

--- a/ext/postbox/schema/EmailMessage.entityType.php
+++ b/ext/postbox/schema/EmailMessage.entityType.php
@@ -1,0 +1,118 @@
+<?php
+
+use CRM_Postbox_ExtensionUtil as E;
+
+return [
+  'name' => 'EmailMessage',
+  'table' => 'civicrm_email_message',
+  'class' => 'CRM_Postbox_DAO_EmailMessage',
+  'getInfo' => fn() => [
+    'title' => E::ts('Email Message'),
+    'title_plural' => E::ts('Email Messages'),
+    'description' => E::ts('Email Messages to send out - e.g. triggered notification emails'),
+    'log' => TRUE,
+  ],
+  'getFields' => fn() => [
+    'id' => [
+      'title' => E::ts('ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'required' => TRUE,
+      'description' => E::ts('Unique Email Message ID'),
+      'primary_key' => TRUE,
+      'auto_increment' => TRUE,
+    ],
+    'from_site_email_address_id' => [
+      'title' => E::ts('Site Email Addres'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => E::ts('Site Email Address to use as Sender'),
+      'entity_reference' => [
+        'entity' => 'SiteEmailAddress',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    // restricted to SiteEmailAddress for now
+    // 'from_name' => [
+    //   'title' => E::ts('From Name'),
+    //   'sql_type' => 'varchar(500)',
+    //   'input_type' => 'Text',
+    // ],
+    // 'from_email' => [
+    //   'title' => E::ts('From Email Address'),
+    //   'sql_type' => 'varchar(500)',
+    //   'input_type' => 'Text',
+    // ],
+    'to_contact_id' => [
+      'title' => E::ts('To Contact ID'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => E::ts('FK to TO Contact'),
+      'entity_reference' => [
+        'entity' => 'Contact',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    'location_type' => [
+      'title' => E::ts('Location Type'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Select',
+      'description' => E::ts('Preferred location type when selecting recipient email'),
+    ],
+    'subject' => [
+      'title' => E::ts('Subject'),
+      'sql_type' => 'text',
+      'input_type' => 'Text',
+    ],
+    'body' => [
+      'title' => E::ts('Message'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => E::ts('Content of email in HTML format'),
+    ],
+    'created_id' => [
+      'title' => ts('Created By'),
+      'readonly' => TRUE,
+      'sql_type' => 'int unsigned',
+      'input_type' => 'EntityRef',
+      'description' => E::ts('FK to Contact who created the email'),
+      'entity_reference' => [
+        'entity' => 'Contact',
+        'key' => 'id',
+        'on_delete' => 'SET NULL',
+      ],
+    ],
+    'date_created' => [
+      'title' => ts('Date Created'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'description' => ts('When was the message created (ie added to the queue)'),
+      'unique_name' => 'email_message_date_created',
+      'default' => 'CURRENT_TIMESTAMP',
+    ],
+    'date_sent' => [
+      'title' => E::ts('Date Sent'),
+      'sql_type' => 'timestamp',
+      'input_type' => 'Select Date',
+      'description' => ts('When was the message successfully sent'),
+      'unique_name' => 'email_message_date_sent',
+      'default' => NULL,
+    ],
+    'error_message' => [
+      'title' => E::ts('Error Message'),
+      'sql_type' => 'text',
+      'input_type' => 'Text',
+      'description' => ts('Error message when attempting to send'),
+      'default' => NULL,
+    ],
+    'extra' => [
+      'title' => E::ts('Additional Configuration'),
+      'sql_type' => 'text',
+      'input_type' => 'TextArea',
+      'description' => ts('Additional configuration - such as additional cc recipients'),
+      'serialize' => CRM_Core_DAO::SERIALIZE_JSON,
+    ],
+  ],
+];

--- a/ext/postbox/settings/postbox.setting.php
+++ b/ext/postbox/settings/postbox.setting.php
@@ -1,0 +1,18 @@
+<?php
+
+use CRM_Postbox_ExtensionUtil as E;
+
+return [
+  'postbox_shutdown_dispatcher' => [
+    'name' => 'postbox_shutdown_dispatcher',
+    'type' => 'Boolean',
+    'html_type' => 'Toggle',
+    'default' => TRUE,
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'title' => E::ts('Enable Shutdown Dispatcher'),
+    'description' => E::ts('
+    By default postbox will use a post shutdown function to dispatch messages from the message queue. You can disable if you want
+      to dispatch messages differently - e.g. using coworker'),
+  ],
+];


### PR DESCRIPTION
Overview
----------------------------------------
Adds `outbound_message` extension for sending transactional emails with Api4.

**Email sending:**
- allows sending arbitrary content - this is useful for e.g. https://github.com/civicrm/civicrm-core/pull/35648 or adding per-form confirmation emails
- if you want to send an email template, this can be rendered with the existing codepaths for doing so, then use EmailMessage.create for the sending part
- handles juggling of emails for a given Contact record, respecting `on_hold`, `do_not_email`, `is_deceased`, `is_deleted` and preferring `location_type` if provided

**Shutdown dispatch:**
-  it includes `\Civi\Queue\ShutdownWorker` helper to work on a Civi queue in a shutdown handler 
-  this means the server can respond to the client (e.g. to load the form confirmation page) and *then* continue doing the long work (e.g. to send the confirmation email).
- the shutdown worker is registered by default when a new message is created; this can be disabled with `outbound_message_shutdown_dispatcher` setting if you want to work on the queue differently (e.g. with coworker)
- the ShutdownWorker helper is generic, could be used for other queues as needed. It could potentially even serve as a zero-config alternative to cron?

**Security consideration:**
- we want to avoid users sending spam
- the api action is restricted to administer CiviCRM
- users with administer CiviCRM can already send arbitrary content to an arbitrary email address using the send email form
- for now it is locked down to only using configured SiteEmailAddress records in the from address (previous version of the extension allowed arbitrary from name/email)

**Api4 entity:**
- familiar interface for triggering programmatic emails, see e.g. https://github.com/civicrm/civicrm-core/pull/35648
- emails to be sent are saved as EmailAddress records, which provides observability using search kit
- EmailMessage entity can be included in FormBuilder forms - the UX for this is a little fiddly, as you end up entering a lot in the LHS values pane; but it basically works
