### PR TITLE
Copy deprecated function to MailingTokens class

### DIFF
--- a/CRM/Mailing/Tokens.php
+++ b/CRM/Mailing/Tokens.php
@@ -10,6 +10,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\MailingGroup;
+
 /**
  * Class CRM_Mailing_Tokens
  *
@@ -74,7 +76,132 @@ class CRM_Mailing_Tokens extends \Civi\Token\AbstractTokenSubscriber {
    */
   public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
     $row->format('text/plain')->tokens($entity, $field,
-      (string) CRM_Utils_Token::getMailingTokenReplacement($field, $prefetch['mailing']));
+      (string) $this->getMailingTokenReplacement($field, $prefetch['mailing']->id ?? NULL, $prefetch['mailing']));
+  }
+
+  /**
+   * @param string $token
+   * @param int|null $id
+   * @param \CRM_Mailing_BAO_Mailing $mailing
+   *
+   * @return string
+   */
+  private function getMailingTokenReplacement($token, ?int $id, $mailing) {
+    switch ($token) {
+      // CRM-7663
+
+      case 'id':
+        $value = $id ?: 'undefined';
+        break;
+
+      // Key is the ID, or the hash when the hash URLs setting is enabled
+      case 'key':
+        $value = $id;
+        if ($hash = CRM_Mailing_BAO_Mailing::getMailingHash($value)) {
+          $value = $hash;
+        }
+        break;
+
+      case 'name':
+        $value = $mailing ? $mailing->name : 'Mailing Name';
+        break;
+
+      case 'group':
+        $groups = $id ? ($this->getGroupNames($id) ?? []) : ['Mailing Groups'];
+        $value = implode(', ', $groups);
+        break;
+
+      case 'subject':
+        $value = $mailing->subject;
+        break;
+
+      case 'viewUrl':
+        $mailingKey = $id;
+        if ($hash = CRM_Mailing_BAO_Mailing::getMailingHash($mailingKey)) {
+          $mailingKey = $hash;
+        }
+        $value = CRM_Utils_System::url('civicrm/mailing/view',
+          "reset=1&id={$mailingKey}",
+          TRUE, NULL, FALSE, TRUE
+        );
+        break;
+
+      case 'editUrl':
+      case 'scheduleUrl':
+        // Note: editUrl and scheduleUrl used to be different, but now there's
+        // one screen which can adapt based on permissions (in workflow mode).
+        $value = CRM_Utils_System::url('civicrm/mailing/send',
+          "reset=1&mid={$id}&continue=true",
+          TRUE, NULL, FALSE, TRUE
+        );
+        break;
+
+      case 'html':
+        $page = new CRM_Mailing_Page_View();
+        $value = $page->run($id, NULL, FALSE, TRUE);
+        break;
+
+      case 'approvalStatus':
+        $value = CRM_Core_PseudoConstant::getLabel('CRM_Mailing_DAO_Mailing', 'approval_status_id', $mailing->approval_status_id);
+        break;
+
+      case 'approvalNote':
+        $value = $mailing->approval_note;
+        break;
+
+      case 'approveUrl':
+        $value = CRM_Utils_System::url('civicrm/mailing/approve',
+          "reset=1&mid={$id}",
+          TRUE, NULL, FALSE, TRUE
+        );
+        break;
+
+      case 'creator':
+        $value = CRM_Contact_BAO_Contact::displayName($mailing->created_id);
+        break;
+
+      case 'creatorEmail':
+        $value = CRM_Contact_BAO_Contact::getPrimaryEmail($mailing->created_id);
+        break;
+
+      default:
+        $value = "{mailing.$token}";
+        break;
+    }
+
+    return $value;
+  }
+
+  /**
+   * Return a list of group names for this mailing.  Does not work with
+   * prior-mailing targets.
+   *
+   * @param int $id
+   *
+   * @return array
+   *   Names of groups receiving this mailing
+   * @throws \CRM_Core_Exception
+   */
+  private function getGroupNames(int $id): array {
+    // This bypasses permissions to maintain compatibility with the SQL it replaced.
+    $mailingGroups = MailingGroup::get(FALSE)
+      ->addSelect('group.frontend_title')
+      ->addJoin('Group AS group', 'LEFT', ['entity_id', '=', 'group.id'])
+      ->addWhere('mailing_id', '=', $id)
+      ->addWhere('entity_table', '=', 'civicrm_group')
+      ->addWhere('group_type', '=', 'Include')
+      ->execute();
+
+    $groupNames = [];
+
+    foreach ($mailingGroups as $group) {
+      $name = $group['group.frontend_title'];
+      if ($name) {
+        $groupNames[] = $name;
+      }
+    }
+
+    return $groupNames;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Copy deprecated function to MailingTokens class

Before
----------------------------------------
Round-about path to the function made it possible to not realise it was being called

After
----------------------------------------
The only non-deprecated caller has it's own copy

Technical Details
----------------------------------------
@seamuslee001 this is follow up to those ones you gave MOP to in the rc/ stable - note I also switching from `group.frontend_title` falling back to `title` to only using `frontend_title` as it was made required a while back. I might take a look at migrating the other callers to use the Token Processor

Comments
----------------------------------------
