### PR TITLE
Refactor CRM_Core_BAO_Country to use Civi::$statics

### DIFF
--- a/CRM/Core/BAO/Country.php
+++ b/CRM/Core/BAO/Country.php
@@ -79,15 +79,16 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
   /**
    * Provide cached default contact country.
    *
-   * @return string
+   * @return string|null
    */
-  public static function defaultContactCountry() {
-    static $cachedContactCountry = NULL;
+  public static function defaultContactCountry(): ?string {
     $defaultContactCountry = Civi::settings()->get('defaultContactCountry');
+    $cachedContactCountry = Civi::$statics[__METHOD__] ?? NULL;
 
     if (!empty($defaultContactCountry) && !$cachedContactCountry) {
       $countryIsoCodes = CRM_Core_PseudoConstant::countryIsoCode();
       $cachedContactCountry = $countryIsoCodes[$defaultContactCountry] ?? NULL;
+      Civi::$statics[__METHOD__] = $cachedContactCountry;
     }
     return $cachedContactCountry;
   }
@@ -150,14 +151,15 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
   /**
    * Provide cached default country name.
    *
-   * @return string
+   * @return string|null
    */
-  public static function defaultContactCountryName() {
-    static $cachedContactCountryName = NULL;
+  public static function defaultContactCountryName(): ?string {
     $defaultContactCountry = Civi::settings()->get('defaultContactCountry');
+    $cachedContactCountryName = Civi::$statics[__METHOD__] ?? NULL;
     if (!$cachedContactCountryName && $defaultContactCountry) {
       $countryCodes = CRM_Core_PseudoConstant::country();
-      $cachedContactCountryName = $countryCodes[$defaultContactCountry];
+      $cachedContactCountryName = $countryCodes[$defaultContactCountry] ?? NULL;
+      Civi::$statics[__METHOD__] = $cachedContactCountryName;
     }
     return $cachedContactCountryName;
   }
@@ -165,12 +167,12 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
   /**
    * Provide cached default currency symbol.
    *
-   * @param string $defaultCurrency
+   * @param string|null $defaultCurrency
    *
    * @return string
    */
-  public static function defaultCurrencySymbol($defaultCurrency = NULL) {
-    static $cachedSymbol = NULL;
+  public static function defaultCurrencySymbol(?string $defaultCurrency = NULL): string {
+    $cachedSymbol = Civi::$statics[__METHOD__] ?? NULL;
     if (!$cachedSymbol || $defaultCurrency) {
       $currency = $defaultCurrency ?: Civi::settings()->get('defaultCurrency');
       if ($currency) {
@@ -180,6 +182,7 @@ class CRM_Core_BAO_Country extends CRM_Core_DAO_Country {
       else {
         $cachedSymbol = '$';
       }
+      Civi::$statics[__METHOD__] = $cachedSymbol;
     }
     return $cachedSymbol;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Refactors the `CRM_Core_BAO_Country` class methods using `static` variables to use `Civi::$statics[__METHOD__]`. Adds return type hints and fixes incorrect return annotations in their docblocks.

Before
----------------------------------------
- PHP `static` keyword makes it harder to reset cache states in test suites or long-running processes. 
- Incorrect return type annotations in their docblocks.

After
----------------------------------------
- Now use `Civi::$statics[__METHOD__]` for caching, which is easily resettable in tests. 
- Added type hints and updated docblocks.
