### PR TITLE
dev/core#6597 Add relationship type ordering

### DIFF
--- a/CRM/Admin/Form/RelationshipType.php
+++ b/CRM/Admin/Form/RelationshipType.php
@@ -44,6 +44,7 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       ],
       'contact_types_a' => ['name' => 'contact_types_a', 'not-auto-addable' => TRUE],
       'contact_types_b' => ['name' => 'contact_types_b', 'not-auto-addable' => TRUE],
+      'weight' => ['name' => 'weight'],
       'is_active' => ['name' => 'is_active'],
     ];
 
@@ -111,6 +112,22 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
   }
 
   /**
+   * Get the next available relationship type weight.
+   *
+   * @return int
+   */
+  protected function getNextWeight(): int {
+    if (!CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_relationship_type', 'weight')) {
+      return 0;
+    }
+
+    return 1 + (int) CRM_Core_DAO::singleValueQuery('
+      SELECT COALESCE(MAX(weight), 0)
+      FROM civicrm_relationship_type
+    ');
+  }
+
+  /**
    * @return array
    */
   public function setDefaultValues() {
@@ -133,7 +150,9 @@ class CRM_Admin_Form_RelationshipType extends CRM_Admin_Form {
       return $defaults;
     }
     else {
-      return parent::setDefaultValues();
+      $defaults = parent::setDefaultValues();
+      $defaults['weight'] = $this->getNextWeight();
+      return $defaults;
     }
   }
 

--- a/CRM/Contact/DAO/RelationshipType.php
+++ b/CRM/Contact/DAO/RelationshipType.php
@@ -20,6 +20,7 @@
  * @property string|null $contact_sub_type_b
  * @property bool|string $is_reserved
  * @property bool|string $is_active
+ * @property int|string $weight
  */
 class CRM_Contact_DAO_RelationshipType extends CRM_Core_DAO_Base {
 }

--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -29,6 +29,33 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
    */
   public function upgrade_6_18_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+    $this->addTask('Add column "RelationshipType.weight"', 'alterSchemaField', 'RelationshipType', 'weight', [
+      'title' => ts('Order'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'required' => TRUE,
+      'description' => ts('Ordering of the relationship types.'),
+      'add' => '6.18',
+      'default' => 0,
+    ]);
+    $this->addTask(ts('Initialize relationship type weights'), 'initializeRelationshipTypeWeights');
+  }
+
+  /**
+   * Initialize relationship type weights.
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public static function initializeRelationshipTypeWeights(CRM_Queue_TaskContext $ctx): bool {
+    CRM_Core_DAO::executeQuery("
+      UPDATE civicrm_relationship_type
+      SET weight = id
+      WHERE weight = 0
+    ");
+
+    return TRUE;
   }
 
 }

--- a/Civi/Api4/RelationshipType.php
+++ b/Civi/Api4/RelationshipType.php
@@ -17,10 +17,12 @@ namespace Civi\Api4;
  * @searchFields label_a_b,description
  *
  * @searchable secondary
+ * @orderBy weight
  * @since 5.19
  * @package Civi\Api4
  */
 class RelationshipType extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
+  use Generic\Traits\SortableEntity;
 
 }

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Administer_Relationship_Types.mgd.php
@@ -19,6 +19,7 @@ return [
         'api_params' => [
           'version' => 4,
           'select' => [
+            'weight',
             'label_a_b',
             'label_b_a',
             'contact_type_a:label',
@@ -27,7 +28,9 @@ return [
             'contact_sub_type_b:label',
             'is_active',
           ],
-          'orderBy' => [],
+          'orderBy' => [
+            'weight' => 'ASC',
+          ],
           'where' => [],
           'groupBy' => [],
           'join' => [],
@@ -67,7 +70,12 @@ return [
             'hide_single' => TRUE,
           ],
           'placeholder' => 5,
-          'sort' => [],
+          'sort' => [
+            [
+              'weight',
+              'ASC',
+            ],
+          ],
           'columns' => [
             [
               'type' => 'field',
@@ -182,6 +190,7 @@ return [
               FALSE,
             ],
           ],
+          'draggable' => 'weight',
         ],
         'acl_bypass' => FALSE,
       ],

--- a/schema/Contact/RelationshipType.entityType.php
+++ b/schema/Contact/RelationshipType.entityType.php
@@ -157,5 +157,14 @@ return [
         'label' => ts('Enabled'),
       ],
     ],
+    'weight' => [
+      'title' => ts('Order'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'required' => TRUE,
+      'description' => ts('Ordering of the relationship types.'),
+      'add' => '6.18',
+      'default' => 0,
+    ],
   ],
 ];


### PR DESCRIPTION
## Overview

This adds persistent ordering support for relationship types.

The AdminUI/SearchKit Relationship Types screen supports listing and editing relationship types, but `RelationshipType` does not currently have a core ordering field. This means the screen cannot support drag-and-drop ordering in the same way as other sortable admin entities.

This change adds a `weight` column to `civicrm_relationship_type`, makes the APIv4 `RelationshipType` entity sortable, and updates the Relationship Types admin SearchKit display to use drag-and-drop ordering.

## Related issue

https://lab.civicrm.org/dev/core/-/work_items/8597

## Related prior discussion

https://lab.civicrm.org/dev/core/-/work_items/3912#note_198002

## Changes

* Adds `weight` to the `RelationshipType` entity schema.
* Adds an upgrade task for existing sites to create `civicrm_relationship_type.weight`.
* Initializes existing relationship type weights from their existing IDs.
* Adds `@orderBy weight` to the APIv4 `RelationshipType` entity.
* Adds `Generic\Traits\SortableEntity` to `RelationshipType`.
* Updates the Relationship Types admin SearchKit display to:

  * select `weight`
  * order by `weight ASC`
  * enable drag-and-drop ordering using `draggable => weight`
* Sets the next available weight when creating a new relationship type.

## Testing

Tested locally on a Drupal 10 / CiviCRM 6.17.alpha1 build.

Verified:

* Patch applies cleanly.
* The `weight` column is added successfully by the upgrade method.
* Existing relationship types receive populated weights.
* APIv4 can select and order by `weight`.
* The Relationship Types admin screen loads successfully.
* The SearchKit table displays relationship types ordered by `weight`.
* Drag-and-drop handles appear for relationship types.

Example verification output:

```text
weight column exists

1 | Child of | 1
2 | Spouse of | 2
3 | Partner of | 3
4 | Sibling of | 4
5 | Employee of | 5
6 | Volunteer for | 6
7 | Head of Household for | 7
8 | Household Member of | 8
9 | Case Coordinator is | 9
10 | Supervised by | 10
```

Note: On my local dev site, `cv updb` did not rerun the new upgrade task because the database was already marked as `6.17.alpha1`. I tested the upgrade method directly after dropping the column locally. On real upgrades from an older database version, this task will run as part of the normal CiviCRM upgrade process.
