### PR TITLE
REF: Simplify passing of trxnID for lineitem/financialitem

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -382,14 +382,14 @@ class CRM_Contribute_BAO_FinancialProcessor {
    * @param array $params
    * @param string $context
    * @param array $fields
-   * @param array $trxnIds
+   * @param int $trxnId FinancialTrxn ID
    * @param int $fieldId
    *
    * @internal
    *
    * @return array
    */
-  private function createFinancialItemsForLine($params, $context, $fields, $trxnIds, $fieldId): array {
+  private function createFinancialItemsForLine($params, $context, $fields, $trxnId, $fieldId): array {
     $postUpdateContribution = $params['contribution'];
     foreach ($fields as $fieldValueId => $lineItemDetails) {
       $previousLineItem = $this->originalLineItems[$lineItemDetails['id'] ?? NULL] ?? [];
@@ -407,7 +407,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
         'entity_table' => 'civicrm_line_item',
         'entity_id' => $lineItemDetails['id'],
       ];
-      $financialItem = CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnIds);
+      $financialItem = CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnId);
       $params['line_item'][$fieldId][$fieldValueId]['deferred_line_total'] = $itemParams['amount'];
       $params['line_item'][$fieldId][$fieldValueId]['financial_item_id'] = $financialItem->id;
 
@@ -437,7 +437,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
       if ($isReversePrior) {
         // In this case we are on the first pass - reverse. Second pass will create new
         // although would be better to restructure to a single pass.
-        $this->reverseLineFinancialItem($lineItemDetails, TRUE, $trxnIds['id']);
+        $this->reverseLineFinancialItem($lineItemDetails, TRUE, $trxnId);
       }
       elseif ($isTaxTransactionRequired) {
         // In this scenario we are on the second pass. We have done a reversal
@@ -447,7 +447,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
         $itemParams['description'] = \Civi::settings()->get('tax_term');
         $itemParams['financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getSalesTaxFinancialAccount($lineItemDetails['financial_type_id']);
         $itemParams['amount'] = CRM_Contribute_BAO_FinancialProcessor::getMultiplier($postUpdateContribution->contribution_status_id) * $lineItemDetails['tax_amount'];
-        CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnIds);
+        CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnId);
       }
       elseif ($isTaxAdjustmentRequired) {
         $taxAmount = (float) $lineItemDetails['tax_amount'];
@@ -455,7 +455,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
         $itemParams['description'] = \Civi::settings()->get('tax_term');
         $itemParams['financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getSalesTaxFinancialAccount($lineItemDetails['financial_type_id']);
         $itemParams['amount'] = CRM_Contribute_BAO_FinancialProcessor::getMultiplier($postUpdateContribution->contribution_status_id) * $taxAmount;
-        CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnIds);
+        CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnId);
       }
     }
     return $params;
@@ -626,9 +626,8 @@ class CRM_Contribute_BAO_FinancialProcessor {
     // @todo we should stop passing $params by reference - splitting this out would be a step towards that.
     $params['entity_id'] = $trxn->id;
 
-    $trxnIds['id'] = $params['entity_id'];
     foreach ($params['line_item'] as $fieldId => $fields) {
-      $params = $this->createFinancialItemsForLine($params, $context, $fields, $trxnIds, $fieldId);
+      $params = $this->createFinancialItemsForLine($params, $context, $fields, $trxn->id, $fieldId);
     }
   }
 
@@ -1179,7 +1178,7 @@ class CRM_Contribute_BAO_FinancialProcessor {
       'description' => $previousItem['description'],
       'status_id' => $previousItem['status_id'],
     ];
-    CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, ['id' => $trxnID]);
+    CRM_Financial_BAO_FinancialItem::create($itemParams, NULL, $trxnID);
   }
 
   /**

--- a/CRM/Core/BAO/FinancialTrxn.php
+++ b/CRM/Core/BAO/FinancialTrxn.php
@@ -343,8 +343,7 @@ WHERE ceft.entity_id = %1";
         'entity_id' => $params['entity_id'],
         'currency' => $params['trxnParams']['currency'],
       ];
-    $trxnIDS['id'] = $trxn->id;
-    CRM_Financial_BAO_FinancialItem::create($fItemParams, NULL, $trxnIDS);
+    CRM_Financial_BAO_FinancialItem::create($fItemParams, NULL, $trxn->id);
   }
 
   /**

--- a/CRM/Core/CodeGen/GenerateData.php
+++ b/CRM/Core/CodeGen/GenerateData.php
@@ -2236,8 +2236,7 @@ ORDER BY cc.id; ";
         'description' => $result->label,
         'financial_account_id' => $result->financial_account_id,
       ];
-      $trxnId['id'] = $trxn->id;
-      $financialItem = CRM_Financial_BAO_FinancialItem::create($financialItem);
+      $financialItem = CRM_Financial_BAO_FinancialItem::create($financialItem, NULL, $trxn->id);
       $entityFinancialTrxnRecord = [
         'entity_table' => "civicrm_financial_item",
         'entity_id' => $financialItem->id,

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -38,11 +38,16 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
    * @param object $contribution
    *   Contribution object.
    * @param bool $taxTrxnID
-   * @param array|null $trxnId
+   * @param int|null $trxnId
    *
    * @return CRM_Financial_DAO_FinancialItem
    */
   public static function add($lineItem, $contribution, $taxTrxnID = FALSE, $trxnId = NULL) {
+    if (is_array($trxnId) && isset($trxnId['id'])) {
+      CRM_Core_Error::deprecatedWarning("Don't pass in trxnId as trxnId['id'] to FinancialItem::add()");
+      $trxnId = $trxnId['id'];
+    }
+
     $financialItemStatus = array_column(\Civi::entity('FinancialItem')->getOptions('status_id'), 'id', 'name');
     $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'contribution_status_id', $contribution->contribution_status_id);
     $itemStatus = NULL;
