### PR TITLE
dev/core#6582 OAuth Client: Automatically refresh session tokens

### DIFF
--- a/ext/oauth-client/Civi/Api4/Action/OAuthSessionToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSessionToken/Refresh.php
@@ -19,6 +19,9 @@ use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
  * - If permission-checks are active and you only have access to "refresh" (but
  *   not to secrets), it will return a minimalist record to indicate completion.
  *
+ * @see OAuthSysToken::refresh
+ *   Please update OAuthSessionToken::refresh() and OAuthSysToken::refresh() in tandem.
+ *
  * @method $this setThreshold(int $limit)
  * @method int getThreshold()
  */

--- a/ext/oauth-client/Civi/Api4/Action/OAuthSessionToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSessionToken/Refresh.php
@@ -1,0 +1,103 @@
+<?php
+namespace Civi\Api4\Action\OAuthSessionToken;
+
+use Civi\Api4\Generic\BasicBatchAction;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+
+/**
+ * Class Refresh
+ * @package Civi\Api4\Action\OAuthSessionToken
+ *
+ * When preparing to connect to a remote OAuth system, use the "refresh" action
+ * to simultaneously refresh and return the auth token.
+ *
+ * Note that it is possible to refresh a token without having permission to view
+ * or edit the specific secrets involved. The result will adjust according to permissions:
+ *
+ * - If permission-checks are disabled, or if you have permission to manage secrets,
+ *   then this will return the full token record.
+ * - If permission-checks are active and you only have access to "refresh" (but
+ *   not to secrets), it will return a minimalist record to indicate completion.
+ *
+ * @method $this setThreshold(int $limit)
+ * @method int getThreshold()
+ */
+class Refresh extends BasicBatchAction {
+
+  /**
+   * Refresh records if they are within the given threshold for expiration.
+   *
+   * Ex: If your token is approaching expiration in 5 seconds, and if your
+   * threshold is 60 seconds, then the token will refresh. But if your token
+   * still has 5 minutes, then there's no need to refresh.
+   *
+   * A negative threshold will always refresh.
+   *
+   * @var int
+   */
+  protected $threshold = 60;
+
+  private $syncFields = ['access_token', 'refresh_token', 'expires', 'token_type'];
+  private $writeFields = ['access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
+  private $selectFields = ['cardinal', 'client_id', 'tag', 'access_token', 'refresh_token', 'expires', 'token_type', 'raw'];
+  private $providers = [];
+
+  protected function getSelect() {
+    return $this->selectFields;
+  }
+
+  protected function doTask($row) {
+    if ($this->threshold >= 0 && \CRM_Utils_Time::time() < $row['expires'] - $this->threshold) {
+      return $this->filterReturn($row);
+    }
+
+    $provider = $this->getProvider($row['client_id']);
+    try {
+      $newToken = $provider->getAccessToken('refresh_token', [
+        'refresh_token' => $row['refresh_token'],
+      ]);
+    }
+    catch (IdentityProviderException $e) {
+      // Token could not be refreshed and is expired.
+      // Remove it from the session
+      civicrm_api4($this->getEntityName(), 'delete', [
+        // You may have permission to refresh even if you can't inspect/update secrets directly.
+        'checkPermissions' => FALSE,
+        'where' => [['cardinal', '=', $row['cardinal']]],
+      ]);
+      return $this->filterReturn($row);
+    }
+
+    $raw = $newToken->jsonSerialize();
+    $row['raw'] = $raw;
+    foreach ($this->syncFields as $field) {
+      if (isset($raw[$field])) {
+        $row[$field] = $raw[$field];
+      }
+    }
+
+    \CRM_OAuth_Hook::oauthToken('refresh', $this->getEntityName(), $row);
+
+    civicrm_api4($this->getEntityName(), 'update', [
+      // You may have permission to refresh even if you can't inspect/update secrets directly.
+      'checkPermissions' => FALSE,
+      'where' => [['cardinal', '=', $row['cardinal']]],
+      'values' => \CRM_Utils_Array::subset($row, $this->writeFields),
+    ]);
+
+    return $this->filterReturn($row);
+  }
+
+  protected function getProvider($clientId) {
+    if (!isset($this->providers[$clientId])) {
+      $client = \Civi\Api4\OAuthClient::get(FALSE)->addWhere('id', '=', $clientId)->execute()->single();
+      $this->providers[$clientId] = \Civi::service('oauth2.league')->createProvider($client);
+    }
+    return $this->providers[$clientId];
+  }
+
+  protected function filterReturn($tokenRecord) {
+    return $this->checkPermissions ? \CRM_OAuth_BAO_OAuthSysToken::redact($tokenRecord) : $tokenRecord;
+  }
+
+}

--- a/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
+++ b/ext/oauth-client/Civi/Api4/Action/OAuthSysToken/Refresh.php
@@ -18,6 +18,9 @@ use Civi\Api4\Generic\BasicBatchAction;
  * - If permission-checks are active and you only have access to "refresh" (but
  *   not to secrets), it will return a minimalist record to indicate completion.
  *
+ * @see OAuthSessionToken::refresh
+ *   Please update OAuthSessionToken::refresh() and OAuthSysToken::refresh() in tandem.
+ *
  * @method $this setThreshold(int $limit)
  * @method int getThreshold()
  */

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -37,6 +37,24 @@ class OAuthSessionToken extends Generic\AbstractEntity {
 
   /**
    * @param bool $checkPermissions
+   * @return \Civi\Api4\Generic\BasicUpdateAction
+   */
+  public static function update($checkPermissions = TRUE): Generic\BasicUpdateAction {
+    $action = new Generic\BasicUpdateAction(
+      static::getEntityName(),
+      __FUNCTION__,
+      function ($item) {
+        $session = \CRM_Core_Session::singleton();
+        $allTokens = $session->get('OAuthSessionTokens') ?? [];
+        $allTokens[$item['cardinal']] = array_merge($allTokens[$item['cardinal']], $item);
+        $session->set('OAuthSessionTokens', $allTokens);
+        return $item;
+      });
+    return $action->setCheckPermissions($checkPermissions);
+  }
+
+  /**
+   * @param bool $checkPermissions
    * @return Generic\BasicBatchAction
    */
   public static function delete($checkPermissions = TRUE): Generic\BasicBatchAction {

--- a/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
+++ b/ext/oauth-client/Civi/Api4/OAuthSessionToken.php
@@ -7,6 +7,7 @@ namespace Civi\Api4;
  *
  * @see https://docs.civicrm.org/dev/en/latest/framework/oauth/#model-token
  *
+ * @method Action\OAuthSessionToken\Refresh refresh($checkPermissions)
  * @primaryKey cardinal
  * @searchable none
  * @since 5.67

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -53,30 +53,6 @@ function oauth_client_civicrm_container($container) {
     \Civi\OAuth\OAuthLeagueFacade::class, []))->setPublic(TRUE);
   $container->setDefinition('oauth2.token', new \Symfony\Component\DependencyInjection\Definition(
     \Civi\OAuth\OAuthTokenFacade::class, []))->setPublic(TRUE);
-  $container->findDefinition('dispatcher')
-    ->addMethodCall('addListener', ['civi.invoke.auth', 'oauth_client_refresh_session_tokens']);
-}
-
-/**
- * Implements symonfony event civi.invoke.auth
- *
- * Refresh the OAuth access tokens stored in the session.
- * Usually an access token has a short life span and comes with
- * a refresh token. The refresh token can be used the ontain a new acess token.
- */
-function oauth_client_refresh_session_tokens($event) {
-  try {
-    // Somehow we need to provide a where clause.
-    // So we filter an session tokens with a refresh token
-    civicrm_api4('OAuthSessionToken', 'refresh', [
-      'checkPermissions' => FALSE,
-      'where' => [
-        ['refresh_token', 'IS NOT NULL'],
-      ],
-    ]);
-  }
-  catch (\CRM_Core_Exception $e) {
-  }
 }
 
 /**

--- a/ext/oauth-client/oauth_client.php
+++ b/ext/oauth-client/oauth_client.php
@@ -53,6 +53,30 @@ function oauth_client_civicrm_container($container) {
     \Civi\OAuth\OAuthLeagueFacade::class, []))->setPublic(TRUE);
   $container->setDefinition('oauth2.token', new \Symfony\Component\DependencyInjection\Definition(
     \Civi\OAuth\OAuthTokenFacade::class, []))->setPublic(TRUE);
+  $container->findDefinition('dispatcher')
+    ->addMethodCall('addListener', ['civi.invoke.auth', 'oauth_client_refresh_session_tokens']);
+}
+
+/**
+ * Implements symonfony event civi.invoke.auth
+ *
+ * Refresh the OAuth access tokens stored in the session.
+ * Usually an access token has a short life span and comes with
+ * a refresh token. The refresh token can be used the ontain a new acess token.
+ */
+function oauth_client_refresh_session_tokens($event) {
+  try {
+    // Somehow we need to provide a where clause.
+    // So we filter an session tokens with a refresh token
+    civicrm_api4('OAuthSessionToken', 'refresh', [
+      'checkPermissions' => FALSE,
+      'where' => [
+        ['refresh_token', 'IS NOT NULL'],
+      ],
+    ]);
+  }
+  catch (\CRM_Core_Exception $e) {
+  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------

The OAuth Client extension contains functionality to store OAuth access token in a session. As OAuth Access tokens are short lived there is functionality (yet) to refresh those tokens.

This PR introduces an API `OAuthSessionToken.refresh` and a hook to refresh the access tokens upon each request.
The latter is debatable whether it is the responsibility of the OAuth Client extension.

See also: https://lab.civicrm.org/dev/core/-/work_items/6582

Background
----------------------------------------

I am working on the OAuth Login extension to integrate Keycloak as an OAuth identity provider. There was no functionality present to refresh the access tokens. Which is needed to keep a user logged in.

Before
----------------------------------------

It would not be possible to refresh OAuth Session tokens. (Only with custom code in a custom extension)

After
----------------------------------------

* OAuth Access tokens are refreshed upon each page request.
* A new API4 `OAuthSessionToken.refresh`  is available to refresh access tokens stored in the user session
