### PR TITLE
dev/core#6416 pass contact Image urlthrough CRM_Utils_String::unstupi…

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
@@ -47,6 +47,8 @@ class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Gene
         ->setDescription(ts('Date closed or disbanded'));
     }
 
+    $spec->getFieldByName('image_URL')->addOutputFormatter([__CLASS__, 'deEncodeImageUrl']);
+
     // Address, Email, Phone, IM primary/billing virtual fields
     // This exposes the joins created by
     // \Civi\Api4\Event\Subscriber\ContactSchemaMapSubscriber::onSchemaBuild()
@@ -235,6 +237,13 @@ class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Gene
   public static function calculateBirthday(array $field): string {
     $anniversarySql = \CRM_Utils_Date::getAnniversarySql($field['sql_name']);
     return "DATEDIFF($anniversarySql, CURDATE())";
+  }
+
+  public static function deEncodeImageUrl(&$value) {
+    if (!isset($value)) {
+      return;
+    }
+    $value = \CRM_Utils_String::unstupifyUrl($value);
   }
 
 }

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -646,4 +646,10 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     }
   }
 
+  public function testContactImageURLNotEncoded(): void {
+    $cid = $this->createTestRecord('Contact', ['last_name' => uniqid(__FUNCTION__), 'image_URL' => 'http://joomla-empty/index.php?option=com_civicrm&amp;task=civicrm/contact/imagefile&amp;photo=image000001_22d61d381164e043bbed2dd014f0ab2c.jpg']);
+    $get = Contact::get(FALSE)->addWhere('id', '=', $cid['id'])->execute()->first();
+    $this->assertEquals('http://joomla-empty/index.php?option=com_civicrm&task=civicrm/contact/imagefile&photo=image000001_22d61d381164e043bbed2dd014f0ab2c.jpg', $get['image_URL']);
+  }
+
 }


### PR DESCRIPTION
…fyUrl to fix issues with ampersands stored in the db

Overview
----------------------------------------
This fixes search kit display of contact urls when on CMSes that have & in the urls e.g. Joomla and non clean url WordPress

Before
----------------------------------------
Contact Images don't load as images in Search Kit display

After
----------------------------------------
Contact Images do load

@colemanw @Edzelopez 
