### PR TITLE
SearchKit - Restore action menu in search results

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/resultsTable/crmSearchAdminResultsTable.component.js
@@ -20,10 +20,17 @@
         ctrl.apiEntity = ctrl.search.api_entity;
         ctrl.settings = _.cloneDeep(CRM.crmSearchAdmin.defaultDisplay.settings);
         ctrl.settings.button = ts('Search');
-        // The default-display settings contain just one column (the last one, with the links menu)
         ctrl.settings.columns = ctrl.search.api_params.select
-          .map(fieldExpr => searchMeta.fieldToColumn(fieldExpr, {label: true, sortable: true}))
-          .concat(ctrl.settings.columns);
+          .map(fieldExpr => searchMeta.fieldToColumn(fieldExpr, {label: true, sortable: true}));
+        // Add the links menu column (see DefaultDisplaySubscriber::fallbackDefault)
+        ctrl.settings.columns.push({
+          type: 'menu',
+          icon: 'fa-bars',
+          size: 'btn-xs',
+          style: 'secondary-outline',
+          alignment: 'text-right',
+          links: [],
+        });
         ctrl.columns = _.cloneDeep(ctrl.settings.columns);
         ctrl.columns.forEach((col) => {
           col.enabled = true;


### PR DESCRIPTION
Overview
----------------------------------------
Adds back the action menu in search results table that was accidentally removed in 33ae493.

This was missing:
<img width="1022" height="653" alt="Screenshot 2026-06-18 at 3 44 32 PM" src="https://github.com/user-attachments/assets/b472921a-dd9f-47fc-85ef-a371ab2395d4" />
