### PR TITLE
SearchKit - Require the user to name the search

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -60,7 +60,6 @@ class Admin {
         ->addSelect('id', 'label', 'color', 'is_selectable', 'description')
         ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')
         ->execute(),
-      'myName' => \CRM_Core_Session::singleton()->getLoggedInContactDisplayName(),
       'dateFormats' => self::getDateFormats(),
       'numberAttributes' => [
         \NumberFormatter::MAX_FRACTION_DIGITS => E::ts('Max Decimal Places'),

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -144,11 +144,6 @@
           default: defaults
         });
 
-        // Set default label
-        ctrl.savedSearch.label = ctrl.savedSearch.label || ts('%1 Search by %2', {
-          1: searchMeta.getEntity(ctrl.savedSearch.api_entity).title,
-          2: CRM.crmSearchAdmin.myName
-        });
         $scope.$bindToRoute({
           param: 'label',
           expr: '$ctrl.savedSearch.label',


### PR DESCRIPTION
Overview
----------------------------------------
Supplying a default of "Contact Search by Standalone Admin" is pretty unhelpful. Better to require the user to give it a name.

Before
----------------------------------------
<img width="869" height="185" alt="Screenshot 2026-05-20 at 2 39 50 PM" src="https://github.com/user-attachments/assets/3c5a0d35-5ef3-4165-9707-a8adc1535734" />


After
----------------------------------------
<img width="766" height="194" alt="Screenshot 2026-05-20 at 2 39 19 PM" src="https://github.com/user-attachments/assets/4e717287-0642-47f6-ae88-841ac1b2fa57" />
