### PR TITLE
CiviCase - Add default subject field to timeline/sequence activities

### DIFF
--- a/CRM/Case/Form/Activity/OpenCase.php
+++ b/CRM/Case/Form/Activity/OpenCase.php
@@ -122,6 +122,28 @@ class CRM_Case_Form_Activity_OpenCase {
       $defaults['location[1][phone][1][phone_type_id]'] = key($phoneType);
     }
 
+    // Set default activity subject based on timeline.
+    $caseTypeId = $defaults['case_type_id'] ?? NULL;
+    if ($caseTypeId) {
+      $caseType = \Civi\Api4\CaseType::get(FALSE)
+        ->addSelect('definition')
+        ->addWhere('id', '=', $caseTypeId)
+        ->execute()
+        ->first();
+      if ($caseType && isset($caseType['definition']['activitySets'])) {
+        foreach ($caseType['definition']['activitySets'] as $activitySet) {
+          if (!empty($activitySet['timeline']) && isset($activitySet['activityTypes'])) {
+            foreach ($activitySet['activityTypes'] as $activityType) {
+              if (($activityType['name'] ?? '') === 'Open Case' && !empty($activityType['default_subject'])) {
+                $defaults['activity_subject'] = $activityType['default_subject'];
+                break 2;
+              }
+            }
+          }
+        }
+      }
+    }
+
     return $defaults;
   }
 

--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -430,12 +430,17 @@ AND        a.is_deleted = 0
       $orderVal = (string) $activityTypeXML->order;
     }
 
+    $defaultSubject = NULL;
+    if (isset($activityTypeXML->default_subject) && (string) $activityTypeXML->default_subject !== '') {
+      $defaultSubject = (string) $activityTypeXML->default_subject;
+    }
+
     if ($activityTypeName == 'Open Case') {
       $activityParams = [
         'activity_type_id' => $activityTypeID,
         'source_contact_id' => $params['creatorID'],
         'is_auto' => FALSE,
-        'subject' => !empty($params['subject']) ? $params['subject'] : $activityTypeName,
+        'subject' => !empty($params['subject']) ? $params['subject'] : ($defaultSubject ?? $activityTypeName),
         'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', $statusName),
         'target_contact_id' => $client,
         'medium_id' => $params['medium_id'] ?? NULL,
@@ -454,6 +459,9 @@ AND        a.is_deleted = 0
         'target_contact_id' => $client,
         'weight' => $orderVal,
       ];
+      if ($defaultSubject !== NULL) {
+        $activityParams['subject'] = $defaultSubject;
+      }
     }
 
     $activityParams['assignee_contact_id'] = $this->getDefaultAssigneeForActivity($activityParams, $activityTypeXML, $params['caseID']);

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -436,7 +436,8 @@
           reference_activity: 'Open Case',
           reference_offset: '1',
           reference_select: 'newest',
