### PR TITLE
Static caching for Afform Behavior ContactAutofill an ContactDedupe

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -48,6 +48,9 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
   }
 
   public static function getModes(string $entityName):array {
+    if (isset(\Civi::$statics[__CLASS__]['getModes'][$entityName])) {
+      return \Civi::$statics[__CLASS__]['getModes'][$entityName];
+    }
     $modes = [];
     if ($entityName === 'Individual') {
       $modes[] = [
@@ -91,6 +94,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
         ];
       }
     }
+    \Civi::$statics[__CLASS__]['getModes'][$entityName] = $modes;
     return $modes;
   }
 

--- a/ext/afform/core/Civi/Afform/Behavior/ContactDedupe.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactDedupe.php
@@ -36,6 +36,9 @@ class ContactDedupe extends AbstractBehavior implements EventSubscriberInterface
   }
 
   public static function getModes(string $entityName):array {
+    if (isset(\Civi::$statics[__CLASS__]['getModes'][$entityName])) {
+      return \Civi::$statics[__CLASS__]['getModes'][$entityName];
+    }
     $modes = [];
     $dedupeRuleGroups = \Civi\Api4\DedupeRuleGroup::get(FALSE)
       ->addWhere('contact_type', '=', $entityName)
@@ -50,6 +53,7 @@ class ContactDedupe extends AbstractBehavior implements EventSubscriberInterface
         'label' => $rule['title'],
       ];
     }
+    \Civi::$statics[__CLASS__]['getModes'][$entityName] = $modes;
     return $modes;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
The Afform autofill behavior function `getModes()` is called quite often. This is not a problem for the ones which just return arrays - but some of them are making db queries.

In my tests for complex sites (many SearchKits and Afforms...) just caching these functions gives a 10-15% performance boost.

Before
----------------------------------------
Many slow calls to `getModes()`.

After
----------------------------------------
Many but fast calls to `getModes()`.
