### PR TITLE
Fix getMaxErrorLevel()

### DIFF
--- a/Civi/Api4/Generic/Result.php
+++ b/Civi/Api4/Generic/Result.php
@@ -262,7 +262,10 @@ class Result extends \ArrayObject implements \JsonSerializable {
    * @return string|null
    */
   public function getMaxErrorLevel(): ?string {
-    $levels = array_column($this->errors, 'level');
+    $levels = [];
+    foreach ($this->errors as $error) {
+      $levels[] = $error->getLevel();
+    }
     // Returns the first match (ie. the most severe)
     return current(array_filter(
       $this->errorLevels,


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to #35966. Fixes getMaxErrorLevel. 

Before
----------------------------------------
Returns NULL

After
----------------------------------------
Returns the max error level

Technical Details
----------------------------------------
\Civi\Api4\Generic\Error is an object not an array so array_column doesn't work.

Comments
----------------------------------------
 @shaneonabike  this fixes the issue you found