### PR TITLE
Cleanup - Remove redundant break after return statements

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -572,15 +572,12 @@ AND        a.is_deleted = 0
       case $defaultAssigneeOptionsValues['BY_RELATIONSHIP']:
         return $this->getDefaultAssigneeByRelationship($activityParams, $activityTypeXML, $caseId);
 
-      break;
       case $defaultAssigneeOptionsValues['SPECIFIC_CONTACT']:
         return $this->getDefaultAssigneeBySpecificContact($activityTypeXML);
 
-      break;
       case $defaultAssigneeOptionsValues['USER_CREATING_THE_CASE']:
         return $activityParams['source_contact_id'];
 
-      break;
       case $defaultAssigneeOptionsValues['NONE']:
       default:
         return NULL;

--- a/CRM/Core/CodeGen/Config.php
+++ b/CRM/Core/CodeGen/Config.php
@@ -77,7 +77,6 @@ class CRM_Core_CodeGen_Config extends CRM_Core_CodeGen_BaseTask {
     foreach ($candidates as $candidate) {
       if (file_exists($candidate)) {
         return $candidate;
-        break;
       }
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Remove redundant and unreachable `break` statements that immediately follow `return` statements in switch-case blocks and loops.
