### PR TITLE
dev/core#6554 follow up usability

### DIFF
--- a/ext/oauth-client/ang/oauthClientCreator.aff.html
+++ b/ext/oauth-client/ang/oauthClientCreator.aff.html
@@ -2,26 +2,26 @@
 
 <div ng-form="create" class="form-horizontal">
   <div class="form-group">
-    <div>
-      <label for="guid">{{ts('Client ID')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
-      <input class="form-control" ng-model="options.client.guid" type="text" id="guid" required />
+    <div class="crm-section">
+      <div class="label"><label for="guid">{{ts('Client ID')}}<span class="crm-marker" title="{{ts('Required')}}">*</span></label></div>
+      <div class="content"><input class="huge form-control" ng-model="options.client.guid" type="text" id="guid" required /></div>
     </div>
-    <div ng-if="theProviders[options.client.provider].options.url">
-      <label for="url{{options.client.id}}">{{ts('URL')}}: <span>*</span></label>
-      <input class="form-control" ng-model="options.client.url" type="text" id="url{{options.client.id}}" required/>
+    <div class="crm-section" ng-if="theProviders[options.client.provider].options.url">
+      <div class="label"><label for="url{{options.client.id}}">{{ts('URL')}}<span>*</span></label></div>
+      <div class="content"><input class="huge form-control" ng-model="options.client.options.url" type="text" id="url{{options.client.id}}" required/></div>
     </div>
-    <div ng-if="theProviders[options.client.provider].options.realm">
-      <label for="realm{{options.client.id}}">{{ts('Realm')}}: <span>*</span></label>
-      <div><input class="form-control" ng-model="options.client.realm" type="text" id="realm{{options.client.id}}" required/></div>
+    <div class="crm-section" ng-if="theProviders[options.client.provider].options.realm">
+      <div class="label"><label for="realm{{options.client.id}}">{{ts('Realm')}}<span>*</span></label></div>
+      <div class="content"><input class="huge form-control" ng-model="options.client.options.realm" type="text" id="realm{{options.client.id}}" required/></div>
     </div>
-    <div ng-if="theProviders[options.client.provider].options.tenancy">
-      <label for="tenant">{{ts('Tenant ID')}}:</label>
-      <input class="form-control" ng-model="options.client.tenant" type="text" id="tenant" />
-      <div class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</div>
+    <div class="crm-section" ng-if="theProviders[options.client.provider].options.tenancy">
+      <div class="label"><label for="tenant">{{ts('Tenant ID')}}</label></div>
+      <div class="content"><input class="huge form-control" ng-model="options.client.tenant" type="text" id="tenant" />
+      <p class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</p></div>
     </div>
-    <div>
-      <label for="secret">{{ts('Client Secret')}}:</label>
-      <input class="form-control" ng-model="options.client.secret" type="text" id="secret" />
+    <div class="crm-section">
+      <div class="label"><label for="secret">{{ts('Client Secret')}}</label></div>
+      <div class="content"><input class="huge form-control" ng-model="options.client.secret" type="text" id="secret" /></div>
     </div>
   </div>
 </div>

--- a/ext/oauth-client/ang/oauthClientEditor.aff.html
+++ b/ext/oauth-client/ang/oauthClientEditor.aff.html
@@ -2,44 +2,43 @@
 
 <div ng-form="update" class="form-horizontal">
   <div class="form-group">
-    <div>
-      <label for="provider{{options.client.id}}">{{ts('Provider')}}:</label>
-      <input class="form-control" ng-model="options.client.provider" disabled id="provider{{options.client.id}}">
+    <div class="crm-section">
+      <div class="label"><label for="provider{{options.client.id}}">{{ts('Provider')}}</label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.provider" disabled id="provider{{options.client.id}}"></div>
     </div>
-    <div>
-      <label for="id{{options.client.id}}">{{ts('Client ID (Private)')}}:</label>
-      <input class="form-control" ng-model="options.client.id" type="text" id="id{{options.client.id}}" disabled/>
+    <div class="crm-section">
+      <div class="label"><label for="id{{options.client.id}}">{{ts('Client ID (Private)')}}</label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.id" type="text" id="id{{options.client.id}}" disabled/></div>
     </div>
-    <div>
-      <label for="guid{{options.client.id}}">{{ts('Client ID (Public)')}}: <span class="crm-marker" title="{{ts('Required')}}">*</span></label>
-      <input class="form-control" ng-model="options.client.guid" type="text" id="guid{{options.client.id}}" required/>
+    <div class="crm-section">
+      <div class="label"><label for="guid{{options.client.id}}">{{ts('Client ID (Public)')}}<span class="crm-marker" title="{{ts('Required')}}">*</span></label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.guid" type="text" id="guid{{options.client.id}}" required/></div>
     </div>
-    <div ng-if="theProviders[options.client.provider].options.url">
-      <label for="url{{options.client.id}}">{{ts('URL')}}: <span>*</span></label>
-      <input class="form-control" ng-model="options.client.url" type="text" id="url{{options.client.id}}" required/>
+    <div class="crm-section" ng-if="theProviders[options.client.provider].options.url">
+      <div class="label"><label for="url{{options.client.id}}">{{ts('URL')}}<span>*</span></label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.options.url" type="text" id="url{{options.client.id}}" required/></div>
     </div>
-    <div ng-if="theProviders[options.client.provider].options.realm">
-      <label for="realm{{options.client.id}}">{{ts('Realm')}}: <span>*</span></label>
-      <div><input class="form-control" ng-model="options.client.realm" type="text" id="realm{{options.client.id}}" required/></div>
+    <div class="crm-section" ng-if="theProviders[options.client.provider].options.realm">
+      <div class="label"><label for="realm{{options.client.id}}">{{ts('Realm')}}<span>*</span></label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.options.realm" type="text" id="realm{{options.client.id}}" required/></div>
     </div>
-    <div ng-if="theProviders[options.client.provider].options.tenancy">
-      <label for="tenant{{options.client.id}}">{{ts('Tenant ID')}}:</label>
-      <input class="form-control" ng-model="options.client.tenant" type="text" id="tenant{{options.client.id}}"/>
+    <div class="crm-section" ng-if="theProviders[options.client.provider].options.tenancy">
+      <div class="label"><label for="tenant{{options.client.id}}">{{ts('Tenant ID')}}</label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.tenant" type="text" id="tenant{{options.client.id}}"/>
       <p class="help-block">{{ts('Optional. Leave blank for consumer accounts. If you have a dedicated instance of Microsoft 365, and your application is not multi-tenancy, then enter your tenant ID here.')}}</p>
+      </div>
     </div>
-    <div>
-      <label for="secret{{options.client.id}}">{{ts('Client Secret')}}:</label>
-      <input class="form-control" ng-model="options.client.secret" type="text" id="secret{{options.client.id}}"/>
+    <div class="crm-section">
+      <div class="label"><label for=secret{{options.client.id}}">{{ts('Client Secret')}}</label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.secret" type="text" id="secret{{options.client.id}}"/></div>
     </div>
-    <div ng-if="options.client.created_date">
-      <label for="created_date{{options.client.id}}">{{ts('Created Date')}}:</label>
-      <input class="form-control" ng-model="options.client.created_date" disabled
-             id="created_date{{options.client.id}}">
+    <div class="crm-section" ng-if="options.client.created_date">
+      <div class="label"><label for="created_date{{options.client.id}}">{{ts('Created Date')}}</label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.created_date" disabled id="created_date{{options.client.id}}"></div>
     </div>
-    <div ng-if="options.client.modified_date">
-      <label for="modified_date{{options.client.id}}">{{ts('Modified Date')}}:</label>
-      <input class="form-control" ng-model="options.client.modified_date" disabled
-             id="modified_date{{options.client.id}}">
+    <div class="crm-section" ng-if="options.client.modified_date">
+      <div class="label"><label for="modified_date{{options.client.id}}">{{ts('Modified Date')}}</label></div>
+      <div class="content"><input class="form-control huge" ng-model="options.client.modified_date" disabled id="modified_date{{options.client.id}}"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------

Improved the configuration screens of the OAuth Client. 

Before
----------------------------------------

<img width="1297" height="873" alt="2026-06-08_16-54" src="https://github.com/user-attachments/assets/49864900-befe-48df-bc2c-493a3bd7d3de" />


After
----------------------------------------

<img width="1297" height="873" alt="2026-06-08_16-54_1" src="https://github.com/user-attachments/assets/1aacfa67-69fa-4d6d-8e6f-ba731df586ac" />

Comments
----------------------------------------

It also contains a typo fix for dev/core#6554 (PR #35871). The option for URL and Realm where not stored in the option section of the client.

The UI is based on the same HTML structure as in Mailing > New Mailing screen. 
