### PR TITLE
(dev/core#6609) Civi\Schema\SchemaHelperTest - Table ordering can be non-deterministic

### DIFF
--- a/tests/phpunit/Civi/Schema/SchemaHelperTest.php
+++ b/tests/phpunit/Civi/Schema/SchemaHelperTest.php
@@ -6,10 +6,12 @@ class SchemaHelperTest extends \CiviUnitTestCase {
 
   public function testGetExistingTables(): void {
     $tables = \Civi::schemaHelper()->getExistingTables(['civicrm_activity', 'civicrm_contact', 'civicrm_false_nothing']);
+    sort($tables); /* Ex: On MariaDB 10.6, result order is unpredictable. */
     $this->assertEquals(['civicrm_activity', 'civicrm_contact'], array_values($tables));
 
     $deprecations = static::captureErrors(E_USER_DEPRECATED, function (): void {
       $tables = \Civi::schemaHelper()->getExistingTables(['civicrm_activity', 'civicrm_contact', 'CiviCRM_TAG']);
+      sort($tables);
       $this->assertEquals(['civicrm_activity', 'civicrm_contact', 'civicrm_tag'], array_values($tables));
     });
     $this->assertEquals(['SchemaHelper should be called with portable table-names (alphanumeric, lowercase). Found non-portable table-name: CiviCRM_TAG'], $deprecations);


### PR DESCRIPTION
Overview
----------------------------------------

Fix test failures on MariaDB 10.6

See: https://lab.civicrm.org/dev/core/-/work_items/6609

Technical Details
--------------------------------------

It seems that the ordering of `INFORMATION_SCHEMA.TABLES` is not consistent. (At least, tests on MariaDB 10.6 are giving different results from MySQL 5.7 and 8.0.)

This update accepts the non-determinism.

An alternative approach would be to normalize across DBMS's (https://github.com/civicrm/civicrm-core/pull/36073).