### PR TITLE
Add SearchKit action to register event participants

### DIFF
--- a/ext/riverlea/core/css/components/_form.css
+++ b/ext/riverlea/core/css/components/_form.css
@@ -479,8 +479,8 @@ input.crm-form-checkbox) + label {
   align-items: center;
   margin-right: 0;
 }
-.crm-container .select2-container-multi.ng-invalid .select2-choices,
-.crm-container .select2-container.ng-invalid .select2-choice {
+.crm-container .select2-container-multi.ng-dirty.ng-invalid .select2-choices,
+.crm-container .select2-container.ng-dirty.ng-invalid .select2-choice {
   border-color: var(--crm-warning-color);
 }
 .crm-container .select2-container .select2-choice .select2-arrow {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchDisplay.css
@@ -23,9 +23,9 @@ form.crm-search-display-page {
 .crm-search-display th:not(:hover) i.fa-sort {
   opacity: .5;
 }
-.crm-search input.ng-invalid,
-.crm-search-display input.ng-invalid,
-.crm-search-task-dialog input.ng-invalid {
+.crm-search input.ng-dirty.ng-invalid,
+.crm-search-display input.ng-dirty.ng-invalid,
+.crm-search-task-dialog input.ng-dirty.ng-invalid {
   border-color: var(--crm-warning-color);
 }
 .crm-search-display button.dropdown-toggle {

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
@@ -2,9 +2,27 @@
    Forked on 12 June 24. Called on SearchKit Admin pages
    Status: not merged (theme edits at foot) */
 
-.crm-search-task-fields {
-  padding-top: 1rem;
-  transition: opacity 0.15s ease;
+.crm-search-task-rows {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--crm-l-medium, 0.5rem);
+}
+.crm-search-task-row {
+  display: contents;
+}
+.crm-search-task-separator {
+  grid-column: 1 / -1;
+  height: var(--crm-l-reg, 1rem);
+}
+.crm-search-task-label-event {
+  font-weight: var(--crm-input-label-weight);
+}
+.crm-search-task-input crm-search-input {
+  display: block;
+}
+#bootstrap-theme .crm-search-task-row .form-group {
+  margin-bottom: 0;
 }
 .crm-search-task-progress {
   padding: 10px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
@@ -6,12 +6,6 @@
   padding-top: 1rem;
   transition: opacity 0.15s ease;
 }
-.crm-search-task-fields .crm-i.fa-exclamation-triangle {
-  margin-inline: var(--crm-l-small);
-  opacity: .8;
-  color: var(--crm-link-color);
-}
-
 .crm-search-task-progress {
   padding: 10px;
   margin-top: 10px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
@@ -2,6 +2,16 @@
    Forked on 12 June 24. Called on SearchKit Admin pages
    Status: not merged (theme edits at foot) */
 
+.crm-search-task-fields {
+  padding-top: 1rem;
+  transition: opacity 0.15s ease;
+}
+.crm-search-task-fields .crm-i.fa-exclamation-triangle {
+  margin-inline: var(--crm-l-small);
+  opacity: .8;
+  color: var(--crm-link-color);
+}
+
 .crm-search-task-progress {
   padding: 10px;
   margin-top: 10px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
@@ -24,6 +24,11 @@
 #bootstrap-theme .crm-search-task-row .form-group {
   margin-bottom: 0;
 }
+@media (max-width: 767px) {
+  .crm-search-task-rows {
+    grid-template-columns: 1fr;
+  }
+}
 .crm-search-task-progress {
   padding: 10px;
   margin-top: 10px;

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
@@ -11,7 +11,7 @@
 .crm-search-task-row {
   display: contents;
 }
-.crm-search-task-separator {
+.crm-search-task-lazy-separator {
   grid-column: 1 / -1;
   height: var(--crm-l-reg, 1rem);
 }

--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchTasks.css
@@ -6,17 +6,14 @@
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
-  gap: var(--crm-l-medium, 0.5rem);
+  gap: var(--crm-l-medium);
 }
 .crm-search-task-row {
   display: contents;
 }
 .crm-search-task-lazy-separator {
   grid-column: 1 / -1;
-  height: var(--crm-l-reg, 1rem);
-}
-.crm-search-task-label-event {
-  font-weight: var(--crm-input-label-weight);
+  height: var(--crm-l-reg);
 }
 .crm-search-task-input crm-search-input {
   display: block;

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/GetSearchTasks.php
@@ -201,7 +201,7 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
       // Add contact tasks which support standalone mode
       $contactTasks = $this->checkPermissions ? \CRM_Contact_Task::permissionedTaskTitles(\CRM_Core_Permission::getPermission()) : NULL;
       // These tasks are redundant with the new api-based ones in SearchKit
-      $redundant = [\CRM_Core_Task::TAG_ADD, \CRM_Core_Task::TAG_REMOVE, \CRM_Core_Task::TASK_DELETE];
+      $redundant = [\CRM_Core_Task::TAG_ADD, \CRM_Core_Task::TAG_REMOVE, \CRM_Core_Task::TASK_DELETE, \CRM_Contact_Task::ADD_EVENT];
       foreach (\CRM_Contact_Task::tasks() as $id => $task) {
         if (
           (!$this->checkPermissions || isset($contactTasks[$id])) &&
@@ -252,6 +252,17 @@ class GetSearchTasks extends \Civi\Api4\Generic\AbstractAction {
         if (!empty($this->savedSearch)) {
           $tasks[$entity['name']]['contact.relationship']['relationshipTypes'] = $this->getRelationshipTypes($this->savedSearch);
         }
+      }
+      if (!$this->checkPermissions || \CRM_Core_Permission::check('edit event participants')) {
+        $tasks[$entity['name']]['event.register'] = [
+          'title' => E::ts('Register for Event'),
+          'icon' => 'fa-ticket',
+          'uiDialog' => ['templateUrl' => '~/crmSearchTasks/crmSearchTaskRegisterEvent.html'],
+          'module' => 'crmSearchTasks',
+          // Initial values can be set via `hook_civicrm_searchKitTasks`
+          // @var array{event_id: int, status_id: int, role_id: int|array, source: string}
+          'values' => [],
+        ];
       }
     }
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -1,8 +1,5 @@
 <div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form name="crmSearchTaskRegisterEventForm" ng-controller="crmSearchTaskRegisterEvent as $ctrl">
-    <div class="messages status no-popup">
-      {{:: ts('Number of selected contacts: %1', {1: $ctrl.ids.length}) }}
-    </div>
     <div class="form-inline">
       <label for="crm-search-task-event-event_id">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
       <input id="crm-search-task-event-event_id" class="form-control"
@@ -11,16 +8,20 @@
              crm-autocomplete-params="$ctrl.autocompleteParams"
              required>
     </div>
-    <div ng-if="$ctrl.fields.length">
-      <div class="form-inline" ng-repeat="clause in $ctrl.values" >
+    <div ng-if="$ctrl.fields.length" class="crm-search-task-fields" ng-class="{'crm-search-task-refreshing': $ctrl.refreshing}">
+      <div class="form-inline" ng-repeat="clause in $ctrl.values track by clause[0]" >
         <input class="form-control crm-auto-width" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field')}" />
-        <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
+        <crm-search-input class="form-group" ng-model="clause[1]" ng-change="$ctrl.markDirty($index)" field="$ctrl.getField(clause[0])" ></crm-search-input>
+        <i ng-if="$ctrl.getField(clause[0]).serialize" class="crm-i fa-exclamation-triangle crm-search-task-warn-icon" title="{{:: ts('Updating a multi-valued field replaces all existing values for this field') }}"></i>
       </div>
       <div class="form-inline" ng-hide="$ctrl.run">
         <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field')}"/>
       </div>
     </div>
-    <div ng-if="!$ctrl.fields.length" class="form-inline">
+    <div ng-if="!$ctrl.fields.length && !values.event_id" class="form-inline">
+      <em>{{:: ts('Select an event to configure registration options.') }}</em>
+    </div>
+    <div ng-if="!$ctrl.fields.length && values.event_id" class="form-inline">
       <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i> {{:: ts('Loading...') }}
     </div>
 
@@ -30,6 +31,6 @@
     </div>
 
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
-    <crm-dialog-button text="ts('Register')" icons="{primary: 'fa-ticket'}" on-click="$ctrl.submit()" disabled="$ctrl.run || !crmSearchTaskRegisterEventForm.$valid" />
+    <crm-dialog-button text="ts('Register %1 Contact(s)', {1: $ctrl.ids.length})" icons="{primary: $ctrl.run ? 'fa-spin fa-spinner' : 'fa-ticket'}" on-click="$ctrl.submit()" disabled="$ctrl.run || !crmSearchTaskRegisterEventForm.$valid" />
   </form>
 </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -1,0 +1,42 @@
+<div id="bootstrap-theme" crm-dialog="crmSearchTask">
+  <form name="crmSearchTaskRegisterEventForm" ng-controller="crmSearchTaskRegisterEvent as $ctrl">
+    <div class="messages status no-popup">
+      {{:: ts('Number of selected contacts: %1', {1: $ctrl.ids.length}) }}
+    </div>
+    <div class="form-inline">
+      <label for="crm-search-task-event-event_id">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
+      <input id="crm-search-task-event-event_id" class="form-control"
+             ng-disabled="values.event_id"
+             ng-model="values.event_id"
+             crm-autocomplete="'Event'"
+             crm-autocomplete-params="{fieldName: 'event_id', filters: {is_active: true}}"
+             required>
+    </div>
+    <div ng-if="$ctrl.ready">
+      <div class="form-inline">
+        <label for="crm-search-task-event-role_id">{{:: ts('Role(s)') }}</label>
+        <input id="crm-search-task-event-role_id" class="form-control huge" ng-model="values.role_id" crm-ui-select="{multiple: true, placeholder: ts('Select role(s)'), data: $ctrl.roleOptions}">
+      </div>
+      <div class="form-inline">
+        <label for="crm-search-task-event-status_id">{{:: ts('Status') }}</label>
+        <select id="crm-search-task-event-status_id" class="form-control" ng-model="values.status_id" crm-ui-select="{allowClear: true}">
+          <option ng-repeat="opt in $ctrl.statusOptions" value="{{ opt.id }}">{{ opt.label }}</option>
+        </select>
+      </div>
+      <div class="form-inline">
+        <label for="crm-search-task-event-source">{{:: ts('Source') }}</label>
+        <input id="crm-search-task-event-source" class="form-control" ng-model="values.source">
+      </div>
+    </div>
+    <div ng-if="!$ctrl.ready" class="form-inline">
+      <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i> {{:: ts('Loading...') }}
+    </div>
+
+    <div ng-if="$ctrl.run" class="crm-search-task-progress">
+      <h5>{{:: ts('Registering participants...') }}</h5>
+      <crm-search-batch-runner entity="'Participant'" action="save" params="$ctrl.run" ids="$ctrl.ids" id-field="contact_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)"></crm-search-batch-runner>
+    </div>
+    <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
+    <crm-dialog-button text="ts('Register')" icons="{primary: 'fa-ticket'}" on-click="$ctrl.submit()" disabled="$ctrl.run || !crmSearchTaskRegisterEventForm.$valid" />
+  </form>
+</div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -11,8 +11,7 @@
     <div ng-if="$ctrl.fields.length" class="crm-search-task-fields" ng-class="{'crm-search-task-refreshing': $ctrl.refreshing}">
       <div class="form-inline" ng-repeat="clause in $ctrl.values track by clause[0]" >
         <input class="form-control crm-auto-width" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field')}" />
-        <crm-search-input class="form-group" ng-model="clause[1]" ng-change="$ctrl.markDirty($index)" field="$ctrl.getField(clause[0])" ></crm-search-input>
-        <i ng-if="$ctrl.getField(clause[0]).serialize" class="crm-i fa-exclamation-triangle crm-search-task-warn-icon" title="{{:: ts('Updating a multi-valued field replaces all existing values for this field') }}"></i>
+        <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
       </div>
       <div class="form-inline" ng-hide="$ctrl.run">
         <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field')}"/>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -1,27 +1,43 @@
 <div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form name="crmSearchTaskRegisterEventForm" ng-controller="crmSearchTaskRegisterEvent as $ctrl">
-    <div class="form-inline">
-      <label for="crm-search-task-event-event_id">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
-      <input id="crm-search-task-event-event_id" class="form-control"
-             ng-model="values.event_id"
-             crm-autocomplete="'Event'"
-             crm-autocomplete-params="$ctrl.autocompleteParams"
-             required>
-    </div>
-    <div ng-if="$ctrl.fields.length" class="crm-search-task-fields" ng-class="{'crm-search-task-refreshing': $ctrl.refreshing}">
-      <div class="form-inline" ng-repeat="clause in $ctrl.values track by clause[0]" >
-        <input class="form-control crm-auto-width" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field')}" />
-        <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
+    <div class="crm-search-task-rows" ng-class="{'crm-search-task-refreshing': $ctrl.refreshing}">
+      <div class="crm-search-task-row">
+        <div class="crm-search-task-label crm-search-task-label-event">{{:: ts('Event') }} <i class="crm-marker">*</i></div>
+        <div class="crm-search-task-input">
+          <input id="crm-search-task-event-event_id" class="form-control"
+                 ng-model="values.event_id"
+                 crm-autocomplete="'Event'"
+                 crm-autocomplete-params="$ctrl.autocompleteParams"
+                 required>
+        </div>
       </div>
-      <div class="form-inline" ng-hide="$ctrl.run">
-        <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field')}"/>
+      <div ng-if="!$ctrl.fields.length && !values.event_id" class="crm-search-task-row">
+        <div class="crm-search-task-label"></div>
+        <div class="crm-search-task-input">
+          <em>{{:: ts('Select an event to configure registration options.') }}</em>
+        </div>
       </div>
-    </div>
-    <div ng-if="!$ctrl.fields.length && !values.event_id" class="form-inline">
-      <em>{{:: ts('Select an event to configure registration options.') }}</em>
-    </div>
-    <div ng-if="!$ctrl.fields.length && values.event_id" class="form-inline">
-      <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i> {{:: ts('Loading...') }}
+      <div ng-if="!$ctrl.fields.length && values.event_id" class="crm-search-task-row">
+        <div class="crm-search-task-label"></div>
+        <div class="crm-search-task-input">
+          <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i> {{:: ts('Loading...') }}
+        </div>
+      </div>
+      <div class="crm-search-task-separator" ng-if="$ctrl.fields.length"></div>
+      <div class="crm-search-task-row" ng-repeat="clause in $ctrl.values track by clause[0]">
+        <div class="crm-search-task-label">
+          <input class="form-control" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field'), containerCssClass: 'crm-auto-width'}" />
+        </div>
+        <div class="crm-search-task-input">
+          <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
+        </div>
+      </div>
+      <div class="crm-search-task-row" ng-hide="$ctrl.run" ng-if="$ctrl.fields.length">
+        <div class="crm-search-task-label">
+          <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field'), containerCssClass: 'crm-auto-width'}"/>
+        </div>
+        <div class="crm-search-task-input"></div>
+      </div>
     </div>
 
     <div ng-if="$ctrl.run" class="crm-search-task-progress">

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -6,29 +6,21 @@
     <div class="form-inline">
       <label for="crm-search-task-event-event_id">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
       <input id="crm-search-task-event-event_id" class="form-control"
-             ng-disabled="values.event_id"
              ng-model="values.event_id"
              crm-autocomplete="'Event'"
-             crm-autocomplete-params="{fieldName: 'event_id', filters: {is_active: true}}"
+             crm-autocomplete-params="$ctrl.autocompleteParams"
              required>
     </div>
-    <div ng-if="$ctrl.ready">
-      <div class="form-inline">
-        <label for="crm-search-task-event-role_id">{{:: ts('Role(s)') }}</label>
-        <input id="crm-search-task-event-role_id" class="form-control huge" ng-model="values.role_id" crm-ui-select="{multiple: true, placeholder: ts('Select role(s)'), data: $ctrl.roleOptions}">
+    <div ng-if="$ctrl.fields.length">
+      <div class="form-inline" ng-repeat="clause in $ctrl.values" >
+        <input class="form-control crm-auto-width" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field')}" />
+        <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
       </div>
-      <div class="form-inline">
-        <label for="crm-search-task-event-status_id">{{:: ts('Status') }}</label>
-        <select id="crm-search-task-event-status_id" class="form-control" ng-model="values.status_id" crm-ui-select="{allowClear: true}">
-          <option ng-repeat="opt in $ctrl.statusOptions" value="{{ opt.id }}">{{ opt.label }}</option>
-        </select>
-      </div>
-      <div class="form-inline">
-        <label for="crm-search-task-event-source">{{:: ts('Source') }}</label>
-        <input id="crm-search-task-event-source" class="form-control" ng-model="values.source">
+      <div class="form-inline" ng-hide="$ctrl.run">
+        <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field')}"/>
       </div>
     </div>
-    <div ng-if="!$ctrl.ready" class="form-inline">
+    <div ng-if="!$ctrl.fields.length" class="form-inline">
       <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i> {{:: ts('Loading...') }}
     </div>
 
@@ -36,6 +28,7 @@
       <h5>{{:: ts('Registering participants...') }}</h5>
       <crm-search-batch-runner entity="'Participant'" action="save" params="$ctrl.run" ids="$ctrl.ids" id-field="contact_id" success="$ctrl.onSuccess(result)" error="$ctrl.onError(error)"></crm-search-batch-runner>
     </div>
+
     <crm-dialog-button text="ts('Cancel')" icons="{primary: 'fa-times'}" on-click="$ctrl.cancel()" disabled="$ctrl.run" />
     <crm-dialog-button text="ts('Register')" icons="{primary: 'fa-ticket'}" on-click="$ctrl.submit()" disabled="$ctrl.run || !crmSearchTaskRegisterEventForm.$valid" />
   </form>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -1,14 +1,13 @@
 <div id="bootstrap-theme" crm-dialog="crmSearchTask">
   <form name="crmSearchTaskRegisterEventForm" ng-controller="crmSearchTaskRegisterEvent as $ctrl">
-    <div class="crm-search-task-rows" ng-class="{'crm-search-task-refreshing': $ctrl.refreshing}">
+    <div class="crm-search-task-rows">
       <div class="crm-search-task-row">
-        <div class="crm-search-task-label crm-search-task-label-event">{{:: ts('Event') }} <i class="crm-marker">*</i></div>
+        <label for="crm-search-task-event-event_id" class="crm-search-task-label crm-search-task-label-event">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
         <div class="crm-search-task-input">
           <input id="crm-search-task-event-event_id" class="form-control"
-                 ng-model="values.event_id"
-                 crm-autocomplete="'Event'"
-                 crm-autocomplete-params="$ctrl.autocompleteParams"
-                 ng-disabled="$ctrl.refreshing"
+                  ng-model="values.event_id"
+                  crm-autocomplete="'Event'"
+                  ng-disabled="$ctrl.refreshing"
                  required>
         </div>
       </div>
@@ -24,7 +23,7 @@
           <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i> {{:: ts('Loading...') }}
         </div>
       </div>
-      <div class="crm-search-task-separator" ng-if="$ctrl.fields.length"></div>
+      <div class="crm-search-task-lazy-separator" ng-if="$ctrl.fields.length"></div>
       <div class="crm-search-task-row" ng-repeat="clause in $ctrl.values track by clause[0]">
         <div class="crm-search-task-label">
           <input class="form-control" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run || $ctrl.refreshing" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field'), containerCssClass: 'crm-auto-width'}" />

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -8,6 +8,7 @@
                  ng-model="values.event_id"
                  crm-autocomplete="'Event'"
                  crm-autocomplete-params="$ctrl.autocompleteParams"
+                 ng-disabled="$ctrl.refreshing"
                  required>
         </div>
       </div>
@@ -26,15 +27,16 @@
       <div class="crm-search-task-separator" ng-if="$ctrl.fields.length"></div>
       <div class="crm-search-task-row" ng-repeat="clause in $ctrl.values track by clause[0]">
         <div class="crm-search-task-label">
-          <input class="form-control" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field'), containerCssClass: 'crm-auto-width'}" />
+          <input class="form-control" ng-change="$ctrl.updateField($index)" ng-disabled="$ctrl.run || $ctrl.refreshing" ng-model="clause[0]" crm-ui-select="{data: $ctrl.availableFields, allowClear: true, placeholder: ts('Field'), containerCssClass: 'crm-auto-width'}" />
         </div>
         <div class="crm-search-task-input">
+          <!-- crm-search-input does not support ng-disabled; pointer-events: none on the container blocks UI interaction during refresh as a fallback -->
           <crm-search-input class="form-group" ng-model="clause[1]" field="$ctrl.getField(clause[0])" ></crm-search-input>
         </div>
       </div>
       <div class="crm-search-task-row" ng-hide="$ctrl.run" ng-if="$ctrl.fields.length">
         <div class="crm-search-task-label">
-          <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field'), containerCssClass: 'crm-auto-width'}"/>
+          <input class="form-control" on-crm-ui-select="$ctrl.addField(selection)" ng-disabled="!$ctrl.fields.length || $ctrl.refreshing" ng-class="{loading: !$ctrl.fields.length}" crm-ui-select="{data: $ctrl.availableFields, placeholder: ts('Add Field'), containerCssClass: 'crm-auto-width'}"/>
         </div>
         <div class="crm-search-task-input"></div>
       </div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.html
@@ -2,7 +2,7 @@
   <form name="crmSearchTaskRegisterEventForm" ng-controller="crmSearchTaskRegisterEvent as $ctrl">
     <div class="crm-search-task-rows">
       <div class="crm-search-task-row">
-        <label for="crm-search-task-event-event_id" class="crm-search-task-label crm-search-task-label-event">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
+        <label for="crm-search-task-event-event_id" class="crm-search-task-label">{{:: ts('Event') }} <i class="crm-marker">*</i></label>
         <div class="crm-search-task-input">
           <input id="crm-search-task-event-event_id" class="form-control"
                   ng-model="values.event_id"

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -1,52 +1,50 @@
 (function(angular, $, _) {
   "use strict";
 
-  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, crmApi4, searchTaskBaseTrait) {
+  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, crmApi4, searchTaskBaseTrait, searchTaskFieldsTrait) {
     const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
-    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait);
+    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait, searchTaskFieldsTrait);
 
     const values = this.task.values && !Array.isArray(this.task.values) ? this.task.values : {};
     $scope.values = values;
 
-    if (values.role_id && !Array.isArray(values.role_id)) {
-      values.role_id = [values.role_id];
-    }
+    this.autocompleteParams = {
+      fieldName: 'event_id'
+    };
 
-    crmApi4({
-      statusField: ['Participant', 'getFields', {
-        action: 'create',
-        loadOptions: ['id', 'label'],
-        where: [['name', '=', 'status_id']]
-      }],
-      roleField: ['Participant', 'getFields', {
-        action: 'create',
-        loadOptions: ['id', 'label'],
-        where: [['name', '=', 'role_id']]
-      }]
-    }).then(function(results) {
-      ctrl.statusOptions = (results.statusField[0] || {}).options || [];
-      ctrl.roleOptions = _.map((results.roleField[0] || {}).options || [], function(opt) {
-        return {id: opt.id, text: opt.label};
+    this.loadFieldsAndValues(this.task, 'Participant', {
+      action: 'create',
+      where: [['name', 'NOT IN', ['contact_id', 'event_id']]]
+    }).then(function() {
+      ['role_id', 'status_id', 'source'].forEach(function(fieldName) {
+        if (!fieldInUse(fieldName)) {
+          ctrl.addField(fieldName);
+        }
       });
-      if (!values.status_id && ctrl.statusOptions.length) {
-        values.status_id = ctrl.statusOptions[0].id;
+      const rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+      if (rolePair && !Array.isArray(rolePair[1])) {
+        rolePair[1] = [rolePair[1]];
       }
-      ctrl.ready = true;
-      if (values.event_id && !values.role_id) {
+      if (values.event_id) {
         loadDefaultRole(values.event_id);
       }
     });
 
+    function fieldInUse(fieldName) {
+      return ctrl.values.some(function(p) { return p[0] === fieldName; });
+    }
+
     function loadDefaultRole(eventId) {
-      if (!eventId) {
-        return;
-      }
+      if (!eventId) { return; }
       crmApi4('Event', 'get', {
         select: ['default_role_id'],
         where: [['id', '=', eventId]]
       }).then(function(results) {
         if (results.length && results[0].default_role_id) {
-          values.role_id = [results[0].default_role_id];
+          const rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+          if (rolePair) {
+            rolePair[1] = [results[0].default_role_id];
+          }
         }
       });
     }
@@ -56,18 +54,21 @@
     });
 
     this.submit = function() {
-      ctrl.start({
-        defaults: _.cloneDeep(values)
+      const defaults = _.zipObject(ctrl.values);
+      if (values.event_id) {
+        defaults.event_id = values.event_id;
+      }
+      Object.keys(defaults).forEach(function(key) {
+        if (defaults[key] === '' || (Array.isArray(defaults[key]) && !defaults[key].length)) {
+          delete defaults[key];
+        }
       });
+      ctrl.start({defaults: defaults, match: ['contact_id', 'event_id']});
     };
 
     this.onSuccess = function(result) {
-      const registered = result.filter(function(r) {
-        return !r.duplicate_id;
-      }).length;
-      const duplicates = result.filter(function(r) {
-        return r.duplicate_id;
-      }).length;
+      const registered = result.filter(function(r) { return !r.duplicate_id; }).length;
+      const duplicates = result.filter(function(r) { return r.duplicate_id; }).length;
       let msg = ts('%count participant(s) registered', {count: registered});
       if (duplicates) {
         msg += '<br>' + ts('%count already registered', {count: duplicates});

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -15,34 +15,11 @@
     var reloading = false;
     var pendingReload = false;
     var lastLoadedRoleId = null;
-    var dirtyFields = {};
     var lastDefaultRoleId = null;
 
     function getEventId() {
       var val = values.event_id;
       return val && _.isObject(val) ? val.id : val;
-    }
-
-    function snapshotValues() {
-      var snap = {};
-      ctrl.values.forEach(function(pair) {
-        snap[pair[0]] = pair[1];
-      });
-      return snap;
-    }
-
-    function restoreSnapshot(snap) {
-      Object.keys(snap).forEach(function(key) {
-        var field = ctrl.getField(key);
-        if (field) {
-          var existing = ctrl.values.find(function(p) { return p[0] === key; });
-          if (existing) {
-            existing[1] = snap[key];
-          } else {
-            ctrl.values.push([key, snap[key]]);
-          }
-        }
-      });
     }
 
     function addPreselectedFields() {
@@ -57,25 +34,16 @@
       }
     }
 
-    this.markDirty = function(index) {
-      if (reloading) { return; }
-      var pair = ctrl.values[index];
-      if (pair) {
-        dirtyFields[pair[0]] = true;
-      }
-    };
-
     function loadFields(eventId) {
-      dirtyFields = {};
       pendingReload = false;
       reloading = true;
-      var snap = snapshotValues();
       if (ctrl.fields.length) {
         ctrl.refreshing = true;
       }
       var getFieldsValues = {event_id: eventId};
-      if (snap.role_id && snap.role_id.length) {
-        getFieldsValues.role_id = snap.role_id;
+      var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+      if (rolePair && rolePair[1] && rolePair[1].length) {
+        getFieldsValues.role_id = rolePair[1];
       }
       crmApi4({
         getFields: ['Participant', 'getFields', {
@@ -96,14 +64,19 @@
         }]
       }).then(function(results) {
         ctrl.fields.length = 0;
-        ctrl.values.length = 0;
+        var keepFields = {};
+        results.getFields.forEach(function(f) { keepFields[f.name] = true; });
+        for (var i = ctrl.values.length - 1; i >= 0; i--) {
+          if (!keepFields[ctrl.values[i][0]]) {
+            ctrl.values.splice(i, 1);
+          }
+        }
         ctrl.fields.push(...results.getFields);
         results.getFields.forEach(function(field) {
           if (field.required && !field.default_value) {
             ctrl.addField(field.name);
           }
         });
-        restoreSnapshot(snap);
         addPreselectedFields();
         var defaultRoleId = results.event.length ? results.event[0].default_role_id : null;
         var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
@@ -122,7 +95,6 @@
         }
         lastDefaultRoleId = defaultRoleId;
         ctrl.refreshing = false;
-      }).then(function() {
         var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
         lastLoadedRoleId = pair ? angular.copy(pair[1]) : null;
         reloading = false;
@@ -176,9 +148,7 @@
       Object.keys(defaults).forEach(function(key) {
         var val = defaults[key];
         var empty = val === '' || val === null || val === undefined || (Array.isArray(val) && !val.length);
-        if (empty && key === 'role_id') {
-          delete defaults[key];
-        } else if (empty && !dirtyFields[key]) {
+        if (empty && (key === 'role_id' || key === 'source')) {
           delete defaults[key];
         }
       });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -130,7 +130,7 @@
       });
     }
 
-    var unwatchEvent = $scope.$watch('values.event_id', function() {
+    $scope.$watch('values.event_id', function() {
       var id = getEventId();
       if (id) {
         loadFields(id);
@@ -145,7 +145,7 @@
       }
     });
 
-    var unwatchRole = $scope.$watch(function() {
+    $scope.$watch(function() {
       var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
       return pair ? pair[1] : null;
     }, function(newRole, oldRole) {
@@ -158,11 +158,6 @@
         }
       }
     }, true);
-
-    $scope.$on('$destroy', function() {
-      unwatchEvent();
-      unwatchRole();
-    });
 
     this.submit = function() {
       const defaults = _.zipObject(ctrl.values);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -12,54 +12,170 @@
       fieldName: 'event_id'
     };
 
-    this.loadFieldsAndValues(this.task, 'Participant', {
-      action: 'create',
-      where: [['name', 'NOT IN', ['contact_id', 'event_id']]]
-    }).then(function() {
-      ['role_id', 'status_id', 'source'].forEach(function(fieldName) {
-        if (!fieldInUse(fieldName)) {
-          ctrl.addField(fieldName);
-        }
-      });
-      const rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-      if (rolePair && !Array.isArray(rolePair[1])) {
-        rolePair[1] = [rolePair[1]];
-      }
-      if (values.event_id) {
-        loadDefaultRole(values.event_id);
-      }
-    });
+    var reloading = false;
+    var pendingReload = false;
+    var lastLoadedRoleId = null;
+    var dirtyFields = {};
+    var lastDefaultRoleId = null;
 
-    function fieldInUse(fieldName) {
-      return ctrl.values.some(function(p) { return p[0] === fieldName; });
+    function getEventId() {
+      var val = values.event_id;
+      return val && _.isObject(val) ? val.id : val;
     }
 
-    function loadDefaultRole(eventId) {
-      if (!eventId) { return; }
-      crmApi4('Event', 'get', {
-        select: ['default_role_id'],
-        where: [['id', '=', eventId]]
-      }).then(function(results) {
-        if (results.length && results[0].default_role_id) {
-          const rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-          if (rolePair) {
-            rolePair[1] = [results[0].default_role_id];
+    function snapshotValues() {
+      var snap = {};
+      ctrl.values.forEach(function(pair) {
+        snap[pair[0]] = pair[1];
+      });
+      return snap;
+    }
+
+    function restoreSnapshot(snap) {
+      Object.keys(snap).forEach(function(key) {
+        var field = ctrl.getField(key);
+        if (field) {
+          var existing = ctrl.values.find(function(p) { return p[0] === key; });
+          if (existing) {
+            existing[1] = snap[key];
+          } else {
+            ctrl.values.push([key, snap[key]]);
           }
         }
       });
     }
 
-    $scope.$watch('values.event_id', function(newEventId) {
-      loadDefaultRole(newEventId);
+    function addPreselectedFields() {
+      ['role_id', 'status_id', 'source'].forEach(function(fieldName) {
+        if (ctrl.values.every(function(p) { return p[0] !== fieldName; })) {
+          ctrl.addField(fieldName);
+        }
+      });
+      var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+      if (rolePair && !Array.isArray(rolePair[1])) {
+        rolePair[1] = [rolePair[1]];
+      }
+    }
+
+    this.markDirty = function(index) {
+      if (reloading) { return; }
+      var pair = ctrl.values[index];
+      if (pair) {
+        dirtyFields[pair[0]] = true;
+      }
+    };
+
+    function loadFields(eventId) {
+      dirtyFields = {};
+      pendingReload = false;
+      reloading = true;
+      var snap = snapshotValues();
+      if (ctrl.fields.length) {
+        ctrl.refreshing = true;
+      }
+      var getFieldsValues = {event_id: eventId};
+      if (snap.role_id && snap.role_id.length) {
+        getFieldsValues.role_id = snap.role_id;
+      }
+      crmApi4({
+        getFields: ['Participant', 'getFields', {
+          action: 'create',
+          select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable', 'required', 'default_value'],
+          loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
+          where: [
+            ['name', 'NOT IN', ['contact_id', 'event_id']],
+            ['deprecated', '=', false],
+            ['readonly', '=', false],
+          ],
+          values: getFieldsValues
+        }],
+        event: ['Event', 'get', {
+          select: ['default_role_id'],
+          where: [['id', '=', eventId]],
+          limit: 1
+        }]
+      }).then(function(results) {
+        ctrl.fields.length = 0;
+        ctrl.values.length = 0;
+        ctrl.fields.push(...results.getFields);
+        results.getFields.forEach(function(field) {
+          if (field.required && !field.default_value) {
+            ctrl.addField(field.name);
+          }
+        });
+        restoreSnapshot(snap);
+        addPreselectedFields();
+        var defaultRoleId = results.event.length ? results.event[0].default_role_id : null;
+        var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+        if (rolePair) {
+          if (!rolePair[1].length || _.isEqual(rolePair[1], [lastDefaultRoleId])) {
+            rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
+          }
+        }
+        lastDefaultRoleId = defaultRoleId;
+        ctrl.refreshing = false;
+      }).then(function() {
+        var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+        lastLoadedRoleId = pair ? angular.copy(pair[1]) : null;
+        reloading = false;
+        if (pendingReload) {
+          pendingReload = false;
+          loadFields(eventId);
+        }
+      }).catch(function(error) {
+        ctrl.refreshing = false;
+        reloading = false;
+        console.error('Failed to load event fields:', error);
+        CRM.alert(ts('Failed to load event fields.'), ts('Error'), 'error');
+      });
+    }
+
+    var unwatchEvent = $scope.$watch('values.event_id', function() {
+      var id = getEventId();
+      if (id) {
+        loadFields(id);
+      } else {
+        ctrl.fields.length = 0;
+        ctrl.values.length = 0;
+        ctrl.refreshing = false;
+        reloading = false;
+        pendingReload = false;
+        lastLoadedRoleId = null;
+        lastDefaultRoleId = null;
+      }
+    });
+
+    var unwatchRole = $scope.$watch(function() {
+      var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
+      return pair ? pair[1] : null;
+    }, function(newRole, oldRole) {
+      var id = getEventId();
+      if (id && Array.isArray(newRole) && newRole.length && !_.isEqual(newRole, lastLoadedRoleId)) {
+        if (reloading) {
+          pendingReload = true;
+        } else {
+          loadFields(id);
+        }
+      }
+    }, true);
+
+    $scope.$on('$destroy', function() {
+      unwatchEvent();
+      unwatchRole();
     });
 
     this.submit = function() {
       const defaults = _.zipObject(ctrl.values);
-      if (values.event_id) {
-        defaults.event_id = values.event_id;
+      var eventId = getEventId();
+      if (eventId) {
+        defaults.event_id = eventId;
       }
       Object.keys(defaults).forEach(function(key) {
-        if (defaults[key] === '' || (Array.isArray(defaults[key]) && !defaults[key].length)) {
+        var val = defaults[key];
+        var empty = val === '' || val === null || val === undefined || (Array.isArray(val) && !val.length);
+        if (empty && key === 'role_id') {
+          delete defaults[key];
+        } else if (empty && !dirtyFields[key]) {
           delete defaults[key];
         }
       });
@@ -78,7 +194,8 @@
     };
 
     this.onError = function(error) {
-      CRM.alert(ts('Registration failed: ') + error, ts('Error'), 'error');
+      console.error('Registration failed:', error);
+      CRM.alert(ts('An error occurred while attempting to register participants.'), ts('Error'), 'error');
     };
 
   });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -1,0 +1,84 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, crmApi4, searchTaskBaseTrait) {
+    const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait);
+
+    const values = this.task.values && !Array.isArray(this.task.values) ? this.task.values : {};
+    $scope.values = values;
+
+    if (values.role_id && !Array.isArray(values.role_id)) {
+      values.role_id = [values.role_id];
+    }
+
+    crmApi4({
+      statusField: ['Participant', 'getFields', {
+        action: 'create',
+        loadOptions: ['id', 'label'],
+        where: [['name', '=', 'status_id']]
+      }],
+      roleField: ['Participant', 'getFields', {
+        action: 'create',
+        loadOptions: ['id', 'label'],
+        where: [['name', '=', 'role_id']]
+      }]
+    }).then(function(results) {
+      ctrl.statusOptions = (results.statusField[0] || {}).options || [];
+      ctrl.roleOptions = _.map((results.roleField[0] || {}).options || [], function(opt) {
+        return {id: opt.id, text: opt.label};
+      });
+      if (!values.status_id && ctrl.statusOptions.length) {
+        values.status_id = ctrl.statusOptions[0].id;
+      }
+      ctrl.ready = true;
+      if (values.event_id && !values.role_id) {
+        loadDefaultRole(values.event_id);
+      }
+    });
+
+    function loadDefaultRole(eventId) {
+      if (!eventId) {
+        return;
+      }
+      crmApi4('Event', 'get', {
+        select: ['default_role_id'],
+        where: [['id', '=', eventId]]
+      }).then(function(results) {
+        if (results.length && results[0].default_role_id) {
+          values.role_id = [results[0].default_role_id];
+        }
+      });
+    }
+
+    $scope.$watch('values.event_id', function(newEventId) {
+      loadDefaultRole(newEventId);
+    });
+
+    this.submit = function() {
+      ctrl.start({
+        defaults: _.cloneDeep(values)
+      });
+    };
+
+    this.onSuccess = function(result) {
+      const registered = result.filter(function(r) {
+        return !r.duplicate_id;
+      }).length;
+      const duplicates = result.filter(function(r) {
+        return r.duplicate_id;
+      }).length;
+      let msg = ts('%count participant(s) registered', {count: registered});
+      if (duplicates) {
+        msg += '<br>' + ts('%count already registered', {count: duplicates});
+      }
+      CRM.alert(msg, ts('Success'), 'success');
+      this.close(result);
+    };
+
+    this.onError = function(error) {
+      CRM.alert(ts('Registration failed: ') + error, ts('Error'), 'error');
+    };
+
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -111,6 +111,14 @@
           if (!rolePair[1].length || _.isEqual(rolePair[1], [lastDefaultRoleId])) {
             rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
           }
+          var roleField = ctrl.getField('role_id');
+          if (roleField && roleField.options && rolePair[1].length) {
+            var validIds = roleField.options.map(function(opt) { return opt.id; });
+            rolePair[1] = rolePair[1].filter(function(id) { return validIds.includes(id); });
+            if (!rolePair[1].length) {
+              rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
+            }
+          }
         }
         lastDefaultRoleId = defaultRoleId;
         ctrl.refreshing = false;

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -1,17 +1,13 @@
 (function(angular, $, _) {
   "use strict";
 
-  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, crmApi4, searchTaskBaseTrait, searchTaskLazyFieldsTrait) {
+  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, searchTaskBaseTrait, searchTaskLazyFieldsTrait) {
     const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
     const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait, searchTaskLazyFieldsTrait);
 
     // Initial task values from hook_civicrm_searchKitTasks (optional pre-configured defaults)
     const values = this.task.values && !Array.isArray(this.task.values) ? this.task.values : {};
     $scope.values = values;
-
-    this.autocompleteParams = {
-      fieldName: 'event_id'
-    };
 
     ctrl.setupLazyFields($scope, {
       fkField: 'event_id',
@@ -33,7 +29,7 @@
         var defaultRoleId = results.event.length ? results.event[0].default_role_id : null;
         var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
         if (rolePair) {
-          if (!rolePair[1].length || _.isEqual(rolePair[1], [ctrl._lastDefaultDepValue])) {
+          if (!rolePair[1].length || _.isEqual(rolePair[1], [ctrl._lastFkMeta])) {
             rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
           }
           // Strip role IDs invalid for the new event
@@ -46,9 +42,10 @@
             }
           }
         }
-        ctrl._lastDefaultDepValue = defaultRoleId;
+        ctrl._lastFkMeta = defaultRoleId;
       },
-      onError: function() {
+      // Config onError (field load failure)
+      onError: function(error) {
         CRM.alert(ts('Failed to load event fields.'), ts('Error'), 'error');
       }
     });
@@ -81,9 +78,11 @@
       this.close(result);
     };
 
+    // Batch runner onError (save failure)
     this.onError = function(error) {
       console.error('Registration failed:', error);
       CRM.alert(ts('An error occurred while attempting to register participants.'), ts('Error'), 'error');
+      this.cancel();
     };
 
   });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -5,6 +5,7 @@
     const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
     const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait, searchTaskFieldsTrait);
 
+    // Initial task values from hook_civicrm_searchKitTasks (optional pre-configured defaults)
     const values = this.task.values && !Array.isArray(this.task.values) ? this.task.values : {};
     $scope.values = values;
 
@@ -12,28 +13,37 @@
       fieldName: 'event_id'
     };
 
+    // Reload guards — prevent cascade reloads when role changes during loadFields()
     var reloading = false;
     var pendingReload = false;
+    // Track last loaded role to detect actual changes vs programmatic updates
     var lastLoadedRoleId = null;
+    // Track last event default role to auto-update role when switching events
     var lastDefaultRoleId = null;
 
+    // event_id can arrive as an object {id, text} from crm-autocomplete or as a raw id
     function getEventId() {
       var val = values.event_id;
       return val && _.isObject(val) ? val.id : val;
     }
 
+    // Pre-select common fields so the form is ready to use immediately after event selection
     function addPreselectedFields() {
       ['role_id', 'status_id', 'source'].forEach(function(fieldName) {
         if (ctrl.values.every(function(p) { return p[0] !== fieldName; })) {
           ctrl.addField(fieldName);
         }
       });
+      // Normalize role_id to array form (multi-select option list)
       var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
       if (rolePair && !Array.isArray(rolePair[1])) {
         rolePair[1] = [rolePair[1]];
       }
     }
 
+    // Lazy-load fields scoped by event and optionally by role
+    // The "values" param passed to getFields filters custom groups that extend Participant
+    // by event_id / role_id (see SpecGatherer::getCustomGroupFilters)
     function loadFields(eventId) {
       pendingReload = false;
       reloading = true;
@@ -41,10 +51,12 @@
         ctrl.refreshing = true;
       }
       var getFieldsValues = {event_id: eventId};
+      // Pass current role selection so role-scoped custom fields are included
       var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
       if (rolePair && rolePair[1] && rolePair[1].length) {
         getFieldsValues.role_id = rolePair[1];
       }
+      // Batched API call: getFields (scoped by event/role) + event (for default_role_id)
       crmApi4({
         getFields: ['Participant', 'getFields', {
           action: 'create',
@@ -64,6 +76,9 @@
         }]
       }).then(function(results) {
         ctrl.fields.length = 0;
+        // Remove values for fields that no longer apply (e.g. after event or role change)
+        // Must use splice() to preserve the array reference that searchTaskFieldsTrait's
+        // availableFields / fieldInUse closures hold via ctrl.values
         var keepFields = {};
         results.getFields.forEach(function(f) { keepFields[f.name] = true; });
         for (var i = ctrl.values.length - 1; i >= 0; i--) {
@@ -72,18 +87,21 @@
           }
         }
         ctrl.fields.push(...results.getFields);
+        // Auto-add required fields that lack a default
         results.getFields.forEach(function(field) {
           if (field.required && !field.default_value) {
             ctrl.addField(field.name);
           }
         });
         addPreselectedFields();
+        // Auto-update role to the new event's default if unchanged from previous default
         var defaultRoleId = results.event.length ? results.event[0].default_role_id : null;
         var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
         if (rolePair) {
           if (!rolePair[1].length || _.isEqual(rolePair[1], [lastDefaultRoleId])) {
             rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
           }
+          // Strip role IDs that are invalid for the new event
           var roleField = ctrl.getField('role_id');
           if (roleField && roleField.options && rolePair[1].length) {
             var validIds = roleField.options.map(function(opt) { return opt.id; });
@@ -110,6 +128,7 @@
       });
     }
 
+    // Reload fields whenever the user selects a different event
     $scope.$watch('values.event_id', function() {
       var id = getEventId();
       if (id) {
@@ -125,6 +144,8 @@
       }
     });
 
+    // Reload fields when the user changes the role (deep watch for array changes)
+    // Role-scoped custom fields may differ from event-scoped ones
     $scope.$watch(function() {
       var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
       return pair ? pair[1] : null;
@@ -145,6 +166,7 @@
       if (eventId) {
         defaults.event_id = eventId;
       }
+      // Strip empty role_id and source so BAO defaults apply (e.g. event's default_role_id)
       Object.keys(defaults).forEach(function(key) {
         var val = defaults[key];
         var empty = val === '' || val === null || val === undefined || (Array.isArray(val) && !val.length);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -57,7 +57,7 @@
 
     this.submit = function() {
       const defaults = _.zipObject(ctrl.values);
-      var eventId = ctrl.getFkId(values.event_id);
+      var eventId = values.event_id;
       if (eventId) {
         defaults.event_id = eventId;
       }

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -1,9 +1,9 @@
 (function(angular, $, _) {
   "use strict";
 
-  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, crmApi4, searchTaskBaseTrait, searchTaskFieldsTrait) {
+  angular.module('crmSearchTasks').controller('crmSearchTaskRegisterEvent', function($scope, crmApi4, searchTaskBaseTrait, searchTaskLazyFieldsTrait) {
     const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
-    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait, searchTaskFieldsTrait);
+    const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait, searchTaskLazyFieldsTrait);
 
     // Initial task values from hook_civicrm_searchKitTasks (optional pre-configured defaults)
     const values = this.task.values && !Array.isArray(this.task.values) ? this.task.values : {};
@@ -13,95 +13,30 @@
       fieldName: 'event_id'
     };
 
-    // Reload guards — prevent cascade reloads when role changes during loadFields()
-    var reloading = false;
-    var pendingReload = false;
-    // Track last loaded role to detect actual changes vs programmatic updates
-    var lastLoadedRoleId = null;
-    // Track last event default role to auto-update role when switching events
-    var lastDefaultRoleId = null;
-
-    // event_id can arrive as an object {id, text} from crm-autocomplete or as a raw id
-    function getEventId() {
-      var val = values.event_id;
-      return val && _.isObject(val) ? val.id : val;
-    }
-
-    // Pre-select common fields so the form is ready to use immediately after event selection
-    function addPreselectedFields() {
-      ['role_id', 'status_id', 'source'].forEach(function(fieldName) {
-        if (ctrl.values.every(function(p) { return p[0] !== fieldName; })) {
-          ctrl.addField(fieldName);
-        }
-      });
-      // Normalize role_id to array form (multi-select option list)
-      var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-      if (rolePair && !Array.isArray(rolePair[1])) {
-        rolePair[1] = [rolePair[1]];
-      }
-    }
-
-    // Lazy-load fields scoped by event and optionally by role
-    // The "values" param passed to getFields filters custom groups that extend Participant
-    // by event_id / role_id (see SpecGatherer::getCustomGroupFilters)
-    function loadFields(eventId) {
-      pendingReload = false;
-      reloading = true;
-      if (ctrl.fields.length) {
-        ctrl.refreshing = true;
-      }
-      var getFieldsValues = {event_id: eventId};
-      // Pass current role selection so role-scoped custom fields are included
-      var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-      if (rolePair && rolePair[1] && rolePair[1].length) {
-        getFieldsValues.role_id = rolePair[1];
-      }
-      // Batched API call: getFields (scoped by event/role) + event (for default_role_id)
-      crmApi4({
-        getFields: ['Participant', 'getFields', {
-          action: 'create',
-          select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable', 'required', 'default_value'],
-          loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
-          where: [
-            ['name', 'NOT IN', ['contact_id', 'event_id']],
-            ['deprecated', '=', false],
-            ['readonly', '=', false],
-          ],
-          values: getFieldsValues
-        }],
-        event: ['Event', 'get', {
-          select: ['default_role_id'],
-          where: [['id', '=', eventId]],
-          limit: 1
-        }]
-      }).then(function(results) {
-        ctrl.fields.length = 0;
-        // Remove values for fields that no longer apply (e.g. after event or role change)
-        // Must use splice() to preserve the array reference that searchTaskFieldsTrait's
-        // availableFields / fieldInUse closures hold via ctrl.values
-        var keepFields = {};
-        results.getFields.forEach(function(f) { keepFields[f.name] = true; });
-        for (var i = ctrl.values.length - 1; i >= 0; i--) {
-          if (!keepFields[ctrl.values[i][0]]) {
-            ctrl.values.splice(i, 1);
-          }
-        }
-        ctrl.fields.push(...results.getFields);
-        // Auto-add required fields that lack a default
-        results.getFields.forEach(function(field) {
-          if (field.required && !field.default_value) {
-            ctrl.addField(field.name);
-          }
-        });
-        addPreselectedFields();
-        // Auto-update role to the new event's default if unchanged from previous default
+    ctrl.setupLazyFields($scope, {
+      fkField: 'event_id',
+      depField: 'role_id',
+      entityName: 'Participant',
+      presetFields: ['role_id', 'status_id', 'source'],
+      // Fetch event's default_role_id to auto-update role when switching events
+      getAdditionalApiCalls: function(eventId) {
+        return {
+          event: ['Event', 'get', {
+            select: ['default_role_id'],
+            where: [['id', '=', eventId]],
+            limit: 1
+          }]
+        };
+      },
+      onFieldsLoaded: function(results) {
+        // Auto-update role to new event's default if unchanged from previous default
         var defaultRoleId = results.event.length ? results.event[0].default_role_id : null;
         var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
         if (rolePair) {
-          if (!rolePair[1].length || _.isEqual(rolePair[1], [lastDefaultRoleId])) {
+          if (!rolePair[1].length || _.isEqual(rolePair[1], [ctrl._lastDefaultDepValue])) {
             rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
           }
-          // Strip role IDs that are invalid for the new event
+          // Strip role IDs invalid for the new event
           var roleField = ctrl.getField('role_id');
           if (roleField && roleField.options && rolePair[1].length) {
             var validIds = roleField.options.map(function(opt) { return opt.id; });
@@ -111,58 +46,16 @@
             }
           }
         }
-        lastDefaultRoleId = defaultRoleId;
-        ctrl.refreshing = false;
-        var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-        lastLoadedRoleId = pair ? angular.copy(pair[1]) : null;
-        reloading = false;
-        if (pendingReload) {
-          pendingReload = false;
-          loadFields(eventId);
-        }
-      }).catch(function(error) {
-        ctrl.refreshing = false;
-        reloading = false;
-        console.error('Failed to load event fields:', error);
+        ctrl._lastDefaultDepValue = defaultRoleId;
+      },
+      onError: function() {
         CRM.alert(ts('Failed to load event fields.'), ts('Error'), 'error');
-      });
-    }
-
-    // Reload fields whenever the user selects a different event
-    $scope.$watch('values.event_id', function() {
-      var id = getEventId();
-      if (id) {
-        loadFields(id);
-      } else {
-        ctrl.fields.length = 0;
-        ctrl.values.length = 0;
-        ctrl.refreshing = false;
-        reloading = false;
-        pendingReload = false;
-        lastLoadedRoleId = null;
-        lastDefaultRoleId = null;
       }
     });
 
-    // Reload fields when the user changes the role (deep watch for array changes)
-    // Role-scoped custom fields may differ from event-scoped ones
-    $scope.$watch(function() {
-      var pair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-      return pair ? pair[1] : null;
-    }, function(newRole, oldRole) {
-      var id = getEventId();
-      if (id && Array.isArray(newRole) && newRole.length && !_.isEqual(newRole, lastLoadedRoleId)) {
-        if (reloading) {
-          pendingReload = true;
-        } else {
-          loadFields(id);
-        }
-      }
-    }, true);
-
     this.submit = function() {
       const defaults = _.zipObject(ctrl.values);
-      var eventId = getEventId();
+      var eventId = ctrl.getFkId(values.event_id);
       if (eventId) {
         defaults.event_id = eventId;
       }

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRegisterEvent.js
@@ -5,6 +5,8 @@
     const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
     const ctrl = angular.extend(this, $scope.model, searchTaskBaseTrait, searchTaskLazyFieldsTrait);
 
+    ctrl._lastDefaultRoleId = null;
+
     // Initial task values from hook_civicrm_searchKitTasks (optional pre-configured defaults)
     const values = this.task.values && !Array.isArray(this.task.values) ? this.task.values : {};
     $scope.values = values;
@@ -25,24 +27,27 @@
         };
       },
       onFieldsLoaded: function(results) {
-        // Auto-update role to new event's default if unchanged from previous default
         var defaultRoleId = results.event.length ? results.event[0].default_role_id : null;
-        var rolePair = ctrl.values.find(function(p) { return p[0] === 'role_id'; });
-        if (rolePair) {
-          if (!rolePair[1].length || _.isEqual(rolePair[1], [ctrl._lastFkMeta])) {
-            rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
+        var newRole = ctrl.getFieldValue('role_id');
+        if (newRole) {
+          if (!newRole.length || _.isEqual(newRole, [ctrl._lastDefaultRoleId])) {
+            newRole = defaultRoleId ? [defaultRoleId] : [];
           }
           // Strip role IDs invalid for the new event
           var roleField = ctrl.getField('role_id');
-          if (roleField && roleField.options && rolePair[1].length) {
+          if (roleField && roleField.options && newRole.length) {
             var validIds = roleField.options.map(function(opt) { return opt.id; });
-            rolePair[1] = rolePair[1].filter(function(id) { return validIds.includes(id); });
-            if (!rolePair[1].length) {
-              rolePair[1] = defaultRoleId ? [defaultRoleId] : [];
+            newRole = newRole.filter(function(id) { return validIds.includes(id); });
+            if (!newRole.length) {
+              newRole = defaultRoleId ? [defaultRoleId] : [];
             }
           }
+          ctrl.setFieldValue('role_id', newRole);
         }
-        ctrl._lastFkMeta = defaultRoleId;
+        ctrl._lastDefaultRoleId = defaultRoleId;
+      },
+      onClear: function() {
+        ctrl._lastDefaultRoleId = null;
       },
       // Config onError (field load failure)
       onError: function(error) {

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
@@ -1,0 +1,174 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchTasks').factory('searchTaskLazyFieldsTrait', function(crmApi4, searchTaskFieldsTrait) {
+    return angular.extend({}, searchTaskFieldsTrait, {
+      _reloading: false,
+      _pendingReload: false,
+      _lastLoadedDepValue: null,
+      _lastDefaultDepValue: null,
+
+      // Extract scalar ID from autocomplete {id, text} objects
+      getFkId: function(value) {
+        return value && _.isObject(value) ? value.id : value;
+      },
+
+      // Set up reactive field loading: watches a FK field (e.g. event_id) and optionally
+      // a dependent field (e.g. role_id). Fields are lazy-loaded scoped by the FK value,
+      // so custom groups matching the context appear.
+      setupLazyFields: function($scope, config) {
+        const ctrl = this;
+
+        if (config.depField) {
+          var depPair = ctrl.values.find(function(p) { return p[0] === config.depField; });
+          if (depPair && !Array.isArray(depPair[1])) {
+            depPair[1] = [depPair[1]];
+          }
+        }
+
+        // FK changed — load fields scoped by the new value, or clear if deselected
+        $scope.$watch('values.' + config.fkField, function() {
+          var id = ctrl.getFkId($scope.values[config.fkField]);
+          if (id) {
+            ctrl._loadFields(id, config);
+          } else {
+            ctrl._clearLazyFields(config);
+          }
+        });
+
+        // Deep watch dep field: reload fields when user changes the dependent value (e.g. role_id).
+        // Comparison against last loaded value prevents reload on programmatic updates.
+        // pendingReload cascade guard prevents duplicate calls during an active load.
+        if (config.depField) {
+          $scope.$watch(function() {
+            var pair = ctrl.values.find(function(p) { return p[0] === config.depField; });
+            return pair ? pair[1] : null;
+          }, function(newVal) {
+            var id = ctrl.getFkId($scope.values[config.fkField]);
+            if (id && Array.isArray(newVal) && newVal.length && !_.isEqual(newVal, ctrl._lastLoadedDepValue)) {
+              if (ctrl._reloading) {
+                ctrl._pendingReload = true;
+              } else {
+                ctrl._loadFields(id, config);
+              }
+            }
+          }, true);
+        }
+
+        return ctrl;
+      },
+
+      // Fetch fields scoped by FK + dep values. The "values" param filters custom groups
+      // via SpecGatherer::getCustomGroupFilters.
+      _loadFields: function(fkValue, config) {
+        this._pendingReload = false;
+        this._reloading = true;
+        if (this.fields.length) {
+          this.refreshing = true;
+        }
+        var getFieldsValues = {};
+        getFieldsValues[config.fkField] = fkValue;
+        // Pass current dep field selection so role-scoped (or dep-scoped) custom groups are included
+        if (config.depField) {
+          var depPair = this.values.find(function(p) { return p[0] === config.depField; });
+          if (depPair && depPair[1] && depPair[1].length) {
+            getFieldsValues[config.depField] = depPair[1];
+          }
+        }
+
+        var excluded = ['contact_id', config.fkField];
+        if (config.getFieldsExclude) {
+          excluded = excluded.concat(config.getFieldsExclude);
+        }
+
+        var apiCalls = {
+          getFields: [config.entityName, 'getFields', {
+            action: 'create',
+            select: ['name', 'label', 'description', 'input_type', 'data_type', 'serialize', 'options', 'fk_entity', 'nullable', 'required', 'default_value'],
+            loadOptions: ['id', 'name', 'label', 'description', 'color', 'icon'],
+            where: [
+              ['name', 'NOT IN', excluded],
+              ['deprecated', '=', false],
+              ['readonly', '=', false],
+            ],
+            values: getFieldsValues
+          }]
+        };
+        if (config.getAdditionalApiCalls) {
+          Object.assign(apiCalls, config.getAdditionalApiCalls(fkValue));
+        }
+
+        var ctrl = this;
+        crmApi4(apiCalls).then(function(results) {
+          // Mutate in place (length = 0, push, splice) to preserve shared array references
+          // that searchTaskFieldsTrait closures (getField, fieldInUse) hold via ctrl.fields / ctrl.values
+          ctrl.fields.length = 0;
+          var keepFields = {};
+          results.getFields.forEach(function(f) { keepFields[f.name] = true; });
+          for (var i = ctrl.values.length - 1; i >= 0; i--) {
+            if (!keepFields[ctrl.values[i][0]]) {
+              ctrl.values.splice(i, 1);
+            }
+          }
+          ctrl.fields.push(...results.getFields);
+          results.getFields.forEach(function(field) {
+            if (field.required && !field.default_value) {
+              ctrl.addField(field.name);
+            }
+          });
+          if (config.presetFields) {
+            config.presetFields.forEach(function(fieldName) {
+              if (ctrl.values.every(function(p) { return p[0] !== fieldName; })) {
+                ctrl.addField(fieldName);
+              }
+            });
+          }
+          if (config.depField) {
+            var depPair = ctrl.values.find(function(p) { return p[0] === config.depField; });
+            if (depPair && !Array.isArray(depPair[1])) {
+              depPair[1] = [depPair[1]];
+            }
+          }
+
+          // Fire callback BEFORE tracking _lastLoadedDepValue so the callback can modify field values first
+          if (config.onFieldsLoaded) {
+            config.onFieldsLoaded(results);
+          }
+
+          if (config.depField) {
+            var pair = ctrl.values.find(function(p) { return p[0] === config.depField; });
+            ctrl._lastLoadedDepValue = pair ? angular.copy(pair[1]) : null;
+          }
+
+          ctrl._reloading = false;
+          ctrl.refreshing = false;
+          if (ctrl._pendingReload) {
+            ctrl._pendingReload = false;
+            ctrl._loadFields(fkValue, config);
+          }
+        }).catch(function(error) {
+          ctrl.refreshing = false;
+          ctrl._reloading = false;
+          console.error('Failed to load fields:', error);
+          if (config.onError) {
+            config.onError(error);
+          }
+        });
+      },
+
+      // Reset all state when FK field is cleared
+      _clearLazyFields: function(config) {
+        this.fields.length = 0;
+        this.values.length = 0;
+        this.refreshing = false;
+        this._reloading = false;
+        this._pendingReload = false;
+        this._lastLoadedDepValue = null;
+        this._lastDefaultDepValue = null;
+        if (config.onClear) {
+          config.onClear();
+        }
+      }
+    });
+  });
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
@@ -7,11 +7,6 @@
       _pendingReload: false,
       _lastLoadedDepValue: null,
 
-      // Extract scalar ID from autocomplete {id, text} objects
-      getFkId: function(value) {
-        return value && _.isObject(value) ? value.id : value;
-      },
-
       // Set up reactive field loading: watches a FK field (e.g. event_id) and optionally
       // a dependent field (e.g. role_id). Fields are lazy-loaded scoped by the FK value,
       // so custom groups matching the context appear.
@@ -22,7 +17,7 @@
 
         // FK changed — load fields scoped by the new value, or clear if deselected
         $scope.$watch('values.' + config.fkField, function() {
-          var id = ctrl.getFkId($scope.values[config.fkField]);
+          var id = $scope.values[config.fkField];
           if (id) {
             ctrl._loadFields(id, config);
           } else {
@@ -37,7 +32,7 @@
           $scope.$watch(function() {
             return ctrl.getFieldValue(config.depField);
           }, function(newVal) {
-            var id = ctrl.getFkId($scope.values[config.fkField]);
+            var id = $scope.values[config.fkField];
             if (id && Array.isArray(newVal) && newVal.length && !_.isEqual(newVal, ctrl._lastLoadedDepValue)) {
               if (ctrl._reloading) {
                 ctrl._pendingReload = true;

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
@@ -6,7 +6,6 @@
       _reloading: false,
       _pendingReload: false,
       _lastLoadedDepValue: null,
-      _lastFkMeta: null,
 
       // Extract scalar ID from autocomplete {id, text} objects
       getFkId: function(value) {
@@ -36,8 +35,7 @@
         // pendingReload cascade guard prevents duplicate calls during an active load.
         if (config.depField) {
           $scope.$watch(function() {
-            var pair = ctrl.values.find(function(p) { return p[0] === config.depField; });
-            return pair ? pair[1] : null;
+            return ctrl.getFieldValue(config.depField);
           }, function(newVal) {
             var id = ctrl.getFkId($scope.values[config.fkField]);
             if (id && Array.isArray(newVal) && newVal.length && !_.isEqual(newVal, ctrl._lastLoadedDepValue)) {
@@ -65,9 +63,9 @@
         getFieldsValues[config.fkField] = fkValue;
         // Pass current dep field selection so role-scoped (or dep-scoped) custom groups are included
         if (config.depField) {
-          var depPair = this.values.find(function(p) { return p[0] === config.depField; });
-          if (depPair && depPair[1] && depPair[1].length) {
-            getFieldsValues[config.depField] = depPair[1];
+          var depVal = this.getFieldValue(config.depField);
+          if (depVal && depVal.length) {
+            getFieldsValues[config.depField] = depVal;
           }
         }
 
@@ -126,8 +124,7 @@
           }
 
           if (config.depField) {
-            var pair = ctrl.values.find(function(p) { return p[0] === config.depField; });
-            ctrl._lastLoadedDepValue = pair ? angular.copy(pair[1]) : null;
+            ctrl._lastLoadedDepValue = angular.copy(ctrl.getFieldValue(config.depField));
           }
 
           ctrl._reloading = false;
@@ -150,11 +147,21 @@
       // Ensure dep field value is array (required by deep-watch comparison and getFields values)
       _normalizeDepField: function(config) {
         if (config.depField) {
-          var depPair = this.values.find(function(p) { return p[0] === config.depField; });
-          if (depPair && !Array.isArray(depPair[1])) {
-            depPair[1] = [depPair[1]];
+          var depVal = this.getFieldValue(config.depField);
+          if (depVal !== null && !Array.isArray(depVal)) {
+            this.setFieldValue(config.depField, [depVal]);
           }
         }
+      },
+
+      getFieldValue: function(fieldName) {
+        var pair = this.values.find(function(p) { return p[0] === fieldName; });
+        return pair ? pair[1] : null;
+      },
+
+      setFieldValue: function(fieldName, value) {
+        var pair = this.values.find(function(p) { return p[0] === fieldName; });
+        if (pair) { pair[1] = value; }
       },
 
       // Reset all state when FK field is cleared
@@ -165,7 +172,6 @@
         this._reloading = false;
         this._pendingReload = false;
         this._lastLoadedDepValue = null;
-        this._lastFkMeta = null;
         if (config.onClear) {
           config.onClear();
         }

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchTaskLazyFieldsTrait.js
@@ -6,7 +6,7 @@
       _reloading: false,
       _pendingReload: false,
       _lastLoadedDepValue: null,
-      _lastDefaultDepValue: null,
+      _lastFkMeta: null,
 
       // Extract scalar ID from autocomplete {id, text} objects
       getFkId: function(value) {
@@ -19,12 +19,7 @@
       setupLazyFields: function($scope, config) {
         const ctrl = this;
 
-        if (config.depField) {
-          var depPair = ctrl.values.find(function(p) { return p[0] === config.depField; });
-          if (depPair && !Array.isArray(depPair[1])) {
-            depPair[1] = [depPair[1]];
-          }
-        }
+        ctrl._normalizeDepField(config);
 
         // FK changed — load fields scoped by the new value, or clear if deselected
         $scope.$watch('values.' + config.fkField, function() {
@@ -123,12 +118,7 @@
               }
             });
           }
-          if (config.depField) {
-            var depPair = ctrl.values.find(function(p) { return p[0] === config.depField; });
-            if (depPair && !Array.isArray(depPair[1])) {
-              depPair[1] = [depPair[1]];
-            }
-          }
+          ctrl._normalizeDepField(config);
 
           // Fire callback BEFORE tracking _lastLoadedDepValue so the callback can modify field values first
           if (config.onFieldsLoaded) {
@@ -149,11 +139,22 @@
         }).catch(function(error) {
           ctrl.refreshing = false;
           ctrl._reloading = false;
+          ctrl._lastLoadedDepValue = null;
           console.error('Failed to load fields:', error);
           if (config.onError) {
             config.onError(error);
           }
         });
+      },
+
+      // Ensure dep field value is array (required by deep-watch comparison and getFields values)
+      _normalizeDepField: function(config) {
+        if (config.depField) {
+          var depPair = this.values.find(function(p) { return p[0] === config.depField; });
+          if (depPair && !Array.isArray(depPair[1])) {
+            depPair[1] = [depPair[1]];
+          }
+        }
       },
 
       // Reset all state when FK field is cleared
@@ -164,7 +165,7 @@
         this._reloading = false;
         this._pendingReload = false;
         this._lastLoadedDepValue = null;
-        this._lastDefaultDepValue = null;
+        this._lastFkMeta = null;
         if (config.onClear) {
           config.onClear();
         }

--- a/ext/search_kit/css/crmSearchDisplay.css
+++ b/ext/search_kit/css/crmSearchDisplay.css
@@ -10,9 +10,9 @@
   opacity: .5;
 }
 
-#bootstrap-theme.crm-search input.ng-invalid,
-#bootstrap-theme.crm-search-display input.ng-invalid,
-.crm-search-task-dialog #bootstrap-theme input.ng-invalid {
+#bootstrap-theme.crm-search input.ng-dirty.ng-invalid,
+#bootstrap-theme.crm-search-display input.ng-dirty.ng-invalid,
+.crm-search-task-dialog #bootstrap-theme input.ng-dirty.ng-invalid {
   border-color: #8a1f11;
 }
 

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -1,6 +1,24 @@
-#bootstrap-theme .crm-search-task-fields {
-  padding-top: 1rem;
-  transition: opacity 0.15s ease;
+.crm-search-task-rows {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.5rem;
+}
+.crm-search-task-row {
+  display: contents;
+}
+.crm-search-task-separator {
+  grid-column: 1 / -1;
+  height: 1rem;
+}
+.crm-search-task-label-event {
+  font-weight: 600;
+}
+.crm-search-task-input crm-search-input {
+  display: block;
+}
+#bootstrap-theme .crm-search-task-row .form-group {
+  margin-bottom: 0;
 }
 .crm-search-task-refreshing {
   opacity: 0.4;

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -1,3 +1,16 @@
+#bootstrap-theme .crm-search-task-fields {
+  padding-top: 1rem;
+  transition: opacity 0.15s ease;
+}
+#bootstrap-theme .crm-search-task-fields .crm-i.fa-exclamation-triangle {
+  margin-inline: var(--crm-l-small, 0.25rem);
+  opacity: .8;
+  color: var(--crm-link-color, #2c789b);
+}
+.crm-search-task-refreshing {
+  opacity: 0.4;
+  pointer-events: none;
+}
 .crm-search-task-progress {
   padding: 10px;
   margin-top: 10px;

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -2,11 +2,6 @@
   padding-top: 1rem;
   transition: opacity 0.15s ease;
 }
-#bootstrap-theme .crm-search-task-fields .crm-i.fa-exclamation-triangle {
-  margin-inline: var(--crm-l-small, 0.25rem);
-  opacity: .8;
-  color: var(--crm-link-color, #2c789b);
-}
 .crm-search-task-refreshing {
   opacity: 0.4;
   pointer-events: none;

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -2,23 +2,28 @@
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--crm-l-medium, 0.5rem);
 }
 .crm-search-task-row {
   display: contents;
 }
 .crm-search-task-separator {
   grid-column: 1 / -1;
-  height: 1rem;
+  height: var(--crm-l-reg, 1rem);
 }
 .crm-search-task-label-event {
-  font-weight: 600;
+  font-weight: var(--crm-input-label-weight);
 }
 .crm-search-task-input crm-search-input {
   display: block;
 }
 #bootstrap-theme .crm-search-task-row .form-group {
   margin-bottom: 0;
+}
+@media (max-width: 767px) {
+  .crm-search-task-rows {
+    grid-template-columns: 1fr;
+  }
 }
 .crm-search-task-refreshing {
   opacity: 0.4;

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -2,17 +2,14 @@
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
-  gap: var(--crm-l-medium, 0.5rem);
+  gap: 0.5rem;
 }
 .crm-search-task-row {
   display: contents;
 }
 .crm-search-task-lazy-separator {
   grid-column: 1 / -1;
-  height: var(--crm-l-reg, 1rem);
-}
-.crm-search-task-label-event {
-  font-weight: var(--crm-input-label-weight);
+  height: 1rem;
 }
 .crm-search-task-input crm-search-input {
   display: block;

--- a/ext/search_kit/css/crmSearchTasks.css
+++ b/ext/search_kit/css/crmSearchTasks.css
@@ -7,7 +7,7 @@
 .crm-search-task-row {
   display: contents;
 }
-.crm-search-task-separator {
+.crm-search-task-lazy-separator {
   grid-column: 1 / -1;
   height: var(--crm-l-reg, 1rem);
 }
@@ -24,10 +24,6 @@
   .crm-search-task-rows {
     grid-template-columns: 1fr;
   }
-}
-.crm-search-task-refreshing {
-  opacity: 0.4;
-  pointer-events: none;
 }
 .crm-search-task-progress {
   padding: 10px;

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -102,7 +102,7 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertNotEmpty($task['uiDialog']);
   }
 
-  public function testRegisterEventEmptySourceDropped(): void {
+  public function testRegisterEventEmptySourceSent(): void {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
 
     $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'EmptySource']);
@@ -113,18 +113,24 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       'end_date' => 'now + 2 months',
     ]);
 
-    // Save without source — like the JS does after stripping empty values
+    // Save with empty source — optional fields are not stripped by JS
     $result = \Civi\Api4\Participant::save(FALSE)
       ->setMatch(['contact_id', 'event_id'])
       ->setDefaults([
         'status_id:name' => 'Registered',
         'role_id' => 1,
       ])
-      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->addRecord([
+        'contact_id' => $contact['id'],
+        'event_id' => $event['id'],
+        'source' => '',
+      ])
       ->execute();
 
     $participant = $result->first();
     $this->assertNotEmpty($participant['id']);
+    $this->assertArrayHasKey('source', $participant);
+    $this->assertEquals('', $participant['source']);
 
     // Verify upsert: same contact+event returns same id (no duplicate created)
     $result2 = \Civi\Api4\Participant::save(FALSE)
@@ -133,7 +139,11 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
         'status_id:name' => 'Registered',
         'role_id' => 1,
       ])
-      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->addRecord([
+        'contact_id' => $contact['id'],
+        'event_id' => $event['id'],
+        'source' => '',
+      ])
       ->execute();
     $this->assertEquals($participant['id'], $result2->first()['id']);
   }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -102,52 +102,6 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertNotEmpty($task['uiDialog']);
   }
 
-  public function testRegisterEventEmptySourceSent(): void {
-    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
-
-    $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'EmptySource']);
-    $event = $this->createTestRecord('Event', [
-      'title' => 'Empty Source Event',
-      'event_type_id' => 1,
-      'start_date' => 'now + 1 month',
-      'end_date' => 'now + 2 months',
-    ]);
-
-    // Save with empty source — optional fields are not stripped by JS
-    $result = \Civi\Api4\Participant::save(FALSE)
-      ->setMatch(['contact_id', 'event_id'])
-      ->setDefaults([
-        'status_id:name' => 'Registered',
-        'role_id' => 1,
-      ])
-      ->addRecord([
-        'contact_id' => $contact['id'],
-        'event_id' => $event['id'],
-        'source' => '',
-      ])
-      ->execute();
-
-    $participant = $result->first();
-    $this->assertNotEmpty($participant['id']);
-    $this->assertArrayHasKey('source', $participant);
-    $this->assertEquals('', $participant['source']);
-
-    // Verify upsert: same contact+event returns same id (no duplicate created)
-    $result2 = \Civi\Api4\Participant::save(FALSE)
-      ->setMatch(['contact_id', 'event_id'])
-      ->setDefaults([
-        'status_id:name' => 'Registered',
-        'role_id' => 1,
-      ])
-      ->addRecord([
-        'contact_id' => $contact['id'],
-        'event_id' => $event['id'],
-        'source' => '',
-      ])
-      ->execute();
-    $this->assertEquals($participant['id'], $result2->first()['id']);
-  }
-
   public function testRegisterEventCustomField(): void {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -102,6 +102,283 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertNotEmpty($task['uiDialog']);
   }
 
+  public function testRegisterEventEmptySourceDropped(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'EmptySource']);
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Empty Source Event',
+      'event_type_id' => 1,
+      'start_date' => 'now + 1 month',
+      'end_date' => 'now + 2 months',
+    ]);
+
+    // Save without source — like the JS does after stripping empty values
+    $result = \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+        'role_id' => 1,
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+
+    $participant = $result->first();
+    $this->assertNotEmpty($participant['id']);
+
+    // Verify upsert: same contact+event returns same id (no duplicate created)
+    $result2 = \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+        'role_id' => 1,
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+    $this->assertEquals($participant['id'], $result2->first()['id']);
+  }
+
+  public function testRegisterEventCustomField(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'CustomField']);
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Custom Field Event',
+      'event_type_id' => 1,
+      'start_date' => 'now + 1 month',
+      'end_date' => 'now + 2 months',
+    ]);
+
+    $cgName = 'reg_test_' . uniqid();
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'name' => $cgName,
+      'title' => 'Register Test',
+      'extends' => 'Participant',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => $cgName,
+      'label' => 'My Field',
+      'name' => 'my_field',
+      'html_type' => 'Text',
+    ]);
+
+    // Save with custom field value
+    \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+        'role_id' => 1,
+      ])
+      ->addRecord([
+        'contact_id' => $contact['id'],
+        'event_id' => $event['id'],
+        $cgName . '.my_field' => 'custom value',
+      ])
+      ->execute();
+
+    // Verify custom field value persisted via get with explicit select
+    $saved = \Civi\Api4\Participant::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->addWhere('event_id', '=', $event['id'])
+      ->addSelect('id', $cgName . '.my_field')
+      ->execute()->first();
+    $this->assertNotEmpty($saved['id']);
+    $this->assertEquals('custom value', $saved[$cgName . '.my_field']);
+
+    // Upsert preserves custom field value when not overwritten
+    \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+        'role_id' => 1,
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+
+    $saved2 = \Civi\Api4\Participant::get(FALSE)
+      ->addWhere('contact_id', '=', $contact['id'])
+      ->addWhere('event_id', '=', $event['id'])
+      ->addSelect('id', $cgName . '.my_field')
+      ->execute()->first();
+    $this->assertEquals('custom value', $saved2[$cgName . '.my_field']);
+  }
+
+  public function testRegisterEventOverwritesRolesOnResave(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'RoleOverwrite']);
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Role Overwrite Event',
+      'event_type_id' => 1,
+      'start_date' => 'now + 1 month',
+      'end_date' => 'now + 2 months',
+    ]);
+
+    // Register with multiple roles
+    $result = \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+        'role_id' => [1, 2],
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+    $participantId = $result->first()['id'];
+    $this->assertNotEmpty($participantId);
+
+    // Verify both roles saved
+    $saved = \Civi\Api4\Participant::get(FALSE)
+      ->addSelect('id', 'role_id')
+      ->addWhere('id', '=', $participantId)
+      ->execute()->first();
+    $this->assertEquals([1, 2], $saved['role_id']);
+
+    // Re-register with a single role — should overwrite, not merge
+    \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+        'role_id' => [1],
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+
+    $saved2 = \Civi\Api4\Participant::get(FALSE)
+      ->addSelect('id', 'role_id')
+      ->addWhere('id', '=', $participantId)
+      ->execute()->first();
+    $this->assertEquals([1], $saved2['role_id'], 'Roles should be overwritten, not appended');
+  }
+
+  public function testRegisterEventPermissionCheck(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $basePerms = ['access CiviCRM', 'manage own search_kit'];
+    $savedSearch = [
+      'api_entity' => 'Contact',
+      'api_params' => [
+        'version' => 4,
+        'select' => ['id'],
+      ],
+    ];
+    $display = [
+      'type' => 'table',
+      'label' => __FUNCTION__,
+      'settings' => [
+        'actions' => TRUE,
+      ],
+    ];
+
+    // Without 'edit event participants', task should be hidden
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = $basePerms;
+
+    $tasks = SearchDisplay::getSearchTasks(TRUE)
+      ->setSavedSearch($savedSearch)
+      ->setDisplay($display)
+      ->execute()->indexBy('name');
+
+    $this->assertArrayNotHasKey('event.register', (array) $tasks);
+
+    // With the permission, task should be visible
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = array_merge($basePerms, ['edit event participants']);
+
+    $tasks2 = SearchDisplay::getSearchTasks(TRUE)
+      ->setSavedSearch($savedSearch)
+      ->setDisplay($display)
+      ->execute()->indexBy('name');
+
+    $this->assertArrayHasKey('event.register', (array) $tasks2);
+  }
+
+  public function testRegisterEventMultipleContacts(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => 2,
+      'defaults' => ['first_name' => 'Multi'],
+    ]);
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Multi Contact Event',
+      'event_type_id' => 1,
+      'start_date' => 'now + 1 month',
+      'end_date' => 'now + 2 months',
+    ]);
+
+    // Simulate what the batch runner does: save each contact with same defaults
+    $ids = [];
+    foreach ($contacts as $contact) {
+      $result = \Civi\Api4\Participant::save(FALSE)
+        ->setMatch(['contact_id', 'event_id'])
+        ->setDefaults([
+          'status_id:name' => 'Registered',
+          'role_id' => 1,
+        ])
+        ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+        ->execute();
+      $ids[] = $result->first()['id'];
+    }
+
+    $this->assertCount(2, $ids);
+    $this->assertNotEquals($ids[0], $ids[1], 'Each contact should get their own participant record');
+  }
+
+  public function testRegisterEventDefaultRoleFromEvent(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'DefaultRole']);
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Default Role Event',
+      'event_type_id' => 1,
+      'default_role_id' => 2,
+      'start_date' => 'now + 1 month',
+      'end_date' => 'now + 2 months',
+    ]);
+
+    // Save without role_id — event's default_role_id should apply via BAO
+    $result = \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'status_id:name' => 'Registered',
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+
+    $saved = \Civi\Api4\Participant::get(FALSE)
+      ->addSelect('id', 'role_id')
+      ->addWhere('id', '=', $result->first()['id'])
+      ->execute()->first();
+    $this->assertEquals([2], $saved['role_id']);
+  }
+
+  public function testRegisterEventDefaultStatusId(): void {
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
+
+    $contact = $this->createTestRecord('Contact', ['first_name' => 'Test', 'last_name' => 'DefaultStatus']);
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Default Status Event',
+      'event_type_id' => 1,
+      'start_date' => 'now + 1 month',
+      'end_date' => 'now + 2 months',
+    ]);
+
+    // Save without status_id — BAO should apply default
+    $result = \Civi\Api4\Participant::save(FALSE)
+      ->setMatch(['contact_id', 'event_id'])
+      ->setDefaults([
+        'role_id' => 1,
+      ])
+      ->addRecord(['contact_id' => $contact['id'], 'event_id' => $event['id']])
+      ->execute();
+
+    $saved = \Civi\Api4\Participant::get(FALSE)
+      ->addSelect('id', 'status_id')
+      ->addWhere('id', '=', $result->first()['id'])
+      ->execute()->first();
+    // Pending from cold (status_id 1) is the BAO default for new participants
+    $this->assertNotNull($saved['status_id']);
+    $this->assertEquals(1, $saved['status_id']);
+  }
+
   public function testAutoFormatName() {
     // Create 3 saved searches; they should all get unique names
     $savedSearch0 = SavedSearch::create(FALSE)

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -74,7 +74,7 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertNull($display['saved_search_id']);
   }
 
-  public function testGetSearchTasksIncludesRegisterParticipantsForContactSearch(): void {
+  public function testGetSearchTasksRegisterEvent(): void {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
 
     $tasks = SearchDisplay::getSearchTasks(FALSE)
@@ -94,11 +94,12 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ])
       ->execute()->indexBy('name');
 
-    $this->assertArrayHasKey('contact.' . \CRM_Contact_Task::ADD_EVENT, (array) $tasks);
-    $task = $tasks['contact.' . \CRM_Contact_Task::ADD_EVENT];
-    $this->assertSame('Register participants for event', $task['title']);
-    $this->assertSame('fa-calendar-plus-o', $task['icon']);
-    $this->assertSame("'civicrm/task/register-participants'", $task['crmPopup']['path']);
+    $this->assertArrayNotHasKey('contact.' . \CRM_Contact_Task::ADD_EVENT, (array) $tasks, 'Old ADD_EVENT task should be excluded via redundant list');
+    $this->assertArrayHasKey('event.register', (array) $tasks);
+    $task = $tasks['event.register'];
+    $this->assertSame('Register for Event', $task['title']);
+    $this->assertSame('fa-ticket', $task['icon']);
+    $this->assertNotEmpty($task['uiDialog']);
   }
 
   public function testAutoFormatName() {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -102,6 +102,13 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
     $this->assertNotEmpty($task['uiDialog']);
   }
 
+  protected function tearDown(): void {
+    \Civi\Api4\CustomGroup::delete(FALSE)
+      ->addWhere('name', 'LIKE', 'reg_test_%')
+      ->execute();
+    parent::tearDown();
+  }
+
   public function testRegisterEventCustomField(): void {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviEvent');
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDisplayTest.php
@@ -338,9 +338,10 @@ class SearchDisplayTest extends \PHPUnit\Framework\TestCase implements HeadlessI
       ->addSelect('id', 'status_id')
       ->addWhere('id', '=', $result->first()['id'])
       ->execute()->first();
-    // Pending from cold (status_id 1) is the BAO default for new participants
+    // Registered is the BAO default for new participants
+    $pendingStatusId = \CRM_Utils_Array::key('Registered', \CRM_Event_BAO_Participant::buildOptions('status_id', 'get'));
     $this->assertNotNull($saved['status_id']);
-    $this->assertEquals(1, $saved['status_id']);
+    $this->assertEquals($pendingStatusId, $saved['status_id']);
   }
 
   public function testAutoFormatName() {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4176,23 +4176,25 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $config = \CRM_Core_Config::singleton();
     $originalPermissions = $config->userPermissionClass->permissions ?? [];
 
-    // Test without edit event participants permission
-    // manage own search_kit is needed to call getSearchTasks with checkPermissions=TRUE
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
+    try {
+      // Test without edit event participants permission
+      // manage own search_kit is needed to call getSearchTasks with checkPermissions=TRUE
+      $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
 
-    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
-    $taskNames = array_column((array) $tasks, 'name');
-    $this->assertNotContains('event.register', $taskNames, 'Task should not appear without edit event participants permission');
+      $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+      $taskNames = array_column((array) $tasks, 'name');
+      $this->assertNotContains('event.register', $taskNames, 'Task should not appear without edit event participants permission');
 
-    // Test with edit event participants permission
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit', 'edit event participants'];
+      // Test with edit event participants permission
+      $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit', 'edit event participants'];
 
-    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
-    $taskNames = array_column((array) $tasks, 'name');
-    $this->assertContains('event.register', $taskNames, 'Task should appear with edit event participants permission');
-
-    // Restore permissions
-    $config->userPermissionClass->permissions = $originalPermissions;
+      $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+      $taskNames = array_column((array) $tasks, 'name');
+      $this->assertContains('event.register', $taskNames, 'Task should appear with edit event participants permission');
+    }
+    finally {
+      $config->userPermissionClass->permissions = $originalPermissions;
+    }
   }
 
   public function testRegisterTestParticipant(): void {
@@ -4214,7 +4216,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       'values' => [
         'contact_id' => $contact['id'],
         'event_id' => $event['id'],
-        'status_id' => 1,
+        'status_id' => \CRM_Utils_Array::key('Registered', \CRM_Event_BAO_Participant::buildOptions('status_id', 'get')),
         'is_test' => TRUE,
       ],
     ]);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4195,57 +4195,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $config->userPermissionClass->permissions = $originalPermissions;
   }
 
