### PR TITLE
dev/core#6570 duplicate translation_source

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1385,10 +1385,11 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    * @param string $separator
    * @param bool $required
    * @param array $optionAttributes - Option specific attributes
+   * @param bool $setRadioTextEscaped
    *
    * @return HTML_QuickForm_group
    */
-  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE, $optionAttributes = []) {
+  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE, $optionAttributes = [], $setRadioTextEscaped = FALSE) {
     $options = [];
     $attributes = $attributes ?: [];
     $allowClear = !empty($attributes['allowClear']);
@@ -1407,6 +1408,9 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         $optAttributes['class'] .= ' required';
       }
       $element = $this->createElement('radio_with_div', NULL, NULL, $var, $key, $optAttributes);
+      if ($setRadioTextEscaped) {
+        $element->setTextEscaped();
+      }
       $options[] = $element;
     }
     if (!empty($attributes['options_per_line'])) {

--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -197,6 +197,7 @@ class CRM_Core_Payment_PayPalIPN {
         ->addValue('payment_processor_id', $input['payment_processor_id'])
         ->addValue('trxn_date', date('YmdHis', strtotime($input['receive_date'])))
         ->addValue('trxn_id', $input['trxn_id'])
+        ->addValue('fee_amount', $input['fee_amount'])
         ->execute();
     }
     else {
@@ -223,6 +224,7 @@ class CRM_Core_Payment_PayPalIPN {
         ->addValue('payment_processor_id', $input['payment_processor_id'])
         ->addValue('trxn_date', date('YmdHis', strtotime($input['receive_date'])))
         ->addValue('trxn_id', $input['trxn_id'])
+        ->addValue('fee_amount', $input['fee_amount'])
         ->execute();
     }
   }
@@ -262,6 +264,7 @@ class CRM_Core_Payment_PayPalIPN {
       ->addValue('payment_processor_id', $input['payment_processor_id'])
       ->addValue('trxn_date', date('YmdHis', strtotime($input['receive_date'])))
       ->addValue('trxn_id', $input['trxn_id'])
+      ->addValue('fee_amount', $input['fee_amount'])
       ->execute();
   }
 

--- a/CRM/Core/Payment/PayPalProIPN.php
+++ b/CRM/Core/Payment/PayPalProIPN.php
@@ -309,6 +309,7 @@ class CRM_Core_Payment_PayPalProIPN {
             ->addValue('payment_processor_id', $input['payment_processor_id'])
             ->addValue('trxn_date', date('YmdHis', strtotime($input['payment_date'])))
             ->addValue('trxn_id', $input['trxn_id'])
+            ->addValue('fee_amount', $input['fee_amount'])
             ->execute();
         }
         else {
@@ -329,6 +330,7 @@ class CRM_Core_Payment_PayPalProIPN {
             ->addValue('payment_processor_id', $input['payment_processor_id'])
             ->addValue('trxn_date', date('YmdHis', strtotime($input['payment_date'])))
             ->addValue('trxn_id', $input['trxn_id'])
+            ->addValue('fee_amount', $input['fee_amount'])
             ->execute();
         }
 
@@ -407,6 +409,7 @@ class CRM_Core_Payment_PayPalProIPN {
       ->addValue('payment_processor_id', $input['payment_processor_id'])
       ->addValue('trxn_date', date('YmdHis', strtotime($input['payment_date'])))
       ->addValue('trxn_id', $input['trxn_id'])
+      ->addValue('fee_amount', $input['fee_amount'])
       ->execute();
   }
 

--- a/CRM/Financial/Form/FrontEndPaymentFormTrait.php
+++ b/CRM/Financial/Form/FrontEndPaymentFormTrait.php
@@ -156,11 +156,11 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     $pps = [];
     if (!empty($this->_paymentProcessors)) {
       foreach ($this->_paymentProcessors as $key => $processor) {
-        $pps[$key] = $this->getPaymentProcessorTitle($processor);
+        $pps[$key] = CRM_Utils_String::purifyHTML($this->getPaymentProcessorTitle($processor));
       }
     }
     if ($this->getPayLaterLabel()) {
-      $pps[0] = $this->getPayLaterLabel();
+      $pps[0] = CRM_Utils_String::purifyHTML($this->getPayLaterLabel());
     }
     return $pps;
   }
@@ -193,7 +193,7 @@ trait CRM_Financial_Form_FrontEndPaymentFormTrait {
     }
     if (count($paymentProcessors) > 1) {
       $this->addRadio('payment_processor_id', ts('Payment Method'), $paymentProcessors,
-        NULL, "&nbsp;", FALSE, $optAttributes
+        NULL, "&nbsp;", FALSE, $optAttributes, TRUE
       );
     }
     elseif (!empty($paymentProcessors)) {

--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -922,6 +922,46 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   }
 
   /**
+   * Return a list of group names for this mailing.  Does not work with
+   * prior-mailing targets.
+   *
+   * @deprecated since 5.71 will be removed around 5.77
+   *
+   * @return array
+   *   Names of groups receiving this mailing
+   */
+  public function &getGroupNames() {
+    CRM_Core_Error::deprecatedWarning('unused function');
+    if (!isset($this->id)) {
+      return [];
+    }
+
+    /*
+    This bypasses permissions to maintain compatibility with the SQL it replaced.  This should ideally not bypass
+    permissions in the future, but it's called by some extensions during mail processing, when cron isn't necessarily
+    called with a logged-in user.
+     */
+    $mailingGroups = MailingGroup::get(FALSE)
+      ->addSelect('group.title', 'group.frontend_title')
+      ->addJoin('Group AS group', 'LEFT', ['entity_id', '=', 'group.id'])
+      ->addWhere('mailing_id', '=', $this->id)
+      ->addWhere('entity_table', '=', 'civicrm_group')
+      ->addWhere('group_type', '=', 'Include')
+      ->execute();
+
+    $groupNames = [];
+
+    foreach ($mailingGroups as $mg) {
+      $name = $mg['group.frontend_title'] ?? $mg['group.title'];
+      if ($name) {
+        $groupNames[] = $name;
+      }
+    }
+
+    return $groupNames;
+  }
+
+  /**
    * Add the mailings.
    *
    * @param array $params

--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -102,7 +102,14 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
   /**
    * @see https://lab.civicrm.org/dev/core/-/issues/6143
    */
-  public static function replaceTranslationSourceIndex() {
+  public static function replaceTranslationSourceIndex(): bool {
+    $duplicate_source_keys = CRM_Core_DAO::executeQuery("SELECT source_key, min(id) AS keep_id FROM civicrm_translation_source GROUP BY source_key HAVING count(id) > 1");
+    while ($duplicate_source_keys->fetch()) {
+      CRM_Core_DAO::executeQuery("DELETE FROM civicrm_translation_source WHERE source_key = %1 AND id != %2", [
+        [$duplicate_source_keys->source_key, 'String'],
+        [$duplicate_source_keys->keep_id, 'Positive'],
+      ]);
+    }
     \CRM_Core_BAO_SchemaHandler::createMissingIndices(CRM_Core_BAO_SchemaHandler::getMissingIndices(FALSE, ['civicrm_translation_source']));
     \CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_translation_source', 'index_source_key');
     return TRUE;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -188,8 +188,8 @@ class CRM_Utils_Token {
   }
 
   /**
-   * @param $token
-   * @param $mailing
+   * @param string $token
+   * @param \CRM_Mailing_BAO_Mailing $mailing
    * @param bool $escapeSmarty
    *
    * @return string

--- a/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ActivitySpecProvider.php
@@ -61,7 +61,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setInputAttrs(['multiple' => TRUE]);
       $field->setDataType('Integer');
       $field->setSerialize(\CRM_Core_DAO::SERIALIZE_COMMA);
-      $field->setOperators(['=', '!=', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL']);
+      $field->setOperators(['=', '!=', 'IN', 'NOT IN', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL']);
       $field->addSqlFilter([__CLASS__, 'getActivityContactFilterSql']);
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
@@ -76,7 +76,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
       $field->setInputAttrs(['multiple' => TRUE]);
       $field->setDataType('Integer');
       $field->setSerialize(\CRM_Core_DAO::SERIALIZE_COMMA);
-      $field->setOperators(['=', '!=', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL']);
+      $field->setOperators(['=', '!=', 'IN', 'NOT IN', 'CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL']);
       $field->addSqlFilter([__CLASS__, 'getActivityContactFilterSql']);
       $field->setSqlRenderer([__CLASS__, 'renderSqlForActivityContactIds']);
       $spec->addFieldSpec($field);
@@ -91,7 +91,7 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
         ->setDescription(ts('All contacts involved in the activity (added by, with, or assigned to).'))
         ->setType('Extra')
         ->setFkEntity('Contact')
-        ->setOperators(['CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS NULL', 'IS NOT NULL'])
+        ->setOperators(['CONTAINS', 'NOT CONTAINS', 'CONTAINS ONE OF', 'NOT CONTAINS ONE OF', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL'])
         ->setInputType('EntityRef')
         ->setInputAttrs(['multiple' => TRUE])
         ->setSerialize(\CRM_Core_DAO::SERIALIZE_COMMA)
@@ -136,8 +136,19 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
   }
 
   public static function getActivityContactFilterSql(array $field, string $fieldAlias, string $operator, $value, Api4SelectQuery $query, int $depth): string {
-    if (in_array($operator, ['=', '!=']) && in_array($field['name'], ['target_contact_id', 'assignee_contact_id'])) {
-      \CRM_Core_Error::deprecatedWarning("Use CONTAINS or NOT CONTAINS when querying {$field['name']}");
+    if (in_array($field['name'], ['target_contact_id', 'assignee_contact_id'])) {
+      if (in_array($operator, ['=', '!='])) {
+        \CRM_Core_Error::deprecatedWarning("Use CONTAINS / NOT CONTAINS when querying {$field['name']}");
+      }
+      elseif (in_array($operator, ['IN', 'NOT IN'])) {
+        \CRM_Core_Error::deprecatedWarning("Use CONTAINS ONE OF / NOT CONTAINS ONE OF when querying {$field['name']}");
+      }
+    }
+    // all_contact_id was only briefly supported in 6.15, so could be removed fairly soon.
+    if (in_array($field['name'], ['target_contact_id', 'assignee_contact_id', 'all_contact_id'])) {
+      if (in_array($operator, ['IS NULL', 'IS NOT NULL'])) {
+        \CRM_Core_Error::deprecatedWarning("Use IS EMPTY / IS NOT EMPTY when querying {$field['name']}");
+      }
     }
 
     // $fieldAlias contains the rendered subquery from self::renderSqlForActivityContactIds.
@@ -147,15 +158,15 @@ class ActivitySpecProvider extends \Civi\Core\Service\AutoService implements Gen
     $recordTypeClause = self::getRecordTypeClause($field['name']);
     $contactIdClause = '1';
 
-    if (!in_array($operator, ['IS NULL', 'IS NOT NULL'])) {
+    if (!in_array($operator, ['IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL'])) {
       // `user_contact_id`, etc has already been converted to an id by `FormattingUtil::formatInputValue`
-      $cids = implode(',', (array) $value);
+      $cids = implode(',', (array) $value) ?: '0';
       \CRM_Utils_Type::validate($cids, 'CommaSeparatedIntegers', TRUE);
       $contactIdClause = "`civicrm_activity_contact`.`contact_id` IN ($cids)";
     }
 
     // CONTAINS ONE OF & NOT CONTAINS ONE OF have already been decomposed by `Api4Query::treeWalkClauses`
-    $op = in_array($operator, ['CONTAINS', 'IN', '=', 'IS NOT NULL']) ? 'IN' : 'NOT IN';
+    $op = in_array($operator, ['CONTAINS', 'IN', '=', 'IS NOT EMPTY', 'IS NOT NULL']) ? 'IN' : 'NOT IN';
     return "$fieldAlias $op (SELECT activity_id FROM `civicrm_activity_contact` WHERE $contactIdClause $recordTypeClause)";
   }
 

--- a/ext/afform/core/Civi/Api4/Utils/AfformTranslateTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformTranslateTrait.php
@@ -5,7 +5,7 @@ namespace Civi\Api4\Utils;
 use CRM_Afform_ExtensionUtil as E;
 
 /**
- * Class AfformSaveTrait
+ * Class AfformTranslateTrait
  * @package Civi\Api4\Action\Afform
  */
 trait AfformTranslateTrait {
@@ -26,18 +26,7 @@ trait AfformTranslateTrait {
       throw new \CRM_Core_Exception("Afform.{$this->getActionName()}: No name provided the form should be saved first.");
     }
     else {
-      // Fetch existing metadata
-      //      $fields = \Civi\Api4\Afform::getfields()->setCheckPermissions(FALSE)->setAction('create')->addSelect('name')->execute()->column('name');
-      //      unset($fields[array_search('layout', $fields)]);
-
-      //      $orig = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->setSelect($fields)->execute()->first();
       $form = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->execute()->first();
-      Civi::log()->warning('orig ' . var_export($form, TRUE));
-
-      // Translate the main title
-      if (!empty($form['title'])) {
-
-      }
 
       // Translate entire afform
       $sourceStrings = $this->getFieldTranslations($form['layout']);
@@ -94,7 +83,7 @@ trait AfformTranslateTrait {
     \Civi\Api4\TranslationSource::save()
       ->addRecord(...$strings)
       ->setMatch([
-        'source',
+        'source_key',
       ])
       ->execute();
   }

--- a/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
+++ b/tests/phpunit/CRM/Core/Payment/PayPalIPNTest.php
@@ -218,6 +218,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
       'txn_type' => 'subscr_payment',
       'last_name' => 'Roberts',
       'payment_fee' => '0.63',
+      'mc_fee' => '0.63',
       'first_name' => 'Robert',
       'txn_id' => '8XA571746W2698126',
       'residence_country' => 'US',
@@ -301,6 +302,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     // assert that contribution is completed after getting response from paypal standard which has transaction id set and completed status
     $this->assertEquals($_REQUEST['txn_id'], $contribution['trxn_id']);
     $this->assertEquals($completedStatusID, $contribution['contribution_status_id']);
+    $this->assertEquals('5.00', $contribution['fee_amount']);
     $this->assertEquals('test12345', $contribution['custom_' . $this->ids['CustomField']['Contribution']]);
   }
 
@@ -369,6 +371,7 @@ class CRM_Core_Payment_PayPalIPNTest extends CiviUnitTestCase {
     $contribution1 = $this->callAPISuccess('Contribution', 'getsingle', ['id' => $this->_contributionID]);
     $this->assertEquals(1, $contribution1['contribution_status_id']);
     $this->assertEquals('8XA571746W2698126', $contribution1['trxn_id']);
+    $this->assertEquals('0.63', $contribution1['fee_amount']);
     // source gets set by processor
     $this->assertEquals('Online Contribution:', substr($contribution1['contribution_source'], 0, 20));
     $contributionRecur = $this->callAPISuccess('contribution_recur', 'getsingle', ['id' => $this->_contributionRecurID]);

--- a/tests/phpunit/api/v4/Entity/ActivityTest.php
+++ b/tests/phpunit/api/v4/Entity/ActivityTest.php
@@ -62,7 +62,7 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     $activity = Activity::update(FALSE)
       ->addWhere('source_contact_id', '=', $sourceContactId)
       ->addWhere('all_contact_id', 'CONTAINS ONE OF', $targetContactIds)
-      ->addWhere('assignee_contact_id', 'IS NULL')
+      ->addWhere('assignee_contact_id', 'IS EMPTY')
       ->addValue('assignee_contact_id', $assigneeContactIds)
       ->execute()->single();
     $this->assertSame($activityID, $activity['id']);
@@ -71,7 +71,7 @@ class ActivityTest extends Api4TestBase implements TransactionalInterface {
     $activity = Activity::get(FALSE)
       ->addSelect('id', 'source_contact_id', 'target_contact_id', 'assignee_contact_id', 'all_contact_id')
       ->addWhere('all_contact_id', 'CONTAINS ONE OF', ['user_contact_id'])
-      ->addWhere('assignee_contact_id', 'IS NOT NULL')
+      ->addWhere('assignee_contact_id', 'IS NOT EMPTY')
       ->execute()->single();
     $this->assertSame($activityID, $activity['id']);
     $this->assertEquals($sourceContactId, $activity['source_contact_id']);


### PR DESCRIPTION
Overview
----------------------------------------
It seems (or it was) possible to create duplicates in `civicrm_translation_source` table.

See https://lab.civicrm.org/dev/core/-/work_items/6570

Before
----------------------------------------
2 strings with different case lead to 2 entries with the same `source_key`.

After
----------------------------------------
Remove the ability in the API to create duplicates.

Comments
----------------------------------------
The database layer should avoid duplicates but we remove the ability at the API layer as well.

There is a wider issue that we need to solve if we want case sensitive string to be translated differently. Currently the `source_key` is on purpose case insensitive to avoid having to retranslate when doing some small typos but if there is a real need to case sensitivity, we might need to change it or to have a way to work with exception.