### PR TITLE
CRM_Utils_System - Check if headers are already sent

### DIFF
--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1004,7 +1004,9 @@ abstract class CRM_Utils_System_Base {
    * @param string $value
    */
   public function setHttpHeader($name, $value) {
-    header("$name: $value");
+    if (!headers_sent()) {
+      header("$name: $value");
+    }
   }
 
   /**

--- a/CRM/Utils/System/UnitTests.php
+++ b/CRM/Utils/System/UnitTests.php
@@ -63,7 +63,7 @@ class CRM_Utils_System_UnitTests extends CRM_Utils_System_Base {
    * @param string $value
    */
   public function setHttpHeader($name, $value) {
-    Civi::$statics[__CLASS__]['header'][] = ("$name: $value");
+    Civi::$statics[__CLASS__]['header'][] = "$name: $value";
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Avoid calling the `header()` function if HTTP headers have already been sent. This prevents "Headers already sent" PHP warnings, particularly in environments like CLI or when output has started.

Before
----------------------------------------
Calling `CRM_Utils_System_Base::setHttpHeader()` would attempt to invoke the php `header()` function unconditionally, which triggers a PHP warning if output has already begun. Also, `CRM_Utils_System_UnitTests::setHttpHeader()` had a redundant set of parentheses when appending the header to statics.

After
----------------------------------------
`CRM_Utils_System_Base::setHttpHeader()` checks if headers have already been sent using `headers_sent()` before calling `header()`. The redundant parentheses in `CRM_Utils_System_UnitTests::setHttpHeader()` have been removed.