-  public function testRegisterEventEndToEnd(): void {
-    // Create test contacts
-    $contacts = $this->saveTestRecords('Contact', [
-      'records' => [
-        ['first_name' => 'John', 'last_name' => uniqid(__FUNCTION__)],
-        ['first_name' => 'Jane', 'last_name' => uniqid(__FUNCTION__)],
-      ],
-      'defaults' => ['contact_type' => 'Individual'],
-    ]);
-
-    // Create test event
-    $event = $this->createTestRecord('Event', [
-      'title' => 'Test Event ' . uniqid(),
-      'is_active' => TRUE,
-      'is_template' => FALSE,
-    ]);
-
-    // Register participants via API
-    $result = civicrm_api4('Participant', 'save', [
-      'checkPermissions' => FALSE,
-      'records' => [
-        [
-          'contact_id' => $contacts[0]['id'],
-          'event_id' => $event['id'],
-          'status_id' => 1,
-          'role_id' => 1,
-        ],
-        [
-          'contact_id' => $contacts[1]['id'],
-          'event_id' => $event['id'],
-          'status_id' => 1,
-          'role_id' => 1,
-        ],
-      ],
-    ]);
-
-    $this->assertCount(2, $result, 'Should create 2 participants');
-
-    // Verify participants exist
-    $participants = civicrm_api4('Participant', 'get', [
-      'checkPermissions' => FALSE,
-      'where' => [['event_id', '=', $event['id']]],
-    ]);
-    $this->assertCount(2, $participants, 'Should find 2 participants for the event');
-
-    // Verify contact IDs
-    $participantContactIds = $participants->column('contact_id');
-    $this->assertContains($contacts[0]['id'], $participantContactIds);
-    $this->assertContains($contacts[1]['id'], $participantContactIds);
-  }
-
   public function testRegisterTestParticipant(): void {
     $contact = $this->createTestRecord('Contact', [
       'first_name' => 'Test',

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4064,57 +4064,6 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $config->userPermissionClass->permissions = $originalPermissions;
   }
 
-  public function testRegisterEventEndToEnd(): void {
-    // Create test contacts
-    $contacts = $this->saveTestRecords('Contact', [
-      'records' => [
-        ['first_name' => 'John', 'last_name' => uniqid(__FUNCTION__)],
-        ['first_name' => 'Jane', 'last_name' => uniqid(__FUNCTION__)],
-      ],
-      'defaults' => ['contact_type' => 'Individual'],
-    ]);
-
-    // Create test event
-    $event = $this->createTestRecord('Event', [
-      'title' => 'Test Event ' . uniqid(),
-      'is_active' => TRUE,
-      'is_template' => FALSE,
-    ]);
-
-    // Register participants via API
-    $result = civicrm_api4('Participant', 'save', [
-      'checkPermissions' => FALSE,
-      'records' => [
-        [
-          'contact_id' => $contacts[0]['id'],
-          'event_id' => $event['id'],
-          'status_id' => 1,
-          'role_id' => 1,
-        ],
-        [
-          'contact_id' => $contacts[1]['id'],
-          'event_id' => $event['id'],
-          'status_id' => 1,
-          'role_id' => 1,
-        ],
-      ],
-    ]);
-
-    $this->assertCount(2, $result, 'Should create 2 participants');
-
-    // Verify participants exist
-    $participants = civicrm_api4('Participant', 'get', [
-      'checkPermissions' => FALSE,
-      'where' => [['event_id', '=', $event['id']]],
-    ]);
-    $this->assertCount(2, $participants, 'Should find 2 participants for the event');
-
-    // Verify contact IDs
-    $participantContactIds = $participants->column('contact_id');
-    $this->assertContains($contacts[0]['id'], $participantContactIds);
-    $this->assertContains($contacts[1]['id'], $participantContactIds);
-  }
-
   public function testRegisterTestParticipant(): void {
     $contact = $this->createTestRecord('Contact', [
       'first_name' => 'Test',

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4016,4 +4016,148 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotContains($contacts[0]['id'], $returnedContactIds, 'Alpha (February 2023) should be excluded');
   }
 
+  public function testRegisterEventTaskExists(): void {
+    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', [
+      'checkPermissions' => FALSE,
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+      ],
+    ]);
+    $taskNames = array_column((array) $tasks, 'name');
+    $this->assertContains('event.register', $taskNames, 'Register for Event task should exist for Contact entity');
+
+    $registerTask = array_filter((array) $tasks, function($task) {
+      return $task['name'] === 'event.register';
+    });
+    $registerTask = reset($registerTask);
+    $this->assertEquals('fa-ticket', $registerTask['icon'] ?? '', 'Task should have ticket icon');
+    $this->assertEquals('Register for Event', $registerTask['title'] ?? '', 'Task should have correct title');
+  }
+
+  public function testRegisterEventTaskPermission(): void {
+    $params = [
+      'checkPermissions' => TRUE,
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+      ],
+    ];
+
+    $config = \CRM_Core_Config::singleton();
+    $originalPermissions = $config->userPermissionClass->permissions ?? [];
+
+    // Test without edit event participants permission
+    // manage own search_kit is needed to call getSearchTasks with checkPermissions=TRUE
+    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
+
+    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+    $taskNames = array_column((array) $tasks, 'name');
+    $this->assertNotContains('event.register', $taskNames, 'Task should not appear without edit event participants permission');
+
+    // Test with edit event participants permission
+    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit', 'edit event participants'];
+
+    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+    $taskNames = array_column((array) $tasks, 'name');
+    $this->assertContains('event.register', $taskNames, 'Task should appear with edit event participants permission');
+
+    // Restore permissions
+    $config->userPermissionClass->permissions = $originalPermissions;
+  }
+
+  public function testRegisterEventEndToEnd(): void {
+    // Create test contacts
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'John', 'last_name' => uniqid(__FUNCTION__)],
+        ['first_name' => 'Jane', 'last_name' => uniqid(__FUNCTION__)],
+      ],
+      'defaults' => ['contact_type' => 'Individual'],
+    ]);
+
+    // Create test event
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Test Event ' . uniqid(),
+      'is_active' => TRUE,
+      'is_template' => FALSE,
+    ]);
+
+    // Register participants via API
+    $result = civicrm_api4('Participant', 'save', [
+      'checkPermissions' => FALSE,
+      'records' => [
+        [
+          'contact_id' => $contacts[0]['id'],
+          'event_id' => $event['id'],
+          'status_id' => 1,
+          'role_id' => 1,
+        ],
+        [
+          'contact_id' => $contacts[1]['id'],
+          'event_id' => $event['id'],
+          'status_id' => 1,
+          'role_id' => 1,
+        ],
+      ],
+    ]);
+
+    $this->assertCount(2, $result, 'Should create 2 participants');
+
+    // Verify participants exist
+    $participants = civicrm_api4('Participant', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [['event_id', '=', $event['id']]],
+    ]);
+    $this->assertCount(2, $participants, 'Should find 2 participants for the event');
+
+    // Verify contact IDs
+    $participantContactIds = $participants->column('contact_id');
+    $this->assertContains($contacts[0]['id'], $participantContactIds);
+    $this->assertContains($contacts[1]['id'], $participantContactIds);
+  }
+
+  public function testRegisterTestParticipant(): void {
+    $contact = $this->createTestRecord('Contact', [
+      'first_name' => 'Test',
+      'last_name' => uniqid(__FUNCTION__),
+      'contact_type' => 'Individual',
+    ]);
+
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Test Event ' . uniqid(),
+      'is_active' => TRUE,
+      'is_template' => FALSE,
+    ]);
+
+    // Create test participant
+    $result = civicrm_api4('Participant', 'create', [
+      'checkPermissions' => FALSE,
+      'values' => [
+        'contact_id' => $contact['id'],
+        'event_id' => $event['id'],
+        'status_id' => 1,
+        'is_test' => TRUE,
+      ],
+    ]);
+
+    $this->assertEquals(TRUE, $result[0]['is_test'], 'Participant should be marked as test');
+
+    // Test participants should be hidden by default
+    $participants = civicrm_api4('Participant', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [['event_id', '=', $event['id']]],
+    ]);
+    $this->assertCount(0, $participants, 'Test participants should be hidden by default');
+
+    // But visible when explicitly queried
+    $testParticipants = civicrm_api4('Participant', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [
+        ['event_id', '=', $event['id']],
+        ['is_test', '=', TRUE],
+      ],
+    ]);
+    $this->assertCount(1, $testParticipants, 'Test participants should be visible when explicitly queried');
+
+  }
+
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4045,23 +4045,25 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $config = \CRM_Core_Config::singleton();
     $originalPermissions = $config->userPermissionClass->permissions ?? [];
 
