### PR TITLE
Multilingual SK: extracting strings to civicrm_translation_source

### DIFF
--- a/CRM/Core/I18n.php
+++ b/CRM/Core/I18n.php
@@ -283,6 +283,27 @@ class CRM_Core_I18n {
         : CRM_Utils_Array::subset(CRM_Core_I18n::languages(), $codes);
   }
 
+  public static function getActiveLocalesOptions(): array {
+    $options = [];
+    $locales = self::uiLanguages();
+    if (count($locales) > 1) {
+      if (\Civi::settings()->get('force_translation_source_locale') ?? TRUE) {
+        $defaultLocale = \Civi::settings()->get('lcMessages');
+        $langLabel = $locales[$defaultLocale];
+        $locales = [];
+        $locales[$defaultLocale] = $langLabel;
+      }
+
+      foreach ($locales as $langCode => $langLabel) {
+        $options[] = [
+          'id' => $langCode,
+          'text' => $langLabel,
+        ];
+      }
+    }
+    return $options;
+  }
+
   /**
    * Replace arguments in a string with their values. Arguments are represented by % followed by their number.
    *

--- a/CRM/Core/I18n/Schema.php
+++ b/CRM/Core/I18n/Schema.php
@@ -69,9 +69,8 @@ class CRM_Core_I18n_Schema {
       CRM_Core_BAO_ConfigSetting::applyLocale(Civi::settings($domain->id), $domain->locales);
     }
 
-    // It should probably be a dispatcher to let extension add their own
-    \Civi\Afform\Utils::initSourceTranslations();
-
+    // extensions might need to do special treatment when this occur
+    \Civi::dispatcher()->dispatch('civi.core.makeMultilingual');
   }
 
   /**

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -46,7 +46,7 @@ class AfformAdminMeta {
       'placement_entities' => array_column(PlacementUtils::getPlacements(), 'entities', 'value'),
       'placement_filters' => self::getPlacementFilterOptions(),
       'search_operators' => \Civi\Afform\Utils::getSearchOperators(),
-      'locales' => self::getLocales(),
+      'locales' => \CRM_Core_I18n::getActiveLocalesOptions(),
     ];
   }
 
@@ -377,27 +377,6 @@ class AfformAdminMeta {
       }
     }
     return $entityFilterOptions;
-  }
-
-  private static function getLocales(): array {
-    $options = [];
-    $locales = \CRM_Core_I18n::uiLanguages();
-    if (count($locales) > 1) {
-      if (\Civi::settings()->get('force_translation_source_locale') ?? TRUE) {
-        $defaultLocale = \Civi::settings()->get('lcMessages');
-        $langLabel = $locales[$defaultLocale];
-        $locales = [];
-        $locales[$defaultLocale] = $langLabel;
-      }
-
-      foreach ($locales as $langCode => $langLabel) {
-        $options[] = [
-          'id' => $langCode,
-          'text' => $langLabel,
-        ];
-      }
-    }
-    return $options;
   }
 
   /**

--- a/ext/afform/core/Civi/Afform/Translator.php
+++ b/ext/afform/core/Civi/Afform/Translator.php
@@ -16,8 +16,16 @@ class Translator extends AutoService implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents(): array {
     return [
+      'civi.core.makeMultilingual' => 'makeMultilingual',
       '&hook_civicrm_alterAngular' => 'translateAfform',
     ];
+  }
+
+  /**
+   * When changing to multilingual, ensure we extract all translation source strings
+   */
+  public function makeMultilingual() {
+    \Civi\Afform\Utils::initSourceTranslations();
   }
 
   /**

--- a/ext/search_kit/CRM/Search/Upgrader.php
+++ b/ext/search_kit/CRM/Search/Upgrader.php
@@ -162,4 +162,16 @@ ENGINE=InnoDB ROW_FORMAT=DYNAMIC";
     return TRUE;
   }
 
+  /**
+   * Add translation source
+   * @return bool
+   */
+  public function upgrade_1008(): bool {
+    $this->ctx->log->info('Applying update 1008 - adding SearchKit translation source.');
+    if (CRM_Core_I18n::isMultilingual()) {
+      \Civi\Search\Translator::initSourceTranslations();
+    }
+    return TRUE;
+  }
+
 }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Create.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Create.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use Civi\Api4\Generic\DAOCreateAction;
