### PR TITLE
Allow Redis caching via UNIX socket

### DIFF
--- a/CRM/Utils/Cache.php
+++ b/CRM/Utils/Cache.php
@@ -113,6 +113,10 @@ class CRM_Utils_Cache {
           $defaults['port'] = CIVICRM_DB_CACHE_PORT;
         }
 
+        if (defined('CIVICRM_DB_CACHE_SOCKET')) {
+          $defaults['socket'] = CIVICRM_DB_CACHE_SOCKET;
+        }
+
         if (defined('CIVICRM_DB_CACHE_TIMEOUT')) {
           $defaults['timeout'] = CIVICRM_DB_CACHE_TIMEOUT;
         }

--- a/CRM/Utils/Cache/Redis.php
+++ b/CRM/Utils/Cache/Redis.php
@@ -60,17 +60,32 @@ class CRM_Utils_Cache_Redis implements CRM_Utils_Cache_Interface {
   public static function connect($config) {
     $host = $config['host'] ?? self::DEFAULT_HOST;
     $port = $config['port'] ?? self::DEFAULT_PORT;
+    $socket = $config['socket'] ?? '';
     // Ugh.
     $pass = CRM_Utils_Constant::value('CIVICRM_DB_CACHE_PASSWORD');
-    $id = implode(':', ['connect', $host, $port /* $pass is constant */]);
+    if (!empty($socket)) {
+      $id = implode(':', ['connect', $socket /* $pass is constant */]);
+    }
+    else {
+      $id = implode(':', ['connect', $host, $port /* $pass is constant */]);
+    }
     if (!isset(Civi::$statics[__CLASS__][$id])) {
       // Ideally, we'd track the connection in the service-container, but the
       // cache connection is boot-critical.
       $redis = new Redis();
-      if (!$redis->connect($host, $port)) {
-        // dont use fatal here since we can go in an infinite loop
-        echo 'Could not connect to redisd server';
-        CRM_Utils_System::civiExit();
+      if (!empty($socket)) {
+        if (!$redis->pconnect($socket)) {
+          // Don't use fatal here since we can go in an infinite loop.
+          echo 'Could not connect to Redis server using socket';
+          CRM_Utils_System::civiExit();
+        }
+      }
+      else {
+        if (!$redis->connect($host, $port)) {
+          // Don't use fatal here since we can go in an infinite loop.
+          echo 'Could not connect to redisd server';
+          CRM_Utils_System::civiExit();
+        }
       }
       if ($pass) {
         $redis->auth($pass);

--- a/templates/CRM/common/civicrm.settings.php.template
+++ b/templates/CRM/common/civicrm.settings.php.template
@@ -458,6 +458,18 @@ if (!defined('CIVICRM_DB_CACHE_PORT')) {
 }
 
 /**
+ * If you are using a cache via a Unix socket, add the path to it here.
+ *
+ * Currently only works with Redis.
+ * For example: `/home/youruser/tmp/redis.sock`
+ *
+ * Note that if a socket is specified, then host and port will be ignored.
+ */
+if (!defined('CIVICRM_DB_CACHE_SOCKET')) {
+  define('CIVICRM_DB_CACHE_SOCKET', '');
+}
+
+/**
  * Change this if your cache server requires a password (currently only works
  * with Redis)
  */


### PR DESCRIPTION
Overview
----------------------------------------
Implements Redis caching via the `CIVICRM_DB_CACHE_HOST` constant as suggested might be possible by @demeritcowboy on [this StackExchange question](https://civicrm.stackexchange.com/questions/38097/redis-running-on-socket).

Before
----------------------------------------
CiviCRM cannot use a Redis cache via a UNIX socket.

After
----------------------------------------
CiviCRM can use a Redis cache via a UNIX socket.

Comments
----------------------------------------
Might need some additional documentation in `civicrm.settings.php` or in the CiviCRM Docs.