### PR TITLE
Formbuilder Payments: Fix setting testMode for CheckoutOption

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
@@ -39,7 +39,7 @@ interface CheckoutOptionInterface {
   /**
    * @return ?int id of associated PaymentProcessor record, if any
    */
-  public function getPaymentProcessorId(): ?int;
+  public function getPaymentProcessorId(bool $testMode = FALSE): ?int;
 
   /**
    * Initiate a new checkout

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -549,7 +549,7 @@ class CheckoutSession {
         ->addValue('contribution_id', $this->getContributionId())
         ->addValue('total_amount', $this->totalAmount)
         ->addValue('fee_amount', $this->feeAmount)
-        ->addValue('payment_processor_id', $this->getCheckoutOption()->getPaymentProcessorId())
+        ->addValue('payment_processor_id', $this->getCheckoutOption()->getPaymentProcessorId($this->isTestMode()))
         ->addValue('trxn_date', date('Ymd H:i:s'))
         ->addValue('trxn_id', $this->transactionId)
         ->addValue('order_reference', $this->orderReference)


### PR DESCRIPTION
Overview
----------------------------------------
**Issue 1:**
`Civi\Checkout\CheckoutOption` defines `public function getPaymentProcessorId(bool $testMode = FALSE): ?int {` but 
`Civi\Checkout\CheckoutOptionInterface` defines `public function getPaymentProcessorId(bool $testMode = FALSE): ?int;`

**Issue 2:**
In `createPayment()` function testMode is not respected so "live" payment processor is always set as the payment processor.

Technical Details
----------------------------------------

Comments
----------------------------------------
@ufundo Can you check please?
