### PR TITLE
dev/core#6613 Dedupe - Fix merging contacts with custom file fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2229,39 +2229,33 @@ WHERE  id IN ( %1, %2 )
     if (empty($fieldIDs)) {
       return;
     }
-    $fields = civicrm_api3('CustomField', 'get', ['id' => ['IN' => $fieldIDs], 'return' => ['custom_group_id.is_multiple', 'custom_group_id.table_name', 'column_name', 'data_type'], 'options' => ['limit' => 0]])['values'];
     $return = [];
     foreach ($fieldIDs as $fieldID) {
       $return[] = 'custom_' . $fieldID;
     }
     $oldContact = civicrm_api3('Contact', 'getsingle', ['id' => $oldContactID, 'return' => $return]);
-    $newContact = civicrm_api3('Contact', 'getsingle', ['id' => $newContactID, 'return' => $return]);
 
     // The moveAllBelongings function has functionality to move custom fields. It doesn't work very well...
     // @todo handle all fields here but more immediately Country since that is broken at the moment.
-    $fieldTypesNotHandledInMergeAttempt = ['File'];
-    foreach ($fields as $field) {
-      $isMultiple = !empty($field['custom_group_id.is_multiple']);
+    $customValues = [];
+    foreach ($fieldIDs as $fieldID) {
+      $field = CRM_Core_BAO_CustomField::getField($fieldID);
+      $isMultiple = !empty($field['custom_group']['is_multiple']);
       if ($field['data_type'] === 'File' && !$isMultiple) {
-        if (!empty($oldContact['custom_' . $field['id']]) && !empty($newContact['custom_' . $field['id']])) {
-          CRM_Core_BAO_File::deleteFileReferences($oldContact['custom_' . $field['id']], $oldContactID, $field['id']);
+        $fieldName = "custom_$fieldID";
+        $rowId = CRM_Core_DAO::singleValueQuery("SELECT id FROM %1 WHERE entity_id = %2", [
+          1 => [$field['custom_group']['table_name'], 'MysqlColumnNameOrAlias'],
+          2 => [$newContactID, 'Integer'],
+        ]);
+        if ($rowId) {
+          $fieldName .= '_' . $rowId;
         }
-        if (!empty($oldContact['custom_' . $field['id']])) {
-          CRM_Core_DAO::executeQuery("
-            UPDATE civicrm_entity_file
-            SET entity_id = $newContactID
-            WHERE file_id = {$oldContact['custom_' . $field['id']]}"
-          );
-        }
+        $customValues[$fieldName] = $oldContact["custom_$fieldID"] ?? NULL;
       }
-      if (in_array($field['data_type'], $fieldTypesNotHandledInMergeAttempt) && !$isMultiple) {
-        CRM_Core_DAO::executeQuery(
-          "INSERT INTO {$field['custom_group_id.table_name']} (entity_id, `{$field['column_name']}`)
-          VALUES ($newContactID, {$oldContact['custom_' . $field['id']]})
-          ON DUPLICATE KEY UPDATE
-          `{$field['column_name']}` = {$oldContact['custom_' . $field['id']]}
-        ");
-      }
+    }
+    if ($customValues) {
+      $customValues['entityID'] = $newContactID;
+      \CRM_Core_BAO_CustomValueTable::setValues($customValues);
     }
   }
 

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Civi\Api4\Contact;
+use Civi\Api4\File;
+use Civi\Api4\Individual;
 
 /**
  * Class CRM_Dedupe_DedupeMergerTest
@@ -1820,6 +1822,70 @@ WHERE
    */
   public function hookLinkCallBack(string $className, array &$links): void {
     $links[] = new CRM_Core_Reference_Basic('civicrm_im', 'name', 'civicrm_contact', 'first_name');
+  }
+
+  /**
+   * Test merging two contacts with a File type custom field.
+   */
+  public function testMergeContactsWithFileCustomField(): void {
+    $this->createCustomGroup([
+      'title' => 'File Field Group',
+      'name' => 'file_field_group',
+      'extends' => 'Individual',
+    ]);
+    $field = $this->createFileCustomField([
+      'custom_group_id' => $this->ids['CustomGroup']['file_field_group'],
+      'label' => 'Test File Field',
+      'name' => 'test_file_field',
+    ]);
+
+    $customFieldName = 'file_field_group.' . $field['name'];
+    $shortFieldName = 'custom_' . $field['id'];
+
+    $keepFile = File::create(FALSE)
+      ->setValues([
+        'mime_type' => 'text/plain',
+        'file_name' => "keep_file.txt",
+        'content' => "keep content",
+      ])
+      ->execute()->single();
+
+    $removeFile = File::create(FALSE)
+      ->setValues([
+        'mime_type' => 'text/plain',
+        'file_name' => "remove_file.txt",
+        'content' => "remove content",
+      ])
+      ->execute()->single();
+
+    // 2. Create two individual contacts.
+    $keepContactID = Individual::create(FALSE)
+      ->setValues(['first_name' => 'Keep', $customFieldName => $removeFile['id']])
+      ->execute()
+      ->single()['id'];
+    $removeContactID = Individual::create(FALSE)
+      ->setValues(['first_name' => 'Remove', $customFieldName => $keepFile['id']])
+      ->execute()
+      ->single()['id'];
+
+    // 3. Merge the two contacts. The move_custom_N key triggers the file merge.
+    $this->mergeContacts($keepContactID, $removeContactID, [
+      "move_{$shortFieldName}" => $keepFile['id'],
+    ]);
+
+    // 4. Assert the remaining contact has new file attached.
+    $remainingValue = Contact::get(FALSE)
+      ->addWhere('id', '=', $keepContactID)
+      ->addSelect($customFieldName)
+      ->execute()
+      ->single()[$customFieldName];
+    $this->assertEquals($remainingValue, $keepFile['id']);
+
+    // Assert old file has been deleted
+    $files = File::get(FALSE)
+      ->addWhere('id', 'IN', [$keepFile['id'], $removeFile['id']])
+      ->execute();
+    $this->assertCount(1, $files);
   }
 
   /**

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -30,6 +30,7 @@
  */
 
 use Civi\Api4\Contact;
+use Civi\Api4\File;
 
 /**
  *  Test APIv3 civicrm_contact* functions
@@ -3845,15 +3846,14 @@ class api_v3_ContactTest extends CiviUnitTestCase {
    */
   public function testMergeCustomFields(): void {
     $contact1 = $this->individualCreate();
-    // Not sure this is quite right but it does get it into the file table
-    $file = $this->callAPISuccess('Attachment', 'create', [
-      'name' => 'header.txt',
-      'mime_type' => 'text/plain',
-      'description' => 'My test description',
-      'content' => 'My test content',
-      'entity_table' => 'civicrm_contact',
-      'entity_id' => $contact1,
-    ]);
+    $file = File::create(FALSE)
+      ->setValues([
+        'mime_type' => 'text/plain',
+        'file_name' => 'header.txt',
+        'content' => 'My test content',
+      ])
+      ->execute()
+      ->single();
 
     $this->createCustomGroupWithFieldsOfAllTypes();
     $fileField = $this->getCustomFieldName('file');
@@ -3909,7 +3909,6 @@ class api_v3_ContactTest extends CiviUnitTestCase {
     ]);
     $this->assertEquals(TRUE, $contact1IsDeletedAfterMerge);
     $mergedContact = $this->callAPISuccessGetSingle('Contact', ['id' => $contact2, 'return' => $customFieldKeys]);
-    $this->assertEquals($contact2, CRM_Core_DAO::singleValueQuery('SELECT entity_id FROM civicrm_entity_file WHERE file_id = ' . $file['id']));
     foreach ($customFieldKeys as $key) {
       $this->assertEquals($contact1CustomFieldValues[$key], $mergedContact[$key]);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes regression where deduping contacts with custom file fields would fail.

Fixes [dev/core#6613](https://lab.civicrm.org/dev/core/-/work_items/6613)

Technical Details
--------
This regressed with 92eb77c46 when custom fields stopped creating associated EntityFile records. The code was still attempting to delete that record, and `CRM_Core_BAO_File::deleteFileReferences` was throwing an exception.
