### PR TITLE
SearchKit - Ensure rows are completely refreshed after inline edit

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayEditableTrait.service.js
@@ -2,7 +2,7 @@
   "use strict";
 
   // Trait shared by any search display controllers which allow sorting
-  angular.module('crmSearchDisplay').factory('searchDisplayEditableTrait', function(crmApi4, crmStatus) {
+  angular.module('crmSearchDisplay').factory('searchDisplayEditableTrait', function(crmApi4, crmStatus, $timeout) {
 
     // Trait properties get mixed into display controller using angular.extend()
     return {
@@ -74,8 +74,13 @@
           _.defaults(result[0].data, row.data);
           // Ensure cssClass gets updated
           delete (row.cssClass);
-          // Note that extend() will preserve top-level items like 'collapsed' while replacing columns and data
-          angular.extend(row, result[0]);
+          // Preserve top-leel items like collapsed
+          _.defaults(result[0], row);
+          // Delete and re-insert the row.
+          this.results.splice(rowIndex, 1);
+          // Wait a tick to force Angular to update the DOM.
+          // This prevents the one-time bindings in `field.html` from getting "stuck" with the old values.
+          $timeout(() => this.results.splice(rowIndex, 0, result[0]));
         }
         // Or it's possible that the update caused this row to no longer match filters, in which case do a full refresh
         else {


### PR DESCRIPTION
Overview
----------------------------------------
When inline-editing in SearchKit, this ensures the entire row gets refreshed, not just the field being edited.

Before
----------------------------------------
- Add the same column value twice to a display (e.g. using rewrite in another column to display the same value)
- Make one of them editable
- Edit
- Notice the other column is still stuck with the old value

After
----------------------------------------
Works.

Technical Details
----------------------------------------
Prevents Angular one-time bindings from getting stuck by using `$timeout` to reinsert updated rows in search results.