### PR TITLE
SearchKit: Fix rendering in Safari

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -170,6 +170,11 @@
           $scope.$watch('$ctrl.filters', onChangeFilters, true);
         }
 
+        // Before testing visibility, ensure the search display tag has a layout box.
+        // Because `<crm-search-display-x>` is an unknown tag to browsers, some of them,
+        // e.g. Safari, do not assign it a layout box, making visibility indeterminate.
+        $element.css('display', 'block');
+
         // If the search display is visible, go ahead & run it
         if ($element.is(':visible')) {
           setUpWatches();


### PR DESCRIPTION
Overview
----------------------------------------
Fixes dev/core#6560

Before
----------------------------------------
Search displays sometimes not rendered in Safari.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
`<crm-search-display>` and its siblings `<crm-search-display-table>`, etc. are not standard HTML tags, and there's a known inconsistency with how they are treated:

- Chrome and Firefox generally assign unknown/custom elements a layout box (effectively behaving like inline elements).
- Safari has, in some versions, not generated a layout box for unknown elements unless they have an explicit display value (or are properly defined custom elements).

This can fool jQuery into returning `false` from `$element.is(':visible')` because it has no defined layout box.