### PR TITLE
SearchKit - Ensure "Doesn't contain any" operator matches NULL

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -261,6 +261,23 @@ abstract class Api4Query {
               }
             }
 
+            if ($not) {
+              try {
+                $exprA = $this->getExpression($clause[0], ['SqlField', 'SqlFunction', 'SqlEquation']);
+                if ($exprA->getType() === 'SqlField') {
+                  $fieldName = count($exprA->getFields()) === 1 ? $exprA->getFields()[0] : NULL;
+                  $field = $this->getField($fieldName, TRUE);
+                  $fieldAlias = $exprA->render($this);
+                  if ($field && ($field['nullable'] ?? TRUE) !== FALSE) {
+                    return "($not($queryString) OR $fieldAlias IS NULL)";
+                  }
+                }
+              }
+              catch (UnauthorizedException $e) {
+                return '';
+              }
+            }
+
             return "$not($queryString)";
           }
         }

--- a/tests/phpunit/api/v4/Action/ContactGetTest.php
+++ b/tests/phpunit/api/v4/Action/ContactGetTest.php
@@ -365,7 +365,38 @@ class ContactGetTest extends Api4TestBase implements TransactionalInterface {
     $result = Contact::get(FALSE)
       ->addWhere('id', 'REGEXP', $findByIDs)
       ->execute();
-    $this->assertCount(4, $result);
+  }
+
+  public function testPreferredCommunicationMethodNotContainsOneOfWithNull(): void {
+    $last_name = uniqid('pref_comm_test');
+
+    $c1 = $this->createTestRecord('Contact', [
+      'first_name' => 'HasPhone',
+      'last_name' => $last_name,
+      'preferred_communication_method' => ['Phone'],
+    ]);
+
+    $c2 = $this->createTestRecord('Contact', [
+      'first_name' => 'HasEmailMail',
+      'last_name' => $last_name,
+      'preferred_communication_method' => ['Email', 'Mail'],
+    ]);
+
+    $c3 = $this->createTestRecord('Contact', [
+      'first_name' => 'HasNull',
+      'last_name' => $last_name,
+      'preferred_communication_method' => NULL,
+    ]);
+
+    $result = Contact::get(FALSE)
+      ->addWhere('last_name', '=', $last_name)
+      ->addWhere('preferred_communication_method', 'NOT CONTAINS ONE OF', ['Email', 'Mail'])
+      ->execute()
+      ->indexBy('id');
+
+    $this->assertArrayHasKey($c1['id'], $result);
+    $this->assertArrayHasKey($c3['id'], $result);
+    $this->assertCount(2, $result);
   }
 
   public function testGetRelatedWithSubType(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fix [dev/core#6548](https://lab.civicrm.org/dev/core/-/work_items/6548)

When searching e.g. for contacts whos preferred communication method does not contain "Phone" this will match contacts who do not have ANY preferred communication method (e.g. NULL).

@artfulrobot 