### PR TITLE
ACL contact cache: use DELETE instead of TRUNCATE to avoid deadlocks

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -175,15 +175,19 @@ WHERE  modified_date IS NULL
    */
   protected static function flushACLContactCache(): void {
     unset(Civi::$statics['CRM_ACL_API']);
-    // CRM_Core_DAO::singleValueQuery("TRUNCATE TABLE civicrm_acl_contact_cache"); // No, force-commits transaction
-    // CRM_Core_DAO::singleValueQuery("DELETE FROM civicrm_acl_contact_cache"); // Transaction-safe
+    // Use DELETE rather than TRUNCATE: TRUNCATE is DDL, so it force-commits the
+    // current transaction and bumps the table's metadata version. Concurrent
+    // connections with an open SELECT on civicrm_acl_contact_cache (e.g. a
+    // reminder cron or another web request) then hit MySQL error 1213
+    // ("Deadlock found... try restarting transaction") or "table definition
+    // has changed". DELETE is plain DML and transaction-safe.
     if (CRM_Core_Transaction::isActive()) {
       CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_COMMIT, function () {
-        CRM_Core_DAO::singleValueQuery('TRUNCATE TABLE civicrm_acl_contact_cache');
+        CRM_Core_DAO::singleValueQuery('DELETE FROM civicrm_acl_contact_cache');
       });
     }
     else {
-      CRM_Core_DAO::singleValueQuery("TRUNCATE TABLE civicrm_acl_contact_cache");
+      CRM_Core_DAO::singleValueQuery("DELETE FROM civicrm_acl_contact_cache");
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_ACL_BAO_Cache::flushACLContactCache()` uses `TRUNCATE TABLE civicrm_acl_contact_cache` to clear the ACL cache, including inside the `PHASE_POST_COMMIT` transaction callback. `TRUNCATE` is DDL and force-commits/bumps the table's metadata version, which can deadlock against any concurrent connection holding an open `SELECT` on that table (e.g. a reminder cron running at the same time as a group-membership change). Switching to `DELETE` removes the DDL side-effects while being functionally equivalent for a cache table.

Before
----------------------------------------
```php
CRM_Core_DAO::singleValueQuery('TRUNCATE TABLE civicrm_acl_contact_cache');
```
Under concurrent load (observed: a reminder cron + a contact group-add both touching `civicrm_acl_contact_cache`), this occasionally throws:
```
SQLSTATE[40001]: Serialization failure: 1213 Deadlock found when trying to get lock; try restarting transaction
```
or
```
Table definition has changed, please retry transaction
```
which aborted the in-progress event registration for the end user.

After
----------------------------------------
```php
CRM_Core_DAO::singleValueQuery('DELETE FROM civicrm_acl_contact_cache');
```
`DELETE` is plain DML and transaction-safe, so it no longer triggers an implicit commit or a metadata-version bump. No AUTO_INCREMENT reset is needed for this table, so behavior is otherwise identical.

Technical Details
----------------------------------------
Two commented-out alternatives (`TRUNCATE ... // No, force-commits transaction` / `DELETE ... // Transaction-safe`) were already present in the code next to the live `TRUNCATE` calls, suggesting this trade-off had been considered before but the `TRUNCATE` variant was left active. This PR removes the dead comments and applies the `DELETE` variant in both branches of `flushACLContactCache()` (the immediate path and the post-commit callback).

Comments
----------------------------------------
Fix has been running in production for several hours without incident after the deadlock was reproduced under real concurrent traffic (reminder cron + registration). Happy to open a matching issue on lab.civicrm.org if that's preferred/required before review.

Fixes https://lab.civicrm.org/dev/core/-/work_items/6623
