### PR TITLE
SchemaHelper - Fix test failure. Warn about non-portable table names.

### DIFF
--- a/mixin/lib/civimix-schema@5/src/SchemaHelper.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelper.php
@@ -76,8 +76,12 @@ return new class() implements SchemaHelperInterface {
     if (empty($tableNames)) {
       return [];
     }
-    $conditions = implode("' OR TABLE_NAME LIKE '", array_map(['\CRM_Core_DAO', 'escapeString'], $tableNames));
-    $dao = \CRM_Core_DAO::executeQuery("SELECT TABLE_NAME AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND (TABLE_NAME LIKE '$conditions')");
+    if ($deprecatedNames = preg_grep('/[^a-z0-9_]/', $tableNames)) {
+      $this->deprecated("SchemaHelper should be called with portable table-names (alphanumeric, lowercase). Found non-portable table-name: " . implode(", ", $deprecatedNames));
+    }
+
+    $escaped = implode("', '", array_map(fn($t) => \CRM_Core_DAO::escapeString(mb_strtolower($t)), $tableNames));
+    $dao = \CRM_Core_DAO::executeQuery("SELECT LOWER(TABLE_NAME) AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND LOWER(TABLE_NAME) IN ('$escaped')");
     return $dao->fetchMap('table_name', 'table_name');
   }
 
@@ -257,6 +261,11 @@ return new class() implements SchemaHelperInterface {
       $this->sqlGenerator = $gen::createFromFolder($this->key, $this->getExtensionDir() . '/schema', $this->key === 'civicrm');
     }
     return $this->sqlGenerator;
+  }
+
+  protected function deprecated(string $message): void {
+    // Distributed as mixin, so prefer highly portable mechanism.
+    trigger_error($message, E_USER_DEPRECATED);
   }
 
 };

--- a/tests/phpunit/Civi/Schema/SchemaHelperTest.php
+++ b/tests/phpunit/Civi/Schema/SchemaHelperTest.php
@@ -5,14 +5,23 @@ namespace Civi\Schema;
 class SchemaHelperTest extends \CiviUnitTestCase {
 
   public function testGetExistingTables(): void {
-    $tables = \Civi::schemaHelper()->getExistingTables(['civicrm_activity', 'civicrm_contact', 'CiviCRM_TAG']);
-    $this->assertEquals(['civicrm_activity', 'civicrm_contact', 'civicrm_tag'], array_values($tables));
+    $tables = \Civi::schemaHelper()->getExistingTables(['civicrm_activity', 'civicrm_contact', 'civicrm_false_nothing']);
+    $this->assertEquals(['civicrm_activity', 'civicrm_contact'], array_values($tables));
+
+    $deprecations = static::captureErrors(E_USER_DEPRECATED, function (): void {
+      $tables = \Civi::schemaHelper()->getExistingTables(['civicrm_activity', 'civicrm_contact', 'CiviCRM_TAG']);
+      $this->assertEquals(['civicrm_activity', 'civicrm_contact', 'civicrm_tag'], array_values($tables));
+    });
+    $this->assertEquals(['SchemaHelper should be called with portable table-names (alphanumeric, lowercase). Found non-portable table-name: CiviCRM_TAG'], $deprecations);
   }
 
   public function testTableExists(): void {
     $this->assertTrue(\Civi::schemaHelper()->tableExists('civicrm_activity'));
     // Function is case-insensitive.
-    $this->assertTrue(\Civi::schemaHelper()->tableExists('CiviCRM_Activity'));
+    $deprecations = static::captureErrors(E_USER_DEPRECATED, function (): void {
+      $this->assertTrue(\Civi::schemaHelper()->tableExists('CiviCRM_Activity'));
+    });
+    $this->assertEquals(['SchemaHelper should be called with portable table-names (alphanumeric, lowercase). Found non-portable table-name: CiviCRM_Activity'], $deprecations);
     $this->assertFalse(\Civi::schemaHelper()->tableExists('civicrm_false_nothing'));
   }
 
@@ -67,6 +76,42 @@ class SchemaHelperTest extends \CiviUnitTestCase {
     ]);
 
     $this->assertTrue(\Civi::schemaHelper()->indexExists('civicrm_activity', 'index_status_id'));
+  }
+
+  /**
+   * Execute a callback. Capture and return any PHP errors (which match the given filter).
+   *
+   * @param int $errorMask
+   *   Ex: E_USER_DEPRECATED|E_DEPRECATED
+   * @param callable $callback
+   * @return string[]
+   */
+  public static function captureErrors(int $errorMask, callable $callback): array {
+    $deprecations = [];
+
+    $previousHandler = set_error_handler(
+      function (int $errno, string $errstr, string $errfile = '', int $errline = 0) use (&$deprecations, &$previousHandler, $errorMask) {
+        if ($errno & $errorMask) {
+          $deprecations[] = $errstr;
+          return TRUE;
+        }
+        elseif ($previousHandler !== NULL) {
+          return (bool) $previousHandler($errno, $errstr, $errfile, $errline);
+        }
+        else {
+          return FALSE;
+        }
+      }
+    );
+
+    try {
+      $callback();
+    }
+    finally {
+      restore_error_handler();
+    }
+
+    return $deprecations;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to #35555 (6.15.alpha) to fix an issue in same-branch (6.15.beta). It refines how a helper in EFv2 (`$schemaHelper->tableExists("...")`) handles tables with unconventional capitalization, and this should fix a failure that appears in https://test.civicrm.org/duderino/?filter=CiviCRM-RC-Periodic.

The underlying issue is that MySQL does not provide a standard approach to case-sensitivity for table-names. CiviCRM generally doesn't have problems with this... because we have standardized on lower-case alphanumerics (`civicrm_foo_bar`). However, if you do try to use mixed-case names... then it's easy to get confused.

ping @demeritcowboy @colemanw 

Before and After
----------------------------------------

* __Original (6.14 and earlier)__: Case-sensitivity is circumstantial (dependent on the MySQL environment), in this helper (and everything else).
* __Current (6.15.alpha, per #35555)__: The helper tries to be case-insensitive. However, it only works in macOS/Windows (where MySQL is typically case-insensitive). In Linux (where MySQL is typically case-sensitive), it doesn't work -- and so the test fails in some CI jobs (esp on MySQL 8.0).
* __Revised (6.15.beta)__: The helper is really case-insensitive (*as attempted in #35555*), and the test passes in more environments. However, we can't actually make all environments consistently case-insensitive... the only way to be predictable to stick to a convention. If you ask EFv2 about a non-portable name, it will emit a warning.

Comments
----------------------------------------

In this approach, it might be useful to emit warnings in a few more parts of EFv2 (e.g. if `hook_entityTypes` encounters an unconventional table-name).

An alternative -- I think it would also be legit to say that EFv2 has no role in regulating or normalizing capitalization. So if a developer chooses to create a table named `CiviCRM_FooBar`, then it's up to them to use `CiviCRM_FooBar` consistently in all other places (and think about MySQL-compat implications on their own).