### PR TITLE
Move membership configuration links to extension

### DIFF
--- a/CRM/Contribute/Form/ContributionPage/TabHeader.php
+++ b/CRM/Contribute/Form/ContributionPage/TabHeader.php
@@ -48,7 +48,7 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
    *
    * @return array|null
    */
-  public static function process(&$form) {
+  public static function process($form) {
     if ($form->getVar('_id') <= 0) {
       return NULL;
     }
@@ -68,35 +68,38 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
     $tabs = [
       'settings' => [
         'title' => ts('Title'),
+        'weight' => -20,
       ] + $default,
       'amount' => [
         'title' => ts('Amounts'),
-      ] + $default,
-      'membership' => [
-        'title' => ts('Memberships'),
+        'weight' => -10,
       ] + $default,
       'thankyou' => [
         'title' => ts('Receipt'),
+        'weight' => 10,
       ] + $default,
       'custom' => [
         'title' => ts('Profiles'),
+        'weight' => 20,
       ] + $default,
       'premium' => [
         'title' => ts('Premiums'),
+        'weight' => 30,
       ] + $default,
       'widget' => [
         'title' => ts('Widgets'),
+        'weight' => 40,
       ] + $default,
       'pcp' => [
         'title' => ts('Personal Campaigns'),
+        'weight' => 50,
       ] + $default,
     ];
 
     $contribPageId = $form->getVar('_id');
     // Call tabset hook to add/remove custom tabs
     CRM_Utils_Hook::tabset('civicrm/admin/contribute', $tabs, ['contribution_page_id' => $contribPageId]);
-    $fullName = $form->getVar('_name');
-    $className = CRM_Utils_String::getClassName($fullName);
+    $className = CRM_Utils_String::getClassName($form->getName());
 
     // Hack for special cases.
     switch ($className) {
@@ -145,6 +148,9 @@ class CRM_Contribute_Form_ContributionPage_TabHeader {
         }
       }
     }
+    usort($tabs, static function ($a, $b) {
+      return (int) ((int) ($a['weight']) > (int) ($b['weight']));
+    });
     return $tabs;
   }
 

--- a/CRM/Contribute/Page/ContributionPage.php
+++ b/CRM/Contribute/Page/ContributionPage.php
@@ -99,7 +99,7 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
    *
    * @return array
    */
-  public function &configureActionLinks() {
+  public function configureActionLinks(): array {
     // check if variable _actionsLinks is populated
     if (!isset(self::$_configureActionLinks)) {
       $urlString = 'civicrm/admin/contribute/';
@@ -123,15 +123,9 @@ class CRM_Contribute_Page_ContributionPage extends CRM_Core_Page {
           'uniqueName' => 'amount',
           'weight' => CRM_Core_Action::getWeight(CRM_Core_Action::UPDATE),
         ],
-        CRM_Core_Action::VIEW => [
-          'name' => ts('Membership Settings'),
-          'title' => ts('Membership Settings'),
-          'url' => $urlString . 'membership',
-          'qs' => $urlParams,
-          'uniqueName' => 'membership',
-          // This should come after Title
-          'weight' => 0,
-        ],
+        // For sites with CiviMember enabled
+        // key CRM_Core_Action::VIEW is the membership
+        // settings tab.
         CRM_Core_Action::EXPORT => [
           'name' => ts('Thank-you and Receipting'),
           'title' => ts('Thank-you and Receipting'),

--- a/CRM/Contribute/xml/Menu/Contribute.xml
+++ b/CRM/Contribute/xml/Menu/Contribute.xml
@@ -56,12 +56,6 @@
     <weight>410</weight>
   </item>
   <item>
-    <path>civicrm/admin/contribute/membership</path>
-    <title>Membership Section</title>
-    <page_callback>CRM_Member_Form_MembershipBlock</page_callback>
-    <weight>420</weight>
-  </item>
-  <item>
     <path>civicrm/admin/contribute/custom</path>
     <title>Include Profiles</title>
     <page_callback>CRM_Contribute_Form_ContributionPage_Custom</page_callback>

--- a/CRM/Member/xml/Menu/Member.xml
+++ b/CRM/Member/xml/Menu/Member.xml
@@ -95,4 +95,11 @@
     <title>Email a Member</title>
     <page_callback>CRM_Member_Form_Task_Email</page_callback>
   </item>
+  <item>
+    <path>civicrm/admin/contribute/membership</path>
+    <title>Membership Section</title>
+    <page_callback>CRM_Member_Form_MembershipBlock</page_callback>
+    <weight>420</weight>
+    <component>CiviMember</component>
+  </item>
 </menu>

--- a/ext/civi_member/civi_member.php
+++ b/ext/civi_member/civi_member.php
@@ -1,3 +1,35 @@
 <?php
 
 require_once 'civi_member.civix.php';
+
+function civi_member_civicrm_tabset($name, &$tabs, $context): void {
+  if ($name === 'civicrm/admin/contribute') {
+    if (!empty($context['contribution_page_id'])) {
+      $tabs['membership'] = [
+        'title' => ts('Memberships'),
+        'weight' => -1,
+        'link' => NULL,
+        'valid' => FALSE,
+        'active' => FALSE,
+        'current' => FALSE,
+        'class' => FALSE,
+        'extra' => FALSE,
+        'template' => FALSE,
+        'count' => FALSE,
+        'icon' => FALSE,
+      ];
+    }
+    else {
+      $tabs[\CRM_Core_Action::VIEW] = [
+        'name' => ts('Membership Settings'),
+        'title' => ts('Membership Settings'),
+        'url' => $context['urlString'] . 'membership',
+        'qs' => $context['urlParams'],
+        'uniqueName' => 'membership',
+        // This should come after Title but before thank-you and receipting.
+        'weight' => -1,
+      ];
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Move membership configuration links to extension

Before
----------------------------------------
Links in core

After
----------------------------------------
Added through the extension - not added when it is disabled

<img width="1420" height="678" alt="image" src="https://github.com/user-attachments/assets/ac42fbe3-af4c-4f6b-b362-f19c92f967a5" />

<img width="1420" height="678" alt="image" src="https://github.com/user-attachments/assets/45cdef49-9d28-49a1-a7cd-5fc446a477a1" />



Technical Details
----------------------------------------
@mattwire something is going on in the tab-header part here & the tab selection is wonky - I know you worked on that - what is the trick to it - ie https://core-35775-484a0sa.civi.bid/civicrm/admin/contribute/thankyou?reset=1&action=update&id=2 is not selecting the right tab 

Comments
----------------------------------------
