### PR TITLE
Add metadata to Afform validate event

### DIFF
--- a/ang/crmUtil/crmApiErrors.js
+++ b/ang/crmUtil/crmApiErrors.js
@@ -1,0 +1,108 @@
+// https://civicrm.org/licensing
+(function (angular, $) {
+  "use strict";
+
+  /**
+   * Turns Civi\Api4\Generic\Result error data into CRM.alert() calls.
+   *
+   * Shared by the `af` module (afForm.component.js) and `crmSearchTasks`
+   * (crmSearchBatchRunner.component.js) via `crmUtil`, so the mapping from
+   * api4 errors to an alert only exists in one place.
+   */
+  angular.module('crmUtil').factory('crmApiErrors', function() {
+    const ts = CRM.ts();
+
+    // CRM.alert() only recognizes a handful of `type` values; Psr\Log\LogLevel has more.
+    const LEVEL_TO_ALERT_TYPE = {
+      emergency: 'error',
+      alert: 'error',
+      critical: 'error',
+      error: 'error',
+      warning: 'warning',
+      notice: 'info',
+      info: 'info',
+      debug: 'info'
+    };
+
+    // Most-to-least severe.
+    const LEVEL_ORDER = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
+
+    /**
+     * Normalize one error into `{message, title, level, code}`, regardless of which of the
+     * currently-in-use shapes it arrived in:
+     *  - Civi\Api4\Generic\Error::jsonSerialize() -> {message, code, title, level, id}
+     *  - CRM_Api4_Page_AJAX exception shape -> {error_message, error_code}
+     *
+     * @param {Object} error
+     * @return {{message: string, title: string, level: string, code: (string|number)}}
+     */
+    function normalizeError(error) {
+      if (!error) {
+        return {message: ts('Unknown error'), title: '', level: 'error', code: 0};
+      }
+      return {
+        message: error.message || error.error_message || ts('Unknown error'),
+        title: error.title || '',
+        level: error.level || 'error',
+        code: error.code || error.error_code || 0
+      };
+    }
+
+    /**
+     * @param {Array|Object} errors An array of raw errors, or a single raw error.
+     * @return {Array}
+     */
+    function normalizeErrors(errors) {
+      const list = angular.isArray(errors) ? errors : [errors];
+      return list.map(normalizeError);
+    }
+
+    /**
+     * @param {string} level A Psr\Log\LogLevel string.
+     * @return {string} A type recognized by CRM.alert().
+     */
+    function mapLevelToAlertType(level) {
+      return LEVEL_TO_ALERT_TYPE[level] || 'error';
+    }
+
+    /**
+     * Combine normalized errors into one alert-ready {message, title}, most severe first.
+     *
+     * @param {Array} errors Normalized errors (see normalizeErrors()).
+     * @return {{message: string, title: string}}
+     */
+    function buildAlertMessage(errors) {
+      const sorted = errors.slice().sort((a, b) => {
+        const indexA = LEVEL_ORDER.indexOf(a.level);
+        const indexB = LEVEL_ORDER.indexOf(b.level);
+        return (indexA === -1 ? LEVEL_ORDER.length : indexA) - (indexB === -1 ? LEVEL_ORDER.length : indexB);
+      });
+      const message = sorted.map((error) => error.message).join('<br>');
+      const title = sorted.length > 1 ? ts('Please resolve these issues') : ((sorted[0] && sorted[0].title) || ts('Validation errors'));
+      return {message: message, title: title};
+    }
+
+    /**
+     * Normalize raw error(s) from an api4 response and show them via CRM.alert().
+     *
+     * @param {Array|Object} errors Raw error(s), e.g. `response.errors`, or a single caught error.
+     * @param {string} [maxErrorLevel] e.g. `response.max_error_level`. Defaults to the most severe
+     *   level found amongst `errors`.
+     */
+    function showErrors(errors, maxErrorLevel) {
+      const normalized = normalizeErrors(errors);
+      const built = buildAlertMessage(normalized);
+      const level = maxErrorLevel || (normalized[0] && normalized[0].level) || 'error';
+      CRM.alert(built.message, built.title, mapLevelToAlertType(level));
+    }
+
+    return {
+      normalizeError: normalizeError,
+      normalizeErrors: normalizeErrors,
+      mapLevelToAlertType: mapLevelToAlertType,
+      buildAlertMessage: buildAlertMessage,
+      showErrors: showErrors
+    };
+  });
+
+})(angular, CRM.$);

--- a/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
@@ -4,15 +4,13 @@ namespace Civi\Afform\Event;
 
 use Civi\Afform\FormDataModel;
 use Civi\Api4\Action\Afform\Submit;
