### PR TITLE
Address log warning

### DIFF
--- a/CRM/Utils/String.php
+++ b/CRM/Utils/String.php
@@ -674,6 +674,7 @@ class CRM_Utils_String {
       $config->set('CSS.MaxImgLength', NULL);
       // Prevent id atrributes from being stripped (useful for e.g. anchors)
       $config->set('Attr.EnableID', TRUE);
+      $config->set('URI.AllowedSymbols', '!$&\'()*+,;={}');
       $def = $config->maybeGetRawHTMLDefinition();
       $uri = $config->getDefinition('URI');
       $uri->addFilter(new CRM_Utils_HTMLPurifier_URIFilter(), $config);


### PR DESCRIPTION
Overview
----------------------------------------
Reported on MM https://chat.civicrm.org/civicrm/pl/y6mxkkda7jdpinwghxffustoac  log errors are being seen

Warning: Cannot retrieve value of undefined directive URI.AllowedSymbols invoked on line 111 in file 

I have not replicated but @composerjk rightly points out that @totten recommended we do this at the time he suggested a corresponding change to `htmlpurifiter` - we have the version of the package with @totten's change 

https://github.com/civicrm/civicrm-core/pull/32674#issuecomment-2846059060

