### PR TITLE
show title, not name, of payment processor on recurring contributions

### DIFF
--- a/CRM/Contribute/Page/ContributionRecur.php
+++ b/CRM/Contribute/Page/ContributionRecur.php
@@ -42,17 +42,17 @@ class CRM_Contribute_Page_ContributionRecur extends CRM_Core_Page {
     }
 
     try {
-      $contributionRecur = civicrm_api3('ContributionRecur', 'getsingle', [
-        'id' => $this->getEntityId(),
-      ]);
+      $contributionRecur = \Civi\Api4\ContributionRecur::get(FALSE)
+        ->addSelect('*', 'payment_processor_id.title')
+        ->addWhere('id', '=', $this->getEntityId())
+        ->execute()
+        ->first();
     }
     catch (Exception $e) {
       CRM_Core_Error::statusBounce(ts('Recurring contribution not found (ID: %1)', [1 => $this->getEntityId()]));
     }
 
-    $contributionRecur['payment_processor'] = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorName(
-      $contributionRecur['payment_processor_id'] ?? NULL
-    );
+    $contributionRecur['payment_processor'] = $contributionRecur['payment_processor_id.title'];
     $idFields = ['contribution_status_id', 'campaign_id', 'financial_type_id'];
     foreach ($idFields as $idField) {
       if (!empty($contributionRecur[$idField])) {


### PR DESCRIPTION
Overview
----------------------------------------
If you view a recurring contribution record (on a contact record), the payment processor will be listed by name, not title. This fixes it (using `title` not `frontend_title` since this isn't the frontend).

Comments
----------------------------------------
I converted to API4 to simplify things.  One could simplify this a lot further still now that we use API4 - but this screen should be replaced by SK soon enough, and that'll avoid having to convert a lot of field names on the template.
