### PR TITLE
FormBuilder - remember last selected tab

### DIFF
--- a/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
+++ b/ext/afform/admin/ang/afAdmin/afAdminList.controller.js
@@ -55,8 +55,16 @@
     });
 
     if (!ctrl.tab) {
-      ctrl.tab = ctrl.tabs[0].name;
+      // If no tab in URL, use the last remembered tab or default to first tab
+      ctrl.tab = CRM.cache.get('afAdminLastTab', ctrl.tabs[0].name);
     }
+
+    // Watch for tab changes and remember the selection
+    $scope.$watch('$ctrl.tab', (newTab) => {
+      if (newTab) {
+        CRM.cache.set('afAdminLastTab', newTab);
+      }
+    });
 
     this.createLinks = () => {
       // Reset search input in dropdown


### PR DESCRIPTION
Overview
----------------------------------------
Remember the user's last selected tab (Submission Forms, Search Forms, etc) when revisiting Form Builder.

Before
----------------------------------------
Returning to the FormBuilder list page always shows the "Submission Forms" tab, regardless of which tab the user was previously viewing.

After
----------------------------------------
Remembers the last tab you were on.

Technical Details
----------------------------------------
Updates [afAdminList.controller.js](file:///Users/colemanwatts/buildkit/build/standalone-clean/web/core/ext/afform/admin/ang/afAdmin/afAdminList.controller.js):
* Initializes `ctrl.tab` using `CRM.cache.get('afAdminLastTab', ctrl.tabs[0].name)` when no tab route parameter is present.
* Sets a watcher on `$ctrl.tab` to update the cache (`CRM.cache.set('afAdminLastTab', newTab)`) upon tab selection changes.

Comments
----------------------------------------
Part of the ongoing improvements to FormBuilder administration UX.