### PR TITLE
Preserve compatibility for IN, NOT IN, IS EMPTY and IS NOT EMPTY for activity contact fields

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -61,7 +61,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setInputAttrs(['multiple' => TRUE]);
       $field->setDataType('Integer');
       $field->setSerialize(\CRM_Core_DAO::SERIALIZE_COMMA);
-      $field->setOperators(['=', '!=', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL']);
+      $field->setOperators(['=', '!=', 'IN', 'NOT IN', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL']);
       $field->addSqlFilter([__CLASS__, 'getActivityContactFilterSql']);
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
@@ -76,7 +76,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setInputAttrs(['multiple' => TRUE]);
       $field->setDataType('Integer');
       $field->setSerialize(\CRM_Core_DAO::SERIALIZE_COMMA);
-      $field->setOperators(['=', '!=', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL']);
+      $field->setOperators(['=', '!=', 'IN', 'NOT IN', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL']);
       $field->addSqlFilter([__CLASS__, 'getActivityContactFilterSql']);
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
@@ -91,7 +91,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
         ->setDescription(ts('All contacts involved in the activity (added by, with, or assigned to).'))
         ->setType('Extra')
         ->setFkEntity('Contact')
-        ->setOperators(['CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL'])
+        ->setOperators(['CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL'])
         ->setInputType('EntityRef')
         ->setInputAttrs(['multiple' => TRUE])
         ->setSerialize(\CRM_Core_DAO::SERIALIZE_COMMA)
@@ -136,8 +136,19 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
   }
 
   public static function getActivityContactFilterSql(array $field, string $fieldAlias, string $operator, $value, Api4SelectQuery $query, int $depth): string {
-    if (in_array($operator, ['=', '!=']) && in_array($field['name'], ['target_contact_id', 'assignee_contact_id'])) {
-      \CRM_Core_Error::deprecatedWarning("Use CONTAINS or NOT CONTAINS when querying {$field['name']}");
+    if (in_array($field['name'], ['target_contact_id', 'assignee_contact_id'])) {
+      if (in_array($operator, ['=', '!='])) {
+        \CRM_Core_Error::deprecatedWarning("Use CONTAINS / NOT CONTAINS when querying {$field['name']}");
+      }
+      elseif (in_array($operator, ['IN', 'NOT IN'])) {
+        \CRM_Core_Error::deprecatedWarning("Use CONTAINS ONE OF / NOT CONTAINS ONE OF when querying {$field['name']}");
+      }
+    }
+    // all_contact_id was only briefly supported in 6.15, so could be removed fairly soon.
+    if (in_array($field['name'], ['target_contact_id', 'assignee_contact_id', 'all_contact_id'])) {
+      if (in_array($operator, ['IS NULL', 'IS NOT NULL'])) {
+        \CRM_Core_Error::deprecatedWarning("Use IS EMPTY / IS NOT EMPTY when querying {$field['name']}");
+      }
     }
 
     // $fieldAlias contains the rendered subquery from self::renderSqlForActivityContactIds.
@@ -147,15 +158,15 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
     $recordTypeClause = self::getRecordTypeClause($field['name']);
     $contactIdClause = '1';
 
-    if (!in_array($operator, ['IS NULL', 'IS NOT NULL'])) {
+    if (!in_array($operator, ['IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL'])) {
       // `user_contact_id`, etc has already been converted to an id by `FormattingUtil::formatInputValue`
-      $cids = implode(',', (array) $value);
+      $cids = implode(',', (array) $value) ?: '0';
       \CRM_Utils_Type::validate($cids, 'CommaSeparatedIntegers', TRUE);
       $contactIdClause = "`civicrm_activity_contact`.`contact_id` IN ($cids)";
     }
 
     // CONTAINS ONE OF & NOT CONTAINS ONE OF have already been decomposed by `Api4Query::treeWalkClauses`
-    $op = in_array($operator, ['CONTAINS', 'IN', '=', 'IS NOT NULL']) ? 'IN' : 'NOT IN';
+    $op = in_array($operator, ['CONTAINS', 'IN', '=', 'IS NOT EMPTY', 'IS NOT NULL']) ? 'IN' : 'NOT IN';
     return "$fieldAlias $op (SELECT activity_id FROM `civicrm_activity_contact` WHERE $contactIdClause $recordTypeClause)";
   }
 

--- a/tests/phpunit/api/v4/Entity/ActivityTest.php
+++ b/tests/phpunit/api/v4/Entity/ActivityTest.php
@@ -62,7 +62,7 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     $activity = Activity::update(FALSE)
       ->addWhere('source_contact_id', '=', $sourceContactId)
       ->addWhere('all_contact_id', 'CONTAINS ONE OF', $targetContactIds)
-      ->addWhere('assignee_contact_id', 'IS NULL')
+      ->addWhere('assignee_contact_id', 'IS EMPTY')
       ->addValue('assignee_contact_id', $assigneeContactIds)
       ->execute()->single();
     $this->assertSame($activityID, $activity['id']);
@@ -71,7 +71,7 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     $activity = Activity::get(FALSE)
       ->addSelect('id', 'source_contact_id', 'target_contact_id', 'assignee_contact_id', 'all_contact_id')
       ->addWhere('all_contact_id', 'CONTAINS ONE OF', ['user_contact_id'])
-      ->addWhere('assignee_contact_id', 'IS NOT NULL')
+      ->addWhere('assignee_contact_id', 'IS NOT EMPTY')
       ->execute()->single();
     $this->assertSame($activityID, $activity['id']);
     $this->assertEquals($sourceContactId, $activity['source_contact_id']);


### PR DESCRIPTION
Follow up on #35902

We had one of these with IN and I found some more with IN in universe, plus one IS NOT EMPTY.

Per discussion have re-added all four, deprecated IS NULL / IS NOT NULL, and added deprecation notices for all.

Also handled the IN / NOT IN [] case, which would otherwise give an error.