### PR TITLE
dev/core#6505 change preimum intro text to be purify rather than esca…

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/PremiumBlock.tpl
@@ -16,7 +16,7 @@
       {/if}
       {if $premiumBlock.premiums_intro_text}
         <div id="premiums-intro" class="crm-section premiums_intro-section">
-          {$premiumBlock.premiums_intro_text|escape}
+          {$premiumBlock.premiums_intro_text|purify}
         </div>
       {/if}
     {/if}


### PR DESCRIPTION
…pe as the field supports having HTML tags in it

Overview
----------------------------------------
Seems like it broke in this commit https://github.com/seamuslee001/civicrm-core/commit/817830b2fb231a5bd5e1a6746d253391afdaca7a#diff-6b993747c85ceec4b537726331c934f4aeac58a54152f850dab5aec2942a1009R19

Before
----------------------------------------
We escape the field but the field may contain HTML as per the description

After
----------------------------------------
We purify the field to make the HTML valid

@eileenmcnaughton @colemanw @aydun 
