### PR TITLE
Prevent white text on white bg for Available Dashlets header

### DIFF
--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -194,6 +194,7 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 #civicrm-dashboard .crm-inactive-dashlet-fieldset > summary {
   background-color: var(--crm-dashlet-dashlets-bg-color);
+  color: var(--crm-text-color);
 }
 #civicrm-dashboard .crm-inactive-dashlet-fieldset > div.crm-accordion-body {
   background-color: var(--crm-dashlet-dashlets-bg-color);


### PR DESCRIPTION
Overview
----------------------------------------
This is an unreleased regression due to #35808 (which looks fantastic). On Walbrook light mode specifically, this causes an issue.

Before
----------------------------------------
White text on white background
<img width="672" height="138" alt="image" src="https://github.com/user-attachments/assets/1e017d16-59db-4346-938b-a8ed227e95c4" />

After
----------------------------------------
<img width="352" height="133" alt="image" src="https://github.com/user-attachments/assets/fcd46234-ce9a-4aa3-a8d5-0e1a6f96d842" />

Comments
----------------------------------------
Tested and looks correct on all four streams, light and dark.
