### PR TITLE
Afform support for dummy processor

### DIFF
--- a/Civi/Payment/CheckoutOption/DummyCheckoutOption.php
+++ b/Civi/Payment/CheckoutOption/DummyCheckoutOption.php
@@ -1,0 +1,113 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Payment\CheckoutOption;
+
+use Civi\Afform\Event\AfformValidateEvent;
+use Civi\Checkout\AfformCheckoutOptionInterface;
+use Civi\Checkout\CheckoutOption;
+use Civi\Checkout\CheckoutSession;
+
+/**
+ * CheckoutOption for the Dummy payment processor.
+ *
+ * For testing FormBuilder payment flows. Provides a simple checkout
+ * widget that immediately processes a payment on confirmation.
+ */
+class DummyCheckoutOption extends CheckoutOption implements AfformCheckoutOptionInterface {
+
+  protected array $liveConnection;
+  protected array $testConnection;
+
+  public function __construct(array $liveConnection, array $testConnection) {
+    $this->liveConnection = $liveConnection;
+    $this->testConnection = $testConnection;
+  }
+
+  protected function getConnectionDetails(bool $testMode = FALSE): array {
+    return $testMode ? $this->testConnection : $this->liveConnection;
+  }
+
+  public function getLabel(): string {
+    return $this->getConnectionDetails()['title'];
+  }
+
+  public function getFrontendLabel(): string {
+    return $this->getConnectionDetails()['frontend_title'];
+  }
+
+  public function getPaymentProcessorId(bool $testMode = FALSE): ?int {
+    return $this->getConnectionDetails($testMode)['id'];
+  }
+
+  public function getAfformModule(): ?string {
+    return 'afDummy';
+  }
+
+  public function getAfformSettings(bool $testMode): array {
+    return [
+      'template' => '~/afDummy/dummy_checkout.html',
+      'fields' => $this->getBillingFields(),
+    ];
+  }
+
+  private function getBillingFields(): array {
+    $countryOptions = array_map(
+      fn($id, $label) => ['id' => $id, 'label' => $label],
+      array_keys(\CRM_Core_PseudoConstant::country()),
+      array_values(\CRM_Core_PseudoConstant::country())
+    );
+
+    return [
+      ['name' => 'credit_card_number', 'htmlType' => 'text', 'title' => ts('Card Number'), 'is_required' => TRUE],
+      ['name' => 'credit_card_exp_date', 'htmlType' => 'date', 'title' => ts('Expiry Date'), 'is_required' => TRUE],
+      ['name' => 'cvv2', 'htmlType' => 'text', 'title' => ts('Security Code'), 'is_required' => TRUE],
+      ['name' => 'billing_first_name', 'htmlType' => 'text', 'title' => ts('First Name'), 'is_required' => TRUE],
+      ['name' => 'billing_last_name', 'htmlType' => 'text', 'title' => ts('Last Name'), 'is_required' => TRUE],
+      ['name' => 'billing_street_address', 'htmlType' => 'text', 'title' => ts('Street Address'), 'is_required' => TRUE],
+      ['name' => 'billing_city', 'htmlType' => 'text', 'title' => ts('City'), 'is_required' => TRUE],
+      ['name' => 'billing_postal_code', 'htmlType' => 'text', 'title' => ts('Postal Code'), 'is_required' => TRUE],
+      ['name' => 'billing_country_id-billing', 'htmlType' => 'select', 'title' => ts('Country'), 'is_required' => TRUE, 'options' => $countryOptions],
+      ['name' => 'billing_state_province_id-billing', 'htmlType' => 'chainSelect', 'title' => ts('State/Province'), 'is_required' => FALSE],
+    ];
+  }
+
+  public function validate(AfformValidateEvent $event): void {
+  }
+
+  /**
+   * Provide the landing URL to the checkout widget so it can redirect
+   * back to complete the checkout after the user confirms.
+   */
+  public function startCheckout(CheckoutSession $session): void {
+    $session->setResponseItem('dummy_checkout', [
+      'landing_url' => $session->getLandingUrl(),
+    ]);
+    $session->setResponseItem('message', FALSE);
+  }
+
+  /**
+   * Called when the user returns from the checkout widget.
+   * Generates a transaction ID (mirroring CRM_Core_Payment_Dummy) and records the payment.
+   */
+  public function continueCheckout(CheckoutSession $session): void {
+    $mode = $session->isTestMode() ? 'test' : 'live';
+    $last = \CRM_Core_DAO::singleValueQuery("SELECT MAX(trxn_id) FROM civicrm_contribution WHERE trxn_id LIKE '{$mode}_%'") ?? '';
+    $last = str_replace($mode, '', $last);
+    $trxnId = $mode . '_' . ((int) $last + 1) . '_' . uniqid();
+
+    $session
+      ->setTransactionId($trxnId)
+      ->success()
+      ->createPayment();
+  }
+
+}

