### PR TITLE
SearchKit - Add option to hide table header in search displays

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -79,6 +79,14 @@
           <input id="crm-search-admin-table-tally-header-title" ng-model="$ctrl.display.settings.tally.label" class="form-control">
         </div>
       </div>
+      <div class="form-inline">
+        <div class="checkbox-inline form-control">
+          <label>
+            <input type="checkbox" ng-model="$ctrl.display.settings.hideThead">
+            <span>{{:: ts('Hide Table Header') }}</span>
+          </label>
+        </div>
+      </div>
     </div>
   </details>
 

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTable.html
@@ -26,7 +26,7 @@
     </details>
   </div>
   <table class="{{:: $ctrl.settings.classes.join(' ') }}">
-    <thead>
+    <thead ng-if="$ctrl.settings.hideThead !== true">
       <tr>
         <th ng-class="{'crm-search-result-select': $ctrl.settings.actions}" ng-include="'~/crmSearchDisplayTable/crmSearchDisplayTaskHeader.html'" ng-if=":: $ctrl.hasExtraFirstColumn()">
           <span class="sr-only">{{:: ts('Bulk row actions')}}</span>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a search display setting to hide table header.

Alternate to #35864


<img width="995" height="632" alt="Screenshot 2026-06-17 at 6 49 24 PM" src="https://github.com/user-attachments/assets/f4b90f98-2251-45e3-92d2-c5829e5578a7" />
