### PR TITLE
Increase civicrm_tag.used_for column length to 512

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixSixteen.php
+++ b/CRM/Upgrade/Incremental/php/SixSixteen.php
@@ -62,6 +62,17 @@ class CRM_Upgrade_Incremental_php_SixSixteen extends CRM_Upgrade_Incremental_Bas
         'label' => ts('Modified Date'),
       ],
     ]);
+    $this->addTask('Change civicrm_tag.used_for to varchar(512)', 'alterSchemaField', 'Tag', 'used_for', [
+      'title' => ts('Used For'),
+      'sql_type' => 'varchar(512)',
+      'input_type' => 'Select',
+      'add' => '3.2',
+      'default' => NULL,
+      'serialize' => CRM_Core_DAO::SERIALIZE_COMMA,
+      'pseudoconstant' => [
+        'option_group_name' => 'tag_used_for',
+      ],
+    ]);
   }
 
 }

--- a/schema/Core/Tag.entityType.php
+++ b/schema/Core/Tag.entityType.php
@@ -106,7 +106,7 @@ return [
     ],
     'used_for' => [
       'title' => ts('Used For'),
-      'sql_type' => 'varchar(64)',
+      'sql_type' => 'varchar(512)',
       'input_type' => 'Select',
       'add' => '3.2',
       'default' => NULL,


### PR DESCRIPTION
Overview
----------------------------------------
The tag_used_for list is now longer and could potentially be longer than 64 chars.
