### PR TITLE
dev/core#6555 Remove broken access to contact summary for 'view my contact' peeps

### DIFF
--- a/CRM/Core/xml/Menu/Contact.xml
+++ b/CRM/Core/xml/Menu/Contact.xml
@@ -126,7 +126,7 @@
      <path_arguments>cid=%%cid%%</path_arguments>
      <title>Contact Summary</title>
      <access_callback>CRM_Core_Permission::checkMenu</access_callback>
-     <access_arguments>access CiviCRM;edit my contact;view my contact</access_arguments>
+     <access_arguments>access CiviCRM</access_arguments>
      <page_callback>CRM_Contact_Page_View_Summary</page_callback>
   </item>
   <item>


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#6555 Remove broken access to contact summary for 'view my contact' peeps

Before
----------------------------------------
It is possible to reach  /civicrm/contact/view with one of

- access CiviCRM
- edit my contact
- view my contact

However, it is thoroughly broken without `access CiviCRM` and looking at the code this appears to have been the case for at least 4 years

After
----------------------------------------
Broken access removed - access CiviCRM required

Technical Details
----------------------------------------
This is intended to address the confusion in https://lab.civicrm.org/dev/core/-/work_items/6555

Comments
----------------------------------------
