### PR TITLE
kcfinder - add normal Civi routes for browse, upload and assets

### DIFF
--- a/ext/ckeditor4/Civi/Kcfinder.php
+++ b/ext/ckeditor4/Civi/Kcfinder.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Civi;
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @service ckeditor4.kcfinder
+ */
+class Kcfinder extends AutoService implements EventSubscriberInterface {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'hook_civicrm_buildAsset' => [['buildJs', 0], ['buildCss', 0]],
+    ];
+  }
+
+  public function buildJs(GenericHookEvent $e): void {
+    if ($e->asset !== 'kcfinder.js') {
+      return;
+    }
+    $e->mimeType = 'text/javascript';
+
+    $content = implode("\n", [
+      $this->buildAsset('js', 'js'),
+      $this->buildAsset('js', 'themes/default'),
+      $this->getJsLocalize($e->params['lng']),
+    ]);
+
+    $content = $this->replaceUrls($content);
+
+    $e->content = $content;
+  }
+
+  public function buildCss(GenericHookEvent $e): void {
+    if ($e->asset !== 'kcfinder.css') {
+      return;
+    }
+
+    $e->mimeType = 'text/css';
+
+    $content = implode("\n", [
+      $this->buildAsset('css', 'css'),
+      $this->buildAsset('css', 'themes/default'),
+    ]);
+
+    $content = $this->replaceUrls($content);
+
+    $e->content = $content;
+  }
+
+  protected function buildAsset(string $type, string $directory): string {
+    $normalWorkingDir = \getcwd();
+    $kcfinderDir = \Civi::paths()->getPath('[civicrm.packages]/kcfinder');
+    chdir($kcfinderDir);
+    require_once 'core/autoload.php';
+
+    \ob_start();
+    $minifier = new \kcfinder\minifier($type);
+    $minifier->minify(NULL, $directory);
+    $content = \ob_get_clean();
+
+    chdir($normalWorkingDir);
+    return $content;
+  }
+
+  protected function replaceUrls(string $content): string {
+    $replacements = [];
+
+    $imageBaseUrl = (string) \Civi::url('[civicrm.packages]/kcfinder/themes/default/img')->setPreferFormat('absolute');
+    //$dynamicAssetUrl = \Civi::url('civicrm/kcfinder/asset');
+
+    $replacements = [
+      # php routes
+      'browse.php' => (string) \Civi::url('civicrm/kcfinder/browse'),
+      #static images
+      'themes/default/img/loading.gif' => "img/loading.gif",
+      'img/loading.gif' => "{$imageBaseUrl}/loading.gif",
+      'img/icons/upload.png' => "{$imageBaseUrl}/icons/upload.png",
+      'img/icons/refresh.png' => "{$imageBaseUrl}/icons/refresh.png",
+      'img/icons/settings.png' => "{$imageBaseUrl}/icons/settings.png",
+      'img/icons/maximize.png' => "{$imageBaseUrl}/icons/maximize.png",
+      'img/icons/about.png' => "{$imageBaseUrl}/icons/about.png",
+    ];
+
+    foreach ($replacements as $old => $new) {
+      $content = str_replace($old, $new, $content);
+    }
+
+    return $content;
+  }
+
+  protected function getJsLocalize(string $lang): string {
+    if (!$lang || $lang === 'en') {
+      return '';
+    }
+
+    $_GET['lng'] = $lang;
+    $normalWorkingDir = \getcwd();
+    $kcfinderDir = \Civi::paths()->getPath('[civicrm.packages]/kcfinder');
+    chdir($kcfinderDir);
+
+    \ob_start();
+    require_once 'js_localize.php';
+    $content = \ob_get_clean();
+
+    chdir($normalWorkingDir);
+    return $content;
+  }
+
+  public static function bootstrapPage() {
+    $_SESSION['KCFINDER']['disabled'] = FALSE;
+    $_SESSION['KCFINDER']['uploadURL'] = \CRM_Core_Config::singleton()->imageUploadURL;
+    $_SESSION['KCFINDER']['uploadDir'] = \CRM_Core_Config::singleton()->imageUploadDir;
+
+    $kcfinderPath = \Civi::paths()->getPath('[civicrm.packages]/kcfinder');
+    chdir($kcfinderPath);
+    require_once 'core/bootstrap.php';
+  }
+
+}

