### PR TITLE
afForm.identifyTokens - fix crash when non-string values passed

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -576,7 +576,15 @@
 
       // these tokens matching/replacing functions should match
       // the serverside implementation in AbstractProcessor::replaceTokens
-      this.identifyTokens = (message) => new Set(message?.match(/\[[a-zA-Z0-9_]+\.[0-9]+\.[^\]]+\]/g));
+      // returns null if no tokens
+      this.identifyTokens = (message) => {
+        if (typeof message !== 'string') {
+          return null;
+        }
+        const tokens = new Set(message.match(/\[[a-zA-Z0-9_]+\.[0-9]+\.[^\]]+\]/g));
+
+        return tokens.size ? tokens : null;
+      };
 
       this.getTokenValues = (tokens) => {
         const values = {};


### PR DESCRIPTION
Overview
----------------------------------------
Non-string values in `afform_default` crash `identifyTokens` - and the field default value isn't loaded at all.


Comments
----------------------------------------
This is a regression in 6.15, will put up a backport too.
