### PR TITLE
Afform - Fix tag selector in SearchKit

### DIFF
--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -210,12 +210,12 @@ class Afform extends Generic\AbstractEntity {
           'title' => E::ts('Tags'),
           'pseudoconstant' => [
             'callback' => [Utils\AfformTags::class, 'getTagOptions'],
-            'suffixes' => [
-              'name',
-              'label',
-              'color',
-              'description',
-            ],
+          ],
+          'suffixes' => [
+            'name',
+            'label',
+            'color',
+            'description',
           ],
           'data_type' => 'Array',
           'input_type' => 'Select',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug when trying to search for Afforms in SearchKit by tag.

Before
----------------------------------------
Cannot make a searchKit search for Afforms by tag. The tag selector fails to populate.


After
----------------------------------------
Tags are selectable.

Technical Details
----------------------------------------
The suffixes array was misplaced, resulting in it not being available to the api metadata.
