### PR TITLE
Follow up to #36140 move new Smarty Classes into Civi Namesapces and …

### DIFF
--- a/CRM/Core/CodeGen/Util/Smarty.php
+++ b/CRM/Core/CodeGen/Util/Smarty.php
@@ -1,4 +1,5 @@
 <?php
+use Civi\Smarty;
 
 /**
  * Class CRM_Core_CodeGen_Util_Smarty
@@ -42,17 +43,12 @@ class CRM_Core_CodeGen_Util_Smarty {
   /**
    * Create a Smarty instance.
    *
-   * @return \Smarty
+   * @return \Civi\Smarty
    * @throws \SmartyException
    */
   public function createSmarty(): Smarty {
     $base = dirname(__DIR__, 4);
-    if (!class_exists('Smarty', FALSE)) {
-      // Prefer Smarty v5; but if we get here in some scenario with another Smarty, use that.
-      $pkgs = file_exists(dirname($base) . "/civicrm-core") ? dirname($base) . "/civicrm-core" : "$base/";
-      require_once $pkgs . '/CRM/Core/Smarty/Smarty.php';
-    }
-    $smarty = new Smarty();
+    $smarty = new \Civi\Smarty();
     $smarty->setTemplateDir("$base/xml/templates");
     // Doesn't seem to work very well.... since I still need require_once below
     $smarty->addPluginsDir(["$base/CRM/Core/Smarty/plugins"]);

--- a/CRM/Core/CodeGen/Util/Template.php
+++ b/CRM/Core/CodeGen/Util/Template.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Smarty;
+
 /**
  * Class CRM_Core_CodeGen_Util_Template
  */

--- a/CRM/Core/SmartyCompatibility.php
+++ b/CRM/Core/SmartyCompatibility.php
@@ -31,29 +31,7 @@
  * with reference to `$template =& CRM_Core_Smarty::singleton();`
  */
 
-/**
- * Get the path to load Smarty.
- *
- * @return string|null
- */
-function crm_smarty_compatibility_get_path() {
-  return \Civi::paths()->getPath('[civicrm.root]/CRM/Core/Smarty/Smarty.php');
-}
-
-/**
- * Fix for bug CRM-392. Not sure if this is the best fix or it will impact
- * other similar PEAR packages. doubt it
- */
-if (!class_exists('Smarty')) {
-  $path = crm_smarty_compatibility_get_path();
-  if ($path) {
-    // Specify the smarty version to load.
-    require_once $path;
-  }
-  else {
-    require_once 'Smarty/Smarty.class.php';
-  }
-}
+use Civi\Smarty;
 
 /**
  *

--- a/Civi/Smarty.php
+++ b/Civi/Smarty.php
@@ -9,28 +9,28 @@
  +--------------------------------------------------------------------+
  */
 
-class_alias('CRM_Core_Smarty_Smarty', 'Smarty');
+namespace Civi;
 
 /**
  *
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
-class CRM_Core_Smarty_Smarty {
+class Smarty {
 
   private \Smarty\Smarty $smarty;
 
   private $registeredPluginDirectories = [];
 
   public function __construct() {
-    $this->smarty = new Smarty\Smarty();
-    if (CRM_Utils_Constant::value('CIVICRM_SMARTY_DEFAULT_ESCAPE')) {
+    $this->smarty = new \Smarty\Smarty();
+    if (\CRM_Utils_Constant::value('CIVICRM_SMARTY_DEFAULT_ESCAPE')) {
       // See https://smarty-php.github.io/smarty/stable/api/extending/extensions/#writing-your-own-extension
       $this->smarty->setExtensions([
-        new Smarty\Extension\CoreExtension(),
-        new CRM_Core_Smarty_EscapeOverrideExtension(),
-        new Smarty\Extension\DefaultExtension(),
-        new Smarty\Extension\BCPluginsAdapter($this->smarty),
+        new \Smarty\Extension\CoreExtension(),
+        new \Civi\Smarty\EscapeOverrideExtension(),
+        new \Smarty\Extension\DefaultExtension(),
+        new \Smarty\Extension\BCPluginsAdapter($this->smarty),
       ]);
       $this->smarty->addDefaultModifiers(['escape:"htmlall"']);
     }
@@ -84,7 +84,7 @@ class CRM_Core_Smarty_Smarty {
           continue;
         }
         $registeredPlugins = $this->smarty->registered_plugins;
-        if (CRM_Utils_File::isIncludable($pluginsDirectory . DIRECTORY_SEPARATOR . $file)) {
+        if (\CRM_Utils_File::isIncludable($pluginsDirectory . DIRECTORY_SEPARATOR . $file)) {
           require_once $pluginsDirectory . DIRECTORY_SEPARATOR . $file;
           $parts = explode('.', $file);
           if (!empty($registeredPlugins[$parts[0]][$parts[1]])) {

--- a/Civi/Smarty/EscapeModifierCompilerOverride.php
+++ b/Civi/Smarty/EscapeModifierCompilerOverride.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Civi\Smarty;
+
 use Smarty\Compile\Modifier\EscapeModifierCompiler;
 
 /**
@@ -10,7 +12,7 @@ use Smarty\Compile\Modifier\EscapeModifierCompiler;
  *
  * @author Rodney Rehm
  */
-class CRM_Core_Smarty_EscapeModifierCompilerOverride extends EscapeModifierCompiler {
+class EscapeModifierCompilerOverride extends EscapeModifierCompiler {
 
   public function compile($params, \Smarty\Compiler\Template $compiler) {
     $esc_type = $this->literal_compiler_param($params, 1, 'html');
@@ -18,7 +20,7 @@ class CRM_Core_Smarty_EscapeModifierCompilerOverride extends EscapeModifierCompi
     ) {
       return parent::compile($params, $compiler);
     }
-    return 'CRM_Core_Smarty::escape((string)' . $params[0] . ', "htmlall")';
+    return '\CRM_Core_Smarty::escape((string)' . $params[0] . ', "htmlall")';
   }
 
 }

--- a/Civi/Smarty/EscapeOverrideExtension.php
+++ b/Civi/Smarty/EscapeOverrideExtension.php
@@ -1,13 +1,15 @@
 <?php
 
+namespace Civi\Smarty;
+
 use Smarty\Extension\Base;
 
-class CRM_Core_Smarty_EscapeOverrideExtension extends Base {
+class EscapeOverrideExtension extends Base {
 
   public function getModifierCompiler(string $modifier): ?\Smarty\Compile\Modifier\ModifierCompilerInterface {
     switch ($modifier) {
       case 'escape':
-        return new CRM_Core_Smarty_EscapeModifierCompilerOverride();
+        return new EscapeModifierCompilerOverride();
 
     }
 

--- a/setup/src/Setup/SmartyUtil.php
+++ b/setup/src/Setup/SmartyUtil.php
@@ -1,22 +1,20 @@
 <?php
 namespace Civi\Setup;
 
+use Civi\Smarty;
+
 class SmartyUtil {
 
   /**
    * Create a Smarty instance.
    *
-   * @return \Smarty
+   * @return \Civi\Smarty
    * @throws \SmartyException
    */
   public static function createSmarty($srcPath) {
-    if (!class_exists('Smarty', FALSE)) {
-      // Prefer Smarty v5; but if we get here in some scenario with another Smarty, use that.
-      require_once $srcPath . '/CRM/Core/Smarty/Smarty.php';
-    }
-    $smarty = new \Smarty();
+    $smarty = new Smarty();
     $smarty->setTemplateDir(implode(DIRECTORY_SEPARATOR, [$srcPath, 'xml', 'templates']));
-    $pluginsDirectory = $smarty->addPluginsDir([
+    $smarty->addPluginsDir([
       implode(DIRECTORY_SEPARATOR, [$srcPath, 'CRM', 'Core', 'Smarty', 'plugins']),
     ]);
     $smarty->setCompileDir(\Civi\Setup\FileUtil::createTempDir('templates_c'));

--- a/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
+++ b/tests/phpunit/E2E/Core/SmartyConsistencyTest.php
@@ -485,11 +485,11 @@ class SmartyConsistencyTest extends \CiviEndToEndTestCase {
     $versions = [
       '5_plain' => [
         'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 0,
-        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.root]/CRM/Core/Smarty/Smarty.php'),
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.root]/Civi/Smarty.php'),
       ],
       '5_auto' => [
         'CIVICRM_SMARTY_DEFAULT_ESCAPE' => 1,
-        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.root]/CRM/Core/Smarty/Smarty.php'),
+        'CIVICRM_SMARTY_AUTOLOAD_PATH' => \Civi::paths()->getPath('[civicrm.root]/Civi/Smarty.php'),
       ],
     ];
 


### PR DESCRIPTION
…remove require once / class_exist handling

Overview
----------------------------------------
This follows up on the feedback provided in #36140 and shifts into the PS7 Namesapce

pin g @colemanw @demeritcowboy @ufundo @eileenmcnaughton 
