### PR TITLE
dev/core#6523 Contribute: Hide empty tax note on existing contribution payment

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -1319,8 +1319,14 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       return;
     }
 
-    $this->assign('taxAmount', $this->getContributionValue('tax_amount'));
-    $this->assign('taxTerm', Civi::settings()->get('tax_term'));
+    $taxAmount = $this->getContributionValue('tax_amount');
+    $taxTerm = trim((string) Civi::settings()->get('tax_term'));
+
+    // Only display the tax note when both values are meaningful. This prevents
+    // output like "(includes  of $0.00)" when there is no tax, or when the tax
+    // term has not been configured.
+    $this->assign('taxAmount', (float) CRM_Utils_Rule::cleanMoney($taxAmount ?? '0') > 0 ? $taxAmount : NULL);
+    $this->assign('taxTerm', $taxTerm ?: NULL);
 
     $lineItems = $this->getExistingContributionLineItems();
     $this->assign('lineItem', [$this->getPriceSetID() => $lineItems]);

--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -87,7 +87,7 @@
       {else}
         <div class="display-block">
           <td class="label">{$form.total_amount.label}</td>
-          <td><span>{$form.total_amount.html}&nbsp;&nbsp;{if $taxAmount}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</span></td>
+          <td><span>{$form.total_amount.html}&nbsp;&nbsp;{if $taxAmount && $taxTerm}{ts 1=$taxTerm 2=$taxAmount|crmMoney}(includes %1 of %2){/ts}{/if}</span></td>
         </div>
       {/if}
     {else}


### PR DESCRIPTION
## Overview

This PR fixes [core#6523](https://lab.civicrm.org/dev/core/-/work_items/6523), where the existing contribution payment page can display a broken or unnecessary tax note when the tax amount is zero or the tax term is not configured.

## Before

When paying an existing pending contribution, the contribution form could display the tax note based only on whether `taxAmount` was present.

This could produce confusing output such as:

`(includes  of $0.00)`

or:

`(includes Sales Tax of $0.00)`

This happened because the template did not confirm that the tax amount was greater than zero or that the tax term was configured before rendering the note.

## After

The tax note is only displayed when both values are meaningful:

* the tax amount is greater than zero
* the tax term is configured

For example:

`tax_amount = 5.00`, `tax_term = Sales Tax`

Displays:

`(includes Sales Tax of $5.00)`

But these cases no longer display a tax note:

`tax_amount = 0.00`, `tax_term = Sales Tax`

`tax_amount = 5.00`, `tax_term = empty`

`tax_amount = 0.00`, `tax_term = empty`

## Technical Details

The form now checks the contribution tax amount and configured tax term before assigning the values to the template.

The tax amount is checked with `CRM_Utils_Rule::cleanMoney()` and must be greater than zero. The tax term is trimmed and must not be empty.

The template also checks both values before rendering the tax note:

```smarty
{if $taxAmount && $taxTerm}
```

This preserves the intended behavior for sites that collect tax while preventing broken output when tax data is incomplete.

## Comments

This change only affects the existing contribution payment flow. Normal contribution pages should not have any behavior change.