### PR TITLE
dev/core#4297 - Move help text to labels on Admin forms

### DIFF
--- a/templates/CRM/Admin/Form/MailSettings.tpl
+++ b/templates/CRM/Admin/Form/MailSettings.tpl
@@ -51,9 +51,9 @@
       <tr class="crm-mail-settings-form-block-is_default"><td class="label">{$form.is_default.label}</td><td>{$form.is_default.html}</td></tr>
       <tr><td class="label">&nbsp;</td><td class="description">{ts}How this mail account will be used. Only one box may be used for bounce processing. It will also be used as the envelope email when sending mass mailings.{/ts}</td></tr>
 
-      <tr class="crm-mail-settings-form-block-is_non_case_email_skipped"><td class="label">&nbsp;</td><td>{$form.is_non_case_email_skipped.html}{$form.is_non_case_email_skipped.label} {help id='is_non_case_email_skipped'}</td></tr>
+      <tr class="crm-mail-settings-form-block-is_non_case_email_skipped"><td class="label">{help id='is_non_case_email_skipped'}</td><td>{$form.is_non_case_email_skipped.html}{$form.is_non_case_email_skipped.label}</td></tr>
 
-      <tr class="crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match"><td class="label">&nbsp;</td><td>{$form.is_contact_creation_disabled_if_no_match.html}{$form.is_contact_creation_disabled_if_no_match.label} {help id='is_contact_creation_disabled_if_no_match'}</td></tr>
+      <tr class="crm-mail-settings-form-block-is_contact_creation_disabled_if_no_match"><td class="label">{help id='is_contact_creation_disabled_if_no_match'}</td><td>{$form.is_contact_creation_disabled_if_no_match.html}{$form.is_contact_creation_disabled_if_no_match.label}</td></tr>
 
       <tr class="crm-mail-settings-form-block-activity_type_id"><td class="label">{$form.activity_type_id.label} {help id='activity_type_id'}</td><td>{$form.activity_type_id.html}</td></tr>
 

--- a/templates/CRM/Admin/Form/MessageTemplates.tpl
+++ b/templates/CRM/Admin/Form/MessageTemplates.tpl
@@ -39,12 +39,10 @@
           </td>
         </tr>
         <tr>
-          <td class="label-left">{$form.msg_subject.label}</td>
+          <td class="label-left">{$form.msg_subject.label} {help id="id-token-subject" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}</td>
           <td>
             {$form.msg_subject.html|crmAddClass:huge}
-            <input class="crm-token-selector big" data-field="msg_subject" />
-            {help id="id-token-subject" tplFile=$tplFile file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}
-          </td>
+            <input class="crm-token-selector big" data-field="msg_subject" /></td>
         </tr>
         <tr>
           <td class="label-left">{$form.file_id.label}</td>

--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -35,11 +35,9 @@
         </tr>
 
         <tr class="crm-scheduleReminder-form-block-when">
-          <td class="label">{$form.absolute_or_relative_date.label}</td>
+          <td class="label">{$form.absolute_or_relative_date.label} {help id="absolute_or_relative_date"}</td>
           <td>
-            {$form.absolute_or_relative_date.html}
-            {help id="absolute_or_relative_date"}
-            {$form.absolute_date.html}
+            {$form.absolute_or_relative_date.html}{$form.absolute_date.html}
           </td>
         </tr>
 
@@ -105,12 +103,12 @@
         {/if}
         {if $multilingual}
           <tr class="crm-scheduleReminder-form-block-filter-contact-language">
-            <td class="label">{$form.filter_contact_language.label}</td>
-            <td>{$form.filter_contact_language.html} {help id="filter_contact_language"}</td>
+            <td class="label">{$form.filter_contact_language.label} {help id="filter_contact_language"}</td>
+            <td>{$form.filter_contact_language.html}</td>
           </tr>
           <tr class="crm-scheduleReminder-form-block-communication-language">
-            <td class="label">{$form.communication_language.label}</td>
-            <td>{$form.communication_language.html} {help id="communication_language"}</td>
+            <td class="label">{$form.communication_language.label} {help id="communication_language"}</td>
+            <td>{$form.communication_language.html}</td>
           </tr>
         {/if}
         <tr class="crm-scheduleReminder-form-block-active">
@@ -123,25 +121,21 @@
         <div class="crm-accordion-body">
           <table id="email-field-table" class="form-layout-compressed">
             <tr>
-              <td class="label">{$form.from_name.label}</td>
+              <td class="label">{$form.from_name.label} {help id="from_name"}</td>
               <td>
                   {$form.from_name.html}
                   {$form.from_email.label}
-                  {$form.from_email.html}
-                  {help id="from_name"}
-              </td>
+                  {$form.from_email.html}</td>
             </tr>
             <tr class="crm-scheduleReminder-form-block-template">
               <td class="label">{$form.template.label}</td>
               <td>{$form.template.html}</td>
             </tr>
             <tr class="crm-scheduleReminder-form-block-subject">
-              <td class="label">{$form.subject.label}</td>
+              <td class="label">{$form.subject.label} {help id="id-token-subject" file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}</td>
               <td>
                   {$form.subject.html|crmAddClass:huge}
-                <input class="crm-token-selector big" data-field="subject" />
-                  {help id="id-token-subject" file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}
-              </td>
+                <input class="crm-token-selector big" data-field="subject" /></td>
             </tr>
           </table>
             {include file="CRM/Contact/Form/Task/EmailCommon.tpl" upload=1 noAttach=1}


### PR DESCRIPTION
Overview
----------------------------------------
Move help text to the label for the Admin/Form templates: MailSettings.tpl, MessageTemplates.tpl, and ScheduleReminders.tpl.

Work item: https://lab.civicrm.org/dev/core/-/work_items/4297

Before
----------------------------------------
### MailSettings
![before_mailsettings](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_mailsettings.png)

### MessageTemplates
![before_messagetemplates](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_messagetemplates.png)

### ScheduleReminders
![before_schedulereminders](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_schedulereminders.png)

After
----------------------------------------
### MailSettings
![after_mailsettings](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_mailsettings.png)

### MessageTemplates
![after_messagetemplates](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_messagetemplates.png)

### ScheduleReminders
![after_schedulereminders](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_schedulereminders.png)
