### PR TITLE
Add return type for Symfony compatibility

### DIFF
--- a/ext/standaloneusers/Civi/Standalone/Security.php
+++ b/ext/standaloneusers/Civi/Standalone/Security.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Security extends Civi\Core\Service\AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       '&civi.standalone.loadUser' => ['onLoadUser', 1000],
       '&civi.standalone.checkPassword' => ['onCheckPassword', -500],

--- a/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
+++ b/tests/phpunit/Civi/Test/ExampleSubscriberTest.php
@@ -44,7 +44,7 @@ class ExampleSubscriberTest extends \PHPUnit\Framework\TestCase implements Headl
     parent::tearDown();
   }
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.api.resolve' => 'myCiviApiResolve',
       'civi.api.prepare' => ['myCiviApiPrepare', 1234],

--- a/tools/extensions/phpstorm/Civi/PhpStorm/Api3Generator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/Api3Generator.php
@@ -10,7 +10,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Api3Generator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.phpstorm.flush' => 'generate',
     ];

--- a/tools/extensions/phpstorm/Civi/PhpStorm/Api4Generator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/Api4Generator.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class Api4Generator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.phpstorm.flush' => 'generate',
       'hook_civicrm_post::CustomGroup' => 'generate',

--- a/tools/extensions/phpstorm/Civi/PhpStorm/EntityGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/EntityGenerator.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class EntityGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.phpstorm.flush' => 'generate',
     ];

--- a/tools/extensions/phpstorm/Civi/PhpStorm/EventGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/EventGenerator.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class EventGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.phpstorm.flush' => 'generate',
     ];

--- a/tools/extensions/phpstorm/Civi/PhpStorm/PathGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/PathGenerator.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class PathGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.phpstorm.flush' => 'generate',
     ];

--- a/tools/extensions/phpstorm/Civi/PhpStorm/PermissionsGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/PermissionsGenerator.php
@@ -10,7 +10,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class PermissionsGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return ['civi.phpstorm.flush' => 'generate'];
   }
 

--- a/tools/extensions/phpstorm/Civi/PhpStorm/SettingsGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/SettingsGenerator.php
@@ -10,7 +10,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class SettingsGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return ['civi.phpstorm.flush' => 'generate'];
   }
 

--- a/tools/extensions/phpstorm/Civi/PhpStorm/StaticGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/StaticGenerator.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class StaticGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return ['civi.phpstorm.flush' => 'generate'];
   }
 

--- a/tools/extensions/phpstorm/Civi/PhpStorm/UrlGenerator.php
+++ b/tools/extensions/phpstorm/Civi/PhpStorm/UrlGenerator.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class UrlGenerator extends AutoService implements EventSubscriberInterface {
 
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       'civi.phpstorm.flush' => 'generate',
     ];


### PR DESCRIPTION
Overview
----------------------------------------
While doing a standalone install via composer, it generated an error due to function inheritance incompatibility with latest Symfony package. 

Added the return type to all the `getSubscribedEvents()` functions.

Before
----------------------------------------
Install fails. CiviCRM doesn't load.
<img width="723" height="92" alt="Screenshot 2026-05-30 at 2 03 27 PM" src="https://github.com/user-attachments/assets/fab458f7-50ff-4803-bb62-3d88f4cf9960" />


After
----------------------------------------
Instal works.

Technical Details
----------------------------------------
Symfony package at play: symfony/event-dispatcher v8.1.0