### PR TITLE
FormBuilder - Reorganize tabs to add "Packaged Forms"

### DIFF
--- a/ext/afform/admin/ang/afAdminFormList.aff.html
+++ b/ext/afform/admin/ang/afAdminFormList.aff.html
@@ -1,9 +1,10 @@
   <af-tabset url-arg="tab" remember-selection="true">
     <af-tab name="form" title="Submission Forms" icon="fa-list-alt">
       <div af-fieldset="">
-        <div class="form-inline">
+        <div class="form-inline crm-formbuilder-search-filters">
           <af-admin-list-menu class="form-group pull-right" tab="form"></af-admin-list-menu>
-          <af-field name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
+          <af-field class="form-group" name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
+          <af-field class="form-group" name="has_base" defn="{input_type: 'Radio', options: [{id: false, label: 'Custom'}, {id: true, label: 'Packaged'}], label: false, afform_default: false}"></af-field>
         </div>
         <crm-search-display-table search-name="Afform_Admin" display-name="Afform_Forms_Table" filters="{type: 'form'}" total-count="$parent.count"></crm-search-display-table>
       </div>
@@ -11,9 +12,10 @@
 
     <af-tab name="search" title="Search Forms" icon="fa-search">
       <div af-fieldset="">
-        <div class="form-inline">
+        <div class="form-inline crm-formbuilder-search-filters">
           <af-admin-list-menu class="form-group pull-right" tab="search"></af-admin-list-menu>
-          <af-field name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
+          <af-field class="form-group" name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
+          <af-field class="form-group" name="has_base" defn="{input_type: 'Radio', options: [{id: false, label: 'Custom'}, {id: true, label: 'Packaged'}], label: false, afform_default: false}"></af-field>
         </div>
         <crm-search-display-table search-name="Afform_Admin" display-name="Afform_Searches_Table" filters="{type: 'search'}" total-count="$parent.count"></crm-search-display-table>
       </div>
@@ -21,20 +23,21 @@
 
     <af-tab name="block" title="Field Blocks" icon="fa-th-large">
       <div af-fieldset="">
-        <div class="form-inline">
+        <div class="form-inline crm-formbuilder-search-filters">
           <af-admin-list-menu class="form-group pull-right" tab="block"></af-admin-list-menu>
-          <af-field name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
+          <af-field class="form-group" name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
+          <af-field class="form-group" name="has_base" defn="{input_type: 'Radio', options: [{id: false, label: 'Custom'}, {id: true, label: 'Packaged'}], label: false, afform_default: false}"></af-field>
         </div>
         <crm-search-display-table search-name="Afform_Admin" display-name="Afform_Blocks_Table" filters="{type: 'block'}" total-count="$parent.count"></crm-search-display-table>
       </div>
     </af-tab>
 
-    <af-tab name="system" title="System Forms" icon="fa-lock">
+    <af-tab name="system" title="Packaged Forms" icon="fa-suitcase">
       <div af-fieldset="">
-        <div class="form-inline">
+        <div class="form-inline crm-formbuilder-search-filters">
           <af-field name="title,name" defn="{name: 'title', label: false, input_attrs: {placeholder: 'Search by name...'}}"></af-field>
         </div>
-        <crm-search-display-table search-name="Afform_Admin" display-name="Afform_System_Table" filters="{type: 'system'}" total-count="$parent.count"></crm-search-display-table>
+        <crm-search-display-table search-name="Afform_Admin" display-name="Afform_System_Table" filters="{has_base: true}" total-count="$parent.count"></crm-search-display-table>
       </div>
     </af-tab>
   </af-tabset>

