### PR TITLE
dev/core#4297 - Move help text to label on Activity form

### DIFF
--- a/templates/CRM/Activity/Form/Activity.tpl
+++ b/templates/CRM/Activity/Form/Activity.tpl
@@ -61,8 +61,8 @@
 
   {if $form.separation}
     <tr class="crm-activity-form-block-separation crm-is-multi-activity-wrapper">
-      <td class="label">{$form.separation.label}</td>
-      <td>{$form.separation.html} {help id="separation"}</td>
+      <td class="label">{$form.separation.label} {help id="separation"}</td>
+      <td>{$form.separation.html}</td>
     </tr>
   {/if}
 


### PR DESCRIPTION
Overview
----------------------------------------
Move help text to the label for the Activity form.

Work item: https://lab.civicrm.org/dev/core/-/work_items/4297

Before
----------------------------------------
![before](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_activity.png)

After
----------------------------------------
![after](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_activity.png)
