### PR TITLE
Don't apply maxlength rule to contact autocomplete when creating multiple relationships

### DIFF
--- a/CRM/Contact/Form/Relationship.php
+++ b/CRM/Contact/Form/Relationship.php
@@ -338,7 +338,7 @@ class CRM_Contact_Form_Relationship extends CRM_Core_Form {
     );
 
     $label = $this->_action & CRM_Core_Action::ADD ? ts('Contact(s)') : ts('Contact');
-    $contactField = $this->addField('related_contact_id', ['label' => $label, 'name' => 'contact_id_b', 'multiple' => TRUE, 'create' => TRUE], TRUE);
+    $contactField = $this->addEntityRef('related_contact_id', $label, ['multiple' => TRUE, 'create' => TRUE], TRUE);
     // This field cannot be updated
     if ($this->_action & CRM_Core_Action::UPDATE) {
       $contactField->freeze();


### PR DESCRIPTION
Before
----------------------------------------
From a contact's relationship tab, add a relationship. Select enough contacts so that the combined length of comma separated ids exceeds 14. Attempt to save. You'll get an error telling you the length cannot exceed 14.

After
----------------------------------------
No more error.

Technical Details
----------------------------------------
This seems to be the only place where addField is used to add a multiple autocomplete. Otherwise, addEntityRef is used directly, which doesn't load the maxlength or other properties, so I've done the same here. We could also strip the maxlength in CRM_Core_Form when multiple is true, but this is a simpler change.