+use Civi\Api4\Generic\Result;
 
 class AfformValidateEvent extends AfformBaseEvent {
 
-  /**
-   * @var array
-   */
-  private array $errors = [];
-
   private array $entityFieldDefn = [];
+
+  private Result $result;
 
   /**
    * AfformValidateEvent constructor.
@@ -21,8 +19,16 @@ class AfformValidateEvent extends AfformBaseEvent {
    * @param \Civi\Afform\FormDataModel $formDataModel
    * @param \Civi\Api4\Action\Afform\Submit $apiRequest
    */
-  public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest) {
+  public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest, Result $result) {
     parent::__construct($afform, $formDataModel, $apiRequest);
+    $this->result = $result;
+  }
+
+  /**
+   * @return \Civi\Api4\Generic\Result
+   */
+  public function getResult(): Result {
+    return $this->result;
   }
 
   /**
@@ -35,8 +41,8 @@ class AfformValidateEvent extends AfformBaseEvent {
    * @deprecated
    */
   public function setError(string $errorMsg): void {
-    \CRM_Core_Error::deprecatedFunctionWarning('addError');
-    $this->errors[] = $errorMsg;
+    \CRM_Core_Error::deprecatedFunctionWarning('$this->getResult()->addError()');
+    $this->getResult()->addError($errorMsg);
   }
 
   /**
@@ -45,9 +51,12 @@ class AfformValidateEvent extends AfformBaseEvent {
    * @param string $errorMsg
    *
    * @return void
+   *
+   * @deprecated
    */
   public function addError(string $errorMsg): void {
-    $this->errors[] = $errorMsg;
+    \CRM_Core_Error::deprecatedFunctionWarning('$this->getResult()->addError()');
+    $this->result->addError($errorMsg);
   }
 
   /**
@@ -56,18 +65,24 @@ class AfformValidateEvent extends AfformBaseEvent {
    * @param array $errors
    *
    * @return void
+   *
+   * @deprecated
    */
   public function setErrors(array $errors): void {
-    $this->errors = $errors;
+    \CRM_Core_Error::deprecatedFunctionWarning('$this->getResult()->setErrors()');
+    $this->result->setErrors($errors);
   }
 
   /**
    * Get all errors that have been set by other callers
    *
    * @return array
+   *
+   * @deprecated
    */
   public function getErrors(): array {
-    return $this->errors;
+    \CRM_Core_Error::deprecatedFunctionWarning('$this->getResult()->getErrors()');
+    return $this->result->getErrors();
   }
 
   /**

--- a/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformValidateEvent.php
@@ -18,6 +18,7 @@ class AfformValidateEvent extends AfformBaseEvent {
    * @param array $afform
    * @param \Civi\Afform\FormDataModel $formDataModel
    * @param \Civi\Api4\Action\Afform\Submit $apiRequest
+   * @param \Civi\Api4\Generic\Result $result
    */
   public function __construct(array $afform, FormDataModel $formDataModel, Submit $apiRequest, Result $result) {
     parent::__construct($afform, $formDataModel, $apiRequest);

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -139,7 +139,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     $this->_formDataModel = new FormDataModel($this->_afform['layout']);
     $this->loadEntities();
     // TODO: use _response more consistently
-    $result->exchangeArray($this->processForm());
+    $this->processForm($result);
   }
 
   /**
@@ -449,9 +449,11 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
+   * @param \Civi\Api4\Generic\Result $result
+   *
    * @return array
    */
