### PR TITLE
dev/core#4297 - Move help text to labels on Contact task forms

### DIFF
--- a/templates/CRM/Contact/Form/Task/Email.tpl
+++ b/templates/CRM/Contact/Form/Task/Email.tpl
@@ -17,17 +17,14 @@
 
 <table class="form-layout-compressed">
   <tr id="selectEmailFrom" class="crm-contactEmail-form-block-fromEmailAddress crm-email-element">
-    <td class="label">{$form.from_email_address.label}</td>
+    <td class="label">{$form.from_email_address.label} {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp" title=$tokenTitle}</td>
     <td>
-      {$form.from_email_address.html}
-      {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp" title=$tokenTitle}
-    </td>
+      {$form.from_email_address.html}</td>
   </tr>
     <tr class="crm-contactEmail-form-block-recipient">
-       <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if}</td>
+       <td class="label">{if $single eq false}{ts}Recipient(s){/ts}{else}{$form.to.label}{/if} {help id="to" file="CRM/Contact/Form/Task/Email.hlp"}</td>
        <td>
-         {$form.to.html} {help id="to" file="CRM/Contact/Form/Task/Email.hlp"}
-       </td>
+         {$form.to.html}</td>
     </tr>
     <tr class="crm-contactEmail-form-block-cc_id" {if empty($form.cc_id.value)}style="display:none;"{/if}>
       <td class="label">{$form.cc_id.label}</td>
@@ -60,12 +57,10 @@
     </tr>
 {/if}
     <tr class="crm-contactEmail-form-block-subject">
-       <td class="label">{$form.subject.label}</td>
+       <td class="label">{$form.subject.label} {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}</td>
        <td>
          {$form.subject.html|crmAddClass:huge}&nbsp;
-         <input class="crm-token-selector big" data-field="subject" />
-         {help id="id-token-subject" tplFile=$tplFile isAdmin=$isAdmin file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}
-       </td>
+         <input class="crm-token-selector big" data-field="subject" /></td>
     </tr>
   {* CRM-15984 --add campaign to email activities *}
   {include file="CRM/Campaign/Form/addCampaignToComponent.tpl" campaignTrClass="crm-contactEmail-form-block-campaign_id"}

--- a/templates/CRM/Contact/Form/Task/Label.tpl
+++ b/templates/CRM/Contact/Form/Task/Label.tpl
@@ -11,8 +11,8 @@
   <div class="messages status no-popup">{include file="CRM/Contact/Form/Task.tpl"}</div>
   <table class="form-layout-compressed">
      <tr class="crm-contact-task-mailing-label-form-block-label_name">
-        <td class="label">{$form.label_name.label}</td>
-        <td>{$form.label_name.html} {help id="label_name" file="CRM/Contact/Form/Task/Label.hlp"}</td>
+        <td class="label">{$form.label_name.label} {help id="label_name" file="CRM/Contact/Form/Task/Label.hlp"}</td>
+        <td>{$form.label_name.html}</td>
      </tr>
      <tr class="crm-contact-task-mailing-label-form-block-location_type_id">
         <td class="label">{$form.location_type_id.label}</td>

--- a/templates/CRM/Contact/Form/Task/SMS.tpl
+++ b/templates/CRM/Contact/Form/Task/SMS.tpl
@@ -26,8 +26,8 @@
 
 <table class="form-layout-compressed">
     <tr class="crm-contactProvider-form-block-Provider">
-       <td class="label">{$form.sms_provider_id.label}</td>
-       <td>{$form.sms_provider_id.html} {help id="sms_provider_id" file="CRM/Contact/Form/Task/SMS.hlp"}</td>
+       <td class="label">{$form.sms_provider_id.label} {help id="sms_provider_id" file="CRM/Contact/Form/Task/SMS.hlp"}</td>
+       <td>{$form.sms_provider_id.html}</td>
     </tr>
     <tr class="crm-contactsms-form-block-recipient">
        <td class="label">{$form.to.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Move help text to the label for the Contact/Form/Task templates: Email.tpl, Label.tpl, and SMS.tpl.

Work item: https://lab.civicrm.org/dev/core/-/work_items/4297

Before
----------------------------------------
### Email
![before_email](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_email.png)

### Label
![before_label](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_label.png)

### SMS
![before_sms](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_sms.png)

After
----------------------------------------
### Email
![after_email](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_email.png)

### Label
![after_label](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_label.png)

### SMS
![after_sms](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_sms.png)
