### PR TITLE
afForm.identifyTokens - fix crash when non-string values passed

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -569,7 +569,15 @@
 
       // these tokens matching/replacing functions should match
       // the serverside implementation in AbstractProcessor::replaceTokens
-      this.identifyTokens = (message) => message?.match(/\[[a-zA-Z0-9_]+\.[0-9]+\.[^\]]+\]/g);
+      // returns null if no tokens
+      this.identifyTokens = (message) => {
+        if (typeof message !== 'string') {
+          return null;
+        }
+        const tokens = new Set(message.match(/\[[a-zA-Z0-9_]+\.[0-9]+\.[^\]]+\]/g));
+
+        return tokens.size ? tokens : null;
+      };
 
       this.getTokenValues = (tokens) => {
         const values = {};


### PR DESCRIPTION
Overview
----------------------------------------
Backport of https://github.com/civicrm/civicrm-core/pull/35908

