### PR TITLE
add Api4 Address.geocode batch action

### DIFF
--- a/Civi/Api4/Action/Address/Geocode.php
+++ b/Civi/Api4/Action/Address/Geocode.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Address;
+
+use Civi\Api4\Generic\Result;
+
+/**
+ * Fetch lat/long coordinates for an address record
+ */
+class Geocode extends \Civi\Api4\Generic\BasicBatchAction {
+
+  protected const ADDRESS_PARTS = [
+    'street_address',
+    'supplemental_address_1',
+    'supplemental_address_2',
+    'supplemental_address_3',
+    'city',
+    'county_id:label',
+    'state_province_id:label',
+    'postal_code',
+    'country_id:label',
+  ];
+
+  /**
+   * @inheritdoc
+   */
+  protected function getSelect() {
+    return ['id', ...self::ADDRESS_PARTS, 'manual_geo_code'];
+  }
+
+  /**
+   * @var bool
+   *
+   * Skip records which have already been geocoded
+   */
+  protected bool $includeAlreadyGeocoded = FALSE;
+
+  /**
+   * @var bool
+   *
+   * Skip records which have been manually geocoded
+   */
+  protected bool $includeManuallyGeocoded = FALSE;
+
+
+  /**
+   * @var string
+   *
+   * Local cache for default country. Addresses with
+   * no country set will use this.
+   */
+  private string $defaultCountryLabel;
+
+  /**
+   * @inheritdoc
+   */
+  protected function getBatchAction() {
+    $action = parent::getBatchAction();
+
+    if (!$this->includeAlreadyGeocoded) {
+      $action->addWhere('geo_code_1', 'IS EMPTY');
+      $action->addWhere('geo_code_2', 'IS EMPTY');
+    }
+    if (!$this->includeManuallyGeocoded) {
+      $action->addWhere('manual_geo_code', 'IS EMPTY');
+    }
+
+    return $action;
+  }
+
+  protected function processBatch(Result $result, array $items): void {
+    $this->defaultCountryLabel = \CRM_Core_BAO_Country::defaultContactCountryName();
+    parent::processBatch($result, $items);
+  }
+
+  public function doTask($record) {
+    try {
+      $record['country_id:label'] ??= $this->defaultCountryLabel;
+
+      // get the non-empty fields
+      $addressStringParts = array_map(fn ($key) => $record[$key], self::ADDRESS_PARTS);
+      $addressString = implode(', ', array_filter($addressStringParts));
+
+      if (!$addressString) {
+        throw new \CRM_Core_Exception('Empty address');
+      }
+
+      $coordinates = \Civi\Api4\Address::getCoordinates(FALSE)
+        ->setAddress($addressString)
+        ->execute()
+        ->first();
+
+      if (!$coordinates) {
+        throw new \CRM_Core_Exception('No coordinates found');
+      }
+
+      \Civi\Api4\Address::update(FALSE)
+        ->addWhere('id', '=', $record['id'])
+        ->addValue('geo_code_1', $coordinates['geo_code_1'])
+        ->addValue('geo_code_2', $coordinates['geo_code_2'])
+        ->execute();
+
+      return [
+        'id' => $record['id'],
+        'status' => 'updated',
+      ];
+    }
+    catch (\Throwable $e) {
+      $message = $e->getMessage();
+      \Civi::log()->debug("Geocoding failed for Address ID {$record['id']}: {$message}");
+      return [
+        'id' => $record['id'],
+        'status' => 'error',
+        'message' => $message,
+      ];
+    }
+  }
+
+}

