### PR TITLE
Fix regression onbehalf_contact_id (for 6.15)

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1262,7 +1262,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
     //create contribution activity w/ individual and target
     //activity w/ organisation contact id when onbelf, CRM-4027
-    if ($this->getSubmittedValue('onbehalf_contact_id')) {
+    if (!empty($params['onbehalf_contact_id'])) {
       $this->addActivity([
         'source_contact_id' => $params['onbehalf_contact_id'],
         'source_record_id' => $contribution->id,


### PR DESCRIPTION
Overview
----------------------------------------

This is a new PR against 6.15, here the original for master: https://github.com/civicrm/civicrm-core/pull/35718

The change in https://github.com/civicrm/civicrm-core/pull/34643 introduced a bug. The param onbehalf_contact_id is not a real form value and cannot be accessed with `$this->getSubmittedValue('onbehalf_contact_id')`

Before
----------------------------------------
Make a contribution with "On Behalf Of Organization". The activity is not created.

After
----------------------------------------
Make a contribution with "On Behalf Of Organization". The activity is created again.
