### PR TITLE
Don't show SearchDisplay table header if empty

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.component.js
@@ -134,6 +134,11 @@
           });
       }
 
+      this.showHeader = function() {
+        return ctrl.hasExtraFirstColumn() ||
+          ctrl.columns.some(col => col.enabled && (col.label || ctrl.isSortable(col)));
+      };
+
       // Get header classes for each column
       this.getHeaderClass = function (column) {
         let headerClasses = [];

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -26,7 +26,7 @@
     </details>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
-    <thead>
+    <thead ng-if=":: $ctrl.showHeader()">
       <tr>
         <th ng-class="{'crm-search-result-select': $ctrl.settings.actions}" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.hasExtraFirstColumn()">
           <span class="sr-only">{{:: ts('Bulk row actions')}}</span>


### PR DESCRIPTION
Overview
----------------------------------------
This is useful for embedded subsearches, where you might not want a header row. Now you can just remove all the column labels, sortable and the header actions option and then the header will disappear.

Before
----------------------------------------
Vestigial header takes up precious space in your subsearch-containing table.
<img width="1301" height="150" alt="image" src="https://github.com/user-attachments/assets/98c2dff9-309d-4876-a031-98d116136330" />


After
----------------------------------------
No more!
<img width="1299" height="138" alt="image" src="https://github.com/user-attachments/assets/41b7d669-edba-427c-9293-5b726d599e22" />
