### PR TITLE
search for non-primary emails when quicksearching on name/email

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1169,6 +1169,7 @@ class CRM_Core_SelectValues {
       [
         'key' => 'sort_name',
         'label' => $includeEmail ? ts('Name/Email') : ts('Name'),
+        'join' => $includeEmail ? ['Email AS Email', 'INNER', ['Email.contact_id', '=', 'id']] : NULL,
       ],
       [
         'key' => 'id',


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/34790 allows us to search on non-primary email/phone/etc. in QuickSearch.  However, if you search by "Name/Email" rather than "Email", we don't search non-primary emails.

You can test this by searching for a non-primary email in quicksearch when "Name/Email" is selected.

Before
----------------------------------------
Can't find contacts by non-primary email when using "Name/Email" quicksearch.

After
----------------------------------------
Can.
