### PR TITLE
(dev/core#6609) CRM_Core_I18n_SchemaTest - Accept equivalent DDL variant on MariaDB 10.6

### DIFF
--- a/tests/phpunit/CRM/Core/I18n/SchemaTest.php
+++ b/tests/phpunit/CRM/Core/I18n/SchemaTest.php
@@ -113,7 +113,7 @@ class CRM_Core_I18n_SchemaTest extends CiviUnitTestCase {
     $testCreateTable = CRM_Core_DAO::executeQuery('SHOW create table civicrm_price_set', [], TRUE, NULL, FALSE, FALSE);
     while ($testCreateTable->fetch()) {
       $this->assertStringContainsString("`title_en_US` varchar(255) COLLATE {$inUseCollation} NOT NULL DEFAULT '' COMMENT '", $testCreateTable->Create_Table);
-      $this->assertStringContainsString("`help_pre_en_US` text COLLATE {$inUseCollation} COMMENT 'Description and/or help text to display before fields in form.'", $testCreateTable->Create_Table);
+      $this->assertMatchesRegularExpression(";`help_pre_en_US` text COLLATE {$inUseCollation} (DEFAULT NULL )?COMMENT 'Description and/or help text to display before fields in form.';", $testCreateTable->Create_Table);
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fix test failures on MariaDB 10.6

See: https://lab.civicrm.org/dev/core/-/work_items/6609

Technical Details
--------------------------------------

It seems that `SHOW CREATE TABLE` in MariaDB is likely to elide `DEFAULT NULL`  when handling `TEXT` columns.