### PR TITLE
(dev/core#6609) SchemaHelper - Normalize table ordering across DBMS's

### DIFF
--- a/mixin/lib/civimix-schema@5/src/SchemaHelper.php
+++ b/mixin/lib/civimix-schema@5/src/SchemaHelper.php
@@ -81,7 +81,7 @@ return new class() implements SchemaHelperInterface {
     }
 
     $escaped = implode("', '", array_map(fn($t) => \CRM_Core_DAO::escapeString(mb_strtolower($t)), $tableNames));
-    $dao = \CRM_Core_DAO::executeQuery("SELECT LOWER(TABLE_NAME) AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND LOWER(TABLE_NAME) IN ('$escaped')");
+    $dao = \CRM_Core_DAO::executeQuery("SELECT LOWER(TABLE_NAME) AS table_name FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND LOWER(TABLE_NAME) IN ('$escaped') ORDER BY table_name");
     return $dao->fetchMap('table_name', 'table_name');
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fix test failures on MariaDB 10.6

See: https://lab.civicrm.org/dev/core/-/work_items/6609

Technical Details
----------------------------------------

It seems that the ordering of `INFORMATION_SCHEMA.TABLES` is not consistent. (At least, tests on MariaDB 10.6 are giving different results from MySQL 5.7 and 8.0.)

This update enforces a common ordering. (Note that we might want to re-publish SchemaHelper.)

An alternative is to accept the non-deterministic ordering (with no update for SchemaHelper) (https://github.com/civicrm/civicrm-core/pull/36072).