### PR TITLE
Date field are not formatted correctly

### DIFF
--- a/templates/CRM/Report/Form/Layout/Table.tpl
+++ b/templates/CRM/Report/Form/Layout/Table.tpl
@@ -123,8 +123,6 @@
                           {/foreach}
                       {elseif $isDateSubtotalField}
                         {$row.$field}
-                      {elseif array_key_exists($field, $row)}
-                          {$row.$field}
                       {elseif $header.type & 4 OR $header.type & 256}
                           {if $header.group_by eq 'MONTH' or $header.group_by eq 'QUARTER'}
                               {$row.$field|crmDate:$config->dateformatPartial}


### PR DESCRIPTION
Overview
----------------------------------------
Regression from https://github.com/civicrm/civicrm-core/commit/a84b955c3475677b1f4a837be32c7da86f9d0191#diff-c840f84440c17c2ebdb1dcbd4d88a840582c398b7f1b2f8678b0f62dd7fb42d5R124

Date fields are shown as values stored in DB rather being converted in date format set in the UI.

Can be replicated on demo site, with birth date field

Before
----------------------------------------
<img width="1614" height="505" alt="Screenshot 2026-06-04 at 00 34 40" src="https://github.com/user-attachments/assets/47eb164b-e818-42c7-b1fc-19bd96eb1caa" />


After
----------------------------------------
Formated correctly