### PR TITLE
Allow for checking access by Joomla User Groups (roles) as well as ba…

### DIFF
--- a/CRM/Core/Permission/Joomla.php
+++ b/CRM/Core/Permission/Joomla.php
@@ -139,6 +139,34 @@ class CRM_Core_Permission_Joomla extends CRM_Core_Permission_Base {
    *   true if yes, else false
    */
   public function checkGroupRole($array) {
+    $user = CRM_Core_Config::singleton()->userSystem->getCurrentJoomlaUser();
+    if (version_compare(JVERSION, '4.0', 'lt')) {
+      $db = JFactory::getDbo();
+    }
+    else {
+      $db = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
+    }
+    $query = $db->getQuery(TRUE);
+    $titles = '';
+    foreach ($array as $group) {
+      $titles .= $db->quoteName($group);
+      $titles .= ',';
+    }
+    $titles = rtrim($titles, ',');
+    $query
+      ->select($db->quoteName('*'))
+      ->from($db->quoteName('#__usergroups'))
+      ->where($db->quoteName('title') . ' IN (' . $titles . ')');
+
+    $db->setQuery($query);
+
+    $result = $db->loadObjectList('id');
+    $userGroups = $user->getAuthorisedGroups();
+    foreach (array_keys($result) as $groupID) {
+      if (array_key_exists($groupID, $userGroups)) {
+        return TRUE;
+      }
+    }
     return FALSE;
   }
 

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -1249,4 +1249,13 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     \Joomla\CMS\Factory::$application = $app;
   }
 
+  public function getRoleNames() {
+    $userGroups = \Joomla\CMS\Helper\UserGroupsHelper::getInstance()->loadAll()->getAll();
+    $roles = [];
+    foreach ($userGroups as $userGroup) {
+      $roles[$userGroup->title] = $userGroup->title;
+    }
+    return $roles;
+  }
+
 }


### PR DESCRIPTION
…sed on individual permissions

Overview
----------------------------------------
This aims to add support for checking access based on user groups (roles) in Joomla as well as based on individual permissions. This would bring it up to how Drupal/Backdrop/WordPress work in CiviCRM

Before
----------------------------------------
No User Groups checking

After
----------------------------------------
User Group checking

ping @webmaster-cses-org-uk @yf-zhou @celinenicolas cc @colemanw 