### PR TITLE
Formbuilder Payments: Add the payment processor ID to a recur

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionInterface.php
@@ -39,7 +39,7 @@ interface CheckoutOptionInterface {
   /**
    * @return ?int id of associated PaymentProcessor record, if any
    */
-  public function getPaymentProcessorId(): ?int;
+  public function getPaymentProcessorId(bool $testMode = FALSE): ?int;
 
   /**
    * Initiate a new checkout

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -554,7 +554,7 @@ class CheckoutSession {
         ->addValue('contribution_id', $this->getContributionId())
         ->addValue('total_amount', $this->totalAmount)
         ->addValue('fee_amount', $this->feeAmount)
-        ->addValue('payment_processor_id', $this->getCheckoutOption()->getPaymentProcessorId())
+        ->addValue('payment_processor_id', $this->getCheckoutOption()->getPaymentProcessorId($this->isTestMode()))
         ->addValue('trxn_date', date('Ymd H:i:s'))
         ->addValue('trxn_id', $this->transactionId)
         ->addValue('order_reference', $this->orderReference)

--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -192,7 +192,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
     $event->setEntityId(0, $savedContribution['id']);
 
     if ($contribution['recur_period'] ?? NULL) {
-      $this->createContributionRecur($savedContribution['id'], $contribution['recur_period']);
+      $this->createContributionRecur($savedContribution['id'], $contribution['recur_period'], $contribution['checkout_option'] ?? NULL);
     }
 
   }
@@ -220,7 +220,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
   /**
    * For a recurring contribution, create a ContributionRecur record as well
    */
-  public function createContributionRecur(int $contributionId, string $recurPeriod) {
+  public function createContributionRecur(int $contributionId, string $recurPeriod, ?string $checkoutOption = NULL) {
     // get values we need to reuse from the contribution record
     $contribution = \Civi\Api4\Contribution::get(FALSE)
       ->addSelect('contact_id', 'total_amount', 'currency', 'is_test')
@@ -245,6 +245,14 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
     // calculate the next scheduled date
     $nextSched = (new DateTime("+ {$recurParams['frequency_interval']} {$recurParams['frequency_unit']}"))->format('Y-m-d');
 
+    if ($checkoutOption) {
+      $checkoutOption = \Civi::service('civi.checkout')->getOption($checkoutOption);
+      $paymentProcessorId = $checkoutOption->getPaymentProcessorId(\Civi::service('civi.checkout')->isTestMode());
+    }
+    else {
+      $paymentProcessorId = NULL;
+    }
+
     $recurRecordId = \Civi\Api4\ContributionRecur::create(FALSE)
       ->addValue('contact_id', $contribution['contact_id'])
       ->addValue('amount', $contribution['total_amount'])
@@ -253,6 +261,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
       ->addValue('frequency_unit', $recurParams['frequency_unit'])
       ->addValue('frequency_interval', $recurParams['frequency_interval'])
       ->addValue('next_sched_contribution_date', $nextSched)
+      ->addValue('payment_processor_id', $paymentProcessorId)
       ->execute()
       ->single()['id'];
 


### PR DESCRIPTION
Overview
----------------------------------------
When we submit a form for payment and call `startCheckout()` we have a checkoutOption but not a payment processor. This means that the ContributionRecur.payment_processor_id never gets set and none of the functions that rely on that work (updating billing details, cancelling recur etc).

Before
----------------------------------------
ContributionRecur.payment_processor_id not set.

After
----------------------------------------
`ContributionRecur.payment_processor_id` set.

Technical Details
----------------------------------------

1. If a checkoutOption is not linked to a payment processor it stays as NULL. That's fine. In the future maybe we'll have a way to manage subscription things without a paymentProcessor, today we don't.
2. @ufundo This brings up the do we/don't we issue again on the `getPaymentProcessorId(bool $testMode = FALSE): ?int;` function. It's critical that we record the correct payment processor ID on the ContributionRecur and accepting the testMode flag makes that very easy to do - I can't see another way? Thoughts?

Comments
----------------------------------------
@rbaugh @ufundo 
