### PR TITLE
Prevent angular error when using Existing Contact on a Search FormBuilder

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -385,7 +385,7 @@
 
       // ngChange callback from Existing entity field
       ctrl.onSelectEntity = function() {
-        if (ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill) {
+        if (ctrl.afForm && ctrl.defn.input_attrs && ctrl.defn.input_attrs.autofill) {
           const val = $scope.getSetSelect();
           const entity = ctrl.afFieldset.modelName;
           const entityIndex = ctrl.getEntityIndex();


### PR DESCRIPTION
If you have a search FormBuilder with an Existing Contact filter field, you'll get an Angular error here at 394 when you select the contact. We don't need to do any data loading into other fields if we're just using Existing Contact as a search filter.

Ideally, the field wouldn't be autofill in a search context, but it looks like that would be a more significant change so I think a guard here does the job.