### PR TITLE
[php8] null array key - grouphierarchy

### DIFF
--- a/CRM/Contact/BAO/Group.php
+++ b/CRM/Contact/BAO/Group.php
@@ -931,12 +931,14 @@ WHERE  id IN $groupIdString
       if ($dao->parents) {
         $parentArray = explode(',', $dao->parents);
         $parent = self::filterActiveGroups($parentArray);
-        $tree[$parent][] = [
-          'id' => $dao->id,
-          'title' => empty($dao->saved_search_id) ? $title : '* ' . $title,
-          'visibility' => $dao->visibility,
-          'description' => $description,
-        ];
+        if ($parent) {
+          $tree[$parent][] = [
+            'id' => $dao->id,
+            'title' => empty($dao->saved_search_id) ? $title : '* ' . $title,
+            'visibility' => $dao->visibility,
+            'description' => $description,
+          ];
+        }
       }
       else {
         $roots[] = [


### PR DESCRIPTION
Overview
----------------------------------------
Array key null

Before
----------------------------------------
```
CRM_Contact_BAO_GroupTest::testGroupHirearchy
Using null as an array offset is deprecated, use an empty string instead

/home/homer/buildkit/build/build-5/web/core/CRM/Contact/BAO/Group.php:934
/home/homer/buildkit/build/build-5/web/core/tests/phpunit/CRM/Contact/BAO/GroupTest.php:105
```

After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------
Another option is to keep the key but use `''` instead, but in this case that makes no sense to me. The key is intended to be a group id, and this $tree always gets filtered to only active groups and `''` is never an active group.