### PR TITLE
Invoke contact pre and post hooks when editing custom fields inline

### DIFF
--- a/CRM/Contact/Form/Inline/CustomData.php
+++ b/CRM/Contact/Form/Inline/CustomData.php
@@ -113,11 +113,16 @@ class CRM_Contact_Form_Inline_CustomData extends CRM_Contact_Form_Inline {
     // Process / save custom data
     // Get the form values and groupTree
     $params = $this->getSubmittedValues();
+    CRM_Utils_Hook::pre('edit', $this->_contactType, $this->getContactID(), $params);
     CRM_Core_BAO_CustomValueTable::postProcess($params,
       'civicrm_contact',
       $this->getContactID(),
       $this->_contactType
     );
+
+    $contact = new CRM_Contact_BAO_Contact();
+    $contact->id = $this->getContactID();
+    CRM_Utils_Hook::post('edit', $this->_contactType, $this->getContactID(), $contact, $params);
 
     $this->log();
 


### PR DESCRIPTION
Overview
----------------------------------------
What's a [decade or so](https://issues.civicrm.org/jira/browse/CRM-15261)?

Comments
----------------------------------------
This seems to give results that are the same as doing the edit via Edit on the contact. For the post hook, neither contains the custom fields, but they are included in `$params`. Arguably the custom fields should be in there, but this achieves parity with the existing hook invocation when editing the contact (and I think it would only make sense to change both of them together, which I'm considering out of scope here).

I'm not sure loading the `$contact` for the post hook makes complete sense in this context, but I suppose that's what subscribers expect. 
