### PR TITLE
update distmaker to add current version as the stable tag in readme.txt

### DIFF
--- a/distmaker/dists/common.sh
+++ b/distmaker/dists/common.sh
@@ -269,6 +269,7 @@ function dm_install_wordpress() {
 
   dm_preg_edit '/^([ \*]*)Version: [0-9\.]+/m' "\1Version: $DM_VERSION" "$to/civicrm.php"
   dm_preg_edit "/^define\( *\'CIVICRM_PLUGIN_VERSION\', *'[0-9\.]+/m" "define('CIVICRM_PLUGIN_VERSION', '$DM_VERSION" "$to/civicrm.php"
+  dm_preg_edit '/^Stable tag: [0-9.]+/m' "Stable tag: $DM_VERSION" "$to/readme.txt"
 }
 
 ## Generate the composer "vendor" folder


### PR DESCRIPTION
Overview
----------------------------------------
WordPress holds the stable tag in readme.txt.  Some plugins and other process look to this to determine if, well, the release is stable.

Before
----------------------------------------
We had to update this tag manually.  We were not good at it.

After
----------------------------------------
distmaker scripts now update the readme.txt to the current version as part of the build process.


Comments
----------------------------------------
We may want to do one last manual update to 6.15 for upcoming release.  Alternative would be to target this to the RC.