### PR TITLE
Add getBillingEmail and getBillingAddress helpers to CheckoutOptionUtils

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
@@ -151,4 +151,105 @@ class CheckoutOptionUtils {
     return $pairs;
   }
 
+  /**
+   * Optional helper function to get the billing email from a contact.
+   *
+   * @param int $contactID
+   *
+   * @return string
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function getBillingEmail(int $contactID): string {
+    if ($contactID) {
+      $email = \Civi\Api4\Email::get(FALSE)
+        ->addSelect('email')
+        ->addWhere('contact_id', '=', $contactID)
+        ->addWhere('is_billing', '=', TRUE)
+        ->execute()
+        ->first();
+      if (!$email) {
+        $email = \Civi\Api4\Email::get(FALSE)
+          ->addSelect('email')
+          ->addWhere('contact_id', '=', $contactID)
+          ->addWhere('is_primary', '=', TRUE)
+          ->execute()
+          ->first();
+      }
+    }
+    return $email['email'] ?? '';
+  }
+
+  /**
+   * Helper function to provide a standard way of getting billing address
+   * CheckoutOptions can optionally use this to retrieve the billing address
+   *   in a standard way from Afform.
+   * It is assumed that by the time this function is called contacts, addresses and contributions
+   *   have been saved. So we can look up the address either by contactID or directly by addressID.
+   * A contribution a billing address not linked to a contact via Contribution.address_id
+   *
+   * @param int|null $addressID
+   * @param int|null $contactID
+   *
+   * @return array
+   *   Returns null if no address is found.
+   *   Returns API4 style ($api4AddressFields) + propertyBag style ($propertyBagAddressParams) fields.
+   *
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
+  public static function getBillingAddress(?int $addressID = NULL, ?int $contactID = NULL): array {
+    $api4AddressFields = [
+      'street_address',
+      'city',
+      'state_province_id',
+      'state_province_id:abbr',
+      'state_province_id:label',
+      'country_id',
+      'country_id:abbr',
+      'country_id:label',
+      'postal_code',
+    ];
+
+    // Map API4 => propertyBag
+    $propertyBagAddressFieldMap = [
+      'street_address' => 'billingStreetAddress',
+      'city' => 'billingCity',
+      'state_province_id:abbr' => 'billingStateProvince',
+      'postal_code' => 'billingPostalCode',
+      'country_id:abbr' => 'billingCountry',
+    ];
+
+    $address = [];
+    if ($addressID) {
+      $address = \Civi\Api4\Address::get(FALSE)
+        ->setSelect($api4AddressFields)
+        ->addWhere('address_id', '=', $addressID)
+        ->execute()
+        ->first();
+    }
+    elseif ($contactID) {
+      $address = \Civi\Api4\Address::get(FALSE)
+        ->setSelect($api4AddressFields)
+        ->addWhere('contact_id', '=', $contactID)
+        ->addWhere('is_billing', '=', TRUE)
+        ->execute()
+        ->first();
+      if (!$address) {
+        $address = \Civi\Api4\Address::get(FALSE)
+          ->setSelect($api4AddressFields)
+          ->addWhere('contact_id', '=', $contactID)
+          ->addWhere('is_primary', '=', TRUE)
+          ->execute()
+          ->first();
+      }
+    }
+    if ($address) {
+      foreach ($propertyBagAddressFieldMap as $api4 => $propertyBag) {
+        $address[$propertyBag] = $address[$api4] ?? '';
+      }
+    }
+    return $address;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/36092. This PR extracts the getBillingEmail and getBillingAddress from that PR into their own helper functions.

#### Billing address helper

Where do you get the billing address from? ... It depends.. Core supports an address_id directly linked to a Contribution (we can't do that in Formbuilder currently and might not want to?). Otherwise we need to get an address from a Contact (which might have just been filled in on the form).

So the billing address helper uses the following logic:

If address_id is set (on Contribution) retrieve the address directly.
ElseIf contact_id is set (on Contribution, required field) retrieve a saved address from that contact (any address added on the form will already have been saved). Logic is look for address with "is_billing" set first, otherwise look for address with "is_primary" set.
getBillingAddress() returns an array containing API4-style keys with id, abbr and label and mapped versions of the same data that was passed into doPayment via quickform/propertyBag (eg. billingCountry = country_id:abbr).

Question: Does FormBuilder set "is_billing" when saving with location_type_id = billing? Yes it does.

#### Billing email helper
This gets an email from the Contribution.contact_id if available. Using the same logic as address, checks "is_billing" and then "is_primary".

Before
----------------------------------------
Each CheckoutOption has to implement it's own logic for getting billing email and billing address.

After
----------------------------------------
CheckoutOptions can optionally use the standard helpers and don't have to implement their own logic.

Technical Details
----------------------------------------
Looks for "is_billing" and then "is_primary".

Comments
----------------------------------------
For discussion around billing contact see https://lab.civicrm.org/dev/core/-/work_items/6626 (but non-blocking for this PR)