### PR TITLE
AdminUI: Restore the Delete button in the Case Summary screen

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Cases.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Cases.mgd.php
@@ -212,6 +212,26 @@ return [
                   'task' => '',
                   'conditions' => [],
                 ],
+                [
+                  'task' => 'delete',
+                  'entity' => 'Case',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-trash',
+                  'text' => E::ts('Delete'),
+                  'style' => 'danger',
+                  'path' => '',
+                  'action' => '',
+                  'conditions' => [
+                    [
+                      'check user permission',
+                      '=',
+                      [
+                        'delete in CiviCase',
+                      ],
+                    ],
+                  ],
+                ],
               ],
               'type' => 'links',
               'alignment' => 'text-right',


### PR DESCRIPTION
Overview
----------------------------------------
The non-AdminUI version has a delete option.  Add this to the AdminUI version

Before
----------------------------------------
Go to a Contact
View the Cases tab
Each case has a 'Manage' link, but not 'Delete'

After
----------------------------------------
Has a Delete link if the user has appropriate permissions.

Technical Details
----------------------------------------

Comments
----------------------------------------
The non-AdminUI version also has a 'Move to another client' option ... for another day!
