### PR TITLE
Tests / I18n - Fix PHP 8.5 warning during setup of PetitionTest

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -274,7 +274,9 @@ class CRM_Core_I18n {
     else {
       $codes = $settings->get('uiLanguages');
       if (!$codes) {
-        $codes = [$settings->get('lcMessages')];
+        $codes = $settings->get('lcMessages') ? [$settings->get('lcMessages')] : [];
+        // This ^^^ seems tighter, but if it proves regressive, then consider:
+        // $codes = [$settings->get('lcMessages') ?? ''];
       }
     }
     return $justCodes ? $codes


### PR DESCRIPTION
Overview
----------------------------------------

Fix  test failure from [php85m80 /  phpunit-crm-2](https://test.civicrm.org/job/CiviCRM-Test-QLow/298817/testReport/(root)/CRM_Campaign_BAO_PetitionTest/testCreateAndConfirmSignatures/).

Before
----------------------------------------

Test failure:

```
CRM_Campaign_BAO_PetitionTest::testCreateAndConfirmSignatures
Cannot modify header information - headers already sent by (output started at /home/homer/buildkit/build/build-0/web/core/CRM/Utils/Array.php:984)

/home/homer/buildkit/build/build-0/web/core/CRM/Campaign/BAO/Petition.php:91
/home/homer/buildkit/build/build-0/web/core/tests/phpunit/CRM/Campaign/BAO/PetitionTest.php:110
/home/homer/buildkit/build/build-0/web/core/tests/phpunit/CiviTest/CiviUnitTestCase.php:4038
/home/homer/buildkit/extern/phpunit9/phpunit9.phar:2552
```

After
----------------------------------------

Pass

Technical Details
----------------------------------------

This is a tricky one to reproduce, in that it depends on test-initialization and prior test-runs. It fails 🔴 on the first run but passes 🟢 on the second run. (*So you could run `PetitionTest` 🔴, take off your socks, re-run `PetitionTest` 🟢, and suppose that your socks fixed the test. But really, `PetitionTest` has the same problem, and you're just barefoot.*)

To provoke the error reliably, I found this pair of commands:

```
civibuild restore MY_BUILD_NAME --no-cms --no-civi && CIVICRM_UF=UnitTests phpunit9 tests/phpunit/CRM/Campaign/BAO/PetitionTest.php
```

Note how the first command resets the test-database. Consequently, in the second command, `PetitionTest` will do its full re-initialization routine.