### PR TITLE
WIP SearchKit Add Email SearchKit display

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/Job/SendSKReports.php
+++ b/ext/search_kit/Civi/Api4/Action/Job/SendSKReports.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Civi\Api4\Action\Job;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use Civi\Api4\SavedSearch;
+use Civi\Api4\SearchDisplay;
+use Civi\Search\EmailSearchDisplays;
+
+class SendSKReports extends AbstractAction {
+
+  /**
+   * Run Job in nonProductionEnvironment
+   * @var bool
+   */
+  protected $runInNonProductionEnvironment = FALSE;
+
+  /**
+   * Language
+   * @var string
+   */
+  protected $language = NULL;
+
+  public function _run(Result $result) {
+    $displays = EmailSearchDisplays::findDisplaysDue();
+    foreach ($displays as $id => $display) {
+      self::sendEmailReport($display);
+      $display['next_run'] = EmailSearchDisplays::calculateNextRunDate($display);
+      SearchDisplay::update(FALSE)
+        ->addValue('settings', $display)
+        ->addWhere('id', '=', $id)
+        ->execute();
+      $result[] = $id;
+    }
+  }
+
+  private static function sendEmailReport($display) {
+    $contactIDs = $display['contactIds'];
+    $savedSearch = SavedSearch::get(FALSE)
+      ->addWhere('id', '=', $display['savedSearch'])
+      ->execute()
+      ->first();
+    SearchDisplay::emailReport(FALSE)
+      ->setContactID(implode(',', $contactIDs))
+      ->setTemplateID($display['messageTemplateId'][0])
+      ->setSubject($display['subject'])
+      ->setFileName($display['fileName'])
+      ->setReportName($display['reportName'])
+      ->setDisplay($display['searchDisplay'])
+      ->setSavedSearch($savedSearch['name'])
+      ->setFormat('pdf')
+      ->execute();
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/Action/Job/SendSKReports.php
+++ b/ext/search_kit/Civi/Api4/Action/Job/SendSKReports.php
@@ -35,13 +35,14 @@ class SendSKReports extends AbstractAction {
     }
   }
 
-  private static function sendEmailReport($display) {
+  private static function sendEmailReport(array $display) {
     $contactIDs = $display['contactIds'];
     $savedSearch = SavedSearch::get(FALSE)
       ->addWhere('id', '=', $display['savedSearch'])
       ->execute()
       ->first();
     SearchDisplay::emailReport(FALSE)
+      ->setFilters($display['filters'])
       ->setContactID(implode(',', $contactIDs))
       ->setTemplateID($display['messageTemplateId'][0])
       ->setSubject($display['subject'])

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -13,6 +13,7 @@ namespace Civi\Search;
 
 use Civi\Api4\Action\SearchDisplay\AbstractRunAction;
 use Civi\Api4\Entity;
+use Civi\Api4\OptionValue;
 use Civi\Api4\Query\SqlEquation;
 use Civi\Api4\Query\SqlFunction;
 use Civi\Api4\SearchDisplay;
@@ -621,6 +622,31 @@ class Admin {
       ->execute()
       ->indexBy('name')
       ->column('title');
+  }
+
+  public static function getEmailReportAdminSettings(): array {
+    // Check minimum permission needed to reach this
+    if (!\CRM_Core_Permission::check('manage own search_kit')) {
+      return [];
+    }
+    return [
+      'frequencies' => self::getFrequencies(),
+    ];
+  }
+
+  private static function getFrequencies(): array {
+    $options = OptionValue::get(FALSE)
+      ->addWhere('option_group_id:name', '=', 'email_report_frequencies')
+      ->execute();
+    $parsedOptions = [];
+    foreach ($options as $option) {
+      $parsedOptions[$option['value']] = $option['label'];
+    }
+    $event = \Civi\Core\Event\GenericHookEvent::create([
+      'emailReportFrequencies' => $parsedOptions,
+    ]);
+    \Civi::dispatcher()->dispatch('civi.search.emailfrequencies', $event);
+    return $event->emailReportFrequencies;
   }
 
 }

--- a/ext/search_kit/Civi/Search/EmailSearchDisplays.php
+++ b/ext/search_kit/Civi/Search/EmailSearchDisplays.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Civi\Search;
+
+use Civi\Api4\SearchDisplay;
+
+class EmailSearchDisplays {
+
+  public static function findDisplaysDue(): array {
+    $displays = [];
+    $emailDisplays = SearchDisplay::get(FALSE)
+      ->addWhere('type:name', '=', 'crm-search-display-email-report')
+      ->execute();
+    foreach ($emailDisplays as $display) {
+      if (!array_key_exists('next_run', $display['settings']) || (!empty($display['settings']['next_run']) && ((int) $display['settings']['next_run']) <= time())) {
+        $displays[$display['id']] = $display['settings'];
+      }
+    }
+    return $displays;
+  }
+
+  /**
+   * @throws \DateMalformedStringException
+   */
+  public static function calculateNextRunDate(array $settings): string {
+    $nextRunDate = '';
+    // Current date/time
+    $now = new \DateTime();
+    if (!empty($settings['frequency']) && $settings['frequency'] === 'custom') {
+      // TODO: add logic for custom
+    }
+    elseif (!empty($settings['frquency']) && $settings['frquency'] === 'first') {
+      $nextRun = new \DateTime('first day of next month 06:00:00');
+      $nextRunDate = $nextRun->getTimestamp();
+    }
+    elseif (!empty($settings['frequency']) && $settings['frequency'] === 'weekly') {
+      $targetWeekday = (int) date('w');
+      $currentWeekday = (int) $now->format('w');
+      $currentHour = (int) $now->format('H');
+
+      // Determine if the run time has passed today
+      $hasPassedToday = ($currentWeekday == $targetWeekday) && ($currentHour >= 6);
+
+      if ($hasPassedToday) {
+        // Next occurrence is next week
+        $nextRun = new \DateTime("next " . date('l', strtotime("+$targetWeekday days")));
+        $nextRun->setTime(6, 0, 0);
+      }
+      else {
+        // Next occurrence is today (if same day) or the upcoming weekday this week
+        if ($currentWeekday == $targetWeekday) {
+          $nextRun = new \DateTime("today 06:00:00");
+        }
+        else {
+          // Calculate days to add to reach the target weekday this week
+          $daysToAdd = ($targetWeekday - $currentWeekday + 7) % 7;
+          $nextRun = new \DateTime("+$daysToAdd days 06:00:00");
+        }
+      }
+      $nextRunDate = $nextRun->getTimestamp();
+    }
+    elseif (!empty($settings['frequency']) && $settings['frequency'] === 'daily') {
+      $nextRun = new \DateTime('today 06:00:00');
+
+      // If 06:00 has already passed today, schedule for tomorrow
+      if ($now->format('H') >= 6) {
+        $nextRun->modify('+1 day');
+      }
+      $nextRunDate = $nextRun->getTimestamp();
+    }
+    elseif (!empty($settings['frequency']) && $settings['frequency'] === 'monthly') {
+      // Simulate the dynamic cron: '0 6 ' . date('j') . ' * *'
+      $targetDay = (int) date('j');
+      $hour = 6;
+      $minute = 0;
+
+      // Start with the target day in the CURRENT month
+      $nextRun = new \DateTime();
+      $nextRun->setDate((int) $now->format('Y'), (int) $now->format('n'), $targetDay);
+      $nextRun->setTime($hour, $minute, 0);
+
+      // If the target time has passed this month, jump to next month
+      // We compare timestamps to handle cases where current day == target day but hour is past
+      if ($now->getTimestamp() >= $nextRun->getTimestamp()) {
+        $nextRun->modify('first day of next month');
+        $nextRun->setDate((int) $nextRun->format('Y'), (int) $nextRun->format('n'), $targetDay);
+
+        // Edge case: If target day is 31 and next month has 30 days,
+        // DateTime will overflow to the next month (e.g., March 3).
+        // To strictly stay on the last day of short months, you might need extra checks,
+        // but standard cron usually skips invalid dates or runs on the last day depending on implementation.
+        // For simple "same day number" logic, this overflow is often acceptable or handled by re-checking the day.
+        if ((int) $nextRun->format('j') !== $targetDay) {
+          // If overflow happened (e.g. asked for 31st in April), force to last day of month or skip?
+          // Standard cron behavior for '31' is to SKIP months with <31 days.
+          // To mimic "skip", we ensure we are on the correct day.
+          // If strict "skip" is needed:
+          // Skip this short month entirely
+          $nextRun->modify('first day of next month');
+          $nextRun->setDate((int) $nextRun->format('Y'), (int) $nextRun->format('n'), $targetDay);
+        }
+      }
+
+      $nextRunDate = $nextRun->getTimestamp();
+    }
+    return $nextRunDate;
+  }
+
+}

--- a/ext/search_kit/Civi/Search/EmailSearchDisplays.php
+++ b/ext/search_kit/Civi/Search/EmailSearchDisplays.php
@@ -11,9 +11,15 @@ class EmailSearchDisplays {
     $emailDisplays = SearchDisplay::get(FALSE)
       ->addWhere('type:name', '=', 'crm-search-display-email-report')
       ->execute();
+    $now = time();
     foreach ($emailDisplays as $display) {
-      if (!array_key_exists('next_run', $display['settings']) || (!empty($display['settings']['next_run']) && ((int) $display['settings']['next_run']) <= time())) {
-        $displays[$display['id']] = $display['settings'];
+      $settings = $display['settings'];
+      // Use next_run if set, otherwise treat startDate as the first scheduled run
+      $dueAt = !empty($settings['next_run'])
+        ? (int) $settings['next_run']
+        : (!empty($settings['startDate']) ? strtotime($settings['startDate']) : NULL);
+      if ($dueAt !== NULL && $dueAt <= $now) {
+        $displays[$display['id']] = $settings;
       }
     }
     return $displays;
@@ -22,88 +28,192 @@ class EmailSearchDisplays {
   /**
    * @throws \DateMalformedStringException
    */
-  public static function calculateNextRunDate(array $settings): string {
-    $nextRunDate = '';
-    // Current date/time
+  public static function calculateNextRunDate(array $settings): int|string {
+    if (empty($settings['startDate'])) {
+      return '';
+    }
+
+    $startDate = new \DateTime($settings['startDate']);
     $now = new \DateTime();
-    if (!empty($settings['frequency']) && $settings['frequency'] === 'custom') {
-      // TODO: add logic for custom
-    }
-    elseif (!empty($settings['frquency']) && $settings['frquency'] === 'first') {
-      $nextRun = new \DateTime('first day of next month 06:00:00');
-      $nextRunDate = $nextRun->getTimestamp();
-    }
-    elseif (!empty($settings['frequency']) && $settings['frequency'] === 'weekly') {
-      $targetWeekday = (int) date('w');
-      $currentWeekday = (int) $now->format('w');
-      $currentHour = (int) $now->format('H');
 
-      // Determine if the run time has passed today
-      $hasPassedToday = ($currentWeekday == $targetWeekday) && ($currentHour >= 6);
+    // If startDate hasn't happened yet, that's the next run regardless of frequency
+    if ($startDate > $now) {
+      return $startDate->getTimestamp();
+    }
 
-      if ($hasPassedToday) {
-        // Next occurrence is next week
-        $nextRun = new \DateTime("next " . date('l', strtotime("+$targetWeekday days")));
-        $nextRun->setTime(6, 0, 0);
+    $frequency = $settings['frequency'] ?? '';
+
+    // Pull the time-of-day off startDate for reuse
+    $h = (int) $startDate->format('H');
+    $m = (int) $startDate->format('i');
+    $s = (int) $startDate->format('s');
+
+    switch ($frequency) {
+      case 'daily':
+        $nextRun = (clone $now)->setTime($h, $m, $s);
+        if ($nextRun <= $now) {
+          $nextRun->modify('+1 day');
+        }
+        return $nextRun->getTimestamp();
+
+      case 'weekly':
+        // Match startDate's weekday + time
+        $targetWeekday = (int) $startDate->format('w');
+        $currentWeekday = (int) $now->format('w');
+        $daysToAdd = ($targetWeekday - $currentWeekday + 7) % 7;
+        $nextRun = (clone $now)->modify("+$daysToAdd days")->setTime($h, $m, $s);
+        if ($nextRun <= $now) {
+          $nextRun->modify('+1 week');
+        }
+        return $nextRun->getTimestamp();
+
+      case 'monthly':
+        // Match startDate's day-of-month + time, clamping for short months
+        $targetDay = (int) $startDate->format('j');
+        $nextRun = clone $now;
+        $daysInMonth = (int) $nextRun->format('t');
+        $nextRun->setDate(
+          (int) $now->format('Y'),
+          (int) $now->format('n'),
+          min($targetDay, $daysInMonth)
+        );
+        $nextRun->setTime($h, $m, $s);
+        if ($nextRun <= $now) {
+          $nextRun->modify('first day of next month');
+          $daysInMonth = (int) $nextRun->format('t');
+          $nextRun->setDate(
+            (int) $nextRun->format('Y'),
+            (int) $nextRun->format('n'),
+            min($targetDay, $daysInMonth)
+          );
+          $nextRun->setTime($h, $m, $s);
+        }
+        return $nextRun->getTimestamp();
+
+      case 'first':
+        // 1st of next month at startDate's time
+        $nextRun = new \DateTime('first day of next month');
+        $nextRun->setTime($h, $m, $s);
+        return $nextRun->getTimestamp();
+
+      case 'custom':
+        if (empty($settings['frequency_custom'])) {
+          return '';
+        }
+        try {
+          $next = self::nextCronMatch($settings['frequency_custom'], $now);
+          return $next->getTimestamp();
+        }
+        catch (\Throwable $e) {
+          \Civi::log()->warning('Invalid cron expression on email report: ' . $e->getMessage());
+          return '';
+        }
+
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * Parse one cron field (e.g. "*", "0,30", "9-17", '*\/15", "1-5") into the
+   * list of integers it matches within [$min, $max].
+   */
+  private static function parseCronField(string $field, int $min, int $max): array {
+    $values = [];
+    foreach (explode(',', $field) as $part) {
+      $step = 1;
+      if (str_contains($part, '/')) {
+        [$range, $stepStr] = explode('/', $part, 2);
+        $step = max(1, (int) $stepStr);
       }
       else {
-        // Next occurrence is today (if same day) or the upcoming weekday this week
-        if ($currentWeekday == $targetWeekday) {
-          $nextRun = new \DateTime("today 06:00:00");
-        }
-        else {
-          // Calculate days to add to reach the target weekday this week
-          $daysToAdd = ($targetWeekday - $currentWeekday + 7) % 7;
-          $nextRun = new \DateTime("+$daysToAdd days 06:00:00");
-        }
+        $range = $part;
       }
-      $nextRunDate = $nextRun->getTimestamp();
-    }
-    elseif (!empty($settings['frequency']) && $settings['frequency'] === 'daily') {
-      $nextRun = new \DateTime('today 06:00:00');
-
-      // If 06:00 has already passed today, schedule for tomorrow
-      if ($now->format('H') >= 6) {
-        $nextRun->modify('+1 day');
+      if ($range === '*') {
+        $start = $min;
+        $end = $max;
       }
-      $nextRunDate = $nextRun->getTimestamp();
-    }
-    elseif (!empty($settings['frequency']) && $settings['frequency'] === 'monthly') {
-      // Simulate the dynamic cron: '0 6 ' . date('j') . ' * *'
-      $targetDay = (int) date('j');
-      $hour = 6;
-      $minute = 0;
-
-      // Start with the target day in the CURRENT month
-      $nextRun = new \DateTime();
-      $nextRun->setDate((int) $now->format('Y'), (int) $now->format('n'), $targetDay);
-      $nextRun->setTime($hour, $minute, 0);
-
-      // If the target time has passed this month, jump to next month
-      // We compare timestamps to handle cases where current day == target day but hour is past
-      if ($now->getTimestamp() >= $nextRun->getTimestamp()) {
-        $nextRun->modify('first day of next month');
-        $nextRun->setDate((int) $nextRun->format('Y'), (int) $nextRun->format('n'), $targetDay);
-
-        // Edge case: If target day is 31 and next month has 30 days,
-        // DateTime will overflow to the next month (e.g., March 3).
-        // To strictly stay on the last day of short months, you might need extra checks,
-        // but standard cron usually skips invalid dates or runs on the last day depending on implementation.
-        // For simple "same day number" logic, this overflow is often acceptable or handled by re-checking the day.
-        if ((int) $nextRun->format('j') !== $targetDay) {
-          // If overflow happened (e.g. asked for 31st in April), force to last day of month or skip?
-          // Standard cron behavior for '31' is to SKIP months with <31 days.
-          // To mimic "skip", we ensure we are on the correct day.
-          // If strict "skip" is needed:
-          // Skip this short month entirely
-          $nextRun->modify('first day of next month');
-          $nextRun->setDate((int) $nextRun->format('Y'), (int) $nextRun->format('n'), $targetDay);
-        }
+      elseif (str_contains($range, '-')) {
+        [$s, $e] = explode('-', $range, 2);
+        $start = (int) $s;
+        $end = (int) $e;
       }
-
-      $nextRunDate = $nextRun->getTimestamp();
+      else {
+        $start = $end = (int) $range;
+      }
+      if ($start < $min || $end > $max || $start > $end) {
+        throw new \InvalidArgumentException("Cron field out of range: $field");
+      }
+      for ($i = $start; $i <= $end; $i += $step) {
+        $values[] = $i;
+      }
     }
-    return $nextRunDate;
+    return array_values(array_unique($values));
+  }
+
+  /**
+   * Find the next datetime strictly after $after that matches a 5-field
+   * cron expression: "minute hour day-of-month month day-of-week".
+   */
+  private static function nextCronMatch(string $expr, \DateTime $after): \DateTime {
+    $parts = preg_split('/\s+/', trim($expr));
+    if (count($parts) !== 5) {
+      throw new \InvalidArgumentException("Cron expression must have 5 fields: $expr");
+    }
+    $minutes  = self::parseCronField($parts[0], 0, 59);
+    $hours    = self::parseCronField($parts[1], 0, 23);
+    $days     = self::parseCronField($parts[2], 1, 31);
+    $months   = self::parseCronField($parts[3], 1, 12);
+    $weekdays = self::parseCronField($parts[4], 0, 6);
+
+    // Cron's "OR" rule: when both DOM and DOW are restricted, a day matches
+    // if EITHER field matches. When only one is restricted, only that one matters.
+    $domAll = (count($days) === 31);
+    $dowAll = (count($weekdays) === 7);
+
+    // Start at the next whole minute after $after
+    $candidate = clone $after;
+    $candidate->setTime((int) $candidate->format('H'), (int) $candidate->format('i'), 0);
+    $candidate->modify('+1 minute');
+
+    // Safety cap: ~4 years of jump-ahead steps is enough for "Feb 29 only" etc.
+    for ($i = 0; $i < 200000; $i++) {
+      $mon = (int) $candidate->format('n');
+      if (!in_array($mon, $months, TRUE)) {
+        $candidate->modify('first day of next month')->setTime(0, 0, 0);
+        continue;
+      }
+      $dom = (int) $candidate->format('j');
+      $dow = (int) $candidate->format('w');
+      if ($domAll && $dowAll) {
+        $dayOk = TRUE;
+      }
+      elseif ($domAll) {
+        $dayOk = in_array($dow, $weekdays, TRUE);
+      }
+      elseif ($dowAll) {
+        $dayOk = in_array($dom, $days, TRUE);
+      }
+      else {
+        $dayOk = in_array($dom, $days, TRUE) || in_array($dow, $weekdays, TRUE);
+      }
+      if (!$dayOk) {
+        $candidate->modify('+1 day')->setTime(0, 0, 0);
+        continue;
+      }
+      $hour = (int) $candidate->format('G');
+      if (!in_array($hour, $hours, TRUE)) {
+        $candidate->modify('+1 hour')->setTime((int) $candidate->format('G'), 0, 0);
+        continue;
+      }
+      $minute = (int) $candidate->format('i');
+      if (!in_array($minute, $minutes, TRUE)) {
+        $candidate->modify('+1 minute');
+        continue;
+      }
+      return $candidate;
+    }
+    throw new \RuntimeException("No cron match within bounds for: $expr");
   }
 
 }

--- a/ext/search_kit/ang/crmSearchDisplayEmailReport.ang.php
+++ b/ext/search_kit/ang/crmSearchDisplayEmailReport.ang.php
@@ -1,0 +1,19 @@
+<?php
+
+// Angular module crmSearchEmailReport.
+// @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+return [
+  'js' => [
+    'ang/crmSearchDisplayEmailReport.js',
+    'ang/crmSearchDisplayEmailReport/*.js',
+    'ang/crmSearchDisplayEmailReport/*/*.js',
+  ],
+  'partials' => [
+    'ang/crmSearchDisplayEmailReport',
+  ],
+  'requires' => ['crmSearchDisplay', 'crmUi', 'crmSearchTasks', 'ui.bootstrap', 'ui.sortable'],
+  'bundles' => ['bootstrap3'],
+  'exports' => [
+    'crm-search-display-email-report' => 'E',
+  ],
+];

--- a/ext/search_kit/ang/crmSearchDisplayEmailReport.js
+++ b/ext/search_kit/ang/crmSearchDisplayEmailReport.js
@@ -1,0 +1,4 @@
+(function(angular, $, _) {
+  // Declare a list of dependencies.
+  angular.module('crmSearchDisplayEmailReport', CRM.angRequires('crmSearchDisplayEmailReport'));
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport.ang.php
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport.ang.php
@@ -1,0 +1,20 @@
+<?php
+
+// Angular module searchAdminDisplayEmailReport.
+// @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+return [
+  'js' => [
+    'ang/searchAdminDisplayEmailReport.js',
+    'ang/searchAdminDisplayEmailReport/*.js',
+    'ang/searchAdminDisplayEmailReport/*/*.js',
+  ],
+  'partials' => [
+    'ang/searchAdminDisplayEmailReport',
+  ],
+  'requires' => [
+    'crmSearchAdmin',
+    'crmSearchDisplayEmailReport',
+  ],
+  'basePages' => ['civicrm/admin/search'],
+  'settingsFactory' => ['\Civi\Search\Admin', 'getEmailReportAdminSettings'],
+];

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport.js
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport.js
@@ -1,0 +1,4 @@
+(function(angular, $, _) {
+  // Declare a list of dependencies.
+  angular.module('searchAdminDisplayEmailReport', CRM.angRequires('searchAdminDisplayEmailReport'));
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.component.js
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.component.js
@@ -1,0 +1,146 @@
+(function (angular, $, CRM) {
+  "use strict";
+
+  angular.module('searchAdminDisplayEmailReport').component('searchAdminDisplayEmailReport', {
+    bindings: {
+      display: '<',
+      apiEntity: '<',
+      apiParams: '<'
+    },
+    require: {
+      parent: '^crmSearchAdminDisplay',
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html',
+    controller: function ($scope, searchMeta, crmApi4) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+
+      this.getInitialDisplaySettings = () => ({
+        searchDisplay: '',
+        filters: {},
+        toContactIds: '',
+        messageTemplateId: '',
+        frequency: '',
+        subject: '',
+        fileName: '',
+        reportName: '',
+        savedSearch: this.crmSearchAdmin.savedSearch.id,
+        frequency_custom: '',
+      });
+
+      this.searchColumns = [];
+
+      this.$onInit = () => {
+
+
+        this.fieldsForfilter = () => ({
+          results: this.crmSearchAdmin.getAllFields('', ['Field', 'Custom', 'Extra']),
+        });
+
+        this.changeInputMode = () => {
+          if (this.inputMode === 'value') {
+            delete this.filter.parent_field;
+            this.filter.value = null;
+          } else {
+            delete this.filter.value;
+            this.filter.parent_field = null;
+          }
+        };
+
+        if (!this.display.settings) {
+          this.display.settings = this.getInitialDisplaySettings();
+        }
+
+        this.email_report_frequencies = this.getEmailReportFrequencies();
+
+        getSearchDisplays().then((result) => {
+          // If search doesn't exist, it can't be used
+          if (!result.savedSearch) {
+            delete this.column.subsearch.search;
+            delete this.column.subsearch.display;
+          }
+          if (!this.display.settings.savedSearch) {
+            this.display.settings.savedSearch = this.crmSearchAdmin.savedSearch.id;
+          }
+        });
+
+        //this.searchColumns = this.apiParams.select.map((select) => {
+        //  const info = searchMeta.parseExpr(select);
+        //  const field = (_.findWhere(info.args, {type: 'field'}) || {}).field || {};
+        //  let dataType = (info.fn && info.fn.data_type) || field.data_type;
+        //  // hack: search kit reports option group columns as
+          // "Integer" data type - but for our purposes they
+          // shouldn't be used for numeric scales
+        //  if (select.includes(':label')) {
+        //    dataType = 'Option';
+        //  }
+        //  return {
+        //    type: 'field',
+        //    key: info.alias,
+        //    dataType: dataType,
+        //    label: searchMeta.getDefaultLabel(select),
+        //  };
+        //});
+
+      };
+
+      this.getEmailReportFrequencies = () => (
+        CRM.searchAdminDisplayEmailReport.frequencies || {}
+      );
+
+      const getSearchField = (fieldName) => searchMeta.getField(fieldName, this.savedSearch.api_entity);
+
+      const getSearchDisplays = () => {
+        this.searchDisplays = null;
+        const displayTypes = CRM.crmSearchAdmin.displayTypes.map((displayType) => { if (displayType.id != 'email_report') { return displayType.id; }});
+        const apiCalls = crmApi4({
+          searchDisplays: ['SearchDisplay', 'get', {
+            select: ['name', 'label'],
+            where: [
+              ['saved_search_id', '=', this.crmSearchAdmin.savedSearch.id],
+              // Include all viewable display types
+              ['type', 'IN', displayTypes],
+            ],
+          }],
+          savedSearch: ['SavedSearch', 'get', {
+            select: ['label', 'api_entity', 'api_params'],
+            where: [['id', '=', this.crmSearchAdmin.savedSearch.id]],
+          }, 0],
+        });
+        apiCalls.then((result) => {
+          this.searchDisplays = result.searchDisplays;
+          this.savedSearch = result.savedSearch;
+          // Parse fields
+          this.subsearchFields = this.savedSearch.api_params.select.reduce((fields, fieldName) => {
+            const field = getSearchField(fieldName);
+            if (field) {
+              fields.push({
+                id: fieldName.split(':')[0],
+                text: field.label,
+              });
+            }
+            return fields;
+          }, []);
+        });
+        return apiCalls;
+      };
+
+      this.addFilter = (fieldName) => {
+        this.display.settings.filters = this.display.settings.filters || [];
+        this.display.settings.filters.push({
+          field: fieldName,
+          operator: null,
+          value: null,
+        });
+      };
+
+      $scope.fieldsForFilter = () => {
+      console.log(this);
+        return {
+          results: this.crmSearchAdmin.getAllFields('', ['Field', 'Custom', 'Extra']),
+        };
+      };
+    }
+
+  });
+})(angular, CRM.$, CRM);

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.component.js
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.component.js
@@ -15,18 +15,24 @@
     controller: function ($scope, searchMeta, crmApi4) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
 
-      this.getInitialDisplaySettings = () => ({
-        searchDisplay: '',
-        filters: {},
-        toContactIds: '',
-        messageTemplateId: '',
-        frequency: '',
-        subject: '',
-        fileName: '',
-        reportName: '',
-        savedSearch: this.crmSearchAdmin.savedSearch.id,
-        frequency_custom: '',
-      });
+      this.getInitialDisplaySettings = () => {
+        const pad = (n) => String(n).padStart(2, '0');
+        const d = new Date();
+        const startDate = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:00`;
+        return {
+          searchDisplay: '',
+          filters: {},
+          toContactIds: '',
+          messageTemplateId: '',
+          frequency: '',
+          startDate: startDate,
+          subject: '',
+          fileName: '',
+          reportName: '',
+          savedSearch: this.crmSearchAdmin.savedSearch.id,
+          frequency_custom: '',
+        };
+      };
 
       this.searchColumns = [];
 
@@ -63,6 +69,93 @@
             this.display.settings.savedSearch = this.crmSearchAdmin.savedSearch.id;
           }
         });
+
+        // Validates a 5-field cron expression. Returns null if valid, or a human-readable error string.
+        this.validateCron = (expr) => {
+          if (!expr || !expr.trim()) {
+            return ts('Cron expression is required when frequency is "custom".');
+          }
+          const trimmed = expr.trim();
+
+          // --- Explicitly unsupported forms ---
+          if (trimmed.startsWith('@')) {
+            return ts('Shorthand aliases (@yearly, @monthly, @weekly, @daily, @hourly, @reboot) are not supported. Use the standard 5-field format.');
+          }
+          if (/[A-Za-z]/.test(trimmed)) {
+            return ts('Named months (JAN, FEB…) and named weekdays (MON, TUE…) are not supported. Use numbers: months 1–12, weekdays 0 (Sun) – 6 (Sat).');
+          }
+          if (/[LW#]/.test(trimmed)) {
+            return ts('Quartz-style extensions (L, W, #) are not supported.');
+          }
+
+          const parts = trimmed.split(/\s+/);
+          if (parts.length === 6) {
+            return ts('6-field cron expressions (with seconds) are not supported. Use the standard 5-field format: minute hour day-of-month month day-of-week.');
+          }
+          if (parts.length !== 5) {
+            return ts('Cron expression must have exactly 5 fields: minute hour day-of-month month day-of-week.');
+          }
+
+          // --- Per-field syntax + range validation ---
+          const fields = [
+            { name: ts('minute'),       min: 0, max: 59 },
+            { name: ts('hour'),         min: 0, max: 23 },
+            { name: ts('day-of-month'), min: 1, max: 31 },
+            { name: ts('month'),        min: 1, max: 12 },
+            { name: ts('day-of-week'),  min: 0, max: 6  },
+          ];
+          for (let i = 0; i < 5; i++) {
+            const fieldErr = validateCronField(parts[i], fields[i].min, fields[i].max);
+            if (fieldErr) {
+              return ts('Invalid %1 field "%2": %3', { 1: fields[i].name, 2: parts[i], 3: fieldErr });
+            }
+          }
+          return null;
+
+          // Inner helper — closure so it can see `ts`
+          function validateCronField(field, min, max) {
+            for (const part of field.split(',')) {
+              let range = part;
+              let step = 1;
+
+              if (part.includes('/')) {
+                const slashed = part.split('/');
+                if (slashed.length !== 2 || !/^\d+$/.test(slashed[1]) || parseInt(slashed[1], 10) < 1) {
+                  return ts('invalid step value');
+                }
+                step = parseInt(slashed[1], 10);
+                range = slashed[0];
+              }
+
+              let start;
+              let end;
+              if (range === '*') {
+                start = min;
+                end = max;
+              } else if (range.includes('-')) {
+                const dashed = range.split('-');
+                if (dashed.length !== 2 || !/^\d+$/.test(dashed[0]) || !/^\d+$/.test(dashed[1])) {
+                  return ts('malformed range');
+                }
+                start = parseInt(dashed[0], 10);
+                end = parseInt(dashed[1], 10);
+              } else {
+                if (!/^\d+$/.test(range)) {
+                  return ts('not a number');
+                }
+                start = end = parseInt(range, 10);
+              }
+
+              if (start < min || end > max) {
+                return ts('value out of range (must be %1–%2)', { 1: min, 2: max });
+              }
+              if (start > end) {
+                return ts('range start is greater than end');
+              }
+            }
+            return null;
+          }
+        };
 
         //this.searchColumns = this.apiParams.select.map((select) => {
         //  const info = searchMeta.parseExpr(select);

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.component.js
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.component.js
@@ -21,7 +21,7 @@
         const startDate = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:00`;
         return {
           searchDisplay: '',
-          filters: {},
+          filters: [],
           toContactIds: '',
           messageTemplateId: '',
           frequency: '',

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html
@@ -59,15 +59,6 @@
       <tbody>
           <crm-search-clause clauses="$ctrl.display.settings.filters" format="string" op="AND" label="{{:: ts('Filters') }}" fields="fieldsForFilter" allow-functions="$ctrl.paramExists('groupBy')" ></crm-search-clause>
       </tbody>
-      <tfoot>
-        <tr>
-          <td colspan="2">
-            <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
-               crm-ui-select="{data: $ctrl.subsearchFields, placeholder: ts('Add Filter')}"
-               on-crm-ui-select="$ctrl.addFilter(selection)" >
-          </td>
-        </tr>
-      </tfoot>
     </table>
   </fieldset>
 

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html
@@ -28,7 +28,19 @@
   </div>
   <div class="form-inline" ng-if="$ctrl.display.settings.frequency == 'custom'">
     <label>{{:: ts('Custom Report Frequency') }}</label>
-    <input type="text" class="form-control" ng-model="$ctrl.display.settings.frequency_custom">
+    <input type="text"
+           class="form-control"
+           ng-model="$ctrl.display.settings.frequency_custom"
+           ng-change="$ctrl.cronError = $ctrl.validateCron($ctrl.display.settings.frequency_custom)"
+           placeholder="0 6 * * 1">
+  </div>
+  <div class="alert alert-danger" ng-if="$ctrl.display.settings.frequency == 'custom' && $ctrl.cronError">
+    <i class="crm-i fa-exclamation-triangle" aria-hidden="true"></i>
+    {{ $ctrl.cronError }}
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('Start Date') }}</label>
+    <input class="form-control" crm-ui-datepicker="{time: true}" ng-model="$ctrl.display.settings.startDate">
   </div>
   <div class="form-inline">
     <label>{{:: ts('Email Subject') }}</label>

--- a/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html
+++ b/ext/search_kit/ang/searchAdminDisplayEmailReport/searchAdminDisplayEmailReport.html
@@ -1,0 +1,62 @@
+<div ng-include="'~/crmSearchAdmin/crmSearchAdminDisplayHeader.html'"></div>
+
+<div class="crm-search-admin-display-email-report">
+
+  <legend>
+    {{:: ts('Email Settings') }}
+  </legend>
+
+  <div class="form-inline">
+    <label>{{:: ts('Search Display') }}</label>
+    <select class="form-control" ng-model="$ctrl.display.settings.searchDisplay">
+      <option ng-repeat="display in $ctrl.searchDisplays" value="{{:: display.name }}">{{:: display.label }}</option>
+  </select>
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('To Contacts') }}</label>
+    <input placeholder="{{:: ts('To Contacts') }}" class="form-control" crm-autocomplete="'Contact'" crm-autocomplete-params="{key: 'sortName', formName: 'searchAdmin', fieldName: 'toContactIds'}" multi="true" auto-open="true" ng-model="$ctrl.display.settings.contactIds">
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('Message Template') }}</label>
+    <input placeholder="{{:: ts('Message Template') }}" class="form-control" crm-autocomplete="'MessageTemplate'" crm-autocomplete-params="{key: 'title', formName: 'searchAdmin', fieldName: 'messageTemplateId'}" multi="true" auto-open="true" ng-model="$ctrl.display.settings.messageTemplateId">
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('Report Frequency') }}</label>
+    <select class="form-control" ng-model="$ctrl.display.settings.frequency">
+      <option ng-repeat="(key, label) in $ctrl.email_report_frequencies" value="{{:: key}}">{{:: label}}</option>
+    </select>
+  </div>
+  <div class="form-inline" ng-if="$ctrl.display.settings.frequency == 'custom'">
+    <label>{{:: ts('Custom Report Frequency') }}</label>
+    <input type="text" class="form-control" ng-model="$ctrl.display.settings.frequency_custom">
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('Email Subject') }}</label>
+    <input type="text" class="form-control" ng-model="$ctrl.display.settings.subject">
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('Report Name') }}</label>
+    <input type="text" class="form-control" ng-model="$ctrl.display.settings.reportName">
+  </div>
+  <div class="form-inline">
+    <label>{{:: ts('File Name') }}</label>
+    <input type="text" class="form-control" ng-model="$ctrl.display.settings.fileName">
+  </div>
+  <fieldset class="api4-clause-fieldset crm-search-filters">
+    <table class="table table-condensed" ng-if="$ctrl.searchDisplays.length">
+      <tbody>
+          <crm-search-clause clauses="$ctrl.display.settings.filters" format="string" op="AND" label="{{:: ts('Filters') }}" fields="fieldsForFilter" allow-functions="$ctrl.paramExists('groupBy')" ></crm-search-clause>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="2">
+            <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
+               crm-ui-select="{data: $ctrl.subsearchFields, placeholder: ts('Add Filter')}"
+               on-crm-ui-select="$ctrl.addFilter(selection)" >
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </fieldset>
+
+</div>

--- a/ext/search_kit/managed/EmailReportFrequencies.mgd.php
+++ b/ext/search_kit/managed/EmailReportFrequencies.mgd.php
@@ -1,0 +1,129 @@
+<?php
+use CRM_Search_ExtensionUtil as E;
+
+return [
+  [
+    'name' => 'OptionGroup_email_report_frequencies',
+    'entity' => 'OptionGroup',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'email_report_frequencies',
+        'title' => E::ts('Email Report Frequencies'),
+        'description' => E::ts('Search Kit Email Report Frequencies'),
+        'data_type' => 'String',
+        'is_reserved' => FALSE,
+        'option_value_fields' => [
+          'name',
+          'label',
+          'description',
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionValue_Weekly',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'email_report_frequencies',
+        'label' => E::ts('Weekly'),
+        'value' => 'weekly',
+        'name' => 'Weekly',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+        'value',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionValue_Daily',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'email_report_frequencies',
+        'label' => E::ts('Daily'),
+        'value' => 'daily',
+        'name' => 'Daily',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+        'value',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionValue_Monthly',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'email_report_frequencies',
+        'label' => E::ts('Monthly'),
+        'value' => 'monthly',
+        'name' => 'Monthly',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+        'value',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionValue_First',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'email_report_frequencies',
+        'label' => E::ts('First of the Month'),
+        'value' => 'first',
+        'name' => 'First',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+        'value',
+      ],
+    ],
+  ],
+  [
+    'name' => 'OptionValue_Custom',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'email_report_frequencies',
+        'label' => E::ts('Custom'),
+        'value' => 'custom',
+        'name' => 'Custom',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+        'value',
+      ],
+    ],
+  ],
+];

--- a/ext/search_kit/managed/SearchDisplayType.mgd.php
+++ b/ext/search_kit/managed/SearchDisplayType.mgd.php
@@ -170,4 +170,26 @@ return [
       'match' => ['option_group_id', 'name'],
     ],
   ],
