### PR TITLE
Batch membership dashboard summary counts into two queries

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1648,6 +1648,189 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = membership.contact_id AND 
   }
 
   /**
+   * Get membership dashboard summary counts for many membership types in two queries.
+   *
+   * Replaces a per-type/per-window loop in CRM_Member_Page_DashBoard (~16 calls per
+   * membership type) with one grouped query over the signup/renewal activity join and
+   * one over current memberships. Clause differences between the originals (activity-type
+   * guard, deleted-contact exclusion) are preserved across the two queries.
+   *
+   * Result families:
+   *   *_new   -> getMembershipJoins (signup activity in window)
+   *   *_renew -> getMembershipRenewals (renewal activity in window)
+   *   *_total -> getMembershipStarts (either activity)
+   *   *_owner -> getMembershipStarts, owner_membership_id IS NULL
+   *   current_total / total_total -> getMembershipCount
+   *   current_owner / total_owner -> getMembershipCount, owner_membership_id IS NULL
+   *
+   * @param array $membershipTypeIds
+   * @param string $preMonth     Previous month start, Y-m-d.
+   * @param string $preMonthEnd  Previous month end, Y-m-d.
+   * @param string $monthStart   Reported month start, Y-m-d.
+   * @param string $yearStart    Reported year start, Y-m-d.
+   * @param string $ymd          End date for month/year/total windows, Y-m-d.
+   * @param string $current      "As of" date for current_total/current_owner, Y-m-d.
+   * @param bool|int $isTest
+   *
+   * @return array
+   *   [membershipTypeId => [family => int]], zero-filled for every requested type.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public static function getMembershipSummaryStats($membershipTypeIds, $preMonth, $preMonthEnd, $monthStart, $yearStart, $ymd, $current, $isTest = 0) {
+    foreach ([$preMonth, $preMonthEnd, $monthStart, $yearStart, $ymd, $current] as $date) {
+      if (!CRM_Utils_Rule::date($date)) {
+        throw new CRM_Core_Exception(ts('Invalid date "%1" (must have form yyyy-mm-dd).', [1 => $date]));
+      }
+    }
+
+    $activityFamilies = [
+      'premonth_new', 'premonth_renew', 'premonth_total',
+      'month_new', 'month_renew', 'month_total',
+      'year_new', 'year_renew', 'year_total',
+      'premonth_owner', 'month_owner', 'year_owner',
+    ];
+    $countFamilies = ['current_total', 'total_total', 'current_owner', 'total_owner'];
+
+    // Pre-fill so callers can read every family without isset() guards; a GROUP BY
+    // query would otherwise omit types that have no matching rows.
+    $stats = [];
+    $typeIds = [];
+    foreach ($membershipTypeIds as $typeId) {
+      $typeId = (int) $typeId;
+      $typeIds[] = $typeId;
+      $stats[$typeId] = array_fill_keys(array_merge($activityFamilies, $countFamilies), 0);
+    }
+    if (empty($typeIds)) {
+      return $stats;
+    }
+    $typeIdList = implode(',', $typeIds);
+    $isTest = $isTest ? 1 : 0;
+
+    // Resolve activity type IDs once. Tests pre-set the statics to simulate a site
+    // where signup/renewal activity types are not configured; the legacy "refresh if
+    // either is falsy" check would overwrite that. Both NULL is the production
+    // initial state, where _getActTypes() populates both.
+    if (self::$_signupActType === NULL && self::$_renewalActType === NULL) {
+      self::_getActTypes();
+    }
+    $signupActType = self::$_signupActType;
+    $renewalActType = self::$_renewalActType;
+    $hasSignup = !empty($signupActType);
+    $hasRenewal = !empty($renewalActType);
+
+    // Query 1: activity-based families. The scan bound on activity_date_time prunes
+    // the activity table to the window union before the per-CASE filters run.
+    if ($hasSignup || $hasRenewal) {
+      $availableActTypes = [];
+      if ($hasSignup) {
+        $availableActTypes[] = (int) $signupActType;
+      }
+      if ($hasRenewal) {
+        $availableActTypes[] = (int) $renewalActType;
+      }
+      $actTypeList = implode(',', $availableActTypes);
+
+      $scanStart = min($preMonth, $monthStart, $yearStart);
+      $scanEnd = max($preMonthEnd, $ymd) . ' 23:59:59';
+
+      $preWindow = 'activity.activity_date_time >= %1 AND activity.activity_date_time <= %2';
+      $monthWindow = 'activity.activity_date_time >= %3 AND activity.activity_date_time <= %4';
+      $yearWindow = 'activity.activity_date_time >= %5 AND activity.activity_date_time <= %4';
+      $isSignup = 'activity.activity_type_id = %6';
+      $isRenewal = 'activity.activity_type_id = %7';
+      $isOwner = 'membership.owner_membership_id IS NULL';
+
+      $activityQuery = "
+        SELECT membership.membership_type_id AS membership_type_id,
+          COUNT(DISTINCT CASE WHEN $isSignup AND $preWindow THEN membership.id END) AS premonth_new,
+          COUNT(DISTINCT CASE WHEN $isRenewal AND $preWindow THEN membership.id END) AS premonth_renew,
+          COUNT(DISTINCT CASE WHEN $preWindow THEN membership.id END) AS premonth_total,
+          COUNT(DISTINCT CASE WHEN $isSignup AND $monthWindow THEN membership.id END) AS month_new,
+          COUNT(DISTINCT CASE WHEN $isRenewal AND $monthWindow THEN membership.id END) AS month_renew,
+          COUNT(DISTINCT CASE WHEN $monthWindow THEN membership.id END) AS month_total,
+          COUNT(DISTINCT CASE WHEN $isSignup AND $yearWindow THEN membership.id END) AS year_new,
+          COUNT(DISTINCT CASE WHEN $isRenewal AND $yearWindow THEN membership.id END) AS year_renew,
+          COUNT(DISTINCT CASE WHEN $yearWindow THEN membership.id END) AS year_total,
+          COUNT(DISTINCT CASE WHEN $isOwner AND $preWindow THEN membership.id END) AS premonth_owner,
+          COUNT(DISTINCT CASE WHEN $isOwner AND $monthWindow THEN membership.id END) AS month_owner,
+          COUNT(DISTINCT CASE WHEN $isOwner AND $yearWindow THEN membership.id END) AS year_owner
+        FROM civicrm_membership membership
+        INNER JOIN civicrm_activity activity ON (activity.source_record_id = membership.id AND activity.activity_type_id IN ($actTypeList))
+        INNER JOIN civicrm_membership_status status ON (membership.status_id = status.id AND status.is_current_member = 1)
+        INNER JOIN civicrm_contact contact ON (contact.id = membership.contact_id AND contact.is_deleted = 0)
+        WHERE membership.membership_type_id IN ($typeIdList)
+          AND membership.is_test = $isTest
+          AND activity.activity_date_time >= %8 AND activity.activity_date_time <= %9
+        GROUP BY membership.membership_type_id
+      ";
+      $params = [
+        1 => [$preMonth, 'String'],
+        2 => [$preMonthEnd . ' 23:59:59', 'String'],
+        3 => [$monthStart, 'String'],
+        4 => [$ymd . ' 23:59:59', 'String'],
+        5 => [$yearStart, 'String'],
+        6 => [(int) $signupActType, 'Integer'],
+        7 => [(int) $renewalActType, 'Integer'],
+        8 => [$scanStart, 'String'],
+        9 => [$scanEnd, 'String'],
+      ];
+      foreach (CRM_Core_DAO::executeQuery($activityQuery, $params)->fetchAll() as $row) {
+        $typeId = (int) $row['membership_type_id'];
+        foreach ($activityFamilies as $family) {
+          $stats[$typeId][$family] = (int) $row[$family];
+        }
+      }
+
+      // Per-function activity-type guard: joins needs signup, renewals needs renewal,
+      // starts (the *_total and *_owner families) needs both. Zero out the families the
+      // originals would return 0 for when a required type is missing.
+      if (!$hasSignup || !$hasRenewal) {
+        foreach ($stats as &$row) {
+          if (!$hasSignup) {
+            $row['premonth_new'] = $row['month_new'] = $row['year_new'] = 0;
+          }
+          if (!$hasRenewal) {
+            $row['premonth_renew'] = $row['month_renew'] = $row['year_renew'] = 0;
+          }
+          $row['premonth_total'] = $row['month_total'] = $row['year_total'] = 0;
+          $row['premonth_owner'] = $row['month_owner'] = $row['year_owner'] = 0;
+        }
+        unset($row);
+      }
+    }
+
+    // Query 2: current-membership families. Deleted-contact exclusion uses a NOT IN
+    // subquery (not an inner join) to match getMembershipCount exactly.
+    $countQuery = "
+      SELECT civicrm_membership.membership_type_id AS membership_type_id,
+        COUNT(CASE WHEN civicrm_membership.start_date <= %1 THEN civicrm_membership.id END) AS current_total,
+        COUNT(CASE WHEN civicrm_membership.start_date <= %2 THEN civicrm_membership.id END) AS total_total,
+        COUNT(CASE WHEN civicrm_membership.owner_membership_id IS NULL AND civicrm_membership.start_date <= %1 THEN civicrm_membership.id END) AS current_owner,
+        COUNT(CASE WHEN civicrm_membership.owner_membership_id IS NULL AND civicrm_membership.start_date <= %2 THEN civicrm_membership.id END) AS total_owner
+      FROM civicrm_membership
+      LEFT JOIN civicrm_membership_status ON (civicrm_membership.status_id = civicrm_membership_status.id)
+      WHERE civicrm_membership.membership_type_id IN ($typeIdList)
+        AND civicrm_membership.contact_id NOT IN (SELECT id FROM civicrm_contact WHERE is_deleted = 1)
+        AND civicrm_membership.is_test = $isTest
+        AND civicrm_membership_status.is_current_member = 1
+      GROUP BY civicrm_membership.membership_type_id
+    ";
+    $countParams = [
+      1 => [$current, 'String'],
+      2 => [$ymd, 'String'],
+    ];
+    foreach (CRM_Core_DAO::executeQuery($countQuery, $countParams)->fetchAll() as $row) {
+      $typeId = (int) $row['membership_type_id'];
+      foreach ($countFamilies as $family) {
+        $stats[$typeId][$family] = (int) $row[$family];
+      }
+    }
+
+    return $stats;
+  }
+
+  /**
    * Get line items representing the default price set.
    *
    * @param int $membershipOrg

--- a/CRM/Member/Page/DashBoard.php
+++ b/CRM/Member/Page/DashBoard.php
@@ -82,96 +82,103 @@ class CRM_Member_Page_DashBoard extends CRM_Core_Page {
       ->execute()
       ->column('title', 'id');
 
+    // Gather every dashboard count across all membership types in two grouped queries
+    // rather than the ~16 per-type queries this loop previously issued.
+    $summaryStats = CRM_Member_BAO_Membership::getMembershipSummaryStats(
+      array_keys($membershipTypes), $preMonth, $preMonthEnd, $monthStart, $yearStart, $ymd, $current
+    );
+
     foreach ($membershipTypes as $key => $value) {
+      $stats = $summaryStats[$key];
 
       $membershipSummary[$key]['premonth']['new'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipJoins($key, $preMonth, $preMonthEnd),
+        'count' => $stats['premonth_new'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['premonth']['renew'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipRenewals($key, $preMonth, $preMonthEnd),
+        'count' => $stats['premonth_renew'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['premonth']['total'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $preMonth, $preMonthEnd),
+        'count' => $stats['premonth_total'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['month']['new'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipJoins($key, $monthStart, $ymd),
+        'count' => $stats['month_new'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['month']['renew'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipRenewals($key, $monthStart, $ymd),
+        'count' => $stats['month_renew'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['month']['total'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $monthStart, $ymd),
+        'count' => $stats['month_total'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['year']['new'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipJoins($key, $yearStart, $ymd),
+        'count' => $stats['year_new'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['year']['renew'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipRenewals($key, $yearStart, $ymd),
+        'count' => $stats['year_renew'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['year']['total'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $yearStart, $ymd),
+        'count' => $stats['year_total'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['current']['total'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipCount($key, $current),
+        'count' => $stats['current_total'],
         'name' => $value,
         'url' => FALSE,
       ];
 
-      $membershipSummary[$key]['total']['total'] = ['count' => CRM_Member_BAO_Membership::getMembershipCount($key, $ymd)];
+      $membershipSummary[$key]['total']['total'] = ['count' => $stats['total_total']];
 
       //LCD also get summary stats for membership owners
       $membershipSummary[$key]['premonth_owner']['premonth_owner'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $preMonth, $preMonthEnd, 0, 1),
+        'count' => $stats['premonth_owner'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['month_owner']['month_owner'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $monthStart, $ymd, 0, 1),
+        'count' => $stats['month_owner'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['year_owner']['year_owner'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipStarts($key, $yearStart, $ymd, 0, 1),
+        'count' => $stats['year_owner'],
         'name' => $value,
         'url' => FALSE,
       ];
 
       $membershipSummary[$key]['current_owner']['current_owner'] = [
-        'count' => CRM_Member_BAO_Membership::getMembershipCount($key, $current, 0, 1),
+        'count' => $stats['current_owner'],
         'name' => $value,
         'url' => FALSE,
       ];
 
-      $membershipSummary[$key]['total_owner']['total_owner'] = ['count' => CRM_Member_BAO_Membership::getMembershipCount($key, $ymd, 0, 1)];
+      $membershipSummary[$key]['total_owner']['total_owner'] = ['count' => $stats['total_owner']];
       //LCD end
     }
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipTest.php
@@ -942,4 +942,446 @@ class CRM_Member_BAO_MembershipTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Parity for the default "current month" dashboard windows.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsMatchesLegacyForCurrentMonth(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->assertSummaryStatsMatchLegacy($typeIds, $this->currentMonthSummaryWindows());
+  }
+
+  /**
+   * Parity for a past ?date= where the month/year windows fall in an earlier year while the
+   * previous-month window is anchored to today. Confirms each per-column CASE WHEN bucket is
+   * applied independently when the windows do not nest.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsMatchesLegacyForPastMonth(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->assertSummaryStatsMatchLegacy($typeIds, $this->pastMonthSummaryWindows());
+  }
+
+  /**
+   * Parity for a future ?date= where month/year windows fall after today. The fixture has no
+   * activity in that future range, so all activity families must agree at zero; count families
+   * still pick up memberships started on or before the future $ymd.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsMatchesLegacyForFutureMonth(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->assertSummaryStatsMatchLegacy($typeIds, $this->futureMonthSummaryWindows());
+  }
+
+  /**
+   * Parity for the January edge: $ymd in January, so preMonth is the previous December and
+   * the previous-month window crosses a year boundary. Uses fixed dates so the test is
+   * deterministic regardless of when it runs.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsMatchesLegacyForJanuaryEdge(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->assertSummaryStatsMatchLegacy($typeIds, $this->januaryEdgeSummaryWindows());
+  }
+
+  /**
+   * Empty type list returns an empty array; a type with no memberships is present in the result
+   * with every family zero-filled (a GROUP BY query would otherwise omit it).
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsZeroFillAndEmptyList(): void {
+    $w = $this->currentMonthSummaryWindows();
+
+    $this->assertSame([], CRM_Member_BAO_Membership::getMembershipSummaryStats(
+      [], $w['preMonth'], $w['preMonthEnd'], $w['monthStart'], $w['yearStart'], $w['ymd'], $w['current']
+    ));
+
+    $emptyType = $this->membershipTypeCreate(['name' => 'Empty type ' . uniqid()]);
+    $stats = CRM_Member_BAO_Membership::getMembershipSummaryStats(
+      [$emptyType], $w['preMonth'], $w['preMonthEnd'], $w['monthStart'], $w['yearStart'], $w['ymd'], $w['current']
+    );
+    $this->assertArrayHasKey($emptyType, $stats);
+    foreach ($this->getMembershipSummaryFamilies() as $family) {
+      $this->assertArrayHasKey($family, $stats[$emptyType], "Missing family $family");
+      $this->assertSame(0, $stats[$emptyType][$family], "Family $family should be zero-filled");
+    }
+  }
+
+  /**
+   * Guard: when the Membership Signup activity type is not configured, getMembershipJoins
+   * returns 0 and getMembershipStarts (the *_total and *_owner families) returns 0. The
+   * batched method must produce the same zero counts for those families and leave the
+   * renewal families intact.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsWithSignupActivityTypeMissing(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->withActivityTypeOverrides(0, NULL, function () use ($typeIds) {
+      $w = $this->currentMonthSummaryWindows();
+      $stats = CRM_Member_BAO_Membership::getMembershipSummaryStats(
+        $typeIds, $w['preMonth'], $w['preMonthEnd'], $w['monthStart'], $w['yearStart'], $w['ymd'], $w['current']
+      );
+      $this->assertActivityFamiliesAreZero($stats, $typeIds, ['*_new', '*_total', '*_owner']);
+    });
+  }
+
+  /**
+   * Guard: when the Membership Renewal activity type is not configured, getMembershipRenewals
+   * returns 0 and getMembershipStarts (the *_total and *_owner families) returns 0. The
+   * batched method must produce the same zero counts for those families and leave the signup
+   * families intact.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsWithRenewalActivityTypeMissing(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->withActivityTypeOverrides(NULL, 0, function () use ($typeIds) {
+      $w = $this->currentMonthSummaryWindows();
+      $stats = CRM_Member_BAO_Membership::getMembershipSummaryStats(
+        $typeIds, $w['preMonth'], $w['preMonthEnd'], $w['monthStart'], $w['yearStart'], $w['ymd'], $w['current']
+      );
+      $this->assertActivityFamiliesAreZero($stats, $typeIds, ['*_renew', '*_total', '*_owner']);
+    });
+  }
+
+  /**
+   * Guard: when neither activity type is configured, all twelve activity families return 0
+   * and the count families (which do not depend on activity) keep their normal values.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testGetMembershipSummaryStatsWithBothActivityTypesMissing(): void {
+    $typeIds = $this->setupMembershipSummaryFixture();
+    $this->withActivityTypeOverrides(0, 0, function () use ($typeIds) {
+      $w = $this->currentMonthSummaryWindows();
+      $stats = CRM_Member_BAO_Membership::getMembershipSummaryStats(
+        $typeIds, $w['preMonth'], $w['preMonthEnd'], $w['monthStart'], $w['yearStart'], $w['ymd'], $w['current']
+      );
+      $activityFamilies = [
+        'premonth_new', 'premonth_renew', 'premonth_total',
+        'month_new', 'month_renew', 'month_total',
+        'year_new', 'year_renew', 'year_total',
+        'premonth_owner', 'month_owner', 'year_owner',
+      ];
+      foreach ($typeIds as $typeId) {
+        foreach ($activityFamilies as $family) {
+          $this->assertSame(0, $stats[$typeId][$family], "Activity family $family must be 0 for type $typeId");
+        }
+      }
+    });
+  }
+
+  /**
+   * The 16 membership dashboard summary families.
+   *
+   * @return string[]
+   */
+  private function getMembershipSummaryFamilies(): array {
+    return [
+      'premonth_new', 'premonth_renew', 'premonth_total',
+      'month_new', 'month_renew', 'month_total',
+      'year_new', 'year_renew', 'year_total',
+      'current_total', 'total_total',
+      'premonth_owner', 'month_owner', 'year_owner',
+      'current_owner', 'total_owner',
+    ];
+  }
+
+  /**
+   * "Current month" dashboard window set (no ?date= override).
+   *
+   * @return array
+   */
+  private function currentMonthSummaryWindows(): array {
+    return [
+      'preMonth' => date('Y-m-01', strtotime('first day of last month')),
+      'preMonthEnd' => date('Y-m-t', strtotime('last day of last month')),
+      'monthStart' => date('Y-m-01'),
+      'yearStart' => date('Y') . '-01-01',
+      'ymd' => date('Y-m-d'),
+      'current' => date('Y-m-d'),
+    ];
+  }
+
+  /**
+   * "Past month" dashboard window set: the previous-month window is anchored to today (as the
+   * dashboard does) while month/year/total windows point at an earlier year, so the windows do
+   * not nest.
+   *
+   * @return array
+   */
+  private function pastMonthSummaryWindows(): array {
+    $pastYear = (int) date('Y') - 2;
+    return [
+      'preMonth' => date('Y-m-01', strtotime('first day of last month')),
+      'preMonthEnd' => date('Y-m-t', strtotime('last day of last month')),
+      'monthStart' => "$pastYear-01-01",
+      'yearStart' => "$pastYear-01-01",
+      'ymd' => "$pastYear-01-31",
+      'current' => date('Y-m-d'),
+    ];
+  }
+
+  /**
+   * "Future month" dashboard window set: $ymd a year ahead. Activity counts should match at 0
+   * (no fixture activity that far ahead); count families pick up memberships started today.
+   *
+   * @return array
+   */
+  private function futureMonthSummaryWindows(): array {
+    $futureYear = (int) date('Y') + 1;
+    return [
+      'preMonth' => "$futureYear-05-01",
+      'preMonthEnd' => "$futureYear-05-31",
+      'monthStart' => "$futureYear-06-01",
+      'yearStart' => "$futureYear-01-01",
+      'ymd' => "$futureYear-06-30",
+      'current' => "$futureYear-06-30",
+    ];
+  }
+
+  /**
+   * January edge window set: $ymd in January, preMonth is the prior-year December. Uses fixed
+   * dates so the test is deterministic regardless of when it runs.
+   *
+   * @return array
+   */
+  private function januaryEdgeSummaryWindows(): array {
+    return [
+      'preMonth' => '2024-12-01',
+      'preMonthEnd' => '2024-12-31',
+      'monthStart' => '2025-01-01',
+      'yearStart' => '2025-01-01',
+      'ymd' => '2025-01-31',
+      'current' => '2025-01-31',
+    ];
+  }
+
+  /**
+   * Build the legacy summary matrix the dashboard would produce, by calling the four per-type
+   * helpers for each membership type and window exactly as CRM_Member_Page_DashBoard does.
+   *
+   * @param int[] $typeIds
+   * @param array $w
+   *
+   * @return array
+   */
+  private function legacyMembershipSummaryMatrix(array $typeIds, array $w): array {
+    $matrix = [];
+    foreach ($typeIds as $typeId) {
+      $typeId = (int) $typeId;
+      $matrix[$typeId] = [
+        'premonth_new' => CRM_Member_BAO_Membership::getMembershipJoins($typeId, $w['preMonth'], $w['preMonthEnd']),
+        'premonth_renew' => CRM_Member_BAO_Membership::getMembershipRenewals($typeId, $w['preMonth'], $w['preMonthEnd']),
+        'premonth_total' => CRM_Member_BAO_Membership::getMembershipStarts($typeId, $w['preMonth'], $w['preMonthEnd']),
+        'month_new' => CRM_Member_BAO_Membership::getMembershipJoins($typeId, $w['monthStart'], $w['ymd']),
+        'month_renew' => CRM_Member_BAO_Membership::getMembershipRenewals($typeId, $w['monthStart'], $w['ymd']),
+        'month_total' => CRM_Member_BAO_Membership::getMembershipStarts($typeId, $w['monthStart'], $w['ymd']),
+        'year_new' => CRM_Member_BAO_Membership::getMembershipJoins($typeId, $w['yearStart'], $w['ymd']),
+        'year_renew' => CRM_Member_BAO_Membership::getMembershipRenewals($typeId, $w['yearStart'], $w['ymd']),
+        'year_total' => CRM_Member_BAO_Membership::getMembershipStarts($typeId, $w['yearStart'], $w['ymd']),
+        'current_total' => CRM_Member_BAO_Membership::getMembershipCount($typeId, $w['current']),
+        'total_total' => CRM_Member_BAO_Membership::getMembershipCount($typeId, $w['ymd']),
+        'premonth_owner' => CRM_Member_BAO_Membership::getMembershipStarts($typeId, $w['preMonth'], $w['preMonthEnd'], 0, 1),
+        'month_owner' => CRM_Member_BAO_Membership::getMembershipStarts($typeId, $w['monthStart'], $w['ymd'], 0, 1),
+        'year_owner' => CRM_Member_BAO_Membership::getMembershipStarts($typeId, $w['yearStart'], $w['ymd'], 0, 1),
+        'current_owner' => CRM_Member_BAO_Membership::getMembershipCount($typeId, $w['current'], 0, 1),
+        'total_owner' => CRM_Member_BAO_Membership::getMembershipCount($typeId, $w['ymd'], 0, 1),
+      ];
+    }
+    return $matrix;
+  }
+
+  /**
+   * Assert the batched method matches the legacy per-type helpers for a given window set.
+   *
+   * @param int[] $typeIds
+   * @param array $w
+   */
+  private function assertSummaryStatsMatchLegacy(array $typeIds, array $w): void {
+    $expected = $this->legacyMembershipSummaryMatrix($typeIds, $w);
+    $actual = CRM_Member_BAO_Membership::getMembershipSummaryStats(
+      $typeIds, $w['preMonth'], $w['preMonthEnd'], $w['monthStart'], $w['yearStart'], $w['ymd'], $w['current']
+    );
+
+    foreach ($expected as $typeId => $families) {
+      $this->assertArrayHasKey($typeId, $actual, "Missing membership type $typeId in batched result");
+      foreach ($families as $family => $count) {
+        $this->assertSame(
+          (int) $count,
+          $actual[$typeId][$family] ?? NULL,
+          "Mismatch for membership type $typeId family $family"
+        );
+      }
+    }
+  }
+
+  /**
+   * Build a dataset that exercises every summary family and edge case: multiple membership
+   * types, a type with no memberships (zero-fill), a membership with both signup and renewal
+   * activities in one window (COUNT(DISTINCT) dedup), an inherited membership (owner
+   * exclusion), and a non-current membership (status exclusion).
+   *
+   * @return int[]
+   *   The membership type ids to report on.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function setupMembershipSummaryFixture(): array {
+    // Activity.create defaults source_contact_id to the logged-in user.
+    $this->createLoggedInUser();
+
+    $typeA = $this->membershipTypeCreate(['name' => 'Summary A ' . uniqid()]);
+    $typeB = $this->membershipTypeCreate(['name' => 'Summary B ' . uniqid()]);
+    $typeEmpty = $this->membershipTypeCreate(['name' => 'Summary Empty ' . uniqid()]);
+
+    $currentStatus = $this->_membershipStatusID;
+    $nonCurrentStatus = (int) $this->callAPISuccess('MembershipStatus', 'create', [
+      'name' => 'noncurrent ' . random_int(1, 100000),
+      'start_event' => 'start_date',
+      'end_event' => 'end_date',
+      'is_current_member' => 0,
+      'is_active' => 1,
+    ])['id'];
+
+    $thisMonth = date('Y-m-01') . ' 10:00:00';
+    $lastMonth = date('Y-m-15', strtotime('first day of last month')) . ' 10:00:00';
+    $thisMonthStart = date('Y-m-01');
+    $lastMonthStart = date('Y-m-01', strtotime('first day of last month'));
+
+    // typeA, m1: signup this month.
+    [, $m1] = $this->createSummaryMembership($typeA, $currentStatus, $thisMonthStart);
+    $this->createSummaryActivity($m1, 'Membership Signup', $thisMonth);
+
+    // typeA, m2: signup AND renewal in the same month (COUNT(DISTINCT) must count it once).
+    [, $m2] = $this->createSummaryMembership($typeA, $currentStatus, $thisMonthStart);
+    $this->createSummaryActivity($m2, 'Membership Signup', $thisMonth);
+    $this->createSummaryActivity($m2, 'Membership Renewal', $thisMonth);
+
+    // typeA, m3: renewal last month (previous-month families).
+    [, $m3] = $this->createSummaryMembership($typeA, $currentStatus, $lastMonthStart);
+    $this->createSummaryActivity($m3, 'Membership Renewal', $lastMonth);
+
+    // typeA, m4: inherited membership with a signup this month — counts in *_total but not *_owner.
+    $this->createSummaryMembership($typeA, $currentStatus, $thisMonthStart, $m1, 'Membership Signup', $thisMonth);
+
+    // typeA, m5: non-current status — excluded everywhere.
+    [, $m5] = $this->createSummaryMembership($typeA, $nonCurrentStatus, $thisMonthStart);
+    $this->createSummaryActivity($m5, 'Membership Signup', $thisMonth);
+
+    // typeB, m6: signup this month.
+    [, $m6] = $this->createSummaryMembership($typeB, $currentStatus, $thisMonthStart);
+    $this->createSummaryActivity($m6, 'Membership Signup', $thisMonth);
+
+    // typeB, m7: signup dated two years ago in January, so the "past month" window set produces
+    // non-zero month_*/year_* counts rather than asserting 0 == 0.
+    $pastYear = (int) date('Y') - 2;
+    [, $m7] = $this->createSummaryMembership($typeB, $currentStatus, "$pastYear-01-10");
+    $this->createSummaryActivity($m7, 'Membership Signup', "$pastYear-01-10 10:00:00");
+
+    // typeB, m8: signup in December 2024, so the January 2025 edge window has a previous-month
+    // hit straddling the year boundary.
+    [, $m8] = $this->createSummaryMembership($typeB, $currentStatus, '2024-12-15');
+    $this->createSummaryActivity($m8, 'Membership Signup', '2024-12-15 10:00:00');
+
+    return [(int) $typeA, (int) $typeB, (int) $typeEmpty];
+  }
+
+  /**
+   * Create a membership for the summary fixture, optionally inherited and with a signup/renewal
+   * activity, returning [contactId, membershipId].
+   *
+   * @return array
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function createSummaryMembership(int $typeId, int $statusId, string $startDate, ?int $ownerMembershipId = NULL, ?string $activityType = NULL, ?string $activityDate = NULL): array {
+    $contactId = $this->individualCreate([], 'summary_' . uniqid());
+    $params = [
+      'contact_id' => $contactId,
+      'membership_type_id' => $typeId,
+      'join_date' => $startDate,
+      'start_date' => $startDate,
+      'status_id' => $statusId,
+      'is_override' => 1,
+      'skipStatusCal' => 1,
+    ];
+    if ($ownerMembershipId) {
+      $params['owner_membership_id'] = $ownerMembershipId;
+    }
+    $membershipId = (int) $this->callAPISuccess('Membership', 'create', $params)['id'];
+    if ($activityType) {
+      $this->createSummaryActivity($membershipId, $activityType, $activityDate);
+    }
+    return [$contactId, $membershipId];
+  }
+
+  /**
+   * Create a membership signup/renewal activity linked to a membership via source_record_id.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private function createSummaryActivity(int $membershipId, string $activityType, string $activityDateTime): void {
+    $this->callAPISuccess('Activity', 'create', [
+      'activity_type_id' => $activityType,
+      'source_record_id' => $membershipId,
+      'activity_date_time' => $activityDateTime,
+      'status_id' => 'Completed',
+      'subject' => 'Membership dashboard summary fixture',
+    ]);
+  }
+
+  /**
+   * Run $callback with the signup/renewal activity-type statics overridden, restoring them
+   * afterwards even if the callback throws. Pass 0 to simulate a missing type, NULL to keep
+   * the real type. Relies on getMembershipSummaryStats() only calling _getActTypes() when both
+   * statics are NULL.
+   *
+   * @param int|null $signupActType
+   * @param int|null $renewalActType
+   * @param callable $callback
+   */
+  private function withActivityTypeOverrides($signupActType, $renewalActType, callable $callback): void {
+    if (CRM_Member_BAO_Membership::$_signupActType === NULL && CRM_Member_BAO_Membership::$_renewalActType === NULL) {
+      CRM_Member_BAO_Membership::_getActTypes();
+    }
+    $originalSignup = CRM_Member_BAO_Membership::$_signupActType;
+    $originalRenewal = CRM_Member_BAO_Membership::$_renewalActType;
+    try {
+      CRM_Member_BAO_Membership::$_signupActType = $signupActType === NULL ? $originalSignup : $signupActType;
+      CRM_Member_BAO_Membership::$_renewalActType = $renewalActType === NULL ? $originalRenewal : $renewalActType;
+      $callback();
+    }
+    finally {
+      CRM_Member_BAO_Membership::$_signupActType = $originalSignup;
+      CRM_Member_BAO_Membership::$_renewalActType = $originalRenewal;
+    }
+  }
+
+  /**
+   * Assert that families matching the given patterns are 0 for every type. A pattern like
+   * '*_new' matches premonth_new, month_new, year_new.
+   *
+   * @param array $stats
+   * @param int[] $typeIds
+   * @param string[] $patterns
+   */
+  private function assertActivityFamiliesAreZero(array $stats, array $typeIds, array $patterns): void {
+    foreach ($typeIds as $typeId) {
+      foreach ($patterns as $pattern) {
+        $suffix = ltrim($pattern, '*');
+        foreach (['premonth', 'month', 'year'] as $prefix) {
+          $family = $prefix . $suffix;
+          $this->assertSame(0, $stats[$typeId][$family], "Family $family must be 0 for type $typeId");
+        }
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
The CiviMember dashboard (`civicrm/member`) builds its summary table by calling four BAO helpers (`getMembershipJoins`, `getMembershipRenewals`, `getMembershipStarts`, `getMembershipCount`) **once per membership type per date window** — about 16 queries for every membership type. On sites with many membership types this runs into thousands of queries per page load and makes the page take the better part of a minute. This PR keeps the page output identical but gathers all the counts in **two grouped queries**.

Before
----------------------------------------
`CRM_Member_Page_DashBoard::preProcess()` loops over every active membership type and, per type, issues 16 separate `COUNT` queries (3 join-based families × {previous month, month, year}, 2 current/total counts, and the owner variants of each). Measured on a production-data copy of a real site (2.24M activities, 145k memberships, **96 active membership types**):

- **1,536 queries** per page load (96 × 16)
- **~50 seconds** of database time

The whole loop is just gathering integers; nothing about the rendered table requires per-type round trips.

After
----------------------------------------
A new `CRM_Member_BAO_Membership::getMembershipSummaryStats()` returns the same counts keyed by membership type id, computed in **two grouped queries** — one conditional-aggregation query over the signup/renewal activity join (the 12 join-based families) and one over current memberships (the 4 count families). `preProcess()` calls it once and reads the counts from the result; the assembled `$membershipSummary` array, the totals, the URLs and the template output are unchanged.

On the same production-data copy:

| Window set | Cells compared (96 types × 16) | Mismatches vs the 4 legacy helpers | Legacy | Batched | Speed-up |
|---|---|---|---|---|---|
| Current month | 1,536 | **0** | 50.6 s | 3.0 s | **16.8×** |
| Past month (`?date=`, disjoint windows) | 1,536 | **0** | 49.3 s | 3.2 s | **15.5×** |

Query count per load drops from **1,536 to 2**.

Technical Details
----------------------------------------
- **`getMembershipSummaryStats($membershipTypeIds, $preMonth, $preMonthEnd, $monthStart, $yearStart, $ymd, $current, $isTest = 0)`** in `CRM/Member/BAO/Membership.php`. It takes the window dates from the caller (no date maths in the BAO), zero-fills every requested type (so a `GROUP BY` that omits a type still returns all 16 families), and returns `[typeId => [family => (int) count]]`.
- **Query 1 (activity families):** `COUNT(DISTINCT CASE WHEN <type/window/owner> THEN membership.id END)` over `civicrm_membership` INNER JOIN a signup/renewal `civicrm_activity` + current-member `civicrm_membership_status` + non-deleted `civicrm_contact`. `COUNT(DISTINCT …)` reproduces the legacy per-membership dedup when a membership has more than one matching activity. The `_total` families carry no activity-type predicate because the join already restricts to signup+renewal (equivalent to `getMembershipStarts`' `IN (signup, renewal)`).
- **Scan bound:** Query 1 also adds `AND activity.activity_date_time BETWEEN LEAST(preMonth, monthStart, yearStart) AND GREATEST(preMonthEnd, ymd) + '23:59:59'` (computed in PHP and parameterised) so the activity scan is pruned to the union of the windows before the per-CASE filters run. Every per-CASE sub-window is a subset of the bound by construction, so the bound is a pure pruning step that cannot change the result.
- **Query 2 (current/total families):** `COUNT(CASE WHEN start_date <= … THEN id END)` over current memberships, excluding deleted contacts with the same `NOT IN (…)` subquery `getMembershipCount` uses. The status join is to-one on the PK so there is no row fan-out — a non-`DISTINCT` `COUNT` is exact.
- **Activity-type guard preserved:** `getMembershipJoins` needs the signup type, `getMembershipRenewals` the renewal type, and `getMembershipStarts` (the `_total`/owner families) both. When a type is missing those families return 0 in the originals; the batched method reproduces that per-family.
- **The four legacy helpers are unchanged** (still callable by third parties).
- **EXPLAIN** on the activity query (same prod-data copy): the activity join uses the `UI_source_record_id` index (`ref`); the `Using temporary; Using filesort` is the `GROUP BY membership_type_id` and is harmless at this scale. No new index is required.
- **Tests:** `CRM/Member/BAO/MembershipTest.php` gains parity tests that assert the batched method equals the 16 legacy calls cell-for-cell over a fixture exercising multiple types, a membership with both a signup and a renewal activity in one window (the `DISTINCT` dedup), an inherited membership (owner exclusion), a non-current-status membership (status exclusion) and a type with no memberships (zero-fill). Window sets covered: current month, past-year `?date=`, future-year `?date=`, and a January edge (preMonth crosses the previous-year December). Three further tests cover the activity-type guard — signup missing, renewal missing, both missing — by overriding the static activity-type IDs through a try/finally helper so the missing-type configuration is simulated without touching the pseudoconstant cache.

Comments
----------------------------------------
- `getMembershipSummaryStats()` resolves the signup/renewal activity-type IDs once via `_getActTypes()` when both statics are NULL; the legacy "refresh if either is falsy" trigger is relaxed so the guard tests can override one static without the refresh stomping the override. Behaviour on a normally-configured site is unchanged.