### PR TITLE
fix: add legal_name to QuickSearch options (dev/core#6521)

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1187,6 +1187,10 @@ class CRM_Core_SelectValues {
         'label' => ts('Last Name'),
       ],
       [
+        'key' => 'legal_name',
+        'label' => ts('Legal Name'),
+      ],
+      [
         'key' => 'Email.email',
         'label' => ts('Email'),
         'adv_search_legacy' => 'email',


### PR DESCRIPTION
Adds legal_name to the hardcoded list in getQuicksearchOptions() so it can be enabled via Search Preferences.
Closes https://lab.civicrm.org/dev/core/-/work_items/6521