### PR TITLE
dev/core#6574 permit logging hook to run during upgrade

### DIFF
--- a/CRM/Logging/Schema.php
+++ b/CRM/Logging/Schema.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Core\Exception\DBQueryException;
+
 /**
  *
  * @package CRM
@@ -628,11 +630,17 @@ AND    (TABLE_NAME LIKE 'log_civicrm_%' $nonStandardTableNameString )
   private function columnsOf($table, $force = FALSE) {
     if ($force || !isset(\Civi::$statics[__CLASS__]['columnsOf'][$table])) {
       $from = (substr($table, 0, 4) == 'log_') ? "`{$this->db}`.$table" : $table;
-      $dao = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM $from", [], TRUE, NULL, FALSE, FALSE);
-      if (is_a($dao, 'DB_Error')) {
+      \Civi::$statics[__CLASS__]['columnsOf'][$table] = [];
+      try {
+        $dao = CRM_Core_DAO::executeQuery("SHOW COLUMNS FROM $from", [], TRUE, NULL, FALSE, FALSE);
+      }
+      catch (DBQueryException $e) {
         return [];
       }
-      \Civi::$statics[__CLASS__]['columnsOf'][$table] = [];
+      if (is_a($dao, 'DB_Error')) {
+        // This should be unreachable - we expect an exception to be thrown per above.
+        return [];
+      }
       while ($dao->fetch()) {
         \Civi::$statics[__CLASS__]['columnsOf'][$table][] = CRM_Utils_Type::escape($dao->Field, 'MysqlColumnNameOrAlias');
       }
@@ -798,8 +806,18 @@ WHERE  table_schema IN ('{$this->db}', '{$civiDB}')";
    *
    * @param string $table
    */
