### PR TITLE
dev/core#6559 Don't crash when {mailing.group} is null

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -216,7 +216,7 @@ class CRM_Utils_Token {
         break;
 
       case 'group':
-        $groups = $mailing ? $mailing->getGroupNames() : ['Mailing Groups'];
+        $groups = $mailing ? ($mailing->getGroupNames() ?? []) : ['Mailing Groups'];
         $value = implode(', ', $groups);
         break;
 


### PR DESCRIPTION
Overview
----------------------------------------
On PHP8, if you use `{mailing.group}` in any context in which there are no groups (e.g. "Preview Mailing", scheduled reminders) it will crash.

https://lab.civicrm.org/dev/core/-/work_items/6559

I couldn't replicate this the way the issue submitter did, but I created a new CiviMail mailing, added `{mailing.group}`, scheduled the mailing, then selected **Preview Mailing** from the mailing screen.

Technical Details
----------------------------------------
Just because `$mailing` exists doesn't mean it's got associated groups - that's context-dependent.

After a bit of testing I've determined this is actually a 6.15 regression so I'm going to rebase this against the rc.