+
+class Create extends DAOCreateAction {
+  use SKActionTrait;
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/SKActionTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/SKActionTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use Civi\Api4\Generic\Traits\DAOActionTrait;
+use Civi\Search\Translator;
+
+trait SKActionTrait {
+  use DAOActionTrait;
+
+  /**
+   * Add i18n extraction to the original trait
+   */
+  protected function writeObjects($items) {
+    $result = parent::writeObjects($items);
+    Translator::updateSearchDisplaySources($result);
+    return $result;
+  }
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Save.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Save.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use Civi\Api4\Generic\DAOSaveAction;
+
+class Save extends DAOSaveAction {
+  use SKActionTrait;
+
+}

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Update.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Update.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Civi\Api4\Action\SearchDisplay;
+
+use Civi\Api4\Generic\DAOUpdateAction;
+
+class Update extends DAOUpdateAction {
+  use SKActionTrait;
+
+}

--- a/ext/search_kit/Civi/Api4/SearchDisplay.php
+++ b/ext/search_kit/Civi/Api4/SearchDisplay.php
@@ -98,6 +98,33 @@ class SearchDisplay extends Generic\DAOEntity {
       ->setCheckPermissions($checkPermissions);
   }
 
+  /**
+   * @param bool $checkPermissions
+   * @return DAOSaveAction
+   */
+  public static function save($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\Save(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return DAOCreateAction
+   */
+  public static function create($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\Create(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
+   * @return DAOUpdateAction
+   */
+  public static function update($checkPermissions = TRUE) {
+    return (new Action\SearchDisplay\Update(__CLASS__, __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
   public static function permissions() {
     $permissions = parent::permissions();
     $permissions['default'] = ['manage own search_kit'];

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -90,6 +90,7 @@ class Admin {
         \NumberFormatter::MAX_FRACTION_DIGITS => E::ts('Max Decimal Places'),
         \NumberFormatter::MIN_FRACTION_DIGITS => E::ts('Min Decimal Places'),
       ],
+      'locales' => \CRM_Core_I18n::getActiveLocalesOptions(),
     ];
     $perms = \Civi\Api4\Permission::get()
       ->addWhere('group', 'IN', ['civicrm', 'cms'])

--- a/ext/search_kit/Civi/Search/Translator.php
+++ b/ext/search_kit/Civi/Search/Translator.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Civi\Search;
+
+use Civi\Core\Service\AutoService;
+use Civi\Api4\TranslationSource;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service civi.search.translator
+ */
+class Translator extends AutoService implements EventSubscriberInterface {
+
+  /**
+   *
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.core.makeMultilingual' => 'makeMultilingual',
+    ];
+  }
+
+  /**
+   * When changing to multilingual, ensure we extract all translation source strings
+   */
+  public function makeMultilingual() {
+    self::initSourceTranslations();
+  }
+
+  public static function initSourceTranslations() {
+    // foreach search display, update
+    $searchDisplays = \Civi\Api4\SearchDisplay::get(FALSE)
+      ->execute();
+    self::updateSearchDisplaySources((array) $searchDisplays);
+  }
+
+  public static function updateSearchDisplaySources(array $searchDisplay) {
+    // extracting labels as source for translation
+    // similar to Civi\Afform\StringVisitor but simpler
+    $translatableFields = ['label', 'title', 'description', 'text', 'empty_value', 'rewrite'];
+    $strings = [];
+    foreach ($searchDisplay as $item) {
+      $settings = $item['settings'] ?? [];
+      self::extractStrings($strings, $settings, $translatableFields);
+    }
+    $strings = array_keys($strings);
+    self::saveTranslations($strings);
+  }
+
+  protected static function extractStrings(array &$strings, array $def, array $translatableFields) {
+    foreach ($def as $key => $value) {
+      if (is_array($value)) {
+        self::extractStrings($strings, $value, $translatableFields);
+      }
+      elseif (in_array($key, $translatableFields)
+        // special case of rewrite, exclude html
+        && !($key == 'rewrite' && ($def['type'] ?? '') == 'html')
+        && self::isWorthy($value)) {
+        $strings[$value] = 1;
+      }
+    }
+  }
+
+  protected static function saveTranslations(array $strings) {
+    // Save the form strings.
+    if (!empty($strings)) {
+      // Create context hash (for now we just record the entity)
+      $context_key = \CRM_Core_BAO_TranslationSource::createGuid(':::search_kit');
+
+      // Build the array for the table.
+      $records = [];
+      foreach ($strings as $value) {
+        $source_key = \CRM_Core_BAO_TranslationSource::createGuid($value);
+        $records[$source_key] = ['source' => $value, 'source_key' => $source_key, 'context_key' => $context_key, 'entity' => 'search_kit'];
+      }
+      $records = array_values($records);
+      TranslationSource::save(FALSE)
+        ->setRecords($records)
+        ->setMatch(['source_key'])
+        ->execute();
+    }
+  }
+
+  protected static function isWorthy(?string $value): bool {
+    return !empty($value)
+      && !is_array($value)
+      // ignore value with smarty
+      && !(str_contains($value, '{') && str_contains($value, '}'))
+      // ignore value with custom translation
+      && (!str_contains($value, 'ts('))
+      // ignore value that are a simple field token
+      && !preg_match('/^\[[A-Za-z0-9._-]+\]$/', trim($value));
+  }
+
+}

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
@@ -6,4 +6,10 @@
     <input id="expires_date" class="form-control" crm-ui-datepicker="{time: true}" ng-model="$ctrl.savedSearch.expires_date" placeholder="{{:: ts('Expires') }}">
   </div>
 </div>
+<div class="form-group" ng-if="$ctrl.locales && $ctrl.locales.length">
+  <label for="locale">
+    {{:: ts('Locale') }} <span class="crm-marker">*</span>
+  </label>
+  <input ng-list crm-ui-select="{multiple: false, data: $ctrl.locales}" class="form-control" id="locale" ng-model="$ctrl.savedSearch.form_values.locale">
+</div>
 <crm-search-admin-tags tag-ids="$ctrl.savedSearch.tag_id" class="btn-group btn-group-sm"></crm-search-admin-tags>

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -39,6 +39,8 @@
       'org.civicrm.afform_admin' in CRM.crmSearchAdmin.modules;
     this.displayTypes = Object.fromEntries(CRM.crmSearchAdmin.displayTypes.map(type => [type.id, type]));
 
+    this.locales = CRM.crmSearchAdmin.locales;
+
     // Only super admins are allowed to create entity displays
     if (!CRM.checkPerm('all CiviCRM permissions and ACLs')) {
       delete this.displayTypes.entity;
@@ -110,6 +112,7 @@
       this.savedSearch.displays = this.savedSearch.displays || [];
       this.savedSearch.form_values = this.savedSearch.form_values || {};
       this.savedSearch.form_values.join = this.savedSearch.form_values.join || {};
+      this.savedSearch.form_values.locale = this.savedSearch.form_values.locale || (this.locales.length === 1 ? this.locales[0].id : '');
       this.savedSearch.groups = this.savedSearch.groups || [];
       this.savedSearch.tag_id = this.savedSearch.tag_id || [];
       this.originalSavedSearch = _.cloneDeep(this.savedSearch);


### PR DESCRIPTION
Overview
----------------------------------------
Like for afform, we extract the labels that could need translation to the civicrm_translation_source so that user can translate them with the new translate UI (civicrm/admin/translation-xx_XX).

After
------
- full init of sources in upgrader if we are in multilingual
- full init of sources when enabling multilingual mode
- sources update when saving the search_kit
- adding of a locale setting in Configure Settings SearchKit (similar to what we do in Afform) :

<img width="811" height="483" alt="Capture d’écran du 2026-05-30 21-30-38" src="https://github.com/user-attachments/assets/912fffae-3a77-4c6e-9409-f20f7e0683b2" />

Technical Details
-----
- added a dispatcher 'civi.core.makeMultilingual' in `CRM/Core/I18n/Schema.php` now that we have 2 extensions that have their own special update.
- moved a function `getLocale` from afform to core i18n `getActiveLocalesOptions` so that SK could use it
- SK needs a special `writeObjects` so I had to create a new trait `SKActionTrait.php` and new custom `Create`, `Save`, `Update` that uses this new trait.