### PR TITLE
dev/core#6547 Create currency type field

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -243,20 +243,22 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Generic {
    * @throws \CRM_Core_Exception
    */
   public static function updateEnabledCurrencies(array $currencies, string $default): void {
-
-    // sort so that when we display drop down, weights have right value
-    sort($currencies);
-    // get labels for all the currencies
     $options = [];
 
-    $currencySymbols = self::getCurrencySymbols();
-    foreach ($currencies as $i => $currency) {
+    $currencyDetails = \Civi\Api4\Currency::get(FALSE)
+      ->addWhere('name', 'IN', $currencies)
+      ->addSelect('name', 'full_name')
+      ->addSelect('IFNULL(CONCAT(name, " (", symbol, ")"), name) AS name_and_symbol')
+      ->addOrderBy('name', 'ASC')
+      ->execute();
+
+    foreach ($currencyDetails as $i => $currency) {
       $options[] = [
-        'label' => $currencySymbols[$currency],
-        'value' => $currency,
+        'label' => $currency['name_and_symbol'],
+        'value' => $currency['name'],
         'weight' => $i + 1,
-        'is_active' => 1,
-        'is_default' => $currency === $default,
+        'description' => $currency['full_name'],
+        'is_default' => $currency['name'] === $default,
       ];
     }
     $optionGroupID = OptionGroup::get(FALSE)->addSelect('id')

--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -76,6 +76,11 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
         'label' => ts('Country'),
       ],
       [
+        'id' => 'Currency',
+        'name' => 'Currency',
+        'label' => ts('Currency'),
+      ],
+      [
         'id' => 'File',
         'name' => 'File',
         'label' => ts('File'),
@@ -113,6 +118,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       'Country' => 'Integer',
       'File' => 'Integer',
       'Link' => 'String',
+      'Currency' => 'String',
       'ContactReference' => 'Integer',
       'EntityReference' => 'Integer',
     ];
@@ -120,7 +126,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
     if ($dataType === 'Date' && !empty($customField['time_format'])) {
       $dataType = 'Timestamp';
     }
-    if (!empty($customField['fk_entity'])) {
+    if (!empty($customField['fk_entity']) && $customField['data_type'] !== 'Currency') {
       $dataType = CRM_Core_BAO_CustomValueTable::getDataTypeForPrimaryKey($customField['fk_entity']);
     }
 
@@ -146,6 +152,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
       'StateProvince' => CRM_Utils_Type::T_INT,
       'File' => CRM_Utils_Type::T_STRING,
       'Link' => CRM_Utils_Type::T_STRING,
+      'Currency' => CRM_Utils_Type::T_STRING,
       'ContactReference' => CRM_Utils_Type::T_INT,
       'EntityReference' => CRM_Utils_Type::T_INT,
       'Country' => CRM_Utils_Type::T_INT,
@@ -2723,6 +2730,7 @@ WHERE      f.id IN ($ids)";
     $dataTypeToFK = [
       'ContactReference' => 'Contact',
       'File' => 'File',
+      'Currency' => 'Currency',
     ];
     return $field['fk_entity'] ?? $dataTypeToFK[$field['data_type']] ?? NULL;
   }
@@ -2789,6 +2797,11 @@ WHERE      f.id IN ($ids)";
         'labelColumn' => 'name',
       ];
     }
