### PR TITLE
SearchKit - Don't needlessly refresh subsearches

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -30,6 +30,7 @@
         for (let p=0; p < placeholderCount; ++p) {
           this.placeholders.push({});
         }
+        const isSubsearch = $element.closest('.crm-search-col-type-subsearch').length > 0;
 
         // Add keys used by crmSearchDisplayTable.toggleColumns
         const setColumnDefaults = (col) => {
@@ -80,7 +81,7 @@
         if (contactTab && !$element.is($('#' + contactTab + ' [search][display]').first())) {
           contactTab = null;
         }
-        let hasCounter = contactTab || ctrl.hasOwnProperty('totalCount');
+        let hasCounter = !isSubsearch && (contactTab || ctrl.hasOwnProperty('totalCount'));
         if (hasCounter) {
           $scope.$watch('$ctrl.rowCount', function(rowCount) {
             // Update totalCount only if no user filters are set
@@ -100,10 +101,12 @@
         }
 
         // Popup forms in this display or surrounding Afform trigger a refresh
-        $element.closest('form').on('crmPopupFormSuccess crmFormSuccess', function() {
-          ctrl.rowCount = null;
-          ctrl.getResultsPronto();
-        });
+        if (!isSubsearch) {
+          $element.closest('form').on('crmPopupFormSuccess crmFormSuccess', () => {
+            ctrl.rowCount = null;
+            ctrl.getResultsPronto();
+          });
+        }
 
         // When filters are changed, trigger callbacks and refresh search (if there's no search button)
         function onChangeFilters() {
@@ -158,7 +161,7 @@
         // Because `angular.$watch` runs immediately as well as on subsequent changes,
         // this also kicks off the first run of the search (if there's no search button).
         function setUpWatches() {
-          if (ctrl.afFieldset) {
+          if (ctrl.afFieldset && !isSubsearch) {
             $scope.$watch(ctrl.afFieldset.getFilterValues, onChangeFilters, true);
           }
           if (ctrl.settings.pager && ctrl.settings.pager.expose_limit) {


### PR DESCRIPTION
Overview
----------------------------------------
Afform filters should not trigger a refresh on subsearches. This fixes that.

Fixes [dev/core#6551](https://lab.civicrm.org/dev/core/-/work_items/6551)