### PR TITLE
FormBuilder Contributions - add price field dependencies to entity sort

### DIFF
--- a/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
+++ b/ext/civi_contribute/Civi/Contribute/Service/CreateContribution.php
@@ -1,8 +1,10 @@
 <?php
 namespace Civi\Contribute\Service;
 
+use Civi\Afform\Event\AfformEntitySortEvent;
 use Civi\Afform\Event\AfformSubmitEvent;
 use Civi\Afform\Event\AfformValidateEvent;
+use Civi\Afform\FormDataModel;
 use Civi\Contribute\Utils\PriceFieldUtils;
 use Civi\Core\Service\AutoService;
 use DateTime;
@@ -34,7 +36,7 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
    *
    * Can be overridden using setActive method
    */
-  protected function isActive($formDataModel): bool {
+  protected function isActive(FormDataModel $formDataModel): bool {
     if (!\Civi::settings()->get('contribute_enable_afform_contributions')) {
       return FALSE;
     }
@@ -55,6 +57,8 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
    */
   public static function getSubscribedEvents(): array {
     return [
+      // add dependencies from Contribution to entities with Price Fields
+      'civi.afform.sort.submit' => ['onAfformEntitySort', 0],
       'civi.afform.validate' => [
         // TODO: this belongs in a hook to validate a form
         // that is being saved or loaded rather than submitted
@@ -260,6 +264,51 @@ class CreateContribution extends AutoService implements EventSubscriberInterface
 
     // TODO: do we need to copy the first contribution as a template?
     // or will it be used anyway if no template contribution exists
+  }
+
+  public function onAfformEntitySort(AfformEntitySortEvent $e): void {
+    $formEntities = $e->getFormDataModel()->getEntities();
+
+    // see if there is a Contribution entity on the form
+    // NOTE: currently we expect max one Contribution entity
+    $contributionEntity = array_find_key($formEntities, fn ($details) => $details['type'] === 'Contribution');
+    if (!$contributionEntity) {
+      // if not, ignore
+      return;
+    }
+
+    foreach ($formEntities as $entity => $details) {
+      // no point adding depedency on itself
+      if ($entity === $contributionEntity) {
+        continue;
+      }
+      if ($this->afformEntityHasPriceField($details)) {
+        $e->addDependency($contributionEntity, $entity);
+      }
+    }
+  }
+
+  private function afformEntityHasPriceField(array $entityDetails): bool {
+    $entityType = $entityDetails['type'];
+    if (!$entityType) {
+      // skip things like 'extra'
+      return FALSE;
+    }
+
+    $priceFields = PriceFieldUtils::getPriceFieldsForEntity($entityType);
+
+    // if there are no price fields for this entity, then
+    if (!$priceFields) {
+      return FALSE;
+    }
+
+    if (\array_intersect_key($priceFields, $entityDetails['data'] ?? [])) {
+      return TRUE;
+    }
+    if (\array_intersect_key($priceFields, $entityDetails['fields'] ?? [])) {
+      return TRUE;
+    }
+    return FALSE;
   }
 
 }

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/AfformContributionTest.php
@@ -2,6 +2,8 @@
 
 namespace Civi\Contribute;
 
+use Civi\Afform\Event\AfformEntitySortEvent;
+use Civi\Afform\FormDataModel;
 use Civi\Api4\Afform;
 use Civi\Contribute\Utils\PriceFieldUtils;
 use Civi\Test;
@@ -276,6 +278,48 @@ class AfformContributionTest extends TestCase implements HeadlessInterface {
       $this->assertEquals(TRUE, \str_contains($e->getMessage(), 'No line items'));
     }
 
+  }
+
+  public function testEntityDependencyOrdering() {
+    $formHtml = <<<HTML
+      <af-form>
+        <af-entity type="Contribution" name="Contribution1" data="{contact_id: 'Individual1'}" />
+        <af-entity type="Participant" name="Participant1">
+        <af-entity type="Participant" name="Participant2" data="{'participant_fields.ticket_option': 10}">
+        <af-entity type="Individual" name="Individual1" />
+        <fieldset af-fieldset="Participant1" class="af-container">
+          <af-field name="participant_fields.ticket_option" />
+          <af-field name="source" />
+        </fieldset>
+        <fieldset af-fieldset="Individual1" class="af-container">
+          <af-field name="first_name" />
+          <af-field name="last_name" />
+        </fieldset>
+      </af-form>
+      HTML;
+
+    $parser = new \CRM_Afform_ArrayHtml();
+    $formDataModel = new FormDataModel($parser->convertHtmlToArray($formHtml));
+
+    $entityValues = [
+      'Contribution1' => [['fields' => ['contact_id' => 'Individual1']]],
+      'Participant1' => [['fields' => ['participant_fields.ticket_option' => '5', 'source' => 'Test Registration']]],
+      'Participant2' => [['fields' => ['participant_fields.ticket_option' => '10']]],
+      'Individual1' => [['fields' => ['first_name' => 'Test', 'last_name' => 'Contact']]],
+    ];
+
+    $sorter = new AfformEntitySortEvent([], $formDataModel, new \Civi\Api4\Generic\BasicGetAction('', ''), $entityValues);
+    \Civi::dispatcher()->dispatch('civi.afform.sort.submit', $sorter);
+    $sorted = $sorter->getSorted();
+
+    // expect Participants and Contact moved before Contribution
+    $expected = [
+      'Individual1',
+      'Participant1',
+      'Participant2',
+      'Contribution1',
+    ];
+    $this->assertEquals($expected, $sorted);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a gotcha where Price Fields don't work if they are on linked entities added *after* the Contribution.

Before
----------------------------------------
- create a form with a Contribution entity
- now add a Participant or Membership entity and add a Price Field to the Participant/Membership
- submit the form => it fails, because the Contribution is saved first, and cant get the linked Participant/Membership to use in its LineItems


After
----------------------------------------
- submit succeeds - dependencies based on Price Fields are registered and resolved (in the same way as Entity Reference dependencies)

Technical Details
----------------------------------------
Based on https://github.com/civicrm/civicrm-core/pull/36161 - much simpler diff when that is merged.

Added a test.

Comments
-------------------------------------
Thanks to Olly (not sure Github handle?) for resurfacing this issue