### PR TITLE
don't crash when formatting a link on a SK with uppercase letters

### DIFF
--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -628,8 +628,8 @@ final class Url implements \JsonSerializable {
     }
 
     // Goal: After this switch(), we should have the $scheme, $path, and $query combined.
-    switch ($scheme) {
-      case 'assetBuilder':
+    switch (strtolower($scheme)) {
+      case 'assetbuilder':
         $assetName = $renderedPieces['path'];
         $assetParams = [];
         parse_str('' . $renderedPieces['query'], $assetParams);


### PR DESCRIPTION
Overview
----------------------------------------
It's legal to enter `HTTPS://example.org` or `Https://example.org` as website values.  However, the uppercase characters can lead to an `Unknown URL Scheme` error.

This is a regression, but it goes back to 6.5, so I'm leaving this against `master`.

To replicate:
* Add/edit a contact's website to have uppercase letters in the protocol.
* Create an SK search and table display for contacts joined to websites.
* Edit the `sort_name` column to display a link, and use the token for the contact's website.
