### PR TITLE
dev/core#6493 revert "SearchKit - Make loading 600ms faster"

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -107,7 +107,7 @@
           ctrl.page = 1;
           ctrl.rowCount = null;
           ctrl.onChangeFilters.forEach(callback => callback.call(ctrl));
-          if (!ctrl.settings.button && !ctrl.doingFirstRun) {
+          if (!ctrl.settings.button) {
             ctrl.getResultsSoon();
           }
         }
@@ -115,7 +115,7 @@
         function onChangePageSize() {
           ctrl.page = 1;
           // Only refresh if search has already been run
-          if (ctrl.results && !ctrl.doingFirstRun) {
+          if (ctrl.results) {
             ctrl.getResultsSoon();
           }
         }
@@ -149,15 +149,9 @@
         }
 
         // Set up watches to refresh search results when needed.
-        // And trigger the first run of the search if appropriate.
+        // Because `angular.$watch` runs immediately as well as on subsequent changes,
+        // this also kicks off the first run of the search (if there's no search button).
         function setUpWatches() {
-          // Kick off first run of the search if there's no search button.
-          if (!ctrl.settings.button) {
-            ctrl.getResultsPronto();
-            // Prevent the below watchers from running the search while we're already doing it.
-            ctrl.doingFirstRun = true;
-            $timeout(() => ctrl.doingFirstRun = false, 1000);
-          }
           if (ctrl.afFieldset) {
             $scope.$watch(ctrl.afFieldset.getFilterValues, onChangeFilters, true);
           }


### PR DESCRIPTION
Overview
----------------------------------------
This reverts commit da41dc78d2664685784dff2a33026e44358f06f1 for the stable release while we work on a better solution for `master`. See https://github.com/civicrm/civicrm-core/pull/35683

This PR is for 6.14. The 6.15 version is here: https://github.com/civicrm/civicrm-core/pull/35692