### PR TITLE
Make it clear that mysql_fts is enabled by default

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixSeventeen.php
+++ b/CRM/Upgrade/Incremental/php/SixSeventeen.php
@@ -25,7 +25,7 @@ class CRM_Upgrade_Incremental_php_SixSeventeen extends CRM_Upgrade_Incremental_B
     if ($rev === '6.17.alpha1') {
       if (Civi::settings()->get('search_mysql_fts')) {
         $settingUrl = (string) \Civi::url('civicrm/admin/setting/search', 'h')->addQuery(['reset' => 1]);
-        $preUpgradeMessage .= '<p>' . ts("This upgrade will add a new Full Text Search index on the `civicrm_contact` table. If you have lots of contacts, this may take a while and use a lot of space on your database server. If you don't want this, turn off Use Mysql Full Text Search in <a %1>Search Preferences</a> before running the upgrade.", [1 => ('href="' . $settingUrl . '"')]) . '</p>';
+        $preUpgradeMessage .= '<p>' . ts("This upgrade will add a new Full Text Search index on the `civicrm_contact` table. If you have lots of contacts, this may take a while and use a lot of space on your database server. Note that this is a new setting which is enabled by default and is different from the older InnoDB Full Text Search setting. If you don't want this, turn off Use Mysql Full Text Search in <a %1>Search Preferences</a> before running the upgrade.", [1 => ('href="' . $settingUrl . '"')]) . '</p>';
       }
     }
   }


### PR DESCRIPTION
And that it is not the same as the older InnoDB full text search setting. Someone reading through this quickly (like me) might not realize that this is a new setting, distinct from the old one, and think that they don't need to worry about it — and then end up with a very slow upgrade.