### PR TITLE
Move FTS upgrader to 6.17

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixSeventeen.php
+++ b/CRM/Upgrade/Incremental/php/SixSeventeen.php
@@ -21,6 +21,15 @@
  */
 class CRM_Upgrade_Incremental_php_SixSeventeen extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
+    if ($rev === '6.17.alpha1') {
+      if (Civi::settings()->get('search_mysql_fts')) {
+        $settingUrl = (string) \Civi::url('civicrm/admin/setting/search')->addQuery(['reset' => 1]);
+        $preUpgradeMessage .= '<p>' . ts('This upgrade will add a new Full Text Search index on `civicrm_contact` table. If you have lots of contacts, this may take a while and use a lot of space on your database server. If you don\'t want this, turn off Use Mysql Full Text Search in <a href="%1">Search Preferences</a> before running the upgrade.', [1 => $settingUrl]) . '</p>';
+      }
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *
@@ -29,6 +38,7 @@ class CRM_Upgrade_Incremental_php_SixSeventeen extends CRM_Upgrade_Incremental_B
    */
   public function upgrade_6_17_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask(ts('Create Mysql Full Text Search indices if active'), 'createMissingFtsIndices');
   }
 
 }

--- a/CRM/Upgrade/Incremental/php/SixSixteen.php
+++ b/CRM/Upgrade/Incremental/php/SixSixteen.php
@@ -21,15 +21,6 @@
  */
 class CRM_Upgrade_Incremental_php_SixSixteen extends CRM_Upgrade_Incremental_Base {
 
-  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL) {
-    if ($rev === '6.16.alpha1') {
-      if (Civi::settings()->get('search_mysql_fts')) {
-        $settingUrl = (string) \Civi::url('civicrm/admin/setting/search')->addQuery(['reset' => 1]);
-        $preUpgradeMessage .= '<p>' . ts('This upgrade will add a new Full Text Search index on `civicrm_contact` table. If you have lots of contacts, this may take a while and use a lot of space on your database server. If you don\'t want this, turn off Use Mysql Full Text Search in <a href="%1">Search Preferences</a> before running the upgrade.', [1 => $settingUrl]) . '</p>';
-      }
-    }
-  }
-
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *
@@ -82,8 +73,6 @@ class CRM_Upgrade_Incremental_php_SixSixteen extends CRM_Upgrade_Incremental_Bas
         'option_group_name' => 'tag_used_for',
       ],
     ]);
-
-    $this->addTask(ts('Create Mysql Full Text Search indices if active'), 'createMissingFtsIndices');
   }
 
 }

--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -270,7 +270,7 @@ return [
     'type' => 'Boolean',
     'html_type' => 'Toggle',
     'default' => TRUE,
-    'add' => '6.16',
+    'add' => '6.17',
     'title' => ts('Use Mysql Full Text Search'),
     'is_domain' => 1,
     'is_contact' => 0,


### PR DESCRIPTION
New indices are in 6.17 so that's where the upgrader belongs.
See https://github.com/civicrm/civicrm-core/pull/35792
