### PR TITLE
Riverlea theme editor - wider preview pane

### DIFF
--- a/ext/riverlea/js/editor.js
+++ b/ext/riverlea/js/editor.js
@@ -86,7 +86,7 @@
 
           <div class="civi-riverlea-stream-editor-edit-pane"></div>
 
-          <div class="civi-riverlea-stream-editor-preview-pane">
+          <div class="civi-riverlea-stream-editor-preview-pane crm-flex-2">
             <iframe></iframe>
           </div>
 


### PR DESCRIPTION
Before
----------------------------------------
- controls and preview are half-half
- preview often collapses to mobile view
<img width="2230" height="1245" alt="image" src="https://github.com/user-attachments/assets/bf2bf2a5-def6-49e8-94ba-4ee0395da20a" />


After
----------------------------------------
- controls and preview are 1 third - 2 thirds
- preview is more often desktop

<img width="2235" height="1321" alt="image" src="https://github.com/user-attachments/assets/24f4cf30-4752-4b04-b5ee-8d26b9c08182" />

