### PR TITLE
dev/core#6566 Fix HTML encoding of Payment Processor Labels on front …

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1385,10 +1385,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param string $separator
    * @param bool $required
    * @param array $optionAttributes - Option specific attributes
+   * @param bool $setRadioTextEscaped
    *
    * @return HTML_QuickForm_group
    */
-  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE, $optionAttributes = []) {
+  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE, $optionAttributes = [], $setRadioTextEscaped = FALSE) {
     $options = [];
     $attributes = $attributes ?: [];
     $allowClear = !empty($attributes['allowClear']);
@@ -1407,6 +1408,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $optAttributes['class'] .= ' required';
       }
       $element = $this->createElement('radio_with_div', NULL, NULL, $var, $key, $optAttributes);
+      if ($setRadioTextEscaped) {
+        $element->setTextEscaped();
+      }
       $options[] = $element;
     }
     if (!empty($attributes['options_per_line'])) {

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -156,11 +156,11 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     $pps = [];
     if (!empty($this->_paymentProcessors)) {
       foreach ($this->_paymentProcessors as $key => $processor) {
-        $pps[$key] = $this->getPaymentProcessorTitle($processor);
+        $pps[$key] = CRM_Utils_String::purifyHTML($this->getPaymentProcessorTitle($processor));
       }
     }
     if ($this->getPayLaterLabel()) {
-      $pps[0] = $this->getPayLaterLabel();
+      $pps[0] = CRM_Utils_String::purifyHTML($this->getPayLaterLabel());
     }
     return $pps;
   }
@@ -193,7 +193,7 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     }
     if (count($paymentProcessors) > 1) {
       $this->addRadio('payment_processor_id', ts('Payment Method'), $paymentProcessors,
-        NULL, "&nbsp;", FALSE, $optAttributes
+        NULL, "&nbsp;", FALSE, $optAttributes, TRUE
       );
     }
     elseif (!empty($paymentProcessors)) {


### PR DESCRIPTION
…end forms

Overview
----------------------------------------
This fixes the abilty of adding html strings to the pay later title

Before
----------------------------------------
HTML escaped on front end forms with pay later title

After
----------------------------------------
HTML shows correctly

ping @eileenmcnaughton @demeritcowboy 
