### PR TITLE
dev/core#6594 fix event registration form type error

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -928,15 +928,14 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    */
   protected function getOptionFullPriceFieldValues(array $field): array {
     $optionFullIds = [];
-    $selectedSelectPriceFieldIds = $line_items = [];
+    $selectedSelectPriceFieldIds = [];
     if ($field['html_type'] === 'Select') {
       if ($this->getParticipantID()) {
-        $line_items = LineItem::get(FALSE)
+        $selectedSelectPriceFieldIds = LineItem::get(FALSE)
           ->addWhere('entity_table', '=', 'civicrm_participant')
           ->addWhere('entity_id', '=', $this->getParticipantID())
-          ->execute()->indexBy('price_field_value_id');
+          ->execute()->column('price_field_value_id');
       }
-      $selectedSelectPriceFieldIds = array_values($line_items);
     }
     foreach ($field['options'] ?? [] as $option) {
       if ($this->getIsOptionFull($option) &&


### PR DESCRIPTION
Overview
----------------------------------------
Addresses [this (#6594)](https://lab.civicrm.org/dev/core/-/work_items/6594).

Before
----------------------------------------
If someone with an existing registration submits the event registration form and participant ID is provided (e.g., via URL), it results in a `TypeError`:
```
array_values(): Argument #1 ($array) must be of type array, Civi\Api4\Generic\Result given
```

After
----------------------------------------
No error

Technical Details
----------------------------------------
The APIv4 function `->indexBy()` returns `Civi\Api4\Generic\Result`, but function `array_values()` expects an array.
Changed code so `$selectedSelectPriceFieldIds` is a non-associative array of price field value IDs.

Comments
----------------------------------------
@celinenicolas @seamuslee001 @eileenmcnaughton 
