### PR TITLE
Move spaces into variables in triggers file

### DIFF
--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -160,11 +160,11 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
       }
       foreach ($tables as $eventName => $events) {
         foreach ($events as $whenName => $parts) {
-          $varString = implode("\n", $parts['variables']);
-          $sqlString = implode("\n", $parts['sql']);
+          $varString = ' ' . implode("\n", $parts['variables']);
+          $sqlString = ' ' . implode("\n", $parts['sql']);
           $validName = \CRM_Core_DAO::shortenSQLName($tableName, 48, TRUE);
           $triggerName = "{$validName}_{$whenName}_{$eventName}";
-          $triggerSQL = "CREATE TRIGGER $triggerName $whenName $eventName ON $tableName FOR EACH ROW BEGIN $varString $sqlString END";
+          $triggerSQL = "CREATE TRIGGER $triggerName $whenName $eventName ON $tableName FOR EACH ROW BEGIN{$varString}{$sqlString} END";
 
           $this->enqueueQuery("DROP TRIGGER IF EXISTS $triggerName");
           $this->enqueueQuery($triggerSQL);


### PR DESCRIPTION
Overview
----------------------------------------
Move spaces into variables in triggers file

Before
----------------------------------------
trailing space on phone trigger if output to a file

After
----------------------------------------
<img width="1328" height="207" alt="image" src="https://github.com/user-attachments/assets/04852fcb-155e-461b-8620-0732059e4a6b" />

Technical Details
----------------------------------------
outputting the triggers & checking them in to version control  is pretty obscure but trailing spaces are a pain in this workflow

Comments
----------------------------------------
