### PR TITLE
Use API4 instead of API3 to pre-create memberships in tests so that we avoid creating unnecessary financial items if we don't need them

### DIFF
--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -348,8 +348,8 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
-
     $membership = $this->callAPISuccess('Membership', 'create', $params);
 
     $this->assertEquals('Anderson, Anthony II', CRM_Member_BAO_Membership::sortName($membership['id']));
@@ -490,6 +490,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'is_override' => 1,
       'status_override_end_date' => date('Ymd'),
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $createdMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
@@ -532,6 +533,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $createdMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
@@ -751,6 +753,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $this->callAPISuccess('Membership', 'create', $params);
@@ -792,6 +795,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'membership_type_id' => $membershipTypeWithRelationship["id"],
       'contact_id'         => $employerId,
       'status_id'          => $this->_membershipStatusID,
+      'version'            => 4,
     ]);
     $membership = $membership['values'][$membership["id"]];
     $this->assertEquals(0, $this->getRelatedMembershipsCount($membership["id"]), 'Related membership count should be 0.');
@@ -852,6 +856,7 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
       'contact_id'         => $organizationId,
       'status_id'          => $this->_membershipStatusID,
       'custom_' . $customField['id'] => $customContactId,
+      'version'            => 4,
     ]);
 
     $membership = $membership['values'][$membership["id"]];

--- a/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipRenewalTest.php
@@ -137,6 +137,7 @@ class CRM_Member_Form_MembershipRenewalTest extends CiviUnitTestCase {
       'membership_type_id' => $this->membershipTypeRollingID,
       'join_date' => '2020-04-13',
       'source' => 'original_source',
+      'version' => 4,
     ])['id'];
 
     $this->paymentInstruments = $this->callAPISuccess('Contribution', 'getoptions', ['field' => 'payment_instrument_id'])['values'];

--- a/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
+++ b/tests/phpunit/CRM/Member/Form/Task/PDFLetterTest.php
@@ -57,6 +57,7 @@ class CRM_Member_Form_Task_PDFLetterTest extends CiviUnitTestCase {
         'join_date' => $date,
         'start_date' => $date,
         'end_date' => date('Y-m-d', strtotime("{$date} +1 year")),
+        'version' => 4,
       ];
       $result = $this->callAPISuccess('Membership', 'create', $params);
       $searchFormValues['mark_x_' . $result['id']] = 1;

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -2216,6 +2216,7 @@ ENDSQLUPDATE;
       'skipStatusCal' => 1,
       'source' => 'Test',
       'sequential' => 1,
+      'version' => 4,
     ];
 
     // Create membership with incorrect status but dates implying status Current.

--- a/tests/phpunit/api/v3/MembershipPaymentTest.php
+++ b/tests/phpunit/api/v3/MembershipPaymentTest.php
@@ -85,6 +85,7 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $membership = $this->callAPISuccess('membership', 'create', $params);
@@ -112,6 +113,7 @@ class api_v3_MembershipPaymentTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $membership = $this->callAPISuccess('membership', 'create', $params);

--- a/tests/phpunit/api/v3/MembershipStatusTest.php
+++ b/tests/phpunit/api/v3/MembershipStatusTest.php
@@ -149,6 +149,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
       'start_date' => '2006-01-21',
       'end_date' => '2006-12-21',
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
     $this->callApiSuccess('membership', 'create', $params);
     $this->callApiSuccess('contact', 'create', ['id' => $contactID, 'is_deceased' => 1]);
@@ -171,6 +172,7 @@ class api_v3_MembershipStatusTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $membershipStatusID,
+      'version' => 4,
     ];
 
     $result = $this->callAPISuccess('Membership', 'create', $params);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -286,6 +286,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   public function testGetWithParamsMemberShipTypeIdContactID(): void {
     $params = $this->_params;
+    $params['version'] = 4;
     $this->callAPISuccess('Membership', 'create', $params);
     $params['membership_type_id'] = $this->_membershipTypeID2;
     $this->callAPISuccess('Membership', 'create', $params);
@@ -485,6 +486,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
     $params = [
       'id' => $OrganizationMembershipID,
       'max_related' => 3,
+      'version' => 4,
     ];
     $this->callAPISuccess('Membership', 'create', $params);
 
@@ -522,6 +524,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'source' => 'Test pay later suite',
       'is_pay_later' => 1,
       'status_id' => 5,
+      'version' => 4,
     ];
     $organizationMembershipID = $this->callAPISuccess('Membership', 'create', $params)['id'];
 
@@ -718,6 +721,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'membership_type_id' => 'General',
       'status_id' => 'Pending',
       'sequential' => 1,
+      'version' => 4,
     ])['values'][0];
     $this->assertEquals(date('Ymd'), $membership['start_date']);
     $this->assertEquals(date('Ymd', strtotime('+1 year -1 day')), $membership['end_date']);
@@ -771,6 +775,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $result = $this->callAPISuccess('membership', 'create', $params);
@@ -860,12 +865,13 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $result = $this->callAPISuccess('membership', 'create', $params);
+    $result = $this->callAPISuccess('Membership', 'create', $params);
 
     //Update Status and check activities created.
     $updateStatus = [
       'id' => $result['id'],
       'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Member_BAO_Membership', 'status_id', 'Cancelled'),
+      'version' => 4,
     ];
     $this->callAPISuccess('Membership', 'create', $updateStatus);
     $activities = civicrm_api4('ActivityContact', 'get', [
@@ -908,7 +914,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'status_id' => $this->_membershipStatusID,
     ];
 
-    $result = $this->callAPISuccess('membership', 'create', $params);
+    $result = $this->callAPISuccess('Membership', 'create', $params);
     $this->callAPISuccess('Membership', 'Delete', [
       'id' => $result['id'],
     ]);
@@ -1103,7 +1109,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
    */
   public function testMembershipCreateValidMembershipTypeString(): void {
     $params = [
-      'membership_contact_id' => $this->_contactID,
+      'contact_id' => $this->_contactID,
       'membership_type_id' => 'General',
       'join_date' => '2011-01-21',
       'start_date' => '2010-01-21',
@@ -1111,6 +1117,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'source' => 'Payment',
       'is_override' => 1,
       'status_id' => $this->_membershipStatusID,
+      'version' => 4,
     ];
 
     $result = $this->callAPISuccess('membership', 'create', $params);
@@ -1211,6 +1218,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'status_id' => 'Pending',
       'skipStatusCal' => 1,
       'is_for_organization' => 1,
+      'version' => 4,
     ];
     $membership = $this->callAPISuccess('Membership', 'create', $params);
 

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -1112,6 +1112,7 @@ class api_v3_RelationshipTest extends CiviUnitTestCase {
     $originalMembership = $this->callAPISuccess('Membership', 'create', [
       'membership_type_id' => $relatedMembershipType['id'],
       'contact_id' => $mainContactID,
+      'version' => 4,
     ]);
     $this->callAPISuccess('Relationship', 'create', [
       'relationship_type_id' => $this->relationshipTypeID,


### PR DESCRIPTION
Overview
----------------------------------------
Use API4 instead of API3 to pre-create memberships in tests so that we avoid creating unnecessary financial items if we don't need them.


Before
----------------------------------------
Using API3 to pre-create memberships for tests. When using API3 membership create lineitems get created even if we are doing nothing with financials.

After
----------------------------------------
Using API4 to pre-create memberships for tests. Bypass unnecessary financials.


Technical Details
----------------------------------------


Comments
----------------------------------------
