### PR TITLE
RiverLea: `.odd` should take precedence over `.even-row`

### DIFF
--- a/ext/riverlea/core/css/components/_tables.css
+++ b/ext/riverlea/core/css/components/_tables.css
@@ -243,7 +243,7 @@ tbody.scrollContent:has(.alternateRow),
   background-color: var(--crm-striped-bg-color) !important;
 }
 .crm-container table.dataTable:is(.stripe,.display) tbody tr.even:not(.disabled),
-.crm-container table tr.even-row:not(.disabled),
+.crm-container table tr.even-row:not(.odd,.disabled),
 tbody.scrollContent tr.alternateRow:not(.disabled),
 .crm-container .table-striped > tbody > tr:nth-of-type(2n):not(.disabled) {
   --crm-striped-bg-color: color-mix(in srgb, var(--crm-table-row-bg-color) 0%, var(--crm-table-row-alternate-bg-color) var(--crm-table-row-alternate-mix));


### PR DESCRIPTION
Overview
----------------------------------------
In sortable tables of type `dataTable` (e.g. on the Event Templates screen) the `.odd` CSS class should take precedence over the `.even-row` class or else row striping gets incorrectly rendered.

Before
----------------------------------------
<img width="1567" height="403" alt="Screenshot 2026-06-05 at 18 20 05" src="https://github.com/user-attachments/assets/25571710-5cad-4054-a249-ba4c5958b173" />

After
----------------------------------------
<img width="1566" height="409" alt="Screenshot 2026-06-05 at 18 20 40" src="https://github.com/user-attachments/assets/ec75c4f0-abb0-406a-bcc9-32a76866e155" />
