### PR TITLE
FormBuilder - support using :name suffixed fields in af-field

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor.js
+++ b/ext/afform/admin/ang/afGuiEditor.js
@@ -197,6 +197,11 @@
 
         getField: function(entityName, fieldName) {
           const fields = CRM.afGuiEditor.entities[entityName].fields;
+
+          // remove any suffix before looking up meta
+          if (fieldName.includes(':')) {
+            fieldName = fieldName.split(':')[0];
+          }
           return fields[fieldName] || fields[fieldName.substr(fieldName.indexOf('.') + 1)];
         },
 

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -41,6 +41,8 @@
        * The UI always deals with IDs;
        * this function translates to and from suffixed values,
        * if the suffixed name is being used in the data object
+       * @todo switch to using :name suffixes throughout where
+       * available
        */
       $scope.entityDataGetterSetter = function(fieldName) {
         const parts = fieldName.split(':');
@@ -204,12 +206,14 @@
 
       // Checks if a field is on the form or set as a value
       $scope.fieldInUse = (fieldName, joinEntity) => {
+        // normalise to unsuffixed for all checks
+        fieldName = $scope.getUnsuffixedName(fieldName);
         const data = ctrl.entity.data || {};
         const unsuffixedDataKeys = Object.keys(data).map(key => {
           return $scope.getUnsuffixedName(key);
         });
         if (!joinEntity) {
-          return (unsuffixedDataKeys.includes(fieldName)) || check(ctrl.editor.layout['#children'], {'#tag': 'af-field', name: fieldName});
+          return unsuffixedDataKeys.includes(fieldName) || check(ctrl.editor.layout['#children'], (item) => item['#tag'] === 'af-field' && $scope.getUnsuffixedName(item.name) === fieldName);
         }
         // Joins might support multiple instances per entity; first fetch them all
         const afJoinContainers = afGui.getFormElements(ctrl.editor.layout['#children'], {'af-join': joinEntity}, (item) => {
@@ -218,8 +222,8 @@
         // Check if ALL af-join containers are using the field
         let inUse = true;
         afJoinContainers.forEach((container) => {
-          if (inUse && !check(container['#children'], {'#tag': 'af-field', name: fieldName})) {
-            inUse = false;
+          if (inUse && !check(container['#children'], (item) => item['#tag'] === 'af-field' && $scope.getUnsuffixedName(item.name) === fieldName)) {
+             inUse = false;
           }
         });
         return inUse;

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -168,13 +168,25 @@
         if (_.isEmpty(defn.input_attrs)) {
           defn.input_attrs = {};
         }
+        const suffix = this.getSuffix();
+        if (suffix) {
+          if (!defn || !defn.options) {
+            console.warn(`Invalid field with suffix but no options: ${fieldName}:${suffix}`);
+            return;
+          }
+          defn.options = defn.options.map((opt) => {
+            opt.id = opt[suffix];
+            return opt;
+          });
+        }
         return defn;
       };
 
-      this.getFieldName = function() {
-        // Search filters can contain multiple field names joined by a comma. Return the first as the primary.
-        return ctrl.node.name?.split(',')[0];
-      };
+      // Search filters can contain multiple field names joined by a comma. Return the first as the primary.
+      // Strip any suffix
+      this.getFieldName = () => ctrl.node.name?.split(',')[0].split(':')[0];
+
+      this.getSuffix = () => ctrl.node.name?.split(',')[0].split(':')[1];
 
       // Get the api entity this field belongs to
       this.getEntity = function() {
@@ -212,7 +224,7 @@
         return this.getOriginalOptions();
       };
 
-      this.getOriginalOptions = function() {
+      this.getOriginalOptions = function () {
         if (ctrl.getDefn().input_type === 'EntityRef') {
           // Build a list of all entities in this form that can be referenced by this field.
           const newOptions = _.map(ctrl.editor.getEntities({type: ctrl.getDefn().fk_entity}), (entity) => {

--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -227,6 +227,14 @@ class FormDataModel {
     if (!$entityName) {
       return NULL;
     }
+    $suffix = NULL;
+    if (\str_contains($fieldName, ':')) {
+      [$fieldName, $suffix] = explode(':', $fieldName, 2);
+      if ($suffix !== 'name') {
+        // we don't know how to deal with non-name suffixes
+        throw new \CRM_Core_Exception("Unsupported suffix for afform field: {$fieldName}:{$suffix}");
+      }
+    }
     // For explicit joins, strip the alias off the field name
     if (strpos($entityName, ' AS ')) {
       [$entityName, $alias] = explode(' AS ', $entityName);
@@ -245,7 +253,11 @@ class FormDataModel {
       'action' => $action,
       'where' => [['name', 'IN', $namesToMatch]],
       'select' => $select,
-      'loadOptions' => ['id', 'label'],
+      'loadOptions' => [
+        'id',
+        'label',
+        ...array_keys(\CRM_Core_SelectValues::optionAttributes()),
+      ],
       // If the admin included this field on the form, then it's OK to get metadata about the field regardless of user permissions.
       'checkPermissions' => FALSE,
       'values' => $values,
@@ -277,6 +289,19 @@ class FormDataModel {
       $field = civicrm_api4($field['fk_entity'], 'getFields', $params)->first();
       if ($field) {
         $field['label'] = $originalField['label'] . ' ' . $field['label'];
+      }
+    }
+    if ($suffix) {
+      $field['suffix'] = $suffix;
+      $field['name'] = $field['name'] . ':' . $suffix;
+      $field['options'] = array_map(function ($option) use ($suffix) {
+        $option['id'] = $option[$suffix];
+        unset($option[$suffix]);
+        return $option;
+      }, $field['options']);
+      // NOTE: we currently only support :name suffixes
+      if ($suffix === 'name') {
+        $field['data_type'] = 'String';
       }
     }
     return $field;

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
@@ -47,4 +47,18 @@ class AfformMetadataTest extends \PHPUnit\Framework\TestCase implements Headless
 
   }
 
+  public function testSuffixedFieldMeta():void {
+    $suffixedFieldMeta = FormDataModel::getField('Individual', 'communication_style_id:name', 'create');
+
+    $this->assertEquals($suffixedFieldMeta['data_type'], 'String');
+
+    // check there are options
+    $options = $suffixedFieldMeta['options'];
+    $this->assertTrue(count($options) >= 2);
+
+    // check the names have been returned as option IDs
+    $optionIds = \array_map(fn ($option) => $option['id'], $options);
+    $this->assertTrue(\in_array('formal', $optionIds));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allows using :name suffixed fields for pseudoconstant fields in FormBuilder, which improves portability.
e.g. `<af-field name="communication_style_id:name">` instead of `<af-field name="communication_style_id">`

Before
----------------------------------------
- suffixes not supported for af-field names
- poor portability - field defaults and custom option lists use ids, rather than names

After
----------------------------------------
Working:
- if a field has `:name` suffix, you can change the field manually in the markup to use this
- the field should work unedited - the AfformMetadataInjector will adapt the filled defn accordingly
- you can still set a default value in the editor. it will be stored as a name rather than an id
- you can set custom options in the editor (removing options, or changing labels), these will be stored against 
- it recognises you've used the field, so wont let you place it again

Outstanding:
- the default when adding a new field in the GUI is still an unsuffixed field. I think this can be a separate PR, once we've done some more assurance of the :suffixed behaviour. For now this is "opt in" using manual code editing.
- using the field as a token won't work. I'm not sure what the behaviour should be here? In a message you might actually want to render the _label_ rather than the name or id value. In a url param you may want the name?
 
Technical Details
----------------------------------------
When using a suffixed field, we copy the option names in the `id` slot on the clientside. This means existing inputs/select2 etc still work.

Comments
----------------------------------------
cc @Edzelopez @monishdeb 
