### PR TITLE
Use API4 to create inherited memberships (skips financial processing that we don't need/want)

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1349,6 +1349,9 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
           $params['status_id'] = $expiredStatusId;
         }
 
+        // action not required from here
+        unset($params['action']);
+
         //don't calculate status again in create( );
         $params['skipStatusCal'] = TRUE;
 
@@ -1374,7 +1377,10 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         if (($params['status_id'] == $deceasedStatusId) || ($params['status_id'] == $expiredStatusId)) {
           // related membership is not active so does not count towards maximum
           if (!self::hasExistingInheritedMembership($params)) {
-            civicrm_api3('Membership', 'create', $params);
+            \Civi\Api4\Membership::save(FALSE)
+              ->addRecord($params)
+              ->setMatch(['id'])
+              ->execute();
           }
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Inherited memberships shouldn't have lineitems. But they get created because API3 create is used. Switch to API4 save instead.

Before
----------------------------------------
Orphaned lineitems created for inherited memberships.

After
----------------------------------------
No lineitems created.

Technical Details
----------------------------------------
Switch to API4.

Comments
----------------------------------------
