### PR TITLE
Include Contribution Page in main area of New Contribution form

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -860,6 +860,13 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     // CRM-7362 --add campaigns.
     CRM_Campaign_BAO_Campaign::addCampaign($this, $this->_values['campaign_id'] ?? NULL);
 
+    $this->add('select', 'contribution_page_id',
+      ts('Contribution Page'),
+      ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::contributionPage(),
+      FALSE,
+      ['class' => 'crm-select2']
+    );
+
     if (empty($this->_payNow)) {
       CRM_Contribute_Form_SoftCredit::buildQuickForm($this);
     }
@@ -1930,13 +1937,6 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
         ['CRM_Contribute_DAO_Contribution', $form->_id, 'creditnote_id']
       );
     }
-
-    $form->add('select', 'contribution_page_id',
-      ts('Contribution Page'),
-      ['' => ts('- select -')] + CRM_Contribute_PseudoConstant::contributionPage(),
-      FALSE,
-      ['class' => 'crm-select2']
-    );
 
     $form->add('textarea', 'note', ts('Notes'), ["rows" => 4, "cols" => 60]);
 

--- a/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
+++ b/templates/CRM/Contribute/Form/AdditionalInfo/AdditionalDetail.tpl
@@ -11,7 +11,6 @@
 {if $isOnline}{assign var=valueStyle value=" class='view-value'"}{else}{assign var=valueStyle value=""}{/if}
 <div id="id-additionalDetail" class="section-shown">
     <table class="form-layout-compressed">
-        <tr  class="crm-contribution-form-block-contribution_page"><td class="label">{$form.contribution_page_id.label}</td><td{$valueStyle}>{$form.contribution_page_id.html|crmAddClass:twenty}</td></tr>
         <tr class="crm-contribution-form-block-note"><td class="label" style="vertical-align:top;">{$form.note.label}</td><td>{$form.note.html}</td></tr>
         <tr class="crm-contribution-form-block-non_deductible_amount"><td class="label">{$form.non_deductible_amount.label}</td><td{$valueStyle}>{$form.non_deductible_amount.html}</td></tr>
         <tr class="crm-contribution-form-block-fee_amount"><td class="label">{$form.fee_amount.label}</td><td{$valueStyle}>{$form.fee_amount.html}</td></tr>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -139,6 +139,11 @@
         {* CRM-7362 --add campaign to contributions *}
         {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignTrClass="crm-contribution-form-block-campaign_id"}
 
+        <tr class="crm-contribution-form-block-contribution_page">
+          <td class="label">{$form.contribution_page_id.label} {help id="contribution_page_id"}</td>
+          <td{$valueStyle}>{$form.contribution_page_id.html|crmAddClass:twenty}</td>
+        </tr>
+
         {if (empty($is_template) && (!$contributionMode || $payNow))}
           <tr class="crm-contribution-form-block-contribution_status_id">
             <td class="label">{$form.contribution_status_id.label}</td>

--- a/templates/CRM/Contribute/Page/Tab.hlp
+++ b/templates/CRM/Contribute/Page/Tab.hlp
@@ -21,6 +21,9 @@
 {ts}Select the appropriate financial type for this transaction.{/ts}
 {/htxt}
 
+{htxt id='contribution_page_id'}
+{ts}Selecting a contribution page will include its receipt message in the email receipt.{/ts}
+{/htxt}
 
 {htxt id="payment_instrument_id"}
   <p>


### PR DESCRIPTION
Overview
----------------------------------------
As the offline contribution receipt now includes the receipt message from the contribution page, I think it makes sense to move the select for the contribution page up into the main area of the form, so data entry doesn't require the user to scroll down and open the Additional Details tab. I suppose there is trade-off between simplicity for those who don't really use contribution pages and easy data entry for those who do, but this feels like the right move to me — but maybe others feel differently?

After
----------------------------------------
<img width="726" height="394" alt="image" src="https://github.com/user-attachments/assets/4753673e-adb4-4773-8e91-90a937f1b283" />

Also added help text:
<img width="351" height="108" alt="image" src="https://github.com/user-attachments/assets/ec0010a5-7ef8-4cd0-9692-47632ae1ad02" />

