### PR TITLE
Add class to Case tables to trigger RiverLea striping

### DIFF
--- a/templates/CRM/Case/Form/ActivityTab.tpl
+++ b/templates/CRM/Case/Form/ActivityTab.tpl
@@ -57,7 +57,7 @@
       </details>
     {/if}
 
-  <table id="case_id_{$caseid}"  class="nestedActivitySelector crm-ajax-table" data-page-length="10">
+  <table id="case_id_{$caseid}"  class="nestedActivitySelector crm-ajax-table display" data-page-length="10">
     <thead><tr>
       <th data-data="activity_date_time" class="crm-case-activities-date">{ts}Date{/ts}</th>
       <th data-data="subject" cell-class="crmf-subject crm-editable" class="crm-case-activities-subject">{ts}Subject{/ts}</th>

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -19,7 +19,7 @@
 
   {crmRegion name="case-view-summary"}
   <h3>{ts}Summary{/ts}</h3>
-  <table class="report crm-entity case-summary" data-entity="case" data-id="{$caseID}" data-cid="{$contactID}">
+  <table class="report crm-entity case-summary display" data-entity="case" data-id="{$caseID}" data-cid="{$contactID}">
     {if $multiClient}
       <tr class="crm-case-caseview-client">
         <td colspan="5" class="label">
@@ -163,7 +163,7 @@
         {* Add checkbox to show inactive roles. For open cases, default value is unchecked, i.e. show active roles. For closed cases default is checked. *}
         <label><input type="checkbox" id="role_inactive" name="role_inactive[]"{if $caseDetails.status_class neq 'Opened'} checked="checked"{/if}>{ts}Show Inactive relationships{/ts}</label>
       </div>
-      <table id="caseRoles-selector-{$caseID}" class="report-layout crm-ajax-table" data-page-length="10">
+      <table id="caseRoles-selector-{$caseID}" class="report-layout crm-ajax-table display" data-page-length="10">
         <thead>
           <tr>
             <th data-data="relation">{ts}Case Role{/ts}</th>
@@ -208,7 +208,7 @@
       <div class="crm-submit-buttons">
         {crmButton p='civicrm/contact/view/rel' q="action=add&reset=1&cid=`$contactId`&caseID=`$caseID`" icon="plus-circle"}{ts}Add client relationship{/ts}{/crmButton}
       </div>
-      <table id="clientRelationships-selector-{$caseID}"  class="report-layout crm-ajax-table" data-page-length="10">
+      <table id="clientRelationships-selector-{$caseID}"  class="report-layout crm-ajax-table display" data-page-length="10">
         <thead>
           <tr>
             <th data-data="relation">{ts}Client Relationship{/ts}</th>
@@ -240,7 +240,7 @@
     <div id="addMembersToGroupDialog" class="hiddenElement">
       <input name="add_member_to_group_contact_id" placeholder="{ts escape='htmlattribute'}- select contacts -{/ts}" class="huge" />
     </div>
-    <table id="globalRelationships-selector-{$caseId}"  class="report-layout crm-ajax-table" data-page-length="10">
+    <table id="globalRelationships-selector-{$caseId}"  class="report-layout crm-ajax-table display" data-page-length="10">
       <thead>
         <tr>
           <th data-data="sort_name">{$globalGroupInfo.title}</th>

--- a/templates/CRM/Case/Page/DashboardSelector.tpl
+++ b/templates/CRM/Case/Page/DashboardSelector.tpl
@@ -8,7 +8,7 @@
  +--------------------------------------------------------------------+
 *}
 {strip}
-<table class="case-selector-{$list} crm-ajax-table" data-page-length='10'>
+<table class="case-selector-{$list} crm-ajax-table display" data-page-length='10'>
 <thead>
   <tr>
     <th data-data="activity_list" data-orderable="false" class="crm-case-activity_list"></th>


### PR DESCRIPTION
Overview
----------------------------------------
Rather than writing new CSS declarations to stripe CiviCase tables, I've just added the `.display` class to them. Brings parity with Greenwich - apart from custom row colours in the Activities table, which seem, erm, complicated to implement.

Case Dashboard Before
----------------------------------------
<img width="3136" height="4982" alt="civicrm-case-dash-pre" src="https://github.com/user-attachments/assets/0d80d874-c9ed-401a-b626-516b2f6a73a2" />

Case Dashboard After
----------------------------------------
<img width="3136" height="4982" alt="civicrm-case-dash-post" src="https://github.com/user-attachments/assets/549d603a-b2c0-4509-8638-a441b9d49786" />

Case View Before
----------------------------------------
<img width="3136" height="4172" alt="civicrm-case-pre" src="https://github.com/user-attachments/assets/9d1a11f6-b646-4037-91e4-677b0c14f4ec" />

Case View After
----------------------------------------
<img width="3136" height="4172" alt="civicrm-case-post" src="https://github.com/user-attachments/assets/34a7771d-008c-4d59-bc20-cb8f37addb1b" />