### PR TITLE
SearchKit - Improve admin UX for picking subsearch displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.component.js
@@ -63,33 +63,30 @@
 
       this.onChangeSearch = () => {
         const searchName = this.column.subsearch?.search;
-        if (!searchName) {
-          delete this.column.subsearch;
-          this.savedSearch = null;
-          this.searchDisplays = null;
-        } else {
+        this.column.subsearch.display = null;
+        this.savedSearch = null;
+        this.searchDisplays = null;
+        if (searchName) {
           this.column.subsearch.filters = [];
           getSubsearchInfo(searchName).then((result) => {
-            if (result.searchDisplays.length) {
-              // Set default label
-              this.column.label = this.column.label || result.savedSearch.label;
-              this.column.rewrite = this.column.rewrite || result.savedSearch.label;
+            // Set default label
+            this.column.label = this.column.label || result.savedSearch.label;
+            this.column.rewrite = this.column.rewrite || result.savedSearch.label;
 
-              this.column.subsearch.display = result.searchDisplays[0].name;
-              // Set default filter
-              const baseEntity = searchMeta.getBaseEntity();
-              const baseKey = baseEntity.primary_key[0];
-              this.savedSearch.api_params.select.forEach((fieldName) => {
-                const field = this.getSubsearchField(fieldName);
-                if (field?.fk_entity === baseEntity.name || (field?.name === baseKey && field?.entity === baseEntity.name)) {
-                  this.column.subsearch.filters.push({
-                    subsearch_field: fieldName.split(':')[0],
-                    parent_field: baseKey,
-                  });
-                }
-              });
-              this.noIdFilterFound = !this.column.subsearch.filters.length;
-            }
+            this.column.subsearch.display = result.searchDisplays[0]?.name || null;
+            // Set default filter
+            const baseEntity = searchMeta.getBaseEntity();
+            const baseKey = baseEntity.primary_key[0];
+            this.savedSearch.api_params.select.forEach((fieldName) => {
+              const field = this.getSubsearchField(fieldName);
+              if (field?.fk_entity === baseEntity.name || (field?.name === baseKey && field?.entity === baseEntity.name)) {
+                this.column.subsearch.filters.push({
+                  subsearch_field: fieldName.split(':')[0],
+                  parent_field: baseKey,
+                });
+              }
+            });
+            this.noIdFilterFound = !this.column.subsearch.filters.length;
           });
         }
       };

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.html
@@ -1,14 +1,11 @@
 <div class="form-inline">
   <input placeholder="{{:: ts('Saved Search') }}" class="form-control" crm-autocomplete="'SavedSearch'" crm-autocomplete-params="{key: 'name', formName: 'searchAdmin', fieldName: 'subsearchSearch'}" auto-open="true" ng-model="$ctrl.column.subsearch.search" ng-change="$ctrl.onChangeSearch()">
   <select class="form-control" ng-model="$ctrl.column.subsearch.display" ng-if="$ctrl.column.subsearch.search" ng-disabled="!$ctrl.searchDisplays">
-    <option ng-repeat="display in $ctrl.searchDisplays" value="{{:: display.name }}">{{:: display.label }}</option>
+    <option ng-value="null">{{:: ts('Search results table') }}</option>
+    <option ng-repeat="display in $ctrl.searchDisplays" ng-value="display.name">{{:: display.label }}</option>
   </select>
 </div>
-<div class="help-block bg-warning" ng-if="$ctrl.searchDisplays && !$ctrl.searchDisplays.length">
-  <i class="crm-i fa-exclamation-triangle" aria-hidden="true" role="img"></i>
-  {{:: ts('The selected saved search does not have any table displays.') }}
-</div>
-<table class="table table-condensed" ng-if="$ctrl.searchDisplays.length">
+<table class="table table-condensed" ng-if="$ctrl.column.subsearch.search">
   <thead>
   <tr>
     <th>{{:: ts('Filter Subsearch Display') }}</th>
@@ -27,10 +24,13 @@
   </tbody>
   <tfoot>
     <tr>
-      <td colspan="2">
+      <td colspan="2" ng-if="$ctrl.savedSearch">
         <input class="form-control crm-action-menu fa-plus collapsible-optgroups"
                crm-ui-select="{data: $ctrl.subsearchFields, placeholder: ts('Add Filter')}"
                on-crm-ui-select="$ctrl.addFilter(selection)" >
+      </td>
+      <td ng-if="!$ctrl.savedSearch">
+        <span class="crm-search-loading-placeholder"></span>
       </td>
     </tr>
   </tfoot>


### PR DESCRIPTION
Overview
----------------------------------------
- Allows the default "Search results table" to be selected
- Fixes display mode being cleared when it shouldn't
- Removes obsolete warning about only supporting table displays (that's no longer the case)