### PR TITLE
Prevent issues if default dashlets are disabled

### DIFF
--- a/CRM/Core/BAO/Dashboard.php
+++ b/CRM/Core/BAO/Dashboard.php
@@ -206,6 +206,7 @@ class CRM_Core_BAO_Dashboard extends CRM_Core_DAO_Dashboard implements EventSubs
       \Civi\Api4\DashboardContact::save(FALSE)
         ->setRecords($defaultDashlets)
         ->setDefaults(['contact_id' => CRM_Core_Session::getLoggedInContactID()])
+        ->setMatch(['contact_id', 'dashboard_id'])
         ->execute();
     }
   }


### PR DESCRIPTION
Turns out this has already been fixed in #35602 and I just didn't notice, but I think this change still makes sense to make sure we don't hit DB errors.