### PR TITLE
FormBuilder - Fix cross-contamination of field config

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -267,7 +267,7 @@
             fieldset['af-title'] = meta.label + ' ' + num;
             // Add boilerplate contents if any
             if (Array.isArray(meta.boilerplate) && meta.boilerplate.length) {
-              fieldset['#children'].push(...meta.boilerplate);
+              fieldset['#children'].push(..._.cloneDeep(meta.boilerplate));
             }
             // Attempt to place the new af-fieldset after the last one on the form
             pos = 1 + _.findLastIndex(editor.layout['#children'], 'af-fieldset');

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -165,6 +165,8 @@
           label: ts('Untitled'),
           required: false
         };
+        // Clone to prevent mutating shared metadata objects
+        defn = _.cloneDeep(defn);
         if (_.isEmpty(defn.input_attrs)) {
           defn.input_attrs = {};
         }


### PR DESCRIPTION
Overview
----------------------------------------
Solves the following bug:

1. Open a new FormBuilder for Individual
2. Add a second Individual to the form
3. Add some placeholder text to Individual1 first_name
4. Notice the same text now appears in Individual2 first_name