### PR TITLE
CustomField - Do not create indexes on serialized fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2805,6 +2805,7 @@ WHERE      f.id IN ($ids)";
       ),
       'required' => $field->is_required,
       'searchable' => $field->is_searchable && $field->is_active,
+      'serialize' => $field->serialize,
     ];
 
     // For adding/dropping FK constraints

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -200,7 +200,8 @@ class CRM_Core_BAO_SchemaHandler {
 
     // Add index if field is searchable if it does not reference a foreign key
     // (skip indexing FK fields because it would be redundant to have 2 indexes)
-    if (!empty($params['searchable']) && empty($params['fk_table_name']) && !$searchIndexExists) {
+    // Also do not add an index if it is a searlizable column
+    if (!empty($params['searchable']) && empty($params['fk_table_name']) && !$searchIndexExists && empty($params['serialize'])) {
       $indexName = $params['name'];
       if ($params['type'] === 'text' || self::getFieldLength($params['type']) > self::MAX_INDEX_LENGTH) {
         $indexName .= '(' . self::MAX_INDEX_LENGTH . ')';
@@ -210,8 +211,8 @@ class CRM_Core_BAO_SchemaHandler {
       $sql .= $prefix;
       $sql .= "index_{$params['name']} ( $indexName )";
     }
-    // Drop search index if field is no longer searchable
-    elseif (empty($params['searchable']) && $searchIndexExists) {
+    // Drop search index if field is no longer searchable OR is a serialized column
+    elseif ($searchIndexExists && (empty($params['searchable']) || !empty($params['serialize']))) {
       $sql .= $separator;
       $sql .= str_repeat(' ', 8);
       $sql .= "DROP INDEX $existingIndex";

--- a/CRM/Upgrade/Incremental/php/SixFifteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFifteen.php
@@ -31,7 +31,24 @@ class CRM_Upgrade_Incremental_php_SixFifteen extends CRM_Upgrade_Incremental_Bas
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
   }
 
+  public static function removeSearchIndexForSerializedCustomFields($ctx): bool {
+    $query = "
+      SELECT f.column_name, g.table_name
+      FROM civicrm_custom_field f
+      INNER JOIN civicrm_custom_group g ON f.custom_group_id = g.id
+      WHERE f.serialize IS NOT NULL AND f.serialize != '0' AND f.is_searchable = 1
+    ";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    while ($dao->fetch()) {
+      $indexName = 'index_' . $dao->column_name;
+      CRM_Core_BAO_SchemaHandler::dropIndexIfExists($dao->table_name, $indexName);
+    }
+    return TRUE;
+  }
+
   public function upgrade_6_15_beta1($rev): void {
+    $this->addTask('dev/core#6390 Remove indexes from serialied custom fields', 'removeSearchIndexForSerializedCustomFields');
+
     $swaps = [
       '{contribution_product.price|boolean}' => '{contribution_product.product_id.price|boolean}',
       '{contribution_product.price|crmMoney}' => '{contribution_product.product_id.price|crmMoney}',

--- a/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldAlterTest.php
@@ -254,18 +254,28 @@ class CustomFieldAlterTest extends Api4TestBase {
       'is_searchable' => TRUE,
     ]);
 
-    // is_searchable defaults to FALSE, so no index
+    // No index should be created because the field is serialized
     $query = "SHOW INDEX FROM {$customGroup['table_name']} WHERE Key_name = 'INDEX_{$field['column_name']}'";
+    $dao = \CRM_Core_DAO::executeQuery($query);
+    $this->assertEquals(0, $dao->N);
+
+    // Change serialize to FALSE (0)
+    CustomField::update(FALSE)
+      ->addWhere('id', '=', $field['id'])
+      ->addValue('serialize', 0)
+      ->execute();
+
+    // Index should now be added because it is no longer serialized
     $dao = \CRM_Core_DAO::executeQuery($query);
     $this->assertEquals(1, $dao->N);
 
-    // Disable the field
+    // Change serialize back to TRUE (1)
     CustomField::update(FALSE)
       ->addWhere('id', '=', $field['id'])
-      ->addValue('is_active', FALSE)
+      ->addValue('serialize', 1)
       ->execute();
 
-    // Index removed when field was disabled
+    // Index should be removed now that it is serialized again
     $dao = \CRM_Core_DAO::executeQuery($query);
     $this->assertEquals(0, $dao->N);
   }


### PR DESCRIPTION
Overview
----------------------------------------
 Fix [dev/core#6390](https://lab.civicrm.org/dev/core/-/issues/6390) and add upgrade step to remove any indexes currently existing in the database.

Before
---------
Serialized custom field gets an index if searchable. The index is pretty useless and can cause errors.

After
-------
Serialized custom field never gets an index.

Comments
------
This replaces https://github.com/civicrm/civicrm-core/pull/35438 @seamuslee001 