### PR TITLE
35335-part2 - use membership title not machine name on backend

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -268,7 +268,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
             $selOrgMemType[$memberOfContactId][0] = ts('- select -');
           }
           if (empty($selOrgMemType[$memberOfContactId][$key])) {
-            $selOrgMemType[$memberOfContactId][$key] = $values['name'] ?? NULL;
+            $selOrgMemType[$memberOfContactId][$key] = $values['title'] ?? NULL;
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------
Port of https://github.com/civicrm/civicrm-core/pull/35716 to stable