### PR TITLE
QuickForm - Add autocompleteFilters

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -2182,6 +2182,10 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
   }
 
   /**
+   * Add an Api4-based autocomplete field.
+   *
+   * Note: filters should be defined by implementing `autocompleteFilters()`.
+   *
    * @param string $name
    * @param string $label
    * @param array $props
@@ -2212,6 +2216,17 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
 
     CRM_Utils_Array::remove($props, 'select', 'api', 'entity');
     return $this->add('text', $name, $label, $props, $required);
+  }
+
+  /**
+   * Form classes should override this to provide filters for autocompletes.
+   *
+   * @param $mainEntityId
+   *   Whatever the _contactId or _entityId is set to (typically the main entity being edited by the form).
+   * @return array
+   */
+  public static function autocompleteFilters($mainEntityId = NULL): array {
+    return [];
   }
 
   /**

--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -33,7 +33,7 @@ class AutocompleteFieldSubscriber extends AutoService implements EventSubscriber
   }
 
   /**
-   * Apply any filters set in the schema for autocomplete fields
+   * Apply any filters set in the QuickForm or field schema for autocomplete fields
    *
    * In order for this to work, the `$fieldName` param needs to be in
    * the format `EntityName.field_name`. Anything not in that format
@@ -50,12 +50,21 @@ class AutocompleteFieldSubscriber extends AutoService implements EventSubscriber
   public function onApiPrepare(\Civi\API\Event\PrepareEvent $event): void {
     $apiRequest = $event->getApiRequest();
     if (is_object($apiRequest) && is_a($apiRequest, 'Civi\Api4\Generic\AutocompleteAction')) {
-      [$formType, $formName] = array_pad(explode(':', (string) $apiRequest->getFormName()), 2, '');
+      [$formType, $formName, $mainEntityId] = array_pad(explode(':', (string) $apiRequest->getFormName()), 3, '');
       [$entityName, $fieldName] = array_pad(explode('.', (string) $apiRequest->getFieldName(), 2), 2, '');
 
       if (!$fieldName) {
         return;
       }
+
+      // Apply any filters defined in the QuickForm
+      if ($formType === 'qf' && is_a($formName, 'CRM_Core_Form', TRUE)) {
+        $formFilters = $formName::autocompleteFilters($mainEntityId);
+        foreach ($formFilters[$fieldName] ?? [] as $key => $value) {
+          $apiRequest->addFilter($key, $value);
+        }
+      }
+
       try {
         $fieldSpec = civicrm_api4($entityName, 'getFields', [
           'checkPermissions' => FALSE,

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -493,4 +493,47 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     }
   }
 
+  public function testFormAutocompleteFilters(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        [
+          'first_name' => 'Include',
+          'last_name' => $lastName,
+          'legal_identifier' => 'include',
+        ],
+        [
+          'first_name' => 'Exclude',
+          'last_name' => $lastName,
+          'legal_identifier' => 'exclude',
+        ],
+        [
+          'first_name' => 'Null',
+          'last_name' => $lastName,
+          'legal_identifier' => NULL,
+        ],
+      ],
+    ]);
+
+    $result = Contact::autocomplete()
+      ->setInput($lastName)
+      ->setFieldName('Contact.some_field_name')
+      ->setFormName('qf:api\v4\Action\AutocompleteTestForm')
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals($lastName . ', Include', $result[0]['label']);
+    $this->assertEquals($contacts[0]['id'], $result[0]['id']);
+  }
+
+}
+
+class AutocompleteTestForm extends \CRM_Core_Form {
+
+  public static function autocompleteFilters($mainEntityId = NULL): array {
+    return [
+      'some_field_name' => ['legal_identifier' => 'include'],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new optional method to the class CRM_Core_Form for registering autocomplete filters. This overcomes the limitation of adding filters directly to `$props['api']` where they will be ignored for security reasons if not part of the autocomplete's SELECT clause.