### PR TITLE
SearchKit - Fit better on smaller screens

### DIFF
--- a/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
+++ b/ext/riverlea/core/org.civicrm.search_kit-css/crmSearchAdmin.css
@@ -32,7 +32,7 @@
 /* Top */
 .crm-search .crm-flex-box.crm-search-admin-outer {
   display: grid;
-  grid-template-columns: 280px auto;
+  grid-template-columns: 13rem auto;
   margin-bottom: var(--crm-l-reg-2);
 }
 .crm-search .crm-flex-box.crm-search-admin-outer:first-of-type {


### PR DESCRIPTION
Overview
----------------------------------------
Less space occupied by the tabs = more room for the search

Before
----------------------------------------
<img width="944" height="792" alt="Screenshot 2026-07-07 at 9 53 46 AM" src="https://github.com/user-attachments/assets/d1a1fca4-088f-431d-b647-dbe16eba368c" />


After
----------------------------------------
<img width="944" height="792" alt="Screenshot 2026-07-07 at 9 54 22 AM" src="https://github.com/user-attachments/assets/8cdbd609-829d-49e5-9d21-5e79278d86eb" />
