### PR TITLE
Add civi.order.validate event

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -16,6 +16,7 @@ use Civi\Api4\LineItem;
 use Civi\Api4\PriceField;
 use Civi\Api4\PriceFieldValue;
 use Civi\Api4\PriceSet;
+use Civi\Order\Event\OrderValidateEvent;
 
 /**
  *
@@ -1655,6 +1656,14 @@ class CRM_Financial_BAO_Order {
     $this->calculateContributionValues();
     // Then we get/calculate the lineitems - they won't have related entity IDs Membership/Participant etc. for new records.
     $this->getLineItems();
+    $event = new OrderValidateEvent($this->contributionValues, $this->contributionRecurValues, $this->lineItems);
+    \Civi::dispatcher()->dispatch('civi.order.validate', $event);
+    $errors = $event->getErrors();
+    if ($errors) {
+      \Civi::log('order')->error('Order Validation errors', ['errors' => $errors]);
+      throw new \CRM_Core_Exception(implode("\n", $errors), 0, ['show_detailed_error' => TRUE]);
+    }
+
     return $this;
   }
 
@@ -1677,6 +1686,7 @@ class CRM_Financial_BAO_Order {
     }
     $this->contributionValues['line_item'] = [$this->getLineItems()];
 
+    // Create the Contribution
     return Contribution::create(FALSE)
       ->setValues($this->contributionValues)->execute();
   }

--- a/Civi/Order/Event/OrderValidateEvent.php
+++ b/Civi/Order/Event/OrderValidateEvent.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Civi\Order\Event;
+
+/**
+ * OrderValidateEvent: Triggered when validating an Order.
+ *
+ * The Order is "readonly". You have access to all values that would be submitted/calculated
+ *   via getContributionValues(), getContributionRecurValues() and getLineItems().
+ * To check if other listeners have already added errors call getErrors().
+ * To add errors call addError() or setErrors().
+ */
+class OrderValidateEvent {
+
+  /**
+   * @var array
+   */
+  private array $errors = [];
+
+  /**
+   * Array of submitted and calculated Contribution values
+   *
+   * @var array
+   */
+  private array $contributionValues;
+
+  /**
+   *  Array of submitted and calculated ContributionRecur values
+   *
+   * @var array
+   */
+  private array $contributionRecurValues;
+
+  /**
+   * Array of submitted and calculated lineItem values
+   *
+   * @var array
+   */
+  private array $lineItems;
+
+  /**
+   * OrderValidateEvent constructor.
+   *
+   * @param array $contributionValues
+   * @param array $contributionRecurValues
+   * @param array $lineItems
+   */
+  public function __construct(array $contributionValues, array $contributionRecurValues, array $lineItems) {
+    $this->contributionValues = $contributionValues;
+    $this->contributionRecurValues = $contributionRecurValues;
+    $this->lineItems = $lineItems;
+  }
+
+  /**
+   * @return array
+   */
+  public function getContributionValues(): array {
+    return $this->contributionValues;
+  }
+
+  /**
+   * @return array
+   */
+  public function getContributionRecurValues(): array {
+    return $this->contributionRecurValues;
+  }
+
+  /**
+   * @return array
+   */
+  public function getLineItems(): array {
+    return $this->lineItems;
+  }
+
+  /**
+   * Add an error
+   *
+   * @param string $errorMsg
+   *
+   * @return void
+   */
+  public function addError(string $errorMsg): void {
+    $this->errors[] = $errorMsg;
+  }
+
+  /**
+   * Replace all existing errors with the specified array
+   *
+   * @param array $errors
+   *
+   * @return void
+   */
+  public function setErrors(array $errors): void {
+    $this->errors = $errors;
+  }
+
+  /**
+   * Get all errors that have been set by other callers
+   *
+   * @return array
+   */
+  public function getErrors(): array {
+    return $this->errors;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/35523

Implements the following event for Order API4:

- civi.order.validate: Allows you to add custom validation when calling Order::create which can return errors back to the user/caller.

In the future, we will probably want to expose an Order::validate API which would call just the validate part of this PR.

**Example use-case for validate**
You are selling tickets for an event managed by a third-party. You can make a call to the third-party API to check if there are still tickets available and return a "Sorry, this event is sold out" if not. Also, you could do things like force the user to buy one event ticket and one membership - eg. "You must purchase a membership if you want an event ticket".

Could be wrapped into an API in a similar way to eg. https://github.com/civicrm/civicrm-core/pull/34006


Before
----------------------------------------
No events to validate an Order.

After
----------------------------------------
Events to validate an Order.

Technical Details
----------------------------------------
The main complexity added in this PR is a refactor to split out the calculation from the saving of the parameters. From a long-term maintenance/testability point of view that'll make things easier going forward because we have specific functions to do specific things instead of trying to do multiple things (ie. calculate params + save in the same function).

Comments
----------------------------------------
@eileenmcnaughton Pulling your comments from #35524:
> Up until now the BAO_Order object has been strictly an internal object and it has been clear that it will change - passing it out to a hook might cause expectation problems - could we pass arrays instead? I worry that we will continue to change it & our internal tags might not be enough

Agree. This PR passes in `contributionValues`, `contributionRecurValues` and `lineItems` which covers all the parameters which would be passed through if Order::create calls `save()`. All 3 arrays are passed through the same functions that are used when saving so that we have a "final" set of parameters that can be looked at for validation.
