### PR TITLE
Remove unwanted whitespace from beginning of JobLog data

### DIFF
--- a/CRM/Admin/Page/JobLog.php
+++ b/CRM/Admin/Page/JobLog.php
@@ -97,6 +97,14 @@ class CRM_Admin_Page_JobLog extends CRM_Core_Page_Basic {
     }
 
     $rows = $jobLogsQuery->execute()->getArrayCopy();
+
+    // Remove unwanted whitespace from beginning of data.
+    array_walk($rows, function(&$item) {
+      if (!empty($item['data'])) {
+        $item['data'] = ltrim($item['data']);
+      }
+    });
+
     $this->assign('rows', $rows);
     $this->assign('jobId', $jid);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Simple change to remove the line break at the beginning of the JobLog data which is visible as a result of being wrapped in a `<pre>` tag. This can't be hidden using CSS.

Before
----------------------------------------
<img width="845" height="225" alt="Screenshot 2026-05-30 at 17 31 03" src="https://github.com/user-attachments/assets/0c7c909d-24a2-4dbf-8795-6390824e3a74" />

After
----------------------------------------
<img width="993" height="206" alt="Screenshot 2026-05-30 at 17 31 29" src="https://github.com/user-attachments/assets/4cbdcb5e-3e09-4624-a910-bc5bc517d802" />