### PR TITLE
Followup to #34708 to truly allow legacy recurring transactions

### DIFF
--- a/CRM/Core/Payment/PayPalIPN.php
+++ b/CRM/Core/Payment/PayPalIPN.php
@@ -277,7 +277,7 @@ class CRM_Core_Payment_PayPalIPN {
   public function main(): void {
     try {
       $input = [];
-      $component = $this->retrieve('module', 'String');
+      $component = $this->retrieve('module', 'String', FALSE);
       $input['component'] = $component;
       $this->getInput($input);
 
@@ -344,7 +344,7 @@ class CRM_Core_Payment_PayPalIPN {
   public function getInput(&$input) {
     $billingID = CRM_Core_BAO_LocationType::getBilling();
     $input['paymentStatus'] = $this->retrieve('payment_status', 'String', FALSE);
-    $input['invoice'] = $this->retrieve('invoice', 'String', TRUE);
+    $input['invoice'] = $this->retrieve('invoice', 'String', FALSE);
     $input['total_amount'] = $this->retrieve('mc_gross', 'Money', FALSE);
     $input['reasonCode'] = $this->retrieve('ReasonCode', 'String', FALSE);
 


### PR DESCRIPTION
Overview
----------------------------------------
This helps to achieve the design intent of #34708 and fixes [dev/core#6629](https://lab.civicrm.org/dev/core/-/work_items/6629).

The idea of supporting legacy transactions isn't quite realised, because an exception is thrown if either the `module` or `invoice` fields are missing from the submitted data, even though these won't be present in legacy transactions (i.e. those originated outside of CiviCRM).

Before
----------------------------------------
Attempting to send a legacy IPN to the PayPal processor results in two (sequential) errors:

```
2026-07-07 20:11:43+0100  [debug] PayPalIPN: Could not find an entry for module input {input}
Array
(
    [input] => Array
        (
        )

)
```

and

```
2026-07-07 22:29:48+0100  [debug] PayPalIPN: Could not find an entry for invoice input {input}
Array
(
    [input] => Array
        (
            [component] => 
            [paymentStatus] => Completed
        )

)
```

After
----------------------------------------
These legacy IPNs are now accepted and processed as normal.

Technical Details
----------------------------------------
The issue arises because the `module` and `invoice` fields (which would normally be set in the custom data) are missing, and an exception is thrown. This PR removes the hard requirement for the fields to be present, allowing legacy transactions to be processed alongside normal CiviCRM ones.

The justification for this is as follows:

- `module` (which is internally mapped to `component`) is, as far as I can tell, not actually used anywhere.
- `invoice` is verified against the `invoice_id` of the recurring contribution (on lines [112](https://github.com/civicrm/civicrm-core/blob/859e441cf0f758334ff8c17fae1e07c1bb2eeac6/CRM/Core/Payment/PayPalIPN.php#L112) and [241](https://github.com/civicrm/civicrm-core/blob/859e441cf0f758334ff8c17fae1e07c1bb2eeac6/CRM/Core/Payment/PayPalIPN.php#L241)). In the case of legacy transactions, these are both `NULL` which is correct, so the check passes. In the case of normal transactions, these will be non-NULL. The comparison is still performed in all cases, so a mismatch will still be detected if the attribute is missing when it shouldn't be.

I also note that these attributes are not required in the `PayPalProIPN` processor.

Comments
----------------------------------------
I believe supporting legacy transactions like this was the intent by @mattwire .
