### PR TITLE
Autocomplete - Fix autocomplete of event templates

### DIFF
--- a/Civi/Api4/Service/Autocomplete/EventAutocompleteProvider.php
+++ b/Civi/Api4/Service/Autocomplete/EventAutocompleteProvider.php
@@ -36,9 +36,17 @@ class EventAutocompleteProvider extends \Civi\Core\Service\AutoService implement
   public function onApiPrepare(\Civi\API\Event\PrepareEvent $event): void {
     $apiRequest = $event->getApiRequest();
     if (is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
-      [$entityName, $fieldName] = array_pad(explode('.', (string) $apiRequest->getFieldName(), 2), 2, '');
-      $entityName = !empty($entityName) ? $entityName : $apiRequest->getEntityName();
-      if (($entityName === 'Event' && $fieldName === 'id') || $fieldName === 'event_id') {
+      $fieldName = (string) $apiRequest->getFieldName();
+      if (str_contains($fieldName, ':')) {
+        $fieldName = explode(':', $fieldName, 2)[1];
+      }
+      if (str_contains($fieldName, '.')) {
+        [$entityName, $fieldName] = explode('.', $fieldName, 2);
+      }
+      else {
+        $entityName = $apiRequest->getEntityName();
+      }
+      if (($entityName === 'Event' && in_array($fieldName, ['id', 'template_id'])) || $fieldName === 'event_id') {
         $showTemplates = $fieldName === 'template_id';
         $apiRequest->addFilter('is_template', $showTemplates);
       }
@@ -57,6 +65,7 @@ class EventAutocompleteProvider extends \Civi\Core\Service\AutoService implement
     $filters = $e->context['filters'] ?? [];
     if (!empty($filters['is_template'])) {
       $e->display['settings']['columns'][0]['key'] = 'template_title';
+      $e->display['settings']['searchFields'][1] = 'template_title';
     }
   }
 

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformAutocompleteUsageTest.php
@@ -433,4 +433,55 @@ EOHTML;
     $this->assertEquals('Yellow', $result[1]['label']);
   }
 
+  /**
+   * Ensure that Afform event autocomplete returns only event templates for template_id field.
+   */
+  public function testAutocompleteEventTemplates(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity actions="{create: true, update: true}" type="Event" name="Event1" label="Event 1" security="RBAC" />
+  <fieldset af-fieldset="Event1" class="af-container" af-title="Event 1">
+    <af-field name="template_id" />
+    <af-field name="id" />
+    <af-field name="title" />
+    <af-field name="start_date" />
+    <af-field name="event_type_id" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    $prefix = uniqid();
+
+    $this->saveTestRecords('Event', [
+      'records' => [
+        ['title' => $prefix . ' Normal Event', 'is_template' => 0],
+        ['template_title' => $prefix . ' Event Template', 'is_template' => 1],
+      ],
+    ]);
+
+    // Searching event template excludes normal events
+    $result = \Civi\Api4\Event::autocomplete()
+      ->setFormName('afform:' . $this->formName)
+      ->setFieldName('Event1:template_id')
+      ->setInput($prefix)
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals($prefix . ' Event Template', $result[0]['label']);
+
+    // Searching normal events excludes templates
+    $result = \Civi\Api4\Event::autocomplete()
+      ->setFormName('afform:' . $this->formName)
+      ->setFieldName('Event1:id')
+      ->setInput($prefix)
+      ->execute();
+    $this->assertCount(1, $result);
+    $this->assertEquals($prefix . ' Normal Event', $result[0]['label']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes autocompletes of event templates.

Technical Details
----------------------------------------
This fixes the feature added in https://github.com/civicrm/civicrm-core/pull/27058 which was since broken in several ways. Partly by https://github.com/civicrm/civicrm-core/pull/32400 and partly by https://github.com/civicrm/civicrm-core/pull/33237

Unit test locks in the fix so it doesn't break again.