### PR TITLE
Fix example event to have from email (used in tests)

### DIFF
--- a/Civi/Test/ExampleData/Event/PaidEvent.php
+++ b/Civi/Test/ExampleData/Event/PaidEvent.php
@@ -39,6 +39,8 @@ class PaidEvent extends EntityExample {
       'pay_later_receipt' => 'Please transfer funds to our bank account.',
       'fee_label' => 'Event fees',
       'allow_selfcancelxfer' => TRUE,
+      'confirm_from_email' => \CRM_Core_BAO_Domain::getNameAndEmail()[1],
+      'confirm_from_name' => \CRM_Core_BAO_Domain::getNameAndEmail()[0],
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix example event to have from email (used in tests)

Before
----------------------------------------
Emails swallowed in tests, log noise

After
----------------------------------------
Emails do their thing

Technical Details
----------------------------------------
This is also used in rendering templates in message admin but this does not negatively impact that

Comments
----------------------------------------
