### PR TITLE
dev/core#6573 include type when reverting search forms to optimise `civi.afform.get`

### DIFF
--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -431,6 +431,7 @@ function afform_civicrm_pre($op, $entity, $id, &$params) {
       ->execute()->first();
     \Civi\Api4\Afform::revert(FALSE)
       ->addWhere('search_displays', 'CONTAINS', $display['saved_search_id.name'] . ".{$display['name']}")
+      ->addWhere('type', '=', 'search')
       ->execute();
   }
   // When deleting a savedSearch, delete any Afforms which use the default display
@@ -441,6 +442,7 @@ function afform_civicrm_pre($op, $entity, $id, &$params) {
       ->execute()->first();
     \Civi\Api4\Afform::revert(FALSE)
       ->addWhere('search_displays', 'CONTAINS', $search['name'])
+      ->addWhere('type', '=', 'search')
       ->execute();
   }
 }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -396,6 +396,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     Afform::create(FALSE)
       ->addValue('name', 'TestAfformToDelete')
       ->addValue('title', 'TestAfformToDelete')
+      ->addValue('type', 'search')
       ->setLayoutFormat('html')
       ->addValue('layout', '<div><crm-search-display-table search-name="TestSearchToDelete" display-name="TestDisplayToDelete"></crm-search-display-table></div>')
       ->execute();
@@ -415,6 +416,7 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     Afform::create(FALSE)
       ->addValue('name', 'TestAfformToDelete2')
       ->addValue('title', 'TestAfformToDelete2')
+      ->addValue('type', 'search')
       ->setLayoutFormat('html')
       ->addValue('layout', '<div><crm-search-display-table search-name="TestSearchToDelete"></crm-search-display-table></div>')
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
Global queries of Afforms are expensive. Specifying the type parameter optimises the lookup. Forms with saved searches in should be `search` forms.

Comments
----------------------------------------
Much narrower fix than https://github.com/civicrm/civicrm-core/pull/36176 - doesn't solve the broader issue but maybe whacks this one particular mole.
