### PR TITLE
add Standalone support to iframe extension

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -691,6 +691,15 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       'use_strict_mode'  => 1,
     ];
 
+    // tweaks when in iframe mode
+    if (defined('CIVICRM_IFRAME') && CIVICRM_IFRAME) {
+      $params['name'] .= 'IFRAME';
+
+      if (!empty($_SERVER['HTTPS'])) {
+        $params['cookie_samesite'] = 'None';
+      }
+    }
+
     return $params;
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -652,41 +652,46 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
 
   /**
    * Start a new session.
-   *
-   * Generally this uses the SessionHander provided by Standaloneusers
-   * extension - but we fallback to a default PHP session to:
-   * a) allow the installer to work (early in the Standalone install, we dont have Standaloneusers yet)
-   * b) avoid unhelpfully hard crash if the ExtensionSystem goes down (without the fallback, the crash
-   * here swallows whatever error is actually causing the crash)
    */
   public function sessionStart() {
-    if (!$this->isUserExtensionAvailable()) {
-      $session_cookie_name = 'SESSCIVISOFALLBACK';
-    }
-    else {
-      $session_cookie_name = 'SESSCIVISO';
+    $this->setSessionHandler();
+    session_start($this->getSessionStartParams());
+  }
 
-      if (ini_get('session.save_handler') === 'redis') {
-        // We'll just use the default, take no action.
-      }
-      else {
-        $session_handler = new SessionHandler();
-        session_set_save_handler($session_handler);
-      }
+  /**
+   * Generally we use the SessionHander provided by Standaloneusers extension,
+   * except:
+   * - in less bootstrapped situations (install, errors) we fallback to a default PHP session
+   * - if using redis session handler, leave well alone
+   */
+  protected function setSessionHandler(): void {
+    if (!$this->isUserExtensionAvailable()) {
+      return;
     }
+    if (ini_get('session.save_handler') === 'redis') {
+      return;
+    }
+    $session_handler = new SessionHandler();
+    session_set_save_handler($session_handler);
+  }
+
+  protected function getSessionStartParams() {
+    $sessionCookieName = ($this->isUserExtensionAvailable()) ? 'SESSCIVISO' : 'SESSCIVISOFALLBACK';
 
     // session lifetime in seconds (default = 24 minutes)
-    $session_max_lifetime = (Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 24) * 60;
+    $sessionLifetime = (Civi::settings()->get('standaloneusers_session_max_lifetime') ?? 24) * 60;
 
-    session_start([
+    $params = [
       'cookie_httponly'  => 1,
       'cookie_secure'    => !empty($_SERVER['HTTPS']),
-      'gc_maxlifetime'   => $session_max_lifetime,
-      'name'             => $session_cookie_name,
+      'gc_maxlifetime'   => $sessionLifetime,
+      'name'             => $sessionCookieName,
       'use_cookies'      => 1,
       'use_only_cookies' => 1,
       'use_strict_mode'  => 1,
-    ]);
+    ];
+
+    return $params;
   }
 
   public function initialize() {

--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -62,6 +62,12 @@ class WebEntrypoint {
       exit();
     }
 
+    // alternative invocation for iframe mode
+    if (self::checkIframeMode()) {
+      self::invokeIframeMode();
+      exit();
+    }
+
     // initialise config and boot container
     \CRM_Core_Config::singleton();
 
@@ -115,6 +121,58 @@ class WebEntrypoint {
     ]);
     \Civi\Setup\BasicRunner::run($ctrl);
     exit();
+  }
+
+  /**
+   * Check if request is for iframe mode
+   * NOTE: this does not check if iframe extension
+   * is enabled yet, as we aren't ready to boot
+   * the container
+   */
+  protected static function checkIframeMode(): bool {
+    // check iframe query param
+    return !empty($_GET['iframe']);
+  }
+
+  /**
+   * Alternative invoke path for iframe extension:
+   * - adapt some request globals
+   * - boot the container
+   * - check iframe extension is enabled
+   * - use the iframe routers invoke method
+   *
+   * It's important to set CIVICRM_IFRAME before boot
+   * so it can be respected in e.g.
+   * CRM_Utils_System_Standalone::startSession
+   */
+  protected static function invokeIframeMode(): void {
+    define('CIVICRM_IFRAME', 1);
+
+    // Do not accept cookies.
+    // The whole issue is that browsers disagree on cookie-handling for embedded iframe content.
+    // (Ex: Safari 16 doesn't send cookies; but Firefox 118 does.)
+    // This means that `iframe.php` has the same cookie-less behavior for all browsers/users/tools.
+    foreach (array_keys($_COOKIE) as $cookie) {
+      unset($_COOKIE[$cookie]);
+    }
+
+    // Default links to stay in iframe mode
+    $GLOBALS['civicrm_url_defaults'][]['scheme'] = 'iframe';
+
+    // boot the container
+    \CRM_Core_Config::singleton();
+
+    // check iframe enabled
+    if (!\Civi::container()->has('iframe.router')) {
+      \CRM_Utils_System::sendInvalidRequestResponse(ts('iframe router is not available'));
+      exit();
+    }
+
+    $route = explode('?', $_SERVER['REQUEST_URI'], 2)[0];
+
+    \Civi::service('iframe.router')->invoke([
+      'route' => trim($route, '/'),
+    ]);
   }
 
 }

