### PR TITLE
Drupal 11+ Claro sidemenu offset

### DIFF
--- a/ext/riverlea/core/css/_cms.css
+++ b/ext/riverlea/core/css/_cms.css
@@ -36,6 +36,9 @@ body.page-civicrm .crm-container div.status {
 }
 
 /* D8+ */
+body.page-civicrm #civicrm-menu-nav {
+  margin-left: var(--drupal-displace-offset-left);
+}
 body.page-civicrm header.content-header {
   margin-bottom: 0;
   background-color: var(--crm-container-bg-color);


### PR DESCRIPTION
The CiviCRM menubar overlaps the Drupal 11+ Claro sidebar menu. This PR uses Drupal's own CSS variable to adjust the position of the menubar to avoid overlap, which allows it to adapt to narrow and wide versions (and also not load on Drupal admin themes that don't set this variable).

Before
----------------------------------------

Narrow:
<img width="1413" height="384" alt="image" src="https://github.com/user-attachments/assets/72129ce7-b61d-41f2-9b51-f8c9316a50cc" />

Wide: 
<img width="1419" height="301" alt="image" src="https://github.com/user-attachments/assets/f66410b3-4d1e-4ae3-aebe-4a8c811020c0" />


After
----------------------------------------

Narrow:
<img width="1392" height="408" alt="image" src="https://github.com/user-attachments/assets/010ef759-3a4a-4965-b1a0-7a2dbc855aef" />

Wide:
<img width="1387" height="333" alt="image" src="https://github.com/user-attachments/assets/59cf3d3d-1a68-40e7-a79c-dd52b5a1bf93" />

Technical Details
----------------------------------------
This only fixes the problem for screens wider than 1024pixels - less than that, Drupal's own variable resets to 0px for some reason, so it stops working.

Comments
----------------------------------------
The default test will be Standalone - but this needs to be tested on Drupal (I have a memory there is a special tag for that?)
