### PR TITLE
Fix display of uploaded files in custom fields multi-entry display

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -4,7 +4,6 @@ namespace Civi\Api4\Action\SearchDisplay;
 
 use Civi\API\Exception\UnauthorizedException;
 use Civi\API\Request;
-use Civi\Api4\Query\SqlField;
 use Civi\Api4\SearchDisplay;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\FormattingUtil;
@@ -252,10 +251,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
           $text = \CRM_Utils_File::cleanFileName($uri);
           $out['val'] = $text;
           $out['links'] = [[
-            'text' => $text,
-            'url' => (string) \CRM_Core_BAO_File::getFileUrl((int) $rawValue),
-            'target' => '_blank',
-            'title' => $text,
+              'text' => $text,
+              'url' => (string) \CRM_Core_BAO_File::getFileUrl((int) $rawValue),
+              'target' => '_blank',
+              'title' => $text,
           ]];
         }
         elseif (!empty($column['editable']) && !$column['rewrite'] && empty($settings['editableRow']['disable'])) {
@@ -1279,8 +1278,18 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return array{url: string, width: int, height: int}|NULL
    */
   private function formatImage($column, $data) {
-    $tokenExpr = $column['rewrite'] ?: '[' . $column['key'] . ']';
-    $url = $this->replaceTokens($tokenExpr, $data, 'url');
+    $key = $column['key'];
+    $url = NULL;
+    if (!$column['rewrite'] && is_numeric($data[$key] ?? NULL)) {
+      $fieldMeta = \CRM_Utils_Array::first($this->getSelectExpression($key)['fields'] ?? []);
+      if (($fieldMeta['fk_entity'] ?? NULL) === 'File') {
+        $url = (string) \CRM_Core_BAO_File::getFileUrl((int) $data[$key]);
+      }
+    }
+    if (!$url) {
+      $tokenExpr = $column['rewrite'] ?: '[' . $key . ']';
+      $url = $this->replaceTokens($tokenExpr, $data, 'url');
+    }
     if (!$url && !empty($column['empty_value'])) {
       $url = $this->replaceTokens($column['empty_value'], $data, 'url');
     }

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -201,12 +201,6 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         return \CRM_Core_Session::getLoggedInContactID();
 
       default:
-        if (!empty($data[$key])) {
-          $item = $this->getSelectExpression($key);
-          if ($item['expr'] instanceof SqlField && isset($item['fields'][$key]) && $item['fields'][$key]['fk_entity'] === 'File') {
-            return (string) \CRM_Core_BAO_File::getFileUrl($data[$key]);
-          }
-        }
         return $data[$key] ?? NULL;
     }
   }
@@ -248,7 +242,23 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
             $out['links'] = $links;
           }
         }
-        elseif (!empty($column['editable']) && empty($settings['editableRow']['disable'])) {
+        elseif (
+          !$column['rewrite']
+          && is_numeric($rawValue)
+          && ($fieldMeta = \CRM_Utils_Array::first($this->getSelectExpression($key)['fields'] ?? []))
+          && ($fieldMeta['fk_entity'] ?? NULL) === 'File'
+          && ($uri = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_File', $rawValue, 'uri', 'id'))
+        ) {
+          $text = \CRM_Utils_File::cleanFileName($uri);
+          $out['val'] = $text;
+          $out['links'] = [[
+            'text' => $text,
+            'url' => (string) \CRM_Core_BAO_File::getFileUrl((int) $rawValue),
+            'target' => '_blank',
+            'title' => $text,
+          ]];
+        }
+        elseif (!empty($column['editable']) && !$column['rewrite'] && empty($settings['editableRow']['disable'])) {
           $edit = $this->formatEditableColumn($column, $data);
           if ($edit) {
             // When internally processing an inline-edit, get all metadata

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -257,7 +257,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
               'title' => $text,
           ]];
         }
-        elseif (!empty($column['editable']) && !$column['rewrite'] && empty($settings['editableRow']['disable'])) {
+        elseif (!empty($column['editable']) && empty($settings['editableRow']['disable'])) {
           $edit = $this->formatEditableColumn($column, $data);
           if ($edit) {
             // When internally processing an inline-edit, get all metadata

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunWithCustomFieldTest.php
@@ -104,7 +104,7 @@ class SearchRunWithCustomFieldTest extends Api4TestBase {
     ];
 
     $result = civicrm_api4('SearchDisplay', 'run', $params);
-    $this->assertStringContainsString('id=' . $file['id'], $result[0]['data']['TestSearchFields.MyFile']);
+    $this->assertEquals($file['id'], $result[0]['data']['TestSearchFields.MyFile']);
     $this->assertStringContainsString('id=' . $file['id'], $result[0]['columns'][1]['img']['src']);
     $this->assertEmpty($result[1]['data']['TestSearchFields.MyFile']);
     // Placeholder image


### PR DESCRIPTION
SearchKit displays that include file upload custom fields (for example, in a multi-entry table on a contact record) show raw storage paths or URL paths.

This patch moves file-link formatting into the column display layer, where SearchKit already builds links for other field types.

**Before**
File upload custom field columns showed the full file URL or server path as plain text, with no link styling. Users had to copy/paste the path to open the file. URLs could be very long, which disrupted the display of the tabular data.

Example display value:

/sites/default/files/civicrm/persist/contribute/upload/abc123/my-document.pdf

**After**
File upload columns show the cleaned filename as the cell text, rendered as a link that opens the file in a new tab.

**Technical Details**
Changes are in ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php:

Added automatic link formatting in formatColumn() — When a column:

- has no rewrite,
- has a numeric raw value,
- references a field with fk_entity === 'File', and
- has a resolvable file URI in the database,
- SearchKit sets:
- - val to the cleaned filename (CRM_Utils_File::cleanFileName())
- - links to a single link object with text, url, target: '_blank', and title

(This fix will apply to any SearchKit display that includes a file FK field, not only multi-entry custom field tables, which is where I encountered the problem).

**Reproduce fix:**
Create a SearchKit search that includes a file upload custom field (ideally on a multi-entry custom group).
Add the field to a table display.
Confirm the column shows the filename as a clickable link.

