### PR TITLE
SearchKit - Fix single params for legacy task links

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -964,14 +964,13 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $link['conditions'] = array_merge($link['conditions'], $task['conditions'] ?? []);
         // Convert legacy tasks (which have a url)
         if (!empty($task['crmPopup'])) {
-          $idField = CoreUtil::getIdFieldName($link['entity']);
           $link['path'] = \CRM_Utils_JS::decode($task['crmPopup']['path']);
           $data = \CRM_Utils_JS::getRawProps($task['crmPopup']['data']);
           // Find the special key that combines selected ids and replace it with id token
           $idsKey = array_search("ids.join(',')", $data);
           unset($data[$idsKey], $link['task']);
           $amp = strpos($link['path'], '?') ? '&' : '?';
-          $link['path'] .= $amp . $idField . '=[' . $link['prefix'] . $idKey . ']';
+          $link['path'] .= $amp . $idsKey . '=[' . $link['prefix'] . $idKey . ']';
           // Add the rest of the data items
           foreach ($data as $dataKey => $dataRaw) {
             $link['path'] .= '&' . $dataKey . '=' . \CRM_Utils_JS::decode($dataRaw);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -430,6 +430,65 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('Delete', $result[0]['columns'][1]['links'][2]['title']);
   }
 
+  public function testContactMapLink(): void {
+    \Civi::settings()->set('mapProvider', 'OpenStreetMaps');
+    \CRM_Contact_Task::$_tasks = [];
+
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'MappingTest'],
+      ],
+    ]);
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'display_name'],
+          'where' => [['id', 'IN', $contacts->column('id')]],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'testDisplay',
+        'settings' => [
+          'actions' => TRUE,
+          'pager' => [],
+          'columns' => [
+            [
+              'key' => 'display_name',
+              'label' => 'Contact',
+              'type' => 'field',
+            ],
+            [
+              'type' => 'buttons',
+              'links' => [
+                [
+                  'entity' => 'Contact',
+                  'task' => 'contact.104',
+                  'icon' => 'fa-map',
+                ],
+              ],
+            ],
+          ],
+        ],
+      ],
+    ];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertEquals(1, $result->count());
+    // The task link should have been converted to a legacy URL link
+    $this->assertArrayNotHasKey('task', $result[0]['columns'][1]['links'][0]);
+    // The URL parameter should be "cids", not "cid" or "id"
+    $url = $result[0]['columns'][1]['links'][0]['url'];
+    $query = parse_url($url, PHP_URL_QUERY);
+    parse_str($query, $queryParams);
+    $this->assertEquals($contacts[0]['id'], $queryParams['cids']);
+    $this->assertArrayNotHasKey('cid', $queryParams);
+    $this->assertArrayNotHasKey('id', $queryParams);
+  }
+
   public function testEnableDisableTaskLinks():void {
     $contributionPage = $this->createTestRecord('ContributionPage', [
       'is_active' => TRUE,


### PR DESCRIPTION

Overview
----------------------------------------
Fixes [dev/core#6598](https://lab.civicrm.org/dev/core/-/work_items/6598)


Technical Details
----------------------------------------
Legacy tasks have a url param defined in the data json like `{cids: ids.join(',')` but the parameter name was being ignored when constructing inline links. I think this bug was masked by some actions accepting 'id' and by the fact that not many people are using this feature.
