### PR TITLE
PHP8 fix - avoid crash when renewing membership

### DIFF
--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1678,7 +1678,7 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
           if ($membershipType->find(TRUE)) {
             // CRM-14051 - membership_type.relationship_type_id is a CTRL-A padded string w one or more ID values.
             // Convert to comma separated list.
-            $inheritedRelTypes = implode(',', CRM_Utils_Array::explodePadded($membershipType->relationship_type_id));
+            $inheritedRelTypes = implode(',', CRM_Utils_Array::explodePadded($membershipType->relationship_type_id) ?? []);
             $permContacts = CRM_Contact_BAO_Relationship::getPermissionedContacts($this->getAuthenticatedContactID(), $membershipType->relationship_type_id);
             if (array_key_exists($membership->contact_id, $permContacts)) {
               $this->_membershipContactID = $membership->contact_id;


### PR DESCRIPTION
Overview
----------------------------------------
I saw this in the logs on one of my sites.  Some folks get a crash when trying to renew their membership if there are no relationships that inherit the membership.

Before
----------------------------------------
```
implode(): If argument #1 ($separator) is of type string, argument #2 ($array) must be of type array, null given
```

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
There might be more to the replication case than this - but I think the issue is clear even without it:
* `relationship_type_id` is `NULL` on any membership types with no inheritances (you can see this with `SELECT id, relationship_type_id FROM civicrm_membership_type;` on the demo data)
* `CRM_Utils_Array::explodePadded()` returns `NULL` if it's passed `NULL` in `$values`.
* `implode()` must take an array as the second argument.  `NULL` causes a crash.