### PR TITLE
SearchKit - Selectable money format

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1352,9 +1352,14 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         break;
 
       case 'Money':
-        $currencyField = $this->getCurrencyField($key) ?? '';
-        $currency = is_string($data[$currencyField] ?? NULL) ? $data[$currencyField] : NULL;
-        $formatted = \Civi::format()->money($rawValue, $currency);
+        if ($format === 'number') {
+          $formatted = \CRM_Utils_Number::formatLocaleNumeric((string) $rawValue);
+        }
+        else {
+          $currencyField = $this->getCurrencyField($key) ?? '';
+          $currency = is_string($data[$currencyField] ?? NULL) ? $data[$currencyField] : NULL;
+          $formatted = \Civi::format()->money($rawValue, $currency);
+        }
         break;
 
       case 'Float':

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Download.php
@@ -73,11 +73,10 @@ class Download extends AbstractRunAction {
       return $rawValue;
     }
 
-    if (in_array($this->format, ['array', 'csv'], TRUE)) {
-      return parent::formatViewValue($key, $rawValue, $data, $dataType, $format);
-    }
-
     if ($dataType === 'Money') {
+      if (in_array($this->format, ['array', 'csv'], TRUE) || $format === 'number') {
+        return $rawValue;
+      }
       $currencyField = $this->getCurrencyField($key);
       $currency = is_string($data[$currencyField] ?? NULL) ? $data[$currencyField] : \Civi::settings()->get('defaultCurrency');
 
@@ -85,6 +84,10 @@ class Download extends AbstractRunAction {
         'currency' => $currency,
         'value' => $rawValue,
       ];
+    }
+
+    if (in_array($this->format, ['array', 'csv'], TRUE)) {
+      return parent::formatViewValue($key, $rawValue, $data, $dataType, $format);
     }
 
     return $rawValue;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -143,7 +143,7 @@ trait ResultDataTrait {
           $cell->getHyperlink()->setUrl($value['links'][0]['url']);
         }
 
