### PR TITLE
SearchKit - Fix tally for searches with duplicate GROUP_CONCAT_ aliases

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -147,12 +147,8 @@ class Run extends AbstractRunAction {
   private function getTally(): array {
     $apiParams = $this->_apiParams;
     unset($apiParams['orderBy'], $apiParams['limit']);
-    $api = Request::create($this->savedSearch['api_entity'], 'get', $apiParams);
-    $api->setDefaultWhereClause();
-    $queryObject = new Api4SelectQuery($api);
-    $queryObject->forceSelectId = FALSE;
-    $sql = $queryObject->getSql();
     $select = [];
+    $tallyFields = [];
     $columns = $this->display['settings']['columns'];
     foreach ($columns as $index => $col) {
       $key = $col['key'] ?? '';
@@ -173,11 +169,34 @@ class Run extends AbstractRunAction {
           }
         }
         $select[] = $sqlFnClass::renderExpression(implode(' ', $fnArgs)) . " `$tallyKey`";
+        $tallyFields[$key] = TRUE;
       }
     }
     if (!$select) {
       return [];
     }
+    // The query is wrapped as a derived table below, so its column aliases must
+    // be unique. SearchKit emits every implicitly-aggregated to-many column with
+    // the same alias ("GROUP_CONCAT_"), which MySQL rejects (error 1060
+    // "Duplicate column name"). Give any repeated alias on an expression column
+    // (which, unlike a bare field, may be aliased) a unique name. Columns
+    // referenced by a tally are left untouched so the outer aggregates resolve.
+    $seenAliases = [];
+    foreach ($apiParams['select'] as $i => $expr) {
+      $sqlExpr = SqlExpression::convert($expr, TRUE);
+      $alias = $sqlExpr->getAlias();
+      if (!isset($seenAliases[$alias])) {
+        $seenAliases[$alias] = TRUE;
+      }
+      elseif (!isset($tallyFields[$alias]) && str_contains($expr, '(')) {
+        $apiParams['select'][$i] = $sqlExpr->getExpr() . ' AS dedupe_tally_col_' . $i;
+      }
+    }
+    $api = Request::create($this->savedSearch['api_entity'], 'get', $apiParams);
+    $api->setDefaultWhereClause();
+    $queryObject = new Api4SelectQuery($api);
+    $queryObject->forceSelectId = FALSE;
+    $sql = $queryObject->getSql();
     $query = 'SELECT ' . implode(', ', $select) . "\nFROM (" . $sql . ")\n`api_query`";
     $dao = \CRM_Core_DAO::executeQuery($query);
     $dao->fetch();

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2140,6 +2140,103 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertSame('Blue', $tally["$groupName.colors:label"]);
   }
 
