### PR TITLE
Sync DAO class annotations with entityType fields

### DIFF
--- a/CRM/ACL/DAO/ACLCache.php
+++ b/CRM/ACL/DAO/ACLCache.php
@@ -8,10 +8,9 @@
 /**
  * Placeholder class retained for legacy compatibility.
  *
- * @property int|string|null $id
  * @property int|string|null $contact_id
  * @property int|string $acl_id
- * @property string $modified_date
+ * @property string|null $modified_date
  */
 class CRM_ACL_DAO_ACLCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Activity/DAO/Activity.php
+++ b/CRM/Activity/DAO/Activity.php
@@ -12,7 +12,7 @@
  * @property int|string|null $source_record_id
  * @property int|string $activity_type_id
  * @property string|null $subject
- * @property string $activity_date_time
+ * @property string|null $activity_date_time
  * @property int|string|null $duration
  * @property string|null $location
  * @property string|null $details
@@ -28,8 +28,8 @@
  * @property int|string|null $engagement_level
  * @property int|string|null $weight
  * @property bool|string $is_star
- * @property string $created_date
- * @property string $modified_date
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_Activity_DAO_Activity extends CRM_Core_DAO_Base {
 }

--- a/CRM/Batch/DAO/Batch.php
+++ b/CRM/Batch/DAO/Batch.php
@@ -13,9 +13,9 @@
  * @property string|null $title
  * @property string|null $description
  * @property int|string|null $created_id
- * @property string|null $created_date
+ * @property string $created_date
  * @property int|string|null $modified_id
- * @property string|null $modified_date
+ * @property string $modified_date
  * @property int|string|null $saved_search_id
  * @property int|string $status_id
  * @property int|string|null $type_id

--- a/CRM/Campaign/DAO/Campaign.php
+++ b/CRM/Campaign/DAO/Campaign.php
@@ -20,9 +20,9 @@
  * @property int|string|null $parent_id
  * @property bool|string $is_active
  * @property int|string|null $created_id
- * @property string|null $created_date
+ * @property string $created_date
  * @property int|string|null $last_modified_id
- * @property string|null $last_modified_date
+ * @property string $last_modified_date
  * @property string|null $goal_general
  * @property float|string|null $goal_revenue
  */

--- a/CRM/Campaign/DAO/Survey.php
+++ b/CRM/Campaign/DAO/Survey.php
@@ -19,9 +19,9 @@
  * @property bool|string $is_active
  * @property bool|string $is_default
  * @property int|string|null $created_id
- * @property string|null $created_date
+ * @property string $created_date
  * @property int|string|null $last_modified_id
- * @property string|null $last_modified_date
+ * @property string $last_modified_date
  * @property int|string|null $result_id
  * @property bool|string $bypass_confirm
  * @property string|null $thankyou_title

--- a/CRM/Case/DAO/Case.php
+++ b/CRM/Case/DAO/Case.php
@@ -16,8 +16,8 @@
  * @property string|null $details
  * @property int|string $status_id
  * @property bool|string $is_deleted
- * @property string $created_date
- * @property string $modified_date
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_Case_DAO_Case extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/ACLContactCache.php
+++ b/CRM/Contact/DAO/ACLContactCache.php
@@ -8,10 +8,10 @@
 /**
  * Placeholder class retained for legacy compatibility.
  *
- * @property int|string|null $id
  * @property int|string|null $user_id
  * @property int|string $contact_id
  * @property string $operation
+ * @property int|string $domain_id
  */
 class CRM_Contact_DAO_ACLContactCache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/Contact.php
+++ b/CRM/Contact/DAO/Contact.php
@@ -56,8 +56,8 @@
  * @property string|null $sic_code
  * @property int|string|null $employer_id
  * @property bool|string $is_deleted
- * @property string $created_date
- * @property string $modified_date
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_Contact_DAO_Contact extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contact/DAO/Group.php
+++ b/CRM/Contact/DAO/Group.php
@@ -17,8 +17,8 @@
  * @property bool|string $is_active
  * @property string|null $visibility
  * @property string|null $group_type
- * @property string $cache_date
- * @property float|string $cache_fill_took
+ * @property string|null $cache_date
+ * @property float|string|null $cache_fill_took
  * @property string|null $parents
  * @property string|null $children
  * @property bool|string $is_hidden