--- a/ext/ckeditor4/Civi/Kcfinder/Page/Browse.php
+++ b/ext/ckeditor4/Civi/Kcfinder/Page/Browse.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Civi\Kcfinder\Page;
+
+class Browse {
+
+  public static function run() {
+    \Civi\Kcfinder::bootstrapPage();
+    $browser = new \kcfinder\browser();
+    $browser->action();
+    exit();
+  }
+
+}

--- a/ext/ckeditor4/Civi/Kcfinder/Page/Upload.php
+++ b/ext/ckeditor4/Civi/Kcfinder/Page/Upload.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Civi\Kcfinder\Page;
+
+class Upload {
+
+  public static function run() {
+    \Civi\Kcfinder::bootstrapPage();
+    $uploader = new \kcfinder\uploader();
+    $uploader->upload();
+  }
+
+}

--- a/ext/ckeditor4/info.xml
+++ b/ext/ckeditor4/info.xml
@@ -38,6 +38,7 @@
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
     <mixin>smarty@1.0.3</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <civix>
     <namespace>CRM/Ckeditor4</namespace>

--- a/ext/ckeditor4/js/crm.ckeditor.js
+++ b/ext/ckeditor4/js/crm.ckeditor.js
@@ -54,8 +54,8 @@
 
     function initialize() {
       var
-        browseUrl = CRM.config.packagesBase + "kcfinder/browse.php?cms=civicrm",
-        uploadUrl = CRM.config.packagesBase + "kcfinder/upload.php?cms=civicrm&format=json",
+        browseUrl = CRM.url('civicrm/kcfinder/browse?reset=1'),
+        uploadUrl = CRM.url('civicrm/kcfinder/upload?reset=1&format=json'),
         preset = $(item).data('preset') || 'default',
         // This variable is always an array but a legacy extension could be setting it as a string.
         customConfig = (typeof CRM.config.CKEditorCustomConfig === 'string') ? CRM.config.CKEditorCustomConfig :

--- a/ext/ckeditor4/xml/Menu/ckeditor4.xml
+++ b/ext/ckeditor4/xml/Menu/ckeditor4.xml
@@ -6,4 +6,16 @@
     <page_callback>CRM_Ckeditor4_Form_CKEditorConfig</page_callback>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/kcfinder/browse</path>
+    <title>kcfinder browse</title>
+    <page_callback>Civi\Kcfinder\Page\Browse::run</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+  <item>
+    <path>civicrm/kcfinder/upload</path>
+    <title>kcfinder upload</title>
+    <page_callback>Civi\Kcfinder\Page\Upload::run</page_callback>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
Overview
----------------------------------------
Remove the need for icky custom entrypoint scripts which are fragile in multi-site deployments.

Before
----------------------------------------
- kcfinder has icky entrypoint scripts `browse.php` and `upload.php` which use some odd bootstrap code
- kcfinder has its own asset minifier, which also uses some odd code/caching

After
----------------------------------------
- normal routes for kcfinder at `civicrm/kcfinder/browse` and `civicrm/kcfinder/upload` which 
- can use asset builder to load kcfinder js/css using `Civi::url('assetBuilder://kcfinder.js')`, `Civi::url('assetBuilder://kcfinder.css')`


Technical Details
----------------------------------------
There's a corresponding MR for civicrm-packages incoming.

Comments
----------------------------------------
I remember @totten once called Kcfinder "the spawn of Satan, but better if it works".