### PR TITLE
Form addRadio: change default separator to avoid superfluous space

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1389,7 +1389,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
    *
    * @return HTML_QuickForm_group
    */
-  public function &addRadio($name, $title, $values, $attributes = [], $separator = NULL, $required = FALSE, $optionAttributes = [], $setRadioTextEscaped = FALSE) {
+  public function &addRadio($name, $title, $values, $attributes = [], $separator = '', $required = FALSE, $optionAttributes = [], $setRadioTextEscaped = FALSE) {
     $options = [];
     $attributes = $attributes ?: [];
     $allowClear = !empty($attributes['allowClear']);


### PR DESCRIPTION
Overview
----------------------------------------

The space causes issues with River flex layout.

Before
----------------------------------------

<img width="2988" height="1278" alt="image" src="https://github.com/user-attachments/assets/eab13d1c-f604-4187-8810-b2a0015c52e5" />

After
----------------------------------------

<img width="2920" height="1064" alt="image" src="https://github.com/user-attachments/assets/8b4df3c9-d51d-4e56-89c0-79c6c3300868" />

Technical Details
----------------------------------------

<img width="2688" height="416" alt="image" src="https://github.com/user-attachments/assets/5686c28a-82f6-4e20-a27e-1ddf50eb8ebe" />

Related: #35208

fyi @vingle 