### PR TITLE
Afform fix preview for additional extra fields

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -122,6 +122,12 @@
             const searchDisplay = ctrl.container.getSearchDisplay();
             defn = _.findWhere(searchDisplay.calc_fields, {name: fieldName});
           }
+        } else if (ctrl.node.defn?.input_type) {
+          // Extra (non-entity) field: seed from the inputType's extra_defn
+          const inputType = afGui.meta.inputTypes.find((t) => t.name === ctrl.node.defn.input_type);
+          if (inputType?.extra_defn) {
+            defn = _.cloneDeep(inputType.extra_defn);
+          }
         }
         defn = defn || {
           label: ts('Untitled'),


### PR DESCRIPTION
Overview
----------------------------------------
_This is a follow up to #35728 which fixed an error when using additional field types without the `extra_defn` specified in `Utils::getInputTypes`. The PR added the `Boolean` to the checkbox, but the admin preview wasn't rendering the field as a checkbox but instead an empty `UL`. _

Before
----------------------------------------
_Checkbox field renders as empty `UL` element that looks like a textarea._

After
----------------------------------------
_Checkbox renders as, well a checkbox._

Technical Details
----------------------------------------
_Added check to fall back to `extra_defn` when the field is not connected to an entity._
