### PR TITLE
fix ambiguous string handling in import

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -829,8 +829,12 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     $options = $this->getFieldOptions($fieldName);
     if ($options !== FALSE) {
       if ($this->isAmbiguous($fieldName, $importedValue)) {
-        // We can't transform it at this stage. Perhaps later we can with
-        // other information such as country.
+        // State/province and county can be disambiguated later with country context.
+        // For all other fields the raw string would cause a downstream type error,
+        // so mark it invalid here so validation surfaces a user-friendly message.
+        if (!str_ends_with($fieldName, 'state_province_id') && !str_ends_with($fieldName, 'county_id')) {
+          return 'invalid_import_value';
+        }
         return $importedValue;
       }
 

--- a/tests/phpunit/CRM/Import/ParserTest.php
+++ b/tests/phpunit/CRM/Import/ParserTest.php
@@ -32,7 +32,12 @@ class CRM_Import_ParserTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    $extension = \Civi\Api4\Extension::get(FALSE)
+      ->addWhere('key', '=', 'civiimport')
+      ->execute()->first();
+    if (empty($extension['status']) || $extension['status'] !== 'installed') {
+      $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    }
   }
 
   /**
@@ -149,6 +154,115 @@ class CRM_Import_ParserTest extends CiviUnitTestCase {
       ],
     ];
     $this->assertEquals($expectedEntities, $hookEntities);
+  }
+
+  /**
+   * Test transformed field value handling for ambiguous import values.
+   *
+   * @dataProvider ambiguousFieldValueProvider
+   */
+  public function testAmbiguousFieldValueTransformation(string $fieldName, string $importedValue, $expectedResult): void {
+    $parser = new ActivityParser();
+    Invasive::set([$parser, 'ambiguousOptions'], [
+      $fieldName => [
+        strtolower($importedValue) => [1, 2],
+      ],
+    ]);
+    Invasive::set([$parser, 'importableFieldsMetadata'], [
+      $fieldName => [
+        'name' => $fieldName,
+        'type' => CRM_Utils_Type::T_INT,
+        'options' => [
+          strtolower($importedValue) => 1,
+        ],
+      ],
+    ]);
+
+    $result = Invasive::call([$parser, 'getTransformedFieldValue'], [$fieldName, $importedValue]);
+    $this->assertEquals($expectedResult, $result);
+  }
+
+  public function ambiguousFieldValueProvider(): array {
+    return [
+      'ambiguous financial_type_id' => [
+        'financial_type_id',
+        'Donation',
+        'invalid_import_value',
+      ],
+      'ambiguous gender_id' => [
+        'gender_id',
+        'Other',
+        'invalid_import_value',
+      ],
+      'ambiguous state_province_id' => [
+        'state_province_id',
+        'WA',
+        'WA',
+      ],
+      'ambiguous address_primary.state_province_id' => [
+        'address_primary.state_province_id',
+        'WA',
+        'WA',
+      ],
+      'ambiguous county_id' => [
+        'county_id',
+        'Washington',
+        'Washington',
+      ],
+      'ambiguous address_primary.county_id' => [
+        'address_primary.county_id',
+        'Washington',
+        'Washington',
+      ],
+    ];
+  }
+
+  /**
+   * Test that ambiguous financial type options return 'invalid_import_value'
+   * instead of passing through raw string.
+   */
+  public function testAmbiguousFinancialTypeImport(): void {
+    $ft1 = \Civi\Api4\FinancialType::get(FALSE)
+      ->addWhere('name', '=', 'Donation')
+      ->execute()->first();
+    $ft2ID = NULL;
+    if ($ft1) {
+      \Civi\Api4\FinancialType::update(FALSE)
+        ->addWhere('id', '=', $ft1['id'])
+        ->addValue('name', 'Coins')
+        ->execute();
+    }
+    try {
+      $ft2 = \Civi\Api4\FinancialType::create(FALSE)
+        ->addValue('name', 'Donation')
+        ->addValue('label', 'Donation 2')
+        ->execute()->first();
+      $ft2ID = $ft2['id'];
+
+      $parser = new \Civi\Import\ContributionParser();
+      $parser->setImportableFieldsMetadata([
+        'financial_type_id' => [
+          'name' => 'financial_type_id',
+          'title' => 'Financial Type',
+          'type' => CRM_Utils_Type::T_INT,
+          'entity' => 'Contribution',
+          'html' => ['type' => 'Select'],
+        ],
+      ]);
+      $result = Invasive::call([$parser, 'getTransformedFieldValue'], ['financial_type_id', 'Donation']);
+      $this->assertEquals('invalid_import_value', $result);
+    }
+    finally {
+      if ($ft2ID) {
+        \Civi\Api4\FinancialType::delete(FALSE)->addWhere('id', '=', $ft2ID)->execute();
+      }
+      if ($ft1) {
+        \Civi\Api4\FinancialType::update(FALSE)
+          ->addWhere('id', '=', $ft1['id'])
+          ->addValue('name', 'Donation')
+          ->execute();
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
If you have an ambiguous value during import, we currently ignore it because if it's a state/province or county, we can disambiguate it later, so we don't mark it invalid.  However, this means any other ambiguous value crashes the queue runner.

To replicate this:
* Rename the financial type "Donation" to "Coins"
* Create a new financial type with a `name` of "Donation".
* Try to import a contribution where the CSV lists the financial type as "Donation".

Before
----------------------------------------
<img width="1855" height="583" alt="image" src="https://github.com/user-attachments/assets/ea391c49-e95c-4567-b242-87bf4dce237d" />

After
----------------------------------------
<img width="803" height="220" alt="Selection_022" src="https://github.com/user-attachments/assets/d6851701-bc69-4b74-9376-a3bf5051331a" />

If you click **See Errors** you'll see that the financial type is an invalid import value.

Comments
----------------------------------------
I'd feel a lot better about defining other return values from `getTransformedFieldValue()` like, e.g., `ambiguous_import_value` so that our error messages could be more informative, but that would blow up the scope of this PR.
