### PR TITLE
dev/core#6593: implement civi.api4.validate event at User update api

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/WriteTrait.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Api4\Action\User;
 
+use Civi\Api4\Event\ValidateValuesEvent;
+use Civi\Api4\User;
 use Civi\API\Exception\UnauthorizedException;
 
 use Civi\Standalone\Security;
@@ -96,6 +98,7 @@ trait WriteTrait {
       //    3.1 if changing a different user to the logged in user, require $hasAdminPermission
 
       $changingPassword = array_key_exists('password', $values);
+      $userId = $loggedInUserID;
       if (!$loggedInUserID) {
         throw new UnauthorizedException("Unauthorized");
       }
@@ -107,6 +110,19 @@ trait WriteTrait {
         if ($changingPassword && !$authenticatedAsLoggedInUser) {
           throw new UnauthorizedException("Unauthorized");
         }
+        if ($changingOtherUser) {
+          $userId = intval($values['id']);
+        }
+      }
+      // Implement civi.api4.validate event.
+      $e = new ValidateValuesEvent($this, [$values], new \CRM_Utils_LazyArray(function () use ($values, $userId) {
+        $user = User::get(FALSE)->addWhere('id', '=', $userId)->execute()->single();
+        $result[] = ['old' => $user, 'new' => $values];
+        return $result;
+      }));
+      \Civi::dispatcher()->dispatch('civi.api4.validate', $e);
+      if (!empty($e->errors)) {
+        throw $e->toException();
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------

In standalone the change password form is implemented in plain AngularJS calling the `User.update` api directly. This API does not implement the `civi.api4.validate` event. So it is hard to add additional validation rules.

Such as the password may be not one of the recent passwords (which is going to implemented in the Standalone Password expiration exition)

Before
----------------------------------------

`civi.api4.validate` event missing from User Update api

After
----------------------------------------

`civi.api4.validate` event dispatched on validation of the user update.


Comments
----------------------------------------

See: https://lab.civicrm.org/dev/core/-/work_items/6593