-  abstract protected function processForm();
+  abstract protected function processForm(Result $result);
 
   /**
    * Gets the clause for looking up join entities, or NULL if not available.

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -139,7 +139,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     $this->_formDataModel = new FormDataModel($this->_afform['layout']);
     $this->loadEntities();
     // TODO: use _response more consistently
-    $this->processForm($result);
+    $result->exchangeArray($this->processForm($result));
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/GetOptions.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\Afform;
 
+use Civi\Api4\Generic\Result;
 use Civi\Api4\SavedSearch;
 use Civi\Api4\Utils\FormattingUtil;
 
@@ -46,7 +47,7 @@ class GetOptions extends AbstractProcessor {
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function processForm() {
+  protected function processForm(Result $result) {
     $formEntity = $this->_formDataModel->getEntity($this->modelName);
     $searchDisplay = $this->_formDataModel->getSearchDisplay($this->modelName);
     $fieldName = $this->fieldName;

--- a/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Prefill.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Api4\Action\Afform;
 
+use Civi\Api4\Generic\Result;
+
 /**
  * Class Prefill
  *
@@ -9,7 +11,7 @@ namespace Civi\Api4\Action\Afform;
  */
 class Prefill extends AbstractProcessor {
 
-  protected function processForm() {
+  protected function processForm(Result $result) {
     $entityValues = $this->_entityValues;
     return \CRM_Utils_Array::makeNonAssociative($entityValues, 'name', 'values');
   }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Process.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Process.php
@@ -3,6 +3,7 @@
 namespace Civi\Api4\Action\Afform;
 
 use Civi\Api4\AfformSubmission;
+use Civi\Api4\Generic\Result;
 
 /**
  * Class Process
@@ -17,7 +18,7 @@ class Process extends AbstractProcessor {
    */
   protected $submissionId;
 
-  protected function processForm() {
+  protected function processForm(Result $result) {
     // get the submitted data
     $afformSubmissionData = AfformSubmission::get(FALSE)
       ->addSelect('data')

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Api4\Action\Afform;
 
+use Civi\Api4\Generic\Result;
 use Civi\Api4\Generic\Traits\ArrayQueryActionTrait;
 use CRM_Afform_ExtensionUtil as E;
 use Civi\Afform\Event\AfformSubmitEvent;
@@ -26,7 +27,7 @@ class Submit extends AbstractProcessor {
    */
   protected $values;
 
-  protected function validate(): array {
+  protected function validate(Result $result): Result {
     // preprocess submitted values
     $this->_entityValues = $this->preprocessSubmittedValues($this->values);
 
@@ -46,16 +47,22 @@ class Submit extends AbstractProcessor {
     }
 
     // Call validation handlers
-    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this);
+    $event = new AfformValidateEvent($this->_afform, $this->_formDataModel, $this, $result);
     \Civi::dispatcher()->dispatch('civi.afform.validate', $event);
-    return $event->getErrors();
+    return $result;
   }
 
-  protected function processForm() {
-    $errors = $this->validate();
-    if ($errors) {
-      \Civi::log('afform')->error('Afform Validation errors: ' . print_r($errors, TRUE));
-      throw new \CRM_Core_Exception(implode("\n", $errors), 0, ['show_detailed_error' => TRUE]);
+  protected function processForm(Result $result) {
+    $validateResult = $this->validate($result);
+    if ($validateResult->hasErrors()) {
+      // Add error data from Result object
+      $this->setResponseItem('errors', $result->getErrors());
+      $this->setResponseItem('max_error_level', $result->getMaxErrorLevel());
+      $this->setResponseItem('is_blocking_error', $result->isBlockingError());
+      \Civi::log('afform')->error('Afform Validation errors: ' . print_r($validateResult->getErrors(), TRUE));
+      if ($validateResult->isBlockingError()) {
+        return [$this->_response];
+      }
     }
 
     // Save submission record
@@ -147,7 +154,7 @@ class Submit extends AbstractProcessor {
           $fieldDefn = $event->getEntityFieldDefn($afEntityName, $fieldName);
           $error = self::getFieldInputError($event, $fieldName, $fieldDefn, $attributes, $values['fields'][$fieldName] ?? NULL);
           if ($error) {
-            $event->addError($error);
+            $event->getResult()->addError($error, FALSE, 'field_input_error');
           }
         }
         foreach ($afEntity['joins'] ?? [] as $joinEntity => $join) {
@@ -156,7 +163,7 @@ class Submit extends AbstractProcessor {
               $fieldDefn = $event->getEntityFieldDefn($afEntityName, $fieldName, $joinEntity);
               $error = self::getFieldInputError($event, $fieldName, $fieldDefn, $attributes, $joinValues[$fieldName] ?? NULL);
               if ($error) {
-                $event->addError($error);
+                $event->getResult()->addError($error, FALSE, 'field_input_error');
               }
             }
           }
@@ -233,7 +240,7 @@ class Submit extends AbstractProcessor {
         foreach ($entity['fields'] as $fieldName => $attributes) {
           $error = self::getEntityRefError($formName, $entityName, $entity['type'], $fieldName, $attributes, $values['fields'][$fieldName] ?? NULL);
           if ($error) {
-            $event->addError($error);
+            $event->getResult()->addError($error, FALSE, 'entity_ref_error');
           }
         }
         foreach ($entity['joins'] ?? [] as $joinEntity => $join) {
@@ -241,7 +248,7 @@ class Submit extends AbstractProcessor {
             foreach ($join['fields'] ?? [] as $fieldName => $attributes) {
               $error = self::getEntityRefError($formName, $entityName . '+' . $joinEntity, $joinEntity, $fieldName, $attributes, $joinValues[$fieldName] ?? NULL);
               if ($error) {
-                $event->addError($error);
+                $event->getResult()->addError($error, FALSE, 'entity_ref_error');
               }
             }
           }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -52,14 +52,22 @@ class Submit extends AbstractProcessor {
     return $result;
   }
 
+  /**
+   * Copies error data from the Result onto the response.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   */
+  protected function setErrorResponseItems(Result $result): void {
+    $this->setResponseItem('errors', $result->getErrors());
+    $this->setResponseItem('max_error_level', $result->getMaxErrorLevel());
+    $this->setResponseItem('is_blocking_error', $result->isBlockingError());
+    \Civi::log('afform')->error('Afform Validation errors: ' . print_r($result->getErrors(), TRUE));
+  }
+
   protected function processForm(Result $result) {
     $validateResult = $this->validate($result);
     if ($validateResult->hasErrors()) {
-      // Add error data from Result object
-      $this->setResponseItem('errors', $result->getErrors());
-      $this->setResponseItem('max_error_level', $result->getMaxErrorLevel());
-      $this->setResponseItem('is_blocking_error', $result->isBlockingError());
-      \Civi::log('afform')->error('Afform Validation errors: ' . print_r($validateResult->getErrors(), TRUE));
+      $this->setErrorResponseItems($validateResult);
       if ($validateResult->isBlockingError()) {
         return [$this->_response];
       }

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitDraft.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitDraft.php
@@ -4,6 +4,7 @@ namespace Civi\Api4\Action\Afform;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\AfformSubmission;
+use Civi\Api4\Generic\Result;
 
 /**
  * Class Submit
@@ -18,7 +19,7 @@ class SubmitDraft extends AbstractProcessor {
    */
   protected $values;
 
-  protected function processForm() {
+  protected function processForm(Result $result) {
     $cid = \CRM_Core_Session::getLoggedInContactID();
     if (!$cid) {
       throw new UnauthorizedException('Only authenticated users may save a draft.');

--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -4,6 +4,7 @@ namespace Civi\Api4\Action\Afform;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\AfformSubmission;
+use Civi\Api4\Generic\Result;
 use Civi\Api4\Utils\CoreUtil;
 
 /**
@@ -60,7 +61,7 @@ class SubmitFile extends AbstractProcessor {
    */
   protected $joinIndex;
 
-  protected function processForm() {
+  protected function processForm(Result $result) {
     if (empty($_FILES['file'])) {
       throw new \CRM_Core_Exception('File upload required');
     }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Validate.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Validate.php
@@ -2,19 +2,23 @@
 
 namespace Civi\Api4\Action\Afform;
 
+use Civi\Api4\Generic\Result;
+
 /**
  * Class Validate
+ *
  * @package Civi\Api4\Action\Afform
  */
 class Validate extends Submit {
 
-  protected function processForm() {
-    $errors = $this->validate();
-    if ($errors) {
-      $this->setResponseItem('errors', $errors);
-      $this->setResponseItem('is_error', TRUE);
-    }
-
+  /**
+   * @param \Civi\Api4\Generic\Result $result
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  protected function processForm(Result $result) {
+    $this->validate($result);
     return [$this->_response];
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Validate.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Validate.php
@@ -18,7 +18,10 @@ class Validate extends Submit {
    * @throws \CRM_Core_Exception
    */
   protected function processForm(Result $result) {
-    $this->validate($result);
+    $validateResult = $this->validate($result);
+    if ($validateResult->hasErrors()) {
+      $this->setErrorResponseItems($validateResult);
+    }
     return [$this->_response];
   }
 

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -392,6 +392,22 @@
         CRM.alert(errorMsg, ts('Sorry'), 'error');
       }
 
+      const handleErrors = (errors, maxErrorLevel) => {
+        let errorMessage = '';
+        let title = '';
+        errors.forEach(error => {
+          errorMessage += error.message;
+          title = error.title;
+        });
+        if (errors.length > 1) {
+          title = ts('Please resolve these issues');
+        }
+        if (title === '') {
+          title = ts('Validation errors');
+        }
+        CRM.alert(errorMessage, title, maxErrorLevel);
+      };
+
       const handleError = (error) => {
         // see: CRM/Api4/Page/AJAX.php
         if (error && error.error_code !== '1') {
@@ -414,6 +430,19 @@
           name: this.getFormMeta().name,
           args: args,
           values: data,
+        }).then((response) => {
+          if (response.is_blocking_error) {
+            handleErrors(response.errors, response.max_error_level);
+          }
+        })
+        .catch((error) => {
+          $element.unblock();
+          handleError(error);
+          $element.trigger('crmFormError', {
+            afform: ctrl.getFormMeta(),
+            data: data,
+            error: error
+          });
         });
       };
 
@@ -468,6 +497,10 @@
           args: args,
           values: data,
         }).then((response) => {
+          if (response.is_blocking_error) {
+            this.handleSubmitError(response);
+            return;
+          }
           submissionResponse = response;
           if (ctrl.fileUploader.getNotUploadedItems().length) {
             _.each(ctrl.fileUploader.getNotUploadedItems(), function(file) {
@@ -485,15 +518,13 @@
           }
         })
         .catch((error) => {
-          $element.unblock();
-
-          handleError(error);
-
-          $element.trigger('crmFormError', {
-            afform: ctrl.getFormMeta(),
-            data: data,
-            submissionResponse: submissionResponse,
-            error: error
+          this.handleSubmitError({
+            errors: [{
+              error_message: error.error_message,
+              error_code: error.error_code,
+            }],
+            is_blocking_error: true,
+            max_error_level: 'error'
           });
         });
         // Show unobtrusive status indicator.
@@ -501,6 +532,25 @@
           // Defaults for `start` and `success` are 'Saving...' and 'Saved' .
           error: ts('Not Saved'),
         }, submitApi);
+      };
+
+      this.handleSubmitError = function(response) {
+        $element.unblock();
+
+        // @fixme: Need to handle all errors per PR X
+        let error = response.errors[0];
+        // @fixme: Temporary map of keys for new API4 error Result
+        error.error_code = error.code;
+        error.error_message = error.message;
+
+        handleError(error);
+
+        $element.trigger('crmFormError', {
+          afform: ctrl.getFormMeta(),
+          data: data,
+          submissionResponse: submissionResponse,
+          error: error
+        });
       };
 
       this.submitDraft = function() {

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -8,7 +8,7 @@
     require: {
       ngForm: 'form'
     },
-    controller: function($scope, $element, $timeout, crmApi4, crmStatus, $window, $location, $parse, FileUploader) {
+    controller: function($scope, $element, $timeout, crmApi4, crmApiErrors, crmStatus, $window, $location, $parse, FileUploader) {
       const
         ctrl = this,
         ts = CRM.ts('org.civicrm.afform');
@@ -392,29 +392,13 @@
         CRM.alert(errorMsg, ts('Sorry'), 'error');
       }
 
-      const handleErrors = (errors, maxErrorLevel) => {
-        let errorMessage = '';
-        let title = '';
-        errors.forEach(error => {
-          errorMessage += error.message;
-          title = error.title;
-        });
-        if (errors.length > 1) {
-          title = ts('Please resolve these issues');
-        }
-        if (title === '') {
-          title = ts('Validation errors');
-        }
-        CRM.alert(errorMessage, title, maxErrorLevel);
-      };
-
       const handleError = (error) => {
         // see: CRM/Api4/Page/AJAX.php
+        const message = crmApiErrors.normalizeError(error).message;
         if (error && error.error_code !== '1') {
-          CRM.alert(error.error_message, ts('Please resolve these issues'), 'warning');
+          CRM.alert(message, ts('Please resolve these issues'), 'warning');
         }
         else {
-          const message = error?.error_message ? error.error_message : ts('Unknown error');
           CRM.alert(message, ts('There is a problem'), 'error');
         }
       };
@@ -432,7 +416,7 @@
           values: data,
         }).then((response) => {
           if (response.is_blocking_error) {
-            handleErrors(response.errors, response.max_error_level);
+            crmApiErrors.showErrors(response.errors, response.max_error_level);
           }
         })
         .catch((error) => {
@@ -518,13 +502,13 @@
           }
         })
         .catch((error) => {
-          this.handleSubmitError({
-            errors: [{
-              error_message: error.error_message,
-              error_code: error.error_code,
-            }],
-            is_blocking_error: true,
-            max_error_level: 'error'
+          $element.unblock();
+          handleError(error);
+          $element.trigger('crmFormError', {
+            afform: ctrl.getFormMeta(),
+            data: data,
+            submissionResponse: submissionResponse,
+            error: error
           });
         });
         // Show unobtrusive status indicator.
@@ -534,22 +518,17 @@
         }, submitApi);
       };
 
+      // Handles a graceful is_blocking_error response (a thrown exception goes through the .catch() above).
       this.handleSubmitError = function(response) {
         $element.unblock();
 
-        // @fixme: Need to handle all errors per PR X
-        let error = response.errors[0];
-        // @fixme: Temporary map of keys for new API4 error Result
-        error.error_code = error.code;
-        error.error_message = error.message;
-
-        handleError(error);
+        crmApiErrors.showErrors(response.errors, response.max_error_level);
 
         $element.trigger('crmFormError', {
           afform: ctrl.getFormMeta(),
           data: data,
           submissionResponse: submissionResponse,
-          error: error
+          error: crmApiErrors.normalizeErrors(response.errors)[0]
         });
       };
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -83,16 +83,11 @@ EOHTML;
         ],
       ],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($values)
-        ->execute();
-      $this->fail();
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('Illegal value for Existing Individual.', $e->getMessage());
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+    $this->assertEquals('Illegal value for Existing Individual.', $this->getBlockingErrorMessages($result));
 
     // Submit with a valid ID, it should work
     $values['Individual1'][0]['fields']['id'] = $contacts['B'];
@@ -196,16 +191,11 @@ EOHTML;
         ],
       ],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($values)
-        ->execute();
-      $this->fail();
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('Illegal value for test_af_fields: contact_ref.', $e->getMessage());
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+    $this->assertEquals('Illegal value for test_af_fields: contact_ref.', $this->getBlockingErrorMessages($result));
 
     // Submit with a valid ID, it should work
     $values['Individual1'][0]['fields']['test_af_fields.contact_ref'] = $contacts['B'];
@@ -302,16 +292,11 @@ EOHTML;
         ],
       ],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($values)
-        ->execute();
-      $this->fail();
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertEquals('Illegal value for test_address_fields: contact_ref.', $e->getMessage());
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+    $this->assertEquals('Illegal value for test_address_fields: contact_ref.', $this->getBlockingErrorMessages($result));
 
     // Submit with a valid ID, it should work
     $values['Individual1'][0]['joins']['Address'][0]['test_address_fields.contact_ref'] = $contacts['A'];

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -37,29 +37,21 @@ EOHTML;
     $submission = [
       ['fields' => ['first_name' => 'a', 'last_name' => '']],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-    }
-    catch (\CRM_Core_Exception $e) {
-    }
-    $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $this->assertStringContainsString('Last Name is a required field.', $this->getBlockingErrorMessages($result));
 
     // Conditional field shown: this will fail validation
     $submission = [
       ['fields' => ['first_name' => 'ebcd', 'last_name' => '']],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-    }
-    catch (\CRM_Core_Exception $e) {
-    }
-    $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $this->assertStringContainsString('Last Name is a required field.', $this->getBlockingErrorMessages($result));
 
     // Conditional field hidden: this will pass validation
     $submission = [
@@ -111,15 +103,11 @@ EOHTML;
         ],
       ],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-    }
-    catch (\CRM_Core_Exception $e) {
-    }
-    $this->assertStringContainsString('Email is a required field.', $e->getMessage());
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $this->assertStringContainsString('Email is a required field.', $this->getBlockingErrorMessages($result));
 
     // Conditional field hidden: this will pass validation
     $submission = [
@@ -165,16 +153,11 @@ EOHTML;
     $submission = [
       ['fields' => ['first_name' => 'A', 'last_name' => '']],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-      $this->fail('Expected validation error for missing last_name under af-required condition.');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $this->assertStringContainsString('Last Name is a required field.', $this->getBlockingErrorMessages($result));
 
     // first_name = B, last_name = empty -> should pass
     $submission = [
@@ -254,16 +237,11 @@ EOHTML;
     $submission = [
       ['fields' => ['first_name' => 'B', 'last_name' => '']],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-      $this->fail('Expected validation error for missing last_name because it is not disabled.');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $this->assertStringContainsString('Last Name is a required field.', $this->getBlockingErrorMessages($result));
   }
 
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformContactUsageTest.php
@@ -504,19 +504,14 @@ EOHTML;
       ],
     ];
 
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($values)
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      // Should fail required fields missing
-      $this->assertStringContainsString('First Name is a required field', $e->getMessage());
-      $this->assertStringContainsString('Email is a required field', $e->getMessage());
-    }
-
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+    // Should fail required fields missing
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('First Name is a required field', $msg);
+    $this->assertStringContainsString('Email is a required field', $msg);
   }
 
   public function testFormValidationMaxlength(): void {
@@ -541,17 +536,12 @@ EOHTML;
       ],
     ];
 
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($values)
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      // Should fail required fields missing
-      $this->assertEquals('Last Name has a max length of 20.', $e->getMessage());
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+    // Should fail required fields missing
+    $this->assertEquals('Last Name has a max length of 20.', $this->getBlockingErrorMessages($result));
   }
 
   public function testFormValidationEntityJoinFields(): void {
@@ -574,18 +564,12 @@ EOHTML;
       ],
     ];
 
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($values)
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      // Should fail required fields missing
-      $this->assertEquals('Email is a required field.', $e->getMessage());
-    }
-
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($values)
+      ->execute();
+    // Should fail required fields missing
+    $this->assertEquals('Email is a required field.', $this->getBlockingErrorMessages($result));
   }
 
   public function testSubmissionLimit() {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
@@ -122,13 +122,11 @@ EOHTML;
       ],
     ];
 
