### PR TITLE
Update Date Label On Additional Payment Form

### DIFF
--- a/CRM/Contribute/Form/AdditionalPayment.php
+++ b/CRM/Contribute/Form/AdditionalPayment.php
@@ -229,7 +229,7 @@ class CRM_Contribute_Form_AdditionalPayment extends CRM_Contribute_Form_Abstract
 
     $this->add('textarea', 'receipt_text', ts('Confirmation Message'));
 
-    $this->addField('trxn_date', ['entity' => 'FinancialTrxn', 'label' => $this->isARefund() ? ts('Refund Date') : ts('Contribution Date'), 'context' => 'Contribution'], FALSE, FALSE);
+    $this->addField('trxn_date', ['entity' => 'FinancialTrxn', 'label' => $this->isARefund() ? ts('Refund Date') : ts('Date'), 'context' => 'Contribution'], FALSE, FALSE);
     $this->assign('eventName', $this->getEventValue('title'));
 
     $this->assign('displayName', $this->getContactValue('display_name'));


### PR DESCRIPTION
Overview
----------------------------------------
This PR updates the date label on the additional payment form as the current labe 'Contribution date' is confusing because in reality its not the contribution date but the payment date. So this PR changes the label to 'Date'.

Before
----------------------------------------
<img width="1792" height="1120" alt="Screenshot 2026-06-12 at 6 04 16 PM" src="https://github.com/user-attachments/assets/e92713e4-9093-4222-808a-e09170d646e5" />


After
----------------------------------------
<img width="1792" height="1120" alt="Screenshot 2026-06-12 at 6 03 56 PM" src="https://github.com/user-attachments/assets/d6d77492-10bf-427e-8168-47aa39d45f6e" />