@@ -88,7 +93,7 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
     }
     if (empty($trxnId)) {
       $trxn = CRM_Core_BAO_FinancialTrxn::getFinancialTrxnId($contribution->id, 'ASC', TRUE);
-      $trxnId['id'] = $trxn['financialTrxnId'];
+      $trxnId = $trxn['financialTrxnId'];
     }
     return self::create($params, NULL, $trxnId);
   }
@@ -100,12 +105,31 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
    *   Associated array to create financial items.
    * @param array $ids
    *   Financial item ids.
-   * @param array $trxnIds
-   *   Financial item ids.
+   * @param int|null $trxnId
+   *   Financial trxn id.
    *
    * @return CRM_Financial_DAO_FinancialItem
    */
-  public static function create(&$params, $ids = NULL, $trxnIds = NULL) {
+  public static function create(&$params, $ids = NULL, $trxnId = NULL) {
+    if ($trxnId) {
+      // trxnId used to be passed in as $trxnId['id']
+      // This flattens that and adds deprecation warnings.
+      // It also accepted multiple trxnIds but there doesn't seem to be anywhere
+      //   that passes in multiple IDs.
+      if (is_array($trxnId) && isset($trxnId['id'])) {
+        CRM_Core_Error::deprecatedWarning("Don't pass in trxnId as trxnId['id'] to FinancialItem::create()");
+        $trxnId = $trxnId['id'];
+      }
+      if (is_array($trxnId)) {
+        // I don't see anywhere that passes in multiple transaction IDs to create..
+        CRM_Core_Error::deprecatedWarning("Don't pass in multiple trxnIds to FinancialItem::create()");
+      }
+      else {
+        // Code below expects an array. @todo simplify code
+        $trxnId = [$trxnId];
+      }
+    }
+
     $financialItem = new CRM_Financial_DAO_FinancialItem();
 
     if (!empty($ids['id'])) {
@@ -121,13 +145,9 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
     }
 
     $financialItem->save();
-    $financialTrxnIDs = $trxnIds['id'] ?? NULL;
-    if (!empty($financialTrxnIDs)) {
-      if (!is_array($financialTrxnIDs)) {
-        $financialTrxnIDs = [$financialTrxnIDs];
-      }
+    if (!empty($trxnId)) {
       $entityFinancialTrxnRecordsToCreate = [];
-      foreach ($financialTrxnIDs as $financialTrxnID) {
+      foreach ($trxnId as $financialTrxnID) {
         $entityFinancialTrxnRecord = [
           'entity_table' => "civicrm_financial_item",
           'entity_id' => $financialItem->id,

--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -916,14 +916,13 @@ WHERE li.contribution_id = %1";
    * @param int $entityID
    * @param string $entityTable
    * @param int $contributionID
-   * @param bool $trxnID
+   * @param int|null $trxnID
    *   Is there a change to the total balance requiring additional transactions to be created.
    */
   protected function addFinancialItemsOnLineItemsChange($lineItemsToAdd, $entityID, $entityTable, $contributionID, $trxnID) {
     $updatedContribution = new CRM_Contribute_BAO_Contribution();
     $updatedContribution->id = $contributionID;
     $updatedContribution->find(TRUE);
-    $trxnArray = $trxnID ? ['id' => $trxnID] : NULL;
 
     foreach ($lineItemsToAdd as $priceFieldValueID => $lineParams) {
       $lineParams = array_merge($lineParams, [
@@ -934,9 +933,9 @@ WHERE li.contribution_id = %1";
       $lineObj = CRM_Price_BAO_LineItem::retrieve($lineParams);
       // insert financial items
       // ensure entity_financial_trxn table has a linking of it.
-      CRM_Financial_BAO_FinancialItem::add($lineObj, $updatedContribution, NULL, $trxnArray);
+      CRM_Financial_BAO_FinancialItem::add($lineObj, $updatedContribution, NULL, $trxnID);
       if (isset($lineObj->tax_amount) && (float) $lineObj->tax_amount !== 0.00) {
-        CRM_Financial_BAO_FinancialItem::add($lineObj, $updatedContribution, TRUE, $trxnArray);
+        CRM_Financial_BAO_FinancialItem::add($lineObj, $updatedContribution, TRUE, $trxnID);
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
When adding LineItems / FinancialItems a financialTrxn ID is passed in (if there are related payments) and used to create EntityFinancialTrxn records.

But the way it is done is really confusing - instead of passing in an ID it's passed in as an array ['id' => ID].

The original intent appears to be that it could support passing multiple financialTrxn IDs but that is not done anywhere in core / extensions that I'm aware of.

Before
----------------------------------------
Confusing passing of trxnID parameter.

After
----------------------------------------
Less confusing, with deprecation notices and support for passing in the old, complicated way.

Technical Details
----------------------------------------
Explained above

Comments
----------------------------------------
Working on eg. https://github.com/civicrm/civicrm-core/pull/35082 and other lineitem / payment related stuff this is one of the most confusing bits and most unclear. There are also some hacks which try to match on latest trxnID for contribution if not matched which can cause unexpected errors (ie. linking to wrong financialItems). That's not part of this PR but will be easier to fix after this because it will require less actual changes.
