### PR TITLE
Dispatch pre and post hooks from Afform api actions

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -47,6 +47,9 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
    * @inheritDoc
    */
   protected function doTask($item) {
+    // Dispatch hook_civicrm_pre
+    \CRM_Utils_Hook::pre('delete', 'Afform', NULL, $item);
+
     /** @var \CRM_Afform_AfformScanner $scanner */
     $scanner = \Civi::service('afform_scanner');
     $files = [
@@ -74,6 +77,11 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
     if (Utils::shouldClearMenuCache($item, $original)) {
       $this->flushMenu = TRUE;
     }
+
+    // Dispatch hook_civicrm_post
+    // param $object is passed by reference
+    $nullValue = NULL;
+    \CRM_Utils_Hook::post('delete', 'Afform', NULL, $nullValue, $item);
 
     return $item;
   }

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -31,6 +31,9 @@ trait AfformSaveTrait {
       $item['created_id'] = \CRM_Core_Session::getLoggedInContactID();
     }
 
+    // Dispatch hook_civicrm_pre
+    \CRM_Utils_Hook::pre($orig ? 'edit' : 'create', 'Afform', NULL, $item);
+
     // FIXME validate all field data.
     $item = _afform_fields_filter($item);
 
@@ -75,7 +78,15 @@ trait AfformSaveTrait {
 
     $item['module_name'] = _afform_angular_module_name($item['name'], 'camel');
     $item['directive_name'] = _afform_angular_module_name($item['name'], 'dash');
-    return $meta + $item;
+
+    $result = $meta + $item;
+
+    // Dispatch hook_civicrm_post
+    // param $object is passed by reference
+    $nullValue = NULL;
+    \CRM_Utils_Hook::post($orig ? 'edit' : 'create', 'Afform', NULL, $nullValue, $result);
+
+    return $result;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Dispatch hooks on Afform create/save/update/revert.

Before
----------------------------------------
No hooks/events dispatched when an Afform is created, saved, updated, or reverted.

After
----------------------------------------
Dispatch `hook_civicrm_pre` and `hook_civicrm_post` when Afform is created/saved/updated/reverted

Technical Details
----------------------------------------
`hook_civicrm_pre`: Action is `create` or `edit`, object id is `NULL`. Afform info is in `$params`.
`hook_civicrm_post`: Action is `delete`, object id is `NULL`, object is `NULL`. Afform info is in `$params`.

Comments
----------------------------------------

