### PR TITLE
Move smarty class to be being deployed using composer

### DIFF
--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -49,8 +49,8 @@ class CRM_Core_CodeGen_Util_Smarty {
     $base = dirname(__DIR__, 4);
     if (!class_exists('Smarty', FALSE)) {
       // Prefer Smarty v5; but if we get here in some scenario with another Smarty, use that.
-      $pkgs = file_exists(dirname($base) . "/civicrm-packages") ? dirname($base) . "/civicrm-packages" : "$base/packages";
-      require_once $pkgs . '/smarty5/Smarty.php';
+      $pkgs = file_exists(dirname($base) . "/civicrm-core") ? dirname($base) . "/civicrm-core" : "$base/";
+      require_once $pkgs . '/CRM/Core/Smarty/Smarty.php';
     }
     $smarty = new Smarty();
     $smarty->setTemplateDir("$base/xml/templates");

--- a/CRM/Core/Smarty/EscapeModifierCompilerOverride.php
+++ b/CRM/Core/Smarty/EscapeModifierCompilerOverride.php
@@ -1,0 +1,24 @@
+<?php
+
+use Smarty\Compile\Modifier\EscapeModifierCompiler;
+
+/**
+ * Smarty escape modifier plugin
+ * Type:     modifier
+ * Name:     escape
+ * Purpose:  escape string for output
+ *
+ * @author Rodney Rehm
+ */
+class CRM_Core_Smarty_EscapeModifierCompilerOverride extends EscapeModifierCompiler {
+
+  public function compile($params, \Smarty\Compiler\Template $compiler) {
+    $esc_type = $this->literal_compiler_param($params, 1, 'html');
+    if ($esc_type !== 'htmlall'
+    ) {
+      return parent::compile($params, $compiler);
+    }
+    return 'CRM_Core_Smarty::escape((string)' . $params[0] . ', "htmlall")';
+  }
+
+}

--- a/CRM/Core/Smarty/EscapeOverrideExtension.php
+++ b/CRM/Core/Smarty/EscapeOverrideExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+use Smarty\Extension\Base;
+
+class CRM_Core_Smarty_EscapeOverrideExtension extends Base {
+
+  public function getModifierCompiler(string $modifier): ?\Smarty\Compile\Modifier\ModifierCompilerInterface {
+    switch ($modifier) {
+      case 'escape':
+        return new CRM_Core_Smarty_EscapeModifierCompilerOverride();
+
+    }
+
+    return NULL;
+  }
+
+}

--- a/CRM/Core/Smarty/Smarty.php
+++ b/CRM/Core/Smarty/Smarty.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+class_alias('CRM_Core_Smarty_Smarty', 'Smarty');
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Core_Smarty_Smarty {
+
+  private \Smarty\Smarty $smarty;
+
+  private $registeredPluginDirectories = [];
+
+  public function __construct() {
+    $this->smarty = new Smarty\Smarty();
+    if (CRM_Utils_Constant::value('CIVICRM_SMARTY_DEFAULT_ESCAPE')) {
+      // See https://smarty-php.github.io/smarty/stable/api/extending/extensions/#writing-your-own-extension
+      $this->smarty->setExtensions([
+        new Smarty\Extension\CoreExtension(),
+        new CRM_Core_Smarty_EscapeOverrideExtension(),
+        new Smarty\Extension\DefaultExtension(),
+        new Smarty\Extension\BCPluginsAdapter($this->smarty),
+      ]);
+      $this->smarty->addDefaultModifiers(['escape:"htmlall"']);
+    }
+  }
+
+  public function __call($name, $arguments) {
+    return call_user_func_array([$this->smarty, $name], $arguments);
+  }
+
+  public function __get($name) {
+    // Quick form accesses these in HTML_QuickForm_Renderer_ArraySmarty->_renderRequired()
+    if ($name === 'left_delimiter') {
+      return $this->smarty->getLeftDelimiter();
+    }
+    if ($name === 'right_delimiter') {
+      return $this->smarty->getRightDelimiter();
+    }
+    return $this->smarty->$name;
+  }
+
+  public function __set($name, $value) {
+    $this->smarty->$name = $value;
+  }
+
+  /**
+   * @throws \Smarty\Exception
+   */
+  public function loadFilter($type, $name) {
+    if ($type === 'pre') {
+      $this->smarty->registerFilter($type, 'smarty_prefilter_' . $name);
+    }
+    else {
+      $this->smarty->loadFilter($type, $name);
+    }
+  }
+
+  /**
+   * @param null|string|array $pluginsDirectories
+   *
+   * @return void
+   * @throws \Smarty\Exception
+   */
+  public function addPluginsDir($pluginsDirectories): void {
+    foreach ((array) $pluginsDirectories as $pluginsDirectory) {
+      if (in_array($pluginsDirectory, $this->registeredPluginDirectories, TRUE)) {
+        continue;
+      }
+      $files = scandir($pluginsDirectory);
+      foreach ($files as $file) {
+        if (str_starts_with($file, '.')) {
+          continue;
+        }
+        $registeredPlugins = $this->smarty->registered_plugins;
+        if (CRM_Utils_File::isIncludable($pluginsDirectory . DIRECTORY_SEPARATOR . $file)) {
+          require_once $pluginsDirectory . DIRECTORY_SEPARATOR . $file;
+          $parts = explode('.', $file);
+          if (!empty($registeredPlugins[$parts[0]][$parts[1]])) {
+            continue;
+          }
+          $this->smarty->registerPlugin($parts[0], $parts[1], 'smarty_' . $parts[0] . '_' . $parts[1]);
+        }
+      }
+      $this->registeredPluginDirectories[] = $pluginsDirectory;
+    }
+  }
+
+  public function getVersion(): ?int {
+    return 5;
+  }
+
+}

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -37,7 +37,7 @@
  * @return string|null
  */
 function crm_smarty_compatibility_get_path() {
-  return \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php');
+  return \Civi::paths()->getPath('[civicrm.root]/CRM/Core/Smarty/Smarty.php');
 }
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,8 @@
     "dmore/chrome-mink-driver": "^2.9",
     "pontedilana/php-weasyprint": "^0.13.0 || ^1 || ^2",
     "knplabs/knp-snappy": "^1.4",
-    "phpseclib/phpseclib2_compat": "^1.0"
+    "phpseclib/phpseclib2_compat": "^1.0",
+    "smarty/smarty": "5.7.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2a9329b707efe4dec8a61352acc0955",
+    "content-hash": "b91c65d5a7be6cadc1af6e17b41f446e",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -4141,6 +4141,82 @@
                 "source": "https://github.com/scssphp/scssphp/tree/v1.13.0"
             },
             "time": "2024-08-17T21:02:11+00:00"