-        if ($value['dataType'] === 'Money') {
+        if ($value['dataType'] === 'Money' && is_array($value['val'])) {
           $numberFormatter = new \NumberFormatter($moneyLocale . '@currency=' . $value['val']['currency'], \NumberFormatter::CURRENCY);
           $currencySymbol = $numberFormatter->getSymbol(\NumberFormatter::CURRENCY_SYMBOL);
           $cell->getStyle()->getNumberFormat()->setFormatCode(new Currency($currencySymbol, locale: $numberFormatter->getLocale()));
@@ -176,7 +176,7 @@ trait ResultDataTrait {
 
     if (!in_array($this->format, ['array', 'csv'], TRUE)) {
       if ($value['dataType'] === 'Money') {
-        return $val['value'];
+        return is_array($val) ? $val['value'] : $val;
       }
 
       if (($value['dataType'] === 'Date' || $value['dataType'] === 'Timestamp') && ($val !== NULL) && !is_array($val)) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -156,6 +156,10 @@
         return ['Date', 'Timestamp'].includes(this.getDataType(key));
       };
 
+      this.isMoney = function(key) {
+        return this.getDataType(key) === 'Money';
+      };
+
       this.getExprFromSelect = function(key) {
         let fieldKey = key.split(':')[0];
         let match = ctrl.savedSearch.api_params.select.find((expr) => {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -24,6 +24,13 @@
     <option ng-repeat="(k, v) in $ctrl.parent.dateFormats" value="{{k}}">{{ v }}</option>
   </select>
 </div>
+<div class="form-inline" ng-if="$ctrl.parent.isMoney(col.key)">
+  <label for="crm-search-admin-edit-money-format-{{ $index }}">{{:: ts('Format') }}</label>
+  <select id="crm-search-admin-edit-money-format-{{ $index }}" class="form-control" ng-model="col.format" title="{{:: ts('Money Format') }}">
+    <option value="">{{:: ts('Currency') }}</option>
+    <option value="number">{{:: ts('Number') }}</option>
+  </select>
+</div>
 <div class="form-inline" ng-if="$ctrl.parent.getDataType(col.key) === 'Float'">
   <label ng-repeat="(key, label) in $ctrl.parent.numberAttributes">
     {{:: label }}

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -550,4 +550,137 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     }
   }
 
+  /**
+   * Test that Money fields are exported as raw numbers in machine-readable
+   * download formats (csv and array).
+   *
+   * Currency symbols and locale formatting must be absent so the values
+   * remain importable by spreadsheet applications without manual cleanup.
+   */
+  public function testDownloadArrayMoney(): void {
+    $cid = Contact::create(FALSE)->execute()->single()['id'];
+    \Civi\Api4\Contribution::create(FALSE)
+      ->setValues([
+        'contact_id' => $cid,
+        'total_amount' => 1234.56,
+        'financial_type_id:name' => 'Donation',
+      ])->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'array',
+      'savedSearch' => [
+        'api_entity' => 'Contribution',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['total_amount'],
+          'where' => [['contact_id', '=', $cid]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'test',
+        'settings' => [
+          'actions' => TRUE,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'total_amount',
+              'label' => 'Total Amount',
+            ],
+          ],
+        ],
+      ],
+      'afform' => NULL,
+    ];
+
+    $result = (array) civicrm_api4('SearchDisplay', 'download', $params);
+    // Row 0 is the header row, row 1 is the data row.
+    static::assertSame('Total Amount', $result[0][0]);
+    // Value must be the raw number, not a currency-formatted string.
+    static::assertSame(1234.56, $result[1][0]);
+  }
+
+  /**
+   * Test that Money fields with format 'number' are exported to XLSX as raw numeric values.
+   */
+  public function testDownloadXlsxMoney(): void {
+    $cid = Contact::create(FALSE)->execute()->single()['id'];
+    \Civi\Api4\Contribution::create(FALSE)
+      ->setValues([
+        'contact_id' => $cid,
+        'total_amount' => 1234.56,
+        'non_deductible_amount' => 1234.56,
+        'financial_type_id:name' => 'Donation',
+      ])->execute();
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'xlsx',
+      'savedSearch' => [
+        'api_entity' => 'Contribution',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['total_amount', 'non_deductible_amount'],
+          'where' => [['contact_id', '=', $cid]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'test',
+        'settings' => [
+          'actions' => TRUE,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'total_amount',
+              'label' => 'Total Amount',
+              'format' => 'number',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'non_deductible_amount',
+              'label' => 'Non Amount',
+            ],
+          ],
+        ],
+      ],
+      'afform' => NULL,
+    ];
+
+    ob_start();
+    try {
+      civicrm_api4('SearchDisplay', 'download', $params);
+      static::fail();
+    }
+    catch (\CRM_Core_Exception_PrematureExitException $e) {
+      // Expected API exit
+    }
+
+    $xlsx = ob_get_clean();
+    $tmpFile = tempnam(sys_get_temp_dir(), 'SearchDownloadTestXslx');
+    try {
+      file_put_contents($tmpFile, $xlsx);
+      $reader = IOFactory::createReader('Xlsx');
+      $spreadsheet = $reader->load($tmpFile);
+      $sheet = $spreadsheet->getSheet(0);
+
+      static::assertSame(2, $sheet->getHighestRow());
+      static::assertSame('B', $sheet->getHighestColumn());
+
+      static::assertSame('Total Amount', $sheet->getCell('A1')->getValue());
+      static::assertSame(1234.56, $sheet->getCell('A2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('A2')->getDataType());
+      static::assertSame('General', $sheet->getCell('A2')->getStyle()->getNumberFormat()->getFormatCode());
+
+      static::assertSame('Non Amount', $sheet->getCell('B1')->getValue());
+      static::assertSame(1234.56, $sheet->getCell('B2')->getValue());
+      static::assertSame(DataType::TYPE_NUMERIC, $sheet->getCell('B2')->getDataType());
+      static::assertSame('[$$-en-US]#,##0.00', $sheet->getCell('B2')->getStyle()->getNumberFormat()->getFormatCode());
+    }
+    finally {
+      unlink($tmpFile);
+    }
+  }
+
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3618,4 +3618,66 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(2001, $result[1]['columns'][1]['val']);
   }
 
+  /**
+   * Test that a Money column's `format` key can suppress the currency symbol.
+   *
+   * When format is empty (default) the value is formatted as currency.
+   * When format is 'number' the value is formatted as a plain number
+   * (same locale-aware formatting as a Float field, without the currency symbol).
+   */
+  public function testMoneyColumnFormat(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $cid = $this->saveTestRecords('Individual', [
+      'records' => [['first_name' => 'Donor', 'last_name' => $lastName]],
+    ])->first()['id'];
+    $this->saveTestRecords('Contribution', [
+      'records' => [['contact_id' => $cid, 'total_amount' => 1234.56, 'financial_type_id:name' => 'Donation']],
+    ]);
+
+    $columnBase = [
+      'type' => 'field',
+      'key' => 'total_amount',
+      'label' => 'Amount',
+    ];
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contribution',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['total_amount'],
+          'where' => [['contact_id', '=', $cid]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'Test',
+        'settings' => [
+          'columns' => [$columnBase],
+        ],
+      ],
+    ];
+
+    // Default (currency) format: value should contain a currency symbol / code.
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+    $currencyFormatted = $result[0]['columns'][0]['val'];
+    // The formatted currency string must differ from the bare numeric value.
+    $this->assertNotEquals('1234.56', $currencyFormatted);
+
+    // Number format: value should be a plain number without currency symbol.
+    $params['display']['settings']['columns'] = [['format' => 'number'] + $columnBase];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+    $numberFormatted = $result[0]['columns'][0]['val'];
+
+    $expected = \CRM_Utils_Number::formatLocaleNumeric('1234.56');
+    $this->assertEquals($expected, $numberFormatted);
+
+    // The two formats must produce different strings.
+    $this->assertNotEquals($currencyFormatted, $numberFormatted);
+  }
+
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3560,4 +3560,62 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(2, $data['Ongoing']);
   }
 
