### PR TITLE
SearchKit - Add placeholder while loading entities

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
@@ -32,8 +32,13 @@
             {{:: entity.title_plural }}
           </a>
         </li>
-        <li title="{{:: ts('Choose other entities on the search screen') }}">
+        <li title="{{:: ts('Choose other entities on the search screen') }}" ng-if="$ctrl.primaryEntities">
           <a ng-href="#/create/Contact?is_template={{ $ctrl.tab === 'template' ? 1 : 0}}">{{:: ts('More...') }}</a>
+        </li>
+        <li title="{{:: ts('Loading...') }}" ng-if="!$ctrl.primaryEntities">
+          <a href>
+            <i class="crm-i fa-spinner fa-spin" role="img" aria-hidden="true"></i>
+          </a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Overview
----------------------------------------
3f0be7f2fe switched from upfront to progressive loading of admin data in SearchKit. Data will typically load by the time the user opens a menu, but in case it doesn't, this gives them an indication that their data is on the way...

<img width="406" height="335" alt="Screenshot 2026-06-18 at 2 06 02 PM" src="https://github.com/user-attachments/assets/299527a5-f7ec-4b81-8397-6c24c6421362" />
