### PR TITLE
Prevent af-repeat buttons defaulting to submit

### DIFF
--- a/ext/afform/core/ang/af/afRepeat.html
+++ b/ext/afform/core/ang/af/afRepeat.html
@@ -1,6 +1,6 @@
 <div af-repeat-item="item" repeat-index="$index" ng-repeat="item in getItems()">
   <ng-transclude></ng-transclude>
-  <button crm-icon="fa-ban" class="btn btn-xs af-repeat-remove-btn" ng-if="canRemove()" ng-click="removeItem($index)"></button>
+  <button type="button" crm-icon="fa-ban" class="btn btn-xs af-repeat-remove-btn" ng-if="canRemove()" ng-click="removeItem($index)"></button>
 </div>
-<button crm-icon="{{ addIcon || 'fa-plus' }}" class="btn btn-sm af-repeat-add-btn" ng-if="canAdd()" ng-click="addItem()">{{ addLabel }}</button>
-<button crm-icon="{{ copyIcon || 'fa-copy' }}" class="btn btn-sm af-repeat-copy-btn" ng-if="canAdd() && element.attr('af-copy') && getItems().length" ng-click="copyItem()">{{ copyLabel }}</button>
+<button type="button" crm-icon="{{ addIcon || 'fa-plus' }}" class="btn btn-sm af-repeat-add-btn" ng-if="canAdd()" ng-click="addItem()">{{ addLabel }}</button>
+<button type="button" crm-icon="{{ copyIcon || 'fa-copy' }}" class="btn btn-sm af-repeat-copy-btn" ng-if="canAdd() && element.attr('af-copy') && getItems().length" ng-click="copyItem()">{{ copyLabel }}</button>


### PR DESCRIPTION
Overview
----------------------------------------
In some scenarios, pressing enter in a form containing repeaters (with add/remove buttons) will unintentionally remove the current item rather than submit the form, as the key press triggers the remove button

Before
----------------------------------------
add/remove buttons are implicitly submit buttons

After
----------------------------------------
add/remove buttons are explictly not submit buttons