### PR TITLE
Use isTestMode flag that can be set in session and provide warning message when form is in test mode

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/Afform.php
+++ b/ext/civi_contribute/Civi/Checkout/Afform.php
@@ -217,6 +217,7 @@ class Afform extends AutoService implements EventSubscriberInterface {
 
     return [
       'checkoutOptions' => $config,
+      'testMode' => $testMode,
     ];
   }
 

--- a/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
+++ b/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
@@ -27,6 +27,10 @@
       // @see \Civi\Checkout\Afform::getSettings
       const options = CRM.afCheckout.checkoutOptions;
 
+      this.getCheckoutIsTestMode = () => {
+        return CRM.afCheckout.testMode ?? false;
+      };
+
       this.getCheckoutOptionKey = () => {
         return this.getContributionValue('checkout_option');
       };

--- a/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.html
+++ b/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.html
@@ -1,3 +1,4 @@
+<div ng-if="$ctrl.getCheckoutIsTestMode()" class="alert alert-warning" crm-icon="fa-cogs">{{ ts('Checkout is in Test Mode.') }}</div>
 <span ng-if="$ctrl.getCheckoutOptionDescription()">{{ $ctrl.getCheckoutOptionDescription() }}</span>
 <div ng-include="$ctrl.getCheckoutOptionTemplate()"></div>
 <div


### PR DESCRIPTION
Overview
----------------------------------------
See related #35817 

Add a warning message to the form when Checkout is in test mode (by session `testMode` param):

<img width="1042" height="617" alt="image" src="https://github.com/user-attachments/assets/45e73a51-da99-4284-8fbb-febcaae5dd12" />

Before
----------------------------------------
No indication that `testMode` has been set on the session.

After
----------------------------------------
Clearly indicated that `testMode` has been set on the session.

Technical Details
----------------------------------------


Comments
----------------------------------------