-    // Test without edit event participants permission
-    // manage own search_kit is needed to call getSearchTasks with checkPermissions=TRUE
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
+    try {
+      // Test without edit event participants permission
+      // manage own search_kit is needed to call getSearchTasks with checkPermissions=TRUE
+      $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
 
-    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
-    $taskNames = array_column((array) $tasks, 'name');
-    $this->assertNotContains('event.register', $taskNames, 'Task should not appear without edit event participants permission');
+      $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+      $taskNames = array_column((array) $tasks, 'name');
+      $this->assertNotContains('event.register', $taskNames, 'Task should not appear without edit event participants permission');
 
-    // Test with edit event participants permission
-    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit', 'edit event participants'];
+      // Test with edit event participants permission
+      $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit', 'edit event participants'];
 
-    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
-    $taskNames = array_column((array) $tasks, 'name');
-    $this->assertContains('event.register', $taskNames, 'Task should appear with edit event participants permission');
-
-    // Restore permissions
-    $config->userPermissionClass->permissions = $originalPermissions;
+      $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+      $taskNames = array_column((array) $tasks, 'name');
+      $this->assertContains('event.register', $taskNames, 'Task should appear with edit event participants permission');
+    }
+    finally {
+      $config->userPermissionClass->permissions = $originalPermissions;
+    }
   }
 
   public function testRegisterTestParticipant(): void {
@@ -4083,7 +4085,7 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
       'values' => [
         'contact_id' => $contact['id'],
         'event_id' => $event['id'],
-        'status_id' => 1,
+        'status_id' => \CRM_Utils_Array::key('Registered', \CRM_Event_BAO_Participant::buildOptions('status_id', 'get')),
         'is_test' => TRUE,
       ],
     ]);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4147,4 +4147,147 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertContains($childGroup['id'], $returnedIds, 'Matching child group should be returned when filtering by title');
   }
 
