### PR TITLE
Set relationship is current type

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/IsCurrentFieldSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/IsCurrentFieldSpecProvider.php
@@ -39,6 +39,7 @@ class IsCurrentFieldSpecProvider extends \Civi\Core\Service\AutoService implemen
       ->setColumnName('is_current')
       ->setDescription(ts('Is active with a non-past end-date'))
       ->setType('Extra')
+      ->setInputType('Toggle')
       ->setSqlRenderer([__CLASS__, $this->getRenderer($field->getEntity())]);
     $spec->addFieldSpec($field);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Added an input type to Relationship's Is Current field so that it no longer is missing from Afform filters.

Fixes [dev/core#6519](https://lab.civicrm.org/dev/core/-/work_items/6519)

Before
----------------------------------------
The Is Current field is not showing in FormBuilder UI.