### PR TITLE
Multilingual SK: SearchKit Export

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1089,7 +1089,9 @@ apiCalls.${results} = [${jsCall}];
           let localizable = _.pluck(_.filter(_.findWhere(getEntity().actions, {name: $scope.action}).fields, {localizable: true}), 'name') || [];
           // More field names that probably should be translated
           localizable = _.union(localizable, ['label', 'title', 'description', 'text']);
-          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2, localizable)) + ';', 'php_ts', 1));
+          // SearchKit settings are not needs to be translated at runtime and not once when the managed file is loaded in the database
+          const ignoreLocalization = ['settings'];
+          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2, localizable, ignoreLocalization)) + ';', 'php_ts', 1));
           break;
       }
     };
@@ -1103,7 +1105,7 @@ apiCalls.${results} = [${jsCall}];
     /**
      * Format value to look like php code
      */
-    function phpFormat(val, indent, indentChildren, localizable) {
+    function phpFormat(val, indent, indentChildren, localizable, ignoreLocalization = []) {
       if (typeof val === 'undefined') {
         return '';
       }
@@ -1121,9 +1123,10 @@ apiCalls.${results} = [${jsCall}];
           return '[]';
         }
         Object.entries(val).forEach(([k, v]) => {
+          const localizableChildren = ignoreLocalization && ignoreLocalization.includes(k) ? [] : localizable;
           const ts = localizable && localizable.includes(k) && typeof v === 'string' && v.length ? 'E::ts(' : '';
           const leadingComma = !ret ? '' : (newLine ? ',' : ', ');
-          ret += leadingComma + newLine + indent + "'" + k + "' => " + ts + phpFormat(v, indentChild, indentChildren, localizable) + (ts ? ')' : '');
+          ret += leadingComma + newLine + indent + "'" + k + "' => " + ts + phpFormat(v, indentChild, indentChildren, localizableChildren, ignoreLocalization) + (ts ? ')' : '');
         });
         return '[' + ret + trailingComma + newLine + baseLine + ']';
       }
@@ -1133,7 +1136,7 @@ apiCalls.${results} = [${jsCall}];
         }
         val.forEach((v) => {
           let leadingComma = !ret ? '' : (newLine ? ',' : ', ');
-          ret += leadingComma + newLine + indent + phpFormat(v, indentChild, indentChildren, localizable);
+          ret += leadingComma + newLine + indent + phpFormat(v, indentChild, indentChildren, localizable, ignoreLocalization);
         });
         return '[' + ret + trailingComma + newLine + baseLine + ']';
       }


### PR DESCRIPTION
Overview
----------------------------------------
Follow-up on https://github.com/civicrm/civicrm-core/pull/33901 to fix the E::ts in the export for SK.

Before
----------------------------------------
Every title, label, description in SearchKit export `PHP + Localization` format are exported using `E::ts()`

After
----------------------------------------
We don't do the `E::ts()` treatment for fields that are in settings array.

Comments
----------------------------------------
Eventually, everything will work with the new translation tables so we'll be able to drop the `E::ts` part completely but we're not there yet.