### PR TITLE
SearchKit - Fix generating function names

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -215,8 +215,7 @@
       function makeAlias() {
         const args = ctrl.args
           .filter(arg => arg.value && (arg.type === 'field' || arg.type === 'number' || arg.type === 'string'))
-          .map(arg => arg.type === 'string' ? safeStringAlias(arg.value) : arg.value)
-          .map(arg => arg.value);
+          .map(arg => arg.type === 'string' ? safeStringAlias(arg.value) : arg.value);
         return (ctrl.fnName + '_' + args.join('_')).replace(/[.:]/g, '_');
       }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#6518

This regressed with https://github.com/civicrm/civicrm-core/pull/35020

Before
----------------------------------------
Sql error when using functions in searchKit.


FYI @braders 