-    $this->expectException(\CRM_Core_Exception::class);
-    $this->expectExceptionMessage('Please go back and complete the CAPTCHA');
-
-    Afform::submit()
+    $result = Afform::submit()
       ->setName($this->formName)
       ->setValues($submission)
       ->execute();
+    $this->assertStringContainsString('Please go back and complete the CAPTCHA', $this->getBlockingErrorMessages($result));
   }
 
   public function testSubmitWithRepeatMinZero(): void {
@@ -182,16 +180,11 @@ EOHTML;
       ],
     ];
 
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues($submissionOneEmptyItem)
-        ->execute();
-      $this->fail('Should have thrown validation exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-    }
-    $this->assertEquals('Email is a required field.', $e->getMessage());
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($submissionOneEmptyItem)
+      ->execute();
+    $this->assertEquals('Email is a required field.', $this->getBlockingErrorMessages($result));
   }
 
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformUsageTestCase.php
@@ -46,4 +46,16 @@ abstract class AfformUsageTestCase extends AfformTestCase {
       ->execute();
   }
 
+  /**
+   * Asserts the result has a blocking error, and returns its messages combined into one string.
+   *
+   * @param \Civi\Api4\Generic\Result $result
+   * @return string
+   */
+  protected function getBlockingErrorMessages(\Civi\Api4\Generic\Result $result): string {
+    $response = $result->first();
+    $this->assertTrue($response['is_blocking_error'] ?? FALSE, 'Expected a blocking validation error');
+    return implode("\n", array_map(fn (\Civi\Api4\Generic\Error $error) => $error->getMessage(), $response['errors']));
+  }
+
 }

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformValidateUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformValidateUsageTest.php
@@ -231,8 +231,8 @@ EOHTML;
     $response = $result->first();
     $this->assertTrue($response['is_error'] ?? FALSE);
     $this->assertCount(2, $response['errors']);
