### PR TITLE
dev/core#6612 - Api4: Fix date comparisons which use GROUP_FIRST

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -128,7 +128,12 @@ class FormattingUtil {
 
     switch ($fieldSpec['data_type'] ?? NULL) {
       case 'Timestamp':
-        $format = 'YmdHis';
+        // In query/filter context (operator is set), use SQL standard 'Y-m-d H:i:s' format.
+        // This is necessary for correct HAVING clause comparisons against aggregate functions
+        // like GROUP_FIRST which return dates as varchar strings in that format via GROUP_CONCAT.
+        // In write context (operator is NULL), keep 'YmdHis' as required by CRM_Utils_Type::validate.
+        // @see https://lab.civicrm.org/dev/core/-/work_items/6612
+        $format = $operator !== NULL ? 'Y-m-d H:i:s' : 'YmdHis';
         // Using `=` with a Y-m-d timestamp means we really want `BETWEEN` midnight and 11:59:59pm.
         if ($operator && is_string($value) && !array_key_exists($value, \CRM_Core_OptionGroup::values('relative_date_filters'))) {
           $isYmd = (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value));
@@ -144,7 +149,10 @@ class FormattingUtil {
         break;
 
       case 'Date':
-        $value = self::formatDateValue('Ymd', $value, $operator, $index);
+        // In query/filter context use 'Y-m-d'; in write context use 'Ymd' (required by CRM_Utils_Type::validate).
+        // @see https://lab.civicrm.org/dev/core/-/work_items/6612
+        $format = $operator !== NULL ? 'Y-m-d' : 'Ymd';
+        $value = self::formatDateValue($format, $value, $operator, $index);
         break;
     }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3739,4 +3739,79 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotEquals($currencyFormatted, $numberFormatted);
   }
 
+  /**
+   * Test that filtering on a GROUP_FIRST date field works correctly.
+   *
+   * GROUP_FIRST uses SUBSTRING_INDEX(GROUP_CONCAT(...)) which returns dates as
+   * a varchar string in "Y-m-d H:i:s" format. Filters applied via FormBuilder
+   * must compare against this format, not the alternate "YmdHis" format.
+   *
+   * @see https://lab.civicrm.org/dev/core/-/work_items/6612
+   * @see \Civi\Api4\Utils\FormattingUtil::formatInputValue
+   */
+  public function testGroupFirstDateFilter(): void {
+    $contacts = $this->saveTestRecords('Individual', [
+      'records' => [
+        ['first_name' => 'Alpha', 'last_name' => uniqid('A')],
+        ['first_name' => 'Beta', 'last_name' => uniqid('B')],
+        ['first_name' => 'Gamma', 'last_name' => uniqid('C')],
+      ],
+    ]);
+
+    // Alpha: Feb 2023 — excluded by filter > 2023-03-01
+    // Beta:  Jun 2023 — included
+    // Gamma: Sep 2023 — included
+    $contributions = $this->saveTestRecords('Contribution', [
+      'records' => [
+        ['contact_id' => $contacts[0]['id'], 'total_amount' => 100, 'receive_date' => '2023-02-01', 'financial_type_id:name' => 'Donation'],
+        ['contact_id' => $contacts[1]['id'], 'total_amount' => 200, 'receive_date' => '2023-06-01', 'financial_type_id:name' => 'Donation'],
+        ['contact_id' => $contacts[2]['id'], 'total_amount' => 300, 'receive_date' => '2023-09-01', 'financial_type_id:name' => 'Donation'],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contribution',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'contact_id',
+            'GROUP_FIRST(receive_date ORDER BY receive_date ASC) AS GROUP_FIRST_receive_date',
+            'SUM(total_amount) AS SUM_total_amount',
+          ],
+          'where' => [
+            ['id', 'IN', $contributions->column('id')],
+          ],
+          'groupBy' => ['contact_id'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'settings' => [
+          'limit' => 50,
+          'pager' => [],
+          'columns' => [
+            ['type' => 'field', 'key' => 'contact_id', 'sortable' => TRUE],
+            ['type' => 'field', 'key' => 'GROUP_FIRST_receive_date', 'sortable' => TRUE],
+            ['type' => 'field', 'key' => 'SUM_total_amount', 'sortable' => TRUE],
+          ],
+        ],
+      ],
+      'filters' => ['GROUP_FIRST_receive_date' => ['>' => '2023-03-01']],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+
+    // Only Beta (June) and Gamma (September) should be returned (after 2023-03-01).
+    // Alpha (February) should be excluded.
+    $this->assertCount(2, $result, 'Should return 2 groups (Beta and Gamma), not Alpha');
+
+    $returnedContactIds = array_column(array_column($result->getArrayCopy(), 'data'), 'contact_id');
+    $this->assertContains($contacts[1]['id'], $returnedContactIds, 'Beta (June 2023) should be included');
+    $this->assertContains($contacts[2]['id'], $returnedContactIds, 'Gamma (September 2023) should be included');
+    $this->assertNotContains($contacts[0]['id'], $returnedContactIds, 'Alpha (February 2023) should be excluded');
+  }
+
 }

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -148,6 +148,45 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertFalse($agg['is_donation_4']);
   }
 
+  /**
+   * Test that GROUP_FIRST on a Date field can be filtered correctly.
+   *
+   * MySQL's GROUP_CONCAT returns Date values as 'Y-m-d' strings. Without a fix,
+   * the filter generates `col` > '20230301' (Ymd format), but when compared to
+   * '2023-06-01' (Y-m-d format from GROUP_CONCAT), the '-' (ASCII 45) < '0' (ASCII 48)
+   * at position 5 means all same-year dates sort incorrectly.
+   *
+   * @see https://lab.civicrm.org/dev/core/-/work_items/6612
+   */
+  public function testGroupFirstDateFieldFilter(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $contacts = $this->saveTestRecords('Individual', [
+      'records' => [
+        // All birth dates in the same year to expose the comparison bug.
+        // Alpha: Feb — excluded by filter > 2023-03-01
+        // Beta:  Jun — included
+        // Gamma: Sep — included
+        ['last_name' => $lastName, 'birth_date' => '2023-02-01'],
+        ['last_name' => $lastName, 'birth_date' => '2023-06-01'],
+        ['last_name' => $lastName, 'birth_date' => '2023-09-01'],
+      ],
+    ]);
+
+    $result = Contact::get(FALSE)
+      ->addSelect('id')
+      ->addSelect('GROUP_FIRST(birth_date ORDER BY id ASC) AS GROUP_FIRST_birth_date')
+      ->addGroupBy('id')
+      ->addWhere('last_name', '=', $lastName)
+      ->addHaving('GROUP_FIRST_birth_date', '>', '2023-03-01')
+      ->execute();
+
+    $this->assertCount(2, $result, 'Should return Beta and Gamma (birth dates after 2023-03-01)');
+    $returnedIds = array_column((array) $result, 'id');
+    $this->assertContains($contacts[1]['id'], $returnedIds, 'Beta (June) should be included');
+    $this->assertContains($contacts[2]['id'], $returnedIds, 'Gamma (September) should be included');
+    $this->assertNotContains($contacts[0]['id'], $returnedIds, 'Alpha (February) should be excluded');
+  }
+
   public function testGroupConcatUnique(): void {
     $cid1 = $this->createTestRecord('Contact')['id'];
     $cid2 = $this->createTestRecord('Contact')['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://lab.civicrm.org/dev/core/-/work_items/6612 date comparisons in SearchKit when using GROUP_FIRST.


Technical Details
----------------------------------------
GROUP_FIRST(date_field) returns dates as "Y-m-d H:i:s" varchar strings (from GROUP_CONCAT). When a filter is applied, Api4 formatted the comparison value using 'YmdHis' format — producing nonsensical string comparisons like "2023-06-01 00:00:00" > "20230301000000", which always fails at the 5th character (- vs 0).

This solves it by adjusting FormattingUtil::formatInputValue to always format dates the same way as they are stored in SQL.