### PR TITLE
multisite cron should be domain-aware

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -55,10 +55,16 @@ class CRM_Core_JobManager {
   public $_source = NULL;
 
   /**
+   * @var int
+   */
+  protected $domainId;
+
+  /**
    * @param \Psr\Log\LoggerInterface|null $logger
    */
   public function __construct($logger = NULL) {
     $this->logger = $logger ?: new CRM_Core_JobLogger();
+    $this->domainId = CRM_Core_Config::domainID();
   }
 
   /**
@@ -79,6 +85,7 @@ class CRM_Core_JobManager {
     // Get a list of the jobs that have completed previously
     $successfulJobs = Job::get(FALSE)
       ->addWhere('is_active', '=', TRUE)
+      ->addWhere('domain_id', '=', $this->domainId)
       ->addClause('OR', ['last_run', 'IS NULL'], ['last_run', '<=', 'last_run_end', TRUE])
       ->addOrderBy('name', 'ASC')
       ->execute()
@@ -92,6 +99,7 @@ class CRM_Core_JobManager {
     // If last_run_end is < last_run job has completed successfully in the past but is now failing to complete.
     $maybeUnsuccessfulJobs = Job::get(FALSE)
       ->addWhere('is_active', '=', TRUE)
+      ->addWhere('domain_id', '=', $this->domainId)
       ->addWhere('last_run', 'IS NOT NULL')
       ->addClause('OR', ['last_run_end', 'IS NULL'], ['last_run', '>', 'last_run_end', TRUE])
       ->addOrderBy('name', 'ASC')


### PR DESCRIPTION
Overview
----------------------------------------
I discovered a regression, but it dates back to 5.80, so I'm going to leave this against master.

#29598 replaced a `getJobs()` function with API4.  However, getJobs() filtered by domain ID.  The replacement code did not.

This means that the cron job for any site runs the scheduled jobs for all the sites.  This can lead to subtle bugs.

To replicate:
* Add a second domain:
```sql
INSERT INTO civicrm_domain (name, description, version, contact_id, locale_custom_strings) VALUES ('Site 2', '6.17alpha1', 'a:1:{s:5:"en_US";a:0:{}}';
```
* Change `CIVICRM_DOMAIN_ID` in `civicrm.settings.php` to `2`.
* Have at least one scheduled job that runs on every cron run.
* If you're on buildkit, add `civicrm_setting['domain']['environment'] = 'Production';` to your `civicrm.settings.php` or cron jobs won't run at all.
* Run cron (`cv cron`, REST call to `Job.execute`, etc.).
* Check your Scheduled Job log (there's a helpful SQL statement below).
* Optionally, add a scheduled job on domain 2.


Before
----------------------------------------
Your domain 1 cron jobs ran even though you were running on domain 2.

After
----------------------------------------
Only domain 2 jobs run on domain 2.

Technical Details
----------------------------------------
I originally made domain ID a local variable in `execute()` but realized it'd be nice to pass that to the cron hook. So it's a little bonus feature that no one has ever asked for or needed.

Comments
----------------------------------------
This is a helpful SQL statement to see which cron jobs ran:
```sql
select cjl.id, job_id, cjl.domain_id, run_time, cj.name, cj.domain_id FROM civicrm_job_log cjl JOIN civicrm_job cj ON cjl.job_id = cj.id ORDER BY id;
```

This shows the domain ID of the Job, and the JobLog. Those should always match.