### PR TITLE
dev/core#6569 clear rather than directly recompute routing table

### DIFF
--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -143,13 +143,6 @@ class CRM_Core_Invoke {
     }
     $item = CRM_Core_Menu::get($path);
 
-    // we should try to compute menus, if item is empty and stay on the same page,
-    // rather than compute and redirect to dashboard.
-    if (!$item) {
-      CRM_Core_Menu::store(FALSE);
-      $item = CRM_Core_Menu::get($path);
-    }
-
     return $item;
   }
 

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -317,20 +317,20 @@ class CRM_Core_Menu {
     return FALSE;
   }
 
+  public static function clear() {
+    $query = 'TRUNCATE civicrm_menu';
+    CRM_Core_DAO::executeQuery($query);
+    Civi::cache('long')->delete('PublicRouteIndex');
+  }
+
   /**
    * This function recomputes menu from xml and populates civicrm_menu.
-   *
-   * @param bool $truncate
    */
-  public static function store($truncate = TRUE) {
-    // first clean up the db
-    if ($truncate) {
-      $query = 'TRUNCATE civicrm_menu';
-      CRM_Core_DAO::executeQuery($query);
-    }
-    Civi::cache('long')->delete('PublicRouteIndex');
-    $menuArray = self::items($truncate);
+  public static function store() {
+    // first clean up existing records
+    self::clear();
 
+    $menuArray = self::items(TRUE);
     self::build($menuArray);
 
     $daoFields = CRM_Core_DAO_Menu::fields();
@@ -573,6 +573,39 @@ class CRM_Core_Menu {
    *   Menu entry array.
    */
   public static function get($path) {
+    $path = (string) $path;
+
+    // all civicrm routes begin with civicrm
+    if ($path !== 'civicrm' && !str_starts_with($path, 'civicrm/')) {
+      return NULL;
+    }
+
+    $item = self::fetch($path);
+    if (!$item) {
+      // if nothing is returned it might just be that the routing table has been
+      // cleared and we need to rebuild it...
+      $anyRoutes = \CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_menu LIMIT 1')->fetch();
+      if ($anyRoutes) {
+        // actual not found
+        return $item;
+      }
+      else {
+        // rebuild and try again
+        self::store();
+        $item = self::fetch($path);
+      }
+    }
+    return $item;
+  }
+
+  /**
+   * @param string $path
+   *   Path of menu item to retrieve.
+   *
+   * @return array
+   *   Menu entry array.
+   */
+  protected static function fetch(string $path) {
     $args = explode('/', $path);
 
     $elements = [];

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -37,7 +37,7 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
       \CRM_Core_ManagedEntities::singleton()->reconcile(E::LONG_NAME);
     }
     if ($this->flushMenu) {
-      \CRM_Core_Menu::store();
+      \CRM_Core_Menu::clear();
     }
   }
 

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -73,7 +73,7 @@ trait AfformSaveTrait {
     }
 
     if (Utils::shouldClearMenuCache($item, $orig ?? [])) {
-      \CRM_Core_Menu::store();
+      \CRM_Core_Menu::clear();
     }
 
     $item['module_name'] = _afform_angular_module_name($item['name'], 'camel');

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -456,7 +456,7 @@ function afform_civicrm_post($op, $entityName, $id, $object, $params) {
       // Adding a new custom field to an empty field group may auto-generate afforms with menu routes.
       // @see Civi\Api4\Action\CustomGroup\GetAfforms::getCustomGroupAfforms
       if ($op === 'create' && $entityName === 'CustomField') {
-        \CRM_Core_Menu::store();
+        \CRM_Core_Menu::clear();
       }
     }
   }

--- a/tests/phpunit/CRM/Core/MenuTest.php
+++ b/tests/phpunit/CRM/Core/MenuTest.php
@@ -70,7 +70,7 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
    * stored and loaded.
    */
   public function testModuleData(): void {
-    CRM_Core_Menu::store(TRUE);
+    CRM_Core_Menu::clear();
     $item = CRM_Core_Menu::get('civicrm/case');
     $this->assertFalse(isset($item['ids_arguments']['exceptions']));
     $this->assertFalse(isset($item['whimsy']));
@@ -80,7 +80,7 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
       $items['civicrm/case']['whimsy'] = 'godliness';
     });
 
-    CRM_Core_Menu::store(TRUE);
+    CRM_Core_Menu::clear();
     $item = CRM_Core_Menu::get('civicrm/case');
     $this->assertTrue(in_array('foobar', $item['ids_arguments']['exceptions']));
     $this->assertEquals('godliness', $item['whimsy']);


### PR DESCRIPTION
Overview
----------------------------------------
Lazily recompute the routing table to avoid doing it multiple times unnecessarily e.g. when creating large numbers of custom fields.

Before
----------------------------------------
- anything that touches the routing table calls `CRM_Core_Menu::store` to rebuild it
- this recomputes the whole table = expensive
- if you aren't actually looking at the routing table in the meantime, this is a lot of wasted time

After
----------------------------------------
- anything that touches the routing table can call `CRM_Core_Menu::clear` to empty it
- it won't be recomputed until someone next calls `CRM_Core_Menu::get`

Technical Details
----------------------------------------
I've removed the `$truncate` param from `CRM_Core_Menu::store` - I don't think it's necessary with this change.

Comments
----------------------------------------
There will be a noticeable lag on the first request after an operation like "create a new Afform route" whilst the rebuild takes place. It's the same time they would have waited to e.g. save the Afform - and it won't be multiple times if they are e.g. installing an extension which creates multiple custom fields.

@eileenmcnaughton can you see if this helps you with https://lab.civicrm.org/dev/core/-/work_items/6569 ?