### PR TITLE
Cast null to '' to overpass sql return, since string as response expe…

### DIFF
--- a/Civi/Core/Exception/DBQueryException.php
+++ b/Civi/Core/Exception/DBQueryException.php
@@ -103,7 +103,7 @@ class DBQueryException extends \CRM_Core_Exception {
     $dbErrorMessage = $this->getUserInfo();
     $matches = [];
     preg_match('/(.*) \[nativecode=/', $dbErrorMessage, $matches);
-    return $matches[1];
+    return $matches[1] ?? '';
   }
 
   /**


### PR DESCRIPTION
We expect string so to prevent typeError when result is null convert to empty string 