### PR TITLE
Case Dashboard Dashlet: replace links in table by a list of links

### DIFF
--- a/templates/CRM/Dashlet/Page/CaseDashboard.tpl
+++ b/templates/CRM/Dashlet/Page/CaseDashboard.tpl
@@ -7,67 +7,51 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-
 <div id="case_dashboard_dashlet" class="form-item">
-
-{capture assign=newCaseURL}{crmURL p="civicrm/case/add" q="action=add&context=standalone&reset=1"}{/capture}
-
-<div class="float-right">
-  <table class="form-layout-compressed">
-   {if $newClient}
-    <tr>
-      <td>
-        <a href="{$newCaseURL}" class="button">
-          <span><i class="crm-i fa-plus-circle" role="img" aria-hidden="true"></i> {ts}New Case{/ts}</span>
-        </a>
-      </td>
+  <div class="float-right">
+    <ul>
+      {if $newClient}
+        {capture assign=newCaseURL}{crmURL p="civicrm/case/add" q="action=add&context=standalone&reset=1"}{/capture}
+        <li>
+          <a href="{$newCaseURL}" class="button"><span><i class="crm-i fa-plus-circle" role="img" aria-hidden="true"></i> {ts}New Case{/ts}</span></a>
+        </li>
+      {/if}
+      {if $myCases}
+        <li>
+          <a href="{crmURL p="civicrm/case" q="reset=1&all=1"}"><span><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Show ALL Cases with Upcoming Activities{/ts}</span></a>
+        </li>
+      {else}
+        <li>
+          <a href="{crmURL p="civicrm/case" q="reset=1&all=0"}"><span><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Show My Cases with Upcoming Activities{/ts}</span></a>
+        </li>
+      {/if}
+      <li>
+        <a href="{crmURL p="civicrm/case/search" q="reset=1&case_owner=2&force=1"}"><span><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Show My Cases{/ts}</span></a>
+      </li>
+    </ul>
+  </div>
+  <h3>{ts}Summary of Involvement{/ts}</h3>
+  <table class="report">
+    <tr class="columnheader">
+      <th>&nbsp;</th>
+      {foreach from=$casesSummary.headers item=header}
+        <th scope="col" class="right" style="padding-right: 10px;"><a href="{$header.url}">{$header.status}</a></th>
+      {/foreach}
     </tr>
-   {/if}
-   {if $myCases}
-    <tr>
-      <td class="right">
-        <a href="{crmURL p="civicrm/case" q="reset=1&all=1"}"><span><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Show ALL Cases with Upcoming Activities{/ts}</span></a>
-      </td>
+    {foreach from=$casesSummary.rows item=row key=caseType}
+      <tr>
+      <th><strong>{$caseType}</strong></th>
+      {foreach from=$casesSummary.headers item=header}
+        {assign var="caseStatus" value=$header.status}
+        <td class="label">
+        {if $row.$caseStatus}
+          <a href="{$row.$caseStatus.url}">{$row.$caseStatus.count}</a>
+        {else}
+          0
+        {/if}
+        </td>
+      {/foreach}
     </tr>
-   {else}
-    <tr>
-      <td class="right">
-        <a href="{crmURL p="civicrm/case" q="reset=1&all=0"}"><span><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Show My Cases with Upcoming Activities{/ts}</span></a>
-      </td>
-    </tr>
-   {/if}
-   <tr>
-     <td class="right">
-       <a href="{crmURL p="civicrm/case/search" q="reset=1&case_owner=1&force=1"}"><span><i class="crm-i fa-chevron-right" role="img" aria-hidden="true"></i> {ts}Show My Cases{/ts}</span></a>
-     </td>
-   </tr>
-  </table>
-</div>
-
-<h3>{ts}Summary of Involvement{/ts}</h3>
-
-<table class="report">
-  <tr class="columnheader">
-    <th>&nbsp;</th>
-    {foreach from=$casesSummary.headers item=header}
-    <th scope="col" class="right" style="padding-right: 10px;"><a href="{$header.url}">{$header.status}</a></th>
     {/foreach}
-  </tr>
-  {foreach from=$casesSummary.rows item=row key=caseType}
-   <tr>
-   <th><strong>{$caseType}</strong></th>
-   {foreach from=$casesSummary.headers item=header}
-    {assign var="caseStatus" value=$header.status}
-    <td class="label">
-    {if $row.$caseStatus}
-    <a href="{$row.$caseStatus.url}">{$row.$caseStatus.count}</a>
-    {else}
-     0
-    {/if}
-    </td>
-   {/foreach}
-  </tr>
-  {/foreach}
-</table>
-
+  </table>
 </div>


### PR DESCRIPTION


Overview
----------------------------------------

Updates the markup of the Case Dashboard Dashlet Dasharoo with a list, so that it looks better in River. I suspect it's also better for screen-readers. 

Before
----------------------------------------

<img width="3182" height="1038" alt="civicase-dashlet-before" src="https://github.com/user-attachments/assets/b6f5bb3c-c818-4e66-a405-682df93fff33" />


After
----------------------------------------

<img width="3182" height="1038" alt="civicase-dashlet-after" src="https://github.com/user-attachments/assets/bf1392d1-655f-4eac-8641-70f2d65110e1" />

Comments
-----------------------

It adds a bit of unwanted padding/margin at the top of the list, which could look better if it wasn't there, but I'm avoiding that rabbit-hole for now, because it's a non-standard element.