### PR TITLE
CRM_Core_Menu - remove unused `navigation` fetch from civicrm_menu

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -586,28 +586,11 @@ class CRM_Core_Menu {
     $queryString = implode(', ', $elements);
     $domainID = CRM_Core_Config::domainID();
 
-    $query = "
-(
-  SELECT *
-  FROM     civicrm_menu
-  WHERE    path in ( $queryString )
-           AND domain_id = $domainID
-  ORDER BY length(path) DESC
-  LIMIT    1
-)
-";
-
-    // TODO: why?
-    if ($path != 'navigation') {
-      $query .= "
-UNION (
-  SELECT *
-  FROM   civicrm_menu
-  WHERE  path IN ( 'navigation' )
-         AND domain_id = $domainID
-)
-";
-    }
+    $query = "SELECT * FROM civicrm_menu
+      WHERE path in ( $queryString )
+      AND domain_id = $domainID
+      ORDER BY length(path) DESC
+      LIMIT 1";
 
     $records = CRM_Core_Dao::executeQuery($query)->fetchAll();
 


### PR DESCRIPTION
Overview
----------------------------------------
I think this code is dead. I can't see how we ever get a record in `civicrm_menu` with `path IN ('navigation')`? I also don't know why you'd want that if `$path != 'navigation'`?
