### PR TITLE
Fix recaptcha2 on Afform

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -658,6 +658,13 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
       $submittableFields = $this->getSubmittableFields($entity['fields']);
       $fileFields = $this->getFileFields($entity['type'], $submittableFields);
       foreach ($submittedValues[$entityName] ?? [] as $values) {
+        if (!is_array($values)) {
+          // For "extra" we might have $values['fields'] if we added any extra fields.
+          // But, if we have eg. recaptcha we will have $values['recaptcha2'] and might
+          //   not have $values['fields']. The below code **requires** $values['fields']
+          //   and must be run to pass the extra field values through to submit etc.
+          continue;
+        }
         // Use default values from DisplayOnly fields + submittable fields on the form
         $values['fields'] = $this->getForcedDefaultValues($entity['fields']) +
           array_intersect_key($values['fields'] ?? [], $submittableFields);

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -88,7 +88,7 @@ class Submit extends AbstractProcessor {
       $this->processVerificationEmail($submission['id']);
     }
     else {
-      // process and save various enities
+      // process and save various entities
       $this->processFormData($this->_entityValues);
 
       $submissionData = $this->combineValuesAndIds($this->getValues(), $this->_entityIds);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
@@ -91,4 +91,44 @@ EOHTML;
     $this->assertSame($expectedMessage, $result[0]['message']);
   }
 
+  public function testSubmitWithRecaptcha(): void {
+    \Civi::settings()->set('recaptchaPrivateKey', 'test_private_key');
+    \Civi::settings()->set('recaptchaPublicKey', 'test_public_key');
+
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'Hello'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC"  />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="last_name" />
+  </fieldset>
+  <crm-recaptcha2 />
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Submit with recaptcha2 token in the extra entity (which replicates what FormBuilder does)
+    $submission = [
+      'Individual1' => [
+        ['fields' => ['first_name' => 'Jane', 'last_name' => 'Doe']],
+      ],
+      'extra' => [
+        'recaptcha2' => '',
+      ],
+    ];
+
+    $this->expectException(\CRM_Core_Exception::class);
+    $this->expectExceptionMessage('Please go back and complete the CAPTCHA');
+
+    Afform::submit()
+      ->setName($this->formName)
+      ->setValues($submission)
+      ->execute();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
If you have a recaptcha on Formbuilder you can't submit the form since 6.15 because it crashes:

```
"exception" => TypeError {#16075
    #message: "Cannot access offset of type string on string"
    #code: 0
    #file: "/var/www/civicrm-wordpress/civicrm/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php"
    #line: 672
    trace: {
      /var/www/civicrm-wordpress/civicrm/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php:672 {
        Civi\Api4\Action\Afform\AbstractProcessor->preprocessSubmittedValues(array $submittedValues)
        › // Use default values from DisplayOnly fields + submittable fields on the form
        › $values['fields'] = $this->getForcedDefaultValues($entity['fields']) +
        ›   array_intersect_key($values['fields'] ?? [], $submittableFields);
```

This is caused by the addition of "extra" fields on FormBuilder.

Before
----------------------------------------
Crash with recaptcha on form.

After
----------------------------------------
No crash, recaptcha works.


Technical Details
----------------------------------------
Explained in code comments.

Comments
----------------------------------------