-          default_assignee_type: $scope.defaultAssigneeTypeValues.NONE
+          default_assignee_type: $scope.defaultAssigneeTypeValues.NONE,
+          default_subject: null
       };
       activitySet.activityTypes.push(activity);
       if(typeof activitySet.timeline !== "undefined" && activitySet.timeline == "1") {

--- a/ext/civi_case/ang/crmCaseType/sequenceTable.html
+++ b/ext/civi_case/ang/crmCaseType/sequenceTable.html
@@ -7,6 +7,7 @@ Required vars: activitySet
   <tr>
     <th></th>
     <th>{{:: ts('Activity') }}</th>
+    <th>{{:: ts('Default subject') }}</th>
     <th></th>
   </tr>
   </thead>
@@ -21,6 +22,14 @@ Required vars: activitySet
       {{ activity.name }}
     </td>
     <td>
+      <input
+        class="crm-form-text"
+        type="text"
+        ng-model="activity.default_subject"
+        placeholder="{{:: ts('(no subject)') }}"
+        />
+    </td>
+    <td>
       <a crm-icon="fa-trash" class="crm-hover-button" ng-click="removeItem(activitySet.activityTypes, activity)" title="{{:: ts('Remove') }}"></a>
     </td>
   </tr>
@@ -28,7 +37,7 @@ Required vars: activitySet
 
   <tfoot>
   <tr class="addRow">
-    <td colspan="3">
+    <td colspan="4">
       <span crm-add-name
            crm-options="activityTypeOptions"
            crm-var="newActivity"

--- a/ext/civi_case/ang/crmCaseType/timelineTable.html
+++ b/ext/civi_case/ang/crmCaseType/timelineTable.html
@@ -12,6 +12,7 @@ Required vars: activitySet
     <th>{{:: ts('Offset') }}</th>
     <th>{{:: ts('Select') }}</th>
     <th>{{:: ts('Default assignee') }}</th>
+    <th>{{:: ts('Default subject') }}</th>
     <th></th>
   </tr>
   </thead>
@@ -87,6 +88,14 @@ Required vars: activitySet
       </p>
     </td>
     <td>
+      <input
+        class="crm-form-text"
+        type="text"
+        ng-model="activity.default_subject"
+        placeholder="{{:: ts('(no subject)') }}"
+        />
+    </td>
+    <td>
       <a class="crm-hover-button"
          crm-icon="fa-trash"
          ng-show="isActivityRemovable(activitySet, activity)"
@@ -99,7 +108,7 @@ Required vars: activitySet
 
   <tfoot>
   <tr class="addRow">
-    <td colspan="8">
+    <td colspan="9">
       <span crm-add-name=""
            crm-options="activityTypeOptions"
            crm-var="newActivity"

--- a/tests/karma/unit/crmCaseTypeSpec.js
+++ b/tests/karma/unit/crmCaseTypeSpec.js
@@ -457,7 +457,8 @@ describe('crmCaseType', function() {
           reference_activity: 'Open Case',
           reference_offset: '1',
           reference_select: 'newest',
-          default_assignee_type: defaultAssigneeDefaultValue.value
+          default_assignee_type: defaultAssigneeDefaultValue.value,
+          default_subject: null
         });
       });
     });

--- a/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeTest.php
@@ -180,6 +180,69 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
       'xml' => file_get_contents(__DIR__ . '/xml/empty-node-text.xml'),
     ];
 
+    $fixtures['default-subject'] = [
+      'json' => json_encode([
+        'activityTypes' => [
+          ['name' => 'First act'],
+          ['name' => 'Second act'],
+        ],
+        'activitySets' => [
+          [
+            'name' => 'set1',
+            'label' => 'Label 1',
+            'timeline' => 1,
+            'activityTypes' => [
+              [
+                'name' => 'Open Case',
+                'status' => 'Completed',
+                'default_subject' => 'Open Case Default Subject',
+              ],
+            ],
+          ],
+          [
+            'name' => 'set2',
+            'label' => 'Label 2',
+            'timeline' => 1,
+            'activityTypes' => [
+              [
+                'name' => 'First act',
+                'status' => 'Scheduled',
+                'reference_activity' => 'Open Case',
+                'reference_offset' => 1,
+                'reference_select' => 'newest',
+                'default_subject' => 'First Act Default Subject',
+                'default_assignee_type' => '2',
+                'default_assignee_relationship' => '2_b_a',
+                'default_assignee_contact' => [],
+              ],
+            ],
+          ],
+        ],
+        'timelineActivityTypes' => [
+          [
+            'name' => 'Open Case',
+            'status' => 'Completed',
+            'default_subject' => 'Open Case Default Subject',
+          ],
+          [
+            'name' => 'First act',
+            'status' => 'Scheduled',
+            'reference_activity' => 'Open Case',
+            'reference_offset' => '1',
+            'reference_select' => 'newest',
+            'default_subject' => 'First Act Default Subject',
+            'default_assignee_type' => '2',
+            'default_assignee_relationship' => '2_b_a',
+            'default_assignee_contact' => [],
+          ],
+        ],
+        'caseRoles' => [
+          ['name' => 'First role', 'creator' => 1, 'manager' => 1],
+        ],
+      ]),
+      'xml' => file_get_contents(__DIR__ . '/xml/default-subject.xml'),
+    ];
+
     $cases = [];
     foreach ([
       'empty-defn',
@@ -190,6 +253,7 @@ class CRM_Case_BAO_CaseTypeTest extends CiviUnitTestCase {
       'forkable-0',
       'forkable-1',
       'statuses',
+      'default-subject',
     ] as $key) {
       $cases[] = [$key, $fixtures[$key]['json'], $fixtures[$key]['xml']];
     }

--- a/tests/phpunit/CRM/Case/BAO/xml/default-subject.xml
+++ b/tests/phpunit/CRM/Case/BAO/xml/default-subject.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CaseType>
+  <name>Housing Support</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>First act</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Second act</name>
+    </ActivityType>
+  </ActivityTypes>
+  <ActivitySets>
+    <ActivitySet>
+      <name>set1</name>
+      <label>Label 1</label>
+      <timeline>true</timeline>
+      <ActivityTypes>
+        <ActivityType>
+          <name>Open Case</name>
+          <status>Completed</status>
+          <default_subject>Open Case Default Subject</default_subject>
+        </ActivityType>
+      </ActivityTypes>
+    </ActivitySet>
+    <ActivitySet>
+      <name>set2</name>
+      <label>Label 2</label>
+      <timeline>true</timeline>
+      <ActivityTypes>
+        <ActivityType>
+          <name>First act</name>
+          <status>Scheduled</status>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>1</reference_offset>
+          <reference_select>newest</reference_select>
+          <default_subject>First Act Default Subject</default_subject>
+          <default_assignee_type>2</default_assignee_type>
+          <default_assignee_relationship>2_b_a</default_assignee_relationship>
+          <default_assignee_contact></default_assignee_contact>
+        </ActivityType>
+      </ActivityTypes>
+    </ActivitySet>
+  </ActivitySets>
+  <CaseRoles>
+    <RelationshipType>
+      <name>First role</name>
+      <creator>1</creator>
+      <manager>1</manager>
+    </RelationshipType>
+  </CaseRoles>
+</CaseType>

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -622,6 +622,47 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
     $this->assertEquals('My Default Subject', $activity['subject']);
   }
 
