### PR TITLE
Dashboard - Improve layout and styling, add full-width columns

### DIFF
--- a/ang/crmDashboard/Dashboard.html
+++ b/ang/crmDashboard/Dashboard.html
@@ -1,16 +1,18 @@
-<div id="civicrm-dashboard">
+<div id="civicrm-dashboard" ng-class="{'crm-dashboard-editing': $ctrl.showInactive}">
   <details class="crm-inactive-dashlet-fieldset crm-accordion-light">
     <summary>
       {{ ts('1 Available Dashlet', {plural: '%count Available Dashlets', count: $ctrl.inactive.length}) }}
       <input ng-if="$ctrl.showInactive" class="crm-form-text" ng-model="$ctrl.filterInactive" type="search" placeholder="{{:: ts('Filter by title...') }}" onclick="event.stopPropagation()">
     </summary>
-    <div ng-if="$ctrl.showInactive" ng-model="$ctrl.inactive" ui-sortable="$ctrl.sortableOptions" class="crm-dashboard-droppable crm-accordion-body">
-      <div class="help">
-        {{:: ts('Drag and drop dashlets onto the left or right columns below to add them to your dashboard. Changes are automatically saved.') }}
+    <div ng-if="$ctrl.showInactive" class="crm-accordion-body">
+      <p class="help">
+        {{:: ts('Drag and drop dashlets to add them to your dashboard. Changes are automatically saved.') }}
         <a crm-ui-help="hs({id: 'dash_configure', title: ts('Dashboard Configuration')})"></a>
-      </div>
-      <div ng-repeat="dashlet in $ctrl.inactive" class="crm-inactive-dashlet" ng-show="$ctrl.filterApplies(dashlet)">
-        <crm-inactive-dashlet dashlet="dashlet" delete="$ctrl.deleteDashlet($index)"></crm-inactive-dashlet>
+      </p>
+      <div class="crm-dashboard-droppable" ui-sortable="$ctrl.sortableOptions" ng-model="$ctrl.inactive">
+        <div ng-repeat="dashlet in $ctrl.inactive" class="crm-inactive-dashlet" ng-show="$ctrl.filterApplies(dashlet)">
+          <crm-inactive-dashlet dashlet="dashlet" delete="$ctrl.deleteDashlet($index)"></crm-inactive-dashlet>
+        </div>
       </div>
     </div>
   </details>

--- a/ang/crmDashboard/Dashboard.html
+++ b/ang/crmDashboard/Dashboard.html
@@ -16,10 +16,20 @@
       </div>
     </div>
   </details>