+    elseif ($field['data_type'] == 'Currency') {
+      $field['pseudoconstant'] = [
+        'optionGroupName' => 'currencies_enabled',
+      ];
+    }
   }
 
   /**
@@ -2831,13 +2844,14 @@ WHERE      f.id IN ($ids)";
       'StateProvince' => 'civicrm_state_province',
       'ContactReference' => 'civicrm_contact',
       'File' => 'civicrm_file',
+      'Currency' => 'civicrm_currency',
       'EntityReference' => CoreUtil::getInfoItem((string) $field->fk_entity, 'table_name'),
     ];
     if (isset($fkFields[$field->data_type])) {
       // Serialized fields store value-separated strings which are incompatible with FK constraints
       if (!$field->serialize) {
         $params['fk_table_name'] = $fkFields[$field->data_type];
-        $params['fk_field_name'] = 'id';
+        $params['fk_field_name'] = $field->data_type === 'Currency' ? 'name' : 'id';
         $params['fk_attributes'] = 'ON DELETE SET NULL';
       }
     }
@@ -2867,6 +2881,9 @@ WHERE      f.id IN ($ids)";
       // This will hold the list of options in format key => label
       $options = [];
 
+      if ($dataType === 'Currency') {
+        $optionGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'currencies_enabled', 'id', 'name');
+      }
       if ($optionGroupID) {
         $options = CRM_Core_OptionGroup::valuesByID(
           $optionGroupID, FALSE, FALSE, FALSE, $context === 'validate' ? 'name' : 'label', !($context === 'validate' || $context === 'get')

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -299,7 +299,7 @@ class CRM_Core_BAO_CustomValueTable {
    *   the mysql data store placeholder
    */
   public static function fieldToSQLType(string $type, $maxLength = NULL, bool $isSerialized = FALSE, ?string $fkEntity = NULL) {
-    if ($fkEntity) {
+    if ($fkEntity && $fkEntity !== 'Currency') {
       $type = self::getDataTypeForPrimaryKey($fkEntity);
     }
 
@@ -310,6 +310,10 @@ class CRM_Core_BAO_CustomValueTable {
     switch ($type) {
       case 'String':
         $maxLength = $maxLength ?: 255;
+        return "varchar($maxLength)";
+
+      case 'Currency':
+        $maxLength = $maxLength ?: 3;
         return "varchar($maxLength)";
 
       case 'Link':

--- a/CRM/Core/BAO/CustomValueTable.php
+++ b/CRM/Core/BAO/CustomValueTable.php
@@ -146,6 +146,7 @@ class CRM_Core_BAO_CustomValueTable {
               break;
 
             case 'RichTextEditor':
+            case 'Currency':
               $type = 'String';
               break;
 

--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -864,6 +864,7 @@ MODIFY      {$columnName} varchar( $length )
         ];
       }
     }
+    CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 0', [], TRUE, NULL, FALSE, FALSE);
     foreach ($tables as $table => $param) {
       $query = "ALTER TABLE $table";
       $dao = CRM_Core_DAO::executeQuery("SHOW FULL COLUMNS FROM $table", [], TRUE, NULL, FALSE, FALSE);
@@ -910,6 +911,7 @@ MODIFY      {$columnName} varchar( $length )
       // Disable i18n rewrite.
       CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, FALSE);
     }
+    CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 1', [], TRUE, NULL, FALSE, FALSE);
     // Rebuild triggers and other schema reconciliation if needed.
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();

--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -371,6 +371,7 @@ class CRM_Core_DAO extends DB_DataObject {
     $FKClassName = $fieldDef['FKClassName'] ?? NULL;
     $dbName = $fieldDef['name'];
     $daoName = str_replace('_BAO_', '_DAO_', get_class($this));
+    $fkColumnName = $fieldDef['FKColumnName'] ?? 'id';
 
     // skip the FK if it is not required
     // if it's contact id we should create even if not required
@@ -382,24 +383,24 @@ class CRM_Core_DAO extends DB_DataObject {
     if (!$required && $dbName != 'contact_id') {
       $fkDAO = new $FKClassName();
       if ($fkDAO->find(TRUE)) {
-        $this->$dbName = $fkDAO->id;
+        $this->$dbName = $fkDAO->$fkColumnName;
       }
     }
 
     elseif (in_array($FKClassName, CRM_Core_DAO::$_testEntitiesToSkip)) {
       $depObject = new $FKClassName();
       $depObject->find(TRUE);
-      $this->$dbName = $depObject->id;
+      $this->$dbName = $depObject->$fkColumnName;
     }
     elseif ($daoName == 'CRM_Member_DAO_MembershipType' && $fieldName == 'member_of_contact_id') {
       // FIXME: the fields() metadata is not specific enough
       $depObject = CRM_Core_DAO::createTestObject($FKClassName, ['contact_type' => 'Organization']);
-      $this->$dbName = $depObject->id;
+      $this->$dbName = $depObject->$fkColumnName;
     }
     else {
       //if it is required we need to generate the dependency object first
       $depObject = CRM_Core_DAO::createTestObject($FKClassName, $params[$dbName] ?? 1);
-      $this->$dbName = $depObject->id;
+      $this->$dbName = $depObject->$fkColumnName;
     }
   }
 
@@ -2463,7 +2464,9 @@ SELECT contact_id
     $config->backtrace = TRUE;
 
     $object = new $daoName();
-    $object->id = $params['id'] ?? NULL;
+    foreach ($params as $k => $v) {
+      $object->$k = $v;
+    }
 
     // array(array(0 => $daoName, 1 => $daoParams))
     $deletions = [];
@@ -2476,6 +2479,7 @@ SELECT contact_id
 
         $FKClassName = $value['FKClassName'] ?? NULL;
         $required = $value['required'] ?? NULL;
+        $fkColumnName = $value['FKColumnName'] ?? 'id';
         if ($FKClassName != NULL
           && $object->$dbName
           && !in_array($FKClassName, CRM_Core_DAO::$_testEntitiesToSkip)
@@ -2485,7 +2489,7 @@ SELECT contact_id
           && $dbName != 'member_of_contact_id'
         ) {
           // x
-          $deletions[] = [$FKClassName, ['id' => $object->$dbName]];
+          $deletions[] = [$FKClassName, [$fkColumnName => $object->$dbName]];
         }
       }
     }

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -247,6 +247,17 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
 
     $this->addToggle('serialize', ts('Multi-Select'));
 
