### PR TITLE
fix implicit nullable in oauth-client

### DIFF
--- a/ext/oauth-client/Civi/OAuth/CiviConnect.php
+++ b/ext/oauth-client/Civi/OAuth/CiviConnect.php
@@ -20,7 +20,7 @@ class CiviConnect extends AutoService {
    * @inject crypto.registry, cache.long
    * @return \Civi\OAuth\CiviConnect
    */
-  public static function factory(\Civi\Crypto\CryptoRegistry $registry, CRM_Utils_Cache_Interface $cache = NULL) {
+  public static function factory(\Civi\Crypto\CryptoRegistry $registry, ?CRM_Utils_Cache_Interface $cache = NULL) {
     $instance = new static();
     $instance->cache = $cache;
     // Registering our key via factory() means that we guarantee CRED key is already registered,


### PR DESCRIPTION
Overview
----------------------------------------
Just knocking these out as I come across them - but if only there was some sort of tool that would analyze the code...statically...

Before
----------------------------------------
```
[PHP Deprecation] Civi\OAuth\CiviConnect::factory(): Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead at /var/www/nmysite.org/web/wp-content/plugins/civicrm/civicrm/ext/oauth-client/Civi/OAuth/CiviConnect.php:23
```

After
----------------------------------------
<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/82ea6fc4-065b-44ac-b7fa-e07c756df4fd" />
