### PR TITLE
Afform - Improve address proximity search inputs

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -33,12 +33,20 @@ class AfformAdminInjector extends AutoSubscriber {
   /**
    * @param \Civi\Core\Event\GenericHookEvent $e
    *
-   * This injects static html to render a small admin-only menu at the top corner of each form.
-   * Permissions are checked client-side.
+   * Proprocess afform html code.
+   *
    * @see afCoreDirective.checkLinkPerm
    */
   public static function preprocess($e) {
     $changeSet = \Civi\Angular\ChangeSet::create('afformAdmin')
+      // Adjust default distance unit for Location input type in the FormBuilder preview template
+      ->alterHtml('~/afGuiEditor/inputType/Location.html', function($doc, $path) {
+        if (\CRM_Utils_Address::getDefaultDistanceUnit() === 'miles') {
+          pq($doc)->find('option[value="km"]')->insertAfter('option[value="miles"]');
+        }
+      })
+      // This injects static html to render a small admin-only menu at the top corner of each form.
+      // Permissions are checked client-side.
       ->alterHtml(';\\.aff\\.html$;', function($doc, $path) {
         try {
           // Inject gear menu with edit links which will be shown if the user has permission

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Location.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Location.html
@@ -1,6 +1,6 @@
 <div class="form-inline">
   <input class="form-control" type="number" readonly placeholder="{{:: ts('Distance') }}">
-  <select class="form-control crm-auto-width" readonly>
+  <select class="form-control crm-auto-width" disabled>
     <option value="km">{{:: ts('Km') }}</option>
     <option value="miles">{{:: ts('Miles') }}</option>
   </select>

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -19,11 +19,18 @@ use CRM_Afform_ExtensionUtil as E;
 class AfformMetadataInjector {
 
   /**
+   * Preprocess
+   *
    * @param \Civi\Core\Event\GenericHookEvent $e
    * @see CRM_Utils_Hook::alterAngular()
    */
   public static function preprocess($e) {
     $changeSet = \Civi\Angular\ChangeSet::create('fieldMetadata')
+      // Adjust default distance unit for Location input type
+      ->alterHtml('~/af/fields/afLocationInput.html', function($doc, $path) {
+        $defaultDistanceUnit = \CRM_Utils_Address::getDefaultDistanceUnit();
+        pq($doc)->find('select[ng-model="$ctrl.values.distance_unit"]')->attr('ng-init', "\$ctrl.values.distance_unit = \$ctrl.values.distance_unit || '$defaultDistanceUnit'");
+      })
       ->alterHtml(';\\.aff\\.html$;', function($doc, $path) {
         try {
           $module = \Civi::service('angular')->getModule(basename($path, '.aff.html'));

--- a/ext/afform/core/ang/af/fields/Location.html
+++ b/ext/afform/core/ang/af/fields/Location.html
@@ -1,8 +1,1 @@
-<div class="form-inline">
-  <input class="form-control" type="number" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance" placeholder="{{:: ts('Distance') }}" >
-  <select class="form-control crm-auto-width" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].distance_unit">
-    <option value="km">{{:: ts('Km') }}</option>
-    <option value="miles">{{:: ts('Miles') }}</option>
-  </select>
-  <input class="form-control" ng-model="dataProvider.getFieldData()[$ctrl.fieldName].address" placeholder="{{:: ts('Street, City, State, Country') }}" ng-model-options="{updateOn: 'blur'}" >
-</div>
+<af-location-input ng-model="dataProvider.getFieldData()[$ctrl.fieldName]"></af-location-input>

--- a/ext/afform/core/ang/af/fields/afLocationInput.component.js
+++ b/ext/afform/core/ang/af/fields/afLocationInput.component.js
@@ -1,0 +1,39 @@
+(function(angular, $, _) {
+  "use strict";
+  angular.module('af').component('afLocationInput', {
+    require: {
+      ngModel: 'ngModel',
+    },
+    templateUrl: '~/af/fields/afLocationInput.html',
+    controller: function($scope, $element) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.afform');
+
+      this.values = {
+        distance: null,
+        // This default is set by `\Civi\Afform\AfformMetadataInjector::preprocess()`
+        distance_unit: null,
+        address: '',
+      };
+
+      this.$onInit = () => {
+        // When the user changes a value, update the model
+        $scope.$watchCollection('$ctrl.values', (values) => {
+          // Only set model value if all fields have been set.
+          if (values.address && values.distance_unit && values.distance !== null) {
+            this.ngModel.$setViewValue(values);
+          } else {
+            this.ngModel.$setViewValue(null);
+          }
+        });
+
+        // When the model changes, update the view
+        this.ngModel.$render = () => {
+          // Only update view if the model is set.
+          this.values = this.ngModel.$viewValue || this.values;
+        };
+
+      };
+
+    }
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/afform/core/ang/af/fields/afLocationInput.html
+++ b/ext/afform/core/ang/af/fields/afLocationInput.html
@@ -1,0 +1,8 @@
+<div class="form-inline">
+  <input class="form-control" type="number" ng-model="$ctrl.values.distance" placeholder="{{:: ts('Distance') }}" >
+  <select class="form-control crm-auto-width" ng-model="$ctrl.values.distance_unit">
+    <option value="km">{{:: ts('Km') }}</option>
+    <option value="miles">{{:: ts('Miles') }}</option>
+  </select>
+  <input class="form-control" ng-model="$ctrl.values.address" placeholder="{{:: ts('Street, City, State, Country') }}" ng-model-options="{updateOn: 'blur'}" >
+</div>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6525](https://lab.civicrm.org/dev/core/-/work_items/6525)

- Auto sets default unit based on site location
- Does not search by proximity until all fields are filled

This prevents invalid queries to the geocoding provider.