### PR TITLE
Add civi.afform.sort.submit event

### DIFF
--- a/ext/afform/core/Civi/Afform/Event/AfformEntitySortEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformEntitySortEvent.php
@@ -29,13 +29,28 @@ class AfformEntitySortEvent extends AfformBaseEvent {
   }
 
   /**
+   * Returns list of entity names that have a defined type.
+   *
+   * @return array
+   */
+  private function getFormEntities(): array {
+    $entities = [];
+    foreach ($this->getFormDataModel()->getEntities() as $name => $entity) {
+      if (!empty($entity['type'])) {
+        $entities[] = $name;
+      }
+    }
+    return $entities;
+  }
+
+  /**
    * Returns entity names sorted by their dependencies
    *
    * @return array
    */
   public function getSortedEntitiesPrefill(): array {
     $sorter = new FixedArraySort();
-    $formEntities = array_keys($this->getFormDataModel()->getEntities());
+    $formEntities = $this->getFormEntities();
     foreach ($formEntities as $entityName) {
       // Add all dependencies that are the valid name of another entity
       $dependencies = array_intersect($this->dependencies[$entityName] ?? [], $formEntities);
@@ -51,13 +66,13 @@ class AfformEntitySortEvent extends AfformBaseEvent {
    */
   public function getEntityDependenciesForSubmit(): void {
     $sorter = new FixedArraySort();
-    $formEntities = array_keys($this->getFormDataModel()->getEntities());
+    $formEntities = $this->getFormEntities();
     $entityValues = $this->entityValues;
 
     foreach ($formEntities as $entityName) {
       $references = [];
-      foreach ($entityValues[$entityName] as $record) {
-        foreach ($record['fields'] as $fieldName => $fieldValue) {
+      foreach ($entityValues[$entityName] ?? [] as $record) {
+        foreach ($record['fields'] ?? [] as $fieldName => $fieldValue) {
           foreach ((array) $fieldValue as $value) {
             if (in_array($value, $formEntities, TRUE) && $value !== $entityName) {
               $references[$value] = $value;

--- a/ext/afform/core/Civi/Afform/Event/AfformEntitySortEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformEntitySortEvent.php
@@ -12,6 +12,10 @@ class AfformEntitySortEvent extends AfformBaseEvent {
 
   private $dependencies = [];
 
+  private $entityValues = [];
+
+  private FixedArraySort $sorter;
+
   /**
    * @param string $dependentEntity
    * @param string $dependsOnEntity
@@ -20,12 +24,16 @@ class AfformEntitySortEvent extends AfformBaseEvent {
     $this->dependencies[$dependentEntity][$dependsOnEntity] = $dependsOnEntity;
   }
 
+  public function setEntityValues(array $entityValues): void {
+    $this->entityValues = $entityValues;
+  }
+
   /**
    * Returns entity names sorted by their dependencies
    *
    * @return array
    */
-  public function getSortedEnties(): array {
+  public function getSortedEntitiesPrefill(): array {
     $sorter = new FixedArraySort();
     $formEntities = array_keys($this->getFormDataModel()->getEntities());
     foreach ($formEntities as $entityName) {
@@ -34,6 +42,42 @@ class AfformEntitySortEvent extends AfformBaseEvent {
       $sorter->add($entityName, $dependencies);
     }
     return $sorter->sort();
+  }
+
+  /**
+   * Returns a list of entity names in order of when they should be processed,
+   * so that an entity being referenced is saved before the entity referencing it.
+   *
+   */
+  public function getEntityDependenciesForSubmit(): void {
+    $sorter = new FixedArraySort();
+    $formEntities = array_keys($this->getFormDataModel()->getEntities());
+    $entityValues = $this->entityValues;
+
+    foreach ($formEntities as $entityName) {
+      $references = [];
+      foreach ($entityValues[$entityName] as $record) {
+        foreach ($record['fields'] as $fieldName => $fieldValue) {
+          foreach ((array) $fieldValue as $value) {
+            if (in_array($value, $formEntities, TRUE) && $value !== $entityName) {
+              $references[$value] = $value;
+            }
+          }
+        }
+      }
+      $sorter->add($entityName, $references);
+    }
+
+    // Return the list of entities ordered by weight
+    $this->sorter = $sorter;
+  }
+
+  /**
+   * @throws \MJS\TopSort\CircularDependencyException
+   * @throws \MJS\TopSort\ElementNotFoundException
+   */
+  public function sort() {
+    return $this->sorter->sort();
   }
 
 }

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -27,37 +27,6 @@ class Utils {
   use \Civi\Api4\Utils\AfformSaveTrait;
 
   /**
-   * Sorts entities according to references to each other
-   *
-   * Returns a list of entity names in order of when they should be processed,
-   * so that an entity being referenced is saved before the entity referencing it.
-   *
-   * @param $formEntities
-   * @param $entityValues
-   * @return string[]
-   */
-  public static function getEntityWeights($formEntities, $entityValues) {
-    $sorter = new \MJS\TopSort\Implementations\FixedArraySort();
-
-    $formEntityNames = array_keys($formEntities);
-    foreach ($formEntities as $entityName => $entity) {
-      $references = [];
-      foreach ($entityValues[$entityName] as $record) {
-        foreach ($record['fields'] as $fieldName => $fieldValue) {
-          foreach ((array) $fieldValue as $value) {
-            if (in_array($value, $formEntityNames, TRUE) && $value !== $entityName) {
-              $references[$value] = $value;
-            }
-          }
-        }
-      }
-      $sorter->add($entityName, $references);
-    }
-    // Return the list of entities ordered by weight
-    return $sorter->sort();
-  }
-
-  /**
    * Subset of APIv4 operators that are appropriate for use on Afforms
    *
    * This list may be further reduced by fields which declare a limited number of

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -155,7 +155,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     else {
       $sorter = new AfformEntitySortEvent($this->_afform, $this->_formDataModel, $this);
       \Civi::dispatcher()->dispatch('civi.afform.sort.prefill', $sorter);
-      $entityNames = $sorter->getSortedEnties();
+      $entityNames = $sorter->getSortedEntitiesPrefill();
     }
 
     foreach ($entityNames as $entityName) {
@@ -777,7 +777,12 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    * Process form data
    */
   public function processFormData(array $entityValues) {
-    $entityWeights = \Civi\Afform\Utils::getEntityWeights($this->_formDataModel->getEntities(), $entityValues);
+    $sorter = new AfformEntitySortEvent($this->_afform, $this->_formDataModel, $this);
+    $sorter->setEntityValues($entityValues);
+    $sorter->getEntityDependenciesForSubmit();
+    \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sorter);
+    $entityWeights = $sorter->sort();
+
     foreach ($entityWeights as $entityName) {
       $entityType = $this->_formDataModel->getEntity($entityName)['type'];
       $records = $this->replaceReferences($entityName, $entityValues[$entityName]);

--- a/ext/afform/core/tests/phpunit/CRM/Afform/UtilTest.php
+++ b/ext/afform/core/tests/phpunit/CRM/Afform/UtilTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Afform\Event\AfformEntitySortEvent;
+use Civi\Afform\FormDataModel;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\TransactionalInterface;
 
@@ -60,13 +62,19 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
     $this->assertEquals($expected, $actual);
   }
 
-  public static function formEntityWeightExampls() {
+  public static function formEntityWeightExamples() {
     $exs = [];
     $exs[] = [
-      [
-        'Individual1' => ['type' => 'Contact', ['fields' => ['first_name', 'last_name']]],
-        'Activity1' => ['type' => 'Activity', ['fields' => ['source_contact_id']]],
-      ],
+      '<af-form><div>
+         <af-entity type="Contact" name="Individual1"/>
+         <af-entity name="Activity1" type="Activity" />
+         <fieldset af-fieldset="Individual1" class="af-container">
+           <af-field name="first_name" /><af-field name="last_name" />
+         </fieldset>
+         <fieldset af-fieldset="Activity1" class="af-container">
+           <af-field name="source_contact_id" />
+         </fieldset>
+      </div></af-form>',
       [
         'Individual1' => [['fields' => ['first_name' => 'Test', 'last_name' => 'Contact']]],
         'Activity1' => [['fields' => ['source_contact_id' => 'Individual1']]],
@@ -77,11 +85,20 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
       ],
     ];
     $exs[] = [
-      [
-        'Individual1' => ['type' => 'Contact', ['fields' => ['first_name', 'last_name']]],
-        'Event1' => ['type' => 'Event', ['fields' => ['created_id']]],
-        'LocBlock1' => ['type' => 'LocBlock', ['fields' => ['event_id']]],
-      ],
+      '<af-form><div>
+         <af-entity type="Contact" name="Individual1"/>
+         <af-entity type="Event" name="Event1" />
+         <af-entity type="LocBlock" name="LocBlock1" />
+         <fieldset af-fieldset="Individual1" class="af-container">
+           <af-field name="first_name" /><af-field name="last_name" />
+         </fieldset>
+         <fieldset af-fieldset="Event1" class="af-container">
+           <af-field name="created_id" />
+         </fieldset>
+         <fieldset af-fieldset="LocBlock1" class="af-container">
+           <af-field name="event_id" />
+         </fieldset>
+      </div></af-form>',
       [
         'Individual1' => [['fields' => ['first_name' => 'Test', 'last_name' => 'Contact']]],
         'Event1' => [['fields' => ['created_id' => 'Individual1']]],
@@ -94,11 +111,20 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
       ],
     ];
     $exs[] = [
-      [
-        'Individual1' => ['type' => 'Contact', ['fields' => ['first_name', 'last_name']]],
-        'LocBlock1' => ['type' => 'LocBlock', ['fields' => ['event_id']]],
-        'Event1' => ['type' => 'Event', ['fields' => ['created_id']]],
-      ],
+      '<af-form><div>
+         <af-entity type="Contact" name="Individual1"/>
+         <af-entity type="LocBlock" name="LocBlock1" />
+         <af-entity type="Event" name="Event1" />
+         <fieldset af-fieldset="Individual1" class="af-container">
+           <af-field name="first_name" /><af-field name="last_name" />
+         </fieldset>
+         <fieldset af-fieldset="LocBlock1" class="af-container">
+           <af-field name="event_id" />
+         </fieldset>
+         <fieldset af-fieldset="Event1" class="af-container">
+           <af-field name="created_id" />
+         </fieldset>
+      </div></af-form>',
       [
         'Individual1' => [['fields' => ['first_name' => 'Test', 'last_name' => 'Contact']]],
         'LocBlock1' => [['fields' => ['event_id' => 'Event1']]],
@@ -111,12 +137,24 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
       ],
     ];
     $exs[] = [
-      [
-        'Activity1' => ['type' => 'Activity', ['fields' => ['source_contact_id']]],
-        'Individual1' => ['type' => 'Contact', ['fields' => ['first_name', 'last_name', 'employer_id']]],
-        'Individual2' => ['type' => 'Contact', ['fields' => ['first_name', 'last_name', 'employer_id']]],
-        'Organization1' => ['type' => 'Contact', ['fields' => ['organization_name']]],
-      ],
+      '<af-form><div>
+         <af-entity type="Activity" name="Activity1"/>
+         <af-entity type="Contact" name="Individual1"/>
+         <af-entity type="Contact" name="Individual2"/>
+         <af-entity type="Contact" name="Organization1"/>
+         <fieldset af-fieldset="Activity1" class="af-container">
+           <af-field name="source_contact_id" />
+         </fieldset>
+         <fieldset af-fieldset="Individual1" class="af-container">
+           <af-field name="first_name" /><af-field name="last_name" /><af-field name="employer_id" />
+         </fieldset>
+         <fieldset af-fieldset="Individual2" class="af-container">
+           <af-field name="first_name" /><af-field name="last_name" /><af-field name="employer_id" />
+         </fieldset>
+         <fieldset af-fieldset="Organization1" class="af-container">
+           <af-field name="organization_name" />
+         </fieldset>
+      </div></af-form>',
       [
         'Activity1' => [['fields' => ['source_contact_id' => 'Individual1', 'target_contact_id' => ['Individual2']]]],
         'Individual1' => [['fields' => ['first_name' => 'Test', 'last_name' => 'Contact', 'employer_id' => 'Organization1']]],
@@ -137,10 +175,18 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
   }
 
   /**
-   * @dataProvider formEntityWeightExampls
+   * @dataProvider formEntityWeightExamples
    */
-  public function testEntityWeights($formEntities, $entityValues, $expectedWeights) {
-    $this->assertEquals($expectedWeights, \Civi\Afform\Utils::getEntityWeights($formEntities, $entityValues));
+  public function testEntityWeights($html, $entityValues, $expectedWeights) {
+    $parser = new \CRM_Afform_ArrayHtml();
+    $formDataModel = new FormDataModel($parser->convertHtmlToArray($html));
+    $sorter = new AfformEntitySortEvent([], $formDataModel, new \Civi\Api4\Generic\BasicGetAction('', ''));
+    $sorter->setEntityValues($entityValues);
+    $sorter->getEntityDependenciesForSubmit();
+    // \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sorter);
+    $entityWeights = $sorter->sort();
+
+    $this->assertEquals($expectedWeights, $entityWeights);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
I didn't know we had a `civi.afform.sort.prefill` event and I just found it. And it was very useful. I needed to prefill Contributions and LineItems but needed the prefill to happen for Contribution first so I could use that to prefill LineItems.

With the `civi.afform.sort.prefill` event you can explicitly set a dependency on one entity for another (eg. Contribution1 for LineItem1).

For submit you have to rely on explicit entity reference fields for the sorter to do it's thing or the order of adding the entities to the form.

By adding a `civi.afform.sort.submit` event we can specify custom/arbitrary dependencies on other entities.

Both myself (with ShoppingCart) and @ufundo (with Afform Payments) have come up against issues like this.

Note: This is a quick and dirty proof of concept. Could do with a bit of refining/cleanup/rework if we want to add this event to reduce duplication etc.

Before
----------------------------------------
No event to control (override) order of civi.afform.submit.

After
----------------------------------------
Event to control (override) order civi.afform.submit.

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw 
