### PR TITLE
dev#6555 - Users with "view all contacts" permission cannot view contact pages

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1126,6 +1126,7 @@ class CRM_Core_Permission {
 
     // Contact-related data permissions.
     $permissions['address'] = [
+      'meta' => [],
       // get is managed by BAO::addSelectWhereClause
       // create/delete are managed by _civicrm_api3_check_edit_permissions
       'default' => [],


### PR DESCRIPTION
Overview
----------------------------------------
Fix contact location entities to have correct permission configuration.

Before
----------------------------------------
Users with "view all contacts" permission but without "access CiviCRM" were unable to view contact pages due to authorization failures.

After
----------------------------------------
Users with "view all contacts" permission can now view contact pages successfully. The Contact Summary page loads contact location data (email, phone, IM, website) without authorization errors.

Technical Details
----------------------------------------
Adding 'meta' => [] aligns meta actions with data actions, allowing both to defer to BAO-level ACL checks where "view all contacts" permission is properly evaluated.

Comments
----------------------------------------
