### PR TITLE
ScheduleReminders - Move token help text back to the token selector

### DIFF
--- a/templates/CRM/Admin/Form/ScheduleReminders.tpl
+++ b/templates/CRM/Admin/Form/ScheduleReminders.tpl
@@ -132,10 +132,12 @@
               <td>{$form.template.html}</td>
             </tr>
             <tr class="crm-scheduleReminder-form-block-subject">
-              <td class="label">{$form.subject.label} {help id="id-token-subject" file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}</td>
+              <td class="label">{$form.subject.label}</td>
               <td>
-                  {$form.subject.html|crmAddClass:huge}
-                <input class="crm-token-selector big" data-field="subject" /></td>
+                {$form.subject.html|crmAddClass:huge}
+                <input class="crm-token-selector big" data-field="subject" />
+                {help id="id-token-subject" file="CRM/Contact/Form/Task/Email.hlp" title=$tokenTitle}
+              </td>
             </tr>
           </table>
             {include file="CRM/Contact/Form/Task/EmailCommon.tpl" upload=1 noAttach=1}


### PR DESCRIPTION
Overview
----------------------------------------
Move token help back to the token selector for consistency with all other forms.

Partially reverts 679cf6ba9a5dfbcf89a4db61e1daf6be9090ae58