### PR TITLE
SearchKit - Fix SearchDownloadTest testDownloadCSV

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/ResultDataTrait.php
@@ -3,6 +3,7 @@
 namespace Civi\Api4\Action\SearchDisplay;
 
 use Civi\Util\PhpSpreadsheetUtil;
+use League\Csv\Bom;
 use League\Csv\Writer;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
@@ -94,7 +95,7 @@ trait ResultDataTrait {
    */
   private function outputCSV(array $rows, array $columns, string $fileName) {
     $csv = Writer::from(new \SplTempFileObject());
-    $csv->setOutputBOM(Writer::BOM_UTF8);
+    $csv->setOutputBOM(Bom::Utf8);
 
     // Header row
     $csv->insertOne(array_column($columns, 'label'));

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -161,7 +161,7 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     $this->assertStringStartsWith("\xEF\xBB\xBF", $csvOutput);
     $csvWithoutBom = substr($csvOutput, 3);
     $lines = preg_split('/\r\n|\r|\n/', rtrim($csvWithoutBom));
-    $rows = array_map('str_getcsv', $lines);
+    $rows = array_map(fn($line) => str_getcsv($line, ',', '"', '\\'), $lines);
 
     // Header + 4 data rows
     $this->assertCount(5, $rows);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -101,18 +101,8 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
 
   /**
    * Test downloading CSV format.
-   *
-   * Must run in separate process to capture direct output to browser
-   *
-   * @runInSeparateProcess
-   * @preserveGlobalState disabled
    */
   public function testDownloadCSV() {
-    $this->markTestIncomplete('Unable to get this test working in separate process, probably due to being in an extension');
-
-    // Re-enable because this test has to run in a separate process
-    \CRM_Extension_System::singleton()->getManager()->install('org.civicrm.search_kit');
-
     $lastName = uniqid(__FUNCTION__);
     $sampleData = [
       ['first_name' => 'One', 'last_name' => $lastName],
@@ -157,14 +147,7 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
       'afform' => NULL,
     ];
 
-    // UTF-8 BOM
-    $expectedOut = preg_quote("\xEF\xBB\xBF");
-    $expectedOut .= preg_quote('"First Last"');
-    foreach ($sampleData as $row) {
-      $expectedOut .= '\s+' . preg_quote('"' . $row['first_name'] . ' ' . $lastName . '"');
-    }
-    $this->expectOutputRegex('#' . $expectedOut . '#');
-
+    ob_start();
     try {
       civicrm_api4('SearchDisplay', 'download', $params);
       $this->fail();
@@ -172,6 +155,21 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
     catch (\CRM_Core_Exception_PrematureExitException $e) {
       // All good, we expected the api to exit
     }
+    $csvOutput = ob_get_clean();
+
+    // Verify BOM and parse CSV
+    $this->assertStringStartsWith("\xEF\xBB\xBF", $csvOutput);
+    $csvWithoutBom = substr($csvOutput, 3);
+    $lines = preg_split('/\r\n|\r|\n/', rtrim($csvWithoutBom));
+    $rows = array_map('str_getcsv', $lines);
+
+    // Header + 4 data rows
+    $this->assertCount(5, $rows);
+    $this->assertEquals(['First Last'], $rows[0]);
+    $this->assertEquals(['One ' . $lastName], $rows[1]);
+    $this->assertEquals(['Two ' . $lastName], $rows[2]);
+    $this->assertEquals(['Three ' . $lastName], $rows[3]);
+    $this->assertEquals(['Four ' . $lastName], $rows[4]);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix test that was being skipped, which turned up a deprecation notice, so fixed that too. That hit another deprecation notice so fixed that as well!

Moral of the story: unit tests are better when they work.