### PR TITLE
Cleanup - Remove unreachable return after throw statements

### DIFF
--- a/CRM/Core/BAO/Discount.php
+++ b/CRM/Core/BAO/Discount.php
@@ -122,7 +122,6 @@ class CRM_Core_BAO_Discount extends CRM_Core_DAO_Discount {
     if (empty($entityID) || empty($entityTable)) {
       // adding this here, to trap errors if values are not sent
       throw new CRM_Core_Exception('Invalid parameters passed to findSet function');
-      return NULL;
     }
 
     $dao = new CRM_Core_DAO_Discount();

--- a/CRM/Core/BAO/UFMatch.php
+++ b/CRM/Core/BAO/UFMatch.php
@@ -65,7 +65,6 @@ class CRM_Core_BAO_UFMatch extends CRM_Core_DAO_UFMatch {
     $session = CRM_Core_Session::singleton();
     if (!is_object($session)) {
       throw new CRM_Core_Exception('wow, session is not an object?');
-      return;
     }
 
     $userSystemID = $userSystem->getBestUFID($user);

--- a/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventSubscribe.php
@@ -114,7 +114,6 @@ SELECT     civicrm_email.id as email_id
 
     if (!$dao->fetch()) {
       throw new CRM_Core_Exception('Please file an issue with the backtrace');
-      return $success;
     }
 
     $se = new CRM_Mailing_Event_BAO_MailingEventSubscribe();

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1010,12 +1010,10 @@ abstract class CRM_Utils_System_Base {
   /**
    * Create CRM contacts for all existing CMS users
    *
-   * @return array
    * @throws \Exception
    */
   public function synchronizeUsers() {
     throw new Exception('CMS user creation not supported for this framework');
-    return [];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Remove unreachable return statements that immediately follow exception throws.

Before
----------------------------------------
In several files in the `CRM/` directory, a `return` statement was present directly after a `throw` statement. Because a `throw` halts execution and exits the block, these return statements were unreachable.

After
----------------------------------------
Just throw.
