### PR TITLE
dev/core#6526: no upgrade links when extension directory not writable

### DIFF
--- a/CRM/Admin/Page/Extensions.php
+++ b/CRM/Admin/Page/Extensions.php
@@ -272,7 +272,7 @@ class CRM_Admin_Page_Extensions extends CRM_Core_Page_Basic {
       if (isset($localExtensionRows[$info->key])) {
         if (array_key_exists('version', $localExtensionRows[$info->key])) {
           if (version_compare($localExtensionRows[$info->key]['version'] ?? '', $info->version, '<')) {
-            $row['upgradelink'] = $mapper->getUpgradeLink($remoteExtensions[$info->key], $localExtensionRows[$info->key]);
+            $row['upgradelink'] = $mapper->getUpgradeLink($remoteExtensions[$info->key], $localExtensionRows[$info->key], CRM_Extension_System::singleton()->getDownloader()->extensionDirectoryWritable());
           }
         }
       }

--- a/CRM/Extension/Downloader.php
+++ b/CRM/Extension/Downloader.php
@@ -71,6 +71,15 @@ class CRM_Extension_Downloader {
   }
 
   /**
+   * Determine whether extension directory is writable
+   *
+   * @return bool
+   */
+  public function extensionDirectoryWritable() {
+    return ($this->containerDir && is_dir($this->containerDir) && is_writable($this->containerDir));
+  }
+
+  /**
    * Determine whether downloading is supported.
    *
    * @param \CRM_Extension_Info $extensionInfo Optional info for (updated) extension

--- a/CRM/Extension/Mapper.php
+++ b/CRM/Extension/Mapper.php
@@ -569,16 +569,25 @@ class CRM_Extension_Mapper {
    *
    * @param CRM_Extension_Info $remoteExtensionInfo
    * @param array $localExtensionInfo
+   * @param bool $extensionDirectoryWritable
    *
    * @return string
    */
-  public function getUpgradeLink($remoteExtensionInfo, $localExtensionInfo) {
+  public function getUpgradeLink($remoteExtensionInfo, $localExtensionInfo, $extensionDirectoryWritable) {
     if (!empty($remoteExtensionInfo) && version_compare($localExtensionInfo['version'] ?? '', $remoteExtensionInfo->version, '<')) {
-      return ts('Version %1 is installed. <a %2>Upgrade to version %3</a>.', [
-        1 => $localExtensionInfo['version'],
-        2 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', "action=update&id={$localExtensionInfo['key']}&key={$localExtensionInfo['key']}") . '"',
-        3 => $remoteExtensionInfo->version,
-      ]);
+      if ($extensionDirectoryWritable) {
+        return ts('Version %1 is installed. <a %2>Upgrade to version %3</a>.', [
+          1 => $localExtensionInfo['version'],
+          2 => 'href="' . CRM_Utils_System::url('civicrm/admin/extensions', "action=update&id={$localExtensionInfo['key']}&key={$localExtensionInfo['key']}") . '"',
+          3 => $remoteExtensionInfo->version,
+        ]);
+      }
+      else {
+        return ts('Version %1 is installed. <strong>Version %2 available</strong>.', [
+          1 => $localExtensionInfo['version'],
+          2 => $remoteExtensionInfo->version,
+        ]);
+      }
     }
   }
 

--- a/CRM/Utils/Check/Component/Env.php
+++ b/CRM/Utils/Check/Component/Env.php
@@ -630,7 +630,7 @@ class CRM_Utils_Check_Component_Env extends CRM_Utils_Check_Component {
             ]);
           }
           elseif (!empty($remotes[$key]) && version_compare($row['version'], $remotes[$key]->version, '<')) {
-            $updates[] = $row['label'] . ': ' . $mapper->getUpgradeLink($remotes[$key], $row);
+            $updates[] = $row['label'] . ': ' . $mapper->getUpgradeLink($remotes[$key], $row, CRM_Extension_System::singleton()->getDownloader()->extensionDirectoryWritable());
           }
           else {
             if (empty($row['label'])) {


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/work_items/6526

Overview
----------------------------------------
If the extension directory is not writable then do not display option to upgrade an extension.

Before
----------------------------------------
An upgrade link.

After
----------------------------------------

<img width="1185" height="143" alt="2026-06-01 16 03 19 bcv lndo site cb9537d5e366" src="https://github.com/user-attachments/assets/a915bd65-3889-4b1a-8269-0d9282a90e87" />
