### PR TITLE
Fix PHP notices on Invoice task form page

### DIFF
--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -57,6 +57,16 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
   public $_selectedOutput;
 
   /**
+   * @var array
+   */
+  public $_emails;
+
+  /**
+   * @var array
+   */
+  public $_fromEmails;
+
+  /**
    * @var bool
    */
   public $submitOnce = TRUE;

--- a/templates/CRM/Contribute/Form/Task/Invoice.tpl
+++ b/templates/CRM/Contribute/Form/Task/Invoice.tpl
@@ -50,10 +50,6 @@
       <td>{$form.output.pdf_invoice.html}</td>
     </tr>
   {/if}
-  <tr class="crm-pdf-element">
-    <td class="label">{$form.pdf_format_id.label}</td>
-    <td>{$form.pdf_format_id.html}</td>
-  </tr>
 </table>
 </div>
 
@@ -79,10 +75,8 @@
     function showhideEmailElements() {
       if ($('input[name="output"]:checked').val() == 'email_invoice') {
         $('.crm-email-element').show();
-        $('.crm-pdf-element').hide();
       }
       else {
-        $('.crm-pdf-element').show();
         $('.crm-email-element').hide();
       }
     }


### PR DESCRIPTION
Fixes PHP 8.2 deprecated dynamic property notices and undefined index notices on the Print/Email Contribution Invoice task page.

![before_invoice](https://raw.githubusercontent.com/colemanw/civicrm-core/refs/heads/screenshots-dev-core-4297/images/before_invoice.png)