-    $this->assertStringContainsString('First Name is a required field', implode("\n", $response['errors']));
-    $this->assertStringContainsString('Last Name is a required field', implode("\n", $response['errors']));
+    $this->assertStringContainsString('First Name is a required field', implode("\n", array_column($response['errors'], 'message')));
+    $this->assertStringContainsString('Last Name is a required field', implode("\n", array_column($response['errors'], 'message')));
 
     // Validate with valid values. Should return no errors.
     $validSubmission = [

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformValidateUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformValidateUsageTest.php
@@ -33,18 +33,13 @@ EOHTML;
     $submission = [
       ['fields' => ['middle_name' => 'Person']],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $msg = $e->getMessage();
-      $this->assertStringContainsString('First Name is a required field', $msg);
-      $this->assertStringContainsString('Last Name is a required field', $msg);
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('First Name is a required field', $msg);
+    $this->assertStringContainsString('Last Name is a required field', $msg);
   }
 
   public function testSubmitWithMaxLengthValidation(): void {
@@ -67,18 +62,13 @@ EOHTML;
     $submission = [
       ['fields' => ['first_name' => 'TooLongName']],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $msg = $e->getMessage();
-      $this->assertStringContainsString('First Name', $msg);
-      $this->assertStringContainsString('length of 5', $msg);
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('First Name', $msg);
+    $this->assertStringContainsString('length of 5', $msg);
 
     Afform::submit()
       ->setName($this->formName)
@@ -106,35 +96,25 @@ EOHTML;
     $submission = [
       ['fields' => ['external_identifier' => 5]],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $msg = $e->getMessage();
-      $this->assertStringContainsString('External', $msg);
-      $this->assertStringContainsString('to 10', $msg);
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('External', $msg);
+    $this->assertStringContainsString('to 10', $msg);
 
     // Submit with value above maximum. Should get validation error.
     $submission = [
       ['fields' => ['external_identifier' => 150]],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Individual1' => $submission])
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $msg = $e->getMessage();
-      $this->assertStringContainsString('External', $msg);
-      $this->assertStringContainsString('to 100', $msg);
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('External', $msg);
+    $this->assertStringContainsString('to 100', $msg);
 
     // Submit with valid value. Should succeed.
     Afform::submit()
@@ -163,35 +143,25 @@ EOHTML;
     $submission = [
       ['fields' => ['role_id' => [1]]],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Participant1' => $submission])
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $msg = $e->getMessage();
-      $this->assertStringContainsString('Participant Role', $msg);
-      $this->assertStringContainsString('at least 2', $msg);
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Participant1' => $submission])
+      ->execute();
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('Participant Role', $msg);
+    $this->assertStringContainsString('at least 2', $msg);
 
     // Submit with more selections than maximum. Should get validation error.
     $submission = [
       ['fields' => ['role_id' => [1, 2, 3, 4]]],
     ];
-    try {
-      Afform::submit()
-        ->setName($this->formName)
-        ->setValues(['Participant1' => $submission])
-        ->execute();
-      $this->fail('Should have thrown exception');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $msg = $e->getMessage();
-      $this->assertStringContainsString('Participant Role', $msg);
-      $this->assertStringContainsString('at most 3', $msg);
-    }
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Participant1' => $submission])
+      ->execute();
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('Participant Role', $msg);
+    $this->assertStringContainsString('at most 3', $msg);
 
     // Submit with valid number of selections. Should succeed.
     Afform::submit()
@@ -228,11 +198,10 @@ EOHTML;
       ->execute();
 
     $this->assertCount(1, $result);
-    $response = $result->first();
-    $this->assertTrue($response['is_error'] ?? FALSE);
-    $this->assertCount(2, $response['errors']);
-    $this->assertStringContainsString('First Name is a required field', implode("\n", array_column($response['errors'], 'message')));
-    $this->assertStringContainsString('Last Name is a required field', implode("\n", array_column($response['errors'], 'message')));
+    $this->assertCount(2, $result->first()['errors']);
+    $msg = $this->getBlockingErrorMessages($result);
+    $this->assertStringContainsString('First Name is a required field', $msg);
+    $this->assertStringContainsString('Last Name is a required field', $msg);
 
     // Validate with valid values. Should return no errors.
     $validSubmission = [

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -91,12 +91,12 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
       return;
     }
     if (count($contributions) > 1) {
-      $event->addError(E::ts('Handling multiple contributions on the same form is not supported'));
+      $event->getResult()->addError(E::ts('Handling multiple contributions on the same form is not supported'), FALSE, 'config_error', '', \Psr\Log\LogLevel::CRITICAL);
       return;
     }
     $contribution = reset($contributions);
     if (count(array_filter($contribution['actions'])) !== 1) {
-      $event->addError(E::ts('Contribution action should be create or update but not both.'));
+      $event->getResult()->addError(E::ts('Contribution action should be create or update but not both.'), FALSE,'config_error', '', \Psr\Log\LogLevel::CRITICAL);
       return;
     }
 

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -96,7 +96,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
     }
     $contribution = reset($contributions);
     if (count(array_filter($contribution['actions'])) !== 1) {
-      $event->getResult()->addError(E::ts('Contribution action should be create or update but not both.'), FALSE,'config_error', '', \Psr\Log\LogLevel::CRITICAL);
+      $event->getResult()->addError(E::ts('Contribution action should be create or update but not both.'), FALSE, 'config_error', '', \Psr\Log\LogLevel::CRITICAL);
       return;
     }
 
@@ -122,7 +122,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
     // this catches cases when user must select one of a number of possible
     // price fields to provide line items, but no specific price field is required
     if (!$lineItems) {
-      $event->addError(E::ts('No line items for creating contribution'));
+      $event->getResult()->addError(E::ts('No line items for creating contribution'));
       return;
     }
 

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformCheckoutTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformCheckoutTest.php
@@ -126,40 +126,34 @@ class AfformCheckoutTest extends TestCase implements HeadlessInterface {
     $this->assertEquals(TRUE, \str_starts_with($nextUrl, 'https://now.go.to'));
   }
 
-  /**
-   * @throws \CRM_Core_Exception
-   */
   public function testCheckoutOptionValidate(): void {
-    try {
-      $response = Afform::submit(FALSE)
-        ->setName('testAfformCheckout')
-        ->setValues([
-          'Individual1' => [
-            [
-              'fields' => [
-                'first_name' => 'Test',
-                'last_name' => 'Contact',
-              ],
+    $response = Afform::submit(FALSE)
+      ->setName('testAfformCheckout')
+      ->setValues([
+        'Individual1' => [
+          [
+            'fields' => [
+              'first_name' => 'Test',
+              'last_name' => 'Contact',
             ],
           ],
-          'Contribution1' => [
-            [
-              'fields' => [
-                'source' => 'testContributionCreate',
-                'default_contribution_amount.contribution_amount' => 50,
-                'checkout_option' => 'test_checkout_option',
-              ],
+        ],
+        'Contribution1' => [
+          [
+            'fields' => [
+              'source' => 'testContributionCreate',
+              'default_contribution_amount.contribution_amount' => 50,
+              'checkout_option' => 'test_checkout_option',
             ],
           ],
-        ])
-        ->execute();
+        ],
+      ])
+      ->execute();
 
-      $this->fail('Afform::validate should have failed');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertEquals(TRUE, \str_contains($e->getMessage(), 'No payments over 10 USD'));
-    }
-
+    $result = $response->first();
+    $this->assertTrue($result['is_blocking_error'] ?? FALSE);
+    $messages = implode("\n", array_map(fn (\Civi\Api4\Generic\Error $error) => $error->getMessage(), $result['errors']));
+    $this->assertEquals(TRUE, \str_contains($messages, 'No payments over 10 USD'));
   }
 
   /**

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
@@ -237,47 +237,41 @@ class AfformContributionTest extends TestCase implements HeadlessInterface {
     $this->assertEquals($participantId, $participantLineItem['entity_id']);
   }
 
-  /**
-   * @throws \CRM_Core_Exception
-   */
   public function testValidateLineItems(): void {
-    try {
-      $response = Afform::submit(FALSE)
-        ->setName('testAfformContribution')
-        ->setValues([
-          'Individual1' => [
-            [
-              'fields' => [
-                'first_name' => 'Test',
-                'last_name' => 'Contact',
-              ],
+    $response = Afform::submit(FALSE)
+      ->setName('testAfformContribution')
+      ->setValues([
+        'Individual1' => [
+          [
+            'fields' => [
+              'first_name' => 'Test',
+              'last_name' => 'Contact',
             ],
           ],
-          'Participant1' => [
-            [
-              'fields' => [
-                'event_id' => $this->eventId,
-                // 'participant_fields.ticket_option' => $this->inPersonPriceFieldValueId,
-              ],
+        ],
+        'Participant1' => [
+          [
+            'fields' => [
+              'event_id' => $this->eventId,
+              // 'participant_fields.ticket_option' => $this->inPersonPriceFieldValueId,
             ],
           ],
-          'Contribution1' => [
-            [
-              'fields' => [
-                'source' => 'testContributionCreate',
-                // 'donation_options.additional_donation' => 5,
-              ],
+        ],
+        'Contribution1' => [
+          [
+            'fields' => [
+              'source' => 'testContributionCreate',
+              // 'donation_options.additional_donation' => 5,
             ],
           ],
-        ])
-        ->execute();
+        ],
+      ])
+      ->execute();
 
-      $this->fail('Afform::submit should have failed');
-    }
-    catch (\CRM_Core_Exception $e) {
-      $this->assertEquals(TRUE, \str_contains($e->getMessage(), 'No line items'));
-    }
-
+    $result = $response->first();
+    $this->assertTrue($result['is_blocking_error'] ?? FALSE);
+    $messages = implode("\n", array_map(fn (\Civi\Api4\Generic\Error $error) => $error->getMessage(), $result['errors']));
+    $this->assertEquals(TRUE, \str_contains($messages, 'No line items'));
   }
 
   public function testEntityDependencyOrdering() {

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/TestCheckoutOption.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/TestCheckoutOption.php
@@ -24,7 +24,7 @@ class TestCheckoutOption extends CheckoutOption implements AfformCheckoutOptionI
     $currency = $submittedValues['Contribution1'][0]['fields']['currency'];
 
     if ($currency === 'USD' && $contributionAmount > 10) {
-      $e->addError('No payments over 10 USD');
+      $e->getResult()->addError('No payments over 10 USD');
     }
   }
 

--- a/ext/recaptcha/Civi/AfformReCaptcha2.php
+++ b/ext/recaptcha/Civi/AfformReCaptcha2.php
@@ -58,7 +58,7 @@ class AfformReCaptcha2 extends AutoService implements EventSubscriberInterface {
     if (AHQ::getTags($layout, 'crm-recaptcha2')) {
       $response = $event->getApiRequest()->getValues()['extra']['recaptcha2'] ?? NULL;
       if (!isset($response) || !\CRM_Utils_ReCAPTCHA::checkResponse($response)) {
-        $event->addError(E::ts('Please go back and complete the CAPTCHA at the bottom of this form.'));
+        $event->getResult()->addError(E::ts('Please go back and complete the CAPTCHA at the bottom of this form.'));
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
@eileenmcnaughton @ufundo @rbaugh per our conversations.

This turns the errors array into a multikeyed array with:
- Message: User facing, translatable message.
- Code: Machine readable string which represents the error.
- Level: String using Psr\Log\LogLevel to define "severity" of the error.

Usage:
- If you set level to LogLevel::ERROR or higher the caller is expected to treat it as an error / something that needs resolving.
- Added helper functions for `getMaxErrorLevel()`, `getErrorsAsString()`, `hasErrors()`, `isError()` for easy interaction from code. Examples of usage of those functions included in this PR.

If this model is accepted I propose extracted it out into a generic "validate event" that we can also use for Order.validate - https://github.com/civicrm/civicrm-core/pull/35815


Before
----------------------------------------
"String" errors with no metadata

After
----------------------------------------
Errors with metadata

Technical Details
----------------------------------------


Comments
----------------------------------------

