### PR TITLE
Revert #35646 - breaks CiviCRM entity < 4.0.6

### DIFF
--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -16,6 +16,8 @@ use Civi\API\Event\ExceptionEvent;
 use Civi\API\Event\ResolveEvent;
 use Civi\API\Event\RespondEvent;
 
+// Removing Exception breaks CiviCRM Entity < 4.0.6
+// @todo  Remove api/Exception end of 2026, or later.
 require_once 'api/Exception.php';
 require_once 'api/v3/utils.php';
 

--- a/Civi/API/Kernel.php
+++ b/Civi/API/Kernel.php
@@ -16,6 +16,7 @@ use Civi\API\Event\ExceptionEvent;
 use Civi\API\Event\ResolveEvent;
 use Civi\API\Event\RespondEvent;
 
+require_once 'api/Exception.php';
 require_once 'api/v3/utils.php';
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------

With #35646 included a fatal error is hit whenever Drupal attempts to build a list of fields if CiviCRM entity is installed.

This is due to a bug fixed in 4.0.6. 

Reverting this commit now will allow time for sites to upgrade to 4.0.6 released today - to avoid hitting this.

Goal is to reintroduce #35646 at or after the end of the year.

Discussion at https://chat.civicrm.org/civicrm/pl/gm397dd1uiy3un6a9kut7hekte

Before
----------------------------------------

no 'unnecessary' include of 'api/Exception.php'  leads to a fatal error, when an bug is hit in CiviCRM Entity < 4.0.6.


After
----------------------------------------

An 'unnecessary' include of 'api/Exception.php' means the error in CiviCRM Entity < 4.0.6 doesn't cause a fatal error.

Technical Details
----------------------------------------
See https://git.drupalcode.org/project/civicrm_entity/-/merge_requests/27

Comments
----------------------------------------
One suspects there is more going on here as well, but I've verified that applying this or applying the patch to CiviCRM entity prevents the error.

To replicate:

Install CiviCRM 6.16-beta1 (on Drupal) + CiviCRM Entity < 4.0.6
Note that the CiviCRM entity release has dropped so you need to explicitly require the version.

`
composer require drupal/civicrm_entity:4.0.5
drush cr
`

You can also observer this on re-install with civicrm entity already installed.

