### PR TITLE
PR commands - fix newlines

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -154,7 +154,7 @@ jobs:
                   --title "Port: \"$PR_TITLE\" to $NEW_BASE" \
                   --body "Port of #${{ github.event.issue.number }} to $NEW_BASE." \
                   --label "port")
-                COMMENT_BODY="\`$NEW_BASE\` port: $NEW_PR_URL\n\nIf this PR changes, you can update the port by running \`/port $NEW_BASE\` again."
+                printf -v COMMENT_BODY "\`$NEW_BASE\` port: $NEW_PR_URL\n\nIf this PR changes, you can update the port by running \`/port $NEW_BASE\` again."
               fi
 
               gh pr comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "$COMMENT_BODY"


### PR DESCRIPTION
Overview
----------------------------------------
Fixes literal newline characters in the comment body when running the `/port` command.
