### PR TITLE
AdminUI - Format custom file fields as links with icons 

### DIFF
--- a/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
+++ b/ext/civicrm_admin_ui/Civi/Api4/Action/CustomGroup/GetSearchKit.php
@@ -13,11 +13,11 @@ use CRM_CivicrmAdminUi_ExtensionUtil as E;
  */
 class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
 
-  protected function getSelect() {
+  protected function getSelect(): array {
     return ['id', 'name', 'title', 'is_multiple', 'style'];
   }
 
-  protected function doTask($item) {
+  protected function doTask($item): array {
     // searches only apply to multi-record CustomGroups
     if (!$item['is_multiple'] || ($item['style'] !== 'Tab with table')) {
       return [
@@ -58,7 +58,25 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     $searchLabel = E::ts('%1 Search', [1 => $group['title']]);
 
     // select all fields by name
-    $select = array_column($group['fields'], 'name');
+    $select = [];
+    $join = [];
+
+    foreach ($group['fields'] as $field) {
+      // Join on custom file fields
+      if ($field['data_type'] === 'File') {
+        $alias = $this->getJoinAlias($group, $field);
+        $select[] = "$alias.file_name";
+        $join[] = [
+          "File AS $alias",
+          'LEFT',
+          [$field['name'], '=', "$alias.id"],
+        ];
+      }
+      else {
+        $select[] = $field['name'];
+      }
+    }
+
     // add id and entity_id - always useful
     $select[] = 'id';
     $select[] = 'entity_id';
@@ -77,6 +95,7 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
           'api_params' => [
             'version' => 4,
             'select' => $select,
+            'join' => $join,
           ],
         ],
         'match' => ['name'],
@@ -91,7 +110,7 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     $columns = [];
 
     foreach ($group['fields'] as $field) {
-      $columns[] = $this->getColumnForField($field);
+      $columns[] = $this->getColumnForField($group, $field);
     }
     $columns[] = $this->getButtonColumn($group);
 
@@ -100,7 +119,7 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     return $searchDisplays;
   }
 
-  protected function getTabSearchDisplay($group, $columns, $displayType = 'table') {
+  protected function getTabSearchDisplay(array $group, array $columns, string $displayType = 'table'): array {
     $searchName = $group['search_name'];
     $displayName = $group['entity_name'] . '_Tab';
     $displayLabel = $group['title'];
@@ -121,6 +140,7 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
           'settings' => [
             'placeholder' => 5,
             'columns' => $columns,
+            'description' => $description,
             'pager' => [
               'show_count' => TRUE,
               'expose_limit' => TRUE,
@@ -156,28 +176,41 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     ];
   }
 
-  protected function getColumnForField($field) {
-    $key = $field['name'];
-    if ($field['option_group_id']) {
-      $key .= ':label';
-    }
+  protected function getColumnForField(array $group, array $field): array {
     // TODO: for entity ref columns, we would like to use
     // a display-friendly column from the joined entity
     // but
     // a) we will need to determine the column based on
     //    the entity (e.g. display_name for contact)
     // b) we will need to add it to the SavedSearch as well
-    return [
+    $column = [
       'type' => 'field',
-      'key' => $key,
+      'key' => $field['name'],
       'label' => $field['label'],
       'sortable' => TRUE,
       'break' => TRUE,
     ];
+
+    // Format pseudoconstant values
+    if ($field['option_group_id']) {
+      $column['key'] .= ':label';
+    }
+    // Format custom file fields
+    elseif ($field['data_type'] === 'File') {
+      $alias = $this->getJoinAlias($group, $field);
+      $column['key'] = "$alias.file_name";
+      $column['icons'] = [
+        ['field' => "$alias.icon", 'side' => 'left'],
+      ];
+      $column['link'] = [
+        'path' => "[$alias.url]",
+      ];
+    }
+
+    return $column;
   }
 
-  protected function getButtonColumn($group) {
-    $groupName = $group['name'];
+  protected function getButtonColumn(array $group): array {
     $entityName = $group['entity_name'];
     return [
       'size' => 'btn-xs',
@@ -212,7 +245,7 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
     ];
   }
 
-  public static function getAllManaged() {
+  public static function getAllManaged(): array {
     // for now we only fetch for Groups that have a Tab
     $all = \Civi\Api4\CustomGroup::getSearchKit(FALSE)
       ->addWhere('is_active', '=', TRUE)
@@ -222,6 +255,11 @@ class GetSearchKit extends \Civi\Api4\Generic\BasicBatchAction {
       ->column('managed');
 
     return array_merge(...$all);
+  }
+
+  private function getJoinAlias(array $group, array $field): string {
+    $fkEntity = $field['fk_entity'] ?? $field['data_type'];
+    return "{$group['entity_name']}_{$fkEntity}_{$field['name']}_01";
   }
 
 }

--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -457,7 +457,7 @@ class Admin {
         // FIXME: See comment above: this loop should be able to handle every entity.
         // Above block could be removed and the first part of this conditional
         // `($field['type'] === 'Custom' || $isVirtualEntity)` can be removed.
-        if (($field['type'] === 'Custom' || $isVirtualEntity) && $field['fk_entity'] && $field['input_type'] === 'EntityRef') {
+        if (($field['type'] === 'Custom' || $isVirtualEntity) && $field['fk_entity'] && in_array($field['input_type'], ['EntityRef', 'File'], TRUE)) {
           $entityRefJoins = self::getEntityRefJoins($entity, $field);
           foreach ($entityRefJoins as $joinEntity => $joinInfo) {
             $joins[$joinEntity][] = $joinInfo;

--- a/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/AdminTest.php
@@ -228,4 +228,56 @@ class AdminTest extends Api4TestBase {
     $this->assertEquals('Multiple Things Activity', $customToActivityJoin['label']);
   }
 
+  public function testCustomFileFieldGetJoins(): void {
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'Multiple Files Group',
+      'name' => 'MultiRecordFiles',
+      'extends' => 'Activity',
+      'is_multiple' => TRUE,
+    ]);
+    $this->createTestRecord('CustomField', [
+      'label' => 'Attached File',
+      'name' => 'attached_file',
+      'custom_group_id.name' => 'MultiRecordFiles',
+      'html_type' => 'File',
+      'data_type' => 'File',
+    ]);
+
+    $this->createTestRecord('CustomGroup', [
+      'title' => 'Single File Group',
+      'name' => 'SingleRecordFile',
+      'extends' => 'Contact',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'label' => 'Single Attached File',
+      'name' => 'single_attached_file',
+      'custom_group_id.name' => 'SingleRecordFile',
+      'html_type' => 'File',
+      'data_type' => 'File',
+    ]);
+
+    $allowedEntities = Admin::getSchema();
+    $joins = Admin::getJoins($allowedEntities);
+
+    $fileJoins = \CRM_Utils_Array::filter($joins['Custom_MultiRecordFiles'], ['alias' => 'Custom_MultiRecordFiles_File_attached_file']);
+    $this->assertCount(1, $fileJoins);
+    $fileJoin = reset($fileJoins);
+    $this->assertEquals([['attached_file', '=', 'Custom_MultiRecordFiles_File_attached_file.id']], $fileJoin['conditions']);
+
+    $reverseJoins = \CRM_Utils_Array::filter($joins['File'], ['alias' => 'File_Custom_MultiRecordFiles_attached_file']);
+    $this->assertCount(1, $reverseJoins);
+    $reverseJoin = reset($reverseJoins);
+    $this->assertEquals([['id', '=', 'File_Custom_MultiRecordFiles_attached_file.attached_file']], $reverseJoin['conditions']);
+
+    $singleFileJoins = \CRM_Utils_Array::filter($joins['Contact'], ['alias' => 'Contact_File_single_attached_file']);
+    $this->assertCount(1, $singleFileJoins);
+    $singleFileJoin = reset($singleFileJoins);
+    $this->assertEquals([['SingleRecordFile.single_attached_file', '=', 'Contact_File_single_attached_file.id']], $singleFileJoin['conditions']);
+
+    $singleReverseJoins = \CRM_Utils_Array::filter($joins['File'], ['alias' => 'File_Contact_single_attached_file']);
+    $this->assertCount(1, $singleReverseJoins);
+    $singleReverseJoin = reset($singleReverseJoins);
+    $this->assertEquals([['id', '=', 'File_Contact_single_attached_file.SingleRecordFile.single_attached_file']], $singleReverseJoin['conditions']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/work_items/6600

Before
----------------------------------------
Custom file fields in the contact summary (Tab with Table groups) were formatted badly as unclickable url strings.

After
----------------------------------------
Formatted nicely as clickable links showing filename and icon

Technical Details
----------
As a prerequisite, this also adds the ability in SearchKit to join from custom field fields to the File entity.
