### PR TITLE
Formbuilder payments: Improve expiry date, add helpers for billing Address and billing Email

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
@@ -129,6 +129,9 @@ class CheckoutOptionUtils {
       if ($field['htmlType'] === 'select') {
         $field['options'] = array_map(fn ($key) => ['id' => $key, 'label' => $field['attributes'][$key]], array_keys($field['attributes']));
       }
+      elseif ($field['htmlType'] === 'date' && $field['name'] === 'credit_card_exp_date') {
+        $field['htmlType'] = 'expiryDate';
+      }
       unset($field['attributes'], $field['extra']);
       return $field;
     }, $allFields);

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -539,6 +539,34 @@ class CheckoutSession {
   }
 
   /**
+   * Optional helper function to map checkout params to their equivalent quickform names.
+   * This allows us to use more sensible names on Afform but easily use existing
+   *   code such as doPayment().
+   *
+   * @param $paramsToMap
+   *
+   * @return array
+   */
+  public function mapAfformToQuickFormForDoPayment($paramsToMap): array {
+    // Afform => QuickForm/doPayment
+    // On quickform we had credit_card_exp_date.Y and credit_card_exp_date.M
+    //   which changes to eg. "m" if you change the date format in CiviCRM.
+    // At some point more sensible "year" and "month" fields were added but these
+    //   could still be ambiguous if you had another month or year field on the form.
+    // So for Afform we choose to prefix them explicity with "expiry_".
+    $map = [
+      'expiry_year' => 'year',
+      'expiry_month' => 'month',
+    ];
+    foreach ($map as $afformKey => $quickformKey) {
+      if (array_key_exists($afformKey, $paramsToMap)) {
+        $paramsToMap[$quickformKey] = $paramsToMap[$afformKey];
+      }
+    }
+    return $paramsToMap;
+  }
+
+  /**
    * @return int
    *   Returns the ID of the FinancialTrxn (Payment) that was created
    *

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -540,6 +540,35 @@ class CheckoutSession {
   }
 
   /**
+   * Optional helper function to get the billing email from a contact.
+   *
+   * @param int $contactID
+   *
+   * @return string|null
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public function getBillingEmail(int $contactID): ?string {
+    if ($contactID) {
+      $email = \Civi\Api4\Email::get(FALSE)
+        ->addSelect('email')
+        ->addWhere('contact_id', '=', $contactID)
+        ->addWhere('is_billing', '=', TRUE)
+        ->execute()
+        ->first();
+      if (!$email) {
+        $email = \Civi\Api4\Email::get(FALSE)
+          ->addSelect('email')
+          ->addWhere('contact_id', '=', $contactID)
+          ->addWhere('is_primary', '=', TRUE)
+          ->execute()
+          ->first();
+      }
+    }
+    return $email['email'] ?? NULL;
+  }
+
+  /**
    * Helper function to provide a standard way of getting billing address
    * CheckoutOptions can optionally use this to retrieve the billing address
    *   in a standard way from Afform.

--- a/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutSession.php
@@ -2,6 +2,7 @@
 
 namespace Civi\Checkout;
 
+use Civi\Api4\Address;
 use Civi\Api4\Contribution;
 use Civi\Api4\Payment;
 
@@ -536,6 +537,93 @@ class CheckoutSession {
   public function setOrderReference(string $orderReference): CheckoutSession {
     $this->orderReference = $orderReference;
     return $this;
+  }
+
+  /**
+   * Helper function to provide a standard way of getting billing address
+   * CheckoutOptions can optionally use this to retrieve the billing address
+   *   in a standard way from Afform.
+   * It is assumed that by the time this function is called contacts, addresses and contributions
+   *   have been saved. So we can look up the address either by contactID or directly by addressID.
+   * A contribution a billing address not linked to a contact via Contribution.address_id
+   *
+   * @param int|null $addressID
+   * @param int|null $contactID
+   *
+   * @return array|null
+   *   Returns null if no address is found.
+   *   Returns API4 style ($api4AddressFields) + propertyBag style ($propertyBagAddressParams) fields.
+   */
+  public function getBillingAddress(?int $addressID = NULL, ?int $contactID = NULL): ?array {
+    $api4AddressFields = [
+      //'location_type_id:name',
+      //'location_type_id',
+      //'is_primary',
+      //'is_billing',
+      'street_address',
+      //'street_number',
+      //'street_number_suffix',
+      //'street_number_predirectional',
+      //'street_name',
+      //'street_type',
+      //'street_number_postdirectional',
+      //'street_unit',
+      //'supplemental_address_1',
+      //'supplemental_address_2',
+      //'supplemental_address_3',
+      'city',
+      //'county_id',
+      //'county_id:abbr',
+      //'county_id:label',
+      'state_province_id',
+      'state_province_id:abbr',
+      'state_province_id:label',
+      'country_id',
+      'country_id:abbr',
+      'country_id:label',
+      //'postal_code_suffix',
+      'postal_code',
+    ];
+
+    // API4 => propertyBag
+    $propertyBagAddressFieldMap = [
+      'street_address' => 'billingStreetAddress',
+      'city' => 'billingCity',
+      'state_province_id:abbr' => 'billingStateProvince',
+      'postal_code' => 'billingPostalCode',
+      'country_id:abbr' => 'billingCountry',
+    ];
+
+    $address = NULL;
+    if ($addressID) {
+      $address = Address::get(FALSE)
+        ->setSelect($api4AddressFields)
+        ->addWhere('address_id', '=', $addressID)
+        ->execute()
+        ->first();
+    }
+    elseif ($contactID) {
+      $address = Address::get(FALSE)
+        ->setSelect($api4AddressFields)
+        ->addWhere('contact_id', '=', $contactID)
+        ->addWhere('is_billing', '=', TRUE)
+        ->execute()
+        ->first();
+      if (!$address) {
+        $address = Address::get(FALSE)
+          ->setSelect($api4AddressFields)
+          ->addWhere('contact_id', '=', $contactID)
+          ->addWhere('is_primary', '=', TRUE)
+          ->execute()
+          ->first();
+      }
+    }
+    if ($address) {
+      foreach ($propertyBagAddressFieldMap as $api4 => $propertyBag) {
+        $address[$propertyBag] = $address[$api4] ?? '';
+      }
+    }
+    return $address;
   }
 
   /**

--- a/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
+++ b/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
@@ -140,6 +140,20 @@
         })))
         .then((options) => this.stateProvinceOptions[controlValue] = options);
 
+      this.months = [];
+      this.expiryYears = [];
+      // Months 01-12 (value and label both zero-padded; the processor casts
+      // to int, so either form is safe).
+      for (let m = 1; m <= 12; m++) {
+        const mm = ('0' + m).slice(-2);
+        this.months.push({ id: mm, label: mm });
+      }
+
+      // Years: current year through +15, as 4-digit values.
+      const thisYear = new Date().getFullYear();
+      for (let y = thisYear; y <= thisYear + 15; y++) {
+        this.expiryYears.push({ id: String(y), label: String(y) });
+      }
 
       this.exportParamValues = () => {
         // this is a quick way to check the data provider is ready

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/date.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/date.html
@@ -1,5 +1,0 @@
-<label>{{:: field.title }}</label>
-<div class="crm-flex-box af-checkout-field-date">
-  <input type="number" name='month' placeholder="MM" ng-model="$ctrl.checkout_params[field.name].M" ng-required="field.is_required">
-  <input type="number" name='year' placeholder="YY" ng-model="$ctrl.checkout_params[field.name].Y" ng-required="field.is_required">
-</div>

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/expiryDate.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/expiryDate.html
@@ -1,0 +1,19 @@
+<label>{{:: field.title }}</label>
+<div>
+  <div class="crm-flex-box af-checkout-field-expiry-date">
+    <select name="expiry_month" class="crm-form-select"
+            aria-label="{{:: ts('Expiration month') }}"
+            ng-model="$ctrl.checkout_params.expiry_month"
+            ng-options="option.id as option.label for option in $ctrl.months"
+            required>
+      <option value="">{{:: ts('Month') }}</option>
+    </select>
+    <select name="expiry_year" class="crm-form-select"
+            aria-label="{{:: ts('Expiration year') }}"
+            ng-model="$ctrl.checkout_params.expiry_year"
+            ng-options="option.id as option.label for option in $ctrl.expiryYears"
+            required>
+      <option value="">{{:: ts('Year') }}</option>
+    </select>
+  </div>
+</div>


### PR DESCRIPTION
Overview
----------------------------------------

#### Expiry date fields

For processors that load card fields on to the form they need to add card expiry fields. The current implementation adds them as "number" fields which don't really work because you can specify eg. month = -10 and year=94. Payment processors generally expect a 4 digit year (and a valid month) and that is what they were being passed by quickform.

- I've converted them to select fields with a fixed set of values.
- I've renamed them so they arrive as `expiry_month` and `expiry_year`. We could just have them come in as `month` and `year` but that could be ambiguous if we have any other date fields defined for the payment fields. So I also added in a function to `mapAfformToQuickFormForDoPayment()` which maps them so we don't have to teach `doPayment()` to understand expiry_month/expiry_year.
- The older-style `credit_card_exp_date.M/Y is unreliable and should not be used (it changes if you change the date format in CiviCRM).

#### Billing address helper

Where do you get the billing address from? ... It depends.. Core supports an address_id directly linked to a Contribution (we can't do that in Formbuilder currently and might not want to?). Otherwise we need to get an address from a Contact (which might have just been filled in on the form).

So the billing address helper uses the following logic:
- If `address_id` is set (on Contribution) retrieve the address directly.
- ElseIf `contact_id` is set (on Contribution, required field) retrieve a saved address from that contact (any address added on the form will already have been saved). Logic is look for address with "is_billing" set first, otherwise look for address with "is_primary" set.

`getBillingAddress()` returns an array containing API4-style keys with id, abbr and label and mapped versions of the same data that was passed into doPayment via quickform/propertyBag (eg. billingCountry = country_id:abbr).

_Question: Does FormBuilder set "is_billing" when saving with location_type_id = billing? Yes it does._

#### Billing email helper

This gets an email from the Contribution.contact_id if available. Using the same logic as address, checks "is_billing" and then "is_primary".

Before
----------------------------------------
Expiry date field not really useable on FormBuilder.

No standard logic for getting address/email so each processor has to implement it's own logic which takes us back to where we were with payment processing and CiviCRM about 10 years ago...

After
----------------------------------------
Expiry date field easy to use on FormBuilder.

Standard logic for getting address/email so each processor can do things in the standard way (some don't require address, some don't require email etc). If address/email is not required or there is a specific reason for doing things a different way just don't call the standard helper.

Technical Details
----------------------------------------
Described above.

Comments
----------------------------------------
@ufundo @rbaugh 

See https://lab.civicrm.org/extensions/payflowpro/-/merge_requests/24 and https://lab.civicrm.org/extensions/authnet/-/merge_requests/45/diffs?commit_id=63d1d786c62e00aa845f13d4a38815ac585c86f6 for example usage
