### PR TITLE
SearchKit - Allow editable columns to use rewrite & implicit joins (dev/core#4615)

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -248,7 +248,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
             $out['links'] = $links;
           }
         }
-        elseif (!empty($column['editable']) && !$column['rewrite'] && empty($settings['editableRow']['disable'])) {
+        elseif (!empty($column['editable']) && empty($settings['editableRow']['disable'])) {
           $edit = $this->formatEditableColumn($column, $data);
           if ($edit) {
             // When internally processing an inline-edit, get all metadata

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -266,6 +266,7 @@ class Admin {
               if ($newField) {
                 $newField['name'] = $field['name'] . '.' . $labelField;
                 $newField['label'] = $field['label'] . ' ' . $newField['label'];
+                $newField['implicit_join'] = $field['fk_entity'];
                 array_splice($entity['fields'], $index + 1, 0, [$newField]);
               }
             }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -252,7 +252,8 @@
       this.canBeEditable = (col) => {
         const expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr);
-        return !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
+        return !col.link && !info.fn && info.args[0] && info.args[0].field &&
+          (info.args[0].field.implicit_join || !info.args[0].field.readonly);
       };
 
       // Checks if a column contains a sortable value

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -190,7 +190,6 @@
           col.rewrite = '';
         } else {
           col.rewrite = '[' + col.key + ']';
-          delete col.editable;
         }
       };
 
@@ -250,10 +249,10 @@
         }
       };
 
-      this.canBeEditable = function(col) {
+      this.canBeEditable = (col) => {
         const expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr);
-        return !col.rewrite && !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
+        return !col.link && !info.fn && info.args[0] && info.args[0].field && !info.args[0].field.readonly;
       };
 
       // Checks if a column contains a sortable value


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#4615](https://lab.civicrm.org/dev/core/-/work_items/4615)

Before
----------------------------------------
- Contact.display_name was not editable
- contact_id was editable but could not use rewrite to display a name instead

After
----------------------------------------
I decided to enable both. So now with a search display you can decide whether you want to

a. Make a contact name column editable (will use an autocomplete to change the contact, not edit the current contact's name)
b. Make an id column editable and use rewrite to have it show the display name.