### PR TITLE
Afform - Add support for default repeat items

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer-menu.html
@@ -16,9 +16,17 @@
       {{:: ts('Repeat') }}
     </label>
     <span ng-style="{visibility: $ctrl.node['af-repeat'] || $ctrl.node['af-repeat'] === '' ? 'visible' : 'hidden'}">
-      <input type="number" class="form-control" ng-model="getSetMin" ng-model-options="{getterSetter: true}" placeholder="{{:: ts('min') }}" min="0" step="1" />
+      <input type="number" class="form-control" ng-model="getSetMin" ng-model-options="{getterSetter: true}" placeholder="0" min="0" step="1" />
       - <input type="number" class="form-control" ng-model="getSetMax" ng-model-options="{getterSetter: true}" placeholder="{{:: ts('max') }}" min="2" max="{{:: getRepeatMax() }}" step="1" />
     </span>
+  </div>
+</li>
+<li ng-if="$ctrl.node['af-repeat'] || $ctrl.node['af-repeat'] === ''">
+  <div class="af-gui-field-select-in-dropdown form-inline">
+    <label class="pull-right">
+      {{:: ts('Initially show:') }}
+      <input type="number" class="form-control" ng-model="getSetNumber('af-repeat-default')" ng-model-options="{getterSetter: true}" placeholder="{{ $node.min || 1 }}" min="0" step="1" />
+    </label>
   </div>
 </li>
 <li ng-click="$event.stopPropagation()" ng-if="!block">

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiContainer.component.js
@@ -181,6 +181,15 @@
         return ctrl.node.max ? parseInt(ctrl.node.max, 10) : null;
       };
 
+      $scope.getSetNumber = function(paramName) {
+        return function(val) {
+          if (arguments.length) {
+            ctrl.node[paramName] = typeof val === 'string' ? parseInt(val, 10) : val;
+          }
+          return typeof ctrl.node[paramName] === 'string' ? parseInt(ctrl.node[paramName], 10) : ctrl.node[paramName];
+        };
+      };
+
       // Returns the maximum number of repeats allowed if this is a joined entity with a limit
       // Value comes from civicrm_custom_group.max_multiple for custom entities,
       // or from afformEntity php file for core entities.

