### PR TITLE
dev/core#6508 Render mailing report with mailto click throughs

### DIFF
--- a/Civi/Core/Url.php
+++ b/Civi/Core/Url.php
@@ -659,6 +659,14 @@ final class Url implements \JsonSerializable {
         $result = $this->getScheme() . '://' . $this->host . $port . $path . $this->composeQuery($renderedPieces['query']);
         break;
 
+      case 'mailto':
+        // https://lab.civicrm.org/dev/core/-/work_items/6508
+        $valid = \CRM_Utils_Rule::email($this->getPath());
+        // What should we do if it is not a valid email?  Can we safely render?
+        // probably low risk not rendering.
+        $result = $valid ? ('mailto:' . $this->getPath()) : '';
+        break;
+
       // Handle 'frontend', 'backend', 'service', and any extras.
       default:
         $result = $userSystem->getRouteUrl($scheme, $renderedPieces['path'], $renderedPieces['query']);

--- a/tests/phpunit/E2E/Core/UrlFacadeTest.php
+++ b/tests/phpunit/E2E/Core/UrlFacadeTest.php
@@ -89,6 +89,33 @@ class UrlFacadeTest extends \CiviEndToEndTestCase {
     }
   }
 
+  public function testMailto(): void {
+    $validEmails = [
+      'duck@example.org',
+      'user.name+tag@sub.example.com',
+    ];
+    foreach ($validEmails as $email) {
+      $expected = 'mailto:' . $email;
+      $localRender = (string) Civi::url('mailto:' . $email);
+      $this->assertEquals($expected, $localRender, "(Local render) Valid mailto for $email should render correctly");
+
+      $remoteRender = $this->remote(__FUNCTION__, fn($e) => (string) Civi::url('mailto:' . $e), [$email]);
+      $this->assertEquals($expected, $remoteRender, "(Remote render) Valid mailto for $email should render correctly");
+    }
+
+    $invalidEmails = [
+      'not-an-email',
+      'example.com',
+    ];
+    foreach ($invalidEmails as $email) {
+      $localRender = (string) Civi::url('mailto:' . $email);
+      $this->assertEquals('', $localRender, "(Local render) Invalid mailto for '$email' should render as empty string");
+
+      $remoteRender = $this->remote(__FUNCTION__, fn($e) => (string) Civi::url('mailto:' . $e), [$email]);
+      $this->assertEquals('', $remoteRender, "(Remote render) Invalid mailto for '$email' should render as empty string");
+    }
+  }
+
   public function testPath() {
     $examples = $this->remote(__FUNCTION__, function() {
       $examples = [];


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#6508 Render mailing report with mailto click throughs

Allow links like mailto:duck@example.org to render


Before
----------------------------------------
<img width="1368" height="365" alt="image" src="https://github.com/user-attachments/assets/0d554e5c-d3e1-4187-ab06-0926983fb965" />


After
----------------------------------------
Renders

<img width="1056" height="371" alt="image" src="https://github.com/user-attachments/assets/9d0f0874-c6f4-4243-b41a-3e97242bb902" />

Clicking on the link fires up an email (the equivalent http links go to the relevant page)

<img width="1061" height="211" alt="image" src="https://github.com/user-attachments/assets/ff605bdf-68d8-4498-8f7e-a9cee2c4e6db" />

Technical Details
----------------------------------------


Comments
----------------------------------------
