### PR TITLE
Order API: Remove ContributionRecur::Create from calculateContributionRecurValues()

### DIFF
--- a/CRM/Financial/BAO/Order.php
+++ b/CRM/Financial/BAO/Order.php
@@ -1611,12 +1611,6 @@ class CRM_Financial_BAO_Order {
       if (empty($this->contributionRecurValues['financial_type_id'])) {
         $this->contributionRecurValues['financial_type_id'] = $this->getDefaultFinancialTypeID();
       }
-
-      $contributionRecur = ContributionRecur::create(FALSE)
-        ->setValues($this->contributionRecurValues)
-        ->execute()
-        ->single();
-      $this->setExistingContributionRecurID($contributionRecur['id']);
     }
   }
 
@@ -1807,6 +1801,8 @@ class CRM_Financial_BAO_Order {
    */
   public function setExistingContributionRecurID(?int $existingContributionRecurID): void {
     $this->existingContributionRecurID = $existingContributionRecurID;
+    // Also set the value on the Contribution
+    $this->contributionValues['contribution_recur_id'] = $existingContributionRecurID;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/35523 I refactored Order API to logically separate validate and save. But I didn't remove a call to ContributionRecur::Create from `calculateContributionRecurValues()` when I added it in `saveContributionRecur()`

Before
----------------------------------------
Two calls, so one will fail or you will get two ContributionRecur created.

After
----------------------------------------
One call, when saving

Technical Details
----------------------------------------


Comments
----------------------------------------

