### PR TITLE
dev/core#6605 fix Custom field applying default instead of value set with `:name`

### DIFF
--- a/Civi/Api4/Generic/AbstractAction.php
+++ b/Civi/Api4/Generic/AbstractAction.php
@@ -459,7 +459,7 @@ abstract class AbstractAction implements \ArrayAccess {
     $entityName = $entityName ?? $this->getEntityName();
     $actionName = $actionName ?? $this->getActionName();
     if (empty(\Civi::$statics['Api4EntityFields'][$entityName][$actionName])) {
-      $allowedTypes = ['Field', 'Filter', 'Extra'];
+      $allowedTypes = ['Field', 'Filter', 'Extra', 'Custom'];
       $getFields = \Civi\API\Request::create($entityName, 'getFields', [
         'version' => 4,
         'checkPermissions' => FALSE,


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6605 fix Custom field applying default instead of value set with `:name`

See https://lab.civicrm.org/dev/core/-/work_items/6605 - I'm not confident in this fix - but it does fix the issue....

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
