### PR TITLE
[REF] CRM_Core_Menu - remove unused `_menuCache` var

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -615,6 +615,9 @@ UNION (
     self::$_menuCache = [];
     $menuPath = NULL;
     while ($menu->fetch()) {
+      if (!str_contains($path, $menu->path)) {
+        continue;
+      }
       self::$_menuCache[$menu->path] = [];
       CRM_Core_DAO::storeValues($menu, self::$_menuCache[$menu->path]);
 
@@ -628,11 +631,8 @@ UNION (
       // Unserialize other elements.
       foreach (self::$_serializedElements as $element) {
         self::$_menuCache[$menu->path][$element] = CRM_Utils_String::unserialize($menu->$element);
-
-        if (str_contains($path, $menu->path)) {
-          $menuPath = &self::$_menuCache[$menu->path];
-        }
       }
+      $menuPath = &self::$_menuCache[$menu->path];
     }
 
     if (str_contains($path, 'report/instance')) {

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -43,7 +43,6 @@ class CRM_Core_Menu {
     'breadcrumb',
   ];
 
-  public static $_menuCache = NULL;
   const MENU_ITEM = 1;
 
   /**
@@ -612,27 +611,24 @@ UNION (
     $menu = new CRM_Core_DAO_Menu();
     $menu->query($query);
 
-    self::$_menuCache = [];
-    $menuPath = NULL;
+    $menuPath = [];
     while ($menu->fetch()) {
       if (!str_contains($path, $menu->path)) {
         continue;
       }
-      self::$_menuCache[$menu->path] = [];
-      CRM_Core_DAO::storeValues($menu, self::$_menuCache[$menu->path]);
+      CRM_Core_DAO::storeValues($menu, $menuPath);
 
       // Move module_data into main item.
-      if (isset(self::$_menuCache[$menu->path]['module_data'])) {
-        CRM_Utils_Array::extend(self::$_menuCache[$menu->path],
-          CRM_Utils_String::unserialize(self::$_menuCache[$menu->path]['module_data']));
-        unset(self::$_menuCache[$menu->path]['module_data']);
+      if (isset($menuPath['module_data'])) {
+        CRM_Utils_Array::extend($menuPath,
+          CRM_Utils_String::unserialize($menuPath['module_data']));
+        unset($menuPath['module_data']);
       }
 
       // Unserialize other elements.
       foreach (self::$_serializedElements as $element) {
-        self::$_menuCache[$menu->path][$element] = CRM_Utils_String::unserialize($menu->$element);
+        $menuPath[$element] = CRM_Utils_String::unserialize($menu->$element);
       }
-      $menuPath = &self::$_menuCache[$menu->path];
     }
 
     if (str_contains($path, 'report/instance')) {

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -597,6 +597,7 @@ class CRM_Core_Menu {
 )
 ";
 
+    // TODO: why?
     if ($path != 'navigation') {
       $query .= "
 UNION (
@@ -608,45 +609,40 @@ UNION (
 ";
     }
 
-    $menu = new CRM_Core_DAO_Menu();
-    $menu->query($query);
+    $records = CRM_Core_Dao::executeQuery($query)->fetchAll();
 
-    $menuPath = [];
-    while ($menu->fetch()) {
-      if (!str_contains($path, $menu->path)) {
-        continue;
-      }
-      CRM_Core_DAO::storeValues($menu, $menuPath);
+    $route = $records[0] ?? NULL;
 
+    if ($route && str_contains($path, $route['path'])) {
       // Move module_data into main item.
-      if (isset($menuPath['module_data'])) {
-        CRM_Utils_Array::extend($menuPath,
-          CRM_Utils_String::unserialize($menuPath['module_data']));
-        unset($menuPath['module_data']);
+      if (isset($route['module_data'])) {
+        CRM_Utils_Array::extend($route, CRM_Utils_String::unserialize($route['module_data']));
+
+        unset($route['module_data']);
       }
 
-      // Unserialize other elements.
-      foreach (self::$_serializedElements as $element) {
-        $menuPath[$element] = CRM_Utils_String::unserialize($menu->$element);
+      // Unserialize other fields
+      foreach (self::$_serializedElements as $field) {
+        $route[$field] = CRM_Utils_String::unserialize($route[$field]);
       }
     }
 
     if (str_contains($path, 'report/instance')) {
       $args = explode('/', $path);
       if (is_numeric(end($args))) {
-        $menuPath['path'] .= '/' . end($args);
+        $route['path'] .= '/' . end($args);
       }
     }
 
     if (preg_match('/^civicrm\/(upgrade\/)?queue\//', $path)) {
-      CRM_Queue_Menu::alter($path, $menuPath);
+      CRM_Queue_Menu::alter($path, $route);
     }
 
-    if (!empty($menuPath)) {
+    if (!empty($route)) {
       $i18n = CRM_Core_I18n::singleton();
-      $i18n->localizeTitles($menuPath);
+      $i18n->localizeTitles($route);
     }
-    return $menuPath;
+    return $route;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This cache appears to be cleared and reset every time it is used; and not used anywhere else. Getting rid and flattening the fetch makes this a much saner function, and then tackling https://lab.civicrm.org/dev/core/-/work_items/6569

Before
----------------------------------------
- clear and set `self::$_menuCache[$menu->path]` every time this function is called
- check four times at the end if `str_contains($path, $menu->path)` and pass the value out to the local var $menuPath if true
- use a `while` loop where we expect one result

After
----------------------------------------
- just use local var `$menuPath`
- do nothing immediately if `str_contains($path, $menu->path)` is false
- explicitly take the first result


