### PR TITLE
search for non-primary emails when quicksearching on name/email

### DIFF
--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -50,7 +50,10 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
       $duplicateOptions = [];
 
       $allowedFilters = \Civi::settings()->get('quicksearch_options');
-      foreach ($apiRequest->getFilters() as $filterField => $val) {
+      $requestFilters = $apiRequest->getFilters();
+      // No filters means this is a sort_name search, which may include email.
+      $sortNameSearch = !$requestFilters;
+      foreach ($requestFilters as $filterField => $val) {
         if (in_array($filterField, $allowedFilters)) {
           // Add trusted filter
           $apiRequest->addFilter($filterField, $val);
@@ -84,7 +87,7 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
 
       // Map contact_autocomplete_options settings to v4 format
       $autocompleteOptionsMap = [
-        2 => 'email_primary.email',
+        2 => 'Email.email',
         3 => 'phone_primary.phone',
         4 => 'address_primary.street_address',
         5 => 'address_primary.city',
@@ -94,15 +97,16 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
       ];
       // If doing a search by a field other than the default,
       // add that field as the column
-      if ($apiRequest->getFilters()) {
-        $filterFields = array_keys($apiRequest->getFilters());
+      if (!$sortNameSearch) {
+        $filterFields = array_keys($requestFilters);
         $columns[0]['rewrite'] = "[sort_name] :: [" . implode('] :: [', $filterFields) . "]";
       }
       else {
         $filterFields = ['sort_name'];
         if (\Civi::settings()->get('includeEmailInName')) {
-          $filterFields[] = 'email_primary.email';
-          $columns[] = ['type' => 'field', 'key' => 'email_primary.email'];
+          $filterFields[] = 'Email.email';
+          $columns[] = ['type' => 'field', 'key' => 'Email.email'];
+          $apiParams['join'][] = ['Email AS Email', 'INNER', ['Email.contact_id', '=', 'id']];
         }
         if (\Civi::settings()->get('includeNickNameInName')) {
           $filterFields[] = 'nick_name';
@@ -145,6 +149,7 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
         $savedSearch['api_params'] = [
           'select' => $apiParams['select'],
           'sets' => [],
+          'groupBy' => ['id' => 'id'],
         ];
         // Add limit to each subset for max efficiency
         $apiParams['orderBy'] = ['sort_name' => 'ASC'];


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/34790 allows us to search on non-primary email/phone/etc. in QuickSearch.  However, if you search by "Name/Email" rather than "Email", we don't search non-primary emails.

You can test this by searching for a non-primary email in quicksearch when "Name/Email" is selected.

Before
----------------------------------------
Can't find contacts by non-primary email when using "Name/Email" quicksearch.

After
----------------------------------------
Can.

Comments
----------------------------------------
Previously, the lack of request filters was used to test if this is a `sort_name` search.  But we need to add a filter if we're searching by (non-primary) emails, so I've broken `$sortNameSearch` into its own variable.