### PR TITLE
html_type must be small letters

### DIFF
--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -268,7 +268,7 @@ return [
     'group' => 'Search Preferences',
     'name' => 'search_mysql_fts',
     'type' => 'Boolean',
-    'html_type' => 'Toggle',
+    'html_type' => 'toggle',
     'default' => TRUE,
     'add' => '6.17',
     'title' => ts('Use Mysql Full Text Search'),


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
One of the letters is big.

After
----------------------------------------
None of the letters is big.

Technical Details
----------------------------------------
This matters because all the letters have to be small.

Comments
----------------------------------------

