### PR TITLE
CiviCampaign - Fix missing tab count on dashboard

### DIFF
--- a/ext/civi_campaign/ang/afsearchCampaignDashboard.aff.html
+++ b/ext/civi_campaign/ang/afsearchCampaignDashboard.aff.html
@@ -6,7 +6,7 @@
         <af-field name="campaign_type_id" defn="{input_attrs: {multiple: true, placeholder: 'Filter by type'}, label: false}" />
         <af-field name="status_id" defn="{input_attrs: {multiple: true, placeholder: 'Filter by status'}, label: false}" />
       </fieldset>
-      <crm-search-display search-name="Administer_Campaigns" display-name="Campaigns_Table" total-count="$parent.count"></crm-search-display>
+      <crm-search-display-table search-name="Administer_Campaigns" display-name="Campaigns_Table" total-count="$parent.count"></crm-search-display-table>
     </div>
   </af-tab>
   <af-tab title="Surveys">


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing counter on the first tab of the Campaign Dashboard.

Before
----------------------------------------
<img width="1114" height="418" alt="Screenshot 2026-06-01 at 8 35 33 PM" src="https://github.com/user-attachments/assets/7ec5f8c5-82cd-4b9d-899e-ec8abe490074" />

After
----------------------------------------
<img width="1104" height="418" alt="Screenshot 2026-06-01 at 8 36 08 PM" src="https://github.com/user-attachments/assets/ddc46403-7dbc-4392-a49d-5f26b1dcb7e8" />


Technical Details
----------------------------------------
This regressed with e714f407d73611ef1836835f5b44bc1ce1911515 because the generic <crm-search-display> tag doesn't yet support the totalCount argument.