### PR TITLE
use membership title not machine name on backend (Part 2) ✌🏻

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -268,7 +268,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
             $selOrgMemType[$memberOfContactId][0] = ts('- select -');
           }
           if (empty($selOrgMemType[$memberOfContactId][$key])) {
-            $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
+            $selOrgMemType[$memberOfContactId][$key] = $values['title'] ?? NULL;
           }
         }
 


### PR DESCRIPTION
When **renewing** a membership on the backend, the machine names are used, not the titles. This is a follow-on from https://github.com/civicrm/civicrm-core/pull/35335

To replicate:

Create a new membership type with spaces.
Add a membership on the back end.
Go to select your membership type - all good (thanks https://github.com/civicrm/civicrm-core/pull/35335)
Now go to renew that membership in the back end
The membership type is shown as a Name_with_spaces

**Before**
Name_with_spaces.

**After**
Name with spaces.

**Comments**
Scanning the code it looks like there are other occurrences of this same display of machine name and not title for membership types. But am not confident enough that it is correct to changes those too. For example this one, https://github.com/civicrm/civicrm-core/blob/f88c595b4fac68287a4cf515ee016bd487317671/CRM/Member/Form/MembershipRenewal.php#L303

_Someone else may do a Part 3 in the series._

@MegaphoneJon 