--- a/ext/afform/core/ang/af/afFieldset.directive.js
+++ b/ext/afform/core/ang/af/afFieldset.directive.js
@@ -3,7 +3,7 @@
   angular.module('af').directive('afFieldset', function() {
     return {
       restrict: 'A',
-      require: ['afFieldset', '?^^afForm'],
+      require: ['afFieldset', '?^^afForm', '?afRepeat'],
       bindToController: {
         modelName: '@afFieldset',
         storeValues: '<'
@@ -11,6 +11,7 @@
       link: function($scope, $el, $attr, ctrls) {
         const self = ctrls[0];
         self.afFormCtrl = ctrls[1];
+        self.afRepeatCtrl = ctrls[2];
       },
       controller: function($scope, $element, crmApi4) {
         const ctrl = this;
@@ -35,11 +36,18 @@
         };
         this.getFieldData = function() {
           const data = ctrl.getData();
-          if (!data.length) {
+          // afRepeat will handle adding items itself
+          if (!data.length && !ctrl.afRepeatCtrl) {
             data.push({fields: {}});
           }
-          return data[0].fields;
+          return data[0]?.fields;
         };
+
+        // Called by afRepeat
+        this.addRepeatItem = () => {
+          this.getData().push({fields: {}});
+        };
+
         this.getFormName = function() {
           return ctrl.afFormCtrl ? ctrl.afFormCtrl.getFormMeta().name : $scope.meta.name;
         };

--- a/ext/afform/core/ang/af/afJoin.directive.js
+++ b/ext/afform/core/ang/af/afJoin.directive.js
@@ -39,6 +39,12 @@
             }
             return data.joins[self.entity];
           };
+
+          // Called by afRepeat
+          this.addRepeatItem = () => {
+            this.getData().push({});
+          };
+
           this.getFieldData = function() {
             const data = this.getData();
             if (!data[this.offset] || (Array.isArray(data[this.offset]) && !data[this.offset].length)) {

--- a/ext/afform/core/ang/af/afRepeat.directive.js
+++ b/ext/afform/core/ang/af/afRepeat.directive.js
@@ -21,12 +21,18 @@
           $scope.element = $el;
         },
         controller: function($scope) {
-          this.getItems = $scope.getItems = function() {
-            const data = getEntityController().getData();
-            while ($scope.min && data.length < $scope.min) {
-              data.push(getRepeatType() === 'join' ? {} : {fields: {}, joins: {}});
-            }
-            return data;
+
+          this.$onInit = () => {
+            $scope.$evalAsync(() => {
+              const data = getEntityController().getData();
+              while (data.length < ($scope.min || 1)) {
+                getEntityController().addRepeatItem();
+              }
+            });
+          };
+
+          this.getItems = $scope.getItems = () => {
+            return getEntityController().getData();
           };
 
           function getRepeatType() {
@@ -40,7 +46,7 @@
           this.getEntityController = getEntityController;
 
           $scope.addItem = function() {
-            $scope.getItems().push(getRepeatType() === 'join' ? {} : {fields: {}});
+            getEntityController().addRepeatItem();
           };
 
           $scope.copyItem = function() {

--- a/ext/afform/core/ang/af/afRepeat.directive.js
+++ b/ext/afform/core/ang/af/afRepeat.directive.js
@@ -9,6 +9,7 @@
         scope: {
           min: '=',
           max: '=',
+          afRepeatDefault: '=',
           addLabel: '@afRepeat',
           addIcon: '@',
           copyLabel: '@afCopy',
@@ -25,7 +26,14 @@
           this.$onInit = () => {
             $scope.$evalAsync(() => {
               const data = getEntityController().getData();
-              while (data.length < ($scope.min || 1)) {
+              let defaultCount = $scope.afRepeatDefault;
+              if (defaultCount === undefined || defaultCount === '' || isNaN(defaultCount)) {
+                defaultCount = 1;
+              }
+              if ($scope.min !== undefined && $scope.min !== '' && defaultCount < $scope.min) {
+                defaultCount = $scope.min;
+              }
+              while (data.length < defaultCount) {
                 getEntityController().addRepeatItem();
               }
             });

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformSubmitUsageTest.php
@@ -131,4 +131,67 @@ EOHTML;
       ->execute();
   }
 
+  public function testSubmitWithRepeatMinZero(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="last_name" />
+  </fieldset>
+  <div af-join="Email" min="0" af-repeat="Add">
+    <af-field name="email" defn="{required: true}" />
+  </div>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Submit with zero items for the Email block: should succeed.
+    $submissionZeroItems = [
+      'Individual1' => [
+        [
+          'fields' => ['first_name' => 'Jane', 'last_name' => 'Doe'],
+          'joins' => [
+            'Email' => [],
+          ],
+        ],
+      ],
+    ];
+
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues($submissionZeroItems)
+      ->execute();
+
+    $this->assertNotEmpty($result[0]['Individual1'][0]['id']);
+
+    // Submit with 1 empty item for the Email block: should trigger validation error.
+    $submissionOneEmptyItem = [
+      'Individual1' => [
+        [
+          'fields' => ['first_name' => 'Jane', 'last_name' => 'Doe'],
+          'joins' => [
+            'Email' => [[]],
+          ],
+        ],
+      ],
+    ];
+
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues($submissionOneEmptyItem)
+        ->execute();
+      $this->fail('Should have thrown validation exception');
+    }
+    catch (\CRM_Core_Exception $e) {
+    }
+    $this->assertEquals('Email is a required field.', $e->getMessage());
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6608](https://lab.civicrm.org/dev/core/-/work_items/6608)

Before
----------------------------------------
In an af-repeat fieldset, you can't delete the last item. Or rather, you can, but it will be immediately replaced with a new blank one.

After
----------------------------------------
Submitting zero items is supported. Also, now you have explicit control over how many items are initially displayed on the form.