### PR TITLE
Smarty - Convert {ts} block to compile-time plugin

### DIFF
--- a/CRM/Core/Smarty/plugins/compiler.ts.php
+++ b/CRM/Core/Smarty/plugins/compiler.ts.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Compiler plugin for opening {ts ...} tags.
+ *
+ * Emits ob_start() and pushes the tag's attributes onto the compiler
+ * tag stack so the closing tag can retrieve them.
+ */
+class smarty_compiler_ts extends \Smarty\Compile\Base {
+
+  protected $optional_attributes = ['_any'];
+
+  protected $option_flags = ['nocache', 'nofilter'];
+
+  public function compile($args, \Smarty\Compiler\Template $compiler, $parameter = [], $tag = NULL, $function = NULL): string {
+    $_attr = $this->getAttributes($compiler, $args);
+
+    // Save attributes and the current nofilter flag for the closing tag.
+    $compiler->openTag('ts', [
+      'attr' => $_attr,
+      'nofilter' => (bool) ($_attr['nofilter'] ?? FALSE),
+    ]);
+
+    return '<?php ob_start(); ?>';
+  }
+
+}

--- a/CRM/Core/Smarty/plugins/compiler.tsclose.php
+++ b/CRM/Core/Smarty/plugins/compiler.tsclose.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Compiler plugin for closing {/ts} tags.
+ *
+ * Retrieves the buffered text, emits the _ts() call, and applies the same
+ * default-modifier / escape_html logic that {$variable} output receives
+ * via PrintExpressionCompiler.
+ */
+class smarty_compiler_tsclose extends \Smarty\Compile\Base {
+
+  public function compile($args, \Smarty\Compiler\Template $compiler, $parameter = [], $tag = NULL, $function = NULL): string {
+    $saved = $compiler->closeTag('ts');
+    $_attr = $saved['attr'];
+
+    // 'escape' parameter is forwarded to _ts() only if it is a custom CiviCRM mode.
+    $explicitEscape = isset($_attr['escape']) ? trim($_attr['escape'], '\'\"') : NULL;
+    $civiEscapes = ['sql', 'js', 'html', 'htmlattribute'];
+
+    $compilerOnlyKeys = ['nofilter', 'nocache'];
+    if ($explicitEscape === NULL || !in_array($explicitEscape, $civiEscapes, TRUE)) {
+      $compilerOnlyKeys[] = 'escape';
+    }
+
+    $runtimeParams = [];
+    foreach (array_diff_key($_attr, array_flip($compilerOnlyKeys)) as $k => $v) {
+      $runtimeParams[] = var_export($k, TRUE) . ' => ' . $v;
+    }
+
+    $output = '_ts(ob_get_clean(), array(' . implode(', ', $runtimeParams) . '))';
+
+    if ($saved['nofilter']) {
+      // Skip all escaping
+    }
+    elseif ($explicitEscape !== NULL) {
+      if (!in_array($explicitEscape, $civiEscapes, TRUE)) {
+        $output = $compiler->compileModifier([['escape', var_export($explicitEscape, TRUE)]], $output);
+      }
+      $compiler->setRawOutput(TRUE);
+    }
+    else {
+      // Apply template-wide filters/modifiers and escape_html
+      if ($compiler->getSmarty()->getDefaultModifiers()) {
+        $modifierlist = [];
+        foreach ($compiler->getSmarty()->getDefaultModifiers() as $key => $modifier) {
+          preg_match_all('/(\' [^\'\\\\]* (?: \\\\. [^\'\\\\]* )* \' | " [^"\\\\]* (?: \\\\. [^"\\\\]* )* " | : | [^:]+)/x', $modifier, $matches);
+          $modifierlist[$key] = array_values(array_filter($matches[0], fn($m) => $m !== ':'));
+        }
+        $output = $compiler->compileModifier($modifierlist, $output);
+      }
+
+      if ($compiler->getTemplate()->getSmarty()->escape_html && !$compiler->isRawOutput()) {
+        $output = "htmlspecialchars((string) ($output), ENT_QUOTES, '" . addslashes(\Smarty\Smarty::$_CHARSET) . "')";
+      }
+    }
+
+    $compiler->setRawOutput(FALSE);
+    return "<?php echo $output; ?>\n";
+  }
+
+}

--- a/tests/phpunit/CRM/Core/SmartyTest.php
+++ b/tests/phpunit/CRM/Core/SmartyTest.php
@@ -56,4 +56,90 @@ class CRM_Core_SmartyTest extends CiviUnitTestCase {
     $this->assertEquals(NULL, $smarty->getTemplateVars()['my_variable']);
   }
 
