### PR TITLE
add force new membership

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1678,7 +1678,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
       if (!$membershipTypeID) {
         continue;
       }
-      if (!$this->getExistingContributionID() && !$this->getExistingMembership($membershipTypeID)) {
+      $forceNewMembership = !empty($this->_membershipBlock['force_new_membership']) ? $this->_membershipBlock['force_new_membership'] : FALSE;
+      if (!$this->getExistingContributionID() && (!$this->getExistingMembership($membershipTypeID) || $forceNewMembership)) {
         // Create membership & hack line items to connect to it
         // NEW Membership, set up as pending and once Contribution is completed, the membership can be finished processing.
         $memParams = [

--- a/CRM/Member/DAO/MembershipBlock.php
+++ b/CRM/Member/DAO/MembershipBlock.php
@@ -14,6 +14,7 @@
  * @property string|null $membership_types
  * @property int|string|null $membership_type_default
  * @property bool|string $display_min_fee
+ * @property bool|string $force_new_membership
  * @property bool|string $is_separate_payment
  * @property string|null $new_title
  * @property string|null $new_text

--- a/CRM/Member/Form/MembershipBlock.php
+++ b/CRM/Member/Form/MembershipBlock.php
@@ -40,6 +40,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
       $defaults = CRM_Member_BAO_Membership::getMembershipBlock($this->getContributionPageID());
     }
     $defaults['member_is_active'] = $defaults['is_active'] ?? FALSE;
+    $defaults['force_new_membership'] = $defaults['force_new_membership'] ?? FALSE;
 
     // Set Display Minimum Fee default to true if we are adding a new membership block
     if (!isset($defaults['id'])) {
@@ -116,6 +117,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
 
       $this->addElement('checkbox', 'is_required', ts('Require Membership Signup'));
       $this->addElement('checkbox', 'display_min_fee', ts('Display Membership Fee'));
+      $this->addElement('checkbox', 'force_new_membership', ts('Force New Membership'));
       $this->addElement('checkbox', 'is_separate_payment', ts('Separate Membership Payment'));
       $this->addElement('text', 'membership_type_label', ts('Membership Types Label'), ['placeholder' => ts('Membership')]);
 
@@ -445,6 +447,7 @@ class CRM_Member_Form_MembershipBlock extends CRM_Contribute_Form_ContributionPa
         $params['is_separate_payment'] = $params['is_separate_payment'] ?? FALSE;
       }
       $params['entity_table'] = 'civicrm_contribution_page';
+      $params['force_new_membership'] = $params['force_new_membership'] ?? FALSE;
       $params['entity_id'] = $this->_id;
 
       $dao = new CRM_Member_DAO_MembershipBlock();

--- a/CRM/Upgrade/Incremental/php/SixSeventeen.php
+++ b/CRM/Upgrade/Incremental/php/SixSeventeen.php
@@ -39,6 +39,14 @@ class CRM_Upgrade_Incremental_php_SixSeventeen extends CRM_Upgrade_Incremental_B
   public function upgrade_6_17_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask(ts('Create Mysql Full Text Search indices if active'), 'createMissingFtsIndices');
+    $this->addTask('Add MembershipBlock.force_new_membership', 'alterSchemaField', 'MembershipBlock', 'force_new_membership', [
+      'title' => ts('Force New Membership'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Force creating new membership'),
+      'default' => FALSE,
+    ], 'AFTER `display_min_fee`');
   }
 
 }

--- a/schema/Member/MembershipBlock.entityType.php
+++ b/schema/Member/MembershipBlock.entityType.php
@@ -75,6 +75,15 @@ return [
       'add' => '1.5',
       'default' => TRUE,
     ],
+    'force_new_membership' => [
+      'title' => ts('Force New Membership'),
+      'sql_type' => 'boolean',
+      'input_type' => 'CheckBox',
+      'required' => TRUE,
+      'description' => ts('Force creating new membership'),
+      'add' => '1.5',
+      'default' => FALSE,
+    ],
     'is_separate_payment' => [
       'title' => ts('Membership Block Is Separate Payment'),
       'sql_type' => 'boolean',

--- a/templates/CRM/Member/Form/MembershipBlock.hlp
+++ b/templates/CRM/Member/Form/MembershipBlock.hlp
@@ -34,3 +34,7 @@
 <p>{ts}If the page 'Separate Membership Payment' is NOT enabled AND the Contribution Amount is enabled so that user's can opt to give more than the minimum membership fee - then the display looks like this:{/ts}</p>
 <p><strong> &nbsp; {ts}General Membership (contribute at least $100.00 to be eligible for this membership){/ts}</strong></p>
 {/htxt}
+
+{htxt id="id-force-new-membership"}
+<p>{ts}When this box is checked, no existing membership is overwritten, instead always a new membership is created.{/ts}
+{/htxt}

--- a/templates/CRM/Member/Form/MembershipBlock.tpl
+++ b/templates/CRM/Member/Form/MembershipBlock.tpl
@@ -90,8 +90,10 @@
           </tr>
           <tr id="displayFee" class="crm-member-membershipblock-form-block-display_min_fee">
               <td class="label"></td><td class="html-adjust">{$form.display_min_fee.html}&nbsp;{$form.display_min_fee.label} {help id="display_min_fee"}</td>
-    </tr>
-
+          </tr>
+          <tr id="forceNewMembership" class="crm-member-membershipblock-form-block-force_new_membership">
+              <td class="label"></td><td class="html-adjust">{$form.force_new_membership.html}&nbsp;{$form.force_new_membership.label} {help id="id-force-new-membership"}</td>
+          </tr>
       </table>
    </div>
   {else}

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -651,6 +651,63 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertMailSentContainingHeaderString('Test Frontend title');
   }
 
+  /**
+   * Submitting the same membership block twice for the same contact should
+   * renew the existing membership rather than create a second one when
+   * force_new_membership is not enabled (the default behaviour).
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSubmitMembershipBlockWithoutForceNewMembership(): void {
+    $this->contributionPageQuickConfigCreate([], [], FALSE, TRUE, TRUE, TRUE);
+    $submitValues = [
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['contribution_amount'] => -1,
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_general'],
+      'id' => $this->getContributionPageID(),
+    ] + $this->getBillingSubmitValues();
+
+    $this->submitOnlineContributionForm($submitValues, $this->getContributionPageID());
+    $this->submitOnlineContributionForm($submitValues, $this->getContributionPageID());
+
+    $memberships = Membership::get(FALSE)->execute();
+    $this->assertCount(1, $memberships, 'The existing membership should be renewed, not duplicated.');
+  }
+
+  /**
+   * When force_new_membership is enabled on the membership block, submitting
+   * the same membership block twice for the same contact should create a
+   * second membership of the same type rather than renewing the existing one.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testSubmitMembershipBlockWithForceNewMembership(): void {
+    $this->contributionPageQuickConfigCreate([], [], FALSE, TRUE, TRUE, TRUE);
+    MembershipBlock::update(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_contribution_page')
+      ->addWhere('entity_id', '=', $this->getContributionPageID())
+      ->addValue('force_new_membership', TRUE)
+      ->execute();
+
+    $submitValues = [
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['contribution_amount'] => -1,
+      'price_' . $this->ids['PriceField']['membership_amount'] => $this->ids['PriceFieldValue']['membership_general'],
+      'id' => $this->getContributionPageID(),
+    ] + $this->getBillingSubmitValues();
+
+    $this->submitOnlineContributionForm($submitValues, $this->getContributionPageID());
+    $this->submitOnlineContributionForm($submitValues, $this->getContributionPageID());
+
+    $memberships = Membership::get(FALSE)
+      ->addOrderBy('id')
+      ->execute();
+    $this->assertCount(2, $memberships, 'A new membership should be created on each submission when force_new_membership is enabled.');
+    // Both memberships should belong to the same contact and be of the same type.
+    $this->assertEquals($memberships[0]['contact_id'], $memberships[1]['contact_id']);
+    $this->assertEquals($memberships[0]['membership_type_id'], $memberships[1]['membership_type_id']);
+  }
+
   public function testSubmitWithPremium(): void {
     $this->contributionPageWithPriceSetCreate();
     $this->submitOnlineContributionForm([


### PR DESCRIPTION
Same as https://github.com/civicrm/civicrm-core/pull/35051

I did a new PR, because the CI did not like my merge there.


Overview
----------------------------------------
In our organisation any new filled contribution page should result in a new membership. 

Technical Details
----------------------------------------
This PR adds a checkbox at the membership section of contribution pages (MembershipBlock) called force_new_membership. A field is added to table civicrm_membership_block
In Confirm.php a new membership is added, no matter if a existing one is found.

Comments
----------------------------------------
Maybe missing or wront in this PR, so comments very welcome:
- translations of the Contribution Page UI
- Database Upgrades, a script, which adds the column force_new_membership in civicrm_membership_block
