### PR TITLE
Adding Searchkit Action error messages configurable by returned response

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -87,25 +87,29 @@
             ctrl.progress = Math.floor(100 * ++currentBatch / totalBatches);
             processedCount += result.countFetched;
             countMatched += ('countMatched' in result ? result.countMatched : result.count);
-            // Determine if we have an error
-            if (result[0]['is_error']) {
-              if (true) {
-                ctrl.error({error: result[0]});
-                return;
-              }
-              else {
-                batchResult.errors += 1;
-                batchResult.messages += result[0]['message'];
-              }
-            }
 
             // Gather all results into one super collection
             if (batchResult) {
               batchResult.push(...result);
             } else {
               batchResult = result;
+              batchResult.message = '';
+              batchResult.errors = 0;
             }
-            if (ctrl.last >= ctrl.ids.length) {
+
+            // Determine if we have an error
+            _.each(result, function(item, index) {
+              if (item.is_error == 1) {
+                batchResult.errors += 1;
+                batchResult.message += item.message;
+                batchResult.title = item.title;
+                batchResult.level = item.level;
+              }
+            });
+
+            if (ctrl.ids.length == 1 && batchResult.errors == 1) {
+              ctrl.error({error: batchResult});
+            } else if (ctrl.last >= ctrl.ids.length) {
               $timeout(function() {
                 // Return a complete record of all batches
                 batchResult.batchCount = processedCount;

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -89,13 +89,13 @@
             countMatched += ('countMatched' in result ? result.countMatched : result.count);
             // Determine if we have an error
             if (result[0]['is_error']) {
-              if (TRUE) {
+              if (true) {
                 ctrl.error({error: result[0]});
                 return;
               }
               else {
                 batchResult.errors += 1;
-                batchResult.error_messages += result[0]['error_message'];
+                batchResult.messages += result[0]['message'];
               }
             }
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -93,21 +93,10 @@
               batchResult.push(...result);
             } else {
               batchResult = result;
-              batchResult.message = '';
-              batchResult.errors = 0;
             }
 
             // Determine if we have an error
-            _.each(result, function(item, index) {
-              if (item.is_error == 1) {
-                batchResult.errors += 1;
-                batchResult.message += item.message;
-                batchResult.title = item.title;
-                batchResult.level = item.level;
-              }
-            });
-
-            if (ctrl.ids.length == 1 && batchResult.errors == 1) {
+            if (result.is_blocking_error) {
               ctrl.error({error: batchResult});
             } else if (ctrl.last >= ctrl.ids.length) {
               $timeout(function() {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchBatchRunner.component.js
@@ -87,6 +87,18 @@
             ctrl.progress = Math.floor(100 * ++currentBatch / totalBatches);
             processedCount += result.countFetched;
             countMatched += ('countMatched' in result ? result.countMatched : result.count);
+            // Determine if we have an error
+            if (result[0]['is_error']) {
+              if (TRUE) {
+                ctrl.error({error: result[0]});
+                return;
+              }
+              else {
+                batchResult.errors += 1;
+                batchResult.error_messages += result[0]['error_message'];
+              }
+            }
+
             // Gather all results into one super collection
             if (batchResult) {
               batchResult.push(...result);

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -44,7 +44,11 @@
       if (result.action === 'inlineEdit') {
         CRM.status(ts('Saved'));
       } else {
-        if (ctrl.apiBatch.successMsg) {
+        // Do we encounter issues?
+        if (result.errors > 0) {
+          CRM.alter(ts(ctrl.apiBatch.partialSuccessMsg, { 1: result.batchCount, 2: entityTitle, 3: result.error_messages }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
+        }
+        else if (ctrl.apiBatch.successMsg) {
           CRM.alert(ts(ctrl.apiBatch.successMsg, { 1: result.batchCount, 2: entityTitle }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
         }
       }
@@ -52,7 +56,7 @@
     };
 
     this.onError = function(error) {
-      CRM.alert(ts(ctrl.apiBatch.errorMsg || error.error_message || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts('Error'), 'error');
+      CRM.alert(ts(error.error_message || ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.error_title || 'Error'), 'error');
       this.cancel();
     };
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -45,10 +45,10 @@
         CRM.status(ts('Saved'));
       } else {
         // Do we encounter issues?
-        if (result.errors > 0) {
-          CRM.alert(ts(ctrl.apiBatch.partialSuccessMsg || 'Completed %1 with issues the following issues: %3', { 1: result.batchCount, 2: entityTitle, 3: result.message }), ts('%1 Complete', { 1: ctrl.task.title }), 'warning');
-        }
-        else if (ctrl.apiBatch.successMsg) {
+        if (result.errors !== undefined && result.errors.length > 0) {
+          this.processErrors(result);
+          CRM.alert(ts(ctrl.apiBatch.partialSuccessMsg || 'Completed (%1) with the following issues: %3', { 1: result.batchCount, 2: entityTitle, 3: result.error_message }), ts('%1 Complete', { 1: ctrl.task.title }), 'warning');
+        } else if (ctrl.apiBatch.successMsg) {
           CRM.alert(ts(ctrl.apiBatch.successMsg, { 1: result.batchCount, 2: entityTitle }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
         }
       }
@@ -56,12 +56,29 @@
     };
 
     this.onError = function(error) {
-      if (error !== undefined) {
-        CRM.alert(ts(error.message || error.error_message || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.title || 'Error'), error.level || 'error');
+      if (error !== undefined && error.errors.length > 0) {
+        this.processErrors(error);
+        CRM.alert(ts(error.error_message || ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), error.error_title || ts('Error'), error.max_error_level || 'error');
       } else {
-        CRM.alert(ts(ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.title || 'Error'), error.level || 'error');
+        CRM.alert(ts(ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), error.error_title || ts('Error'), error.level || 'error');
       }
       this.cancel();
+    };
+
+    this.processErrors = function(result) {
+      result.error_message = '';
+      result.batchCount -= result.errors.length;
+      if (result.max_error_level == 'alert' || result.max_error_level == 'emergency') {
+        result.max_error_level = 'error';
+      }
+
+      result.errors.forEach((error) => {
+        if (result.error_message.length > 0) {
+          result.error_message += ' ';
+        }
+        result.error_message += error.message;
+        result.error_title = error.title;
+      });
     };
 
   });

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -46,7 +46,7 @@
       } else {
         // Do we encounter issues?
         if (result.errors > 0) {
-          CRM.alter(ts(ctrl.apiBatch.partialSuccessMsg, { 1: result.batchCount, 2: entityTitle, 3: result.messages }), ts('%1 Complete', { 1: ctrl.task.title }), 'warning');
+          CRM.alert(ts(ctrl.apiBatch.partialSuccessMsg || 'Completed %1 with issues the following issues: %3', { 1: result.batchCount, 2: entityTitle, 3: result.message }), ts('%1 Complete', { 1: ctrl.task.title }), 'warning');
         }
         else if (ctrl.apiBatch.successMsg) {
           CRM.alert(ts(ctrl.apiBatch.successMsg, { 1: result.batchCount, 2: entityTitle }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
@@ -56,7 +56,11 @@
     };
 
     this.onError = function(error) {
-      CRM.alert(ts(error.message || ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.title || 'Error'), error.level || 'error');
+      if (error !== undefined) {
+        CRM.alert(ts(error.message || error.error_message || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.title || 'Error'), error.level || 'error');
+      } else {
+        CRM.alert(ts(ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.title || 'Error'), error.level || 'error');
+      }
       this.cancel();
     };
 

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskApiBatch.ctrl.js
@@ -46,7 +46,7 @@
       } else {
         // Do we encounter issues?
         if (result.errors > 0) {
-          CRM.alter(ts(ctrl.apiBatch.partialSuccessMsg, { 1: result.batchCount, 2: entityTitle, 3: result.error_messages }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
+          CRM.alter(ts(ctrl.apiBatch.partialSuccessMsg, { 1: result.batchCount, 2: entityTitle, 3: result.messages }), ts('%1 Complete', { 1: ctrl.task.title }), 'warning');
         }
         else if (ctrl.apiBatch.successMsg) {
           CRM.alert(ts(ctrl.apiBatch.successMsg, { 1: result.batchCount, 2: entityTitle }), ts('%1 Complete', { 1: ctrl.task.title }), 'success');
@@ -56,7 +56,7 @@
     };
 
     this.onError = function(error) {
-      CRM.alert(ts(error.error_message || ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.error_title || 'Error'), 'error');
+      CRM.alert(ts(error.message || ctrl.apiBatch.errorMsg || '', {1: ctrl.ids.length, 2: ctrl.entityTitle}), ts(error.title || 'Error'), error.level || 'error');
       this.cancel();
     };
 


### PR DESCRIPTION
Overview
----------------------------------------

Presently we have the ability to set Searchkit Task errors via `hook_civicrm_searchKitTasks` but sometimes they can be super generic, and we might want more precision.

It could also be useful to provide all the issues that have occurred including successes.

Before
----------------------------------------

+ Required to throw an Exception from a custom `\Civi\Api4\Generic\BasicBatchAction`
+ Message was fed from the searchKitTasks hook and not custom for different cases

After
----------------------------------------

+ You can now return an array of details including `error_message` and `error_type`
+ The message is displayed to the user instead of the default message

<img width="588" height="484" alt="image" src="https://github.com/user-attachments/assets/802a9428-feee-400c-b98a-5f43c9a6218b" />

 ```
 `['is_error' => TRUE, 'error_title' => 'Yippeee', 'error_message' => E::ts('You can\'t remove the last user pleaaase'), 'error_type' => 'warning']
```

Example
----------------------------------------

_Really horrible but you get the gist_

```php
<?php

namespace Civi\Api4\Action\Relationship;

use CRM_Digitalcontracts_ExtensionUtil as E;
use Exception;

class RemoveSuperAdmin extends \Civi\Api4\Generic\BasicBatchAction {

  protected function doTask($item) {
    foreach ($item as $key => $rid) {
      
       return ['is_error' => TRUE, 'error_title' => 'Yippeee', 'error_message' => E::ts('You can\'t remove the last user pleaaase'), 'error_type' => 'warning'];
    }
    return $item;
  }
```

Comments
----------------------------------------

+ I need some help as I set it up to batch up the error messages if this is configurable but I don't think that the `BatchRunner.component.js` is aware of the custom values in the hook?? Maybe they are... or we could take a hard line (for now) and say that if there is one item we return the error otherwise we batch them?
+ If you don't like way that I am returning the error (array wise) I'm happy to change that as well. I came across this and my gutt says this is kind of how we are doing it elsewhere... but I would prefer to standardize it like other places

cc @mattwire @colemanw 