### PR TITLE
SixFourteen: fix sql params

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixFourteen.php
+++ b/CRM/Upgrade/Incremental/php/SixFourteen.php
@@ -106,8 +106,8 @@ class CRM_Upgrade_Incremental_php_SixFourteen extends CRM_Upgrade_Incremental_Ba
     $duplicate_source_keys = CRM_Core_DAO::executeQuery("SELECT source_key, min(id) AS keep_id FROM civicrm_translation_source GROUP BY source_key HAVING count(id) > 1");
     while ($duplicate_source_keys->fetch()) {
       CRM_Core_DAO::executeQuery("DELETE FROM civicrm_translation_source WHERE source_key = %1 AND id != %2", [
-        [$duplicate_source_keys->source_key, 'String'],
-        [$duplicate_source_keys->keep_id, 'Positive'],
+        1 => [$duplicate_source_keys->source_key, 'String'],
+        2 => [$duplicate_source_keys->keep_id, 'Positive'],
       ]);
     }
     \CRM_Core_BAO_SchemaHandler::createMissingIndices(CRM_Core_BAO_SchemaHandler::getMissingIndices(FALSE, ['civicrm_translation_source']));


### PR DESCRIPTION
Fixes a fatal SQL error during the upgrade.

```
Debug Info:                                                                                                                                                                                                          
 DELETE FROM civicrm_translation_source WHERE source_key = 1 AND id != %2
 [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '%2' at line 1]           
```

cc @eileenmcnaughton 