### PR TITLE
[PHP8.5] Fix notice error on running ECK unit tests

### DIFF
--- a/CRM/Core/DAO/AllCoreTables.php
+++ b/CRM/Core/DAO/AllCoreTables.php
@@ -487,7 +487,7 @@ class CRM_Core_DAO_AllCoreTables {
    * @internal
    */
   public static function invoke($className, $event, &$values) {
-    $entityName = self::getEntityNameForClass($className);
+    $entityName = self::getEntityNameForClass($className) ?? '';
     $entityTypes = EntityRepository::getEntities();
     if (isset($entityTypes[$entityName][$event])) {
       foreach ($entityTypes[$entityName][$event] as $filter) {


### PR DESCRIPTION
Overview
----------------------------------------
This aims to fix this PHP8.5 notice deprecation when running ECK unit tests on PHP8.5 "Deprecated: Using null as an array offset is deprecated, use an empty string instead in /home/homer/buildkit/build/build-3/web/core/CRM/Core/DAO/AllCoreTables.php on line 492" https://test.civicrm.org/job/CiviCRM-Ext-Edge-Matrix/BUILDTYPE=git,CIVIVER=6.15,EXTKEY=de.systopia.eck,label=bknix-tmp-edge/1851/console

ping @colemanw @eileenmcnaughton 
