### PR TITLE
dev/core#6403 Fix soft_credit/honoree profile overriding pre profile on contribution pages where join id higher

### DIFF
--- a/CRM/Core/WorkflowMessage/ProfileTrait.php
+++ b/CRM/Core/WorkflowMessage/ProfileTrait.php
@@ -141,7 +141,13 @@ trait CRM_Core_WorkflowMessage_ProfileTrait {
             }
           }
           $profile = $profiles[$join['uf_group_id']];
-          $profile['placement'] = $join['weight'] === 1 ? 'pre' : 'post';
+          if ('CiviContribute' === $join['module']) {
+            $profile['placement'] = $join['weight'] === 1 ? 'pre' : 'post';
+          }
+          else {
+            // e.g. soft_credit (honoree)
+            $profile['placement'] = $join['module'];
+          }
           $profile['module'] = $join['module'];
           $profile['title'] = $join['uf_group_id.frontend_title'];
           $profile['fields'] = $contactID ? $this->getProfileFields($join['uf_group_id'], $contactID, (string) $join['module']) : [];

--- a/Civi/Test/ContributionPageTestTrait.php
+++ b/Civi/Test/ContributionPageTestTrait.php
@@ -13,8 +13,6 @@ namespace Civi\Test;
 
 use Civi\API\EntityLookupTrait;
 use Civi\Api4\UFField;
-use Civi\Api4\UFGroup;
-use Civi\Api4\UFJoin;
 use Civi\Payment\System;
 
 /**
@@ -470,13 +468,12 @@ trait ContributionPageTestTrait {
     $profileName = $identifier . $profile['name'];
     $profileIdentifier = $profileName;
     try {
-      $this->setTestEntity('UFGroup', UFGroup::create(FALSE)->setValues([
+      $this->createTestEntity('UFGroup', [
         'group_type' => 'Individual,Contact',
         'name' => $profileName,
         'title' => $profile['title'],
         'frontend_title' => 'Public ' . $profile['title'],
-      ])->execute()->first(),
-        $profileIdentifier);
+      ], $profileIdentifier);
     }
     catch (\CRM_Core_Exception $e) {
       $this->fail('UF group creation failed for ' . $profileName . ' with error ' . $e->getMessage());
@@ -492,13 +489,13 @@ trait ContributionPageTestTrait {
         ->first(), $field . '_' . $profileIdentifier);
     }
     try {
-      $this->setTestEntity('UFJoin', UFJoin::create(FALSE)->setValues([
+      $this->createTestEntity('UFJoin', [
         'module' => 'CiviContribute',
         'uf_group_id:name' => $profileName,
         'entity_id' => $this->getContributionPageID($identifier),
         'entity_table' => 'civicrm_contribution_page',
         'weight' => $profile['weight'],
-      ])->execute()->first(), $profileIdentifier);
+      ], $profileIdentifier);
     }
     catch (\CRM_Core_Exception $e) {
       $this->fail('UF join creation failed for UF Group ' . $profileName . ' with error ' . $e->getMessage());

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -1393,15 +1393,7 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
       $this->callAPISuccess('UFField', 'create', $params);
     }
     $this->contributionPageWithPriceSetCreate();
-    $this->callAPISuccess('UFJoin', 'create', [
-      'is_active' => 1,
-      'module' => 'CiviEvent',
-      'entity_table' => 'civicrm_event',
-      'entity_id' => $this->getContributionPageID(),
-      'weight' => 1,
-      'uf_group_id' => 1,
-    ]);
-    $this->callAPISuccess('UFJoin', 'create', [
+    $this->createTestEntity('UFJoin', [
       'is_active' => 1,
       'module' => 'soft_credit',
       'entity_table' => 'civicrm_contribution_page',
@@ -1419,7 +1411,11 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
           ],
         ],
       ],
-    ]);
+    ], 'tribute');
+    // To replicate https://lab.civicrm.org/dev/core/-/work_items/6403 alter the natural sort order
+    // by forcing the pre profile join id higher than the soft_credit / honoree profile ID.
+    $newID = $this->ids['UFJoin']['tribute'] + 1;
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_uf_join SET id = ' . $newID . ' WHERE weight = 1 AND module = "CiviContribute"');
     $processor = \Civi\Payment\System::singleton()->getById($this->ids['PaymentProcessor']['dummy']);
     $processor->setDoDirectPaymentResult(['payment_status_id' => 1, 'fee_amount' => .72]);
     $this->submitOnlineContributionForm([
@@ -1444,6 +1440,8 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
         'In Memory of',
         'Name    James Bond',
         'Vaxhaul Cross',
+        'Public Page Pre Profile',
+        'email	dave@example.com',
       ],
     );
   }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6403 Fix soft_credit/honoree profile overriding pre profile on contribution pages where join id higher

Before
----------------------------------------
In the emailed receipt with the default template, the soft_credit/honoree section may be displayed in the pre profile place as well as where it should show - this depends on whether the uf_join ID is higher or lower than the pre profile join id.

After
----------------------------------------
soft_credit/honoree profile never assigned the `pre` profile placement

Technical Details
----------------------------------------
This was not originally captured by the relevant unit test because the non-post profile with the lowest join ID was being placed in the pre block and in the test that was the `pre` profile

Comments
----------------------------------------
