### PR TITLE
dev/core#6313 - Prevent duplicate submission for paid events too when there's no confirmation page

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -497,11 +497,8 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
 
     if (!$allAreBillingModeProcessors || !empty($this->_values['event']['is_pay_later']) || $bypassPayment
     ) {
-
       //freeze button to avoid multiple calls.
-      if (empty($this->_values['event']['is_monetary'])) {
-        $this->submitOnce = TRUE;
-      }
+      $this->submitOnce = TRUE;
 
       // CRM-11182 - Optional confirmation screen
       // Change button label depending on whether the next action is confirm or register


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6313

Before
----------------------------------------
Possible to submit twice when there's no confirmation page configured.

After
----------------------------------------
Maybe still possible but you have to work harder.

Technical Details
----------------------------------------
It's not clear to me why it was only being set for free events. The switch to allow no confirmation page for paid events is somewhat recent, so it might have just been for code-consistency when it was originally added.

I've cautiously kept it within the outer `if`, as opposed to a class declaration that unconditionally applies in all cases. It could probably be completely unconditional, but maybe there is some ajax-y stuff that happens in some cases that blocks the submit, and then would prevent subsequently submitting the form.

Comments
----------------------------------------

