### PR TITLE
SearchKit - Enable totals in header as well as footer

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayBatch.html
@@ -80,9 +80,9 @@
       </div>
       <div class="form-inline" ng-if="col.type === 'field' && $ctrl.display.settings.tally">
         <label for="crm-search-admin-edit-col-footer-label-{{:: $index }}">{{:: ts('Footer') }}</label>
-        <input class="form-control" id="crm-search-admin-edit-col-footer-label-{{:: $index }}" ng-model="col.tally.label" placeholder="{{:: ts('No label') }}" title="{{:: ts('Footer label') }}">
+        <input class="form-control" id="crm-search-admin-edit-col-footer-label-{{:: $index }}" ng-model="col.tally.label" placeholder="{{:: ts('No label') }}" title="{{:: ts('Totals label') }}">
         <label for="crm-search-admin-edit-col-footer-agg-{{:: $index }}">{{:: ts('Aggregate') }}</label>
-        <select id="crm-search-admin-edit-col-footer-agg-{{:: $index }}" class="form-control" ng-model="col.tally.fn" ng-change="$ctrl.onChangeTallyFn(col)" title="{{:: ts('Footer aggregate function') }}">
+        <select id="crm-search-admin-edit-col-footer-agg-{{:: $index }}" class="form-control" ng-model="col.tally.fn" ng-change="$ctrl.onChangeTallyFn(col)" title="{{:: ts('Totals aggregate function') }}">
           <option value="">{{:: ts('None') }}</option>
           <option value="SUM">{{:: ts('Sum') }}</option>
           <option value="AVG">{{:: ts('Average') }}</option>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -52,6 +52,16 @@
             this.setColumnMode('auto');
           }
         }
+        // Backwards compatibility: default header/footer placement
+        if (ctrl.display.settings.tally) {
+          const tally = ctrl.display.settings.tally;
+          if (tally.header === undefined) {
+            tally.header = false;
+          }
+          if (tally.footer === undefined) {
+            tally.footer = true;
+          }
+        }
       };
 
       this.setColumnMode = (value) => {
@@ -99,13 +109,18 @@
         }
       };
 
