### PR TITLE
Update Contribution duplicate check to give more information on duplicates

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -101,9 +101,21 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
     $contributionID = $params['id'] ?? NULL;
     $action = $contributionID ? 'edit' : 'create';
-    $duplicates = [];
-    if (self::checkDuplicate($params, $duplicates, $contributionID)) {
-      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicates)]);
+    $duplicates = self::getDuplicates($params, $contributionID);
+    if ($duplicates) {
+      $duplicateList = [];
+      foreach ($duplicates as $duplicate) {
+        $duplicateDetail = '[id: ' . $duplicate['id'];
+        if (!empty($params['trxn_id']) && strtolower($duplicate['trxn_id']) === strtolower($params['trxn_id'])) {
+          $duplicateDetail .= ', trxn_id: ' . $duplicate['trxn_id'];
+        }
+        if (!empty($params['invoice_id']) && strtolower($duplicate['invoice_id']) === strtolower($params['invoice_id'])) {
+          $duplicateDetail .= ', invoice_id: ' . $duplicate['invoice_id'];
+        }
+        $duplicateDetail .= ']';
+        $duplicateList[] = $duplicateDetail;
+      }
+      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicateList)]);
       throw new CRM_Core_Exception($message);
     }
 
@@ -1322,6 +1334,43 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
    * Check if there is a contribution with the same trxn_id or invoice_id.
    *
    * @param array $input
+   *   Input, potentially containing trxn_id or invoice_id
+   * @param int|null $id
+   *
+   * @return array
+   *   array of any existing duplicates
+   * @throws \CRM_Core_Exception
+   */
+  private static function getDuplicates(array $input, ?int $id = NULL): array {
+    $apiCall = Contribution::get(FALSE)
+      ->addSelect('trxn_id', 'invoice_id');
+
+    if ($id) {
+      $apiCall->addWhere('id', '<>', $id);
+    }
+
+    if (!empty($input['trxn_id']) && !empty($input['invoice_id'])) {
+      $apiCall->addClause('OR', [
+        ['trxn_id', '=', $input['trxn_id']],
+        ['invoice_id', '=', $input['invoice_id']],
+      ]);
+    }
+    elseif (!empty($input['trxn_id'])) {
+      $apiCall->addWhere('trxn_id', '=', $input['trxn_id']);
+    }
+    elseif (!empty($input['invoice_id'])) {
+      $apiCall->addWhere('invoice_id', '=', $input['invoice_id']);
+    }
+    else {
+      return [];
+    }
+    return (array) $apiCall->execute()->indexBy('id');
+  }
+
+  /**
+   * Check if there is a contribution with the same trxn_id or invoice_id.
+   *
+   * @param array $input
    *   An assoc array of name/value pairs.
    * @param array $duplicates
    *   (reference) store ids of duplicate contribs.
@@ -1329,8 +1378,11 @@ INNER JOIN  civicrm_contact contact ON ( contact.id = c.contact_id )
    *
    * @return bool
    *   true if duplicate, false otherwise
+   *
+   * @deprecated since 6.17 will be removed around 6.30
    */
   public static function checkDuplicate($input, &$duplicates, $id = NULL) {
+    CRM_Core_Error::deprecatedFunctionWarning('no alternative');
     if (!$id) {
       $id = $input['id'] ?? NULL;
     }

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -99,7 +99,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
       return NULL;
     }
 
-    $contributionID = $params['id'] ?? NULL;
+    $contributionID = empty($params['id']) ? NULL : (int) $params['id'];
     $action = $contributionID ? 'edit' : 'create';
     self::disallowDuplicates($params, $contributionID);
 

--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -101,23 +101,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
 
     $contributionID = $params['id'] ?? NULL;
     $action = $contributionID ? 'edit' : 'create';
-    $duplicates = self::getDuplicates($params, $contributionID);
-    if ($duplicates) {
-      $duplicateList = [];
-      foreach ($duplicates as $duplicate) {
-        $duplicateDetail = '[id: ' . $duplicate['id'];
-        if (!empty($params['trxn_id']) && strtolower($duplicate['trxn_id']) === strtolower($params['trxn_id'])) {
-          $duplicateDetail .= ', trxn_id: ' . $duplicate['trxn_id'];
-        }
-        if (!empty($params['invoice_id']) && strtolower($duplicate['invoice_id']) === strtolower($params['invoice_id'])) {
-          $duplicateDetail .= ', invoice_id: ' . $duplicate['invoice_id'];
-        }
-        $duplicateDetail .= ']';
-        $duplicateList[] = $duplicateDetail;
-      }
-      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicateList)]);
-      throw new CRM_Core_Exception($message);
-    }
+    self::disallowDuplicates($params, $contributionID);
 
     //set defaults in create mode
     if (!$contributionID) {
@@ -750,6 +734,32 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
     }
     $defaults[$dst] = $look[$defaults[$src]];
     return TRUE;
