### PR TITLE
Fix followup go #34708 in recording of PayPal Fees as passed in via IPN

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -197,6 +197,7 @@ class CRM_Core_Payment_PayPalIPN {
         ->addValue('payment_processor_id', $input['payment_processor_id'])
         ->addValue('trxn_date', date('YmdHis', strtotime($input['receive_date'])))
         ->addValue('trxn_id', $input['trxn_id'])
+        ->addValue('fee_amount', $input['fee_amount'])
         ->execute();
     }
     else {
@@ -223,6 +224,7 @@ class CRM_Core_Payment_PayPalIPN {
         ->addValue('payment_processor_id', $input['payment_processor_id'])
         ->addValue('trxn_date', date('YmdHis', strtotime($input['receive_date'])))
         ->addValue('trxn_id', $input['trxn_id'])
+        ->addValue('fee_amount', $input['fee_amount'])
         ->execute();
     }
   }
@@ -262,6 +264,7 @@ class CRM_Core_Payment_PayPalIPN {
       ->addValue('payment_processor_id', $input['payment_processor_id'])
       ->addValue('trxn_date', date('YmdHis', strtotime($input['receive_date'])))
       ->addValue('trxn_id', $input['trxn_id'])
+      ->addValue('fee_amount', $input['fee_amount'])
       ->execute();
   }
 

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -309,6 +309,7 @@ class CRM_Core_Payment_PayPalProIPN {
             ->addValue('payment_processor_id', $input['payment_processor_id'])
             ->addValue('trxn_date', date('YmdHis', strtotime($input['payment_date'])))
             ->addValue('trxn_id', $input['trxn_id'])
+            ->addValue('fee_amount', $input['fee_amount'])
             ->execute();
         }
         else {
@@ -329,6 +330,7 @@ class CRM_Core_Payment_PayPalProIPN {
             ->addValue('payment_processor_id', $input['payment_processor_id'])
             ->addValue('trxn_date', date('YmdHis', strtotime($input['payment_date'])))
             ->addValue('trxn_id', $input['trxn_id'])
+            ->addValue('fee_amount', $input['fee_amount'])
             ->execute();
         }
 
@@ -407,6 +409,7 @@ class CRM_Core_Payment_PayPalProIPN {
       ->addValue('payment_processor_id', $input['payment_processor_id'])
       ->addValue('trxn_date', date('YmdHis', strtotime($input['payment_date'])))
       ->addValue('trxn_id', $input['trxn_id'])
+      ->addValue('fee_amount', $input['fee_amount'])
       ->execute();
   }
 

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -218,6 +218,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'txn_type' => 'subscr_payment',
       'last_name' => 'Roberts',
       'payment_fee' => '0.63',
+      'mc_fee' => '0.63',
       'first_name' => 'Robert',
       'txn_id' => '8XA571746W2698126',
       'residence_country' => 'US',
@@ -301,6 +302,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
     $this->assertEquals($_REQUEST['txn_id'], $contribution['trxn_id']);
     $this->assertEquals($completedStatusID, $contribution['contribution_status_id']);
+    $this->assertEquals('5.00', $contribution['fee_amount']);
     $this->assertEquals('test12345', $contribution['custom_' . $this->ids['CustomField']['Contribution']]);
   }
 
@@ -369,6 +371,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $contribution1 = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $this->_contributionID]);
     $this->assertEquals(1, $contribution1['contribution_status_id']);
     $this->assertEquals('8XA571746W2698126', $contribution1['trxn_id']);
+    $this->assertEquals('0.63', $contribution1['fee_amount']);
     // source gets set by processor
     $this->assertEquals('Online Contribution:', substr($contribution1['contribution_source'], 0, 20));
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a regression from #34708 where the fees that are recorded in mc_fee are no longer being recorded as part of the payment / civicrm_contribution record

Before
----------------------------------------
Processor Fees not being recorded

After
----------------------------------------
Fees being recorded again

ping @eileenmcnaughton @johntwyman @mattwire @andrew-cormick-dockery 