### PR TITLE
Add crm-count class to Contribution tabs

### DIFF
--- a/templates/CRM/Contribute/Page/Tab.tpl
+++ b/templates/CRM/Contribute/Page/Tab.tpl
@@ -18,12 +18,12 @@
         {include file="CRM/common/TabSelected.tpl" defaultTab="contributions" tabContainer="#secondaryTabContainer"}
 
         <ul class="ui-tabs-nav ui-corner-all ui-helper-reset ui-helper-clearfix ui-widget-header">
-          <li id="tab_contributions" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active">
+          <li id="tab_contributions" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab ui-tabs-active ui-state-active crm-count-{$tabCount}">
             <a href="#contributions-subtab" title="{ts escape='htmlattribute'}Contributions{/ts}">
               {ts}Contributions{/ts} <em>{$tabCount}</em>
             </a>
           </li>
-          <li id="tab_recurring" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab">
+          <li id="tab_recurring" class="crm-tab-button ui-corner-all ui-tabs-tab ui-corner-top ui-state-default ui-tab crm-count-{$contributionRecurCount}">
             <a href="#recurring-subtab" title="{ts escape='htmlattribute'}Recurring Contributions{/ts}">
               {ts}Recurring Contributions{/ts} <em>{$contributionRecurCount}</em>
             </a>


### PR DESCRIPTION
Overview
----------------------------------------

Makes it easier to see when the tab count is zero or non-zero.

Before
----------------------------------------

<img width="1842" height="1010" alt="image" src="https://github.com/user-attachments/assets/d8015f21-43dc-43b9-988c-2f75f533a2f6" />


After
----------------------------------------

<img width="1842" height="1010" alt="image" src="https://github.com/user-attachments/assets/90e5d61d-c0ac-4dd9-bf30-5f1eeb8faa1b" />

Other example, where there are some contributions, but not recurring (which is what initially made me look into this)

<img width="1906" height="840" alt="image" src="https://github.com/user-attachments/assets/63e6cec1-0964-4f2f-8877-b5c81956f1ef" />


Technical Details
----------------------------------------

This pattern is used elsewhere for tabs.
