### PR TITLE
Stop assiging participant_status to event_online template

### DIFF
--- a/CRM/Event/BAO/Event.php
+++ b/CRM/Event/BAO/Event.php
@@ -1125,19 +1125,6 @@ WHERE civicrm_event.is_active = 1
           'selfservice_preposition' => $values['event']['selfcancelxfer_time'] < 0 ? ts('after') : ts('before'),
         ]);
 
-        // CRM-13890 : NOTE wait list condition need to be given so that
-        // wait list message is shown properly in email i.e. WRT online event registration template
-        if (empty($tplParams['participant_status']) && empty($values['params']['isOnWaitlist'])) {
-          // @todo - this is no longer used in the core template - deprecate & remove
-          $statusId = CRM_Core_DAO::getFieldValue('CRM_Event_DAO_Participant', $participantId, 'status_id', 'id', TRUE);
-          $tplParams['participant_status'] = CRM_Event_PseudoConstant::participantStatus($statusId, NULL, 'label');
-        }
-        //CRM-15754 - if participant_status contains status ID
-        // @todo - this is no longer used in the core template - deprecate & remove
-        elseif (!empty($tplParams['participant_status']) && CRM_Utils_Rule::integer($tplParams['participant_status'])) {
-          $tplParams['participant_status'] = CRM_Event_PseudoConstant::participantStatus($tplParams['participant_status'], NULL, 'label');
-        }
-
         $sendTemplateParams = [
           'workflow' => 'event_online_receipt',
           'isTest' => $isTest,

--- a/CRM/Upgrade/Incremental/php/SixSeventeen.php
+++ b/CRM/Upgrade/Incremental/php/SixSeventeen.php
@@ -39,6 +39,12 @@ class CRM_Upgrade_Incremental_php_SixSeventeen extends CRM_Upgrade_Incremental_B
   public function upgrade_6_17_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask(ts('Create Mysql Full Text Search indices if active'), 'createMissingFtsIndices');
+    $from = '{$participant_status}';
+    $to = '{participant.status_id:label}';
+    $template = 'event_offline_receipt';
+    $this->addTask('Replace . ' . $from . ' with ' . $to . ' in ' . $template,
+      'updateMessageToken', $template, $from, $to, $rev
+    );
   }
 
 }


### PR DESCRIPTION

Overview
----------------------------------------
Stop assiging participant_status to event_online template

Before
----------------------------------------
Code to assign token but core template does not use it & it has been on the deprecation system check for a while

After
----------------------------------------
gone

Technical Details
----------------------------------------
People have been receiving warnings for this for some time

https://github.com/civicrm/civicrm-core/blob/ad7d247fb9f68db0317889093f1e0c930e8d4804/CRM/Utils/Token.php#L1469

I did add to the upgrade script - although it is probably unnecessary given the long-running warnngs

Comments
----------------------------------------
