### PR TITLE
Api4 - Granular error tracking

### DIFF
--- a/CRM/Api4/Page/AJAX.php
+++ b/CRM/Api4/Page/AJAX.php
@@ -154,6 +154,11 @@ class CRM_Api4_Page_AJAX extends CRM_Core_Page {
       foreach (get_class_vars(get_class($result)) as $key => $val) {
         $response[$key] = $result->$key;
       }
+      // Add error data from Result object
+      $response['errors'] = $result->getErrors();
+      $response['max_error_level'] = $result->getMaxErrorLevel();
+      $response['is_blocking_error'] = $result->isBlockingError();
+
       unset($response['rowCount']);
       $response['count'] = $result->count();
       $response['countFetched'] = $result->countFetched();

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -96,7 +96,7 @@ class BasicBatchAction extends AbstractBatchAction {
         $result[] = $this->doTask($item);
       }
       catch (\Throwable $t) {
-        $result->addError($t->getMessage(), log: TRUE, code: $t->getCode());
+        $result->addError($t->getMessage(), TRUE, $t->getCode());
       }
     }
   }

--- a/Civi/Api4/Generic/BasicBatchAction.php
+++ b/Civi/Api4/Generic/BasicBatchAction.php
@@ -96,7 +96,7 @@ class BasicBatchAction extends AbstractBatchAction {
         $result[] = $this->doTask($item);
       }
       catch (\Throwable $t) {
-        \Civi::log()->error('Failed to run ' . $this->getEntityName() . '::' . $this->getActionName() . ' for item: ' . $item['id'] . '. Error: ' . $t->getMessage());
+        $result->addError($t->getMessage(), log: TRUE, code: $t->getCode());
       }
     }
   }

