### PR TITLE
NFC: Test only: Use Membership instead of this->_entity in test so it's easier to grep

### DIFF
--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -319,10 +319,10 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = 'custom string';
 
-    $result = $this->callAPISuccess($this->_entity, 'create', $params);
+    $result = $this->callAPISuccess('Membership', 'create', $params);
 
     $getParams = ['membership_type_id' => $params['membership_type_id'], 'return' => 'custom_' . $ids['custom_field_id']];
-    $check = $this->callAPISuccess($this->_entity, 'get', $getParams);
+    $check = $this->callAPISuccess('Membership', 'get', $getParams);
     $this->assertEquals('custom string', $check['values'][$result['id']]['custom_' . $ids['custom_field_id']]);
   }
 
@@ -812,8 +812,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
 
-    $result = $this->callAPISuccess($this->_entity, 'create', $params);
-    $check = $this->callAPISuccess($this->_entity, 'get', [
+    $result = $this->callAPISuccess('Membership', 'create', $params);
+    $check = $this->callAPISuccess('Membership', 'get', [
       'id' => $result['id'],
       'contact_id' => $this->_contactID,
     ]);
@@ -991,12 +991,12 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
 
     $params = $this->_params;
     $params['custom_' . $ids['custom_field_id']] = "custom string";
-    $result = $this->callAPISuccess($this->_entity, 'create', $params);
-    $result = $this->callAPISuccess($this->_entity, 'create', [
+    $result = $this->callAPISuccess('Membership', 'create', $params);
+    $result = $this->callAPISuccess('Membership', 'create', [
       'id' => $result['id'],
       'custom_' . $ids['custom_field_id'] => "new custom",
     ]);
-    $check = $this->callAPISuccess($this->_entity, 'get', [
+    $check = $this->callAPISuccess('Membership', 'get', [
       'id' => $result['id'],
       'contact_id' => $this->_contactID,
     ]);
@@ -1142,8 +1142,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   public function testEmptyJoinDate(): void {
     unset($this->_params['join_date'], $this->_params['is_override']);
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals(date('Y-m-d'), $result['join_date']);
     $this->assertEquals('2009-01-21', $result['start_date']);
     $this->assertEquals('2009-12-21', $result['end_date']);
@@ -1156,8 +1156,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   public function testEmptyStartDateFixed(): void {
     unset($this->_params['start_date'], $this->_params['is_override']);
     $this->_params['membership_type_id'] = $this->_membershipTypeID2;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2008-03-01', $result['start_date']);
     $this->assertEquals('2009-12-21', $result['end_date']);
@@ -1171,8 +1171,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
     $this->callAPISuccess('membership_type', 'create', ['id' => $this->_membershipTypeID2, 'duration_interval' => 1]);
     $this->_params['membership_type_id'] = $this->_membershipTypeID2;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2008-03-01', $result['start_date']);
     $this->assertEquals('2010-02-28', $result['end_date']);
@@ -1185,8 +1185,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
     $this->callAPISuccess('membership_type', 'create', ['id' => $this->_membershipTypeID2, 'duration_interval' => 5]);
     $this->_params['membership_type_id'] = $this->_membershipTypeID2;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2008-03-01', $result['start_date']);
     $this->assertEquals('2014-02-28', $result['end_date']);
@@ -1277,8 +1277,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $dates = [
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-01', $result['start_date']);
     $this->assertEquals('2019-12-31', $result['end_date']);
@@ -1307,8 +1307,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'start_date' => '28-Jan 2015',
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-28', $result['start_date']);
     $this->assertEquals('2019-12-31', $result['end_date']);
@@ -1338,8 +1338,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $dates = [
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-01', $result['start_date']);
     $this->assertEquals('2015-12-31', $result['end_date']);
@@ -1368,8 +1368,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'start_date' => '28-Jan 2015',
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-28', $result['start_date']);
     $this->assertEquals('2015-12-31', $result['end_date']);
@@ -1398,8 +1398,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'start_date' => '28-Jan 2015',
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-28', $result['start_date']);
     $this->assertEquals('2016-10-31', $result['end_date']);
@@ -1429,8 +1429,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $dates = [
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2014-11-01', $result['start_date']);
     $this->assertEquals('2016-10-31', $result['end_date']);
@@ -1459,8 +1459,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'start_date' => '28-Jan 2015',
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2015-01-28', $result['start_date']);
     $this->assertEquals('2020-10-31', $result['end_date']);
@@ -1491,8 +1491,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $dates = [
       'join_date' => '28-Jan 2015',
     ];
-    $result = $this->callAPISuccess($this->_entity, 'create', array_merge($this->_params, $dates));
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', array_merge($this->_params, $dates));
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2015-01-28', $result['join_date']);
     $this->assertEquals('2014-11-01', $result['start_date']);
     $this->assertEquals('2020-10-31', $result['end_date']);
@@ -1503,8 +1503,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   public function testEmptyStartDateRolling(): void {
     unset($this->_params['start_date'], $this->_params['is_override']);
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2009-01-21', $result['start_date']);
     $this->assertEquals('2009-12-21', $result['end_date']);
@@ -1517,8 +1517,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   public function testEmptyEndDateFixed(): void {
     unset($this->_params['start_date'], $this->_params['is_override'], $this->_params['end_date']);
     $this->_params['membership_type_id'] = $this->_membershipTypeID2;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2008-03-01', $result['start_date']);
     $this->assertEquals('2010-02-28', $result['end_date']);
@@ -1531,8 +1531,8 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
   public function testEmptyEndDateRolling(): void {
     unset($this->_params['is_override'], $this->_params['end_date']);
     $this->_params['membership_type_id'] = $this->_membershipTypeID;
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2009-01-21', $result['start_date']);
     $this->assertEquals('2010-01-20', $result['end_date']);
@@ -1542,11 +1542,11 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    * Test that if dates are set they not over-ridden if id is passed in
    */
   public function testMembershipDatesNotOverridden(): void {
-    $result = $this->callAPISuccess($this->_entity, 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'create', $this->_params);
     unset($this->_params['end_date'], $this->_params['start_date']);
     $this->_params['id'] = $result['id'];
-    $this->callAPISuccess($this->_entity, 'create', $this->_params);
-    $result = $this->callAPISuccess($this->_entity, 'getsingle', ['id' => $result['id']]);
+    $this->callAPISuccess('Membership', 'create', $this->_params);
+    $result = $this->callAPISuccess('Membership', 'getsingle', ['id' => $result['id']]);
     $this->assertEquals('2009-01-21', $result['join_date']);
     $this->assertEquals('2009-01-21', $result['start_date']);
     $this->assertEquals('2009-12-21', $result['end_date']);


### PR DESCRIPTION
Overview
----------------------------------------
As we're converting some of the Membership API calls to use API4 in tests it's easier to find them if they're called 'Membership' rather than being called 'Membership' via a class variable `$this->_entity`.

Before
----------------------------------------
Class variable $this->_entity = 'Membership' used.

After
----------------------------------------
'Membership' used directly.

Technical Details
----------------------------------------


Comments
----------------------------------------
@eileenmcnaughton 
