### PR TITLE
Theme Editor - reinstate stream card icons

### DIFF
--- a/ext/riverlea/css/stream-list.css
+++ b/ext/riverlea/css/stream-list.css
@@ -22,6 +22,9 @@ civi-riverlea-stream-card .panel-heading {
   justify-content: space-between;
   align-items: center;
 }
+civi-riverlea-stream-card .panel-heading h3 .crm-i {
+  margin-right: var(--crm-l-small);
+}
 civi-riverlea-stream-card .panel-heading .crm-buttons {
   justify-content: flex-end;
 }

--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -323,7 +323,9 @@
       this.innerHTML = `
       <div class="panel panel-info">
         <div class="panel-heading">
-          <h3></h3>
+          <h3>
+            <i class="crm-i" role="img" aria-disabled="true"></i>
+          </h3>
           <div class="civi-riverlea-stream-header-tags"></div>
           <div class="civi-riverlea-stream-header-buttons crm-buttons"></div>
         </div>
@@ -342,7 +344,11 @@
       </div>
       `;
 
-      this.querySelector('h3').innerText = this.data.label;
+      // add icon for packaged vs custom stream
+      this.querySelector('.panel-heading .crm-i').classList.add(this.data.base_module ? 'fa-box' : 'fa-palette');
+
+      this.querySelector('h3').append(this.data.label);
+
       if (this.data.description) {
         this.querySelector('.panel-body p').innerText = this.data.description;
       }
@@ -415,12 +421,9 @@
       if (this.state.is_frontend) {
         container.append(createTag(ts('Frontend')));
       }
-      // if a Stream is not package in a module, it is a custom
-      // stream
-      if (!this.data.base_module) {
-        container.append(createTag(ts('Custom'), 'label-info'));
-      }
-      else if (this.data.local_modified_date) {
+      // highlight local changes to packaged streams
+      // (not expected but can happen, e.g. with API)
+      if (this.data.local_modified_date) {
         container.append(createTag(ts('Local changes'), 'label-info'));
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Reinstate icons to differentiate packaged vs custom streams, following https://github.com/civicrm/civicrm-core/pull/35872

Previously we had window + double window; but I think the key distinction is packaged vs custom; so trying box vs palette.

There are two alternatives.

Before
----------------------------------------
<img width="1387" height="717" alt="image" src="https://github.com/user-attachments/assets/f2ce626c-5a1e-4559-8e68-68e030a58e20" />


After
----------------------------------------
- Option A = this PR = add icons back in front of the title, remove the "Custom" tag
<img width="1406" height="670" alt="image" src="https://github.com/user-attachments/assets/4cab0643-98bb-40cb-ad1c-ac92510f9f01" />


- Option B = follow up incoming = add icons to the tags, and add a tag for packaged
<img width="1377" height="730" alt="image" src="https://github.com/user-attachments/assets/dc0b644f-7590-43d1-a1d5-6cddcd96ff1b" />


Comments
----------------------------------------
My sense was the icons are not self-explanatory, hence having the tag to spell out "Custom". But there is quite a lot going on on this page, so I'm hesitant to have the same info in two places.

I think on balance I probably lean towards Option A. It's somewhat subtle but you can also infer the packagedness from the lack of Edit/Delete buttons.