### PR TITLE
Fix IDOR and Directory Traversal in CRM_Contact_Page_ImageFile

### DIFF
--- a/CRM/Contact/Page/ImageFile.php
+++ b/CRM/Contact/Page/ImageFile.php
@@ -30,33 +30,70 @@ class CRM_Contact_Page_ImageFile extends CRM_Core_Page {
    * @throws \Exception
    */
   public function run() {
-    if (!preg_match('/^[^\/]+\.(jpg|jpeg|png|gif)$/i', $_GET['photo'])) {
+    $photo = $_GET['photo'] ?? '';
+    if (!$this->isValidPhotoName($photo)) {
       throw new CRM_Core_Exception(ts('Malformed photo name'));
     }
 
-    // FIXME Optimize performance of image_url query
-    $sql = "SELECT id FROM civicrm_contact WHERE image_url like %1;";
-    $params = [
-      1 => ["%" . $_GET['photo'], 'String'],
-    ];
-    $dao = CRM_Core_DAO::executeQuery($sql, $params);
-    $cid = NULL;
-    while ($dao->fetch()) {
-      $cid = $dao->id;
-    }
-    if ($cid) {
-      $config = CRM_Core_Config::singleton();
-      $fileExtension = strtolower(pathinfo($_GET['photo'], PATHINFO_EXTENSION));
-      $this->download(
-        $config->customFileUploadDir . $_GET['photo'],
-        'image/' . ($fileExtension == 'jpg' ? 'jpeg' : $fileExtension),
-        $this->ttl
-      );
+    $contactIDs = $this->getContactIDsForPhoto($photo);
+    if ($contactIDs) {
+      foreach ($contactIDs as $cid) {
+        if ($this->canViewContact($cid)) {
+          $config = CRM_Core_Config::singleton();
+          $fileExtension = strtolower(pathinfo($photo, PATHINFO_EXTENSION));
+          $this->download(
+            $config->customFileUploadDir . $photo,
+            'image/' . ($fileExtension == 'jpg' ? 'jpeg' : $fileExtension),
+            $this->ttl
+          );
+          CRM_Utils_System::civiExit();
+        }
+      }
+      header('HTTP/1.0 403 Forbidden');
     }
     else {
       header("HTTP/1.0 404 Not Found");
     }
     CRM_Utils_System::civiExit();
+  }
+
+  /**
+   * @param string $photo
+   * @return bool
+   */
+  protected function isValidPhotoName($photo) {
+    return (bool) preg_match('/^[^\/\\\\]+\.(jpg|jpeg|png|gif)$/i', $photo);
+  }
+
+  /**
+   * @param string $photo
+   * @return array<int>
+   */
+  protected function getContactIDsForPhoto($photo) {
+    // FIXME Optimize performance of image_url query.
+    $escapedPhoto = strtr($photo, [
+      '%' => '\\%',
+      '_' => '\\_',
+    ]);
+    $sql = "SELECT id FROM civicrm_contact WHERE image_url LIKE %1 OR image_url LIKE %2 ORDER BY id";
+    $params = [
+      1 => ['%?photo=' . $escapedPhoto, 'String'],
+      2 => ['%&photo=' . $escapedPhoto, 'String'],
+    ];
+    $dao = CRM_Core_DAO::executeQuery($sql, $params);
+    $contactIDs = [];
+    while ($dao->fetch()) {
+      $contactIDs[] = (int) $dao->id;
+    }
+    return $contactIDs;
+  }
+
+  /**
+   * @param int $contactID
+   * @return bool
+   */
+  protected function canViewContact($contactID) {
+    return CRM_Contact_BAO_Contact_Permission::allow($contactID, CRM_Core_Permission::VIEW);
   }
 
   /**

--- a/tests/phpunit/CRM/Contact/Page/ImageFileTest.php
+++ b/tests/phpunit/CRM/Contact/Page/ImageFileTest.php
@@ -19,15 +19,9 @@ class CRM_Contact_Page_ImageFileTest extends CiviUnitTestCase {
   }
 
   public function testGetContactIDsForPhotoRequiresPhotoQueryParameterMatch(): void {
-    $expectedContactID = $this->individualCreate([
-      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=contact.jpg',
-    ]);
-    $this->individualCreate([
-      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=other-contact.jpg',
-    ]);
-    $this->individualCreate([
-      'image_url' => 'https://example.org/files/contact.jpg',
-    ]);
+    $expectedContactID = $this->createContactWithImageUrl('https://example.org/civicrm/contact/imagefile?photo=contact.jpg');
+    $this->createContactWithImageUrl('https://example.org/civicrm/contact/imagefile?photo=other-contact.jpg');
+    $this->createContactWithImageUrl('https://example.org/files/contact.jpg');
 
     $page = new CRM_Contact_Page_ImageFileTest_Page();
 
@@ -35,16 +29,21 @@ class CRM_Contact_Page_ImageFileTest extends CiviUnitTestCase {
   }
 
   public function testGetContactIDsForPhotoEscapesSqlLikeWildcards(): void {
-    $expectedContactID = $this->individualCreate([
-      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=contact_.jpg',
-    ]);
-    $this->individualCreate([
-      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=contactx.jpg',
-    ]);
+    $expectedContactID = $this->createContactWithImageUrl('https://example.org/civicrm/contact/imagefile?photo=contact_.jpg');
+    $this->createContactWithImageUrl('https://example.org/civicrm/contact/imagefile?photo=contactx.jpg');
 
     $page = new CRM_Contact_Page_ImageFileTest_Page();
 
     $this->assertEquals([$expectedContactID], $page->getContactIDsForPhotoPublic('contact_.jpg'));
+  }
+
+  private function createContactWithImageUrl(string $imageUrl): int {
+    $contactID = (int) $this->individualCreate();
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_contact SET image_url = %1 WHERE id = %2', [
+      1 => [$imageUrl, 'String'],
+      2 => [$contactID, 'Integer'],
+    ]);
+    return $contactID;
   }
 
 }

--- a/tests/phpunit/CRM/Contact/Page/ImageFileTest.php
+++ b/tests/phpunit/CRM/Contact/Page/ImageFileTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @group headless
+ */
+class CRM_Contact_Page_ImageFileTest extends CiviUnitTestCase {
+
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_contact']);
+    parent::tearDown();
+  }
+
+  public function testIsValidPhotoNameRejectsDirectorySeparators(): void {
+    $page = new CRM_Contact_Page_ImageFileTest_Page();
+
+    $this->assertTrue($page->isValidPhotoNamePublic('contact.jpg'));
+    $this->assertFalse($page->isValidPhotoNamePublic('../contact.jpg'));
+    $this->assertFalse($page->isValidPhotoNamePublic('..\\contact.jpg'));
+  }
+
+  public function testGetContactIDsForPhotoRequiresPhotoQueryParameterMatch(): void {
+    $expectedContactID = $this->individualCreate([
+      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=contact.jpg',
+    ]);
+    $this->individualCreate([
+      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=other-contact.jpg',
+    ]);
+    $this->individualCreate([
+      'image_url' => 'https://example.org/files/contact.jpg',
+    ]);
+
+    $page = new CRM_Contact_Page_ImageFileTest_Page();
+
+    $this->assertEquals([$expectedContactID], $page->getContactIDsForPhotoPublic('contact.jpg'));
+  }
+
+  public function testGetContactIDsForPhotoEscapesSqlLikeWildcards(): void {
+    $expectedContactID = $this->individualCreate([
+      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=contact_.jpg',
+    ]);
+    $this->individualCreate([
+      'image_url' => 'https://example.org/civicrm/contact/imagefile?photo=contactx.jpg',
+    ]);
+
+    $page = new CRM_Contact_Page_ImageFileTest_Page();
+
+    $this->assertEquals([$expectedContactID], $page->getContactIDsForPhotoPublic('contact_.jpg'));
+  }
+
+}
+
+class CRM_Contact_Page_ImageFileTest_Page extends CRM_Contact_Page_ImageFile {
+
+  public function isValidPhotoNamePublic($photo): bool {
+    return $this->isValidPhotoName($photo);
+  }
+
+  public function getContactIDsForPhotoPublic($photo): array {
+    return $this->getContactIDsForPhoto($photo);
+  }
+
+}


### PR DESCRIPTION
## Summary
This MR updates CRM_Contact_Page_ImageFile to fix two security issues.

## Problem
- Directory traversal via the photo parameter.
- Missing access check causing IDOR exposure.

## Solution
- Tighten photo input validation to block path traversal patterns.
- Require contact view permission before serving image files.

## Tests
- Added PHPUnit coverage for validation and permission checks.

## Issue
security/core#105