### PR TITLE
Pass in invoiceID and contributionID from AdditionalPayment form

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -407,6 +407,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
     if ($paymentParams['amount'] > 0.0) {
       if (!empty($this->contributionID)) {
         if (empty($paymentParams['description'])) {
+          $paymentParams['contributionID'] = $this->contributionID;
           $paymentParams['description'] = CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $this->_contributionId, 'source');
         }
 
@@ -419,6 +420,8 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
       try {
         // Re-retrieve the payment processor in case the form changed it, CRM-7179
         $payment = \Civi\Payment\System::singleton()->getById($this->getPaymentProcessorID());
+        $payment->setBackOffice(TRUE);
+        $paymentParams['invoiceID'] = $this->getInvoiceID();
         $result = $payment->doPayment($paymentParams);
         return [
           'fee_amount' => $result['fee_amount'] ?? 0,

--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -1241,7 +1241,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     CRM_Contribute_Form_AdditionalInfo::postProcessCommon($params, $this->_params, $this);
 
     if (empty($this->_params['invoice_id'])) {
-      $this->_params['invoiceID'] = bin2hex(random_bytes(16));
+      $this->_params['invoiceID'] = $this->getInvoiceID();
     }
     else {
       $this->_params['invoiceID'] = $this->_params['invoice_id'];

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -2024,16 +2024,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
   }
 
   /**
-   * @return string
-   */
-  public function getInvoiceID(): string {
-    if (!$this->invoiceID) {
-      $this->invoiceID = bin2hex(random_bytes(16));
-    }
-    return $this->invoiceID;
-  }
-
-  /**
    * Build the radio/text form elements for the amount field
    *
    * @internal function is not currently called by any extentions in our civi


### PR DESCRIPTION
Overview
----------------------------------------
Both parameters generally expected and are available on the form!

Before
----------------------------------------
invoiceID / contributionID not passed in. 

After
----------------------------------------
Passed in 

Technical Details
----------------------------------------

Comments
----------------------------------------
