### PR TITLE
Standalone - Fix broken KCFinder (again)

### DIFF
--- a/setup/res/civicrm.standalone.php.txt
+++ b/setup/res/civicrm.standalone.php.txt
@@ -10,8 +10,14 @@
 // this file should set these two globals
 global $appRootPath, $settingsPath;
 
-// this file should always be in the project root
-$appRootPath = __DIR__;
+// Determine project root path dynamically depending on whether this file
+// is placed in the project root or the core subdirectory.
+if (basename(__DIR__) === 'core') {
+  $appRootPath = dirname(__DIR__);
+}
+else {
+  $appRootPath = __DIR__;
+}
 
 // standard file structure with top-level private, public and extensions dirs.
 $autoLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'core', 'vendor', 'autoload.php']);
@@ -21,7 +27,7 @@ $classLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'core', 'CRM', 'Core'
 # $autoLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath , 'vendor', 'autoload.php']);
 # $classLoader = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'vendor', 'civicrm', 'civicrm-core', 'CRM', 'Core', 'ClassLoader.php']);
 
-$settingsPath = implode(DIRECTORY_SEPARATOR, [__DIR__, 'private', 'civicrm.settings.php']);
+$settingsPath = implode(DIRECTORY_SEPARATOR, [$appRootPath, 'private', 'civicrm.settings.php']);
 
 require_once $autoLoader;
 require_once $classLoader;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes broken image popup in Standalone.

Before
----------------------------------------
Go to `/civicrm/admin/badgelayout/add?reset=1&action=update&id=1` and click on **Image (top left)**. KCFinder will popup and fail:

<img width="1824" height="1548" alt="Screenshot 2026-06-17 at 10 28 14 AM" src="https://github.com/user-attachments/assets/a2ba2b27-4dc7-4024-b784-81a8765e1af1" />

After
----------------------------------------
KCFinder will popup and work:

<img width="1824" height="1548" alt="Screenshot 2026-06-17 at 10 25 24 AM" src="https://github.com/user-attachments/assets/d94af707-d8b3-4443-94c2-b1b3268d37f9" />


Technical Details
----------------------------------------
At some point KCFinder broke on standalone again; not sure why but it was previously fixed via 2ec1d207cb by @ufundo. The new problem appears to be invalid path translation inside `civicrm.config.php` where the paths are constructed relative to the file's current directory using __DIR__:

- `$appRootPath = __DIR__;` (resolves to ~/buildkit/build/standalone-clean/web/core)
- `$autoLoader = implode(..., [$appRootPath, 'core', 'vendor', 'autoload.php']);` (resolves to web/core/core/vendor/autoload.php)

Note the repetition of `core/core`.

This fix appears to solve it, but only for new standalone builds. I'm not sure what to do about existing installs with this problem.

@ufundo another interesting thing I noted, and I'm not sure if this was intentional, is that when `findConfigFile()` starts traversing up the directory structure it reaches `web/core/` and finds `civicrm.config.php` and returns that path, never actually reaching `web/civicrm.standalone.php`. So I'm not sure why it's also looking for that file?
At any rate, both files appear to inherit from the same template `setup/res/civicrm.standalone.php.txt`... I think?
 