### PR TITLE
Allow user role permissions (permissions that imply a logged in user …

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1907,4 +1907,41 @@ class CRM_Core_Permission {
     return $permissions;
   }
 
+  /**
+   * Formats permissions into a nested list for Select2
+   *
+   * @param array $groups Permission Types
+   *
+   * @return array[]
+   */
+  public static function getPermissionList(array $groups): array {
+    $perms = \Civi\Api4\Permission::get(FALSE)
+      ->addWhere('group', 'IN', $groups)
+      ->addWhere('is_active', '=', 1)
+      ->setOrderBy(['title' => 'ASC'])
+      ->execute();
+    $permissions = [];
+    $categories = [];
+    foreach ($perms as $perm) {
+      // By convention, permission labels begin with a category followed by a colon.
+      $titleParts = explode(':', $perm['title'], 2);
+      if (count($titleParts) === 1) {
+        array_unshift($titleParts, ts('Generic'));
+      }
+      $category = trim($titleParts[0]);
+      $categories[$category][] = [
+        'id' => $perm['name'],
+        'text' => ucfirst(trim($titleParts[1])),
+        'description' => $perm['description'] ?? NULL,
+      ];
+    }
+    foreach ($categories as $category => $perms) {
+      $permissions[] = [
+        'text' => $category,
+        'children' => $perms,
+      ];
+    }
+    return $permissions;
+  }
+
 }

--- a/Civi/Api4/Permission.php
+++ b/Civi/Api4/Permission.php
@@ -57,6 +57,7 @@ class Permission extends Generic\AbstractEntity {
             'afform' => 'afform',
             'afformGeneric' => 'afformGeneric',
             'unknown' => 'unknown',
+            'userRole' => 'userRole',
           ],
           'input_attrs' => [
             'label' => ts('Group'),

--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -328,7 +328,7 @@ class AfformAdminMeta {
         'danger' => E::ts('Danger'),
       ];
 
-      $permissions = self::getPermissionList();
+      $permissions = \CRM_Core_Permission::getPermissionList(['afformGeneric', 'const', 'civicrm', 'cms', 'userRole']);
 
       $dateRanges = \CRM_Utils_Array::makeNonAssociative(\CRM_Core_OptionGroup::values('relative_date_filters'), 'id', 'label');
       $dateRanges = array_merge([['id' => '{}', 'label' => E::ts('Choose Date Range')]], $dateRanges);
@@ -398,41 +398,6 @@ class AfformAdminMeta {
       }
     }
     return $options;
-  }
-
-  /**
-   * Formats permissions into a nested list for Select2
-   *
-   * @return array[]
-   */
-  public static function getPermissionList(): array {
-    $perms = \Civi\Api4\Permission::get(FALSE)
-      ->addWhere('group', 'IN', ['afformGeneric', 'const', 'civicrm', 'cms', 'userRole'])
-      ->addWhere('is_active', '=', 1)
-      ->setOrderBy(['title' => 'ASC'])
-      ->execute();
-    $permissions = [];
-    $categories = [];
-    foreach ($perms as $perm) {
-      // By convention, permission labels begin with a category followed by a colon.
-      $titleParts = explode(':', $perm['title'], 2);
-      if (count($titleParts) === 1) {
-        array_unshift($titleParts, ts('Generic'));
-      }
-      $category = trim($titleParts[0]);
-      $categories[$category][] = [
-        'id' => $perm['name'],
-        'text' => ucfirst(trim($titleParts[1])),
-        'description' => $perm['description'] ?? NULL,
-      ];
-    }
-    foreach ($categories as $category => $perms) {
-      $permissions[] = [
-        'text' => $category,
-        'children' => $perms,
-      ];
-    }
-    return $permissions;
   }
 
 }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -74,7 +74,7 @@ class Admin {
       'joins' => self::getJoins($schema),
       'pseudoFields' => AbstractRunAction::getPseudoFields(),
       'operators' => \CRM_Utils_Array::makeNonAssociative(self::getOperators()),
-      'permissions' => [],
+      'permissions' => \CRM_Core_Permission::getPermissionList(['civicrm', 'cms', 'userRole']),
       'functions' => self::getSqlFunctions(),
       'displayTypes' => Display::getDisplayTypes(['id', 'name', 'label', 'description', 'icon', 'grouping']),
       'styles' => \CRM_Utils_Array::makeNonAssociative(self::getStyles()),
@@ -91,18 +91,6 @@ class Admin {
         \NumberFormatter::MIN_FRACTION_DIGITS => E::ts('Min Decimal Places'),
       ],
     ];
-    $perms = \Civi\Api4\Permission::get()
-      ->addWhere('group', 'IN', ['civicrm', 'cms', 'userRole'])
-      ->addWhere('is_active', '=', 1)
-      ->setOrderBy(['title' => 'ASC'])
-      ->execute();
-    foreach ($perms as $perm) {
-      $data['permissions'][] = [
-        'id' => $perm['name'],
-        'text' => $perm['title'],
-        'description' => $perm['description'] ?? NULL,
-      ];
-    }
     return $data;
   }
 

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -92,7 +92,7 @@ class Admin {
       ],
     ];
     $perms = \Civi\Api4\Permission::get()
-      ->addWhere('group', 'IN', ['civicrm', 'cms'])
+      ->addWhere('group', 'IN', ['civicrm', 'cms', 'userRole'])
       ->addWhere('is_active', '=', 1)
       ->setOrderBy(['title' => 'ASC'])
       ->execute();


### PR DESCRIPTION
…must have a certain CMS role) to be shown in search kit admin interface and used as part of conditional checks

Overview
----------------------------------------
This allows for user role permissions to show in the search kit admin screen similar to in Afform to allow for conditionals to be based on a membership of a CMS role / group instead of just based on an individual permission

ping @celinenicolas @yf-zhou @colemanw 