### PR TITLE
plain text for nestedGroup()

### DIFF
--- a/CRM/Campaign/BAO/Query.php
+++ b/CRM/Campaign/BAO/Query.php
@@ -341,7 +341,7 @@ civicrm_activity_assignment.record_type_id = $assigneeID ) ";
     $form->add('select', 'contact_type', ts('Contact Type(s)'), $contactTypes, FALSE,
       ['id' => 'contact_type', 'multiple' => 'multiple', 'class' => 'crm-select2']
     );
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     $form->add('select', 'group', ts('Groups'), $groups, FALSE,
       ['multiple' => 'multiple', 'class' => 'crm-select2']
     );

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Basic.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Basic.php
@@ -75,7 +75,7 @@ class CRM_Contact_Form_Search_Custom_Basic extends CRM_Contact_Form_Search_Custo
     $form->add('select', 'contact_type', ts('Find...'), $contactTypes, FALSE, ['class' => 'crm-select2 huge']);
 
     // add select for groups
-    $group = ['' => ts('- any group -')] + CRM_Core_PseudoConstant::nestedGroup();
+    $group = ['' => ts('- any group -')] + CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     $form->addElement('select', 'group', ts('in'), $group, ['class' => 'crm-select2 huge']);
 
     // add select for categories

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/DateAdded.php
@@ -49,7 +49,7 @@ class CRM_Contact_Form_Search_Custom_DateAdded extends CRM_Contact_Form_Search_C
     $form->add('datepicker', 'start_date', ts('Start Date'), [], FALSE, ['time' => FALSE]);
     $form->add('datepicker', 'end_date', ts('End Date'), [], FALSE, ['time' => FALSE]);
 
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     $select2style = [
       'multiple' => TRUE,

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Group.php
@@ -173,7 +173,7 @@ class CRM_Contact_Form_Search_Custom_Group extends CRM_Contact_Form_Search_Custo
 
     $this->setTitle(ts('Include / Exclude Search'));
 
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     $tags = CRM_Core_DAO_EntityTag::buildOptions('tag_id', 'get');
     if (count($groups) == 0 || count($tags) == 0) {

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/Proximity.php
@@ -99,7 +99,7 @@ class CRM_Contact_Form_Search_Custom_Proximity extends CRM_Contact_Form_Search_C
     $form->add('text', 'geo_code_1', ts('Latitude'));
     $form->add('text', 'geo_code_2', ts('Longitude'));
 
-    $group = ['' => ts('- any group -')] + CRM_Core_PseudoConstant::nestedGroup();
+    $group = ['' => ts('- any group -')] + CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
     $form->addElement('select', 'group', ts('Group'), $group, ['class' => 'crm-select2 huge']);
 
     $tag = ['' => ts('- any tag -')] + CRM_Core_DAO_EntityTag::buildOptions('tag_id', 'get');

--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/RandomSegment.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/RandomSegment.php
@@ -69,7 +69,7 @@ class CRM_Contact_Form_Search_Custom_RandomSegment extends CRM_Contact_Form_Sear
       TRUE
     );
 
-    $groups = CRM_Core_PseudoConstant::nestedGroup();
+    $groups = CRM_Core_PseudoConstant::nestedGroup(textFormat: 'plain');
 
     $select2style = [
       'multiple' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Follow-up to https://github.com/civicrm/civicrm-core/pull/35220#issuecomment-4397922639

Addresses more places where `CRM_Core_PseudoConstant::nestedGroup()` double encodes HTML and looks terrible.