### PR TITLE
add fix for radio and checkbox issue with WP 7. 

### DIFF
--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -187,6 +187,11 @@ body.wp-admin .crm-container input[type="radio"] {
   height: var(--crm-l-reg);
   width: var(--crm-l-reg);
 }
+body.wp-admin .crm-container input[type="checkbox"]:checked,
+body.wp-admin .crm-container input[type="radio"]:checked {
+  background: var(--crm-input-radio-color);
+  border-color: var(--crm-input-radio-color);
+}
 body.wp-admin .crm-container input[type="radio"] {
   border-radius: 50%;
 }


### PR DESCRIPTION
Overview
----------------------------------------
see https://lab.civicrm.org/dev/core/-/work_items/6483  props @christianwach 

Before
----------------------------------------
Using a RiverLea Theme check a box - nothing.
After
----------------------------------------
Users are able to see that a checkbox or radio button has been selected.

Comments
----------------------------------------
Targeting RC