### PR TITLE
CRM-4297 - Relocate help icon to label for Event forms

### DIFF
--- a/templates/CRM/Event/Form/EventFees.tpl
+++ b/templates/CRM/Event/Form/EventFees.tpl
@@ -75,7 +75,7 @@
                     <tr class="crm-event-eventfees-form-block-trxn_id"><td class="label">{$form.trxn_id.label}</td><td>{$form.trxn_id.html}</td></tr>
                 {/if}
                 <tr class="crm-event-eventfees-form-block-contribution_status_id"><td class="label">{$form.contribution_status_id.label}</td><td>{$form.contribution_status_id.html}</td></tr>
-                <tr class="crm-event-eventfees-form-block-payment_instrument_id"><td class="label">{$form.payment_instrument_id.label}<span class="crm-marker"> *</span></td><td>{$form.payment_instrument_id.html} {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td></tr>
+                <tr class="crm-event-eventfees-form-block-payment_instrument_id"><td class="label">{$form.payment_instrument_id.label}<span class="crm-marker"> *</span> {help id="payment_instrument_id" file="CRM/Contribute/Page/Tab.hlp"}</td><td>{$form.payment_instrument_id.html}</td></tr>
              </table>
            </fieldset>
            </td>
@@ -104,8 +104,8 @@
               {/if}
         </tr>
         <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
-          <td class="label">{$form.from_email_address.label}</td>
-          <td>{$form.from_email_address.html}  {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+          <td class="label">{$form.from_email_address.label} {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+          <td>{$form.from_email_address.html}</td>
         </tr>
         <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>
@@ -131,8 +131,8 @@
           </td>
       </tr>
       <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
-        <td class="label">{$form.from_email_address.label}</td>
-        <td>{$form.from_email_address.html} {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+        <td class="label">{$form.from_email_address.label} {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+        <td>{$form.from_email_address.html}</td>
       </tr>
       <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
         <td class="label">{$form.receipt_text.label}</td>

--- a/templates/CRM/Event/Form/ManageEvent/Fee.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Fee.tpl
@@ -117,8 +117,8 @@
     <div id="isDiscount">
          <table class="form-layout">
              <tr class="crm-event-manage-fee-form-block-is_discount">
-                <td class="label">{$form.is_discount.label}</td>
-                <td>{$form.is_discount.html} {help id="is_discount"}</td>
+                <td class="label">{$form.is_discount.label} {help id="is_discount"}</td>
+                <td>{$form.is_discount.html}</td>
              </tr>
          </table>
     </div>

--- a/templates/CRM/Event/Form/ManageEvent/Registration.tpl
+++ b/templates/CRM/Event/Form/ManageEvent/Registration.tpl
@@ -39,8 +39,8 @@
 <table class="form-layout-compressed">
 
   <tr class="crm-event-manage-registration-form-block-registration_link_text">
-    <td class="label">{$form.registration_link_text.label} <span class="crm-marker">*</span>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='registration_link_text' id=$eventID}{/if}</td>
-    <td>{$form.registration_link_text.html} {help id="link_text"}</td>
+    <td class="label">{$form.registration_link_text.label} <span class="crm-marker">*</span>{if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='registration_link_text' id=$eventID}{/if} {help id="link_text"}</td>
+    <td>{$form.registration_link_text.html}</td>
   </tr>
   {if !$isTemplate}
     <tr class="crm-event-manage-registration-form-block-registration_start_date">

--- a/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
+++ b/templates/CRM/Event/Form/ParticipantFeeSelection.tpl
@@ -140,8 +140,8 @@ CRM.$(function($) {
           </td>
        </tr>
        <tr id="from-email" class="crm-event-eventfees-form-block-from_email_address">
-         <td class="label">{$form.from_email_address.label}</td>
-         <td>{$form.from_email_address.html}  {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+         <td class="label">{$form.from_email_address.label} {help id="from_email_address" file="CRM/Contact/Form/Task/Help/Email/id-from_email.hlp"}</td>
+         <td>{$form.from_email_address.html}</td>
        </tr>
        <tr id='notice' class="crm-event-eventfees-form-block-receipt_text">
          <td class="label">{$form.receipt_text.label}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Move help text to the label for the Event forms: EventFees.tpl, ManageEvent/Fee.tpl, ManageEvent/Registration.tpl, and ParticipantFeeSelection.tpl.

Work item: https://lab.civicrm.org/dev/core/-/work_items/4297

Before
----------------------------------------
### Participant Add / EventFees
<img width="1288" height="734" alt="Screenshot 2026-06-26 at 11 55 14 PM" src="https://github.com/user-attachments/assets/80dcfd7b-ed6a-435b-8bc9-33583eb174b1" />


### Manage Event Registration
![before_event_manage_reg](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_event_manage_reg.png)

After
----------------------------------------
### Participant Add / EventFees
<img width="1302" height="720" alt="Screenshot 2026-06-26 at 11 55 34 PM" src="https://github.com/user-attachments/assets/c6554595-0c6e-4c45-b848-e268fde95efd" />


### Manage Event Registration
<img width="2084" height="1538" alt="Screenshot 2026-06-26 at 11 57 34 PM" src="https://github.com/user-attachments/assets/a1e930d6-e1ba-46c4-9d23-e624ee8e1b53" />
