### PR TITLE
[dev/joomla#54] Fix JPluginHelper not found error in Joomla! 5 without compatibility plugin

### DIFF
--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -644,8 +644,8 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
       $version = new JVersion();
       return $version->getShortVersion();
     }
-    elseif (class_exists('Version')) {
-      $version = new Version();
+    elseif (class_exists('\Joomla\CMS\Version')) {
+      $version = new \Joomla\CMS\Version();
       return $version->getShortVersion();
     }
     else {
@@ -663,12 +663,7 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
         $versionPhp = $joomlaBase . '/libraries/cms/version/version.php';
       }
       require $versionPhp;
-      $class = 'jVersion';
-      if (!class_exists('jVersion')) {
-        $class = 'Version';
-      }
-      $jversion = new $class();
-      define('JVERSION', $jversion->getShortVersion());
+      define('JVERSION', $this->getVersion());
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
As part of work towards [joomla#54](https://lab.civicrm.org/dev/joomla/-/work_items/54), I have tested CiviCRM with the Joomla! Compatibility Plugin DISABLED.

This revealed an outdated Joomla! class reference that got missed!

Before
----------------------------------------
Disabling the J5 Compatibility Plugin and then trying to access CiviCRM administrator results in this error:

<img width="377" height="224" alt="Screenshot 2026-06-05 232315" src="https://github.com/user-attachments/assets/f0bcb30f-2ef3-4b6a-ae3e-e919b5bafc15" />

After
----------------------------------------
CiviCRM loads as expected.

Technical Details
----------------------------------------
The bug is caused by the fact that `CRM_Utils_System_Joomla::getVersion()` returns "Unknown" with the Compatibility Plugin disabled. This is because the `JVersion` class alias no longer exists, so it tries to load `Version` but this is incorrect: the fully-qualified name should be used, i.e. `\Joomla\CMS\Version`.

As a result, `plugin_init()` in `admin.civicrm.php` tries to execute the [legacy code branch](https://github.com/civicrm/civicrm-joomla/blob/62e15fc3aa6e7f21195794f220e4997819318ac5/admin/admin.civicrm.php#L82), which includes a (now-invalid) reference to `JPluginHelper` (and other things).

The legacy code branch (along with others elsewhere) can and should be deleted in due course.

Comments
----------------------------------------
Please see also PR #35480, which fixes a mild bug in `CRM_Utils_System_Joomla::getJVersion()` whereby there is no return value.