### PR TITLE
Strip non-numeric characters for phone fields in quicksearch autocomplete

### DIFF
--- a/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/ContactAutocompleteProvider.php
@@ -52,6 +52,9 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
       $allowedFilters = \Civi::settings()->get('quicksearch_options');
       foreach ($apiRequest->getFilters() as $filterField => $val) {
         if (in_array($filterField, $allowedFilters)) {
+          if ($filterField === 'phone_primary.phone' || $filterField === 'Phone.phone_numeric') {
+            $val = preg_replace('/\D/', '', $val);
+          }
           // Add trusted filter
           $apiRequest->addFilter($filterField, $val);
           $apiRequest->setInput($val);
@@ -153,7 +156,11 @@ class ContactAutocompleteProvider extends \Civi\Core\Service\AutoService impleme
         $prefix = \Civi::settings()->get('includeWildCardInName') ? '%' : '';
         foreach ($filterFields as $field) {
           $params = $apiParams;
-          $params['where'][] = [$field, 'LIKE', $prefix . $apiRequest->getInput() . '%'];
+          $inputVal = $apiRequest->getInput();
+          if ($field === 'phone_primary.phone' || $field === 'Phone.phone_numeric') {
+            $inputVal = preg_replace('/\D/', '', $inputVal);
+          }
+          $params['where'][] = [$field, 'LIKE', $prefix . $inputVal . '%'];
           // Strip all suffixes from inner select array (pseudoconstants will be evaluated by the outer query)
           $params['select'] = array_map(function ($field) {
             return explode(':', $field)[0];

--- a/tests/phpunit/api/v4/Action/AutocompleteQuicksearchTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteQuicksearchTest.php
@@ -383,4 +383,36 @@ class AutocompleteQuicksearchTest extends \api\v4\Api4TestBase {
     $this->assertEquals('TestXYZblacksmith, Mary :: 1600 Marigold Lane', $result[$contacts[2]['id']]['label']);
   }
 
+  public function testQuicksearchAutocompleteWithNonNumericPhone(): void {
+    Setting::set(FALSE)
+      ->addValue('quicksearch_options', ['sort_name', 'phone_primary.phone'])
+      ->execute();
+
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'A', 'last_name' => 'Aaa', 'phone_primary.phone' => '123456'],
+        ['first_name' => 'B', 'last_name' => 'Bbb', 'phone_primary.phone' => '789012'],
+      ],
+    ]);
+
+    $cid = $contacts[0]['id'];
+
+    // Search with non-numeric formatting in phone number
+    $resultWithNonNumeric = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setFilters(['phone_primary.phone' => '(123) 456'])
+      ->execute();
+
+    $resultNumeric = Contact::autocomplete(FALSE)
+      ->setFormName('crmMenubar')
+      ->setFieldName('crm-qsearch-input')
+      ->setFilters(['phone_primary.phone' => '123456'])
+      ->execute();
+
+    $this->assertEquals($resultNumeric, $resultWithNonNumeric);
+    $this->assertCount(1, $resultNumeric);
+    $this->assertEquals($cid, $resultNumeric[0]['id']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
More consistent results when searching for contacts by phone number.

Before
----------------------------------------
Typing any non-numeric character (like +1 or (888) or 555-5555) would cause the search to fail.

After
----------------------------------------
Non-numeric characters are ignored in the search, only the actual phone numbers are compared.