+  /**
+   * Tests CRM_Case_Form_Activity_OpenCase::setDefaultValues.
+   */
+  public function testOpenCaseFormDefaultSubject(): void {
+    $caseTypeParams = [
+      'name' => 'test_case_type_subject',
+      'title' => 'Test Case Type Subject',
+      'definition' => [
+        'activityTypes' => [
+          ['name' => 'Open Case', 'max_instances' => 1],
+        ],
+        'activitySets' => [
+          [
+            'name' => 'standard_timeline',
+            'label' => 'Standard Timeline',
+            'timeline' => 1,
+            'activityTypes' => [
+              [
+                'name' => 'Open Case',
+                'status' => 'Completed',
+                'default_subject' => 'Form Default Subject',
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+    $caseType = CRM_Case_BAO_CaseType::create($caseTypeParams);
+
+    $form = new stdClass();
+    $form->_context = 'standalone';
+    $form->_caseStatusId = NULL;
+    $form->_caseTypeId = $caseType->id;
+
+    $defaults = CRM_Case_Form_Activity_OpenCase::setDefaultValues($form);
+
+    $this->assertEquals('Form Default Subject', $defaults['activity_subject'] ?? NULL);
+
+    CRM_Case_BAO_CaseType::deleteRecord(['id' => $caseType->id]);
+  }
+
   private function getActivityTypeXMl(): SimpleXMLElement {
     try {
       $activityTypeXml = '<activity-type><name>Open Case</name></activity-type>';

--- a/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ProcessTest.php
@@ -603,6 +603,25 @@ class CRM_Case_XMLProcessor_ProcessTest extends CiviCaseTestCase {
     );
   }
 
+  /**
+   * Tests the creation of activities with a default subject.
+   */
+  public function testCreateActivityWithDefaultSubject(): void {
+    $activityTypeXml = $this->getActivityTypeXMl();
+    $activityTypeXml->default_subject = 'My Default Subject';
+
+    $this->process->createActivity($activityTypeXml, $this->activityParams);
+
+    $result = $this->callAPISuccess('Activity', 'get', [
+      'target_contact_id' => $this->activityParams['clientID'],
+      'return' => ['subject'],
+    ]);
+    $activity = CRM_Utils_Array::first($result['values']);
+
+    $this->assertNotNull($activity);
+    $this->assertEquals('My Default Subject', $activity['subject']);
+  }
+
   private function getActivityTypeXMl(): SimpleXMLElement {
     try {
       $activityTypeXml = '<activity-type><name>Open Case</name></activity-type>';


### PR DESCRIPTION
Overview
----------------------------------------
Allows a default subject to be set for every activity in the case timeline.

<img width="1579" height="397" alt="Screenshot 2026-06-16 at 11 02 45 AM" src="https://github.com/user-attachments/assets/bad2f58d-60df-4efb-85a1-bbd8205b81a4" />


See [dev/core#6575](https://lab.civicrm.org/dev/core/-/work_items/6575)