### PR TITLE
Contribution Main: avoid intro_text markup if no intro text

### DIFF
--- a/templates/CRM/Contribute/Form/Contribution/Main.tpl
+++ b/templates/CRM/Contribute/Form/Contribution/Main.tpl
@@ -64,9 +64,11 @@
     {/if}
     {/crmRegion}
 
-    <div id="intro_text" class="crm-public-form-item crm-section intro_text-section">
-      {$intro_text|purify}
-    </div>
+    {if $intro_text}
+      <div id="intro_text" class="crm-public-form-item crm-section intro_text-section">
+        {$intro_text|purify}
+      </div>
+    {/if}
     {include file="CRM/common/cidzero.tpl"}
 
     {if $isShowMembershipBlock && $hasExistingLifetimeMembership}


### PR DESCRIPTION
Overview
----------------------------------------

Avoid excessive padding if the intro text is empty and the River theme is used (or any theme that adds padding to the intro text, which is a normal thing to do).

Before
----------------------------------------

<img width="1614" height="466" alt="image" src="https://github.com/user-attachments/assets/d70cd063-6050-4194-8cba-a33a2fb9a034" />

After
----------------------------------------

<img width="1614" height="466" alt="image" src="https://github.com/user-attachments/assets/fcb434a3-0a6f-44aa-aba2-838706758d5d" />

Technical Details
----------------------------------------

The same is already done for the footer.

Comments
----------------------------------------

Yes, some padding might be necessary, however having empty elements makes it more difficult to theme consistently.