### PR TITLE
add iframe-resizer scripts to iframe extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 !/ext/contributioncancelactions
 !/ext/recaptcha
 !/ext/iframe
+/ext/iframe/packages
 !/ext/oembed
 !/ext/payflowpro
 !/ext/ckeditor4

--- a/composer.json
+++ b/composer.json
@@ -226,6 +226,16 @@
         "version": "3.4.1",
         "ignore": ["fonts", "test", "tasks", "lib"]
       },
+      "ext-iframe-resizer-child": {
+        "url": "https://raw.githubusercontent.com/davidjbradshaw/iframe-resizer/refs/tags/v4.3.11/js/iframeResizer.contentWindow.js",
+        "path": "ext/iframe/packages/iframe-resizer.child.js",
+        "version": "4.3.11"
+      },
+      "ext-iframe-resizer-parent": {
+        "url": "https://raw.githubusercontent.com/davidjbradshaw/iframe-resizer/refs/tags/v4.3.11/js/iframeResizer.js",
+        "path": "ext/iframe/packages/iframe-resizer.parent.js",
+        "version": "4.3.11"
+      },
       "font-awesome": {
         "url": "https://github.com/FortAwesome/Font-Awesome/releases/download/6.6.0/fontawesome-free-6.6.0-web.zip",
         "ignore": ["*/.*", "*.json", "src", "*.yml", "Gemfile", "Gemfile.lock", "*.md"]

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -96,6 +96,7 @@ class Router extends AutoService {
   protected function invokeBasic(array $params): void {
     \Civi::resources()->addCoreResources('html-header');
     \Civi::resources()->addScriptFile(E::LONG_NAME, 'packages/iframe-resizer.child.js');
+    \Civi::resources()->addStyleFile(E::LONG_NAME, 'css/iframe.css');
 
     ob_start();
     $pageContent = \CRM_Core_Invoke::invoke(explode('/', $params['route']));

--- a/ext/iframe/Civi/Iframe/Router.php
+++ b/ext/iframe/Civi/Iframe/Router.php
@@ -94,7 +94,8 @@ class Router extends AutoService {
    * @throws \CRM_Core_Exception
    */
   protected function invokeBasic(array $params): void {
-    \CRM_Core_Resources::singleton()->addCoreResources('html-header');
+    \Civi::resources()->addCoreResources('html-header');
+    \Civi::resources()->addScriptFile(E::LONG_NAME, 'packages/iframe-resizer.child.js');
 
     ob_start();
     $pageContent = \CRM_Core_Invoke::invoke(explode('/', $params['route']));

--- a/ext/iframe/css/iframe.css
+++ b/ext/iframe/css/iframe.css
@@ -1,4 +1,9 @@
 .civicrm-iframe-page {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
   font-size: 100%;
+  min-height: unset!important;
+}
+.civicrm-iframe-page #crm-container,
+.civicrm-iframe-page .crm-container {
+  min-height: unset!important;
 }

--- a/ext/iframe/css/iframe.css
+++ b/ext/iframe/css/iframe.css
@@ -1,0 +1,4 @@
+.civicrm-iframe-page {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 100%;
+}

--- a/ext/riverlea/core/css/_base.css
+++ b/ext/riverlea/core/css/_base.css
@@ -171,12 +171,6 @@ body {
   color: var(--crm-text-color);
 }
 
-/* iFrame */
-
-body.civicrm-iframe-page {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 100%;
-}
 
 /* Core type */
 


### PR DESCRIPTION
Overview
----------------------------------------
Adds scripts from  https://github.com/davidjbradshaw/iframe-resizer to the `iframe` extension to allow for automatic resizing of embedded iframes.

The child script is queued on Civi iframe page.

The parent script should be loaded and initialised on the page that is doing the embedding.

Before
----------------------------------------
- awkward iframes with scrollbars

After
----------------------------------------
- automatically resizing iframes that can be more seamless with parent page
- Example parent code:
```
<iframe src="https://smaster.demo.civicrm.org/civicrm/contribute/transact?id=1&iframe=1" id="my-civi-frame"></iframe>
<script src="https://smaster.demo.civicrm.org/core/ext/iframe/packages/iframe-resizer.parent.js"></script>
<!-- or using cdn <script src="https://cdn.jsdelivr.net/gh/davidjbradshaw/iframe-resizer@4.3.11/js/iframeResizer.min.js"></script> -->
<script>iFrameResize({log: 'collapsed',}, '#my-civi-frame');</script>
```

Comments
----------------------------------------
I thought about only queuing in the router conditionally based on a setting, but it's a tiny script so feels not to merit it.

As @mlutfy has said it would be good to have a button to generate the embed code.

The library has recently restricted the open source license for non-commercial use - see https://iframe-resizer.com/licenses/.

I _think_ we are fine to include it in CiviCRM but if someone has doubts maybe we could reach out to the maintainer for clarification?
