### PR TITLE
dev/core#6561 Fix error on recurring contribution with no line items in template

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -544,7 +544,7 @@ LEFT  JOIN civicrm_line_item line  ON ( line.contribution_id = con.id AND line.e
         $result['line_item'] = $isFlattenLineItems ? $lineItems : [$order->getPriceSetID() => $lineItems];
       }
       else {
-        \Civi::log()->warning('Contribution template with no line items loaded. This is unexpected & unsupported');
+        \Civi::log()->warning("Contribution template (id: $templateContribution[id]) has no line items. This is unexpected & unsupported.");
       }
       // If the template contribution was made on-behalf then add the
       // relevant values to ensure the activity reflects that.

--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -543,6 +543,9 @@ LEFT  JOIN civicrm_line_item line  ON ( line.contribution_id = con.id AND line.e
       if ($lineItems) {
         $result['line_item'] = $isFlattenLineItems ? $lineItems : [$order->getPriceSetID() => $lineItems];
       }
+      else {
+        \Civi::log()->warning('Contribution template with no line items loaded. This is unexpected & unsupported');
+      }
       // If the template contribution was made on-behalf then add the
       // relevant values to ensure the activity reflects that.
       $relatedContact = CRM_Contribute_BAO_Contribution::getOnbehalfIds($result['id']);

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -132,7 +132,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     // CRM-16398: If current recurring contribution got > 1 lineitems then make amount field readonly
     $amtAttr = ['size' => 20];
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getContributionRecurID(), [], TRUE);
-    if ($templateContribution && count($templateContribution['line_item']) > 1) {
+    if ($templateContribution && isset($templateContribution['line_item']) && count($templateContribution['line_item']) > 1) {
       $amtAttr += ['readonly' => TRUE];
     }
     $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,

--- a/CRM/Contribute/Form/UpdateSubscription.php
+++ b/CRM/Contribute/Form/UpdateSubscription.php
@@ -132,7 +132,7 @@ class CRM_Contribute_Form_UpdateSubscription extends CRM_Contribute_Form_Contrib
     // CRM-16398: If current recurring contribution got > 1 lineitems then make amount field readonly
     $amtAttr = ['size' => 20];
     $templateContribution = CRM_Contribute_BAO_ContributionRecur::getTemplateContribution($this->getContributionRecurID(), [], TRUE);
-    if ($templateContribution && isset($templateContribution['line_item']) && count($templateContribution['line_item']) > 1) {
+    if (count($templateContribution['line_item'] ?? []) > 1) {
       $amtAttr += ['readonly' => TRUE];
     }
     $this->addMoney('amount', ts('Recurring Contribution Amount'), TRUE, $amtAttr,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6561 Fix error on recurring contribution with no line items in template

Before
----------------------------------------
Template contributions are expected to have line items. Not having them is bad data - but it should not cause an avoidable fatal error here

After
----------------------------------------
Fatal error has gone - some log noise instead

Technical Details
----------------------------------------

Comments
----------------------------------------
