### PR TITLE
SearchKit - Ensure embedded subsearches are exported along with parent

### DIFF
--- a/Civi/Api4/Generic/ExportAction.php
+++ b/Civi/Api4/Generic/ExportAction.php
@@ -133,6 +133,21 @@ class ExportAction extends AbstractAction {
         $this->exportRecord('OptionGroup', $record['option_group_id'], $result);
       }
     }
+    // Include subsearches embedded in searchDisplay settings
+    if ($entityType === 'SearchDisplay') {
+      foreach ($record['settings']['columns'] ?? [] as $column) {
+        if (($column['type'] ?? '') === 'subsearch' && !empty($column['subsearch']['search'])) {
+          $subSearchId = civicrm_api4('SavedSearch', 'get', [
+            'checkPermissions' => $this->checkPermissions,
+            'select' => ['id'],
+            'where' => [['name', '=', $column['subsearch']['search']]],
+          ])->column('id')[0] ?? NULL;
+          if ($subSearchId && empty($this->exportedEntities['SavedSearch'][$subSearchId])) {
+            $this->exportRecord('SavedSearch', $subSearchId, $result);
+          }
+        }
+      }
+    }
     // Don't use joins/pseudoconstants if null or if it has the same value as the original
     foreach ($pseudofields as $alias => $fieldName) {
       if (!isset($record[$alias]) || $record[$alias] == ($record[$fieldName] ?? NULL)) {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchExportTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchExportTest.php
@@ -120,4 +120,89 @@ class SearchExportTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $this->assertEquals('TestSearchToExport', $export['SavedSearch_TestSearchToExport_SearchDisplay_SecondDisplayToExport']['params']['values']['saved_search_id.name']);
   }
 
+  /**
+   * Test using the Export action on a SavedSearch that embeds a subsearch.
+   */
+  public function testExportSearchWithSubsearch() {
+    $subSearch = SavedSearch::create(FALSE)
+      ->setValues([
+        'name' => 'SubSearchToExport',
+        'label' => 'SubSearchToExport',
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id'],
+        ],
+      ])
+      ->execute()->first();
+
+    SearchDisplay::create(FALSE)
+      ->setValues([
+        'name' => 'SubDisplayToExport',
+        'label' => 'SubDisplayToExport',
+        'saved_search_id.name' => 'SubSearchToExport',
+        'type' => 'table',
+        'settings' => [
+          'columns' => [
+            [
+              'key' => 'id',
+              'label' => 'Contact ID',
+              'type' => 'field',
+            ],
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ])
+      ->execute();
+
+    $search = SavedSearch::create(FALSE)
+      ->setValues([
+        'name' => 'TestSearchToExport',
+        'label' => 'TestSearchToExport',
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id'],
+        ],
+      ])
+      ->execute()->first();
+
+    SearchDisplay::create(FALSE)
+      ->setValues([
+        'name' => 'TestDisplayToExport',
+        'label' => 'TestDisplayToExport',
+        'saved_search_id.name' => 'TestSearchToExport',
+        'type' => 'table',
+        'settings' => [
+          'columns' => [
+            [
+              'key' => 'id',
+              'label' => 'Contact ID',
+              'type' => 'field',
+            ],
+            [
+              'type' => 'subsearch',
+              'subsearch' => [
+                'search' => 'SubSearchToExport',
+                'display' => 'SubDisplayToExport',
+                'subsearch_mode' => 'dropdown',
+              ],
+            ],
+          ],
+        ],
+        'acl_bypass' => FALSE,
+      ])
+      ->execute();
+
+    $export = SavedSearch::export(FALSE)
+      ->setId($search['id'])
+      ->execute()
+      ->indexBy('name');
+
+    $this->assertArrayHasKey('SavedSearch_TestSearchToExport', $export);
+    $this->assertArrayHasKey('SavedSearch_SubSearchToExport', $export);
+    $this->assertArrayHasKey('SavedSearch_SubSearchToExport_SearchDisplay_SubDisplayToExport', $export);
+    $this->assertArrayHasKey('SavedSearch_TestSearchToExport_SearchDisplay_TestDisplayToExport', $export);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

When exporting a SearchDisplay, this ensures any embedded saved searches are included.

https://lab.civicrm.org/dev/core/-/work_items/6567