### PR TITLE
Fix display of Financial Accounts on pre-AdminUI Financial Types screen

### DIFF
--- a/CRM/Financial/Page/FinancialType.php
+++ b/CRM/Financial/Page/FinancialType.php
@@ -114,7 +114,7 @@ class CRM_Financial_Page_FinancialType extends CRM_Core_Page_Basic {
       }
 
       if (!empty($financialAccountId)) {
-        $financialType[$dao->id]['financial_account'] = implode(',', $financialAccountId);
+        $financialType[$dao->id]['financial_account'] = implode(', ', $financialAccountId);
       }
 
       // form all action links


### PR DESCRIPTION
Overview
----------------------------------------
This is fixed in AdminUI extension, but it's not clear when the current screen is being retired - so here's a fix for the current display of Financial Accounts on the Financial Types screen.

Before
----------------------------------------
<img width="1022" height="278" alt="Screenshot 2026-05-30 at 22 43 44" src="https://github.com/user-attachments/assets/6b2e6a8d-d695-42d8-b9d2-67213e0c1a68" />

After
----------------------------------------
<img width="1030" height="281" alt="Screenshot 2026-05-30 at 22 44 15" src="https://github.com/user-attachments/assets/cf194379-51bf-42b9-b5ce-928e2d97d04e" />
