### PR TITLE
Add subsearches to the list of editable searches from Afforms

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminInjector.php
@@ -13,6 +13,7 @@ namespace Civi\AfformAdmin;
 
 use Civi\Api4\Afform;
 use Civi\Api4\SavedSearch;
+use Civi\Api4\SearchDisplay;
 use Civi\Core\Service\AutoSubscriber;
 use CRM_Afform_ExtensionUtil as E;
 
@@ -67,8 +68,21 @@ class AfformAdminInjector extends AutoSubscriber {
           }
           if ($afform['search_displays']) {
             $searchNames = [];
+            $displayNames = [];
             foreach ($afform['search_displays'] as $searchAndDisplayName) {
               $searchNames[] = explode('.', $searchAndDisplayName)[0];
+              $displayNames[] = explode('.', $searchAndDisplayName)[1];
+            }
+            $searchDisplays = SearchDisplay::get(FALSE)
+              ->addWhere('name', 'IN', $displayNames)
+              ->addSelect('settings')
+              ->execute();
+            foreach ($searchDisplays as $searchDisplay) {
+              foreach ($searchDisplay['settings']['columns'] ?? [] as $column) {
+                if ($column['type'] === 'subsearch' && !empty($column['subsearch']['search'])) {
+                  $searchNames[] = $column['subsearch']['search'];
+                }
+              }
             }
             $savedSearches = SavedSearch::get(FALSE)
               ->addWhere('name', 'IN', $searchNames)


### PR DESCRIPTION
Overview
----------------------------------------
Include any subsearches in the top right gear icon so you can edit them quickly from the form, otherwise you have to figure out the name and go search for it in SK.

<img width="515" height="146" alt="image" src="https://github.com/user-attachments/assets/c6297c07-ef05-4e3d-8c41-9e950840f857" />

Does add one query, but that seems bearable. However, if I'm reading this right, it is actually run for all users, including anonymous, which seems less than ideal. Maybe we should change that?