### PR TITLE
Add in AbstractScheduledJob Generic class to avoid extension owners h…

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -175,6 +175,9 @@ class CRM_Core_JobManager {
     }
 
     CRM_Utils_Hook::preJob($job, $params);
+    if (array_key_exists('runInNonProductionEnvironment', $params)) {
+      $params['runInNonProductionEnvironment'] = (bool) $params['runInNonProductionEnvironment'];
+    }
     try {
       $result = civicrm_api($job->api_entity, $job->api_action, $params);
     }

--- a/Civi/Api4/Generic/AbstractScheduledJob.php
+++ b/Civi/Api4/Generic/AbstractScheduledJob.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4\Generic;
+
+/**
+ * Base class for all api v4 scheduled jobs.
+ *
+ * This allows for extensions to create scheduled job actions without needing to specify the runInNonProductionEnvironmentJob command themselves
+ *
+ * @method bool getRunInNonProductionEnvironment()
+ * @method $this setRunInNonProductionEnvironment(bool $runInNonProductionEnvironment) Specify if this job should be run in NonProducitonEnvironments or not
+ */
+abstract class AbstractScheduledJob extends AbstractAction {
+
+  /**
+   * Should this Job be run in Non production Environments
+   *
+   * @var bool
+   */
+  protected $runInNonProductionEnvironment = FALSE;
+
+}

--- a/ext/civi_mail/Civi/Api4/Action/Mailing/ProcessQueue.php
+++ b/ext/civi_mail/Civi/Api4/Action/Mailing/ProcessQueue.php
@@ -12,19 +12,9 @@
 
 namespace Civi\Api4\Action\Mailing;
 
-use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\AbstractScheduledJob;
 
-class ProcessQueue extends AbstractAction {
-
-  /**
-   * @var bool
-   */
-  protected $runInNonProductionEnvironment = TRUE;
-
-  /**
-   * @var null
-   */
-  protected $language = NULL;
+class ProcessQueue extends AbstractScheduledJob {
 
   public function _run(\Civi\Api4\Generic\Result $result) {
     $queue = \Civi::queue('civicrm.mailing.event.queue', [


### PR DESCRIPTION
…aving to always add runInNonProductionEnvironment to their APIv4 classes

Overview
----------------------------------------
This aims to add a Generic APIv4 class to support scheduled jobs and modifies an existing job to use the new class and ensure that we are always passing a boolean value for the runInNonProductionEnvironment param

Before
----------------------------------------
No Generic Class

After
----------------------------------------
Generic Class

ping @mattwire @artfulrobot @colemanw 