+    // Fetch currency options for entity
+    $extends = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $this->_gid, 'extends');
+    $currencyOptions = civicrm_api4($extends, 'getFields', [
+      'checkPermissions' => FALSE,
+      'where' => [
+        ['fk_entity', '=', 'Currency'],
+      ],
+    ])->column('title', 'name');
+
+    $this->add('select', 'control_field', ts('Currency Field'), ['' => ts('None (Site Default)')] + $currencyOptions);
+
     $this->addAutocomplete('fk_entity', ts('Entity'), [
       'class' => 'twenty',
       // Don't allow entity to be changed once field is created

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -56,6 +56,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
 
   private static $htmlTypesWithMandatorySerialize = ['CheckBox'];
 
+  private static $dataTypesWithoutSerialize = ['EntityReference', 'Currency'];
+
+  private static $dataTypesWithoutOptionGroup = ['Boolean', 'Country', 'StateProvince', 'ContactReference', 'EntityReference', 'Currency'];
+
   /**
    * Maps each data_type to allowed html_type options
    *
@@ -71,6 +75,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     'Boolean' => ['Toggle', 'Radio'],
     'StateProvince' => ['Select'],
     'Country' => ['Select'],
+    'Currency' => ['Select'],
     'File' => ['File'],
     'Link' => ['Link'],
     'ContactReference' => ['Autocomplete-Select'],
@@ -89,6 +94,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     $this->assign('dataToHTML', self::$_dataToHTML);
     $this->assign('htmlTypesWithOptionalSerialize', self::$htmlTypesWithOptionalSerialize);
     $this->assign('htmlTypesWithMandatorySerialize', self::$htmlTypesWithMandatorySerialize);
+    $this->assign('dataTypesWithoutSerialize', self::$dataTypesWithoutSerialize);
 
     $this->_values = [];
     //get the values form db if update.
@@ -764,8 +770,8 @@ SELECT count(*)
         $_flagOption = $_emptyRow = 0;
       }
     }
-    elseif (in_array($htmlType, self::$htmlTypesWithOptions) &&
-      !in_array($dataType, ['Boolean', 'Country', 'StateProvince', 'ContactReference', 'EntityReference'])
+    elseif (in_array($htmlType, self::$htmlTypesWithOptions, TRUE) &&
+      !in_array($dataType, self::$dataTypesWithoutOptionGroup, TRUE)
     ) {
       if (!$fields['option_group_id']) {
         $errors['option_group_id'] = ts('You must select a Multiple Choice Option set if you chose Reuse an existing set.');
@@ -827,7 +833,7 @@ AND    option_group_id = %2";
 
     // If switching to a new option list, validate existing data
     if (empty($errors) && $self->_id && in_array($htmlType, self::$htmlTypesWithOptions) &&
-      !in_array($dataType, ['Boolean', 'Country', 'StateProvince', 'ContactReference', 'EntityReference'])) {
+      !in_array($dataType, self::$dataTypesWithoutOptionGroup, TRUE)) {
       $oldHtmlType = $self->_values['html_type'];
       $oldOptionGroup = $self->_values['option_group_id'];
       if ($oldHtmlType === 'Text' || $oldOptionGroup != $fields['option_group_id'] || $fields['option_type'] == 1) {

--- a/CRM/Export/BAO/ExportProcessor.php
+++ b/CRM/Export/BAO/ExportProcessor.php
@@ -1443,7 +1443,7 @@ class CRM_Export_BAO_ExportProcessor {
     // tests will fail on the enotices until they all are & then all the 'else'
     // below can go.
     $fieldSpec = $queryFields[$columnName] ?? [];
-    if (empty($fieldSpec['html_type']) && !empty($fieldSpec['html'])) {
+    if (empty($fieldSpec['html_type']) && !empty($fieldSpec['html']['type'])) {
       $fieldSpec['html_type'] = $fieldSpec['html']['type'];
     }
     elseif (empty($fieldSpec['html_type'])) {

--- a/CRM/Financial/BAO/Currency.php
+++ b/CRM/Financial/BAO/Currency.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Core\Event\GenericHookEvent;
+use Civi\Core\HookInterface;
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+class CRM_Financial_BAO_Currency extends CRM_Financial_DAO_Currency implements HookInterface {
+
+  /**
+   * Provide default SearchDisplay for Currency autocompletes
+   *
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   */
+  public static function on_civi_search_defaultDisplay(GenericHookEvent $e) {
+    if ($e->display['settings'] || $e->display['type'] !== 'autocomplete' || $e->savedSearch['api_entity'] !== 'Currency') {
+      return;
+    }
+    $e->display['settings'] = [
+      'sort' => [
+        ['full_name', 'ASC'],
+      ],
+      'columns' => [
+        [
+          'type' => 'field',
+          'key' => 'full_name',
+        ],
+        [
+          'type' => 'field',
+          'key' => 'name',
+          'rewrite' => '[symbol] [name]',
+        ],
+      ],
+    ];
+  }
+
+}

--- a/CRM/Logging/ReportDetail.php
+++ b/CRM/Logging/ReportDetail.php
@@ -244,7 +244,8 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
           $from = $values[$field][$from];
         }
         elseif (!empty($from) && !empty($fkClassName)) {
-          $from = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $from);
+          $fkColumnName = $tableDAOFields[$field]['FKColumnName'] ?? 'id';
+          $from = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $from, $fkColumnName);
         }
         elseif (!empty($from) && is_numeric($from) && array_key_exists("id", $cfArray) && is_int($cfArray["id"])) {
           // Translate the id into something more useful for display, namely for id's that refer to option values and contacts.
@@ -265,7 +266,8 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
           $to = $values[$field][$to];
         }
         elseif (!empty($to) && !empty($fkClassName)) {
-          $to = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $to);
+          $fkColumnName = $tableDAOFields[$field]['FKColumnName'] ?? 'id';
+          $to = $this->convertForeignKeyValuesToLabels($fkClassName, $field, $to, $fkColumnName);
         }
         elseif (!empty($to) && is_numeric($to) && array_key_exists("id", $cfArray) && is_int($cfArray["id"])) {
           // Translate the id into something more useful for display, namely for id's that refer to option values and contacts.
@@ -521,14 +523,15 @@ class CRM_Logging_ReportDetail extends CRM_Report_Form {
    *
    * @param string $fkClassName
    * @param string $field
-   * @param int $keyval
+   * @param string|int $keyval
+   * @param string $fkColumnName
    * @return string
    */
-  private function convertForeignKeyValuesToLabels(string $fkClassName, string $field, int $keyval): string {
+  private function convertForeignKeyValuesToLabels(string $fkClassName, string $field, string|int $keyval, string $fkColumnName = 'id'): string {
     if ($fkClassName::getLabelField()) {
-      $labelValue = CRM_Core_DAO::getFieldValue($fkClassName, $keyval, $fkClassName::getLabelField());
+      $labelValue = CRM_Core_DAO::getFieldValue($fkClassName, $keyval, $fkClassName::getLabelField(), $fkColumnName);
       // Not sure if this should use ts - there's not a lot of context (`%1 (id: %2)`) - and also the similar field labels above don't use ts.
-      return "{$labelValue} (id: {$keyval})";
+      return "{$labelValue} ({$fkColumnName}: {$keyval})";
     }
     return (string) $keyval;
   }

--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -74,6 +74,27 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
     ]);
     $this->addTask(ts('Create index %1', [1 => 'civicrm_membership_status.UI_name']), 'addIndex', 'civicrm_membership_status', 'name', 'UI');
     $this->addTask(ts('Create index %1', [1 => 'civicrm_participant_status_type.UI_name']), 'addIndex', 'civicrm_participant_status_type', 'name', 'UI');
+
+    $this->addTask('Add unique index to Currency.name', 'addIndex', 'civicrm_currency', 'name', 'UI');
+
+    // Add FK to currency fields
+    $entitiesWithCurrency = [
+      'Contribution' => 'currency',
+      'ContributionPage' => 'currency',
+      'ContributionRecur' => 'currency',
+      'ContributionSoft' => 'currency',
+      'Product' => 'currency',
+      'Event' => 'currency',
+      'Participant' => 'fee_currency',
+      'FinancialItem' => 'currency',
+      'FinancialTrxn' => 'currency',
+      'PCP' => 'currency',
+      'Pledge' => 'currency',
+      'PledgePayment' => 'currency',
+    ];
+    foreach ($entitiesWithCurrency as $entityName => $fieldName) {
+      $this->addTask("Add foreign key to $entityName.$fieldName", 'addCurrencyFk', $entityName, $fieldName);
+    }
   }
 
   /**
@@ -89,6 +110,23 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
       SET weight = id
       WHERE weight = 0
     ");
+
+    return TRUE;
+  }
+
+  public static function addCurrencyFk($ctx, $entityName, $fieldName): bool {
+    $tableName = Civi::entity($entityName)->getMeta('table');
+
+    // Safety check, remove any invalid currency
+    CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$fieldName` = NULL WHERE `$fieldName` IS NOT NULL AND `$fieldName` NOT IN (SELECT `name` FROM `civicrm_currency`)", i18nRewrite: FALSE);
+
+    Civi::schemaHelper()->createForeignKey($tableName, $fieldName, [
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
+    ]);
 
     return TRUE;
   }

--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -95,6 +95,15 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
     foreach ($entitiesWithCurrency as $entityName => $fieldName) {
       $this->addTask("Add foreign key to $entityName.$fieldName", 'addCurrencyFk', $entityName, $fieldName);
     }
+
+    $this->addTask('Add CustomField.control_field column', 'alterSchemaField', 'CustomField', 'control_field', [
+      'title' => ts('Depends on'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Select',
+      'description' => ts('Name of the field that this field depends on.'),
+      'add' => '6.18',
+      'default' => NULL,
+    ], 'AFTER in_selector');
   }
 
   /**

--- a/CRM/Upgrade/Incremental/sql/6.18.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.18.alpha1.mysql.tpl
@@ -34,3 +34,8 @@ UPDATE civicrm_participant_status_type s1, civicrm_participant_status_type s2
   SET s2.name = CONCAT(s2.name, '_', s2.id)
   WHERE s2.name = s1.name AND s2.id > s1.id;
 
+UPDATE civicrm_option_value v
+  INNER JOIN civicrm_option_group g ON v.option_group_id = g.id
+  INNER JOIN civicrm_currency c ON v.value = c.name
+  SET {localize field='description'}v.description = c.full_name{/localize}
+  WHERE g.name = 'currencies_enabled';

--- a/CRM/Utils/Type.php
+++ b/CRM/Utils/Type.php
@@ -382,6 +382,7 @@ class CRM_Utils_Type {
       'Timestamp',
       'ContactReference',
       'EntityReference',
+      'Currency',
       'MysqlColumnNameOrAlias',
       'MysqlOrderByDirection',
       'MysqlOrderBy',
@@ -418,6 +419,7 @@ class CRM_Utils_Type {
       case 'String':
       case 'Link':
       case 'Memo':
+      case 'Currency':
         return $data;
 
       case 'Date':

--- a/Civi/Api4/Currency.php
+++ b/Civi/Api4/Currency.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+namespace Civi\Api4;
+
+/**
+ * Currency entity.
+ *
+ * @searchFields full_name
+ * @since 6.18
+ * @package Civi\Api4
+ */
+class Currency extends Generic\DAOEntity {
+
+}

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -287,13 +287,18 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
           $addressField = \Civi::entity('Address')->getField($addressFieldName);
           $field['pseudoconstant'] = $addressField['pseudoconstant'];
         }
