### PR TITLE
Add source_record_id to Merge activities

### DIFF
--- a/CRM/Dedupe/Merger.php
+++ b/CRM/Dedupe/Merger.php
@@ -1721,6 +1721,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
     $activity = civicrm_api3('activity', 'create', [
       'source_contact_id' => CRM_Core_Session::getLoggedInContactID() ? CRM_Core_Session::getLoggedInContactID() :
       $mainId,
+      'source_record_id' => $otherId,
       'subject' => ts('Contact ID %1 has been merged and deleted.', $params),
       'target_contact_id' => $mainId,
       'activity_type_id' => 'Contact Merged',
@@ -1733,6 +1734,7 @@ INNER JOIN  civicrm_membership membership2 ON membership1.membership_type_id = m
       civicrm_api3('activity', 'create', [
         'source_contact_id' => CRM_Core_Session::getLoggedInContactID() ? CRM_Core_Session::getLoggedInContactID() :
         $otherId,
+        'source_record_id' => $mainId,
         'subject' => ts('Contact ID %1 has been merged into Contact ID %2 and deleted.', $params),
         'target_contact_id' => $otherId,
         'activity_type_id' => 'Contact Deleted by Merge',


### PR DESCRIPTION
Overview
----------------------------------------
Contact Merged and Contact deleted by Merge activities are created with a target_contact (the contact being merged into and the contact being deleted by merge). The id for the other contact in the merge is in the message subject, but if you want to work with that programatically, you have to parse it out.

This puts the other contact id into the source_record_id field. I'm not sure that is entirely intuitive, but I don't think it hurts anything. We could instead add a custom field specifically for this, but this seems simpler.