### PR TITLE
dev/core#6606 Default status Pending for new backoffice contributions

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -510,6 +510,15 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
       $defaults['payment_instrument_id'] = $this->getDefaultPaymentInstrumentId();
     }
 
+    if (!$this->_id && empty($defaults['contribution_status_id'])) {
+      // Default to Pending: a newly recorded back-office contribution has not been received yet.
+      $defaults['contribution_status_id'] = CRM_Core_PseudoConstant::getKey(
+        'CRM_Contribute_BAO_Contribution',
+        'contribution_status_id',
+        'Pending'
+      );
+    }
+
     $this->assign('is_test', !empty($defaults['is_test']));
     $this->assign('email', $this->getContactValue('email_primary.email'));
     $this->assign('is_pay_later', !empty($defaults['is_pay_later']));

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -194,6 +194,14 @@ class CRM_Event_Form_EventFees {
         $defaults[$f] = $contribution->$f;
       }
     }
+    else {
+      // Default to Pending: a newly recorded back-office contribution has not been received yet.
+      $defaults['contribution_status_id'] = CRM_Core_PseudoConstant::getKey(
+        'CRM_Contribute_BAO_Contribution',
+        'contribution_status_id',
+        'Pending'
+      );
+    }
     return $defaults;
   }
 


### PR DESCRIPTION
Overview

When creating a new contribution via the back-office — either by editing a participant registration and checking "Record Contribution", or by creating a contribution directly — the Payment Status field defaulted to Completed instead of Pending. Pending is the correct initial status according to the new philosophy on contributions and payments. See also: [lab.civicrm.org issue #6606](https://lab.civicrm.org/dev/core/-/work_items/6606)

### Before

The Payment Status dropdown defaults to Completed when opening the participant edit form with "Record Contribution" checked (and no existing online pending contribution), or when opening the new contribution form. The administrator must manually switch to Pending before saving.

Payment Status: [Completed]   ← incorrect default

### After

The Payment Status dropdown defaults to Pending in both forms.

Payment Status: [Pending]     ← correct default

### Technical Details

The fix adds an else block in two places that explicitly sets contribution_status_id to Pending when no existing contribution status is present:

- CRM/Event/Form/EventFees.php — participant edit back-office:
- CRM/Contribute/Form/Contribution.php — back-office contribution form:

Without this, the browser selects the first rendered option. Because `getPendingAndCompleteStatuses()` happens to return Completed (id=1) before Pending (id=2), Completed was silently selected as default.

### Comments

This is more in line with the philosophy of a contribution that is always pending and payments that are made towards it.