+  /**
+   * Tally a search whose select contains several to-many columns sharing the
+   * same alias.
+   *
+   * When more than one field is pulled through a to-many join, SearchKit emits
+   * each as `GROUP_CONCAT(...) AS GROUP_CONCAT_` - i.e. with the same alias. The
+   * tally wraps the search as a derived table, where MySQL forbids duplicate
+   * column names (error 1060). The duplicate, un-tallied columns must not prevent
+   * the base-entity COUNT from being tallied.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testTallyWithDuplicateGroupConcatAlias(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $contacts = $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'A', 'last_name' => $lastName],
+        ['first_name' => 'B', 'last_name' => $lastName],
+        ['first_name' => 'C', 'last_name' => $lastName],
+      ],
+    ]);
+    // Give some contacts >1 email so the to-many join multiplies the joined rows.
+    $this->saveTestRecords('Email', [
+      'records' => [
+        ['contact_id' => $contacts[0]['id'], 'email' => 'a1@example.com', 'location_type_id' => 1],
+        ['contact_id' => $contacts[0]['id'], 'email' => 'a2@example.com', 'location_type_id' => 2],
+        ['contact_id' => $contacts[1]['id'], 'email' => 'b1@example.com', 'location_type_id' => 1],
+      ],
+    ]);
+
+    $this->createTestRecord('SavedSearch', [
+      'name' => __FUNCTION__,
+      'label' => __FUNCTION__,
+      'api_entity' => 'Contact',
+      'api_params' => [
+        'version' => 4,
+        'select' => [
+          'id',
+          'display_name',
+          // Two aggregated to-many columns emitted with the SAME alias, exactly
+          // as SearchKit does for plain fields selected through a to-many join.
+          'GROUP_CONCAT(DISTINCT Contact_Email_email_01.email) AS GROUP_CONCAT_',
+          'GROUP_CONCAT(DISTINCT Contact_Email_email_01.location_type_id) AS GROUP_CONCAT_',
+        ],
+        'join' => [
+          [
+            'Email AS Contact_Email_email_01',
+            'LEFT',
+            ['id', '=', 'Contact_Email_email_01.contact_id'],
+          ],
+        ],
+        'where' => [
+          ['id', 'IN', $contacts->column('id')],
+        ],
+        'groupBy' => ['id'],
+      ],
+    ]);
+    $this->createTestRecord('SearchDisplay', [
+      'name' => __FUNCTION__,
+      'label' => __FUNCTION__,
+      'saved_search_id.name' => __FUNCTION__,
+      'type' => 'table',
+      'settings' => [
+        'limit' => 50,
+        'pager' => [],
+        'columns' => [
+          [
+            'type' => 'field',
+            'key' => 'id',
+            'label' => 'ID',
+            'sortable' => TRUE,
+            // Only the base id is tallied; the duplicate-aliased columns are not.
+            'tally' => ['fn' => 'COUNT'],
+          ],
+          [
+            'type' => 'field',
+            'key' => 'display_name',
+            'label' => 'Name',
+            'sortable' => TRUE,
+          ],
+        ],
+        'actions' => TRUE,
+        'tally' => ['label' => 'Total'],
+      ],
+    ]);
+
+    $tally = SearchDisplay::run(FALSE)
+      ->setReturn('tally')
+      ->setDisplay(__FUNCTION__)
+      ->setSavedSearch(__FUNCTION__)
+      ->execute()->single();
+
+    // One row per contact (grouped by id), so COUNT is 3 - not the 4 joined
+    // email rows.
+    $this->assertSame('3', $tally['id']);
+  }
+
   public function testTallyWithGroupBy(): void {
     \Civi::settings()->set('dateformatshortdate', '%m/%d/%Y');
     $contacts = $this->saveTestRecords('Individual', [


### PR DESCRIPTION
# SearchKit - Fix tally for searches with duplicate `GROUP_CONCAT_` column aliases

## Overview

A SearchKit display footer tally (`return => 'tally'`) crashes with a SQL error when
the search selects more than one field through a to-many join. No tally is shown and
the display fails to load.

## Before

When a plain field is selected through a to-many join, SearchKit aggregates it and
emits it in the API select as:

```
GROUP_CONCAT(DISTINCT <join>.<field>) AS GROUP_CONCAT_
```

Every such column is emitted with the **same** alias, `GROUP_CONCAT_`. A normal
result set tolerates duplicate column aliases, so the display itself renders fine.

`SearchDisplay::Run::getTally()`, however, wraps the whole search as a derived table
in order to aggregate over it:

```sql
SELECT COUNT(`id`) `tally_0`, ...
FROM ( SELECT ..., GROUP_CONCAT(...) AS `GROUP_CONCAT_`,
                   GROUP_CONCAT(...) AS `GROUP_CONCAT_`, ... ) `api_query`
```

MySQL forbids duplicate column names in a derived table, so the query fails:

```
DB Error: unknown error [nativecode=1060 ** Duplicate column name 'GROUP_CONCAT_']
```

(Reproduced on a real `Activity` search with several contact/address/tag fields
pulled through `ActivityContact` and other to-many joins, tallying `COUNT(id)`.)

## After

Before building the wrapped query, `getTally()` de-duplicates the inner column
aliases. Any repeated alias on an *expression* column (which, unlike a bare field,
may legally be re-aliased) is given a unique throwaway alias. Columns referenced by
a tally are left untouched so the outer aggregates still resolve.

The full inner query is otherwise unchanged, so the grouping (and therefore the
tally totals) are identical to what the display shows.

## Technical Details

- The fix lives in `ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php::getTally()`.
- Only the second and subsequent occurrences of a duplicated alias are rewritten;
  bare field columns are never re-aliased (Api4 disallows aliasing a bare field).
- Combines with the existing empty-`$select` guard (a tally row enabled with no
  aggregate function configured returns an empty tally instead of building invalid
  SQL).

## Tests

Adds `SearchRunTest::testTallyWithDuplicateGroupConcatAlias`, which builds a search
selecting two to-many columns that share the `GROUP_CONCAT_` alias and tallies
`COUNT(id)`. The test errors with 1060 on `master` and passes with this change;
`COUNT` correctly returns the number of grouped rows (contacts), not the multiplied
join rows.

## Comments

This is purely a footer-tally fix; display rendering, search results and the tally
totals themselves are unaffected.
