### PR TITLE
Formbuilder: Validate conditionals using existing entity IDs on submit if available to match clientside

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -92,6 +92,15 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     return $this->_entityValues;
   }
 
+  /**
+   * Get the entityIDs that are defined on the form.
+   *
+   * @return array
+   */
+  public function getEntityIds() {
+    return $this->_entityIds;
+  }
+
   protected array $_response = [];
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -307,8 +307,28 @@ class Submit extends AbstractProcessor {
     // Check if element is visible
     $isVisible = TRUE;
     $conditionals = $attributes['af-if'] ?? [];
+
+    // When the form is prefilled entity IDs are passed to the form.
+    // But if there is no "id" (existing entity) field on the form they will not be submitted
+    //   via getSubmittedValues() but they *are* still available in the API request.
+    // Eg. Add required fields: first_name/last_name to the form, wrap them in a conditional
+    //   which shows them if Individual1.id is empty. Prefill current user.
+    // Conditional works when evaluated on clientside/ajs, but does NOT work when evaluated here
+    //   during submit because there is no entity ID in the submitted values. But we *do* have
+    //   entityID in the API request and so don't need those fields to be filled in.
+    $allEntityValues = $event->getSubmittedValues();
+    $allEntityIds = $event->getApiRequest()->getEntityIds();
+    // Merge API request entityIDs into the submitted values to validate conditionals in the same
+    //   way as they are validated clientside.
+    foreach ($allEntityValues as $entityName => $entitiesValues) {
+      foreach ($entitiesValues as $entityIndex => $entityValues) {
+        if (!isset($entityValues['fields']['id']) && isset($allEntityIds[$entityName][$entityIndex]['id'])) {
+          $allEntityValues[$entityName][$entityIndex]['fields']['id'] = $allEntityIds[$entityName][$entityIndex]['id'];
+        }
+      }
+    }
     foreach ($conditionals as $conditional) {
-      $isVisible = self::checkAfformConditional($conditional, $event->getSubmittedValues());
+      $isVisible = self::checkAfformConditional($conditional, $allEntityValues);
       if (!$isVisible) {
         break;
       }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -266,4 +266,67 @@ EOHTML;
     }
   }
 
+  /**
+   * Required field based on af-if conditional keyed on the entity's own id,
+   * where the id is supplied via prefill/setArgs() rather than the submission itself.
+   *
+   * @see https://github.com/civicrm/civicrm-core/pull/35863
+   */
+  public function testConditionalRequiredFieldBasedOnPrefilledEntityId(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" url-autofill="1" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <div af-if="([[&amp;quot;Individual1[0][fields][id]&amp;quot;,&amp;quot;IS EMPTY&amp;quot;]])">
+      <af-field name="first_name" defn="{required: true, input_attrs: {}}" />
+      <af-field name="last_name" defn="{required: true, input_attrs: {}}" />
+    </div>
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Conditional rule is that first_name/last_name are required only if Individual1.id is empty.
+
+    // Existing contact, prefilled via setArgs (like current-user prefill).
+    // first_name/last_name are omitted from the submission because the
+    // container is hidden clientside (Individual1.id is not empty).
+    $cid = $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'Existing', 'last_name' => 'Person'],
+      ],
+    ])->column('id')[0];
+
+    $submission = [
+      ['fields' => []],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->setArgs(['Individual1' => $cid])
+      ->execute();
+
+    $this->assertEquals($cid, $result[0]['Individual1'][0]['id']);
+
+    // New contact, no id supplied anywhere -> Individual1.id IS EMPTY ->
+    // container visible -> first_name/last_name become required.
+    $submission = [
+      ['fields' => []],
+    ];
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+      $this->fail('Expected validation error for missing first_name when Individual1.id is empty.');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertStringContainsString('First Name is a required field.', $e->getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Set up a form with Individual1 entity and required first_name/last_name fields. Set prefill to "current user". Wrap first_name/last_name in a container and add a conditional "Show if Individual1.id is empty". Submit the form.

It passes clientside validation because the required first_name/last_name fields are hidden. It fails serverside validation because it doesn't find an ID for Individual1 so rejects the submission with "first_name/last_name fields are required" error.

Before
----------------------------------------
Server-side conditionals evaluated without prefilled entity ID.

After
----------------------------------------
Server-side conditionals evaluated with prefilled entity ID.

Technical Details
----------------------------------------
Hopefully described in code comments.

Comments
----------------------------------------

