### PR TITLE
Set fts search setting to default to FALSE not TRUE

### DIFF
--- a/settings/Search.setting.php
+++ b/settings/Search.setting.php
@@ -269,7 +269,7 @@ return [
     'name' => 'search_mysql_fts',
     'type' => 'Boolean',
     'html_type' => 'toggle',
-    'default' => TRUE,
+    'default' => FALSE,
     'add' => '6.17',
     'title' => ts('Use Mysql Full Text Search'),
     'is_domain' => 1,


### PR DESCRIPTION


Overview
----------------------------------------
Set fts search setting to default to FALSE not TRUE

This is a new setting & I don't think it should be on by default. Obviously it creates the slow upload but our experience of using it was not great either - having it opt in initially would be a more normal process for something with potential signficant impact and variable usefulness

Before
----------------------------------------
fts search setting is new in 6.17 & defaults to TRUE to enable it

After
----------------------------------------
fts search setting defaults to FALSE, requiring someone to enable it

Technical Details
----------------------------------------
FTS has always been off by default in the past - this is a potentially good improvement for many sites but I think setting to TRUE from the get go is too aggressive

Comments
----------------------------------------