### PR TITLE
Fix disabling default donation afform

### DIFF
--- a/ext/civi_contribute/ang/afformNewDonation.aff.php
+++ b/ext/civi_contribute/ang/afformNewDonation.aff.php
@@ -2,7 +2,18 @@
 use CRM_Contribute_ExtensionUtil as E;
 
 if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
-  return [];
+  // Ideally the form wouldn't exist at all when the setting is disabled
+  // but that is not easily achieved - so this is a slightly hacky alternative.
+  // Making it a system form means it cannot be opened for editing (which causes errors
+  // because the Contribution entity is not available)
+  // The setting is only intended to be transitional so hopefully this will
+  // be removed in due course.
+  return [
+    'type' => 'system',
+    'title' => E::ts('New Donation (disabled)'),
+    'description' => E::ts('Enable Contribution Forms in CiviContribute settings to use'),
+    'submit_enabled' => FALSE,
+  ];
 }
 
 return [


### PR DESCRIPTION
Before
----------------------------------------
- broken, untitled form appears in FormBuilder listing when Contribution Forms disabled

After
----------------------------------------
- titled form appears in FormBuilder System Forms listing when Contribution Forms disabled. You can't open for editing, so you don't see that it's broken


Comments
----------------------------------------
It's not the prettiest solution, but otherwise we need a whole listener to add/remove the form. This should only be transitional anyway.

Maybe it would be good to have an `is_active` key in `*.aff.php` which totally suppresses a form?