+  public function testRegisterEventTaskExists(): void {
+    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', [
+      'checkPermissions' => FALSE,
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+      ],
+    ]);
+    $taskNames = array_column((array) $tasks, 'name');
+    $this->assertContains('event.register', $taskNames, 'Register for Event task should exist for Contact entity');
+
+    $registerTask = array_filter((array) $tasks, function($task) {
+      return $task['name'] === 'event.register';
+    });
+    $registerTask = reset($registerTask);
+    $this->assertEquals('fa-ticket', $registerTask['icon'] ?? '', 'Task should have ticket icon');
+    $this->assertEquals('Register for Event', $registerTask['title'] ?? '', 'Task should have correct title');
+  }
+
+  public function testRegisterEventTaskPermission(): void {
+    $params = [
+      'checkPermissions' => TRUE,
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+      ],
+    ];
+
+    $config = \CRM_Core_Config::singleton();
+    $originalPermissions = $config->userPermissionClass->permissions ?? [];
+
+    // Test without edit event participants permission
+    // manage own search_kit is needed to call getSearchTasks with checkPermissions=TRUE
+    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit'];
+
+    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+    $taskNames = array_column((array) $tasks, 'name');
+    $this->assertNotContains('event.register', $taskNames, 'Task should not appear without edit event participants permission');
+
+    // Test with edit event participants permission
+    $config->userPermissionClass->permissions = ['access CiviCRM', 'manage own search_kit', 'edit event participants'];
+
+    $tasks = civicrm_api4('SearchDisplay', 'getSearchTasks', $params);
+    $taskNames = array_column((array) $tasks, 'name');
+    $this->assertContains('event.register', $taskNames, 'Task should appear with edit event participants permission');
+
+    // Restore permissions
+    $config->userPermissionClass->permissions = $originalPermissions;
+  }
+
+  public function testRegisterEventEndToEnd(): void {
+    // Create test contacts
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'John', 'last_name' => uniqid(__FUNCTION__)],
+        ['first_name' => 'Jane', 'last_name' => uniqid(__FUNCTION__)],
+      ],
+      'defaults' => ['contact_type' => 'Individual'],
+    ]);
+
+    // Create test event
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Test Event ' . uniqid(),
+      'is_active' => TRUE,
+      'is_template' => FALSE,
+    ]);
+
+    // Register participants via API
+    $result = civicrm_api4('Participant', 'save', [
+      'checkPermissions' => FALSE,
+      'records' => [
+        [
+          'contact_id' => $contacts[0]['id'],
+          'event_id' => $event['id'],
+          'status_id' => 1,
+          'role_id' => 1,
+        ],
+        [
+          'contact_id' => $contacts[1]['id'],
+          'event_id' => $event['id'],
+          'status_id' => 1,
+          'role_id' => 1,
+        ],
+      ],
+    ]);
+
+    $this->assertCount(2, $result, 'Should create 2 participants');
+
+    // Verify participants exist
+    $participants = civicrm_api4('Participant', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [['event_id', '=', $event['id']]],
+    ]);
+    $this->assertCount(2, $participants, 'Should find 2 participants for the event');
+
+    // Verify contact IDs
+    $participantContactIds = $participants->column('contact_id');
+    $this->assertContains($contacts[0]['id'], $participantContactIds);
+    $this->assertContains($contacts[1]['id'], $participantContactIds);
+  }
+
+  public function testRegisterTestParticipant(): void {
+    $contact = $this->createTestRecord('Contact', [
+      'first_name' => 'Test',
+      'last_name' => uniqid(__FUNCTION__),
+      'contact_type' => 'Individual',
+    ]);
+
+    $event = $this->createTestRecord('Event', [
+      'title' => 'Test Event ' . uniqid(),
+      'is_active' => TRUE,
+      'is_template' => FALSE,
+    ]);
+
+    // Create test participant
+    $result = civicrm_api4('Participant', 'create', [
+      'checkPermissions' => FALSE,
+      'values' => [
+        'contact_id' => $contact['id'],
+        'event_id' => $event['id'],
+        'status_id' => 1,
+        'is_test' => TRUE,
+      ],
+    ]);
+
+    $this->assertEquals(TRUE, $result[0]['is_test'], 'Participant should be marked as test');
+
+    // Test participants should be hidden by default
+    $participants = civicrm_api4('Participant', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [['event_id', '=', $event['id']]],
+    ]);
+    $this->assertCount(0, $participants, 'Test participants should be hidden by default');
+
+    // But visible when explicitly queried
+    $testParticipants = civicrm_api4('Participant', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [
+        ['event_id', '=', $event['id']],
+        ['is_test', '=', TRUE],
+      ],
+    ]);
+    $this->assertCount(1, $testParticipants, 'Test participants should be visible when explicitly queried');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This PR replaces the older, problematic PHP-based popup for registering participants with a SearchKit-native action built using Angular and APIv4 endpoints. It enables consistent batch registration for any number of selected contacts.

