### PR TITLE
php warning when moving custom field to another group

### DIFF
--- a/CRM/Custom/Form/MoveField.php
+++ b/CRM/Custom/Form/MoveField.php
@@ -141,7 +141,7 @@ class CRM_Custom_Form_MoveField extends CRM_Core_Form {
     $self->_dstGID = $fields['dst_group_id'];
     $tmp = CRM_Core_BAO_CustomField::_moveFieldValidate($self->_srcFID, $self->_dstGID);
     $errors = [];
-    if ($tmp['newGroupID']) {
+    if (!empty($tmp['newGroupID'])) {
       $errors['dst_group_id'] = $tmp['newGroupID'];
     }
     return empty($errors) ? TRUE : $errors;


### PR DESCRIPTION
Overview
----------------------------------------
php warning when moving custom field to another group

Before
----------------------------------------
1. Use the "move" action to move a custom field to another group and do it good so that it's a valid move.
2. php warning about offset on true

After
----------------------------------------


Technical Details
----------------------------------------
When there's no issues, it returns true, so it can't be treated as an array.
Also sometimes even when it is an array it might not have the newGroup element if there was some other validation issue.

Comments
----------------------------------------

