### PR TITLE
Afform - Clear menu cache when creating custom fields (dev/core#6502)

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -453,6 +453,11 @@ function afform_civicrm_post($op, $entityName, $id, $object, $params) {
   if ($entityName === 'CustomGroup' || $entityName === 'CustomField') {
     if (!\CRM_Core_Config::isUpgradeMode()) {
       _afform_clear();
+      // Adding a new custom field to an empty field group may auto-generate afforms with menu routes.
+      // @see Civi\Api4\Action\CustomGroup\GetAfforms::getCustomGroupAfforms
+      if ($op === 'create' && $entityName === 'CustomField') {
+        \CRM_Core_Menu::store();
+      }
     }
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the need to manually clear caches after adding a new "Tabl with Table" custom group.

See https://lab.civicrm.org/dev/core/-/work_items/6502

Before
----------------------------------------
 Create a "Tab with table" custom group for contacts and add 1 or more fields to it. Now visit a contact summary screen and try to add a record for that group. The popup afform will not be found.

After
----------------------------------------
As soon as a field is created for that group, the popup will work.
