### PR TITLE
dev/core#6590 - goofy custom fields button title

### DIFF
--- a/managed/administer/SavedSearch_Administer_Custom_Groups.mgd.php
+++ b/managed/administer/SavedSearch_Administer_Custom_Groups.mgd.php
@@ -138,7 +138,7 @@ return [
                   'join' => '',
                   'target' => '',
                   'icon' => 'fa-list-alt',
-                  'text' => 'Fields (%1)',
+                  'text' => 'Fields ([COUNT_CustomGroup_CustomField_custom_group_id_01_id])',
                   'style' => 'default',
                   'path' => 'civicrm/admin/custom/group/fields#/?gid=[id]',
                   'condition' => [],


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6590

Before
----------------------------------------
`Fields (%1)`

After
----------------------------------------
`Fields`

Technical Details
----------------------------------------
I suppose for multilingual to work in future can't have this kind of variable title.

Comments
----------------------------------------

