### PR TITLE
Remove support for civicrmHooks.php

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -206,14 +206,6 @@ abstract class CRM_Utils_Hook {
       // include external file
       $this->commonIncluded = TRUE;
 
-      $config = CRM_Core_Config::singleton();
-      if (!empty($config->customPHPPathDir)) {
-        $civicrmHooksFile = CRM_Utils_File::addTrailingSlash($config->customPHPPathDir) . 'civicrmHooks.php';
-        if (file_exists($civicrmHooksFile)) {
-          @include_once $civicrmHooksFile;
-        }
-      }
-
       if (!empty($fnPrefix)) {
         $this->commonCiviModules[$fnPrefix] = $fnPrefix;
       }

--- a/CRM/Utils/Hook/WordPress.php
+++ b/CRM/Utils/Hook/WordPress.php
@@ -155,14 +155,6 @@ class CRM_Utils_Hook_WordPress extends CRM_Utils_Hook {
 
       if ($this->wordpressModules === NULL) {
 
-        // include custom PHP file - copied from parent->commonBuildModuleList()
-        $config = CRM_Core_Config::singleton();
-        if (!empty($config->customPHPPathDir) &&
-          file_exists("{$config->customPHPPathDir}/civicrmHooks.php")
-        ) {
-          @include_once "{$config->customPHPPathDir}/civicrmHooks.php";
-        }
-
         // initialise with the pre-existing 'wordpress' prefix
         $this->wordpressModules = ['wordpress'];
 


### PR DESCRIPTION
Overview
----------------------------------------

This file was used by CiviCRM Standalone a very long time ago, when CiviCRM extensions did not exist. Since Standalone did not have CMS to rely on, this was how devs could have custom hooks. Very few devs know about it.

Comments
----------------------------------------

Found this via google:

- https://docs.civicrm.org/dev/en/latest/hooks/usage/joomla/
- https://docs.civicrm.org/dev/en/latest/hooks/usage/wordpress/

I opened an issue on the dev docs: https://lab.civicrm.org/documentation/docs/dev/-/work_items/902

cc @seamuslee001 