### PR TITLE
Fix null warning during regen

### DIFF
--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1536,18 +1536,18 @@ class CRM_Utils_System {
       else {
         // Drupal setting
         global $civicrm_root;
-        if (!str_contains($civicrm_root,
+        if (!str_contains((string) $civicrm_root,
           DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . 'all' . DIRECTORY_SEPARATOR . 'modules')
         ) {
-          $startPos = strpos($civicrm_root,
+          $startPos = strpos((string) $civicrm_root,
             DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR
           );
-          $endPos = strpos($civicrm_root,
+          $endPos = strpos((string) $civicrm_root,
             DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR
           );
           if ($startPos && $endPos) {
             // if component is in sites/SITENAME/modules
-            $siteName = substr($civicrm_root,
+            $siteName = substr((string) $civicrm_root,
               $startPos + 7,
               $endPos - $startPos - 7
             );

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -352,7 +352,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
         str_replace('\\', '/', (string) $civicrm_root)
       );
 
-    $siteName = $config->userSystem->parseDrupalSiteNameFromRoot($civicrm_root);
+    $siteName = $config->userSystem->parseDrupalSiteNameFromRoot((string) $civicrm_root);
     if ($siteName) {
       $civicrmDirName = trim(basename($civicrm_root));
       $userFrameworkResourceURL = $baseURL . "sites/$siteName/modules/$civicrmDirName/";
@@ -360,7 +360,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
 
     return [
       'url' => CRM_Utils_File::addTrailingSlash($userFrameworkResourceURL, '/'),
-      'path' => CRM_Utils_File::addTrailingSlash($civicrm_root),
+      'path' => CRM_Utils_File::addTrailingSlash((string) $civicrm_root),
     ];
   }
 

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -349,7 +349,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     // or in modules.
     $cmsPath = $config->userSystem->cmsRootPath();
     $userFrameworkResourceURL = $baseURL . str_replace("$cmsPath/", '',
-        str_replace('\\', '/', $civicrm_root)
+        str_replace('\\', '/', (string) $civicrm_root)
       );
 
     $siteName = $config->userSystem->parseDrupalSiteNameFromRoot($civicrm_root);


### PR DESCRIPTION
PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/CRM/Utils/System/DrupalBase.php on line 352
PHP Stack trace:
PHP   1. {main}() /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/xml/GenCode.php:0
PHP   2. CRM_Core_CodeGen_Main->main() /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/xml/GenCode.php:58
PHP   3. CRM_Core_CodeGen_Main->getTasks() /srv/civi-sites/dmaster/web/sites/all/modules/civicrm/CRM/Core/CodeGen/Main.php:130
PHP   4. CRM_Core_CodeGen_PhpSchema->__construct($config = class CRM_Core_CodeGen_Main { public $buildVersion = '6.16'; public $db_version = '6.16.alpha1'; public $cms = 'drupal'; public $CoreDAOCodePath = '../CRM/Core/DAO/'; public $sqlCodePath = '../sql/'; public $phpCodePath = '../'; public $tplCo