Before
----------------------------------------
The previous "Register participants for event" action relied on an older PHP-based pop-up form. This form did not behave as expected or scale properly when multiple contacts were selected simultaneously.
<img width="1725" height="832" alt="Screenshot From 2026-06-09 16-50-22" src="https://github.com/user-attachments/assets/fbea9dec-97de-4c7d-a497-19c5f0e84c25" />

After
----------------------------------------
Contacts can now be registered via a modern, native SearchKit action dialog. It functions reliably regardless of how many contacts are selected.
<img width="1718" height="727" alt="Screenshot From 2026-06-09 16-49-05" src="https://github.com/user-attachments/assets/a9cc71f3-a89e-4575-8172-b969304902ae" />

Technical Details
----------------------------------------
- The task calls existing APIv4 endpoints (`Participant::save` with batch defaults, `Participant::getFields`, `Event::get`) — no new API actions were added.
- A key improvement over the old form-based approach is that default field values can be pre-configured per search display via `hook_civicrm_searchKitTasks`, enabling saved searches that auto-fill event, role, or status for a streamlined workflow.
- Fee handling and price-set selection are not included in this basic registration task, as that is outside its scope.
- Note that date/time fields and the notes section were considered but left out of scope for this initial task. The
dialog includes just the core fields needed for basic registration: event, role(s), status, and source.
- The role(s) are auto populated to the event default when an event is selected.

Comments
----------------------------------------
I started working on a SearchKit-native register participants task before the "Register participants for event" action was recently added, and recently sat down to finish it.

The recently added SearchKit action appears to have an issue — when I select multiple contacts it doesn't behave as expected. The form was a PHP-based popup, not built with Angular and APIv4 endpoints. Rather than try to patch the old form, this replaces it with a SearchKit-native action that works consistently for any number of selected contacts.