### PR TITLE
use correct mysql cert constant objects for php version, resolve test…

### DIFF
--- a/setup/src/Setup/DrupalUtil.php
+++ b/setup/src/Setup/DrupalUtil.php
@@ -57,11 +57,11 @@ class DrupalUtil {
     $pdo = $cmsDatabaseParams['pdo'];
 
     $pdo_map = [
-      \PDO::MYSQL_ATTR_SSL_CA => 'ca',
-      \PDO::MYSQL_ATTR_SSL_KEY => 'key',
-      \PDO::MYSQL_ATTR_SSL_CERT => 'cert',
-      \PDO::MYSQL_ATTR_SSL_CAPATH => 'capath',
-      \PDO::MYSQL_ATTR_SSL_CIPHER => 'cipher',
+      self::pdoMysqlConstant('ATTR_SSL_CA') => 'ca',
+      self::pdoMysqlConstant('ATTR_SSL_KEY') => 'key',
+      self::pdoMysqlConstant('ATTR_SSL_CERT') => 'cert',
+      self::pdoMysqlConstant('ATTR_SSL_CAPATH') => 'capath',
+      self::pdoMysqlConstant('ATTR_SSL_CIPHER') => 'cipher',
     ];
 
     $ssl_params = [];
@@ -78,11 +78,31 @@ class DrupalUtil {
     // made-up indicator ssl=1 that isn't a real mysqli option but which we
     // recognize. It's possible they have other params set too which we pass
     // along from above, but that may not be compatible but it's up to them.
-    if (($pdo[\PDO::MYSQL_ATTR_SSL_CA] ?? NULL) === TRUE && ($pdo[\PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] ?? NULL) === FALSE) {
+    if (($pdo[self::pdoMysqlConstant('ATTR_SSL_CA')] ?? NULL) === TRUE && ($pdo[self::pdoMysqlConstant('ATTR_SSL_VERIFY_SERVER_CERT')] ?? NULL) === FALSE) {
       $ssl_params['ssl'] = 1;
     }
 
     return $ssl_params;
+  }
+
+  /**
+   * Resolve a driver-specific PDO MySQL constant across PHP versions.
+   *
+   * PHP 8.4 introduced the Pdo\Mysql subclass (e.g. Pdo\Mysql::ATTR_SSL_CA) and
+   * PHP 8.5 deprecates the old PDO::MYSQL_ATTR_* constants in favour of it. The
+   * new constants don't exist on PHP 8.1-8.3, so we pick whichever is valid for
+   * the running PHP version. (Referencing the old constant directly on PHP 8.5+
+   * raises an E_DEPRECATED notice.) Both forms share the same integer value, so
+   * the result is consistent across versions.
+   *
+   * @param string $name
+   *   The modern (PHP 8.4+) short constant name, e.g. 'ATTR_SSL_CA'.
+   * @return int
+   */
+  public static function pdoMysqlConstant(string $name): int {
+    return defined('Pdo\Mysql::' . $name)
+      ? constant('Pdo\Mysql::' . $name)
+      : constant('PDO::MYSQL_' . $name);
   }
 
   /**

--- a/tests/phpunit/Civi/Setup/DrupalUtilTest.php
+++ b/tests/phpunit/Civi/Setup/DrupalUtilTest.php
@@ -29,8 +29,8 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       'no client certificate, no server verification' => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_CA => TRUE,
-            \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => FALSE,
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CA') => TRUE,
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_VERIFY_SERVER_CERT') => FALSE,
           ],
         ],
         ['ssl' => 1],
@@ -38,9 +38,9 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       'typical client certificate with server verification' => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_CA => '/tmp/cacert.crt',
-            \PDO::MYSQL_ATTR_SSL_KEY => '/tmp/my.key',
-            \PDO::MYSQL_ATTR_SSL_CERT => '/tmp/cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CA') => '/tmp/cacert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_KEY') => '/tmp/my.key',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CERT') => '/tmp/cert.crt',
           ],
         ],
         [
@@ -52,9 +52,9 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       'client certificate, no server verification' => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => FALSE,
-            \PDO::MYSQL_ATTR_SSL_KEY => '/tmp/my.key',
-            \PDO::MYSQL_ATTR_SSL_CERT => '/tmp/cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_VERIFY_SERVER_CERT') => FALSE,
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_KEY') => '/tmp/my.key',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CERT') => '/tmp/cert.crt',
           ],
         ],
         [
@@ -65,9 +65,9 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       'self-signed client certificate with server verification' => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_CA => '/tmp/cert.crt',
-            \PDO::MYSQL_ATTR_SSL_KEY => '/tmp/my.key',
-            \PDO::MYSQL_ATTR_SSL_CERT => '/tmp/cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CA') => '/tmp/cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_KEY') => '/tmp/my.key',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CERT') => '/tmp/cert.crt',
           ],
         ],
         [
@@ -79,11 +79,11 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       'Not sure what would happen in practice but is all the string params' => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_CA => '/tmp/cacert.crt',
-            \PDO::MYSQL_ATTR_SSL_KEY => '/tmp/my.key',
-            \PDO::MYSQL_ATTR_SSL_CERT => '/tmp/cert.crt',
-            \PDO::MYSQL_ATTR_SSL_CAPATH => '/tmp/cacert_folder',
-            \PDO::MYSQL_ATTR_SSL_CIPHER => 'aes',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CA') => '/tmp/cacert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_KEY') => '/tmp/my.key',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CERT') => '/tmp/cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CAPATH') => '/tmp/cacert_folder',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CIPHER') => 'aes',
           ],
         ],
         [
@@ -97,11 +97,11 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       'Ditto, but showing extra ones should get ignored' => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_CA => '/tmp/cacert.crt',
-            \PDO::MYSQL_ATTR_SSL_KEY => '/tmp/my.key',
-            \PDO::MYSQL_ATTR_SSL_CERT => '/tmp/cert.crt',
-            \PDO::MYSQL_ATTR_SSL_CAPATH => '/tmp/cacert_folder',
-            \PDO::MYSQL_ATTR_SSL_CIPHER => 'aes',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CA') => '/tmp/cacert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_KEY') => '/tmp/my.key',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CERT') => '/tmp/cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CAPATH') => '/tmp/cacert_folder',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CIPHER') => 'aes',
             'fourteen' => 'the number fourteen',
           ],
         ],
@@ -116,9 +116,9 @@ class DrupalUtilTest extends \CiviUnitTestCase {
       "some windows paths shouldn't get mangled" => [
         [
           'pdo' => [
-            \PDO::MYSQL_ATTR_SSL_CA => 'C:/Program Files/MariaDB 10.3/data/cacert.crt',
-            \PDO::MYSQL_ATTR_SSL_KEY => 'C:/Program Files/MariaDB 10.3/data/my.key',
-            \PDO::MYSQL_ATTR_SSL_CERT => 'C:\\Program Files\\MariaDB 10.3\\data\\cert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CA') => 'C:/Program Files/MariaDB 10.3/data/cacert.crt',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_KEY') => 'C:/Program Files/MariaDB 10.3/data/my.key',
+            DrupalUtil::pdoMysqlConstant('ATTR_SSL_CERT') => 'C:\\Program Files\\MariaDB 10.3\\data\\cert.crt',
           ],
         ],
         [


### PR DESCRIPTION
… deprecation failures for PHP8.5

Overview
----------------------------------------
Resolve 7 errors in php8.5 tests, e.g https://test.civicrm.org/job/CiviCRM-Test-QLow/299171/testReport/


Before
----------------------------------------
Test results
```
Civi\Setup\DrupalUtilTest::testGuessSslParams with data set "no client certificate, no server verification" (array(array(true, false)), array(1))
Constant PDO::MYSQL_ATTR_SSL_CA is deprecated since 8.5, use Pdo\Mysql::ATTR_SSL_CA instead

/home/homer/buildkit/build/build-7/web/core/setup/src/Setup/DrupalUtil.php:60
/home/homer/buildkit/build/build-7/web/core/tests/phpunit/Civi/Setup/DrupalUtilTest.php:18
/home/homer/buildkit/build/build-7/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4038
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```

After
----------------------------------------
No failures

Technical Details
----------------------------------------
We have to look whether the new class exists before using the constant. Shenanigans can be changed to the PHP8.4+ versions as soon as PHP8.4 or above is the minimum version.

