### PR TITLE
SearchKit - Make "no results text" disableable 

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -145,6 +145,10 @@
         }
       };
 
+      this.toggleNoResultsText = () => {
+        ctrl.display.settings.noResultsText = ctrl.display.settings.noResultsText === false ? '' : false;
+      };
+
       this.getDataType = function(key) {
         const expr = ctrl.getExprFromSelect(key);
         const info = searchMeta.parseExpr(expr);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/noResultsText.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/noResultsText.html
@@ -1,0 +1,7 @@
+<div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the table is empty.') }}">
+  <label>
+    <input type="checkbox" ng-checked="$ctrl.display.settings.noResultsText !== false" ng-click="$ctrl.parent.toggleNoResultsText()">
+    {{:: ts('No Results Text') }}
+  </label>
+  <input class="form-control crm-flex-1" ng-if="$ctrl.display.settings.noResultsText !== false" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}" aria-label="{{:: ts('No Results Text') }}">
+</div>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayGrid.html
@@ -14,10 +14,7 @@
         </select>
         <div class="form-group" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
       </div>
-      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if there are no results.') }}">
-        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-      </div>
+      <div ng-include="'~/crmSearchAdmin/displays/common/noResultsText.html'"></div>
       <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>
       <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
       <search-admin-toolbar-config display="$ctrl.display" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></search-admin-toolbar-config>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayList.html
@@ -20,10 +20,7 @@
     </fieldset>
     <fieldset>
       <div class="form-inline crm-search-admin-flex-row" ng-include="'~/crmSearchAdmin/displays/common/searchButtonConfig.html'"></div>
-      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if no results.') }}">
-        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-      </div>
+      <div ng-include="'~/crmSearchAdmin/displays/common/noResultsText.html'"></div>
     </fieldset>
     <fieldset>
       <search-admin-pager-config display="$ctrl.display"></search-admin-pager-config>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -34,10 +34,7 @@
     <summary>{{:: ts('Style') }}</summary>
     <div class="crm-accordion-body">
       <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
-      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the table is empty.') }}">
-        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-      </div>
+      <div ng-include="'~/crmSearchAdmin/displays/common/noResultsText.html'"></div>
       <div class="form-inline">
         <label>{{:: ts('Table Style') }}</label>
         <div class="checkbox-inline form-control" ng-repeat="style in $ctrl.parent.tableClasses">

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTree.html
@@ -32,10 +32,7 @@
     <summary>{{:: ts('Style') }}</summary>
     <div class="crm-accordion-body">
       <search-admin-placeholder-config display="$ctrl.display"></search-admin-placeholder-config>
-      <div class="form-inline crm-search-admin-flex-row" title="{{:: ts('Text to display if the tree is empty.') }}">
-        <label for="crm-search-admin-display-no-results-text">{{:: ts('No Results Text') }}</label>
-        <input class="form-control crm-flex-1" id="crm-search-admin-display-no-results-text" ng-model="$ctrl.display.settings.noResultsText" placeholder="{{:: ts('None found.') }}">
-      </div>
+      <div ng-include="'~/crmSearchAdmin/displays/common/noResultsText.html'"></div>
       <search-admin-css-rules label="{{:: ts('Item Style') }}" item="$ctrl.display.settings"></search-admin-css-rules>
     </div>
   </details>

--- a/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
+++ b/ext/search_kit/ang/crmSearchDisplayGrid/crmSearchDisplayGrid.html
@@ -9,7 +9,7 @@
     class="crm-search-display-grid-container crm-search-display-grid-layout-{{$ctrl.settings.colno}}"
     ng-include="'~/crmSearchDisplayGrid/crmSearchDisplayGrid' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'"
   ></div>
-  <div ng-if="$ctrl.rowCount === 0" class="crm-search-display-grid-no-results">
+  <div ng-if="$ctrl.rowCount === 0 && $ctrl.settings.noResultsText !== false" class="crm-search-display-grid-no-results">
     <p class="alert alert-info text-center">
       {{ $ctrl.settings.noResultsText || ts('None found.') }}
     </p>

--- a/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
+++ b/ext/search_kit/ang/crmSearchDisplayList/crmSearchDisplayList.html
@@ -17,7 +17,7 @@
     ng-include="'~/crmSearchDisplayList/crmSearchDisplayList' + ($ctrl.loading ? 'Loading' : 'Items') + '.html'"
     ng-style="{'list-style': $ctrl.settings.symbol}"
     ></ul>
-   <div ng-if="$ctrl.rowCount === 0" class="crm-search-display-list-no-results">
+   <div ng-if="$ctrl.rowCount === 0 && $ctrl.settings.noResultsText !== false" class="crm-search-display-list-no-results">
       <p class="alert alert-info text-center">
         {{ $ctrl.settings.noResultsText || ts('None found.') }}
       </p>

--- a/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
+++ b/ext/search_kit/ang/crmSearchDisplayTable/crmSearchDisplayTableBody.html
@@ -19,7 +19,7 @@
   <td ng-repeat="(colIndex, colData) in row.columns track by $index" ng-if="$ctrl.columns[colIndex].enabled" ng-include=":: $ctrl.getFieldTemplate(colIndex, colData)" title="{{:: colData.title }}" ng-class="{'crm-search-field-editing': colData.editing}" class="crm-search-col-type-{{:: $ctrl.columns[colIndex].type }} {{:: $ctrl.getRowClass(row) }} {{:: colData.cssClass }} {{ row.cssClass }}" data-field-name="{{:: $ctrl.columns[colIndex].key }}">
   </td>
 </tr>
-<tr ng-if="$ctrl.rowCount === 0">
+<tr ng-if="$ctrl.rowCount === 0 && $ctrl.settings.noResultsText !== false">
   <td colspan="{{ $ctrl.columns.length + 2 }}">
     <p class="alert alert-info text-center">
       {{ $ctrl.settings.noResultsText || ts('None found.') }}

--- a/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.html
+++ b/ext/search_kit/ang/crmSearchDisplayTree/crmSearchDisplayTree.html
@@ -7,4 +7,9 @@
   </div>
   <ul ng-if="$ctrl.loading" ng-include="'~/crmSearchDisplayTree/crmSearchDisplayTreeLoading.html'"></ul>
   <crm-search-display-tree-branch ng-if="!$ctrl.loading" items="$ctrl.tree" parent-key="null"></crm-search-display-tree-branch>
+  <div ng-if="$ctrl.rowCount === 0 && $ctrl.tree.length === 0 && $ctrl.settings.noResultsText !== false" class="crm-search-display-list-no-results">
+    <p class="alert alert-info text-center">
+      {{ $ctrl.settings.noResultsText || ts('None found.') }}
+    </p>
+  </div>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Now you can turn off the "no results text" entirely for a search display.

<img width="409" height="179" alt="Screenshot 2026-07-02 at 3 12 18 PM" src="https://github.com/user-attachments/assets/02315cfb-f7a2-4374-be8c-787420b053b8" />

Comments
-----

Note: The "Tree" display had a configuration option for the "no results text" but wasn't actually showing it. This fixes that as well.