+        if ($customField['data_type'] === 'Currency') {
+          $field['pseudoconstant'] = [
+            'option_group_name' => 'currencies_enabled',
+          ];
+        }
         // Set FK for EntityRef, ContactRef & File fields
         $fkEntity = \CRM_Core_BAO_CustomField::getFkEntity($customField);
         if ($fkEntity) {
           $onDelete = empty($customField['fk_entity_on_delete']) ? 'SET NULL' : strtoupper(str_replace('_', ' ', $customField['fk_entity_on_delete']));
           $field['entity_reference'] = [
             'entity' => $fkEntity,
-            'key' => 'id',
+            'key' => $fkEntity === 'Currency' ? 'name' : 'id',
             'on_delete' => $onDelete,
           ];
         }

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -326,6 +326,10 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
             $field['pseudoconstant']['prefetch'] = 'disabled';
           }
         }
+        // Control field
+        if (isset($customField['control_field'])) {
+          $field['input_attrs']['control_field'] = $customField['control_field'];
+        }
         $customFields[$fieldName] = $field;
       }
     }

--- a/api/v3/utils.php
+++ b/api/v3/utils.php
@@ -1745,14 +1745,15 @@ function _civicrm_api3_getValidDate($dateValue, $fieldName, $fieldType) {
  */
 function _civicrm_api3_validate_constraint($fieldValue, $fieldName, $fieldInfo, $entity) {
   $daoName = $fieldInfo['FKClassName'];
+  $fkColumnName = $fieldInfo['FKColumnName'] ?? 'id';
   $fieldInfo = [$fieldName => $fieldInfo];
   $params = [$fieldName => $fieldValue];
   _civicrm_api3_validate_fields($entity, NULL, $params, $fieldInfo);
   /** @var CRM_Core_DAO $dao */
   $dao = new $daoName();
-  $dao->id = $params[$fieldName];
+  $dao->$fkColumnName = $params[$fieldName];
   $dao->selectAdd();
-  $dao->selectAdd('id');
+  $dao->selectAdd($fkColumnName);
   if (!$dao->find()) {
     throw new CRM_Core_Exception("$fieldName is not valid : " . $fieldValue);
   }
@@ -2236,7 +2237,7 @@ function _civicrm_api3_validate_html(&$params, &$fieldName, $fieldInfo) {
  * @throws Exception
  */
 function _civicrm_api3_validate_string(&$params, &$fieldName, &$fieldInfo, $entity, $action) {
-  $isGet = substr($action, 0, 3) === 'get';
+  $isGet = substr($action ?? '', 0, 3) === 'get';
   [$fieldValue, $op] = _civicrm_api3_field_value_check($params, $fieldName, 'String');
   if (str_contains(($op ?? ''), 'NULL') || str_contains(($op ?? ''), 'EMPTY') || CRM_Utils_System::isNull($fieldValue)) {
     return;

--- a/ext/civigrant/CRM/Grant/Upgrader.php
+++ b/ext/civigrant/CRM/Grant/Upgrader.php
@@ -62,4 +62,20 @@ class CRM_Grant_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_1003(): bool {
+    $this->ctx->log->info('Applying Update 1003 - Adding FK to currency field');
+    $tableName = 'civicrm_grant';
+    $fieldName = 'currency';
+
+    E::schema()->createForeignKey($tableName, $fieldName, [
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'CASCADE',
+      ],
+    ]);
+
+    return TRUE;
+  }
+
 }

--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -181,6 +181,9 @@ return [
     'amount_requested' => [
       'title' => E::ts('Amount Requested in Original Currency'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'description' => E::ts('Requested grant amount, in original currency (optional).'),
       'add' => '1.8',

--- a/ext/civigrant/schema/Grant.entityType.php
+++ b/ext/civigrant/schema/Grant.entityType.php
@@ -213,6 +213,11 @@ return [
       'input_attrs' => [
         'maxlength' => 3,
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'CASCADE',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1704,61 +1704,50 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
     $moneyFieldAlias = array_keys($clause['fields'])[0];
     $moneyField = $clause['fields'][$moneyFieldAlias];
-    $prefix = substr($moneyFieldAlias, 0, strrpos($moneyFieldAlias, $moneyField['name']));
 
-    // Custom fields do their own thing wrt currency
-    if ($moneyField['type'] === 'Custom') {
-      return NULL;
-    }
+    if (!empty($moneyField['input_attrs']['control_field'])) {
+      $prefix = substr($moneyFieldAlias, 0, strrpos($moneyFieldAlias, $moneyField['name']));
+      $currencyFieldName = $prefix . $moneyField['input_attrs']['control_field'];
 
-    // First look for a currency field on the same entity as the money field
-    $ownCurrencyField = $this->findCurrencyField($moneyField['entity']);
-    if ($ownCurrencyField) {
-      return $this->currencyFields[$select] = $prefix . $ownCurrencyField;
-    }
-
-    // Next look at the previously-joined entity
-    if ($prefix && $this->getQuery()) {
-      $parentJoin = $this->getQuery()->getJoinParent(rtrim($prefix, '.'));
-      $parentCurrencyField = $parentJoin ? $this->findCurrencyField($this->getQuery()->getExplicitJoin($parentJoin)['entity']) : NULL;
-      if ($parentCurrencyField) {
-        return $this->currencyFields[$select] = $parentJoin . '.' . $parentCurrencyField;
-      }
-    }
-
-    // Fall back on the base entity
-    $baseCurrencyField = $this->findCurrencyField($this->savedSearch['api_entity']);
-    if ($baseCurrencyField) {
-      return $this->currencyFields[$select] = $baseCurrencyField;
-    }
-
-    // Finally, try adding an implicit join
-    // e.g. the LineItem entity can use `contribution_id.currency`
-    foreach ($this->findFKFields($moneyField['entity']) as $fieldName => $fkEntity) {
-      $joinCurrencyField = $this->findCurrencyField($fkEntity);
-      if ($joinCurrencyField) {
-        return $this->currencyFields[$select] = $prefix . $fieldName . '.' . $joinCurrencyField;
-      }
-    }
-    return NULL;
-  }
-
-  /**
-   * Find currency field for an entity.
-   *
-   * @param string $entityName
-   * @return string|null
-   */
-  private function findCurrencyField(string $entityName): ?string {
-    $entityDao = CoreUtil::getInfoItem($entityName, 'dao');
-    if ($entityDao) {
-      // Check for a pseudoconstant that points to civicrm_currency.
-      foreach ($entityDao::getSupportedFields() as $fieldName => $field) {
-        if (($field['pseudoconstant']['table'] ?? NULL) === 'civicrm_currency') {
-          return $fieldName;
+      // If the currency field specifies a join, check if this entity is already joined to it.
+      if (str_contains($moneyField['input_attrs']['control_field'], '.')) {
+        [$joinEntityFieldName, $controlFieldName] = explode('.', $moneyField['input_attrs']['control_field']);
+        $joinEntityField = $this->getField($prefix . $joinEntityFieldName);
+        if ($joinEntityField && !empty($joinEntityField['fk_entity'])) {
+          foreach ($this->getQuery()->getExplicitJoins() as $join) {
+            if ($join['alias'] . '.' === $prefix) {
+              foreach ($join['on'] as $on) {
+                if ($on[3] ?? TRUE !== TRUE || !is_string($on[0]) || !is_string($on[2] ?? NULL)) {
+                  continue;
+                }
+                $clause = [
+                  $on[0] => $this->getField($on[0]),
+                  $on[2] => $this->getField($on[2]),
+                ];
+                if ($clause[$on[0]] === NULL || $clause[$on[2]] === NULL) {
+                  continue;
+                }
+                foreach ([$clause, array_reverse($clause)] as $fields) {
+                  $field1Name = array_keys($fields)[0];
+                  $field2Name = array_keys($fields)[1];
+                  $field1 = $fields[$field1Name];
+                  $field2 = $fields[$field2Name];
+                  if (!str_starts_with($field1Name, $prefix)) {
+                    continue;
+                  }
+                  if ($field2['entity'] === $joinEntityField['fk_entity']) {
+                    $currencyEntityPrefix = substr($field2['path'], 0, strrpos($field2['path'], $field2['name']));
+                    return $this->currencyFields[$select] = $currencyEntityPrefix . $controlFieldName;
+                  };
+                }
+              }
+            }
+          }
         }
       }
+      return $this->currencyFields[$select] = $currencyFieldName;
     }
+
     return NULL;
   }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2060,6 +2060,94 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('$250.00', $result[3]['columns'][0]['val']);
   }
 
+  public function testCustomFieldCurrency(): void {
+    $this->createTestRecord('CustomGroup', [
+      'extends' => 'Participant',
+      'name' => 'test_part_grp',
+      'title' => 'Test Participant Group',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'test_part_grp',
+      'name' => 'custom_currency',
+      'label' => 'Custom Currency',
+      'data_type' => 'Currency',
+      'html_type' => 'Select',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'test_part_grp',
+      'name' => 'custom_money_custom',
+      'label' => 'Custom Money Custom',
+      'data_type' => 'Money',
+      'html_type' => 'Text',
+      'control_field' => 'test_part_grp.custom_currency',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'test_part_grp',
+      'name' => 'custom_money_core',
+      'label' => 'Custom Money Core',
+      'data_type' => 'Money',
+      'html_type' => 'Text',
+      'control_field' => 'fee_currency',
+    ]);
+    $this->createTestRecord('CustomField', [
+      'custom_group_id.name' => 'test_part_grp',
+      'name' => 'custom_money_default',
+      'label' => 'Custom Money Default',
+      'data_type' => 'Money',
+      'html_type' => 'Text',
+    ]);
+
+    $contactId = $this->createTestRecord('Contact', ['contact_type' => 'Individual'])['id'];
+    $eventId = $this->createTestRecord('Event', ['title' => 'Test Event'])['id'];
+
+    $participants = $this->saveTestRecords('Participant', [
+      'records' => [
+        [
+          'contact_id' => $contactId,
+          'event_id' => $eventId,
+          'fee_currency' => 'GBP',
+          'test_part_grp.custom_currency' => 'JPY',
+          'test_part_grp.custom_money_custom' => 500,
+          'test_part_grp.custom_money_core' => 300,
+          'test_part_grp.custom_money_default' => 200,
+        ],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Participant',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'test_part_grp.custom_money_custom',
+            'test_part_grp.custom_money_core',
+            'test_part_grp.custom_money_default',
+            'id',
+          ],
+          'where' => [['id', 'IN', $participants->column('id')]],
+        ],
+      ],
+      'display' => NULL,
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(1, $result);
+
+    // 1. Custom money field controlled by another custom Currency field (JPY -> ¥500)
+    $this->assertEquals('JPY', $result[0]['data']['test_part_grp.custom_currency']);
+    $this->assertEquals('¥500', $result[0]['columns'][0]['val']);
+
+    // 2. Custom money field controlled by core fee_currency field (GBP -> £300.00)
+    $this->assertEquals('GBP', $result[0]['data']['fee_currency']);
+    $this->assertEquals('£300.00', $result[0]['columns'][1]['val']);
+
+    // 3. Custom money field with no control field (uses default currency -> $200.00)
+    $this->assertEquals('$200.00', $result[0]['columns'][2]['val']);
+  }
+
   public function testTally(): void {
     // Really long custom group name - testing to see if tally works with > 64 character column keys
     $groupName = str_repeat('a', 63);

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -203,6 +203,9 @@ return [
     'non_deductible_amount' => [
       'title' => ts('Non-deductible Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'description' => ts('Portion of total amount which is NOT tax deductible. Equal to total_amount for non-deductible financial types.'),
       'add' => '1.3',
@@ -227,6 +230,7 @@ return [
       ],
       'input_attrs' => [
         'label' => ts('Total Amount'),
+        'control_field' => 'currency',
       ],
     ],
     'fee_amount' => [
@@ -241,6 +245,7 @@ return [
         'duplicate_matching',
       ],
       'input_attrs' => [
+        'control_field' => 'currency',
         'label' => ts('Fee Amount'),
       ],
     ],
@@ -259,6 +264,7 @@ return [
       'input_attrs' => [
         'label' => ts('Net Amount'),
         'formula' => '[total_amount] - [fee_amount]',
+        'control_field' => 'currency',
       ],
     ],
     'trxn_id' => [
@@ -553,6 +559,9 @@ return [
     'tax_amount' => [
       'title' => ts('Tax Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Total tax amount of this contribution.'),

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -314,6 +314,11 @@ return [
       'input_attrs' => [
         'label' => ts('Currency'),
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Contribute/ContributionPage.entityType.php
+++ b/schema/Contribute/ContributionPage.entityType.php
@@ -257,6 +257,7 @@ return [
       'description' => ts('Minimum initial amount for partial payment'),
       'add' => '4.3',
       'input_attrs' => [
+        'control_field' => 'currency',
         'label' => ts('Min. Initial Amount'),
       ],
     ],
@@ -279,6 +280,9 @@ return [
     'min_amount' => [
       'title' => ts('Minimum Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('if other amounts allowed, user can configure minimum allowed.'),
       'add' => '1.3',
@@ -286,6 +290,9 @@ return [
     'max_amount' => [
       'title' => ts('Maximum Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('if other amounts allowed, user can configure maximum allowed.'),
       'add' => '1.3',
@@ -298,6 +305,7 @@ return [
       'add' => '1.5',
       'input_attrs' => [
         'label' => ts('Goal Amount'),
+        'control_field' => 'currency',
       ],
     ],
     'thankyou_title' => [

--- a/schema/Contribute/ContributionPage.entityType.php
+++ b/schema/Contribute/ContributionPage.entityType.php
@@ -462,6 +462,11 @@ return [
       'description' => ts('3 character string, value from config setting or input via user.'),
       'add' => '3.3',
       'default' => NULL,
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -70,6 +70,9 @@ return [
     'amount' => [
       'title' => ts('Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Amount to be collected (including any sales tax) by payment processor each recurrence.'),

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -82,6 +82,11 @@ return [
       'description' => ts('3 character string, value from config setting or input via user.'),
       'add' => '3.2',
       'default' => NULL,
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Contribute/ContributionSoft.entityType.php
+++ b/schema/Contribute/ContributionSoft.entityType.php
@@ -94,6 +94,11 @@ return [
       'description' => ts('3 character string, value from config setting or input via user.'),
       'add' => '3.2',
       'default' => NULL,
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Contribute/ContributionSoft.entityType.php
+++ b/schema/Contribute/ContributionSoft.entityType.php
@@ -77,6 +77,9 @@ return [
     'amount' => [
       'title' => ts('Soft Credit Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'required' => TRUE,
       'description' => ts('Amount of this soft credit.'),

--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -103,6 +103,11 @@ return [
       'input_attrs' => [
         'label' => ts('Currency'),
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Contribute/Product.entityType.php
+++ b/schema/Contribute/Product.entityType.php
@@ -86,6 +86,9 @@ return [
     'price' => [
       'title' => ts('Price'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('Sell price or market value for premiums. For tax-deductible contributions, this will be stored as non_deductible_amount in the contribution record.'),
       'add' => '1.4',
@@ -141,6 +144,9 @@ return [
     'min_contribution' => [
       'title' => ts('Minimum Contribution'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('Minimum contribution required to be eligible to select this premium.'),
       'add' => '1.4',
@@ -148,6 +154,9 @@ return [
     'cost' => [
       'title' => ts('Cost'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('Actual cost of this product. Useful to determine net return from sale or using this as an incentive.'),
       'add' => '1.4',

--- a/schema/Core/CustomField.entityType.php
+++ b/schema/Core/CustomField.entityType.php
@@ -326,6 +326,14 @@ return [
       'add' => '4.5',
       'default' => FALSE,
     ],
+    'control_field' => [
+      'title' => ts('Depends on'),
+      'sql_type' => 'varchar(255)',
+      'input_type' => 'Select',
+      'description' => ts('Name of the field that this field depends on.'),
+      'add' => '6.18',
+      'default' => NULL,
+    ],
     'fk_entity' => [
       'title' => ts('Entity'),
       'sql_type' => 'varchar(255)',

--- a/schema/Event/Event.entityType.php
+++ b/schema/Event/Event.entityType.php
@@ -597,6 +597,9 @@ return [
     'min_initial_amount' => [
       'title' => ts('Minimum Initial Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'description' => ts('Minimum initial amount for partial payment'),
       'add' => '4.3',

--- a/schema/Event/Event.entityType.php
+++ b/schema/Event/Event.entityType.php
@@ -761,6 +761,11 @@ return [
       'input_attrs' => [
         'label' => ts('Currency'),
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Event/Participant.entityType.php
+++ b/schema/Event/Participant.entityType.php
@@ -280,6 +280,11 @@ return [
         'export',
         'duplicate_matching',
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Event/Participant.entityType.php
+++ b/schema/Event/Participant.entityType.php
@@ -218,6 +218,9 @@ return [
     'fee_amount' => [
       'title' => ts('Fee Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'fee_currency',
+      ],
       'input_type' => 'Text',
       'description' => ts('actual processor fee if known - may be 0.'),
       'add' => '2.1',

--- a/schema/Financial/Currency.entityType.php
+++ b/schema/Financial/Currency.entityType.php
@@ -11,6 +11,15 @@ return [
     'log' => TRUE,
     'add' => '1.7',
   ],
+  'getIndices' => fn() => [
+    'UI_name' => [
+      'fields' => [
+        'name' => TRUE,
+      ],
+      'unique' => TRUE,
+      'add' => '6.18',
+    ],
+  ],
   'getFields' => fn() => [
     'id' => [
       'title' => ts('Currency ID'),

--- a/schema/Financial/FinancialItem.entityType.php
+++ b/schema/Financial/FinancialItem.entityType.php
@@ -103,6 +103,11 @@ return [
       'usage' => [
         'export',
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Financial/FinancialItem.entityType.php
+++ b/schema/Financial/FinancialItem.entityType.php
@@ -88,6 +88,9 @@ return [
     'amount' => [
       'title' => ts('Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'required' => TRUE,
       'description' => ts('Total amount of this item'),

--- a/schema/Financial/FinancialTrxn.entityType.php
+++ b/schema/Financial/FinancialTrxn.entityType.php
@@ -122,6 +122,11 @@ return [
       'usage' => [
         'export',
       ],
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Financial/FinancialTrxn.entityType.php
+++ b/schema/Financial/FinancialTrxn.entityType.php
@@ -93,6 +93,9 @@ return [
     'total_amount' => [
       'title' => ts('Financial Total Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'required' => TRUE,
       'description' => ts('amount of transaction'),
@@ -101,6 +104,9 @@ return [
     'fee_amount' => [
       'title' => ts('Financial Fee Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('actual processor fee if known - may be 0.'),
       'add' => '1.3',
@@ -108,6 +114,9 @@ return [
     'net_amount' => [
       'title' => ts('Financial Net Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('actual funds transfer amount. total less fees. if processor does not report actual fee during transaction, this is set to total_amount.'),
       'add' => '1.3',

--- a/schema/PCP/PCP.entityType.php
+++ b/schema/PCP/PCP.entityType.php
@@ -136,6 +136,9 @@ return [
     'goal_amount' => [
       'title' => ts('Goal Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'description' => ts('Goal amount of this Personal Campaign Page.'),
       'add' => '2.2',

--- a/schema/PCP/PCP.entityType.php
+++ b/schema/PCP/PCP.entityType.php
@@ -147,6 +147,11 @@ return [
       'description' => ts('3 character string, value from config setting or input via user.'),
       'add' => '3.2',
       'default' => NULL,
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Pledge/Pledge.entityType.php
+++ b/schema/Pledge/Pledge.entityType.php
@@ -134,6 +134,11 @@ return [
       'description' => ts('3 character string, value from config setting or input via user.'),
       'add' => '3.2',
       'default' => NULL,
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Pledge/Pledge.entityType.php
+++ b/schema/Pledge/Pledge.entityType.php
@@ -104,6 +104,9 @@ return [
     'amount' => [
       'title' => ts('Total Pledged'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Total pledged amount.'),
@@ -118,6 +121,9 @@ return [
     'original_installment_amount' => [
       'title' => ts('Original Installment Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Original amount for each of the installments.'),

--- a/schema/Pledge/PledgePayment.entityType.php
+++ b/schema/Pledge/PledgePayment.entityType.php
@@ -80,6 +80,9 @@ return [
     'scheduled_amount' => [
       'title' => ts('Scheduled Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'required' => TRUE,
       'description' => ts('Pledged amount for this payment (the actual contribution amount might be different).'),
@@ -94,6 +97,9 @@ return [
     'actual_amount' => [
       'title' => ts('Actual Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'currency',
+      ],
       'input_type' => NULL,
       'description' => ts('Actual amount that is paid as the Pledged installment amount.'),
       'add' => '3.2',

--- a/schema/Pledge/PledgePayment.entityType.php
+++ b/schema/Pledge/PledgePayment.entityType.php
@@ -111,6 +111,11 @@ return [
       'description' => ts('3 character string, value from config setting or input via user.'),
       'add' => '3.2',
       'default' => NULL,
+      'entity_reference' => [
+        'entity' => 'Currency',
+        'key' => 'name',
+        'on_delete' => 'SET NULL',
+      ],
       'pseudoconstant' => [
         'table' => 'civicrm_currency',
         'key_column' => 'name',

--- a/schema/Price/LineItem.entityType.php
+++ b/schema/Price/LineItem.entityType.php
@@ -140,11 +140,15 @@ return [
       'add' => '1.7',
       'input_attrs' => [
         'label' => ts('Unit Price'),
+        'control_field' => 'contribution_id.currency',
       ],
     ],
     'line_total' => [
       'title' => ts('Line Item Total'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'contribution_id.currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('qty * unit_price'),
@@ -202,6 +206,9 @@ return [
     'non_deductible_amount' => [
       'title' => ts('Non-deductible Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'contribution_id.currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Portion of total amount which is NOT tax deductible.'),
@@ -211,6 +218,9 @@ return [
     'tax_amount' => [
       'title' => ts('Tax Amount'),
       'sql_type' => 'decimal(20,2)',
+      'input_attrs' => [
+        'control_field' => 'contribution_id.currency',
+      ],
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('tax of each item'),

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -179,7 +179,8 @@
       originalSerialize = {/literal}{if empty($originalSerialize)}false{else}true{/if}{literal},
       htmlTypes = CRM.utils.getOptions($('#html_type', $form)),
       htmlTypesWithOptionalSerialize = {/literal}{$htmlTypesWithOptionalSerialize|json}{literal},
-      htmlTypesWithMandatorySerialize = {/literal}{$htmlTypesWithMandatorySerialize|json}{literal};
+      htmlTypesWithMandatorySerialize = {/literal}{$htmlTypesWithMandatorySerialize|json}{literal},
+      dataTypesWithoutSerialize = {/literal}{$dataTypesWithoutSerialize|json}{literal};
 
     // Vars used by makeDefaultValueField()
     let oldDataType = null,
@@ -312,7 +313,7 @@
 
       $("#noteColumns, #noteRows, #noteLength", $form).toggle(dataType === 'Memo');
 
-      $(".crm-custom-field-form-block-serialize", $form).toggle(htmlTypesWithOptionalSerialize.includes(htmlType) && dataType !== 'EntityReference');
+      $(".crm-custom-field-form-block-serialize", $form).toggle(htmlTypesWithOptionalSerialize.includes(htmlType) && !dataTypesWithoutSerialize.includes(dataType));
 
       makeDefaultValueField(dataType);
     }
@@ -358,6 +359,11 @@
 
         case 'StateProvince':
           field.crmAutocomplete('StateProvince', autocompeteApiParams, autocompleteSelectParams);
+          return;
+
+        case 'Currency':
+          autocompeteApiParams.key = 'name';
+          field.crmAutocomplete('Currency', autocompeteApiParams, autocompleteSelectParams);
           return;
       }
       if (newHasOptionGroup && newOptionGroupId) {

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -44,6 +44,10 @@
         <span class="description">{ts}Leave blank to use the default placeholder.{/ts}</span>
       </td>
     </tr>
+    <tr class="crm-custom-field-form-block-control_field" style="display:none">
+      <td class="label">{$form.control_field.label}</td>
+      <td class="html-adjust">{$form.control_field.html}</td>
+    </tr>
     <tr class="crm-custom-field-form-block-serialize">
       <td class="label">{$form.serialize.label}</td>
       <td class="html-adjust">{$form.serialize.html}</td>
@@ -208,6 +212,9 @@
 
       // Toggle file access
       $('tr.crm-custom-field-form-block-file_is_public').toggle(dataType === 'File');
+
+      // Currency selector
+      $('.crm-custom-field-form-block-control_field').toggle(dataType === 'Money');
     }
 
     function onChangeHtmlType() {

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -199,7 +199,7 @@
       }
       // Hide html_type if there is only one option
       $('.crm-custom-field-form-block-html_type').toggle(allowedHtmlTypes.length > 1);
-      customOptionHtmlType(dataType);
+      customOptionHtmlType();
 
       // Show/hide entityReference selector
       $('.crm-custom-field-form-block-fk_entity').toggle(dataType === 'EntityReference');
@@ -282,10 +282,11 @@
         const reuseOptions = $('[name=option_type]:checked', $form).val() === '2';
         $("#hideDefault", $form).toggle(reuseOptions);
       }
-      else if (['String', 'Int', 'Float', 'Money'].includes(dataType)) {
-        $("#hideDefault, #searchable", $form).show();
-      } else {
-        if (dataType === 'File') {
+      else {
+        $("#showoption", $form).hide();
+        if (['String', 'Int', 'Float', 'Money'].includes(dataType)) {
+          $("#hideDefault, #searchable", $form).show();
+        } else if (dataType === 'File') {
           $("#default_value", $form).val('');
           $("#hideDefault, #searchable", $form).hide();
         } else if (dataType === 'ContactReference') {

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -67,6 +67,11 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
           'html_type' => 'Number',
         ],
         [
+          'name' => 'currency_field',
+          'data_type' => 'Currency',
+          'html_type' => 'Select',
+        ],
+        [
           'name' => 'money',
           'data_type' => 'Money',
           'html_type' => 'Number',
@@ -325,6 +330,24 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $this->assertNull($field['operators']);
     $this->assertNull($field['serialize']);
     $this->assertEquals(['groups' => 123], $field['input_attrs']['filter']);
+
+    // Check currency field
+    $field = $fields["$customGroupName.currency_field"];
+    $this->assertSame('Select', $field['input_type']);
+    $this->assertSame('String', $field['data_type']);
+    $this->assertEquals('Currency', $field['fk_entity']);
+    $this->assertEquals('name', $field['fk_column']);
+    $this->assertTrue($field['options']);
+    $this->assertNull($field['operators']);
+    $this->assertNull($field['serialize']);
+
+    // Ensure every applicable field actually has a FK index in the database table
+    $tableName = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_CustomGroup', $customGroupName, 'table_name', 'name');
+    foreach (['state', 'file', 'entityref', 'contactref', 'currency_field'] as $fieldName) {
+      $columnName = $customFields[$fieldName]['column_name'];
+      $fkName = 'FK_' . \CRM_Core_BAO_SchemaHandler::getIndexName($tableName, $columnName);
+      $this->assertTrue(\CRM_Core_BAO_SchemaHandler::checkFKExists($tableName, $fkName), "FK constraint $fkName should exist on table $tableName");
+    }
   }
 
   public function testDisabledAndHiddenFields(): void {

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -75,6 +75,7 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
           'name' => 'money',
           'data_type' => 'Money',
           'html_type' => 'Number',
+          'control_field' => __FUNCTION__ . '.currency_field',
         ],
         [
           'name' => 'memo',
@@ -197,6 +198,7 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $this->assertFalse($field['options']);
     $this->assertNull($field['operators']);
     $this->assertNull($field['serialize']);
+    $this->assertSame(__FUNCTION__ . '.currency_field', $field['input_attrs']['control_field']);
 
     // Check memo field
     $field = $fields["$customGroupName.memo"];


### PR DESCRIPTION
Overview
----------------------------------------
Defines a currency type field that can be used to control the currency of money fields.

https://lab.civicrm.org/dev/core/-/work_items/6547

**Note to reviewers:** The lengthy discussion about test failures below is entirely unrelated to this PR, tl;dr this just happened to touch a file that had pre-existing problems (it's now fixed).

<img width="2268" height="668" alt="Screenshot 2026-07-04 at 7 07 17 PM" src="https://github.com/user-attachments/assets/cc7b05b8-59dc-4eb3-a4f7-df9e14458978" />

----

The currency field is now selectable for custom money fields. The entity's currency field is also available (in this example, you can select the custom field, the contribution currency, or the site defalut).

<img width="2270" height="796" alt="Screenshot 2026-07-04 at 7 07 52 PM" src="https://github.com/user-attachments/assets/9b93368a-1719-40a4-97e1-c42749c5d917" />
