### PR TITLE
SearchKit query timeout setting

### DIFF
--- a/CRM/Contact/DAO/SavedSearch.php
+++ b/CRM/Contact/DAO/SavedSearch.php
@@ -23,6 +23,7 @@
  * @property string $modified_date
  * @property string|null $description
  * @property bool|string $is_template
+ * @property int|string|null $timeout
  */
 class CRM_Contact_DAO_SavedSearch extends CRM_Core_DAO_Base {
 }

--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -29,6 +29,20 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
    */
   public function upgrade_6_18_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
+
+    $this->addTask('Add column "SavedSearch.timeout"', 'alterSchemaField', 'SavedSearch', 'timeout', [
+      'title' => ts('Query Timeout'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'description' => ts('Maximum query execution time in seconds. Overrides the site-wide SearchKit timeout. 0 = no timeout. NULL = use site default.'),
+      'add' => '6.18',
+      'default' => NULL,
+      'input_attrs' => [
+        'label' => ts('Query Timeout'),
+        'min' => 0,
+      ],
+    ], 'AFTER `description`');
+
     $this->addTask('Add column "RelationshipType.weight"', 'alterSchemaField', 'RelationshipType', 'weight', [
       'title' => ts('Order'),
       'sql_type' => 'int unsigned',

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -178,7 +178,8 @@ class CRM_Utils_SQL {
    * @return string
    */
   public static function getDatabaseVersion() {
-    return CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
+    \Civi::$statics[__METHOD__] ??= CRM_Core_DAO::singleValueQuery('SELECT VERSION()');
+    return \Civi::$statics[__METHOD__];
   }
 
   public static function connect($dsn) {

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -144,6 +144,16 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       $this->display['settings']['columns'] = $defaultDisplay['settings']['columns'];
     }
 
+    // Resolve the effective query timeout:
+    // - Per-search `timeout` field takes precedence (NULL means "not set, use site default").
+    // - Fall back to the site-wide `search_kit_timeout` setting.
+    // - A value of 0 from either source means "no timeout".
+    $timeout = $this->savedSearch['timeout'] ?? NULL;
+    if ($timeout === NULL) {
+      $timeout = (int) \Civi::settings()->get('search_kit_timeout');
+    }
+    $autoClean = ($timeout > 0) ? \CRM_Utils_AutoClean::swapMaxExecutionTime($timeout) : NULL;
+
     $this->processResult($result);
   }
 

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -9,6 +9,7 @@ use Civi\Api4\Result\SearchDisplayRunResult;
 use Civi\Api4\SearchDisplay;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Api4\Utils\FormattingUtil;
+use CRM_Search_ExtensionUtil as E;
 
 /**
  * Load the results for rendering a SearchDisplay.
@@ -114,6 +115,17 @@ class Run extends AbstractRunAction {
 
     try {
       $apiResult = civicrm_api4($entityName, 'get', $apiParams, $index);
+    }
+    catch (\Civi\Core\Exception\DBQueryException $e) {
+      // MySQL error 3024 = ER_QUERY_TIMEOUT; MariaDB error 1969 = ER_STATEMENT_TIMEOUT
+      if (in_array($e->getSQLErrorCode(), [3024, 1969], TRUE)) {
+        throw new \CRM_Core_Exception(
+          E::ts('The search query timed out. Try narrowing your search or contact your administrator.'),
+          'search_timeout'
+        );
+      }
+      \Civi::log()->error('SearchDisplay.Run error: ' . get_class($e) . ": {$entityName}.get: [display_id] " . ($this->display['id'] ?? 'null') . ' [saved_search_id] ' . ($this->display['saved_search_id'] ?? 'null') . ' [label] ' . ($this->display['label'] ?? '') . ' [error] ' . $e->getMessage());
+      throw $e;
     }
     catch (\Throwable $e) {
       \Civi::log()->error("SearchDisplay.Run error: " . get_class($e) . ": {$entityName}.get: [display_id] " . ($this->display['id'] ?? 'null') . ' [saved_search_id] ' . ($this->display['saved_search_id'] ?? 'null') . ' [label] ' . ($this->display['label'] ?? '') . ' [error] ' . $e->getMessage());

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -37,7 +37,7 @@
           savedSearch: function($route, crmApi4) {
             const params = $route.current.params;
             return crmApi4('SavedSearch', 'get', {
-              select: ['id', 'name', 'label', 'description', 'api_entity', 'api_params', 'form_values', 'is_template', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
+              select: ['id', 'name', 'label', 'description', 'api_entity', 'api_params', 'form_values', 'is_template', 'expires_date', 'timeout', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
               where: [['id', '=', params.id]],
               join: [
                 ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],
@@ -65,7 +65,7 @@
           savedSearch: function($route, crmApi4) {
             const params = $route.current.params;
             return crmApi4('SavedSearch', 'get', {
-              select: ['label', 'description', 'api_entity', 'api_params', 'form_values', 'is_template', 'expires_date', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
+              select: ['label', 'description', 'api_entity', 'api_params', 'form_values', 'is_template', 'expires_date', 'timeout', 'GROUP_CONCAT(DISTINCT entity_tag.tag_id) AS tag_id'],
               where: [['id', '=', params.id]],
               join: [
                 ['EntityTag AS entity_tag', 'LEFT', ['entity_tag.entity_table', '=', '"civicrm_saved_search"'], ['id', '=', 'entity_tag.entity_id']],

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
@@ -4,6 +4,14 @@
   <textarea class="form-control" rows=3 placeholder="{{:: ts('None') }}" ng-model="$ctrl.savedSearch.description"></textarea>
 </label>
 <label>
+  {{:: ts('Query Timeout (seconds)') }}
+  <a crm-ui-help="hs({id: 'timeout', title: ts('Query Timeout (seconds)')})"></a>
+  <div class="form-group">
+    <input type="number" min="0" class="form-control six" ng-model="$ctrl.savedSearch.timeout"
+           placeholder="{{:: ts('Site default') }}">
+  </div>
+</label>
+<label>
   {{:: ts('Search Expiry Date') }}
   <a crm-ui-help="hs({id: 'expires_date', title: ts('Search Expiry Date')})"></a>
   <div class="input-group">

--- a/ext/search_kit/ang/crmSearchDisplay/searchDisplayError.html
+++ b/ext/search_kit/ang/crmSearchDisplay/searchDisplayError.html
@@ -1,0 +1,4 @@
+<p class="alert alert-warning text-center" ng-if="$ctrl.serverError">
+  <i class="crm-i fa-circle-exclamation" role="img" aria-hidden="true"></i>
+  {{ $ctrl.serverError }}
+</p>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -274,6 +274,7 @@
           }
           ctrl.results = apiResults.run;
           ctrl.loading = false;
+          ctrl.serverError = null;
           // Update rowCount if running for the first time or during an update op
           if (!ctrl.rowCount || editedRow) {
             // No need to fetch count if on page 1 and result count is under the limit
@@ -297,7 +298,10 @@
             return; // Another request started after this one
           }
           ctrl.results = [];
+          ctrl.rowCount = null;
           ctrl.loading = false;
+          // Show error message if e.g. query timed out
+          ctrl.serverError = error?.run?.error_message ?? ts('Connection error');
           // Run all postRun callbacks on error
           ctrl.onPostRun.forEach(callback => callback.call(ctrl, error, 'error', editedRow));
         });

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -14,5 +14,6 @@
       {{ $ctrl.settings.noResultsText || ts('None found.') }}
     </p>
   </div>
+  <div ng-include="'~/crmSearchDisplay/searchDisplayError.html'"></div>
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -21,6 +21,7 @@
       <p class="alert alert-info text-center">
         {{ $ctrl.settings.noResultsText || ts('None found.') }}
       </p>
-    </div>
+   </div>
+   <div ng-include="'~/crmSearchDisplay/searchDisplayError.html'"></div>
   <div ng-include="'~/crmSearchDisplay/Pager.html'"></div>
 </div>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -26,3 +26,7 @@
     </p>
   </td>
 </tr>
+<tr ng-if="$ctrl.serverError">
+  <td colspan="{{ $ctrl.columns.length + 2 }}" ng-include="'~/crmSearchDisplay/searchDisplayError.html'">
+  </td>
+</tr>

--- a/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.html
+++ b/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.html
@@ -12,4 +12,5 @@
       {{ $ctrl.settings.noResultsText || ts('None found.') }}
     </p>
   </div>
+  <div ng-include="'~/crmSearchDisplay/searchDisplayError.html'"></div>
 </div>

--- a/ext/search_kit/info.xml
+++ b/ext/search_kit/info.xml
@@ -46,6 +46,7 @@
     <mixin>mgd-php@2.0.0</mixin>
     <mixin>entity-types-php@2.0.0</mixin>
     <mixin>smarty@1.0.3</mixin>
+    <mixin>setting-php@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Search</namespace>

--- a/ext/search_kit/settings/search_kit.setting.php
+++ b/ext/search_kit/settings/search_kit.setting.php
@@ -1,0 +1,34 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Settings metadata for the SearchKit extension.
+ */
+return [
+  'search_kit_timeout' => [
+    'group_name' => 'Search Preferences',
+    'group' => 'Search Preferences',
+    'name' => 'search_kit_timeout',
+    'type' => 'Integer',
+    'html_type' => 'number',
+    'html_attributes' => [
+      'class' => 'six',
+      'min' => 0,
+    ],
+    'default' => 0,
+    'add' => '6.18',
+    'title' => ts('SearchKit Query Timeout'),
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'help_text' => ts('Maximum number of seconds a SearchKit query may run before being cancelled. Set to 0 to disable. Requires MariaDB 10.2+ or MySQL 5.7+. Individual searches can override this value.'),
+    'settings_pages' => ['search' => ['section' => 'searchkit', 'weight' => 10]],
+  ],
+];

--- a/ext/search_kit/templates/CRM/Search/Help/Compose.hlp
+++ b/ext/search_kit/templates/CRM/Search/Help/Compose.hlp
@@ -3,6 +3,10 @@
   <p>{ts}Note: Rewrite occurs after HAVING has been applied, so does not affect the HAVING filter.{/ts}</p>
 {/htxt}
 
+{htxt id="timeout"}
+  <p>{ts}Maximum query execution time in seconds. Overrides the site-wide SearchKit timeout. 0 = no timeout. Leave blank to use site default.{/ts}</p>
+{/htxt}
+
 {htxt id="description"}
   <p>{ts}Description is visible in SearchKit to help you remember the purpose of each search, and is also shown above the default "Search results table" display.{/ts}</p>
 {/htxt}

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchTimeoutTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchTimeoutTest.php
@@ -1,0 +1,151 @@
+<?php
+namespace Civi\ext\search_kit\tests\phpunit\api\v4\SearchDisplay;
+
+// Not sure why this is needed but without it Jenkins crashed
+require_once __DIR__ . '/../../../../../../../tests/phpunit/api/v4/Api4TestBase.php';
+
+use api\v4\Api4TestBase;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * @group headless
+ */
+class SearchTimeoutTest extends Api4TestBase implements TransactionalInterface {
+  use \Civi\Test\ACLPermissionTrait;
+
+  /**
+   * @var int|null
+   */
+  private $assertedMaxExecutionTime = NULL;
+
+  /**
+   * @var \Exception|null
+   */
+  private $exceptionToThrowInHook = NULL;
+
+  /**
+   * Helper to check if the backtrace contains the query execution phase of SearchDisplay.
+   */
+  private function isInsideProcessResult(): bool {
+    $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+    $inProcessResult = FALSE;
+    foreach ($trace as $frame) {
+      $class = $frame['class'] ?? '';
+      $function = $frame['function'];
+      if ($class === 'Civi\Api4\Action\SearchDisplay\Run' && $function === 'processResult') {
+        $inProcessResult = TRUE;
+      }
+      if (in_array($function, ['preprocessLinks', 'preprocessLink', 'loadSearchDisplay', 'augmentSelectClause', 'applyFilters'], TRUE)) {
+        return FALSE;
+      }
+    }
+    return $inProcessResult;
+  }
+
+  /**
+   * Implements hook_civicrm_selectWhereClause().
+   */
+  public function _hook_selectWhereClause($entity, &$clauses) {
+    if ($entity === 'Contact' && $this->isInsideProcessResult()) {
+      $this->assertedMaxExecutionTime = \CRM_Core_DAO::getMaxExecutionTime();
+      if ($this->exceptionToThrowInHook) {
+        throw $this->exceptionToThrowInHook;
+      }
+    }
+  }
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * Test the query timeout logic (setting and saved search overrides).
+   */
+  public function testQueryTimeout(): void {
+    // 1. Verify default timeout matches the original database execution time (no change is made during search).
+    $this->assertedMaxExecutionTime = NULL;
+    $this->exceptionToThrowInHook = NULL;
+
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_selectWhereClause', [$this, '_hook_selectWhereClause']);
+
+    try {
+      $originalDbTimeout = \CRM_Core_DAO::getMaxExecutionTime();
+
+      $lastName = uniqid(__FUNCTION__);
+      $cid = $this->createTestRecord('Individual', ['last_name' => $lastName])['id'];
+
+      $params = [
+        'checkPermissions' => FALSE,
+        'return' => 'page:1',
+        'savedSearch' => [
+          'api_entity' => 'Contact',
+          'api_params' => [
+            'version' => 4,
+            'select' => ['id'],
+            'where' => [['last_name', '=', $lastName]],
+          ],
+        ],
+        'display' => NULL,
+      ];
+
+      // Ensure site setting is 0 initially.
+      \Civi::settings()->revert('search_kit_timeout');
+
+      civicrm_api4('SearchDisplay', 'run', $params);
+      // Since timeout was 0, it should not have swapped the execution time (matching the original value).
+      $this->assertEquals($originalDbTimeout, $this->assertedMaxExecutionTime);
+
+      // 2. Test site-wide setting.
+      \Civi::settings()->set('search_kit_timeout', 123);
+      civicrm_api4('SearchDisplay', 'run', $params);
+      $this->assertEquals(123, $this->assertedMaxExecutionTime);
+
+      // 3. Test SavedSearch per-search timeout override takes precedence.
+      $params['savedSearch']['timeout'] = 45;
+      civicrm_api4('SearchDisplay', 'run', $params);
+      $this->assertEquals(45, $this->assertedMaxExecutionTime);
+
+      // 4. Test SavedSearch timeout override of 0 disables timeout.
+      $params['savedSearch']['timeout'] = 0;
+      civicrm_api4('SearchDisplay', 'run', $params);
+      $this->assertEquals($originalDbTimeout, $this->assertedMaxExecutionTime);
+
+      // Revert settings.
+      \Civi::settings()->revert('search_kit_timeout');
+
+      // 5. Test catching database query timeout exceptions (for both MySQL and MariaDB).
+      foreach ([3024, 1969] as $errorCode) {
+        $pearError = new \DB_Error(
+          \DB_ERROR_NOSUCHDB,
+          PEAR_ERROR_RETURN,
+          \E_USER_WARNING,
+          "SELECT * FROM civicrm_contact [nativecode={$errorCode} ** Query execution was interrupted]"
+        );
+        $this->exceptionToThrowInHook = new \Civi\Core\Exception\DBQueryException(
+          'Query execution was interrupted',
+          0,
+          ['exception' => $pearError]
+        );
+
+        try {
+          civicrm_api4('SearchDisplay', 'run', $params);
+          $this->fail("Expected search timeout exception for code {$errorCode} was not thrown.");
+        }
+        catch (\CRM_Core_Exception $e) {
+          $this->assertEquals('search_timeout', $e->getErrorCode());
+          $this->assertStringContainsString('The search query timed out', $e->getMessage());
+        }
+      }
+    }
+    finally {
+      \CRM_Utils_Hook::singleton()->setHook('civicrm_selectWhereClause', NULL);
+      $this->exceptionToThrowInHook = NULL;
+    }
+  }
+
+}

--- a/schema/Contact/SavedSearch.entityType.php
+++ b/schema/Contact/SavedSearch.entityType.php
@@ -185,6 +185,18 @@ return [
         'cols' => 60,
       ],
     ],
+    'timeout' => [
+      'title' => ts('Query Timeout'),
+      'sql_type' => 'int unsigned',
+      'input_type' => 'Number',
+      'description' => ts('Maximum query execution time in seconds. Overrides the site-wide SearchKit timeout. 0 = no timeout. Leave blank to use site default.'),
+      'add' => '6.18',
+      'default' => NULL,
+      'input_attrs' => [
+        'label' => ts('Query Timeout'),
+        'min' => 0,
+      ],
+    ],
     'is_template' => [
       'title' => ts('Template'),
       'sql_type' => 'boolean',


### PR DESCRIPTION
Overview
----------------------------------------
Adds a SearchKit setting, that can be configured globally and on a per-search basis, to limit the execution time of search queries.

See https://lab.civicrm.org/dev/core/-/work_items/6545

<img width="816" height="342" alt="Screenshot 2026-07-10 at 1 29 53 PM" src="https://github.com/user-attachments/assets/bbc496f5-ba2d-4c89-95e3-7127b7ed48ac" />

-------

**Result:** If the query exceeds the limit, this error will be displayed in place of the results:

<img width="1246" height="258" alt="Screenshot 2026-07-10 at 1 29 38 PM" src="https://github.com/user-attachments/assets/62133a67-5518-4e75-b0bb-cf3899ba6f5b" />

Notes
------

This generally improves the error display in SearchKit, which previously did not show up very well.