### PR TITLE
dev/core#6630 Trigger rebuild fails in cases when SHOW TABLES query returns empty values.

### DIFF
--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -77,10 +77,17 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
 
     $triggers = [];
     $existingTables = [];
-    foreach (\CRM_Core_DAO::executeQuery('SHOW TABLES')->fetchAll() as $table) {
-      $tableName = reset($table);
-      $existingTables[$tableName] = $tableName;
-    };
+    $query = "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'";
+    $results = \CRM_Core_DAO::executeQuery($query)->fetchAll();
+
+    if (!empty($results)) {
+      foreach ($results as $row) {
+        $tableName = reset($row);
+        if (!empty($tableName)) {
+          $existingTables[$tableName] = $tableName;
+        }
+      }
+    }
 
     // now enumerate the tables and the events and collect the same set in a different format
     foreach ($info as $value) {


### PR DESCRIPTION
Fixes dev/core#6630: Trigger rebuild fails in cases when SHOW TABLES query returns empty values.

Overview
----------------------------------------
This changes the query that lists table names so that it uses the information schema rather than SHOW TABLES.

Before
----------------------------------------
Triggers are deleted but not rebuilt.

Logs show "trigger on non-existent table"  warnings for tables that do exist.

Status page shows warning:
"Missing Relationship Cache Trigger
Your database is missing functionality to populate the relationship cache."

After
----------------------------------------
Triggers are deleted and rebuilt as expected.

Comments
----------------------------------------
I'm not certain why the SHOW TABLES query sometimes returns empty values. I have compared user grants on sites where this has occurred (Standalone and WordPress) and on sites where it has not (Drupal, Backdrop) and the user grants are the same. This code change does prevent the warnings and does allow the triggers to be rebuilt.