### PR TITLE
Actions - Fix `/port` command (again)

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -153,8 +153,7 @@ jobs:
                   --head "$PORT_BRANCH" \
                   --title "Port: \"$PR_TITLE\" to $NEW_BASE" \
                   --body "Port of #${{ github.event.issue.number }} to $NEW_BASE." \
-                  --label "port" \
-                  --json url --jq '.url')
+                  --label "port")
                 COMMENT_BODY="🚀 Successfully created port PR: $NEW_PR_URL"
               fi
               


### PR DESCRIPTION
Overview
----------------------------------------
Gets the new `/port` command working for our GitHub actions workflow.

Technical Details
------
The issue is that the runner environment's version of the GitHub CLI does not support the `--json` and `--jq` flags on the `gh pr create` command, which resulted in the` unknown flag: --json` error.

By default, the `gh pr create` command prints the new pull request URL directly to standard output upon success. Simply removing these flags fixes the compatibility issue while successfully capturing the PR URL.