### PR TITLE
Clarify website URL input

### DIFF
--- a/CRM/Contact/Form/Edit/Website.php
+++ b/CRM/Contact/Form/Edit/Website.php
@@ -42,8 +42,8 @@ class CRM_Contact_Form_Edit_Website {
     $form->addField("website[$blockId][website_type_id]", ['entity' => 'website', 'class' => 'eight', 'placeholder' => NULL, 'title' => ts('Website Type %1', [1 => $blockId])]);
 
     //Website box
-    $form->addField("website[$blockId][url]", ['entity' => 'website', 'aria-label' => ts('Website URL %1', [1 => $blockId])]);
-    $form->addRule("website[$blockId][url]", ts('Enter a valid web address beginning with \'http://\' or \'https://\'.'), 'url');
+    $form->addField("website[$blockId][url]", ['entity' => 'website', 'aria-label' => ts('Website URL %1', [1 => $blockId]), 'placeholder' => 'https://example.org', 'data-msg-url' => ts('Enter a valid website address, such as https://example.org')]);
+    $form->addRule("website[$blockId][url]", ts('Enter a valid website address, such as https://example.org'), 'url');
 
   }
 

--- a/CRM/Core/BAO/UFGroup.php
+++ b/CRM/Core/BAO/UFGroup.php
@@ -2009,7 +2009,7 @@ AND    ( entity_id IS NULL OR entity_id <= 0 )
     }
     elseif (substr($fieldName, 0, 4) === 'url-') {
       $form->add('text', $name, $title, CRM_Core_DAO::getAttribute('CRM_Core_DAO_Website', 'url'), $required);
-      $form->addRule($name, ts('Enter a valid web address beginning with \'http://\' or \'https://\'.'), 'url');
+      $form->addRule($name, ts('Enter a valid website address, such as https://example.org'), 'url');
     }
     // Note should be rendered as textarea
     elseif (substr($fieldName, -4) == 'note') {

--- a/templates/CRM/Contact/Form/Contact.hlp
+++ b/templates/CRM/Contact/Form/Contact.hlp
@@ -65,7 +65,7 @@
 {/htxt}
 
 {htxt id="id-website"}
-<p>{ts}Record one or more web addresses (URLs) associated with this contact. Examples include personal web addresses like a Facebook or Twitter page, as well as links to a company or organization web site or page.{/ts}</p>
+<p>{ts}Record one or more web addresses (URLs) associated with this contact, such as a social media page or an organization’s website.{/ts}</p>
 {/htxt}
 
 


### PR DESCRIPTION
Overview
----------------------------------------
This updates the backend contact website field to make the expected format clearer for admins.

Before
----------------------------------------
People sometimes do not add https:// and complain it is rejecting them. I get this every so often.

After
----------------------------------------
- Add a placeholder of https://example.org to the backend website field
- Update the backend validation message to say: "Enter a valid web address beginning with 'https://'."
- Tweaks help icon message

Note
----------------------------------------

- Used https:// only without getting overly wordy ```http:// or https://``` though profile front end forms does still do that https://github.com/civicrm/civicrm-core/blob/master/CRM/Core/BAO/UFGroup.php#L2012

- Ideally, they type civicrm.com, the form recognizes that as website, and it automatically saves by pre-pending https:// so it is https://civicrm.com. If http:// or https:// is added directly, it doesn't do anything.