### PR TITLE
Standalone: Don't crash on PHP notices in extensions when debugging is enabled

### DIFF
--- a/Civi/Standalone/ErrorHandler.php
+++ b/Civi/Standalone/ErrorHandler.php
@@ -60,7 +60,11 @@ class ErrorHandler {
     . htmlspecialchars("$errstr [$errno]\n") . '<code>' . htmlspecialchars($errfile) . "</code> line $errline"
     . $trace
     . '</li>';
-    \CRM_Core_Smarty::singleton()->assign('standaloneErrors', implode("\n", \Civi::$statics[__FUNCTION__]));
+    // Don't assign unless we can be sure that Civi is sufficiently booted.
+    $dispatcherReady = (new \Civi\Core\CiviEventDispatcher())->checkDispatchPolicy('hooks_ready_to_run');
+    if ($dispatcherReady === 'run') {
+       \CRM_Core_Smarty::singleton()->assign('standaloneErrors', implode("\n", \Civi::$statics[__FUNCTION__]));
+    }
 
     self::$handlingError = FALSE;
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6557

Before
----------------------------------------
Crash when any Civi extensions generate any sort of PHP notice/warning 

After
----------------------------------------
No crash.

Technical Details
----------------------------------------
Like #32444 and #32525, this is a scenario in which we might try to call hooks in standalone before we've sufficiently booted Civi.