### PR TITLE
AdminUI - Add missing component checks to managed SavedSearches

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Pledge_Payments.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Pledge_Payments.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_pledge extension.
+if (!CRM_Core_Component::isEnabled('CiviPledge')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Contact_Summary_Pledge_Payments',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Pledges.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Contact_Summary_Pledges.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_pledge extension.
+if (!CRM_Core_Component::isEnabled('CiviPledge')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Contact_Summary_Pledges',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Headers_Footers_and_Automated_Messages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Headers_Footers_and_Automated_Messages.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_mail extension.
+if (!CRM_Core_Component::isEnabled('CiviMail')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Headers_Footers_and_Automated_Messages',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Click_throughs_Report.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Mailing_Click_throughs_Report.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_mail extension.
+if (!CRM_Core_Component::isEnabled('CiviMail')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Mailing_Click_throughs_Report',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Premiums.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_Premiums.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Manage_Premiums',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Personal_Campaign_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Personal_Campaign_Pages.mgd.php
@@ -2,6 +2,11 @@
 
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Personal_Campaign_Pages',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Contribution_Pages.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Contribution_Pages.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_contribute extension.
+if (!CRM_Core_Component::isEnabled('CiviContribute')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Price_Set_Usage_Contribution_Pages',

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Events.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Price_Set_Usage_Events.mgd.php
@@ -1,6 +1,11 @@
 <?php
 use CRM_CivicrmAdminUi_ExtensionUtil as E;
 
+// Temporary check can be removed when moving this file to the civi_event extension.
+if (!CRM_Core_Component::isEnabled('CiviEvent')) {
+  return [];
+}
+
 return [
   [
     'name' => 'SavedSearch_Price_Set_Usage_Events',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes inconsistency in the AdminUI extension. SavedSearches should not be visible if they depend on a disabled component.