-  private function createLogTableFor($table) {
-    $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE $table", [], TRUE, NULL, FALSE, FALSE);
+  private function createLogTableFor(string $table): void {
+    try {
+      $dao = CRM_Core_DAO::executeQuery("SHOW CREATE TABLE $table", [], TRUE, NULL, FALSE, FALSE);
+    }
+    catch (DBQueryException $e) {
+      if ($e->getSQLErrorCode() === 1146) {
+        // This would happen if an extension was registering a log table where the main table is deleted.
+        \Civi::log()->warning('Could not create log table for non-existent table ' . $table);
+        unset($this->tables[$table]);
+        return;
+      }
+    }
     $dao->fetch();
     $query = $dao->Create_Table;
 

--- a/CRM/Upgrade/DispatchPolicy.php
+++ b/CRM/Upgrade/DispatchPolicy.php
@@ -114,6 +114,13 @@ class CRM_Upgrade_DispatchPolicy {
       // ManagedEntities::reconcile() can remove data. Running prematurely would be actively harmful.
       'hook_civicrm_managed' => 'fail',
 
+      // In some cases this is used to ensure tables are not logged - we want to allow this
+      // to avoid creating inappropriate log tables during upgrade.
+      // While it is possible they might also add log tables we have some protection
+      // against this causing errors (see test testAlterSchemaEnableLoggingWithMadeUpTableInHook)
+      // https://lab.civicrm.org/dev/core/-/work_items/6574
+      'hook_civicrm_alterLogTables' => 'run',
+
       'hook_civicrm_crypto' => 'drop',
       '/^hook_civicrm_(pre|post)$/' => 'drop',
       '/^hook_civicrm_/' => $strict ? 'warn-drop' : 'drop',

--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -76,6 +76,11 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
     }
 
     $triggers = [];
+    $existingTables = [];
+    foreach (\CRM_Core_DAO::executeQuery('SHOW TABLES')->fetchAll() as $table) {
+      $tableName = reset($table);
+      $existingTables[$tableName] = $tableName;
+    };
 
     // now enumerate the tables and the events and collect the same set in a different format
     foreach ($info as $value) {
@@ -96,6 +101,13 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
       }
       else {
         $tables = $value['table'];
+      }
+
+      foreach ($tables as $table) {
+        if (empty($existingTables[$table])) {
+          \Civi::log()->warning('trigger on non-existent table ' . $table);
+          continue 2;
+        }
       }
 
       if (is_string($value['event']) == TRUE) {

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -75,6 +75,37 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
     }
   }
 
+  public function testAlterSchemaAddFieldOnLoggingExcludedTable(): void {
+    $this->hookClass->setHook('civicrm_alterLogTables', [$this, 'hookNoTimezoneLog']);
+    Civi::settings()->set('logging', TRUE);
+    $this->assertFalse(\Civi::schemaHelper()->tableExists('log_civicrm_timezone'));
+    $this->assertTrue(\Civi::schemaHelper()->tableExists('log_civicrm_translation'));
+
+    \Civi::schemaHelper()->dropSchemaField('Timezone', 'gmt');
+    $this->assertFalse(\Civi::schemaHelper()->schemaFieldExists('Timezone', 'gmt'));
+    $this->assertFalse(\Civi::schemaHelper()->tableExists('log_civicrm_timezone'));
+
+    \Civi::schemaHelper()->alterSchemaField('Timezone', 'gmt', [
+      'title' => ts('GMT Name of Timezone'),
+      'sql_type' => 'varchar(64)',
+      'input_type' => 'Text',
+      'description' => ts('GMT name of the timezone'),
+      'add' => '1.8',
+    ]);
+    $this->assertFalse(\Civi::schemaHelper()->tableExists('log_civicrm_timezone'));
+  }
+
+  /**
+   * Alter log spec to not log civicrm_timzone
+   *
+   * @param array $logTableSpec
+   *
+   * @return void
+   */
+  public function hookNoTimezoneLog(array &$logTableSpec): void {
+    unset($logTableSpec['civicrm_timezone']);
+  }
+
   /**
    * Tests that choosing to ignore a custom table does not result in e-notices.
    */

--- a/tests/phpunit/CRM/Logging/SchemaTest.php
+++ b/tests/phpunit/CRM/Logging/SchemaTest.php
@@ -96,7 +96,19 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
   }
 
   /**
-   * Alter log spec to not log civicrm_timzone
+   * If a hook adds a table that does not exist we should skip rather than fail.
+   *
+   * @return void
+   */
+  public function testAlterSchemaEnableLoggingWithMadeUpTableInHook(): void {
+    $this->hookClass->setHook('civicrm_alterLogTables', [$this, 'hookMadeUpTable']);
+    Civi::settings()->set('logging', TRUE);
+    $this->assertFalse(\Civi::schemaHelper()->tableExists('log_civicrm_fantasy'));
+    $this->assertTrue(\Civi::schemaHelper()->tableExists('log_civicrm_translation'));
+  }
+
+  /**
+   * Alter log spec to not log civicrm_timezone
    *
    * @param array $logTableSpec
    *
@@ -104,6 +116,17 @@ class CRM_Logging_SchemaTest extends CiviUnitTestCase {
    */
   public function hookNoTimezoneLog(array &$logTableSpec): void {
     unset($logTableSpec['civicrm_timezone']);
+  }
+
+  /**
+   * Alter log spec to not log civicrm_timzone
+   *
+   * @param array $logTableSpec
+   *
+   * @return void
+   */
+  public function hookMadeUpTable(array &$logTableSpec): void {
+    $logTableSpec['civicrm_fantasy'] = [];
   }
 
   /**

--- a/tests/phpunit/Civi/Schema/SchemaHelperTest.php
+++ b/tests/phpunit/Civi/Schema/SchemaHelperTest.php
@@ -35,7 +35,7 @@ class SchemaHelperTest extends \CiviUnitTestCase {
     $this->assertFalse(\Civi::schemaHelper()->indexExists('civicrm_activity', 'index_false_nothing'));
   }
 
-  public function testAlterSchemaFieldWithForiegnKey(): void {
+  public function testAlterSchemaFieldWithForeignKey(): void {
     \Civi::schemaHelper()->dropForeignKey('civicrm_activity', 'FK_civicrm_activity_parent_id');
 
     $this->assertFalse(\Civi::schemaHelper()->foreignKeyExists('civicrm_activity', 'FK_civicrm_activity_parent_id'));


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6574 permit logging hook to run during upgrade

Before
----------------------------------------
if an extension removes a table from logging using `hook_civicrm_alterLogTables` it could still be created if that table is altered during upgrade. Given these are likely excluded due to size this can have significant implications.

After
----------------------------------------
The hook runs during upgrade

Technical Details
----------------------------------------
 While the use case here is to ensure logging-excluded tables are
not created during upgrade there is a theoretical possibility (in
this scenario and others) that the hook could ADD logging
for a table that does not exist. This also creates that scenario in a test
and ensures that it skips rather than fails in that scenario

Comments
----------------------------------------
This is a regression as the performance on our most recent upgrade has regressed to 'awful' - but I don't think it warrants a stable backport

