### PR TITLE
dev/core#6564 Add test to demonstrate issue

### DIFF
--- a/tests/phpunit/api/v4/Entity/ActivityTest.php
+++ b/tests/phpunit/api/v4/Entity/ActivityTest.php
@@ -58,6 +58,13 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNull($activity['assignee_contact_id']);
     $this->assertEquals(0, $activity['assignee_contact_count']);
 
+    // Also check equals operator. This would throw an exception if it fails.
+    Activity::get(FALSE)
+      ->addSelect('source_contact_id', 'target_contact_id', 'assignee_contact_id')
+      ->addSelect('target_contact_count', 'assignee_contact_count')
+      ->addWhere('target_contact_id', '=', reset($activity['target_contact_id']))
+      ->execute()->single();
+
     // Update to set assignee_contact_id
     $activity = Activity::update(FALSE)
       ->addWhere('source_contact_id', '=', $sourceContactId)


### PR DESCRIPTION


Overview
----------------------------------------
dev/core#6564 Add test to demonstrate issue

activity_target_id no longer accepts '=' as the operator.

While from a schema level this might be logic I think it's a contract change and as such is a regression

It does work again with an addition to https://github.com/civicrm/civicrm-core/commit/2b0a0d7a751c18af25e79852e7c3bae24a90963e#diff-ef0183be3404fa3298b6f3ce3d2f5dfb23f938775392e86aa9bc150b2b8aad31R64 - that being the line that caused the change....

Before
----------------------------------------
No test

After
----------------------------------------
test

Technical Details
----------------------------------------
Ideally we can discuss but we can probably address by changing the operators per above comment

Comments
----------------------------------------

