### PR TITLE
Mailing job permission issue cli mode

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -117,6 +117,11 @@ class CRM_Core_Permission {
    *   true if contact has permission(s), else false
    */
   public static function check($permissions, $contactId = NULL) {
+    // if no contact id is passed, use the logged in contact id
+    if (empty($contactId) && php_sapi_name() == "cli") {
+      $contactId = CRM_Core_Session::singleton()->getLoggedInContactID();
+    }
+
     $permissions = (array) $permissions;
     $userId = CRM_Core_BAO_UFMatch::getUFId($contactId);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix for 
```
[cron:error] Finished execution of Process CiviMail Queue items with result: Failure, Error message: Authorization failed: CiviCRM APIv4 (Mailing::runQueue)
[cron:error] Finished execution of Send Scheduled Mailings with result: Failure, Error message: API permission check failed for Group/get call; insufficient permission: require access CiviCRM
```

 `cv core:cron -U 'Cron User'` not able to send email until this fix. This will get contact id correctly.
 
 i know we already have https://github.com/civicrm/civicrm-core/pull/35314 PR , @jackrabbithanna want to check these changes are ok.