### PR TITLE
Accept valid classes as parameter types in api

### DIFF
--- a/Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php
@@ -97,6 +97,11 @@ class ValidateFieldsSubscriber extends Generic\AbstractPrepareSubscriber {
           return TRUE;
 
         default:
+          if (is_string($type) && class_exists($type)) {
+            if ($value instanceof $type) {
+              return TRUE;
+            }
+          }
           throw new \CRM_Core_Exception('Unknown parameter type: ' . $type);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Accept valid classes as parameter types in api

Before
----------------------------------------
We accept an `object` as a parameter for the api if specified in the docblock but if the class is specified there is a validation error

After
----------------------------------------
As long as it is a valid class we validate against it 

Technical Details
----------------------------------------
accepting objects as parameters does not port well across api syntaxes - but we already do that so it's not new. Given we do then it is better practice to specific the actual object.

Note that my use case right now is passing in a mock class returning a guzzle client for a unit test in custom code

Comments
----------------------------------------
@colemanw 