+  /**
+   * Test that {ts} correctly handles escaping attributes, template-wide
+   * escape_html, and {setfilter} blocks.
+   *
+   * @param string $template
+   * @param string $expectedResult
+   * @param array $templateVars
+   * @param bool $globalEscapeHtml
+   *
+   * @dataProvider tsEscapingProvider
+   */
+  public function testTsEscaping(string $template, string $expectedResult, array $templateVars = [], bool $globalEscapeHtml = FALSE): void {
+    $smarty = \CRM_Core_Smarty::singleton();
+    $oldEscapeHtml = $smarty->escape_html;
+    $smarty->escape_html = $globalEscapeHtml;
+    try {
+      $this->assertEquals($expectedResult, \CRM_Utils_String::parseOneOffStringThroughSmarty($template, $templateVars));
+    }
+    finally {
+      $smarty->escape_html = $oldEscapeHtml;
+    }
+  }
+
+  public static function tsEscapingProvider(): array {
+    return [
+      'plain' => [
+        '{ts}Hello World{/ts}',
+        'Hello World',
+      ],
+      'no_escape' => [
+        '{ts}Hello <b>World</b>{/ts}',
+        'Hello <b>World</b>',
+      ],
+      'escape_html_attr' => [
+        '{ts escape="html"}Hello <b>World</b>{/ts}',
+        'Hello &lt;b&gt;World&lt;/b&gt;',
+      ],
+      'sub_literal' => [
+        '{ts 1="Dave"}Hello %1{/ts}',
+        'Hello Dave',
+      ],
+      'sub_var' => [
+        '{ts 1=$name}Hello %1{/ts}',
+        'Hello Alice',
+        ['name' => 'Alice'],
+      ],
+      'setfilter' => [
+        '{setfilter escape:"html"}{ts}Hello <b>World</b>{/ts}{/setfilter}',
+        'Hello &lt;b&gt;World&lt;/b&gt;',
+      ],
+      'nofilter_in_setfilter' => [
+        '{setfilter escape:"html"}{ts nofilter}Hello <b>World</b>{/ts}{/setfilter}',
+        'Hello <b>World</b>',
+      ],
+      'escape_url' => [
+        '{ts escape="url"}Hello World &amp;{/ts}',
+        'Hello%20World%20%26amp%3B',
+      ],
+      'global_escape' => [
+        '{ts}Hello <b>World</b>{/ts}',
+        'Hello &lt;b&gt;World&lt;/b&gt;',
+        [],
+        TRUE,
+      ],
+      'global_no_double' => [
+        '{ts escape="html"}Hello <b>World</b>{/ts}',
+        'Hello &lt;b&gt;World&lt;/b&gt;',
+        [],
+        TRUE,
+      ],
+      'escape_sql' => [
+        '{ts escape="sql"}Hello \'World\'{/ts}',
+        'Hello \\\'World\\\'',
+      ],
+      'escape_js' => [
+        '{ts escape="js"}Hello "World" & \'Dave\'{/ts}',
+        'Hello \u0022World\u0022 \u0026 \u0027Dave\u0027',
+      ],
+      'nofilter_with_vars_in_setfilter' => [
+        '{setfilter escape:"html"}{ts nofilter 1=$world|escape:"html" 2=$markup}Hello <b>%1</b> %2{/ts}{/setfilter}',
+        'Hello <b>&lt;b&gt;Earth&lt;/b&gt;</b> <i>Space</i>',
+        ['world' => '<b>Earth</b>', 'markup' => '<i>Space</i>'],
+      ],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Toward moving [dev/core#1328](https://lab.civicrm.org/dev/core/-/work_items/1328) forward, this adjusts our Smarty `{ts}` block to respect the template-wide `escape_html` setting and any enclosing `{setfilter}` block, just like `{$variable}` does.


Technical Details
----------------------------------------
On the opening `{ts ...}` tag, the compiler emits `ob_start()` so that the literal text between the tags is captured at runtime.  On the closing `{/ts}` tag, the compiler emits the call to `_ts(ob_get_clean(), $params)` and then wraps the result in exactly the same modifier / escape_html logic that PrintExpressionCompiler applies to `{$variable}` output.

Because all of this is resolved at compile time, `{setfilter escape}` and `$smarty->escape_html` both work transparently with no changes to existing `.tpl` files. Since we don't (yet) use either of those settings, there should be no functional change to any templates, but it makes way for us to start using those settings with consistent results.

The explicit `{ts escape='html'}` attribute is still honored: if it is present, the plugin forces `htmlspecialchars()` regardless of the filter state, and sets the "raw output" flag so that `escape_html` auto-escaping does not double-escape the result (matching Smarty's own behaviour for `{$var|escape:'html'}`).