+  <div class="crm-dashboard-droppable crm-dashboard-column-2" ng-model="$ctrl.columns[2]" ui-sortable="$ctrl.sortableOptions">
+    <div ng-repeat="dashlet in $ctrl.columns[2]" class="crm-dashlet">
+      <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet(2, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
+    </div>
+  </div>
   <div class="crm-flex-box">
-    <div ng-repeat="(colIndex, column) in $ctrl.columns" class="crm-flex-{{2 + colIndex}} crm-dashboard-droppable" ng-model="column" ui-sortable="$ctrl.sortableOptions">
-      <div ng-repeat="dashlet in column" class="crm-dashlet">
-        <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet(colIndex, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
+    <div class="crm-flex-2 crm-dashboard-droppable" ng-model="$ctrl.columns[0]" ui-sortable="$ctrl.sortableOptions">
+      <div ng-repeat="dashlet in $ctrl.columns[0]" class="crm-dashlet">
+        <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet(0, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
+      </div>
+    </div>
+    <div class="crm-flex-3 crm-dashboard-droppable" ng-model="$ctrl.columns[1]" ui-sortable="$ctrl.sortableOptions">
+      <div ng-repeat="dashlet in $ctrl.columns[1]" class="crm-dashlet">
+        <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet(1, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
       </div>
     </div>
   </div>

--- a/ang/crmDashboard/Dashboard.html
+++ b/ang/crmDashboard/Dashboard.html
@@ -1,13 +1,10 @@
 <div id="civicrm-dashboard">
-  <fieldset class="crm-inactive-dashlet-fieldset">
-    <legend>
-      <a href class="crm-hover-button" ng-click="$ctrl.toggleInactive()">
-        <i class="crm-i fa-{{ $ctrl.showInactive ? 'minus' : 'plus' }}" role="img" aria-hidden="true"></i>
-        {{ ts('1 Available Dashlet', {plural: '%count Available Dashlets', count: $ctrl.inactive.length}) }}
-      </a>
-      <input ng-if="$ctrl.showInactive" class="crm-form-text" ng-model="$ctrl.filterInactive" type="search" placeholder="{{:: ts('Filter by title...') }}">
-    </legend>
-    <div ng-if="$ctrl.showInactive" ng-model="$ctrl.inactive" ui-sortable="$ctrl.sortableOptions" class="crm-dashboard-droppable">
+  <details class="crm-inactive-dashlet-fieldset crm-accordion-light">
+    <summary>
+      {{ ts('1 Available Dashlet', {plural: '%count Available Dashlets', count: $ctrl.inactive.length}) }}
+      <input ng-if="$ctrl.showInactive" class="crm-form-text" ng-model="$ctrl.filterInactive" type="search" placeholder="{{:: ts('Filter by title...') }}" onclick="event.stopPropagation()">
+    </summary>
+    <div ng-if="$ctrl.showInactive" ng-model="$ctrl.inactive" ui-sortable="$ctrl.sortableOptions" class="crm-dashboard-droppable crm-accordion-body">
       <div class="help">
         {{:: ts('Drag and drop dashlets onto the left or right columns below to add them to your dashboard. Changes are automatically saved.') }}
         <a crm-ui-help="hs({id: 'dash_configure', title: ts('Dashboard Configuration')})"></a>
@@ -16,7 +13,7 @@
         <crm-inactive-dashlet dashlet="dashlet" delete="$ctrl.deleteDashlet($index)"></crm-inactive-dashlet>
       </div>
     </div>
-  </fieldset>
+  </details>
   <div class="crm-flex-box">
     <div ng-repeat="(colIndex, column) in $ctrl.columns" class="crm-flex-{{2 + colIndex}} crm-dashboard-droppable" ng-model="column" ui-sortable="$ctrl.sortableOptions">
       <div ng-repeat="dashlet in column" class="crm-dashlet">

--- a/ang/crmDashboard/Dashboard.html
+++ b/ang/crmDashboard/Dashboard.html
@@ -33,4 +33,9 @@
       </div>
     </div>
   </div>
+  <div class="crm-dashboard-droppable crm-dashboard-column-3" ng-model="$ctrl.columns[3]" ui-sortable="$ctrl.sortableOptions">
+    <div ng-repeat="dashlet in $ctrl.columns[3]" class="crm-dashlet">
+      <crm-dashlet dashlet="dashlet" remove="$ctrl.removeDashlet(3, $index)" fullscreen="$ctrl.showFullscreen(dashlet)" ng-if="$ctrl.fullscreenDashlet !== dashlet.name"></crm-dashlet>
+    </div>
+  </div>
 </div>

--- a/ang/crmDashboard/crmDashboard.component.js
+++ b/ang/crmDashboard/crmDashboard.component.js
@@ -8,7 +8,11 @@
       this.inactive = [];
       this.sortableOptions = {
         connectWith: '.crm-dashboard-droppable',
-        handle: '.crm-dashlet-header'
+        handle: '.crm-dashlet-header',
+        tolerance: 'pointer',
+        start: (event, ui) => {
+          $('.crm-dashboard-droppable').sortable('refresh');
+        }
       };
       $scope.hs = crmUiHelp({file: 'CRM/Contact/Page/Dashboard'});
 
@@ -32,6 +36,12 @@
             this.onToggleInactive(event.target.open);
           });
         });