--- a/ext/iframe/Civi/Iframe/Iframe.php
+++ b/ext/iframe/Civi/Iframe/Iframe.php
@@ -21,7 +21,7 @@ class Iframe extends AutoService implements EventSubscriberInterface {
    * @return bool
    */
   public function isSupported(): bool {
-    return CIVICRM_UF === 'WordPress' || class_exists($this->getTemplate());
+    return in_array(CIVICRM_UF, ['WordPress', 'Standalone'], TRUE) || class_exists($this->getTemplate());
   }
 
   /**
@@ -43,14 +43,23 @@ class Iframe extends AutoService implements EventSubscriberInterface {
    * @throws \CRM_Core_Exception
    */
   public function onRenderUrl(Url $url, ?string &$result) {
-    if (CIVICRM_UF === 'WordPress') {
-      $result = \Civi::url('frontend://', 'a')
-        ->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags'])
-        ->addQuery('_cvwpif=1');
-      return;
+    switch (CIVICRM_UF) {
+      case 'WordPress':
+        $result = \Civi::url('frontend://', 'a')
+          ->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags'])
+          ->addQuery('_cvwpif=1');
+        return;
+
+      case 'Standalone':
+        $result = \Civi::url('frontend://', 'a')
+          ->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags'])
+          ->addQuery('iframe=1');
+        return;
+
+      default:
+        $result = \Civi::url('[civicrm.iframe]', 'a')->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags']);
     }
 
-    $result = \Civi::url('[civicrm.iframe]', 'a')->merge($url, ['path', 'query', 'fragment', 'fragmentQuery', 'flags']);
   }
 
 }

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -137,6 +137,9 @@ class Router extends AutoService {
         $kernel->terminate($request, $response);
         break;
 
+      case 'Standalone':
+        throw new \LogicException("No 'cms' mode for iframes on Standalone");
+
       case 'WordPress':
         // N.B. There are sufficient events in WP API to enforce IFRAME invariants.
         // @see \CiviCRM_For_WordPress::activate_iframe()

--- a/ext/iframe/Civi/Iframe/ScriptManager.php
+++ b/ext/iframe/Civi/Iframe/ScriptManager.php
@@ -32,8 +32,8 @@ class ScriptManager extends AutoService implements HookInterface {
       return;
     }
 
-    if (CIVICRM_UF === 'WordPress') {
-      // WP doesn't require installing a separate `/iframe.php`. Instead, it uses `?_cvwpif=1`.
+    if (CIVICRM_UF === 'Standalone' || CIVICRM_UF === 'WordPress') {
+      // Standalone / WP don't require installing a separate `/iframe.php`. Instead, they use `?iframe=1` / `?_cvwpif=1`
       return;
     }
 

--- a/ext/iframe/README.md
+++ b/ext/iframe/README.md
@@ -6,7 +6,7 @@ as "Contribution Pages").  This is a primary building-block for the [oEmbed](htt
 
 At time of writing, the extension is in an incubation period. It does not appear in the regular list of extensions.
 
-## Quick start
+## Installation
 
 * Enable the `iframe` extension.
 
@@ -15,17 +15,34 @@ At time of writing, the extension is in an incubation period. It does not appear
     cv en iframe
     ```
 
-* Install the entry-point script (`iframe.php`). There are three ways to do this:
+* On Drupal / Backdrop you must now install the entry-point script (`iframe.php`). There are three ways to do this:
     * __Web UI__: Open the "System Status". If you have permission, it will show a button "Deploy now".
     * __Manual__: Open the "System Status". It will show a button "Deploy instructions". Copy-paste the content into the target file.
     * __CLI/API__: Run `cv api4 Iframe.installScript`
 
-* Pick a CiviCRM page (eg `civicrm/contribute/transact?reset=1&id=1`). On an external website, you can make an HTML page which embeds the CiviCRM page:
+## Usage
+
+Pick a CiviCRM page (eg `civicrm/contribute/transact?reset=1&id=1`). On an external website, you can make an HTML page which embeds the CiviCRM page. The formation of the embed URL varies based on your CMS.
+
+* On Standalone, add `?iframe=1`:
     ```html
-    <IFRAME SRC="http://example.org/iframe.php/civicrm/contribute/transact?reset=1&id=1"/>
+    <iframe src="http://example.org/civicrm/contribute/transact?reset=1&id=1&iframe=1"></iframe>
     ```
 
-* Optionally, navigate to "Administer > System Settings > IFrame Connector Settings" to fine-tune the options.
+* On Wordpress, add `?_cvwpif=1`:
+    ```html
+    <iframe src="http://example.org/civicrm/contribute/transact?reset=1&id=1&_cvwpif=1"></iframe>
+    ```
+
+* On Drupal or Backdrop, add `iframe.php/` to the start of the path:
+
+    ```html
+    <iframe src="http://example.org/iframe.php/civicrm/contribute/transact?reset=1&id=1"></iframe>
+    ```
+
+## Configuration
+
+Navigate to "Administer > System Settings > IFrame Connector Settings" to fine-tune the options.
 
 ## Overview
 

--- a/ext/iframe/tests/phpunit/CRM/Iframe/IframeTest.php
+++ b/ext/iframe/tests/phpunit/CRM/Iframe/IframeTest.php
@@ -22,7 +22,7 @@ class CRM_Iframe_IframeTest extends \PHPUnit\Framework\TestCase implements EndTo
       $this->markTestSkipped('iframe extension does not support activation in this environment');
     }
 
-    if (CIVICRM_UF !== 'WordPress') {
+    if (!in_array(CIVICRM_UF, ['WordPress', 'Standalone'], TRUE)) {
       \Civi\Api4\Iframe::installScript()->setCheckPermissions(FALSE)->execute();
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is relatively easy because we have full control of the code :)

Before
----------------------------------------
- `iframe` supports Drupal / Backdrop / Wordpress

After
----------------------------------------
- `iframe` supports Drupal / Backdrop / Wordpress / Standalone

Technical Details
----------------------------------------
Given we already control the Standalone entrypoint, we can easily handle using a nice query param `iframe=1`. We also check the `iframe.router` service exists, as a proxy for whether iframe extension is installed.