### PR TITLE
dev/core#6431 fail hard when membership configured but CiviMember not enabled

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -738,6 +738,9 @@ class CRM_Financial_BAO_Order {
             unset($metadata[$index]['options'][$optionID]);
           }
           elseif (!empty($option['membership_type_id'])) {
+            if (!CRM_Core_Component::isEnabled('CiviMember')) {
+              throw new CRM_Core_Exception('Price set is configured for CiviMember but CiviMember is disabled. Please enable CiviMember to use it');
+            }
             $membershipType = CRM_Member_BAO_MembershipType::getMembershipType((int) $option['membership_type_id']);
             $metadata[$index]['options'][$optionID]['membership_type_id.auto_renew'] = (int) $membershipType['auto_renew'];
             $metadata[$index]['supports_auto_renew'] = $metadata[$index]['supports_auto_renew'] ?? $membershipType['auto_renew'] ?: (bool) $membershipType['auto_renew'];


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6431 fail hard when membership configured but CiviMember not enabled

Before
----------------------------------------
If you enable CiviMember and configure a page & the disable it the membership configuration persists and can be 'invisibly used' per https://lab.civicrm.org/dev/core/-/work_items/6431

This is a fairly obscure scenario but is potentially confusing

After
----------------------------------------
Exception thrown if a price set used with membership config but CiviMember not enabled (screenshot is obviously with max debugging)

<img width="1728" height="588" alt="image" src="https://github.com/user-attachments/assets/9df44426-7a7a-425d-99be-0d13f9c229de" />

Technical Details
----------------------------------------
Presumably the site admin has been playing around to get here so we don't have to provide some easy resolution - but by failing harder & sooner the admin should be better able to see what is going on

Comments
----------------------------------------
