### PR TITLE
Queue Runner - use refresh rather than back for retry icon

### DIFF
--- a/templates/CRM/Queue/Page/Runner.tpl
+++ b/templates/CRM/Queue/Page/Runner.tpl
@@ -13,7 +13,7 @@
     <div id="crm-queue-runner-title">{ts}Beginning first step{/ts}</div>
     <div id="crm-queue-runner-buttonset" class="crm-flex-box" style="flex: 0 0 max-content;">
       {if $queueRunnerData['buttons']['retry']}
-      <button class="btn btn-primary" id="crm-queue-runner-retry"><i class="crm-i fa-backward-step"></i>{ts}Retry{/ts}</button>
+      <button class="btn btn-primary" id="crm-queue-runner-retry"><i class="crm-i fa-refresh"></i>{ts}Retry{/ts}</button>
       {/if}
       {if $queueRunnerData['buttons']['skip']}
       <button class="btn btn-warning" id="crm-queue-runner-skip"><i class="crm-i fa-fast-forward"></i>{ts}Skip{/ts}</button>


### PR DESCRIPTION
Before
----------------------------------------
- the icon to retry a failed step is "Previous"

<img width="1273" height="184" alt="image" src="https://github.com/user-attachments/assets/f0d1e9b6-b08b-4795-be29-a114770c8fb0" />


After
----------------------------------------
- the icon to retry a failed step is Refresh

<img width="1328" height="214" alt="image" src="https://github.com/user-attachments/assets/395cde60-255f-433c-8c6d-2026b0af5246" />


