### PR TITLE
dev/core#6504: Only mark as sold out price options that have limits

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2067,7 +2067,7 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
 
       $optionFullIds = [];
       foreach ($options as $option) {
-        if (isset($recordedOptionsCount[$option['id']]) && ($recordedOptionsCount[$option['id']] >= $option['max_value'])) {
+        if (!empty($option['max_value']) && isset($recordedOptionsCount[$option['id']]) && ($recordedOptionsCount[$option['id']] >= $option['max_value'])) {
           $optionFullIds[$option['id']] = $option['id'];
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
We should only mark as sold out price options that actually have limits, obviously. A limit of 0 is, unfortunately, equivalent to no limit elsewhere, so this follows that convention.