### PR TITLE
Prevent email template failure if employer name or email contains apostrophe

### DIFF
--- a/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
+++ b/xml/templates/message_templates/contribution_invoice_receipt_html.tpl
@@ -25,7 +25,7 @@
         <td valign="bottom" style="white-space: nowrap"><b><font size="1" align="right">{domain.name}</font></b></td>
       </tr>
       <tr>
-        <td><font size="1" align="center">{contact.display_name}{if '{contact.current_employer}'} ({contact.current_employer}){/if}</font></td>
+        <td><font size="1" align="center">{contact.display_name}{if {contact.current_employer|boolean}} ({contact.current_employer}){/if}</font></td>
         <td><font size="1" align="right">{contribution.receive_date|crmDate:"Full"}</font></td>
         <td style="white-space: nowrap"><font size="1" align="right">
           {domain.street_address}
@@ -210,7 +210,7 @@
         <td><font size="1" align="right">{domain.name}</font></td>
       </tr>
       <tr>
-        <td style="padding-left:17px;"><font size="1" align="center">{contact.display_name}{if '{contact.current_employer}'} ({contact.current_employer}){/if}</font></td>
+        <td style="padding-left:17px;"><font size="1" align="center">{contact.display_name}{if {contact.current_employer|boolean}} ({contact.current_employer}){/if}</font></td>
         <td style="padding-left:30px;"><font size="1" align="right">{contribution.receive_date|crmDate:"Full"}</font></td>
         <td><font size="1" align="right">
           {domain.street_address}

--- a/xml/templates/message_templates/participant_cancelled_html.tpl
+++ b/xml/templates/message_templates/participant_cancelled_html.tpl
@@ -105,7 +105,7 @@
         {/if}
       {/if}
 
-    {if '{contact.email}'}
+    {if {contact.email|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Registered Email{/ts}

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -139,7 +139,7 @@
      </tr>
      {/if}
 
-     {if '{contact.email}'}
+     {if {contact.email|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Registered Email{/ts}

--- a/xml/templates/message_templates/participant_transferred_html.tpl
+++ b/xml/templates/message_templates/participant_transferred_html.tpl
@@ -105,7 +105,7 @@
         {/if}
       {/if}
 
-     {if '{contact.email}'}
+     {if {contact.email|boolean}}
       <tr>
        <th {$headerStyle}>
         {ts}Registered Email{/ts}


### PR DESCRIPTION
If employer name, for example, contains a `'`, then things will break.