### PR TITLE
FTS - add Api4 support

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/FullTextSearchFilterSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FullTextSearchFilterSpecProvider.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * @service
+ * @internal
+ */
+class FullTextSearchFilterSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @param \Civi\Api4\Service\Spec\RequestSpec $spec
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $entity = $dbEntity = $spec->getEntity();
+    if (CoreUtil::isContact($entity)) {
+      $dbEntity = 'Contact';
+    }
+    $indices = \Civi::service('civi.schema.fts')->getIndicesForEntity($dbEntity);
+
+    foreach ($indices as $name => $index) {
+      $field = new FieldSpec($name, $entity, 'String');
+      $label = $index['label'];
+      $description = $index['description'] ?: ts('Full text search on %1', [1 => $label]);
+      $field->setLabel($label)
+        ->setTitle(ts('Full Text Search: %1', [1 => $label]))
+        ->setColumnName('id')
+        ->setDescription($description)
+        ->setType('Filter')
+        ->setInputType('Text')
+        ->setOperators(['MATCHES'])
+        ->addSqlFilter(fn (array $field, string $fieldAlias, string $operator, $value) => self::getMatchFilterSql($index['columns'], $fieldAlias, $value));
+      $spec->addFieldSpec($field);
+    }
+  }
+
+  /**
+   * @param string $entity
+   * @param string $action
+   *
+   * @return bool
+   */
+  public function applies($entity, $action): bool {
+    if (!\Civi::settings()->get('search_mysql_fts')) {
+      return FALSE;
+    }
+    if ($action !== 'get') {
+      return FALSE;
+    }
+    // TO CHECK: is checking here helpful? we have to look up indexNames again in modifySpec
+    // in order to loop over them -- if there are none modifySpec will be a no-op
+    if (CoreUtil::isContact($entity)) {
+      $entity = 'Contact';
+    }
+    return !!\Civi::service('civi.schema.fts')->getIndicesForEntity($entity);
+  }
+
+  /**
+   * @param array $columns
+   * @param string $fieldAlias
+   * @param string $value
+   * return string
+   */
+  public static function getMatchFilterSql(array $columns, string $fieldAlias, string $value): string {
+    $columns = array_map(fn ($column) => \str_replace('id', $column, $fieldAlias), $columns);
+    $match = implode(',', $columns);
+    $value = \CRM_Core_DAO::escapeString($value);
+    return "MATCH({$match}) AGAINST ('$value')";
+  }
+
+}

--- a/Civi/Api4/Service/Spec/Provider/FullTextSearchFilterSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FullTextSearchFilterSpecProvider.php
@@ -42,8 +42,8 @@ class FullTextSearchFilterSpecProvider extends \Civi\Core\Service\AutoService im
         ->setDescription($description)
         ->setType('Filter')
         ->setInputType('Text')
-        ->setOperators(['MATCHES'])
-        ->addSqlFilter(fn (array $field, string $fieldAlias, string $operator, $value) => self::getMatchFilterSql($index['columns'], $fieldAlias, $value));
+        ->setOperators(['CONTAINS', 'LIKE', 'MATCHES'])
+        ->addSqlFilter(fn (array $field, string $fieldAlias, string $operator, $value) => self::getMatchFilterSql($index['columns'], $fieldAlias, $operator, $value));
       $spec->addFieldSpec($field);
     }
   }
@@ -72,14 +72,52 @@ class FullTextSearchFilterSpecProvider extends \Civi\Core\Service\AutoService im
   /**
    * @param array $columns
    * @param string $fieldAlias
+   * @param string $operator
    * @param string $value
    * return string
    */
