### PR TITLE
Extension Queue: allow disabling of extensions and optional task title

### DIFF
--- a/CRM/Extension/QueueDownloader.php
+++ b/CRM/Extension/QueueDownloader.php
@@ -143,10 +143,26 @@ class CRM_Extension_QueueDownloader {
    *
    * @param array $keys
    *   Ex: ['my.ext1', 'my.ext2']
+   * @param string|null $title
+   *   Task title shown to the user. Defaults to a list of extension keys.
    * @return $this
    */
-  public function addEnable(array $keys) {
-    $this->batches[] = ['type' => 'enable', 'keys' => $keys];
+  public function addEnable(array $keys, ?string $title = NULL) {
+    $this->batches[] = ['type' => 'enable', 'keys' => $keys, 'title' => $title];
+    return $this;
+  }
+
+  /**
+   * Add a set of keys which should be disabled.
+   *
+   * @param array $keys
+   *   Ex: ['my.ext1', 'my.ext2']
+   * @param string|null $title
+   *   Task title shown to the user. Defaults to a list of extension keys.
+   * @return $this
+   */
+  public function addDisable(array $keys, ?string $title = NULL) {
+    $this->batches[] = ['type' => 'disable', 'keys' => $keys, 'title' => $title];
     return $this;
   }
 
@@ -169,7 +185,13 @@ class CRM_Extension_QueueDownloader {
     foreach ($this->batches as $batch) {
       switch ($batch['type']) {
         case 'enable':
-          $queue->createItem(static::task(ts('Enable %1', [1 => $this->quotedList($batch['keys'])]), 'enable', [$batch['keys']]));
+          $task_title = $batch['title'] ?? ts('Enable %1', [1 => $this->quotedList($batch['keys'])]);
+          $queue->createItem(static::task($task_title, 'enable', [$batch['keys']]));
+          break;
+
+        case 'disable':
+          $task_title = $batch['title'] ?? ts('Disable %1', [1 => $this->quotedList($batch['keys'])]);
+          $queue->createItem(static::task($task_title, 'disable', [$batch['keys']]));
           break;
 
         case 'download':

--- a/CRM/Extension/QueueTasks.php
+++ b/CRM/Extension/QueueTasks.php
@@ -125,6 +125,14 @@ class CRM_Extension_QueueTasks {
     return TRUE;
   }
 
+  /**
+   * Disable the listed extensions.
+   */
+  public static function disable(CRM_Queue_TaskContext $ctx, ?string $stagingPath, array $keys): bool {
+    CRM_Extension_System::singleton()->getManager()->disable($keys);
+    return TRUE;
+  }
+
   public static function upgradeDb(CRM_Queue_TaskContext $ctx): bool {
     if (CRM_Extension_Upgrades::hasPending()) {
       CRM_Extension_Upgrades::fillQueue($ctx->queue);


### PR DESCRIPTION
Overview
----------------------------------------

- Makes it possible to use the Extension Queue Downloader so that extensions can be disabled (not just enabled/downloaded).
- Allows devs to set a custom title to tasks, so that they see a more human-friendly label, instead of say, "Enable org.foo.whatever".

Comments
----------------------------------------

This is required for CiviCRM Spark, where we have a custom UI for enabling/disabling extensions. I wanted the UI to be as user-friendly as possible, and with labels that made sense to users. The code is here: https://lab.civicrm.org/core-team/civicrm-spark/org.civicrm.mycivi/-/blob/master/CRM/Mycivi/Form/SparkFeatures.php

Example:

[spark-features.webm](https://github.com/user-attachments/assets/87a09693-25dc-4716-94af-edf87364028a)

(ignore the Twilio error, it was just a typo, and the warnings at the end are because it's a dev site)

cc @totten 