### PR TITLE
dev/core#6602 Follow up to previous fix.

### DIFF
--- a/templates/CRM/Member/Form/Selector.tpl
+++ b/templates/CRM/Member/Form/Selector.tpl
@@ -42,8 +42,8 @@
             <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}" title="{ts escape='htmlattribute'}View contact record{/ts}">{$row.sort_name}</a>
         </td>
     {/if}
-    <td class="crm-membership-type crm-membership-type_{$row.membership_type}">
-        {$row.membership_type|escape}
+    <td class="crm-membership-type crm-membership-type_{$row.membership_type|escape}">
+        {$row.membership_type|purify}
         {if $row.owner_membership_id}<br />({ts}by relationship{/ts}){/if}
     </td>
     <td class="crm-membership-join_date">{$row.membership_join_date|truncate:10:''|crmDate}</td>


### PR DESCRIPTION
Downgrade escape to purify in the html context due to this breaking some extension hook based workflows.

Adds escape in the attribute context.