-  public static function getMatchFilterSql(array $columns, string $fieldAlias, string $value): string {
+  public static function getMatchFilterSql(array $columns, string $fieldAlias, string $operator, string $value): string {
     $columns = array_map(fn ($column) => \str_replace('id', $column, $fieldAlias), $columns);
-    $match = implode(',', $columns);
+    $columnList = implode(',', $columns);
+
+    // escape user entered value
     $value = \CRM_Core_DAO::escapeString($value);
-    return "MATCH({$match}) AGAINST ('$value')";
+
+    switch ($operator) {
+      // CONTAINS = full word matches
+      case 'CONTAINS':
+        return "MATCH({$columnList}) AGAINST ('$value' IN NATURAL LANGUAGE MODE)";
+
+      // MATCHES = raw FTS boolean expression
+      case 'MATCHES':
+        return "MATCH({$columnList}) AGAINST ('$value' IN BOOLEAN MODE)";
+
+      // LIKE = we aim to provide interop with Mysql LIKE syntax though
+      // this only works with trailing wildcard
+      case 'LIKE':
+        $words = explode(' ', $value);
+
+        $words = array_filter(array_map(function ($word) use ($fieldAlias) {
+          $wildcardPos = strpos($word, '%');
+          // if no wildcards leave as is
+          if ($wildcardPos === FALSE) {
+            return '+' . $word;
+          }
+          // trailing wildcard replace with FTS wildcard *
+          if ($wildcardPos === (strlen($word) - 1)) {
+            return '+' . rtrim($word, '%') . '*';
+          }
+          // if non-trailing wildcards then FTS can't handle
+          // Q: should we just log?
+          throw new \CRM_Core_Exception("Invalid wildcard in FTS query expression {$fieldAlias} LIKE {$word} - ignoring");
+        }, $words));
+
+        $value = implode(' ', $words);
+
+        return "MATCH({$columnList}) AGAINST ('$value' IN BOOLEAN MODE)";
+    }
+
+    throw new \CRM_Core_Exception('Unrecognised operator for Full Text Search field');
   }
 
 }

--- a/Civi/Api4/Utils/CoreUtil.php
+++ b/Civi/Api4/Utils/CoreUtil.php
@@ -191,6 +191,7 @@ class CoreUtil {
     $operators[] = 'NOT REGEXP';
     $operators[] = 'REGEXP BINARY';
     $operators[] = 'NOT REGEXP BINARY';
+    $operators[] = 'MATCHES';
     return $operators;
   }
 

