### PR TITLE
dev/core#6506 SearchKit - Improve load time of admin screen

### DIFF
--- a/ext/search_kit/CRM/Search/Page/AJAX.php
+++ b/ext/search_kit/CRM/Search/Page/AJAX.php
@@ -17,8 +17,8 @@ use CRM_Search_ExtensionUtil as E;
 class CRM_Search_Page_AJAX extends CRM_Core_Page {
 
   public function run() {
-    $response = \Civi\Search\Admin::getAdminSettings();
-    CRM_Utils_JSON::output($response);
+    $response = \Civi\Search\Admin::getAdminMetadata();
+    CRM_Utils_System::sendJSONResponse($response);
   }
 
 }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -32,7 +32,38 @@ class Admin {
    * @return array
    * @throws \CRM_Core_Exception
    */
-  public static function getAdminSettings():array {
+  public static function getAdminSettings(): array {
+    // Check minimum permission needed to reach this
+    if (!\CRM_Core_Permission::check('manage own search_kit')) {
+      return [];
+    }
+    $cacheKey = \Civi::cache('metadata')->get('search_kit_admin_settings_key');
+    if (!$cacheKey) {
+      $cacheKey = uniqid();
+      \Civi::cache('metadata')->set('search_kit_admin_settings_key', $cacheKey);
+    }
+    $data = [
+      'defaultPagerSize' => (int) \Civi::settings()->get('default_pager_size'),
+      'modules' => \CRM_Core_BAO_Managed::getBaseModules(),
+      'cacheKey' => $cacheKey,
+      'tags' => Tag::get()
+        ->addSelect('id', 'label', 'color', 'is_selectable', 'description')
+        ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')
+        ->execute(),
+    ];
+    return $data;
+  }
+
+  /**
+   * Returns system metadata needed for the `crmSearchAdmin` Angular module.
+   *
+   * Note: All dynamic data returned by this function MUST be derived from the `metadata` cache (or Civi::$statics).
+   * Flushing that one cache must be sufficient to make this function return fresh data.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public static function getAdminMetadata(): array {
     // Check minimum permission needed to reach this
     if (!\CRM_Core_Permission::check('manage own search_kit')) {
       return [];
@@ -47,19 +78,13 @@ class Admin {
       'functions' => self::getSqlFunctions(),
       'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon', 'grouping']),
       'styles' => \CRM_Utils_Array::makeNonAssociative(self::getStyles()),
-      'defaultPagerSize' => (int) \Civi::settings()->get('default_pager_size'),
       'defaultDisplay' => SearchDisplay::getDefault(FALSE)->setSavedSearch(['id' => NULL])->execute()->first(),
-      'modules' => \CRM_Core_BAO_Managed::getBaseModules(),
       'defaultDistanceUnit' => \CRM_Utils_Address::getDefaultDistanceUnit(),
       'optionAttributes' => \CRM_Core_SelectValues::optionAttributes(),
       'jobFrequency' => \Civi\Api4\Job::getFields()
         ->addWhere('name', '=', 'run_frequency')
         ->setLoadOptions(['id', 'label'])
         ->execute()->first()['options'],
-      'tags' => Tag::get()
-        ->addSelect('id', 'label', 'color', 'is_selectable', 'description')
-        ->addWhere('used_for', 'CONTAINS', 'civicrm_saved_search')
-        ->execute(),
       'dateFormats' => self::getDateFormats(),
       'numberAttributes' => [
         \NumberFormatter::MAX_FRACTION_DIGITS => E::ts('Max Decimal Places'),

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -20,11 +20,19 @@
         controller: 'searchCreate',
         reloadOnSearch: false,
         template: '<crm-search-admin saved-search="$ctrl.savedSearch"></crm-search-admin>',
+        resolve: {
+          loadMetadata: function (searchMeta) {
+            return searchMeta.loadMetadata();
+          },
+        },
       });
       $routeProvider.when('/edit/:id', {
         controller: 'searchEdit',
         template: '<crm-search-admin saved-search="$ctrl.savedSearch"></crm-search-admin>',
         resolve: {
+          loadMetadata: function(searchMeta) {
+            return searchMeta.loadMetadata();
+          },
           // Load saved search
           savedSearch: function($route, crmApi4) {
             const params = $route.current.params;
@@ -50,6 +58,9 @@
         controller: 'searchClone',
         template: '<crm-search-admin saved-search="$ctrl.savedSearch"></crm-search-admin>',
         resolve: {
+          loadMetadata: function(searchMeta) {
+            return searchMeta.loadMetadata();
+          },
           // Load saved search
           savedSearch: function($route, crmApi4) {
             const params = $route.current.params;
@@ -79,7 +90,12 @@
       searchEntity = 'SavedSearch';
 
       // Metadata needed for filters
-      this.entitySelect = searchMeta.getPrimaryAndSecondaryEntitySelect();
+      this.entitySelect = () => {
+        return {
+          results: searchMeta.metadataLoaded ? searchMeta.getPrimaryAndSecondaryEntitySelect() : []
+        };
+      };
+
       this.modules = Object.entries(CRM.crmSearchAdmin.modules).map(([key, label]) => ({
         text: label,
         id: key
@@ -89,9 +105,12 @@
         return {results: formatForSelect2(CRM.crmSearchAdmin.tags, 'id', 'label', ['color', 'description'])};
       };
 
-      this.getPrimaryEntities = function() {
+      const populatePrimaryEntities = ()=> {
         this.primaryEntities = CRM.crmSearchAdmin.schema.filter(entity => entity.searchable === 'primary');
       };
+
+      searchMeta.loadMetadata()
+        .then(() => $scope.$evalAsync(populatePrimaryEntities));
 
       // Tabs include a rowCount which will be updated by the search controller
       this.tabs = [
@@ -159,6 +178,8 @@
     })
 
     .factory('searchMeta', function($q, crmApi4, formatForSelect2, md5) {
+      const localMetadataCacheName = 'searchMeta' + CRM.config.cid + CRM.config.lcMessages;
+
       function getEntity(entityName) {
         if (entityName) {
           return CRM.crmSearchAdmin.schema.find(entity => entity.name === entityName);
@@ -552,7 +573,37 @@
             children: formatForSelect2(secondaryEntities, 'name', 'title_plural', ['description', 'icon'])
           });
           return select;
-        }
+        },
+        metadataLoaded: false,
+        metadataLoading: null,
+        loadMetadata: function() {
+          if (this.metadataLoading) {
+            return this.metadataLoading;
+          }
+          const cachedMetadata = CRM.cache.get(localMetadataCacheName);
+          if (cachedMetadata && cachedMetadata.cacheKey === CRM.crmSearchAdmin.cacheKey) {
+            Object.assign(CRM.crmSearchAdmin, cachedMetadata);
+            this.metadataLoaded = true;
+            const deferred = $q.defer();
+            deferred.resolve();
+            return deferred.promise;
+          }
+          else {
+            return this.refreshMetadata();
+          }
+        },
+        refreshMetadata: function () {
+          this.metadataLoaded = false;
+          this.metadataLoading = fetch(CRM.url('civicrm/ajax/admin/search'))
+            .then((response) => response.json())
+            .then((data) => {
+              data.cacheKey = CRM.crmSearchAdmin.cacheKey;
+              CRM.cache.set(localMetadataCacheName, data);
+              Object.assign(CRM.crmSearchAdmin, data);
+              this.metadataLoaded = true;
+            });
+          return this.metadataLoading;
+        },
       };
     })
     .directive('contenteditable', function() {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -3,7 +3,7 @@
 
   angular.module('crmSearchAdmin').component('crmSearchAdminImport', {
     templateUrl: '~/crmSearchAdmin/crmSearchAdminImport.html',
-    controller: function ($scope, dialogService, crmApi4) {
+    controller: function ($scope, dialogService, crmApi4, searchMeta) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
         ctrl = this;
 
@@ -115,9 +115,7 @@
               'success'
             );
             // Refresh admin settings (if a db entity was saved the list of entities will be changed)
-            fetch(CRM.url('civicrm/ajax/admin/search'))
-              .then(response => response.json())
-              .then(data => CRM.crmSearchAdmin = data);
+            searchMeta.refreshMetadata();
             dialogService.close('crmSearchAdminImport');
           }, function(error) {
             ctrl.running = false;

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayEntity.decorator.js
@@ -66,9 +66,7 @@
           display._job = apiResults['job_' + display.name];
         }
         // Refresh admin settings to reflect any new/updated entity + joins
-        fetch(CRM.url('civicrm/ajax/admin/search'))
-          .then(response => response.json())
-          .then(data => CRM.crmSearchAdmin = data);
+        searchMeta.refreshMetadata();
       }
     });
     return $delegate;

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -222,23 +222,29 @@
             classes: ['table', 'table-striped'],
             sort: [['modified_date', 'DESC']],
             columns: [
-              searchMeta.fieldToColumn('label', {
-                label: true,
+              {
+                key: 'label',
+                type: 'field',
+                label: ts('Label'),
                 title: ts('Edit Label'),
                 editable: true
-              }),
-              searchMeta.fieldToColumn('description', {
-                label: true,
+              },
+              {
+                key: 'description',
+                type: 'field',
+                label: ts('Description'),
                 title: ts('Edit Description'),
                 editable: true
-              }),
-              searchMeta.fieldToColumn('api_entity:label', {
-                label: true,
+              },
+              {
+                key: 'api_entity:label',
+                type: 'field',
+                label: ts('For'),
                 empty_value: ts('Missing'),
                 cssRules: [
                   ['font-italic', 'api_entity:label', 'IS EMPTY']
                 ]
-              }),
+              },
               {
                 type: 'include',
                 label: ts('Tags'),
@@ -268,60 +274,60 @@
           });
         }
         if (!ctrl.filters.is_template) {
-          ctrl.display.settings.columns.push(
-            searchMeta.fieldToColumn('GROUP_CONCAT(UNIQUE group.title) AS groups', {
-              label: ts('Smart Group')
-            })
-          );
+          ctrl.display.settings.columns.push({
+            key: 'groups',
+            type: 'field',
+            label: ts('Smart Group'),
+          });
         }
         if (ctrl.filters.has_base || ctrl.filters.is_template) {
-          ctrl.display.settings.columns.push(
-            searchMeta.fieldToColumn('base_module:label', {
-              label: ts('Package'),
-              title: '[base_module]',
-              empty_value: ctrl.filters.has_base ? ts('Missing') : null,
-              cssRules: [
-                ['font-italic', 'base_module:label', 'IS EMPTY']
-              ]
-            })
-          );
-          ctrl.display.settings.columns.push(
+          ctrl.display.settings.columns.push({
+            key: 'base_module:label',
+            type: 'field',
+            label: ts('Package'),
+            title: '[base_module]',
+            empty_value: ctrl.filters.has_base ? ts('Missing') : null,
+            cssRules: [
+              ['font-italic', 'base_module:label', 'IS EMPTY']
+            ]
+          });
+          ctrl.display.settings.columns.push({
             // Using 'local_modified_date' as the column + an empty_value will only show the rewritten value
             // if the record has been modified from its packaged state.
-            searchMeta.fieldToColumn('local_modified_date', {
-              label: ts('Modified'),
-              empty_value: ts('No'),
-              title: ts('Whether and when a search was modified from its packaged settings'),
-              rewrite: ts('%1 by %2', {1: '[date_modified]', 2: '[modified_id.display_name]'}),
-              cssRules: [
-                ['font-italic', 'local_modified_date', 'IS EMPTY']
-              ]
-            })
-          );
+            key: 'local_modified_date',
+            type: 'field',
+            label: ts('Modified'),
+            empty_value: ts('No'),
+            title: ts('Whether and when a search was modified from its packaged settings'),
+            rewrite: ts('%1 by %2', {1: '[date_modified]', 2: '[modified_id.display_name]'}),
+            cssRules: [
+              ['font-italic', 'local_modified_date', 'IS EMPTY']
+            ]
+          });
         } else {
-          ctrl.display.settings.columns.push(
-            searchMeta.fieldToColumn('created_date', {
-              label: ts('Created'),
-              title: '[created_date]',
-              rewrite: ts('%1 by %2', {1: '[date_created]', 2: '[created_id.display_name]'})
-            })
-          );
-          ctrl.display.settings.columns.push(
-            searchMeta.fieldToColumn('modified_date', {
-              label: ts('Modified'),
-              title: '[modified_date]',
-              rewrite: ts('%1 by %2', {1: '[date_modified]', 2: '[modified_id.display_name]'})
-            })
-          );
+          ctrl.display.settings.columns.push({
+            key: 'created_date',
+            type: 'field',
+            label: ts('Created'),
+            title: '[created_date]',
+            rewrite: ts('%1 by %2', {1: '[date_created]', 2: '[created_id.display_name]'})
+          });
+          ctrl.display.settings.columns.push({
+            key: 'modified_date',
+            type: 'field',
+            label: ts('Modified'),
+            title: '[modified_date]',
+            rewrite: ts('%1 by %2', {1: '[date_modified]', 2: '[modified_id.display_name]'})
+          });
         }
         if (!ctrl.filters.is_template) {
-          ctrl.display.settings.columns.push(
-            searchMeta.fieldToColumn('expires_date', {
-              label: ts('Expires'),
-              title: '[expires_date]',
-              rewrite: '[expires]'
-            })
-          );
+          ctrl.display.settings.columns.push({
+            key: 'expires_date',
+            type: 'field',
+            label: ts('Expires'),
+            title: '[expires_date]',
+            rewrite: '[expires]'
+          });
         }
         ctrl.display.settings.columns.push({
           type: 'include',

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
@@ -22,7 +22,7 @@
         <i class="crm-i fa-plus" role="img" aria-hidden="true"></i>
         {{ $ctrl.tab === 'template' ? ts('New Template') : ts('New Search') }}
       </a>
-      <button type="button" ng-click="$ctrl.getPrimaryEntities()" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right">
@@ -42,7 +42,7 @@
         <i class="crm-i fa-plus" role="img" aria-hidden="true"></i>
         {{:: ts('New Data Segment') }}
       </a>
-      <button type="button" ng-click="$ctrl.getPrimaryEntities()" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
Overview
----------------------------------------
Greatly improves loading time of the SearchKit admin screens (browsing, creating and editing saved searches).

Before
----------------------------------------
Very long initial load time.

After
----------------------------------------
Very fast.

Technical Details
----------------------------------------
Leverages the localStorage cache for most metadata. When that cache is warm, loading is almost instant. When cold, it progressively fetches metadata in the background so the search listing page still loads faster than before.