### PR TITLE
Afform - Show form type in page title

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -222,6 +222,11 @@
         return editor.afform.type;
       };
 
+      this.getFormTypeLabel = () => {
+        const options = this.meta.afform_fields.type.options;
+        return options.find(option => option.id === editor.afform.type).label;
+      };
+
       $scope.updateLayoutHtml = function() {
         $scope.layoutHtml = '...Loading...';
         crmApi4('Afform', 'convert', {layout: editor.afform.layout, from: 'deep', to: 'html', formatWhitespace: true})

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.html
@@ -1,5 +1,5 @@
 <div id="bootstrap-theme">
-  <h1 crm-page-title>{{ ts('FormBuilder: %1', {1: editor.afform.title || ts('Untitled')}) }}</h1>
+  <h1 crm-page-title>{{:: editor.getFormTypeLabel() }}: {{ editor.afform.title || ts('Untitled') }}</h1>
   <div id="afGuiEditor" class="crm-flex-box">
     <div id="afGuiEditor-palette" class="crm-flex-3" ng-include="'~/afGuiEditor/afGuiEditorPalette.html'"></div>
     <div id="afGuiEditor-canvas" class="crm-flex-5" ng-include="'~/afGuiEditor/afGuiEditorCanvas.html'"></div>


### PR DESCRIPTION
Overview
----------------------------------------
Better page title when editing a FormBuilder form.

Before
----------------------------------------
<img width="668" height="267" alt="Screenshot 2026-07-02 at 3 09 42 PM" src="https://github.com/user-attachments/assets/c0ff11e4-5fc7-476f-af42-e542f620d576" />

After
----------------------------------------
<img width="668" height="267" alt="Screenshot 2026-07-02 at 3 09 20 PM" src="https://github.com/user-attachments/assets/4ad3d3bb-b8d0-4703-bc5b-a103c9907355" />