--- a/Civi/Schema/FullTextSearch.php
+++ b/Civi/Schema/FullTextSearch.php
@@ -55,22 +55,30 @@ class FullTextSearch extends AutoService implements EventSubscriberInterface {
   public function setDefaultIndices(GenericHookEvent $e): void {
     $e->indices = [
       'Contact' => [
-        'contact_names' => ['first_name', 'middle_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name'],
+        'contact_names' => [
+          'label' => ts('All Contact Names'),
+          'description' => ts('Search across all contact name fields'),
+          'columns' => ['first_name', 'middle_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name'],
+        ],
       ],
     ];
   }
 
   /**
-   * Get the names of defined indices for each entity
+   * Get indices for each entity
    *
    * @return array
    *   [
-   *     entity1 => [index1, index2,...],
+   *     index1 => [
+   *       'label' => indexLabel,
+   *       'description' => indexDescription,
+   *       'columns' => [column1,column2,...],
+   *     ],
    *     ...
    *   ]
    */
-  public function getIndexNamesForEntity(string $entity): array {
-    return array_keys($this->getDefinedIndices()[$entity] ?? []);
+  public function getIndicesForEntity(string $entity): array {
+    return $this->getDefinedIndices()[$entity] ?? [];
   }
 
   /**
@@ -82,7 +90,11 @@ class FullTextSearch extends AutoService implements EventSubscriberInterface {
    * @return array
    *   [
    *     entity1 => [
-   *      index1 => [column1, column2, ..]
+   *       index1 => [
+   *         'label' => indexLabel,
+   *         'description' => indexDescription,
+   *         'columns' => [column1,column2,...],
+   *       ],
    *      ...
    *     ...
    *   ]
@@ -128,7 +140,7 @@ class FullTextSearch extends AutoService implements EventSubscriberInterface {
       if (!$toAdd) {
         continue;
       }
-      $sqls = array_map(fn ($name) => "ADD FULLTEXT INDEX {$name} (" . implode(',', $indices[$name]) . ")", $toAdd);
+      $sqls = array_map(fn ($name) => "ADD FULLTEXT INDEX {$name} (" . implode(',', $indices[$name]['columns']) . ")", $toAdd);
       $sql = "ALTER TABLE {$table} " . \implode(', ', $sqls);
       \CRM_Core_DAO::executeQuery($sql);
     }

--- a/Civi/Schema/FullTextSearch.php
+++ b/Civi/Schema/FullTextSearch.php
@@ -55,7 +55,7 @@ class FullTextSearch extends AutoService implements EventSubscriberInterface {
   public function setDefaultIndices(GenericHookEvent $e): void {
     $e->indices = [
       'Contact' => [
-        'contact_name' => ['first_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name'],
+        'contact_names' => ['first_name', 'middle_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name'],
       ],
     ];
   }

--- a/tests/phpunit/Civi/Schema/FullTextSearchIndicesTest.php
+++ b/tests/phpunit/Civi/Schema/FullTextSearchIndicesTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * @group headless
  */
-class FullTextSearchTest extends TestCase implements HeadlessInterface {
+class FullTextSearchIndicesTest extends TestCase implements HeadlessInterface {
 
   /**
    * Keep in sync with Civi\Schema\FullTextSearch::setDefaultIndices
@@ -40,12 +40,12 @@ class FullTextSearchTest extends TestCase implements HeadlessInterface {
     $settings->set('search_mysql_fts', FALSE);
     $settings->set('search_mysql_fts', TRUE);
 
-    // check contact_name is available
+    // check contact_names is available
     $contactIndexes = $service->getIndicesForEntity('Contact');
-    $this->assertTrue(\array_key_exists('contact_name', $contactIndexes), 'contact_name in available indexes');
+    $this->assertTrue(\array_key_exists('contact_names', $contactIndexes), 'contact_names in available indexes');
 
     $this->tryQueryUsingContactName();
-    $this->assertTrue(TRUE, 'Query using contact_name index didn\'t crash');
+    $this->assertTrue(TRUE, 'Query using contact_names index didn\'t crash');
   }
 
   public function testTurnOff(): void {
@@ -58,17 +58,17 @@ class FullTextSearchTest extends TestCase implements HeadlessInterface {
     // check we can no longer use it
     try {
       $this->tryQueryUsingContactName();
-      $this->fail('Query using contact_name should have failed as we removed it');
+      $this->fail('Query using contact_names should have failed as we removed it');
     }
     catch (\Throwable $e) {
-      $this->assertTrue(TRUE, 'Query using contact_name index failed, as expected');
+      $this->assertTrue(TRUE, 'Query using contact_names index failed, as expected');
     }
   }
 
   protected function tryQueryUsingContactName(): void {
     // columns must match definition from Civi\Schema\FullTextSearch::setDefaultIndices
-    $match = \implode(',', ['first_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name']);
-    // check we can contact_name index defined in ContactType.entityType.php
+    $match = \implode(',', ['first_name', 'middle_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name']);
+    // check we can contact_names index defined in ContactType.entityType.php
     \CRM_Core_DAO::executeQuery("SELECT id FROM civicrm_contact WHERE MATCH({$match}) AGAINST ('joe')");
   }
 

--- a/tests/phpunit/Civi/Schema/FullTextSearchTest.php
+++ b/tests/phpunit/Civi/Schema/FullTextSearchTest.php
@@ -41,8 +41,8 @@ class FullTextSearchTest extends TestCase implements HeadlessInterface {
     $settings->set('search_mysql_fts', TRUE);
 
     // check contact_name is available
-    $contactIndexes = $service->getIndexNamesForEntity('Contact');
-    $this->assertTrue(in_array('contact_name', $contactIndexes), 'contact_name in available indexes');
+    $contactIndexes = $service->getIndicesForEntity('Contact');
+    $this->assertTrue(\array_key_exists('contact_name', $contactIndexes), 'contact_name in available indexes');
 
     $this->tryQueryUsingContactName();
     $this->assertTrue(TRUE, 'Query using contact_name index didn\'t crash');

--- a/tests/phpunit/api/v4/Action/FullTextSearchQueryTest.php
+++ b/tests/phpunit/api/v4/Action/FullTextSearchQueryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Contact;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class FullTextSearchQueryTest extends Api4TestBase implements TransactionalInterface {
+
+  protected function createTestContacts(): void {
+    Contact::save(FALSE)
+      ->setRecords([
+        [
+          'first_name' => 'John',
+          'last_name' => 'Smith',
+        ],
+        [
+          'first_name' => 'Jonny',
+          'legal_name' => 'Jonathon Rotten',
+          'last_name' => 'Rotten',
+        ],
+        [
+          'first_name' => 'Jonny',
+          'last_name' => 'Boy',
+        ],
+        [
+          'first_name' => 'Jonathon',
+          'last_name' => 'Swift',
+        ],
+        [
+          'first_name' => 'Jess',
+          'last_name' => '',
+        ],
+        [
+          'first_name' => 'Johannes',
+          'last_name' => 'Kahn',
+        ],
+        [
+          'first_name' => 'Samuel',
+          'last_name' => 'Johnson',
+          'birth_date' => '1709-09-18',
+        ],
+        [
+          'first_name' => 'Alexander',
+          'middle_name' => 'Boris de Pfeffel',
+          'last_name' => 'Johnson',
+          'birth_date' => '1964-06-19',
+        ],
+      ])
+      ->execute();
+
+    \Civi::settings()->set('search_mysql_fts', TRUE);
+  }
+
+  public function testContainsQueries(): void {
+    $this->createTestContacts();
+
+    // find in first name and legal_name
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'CONTAINS', 'Jonathon')
+      ->execute();
+
+    $this->assertEquals(2, $results->count());
+
+    // match multiple words, check better matches come first
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'CONTAINS', 'Boris Johnson')
+      ->execute();
+
+    $this->assertEquals('Alexander', $results[0]['first_name']);
+    $this->assertEquals('Samuel', $results[1]['first_name']);
+
+    // check it wasn't coincidentally first
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'CONTAINS', 'Samuel Johnson')
+      ->execute();
+
+    $this->assertEquals('Samuel', $results[0]['first_name']);
+    $this->assertEquals('Alexander', $results[1]['first_name']);
+  }
+
+  public function testMatchesQueries(): void {
+    $this->createTestContacts();
+
+    // match two words
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'MATCHES', '+Jonny +Rotten')
+      ->execute();
+
+    $this->assertEquals(1, $results->count());
+    $this->assertEquals('Jonny Rotten', $results->single()['display_name']);
+
+    // include exclude - only match should be Jonny Boy
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'MATCHES', '+Jonny -Rotten')
+      ->execute();
+
+    $this->assertEquals(1, $results->count());
+    $this->assertEquals('Jonny Boy', $results->single()['display_name']);
+  }
+
+  public function testLikeQueries(): void {
+    $this->createTestContacts();
+
+    // supprt Mysql LIKE style wildcards
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'LIKE', 'Jon%')
+      ->execute();
+
+    $this->assertEquals(3, $results->count());
+
+    // only trailing wildcards are supported
+    try {
+      $results = \Civi\Api4\Contact::get(FALSE)
+        ->addWhere('contact_names', 'LIKE', 'J%n')
+        ->execute();
+
+      $this->fail('Invalid wildcard for FTS LIKE');
+    }
+    catch (\Throwable $e) {
+      $this->assertTrue(\str_contains($e->getMessage(), 'Invalid wildcard in FTS query'));
+    }
+
+    // multiple words can be provided
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'LIKE', 'Joh% Kah%')
+      ->execute();
+
+    $this->assertEquals(1, $results->count());
+    // the best match should be first
+    $this->assertEquals('Johannes Kahn', $results->first()['display_name']);
+  }
+
+  public function testInteractionWithExplicitOrderBy(): void {
+    $this->createTestContacts();
+
+    // check it wasn't coincidentally first
+    $results = \Civi\Api4\Contact::get(FALSE)
+      ->addWhere('contact_names', 'CONTAINS', 'Boris Johnson')
+      ->addOrderBy('birth_date', 'ASC')
+      ->execute();
+
+    // birth date should take precedence over the better FTS match
+    $this->assertEquals('Samuel', $results->first()['first_name']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Expose FTS indices in Api4 as filter fields. ~~Start to incorporate for use in Quicksearch~~ Moved to separate PR.

Before
----------------------------------------
- FTS indices are created but no way to use


After
----------------------------------------
- FTS indices can be used in api4 queries, e.g.
  1. `->addWhere('contact_names', 'CONTAINS', 'Ben')` - whole word match
  2. `->addWhere('contact_names', 'CONTAINS', 'Ben Walpole')` - multiple whole word matches, ranked by best match, order doesn't matter 
  3. `->addWhere('contact_names', 'LIKE', 'Ben%')` - partial word match
  4. `->addWhere('contact_names', 'LIKE', 'Ben% Wal%')` - multiple partial word match, order doesn't matter
  5. `->addWhere('contact_names', 'MATCHES', '+Ben -Jones')` - boolean match, find records containing Ben but NOT Jones

- FTS indices can be used in Search Forms by adding input corresponding to the index - this will use the trailing wildcard (case 3) by default

Technical Details
----------------------------------------
Mysql Full Text Search indices can be used in different ways - Natural Language / Boolean etc. 

The challenge is working out what combos to expose in Api4, and how to map that to existing operators etc. in a way that is easy enough to use; but expressive enough.

I have gone with:
-  `CONTAINS` for Natural Language mode (ie match full words); 
- `LIKE` for Boolean mode with partial interop with Mysql LIKE % wildcards (thoug there's an important functional difference in that FTS matching only supports a trailing wildcard)
- `MATCHES` for full Boolean expressions (which can be like `+John -Smith` (find me John that *doesn't* contain Smith).

This is integrated with QuickSearch in a follow on PR.