+  }
+
+  /**
+   * @param array $values
+   * @param int|null $contributionID
+   *
+   * @throws \CRM_Core_Exception
+   */
+  private static function disallowDuplicates(array $values, ?int $contributionID): void {
+    $duplicates = self::getDuplicates($values, $contributionID);
+    if ($duplicates) {
+      $duplicateList = [];
+      foreach ($duplicates as $duplicate) {
+        $duplicateDetail = '[id: ' . $duplicate['id'];
+        if (!empty($values['trxn_id']) && strtolower($duplicate['trxn_id']) === strtolower($values['trxn_id'])) {
+          $duplicateDetail .= ', trxn_id: ' . $duplicate['trxn_id'];
+        }
+        if (!empty($values['invoice_id']) && strtolower($duplicate['invoice_id']) === strtolower($values['invoice_id'])) {
+          $duplicateDetail .= ', invoice_id: ' . $duplicate['invoice_id'];
+        }
+        $duplicateDetail .= ']';
+        $duplicateList[] = $duplicateDetail;
+      }
+      $message = ts("Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: %1", [1 => implode(', ', $duplicateList)]);
+      throw new CRM_Core_Exception($message, 'duplicate_record', ['entity' => 'contribution', 'records' => $duplicates]);
+    }
   }
 
   /**

--- a/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Civi\Entity;
+
+use Civi\Api4\Contribution;
+use Civi\Test;
+use Civi\Test\EntityTrait;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use Civi\Core\HookInterface;
+use Civi\Test\TransactionalInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * FIXME - Add test description.
+ *
+ * Tips:
+ *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
+ *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables, then either:
+ *       a. Do all that using setupHeadless() and Civi\Test.
+ *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *
+ * @group headless
+ */
+class ContributionTest extends TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+  use EntityTrait;
+
+  /**
+   * Setup used when HeadlessInterface is implemented.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * @link https://github.com/civicrm/org.civicrm.testapalooza/blob/master/civi-test.md
+   *
+   * @return \Civi\Test\CiviEnvBuilder
+   *
+   * @throws \CRM_Extension_Exception_ParseException
+   */
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test duplicates fail with an appropriate message.
+   *
+   * @dataProvider duplicateCheckProvider
+   */
+  public function testDuplicateCheck(array $duplicateValues, string $expectedMessage): void {
+    $values = [
+      'contact_id' => $this->createTestEntity('Contact', ['first_name' => 'Bob', 'contact_type' => 'Individual'])['id'],
+      'trxn_id' => 'abc',
+      'invoice_id' => 'xyz',
+      'total_amount' => 20,
+      'financial_type_id:name' => 'Donation',
+    ];
+    $this->createTestEntity('Contribution', $values, 'original');
+
+    try {
+      Contribution::create(FALSE)
+        ->setValues(array_merge($values, $duplicateValues))
+        ->execute();
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertEquals(
+        sprintf($expectedMessage, $this->ids['Contribution']['original']),
+        $e->getMessage()
+      );
+      return;
+    }
+    $this->fail('We should have had an exception');
+  }
+
+  public static function duplicateCheckProvider(): array {
+    return [
+      'trxn_id match' => [
+        ['invoice_id' => 'different_invoice'],
+        'Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: [id: %s, trxn_id: abc]',
+      ],
+      'invoice_id match' => [
+        ['trxn_id' => 'different_trxn'],
+        'Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: [id: %s, invoice_id: xyz]',
+      ],
+      'trxn_id and invoice_id match' => [
+        [],
+        'Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: [id: %s, trxn_id: abc, invoice_id: xyz]',
+      ],
+    ];
+  }
+}

--- a/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Entity/ContributionTest.php
@@ -92,4 +92,5 @@ class ContributionTest extends TestCase implements HeadlessInterface, HookInterf
       ],
     ];
   }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Update Contribution duplicate check to give more information on duplicates
It can be a bit tedious figuring out which value was the duplicate to put it in the exception.

Before
----------------------------------------
```
[CRM_Core_Exception]                                                                                            
  Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: 139456491 
```

After
----------------------------------------
the conflicting value is also shown - eg

 'Duplicate error - existing contribution record(s) have a matching Transaction ID or Invoice Reference. Contribution record ID(s) are: [id: 139456491, invoice_id: xyz]'

Technical Details
----------------------------------------
This is the only core caller of the `checkDuplicate` function & it's signature is weird for a function when we know what the inputs are so I deprecated the other & added a new private one. The deprecated function has one universe caller in uk.co.compucorp.civicrm.booking and I note @mattwire is a maintainer so that should be pretty manageable

I DID think about creating a new DuplicateRecord exception type & am open to adding it - whether we do that or not I did set `errorData` that is useful in this context on the exception

Comments
----------------------------------------