--- a/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
+++ b/tests/phpunit/CRM/Utils/Geocode/TestProvider.php
@@ -5,6 +5,20 @@ class CRM_Utils_Geocode_TestProvider {
   public const GEO_CODE_1 = '38.897957';
   public const GEO_CODE_2 = '-77.036560';
 
+  /**
+   * Log of address strings passed to getCoordinates(); reset between tests.
+   *
+   * @var string[]
+   */
+  public static array $receivedAddresses = [];
+
+  /**
+   * Reset the call log between tests.
+   */
+  public static function reset(): void {
+    self::$receivedAddresses = [];
+  }
+
   public static function format(&$values, $stateName = FALSE) {
     $address = ($values['street_address'] ?? '') . ($values['city'] ?? '');
 
@@ -21,6 +35,7 @@ class CRM_Utils_Geocode_TestProvider {
   }
 
   public static function getCoordinates($address): array {
+    self::$receivedAddresses[] = $address;
     if (str_starts_with($address, self::ADDRESS)) {
       return ['geo_code_1' => self::GEO_CODE_1, 'geo_code_2' => self::GEO_CODE_2];
     }

--- a/tests/phpunit/api/v4/Action/AddressGeocodeTest.php
+++ b/tests/phpunit/api/v4/Action/AddressGeocodeTest.php
@@ -1,0 +1,299 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4\Action;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\Address;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Tests for the Api4 Address.geocode action.
+ *
+ * Uses CRM_Utils_Geocode_TestProvider, a mock provider that
+ * records every address string it receives and returns fixed dummy coordinates.
+ *
+ * @group headless
+ */
+class AddressGeocodeTest extends Api4TestBase implements TransactionalInterface {
+
+  /**
+   * Dummy lat/long values returned by the mock provider.
+   */
+  private const GEO_CODE_1 = \CRM_Utils_Geocode_TestProvider::GEO_CODE_1;
+  private const GEO_CODE_2 = \CRM_Utils_Geocode_TestProvider::GEO_CODE_2;
+
+  public function setUp(): void {
+    parent::setUp();
+    \CRM_Utils_Geocode_TestProvider::reset();
+    // Point the geocoding subsystem at our mock provider.
+    \Civi\Api4\Setting::set()
+      ->addValue('geoProvider', 'TestProvider')
+      ->execute();
+  }
+
+  public function tearDown(): void {
+    \Civi\Api4\Setting::revert()
+      ->addSelect('geoProvider')
+      ->addSelect('defaultContactCountry')
+      ->execute();
+    parent::tearDown();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a contact + address record with the supplied field values.
+   *
+   * @param array $addressValues
+   * @return array The created address record (id + supplied values).
+   */
+  private function createAddress(array $addressValues = []): array {
+    $contactId = $this->createTestRecord('Contact')['id'];
+    $address = Address::create(FALSE)
+      ->setSkipGeocode(TRUE)
+      ->setValues(array_merge(
+        ['contact_id' => $contactId, 'location_type_id' => 1],
+        $addressValues
+      ))
+      ->execute()
+      ->single();
+    // Register for automatic cleanup.
+    $this->registerTestRecord('Address', $address['id']);
+    return $address;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tests
+  // ---------------------------------------------------------------------------
+
+  /**
+   * The geocoding provider receives a well-formed, comma-separated address
+   * string assembled from the non-empty address fields.
+   */
+  public function testGeocodeProviderReceivesWellFormedInput(): void {
+    $address = $this->createAddress([
+      // Use the TestProvider's known address so getCoordinates() returns real
+      // coordinates rather than an empty array.
+      'street_address' => '600 Pennsylvania Avenue NW',
+      'city' => 'Washington',
+      'postal_code' => '20500',
+    ]);
+
+    Address::geocode(FALSE)
+      ->addWhere('id', '=', $address['id'])
+      ->execute();
+
+    $received = \CRM_Utils_Geocode_TestProvider::$receivedAddresses;
+    $this->assertCount(1, $received, 'Provider should be called exactly once per address');
+
+    $addressString = $received[0];
+
+    // The string must be non-empty.
+    $this->assertNotEmpty($addressString);
+
+    // All non-empty parts that were supplied must appear in the string.
+    $this->assertStringContainsString('600 Pennsylvania Avenue NW', $addressString);
+    $this->assertStringContainsString('Washington', $addressString);
+    $this->assertStringContainsString('20500', $addressString);
+
+    // Parts are joined by ', ' – verify the separator is present.
+    $this->assertStringContainsString(', ', $addressString);
+
+    // Empty fields must NOT produce trailing/leading separators or
+    // double-comma artefacts like ", ,".
+    $this->assertStringNotContainsString(', ,', $addressString);
+    $this->assertDoesNotMatchRegularExpression('/^, |, $/', $addressString);
+  }
+
+  /**
+   * When an address has no country set, the default contact country name is
+   * appended to the address string sent to the geocoding provider.
+   */
+  public function testDefaultCountryIsAppendedWhenMissing(): void {
+    // Use the US as the default country (ID 1228 in the standard CiviCRM
+    // country list). Look up its label the same way the action does so the
+    // assertion is not tied to a hardcoded string.
+    $usCountryId = 1228;
+    $expectedCountryName = \CRM_Core_PseudoConstant::country()[$usCountryId];
+
+    \Civi\Api4\Setting::set()
+      ->addValue('defaultContactCountry', $usCountryId)
+      ->execute();
+
+    // defaultContactCountryName() uses a static cache; ensure it is primed
+    // with the new setting value before the action reads it.
+    \CRM_Core_BAO_Country::defaultContactCountryName();
+
+    $address = $this->createAddress([
+      'street_address' => '600 Pennsylvania Avenue NW',
+      'city' => 'Washington',
+      // No country_id – the action should fall back to the default.
+    ]);
+
+    Address::geocode(FALSE)
+      ->addWhere('id', '=', $address['id'])
+      ->execute();
+
+    $addressString = \CRM_Utils_Geocode_TestProvider::$receivedAddresses[0] ?? '';
+    $this->assertStringContainsString($expectedCountryName, $addressString,
+      'Default contact country should be appended when address has no country'
+    );
+  }
+
+  /**
+   * After a successful geocode, the address record is updated with lat/long.
+   */
+  public function testGeocodeUpdatesAddressCoordinates(): void {
+    $address = $this->createAddress([
+      'street_address' => '600 Pennsylvania Avenue NW',
+      'city' => 'Washington',
+    ]);
+
+    $result = Address::geocode(FALSE)
+      ->addWhere('id', '=', $address['id'])
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('updated', $result->first()['status']);
+
+    $updated = Address::get(FALSE)
+      ->addWhere('id', '=', $address['id'])
+      ->addSelect('geo_code_1', 'geo_code_2')
+      ->execute()
+      ->first();
+
+    $this->assertEquals(self::GEO_CODE_1, $updated['geo_code_1']);
+    $this->assertEquals(self::GEO_CODE_2, $updated['geo_code_2']);
+  }
+
+  /**
+   * Addresses that already have geo_code_1 and geo_code_2 set are skipped
+   * by default (includeAlreadyGeocoded = FALSE).
+   *
+   * Setting includeAlreadyGeocoded = TRUE forces them to be re-geocoded.
+   */
+  public function testAlreadyGeocodedAddressesSkippedByDefault(): void {
+    // Address with pre-existing lat/long values.
+    $alreadyGeocoded = $this->createAddress([
+      'street_address' => '1600 Pennsylvania Ave NW',
+      'city' => 'Washington',
+      'geo_code_1' => '38.8977',
+      'geo_code_2' => '-77.0366',
+    ]);
+
+    // Address without lat/long – should be processed.
+    $notYetGeocoded = $this->createAddress([
+      'street_address' => '221B Baker Street',
+      'city' => 'London',
+    ]);
+
+    // --- Default behaviour: skip already-geocoded ---
+    $result = Address::geocode(FALSE)
+      ->addWhere('id', 'IN', [$alreadyGeocoded['id'], $notYetGeocoded['id']])
+      ->execute()
+      ->indexBy('id');
+
+    $this->assertArrayNotHasKey($alreadyGeocoded['id'], (array) $result,
+      'Already-geocoded address should be skipped by default'
+    );
+    $this->assertArrayHasKey($notYetGeocoded['id'], (array) $result,
+      'Un-geocoded address should be processed'
+    );
+    $this->assertCount(1, \CRM_Utils_Geocode_TestProvider::$receivedAddresses,
+      'Provider called only for the un-geocoded address'
+    );
+
+    // --- With includeAlreadyGeocoded: both are processed ---
+    \CRM_Utils_Geocode_TestProvider::reset();
+
+    $result = Address::geocode(FALSE)
+      ->addWhere('id', 'IN', [$alreadyGeocoded['id'], $notYetGeocoded['id']])
+      ->setIncludeAlreadyGeocoded(TRUE)
+      ->execute()
+      ->indexBy('id');
+
+    $this->assertArrayHasKey($alreadyGeocoded['id'], (array) $result,
+      'Already-geocoded address should be included when includeAlreadyGeocoded=TRUE'
+    );
+    $this->assertArrayHasKey($notYetGeocoded['id'], (array) $result);
+    $this->assertCount(2, \CRM_Utils_Geocode_TestProvider::$receivedAddresses,
+      'Provider should be called for both addresses'
+    );
+  }
+
+  /**
+   * Addresses flagged as manually geocoded are skipped by default
+   * (includeManuallyGeocoded = FALSE).
+   *
+   * Setting includeManuallyGeocoded = TRUE forces them to be re-geocoded.
+   */
+  public function testManuallyGeocodedAddressesSkippedByDefault(): void {
+    // Address marked as manually geocoded.
+    $manuallyGeocoded = $this->createAddress([
+      'street_address' => '742 Evergreen Terrace',
+      'city' => 'Springfield',
+      'manual_geo_code' => TRUE,
+    ]);
+
+    // Normal address without manual flag – should be processed.
+    $normalAddress = $this->createAddress([
+      'street_address' => '4 Privet Drive',
+      'city' => 'Little Whinging',
+    ]);
+
+    // --- Default behaviour: skip manually geocoded ---
+    $result = Address::geocode(FALSE)
+      ->addWhere('id', 'IN', [$manuallyGeocoded['id'], $normalAddress['id']])
+      ->execute()
+      ->indexBy('id');
+
+    $this->assertArrayNotHasKey($manuallyGeocoded['id'], (array) $result,
+      'Manually geocoded address should be skipped by default'
+    );
+    $this->assertArrayHasKey($normalAddress['id'], (array) $result,
+      'Normal address should be processed'
+    );
+    $this->assertCount(1, \CRM_Utils_Geocode_TestProvider::$receivedAddresses,
+      'Provider called only for the normal address'
+    );
+
+    // --- With includeManuallyGeocoded: the manually-geocoded address is processed ---
+    // Note: normalAddress was geocoded in the previous pass, so we also set
+    // includeAlreadyGeocoded=TRUE to ensure it stays in scope for this assertion.
+    \CRM_Utils_Geocode_TestProvider::reset();
+
+    $result = Address::geocode(FALSE)
+      ->addWhere('id', 'IN', [$manuallyGeocoded['id'], $normalAddress['id']])
+      ->setIncludeManuallyGeocoded(TRUE)
+      ->setIncludeAlreadyGeocoded(TRUE)
+      ->execute()
+      ->indexBy('id');
+
+    $this->assertArrayHasKey($manuallyGeocoded['id'], (array) $result,
+      'Manually geocoded address should be included when includeManuallyGeocoded=TRUE'
+    );
+    $this->assertArrayHasKey($normalAddress['id'], (array) $result);
+    $this->assertCount(2, \CRM_Utils_Geocode_TestProvider::$receivedAddresses,
+      'Provider should be called for both addresses'
+    );
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Bring address geocoding into Api4 era.

Before
----------------------------------------
- you can getCoordinates of an address string using Api4
- but you need to use api3 / other stuff to geocode address records

After
----------------------------------------
- you can geocode address records using e.g.
  - `\Civi\Api4\Address::geocode(FALSE)->addWhere('id', '=', 192)->execute();` for a specific record
  - `\Civi\Api4\Address::geocode(FALSE)->setLimit(100)->execute();` for up to 100 records that need doing
- by default it will skip already geocoded records, and records that have the manual geocoding flag. These can be overridden using the action params if desired

Technical Details
----------------------------------------
You can get wildly wrong geocoding results if you dont have country set for an address. This appends the default contact country if there is no explicit address. Ideally this would have been done when the address was saved, but that doesn't happen through lots of paths (webform etc)