### PR TITLE
Fix batch export download file

### DIFF
--- a/CRM/Core/BAO/File.php
+++ b/CRM/Core/BAO/File.php
@@ -96,7 +96,7 @@ class CRM_Core_BAO_File extends CRM_Core_DAO_File implements \Civi\Core\HookInte
 
   /**
    * @param string $data
-   * @param int $fileTypeID
+   * @param ?int $fileTypeID
    * @param string $entityTable
    * @param int $entityID
    * @param string|false $entitySubtype

--- a/CRM/Financial/BAO/ExportFormat.php
+++ b/CRM/Financial/BAO/ExportFormat.php
@@ -215,14 +215,26 @@ abstract class CRM_Financial_BAO_ExportFormat {
       'source_record_id' => $values['id'],
       'target_contact_id' => $session->get('userID'),
       'details' => $details,
-      'attachFile_1' => [
-        'uri' => $fileName,
-        'type' => 'text/csv',
-        'location' => $fileName,
-        'upload_date' => date('YmdHis'),
-      ],
     ];
-    civicrm_api3('Activity', 'create', $activityParams);
+    $activity = civicrm_api3('Activity', 'create', $activityParams);
+
+    $file = [
+      'uri' => $fileName,
+      'type' => 'text/csv',
+      'location' => $fileName,
+      'upload_date' => date('YmdHis'),
+    ];
+    CRM_Core_BAO_File::filePostProcess(
+      $fileName,
+      NULL,
+      'civicrm_activity',
+      $activity['id'],
+      NULL,
+      TRUE,
+      $file,
+      'attachFile_1',
+      'text/csv'
+    );
   }
 
   /**

--- a/CRM/Financial/BAO/ExportFormat/CSV.php
+++ b/CRM/Financial/BAO/ExportFormat/CSV.php
@@ -114,7 +114,7 @@ class CRM_Financial_BAO_ExportFormat_CSV extends CRM_Financial_BAO_ExportFormat 
    */
   public function putFile($export) {
     $config = CRM_Core_Config::singleton();
-    $fileName = $config->uploadDir . 'Financial_Transactions_' . $this->_batchIds . '_' . date('YmdHis') . '.' . $this->getFileExtension();
+    $fileName = $config->customFileUploadDir . 'Financial_Transactions_' . $this->_batchIds . '_' . date('YmdHis') . '.' . $this->getFileExtension();
     $this->_downloadFile[] = $config->customFileUploadDir . CRM_Utils_File::cleanFileName(basename($fileName));
     $out = fopen($fileName, 'w');
     if (!empty($export['headers'])) {

--- a/CRM/Financial/BAO/ExportFormat/IIF.php
+++ b/CRM/Financial/BAO/ExportFormat/IIF.php
@@ -82,7 +82,7 @@ class CRM_Financial_BAO_ExportFormat_IIF extends CRM_Financial_BAO_ExportFormat 
    */
   public function putFile($out) {
     $config = CRM_Core_Config::singleton();
-    $fileName = $config->uploadDir . 'Financial_Transactions_' . $this->_batchIds . '_' . date('YmdHis') . '.' . $this->getFileExtension();
+    $fileName = $config->customFileUploadDir . 'Financial_Transactions_' . $this->_batchIds . '_' . date('YmdHis') . '.' . $this->getFileExtension();
     $this->_downloadFile[] = $config->customFileUploadDir . CRM_Utils_File::cleanFileName(basename($fileName));
     $buffer = fopen($fileName, 'w');
     fwrite($buffer, $out);


### PR DESCRIPTION
Overview
----------------------------------------
This was reported after the 6.15 security release but I can't see how it was working before. However, database records show that it *was* working. But there don't seem to be any relevant changes to files recently or Activity API3 that would make it work or stop it working!

Before
----------------------------------------
- Batch export as CSV/IIF downloads a blank file.
- Batch export doesn't create a File record or link it to the activity (via an EntityFile record) so "Download" doesn't work.

After
----------------------------------------
- Batch export as CSV/IIF downloads the file.
- Batch export creates a File record and links it to the activity (via an EntityFile record) so "Download" works.

Technical Details
----------------------------------------
Explained above. The code just looks wrong but it appears to have worked previously, I'm just not sure how!

Comments
----------------------------------------