--- a/Civi/Payment/DummyConnections.php
+++ b/Civi/Payment/DummyConnections.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Payment;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoService;
+use Civi\Payment\CheckoutOption\DummyCheckoutOption;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Registers CheckoutOptions for all Dummy payment processor instances.
+ *
+ * @service civi.payment.dummy_connections
+ */
+class DummyConnections extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.checkout.options' => 'getCheckoutOptions',
+    ];
+  }
+
+  public function getCheckoutOptions(GenericHookEvent $e): void {
+    foreach ($this->getPaymentProcessorPairs() as $name => $pair) {
+      $e->options['dummy_' . $name] = new DummyCheckoutOption($pair['live'], $pair['test']);
+    }
+  }
+
+  private function getPaymentProcessorPairs(): array {
+    // The "is_test" clause isn't a no-op, API4 default is to ignore test processors.
+    $all = \Civi\Api4\PaymentProcessor::get(FALSE)
+      ->addWhere('payment_processor_type_id:name', '=', 'Dummy')
+      ->addWhere('is_test', 'IN', [TRUE, FALSE])
+      ->execute();
+
+    $pairs = [];
+    foreach ($all as $processor) {
+      $pairs[$processor['name']][$processor['is_test'] ? 'test' : 'live'] = $processor;
+    }
+    return $pairs;
+  }
+
+}

--- a/ang/afDummy.ang.php
+++ b/ang/afDummy.ang.php
@@ -1,0 +1,16 @@
+<?php
+
+// Angular module afDummy.
+// @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
+return [
+  'js' => [
+    'ang/afDummy.js',
+    'ang/afDummy/*.js',
+  ],
+  'partials' => ['ang/afDummy'],
+  'settings' => [],
+  'requires' => ['afCheckout'],
+  'exports' => [
+    'af-dummy-checkout' => 'E',
+  ],
+];

--- a/ang/afDummy.js
+++ b/ang/afDummy.js
@@ -1,0 +1,3 @@
+(function(angular, $, _) {
+  angular.module('afDummy', CRM.angRequires('afDummy'));
+})(angular, CRM.$, CRM._);

--- a/ang/afDummy/dummyCheckout.component.js
+++ b/ang/afDummy/dummyCheckout.component.js
@@ -1,0 +1,34 @@
+(function(angular, $, _) {
+  angular.module('afDummy').component('afDummyCheckout', {
+    require: {
+      afCheckoutBlock: '^^afCheckoutBlock',
+    },
+    templateUrl: '~/afDummy/dummyCheckout.html',
+    controller: function($scope, $element) {
+      const ts = $scope.ts = CRM.ts(null);
+
+      this.redirecting = false;
+
+      const listener = (e, data) => this.onAfformSuccess(data);
+
+      this.onAfformSuccess = (data) => {
+        const response = data.submissionResponse;
+        if (!response || !response.length || !response[0].dummy_checkout) {
+          return;
+        }
+        this.redirecting = true;
+        window.location.href = response[0].dummy_checkout.landing_url;
+      };
+
+      this.$onInit = () => {
+        this.getFormElement().on('crmFormSuccess', listener);
+      };
+
+      this.$onDestroy = () => {
+        this.getFormElement().off('crmFormSuccess', listener);
+      };
+
+      this.getFormElement = () => $element.closest('af-form');
+    },
+  });
+})(angular, CRM.$, CRM._);

--- a/ang/afDummy/dummyCheckout.html
+++ b/ang/afDummy/dummyCheckout.html
@@ -1,0 +1,4 @@
+<span ng-if="$ctrl.redirecting">
+  <i class="crm-i fa-spinner fa-spin" aria-hidden="true"></i>
+  {{ ts('Processing...') }}
+</span>

--- a/ang/afDummy/dummy_checkout.html
+++ b/ang/afDummy/dummy_checkout.html
@@ -1,0 +1,1 @@
+<af-dummy-checkout></af-dummy-checkout>


### PR DESCRIPTION
Overview
----------------------------------------
While adding new features for FormBuilder Payments it's been hard to test without a dummy processor.  So here one is.

Before
----------------------------------------
No dummy processor support in afform.

After
----------------------------------------
Dummy processor support in afform.

Comments
----------------------------------------
Is this the best place for the Angular module?
