### PR TITLE
next/back buttons for tabsets

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -306,6 +306,32 @@ class AfformAdminMeta {
             ],
           ],
         ],
+        'next_button' => [
+          'title' => E::ts('Next Button'),
+          'element' => [
+            '#tag' => 'button',
+            'class' => 'af-button btn btn-primary',
+            'type' => 'button',
+            'crm-icon' => 'fa-arrow-right',
+            'af-tab-nav' => 'next',
+            '#children' => [
+              ['#text' => E::ts('Next')],
+            ],
+          ],
+        ],
+        'back_button' => [
+          'title' => E::ts('Back Button'),
+          'element' => [
+            '#tag' => 'button',
+            'class' => 'af-button btn btn-default',
+            'type' => 'button',
+            'crm-icon' => 'fa-arrow-left',
+            'af-tab-nav' => 'back',
+            '#children' => [
+              ['#text' => E::ts('Back')],
+            ],
+          ],
+        ],
         'fieldset' => [
           'title' => E::ts('Fieldset'),
           'afform_type' => ['form'],

--- a/ext/afform/core/ang/af/afTabNav.directive.js
+++ b/ext/afform/core/ang/af/afTabNav.directive.js
@@ -1,0 +1,48 @@
+// https://civicrm.org/licensing
+(function(angular, $, _) {
+  "use strict";
+
+  // Attribute directive applied to next/back tab navigation buttons.
+  // Uses require to reach the ancestor afTabset controller regardless of transclusion.
+  angular.module('af').directive('afTabNav', function() {
+    return {
+      restrict: 'A',
+      bindToController: {},
+      require: {
+        afTabset: '?^^afTabset',
+      },
+      controller: function($scope, $element) {
+        this.$onInit = () => {
+          if (!this.afTabset) {
+            return;
+          }
+          const direction = $element.attr('af-tab-nav');
+
+          $element.on('click', (e) => {
+            e.preventDefault();
+            $scope.$apply(() => {
+              if (direction === 'next') {
+                this.afTabset.nextTab();
+              } else {
+                this.afTabset.prevTab();
+              }
+            });
+          });
+
+          if (direction === 'back') {
+            $scope.$watch(
+              () => this.afTabset.isFirstTab(),
+              (isFirst) => $element.prop('disabled', isFirst)
+            );
+          } else {
+            $scope.$watch(
+              () => this.afTabset.isLastTab(),
+              (isLast) => $element.prop('disabled', isLast)
+            );
+          }
+        };
+      }
+    };
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/afform/core/ang/af/afTabset.component.js
+++ b/ext/afform/core/ang/af/afTabset.component.js
@@ -55,6 +55,29 @@
         this.selectedTab = tabName;
       };
 
+      this.nextTab = () => {
+        const idx = this.tabs.findIndex(t => t.name === this.selectedTab);
+        if (idx < this.tabs.length - 1) {
+          this.selectTab(this.tabs[idx + 1].name);
+        }
+      };
+
+      this.prevTab = () => {
+        const idx = this.tabs.findIndex(t => t.name === this.selectedTab);
+        if (idx > 0) {
+          this.selectTab(this.tabs[idx - 1].name);
+        }
+      };
+
+      this.isFirstTab = () => {
+        return this.tabs.findIndex(t => t.name === this.selectedTab) <= 0;
+      };
+
+      this.isLastTab = () => {
+        const idx = this.tabs.findIndex(t => t.name === this.selectedTab);
+        return idx < 0 || idx >= this.tabs.length - 1;
+      };
+
       this.getFormName = () => this.afFormCtrl?.getFormMeta().name ?? $scope.$parent.meta.name;
 
       this.getCacheKey = () => this.getFormName() + 'SelectedTab';


### PR DESCRIPTION
Overview
----------------------------------------
This adds "Next Button" and "Back Button" elements to FormBuilder.  They're added to tabs in tabsets and do what they say on the tin.

Comments
----------------------------------------
My original plan was to also make tabsets stylable similarly to #35768. I realized that would quickly blow out the scope and can be added in future versions.  But my vision here is to allow you to:
* Hide the tab buttons
* Make the tab buttons unclickable
* Enable transitions with `ngAnimate`.

I can't find the work item, but @kapn1966 and I have a plan to offer out-of-the-box FormBuilder payment pages that look good.  This is on that roadmap.
