### PR TITLE
Fix dev/core#6335

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1498,8 +1498,14 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
         ->addWhere('contribution_recur_id.contribution_status_id:name', '!=', 'Cancelled')
         ->execute()->first();
       if (isset($membership['contribution_recur_id'])) {
-        $paymentObject = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($membership['contribution_recur_id']);
-        $supportsCancel[$cacheKeyString] = $paymentObject->supports('cancelRecurring');
+        try {
+          $paymentObject = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($membership['contribution_recur_id']);
+          $supportsCancel[$cacheKeyString] = $paymentObject->supports('cancelRecurring');
+        }
+        catch (CRM_Core_Exception $e) {
+          // An error could be thrown because the payment processor id on the contribution recur can be NULL.
+          // This happens with CiviSepa.
+        }
       }
     }
     return $supportsCancel[$cacheKeyString];

--- a/CRM/Member/Page/Tab.php
+++ b/CRM/Member/Page/Tab.php
@@ -125,10 +125,16 @@ class CRM_Member_Page_Tab extends CRM_Core_Page {
         $isUpdateBilling = $isCancelSupported = FALSE;
         $contributionRecurID = $dao->contribution_recur_id;
         if ($contributionRecurID) {
-          $paymentObject = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($contributionRecurID);
-          if (!empty($paymentObject)) {
-            $isUpdateBilling = $paymentObject->supports('updateSubscriptionBillingInfo');
-            $isCancelSupported = $paymentObject->supports('cancelRecurring');
+          try {
+            $paymentObject = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($contributionRecurID);
+            if (!empty($paymentObject)) {
+              $isUpdateBilling = $paymentObject->supports('updateSubscriptionBillingInfo');
+              $isCancelSupported = $paymentObject->supports('cancelRecurring');
+            }
+          }
+          catch (CRM_Core_Exception $e) {
+            // An error could be thrown because the payment processor id on the contribution recur can be NULL.
+            // This happens with CiviSepa.
           }
         }
 


### PR DESCRIPTION
Overview
----------------------------------------

When using CiviMember and CiviSepa it is not possible anymore to view the membership tab.

Reproduction steps
----------------------------------------
1. Setup CiviMember (configure a membership)
1. Setup CiviSepa
1. Setup a sepa mandate
1. Setup a membership and link it to the recurring contribution created in the previous step when you created a mandate)
1. Now try to open the contact and browse to the member ship tab

Current behaviour
----------------------------------------

A popup shows with Network Error. And no memberships are shown

Expected behaviour
----------------------------------------

No popup should be shown and memberships should be visible. 

Environment information
----------------------------------------

* __CiviCRM:__ 6.14 (and in 6.10 it was working)

Comments
----------------------------------------

I identified the following commit introduced the error: https://github.com/civicrm/civicrm-core/commit/70243d65b4f23f5a551f2c7262f9aef2ce435b07

That commit changed how to lookup a payment processor and does an assumption that the contribution recur is linked to a payment processor (which is not the case in CiviSepa).