### PR TITLE
Re-try glob if empty the 1st time

### DIFF
--- a/Civi/Schema/EntityRepository.php
+++ b/Civi/Schema/EntityRepository.php
@@ -90,6 +90,11 @@ class EntityRepository {
     $entityTypes = [];
     $path = dirname(__DIR__, 2) . '/schema/*/*.entityType.php';
     $files = (array) glob($path);
+    // awkwardly on some systems (docker on mac) globs can be unreliable
+    // trying again can help with volume caching
+    if (!$files) {
+      $files = (array) glob($path);
+    }
     foreach ($files as $file) {
       if (isset($cache[$file])) {
         $entity = $cache[$file];


### PR DESCRIPTION
Overview
----------------------------------------
When running in a Docker/MacOS environment and having core files in a mounted volume, there can be an issue when Civi tries to load the entity files.

To circumvent this issue, we simply re-try to scan files if it's empty the 1st time around.
A bit of a hacky way, but this is an edge case scenario that is platform dependant and unlikely to occur in production environments. Still, might be useful to devs in the future.

<img width="1241" height="157" alt="Screenshot 2026-05-30 at 2 15 26 PM" src="https://github.com/user-attachments/assets/4eff1505-4057-419e-8ca8-79c62fd178f2" />


Before
----------------------------------------
Fails to install or load Civi.

After
----------------------------------------
It works.

Technical Details
----------------------------------------
Explanation of the issue (from Claude): "_FUSE filesystems go through userspace for every syscall, and this one is clearly non-deterministic on the first glob() traversal — likely a lazy-mount or cache-warming issue where the first readdir call doesn't return all entries but subsequent ones do. This is a known pain point with Docker Desktop's macOS filesystem mounting (it uses virtiofs or similar under the hood with fakeowner)._"

cc @seamuslee001 