### PR TITLE
(dev/core#6471) Standalone - Hook for external credentials should see full credentials

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -74,6 +74,18 @@ class Login extends AbstractAction {
   protected ?string $originalUrl = NULL;
 
   public function _run(Result $result) {
+    try {
+      return $this->_runReal($result);
+    }
+    catch (\Civi\Standalone\LoginException $e) {
+      Civi::log()->warning($e->getMessage(), $e->getErrorData());
+      $event = new LoginEvent('login_exception', $e->userID);
+      Civi::dispatcher()->dispatch('civi.standalone.login', $event);
+      $result['publicError'] = $e->publicError;
+    }
+  }
+
+  public function _runReal(Result $result) {
     if (empty($this->mfaClass)) {
       // Initial call with username, password.
       return $this->passwordCheck($result);

--- a/ext/standaloneusers/Civi/Api4/Action/User/Login.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/Login.php
@@ -189,7 +189,11 @@ class Login extends AbstractAction {
     }
 
     // Check for matching user
-    $user = Civi::service('standaloneusers.security')->loadUser($this->identifier);
+    $cred = [
+      'username' => $this->identifier,
+      'password' => $this->password,
+    ];
+    $user = Civi::service('standaloneusers.security')->loadUser($cred);
 
     // Allow flood control (etc.) by extensions.
     $event = new LoginEvent('pre_credentials_check', $user['id'] ?? NULL);
@@ -211,7 +215,8 @@ class Login extends AbstractAction {
       return;
     }
 
-    $userID = \Civi::service('standaloneusers.security')->checkPassword($user, $this->password);
+    $userID = \Civi::service('standaloneusers.security')->checkPassword($cred, $user) ? $user['id'] : NULL;
+
     if (!$userID) {
       // Allow monitoring of failed attempts.
       $event = new LoginEvent('post_credentials_check', $user['id'], 'wrongUserPassword');

--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -18,8 +18,12 @@ class Standalone implements AuthxInterface {
    */
   public function checkPassword(string $username, string $password) {
     $security = \Civi::service('standaloneusers.security');
-    $user = $security->loadUser($username);
-    return $security->checkPassword($user, $password);
+    $cred = [
+      'username' => $username,
+      'password' => $password,
+    ];
+    $user = $security->loadUser($cred);
+    return $user && $security->checkPassword($cred, $user) ? $user['id'] : NULL;
   }
 
   /**

--- a/ext/standaloneusers/Civi/Standalone/LoginException.php
+++ b/ext/standaloneusers/Civi/Standalone/LoginException.php
@@ -1,0 +1,21 @@
+<?php
+namespace Civi\Standalone;
+
+/**
+ * User visible exception when handling standalone's login.
+ *
+ * Messages should be printable.
+ */
+class LoginException extends \CRM_Core_Exception {
+
+  public readonly string $publicError;
+
+  public readonly mixed $userID;
+
+  public function __construct(string $publicError, mixed $userID = NULL, $message = NULL, $error_code = 0, $errorData = [], $previous = NULL) {
+    $this->publicError = $publicError;
+    $this->userID = $userID;
+    parent::__construct($message ?? $publicError, $error_code, $errorData, $previous);
+  }
+
+}

--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -113,53 +113,54 @@ class Security extends Civi\Core\Service\AutoService implements EventSubscriberI
   /**
    * Standaloneusers implementation of AuthxInterface::checkPassword
    *
+   * @param array{user: string, password: string} $cred
+   *   The submitted credential
    * @param array|NULL|FALSE $user
    *   APIv4-style user-record
-   * @param string $plaintextPassword
    * @return int|NULL
    *   The User id, if check was successful, otherwise NULL
    * @see \Civi\Authx\Standalone
    */
-  public function checkPassword($user, string $plaintextPassword): ?int {
-    if (!$user) {
-      return NULL;
-    }
+  public function checkPassword(array $cred, array $user): bool {
     if (!is_array($user)) {
       throw new \LogicException("Security::checkPassword() expects user as array. Received type: " . gettype($user));
     }
     $success = NULL;
     Civi::dispatcher()->dispatch('civi.standalone.checkPassword', Civi\Core\Event\GenericHookEvent::create([
+      'cred' => $cred,
       'user' => $user,
-      'password' => $plaintextPassword,
       'success' => &$success,
     ]));
-    return $success ? $user['id'] : NULL;
+    // return $success ? $user['id'] : NULL;
+    return $success ?: FALSE;
   }
 
-  public function onCheckPassword(array $user, string $password, ?bool &$success): void {
-    if ($success === NULL && !empty($user['hashed_password']) && $this->checkHashedPassword($password, $user['hashed_password'])) {
+  public function onCheckPassword(array $cred, array $user, ?bool &$success): void {
+    if ($success === NULL && !empty($user['hashed_password']) && $this->checkHashedPassword($cred['password'], $user['hashed_password'])) {
       $success = TRUE;
     }
   }
 
   /**
-   * @param string $identifier
+   * @param array{username: string, password: string|null} $cred
+   *   The submitted credentials for the intended user.
+   *   Note: In loadUser() for standard user-accounts, the "password" property is not used.
+   *   However, when connecting to some distributed user-databases (e.g. LDAP without
+   *   a service-account), the password may help to locate the user's own metadata.
    * @return array|null
-   * @throws \CRM_Core_Exception
-   * @throws \Civi\API\Exception\UnauthorizedException
    */
-  public function loadUser(string $identifier): ?array {
+  public function loadUser(array $cred): ?array {
     $user = NULL;
     Civi::dispatcher()->dispatch('civi.standalone.loadUser', Civi\Core\Event\GenericHookEvent::create([
-      'identifier' => $identifier,
+      'cred' => $cred,
       'user' => &$user,
     ]));
     return $user;
   }
 
-  public function onLoadUser(string $identifier, ?array &$user): void {
+  public function onLoadUser(array $cred, ?array &$user): void {
     $user = \Civi\Api4\User::get(FALSE)
-      ->addWhere('username', '=', $identifier)
+      ->addWhere('username', '=', $cred['username'])
       ->addWhere('is_active', '=', TRUE)
       ->execute()->first();
 
@@ -168,7 +169,7 @@ class Security extends Civi\Core\Service\AutoService implements EventSubscriberI
     if (!$user) {
       // Since the identifier did not match a username, try an email.
       $user = \Civi\Api4\User::get(FALSE)
-        ->addWhere('uf_name', '=', $identifier)
+        ->addWhere('uf_name', '=', $cred['username'])
         ->addWhere('is_active', '=', TRUE)
         ->execute()->first();
     }

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -76,8 +76,8 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
       ->execute()->single();
 
     // Test that the password can be checked ok.
-    $this->assertTrue((bool) $security->checkPassword($user, 'secret1'));
-    $this->assertFalse((bool) $security->checkPassword($user, 'some other password'));
+    $this->assertTrue($security->checkPassword(['password' => 'secret1'], $user));
+    $this->assertFalse($security->checkPassword(['password' => 'some other password'], $user));
   }
 
   public function testPerms() {
@@ -210,7 +210,7 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
 
     $this->assertEquals(1, $result['success']);
     $user = User::get(FALSE)->addWhere('id', '=', $userID)->execute()->single();
-    $this->assertTrue((bool) $security->checkPassword($user, 'fingersCrossed'));
+    $this->assertTrue($security->checkPassword(['password' => 'fingersCrossed'], $user));
 
     // Should not work a 2nd time with same token.
     try {

--- a/tests/extensions/extuser-test/Civi/ExtuserTest/ExtuserSync.php
+++ b/tests/extensions/extuser-test/Civi/ExtuserTest/ExtuserSync.php
@@ -22,23 +22,31 @@ class ExtuserSync extends AutoService implements EventSubscriberInterface {
     ];
   }
 
-  public function onLoadUser(string $identifier, ?array &$user): void {
-    $row = \Civi::service('extuser_list')->get($identifier);
+  public function onLoadUser(array $cred, ?array &$user): void {
+    $row = \Civi::service('extuser_list')->get($cred['username']);
     if (!$row) {
       return;
     }
 
     if (!$user) {
-      $user = $this->createUser($identifier, $row);
+      $user = $this->createUser($cred['username'], $row);
     }
     elseif ($user && strtotime($user['when_updated']) < strtotime($row['timestamp'])) {
-      $user = $this->updateUser($user, $identifier, $row);
+      $user = $this->updateUser($user, $cred['username'], $row);
+    }
+
+    // This next assertion is NOT required from a general authentication POV.
+    // Most implementations of onLoadUser should ignore the $password.
+    // However, for purposes of E2E testing of the 'civi.standalone.loadUser' contract,
+    // we want to verify that $password is passed through.
+    if (empty($cred['password'])) {
+      throw new \LogicException("civi.standalone.loadUser should provide access to the submitted password.");
     }
   }
 
-  public function onCheckPassword(array $user, string $password, ?bool &$success): void {
+  public function onCheckPassword(array $cred, array $user, ?bool &$success): void {
     if ($row = \Civi::service('extuser_list')->get($user['username'])) {
-      $success = hash_equals($row['sketch'], hash('sha256', $password));
+      $success = hash_equals($row['sketch'], hash('sha256', $cred['password']));
     }
   }
 

--- a/tests/extensions/extuser-test/tests/phpunit/Civi/ExtuserTest/ExtUserTest.php
+++ b/tests/extensions/extuser-test/tests/phpunit/Civi/ExtuserTest/ExtUserTest.php
@@ -75,7 +75,7 @@ class ExtUserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterfa
    */
   private function createExternalStaffUser() {
     $username = 'exttest_' . \CRM_Utils_String::createRandom(8, CRM_Utils_String::ALPHANUMERIC);
-    $secret = \CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
+    $secret = 'exttest_' . \CRM_Utils_String::createRandom(16, CRM_Utils_String::ALPHANUMERIC);
 
     $userdb = \Civi::service('extuser_list');
     $userdb->save([


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #35561 from 6.15.alpha, which introduced new events for testing external credentials. This updates the events in 6.15.beta to address some edge-cases in testing with https://lab.civicrm.org/extensions/ldap. Specifically, it ensures that the submitted credentials (*username/password*) are available to both events (with a consistent data-format).

Note: Merging this into 6.15.beta will keep the event-definition cohesive (*i.e. all published versions of CiviCRM will have the same events*). However, since the hook is very new and publicly unused, it would be OK to shift forward to 6.16.alpha or or 6.16.beta.

Before
--------

The existing event signatures are:

* `civi.standalone.loadUser(string $identifier, array &$user)`
* `civi.standalone.checkPassword(array $user, string $password, bool &$success)`

After
-----

The events receive `$cred`, which is the submitted/proposed user credential (`array{username: string, password: string}`). The new event signatures:

* `civi.standalone.loadUser(array $cred, array &$user)`
* `civi.standalone.checkPassword(array $cred, array $user, string $password, bool &$success)`

Technical Details
----------------------------------------

There are two general arguments for this:

1. Aesthetically, the new signatures are more consistent. You get the same information for both events. It's easier to iterate on that (providing more information in the future, if needed).
2. Functionally, it allows us to address another sub-protocol for LDAP authentication. I'll describe the scenario in case it comes up for posterity. (But I don't think it's too important for folks here to deal with it right now.)

    When you are given a username and password, you need to read the user and test the password. In the LDAP world, there are different sub-protocols for this. You can see this in (e.g.) Drupal and Joomla LDAP integrations, which both support all of the following sub-protocols. Each protocol has pro/con, but we don't need to go through that. It's enough to say that these are common for LDAP products. The sub-protocols include:

    * (A) Connect to LDAP as a "service-user" (e.g. "CiviCRM application-user"). Search for `uid={$username}` and read the user-record. Once you have the user-record, then test the password.
    * (B) Connect to LDAP as an anonymous user. Search for `uid={$username}` and read the user-record. Once you have the user-record, then test the password.
    * (C) Make an educated guess about the full user ID (e.g. `cn={$username},ou=People,dc=example,dc=com`). Connect to LDAP as the target-user, then read the user-record.

    The existing events works for (A)+(B) but not (C). For (C), we need to have the full credential (username/password) at the moment when we load the user-record.