--- a/ext/afform/admin/managed/SavedSearch_Afform_Admin.mgd.php
+++ b/ext/afform/admin/managed/SavedSearch_Afform_Admin.mgd.php
@@ -63,6 +63,7 @@ return [
           'sort' => [
             ['title', 'ASC'],
           ],
+          'noResultsText' => 'Clear the above filters to see all forms.',
           'columns' => [
             [
               'type' => 'html',
@@ -191,6 +192,7 @@ return [
           'sort' => [
             ['title', 'ASC'],
           ],
+          'noResultsText' => 'Clear the above filters to see all forms.',
           'columns' => [
             [
               'type' => 'html',
@@ -330,6 +332,7 @@ return [
           'sort' => [
             ['title', 'ASC'],
           ],
+          'noResultsText' => 'Clear the above filters to see all forms.',
           'columns' => [
             [
               'type' => 'html',
@@ -457,13 +460,28 @@ return [
               'type' => 'html',
               'key' => 'title',
               'label' => E::ts('Title'),
+              'title' => NULL,
               'sortable' => TRUE,
               'rewrite' => '<strong>{$title|escape}</strong><div class="help-block">{$name|escape}</div>',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'type:label',
+              'label' => E::ts('Type'),
+              'sortable' => TRUE,
             ],
             [
               'path' => '~/afAdmin/afListPlacementColumn.html',
               'type' => 'include',
               'label' => E::ts('Placement'),
+            ],
+            [
+              'type' => 'html',
+              'key' => 'submission_count',
+              'label' => E::ts('Submissions'),
+              'sortable' => TRUE,
+              'rewrite' => '{if $submission_count}<a href="{crmURL p=\'civicrm/admin/afform/submissions#/?name=[name]\'}">{ts count=$submission_count plural=\'%count Submissions\' escape=\'html\'}1 Submission{/ts}</a>
+<div class="help-block">{ts 1=$submission_date|crmDate:"shortdate" escape=\'html\'}Last submitted %1{/ts}</div>{/if}',
             ],
             [
               'type' => 'field',
@@ -481,24 +499,41 @@ return [
               'size' => 'btn-xs',
               'links' => [
                 [
+                  'path' => 'civicrm/admin/afform#/edit/[name]',
+                  'icon' => 'fa-pencil',
+                  'text' => E::ts('Edit'),
+                  'style' => 'primary',
+                  'size' => 'btn-xs',
+                  'conditions' => [
+                    ['type', '!=', 'system'],
+                  ],
+                  'task' => '',
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
+                  'path' => 'civicrm/admin/afform#/clone/[name]',
+                  'icon' => 'fa-files-o',
+                  'text' => E::ts('Clone'),
+                  'style' => 'secondary',
+                  'size' => 'btn-xs',
+                  'conditions' => [
+                    ['type', '!=', 'system'],
+                  ],
+                  'task' => '',
+                  'entity' => '',
+                  'action' => '',
+                  'join' => '',
+                  'target' => '',
+                ],
+                [
                   'task' => 'revert',
                   'entity' => 'Afform',
                   'icon' => 'fa-undo',
                   'text' => E::ts('Revert'),
                   'style' => 'warning',
-                  'size' => 'btn-xs',
-                  'path' => '',
-                  'action' => '',
-                  'join' => '',
-                  'target' => '',
-                  'conditions' => [],
-                ],
-                [
-                  'task' => 'delete',
-                  'entity' => 'Afform',
-                  'icon' => 'fa-trash',
-                  'text' => E::ts('Delete'),
-                  'style' => 'danger',
                   'size' => 'btn-xs',
                   'path' => '',
                   'action' => '',

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -408,8 +408,10 @@ class Afform extends Generic\AbstractEntity {
         ];
         $fields[] = [
           'name' => 'has_base',
+          'title' => E::ts('Packaged'),
           'type' => 'Extra',
           'data_type' => 'Boolean',
+          'input_type' => 'Radio',
           'description' => 'Is provided by an extension',
           'readonly' => TRUE,
         ];

--- a/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
+++ b/ext/riverlea/core/org.civicrm.afform_admin-ang/afGuiEditor.css
@@ -2,6 +2,14 @@
    Forked on 24 July 24. Called on Form Builder
    Status: merged */
 
+/* Listing */
+
+/* Custom/Packaged radios */
+#bootstrap-theme.afadmin-list .crm-formbuilder-search-filters .af-field-type-radio label:first-child {
+  padding-left: var(--crm-l-medium-2);
+  padding-right: 0;
+}
+
 /* Editor */
 
 #afGuiEditor {

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -114,10 +114,13 @@
 
       // Tabs include a rowCount which will be updated by the search controller
       this.tabs = [
-        {name: 'custom', title: ts('Custom Searches'), icon: 'fa-search-plus', rowCount: null, filters: {has_base: false}},
-        {name: 'packaged', title: ts('Packaged Searches'), icon: 'fa-suitcase', rowCount: null, filters: {has_base: true}},
+        {name: 'custom', title: ts('Saved Searches'), icon: 'fa-search-plus', rowCount: null, filters: {has_base: false}},
         {name: 'template', title: ts('Search Templates'), icon: 'fa-clipboard', rowCount: null, filters: {is_template: true}},
+        {name: 'segment', title: ts('Search Segments'), icon: 'fa-object-group', rowCount: null},
+        {name: 'packaged', title: ts('Packaged Searches'), icon: 'fa-suitcase', rowCount: null, filters: {has_base: true}},
       ];
+      // Used for the segment tab count
+      this.searchSegmentTab = this.tabs[2];
       $scope.$bindToRoute({
         expr: '$ctrl.tab',
         param: 'tab',

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/searchList.html
@@ -1,5 +1,5 @@
 <form id="bootstrap-theme" class="crm-search">
-  <h1 crm-page-title>{{:: ts('Saved Searches') }}</h1>
+  <h1 crm-page-title>{{:: ts('SearchKit') }}</h1>
 
   <!-- Tabs based on the has_base filter -->
   <div class="crm-search-nav-tabs">
@@ -8,12 +8,6 @@
         <a href ng-click="$ctrl.tab = tab.name"><i class="crm-i {{:: tab.icon }}" role="img" aria-hidden="true"></i>
           {{:: tab.title }}
           <span class="badge">{{ tab.rowCount }}</span>
-        </a>
-      </li>
-      <li role="tab" ng-class="{active: $ctrl.tab === 'segment'}">
-        <a href ng-click="$ctrl.tab = 'segment'"><i class="crm-i fa-object-group" role="img" aria-hidden="true"></i>
-          {{:: ts('Search Segments') }}
-          <span class="badge">{{ $ctrl.searchSegmentCount }}</span>
         </a>
       </li>
     </ul>
@@ -59,7 +53,7 @@
     </div>
   </div>
 
-  <div role="tabpanel" ng-repeat="tab in $ctrl.tabs" ng-show="$ctrl.tab === tab.name">
+  <div role="tabpanel" ng-repeat="tab in $ctrl.tabs" ng-show="$ctrl.tab === tab.name" ng-if="tab.name !== 'segment'">
     <div class="form-inline">
       <input class="form-control" type="search" ng-model="tab.filters.label.CONTAINS" placeholder="{{:: ts('Filter by label...') }}">
       <input class="form-control" type="search" ng-if="tab.name === 'custom'" ng-model="tab.filters['created_id.display_name,modified_id.display_name'].CONTAINS" placeholder="{{:: ts('Filter by author...') }}">
@@ -78,6 +72,6 @@
     <crm-search-admin-search-listing filters="tab.filters" tab-count="tab.rowCount"></crm-search-admin-search-listing>
   </div>
   <div ng-show="$ctrl.tab === 'segment'">
-    <crm-search-admin-segment-listing total-count="$ctrl.searchSegmentCount"></crm-search-admin-segment-listing>
+    <crm-search-admin-segment-listing total-count="$ctrl.searchSegmentTab.rowCount"></crm-search-admin-segment-listing>
   </div>
 </form>


### PR DESCRIPTION
Overview
----------------------------------------
Improves FormBuilder and SearchKit tabs to be consistent with each other. Replaces seldom-used "System Forms" tab with "Packaged Forms". Adds a filter to the other tabs to make it possible to still view packaged forms there if desired.

Before
----------------------------------------

<img width="1463" height="446" alt="Screenshot 2026-06-30 at 5 23 48 PM" src="https://github.com/user-attachments/assets/54812757-2714-4fc7-9521-5ae350ada697" />

----------

<img width="1463" height="446" alt="Screenshot 2026-06-30 at 5 24 11 PM" src="https://github.com/user-attachments/assets/eb7ee23a-2c70-4028-b034-ff06357c6962" />


After
----------------------------------------

<img width="1463" height="446" alt="Screenshot 2026-06-30 at 5 24 40 PM" src="https://github.com/user-attachments/assets/779b7119-8f5c-4ae6-976a-dbc69ab70f32" />

----

<img width="1463" height="446" alt="Screenshot 2026-06-30 at 5 24 05 PM" src="https://github.com/user-attachments/assets/94aadd61-08dd-42d8-854e-87103974e7fd" />

