### PR TITLE
Formbuilder Payments: Allow test mode payment on live contribution

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -127,7 +127,12 @@ class CheckoutSession {
       ->single();
 
     $this->totalAmount = $contribution['total_amount'];
-    $this->testMode = $contribution['is_test'];
+    // If we explicitly set TestMode then respect it. Otherwise use the value on the Contribution
+    // When using Afform Contribution in "Create" mode they will match.
+    // In "Update" mode they might not - eg. you are testing an "invoice payment workflow"
+    //   and want to do an end-to-end test but without taking a live payment.
+    $sessionTestMode = \Civi::service('civi.checkout')->isTestMode();
+    $this->testMode = $sessionTestMode ?: $contribution['is_test'];
 
     // set default messages
     // NOTE: we use "payment" instead of checkout


### PR DESCRIPTION
Overview
----------------------------------------
Also see related #35825 

Contribution Pages in CiviCRM have an "invoice" mode where they can be used to pay for existing contributions. We can also do that with formbuilder payments.

This allows for a diverse set of workflows. For example:

1. User 1 (maybe an employee) has a form that allows for placing "orders" - creates a pending contribution with various lineitems and chooses "Pay later" (or that is the only option). Eg. registering for an event.
2. User 2 (maybe the employer/accounts team) has a form that lists pending payments for their employees and provides a link to make payment. That link loads a form with the existing contribution and a "live" payment processor so that User 2 can make payment on User 1 behalf.

These are (at least) two separate workflows which can be built and tested independently. But sometimes it's necessary to do a full end-to-end test.
With contribution pages you can do that because you can pass in "action=preview" and it doesn't care if the `contribution['is_test']` flag is set. It *is* obvious from a payment/data perspective because you can see that the test processor was used to make the payment.

We need to be able to do similar with formbuilder. This PR makes that possible.

Before
----------------------------------------
Every workflow that creates a contribution must be changed to `is_test=TRUE`.

After
----------------------------------------
Only the actual payment workflow needs changing to `is_test=TRUE`. This can be done eg. by creating a clone of the live payment form or temporarily changing test mode to TRUE on the payment form without touching any other workflows.

Technical Details
----------------------------------------
Described above. Basically just respects the setting on the form in preference to the value on the contribution.

Comments
----------------------------------------
@ufundo @rbaugh 
