### PR TITLE
Switch accesskeys css to a class

### DIFF
--- a/templates/CRM/common/accesskeys.hlp
+++ b/templates/CRM/common/accesskeys.hlp
@@ -9,7 +9,7 @@
 *}
 {htxt id="accesskeys"}
   <p></p>
-  <ul id="crmAccessKeyList">
+  <ul class="crmAccessKeyList">
     <li>{$accessKey}+<span>E</span> - {ts}Edit Contact (View Contact Summary Page){/ts}</li>
     <li>{$accessKey}+<span>S</span> - {ts}Save Button{/ts}</li>
     <li>{$accessKey}+<span>N</span> - {ts}Add a new record in each tab (Activities, Tags,..etc){/ts}</li>
@@ -17,10 +17,10 @@
     <li>{$accessKey}+<span>Q</span> - {ts}Quicksearch{/ts}</li>
   </ul>
   {literal}<style>
-    #crmAccessKeyList li {
+    .crmAccessKeyList li {
       margin-top: 5px;
     }
-    #crmAccessKeyList span {
+    .crmAccessKeyList span {
       display: inline-block;
       background: grey;
       font-size: 80%;


### PR DESCRIPTION
Then if you're adding an extra you can re-use the class instead of duplicating the id. No examples of accesskeys.extra.hlp in universe, so I think safe enough to change.