### PR TITLE
dev/core#6554: Add setting for url and realm to OAuth client (needed for integrating Keycloak)

### DIFF
--- a/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
+++ b/ext/oauth-client/Civi/OAuth/CiviGenericProvider.php
@@ -29,6 +29,16 @@ class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider
    */
   protected $tenant;
 
+  /**
+   * @var string
+   */
+  protected $url;
+
+  /**
+   * @var string
+   */
+  protected $realm;
+
   protected function fillProperties(array $options = []) {
     // If this client is generated for CiviConnect bridge, then swap the credentials.
     $needClient = ($options['clientId'] ?? NULL) === '{civi_connect}';
@@ -59,7 +69,7 @@ class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider
    */
   public function getBaseAuthorizationUrl() {
     $url = parent::getBaseAuthorizationUrl();
-    return $this->replaceTenantToken($url);
+    return $this->replaceUrlToken($url);
   }
 
   /**
@@ -72,20 +82,35 @@ class CiviGenericProvider extends \League\OAuth2\Client\Provider\GenericProvider
    */
   public function getBaseAccessTokenUrl(array $params) {
     $url = parent::getBaseAccessTokenUrl($params);
-    return $this->replaceTenantToken($url);
+    return $this->replaceUrlToken($url);
   }
 
   /**
-   * Replace {{tenant}} in the endpoint URLs with 'common' for consumer accounts
-   * or the tenancy ID for dedicated services.
+   * Replaces the following tokens in the end point url
+   *
+   * {{tenant}} 'common' for consumer accounts or the configured tenancy ID
+   * {{url}} configured URL
+   * {{realm}} configured Realm
    *
    * @param string $str URL to replace
    * @return string
    */
-  private function replaceTenantToken($str) {
+  private function replaceUrlToken($str) {
     if (str_contains($str, '{{tenant}}')) {
       $tenant = !empty($this->tenant) ? $this->tenant : 'common';
       $str = str_replace('{{tenant}}', $tenant, $str);
+    }
+    if (str_contains($str, '{{url}}')) {
+      $url = !empty($this->url) ? $this->url : '';
+      if (str_ends_with($url, '/')) {
+        // Remove the ending slash
+        $url = substr($url, 0, -1);
+      }
+      $str = str_replace('{{url}}', $url, $str);
+    }
+    if (str_contains($str, '{{realm}}')) {
+      $realm = !empty($this->realm) ? $this->realm : 'master';
+      $str = str_replace('{{realm}}', $realm, $str);
     }
     return $str;
   }

--- a/ext/oauth-client/ang/oauthClientCreator.aff.html
+++ b/ext/oauth-client/ang/oauthClientCreator.aff.html
@@ -6,6 +6,14 @@
       <label for="guid">{{ts('Client ID')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
       <input class="form-control" ng-model="options.client.guid" type="text" id="guid" required />
     </div>
+    <div ng-if="theProviders[options.client.provider].options.url">
+      <label for="url{{options.client.id}}">{{ts('URL')}}: <span>*</span></label>
+      <input class="form-control" ng-model="options.client.url" type="text" id="url{{options.client.id}}" required/>
+    </div>
+    <div ng-if="theProviders[options.client.provider].options.realm">
+      <label for="realm{{options.client.id}}">{{ts('Realm')}}: <span>*</span></label>
+      <div><input class="form-control" ng-model="options.client.realm" type="text" id="realm{{options.client.id}}" required/></div>
+    </div>
     <div ng-if="theProviders[options.client.provider].options.tenancy">
       <label for="tenant">{{ts('Tenant ID')}}:</label>
       <input class="form-control" ng-model="options.client.tenant" type="text" id="tenant" />

--- a/ext/oauth-client/ang/oauthClientEditor.aff.html
+++ b/ext/oauth-client/ang/oauthClientEditor.aff.html
@@ -14,6 +14,14 @@
       <label for="guid{{options.client.id}}">{{ts('Client ID (Public)')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
       <input class="form-control" ng-model="options.client.guid" type="text" id="guid{{options.client.id}}" required/>
     </div>
+    <div ng-if="theProviders[options.client.provider].options.url">
+      <label for="url{{options.client.id}}">{{ts('URL')}}: <span>*</span></label>
+      <input class="form-control" ng-model="options.client.url" type="text" id="url{{options.client.id}}" required/>
+    </div>
+    <div ng-if="theProviders[options.client.provider].options.realm">
+      <label for="realm{{options.client.id}}">{{ts('Realm')}}: <span>*</span></label>
+      <div><input class="form-control" ng-model="options.client.realm" type="text" id="realm{{options.client.id}}" required/></div>
+    </div>
     <div ng-if="theProviders[options.client.provider].options.tenancy">
       <label for="tenant{{options.client.id}}">{{ts('Tenant ID')}}:</label>
       <input class="form-control" ng-model="options.client.tenant" type="text" id="tenant{{options.client.id}}"/>


### PR DESCRIPTION
Overview
----------------------------------------

When using Keycloak as an open ID provider. There is no generic way yet to set the url of your keycloak server and nor the realm setting (the realm is Keycloak setting).

Before
----------------------------------------

If a provider needs a url and a realm setting then it is not possible to let the administrator configure this.

After
----------------------------------------

A setting for the url and realm.  See screenshot below:

<img width="1919" height="875" alt="2026-06-05_13-45" src="https://github.com/user-attachments/assets/9cf39281-7d78-46de-90e5-68df38507821" />


Technical Details
----------------------------------------

When no realm is provided then it will default to master.

This PR renames the function `replaceTenantToken` to `replaceUrlToken` which in turn then replaces three tokens `{{tenant}}`, {{url}}` and `{{realm}}`

Comments
----------------------------------------

The provider file for Keycloak is not included in this PR. And will be provided by the OAuth (Login extension)[https://github.com/greenpeace-cee/oauth_login/tree/main] and the file will look like:

```json
{ 
  "title": "Keycloak", 
  "class": "Civi\\OAuth\\CiviGenericProvider", 
  "options": { 
    "urlAuthorize": "{{url}}/realms/{{realm}}/protocol/openid-connect/auth", 
    "urlAccessToken": "{{url}}/realms/{{realm}}/protocol/openid-connect/token", 
    "urlResourceOwnerDetails": "{{use_id_token}}", 
    "scopeSeparator": " ", 
    "scopes": [ 
      "openid", 
      "email" 
    ], 
    "tenancy": false,
    "url": true,
    "realm": true
  },
  "tags": ["Login"]
}

```

See as well: https://lab.civicrm.org/dev/core/-/work_items/6554 and https://lab.civicrm.org/dev/core/-/work_items/4991#note_198875


