### PR TITLE
dev/core#6596 Do not double encode Price Field Placeholder

### DIFF
--- a/CRM/Price/BAO/PriceField.php
+++ b/CRM/Price/BAO/PriceField.php
@@ -465,7 +465,7 @@ class CRM_Price_BAO_PriceField extends CRM_Price_DAO_PriceField {
         }
 
         $element = &$qf->add('select', $elementName, $label, $selectOption, $useRequired && $field->is_required, [
-          'placeholder' => ts('- select %1 -', [1 => htmlspecialchars($label)]),
+          'placeholder' => ts('- select %1 -', [1 => $label]),
           'price' => json_encode($priceVal),
           'class' => 'crm-select2' . $class,
           'data-price-field-values' => json_encode($customOption),


### PR DESCRIPTION
Overview
----------------------------------------
Given that attributes such as the placeholder are already escaped by quickform https://github.com/civicrm/civicrm-packages/blob/master/HTML/Common.php#L144 we do not need to also escape here as well

Before
----------------------------------------
Placeholder text double escaped

After
----------------------------------------
Placeholder text escaped once

ping @colemanw @daylenca
 