### PR TITLE
Alphabetise local extensions on "CiviCRM Extensions" screen

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -133,6 +133,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
     // $manager->refresh();
 
     $localExtensionRows = $this->formatLocalExtensionRows();
+    uasort($localExtensionRows, fn($a, $b) => strcasecmp($a['name'], $b['name']));
     $this->assign('localExtensionRows', $localExtensionRows);
 
     $remoteExtensionRows = $this->formatRemoteExtensionRows($localExtensionRows);


### PR DESCRIPTION
Overview
----------------------------------------
Local extensions on the "CiviCRM Extensions" screen are currently listed by extension `key` which produces a non-intuitive order requiring an extra click to sort by name to make sense if it.

Before
----------------------------------------
Sample sorted by extension `key`
<img width="1019" height="580" alt="Screenshot 2026-05-31 at 22 12 12" src="https://github.com/user-attachments/assets/dc37d9e4-fa06-4a5f-93a1-b834b777b07c" />

After
----------------------------------------
Sample sorted by extension `name`
<img width="1004" height="599" alt="Screenshot 2026-05-31 at 22 12 51" src="https://github.com/user-attachments/assets/35af45c6-3758-4d79-abab-4cdefab90ddf" />
