### PR TITLE
dev/core#6431 Save NULL to membership_type_id on OptionValue form if CiviMember disabled

### DIFF
--- a/CRM/Price/Form/Option.php
+++ b/CRM/Price/Form/Option.php
@@ -346,7 +346,7 @@ class CRM_Price_Form_Option extends CRM_Core_Form {
       $params['id'] = $this->_oid ?? NULL;
       $params['custom'] = CRM_Core_BAO_CustomField::postProcess($params, $params['id'], 'PriceFieldValue');
 
-      CRM_Price_BAO_PriceFieldValue::writeRecord($params);
+      CRM_Price_BAO_PriceFieldValue::writeRecord($params + ['membership_type_id' => NULL, 'membership_num_terms' => NULL]);
 
       CRM_Core_Session::setStatus(ts("The option '%1' has been saved.", [1 => $params['label']]), ts('Value Saved'), 'success');
     }


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#6431 Save NULL to membership_type_id on OptionValue form if CiviMember disabled

In this scenario the fields membership_type_id & membership_num_terms are not visible on the form but they are silently retained if saving with CiviMember disabled. A more intuitive behaviour is to wipe out fields not on the form if the option is saved with CiviMember disabled

Before
----------------------------------------
On a site where a price set is configured with membership price options but CiviMember is disabled re-saving the option values does not display the remove the membership_type_id & membership_num_terms fields and on save does not remove the values

After
----------------------------------------
on save the values are removed

Technical Details
----------------------------------------
This & https://github.com/civicrm/civicrm-core/pull/35773 are some fairly minimal efforts to mitigate against this obscure scenario and address some of the more confusing aspects. We could move the clearing out of the values to a BAO pre hook (or make it an AND) but probably no-one will hit it again & the worst of it seems to be the confusion - which should be clearer with the error in #35773 

Comments
----------------------------------------
