### PR TITLE
Followup from pull/35275: authx credential parsing

### DIFF
--- a/ext/authx/Civi/Authx/CheckCredentialEvent.php
+++ b/ext/authx/Civi/Authx/CheckCredentialEvent.php
@@ -67,7 +67,9 @@ class CheckCredentialEvent extends \Civi\Core\Event\GenericHookEvent {
    *   For stateful HTTP session or CLI pipe, that's a wildcard.
    */
   public function __construct(string $cred, string $requestPath) {
-    [$this->credFormat, $this->credValue] = explode(' ', "$cred ", 2);
+    $parts = explode(' ', $cred, 2);
+    $this->credFormat = $parts[0];
+    $this->credValue = $parts[1] ?? '';
     $this->requestPath = $requestPath;
   }
 


### PR DESCRIPTION
Follow up from https://github.com/civicrm/civicrm-core/pull/35275

As @chrwie [pointed out](https://github.com/civicrm/civicrm-core/commit/c78323410595940a240b2708f04c07ad53eab61a#commitcomment-186492110) this PR introduced a problem as well as a fix. It fixed the case that the credential string had no space, but broke it for the case it does; or specifially, it, broke the credValue. This was my mistake because I had not considered the effect of the length limit of 2 in the explode() params.

This longer-winded fix should correct that and fix the first problem, too.

```php
<?php
foreach ([
    '' => ['', ''],
    'foo' => ['foo', ''], 
    'foo bar' => ['foo', 'bar'],
    'foo bar baz' => ['foo', 'bar baz'],
    'foo bar ' => ['foo', 'bar '],
    ] as $cred => $expectation) {
    $p = explode(' ', $cred, 2);
    $a = $p[0];
    $b = $p[1] ?? '';
    $got = [$a, $b];
    print  (($expectation == $got) ? 'OK: ' : 'FAIL: ')
      . json_encode($cred) . ' → got '
      . json_encode($got)
      . " expected " . json_encode($expectation)
      . "\n";
}
```

```text
// Outputs:

OK: "" → got ["",""] expected ["",""]
OK: "foo" → got ["foo",""] expected ["foo",""]
OK: "foo bar" → got ["foo","bar"] expected ["foo","bar"]
OK: "foo bar baz" → got ["foo","bar baz"] expected ["foo","bar baz"]
OK: "foo bar " → got ["foo","bar "] expected ["foo","bar "]
```

I didn't add this test to the test code.