### PR TITLE
Afform css, fixes regression that makes .af-layout-inline the same as .af-layout-cols

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -11,8 +11,7 @@ a.af-api4-action-idle {
   flex-wrap: wrap;
   gap: var(--crm-flex-gap, 0.5rem);
 }
-.af-container.af-layout-cols > *,
-.af-container.af-layout-inline > * {
+.af-container.af-layout-cols > * {
   flex: 1;
 }
 .af-container.af-layout-inline {


### PR DESCRIPTION
FormBuilder lets you arrange form elements in three ways: the default (stacked), then `-af-layout-inline` and `.af-layout-cols`, ie what's selectable here:

<img width="199" height="51" alt="image" src="https://github.com/user-attachments/assets/da4b055b-4f55-43ea-989b-e81bd0d41118" />

RiverLea changed the underlying css to Flex and somewhere along the way broke the difference between Inline (which shrinks each element to their width) and Column (fixed width for each element). This was then merged with `afcore.css` at the end of last year (https://github.com/civicrm/civicrm-core/pull/34165), making the regression everywhere.

Thankfully it's barely noticeable in most situations, and was only found because I was looking at the form patterns for a new [Dress Code update](https://lab.civicrm.org/extensions/dresscode/-/merge_requests/41) and couldn't see a difference between these two patterns.

Before
----------------------------------------
Regular inputs:
<img width="1172" height="312" alt="image" src="https://github.com/user-attachments/assets/534c0173-a31a-49d1-b3ec-92b548d3a930" />

With long input:
<img width="1166" height="261" alt="image" src="https://github.com/user-attachments/assets/96929828-1a64-4565-b05b-9f4547776b80" />

After
----------------------------------------
Regular inputs:
<img width="1172" height="309" alt="image" src="https://github.com/user-attachments/assets/b388369f-4d64-498f-a828-8579046d3ed2" />

With long input:
<img width="1167" height="329" alt="image" src="https://github.com/user-attachments/assets/54bf7285-d1d6-494f-aa31-dab6ec0517a7" />

Comments
----------------------------------------
The css change here is minor but it will have consequences on existing forms. The biggest likely problem will be people having selected af-layout-inline when they wanted af-layout-cols and finding forms have lost spacing. But hopefully the icon in FormBuilder pushed people in the right direction (and most FormBuilder implementers remember how it used to work).

But that's why I'm putting this against master rather than the beta even tho it's a regression - to flag it with FB users to be aware of. The quick fix is 'if after upgrading to 6.17 your form spacing collapses, switch it to `af-layout-cols` 

<img width="80" height="46" alt="image" src="https://github.com/user-attachments/assets/999e7cee-500c-4e2c-a92b-81e0dc6875b8" />

NB - `af-layout-cols` is unchanged with the PR, copied below for reference:

<img width="1170" height="262" alt="image" src="https://github.com/user-attachments/assets/d25e5b9a-05dd-46f0-b901-6d12b7421ad2" />
<img width="1168" height="181" alt="image" src="https://github.com/user-attachments/assets/5c2e8e68-c46c-4409-b0c4-a6e8b4700049" />

cc @colemanw / @ufundo 