+  [
+    'name' => 'OptionValue_SearchDisplay_EmailReport',
+    'entity' => 'OptionValue',
+    'cleanup' => 'unused',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'option_group_id.name' => 'search_display_type',
+        'label' => E::ts('Email Report'),
+        'value' => 'email_report',
+        'name' => 'crm-search-display-email-report',
+        'icon' => 'fa-email',
+        'grouping' => 'non-viewable',
+      ],
+      'match' => [
+        'option_group_id',
+        'name',
+        'value',
+      ],
+    ],
+  ],
 ];

--- a/ext/search_kit/search_kit.php
+++ b/ext/search_kit/search_kit.php
@@ -2,6 +2,8 @@
 
 require_once 'search_kit.civix.php';
 use CRM_Search_ExtensionUtil as E;
+use Civi\Api4\OptionValue;
+use Civi\Api4\SearchDisplay;
 
 /**
  * Implements hook_civicrm_config().
@@ -72,6 +74,26 @@ function search_kit_civicrm_pre($op, $entity, $id, &$params) {
     \Civi\Api4\SearchDisplay::delete(FALSE)
       ->addWhere('saved_search_id', '=', $id)
       ->execute();
+  }
+  if ($entity === 'SearchDisplay' && in_array($op, ['create', 'edit'])) {
+    $emailSearchDisplayID = OptionValue::get(FALSE)
+      ->addWhere('name', '=', 'crm-search-display-email-report')
+      ->addWhere('option_group_id:name', '=', 'search_display_type')
+      ->execute()->first();
+    if ($params['type'] == $emailSearchDisplayID) {
+      if ($op == 'create') {
+        $params['settings']['next_run'] = \Civi\Search\EmailSearchDisplays::calculateNextRunDate($params['settings']);
+      }
+      else {
+        $searchDisplay = SearchDisplay::get(FALSE)
+          ->addWhere('id', '=', $id)
+          ->execute()
+          ->first();
+        if ($searchDisplay['settings']['frequency'] != $params['settings']['frequency']) {
+          $params['settings']['next_run'] = \Civi\Search\EmailSearchDisplays::calculateNextRunDate($params['settings']);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
_Adds a new SearchKit display for configuring the emailing of a SearchDisplay. The settings for the display are the params needed for the `SearchDisplay::EmailReport` action. Each Email display connects to another display in the SK report. So you can email different displays and various times and to different people. The email frequency is set up and created after the first run. When the `SendSKReports` action is run, it looks for any displays that need to be run and processes them. Once processed, it sets the next run time based on the Frequency provided within the display settings._

_One note, this was originally set up to have the next run date generated via a cron expression. This was so that the reports could be run at certain times and dates. This PR was adjusted to be more generic PHP date logic rather than adding a CronExpression package into core. Another option would be to add a hook that could allow for overriding and then someone could be more specific in how the next run time was generated._