--- a/Civi/Api4/Generic/Error.php
+++ b/Civi/Api4/Generic/Error.php
@@ -19,32 +19,53 @@ use Psr\Log\LogLevel;
 class Error implements \JsonSerializable {
 
   /**
+   * The error severity (use Psr\Log\LogLevel strings)
+   *
    * @var string
    */
-  private $level;
+  private string $level;
+
+  /**
+   * Optional title for the error
+   *
+   * @var string
+   */
+  private string $title;
 
   /**
    * @var string
    */
-  private $message;
+  private string $message;
 
   /**
+   * Optional (machine-readable) code for the error
+   *
    * @var int|string
    */
-  private $code;
+  private int|string $code;
+
+  /**
+   * Optional additional metadata that can be used to attach custom information
+   *   to the error which can be used by the error handler (eg. frontend message display).
+   *
+   * @var array
+   */
+  private array $metadata;
 
   /**
    * @var string
    */
-  private $id;
+  private string $id;
 
   /**
    * Error constructor.
    */
-  public function __construct(string $message, string $level = LogLevel::ERROR, $code = 0) {
-    $this->level = $level;
+  public function __construct(string $message, int|string $code = 0, string $title = '', string $level = LogLevel::ERROR, array $metadata = []) {
     $this->message = $message;
     $this->code = $code;
+    $this->title = $title;
+    $this->level = $level;
+    $this->metadata = $metadata;
     $this->id = \CRM_Core_Error::createErrorId();
   }
 
@@ -59,8 +80,24 @@ class Error implements \JsonSerializable {
    * @param string $level
    * @return $this
    */
-  public function setLevel(string $level) {
+  public function setLevel(string $level): Error {
     $this->level = $level;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTitle(): string {
+    return $this->title;
+  }
+
+  /**
+   * @param string $title
+   * @return $this
+   */
+  public function setTitle(string $title): Error {
+    $this->title = $title;
     return $this;
   }
 
@@ -75,7 +112,7 @@ class Error implements \JsonSerializable {
    * @param string $message
    * @return $this
    */
-  public function setMessage(string $message) {
+  public function setMessage(string $message): Error {
     $this->message = $message;
     return $this;
   }
@@ -83,7 +120,7 @@ class Error implements \JsonSerializable {
   /**
    * @return int|string
    */
-  public function getCode() {
+  public function getCode(): int|string {
     return $this->code;
   }
 
@@ -91,11 +128,30 @@ class Error implements \JsonSerializable {
    * @param int|string $code
    * @return $this
    */
-  public function setCode($code) {
+  public function setCode(int|string $code): Error {
     $this->code = $code;
     return $this;
   }
 
+  /**
+   * @return array
+   */
+  public function getMetadata(): array {
+    return $this->metadata;
+  }
+
+  /**
+   * @param array $metadata
+   * @return $this
+   */
+  public function setMetadata(array $metadata): Error {
+    $this->metadata = $metadata;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
   public function getId(): string {
     return $this->id;
   }
@@ -107,7 +163,9 @@ class Error implements \JsonSerializable {
     return [
       'level' => $this->level,
       'message' => $this->message,
+      'title' => $this->title,
       'code' => $this->code,
+      'metadata' => $this->metadata,
       'id' => $this->id,
     ];
   }

--- a/Civi/Api4/Generic/Error.php
+++ b/Civi/Api4/Generic/Error.php
@@ -45,14 +45,6 @@ class Error implements \JsonSerializable {
   private int|string $code;
 
   /**
-   * Optional additional metadata that can be used to attach custom information
-   *   to the error which can be used by the error handler (eg. frontend message display).
-   *
-   * @var array
-   */
-  private array $metadata;
-
-  /**
    * @var string
    */
   private string $id;
@@ -60,12 +52,11 @@ class Error implements \JsonSerializable {
   /**
    * Error constructor.
    */
-  public function __construct(string $message, int|string $code = 0, string $title = '', string $level = LogLevel::ERROR, array $metadata = []) {
+  public function __construct(string $message, int|string $code = 0, string $title = '', string $level = LogLevel::ERROR) {
     $this->message = $message;
     $this->code = $code;
     $this->title = $title;
     $this->level = $level;
-    $this->metadata = $metadata;
     $this->id = \CRM_Core_Error::createErrorId();
   }
 
@@ -134,22 +125,6 @@ class Error implements \JsonSerializable {
   }
 
   /**
-   * @return array
-   */
-  public function getMetadata(): array {
-    return $this->metadata;
-  }
-
-  /**
-   * @param array $metadata
-   * @return $this
-   */
-  public function setMetadata(array $metadata): Error {
-    $this->metadata = $metadata;
-    return $this;
-  }
-
-  /**
    * @return string
    */
   public function getId(): string {
@@ -165,7 +140,6 @@ class Error implements \JsonSerializable {
       'message' => $this->message,
       'title' => $this->title,
       'code' => $this->code,
-      'metadata' => $this->metadata,
       'id' => $this->id,
     ];
   }

--- a/Civi/Api4/Generic/Error.php
+++ b/Civi/Api4/Generic/Error.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Generic;
+
+use Psr\Log\LogLevel;
+
+/**
+ * Class representing an APIv4 error.
+ */
+class Error implements \JsonSerializable {
+
+  /**
+   * @var string
+   */
+  private $level;
+
+  /**
+   * @var string
+   */
+  private $message;
+
+  /**
+   * @var int|string
+   */
+  private $code;
+
+  /**
+   * @var string
+   */
+  private $id;
+
+  /**
+   * Error constructor.
+   */
+  public function __construct(string $message, string $level = LogLevel::ERROR, $code = 0) {
+    $this->level = $level;
+    $this->message = $message;
+    $this->code = $code;
+    $this->id = \CRM_Core_Error::createErrorId();
+  }
+
+  /**
+   * @return string
+   */
+  public function getLevel(): string {
+    return $this->level;
+  }
+
+  /**
+   * @param string $level
+   * @return $this
+   */
+  public function setLevel(string $level) {
+    $this->level = $level;
+    return $this;
+  }
+
+  /**
+   * @return string
+   */
+  public function getMessage(): string {
+    return $this->message;
+  }
+
+  /**
+   * @param string $message
+   * @return $this
+   */
+  public function setMessage(string $message) {
+    $this->message = $message;
+    return $this;
+  }
+
+  /**
+   * @return int|string
+   */
+  public function getCode() {
+    return $this->code;
+  }
+
+  /**
+   * @param int|string $code
+   * @return $this
+   */
+  public function setCode($code) {
+    $this->code = $code;
+    return $this;
+  }
+
+  public function getId(): string {
+    return $this->id;
+  }
+
+  /**
+   * @return array
+   */
+  public function jsonSerialize(): array {
+    return [
+      'level' => $this->level,
+      'message' => $this->message,
+      'code' => $this->code,
+      'id' => $this->id,
+    ];
+  }
+
+}

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -11,6 +11,8 @@
 
 namespace Civi\Api4\Generic;
 
+use Psr\Log\LogLevel;
+
 /**
  * Container for api results.
  *
@@ -35,6 +37,10 @@ class Result extends \ArrayObject implements \JsonSerializable {
    * @var array
    */
   public $debug;
+  /**
+   * @var array
+   */
+  private array $errors = [];
   /**
    * Api version
    * @var int
@@ -186,6 +192,40 @@ class Result extends \ArrayObject implements \JsonSerializable {
 
   public function hasCountMatched(): bool {
     return isset($this->matchedCount);
+  }
+
+  /**
+   * @return \Civi\Api4\Generic\Error[]
+   */
+  public function getErrors(): array {
+    return $this->errors;
+  }
+
+  /**
+   * @param \Civi\Api4\Generic\Error[] $errors
+   * @return $this
+   */
+  public function setErrors(array $errors) {
+    $this->errors = $errors;
+    return $this;
+  }
+
+  /**
+   * @return $this
+   */
+  public function addError(string $message, bool $log = FALSE, $level = LogLevel::ERROR, $code = 0) {
+    $error = new Error($message, $level, $code);
+    $this->errors[] = $error;
+    if ($log) {
+      $context = [
+        'entity' => $this->entity,
+        'action' => $this->action,
+        'error_id' => $error->getId(),
+        'error_code' => $code,
+      ];
+      \Civi::log()->log($level, $error->getMessage(), $context);
+    }
+    return $this;
   }
 
   /**

--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -211,10 +211,17 @@ class Result extends \ArrayObject implements \JsonSerializable {
   }
 
   /**
+   * @param string $message The human readable error message
+   * @param bool $log Should we log the error
+   * @param int|string $code The machine readable error code/message
+   * @param string $title Optional title for the error message
+   * @param string $level Level (using Psr/LogLevel strings) of error, eg. warning, error
+   * @param array $metadata Array of extra metadata that can be added to the error
+   *
    * @return $this
    */
-  public function addError(string $message, bool $log = FALSE, $level = LogLevel::ERROR, $code = 0) {
-    $error = new Error($message, $level, $code);
+  public function addError(string $message, bool $log = FALSE, int|string $code = 0, string $title = '', string $level = LogLevel::ERROR, array $metadata = []) {
+    $error = new Error($message, $code, $title, $level, $metadata);
     $this->errors[] = $error;
     if ($log) {
       $context = [
@@ -226,6 +233,51 @@ class Result extends \ArrayObject implements \JsonSerializable {
       \Civi::log()->log($level, $error->getMessage(), $context);
     }
     return $this;
+  }
+
+  /**
+   * Helper function to check if any errors were defined
+   *
+   * @return bool
+   */
+  public function hasErrors(): bool {
+    return count($this->errors) > 0;
+  }
+
+  /**
+   * Ordered by most serious first. These are the levels that are treated as an "error".
+   *
+   * @var array
+   */
+  private array $errorLevels = [
+    LogLevel::EMERGENCY,
+    LogLevel::ALERT,
+    LogLevel::CRITICAL,
+    LogLevel::ERROR,
+  ];
+
+  /**
+   * Helper function to get the maximum severity of error
+   *
+   * @return string|null
+   */
+  public function getMaxErrorLevel(): ?string {
+    $levels = array_column($this->errors, 'level');
+    // Returns the first match (ie. the most severe)
+    return current(array_filter(
+      $this->errorLevels,
+      fn($level) => in_array($level, $levels)
+    )) ?: NULL;
+  }
+
+  /**
+   * We might have defined "errors" which are level info, warning and should be shown to the user but won't "fail" validation.
+   * If we return TRUE, assume we have something that needs resolving / is invalid.
+   *
+   * @return bool
+   */
+  public function isBlockingError(): bool {
+    return in_array($this->getMaxErrorLevel(), $this->errorLevels);
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -185,6 +185,30 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
     $this->assertEquals([400, 1600], \CRM_Utils_Array::collect('frobnication', (array) $result));
   }
 
+  public function testBatchActionErrorHandling(): void {
+    $objects = [
+      ['group' => 'one', 'color' => 'blue', 'number' => 20],
+      ['group' => 'one', 'color' => 'blue', 'number' => 30],
+    ];
+    $this->replaceRecords($objects);
+    $message = 'Test error message';
+
+    $action = new \Civi\Api4\Generic\BasicBatchAction('MockBasicEntity', 'batchFail', function($item) use ($message) {
+      throw new \Exception($message, 999);
+    });
+    $action->setCheckPermissions(FALSE);
+    $action->addWhere('color', '=', 'blue');
+
+    $result = $action->execute();
+    $this->assertCount(0, $result);
+    $errors = $result->getErrors();
+    $this->assertCount(2, $errors);
+    $this->assertInstanceOf(\Civi\Api4\Generic\Error::class, $errors[0]);
+    $this->assertEquals(\Psr\Log\LogLevel::ERROR, $errors[0]->getLevel());
+    $this->assertSame($message, $errors[0]->getMessage());
+    $this->assertSame(999, $errors[0]->getCode());
+  }
+
   public function testGetFields(): void {
     $getFields = MockBasicEntity::getFields()->execute()->indexBy('name');
 


### PR DESCRIPTION
Overview
----------------------------------------
WIP to support more granular error tracking in Api4.

Before
----------------------------------------
Every api call was considered success or failure on the whole

After
----------------------------------------
More granular tracking allows part of the api call to succeed while tracking any errors. This is especially useful for batch actions where > 1 record is being processed. This allows some to succeed and others to fail, and all relevant info will be returned.

TODO: Change `CRM_Api4_Page_AJAX::execute` to return the new format and deal will all the fallout from the changed contract.