### PR TITLE
Add default Contact when Membership is added to a Form

### DIFF
--- a/ext/afform/admin/afformEntities/Membership.php
+++ b/ext/afform/admin/afformEntities/Membership.php
@@ -2,6 +2,7 @@
 return [
   'type' => 'primary',
   'defaults' => "{
+    data: {contact_id: 'user_contact_id'},
     actions: {create: true, update: true}
   }",
   'boilerplate' => [],


### PR DESCRIPTION
Overview
----------------------------------------
When adding a Membership to a FormBuilder form, add 'Contact' as a default field.

Before
----------------------------------------
User adds a Membership, test the form, find its not created, go to the logs, find that Contact is required etc.

After
----------------------------------------
User adds a Membership, default Contact is added.  Just like when adding a Contribution.

<img width="341" height="313" alt="image" src="https://github.com/user-attachments/assets/cf15700e-884e-41fd-b20c-80f056a79b94" />

