### PR TITLE
dev/core#6570 duplicate translation_source

### DIFF
--- a/ext/afform/core/Civi/Api4/Utils/AfformTranslateTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformTranslateTrait.php
@@ -5,7 +5,7 @@ namespace Civi\Api4\Utils;
 use CRM_Afform_ExtensionUtil as E;
 
 /**
- * Class AfformSaveTrait
+ * Class AfformTranslateTrait
  * @package Civi\Api4\Action\Afform
  */
 trait AfformTranslateTrait {
@@ -26,18 +26,7 @@ trait AfformTranslateTrait {
       throw new \CRM_Core_Exception("Afform.{$this->getActionName()}: No name provided the form should be saved first.");
     }
     else {
-      // Fetch existing metadata
-      //      $fields = \Civi\Api4\Afform::getfields()->setCheckPermissions(FALSE)->setAction('create')->addSelect('name')->execute()->column('name');
-      //      unset($fields[array_search('layout', $fields)]);
-
-      //      $orig = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->setSelect($fields)->execute()->first();
       $form = \Civi\Api4\Afform::get()->setCheckPermissions(FALSE)->addWhere('name', '=', $item['name'])->execute()->first();
-      Civi::log()->warning('orig ' . var_export($form, TRUE));
-
-      // Translate the main title
-      if (!empty($form['title'])) {
-
-      }
 
       // Translate entire afform
       $sourceStrings = $this->getFieldTranslations($form['layout']);
@@ -94,7 +83,7 @@ trait AfformTranslateTrait {
     \Civi\Api4\TranslationSource::save()
       ->addRecord(...$strings)
       ->setMatch([
-        'source',
+        'source_key',
       ])
       ->execute();
   }


### PR DESCRIPTION
Overview
----------------------------------------
It seems (or it was) possible to create duplicates in `civicrm_translation_source` table.

See https://lab.civicrm.org/dev/core/-/work_items/6570

Before
----------------------------------------
2 strings with different case lead to 2 entries with the same `source_key`.

After
----------------------------------------
Remove the ability in the API to create duplicates.

Comments
----------------------------------------
The database layer should avoid duplicates but we remove the ability at the API layer as well.

There is a wider issue that we need to solve if we want case sensitive string to be translated differently. Currently the `source_key` is on purpose case insensitive to avoid having to retranslate when doing some small typos but if there is a real need to case sensitivity, we might need to change it or to have a way to work with exception.