### PR TITLE
CRM-4297 - Relocate help icon to label for Badge Layout, Financial Batch and SMS forms

### DIFF
--- a/templates/CRM/Badge/Form/Layout.tpl
+++ b/templates/CRM/Badge/Form/Layout.tpl
@@ -22,8 +22,8 @@
         <td>{$form.title.html}</td>
       </tr>
       <tr class="crm-badge-layout-form-block-label_format_name">
-        <td class="label">{$form.label_format_name.label}</td>
-        <td>{$form.label_format_name.html} {help id="label_format_name" file="CRM/Badge/Form/Layout.hlp"}</td>
+        <td class="label">{$form.label_format_name.label} {help id="label_format_name" file="CRM/Badge/Form/Layout.hlp"}</td>
+        <td>{$form.label_format_name.html}</td>
       </tr>
       <tr class="crm-badge-layout-form-block-description">
         <td class="label">{$form.description.label}</td>

--- a/templates/CRM/Financial/Form/FinancialBatch.tpl
+++ b/templates/CRM/Financial/Form/FinancialBatch.tpl
@@ -48,16 +48,16 @@
     <div class="crm-accordion-body">
       <table class="form-layout">
         <tr class="crm-contribution-form-block-payment_instrument">
-          <td class="label">{$form.payment_instrument_id.label}</td>
-          <td class="html-adjust">{$form.payment_instrument_id.html} {help id="payment_instrument_id"}</td>
+          <td class="label">{$form.payment_instrument_id.label} {help id="payment_instrument_id"}</td>
+          <td class="html-adjust">{$form.payment_instrument_id.html}</td>
         </tr>
         <tr class="crm-contribution-form-block-item_count">
-          <td class="label">{$form.item_count.label}</td>
-          <td class="html-adjust">{$form.item_count.html|crmAddClass:number} {help id="item_count"}</td>
+          <td class="label">{$form.item_count.label} {help id="item_count"}</td>
+          <td class="html-adjust">{$form.item_count.html|crmAddClass:number}</td>
         </tr>
         <tr class="crm-contribution-form-block-total">
-          <td class="label">{$form.total.label}</td>
-          <td class="html-adjust">{$form.total.html|crmAddClass:number} {help id="total"}</td>
+          <td class="label">{$form.total.label} {help id="total"}</td>
+          <td class="html-adjust">{$form.total.html|crmAddClass:number}</td>
         </tr>
       </table>
     </div>

--- a/templates/CRM/SMS/Form/Group.tpl
+++ b/templates/CRM/SMS/Form/Group.tpl
@@ -17,8 +17,8 @@
 {include file="CRM/common/WizardHeader.tpl"}
 
   <table class="form-layout">
-   <tr class="crm-mailing-group-form-block-name"><td class="label">{$form.name.label}</td><td>{$form.name.html} {help id="name"}</td></tr>
-   <tr class="crm-mailing-upload-form-block-sms_provider_id"><td class="label">{$form.sms_provider_id.label}</td><td>{$form.sms_provider_id.html}  {help id="sms_provider_id" isAdmin=$isAdmin}</td></tr>
+   <tr class="crm-mailing-group-form-block-name"><td class="label">{$form.name.label} {help id="name"}</td><td>{$form.name.html}</td></tr>
+   <tr class="crm-mailing-upload-form-block-sms_provider_id"><td class="label">{$form.sms_provider_id.label} {help id="sms_provider_id" isAdmin=$isAdmin}</td><td>{$form.sms_provider_id.html}</td></tr>
   </table>
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Move help text to the label for the miscellaneous forms: Badge/Form/Layout.tpl, Financial/Form/FinancialBatch.tpl, and SMS/Form/Group.tpl.

Work item: https://lab.civicrm.org/dev/core/-/work_items/4297

Before
----------------------------------------
### Badge Layout
<img width="1250" height="602" alt="Screenshot 2026-06-26 at 11 42 28 PM" src="https://github.com/user-attachments/assets/0dfbb77e-aa26-4a1a-9520-fcf6deed013d" />


### Accounting Batch
<img width="1550" height="1046" alt="Screenshot 2026-06-26 at 11 46 57 PM" src="https://github.com/user-attachments/assets/4c377b9a-89c9-467c-95e2-d3e39fe00b36" />


### Mass SMS
![before_sms_group](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_sms_group.png)

After
----------------------------------------
### Badge Layout
<img width="1472" height="606" alt="Screenshot 2026-06-26 at 11 40 33 PM" src="https://github.com/user-attachments/assets/e02fb094-869b-47e8-a5c3-2d9f88750bee" />


### Accounting Batch
<img width="1572" height="1062" alt="Screenshot 2026-06-26 at 11 46 29 PM" src="https://github.com/user-attachments/assets/2d150628-4d28-4be1-8e67-35ba7419230c" />


### Mass SMS
<img width="2112" height="1244" alt="Screenshot 2026-06-26 at 11 44 49 PM" src="https://github.com/user-attachments/assets/e85715af-5b02-430e-b251-edb2ad74f417" />

