### PR TITLE
dev/core#6467 Fix price token for membership receipt

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFifteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFifteen.php
@@ -31,4 +31,19 @@ class CRM_Upgrade_Incremental_php_SixFifteen extends CRM_Upgrade_Incremental_Bas
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
+  public function upgrade_6_15_beta1($rev): void {
+    $swaps = [
+      '{contribution_product.price|boolean}' => '{contribution_product.product_id.price|boolean}',
+      '{contribution_product.price|crmMoney}' => '{contribution_product.product_id.price|crmMoney}',
+      'ts 1=$price|crmMoney' => "ts 1=\\'{contribution_product.product_id.price|crmMoney}\\'",
+    ];
+    foreach (['membership_online_receipt', 'contribution_online_receipt', 'contribution_offline_receipt'] as $type) {
+      foreach ($swaps as $from => $to) {
+        $this->addTask('Replace . ' . $from . ' with ' . $to . $type,
+          'updateMessageToken', $type, $from, $to, $rev
+        );
+      }
+    }
+  }
+
 }

--- a/xml/templates/message_templates/membership_online_receipt_html.tpl
+++ b/xml/templates/message_templates/membership_online_receipt_html.tpl
@@ -386,11 +386,11 @@
           </td>
         </tr>
       {/if}
-      {if {contribution.non_deductible_amount|boolean} AND {contribution_product.price|boolean}}
+      {if {contribution.non_deductible_amount|boolean} AND {contribution_product.product_id.price|boolean}}
         <tr>
           <td colspan="2" {$valueStyle}>
-            <p>{ts 1='{contribution_product.price|crmMoney}'}The value of this premium is %1. This may affect the amount of the tax deduction you can claim. Consult your tax advisor for more information.{/ts}</p>
-         </td>
+            <p>{ts 1='{contribution_product.product_id.price|crmMoney}'}The value of this premium is %1. This may affect the amount of the tax deduction you can claim. Consult your tax advisor for more information.{/ts}</p>
+          </td>
         </tr>
       {/if}
     {/if}


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6467 Fix price token for membership receipt - per the analysis by @composerjk  on the gitlab https://lab.civicrm.org/dev/core/-/work_items/6467

Before
----------------------------------------
The non-deductible text does not show up using the default or an upgraded template

After
----------------------------------------
<img width="1080" height="350" alt="image" src="https://github.com/user-attachments/assets/83c15386-21a3-4221-b7f6-f4e2605ba09e" />


Technical Details
----------------------------------------
I made a bunch of changes to make this show up properly in the MessageTemplate preview but ultimately decided to target master with that part - see https://github.com/civicrm/civicrm-core/pull/35714

6.14 patch will require changed upgrader target

Comments
----------------------------------------
