### PR TITLE
Fix WordPress "Skip to main content" and "Skip to toolbar" links

### DIFF
--- a/js/crm.wordpress.js
+++ b/js/crm.wordpress.js
@@ -1,4 +1,4 @@
-// http://civicrm.org/licensing
+// https://civicrm.org/licensing
 CRM.$(function($) {
   $(document)
     .on('crmWysiwygCreate', function(e, type, editor) {
@@ -8,14 +8,17 @@ CRM.$(function($) {
         });
       }
     });
-  // Prevent screen reader shortcuts from changing the document hash and breaking angular routes
+  // Prevent screen reader shortcuts from changing the document hash and breaking angular routes.
   $('a.screen-reader-shortcut').click(function() {
     var target = $(this).attr('href');
-    // Show toolbar if hidden
+    // Show toolbar if hidden.
     if (target === '#wp-toolbar' && CRM.menubar.position === 'over-cms-menu') {
       CRM.menubar.togglePosition(false);
     }
-    $(target).focus();
+    // The targets are "div" elements so need special handling.
+    $(target).css('outline', 'none !important').attr("tabindex", -1).trigger('focus');
+    // Prevent unwanted jump.
+    $('html').scrollTop(0);
     return false;
   });
   $('<a href="#crm-qsearch-input" class="screen-reader-shortcut">' + ts("Open CiviCRM Menu") + '</a>')


### PR DESCRIPTION
Overview
----------------------------------------
Fixes bug described in [this Lab issue](https://lab.civicrm.org/dev/core/-/work_items/6527).

Before
----------------------------------------
WordPress "Skip to main content" and "Skip to toolbar" links non-functional.

After
----------------------------------------
WordPress "Skip to main content" and "Skip to toolbar" links work as expected.

Comments
----------------------------------------
Also updates a deprecated jQuery `focus()` statement.