### PR TITLE
dev/core#4297 - Move help text to labels on Price forms

### DIFF
--- a/templates/CRM/Price/Form/Field.tpl
+++ b/templates/CRM/Price/Form/Field.tpl
@@ -104,11 +104,9 @@
       </tr>
     {if $useForEvent}
       <tr class="crm-price-field-form-block-count">
-        <td class="label">{$form.count.label|smarty:nodefaults}</td>
+        <td class="label">{$form.count.label|smarty:nodefaults} {help id="id-participant-count"}</td>
         <td>{$form.count.html}<br />
-          <span class="description">{ts}Enter a value here if you want to increment the number of registered participants per unit against the maximum number of participants allowed for this event.{/ts}</span>
-          {help id="id-participant-count"}
-        </td>
+          <span class="description">{ts}Enter a value here if you want to increment the number of registered participants per unit against the maximum number of participants allowed for this event.{/ts}</span></td>
       </tr>
       <tr class="crm-price-field-form-block-max_value">
         <td class="label">{$form.max_value.label|smarty:nodefaults}</td>

--- a/templates/CRM/Price/Form/Option.tpl
+++ b/templates/CRM/Price/Form/Option.tpl
@@ -16,12 +16,11 @@
   {else}
     <table class="form-layout">
       {if $showMember}
+        {capture assign='helpTitle'}{ts}Price Options{/ts}{/capture}
         <tr class="crm-price-option-form-block-membership_type_id">
-          <td class="label">{$form.membership_type_id.label}</td>
+          <td class="label">{$form.membership_type_id.label} {help id="member-price-options" file="CRM/Price/Page/Field.hlp" title=$helpTitle}</td>
           <td>{$form.membership_type_id.html}
-            <br /> <span class="description">{ts}If a membership type is selected, a membership will be created or renewed when users select this option. Leave this blank if you are using this for non-membership options (e.g. magazine subscription).{/ts}
-              {capture assign='helpTitle'}{ts}Price Options{/ts}{/capture}
-              {help id="member-price-options" file="CRM/Price/Page/Field.hlp" title=$helpTitle}</span>
+            <br /> <span class="description">{ts}If a membership type is selected, a membership will be created or renewed when users select this option. Leave this blank if you are using this for non-membership options (e.g. magazine subscription).{/ts}</span>
           </td>
         </tr>
         <tr class="crm-price-option-form-block-membership_num_terms">
@@ -68,15 +67,15 @@
       {* fix for CRM-10241 *}
       {if !empty($form.count.html)}
         <tr class="crm-price-option-form-block-count">
-          <td class="label">{$form.count.label}</td>
-          <td>{$form.count.html} {help id="count" file="CRM/Price/Page/Field.hlp"}</td>
+          <td class="label">{$form.count.label} {help id="count" file="CRM/Price/Page/Field.hlp"}</td>
+          <td>{$form.count.html}</td>
         </tr>
         {* 2 line fix for CRM-10241 *}
       {/if}
       {if !empty($form.max_value.html)}
         <tr class="crm-price-option-form-block-max_value">
-          <td class="label">{$form.max_value.label}</td>
-          <td>{$form.max_value.html} {help id="max_value" file="CRM/Price/Page/Field.hlp"}</td>
+          <td class="label">{$form.max_value.label} {help id="max_value" file="CRM/Price/Page/Field.hlp"}</td>
+          <td>{$form.max_value.html}</td>
         </tr>
         {* fix for CRM-10241 *}
       {/if}
@@ -94,8 +93,8 @@
       </tr>
       {/if}
       <tr class="crm-price-field-form-block-visibility_id">
-        <td class="label">{$form.visibility_id.label}</td>
-        <td>&nbsp;{$form.visibility_id.html} {help id="visibility_id" file="CRM/Price/Page/Field.hlp"}</td>
+        <td class="label">{$form.visibility_id.label} {help id="visibility_id" file="CRM/Price/Page/Field.hlp"}</td>
+        <td>&nbsp;{$form.visibility_id.html}</td>
       </tr>
     </table>
 


### PR DESCRIPTION
Overview
----------------------------------------
Move help text to the label for the Price/Form templates: Field.tpl and Option.tpl.

Work item: https://lab.civicrm.org/dev/core/-/work_items/4297

Before
----------------------------------------
### Field
![before_price_field](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_price_field.png)

### Option
![before_price_option](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_price_option.png)

After
----------------------------------------
### Field
![after_price_field](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_price_field.png)

### Option
![after_price_option](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/after_price_option.png)
