### PR TITLE
SearchKit: Add register participants contact task

### DIFF
--- a/CRM/Contact/Task.php
+++ b/CRM/Contact/Task.php
@@ -246,6 +246,8 @@ class CRM_Contact_Task extends CRM_Core_Task {
         self::$_tasks[self::ADD_EVENT] = [
           'title' => ts('Register participants for event'),
           'class' => 'CRM_Event_Form_Task_Register',
+          'url' => 'civicrm/task/register-participants',
+          'icon' => 'fa-calendar-plus-o',
         ];
       }
 

--- a/CRM/Event/xml/Menu/Event.xml
+++ b/CRM/Event/xml/Menu/Event.xml
@@ -19,6 +19,12 @@
      <component>CiviEvent</component>
   </item>
   <item>
+     <path>civicrm/task/register-participants</path>
+     <page_callback>CRM_Event_Form_Task_Register</page_callback>
+     <access_arguments>access CiviCRM,access CiviEvent</access_arguments>
+     <component>CiviEvent</component>
+  </item>
+  <item>
      <path>civicrm/event/info</path>
      <page_callback>CRM_Event_Page_EventInfo</page_callback>
      <title>Event Information</title>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -74,6 +74,33 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertNull($display['saved_search_id']);
   }
 
+  public function testGetSearchTasksIncludesRegisterParticipantsForContactSearch(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $tasks = SearchDisplay::getSearchTasks(FALSE)
+      ->setSavedSearch([
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id'],
+        ],
+      ])
+      ->setDisplay([
+        'type' => 'table',
+        'label' => __FUNCTION__,
+        'settings' => [
+          'actions' => TRUE,
+        ],
+      ])
+      ->execute()->indexBy('name');
+
+    $this->assertArrayHasKey('contact.' . \CRM_Contact_Task::ADD_EVENT, (array) $tasks);
+    $task = $tasks['contact.' . \CRM_Contact_Task::ADD_EVENT];
+    $this->assertSame('Register participants for event', $task['title']);
+    $this->assertSame('fa-calendar-plus-o', $task['icon']);
+    $this->assertSame("'civicrm/task/register-participants'", $task['crmPopup']['path']);
+  }
+
   public function testAutoFormatName() {
     // Create 3 saved searches; they should all get unique names
     $savedSearch0 = SavedSearch::create(FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
Adds the missing SearchKit action metadata for the existing contact task “Register participants for event”.

Fixes https://lab.civicrm.org/dev/core/-/work_items/4344

Before
----------------------------------------
SearchKit contact table displays could not offer the existing “Register participants for event” batch action because the legacy contact task did not define a standalone URL, so SearchKit skipped it when building table actions.

After
----------------------------------------
When CiviEvent is enabled and the user has CiviEvent access, SearchKit contact table actions include “Register participants for event”. The action opens `CRM_Event_Form_Task_Register` in a popup through `civicrm/task/register-participants`.

Technical Details
----------------------------------------
- Adds `url` and `icon` metadata to `CRM_Contact_Task::ADD_EVENT`.
- Registers the route in the CiviEvent menu XML with `<component>CiviEvent</component>`.
- Adds a SearchKit API test confirming the contact task is returned by `SearchDisplay.getSearchTasks`.

Tests
----------------------------------------
- `civilint CRM/Contact/Task.php CRM/Event/xml/Menu/Event.xml ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php`
- `CIVICRM_UF=UnitTests phpunit9 ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php --filter testGetSearchTasksIncludesRegisterParticipantsForContactSearch`
- `CIVICRM_UF=UnitTests phpunit9 ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php`
- `CIVICRM_UF=UnitTests phpunit9 tests/phpunit/CRM/Event/Form/Task/RegisterTest.php`

Comments
----------------------------------------
A local standalone build was also seeded with sample contacts/event data and verified via `cv -U admin api4 SearchDisplay.getSearchTasks` to return `contact.105`.