+        },
+        {
+            "name": "smarty/smarty",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/smarty-php/smarty.git",
+                "reference": "73da7e90f302175a570662fcb0ba41f57b7a92ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/73da7e90f302175a570662fcb0ba41f57b7a92ab",
+                "reference": "73da7e90f302175a570662fcb0ba41f57b7a92ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.27"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^7.5",
+                "smarty/smarty-lexer": "^4.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Smarty\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Monte Ohrt",
+                    "email": "monte@ohrt.com"
+                },
+                {
+                    "name": "Uwe Tews",
+                    "email": "uwe.tews@googlemail.com"
+                },
+                {
+                    "name": "Rodney Rehm",
+                    "email": "rodney.rehm@medialize.de"
+                },
+                {
+                    "name": "Simon Wisselink",
+                    "homepage": "https://www.iwink.nl/"
+                }
+            ],
+            "description": "Smarty - the compiling PHP template engine",
+            "homepage": "https://smarty-php.github.io/smarty/",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "forum": "https://github.com/smarty-php/smarty/discussions",
+                "issues": "https://github.com/smarty-php/smarty/issues",
+                "source": "https://github.com/smarty-php/smarty/tree/v5.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/wisskid",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-19T21:36:38+00:00"
         },
         {
             "name": "soundasleep/html2text",

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -12,8 +12,7 @@ class SmartyUtil {
   public static function createSmarty($srcPath) {
     if (!class_exists('Smarty', FALSE)) {
       // Prefer Smarty v5; but if we get here in some scenario with another Smarty, use that.
-      $packagePath = PackageUtil::getPath($srcPath);
-      require_once $packagePath . '/smarty5/Smarty.php';
+      require_once $srcPath . '/CRM/Core/Smarty/Smarty.php';
     }
     $smarty = new \Smarty();
     $smarty->setTemplateDir(implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']));

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -485,11 +485,11 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
     $versions = [
       '5_plain' => [
         'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 0,
-        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php'),
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.root]/CRM/Core/Smarty/Smarty.php'),
       ],
       '5_auto' => [
         'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 1,
-        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.packages]/smarty5/Smarty.php'),
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.root]/CRM/Core/Smarty/Smarty.php'),
       ],
     ];
 


### PR DESCRIPTION
Overview
----------------------------------------
This moves to shifting to a model of the smarty library being supplied via composer rather than in the packages

Before
----------------------------------------
smarty5 deployed using packages

After
----------------------------------------
smarty5 deployed using composer