-      this.toggleTally = () => {
-        if (this.display.settings.tally) {
+      // Toggles the tally display for a given position ('header' or 'footer').
+      // Initializes default settings on first enable, or cleans them up if disabled everywhere.
+      this.toggleTally = (position) => {
+        const hasTally = !!this.display.settings.tally;
+        if (!hasTally) {
+          this.display.settings.tally = {label: ts('Totals'), header: false, footer: false};
+          this.setTallyDefaults();
+        }
+        this.display.settings.tally[position] = !this.display.settings.tally[position];
+        if (!this.display.settings.tally.header && !this.display.settings.tally.footer) {
           delete this.display.settings.tally;
           this.display.settings.columns.forEach((col) => delete col.tally);
-        } else {
-          this.display.settings.tally = {label: ts('Total')};
-          this.setTallyDefaults();
         }
       };
 

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -67,6 +67,18 @@
           {{:: ts('Enable Column Picker') }}
         </label>
       </div>
+      <div class="form-inline">
+        <div class="checkbox-inline form-control" title="{{:: ts('Shows grand totals or other statistics, configured per-column.') }}">
+          <label>
+            <input type="checkbox" ng-click="$ctrl.toggleTally('header')" ng-checked="!!$ctrl.display.settings.tally.header">
+            <span>{{:: ts('Show Totals in Header') }}</span>
+          </label>
+        </div>
+        <div class="form-group" ng-if="$ctrl.display.settings.tally.header">
+          <label for="crm-search-admin-table-tally-header-title">{{:: ts('Label') }}</label>
+          <input id="crm-search-admin-table-tally-header-title" ng-model="$ctrl.display.settings.tally.label" class="form-control">
+        </div>
+      </div>
     </div>
   </details>
 
@@ -77,11 +89,11 @@
       <div class="form-inline">
         <div class="checkbox-inline form-control" title="{{:: ts('Shows grand totals or other statistics, configured per-column.') }}">
           <label>
-            <input type="checkbox" ng-click="$ctrl.toggleTally()" ng-checked="!!$ctrl.display.settings.tally">
+            <input type="checkbox" ng-click="$ctrl.toggleTally('footer')" ng-checked="!!$ctrl.display.settings.tally.footer">
             <span>{{:: ts('Show Totals in Footer') }}</span>
           </label>
         </div>
-        <div class="form-group" ng-if="$ctrl.display.settings.tally">
+        <div class="form-group" ng-if="$ctrl.display.settings.tally.footer">
           <label for="crm-search-admin-table-tally-title">{{:: ts('Label') }}</label>
           <input id="crm-search-admin-table-tally-title" ng-model="$ctrl.display.settings.tally.label" class="form-control">
         </div>
@@ -170,15 +182,15 @@
           </div>
           <div ng-include="'~/crmSearchAdmin/displays/colType/' + col.type + '.html'"></div>
           <div class="form-inline" ng-if="col.type === 'field' && $ctrl.display.settings.tally">
-            <label for="crm-search-admin-edit-footer-label-{{:: $index }}">{{:: ts('Footer') }}</label>
-            <input class="form-control" id="crm-search-admin-edit-footer-label-{{:: $index }}" ng-model="col.tally.label" placeholder="{{:: ts('No label') }}" title="{{:: ts('Footer label') }}">
-            <label for="crm-search-admin-edit-footer-agg-{{:: $index }}">{{:: ts('Aggregate') }}</label>
-            <input id="crm-search-admin-edit-footer-agg-{{:: $index }}" class="form-control" ng-model="col.tally.fn" crm-ui-select="{data: $ctrl.getTallyFunctions, placeholder: ts('None'), allowClear: true}" title="{{:: ts('Footer aggregate function') }}">
+            <label for="crm-search-admin-edit-tally-label-{{:: $index }}">{{:: ts('Totals') }}</label>
+            <input class="form-control" id="crm-search-admin-edit-tally-label-{{:: $index }}" ng-model="col.tally.label" placeholder="{{:: ts('No label') }}" title="{{:: ts('Totals label') }}">
+            <label for="crm-search-admin-edit-tally-agg-{{:: $index }}">{{:: ts('Aggregate') }}</label>
+            <input id="crm-search-admin-edit-tally-agg-{{:: $index }}" class="form-control" ng-model="col.tally.fn" crm-ui-select="{data: $ctrl.getTallyFunctions, placeholder: ts('None'), allowClear: true}" title="{{:: ts('Totals aggregate function') }}">
             <label>
               <input type="checkbox" ng-click="$ctrl.toggleTallyRewrite(col)" ng-checked="!!col.tally.rewrite">
-              {{:: ts('Footer Rewrite') }}
+              {{:: ts('Totals Rewrite') }}
             </label>
-            <input class="form-control" ng-if="col.tally.rewrite" ng-model="col.tally.rewrite" placeholder="{{:: ts('None') }}" title="{{:: ts('Footer rewrite with tokens') }}" ng-model-options="{updateOn: 'blur'}">
+            <input class="form-control" ng-if="col.tally.rewrite" ng-model="col.tally.rewrite" placeholder="{{:: ts('None') }}" title="{{:: ts('Totals rewrite with tokens') }}" ng-model-options="{updateOn: 'blur'}">
             <crm-search-admin-token-select ng-if="col.tally.rewrite" model="col.tally" field="rewrite" only-select="true"></crm-search-admin-token-select>
           </div>
         </div>

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -217,7 +217,7 @@
             markup += '<p><i class="crm-i fa-warning" role="img" aria-hidden="true"></i> ' + _.escape(item) + '</p>';
           });
           CRM.confirm({
-            title: ts('Tally Mismatch'),
+            title: ts('Totals Mismatch'),
             message: markup + '<p>' + _.escape(ts('Run import anyway?')) + '</p>',
             options: {
               no: ts('Cancel'),

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -36,12 +36,15 @@
           <span class="crm-search-display-table-column-label">{{:: col.label }}</span>
         </th>
       </tr>
+      <tr class="crm-search-display-tally" ng-if="!$ctrl.loading && $ctrl.results.length && $ctrl.settings.tally && $ctrl.settings.tally.header" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTally.html'"></tr>
     </thead>
     <tbody ng-if="$ctrl.loading" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTableLoading.html'"></tbody>
     <tbody ng-if="!$ctrl.loading && !$ctrl.settings.draggable" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTableBody.html'"></tbody>
     <tbody ng-if="!$ctrl.loading && $ctrl.settings.draggable" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTableBody.html'" ui-sortable="$ctrl.draggableOptions" ng-model="$ctrl.results"></tbody>
     <tbody ng-if="!$ctrl.loading && $ctrl.settings.editableRow.create" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTableCreateNew.html'"></tbody>
-    <tfoot ng-if="!$ctrl.loading && $ctrl.results.length && $ctrl.settings.tally" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTally.html'"></tfoot>
+    <tfoot ng-if="!$ctrl.loading && $ctrl.results.length && $ctrl.settings.tally && $ctrl.settings.tally.footer !== false">
+      <tr class="crm-search-display-tally" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTally.html'"></tr>
+    </tfoot>
   </table>
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTally.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTally.html
@@ -1,13 +1,11 @@
-<!-- Placeholder table rows shown during ajax loading -->
-<tr>
-  <td ng-if=":: $ctrl.hasExtraFirstColumn()">
-    {{:: $ctrl.settings.tally.label }}
-  </td>
-  <td ng-repeat="col in $ctrl.columns" ng-if="col.enabled">
-    <div ng-if="!$ctrl.tally" class="crm-search-loading-placeholder"></div>
-    <div ng-if="$ctrl.tally">
-      {{:: col.tally.label }}
-      {{ $ctrl.isArray($ctrl.tally[col.key]) ? $ctrl.tally[col.key].join(', ') : $ctrl.tally[col.key] }}
-    </div>
-  </td>
-</tr>
+<!-- Header/Footer tally row -->
+<td ng-if=":: $ctrl.hasExtraFirstColumn()">
+  {{:: $ctrl.settings.tally.label }}
+</td>
+<td ng-repeat="col in $ctrl.columns" ng-if="col.enabled">
+  <div ng-if="!$ctrl.tally" class="crm-search-loading-placeholder"></div>
+  <div ng-if="$ctrl.tally">
+    {{:: col.tally.label }}
+    {{ $ctrl.isArray($ctrl.tally[col.key]) ? $ctrl.tally[col.key].join(', ') : $ctrl.tally[col.key] }}
+  </div>
+</td>


### PR DESCRIPTION
Overview
----------------------------------------
For SearchDisplay tables, adds a new placement option for the tally (search aggregate totals).
See [dev/core#6544](https://lab.civicrm.org/dev/core/-/work_items/6544)

Before
----------------------------------------
Tally can only be placed in the footer.

After
----------------------------------------
Tally can now be shown in the header, footer, or both.

<img width="621" height="460" alt="Screenshot 2026-06-03 at 11 09 19 PM" src="https://github.com/user-attachments/assets/060d5f5a-0cb0-4567-aa3d-83072276edae" />