### PR TITLE
Afform.submitFile - return uploaded file info to client

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -147,7 +147,8 @@ class SubmitFile extends AbstractProcessor {
       ],
       'checkPermissions' => FALSE,
     ]);
-    return [];
+    $fileInfo = $this->getFileInfo($fileId, $this->modelName);
+    return [$fileInfo];
   }
 
   private function getDraft(): array {


### PR DESCRIPTION
Overview
----------------------------------------
Ensures the successfully uploaded file is rendered for user after they submit.

Before
----------------------------------------
- when you load a record with an uploaded file in afform, it has a nice display like this:

**Exhibit A**
<img width="519" height="101" alt="image" src="https://github.com/user-attachments/assets/6cf14e2c-2632-4aa7-ae70-fc33c076783c" />

- when you are selecting a file, you have an input like this:

**Exhibit B**
<img width="491" height="143" alt="image" src="https://github.com/user-attachments/assets/9d181614-aec4-44de-84cf-458026eaca49" />

- after you have successfully submitted the file, it still looks like you are picking the file, ie you get the Exhibit B view


After
----------------------------------------
- after you have successfully submitted the file, you get the nice reassuring Exhibit A view


Comments
----------------------------------------
Quirk: it works if your form is in submit draft mode. This brings the real submit into line with submit draft.