--- a/CRM/Contact/DAO/GroupContactCache.php
+++ b/CRM/Contact/DAO/GroupContactCache.php
@@ -8,7 +8,6 @@
 /**
  * Placeholder class retained for legacy compatibility.
  *
- * @property int|string|null $id
  * @property int|string $group_id
  * @property int|string $contact_id
  */

--- a/CRM/Contact/DAO/SavedSearch.php
+++ b/CRM/Contact/DAO/SavedSearch.php
@@ -18,10 +18,11 @@
  * @property string|null $api_params
  * @property int|string|null $created_id
  * @property int|string|null $modified_id
- * @property string $expires_date
+ * @property string|null $expires_date
  * @property string $created_date
  * @property string $modified_date
  * @property string|null $description
+ * @property bool|string $is_template
  */
 class CRM_Contact_DAO_SavedSearch extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/Contribution.php
+++ b/CRM/Contribute/DAO/Contribution.php
@@ -39,6 +39,8 @@
  * @property float|string $tax_amount
  * @property string|null $revenue_recognition_date
  * @property bool|string $is_template
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_Contribute_DAO_Contribution extends CRM_Core_DAO_Base {
 }

--- a/CRM/Contribute/DAO/ContributionPage.php
+++ b/CRM/Contribute/DAO/ContributionPage.php
@@ -50,7 +50,7 @@
  * @property string|null $start_date
  * @property string|null $end_date
  * @property int|string|null $created_id
- * @property string|null $created_date
+ * @property string $created_date
  * @property string|null $currency
  * @property int|string|null $campaign_id
  * @property bool|string $is_share

--- a/CRM/Contribute/DAO/ContributionRecur.php
+++ b/CRM/Contribute/DAO/ContributionRecur.php
@@ -17,7 +17,7 @@
  * @property int|string|null $installments
  * @property string $start_date
  * @property string $create_date
- * @property string|null $modified_date
+ * @property string $modified_date
  * @property string|null $cancel_date
  * @property string|null $cancel_reason
  * @property string|null $end_date

--- a/CRM/Core/DAO/ActionSchedule.php
+++ b/CRM/Core/DAO/ActionSchedule.php
@@ -46,10 +46,10 @@
  * @property string|null $used_for
  * @property string|null $filter_contact_language
  * @property string|null $communication_language
- * @property string $created_date
- * @property string $modified_date
- * @property string $effective_start_date
- * @property string $effective_end_date
+ * @property string|null $created_date
+ * @property string|null $modified_date
+ * @property string|null $effective_start_date
+ * @property string|null $effective_end_date
  */
 class CRM_Core_DAO_ActionSchedule extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Cache.php
+++ b/CRM/Core/DAO/Cache.php
@@ -8,13 +8,12 @@
 /**
  * Placeholder class retained for legacy compatibility.
  *
- * @property int|string|null $id
  * @property string $group_name
  * @property string|null $path
  * @property string|null $data
  * @property int|string|null $component_id
- * @property string|null $created_date
- * @property string $expired_date
+ * @property string $created_date
+ * @property string|null $expired_date
  */
 class CRM_Core_DAO_Cache extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/CustomField.php
+++ b/CRM/Core/DAO/CustomField.php
@@ -10,7 +10,7 @@
  *
  * @property int|string|null $id
  * @property int|string $custom_group_id
- * @property string|null $name
+ * @property string $name
  * @property string $label
  * @property string $data_type
  * @property string $html_type
@@ -24,6 +24,7 @@
  * @property string|null $attributes
  * @property bool|string|null $is_active
  * @property bool|string $is_view
+ * @property bool|string $file_is_public
  * @property int|string|null $options_per_line
  * @property int|string|null $text_length
  * @property int|string|null $start_date_years

--- a/CRM/Core/DAO/CustomGroup.php
+++ b/CRM/Core/DAO/CustomGroup.php
@@ -9,12 +9,12 @@
  * Placeholder class retained for legacy compatibility.
  *
  * @property int|string|null $id
- * @property string|null $name
+ * @property string $name
  * @property string $title
