### PR TITLE
dev/core#6509, dev/core#4354 - move activity assignee notification to BAO layer

### DIFF
--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -301,6 +301,9 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
 
     // Track which assignee contacts are being added so we can notify them.
     $notifyAssigneeContactIds = $params['assignee_contact_id'] ?? [];
+    if (!is_array($notifyAssigneeContactIds)) {
+      $notifyAssigneeContactIds = [$notifyAssigneeContactIds];
+    }
     if ($action == 'edit') {
       // Only notify newly added assignee contact ids.
       $previousAssigneeContactIds = \Civi\Api4\Activity::get(TRUE)

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -298,6 +298,17 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
 
     $action = empty($params['id']) ? 'create' : 'edit';
+
+    // Track which assignee contacts are being added so we can notify them.
+    $notifyAssigneeContactIds = $params['assignee_contact_id'] ?? [];
+    if ($action == 'edit') {
+      // Only notify newly added assignee contact ids.
+      $previousAssigneeContactIds = \Civi\Api4\Activity::get(TRUE)
+        ->addWhere('id', '=', $params['id'])
+        ->addSelect('assignee_contact_id')
+        ->execute()->first()['assignee_contact_id'] ?? [];
+      $notifyAssigneeContactIds = array_diff($notifyAssigneeContactIds, $previousAssigneeContactIds);
+    }
     CRM_Utils_Hook::pre($action, 'Activity', $params['id'] ?? NULL, $params);
 
     $activity->copyValues($params);
@@ -512,7 +523,40 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     CRM_Contact_BAO_GroupContactCache::opportunisticCacheFlush();
 
     CRM_Utils_Hook::post($action, 'Activity', $activity->id, $activity, $params);
+
+    self::notifyAssignedContacts($result, $notifyAssigneeContactIds);
+
     return $result;
+  }
+
+  /**
+   * Notify assigned contacts.
+   *
+   * @param CRM_Activity_DAO_Activity $activity
+   * @param array $notifyAssigneeContactIds Contact Ids to send notification
+   * @return void
+   */
+  public static function notifyAssignedContacts(CRM_Activity_DAO_Activity $activity, array $notifyAssigneeContactIds): void {
+    if (empty($notifyAssigneeContactIds)) {
+      return;
+    }
+    if (Civi::settings()->get('activity_assignee_notification')) {
+      $doNotNotifyTypes = Civi::settings()->get('do_not_notify_assignees_for');
+      if (!in_array($activity->activity_type_id, $doNotNotifyTypes)) {
+        $mailToContacts = [];
+        $assigneeContactDetails = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames([$activity->id], TRUE, FALSE);
+        foreach ($notifyAssigneeContactIds as $contactId) {
+          $email = $assigneeContactDetails[$contactId]['email'] ?? NULL;
+          if ($email) {
+            $mailToContacts[$email] = $assigneeContactDetails[$contactId];
+          }
+        }
+        // If this fails, no way to notify the user.
+        if ($mailToContacts) {
+          CRM_Activity_BAO_Activity::sendToAssignee($activity, $mailToContacts);
+        }
+      }
+    }
   }
 
   /**

--- a/CRM/Activity/BAO/Activity.php
+++ b/CRM/Activity/BAO/Activity.php
@@ -306,7 +306,7 @@ class CRM_Activity_BAO_Activity extends CRM_Activity_DAO_Activity {
     }
     if ($action == 'edit') {
       // Only notify newly added assignee contact ids.
-      $previousAssigneeContactIds = \Civi\Api4\Activity::get(TRUE)
+      $previousAssigneeContactIds = \Civi\Api4\Activity::get(FALSE)
         ->addWhere('id', '=', $params['id'])
         ->addSelect('assignee_contact_id')
         ->execute()->first()['assignee_contact_id'] ?? [];

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1031,7 +1031,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       // Assignee contacts are only notified if added on submission. We don't
       // want to re-notify contacts previously added if we are updating an
       // activity.
-      $previousAssigneeContacts = \Civi\Api4\Activity::get(TRUE)
+      $previousAssigneeContacts = \Civi\Api4\Activity::get(FALSE)
         ->addWhere('id', '=', $this->_activityId)
         ->addSelect('assignee_contact_id')
         ->execute()->first()['assignee_contact_id'] ?? [];
@@ -1105,7 +1105,7 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       if ($followupActivity) {
         if (!in_array($followUpActivity->activity_type_id, $doNotNotifyActivityIds)) {
           // These are always going to be new activities so we always notify.
-          $assignees = \Civi\Api4\Activity::get(TRUE)
+          $assignees = \Civi\Api4\Activity::get(FALSE)
             ->addWhere('id', '=', $followupActivity->id)
             ->addSelect('assignee_contact_id')
             ->execute()->first()['assignee_contact_id'] ?? [];

--- a/CRM/Activity/Form/Activity.php
+++ b/CRM/Activity/Form/Activity.php
@@ -1022,18 +1022,20 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
    * @throws \CRM_Core_Exception
    */
   protected function processActivity(&$params) {
-    $activityAssigned = [];
-    $activityContacts = CRM_Activity_BAO_ActivityContact::buildOptions('record_type_id', 'validate');
-    $assigneeID = CRM_Utils_Array::key('Activity Assignees', $activityContacts);
-    // format assignee params
-    if (!CRM_Utils_Array::crmIsEmptyArray($params['assignee_contact_id'])) {
-      //skip those assignee contacts which are already assigned
-      //while sending a copy.CRM-4509.
-      $activityAssigned = array_flip($params['assignee_contact_id']);
-      if ($this->_activityId) {
-        $assigneeContacts = CRM_Activity_BAO_ActivityContact::getNames($this->_activityId, $assigneeID);
-        $activityAssigned = array_diff_key($activityAssigned, $assigneeContacts);
-      }
+    $newAssigneeContacts = $params['assignee_contact_id'] ?? [];
+    if ($this->_activityId) {
+      // Keep track of assignees that will be notified.
+      //
+      // We don't notify in the form layer. We only track who will be notified
+      // in the BAO layer so we can set the user status message accordingly.
+      // Assignee contacts are only notified if added on submission. We don't
+      // want to re-notify contacts previously added if we are updating an
+      // activity.
+      $previousAssigneeContacts = \Civi\Api4\Activity::get(TRUE)
+        ->addWhere('id', '=', $this->_activityId)
+        ->addSelect('assignee_contact_id')
+        ->execute()->first()['assignee_contact_id'] ?? [];
+      $newAssigneeContacts = array_diff($newAssigneeContacts, $previousAssigneeContacts);
     }
 
     // call begin post process. Idea is to let injecting file do
@@ -1080,46 +1082,43 @@ class CRM_Activity_Form_Activity extends CRM_Contact_Form_Task {
       $followupStatus = ts('A followup activity has been scheduled.');
     }
 
-    // send copy to assignee contacts.CRM-4509
+    // The BAO layer notifies assigned contacts for this activity and
+    // any follow up activites created. The form layer just keeps track
+    // of whether or not someone should have been notified and lets the
+    // user know via the $mailStatus variable.
     $mailStatus = '';
-
-    if (Civi::settings()->get('activity_assignee_notification')
-      && !in_array($activity->activity_type_id, Civi::settings()
-        ->get('do_not_notify_assignees_for'))) {
-      $activityIDs = [$activity->id];
-      if ($followupActivity) {
-        $activityIDs = array_merge($activityIDs, [$followupActivity->id]);
-      }
-      $assigneeContacts = CRM_Activity_BAO_ActivityAssignment::getAssigneeNames($activityIDs, TRUE, FALSE);
-
-      if (!CRM_Utils_Array::crmIsEmptyArray($params['assignee_contact_id'])) {
-        $mailToContacts = [];
-
-        // Build an associative array with unique email addresses.
-        foreach ($activityAssigned as $id => $dnc) {
-          if (isset($id) && array_key_exists($id, $assigneeContacts)) {
-            $mailToContacts[$assigneeContacts[$id]['email']] = $assigneeContacts[$id];
+    if (Civi::settings()->get('activity_assignee_notification')) {
+      $doNotNotifyActivityIds = Civi::settings()->get('do_not_notify_assignees_for');
+      if (!in_array($activity->activity_type_id, $doNotNotifyActivityIds)) {
+        foreach ($newAssigneeContacts as $contactId) {
+          $email = \Civi\Api4\Email::get(FALSE)
+            ->addWhere('contact_id', '=', $contactId)
+            ->addWhere('is_primary', '=', TRUE)
+            ->execute()->first()['email'] ?? NULL;
+          if ($email) {
+            $mailStatus .= ts("A copy of the activity has also been sent to assignee contact(s).");
+            break;
           }
         }
-
-        $sent = CRM_Activity_BAO_Activity::sendToAssignee($activity, $mailToContacts);
-        if ($sent) {
-          $mailStatus .= ts("A copy of the activity has also been sent to assignee contacts(s).");
-        }
       }
-
-      // Also send email to follow-up activity assignees if set
+      // Also notify user if follow-up activity assignees should have received an email.
       if ($followupActivity) {
-        $mailToFollowupContacts = [];
-        foreach ($assigneeContacts as $values) {
-          if ($values['activity_id'] == $followupActivity->id) {
-            $mailToFollowupContacts[$values['email']] = $values;
+        if (!in_array($followUpActivity->activity_type_id, $doNotNotifyActivityIds)) {
+          // These are always going to be new activities so we always notify.
+          $assignees = \Civi\Api4\Activity::get(TRUE)
+            ->addWhere('id', '=', $followupActivity->id)
+            ->addSelect('assignee_contact_id')
+            ->execute()->first()['assignee_contact_id'] ?? [];
+          foreach ($assignees as $contactId) {
+            $email = \Civi\Api4\Email::get(FALSE)
+              ->addWhere('contact_id', '=', $contactId)
+              ->addWhere('is_primary', '=', TRUE)
+              ->execute()->first()['email'] ?? NULL;
+            if ($email) {
+              $mailStatus .= '<br />' . ts("A copy of the follow-up activity has also been sent to follow-up assignee contact(s).");
+              break;
+            }
           }
-        }
-
-        $sentFollowup = CRM_Activity_BAO_Activity::sendToAssignee($followupActivity, $mailToFollowupContacts);
-        if ($sentFollowup) {
-          $mailStatus .= '<br />' . ts("A copy of the follow-up activity has also been sent to follow-up assignee contacts(s).");
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
First step in fixing https://lab.civicrm.org/dev/core/-/work_items/6509 by moving the activity assignment notification code out of the form layer and into the BAO layer. 

Before
----------------------------------------

The form layer handled notification when an activity is assigned to a contact.

After
----------------------------------------

This has been moved to the BAO layer. 

Comments
----------------------------------------

This does not change how activity creation works. It maintains notification to assigned contacts when an activity is created via the form layer and it does not notify assigned contacts when they are created via imports, form builder or the API. The idea is that a future commit would introduce notifications just in form builder.