### PR TITLE
River - revised dashboard css adjustments: adjusts box-shadow, swaps to semantic variables, new variable for colour

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -350,6 +350,7 @@
   --crm-dashlet-padding: var(--crm-l-small-2);
   --crm-dashlet-box-shadow: var(--crm-shadow-popup);
   --crm-dashlet-dashlets-bg-color: var(--crm-container-bg-color);
+  --crm-dashlet-dashlets-color: var(--crm-text-color);
   --crm-dashlet-header-bg-color: var(--crm-accordion-header-bg-color);
   --crm-dashlet-header-color: var(--crm-accordion-header-color);
   --crm-dashlet-header-border: unset;

--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -4,36 +4,24 @@
 #civicrm-dashboard > .crm-flex-box {
   display: grid;
   grid-template-columns: var(--crm-dashlet-columns);
-  gap: var(--crm-l-reg);
+  gap: var(--crm-padding-reg);
 }
-#civicrm-dashboard.crm-dashboard-editing .crm-dashboard-droppable,
-#civicrm-dashboard.crm-dashboard-dragging .crm-dashboard-droppable {
+#civicrm-dashboard:is(.crm-dashboard-editing,.crm-dashboard-dragging) .crm-dashboard-droppable {
   /* avoid total collapse else no droppable area if all widgets removed */
   min-height: 10rem;
 }
-#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2,
-#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3,
-#civicrm-dashboard.crm-dashboard-editing > .crm-flex-box > .crm-dashboard-droppable,
-#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-2,
-#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-3,
-#civicrm-dashboard.crm-dashboard-dragging > .crm-flex-box > .crm-dashboard-droppable {
+#civicrm-dashboard:has(.crm-inactive-dashlet-fieldset[open]) .crm-dashboard-droppable {
   border: 3px dashed var(--crm-c-gray-400);
-  padding: var(--crm-l-reg);
+  padding: var(--crm-padding-reg);
 }
-#civicrm-dashboard.crm-dashboard-editing .crm-dashlet,
-#civicrm-dashboard.crm-dashboard-dragging .crm-dashlet {
+#civicrm-dashboard:has(.crm-inactive-dashlet-fieldset[open]) .crm-dashlet {
   max-height: 15rem;
   overflow: hidden;
 }
-#civicrm-dashboard > .crm-dashboard-column-2:has(.crm-dashlet),
-#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-2,
-#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-2 {
-  margin-bottom: var(--crm-l-reg);
-}
-#civicrm-dashboard > .crm-dashboard-column-3:has(.crm-dashlet),
-#civicrm-dashboard.crm-dashboard-editing > .crm-dashboard-column-3,
-#civicrm-dashboard.crm-dashboard-dragging > .crm-dashboard-column-3 {
-  margin-top: var(--crm-l-reg);
+#civicrm-dashboard:has(.crm-inactive-dashlet-fieldset[open]) {
+  display: flex;
+  flex-direction: column;
+  gap: var(--crm-padding-reg);
 }
 .crm-container .crm-dashlet {
   border-radius: var(--crm-dashlet-radius);
@@ -188,24 +176,29 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 
 /* Available (inactive) dashlets */
 #civicrm-dashboard .crm-inactive-dashlet-fieldset {
-  padding: 0;
-  border: 0;
-  margin-bottom: var(--crm-l-reg);
-}
-#civicrm-dashboard .crm-inactive-dashlet-fieldset > summary {
   background-color: var(--crm-dashlet-dashlets-bg-color);
-  color: var(--crm-text-color);
-}
-#civicrm-dashboard .crm-inactive-dashlet-fieldset > div.crm-accordion-body {
-  background-color: var(--crm-dashlet-dashlets-bg-color);
-  box-shadow: var(--crm-dashlet-box-shadow);
   border-radius: var(--crm-dashlet-radius);
-  padding: var(--crm-l-reg);
+  margin-bottom: var(--crm-padding-reg);
 }
-#civicrm-dashboard .crm-inactive-dashlet-fieldset > div.crm-accordion-body > div.crm-dashboard-droppable {
+#civicrm-dashboard .crm-inactive-dashlet-fieldset[open] {
+  box-shadow: var(--crm-dashlet-box-shadow);
+}
+#civicrm-dashboard .crm-inactive-dashlet-fieldset summary {
+  background-color: var(--crm-dashlet-dashlets-bg-color);
+  color: var(--crm-dashlet-dashlets-color);
+}
+#civicrm-dashboard .crm-inactive-dashlet-fieldset summary input {
+  margin-left: var(--crm-padding-reg);
+}
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > .crm-accordion-body {
+  padding: var(--crm-padding-reg);
+}
+#civicrm-dashboard .crm-inactive-dashlet-fieldset > .crm-accordion-body > .crm-dashboard-droppable {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--crm-l-reg);
+  gap: var(--crm-padding-reg);
+  padding: 0;
+  border: 0;
 }
 .crm-container .crm-inactive-dashlet {
   width: 20rem;
@@ -220,8 +213,8 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border-radius: var(--crm-dashlet-radius) var(--crm-dashlet-radius) 0 0;
 }
 .crm-container .crm-inactive-dashlet .crm-dashlet-header h3 {
-  font-size: 75%;
-  padding-left: var(--crm-l-small-1);
+  font-size: var(--crm-font-small-size);
+  padding-left: var(--crm-padding-small);
 }
 
 /* Searchkit Dashlets */


### PR DESCRIPTION
Following @colemanw nice Dashboard improvements (https://github.com/civicrm/civicrm-core/pull/35808), some css tweaks for River:
- Added a new variable for dashlet selector text-color to allow for darker backgroudn colours in Streams, in response to this fix by @larssandergreen https://github.com/civicrm/civicrm-core/pull/35912
- Changed Primitive Variable Names to Semantic names where possible (ref), e.g. `--crm-padding-reg` in place of `--crm-l-reg`. This doesn't change the appearance but makes it easier for Streams to update, say, all the regular padding, or all the small font sizes at the same time.
- moved the drop-shadow from the inactive dashlet Details body to the entire open Details (see below)
- added regular padding gap between the inactive dashlet title and the search input (see below)
- reduced some css selectors, removed some un-used ones

Before
----------------------------------------
<img width="615" height="709" alt="image" src="https://github.com/user-attachments/assets/2de1f14d-8106-4d4a-8d6b-46b218a5f9b1" />

After
----------------------------------------
<img width="604" height="361" alt="image" src="https://github.com/user-attachments/assets/d5263594-c610-4a3a-863a-47912633cbe2" />
<img width="657" height="343" alt="image" src="https://github.com/user-attachments/assets/f9b3290f-1858-43f1-994e-94309ef46f97" />

Technical Details
----------------------------------------
The only two visual changes are above - the rest are structural tweaks.