### PR TITLE
Add hasValue() for pre hook to check if a value is included without confusing null

### DIFF
--- a/Civi/Core/Event/PreEvent.php
+++ b/Civi/Core/Event/PreEvent.php
@@ -69,17 +69,38 @@ class PreEvent extends GenericHookEvent {
    * @since 6.15
    */
   public function getValue(string $paramName) {
-    if (isset($this->params[$paramName])) {
-      return $this->params[$paramName];
+    return $this->findValue($paramName)[1];
+  }
+
+  /**
+   * Checks whether a parameter is present, even if its value is NULL.
+   *
+   * Unlike getValue(), this distinguishes a parameter set to NULL from one that
+   * is not present at all.
+   *
+   * @since 6.17
+   */
+  public function hasValue(string $paramName): bool {
+    return $this->findValue($paramName)[0];
+  }
+
+  /**
+   * Looks up a parameter in all the places it may be set.
+   *
+   * @return array [if parameter is present, value or NULL].
+   */
+  private function findValue(string $paramName): array {
+    if (array_key_exists($paramName, $this->params)) {
+      return [TRUE, $this->params[$paramName]];
     }
 
     // If this looks like the name of a custom field, try to find it.
     if (substr_count($paramName, '.') !== 1 || str_starts_with($paramName, '.') || str_ends_with($paramName, '.')) {
-      return NULL;
+      return [FALSE, NULL];
     }
     $customField = \CRM_Core_BAO_CustomField::getFieldByName($paramName);
     if (!$customField) {
-      return NULL;
+      return [FALSE, NULL];
     }
     $customFieldId = $customField['id'];
     $shortName = "custom_$customFieldId";
@@ -88,15 +109,15 @@ class PreEvent extends GenericHookEvent {
     // 1. In the 'custom' array, keyed by custom field id.
     if (!empty($this->params['custom'][$customFieldId])) {
       $customParam = reset($this->params['custom'][$customFieldId]);
-      return $this->formatCustomValue($customField, $customParam['value'] ?? NULL);
+      return [TRUE, $this->formatCustomValue($customField, $customParam['value'] ?? NULL)];
     }
     // 2. In the params, possibly suffixed with an id.
     foreach ($this->params as $key => $value) {
       if ($key === $shortName || str_starts_with($key, $shortName . '_')) {
-        return $this->formatCustomValue($customField, $value);
+        return [TRUE, $this->formatCustomValue($customField, $value)];
       }
     }
-    return NULL;
+    return [FALSE, NULL];
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/HookPreTest.php
+++ b/tests/phpunit/CRM/Core/BAO/HookPreTest.php
@@ -106,6 +106,17 @@ class CRM_Core_BAO_HookPreTest extends CiviUnitTestCase {
       'testGroupWithHookPre.field4' => ['L', 'P'],
     ], $getValues);
 
+    $this->assertTrue($event->hasValue('first_name'));
+    $this->assertTrue($event->hasValue('testGroupWithHookPre.field1'));
+    $this->assertFalse($event->hasValue('last_name'));
+    $this->assertFalse($event->hasValue('testGroupWithHookPre.nosuchfield'));
+
+    $this->assertFalse($event->hasValue('nick_name'));
+    $event->params['nick_name'] = NULL;
+    $this->assertTrue($event->hasValue('nick_name'));
+    $this->assertNull($event->getValue('nick_name'));
+    unset($event->params['nick_name']);
+
     $this->assertSame('Mr. Wrong', $event->getValue('first_name'));
     $this->assertSame('wrong value', $event->getValue('testGroupWithHookPre.field1'));
     $this->assertSame(123, $event->getValue('testGroupWithHookPre.field2'));


### PR DESCRIPTION
Overview
----------------------------------------
Followup on #35492.
The trouble with `getValue` alone is that you can't tell the difference between "this field has a value and the value is `NULL`" and "this field is not set". You can check for `''` versus `NULL` from a quickform or even a SK batch action, but for a direct API call, you can't differentiate these cases. `hasValue` does this for you.