### PR TITLE
[REF] streamline AfformEntitySortEvent

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -95,10 +95,11 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
   }
 
   public static function onAfformSortPrefill(AfformEntitySortEvent $event): void {
-    foreach ($event->getFormDataModel()->getEntities() as $entityName => $entity) {
+    $entities = $event->getFormDataModel()->getEntities();
+    foreach ($entities as $entityName => $entity) {
       $autoFillMode = $entity['autofill'] ?? '';
       $relatedContact = $entity['autofill-relationship'] ?? NULL;
-      if ($relatedContact && str_starts_with($autoFillMode, 'relationship:')) {
+      if ($relatedContact && array_key_exists($relatedContact, $entities) && str_starts_with($autoFillMode, 'relationship:')) {
         $event->addDependency($entityName, $relatedContact);
       }
     }

--- a/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
+++ b/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
@@ -64,10 +64,8 @@ class GroupSubscription extends AbstractBehavior implements EventSubscriberInter
   public static function onAfformSortPrefill(AfformEntitySortEvent $event): void {
     $formEntities = $event->getFormDataModel()->getEntities();
     foreach ($formEntities as $entityName => $entity) {
-      if ($entity['type'] === 'GroupSubscription') {
-        if (isset($formEntities[$entity['data']['contact_id']])) {
-          $event->addDependency($entityName, $entity['data']['contact_id']);
-        }
+      if ($entity['type'] === 'GroupSubscription' && \array_key_exists($entity['data']['contact_id'], $formEntities)) {
+        $event->addDependency($entityName, $entity['data']['contact_id']);
       }
     }
   }

--- a/ext/afform/core/Civi/Afform/Event/AfformEntitySortEvent.php
+++ b/ext/afform/core/Civi/Afform/Event/AfformEntitySortEvent.php
@@ -2,97 +2,105 @@
 
 namespace Civi\Afform\Event;
 
+use Civi\Afform\FormDataModel;
+use Civi\Api4\Generic\AbstractAction;
 use MJS\TopSort\Implementations\FixedArraySort;
 
 /**
- * This event allows listeners to declare that entities depend on others.
- * These dependencies change the order in which entities are resolved.
+ * This event gathers dependencies between entities on the form.
+ * This is used to sort entities before processing, so dependencies
+ * are saved first and entity references can be resolved
  */
 class AfformEntitySortEvent extends AfformBaseEvent {
 
-  private $dependencies = [];
+  protected array $entityValues;
 
-  private $entityValues = [];
+  /**
+   * @var string[][]
+   *
+   * [
+   *   entityName => [dependentEntity1, dependentEntity2],
+   *   ...
+   * ]
+   *
+   * internal storage for dependencies, which will then be passed to the top sort
+   */
+  protected array $elements = [];
 
-  private FixedArraySort $sorter;
+  public function __construct(array $afform, FormDataModel $formDataModel, AbstractAction $apiRequest, array $entityValues = []) {
+    parent::__construct($afform, $formDataModel, $apiRequest);
+    $this->entityValues = $entityValues;
+
+    // add all entity names as nodes (with no dependencies at this stage)
+    // Q: should we add dependencies based on data values here?
+    foreach ($formDataModel->getEntities() as $entity => $details) {
+      if (empty($details['type'])) {
+        // this filters out things like "extra" which aren't really entities
+        // but are returned by `getEntities`
+        // TODO: filter out upstream?
+        continue;
+      }
+      $this->addEntity($entity);
+    }
+
+    // add entity ref dependencies from values, if any
+    $this->addEntityRefDependencies();
+  }
+
+  /**
+   * @param string $entityName
+   *   add an entity to the list of nodes
+   */
+  public function addEntity(string $entityName): void {
+    $this->elements[$entityName] ??= [];
+  }
 
   /**
    * @param string $dependentEntity
    * @param string $dependsOnEntity
    */
   public function addDependency(string $dependentEntity, string $dependsOnEntity): void {
-    $this->dependencies[$dependentEntity][$dependsOnEntity] = $dependsOnEntity;
-  }
-
-  public function setEntityValues(array $entityValues): void {
-    $this->entityValues = $entityValues;
-  }
-
-  /**
-   * Returns list of entity names that have a defined type.
-   *
-   * @return array
-   */
-  private function getFormEntities(): array {
-    $entities = [];
-    foreach ($this->getFormDataModel()->getEntities() as $name => $entity) {
-      if (!empty($entity['type'])) {
-        $entities[] = $name;
-      }
-    }
-    return $entities;
+    // ensure the node exists
+    $this->addEntity($dependentEntity);
+    // add the dependency to the list of entities
+    $this->elements[$dependentEntity][] = $dependsOnEntity;
   }
 
   /**
-   * Returns entity names sorted by their dependencies
+   * Add dependencies between Entities based on EntityRef values in the
+   * submission
    *
-   * @return array
+   * TODO: this just matches string literals. If you have a text field and
+   * enter "Individual1" that could get interpreted as a reference. It might
+   * be good to check the field type
    */
-  public function getSortedEntitiesPrefill(): array {
-    $sorter = new FixedArraySort();
-    $formEntities = $this->getFormEntities();
-    foreach ($formEntities as $entityName) {
-      // Add all dependencies that are the valid name of another entity
-      $dependencies = array_intersect($this->dependencies[$entityName] ?? [], $formEntities);
-      $sorter->add($entityName, $dependencies);
-    }
-    return $sorter->sort();
-  }
+  protected function addEntityRefDependencies(): void {
+    $formEntities = array_keys($this->getFormDataModel()->getEntities());
 
-  /**
-   * Returns a list of entity names in order of when they should be processed,
-   * so that an entity being referenced is saved before the entity referencing it.
-   *
-   */
-  public function getEntityDependenciesForSubmit(): void {
-    $sorter = new FixedArraySort();
-    $formEntities = $this->getFormEntities();
-    $entityValues = $this->entityValues;
-
-    foreach ($formEntities as $entityName) {
-      $references = [];
-      foreach ($entityValues[$entityName] ?? [] as $record) {
-        foreach ($record['fields'] ?? [] as $fieldName => $fieldValue) {
+    foreach ($this->entityValues as $entityName => $records) {
+      foreach ($records as $record) {
+        foreach ($record['fields'] ?? [] as $fieldValue) {
           foreach ((array) $fieldValue as $value) {
-            if (in_array($value, $formEntities, TRUE) && $value !== $entityName) {
-              $references[$value] = $value;
+            if (in_array($value, $formEntities, TRUE)) {
+              $this->addDependency($entityName, $value);
             }
           }
         }
       }
-      $sorter->add($entityName, $references);
     }
-
-    // Return the list of entities ordered by weight
-    $this->sorter = $sorter;
   }
 
   /**
+   * @return string[] list of entities sorted by dependencies
    * @throws \MJS\TopSort\CircularDependencyException
    * @throws \MJS\TopSort\ElementNotFoundException
    */
-  public function sort() {
-    return $this->sorter->sort();
+  public function getSorted(): array {
+    $sorter = new FixedArraySort();
+    foreach ($this->elements as $element => $dependencies) {
+      $sorter->add($element, $dependencies);
+    }
+    return $sorter->sort();
   }
 
 }

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -153,9 +153,9 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     // When loading the whole form, process every entity in order of dependencies.
     // also when filling a single entity from an autocomplete, as that may affect other entities.
     else {
-      $sorter = new AfformEntitySortEvent($this->_afform, $this->_formDataModel, $this);
-      \Civi::dispatcher()->dispatch('civi.afform.sort.prefill', $sorter);
-      $entityNames = $sorter->getSortedEntitiesPrefill();
+      $sortEvent = new AfformEntitySortEvent($this->_afform, $this->_formDataModel, $this);
+      \Civi::dispatcher()->dispatch('civi.afform.sort.prefill', $sortEvent);
+      $entityNames = $sortEvent->getSorted();
     }
 
     foreach ($entityNames as $entityName) {
@@ -806,13 +806,11 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    * Process form data
    */
   public function processFormData(array $entityValues) {
-    $sorter = new AfformEntitySortEvent($this->_afform, $this->_formDataModel, $this);
-    $sorter->setEntityValues($entityValues);
-    $sorter->getEntityDependenciesForSubmit();
-    \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sorter);
-    $entityWeights = $sorter->sort();
+    $sortEvent = new AfformEntitySortEvent($this->_afform, $this->_formDataModel, $this, $entityValues);
+    \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sortEvent);
+    $sortedEntityNames = $sortEvent->getSorted();
 
-    foreach ($entityWeights as $entityName) {
+    foreach ($sortedEntityNames as $entityName) {
       $entityType = $this->_formDataModel->getEntity($entityName)['type'];
       $records = $this->replaceReferences($entityName, $entityValues[$entityName]);
       $this->fillIdFields($records, $entityName);

--- a/ext/afform/core/tests/phpunit/CRM/Afform/UtilTest.php
+++ b/ext/afform/core/tests/phpunit/CRM/Afform/UtilTest.php
@@ -180,11 +180,9 @@ class CRM_Afform_UtilTest extends \PHPUnit\Framework\TestCase implements Headles
   public function testEntityWeights($html, $entityValues, $expectedWeights) {
     $parser = new \CRM_Afform_ArrayHtml();
     $formDataModel = new FormDataModel($parser->convertHtmlToArray($html));
-    $sorter = new AfformEntitySortEvent([], $formDataModel, new \Civi\Api4\Generic\BasicGetAction('', ''));
-    $sorter->setEntityValues($entityValues);
-    $sorter->getEntityDependenciesForSubmit();
-    // \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sorter);
-    $entityWeights = $sorter->sort();
+    $sorter = new AfformEntitySortEvent([], $formDataModel, new \Civi\Api4\Generic\BasicGetAction('', ''), $entityValues);
+    \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sorter);
+    $entityWeights = $sorter->getSorted();
 
     $this->assertEquals($expectedWeights, $entityWeights);
   }

--- a/ext/civi_case/Civi/Afform/Behavior/ContactAutofillBasedOnCase.php
+++ b/ext/civi_case/Civi/Afform/Behavior/ContactAutofillBasedOnCase.php
@@ -56,10 +56,11 @@ class ContactAutofillBasedOnCase extends AutoService implements EventSubscriberI
   }
 
   public static function onAfformSortPrefill(AfformEntitySortEvent $event): void {
-    foreach ($event->getFormDataModel()->getEntities() as $entityName => $entity) {
+    $entities = $event->getFormDataModel()->getEntities();
+    foreach ($entities as $entityName => $entity) {
       $autoFillMode = $entity['autofill'] ?? '';
       $relatedCase = $entity['autofill-case'] ?? NULL;
-      if ($relatedCase && str_starts_with($autoFillMode, 'role_on_case:')) {
+      if ($relatedCase && \array_key_exists($relatedCase, $entities) && str_starts_with($autoFillMode, 'role_on_case:')) {
         $event->addDependency($entityName, $relatedCase);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Cleans up new code around AfformEntitySortEvent.

Before
----------------------------------------
- an odd mix of a `FixedArraySort` param, and then ephemeral `FixedArraySort`s created by some of its methods
- a few inaccurate docblocs, unclear what if anything is returned from various methods
- the `FixedArraySort` object has an internal list of entities and dependences, then we create another one on top, which we then pass into the `FixedArraySort` at various point

After
----------------------------------------
- use one `FixedArraySort` instance throughout the whole event
- always go through `->addDependency` and put dependencies straight into the `FixedArraySort`

Technical Details
----------------------------------------
This no longer sets entity values on the event. This means they won't be available to listeners.

If they need to be available to listeners, we should add them up front as an additional param to the constructor, rather than relying on someone to set them at some point.

Comments
-----------------------------------------
I would like to add a listener to make sure Contribution price fields are factored into the save ordering. 

@mattwire does this still work for you?