- * @property string|null $extends
+ * @property string $extends
  * @property int|string|null $extends_entity_column_id
  * @property string|null $extends_entity_column_value
- * @property string|null $style
+ * @property string $style
  * @property bool|string $collapse_display
  * @property string|null $help_pre
  * @property string|null $help_post

--- a/CRM/Core/DAO/File.php
+++ b/CRM/Core/DAO/File.php
@@ -14,7 +14,7 @@
  * @property string|null $uri
  * @property string|null $description
  * @property bool|string $is_public
- * @property string|null $upload_date
+ * @property string $upload_date
  * @property int|string|null $created_id
  */
 class CRM_Core_DAO_File extends CRM_Core_DAO_Base {

--- a/CRM/Core/DAO/Job.php
+++ b/CRM/Core/DAO/Job.php
@@ -11,9 +11,9 @@
  * @property int|string|null $id
  * @property int|string $domain_id
  * @property string|null $run_frequency
- * @property string $last_run
- * @property string $last_run_end
- * @property string $scheduled_run_date
+ * @property string|null $last_run
+ * @property string|null $last_run_end
+ * @property string|null $scheduled_run_date
  * @property string|null $name
  * @property string|null $description
  * @property string|null $api_entity

--- a/CRM/Core/DAO/JobLog.php
+++ b/CRM/Core/DAO/JobLog.php
@@ -10,7 +10,7 @@
  *
  * @property int|string|null $id
  * @property int|string $domain_id
- * @property string|null $run_time
+ * @property string $run_time
  * @property int|string|null $job_id
  * @property string|null $name
  * @property string|null $command

--- a/CRM/Core/DAO/Managed.php
+++ b/CRM/Core/DAO/Managed.php
@@ -13,9 +13,9 @@
  * @property string $name
  * @property string $entity_type
  * @property int|string|null $entity_id
+ * @property string|null $checksum
  * @property string $cleanup
- * @property string $checksum
- * @property string $entity_modified_date
+ * @property string|null $entity_modified_date
  */
 class CRM_Core_DAO_Managed extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/Navigation.php
+++ b/CRM/Core/DAO/Navigation.php
@@ -13,7 +13,7 @@
  * @property string|null $label
  * @property string|null $name
  * @property string|null $url
- * @property string $icon
+ * @property string|null $icon
  * @property string|null $permission
  * @property string|null $permission_operator
  * @property int|string|null $parent_id

--- a/CRM/Core/DAO/Note.php
+++ b/CRM/Core/DAO/Note.php
@@ -13,9 +13,9 @@
  * @property int|string $entity_id
  * @property string|null $note
  * @property int|string|null $contact_id
- * @property string|null $note_date
+ * @property string $note_date
  * @property string $created_date
- * @property string|null $modified_date
+ * @property string $modified_date
  * @property string|null $subject
  * @property string $privacy
  */

--- a/CRM/Core/DAO/OptionValue.php
+++ b/CRM/Core/DAO/OptionValue.php
@@ -22,7 +22,6 @@
  * @property bool|string|null $is_reserved
  * @property bool|string|null $is_active
  * @property int|string|null $component_id
- * @property int|string|null $domain_id
  * @property int|string|null $visibility_id
  * @property string|null $icon
  * @property string|null $color

--- a/CRM/Core/DAO/PrevNextCache.php
+++ b/CRM/Core/DAO/PrevNextCache.php
@@ -11,7 +11,7 @@
  * @property int|string|null $id
  * @property string|null $entity_table
  * @property int|string $entity_id1
- * @property int|string $entity_id2
+ * @property int|string|null $entity_id2
  * @property string|null $cachekey
  * @property string|null $data
  * @property bool|string $is_selected

--- a/CRM/Core/DAO/SiteEmailAddress.php
+++ b/CRM/Core/DAO/SiteEmailAddress.php
@@ -7,6 +7,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $display_name
+ * @property string $email
+ * @property string|null $description
+ * @property bool|string $is_active
+ * @property bool|string $is_default
+ * @property int|string $domain_id
  */
 class CRM_Core_DAO_SiteEmailAddress extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/SiteToken.php
+++ b/CRM/Core/DAO/SiteToken.php
@@ -8,16 +8,17 @@
 /**
  * Placeholder class retained for legacy compatibility.
  *
- * @property int $id
- * @property int $domain_id
+ * @property int|string|null $id
+ * @property int|string $domain_id
  * @property string $name
- * @property string $body_html
- * @property string $body_text
- * @property bool $is_active
- * @property bool $is_reserved
- * @property int $created_id
- * @property int $modified_id
- * @property string $modified_date
+ * @property string $label
+ * @property string|null $body_html
+ * @property string|null $body_text
+ * @property bool|string $is_active
+ * @property bool|string $is_reserved
+ * @property int|string|null $created_id
+ * @property int|string|null $modified_id
+ * @property string|null $modified_date
  */
 class CRM_Core_DAO_SiteToken extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/SystemLog.php
+++ b/CRM/Core/DAO/SystemLog.php
@@ -12,7 +12,7 @@
  * @property string $message
  * @property string|null $context
  * @property string|null $level
- * @property string|null $timestamp
+ * @property string $timestamp
  * @property int|string|null $contact_id
  * @property string|null $hostname
  */

--- a/CRM/Core/DAO/Translation.php
+++ b/CRM/Core/DAO/Translation.php
@@ -9,12 +9,13 @@
  * Placeholder class retained for legacy compatibility.
  *
  * @property int|string|null $id
- * @property string $entity_table
- * @property string $entity_field
- * @property int|string $entity_id
+ * @property string|null $entity_table
+ * @property string|null $entity_field
+ * @property int|string|null $entity_id
  * @property string $language
  * @property int|string $status_id
- * @property string $string
+ * @property string|null $string
+ * @property string|null $source_key
  */
 class CRM_Core_DAO_Translation extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/TranslationSource.php
+++ b/CRM/Core/DAO/TranslationSource.php
@@ -8,8 +8,13 @@
 /**
  * Placeholder class retained for legacy compatibility.
  *
- * @property int $id
+ * @property int|string|null $id
+ * @property string $entity
+ * @property string|null $entity_field
+ * @property int|string|null $entity_id
+ * @property string $context_key
  * @property string $source
+ * @property string $source_key
  */
 class CRM_Core_DAO_TranslationSource extends CRM_Core_DAO_Base {
 }

--- a/CRM/Core/DAO/UserJob.php
+++ b/CRM/Core/DAO/UserJob.php
@@ -10,14 +10,16 @@
  *
  * @property int|string|null $id
  * @property string|null $name
+ * @property string|null $label
  * @property int|string|null $created_id
  * @property string $created_date
- * @property string $start_date
- * @property string $end_date
- * @property string $expires_date
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property string|null $expires_date
  * @property int|string $status_id
  * @property string $job_type
  * @property int|string|null $queue_id
+ * @property int|string|null $search_display_id
  * @property string|null $metadata
  * @property bool|string $is_template
  */

--- a/CRM/Core/DAO/WordReplacement.php
+++ b/CRM/Core/DAO/WordReplacement.php
@@ -9,8 +9,8 @@
  * Placeholder class retained for legacy compatibility.
  *
  * @property int|string|null $id
- * @property string|null $find_word
- * @property string|null $replace_word
+ * @property string $find_word
+ * @property string $replace_word
  * @property bool|string $is_active
  * @property string|null $match_type
  * @property int|string|null $domain_id

--- a/CRM/Event/DAO/Event.php
+++ b/CRM/Event/DAO/Event.php
@@ -74,7 +74,6 @@
  * @property bool|string $is_share
  * @property bool|string $is_confirm_enabled
  * @property int|string|null $parent_event_id
- * @property int|string|null $slot_label_id
  * @property int|string|null $dedupe_rule_group_id
  * @property bool|string $is_billing_required
  * @property bool|string $is_show_calendar_links

--- a/CRM/Event/DAO/Participant.php
+++ b/CRM/Event/DAO/Participant.php
@@ -27,6 +27,8 @@
  * @property int|string|null $must_wait
  * @property int|string|null $transferred_to_contact_id
  * @property int|string|null $created_id
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_Event_DAO_Participant extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/FinancialAccount.php
+++ b/CRM/Financial/DAO/FinancialAccount.php
@@ -10,6 +10,7 @@
  *
  * @property int|string|null $id
  * @property string $name
+ * @property string $label
  * @property int|string|null $contact_id
  * @property int|string $financial_account_type_id
  * @property string|null $accounting_code

--- a/CRM/Financial/DAO/FinancialType.php
+++ b/CRM/Financial/DAO/FinancialType.php
@@ -10,6 +10,7 @@
  *
  * @property int|string|null $id
  * @property string $name
+ * @property string $label
  * @property string|null $description
  * @property bool|string $is_deductible
  * @property bool|string $is_reserved

--- a/CRM/Financial/DAO/PaymentProcessor.php
+++ b/CRM/Financial/DAO/PaymentProcessor.php
@@ -32,6 +32,7 @@
  * @property int|string|null $payment_type
  * @property int|string|null $payment_instrument_id
  * @property string|null $accepted_credit_cards
+ * @property string|null $config
  */
 class CRM_Financial_DAO_PaymentProcessor extends CRM_Core_DAO_Base {
 }

--- a/CRM/Financial/DAO/PaymentToken.php
+++ b/CRM/Financial/DAO/PaymentToken.php
@@ -12,7 +12,7 @@
  * @property int|string $contact_id
  * @property int|string $payment_processor_id
  * @property string $token
- * @property string|null $created_date
+ * @property string $created_date
  * @property int|string|null $created_id
  * @property string|null $expiry_date
  * @property string|null $email

--- a/CRM/Mailing/DAO/Mailing.php
+++ b/CRM/Mailing/DAO/Mailing.php
@@ -34,15 +34,15 @@
  * @property int|string|null $msg_template_id
  * @property bool|string $override_verp
  * @property int|string|null $created_id
- * @property string $created_date
- * @property string $modified_date
+ * @property string|null $created_date
+ * @property string|null $modified_date
  * @property int|string|null $scheduled_id
- * @property string $scheduled_date
- * @property string $start_date
- * @property string $end_date
- * @property string status
+ * @property string|null $scheduled_date
+ * @property string|null $start_date
+ * @property string|null $end_date
+ * @property string|null $status
  * @property int|string|null $approver_id
- * @property string $approval_date
+ * @property string|null $approval_date
  * @property int|string|null $approval_status_id
  * @property string|null $approval_note
  * @property bool|string $is_archived

--- a/CRM/Mailing/DAO/MailingAB.php
+++ b/CRM/Mailing/DAO/MailingAB.php
@@ -21,7 +21,7 @@
  * @property string|null $declare_winning_time
  * @property int|string|null $group_percentage
  * @property int|string|null $created_id
- * @property string $created_date
+ * @property string|null $created_date
  */
 class CRM_Mailing_DAO_MailingAB extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/DAO/MailingJob.php
+++ b/CRM/Mailing/DAO/MailingJob.php
@@ -10,9 +10,9 @@
  *
  * @property int|string|null $id
  * @property int|string $mailing_id
- * @property string $scheduled_date
- * @property string $start_date
- * @property string $end_date
+ * @property string|null $scheduled_date
+ * @property string|null $start_date
+ * @property string|null $end_date
  * @property string|null $status
  * @property bool|string $is_test
  * @property string|null $job_type

--- a/CRM/Mailing/DAO/Spool.php
+++ b/CRM/Mailing/DAO/Spool.php
@@ -13,8 +13,8 @@
  * @property string|null $recipient_email
  * @property string|null $headers
  * @property string|null $body
- * @property string $added_at
- * @property string $removed_at
+ * @property string|null $added_at
+ * @property string|null $removed_at
  */
 class CRM_Mailing_DAO_Spool extends CRM_Core_DAO_Base {
 }

--- a/CRM/Mailing/Event/DAO/MailingEventQueue.php
+++ b/CRM/Mailing/Event/DAO/MailingEventQueue.php
@@ -9,8 +9,8 @@
  * Placeholder class retained for legacy compatibility.
  *
  * @property int|string|null $id
- * @property int|string $job_id
- * @property int|string $mailing_id
+ * @property int|string|null $job_id
+ * @property int|string|null $mailing_id
  * @property bool|string $is_test
  * @property int|string|null $email_id
  * @property int|string $contact_id

--- a/CRM/Member/DAO/MembershipType.php
+++ b/CRM/Member/DAO/MembershipType.php
@@ -11,6 +11,8 @@
  * @property int|string|null $id
  * @property int|string $domain_id
  * @property string $name
+ * @property string $title
+ * @property string $frontend_title
  * @property string|null $description
  * @property int|string $member_of_contact_id
  * @property int|string $financial_type_id

--- a/CRM/Price/DAO/LineItem.php
+++ b/CRM/Price/DAO/LineItem.php
@@ -9,6 +9,8 @@
  * Placeholder class retained for legacy compatibility.
  *
  * @property int|string|null $id
+ * @property string|null $created_date
+ * @property string|null $modified_date
  * @property string $entity_table
  * @property int|string $entity_id
  * @property int|string|null $contribution_id

--- a/CRM/Queue/DAO/Queue.php
+++ b/CRM/Queue/DAO/Queue.php
@@ -11,13 +11,13 @@
  * @property int|string|null $id
  * @property string $name
  * @property string $type
- * @property string $runner
+ * @property string|null $runner
  * @property int|string $batch_limit
  * @property int|string $lease_time
  * @property int|string $retry_limit
- * @property int|string $retry_interval
- * @property string $status
- * @property string $error
+ * @property int|string|null $retry_interval
+ * @property string|null $status
+ * @property string|null $error
  * @property bool|string $is_template
  */
 class CRM_Queue_DAO_Queue extends CRM_Core_DAO_Base {

--- a/CRM/Queue/DAO/QueueItem.php
+++ b/CRM/Queue/DAO/QueueItem.php
@@ -12,7 +12,7 @@
  * @property string $queue_name
  * @property int|string $weight
  * @property string $submit_time
- * @property string $release_time
+ * @property string|null $release_time
  * @property int|string $run_count
  * @property string|null $data
  */

--- a/ext/afform/core/CRM/Afform/DAO/AfformSubmission.php
+++ b/ext/afform/core/CRM/Afform/DAO/AfformSubmission.php
@@ -7,6 +7,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $contact_id
+ * @property string|null $afform_name
+ * @property string|null $data
+ * @property string|null $submission_date
+ * @property int|string $status_id
  */
 class CRM_Afform_DAO_AfformSubmission extends CRM_Core_DAO_Base {
 }

--- a/ext/afform/core/CRM/Afform/DAO/SearchParamSet.php
+++ b/ext/afform/core/CRM/Afform/DAO/SearchParamSet.php
@@ -7,6 +7,16 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string|null $afform_name
+ * @property string $label
+ * @property string|null $filters
+ * @property string|null $columns
+ * @property string|null $icon
+ * @property int|string|null $created_by
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_Afform_DAO_SearchParamSet extends CRM_Core_DAO_Base {
 }

--- a/ext/civigrant/CRM/Grant/DAO/Grant.php
+++ b/ext/civigrant/CRM/Grant/DAO/Grant.php
@@ -7,6 +7,22 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $contact_id
+ * @property string|null $application_received_date
+ * @property string|null $decision_date
+ * @property string|null $money_transfer_date
+ * @property string|null $grant_due_date
+ * @property bool|string $grant_report_received
+ * @property int|string $grant_type_id
+ * @property float|string $amount_total
+ * @property float|string|null $amount_requested
+ * @property float|string|null $amount_granted
+ * @property string $currency
+ * @property string|null $rationale
+ * @property int|string $status_id
+ * @property int|string|null $financial_type_id
  */
 class CRM_Grant_DAO_Grant extends CRM_Core_DAO_Base {
 }

--- a/ext/eventcart/CRM/Event/Cart/DAO/EventCartParticipant.php
+++ b/ext/eventcart/CRM/Event/Cart/DAO/EventCartParticipant.php
@@ -9,8 +9,8 @@
  * Placeholder class retained for legacy compatibility.
  *
  * @property int|string|null $id
- * @property int $participant_id
- * @property int $cart_id
+ * @property int|string|null $participant_id
+ * @property int|string|null $cart_id
  */
 class CRM_Event_Cart_DAO_EventCartParticipant extends CRM_Core_DAO_Base {
 }

--- a/ext/oauth-client/CRM/OAuth/DAO/OAuthClient.php
+++ b/ext/oauth-client/CRM/OAuth/DAO/OAuthClient.php
@@ -8,12 +8,13 @@
  *
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. Property annotations may be added, but are not required.
- * @property string $id
+ *
+ * @property int|string|null $id
  * @property string $provider
  * @property string $guid
- * @property string $tenant
- * @property string $secret
- * @property string $options
+ * @property string|null $tenant
+ * @property string|null $secret
+ * @property string|null $options
  * @property bool|string $is_active
  * @property string $created_date
  * @property string $modified_date

--- a/ext/oauth-client/CRM/OAuth/DAO/OAuthContactToken.php
+++ b/ext/oauth-client/CRM/OAuth/DAO/OAuthContactToken.php
@@ -8,22 +8,23 @@
  *
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. Property annotations may be added, but are not required.
- * @property string $id
- * @property string $tag
- * @property string $client_id
- * @property string $contact_id
- * @property string $grant_type
- * @property string $scopes
- * @property string $token_type
- * @property string $access_token
- * @property string $expires
- * @property string $refresh_token
- * @property string $resource_owner_name
- * @property string $resource_owner
- * @property string $error
- * @property string $raw
- * @property string $created_date
- * @property string $modified_date
+ *
+ * @property int|string|null $id
+ * @property string|null $tag
+ * @property int|string|null $client_id
+ * @property int|string|null $contact_id
+ * @property string|null $grant_type
+ * @property string|null $scopes
+ * @property string|null $token_type
+ * @property string|null $access_token
+ * @property int|string|null $expires
+ * @property string|null $refresh_token
+ * @property string|null $resource_owner_name
+ * @property string|null $resource_owner
+ * @property string|null $error
+ * @property string|null $raw
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_OAuth_DAO_OAuthContactToken extends CRM_OAuth_DAO_Base {
 

--- a/ext/oauth-client/CRM/OAuth/DAO/OAuthSysToken.php
+++ b/ext/oauth-client/CRM/OAuth/DAO/OAuthSysToken.php
@@ -8,21 +8,22 @@
  *
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. Property annotations may be added, but are not required.
- * @property string $id
- * @property string $tag
- * @property string $client_id
- * @property string $grant_type
- * @property string $scopes
- * @property string $token_type
- * @property string $access_token
- * @property string $expires
- * @property string $refresh_token
- * @property string $resource_owner_name
- * @property string $resource_owner
- * @property string $error
- * @property string $raw
- * @property string $created_date
- * @property string $modified_date
+ *
+ * @property int|string|null $id
+ * @property string|null $tag
+ * @property int|string|null $client_id
+ * @property string|null $grant_type
+ * @property string|null $scopes
+ * @property string|null $token_type
+ * @property string|null $access_token
+ * @property int|string|null $expires
+ * @property string|null $refresh_token
+ * @property string|null $resource_owner_name
+ * @property string|null $resource_owner
+ * @property string|null $error
+ * @property string|null $raw
+ * @property string|null $created_date
+ * @property string|null $modified_date
  */
 class CRM_OAuth_DAO_OAuthSysToken extends CRM_OAuth_DAO_Base {
 

--- a/ext/postbox/CRM/Postbox/DAO/EmailMessage.php
+++ b/ext/postbox/CRM/Postbox/DAO/EmailMessage.php
@@ -8,6 +8,18 @@
  *
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. Property annotations may be added, but are not required.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $from_site_email_address_id
+ * @property int|string|null $to_contact_id
+ * @property string|null $location_type
+ * @property string|null $subject
+ * @property string|null $body
+ * @property int|string|null $created_id
+ * @property string|null $date_created
+ * @property string|null $date_sent
+ * @property string|null $error_message
+ * @property string|null $extra
  */
 class CRM_Postbox_DAO_EmailMessage extends CRM_Postbox_DAO_Base {
 

--- a/ext/riverlea/CRM/riverlea/DAO/RiverleaStream.php
+++ b/ext/riverlea/CRM/riverlea/DAO/RiverleaStream.php
@@ -8,6 +8,21 @@
  *
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. Property annotations may be added, but are not required.
+ *
+ * @property int|string|null $id
+ * @property string|null $name
+ * @property string $label
+ * @property string|null $description
+ * @property bool|string $is_reserved
+ * @property string|null $extension
+ * @property string|null $file_prefix
+ * @property string|null $css_file
+ * @property string|null $css_file_dark
+ * @property string|null $vars
+ * @property string|null $vars_dark
+ * @property string|null $custom_css
+ * @property string|null $custom_css_dark
+ * @property string|null $modified_date
  */
 class CRM_riverlea_DAO_RiverleaStream extends CRM_riverlea_DAO_Base {
 

--- a/ext/search_kit/CRM/Search/DAO/SearchDisplay.php
+++ b/ext/search_kit/CRM/Search/DAO/SearchDisplay.php
@@ -11,6 +11,14 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $label
+ * @property int|string $saved_search_id
+ * @property string $type
+ * @property string|null $settings
+ * @property bool|string|null $acl_bypass
  */
 class CRM_Search_DAO_SearchDisplay extends CRM_Core_DAO_Base {
 }

--- a/ext/search_kit/CRM/Search/DAO/SearchSegment.php
+++ b/ext/search_kit/CRM/Search/DAO/SearchSegment.php
@@ -11,6 +11,13 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $label
+ * @property string|null $description
+ * @property string $entity_name
+ * @property string|null $items
  */
 class CRM_Search_DAO_SearchSegment extends CRM_Core_DAO_Base {
 }

--- a/ext/standaloneusers/CRM/Standaloneusers/DAO/Role.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/DAO/Role.php
@@ -11,6 +11,12 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $name
+ * @property string $label
+ * @property string $permissions
+ * @property bool|string $is_active
  */
 class CRM_Standaloneusers_DAO_Role extends CRM_Core_DAO_Base {
 }

--- a/ext/standaloneusers/CRM/Standaloneusers/DAO/Session.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/DAO/Session.php
@@ -11,6 +11,11 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property string $session_id
+ * @property string|null $data
+ * @property string|null $last_accessed
  */
 class CRM_Standaloneusers_DAO_Session extends CRM_Core_DAO_Base {
 }

--- a/ext/standaloneusers/CRM/Standaloneusers/DAO/Totp.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/DAO/Totp.php
@@ -9,6 +9,13 @@ use CRM_Standaloneusers_ExtensionUtil as E;
  *
  * This stub provides compatibility. It is not intended to be modified in a
  * substantive way. However, you may add comments and annotations.
+ *
+ * @property int|string|null $id
+ * @property int|string $user_id
+ * @property string $seed
+ * @property string $hash
+ * @property string $period
+ * @property string $length
  */
 class CRM_Standaloneusers_DAO_Totp extends CRM_Standaloneusers_DAO_Base {
 

--- a/ext/standaloneusers/CRM/Standaloneusers/DAO/User.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/DAO/User.php
@@ -11,6 +11,21 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string $domain_id
+ * @property int|string $uf_id
+ * @property string|null $uf_name
+ * @property int|string|null $contact_id
+ * @property string $username
+ * @property string $hashed_password
+ * @property string|null $when_created
+ * @property string|null $when_last_accessed
+ * @property string|null $when_updated
+ * @property bool|string $is_active
+ * @property string|null $timezone
+ * @property string|null $language
+ * @property string|null $password_reset_token
  */
 class CRM_Standaloneusers_DAO_User extends CRM_Core_DAO_Base {
 }

--- a/ext/standaloneusers/CRM/Standaloneusers/DAO/UserRole.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/DAO/UserRole.php
@@ -11,6 +11,10 @@
 
 /**
  * Placeholder class retained for legacy compatibility.
+ *
+ * @property int|string|null $id
+ * @property int|string|null $user_id
+ * @property int|string|null $role_id
  */
 class CRM_Standaloneusers_DAO_UserRole extends CRM_Core_DAO_Base {
 }


### PR DESCRIPTION
Overview
----------------------------------------
Re-sync class docblock `@property` annotations in DAO stub files with their corresponding `.entityType.php` field declarations.

Before
----------------------------------------
DAO stub file annotations have drifted a bit since we generated them a couple years ago.

After
----------------------------------------
All 64 DAO files have had their `@property` annotations corrected to align with `entityType.php` metadata; note: deprecated fields are omitted from the docblocks.

Technical Details
----------------------------------------
This was done via script.
