### PR TITLE
Remove compressed layout on backend new Contribution, Participant and Relationship (and radio fix)

### DIFF
--- a/CRM/Core/Form.php
+++ b/CRM/Core/Form.php
@@ -1904,7 +1904,7 @@ class CRM_Core_Form extends HTML_QuickForm_Page {
         return $this->add('datepicker', $name, $label, $attributes, $required, $fieldSpec['datepicker']['extra']);
 
       case 'Radio':
-        $separator = $props['separator'] ?? NULL;
+        $separator = $props['separator'] ?? '';
         unset($props['separator']);
         if (!isset($props['allowClear'])) {
           $props['allowClear'] = !$required;

--- a/templates/CRM/Contact/Form/Relationship.tpl
+++ b/templates/CRM/Contact/Form/Relationship.tpl
@@ -11,7 +11,7 @@
 
   {if $action eq 2 or $action eq 1} {* add and update actions *}
     <div class="crm-block crm-form-block crm-relationship-form-block">
-      <table class="form-layout-compressed">
+      <table class="form-layout">
         <tr class="crm-relationship-form-block-relationship_type_id">
           <td class="label">{$form.relationship_type_id.label}</td>
           <td>{$form.relationship_type_id.html}</td>

--- a/templates/CRM/Contribute/Form/Contribution.tpl
+++ b/templates/CRM/Contribute/Form/Contribution.tpl
@@ -56,7 +56,7 @@
       </div>
     {/if}
       {if !empty($isOnline)}{assign var=valueStyle value=" class='view-value'"}{else}{assign var=valueStyle value=""}{/if}
-      <table class="form-layout-compressed">
+      <table class="form-layout">
         <tr class="crm-contribution-form-block-contact_id">
           <td class="label">{$form.contact_id.label}</td>
           <td>{$form.contact_id.html nofilter}</td>

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -68,7 +68,7 @@
       {$deleteMessage|smarty:nodefaults}
     </div>
     {else}
-      <table class="form-layout-compressed">
+      <table class="form-layout">
         <tr class="crm-membership-form-contact-id">
            <td class="label">{$form.contact_id.label}</td>
            <td>{$form.contact_id.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------

Uses a less compact layout for the New Contribution, New Participant and New Relationship forms.

There doesn't seem to be a good reason to compact the layout, and it can lead to wasted space or other layout glitches.

Examples
----------------------------------------

### New contribution - full screen

Ex: go to the menu: Contribution > New Contribution,  then select a price set:

Before:

<img width="3244" height="992" alt="image" src="https://github.com/user-attachments/assets/375fa9e5-a7f7-4e0e-b0f7-8b0af6d1ec74" />

After:

<img width="3244" height="992" alt="image" src="https://github.com/user-attachments/assets/0fb6aac6-5c7c-435d-af18-5cdf0466b91c" />

### New contribution - popup

Before:

<img width="3244" height="992" alt="image" src="https://github.com/user-attachments/assets/d4ca3d89-78db-4142-8001-936eb44b3e63" />

After:

<img width="3244" height="992" alt="image" src="https://github.com/user-attachments/assets/c7759dbc-0df4-4d82-8a3a-1d65b18f7474" />

### New Relationship

A bit unrelated, but while testing, I noticed the radio buttons had an incorrect padding here:

<img width="3244" height="992" alt="image" src="https://github.com/user-attachments/assets/0660d468-aad5-46e2-a43c-04b73a3382c1" />

After (with TheIsland, but it's just different colours):

<img width="3244" height="992" alt="image" src="https://github.com/user-attachments/assets/6620d9e2-8ca2-433e-b7b5-42dd31cb0c6a" />


Comments
----------------------------------------

for the radio button issues, see also #36055 and #35208

cc @vingle fyi