+
+        const totalActive = this.columns.reduce((sum, col) => sum + col.length, 0);
+        if (totalActive === 0) {
+          $element.find('.crm-inactive-dashlet-fieldset').prop('open', true);
+          this.onToggleInactive(true);
+        }
       };
 
       this.$onDestroy = () => {

--- a/ang/crmDashboard/crmDashboard.component.js
+++ b/ang/crmDashboard/crmDashboard.component.js
@@ -3,24 +3,22 @@
   angular.module('crmDashboard').component('crmDashboard', {
     templateUrl: '~/crmDashboard/Dashboard.html',
     controller: function ($scope, $element, crmApi4, crmUiHelp, dialogService, crmStatus) {
-      var ts = $scope.ts = CRM.ts(),
-        ctrl = this;
+      const ts = $scope.ts = CRM.ts();
       this.columns = [[], []];
       this.inactive = [];
-      this.contactDashlets = {};
       this.sortableOptions = {
         connectWith: '.crm-dashboard-droppable',
         handle: '.crm-dashlet-header'
       };
       $scope.hs = crmUiHelp({file: 'CRM/Contact/Page/Dashboard'});
 
-      this.$onInit = function() {
+      this.$onInit = () => {
         // Sort dashlets into columns
-        _.each(CRM.crmDashboard.dashlets, function(dashlet) {
+        CRM.crmDashboard.dashlets.forEach((dashlet) => {
           if (dashlet['dashboard_contact.is_active']) {
-            ctrl.columns[dashlet['dashboard_contact.column_no']].push(dashlet);
+            this.columns[dashlet['dashboard_contact.column_no']].push(dashlet);
           } else {
-            ctrl.inactive.push(dashlet);
+            this.inactive.push(dashlet);
           }
         });
 
@@ -28,10 +26,10 @@
         $scope.$watchCollection('$ctrl.columns[1]', onChange);
       };
 
-      var save = _.debounce(function() {
-        $scope.$apply(function() {
-          var toSave = [];
-          _.each(ctrl.inactive, function(dashlet) {
+      const save = _.debounce(() => {
+        $scope.$apply(() => {
+          const toSave = [];
+          this.inactive.forEach((dashlet) => {
             if (dashlet['dashboard_contact.id']) {
               toSave.push({
                 dashboard_id: dashlet.id,
@@ -40,9 +38,9 @@
               });
             }
           });
-          _.each(ctrl.columns, function(dashlets, col) {
-            _.each(dashlets, function(dashlet, index) {
-              var item = {
+          this.columns.forEach((dashlets, col) => {
+            dashlets.forEach((dashlet, index) => {
+              const item = {
                 dashboard_id: dashlet.id,
                 is_active: true,
                 column_no: col,
@@ -58,9 +56,9 @@
             records: toSave,
             defaults: {contact_id: 'user_contact_id'}
           }, 'dashboard_id'))
-            .then(function(results) {
-              _.each(ctrl.columns, function(dashlets) {
-                _.each(dashlets, function(dashlet) {
+            .then((results) => {
+              this.columns.forEach((dashlets) => {
+                dashlets.forEach((dashlet) => {
                   dashlet['dashboard_contact.id'] = results[dashlet.id].id;
                 });
               });
@@ -69,57 +67,57 @@
       }, 2000);
 
       // Sort inactive dashlets by label. This makes them easier to find if there is a large number.
-      function sortInactive() {
-        ctrl.inactive = _.sortBy(ctrl.inactive, 'label');
-      }
+      const sortInactive = () => {
+        this.inactive = this.inactive.slice().sort((a, b) => a.label.localeCompare(b.label));
+      };
 
       // Show/hide inactive dashlets
-      this.toggleInactive = function() {
+      this.toggleInactive = () => {
         // Ensure inactive dashlets are sorted before showing them
         sortInactive();
-        ctrl.showInactive = !ctrl.showInactive;
+        this.showInactive = !this.showInactive;
       };
 
-      this.filterApplies = function(dashlet) {
-        return !ctrl.filterInactive || _.includes(dashlet.label.toLowerCase(), ctrl.filterInactive.toLowerCase());
+      this.filterApplies = (dashlet) => {
+        return !this.filterInactive || dashlet.label.toLowerCase().includes(this.filterInactive.toLowerCase());
       };
 
-      this.removeDashlet = function(column, index) {
-        ctrl.inactive.push(ctrl.columns[column][index]);
-        ctrl.columns[column].splice(index, 1);
+      this.removeDashlet = (column, index) => {
+        this.inactive.push(this.columns[column][index]);
+        this.columns[column].splice(index, 1);
         // Place the dashlet back in the correct abc order
         sortInactive();
       };
 
-      this.deleteDashlet = function(index) {
+      this.deleteDashlet = (index) => {
         crmStatus(
           {start: ts('Deleting'), success: ts('Deleted')},
-          crmApi4('Dashboard', 'delete', {where: [['id', '=', ctrl.inactive[index].id]]})
+          crmApi4('Dashboard', 'delete', {where: [['id', '=', this.inactive[index].id]]})
         );
-        ctrl.inactive.splice(index, 1);
+        this.inactive.splice(index, 1);
       };
 
-      this.showFullscreen = function(dashlet) {
-        ctrl.fullscreenDashlet = dashlet.name;
-        var options = CRM.utils.adjustDialogDefaults({
+      this.showFullscreen = (dashlet) => {
+        this.fullscreenDashlet = dashlet.name;
+        const options = CRM.utils.adjustDialogDefaults({
           width: '90%',
           height: '90%',
           autoOpen: false,
           title: dashlet.label
         });
         dialogService.open('fullscreenDashlet', '~/crmDashboard/FullscreenDialog.html', dashlet, options)
-          .then(function() {
-            ctrl.fullscreenDashlet = null;
-          }, function() {
-            ctrl.fullscreenDashlet = null;
+          .then(() => {
+            this.fullscreenDashlet = null;
+          }, () => {
+            this.fullscreenDashlet = null;
           });
       };
 
-      function onChange(newVal, oldVal) {
+      const onChange = (newVal, oldVal) => {
         if (oldVal !== newVal) {
           save();
         }
-      }
+      };
 
     }
   });

--- a/ang/crmDashboard/crmDashboard.component.js
+++ b/ang/crmDashboard/crmDashboard.component.js
@@ -4,7 +4,7 @@
     templateUrl: '~/crmDashboard/Dashboard.html',
     controller: function ($scope, $element, crmApi4, crmUiHelp, dialogService, crmStatus) {
       const ts = $scope.ts = CRM.ts();
-      this.columns = [[], [], []];
+      this.columns = [[], [], [], []];
       this.inactive = [];
       this.sortableOptions = {
         connectWith: '.crm-dashboard-droppable',
@@ -29,6 +29,7 @@
         $scope.$watchCollection('$ctrl.columns[0]', onChange);
         $scope.$watchCollection('$ctrl.columns[1]', onChange);
         $scope.$watchCollection('$ctrl.columns[2]', onChange);
+        $scope.$watchCollection('$ctrl.columns[3]', onChange);
 
         // Listen for toggle events on the details element
         $element.find('.crm-inactive-dashlet-fieldset').on('toggle', (event) => {

--- a/ang/crmDashboard/crmDashboard.component.js
+++ b/ang/crmDashboard/crmDashboard.component.js
@@ -11,7 +11,11 @@
         handle: '.crm-dashlet-header',
         tolerance: 'pointer',
         start: (event, ui) => {
+          $('#civicrm-dashboard').addClass('crm-dashboard-dragging');
           $('.crm-dashboard-droppable').sortable('refresh');
+        },
+        stop: (event, ui) => {
+          $('#civicrm-dashboard').removeClass('crm-dashboard-dragging');
         }
       };
       $scope.hs = crmUiHelp({file: 'CRM/Contact/Page/Dashboard'});

--- a/ang/crmDashboard/crmDashboard.component.js
+++ b/ang/crmDashboard/crmDashboard.component.js
@@ -24,6 +24,17 @@
 
         $scope.$watchCollection('$ctrl.columns[0]', onChange);
         $scope.$watchCollection('$ctrl.columns[1]', onChange);
+
+        // Listen for toggle events on the details element
+        $element.find('.crm-inactive-dashlet-fieldset').on('toggle', (event) => {
+          $scope.$apply(() => {
+            this.onToggleInactive(event.target.open);
+          });
+        });
+      };
+
+      this.$onDestroy = () => {
+        $element.find('.crm-inactive-dashlet-fieldset').off('toggle');
       };
 
       const save = _.debounce(() => {
@@ -71,11 +82,13 @@
         this.inactive = this.inactive.slice().sort((a, b) => a.label.localeCompare(b.label));
       };
 
-      // Show/hide inactive dashlets
-      this.toggleInactive = () => {
-        // Ensure inactive dashlets are sorted before showing them
-        sortInactive();
-        this.showInactive = !this.showInactive;
+      // Handle disclosure element toggle
+      this.onToggleInactive = (isOpen) => {
+        this.showInactive = isOpen;
+        if (isOpen) {
+          // Ensure inactive dashlets are sorted before showing them
+          sortInactive();
+        }
       };
 
       this.filterApplies = (dashlet) => {

--- a/ang/crmDashboard/crmDashboard.component.js
+++ b/ang/crmDashboard/crmDashboard.component.js
@@ -4,7 +4,7 @@
     templateUrl: '~/crmDashboard/Dashboard.html',
     controller: function ($scope, $element, crmApi4, crmUiHelp, dialogService, crmStatus) {
       const ts = $scope.ts = CRM.ts();
-      this.columns = [[], []];
+      this.columns = [[], [], []];
       this.inactive = [];
       this.sortableOptions = {
         connectWith: '.crm-dashboard-droppable',
@@ -24,6 +24,7 @@
 
         $scope.$watchCollection('$ctrl.columns[0]', onChange);
         $scope.$watchCollection('$ctrl.columns[1]', onChange);
+        $scope.$watchCollection('$ctrl.columns[2]', onChange);
 
         // Listen for toggle events on the details element
         $element.find('.crm-inactive-dashlet-fieldset').on('toggle', (event) => {

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -64,19 +64,17 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   opacity: 1;
 }
 
-fieldset.crm-inactive-dashlet-fieldset {
+#civicrm-dashboard .crm-inactive-dashlet-fieldset {
   border: 0 none;
 }
 
-fieldset.crm-inactive-dashlet-fieldset > div {
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > div {
   background-color: lightgray;
   padding: 8px;
 }
 
-fieldset.crm-inactive-dashlet-fieldset legend {
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > summary {
   background-color: #eee;
-  display: block;
-  top: 4px;
 }
 
 .crm-container .crm-inactive-dashlet {

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -16,6 +16,10 @@
   border: 3px dashed var(--crm-c-gray-400);
   padding: var(--crm-l-reg);
 }
+#civicrm-dashboard.crm-dashboard-editing .crm-dashlet {
+  max-height: 15rem;
+  overflow: hidden;
+}
 #civicrm-dashboard > .crm-dashboard-column-2:has(.crm-dashlet),
 #civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2 {
   margin-bottom: var(--crm-l-reg);

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -6,13 +6,18 @@
   grid-template-columns: var(--crm-dashlet-columns);
   gap: var(--crm-l-reg);
 }
-#civicrm-dashboard .crm-dashboard-droppable {
+#civicrm-dashboard.crm-dashboard-editing .crm-dashboard-droppable {
   /* avoid total collapse else no droppable area if all widgets removed */
   min-height: 10rem;
 }
+#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2,
 #civicrm-dashboard.crm-dashboard-editing > .crm-flex-box > .crm-dashboard-droppable {
   border: 3px dashed var(--crm-c-gray-400);
   padding: var(--crm-l-reg);
+}
+#civicrm-dashboard > .crm-dashboard-column-2:has(.crm-dashlet),
+#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2 {
+  margin-bottom: var(--crm-l-reg);
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -5,8 +5,14 @@
   display: grid;
   grid-template-columns: var(--crm-dashlet-columns);
   gap: var(--crm-l-reg);
+}
+#civicrm-dashboard .crm-dashboard-droppable {
   /* avoid total collapse else no droppable area if all widgets removed */
-  min-height: var(--crm-l-reg);
+  min-height: 10rem;
+}
+#civicrm-dashboard.crm-dashboard-editing > .crm-flex-box > .crm-dashboard-droppable {
+  border: 3px dashed var(--crm-c-gray-400);
+  padding: var(--crm-l-reg);
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);
@@ -98,36 +104,28 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 .crm-dashlet #help {
   margin: var(--crm-contact-block-padding);
 }
-.crm-container .crm-inactive-dashlet-fieldset .help {
-  width: 100%;
-  margin: 0;
+
+/* Dragging */
+#civicrm-dashboard .crm-dashlet.ui-sortable-helper,
+#civicrm-dashboard .crm-inactive-dashlet.ui-sortable-helper {
+  height: var(--crm-l-large-2) !important;
+  opacity: .8;
 }
-.crm-container .crm-inactive-dashlet {
-  display: inline-block;
-  width: 340px;
-  height: var(--crm-l-large-2);
-  box-shadow: var(--crm-shadow-popup);
-  background-color: color-mix(in srgb, var(--crm-dashlet-bg-color) 90%, #fff 10%);
-  border-radius: var(--crm-dashlet-radius);
-  margin: 0;
-}
-.crm-container .crm-inactive-dashlet .crm-dashlet-header {
-  height: 2rem;
-  border-radius: var(--crm-dashlet-radius) var(--crm-dashlet-radius) 0 0;
-}
-.crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {
-  font-size: 75%;
-  padding-left: var(--crm-l-small-1);
-}
+
+/* Drop Zone */
 #civicrm-dashboard .ui-sortable-placeholder {
   border: 2px dashed var(--crm-c-gray-700);
-  visibility: visible;
-  width: 226px;
-  height: 66px;
+  visibility: visible !important;
+  width: 100%;
+  height: var(--crm-l-large-2);
   vertical-align: bottom;
+  box-shadow: none;
 }
-#civicrm-dashboard .ui-sortable-placeholder * {
-  visibility: hidden;
+#civicrm-dashboard .crm-inactive-dashlet-fieldset .ui-sortable-placeholder {
+  width: 20rem;
+}
+#civicrm-dashboard .ui-sortable-placeholder > * {
+  display: none;
 }
 
 /* News feed */
@@ -146,7 +144,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   padding: var(--crm-accordion-body-padding);
 }
 
-/* Getting statrted */
+/* Getting started */
 #civicrm-getting-started table {
   box-shadow: none;
   border: 0 solid transparent;
@@ -172,17 +170,35 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border: 0;
   margin-bottom: var(--crm-l-reg);
 }
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > summary {
+  background-color: var(--crm-dashlet-dashlets-bg-color);
+}
 #civicrm-dashboard .crm-inactive-dashlet-fieldset > div.crm-accordion-body {
   background-color: var(--crm-dashlet-dashlets-bg-color);
   box-shadow: var(--crm-dashlet-box-shadow);
   border-radius: var(--crm-dashlet-radius);
+  padding: var(--crm-l-reg);
+}
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > div.crm-accordion-body > div.crm-dashboard-droppable {
   display: flex;
   flex-wrap: wrap;
   gap: var(--crm-l-reg);
-  padding: var(--crm-l-reg);
 }
-#civicrm-dashboard .crm-inactive-dashlet-fieldset > summary {
-  background-color: var(--crm-dashlet-dashlets-bg-color);
+.crm-container .crm-inactive-dashlet {
+  width: 20rem;
+  height: var(--crm-l-large-2);
+  box-shadow: var(--crm-shadow-popup);
+  background-color: color-mix(in srgb, var(--crm-dashlet-bg-color) 90%, #fff 10%);
+  border-radius: var(--crm-dashlet-radius);
+  margin: 0;
+}
+.crm-container .crm-inactive-dashlet .crm-dashlet-header {
+  height: 2rem;
+  border-radius: var(--crm-dashlet-radius) var(--crm-dashlet-radius) 0 0;
+}
+.crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {
+  font-size: 75%;
+  padding-left: var(--crm-l-small-1);
 }
 
 /* Searchkit Dashlets */

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -11,6 +11,7 @@
   min-height: 10rem;
 }
 #civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2,
+#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3,
 #civicrm-dashboard.crm-dashboard-editing > .crm-flex-box > .crm-dashboard-droppable {
   border: 3px dashed var(--crm-c-gray-400);
   padding: var(--crm-l-reg);
@@ -18,6 +19,10 @@
 #civicrm-dashboard > .crm-dashboard-column-2:has(.crm-dashlet),
 #civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2 {
   margin-bottom: var(--crm-l-reg);
+}
+#civicrm-dashboard > .crm-dashboard-column-3:has(.crm-dashlet),
+#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3 {
+  margin-top: var(--crm-l-reg);
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -6,26 +6,33 @@
   grid-template-columns: var(--crm-dashlet-columns);
   gap: var(--crm-l-reg);
 }
-#civicrm-dashboard.crm-dashboard-editing .crm-dashboard-droppable {
+#civicrm-dashboard.crm-dashboard-editing .crm-dashboard-droppable,
+#civicrm-dashboard.crm-dashboard-dragging .crm-dashboard-droppable {
   /* avoid total collapse else no droppable area if all widgets removed */
   min-height: 10rem;
 }
 #civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2,
 #civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3,
-#civicrm-dashboard.crm-dashboard-editing > .crm-flex-box > .crm-dashboard-droppable {
+#civicrm-dashboard.crm-dashboard-editing > .crm-flex-box > .crm-dashboard-droppable,
+#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-2,
+#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-3,
+#civicrm-dashboard.crm-dashboard-dragging > .crm-flex-box > .crm-dashboard-droppable {
   border: 3px dashed var(--crm-c-gray-400);
   padding: var(--crm-l-reg);
 }
-#civicrm-dashboard.crm-dashboard-editing .crm-dashlet {
+#civicrm-dashboard.crm-dashboard-editing .crm-dashlet,
+#civicrm-dashboard.crm-dashboard-dragging .crm-dashlet {
   max-height: 15rem;
   overflow: hidden;
 }
 #civicrm-dashboard > .crm-dashboard-column-2:has(.crm-dashlet),
-#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2 {
+#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2,
+#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-2 {
   margin-bottom: var(--crm-l-reg);
 }
 #civicrm-dashboard > .crm-dashboard-column-3:has(.crm-dashlet),
-#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3 {
+#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3,
+#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-3 {
   margin-top: var(--crm-l-reg);
 }
 .crm-container .crm-dashlet {

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -113,6 +113,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   margin: 0;
 }
 .crm-container .crm-inactive-dashlet .crm-dashlet-header {
+  height: 2rem;
   border-radius: var(--crm-dashlet-radius) var(--crm-dashlet-radius) 0 0;
 }
 .crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -114,6 +114,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 #civicrm-dashboard .crm-dashlet.ui-sortable-helper,
 #civicrm-dashboard .crm-inactive-dashlet.ui-sortable-helper {
   height: var(--crm-l-large-2) !important;
+  max-width: 30rem;
   opacity: .8;
 }
 

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -1,5 +1,5 @@
 /* Style rules for Dashboard home screen.
-   Forked on 11 June 24, updated 16 Jan 25. */
+   Forked on 11 June 24, updated 30 May 26. */
 
 #civicrm-dashboard > .crm-flex-box {
   display: grid;
@@ -39,7 +39,6 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
-  color: var(--crm-dashlet-header-color);
   font-size: var(--crm-dashlet-header-font-size);
 }
 .crm-container .crm-dashlet-header a {
@@ -167,13 +166,13 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border: 0 solid transparent;
 }
 
-/* Add dashlet */
-fieldset.crm-inactive-dashlet-fieldset {
+/* Available (inactive) dashlets */
+#civicrm-dashboard .crm-inactive-dashlet-fieldset {
   padding: 0;
   border: 0;
   margin-bottom: var(--crm-l-reg);
 }
-fieldset.crm-inactive-dashlet-fieldset > div {
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > div.crm-accordion-body {
   background-color: var(--crm-dashlet-dashlets-bg-color);
   box-shadow: var(--crm-dashlet-box-shadow);
   border-radius: var(--crm-dashlet-radius);
@@ -182,16 +181,10 @@ fieldset.crm-inactive-dashlet-fieldset > div {
   gap: var(--crm-l-reg);
   padding: var(--crm-l-reg);
 }
-fieldset.crm-inactive-dashlet-fieldset legend {
-  background-color: transparent;
-  display: block;
-  margin-bottom: var(--crm-l-reg);
-  top: var(--crm-l-small);
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > summary {
+  background-color: var(--crm-dashlet-dashlets-bg-color);
 }
-fieldset.crm-inactive-dashlet-fieldset legend .crm-hover-button {
-  padding: var(--crm-btn-large-padding);
-  margin-right: var(--crm-l-reg);
-}
+
 /* Searchkit Dashlets */
 
 .crm-dashlet .crm-search-display .form-inline {


### PR DESCRIPTION
Overview
----------------------------------------
This pull request introduces several layout and usability improvements to the CiviCRM home page dashboard:
1. Adds two new full-width drag-and-drop sections: one at the top (section 2) and one at the bottom (section 3).
2. Introduces visual drop zone styling (dashed borders, padding) when in editing mode.
3. Constrains active dashlet heights to `15rem` and hides overflow while editing to keep the layout compact and manageable.
4. Automatically opens the "Available Dashlets" fieldset on page load if the user's dashboard is completely empty.
5. Improves the drag-and-drop user experience (such as dropping wide full-width elements into narrow columns).

<img width="841" height="779" alt="image" src="https://github.com/user-attachments/assets/9a786e6e-e885-4156-b665-d083adb2d7cb" />

Before
----------------------------------------
- The dashboard was limited to a simple 2-column layout (columns 0 and 1).
- When entering edit mode, there were no dashed border visual indicators showing where columns/drop zones are.
- If a user visited a completely empty dashboard, the page would remain blank without prompting them to configure it.
- Dragging wide dashlets (e.g., from column 2) and dropping them onto narrower columns was difficult or failed because the drag helper was extremely wide and couldn't satisfy the default jQuery UI Sortable intersection threshold (50% overlap).

After
----------------------------------------
- **Four-Section Layout**: The dashboard now supports:
  - Section 2: Full-width at the top.
  - Sections 0 and 1: Two side-by-side columns in the middle.
  - Section 3: Full-width at the bottom.
- **Drop Zone Indicators**: When the "Available Dashlets" accordion is open (`crm-dashboard-editing` class is present), active columns are highlighted with a dashed gray border, padding, and a standard min-height to represent drop zones.
- **Editing Constraint**: Active dashlets are constrained to a maximum height of `15rem` with hidden overflow during edit mode to facilitate easier dragging and drop zone visibility.
- **Drag UX Improvements**: 
  - The jQuery UI Sortable `tolerance` option is set to `'pointer'`, allowing large/wide dashlets to be dropped into narrow columns seamlessly.
  - Active drag helpers are constrained to a maximum width of `30rem` to keep the drag preview compact and easy to place.
  - All sortable lists are refreshed dynamically on drag start to prevent caching issues.
  - Spaced full-width columns dynamically using `:has(.crm-dashlet)` so empty columns don't occupy layout space when not in editing mode.
- **Auto-Open Available Dashlets**: When a user loads the dashboard and has no active dashlets in any of the four columns, the "Available Dashlets" drawer automatically opens.

Technical Details
----------------------------------------
- Expanded `$ctrl.columns` to 4 columns: `[[], [], [], []]` and added corresponding watches.
- Changed AngularJS template to render column 2 and column 3 outside the `.crm-flex-box` grid, and replaced the `ng-repeat` array iterator with explicit column bindings for columns 0 and 1.
- Modified styles in `ext/riverlea/core/css/dashboard.css` in the Riverlea theme extension.

Comments
----------------------------------------
- Tests in `tests/phpunit/CRM/Core/BAO/DashboardTest.php` were run and are fully passing.
- Checked styles and javascript with `civilint`.