### PR TITLE
Checkout - remove stray $testMode param to CheckoutOption::getPaymentProcessorId

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutOption.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOption.php
@@ -13,11 +13,17 @@ abstract class CheckoutOption implements CheckoutOptionInterface {
     return $this->getLabel();
   }
 
+  /**
+   * @inheritdoc
+   */
   public function getPaymentMethod(): ?string {
     return NULL;
   }
 
-  public function getPaymentProcessorId(bool $testMode = FALSE): ?int {
+  /**
+   * @inheritdoc
+   */
+  public function getPaymentProcessorId(): ?int {
     return NULL;
   }
 
@@ -41,7 +47,7 @@ abstract class CheckoutOption implements CheckoutOptionInterface {
    * legacy payment processors where 1 PaymentProcessor = 1 Checkout Option
    */
   protected function getQuickformProcessor(bool $testMode = FALSE): ?\CRM_Core_Payment {
-    $id = $this->getPaymentProcessorId($testMode);
+    $id = $this->getPaymentProcessorId();
     $connection = \Civi\Api4\PaymentProcessor::get(FALSE)->addWhere('id', '=', $id)->execute()->first();
     if (!$connection || empty($connection['name'])) {
       return NULL;

--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
@@ -37,6 +37,11 @@ interface CheckoutOptionInterface {
   public function getPaymentMethod(): ?string;
 
   /**
+   * NOTE: this function does not take a testMode param - the intention is
+   * that consumers should generally consider whether to use test or live processor
+   * depending on other signals in a given context, and not distinguish between
+   * test / live payment processor record IDs
+   *
    * @return ?int id of associated PaymentProcessor record, if any
    */
   public function getPaymentProcessorId(): ?int;


### PR DESCRIPTION
Overview
----------------------------------------
Alternative to https://github.com/civicrm/civicrm-core/pull/35816 

I was intending to remove these in order to minimise the different signals for test mode. 

Note how `getQuickformProcessor` implementation does not actually depend on or respect it.