+  /**
+   * Test that a display column's `format` key controls the date formatting.
+   *
+   * Verifies the feature introduced by commit 6281d10e: when a column carries
+   * a `format` value (e.g. 'dateformatYear'), the Run action formats the date
+   * using that named CiviCRM date-format setting instead of the site default.
+   */
+  public function testSelectableDateFormat(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'Alice', 'last_name' => $lastName, 'birth_date' => '1985-03-15'],
+        ['first_name' => 'Bob', 'last_name' => $lastName, 'birth_date' => '2001-11-07'],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['first_name', 'birth_date'],
+          'where' => [['last_name', '=', $lastName]],
+          'orderBy' => ['first_name' => 'ASC'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'Test',
+        'settings' => [
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'first_name',
+              'label' => 'First Name',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'birth_date',
+              'label' => 'Birth Date',
+              // Request year-only formatting via a named CiviCRM date setting.
+              'format' => 'dateformatYear',
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(2, $result);
+
+    // Column index 1 is the birth_date column.
+    $this->assertEquals(1985, $result[0]['columns'][1]['val']);
+    $this->assertEquals(2001, $result[1]['columns'][1]['val']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Improves money formatting in SearchKit with a user-selectable formatting option.

Technical Details
----------------------------------------
Adds a 'Format' dropdown for Money-type display columns with two options:
- Currency (default): formats using Civi::format()->money(), including the
  currency symbol.
- Number: formats using CRM_Utils_Number::formatLocaleNumeric(), producing a
  plain locale-aware number without a currency symbol (consistent with how
  Float fields are displayed).

Ensures that csv and array outputs from SearchKit.download are always unformatted per @larssandergreen's request.