### PR TITLE
LoggingTest - Update checkLogTableCreated() to pass on MariaDB

### DIFF
--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -236,7 +236,8 @@ class api_v3_LoggingTest extends CiviUnitTestCase {
     $dao->fetch();
     $this->assertEquals('log_civicrm_contact', $dao->Table);
     $tableField = 'Create_Table';
-    $this->assertStringContainsString('`log_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,', $dao->$tableField);
+    $this->assertMatchesRegularExpression(';`log_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP(\(\))?,;i', $dao->$tableField);
+    // MySQL tends to report `CURRENT_TIMESTAMP`, but MariaDB tends to report `current_timestamp()`.
     $this->assertStringContainsString('`log_conn_id` varchar(17)', $dao->$tableField);
     return $dao->$tableField;
   }


### PR DESCRIPTION
Overview
----------------------------------------

Fix test failures that only appear on MariaDB.

Technical Details
----------------------------------------

When calling `SHOW CREATE TABLE` on MySQL vs MariaDB, the `log_date` column is described in a slightly different way:

```sql
-- MySQL
`log_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n

-- MariaDB
`log_date` timestamp NOT NULL DEFAULT current_timestamp(),\n
```

This leads to test-failures in `checkLogTableCreated()`, because the string-comparison is too tight. The update allows either formulation.

