### PR TITLE
River: multiple bootstrap dropdown/background/hover colour fixes

### DIFF
--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -536,7 +536,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-primary-color);
   color: var(--crm-primary-text-color);
 }
-#bootstrap-theme .bg-primary a,
+#bootstrap-theme li.bg-primary > a,
+#bootstrap-theme .bg-primary > span > a:not(.btn),
 #bootstrap-theme .dropdown-menu .bg-primary .crm-i::before {
   color: var(--crm-primary-text-color);
 }
@@ -549,7 +550,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-secondary-color);
   color: var(--crm-secondary-text-color);
 }
-#bootstrap-theme .bg-secondary a,
+#bootstrap-theme li.bg-secondary > a,
+#bootstrap-theme .bg-secondary > span > a:not(.btn),
 #bootstrap-theme .dropdown-menu .bg-secondary .crm-i::before {
   color: var(--crm-secondary-text-color);
 }
@@ -562,7 +564,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-success-color);
   color: var(--crm-success-text-color);
 }
-#bootstrap-theme .bg-success a,
+#bootstrap-theme li.bg-success > a,
+#bootstrap-theme .bg-success > span > a:not(.btn),
 #bootstrap-theme .dropdown-menu .bg-success .crm-i::before  {
   color: var(--crm-success-text-color);
 }
@@ -576,7 +579,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-info-color);
   color: var(--crm-info-text-color);
 }
-#bootstrap-theme .bg-info a,
+#bootstrap-theme li.bg-info > a,
+#bootstrap-theme .bg-info > span > a:not(.btn),
 #bootstrap-theme .dropdown-menu .bg-info .crm-i::before {
   color: var(--crm-info-text-color);
 }
@@ -590,7 +594,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-warning-color);
   color: var(--crm-warning-text-color);
 }
-#bootstrap-theme .bg-warning a,
+#bootstrap-theme li.bg-warning > a,
+#bootstrap-theme .bg-warning > span > a:not(.btn),
 #bootstrap-theme .dropdown-menu .bg-warning .crm-i::before {
   color: var(--crm-warning-text-color);
 }
@@ -604,7 +609,8 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-danger-color);
   color: var(--crm-danger-text-color);
 }
-#bootstrap-theme .bg-danger a,
+#bootstrap-theme li.bg-danger > a,
+#bootstrap-theme .bg-danger > span > a:not(.btn),
 #bootstrap-theme .dropdown-menu .bg-danger .crm-i::before {
   color: var(--crm-danger-text-color);
 }

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -566,7 +566,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
 }
 #bootstrap-theme li.bg-success > a,
 #bootstrap-theme .bg-success > span > a:not(.btn),
-#bootstrap-theme .dropdown-menu .bg-success .crm-i::before  {
+#bootstrap-theme .dropdown-menu .bg-success .crm-i::before {
   color: var(--crm-success-text-color);
 }
 #bootstrap-theme a.bg-success:is(:hover,:focus),

--- a/ext/riverlea/core/css/components/_components.css
+++ b/ext/riverlea/core/css/components/_components.css
@@ -536,87 +536,83 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before {
   background-color: var(--crm-primary-color);
   color: var(--crm-primary-text-color);
 }
-#bootstrap-theme .bg-primary a {
+#bootstrap-theme .bg-primary a,
+#bootstrap-theme .dropdown-menu .bg-primary .crm-i::before {
   color: var(--crm-primary-text-color);
 }
-#bootstrap-theme a.bg-primary:hover,
-#bootstrap-theme a.bg-primary:focus {
+#bootstrap-theme a.bg-primary:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu .bg-primary a:is(:hover,:focus) {
   background-color: var(--crm-primary-hover-color);
+  color: var(--crm-primary-hover-text-color);
 }
 #bootstrap-theme .bg-secondary {
   background-color: var(--crm-secondary-color);
   color: var(--crm-secondary-text-color);
 }
-#bootstrap-theme .bg-secondary a {
+#bootstrap-theme .bg-secondary a,
+#bootstrap-theme .dropdown-menu .bg-secondary .crm-i::before {
   color: var(--crm-secondary-text-color);
 }
-#bootstrap-theme a.bg-secondary:hover,
-#bootstrap-theme a.bg-secondary:focus {
+#bootstrap-theme a.bg-secondary:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu .bg-secondary a:is(:hover,:focus) {
   background-color: var(--crm-secondary-hover-color);
+  color: var(--crm-secondary-hover-text-color);
 }
-#bootstrap-theme .dropdown-menu .bg-success a,
-#bootstrap-theme .dropdown-menu a.bg-success,
 #bootstrap-theme .bg-success {
   background-color: var(--crm-success-color);
   color: var(--crm-success-text-color);
 }
-#bootstrap-theme a.bg-success:hover,
-#bootstrap-theme a.bg-success:focus,
-#bootstrap-theme .dropdown-menu a.bg-success:hover,
-#bootstrap-theme .dropdown-menu .bg-success a:hover {
+#bootstrap-theme .bg-success a,
+#bootstrap-theme .dropdown-menu .bg-success .crm-i::before  {
+  color: var(--crm-success-text-color);
+}
+#bootstrap-theme a.bg-success:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu a.bg-success:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu .bg-success a:is(:hover,:focus) {
   background: color-mix(in srgb, var(--crm-success-color) 87.5%, #000 12.5%);
   color: var(--crm-success-text-color);
 }
-#bootstrap-theme .dropdown-menu .bg-info a,
-#bootstrap-theme .dropdown-menu a.bg-info,
 #bootstrap-theme .bg-info {
   background-color: var(--crm-info-color);
   color: var(--crm-info-text-color);
 }
-#bootstrap-theme a.bg-info:hover,
-#bootstrap-theme a.bg-info:focus,
-#bootstrap-theme .dropdown-menu .bg-info a:hover,
-#bootstrap-theme .dropdown-menu a.bg-info:hover {
+#bootstrap-theme .bg-info a,
+#bootstrap-theme .dropdown-menu .bg-info .crm-i::before {
+  color: var(--crm-info-text-color);
+}
+#bootstrap-theme a.bg-info:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu .bg-info a:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu a.bg-info:is(:hover,:focus) {
   background: color-mix(in srgb, var(--crm-info-color) 87.5%, #000 12.5%);
   color: var(--crm-info-text-color);
 }
-#bootstrap-theme .bg-warning,
-#bootstrap-theme .dropdown-menu .bg-warning a,
-#bootstrap-theme .dropdown-menu a.bg-warning {
+#bootstrap-theme .bg-warning {
   background-color: var(--crm-warning-color);
-  color: var(--crm-warning-text-color) !important /* FormBuilder vs .disabled */;
-}
-#bootstrap-theme a.bg-warning:hover,
-#bootstrap-theme a.bg-warning:focus,
-#bootstrap-theme .dropdown-menu .bg-warning a:hover,
-#bootstrap-theme .dropdown-menu a.bg-warning:hover {
-  background: color-mix(in srgb, var(--crm-warning-color) 87.5%, #000 12.5%);
   color: var(--crm-warning-text-color);
 }
-#bootstrap-theme .bg-danger,
-#bootstrap-theme .dropdown-menu .bg-danger a,
-#bootstrap-theme .dropdown-menu a.bg-danger {
-  background-color: var(--crm-danger-color);
-  color: var(--crm-danger-text-color);
-}
-#bootstrap-theme a.bg-danger:hover,
-#bootstrap-theme a.bg-danger:focus,
-#bootstrap-theme .dropdown-menu .bg-danger a:hover,
-#bootstrap-theme .dropdown-menu a.bg-danger:hover {
-  background: color-mix(in srgb, var(--crm-danger-color) 87.5%, #000 12.5%);
-  color: var(--crm-danger-text-color);
-}
-#bootstrap-theme .dropdown-menu .bg-danger .crm-i::before {
-  color: var(--crm-danger-text-color);
-}
+#bootstrap-theme .bg-warning a,
 #bootstrap-theme .dropdown-menu .bg-warning .crm-i::before {
   color: var(--crm-warning-text-color);
 }
-#bootstrap-theme .dropdown-menu .bg-success .crm-i::before {
-  color: var(--crm-success-text-color);
+#bootstrap-theme a.bg-warning:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu .bg-warning a:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu a.bg-warning:is(:hover,:focus) {
+  background: color-mix(in srgb, var(--crm-warning-color) 87.5%, #000 12.5%);
+  color: var(--crm-warning-text-color);
 }
-#bootstrap-theme .dropdown-menu .bg-info .crm-i::before {
-  color: var(--crm-info-text-color);
+#bootstrap-theme .bg-danger {
+  background-color: var(--crm-danger-color);
+  color: var(--crm-danger-text-color);
+}
+#bootstrap-theme .bg-danger a,
+#bootstrap-theme .dropdown-menu .bg-danger .crm-i::before {
+  color: var(--crm-danger-text-color);
+}
+#bootstrap-theme a.bg-danger:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu .bg-danger a:is(:hover,:focus),
+#bootstrap-theme .dropdown-menu a.bg-danger:is(:hover,:focus) {
+  background: color-mix(in srgb, var(--crm-danger-color) 87.5%, #000 12.5%);
+  color: var(--crm-danger-text-color);
 }
 
 /* CKEditor Config */

--- a/ext/riverlea/core/css/components/_dropdowns.css
+++ b/ext/riverlea/core/css/components/_dropdowns.css
@@ -84,8 +84,8 @@
 .crm-participant-list-inner ul a:is(:hover,:focus),
 #crm-create-new-list ul a:is(:hover,:focus) {
   text-decoration: none;
-  color: var(--crm-text-color);
-  background-color: var(--crm-container-bg-color);
+  color: var(--crm-dropdown-hover-text-color);
+  background-color: var(--crm-dropdown-hover-bg-color);
 }
 
 /* In-table dropdown */
@@ -331,28 +331,29 @@
   color: var(--crm-dropdown-color);
   border-radius: var(--crm-l-radius);
   white-space: nowrap;
+  text-decoration: none;
 }
 .crm-container .dropdown-menu > li:not(.disabled) > a i.crm-i {
   padding-right: var(--crm-l-small);
   color: var(--crm-dropdown-color);
 }
-.crm-container .dropdown-menu > li > a:hover,
-.crm-container .dropdown-menu > li > a:focus,
+:is(#bootstrap-theme,.crm-container) .dropdown-menu > li > a:is(:hover,:focus),
 .crm-container .dropdown-menu > .active > a,
-.crm-container .dropdown-menu > .active > a:hover,
-.crm-container .dropdown-menu > .active > a:focus {
-  color: var(--crm-dropdown-hover-text-color) !important; /* vs BS .btn-secondary:hover */
+.crm-container .dropdown-menu > .active > a:is(:hover,:focus) {
+  color: var(--crm-dropdown-hover-text-color);
   background-color: var(--crm-dropdown-hover-bg-color);
   border-radius: var(--crm-l-radius);
 }
-.crm-container .dropdown-menu > li:not(.disabled) > a:hover i.crm-i,
-.crm-container .dropdown-menu > li:not(.disabled) > a:focus i.crm-i {
+.crm-container .dropdown-menu > li:not(.disabled) > a:is(:hover,:focus) i.crm-i {
   color: var(--crm-dropdown-hover-text-color);
 }
-.crm-container .dropdown-menu > .disabled > a:hover,
-.crm-container .dropdown-menu > .disabled > a:focus {
+.crm-container .dropdown-menu > li.disabled > a {
+  color: color-mix(in srgb, var(--crm-dropdown-color) 60%, var(--crm-dropdown-bg-color) 40%);
+}
+:is(#bootstrap-theme,.crm-container) .dropdown-menu > .disabled > a:is(:hover,:focus) {
   cursor: not-allowed;
   background-color: transparent;
+  color: color-mix(in srgb, var(--crm-dropdown-color) 60%, var(--crm-dropdown-bg-color) 40%);
 }
 .crm-container .open > .dropdown-menu,
 .crm-container .open .btn.dropdown-toggle + .dropdown-menu {


### PR DESCRIPTION
Fixes multiple long-standing issues in River(Lea) with dropdown menus, bootstrap background colours in dropdowns, and hover states, including multiple broken issues where hover makes text illegible, as well as some smaller issues (broken dark-mode, inherited underline, wrong colour for hover state) and a bit of css tidying for the impacted areas. There are multiple fixes here but they all use the same css so couldn't really be separated.

Before
----------------------------------------

1. .`bg-primary` `bg-danger`, `bg-success` and `bg-info` hover states in dropdowns are illegibile
2. `.disabled` items in dropdown no longer look different. 
3. Hover state on `disabled` items makes them impossible to see
4. . sub-menu hover items have the link underline if a Stream sets one. Not needed as hover state is already indicated with colour change.
5. `bg-secondary` hover state doesn't use the `--crm-secondary-hover-color` variable (unlike the others)
6. Action menu dropdowns hover state doesn't work in dark-mode. It also (and this is the cause) doesn't use the default dropdown hover bg and text colour variables.
7. Links in table rows with emphasis colours don't always use the emphasis colour, so can be illegible (depending on the emphasis colour

1.
<img width="175" height="46" alt="image" src="https://github.com/user-attachments/assets/a06d7bea-59f0-4024-8bb7-87fb44400134" />
<img width="202" height="168" alt="image" src="https://github.com/user-attachments/assets/52efea9e-f3cc-4634-9b5e-7f6f54857030" />

2.
<img width="319" height="118" alt="image" src="https://github.com/user-attachments/assets/65d181c6-1f71-4cc0-b8d3-6f447e166df7" />

3. 
<img width="308" height="116" alt="image" src="https://github.com/user-attachments/assets/6dfc0abc-55fc-41c2-baa4-b01c692d8b9f" />

4. 
<img width="386" height="384" alt="image" src="https://github.com/user-attachments/assets/f1d56aba-43bb-4b2f-872a-83365b0cd9fa" />

5.
<img width="204" height="51" alt="image" src="https://github.com/user-attachments/assets/fc10f946-41ba-43c2-b363-ad6b8cb6fbda" />

6. 
<img width="1002" height="434" alt="image" src="https://github.com/user-attachments/assets/c1f6bb85-b661-461f-84ae-28d53be5a53a" />

7.
<img width="1009" height="55" alt="image" src="https://github.com/user-attachments/assets/327ae38e-97ca-48c4-8283-9bb461040e3d" />
<img width="1000" height="52" alt="image" src="https://github.com/user-attachments/assets/9d8443c2-75af-40fc-94bc-943c82d4d1b7" />

After
----------------------------------------
1. Fixed
<img width="178" height="263" alt="image" src="https://github.com/user-attachments/assets/431b07c8-cb92-4bde-8b2b-6fa51d897c86" />

2. Fixed (using a tint of the dropdown text colour variable so it can adapt to different dropdown text colours & dark-mode)
<img width="654" height="218" alt="image" src="https://github.com/user-attachments/assets/8b640ce4-8ae9-430d-b65f-7cdb546a1c4b" />
<img width="273" height="103" alt="image" src="https://github.com/user-attachments/assets/50c29b00-ac63-4404-bd13-777db671f97e" />

3. Fixed (looks the same as screengrabs above now)

4. Fixed
<img width="382" height="386" alt="image" src="https://github.com/user-attachments/assets/e962d48f-5021-403e-8004-17cf96f3eb9c" />

5. Fixed
<img width="189" height="55" alt="image" src="https://github.com/user-attachments/assets/5e89b7dc-c982-4b2c-8ee5-52f04c5679b4" />

6. Fixed
<img width="1022" height="480" alt="image" src="https://github.com/user-attachments/assets/f6d8cda6-682d-41f7-b3f8-d3c44fb4fe55" />

7. Fixed
<img width="1049" height="38" alt="image" src="https://github.com/user-attachments/assets/c4b4c72a-3a26-4a0d-9b27-702b3cfa1806" />

Technical Details
----------------------------------------
The CSS changes at L539 in components.css onwards might look like quite a change. But it's actually a tidy-up/simplification. There's now just three selector patterns (below), which get applied exactly the same to each of the emphasis colour styles like `bg-success`, `bg-warning` etc (before it was a bit of a mess, each a bit different, with some duplication).

```
#bootstrap-theme .bg-primary {
  background-color: var(--crm-primary-color);
  color: var(--crm-primary-text-color);
}
#bootstrap-theme .bg-primary a,
#bootstrap-theme .dropdown-menu .bg-primary .crm-i::before {
  color: var(--crm-primary-text-color);
}
#bootstrap-theme a.bg-primary:is(:hover,:focus),
#bootstrap-theme .dropdown-menu .bg-primary a:is(:hover,:focus) {
  background-color: var(--crm-primary-hover-color);
  color: var(--crm-primary-hover-text-color);
}
```

Comments
----------------------------------------
This has been tested in the obvious places (Dress Code, Search Kit table with each table style, each dropdown style, each button style) on all four streams light and dark. This is being kept as a draft PR because the testing found that SearchKit table rows with emphases background colours cause problems on Thames, Hackney and some contrast issues on Walbrook. 

E.g. Hackney and Thames below:

<img width="1050" height="296" alt="image" src="https://github.com/user-attachments/assets/132da82d-96ee-4431-a938-ca9c50c242df" />
<img width="1063" height="247" alt="image" src="https://github.com/user-attachments/assets/3fd0c21a-e4c8-4c6b-91a8-fbc3f1022c29" />

But then with row colours:

<img width="1063" height="249" alt="image" src="https://github.com/user-attachments/assets/94654f4c-903b-403e-aeda-1acb9115a928" />
<img width="1052" height="342" alt="image" src="https://github.com/user-attachments/assets/16a4a778-f4ce-4514-a412-a2f3414962fe" />

But - there are problems with these at present.. e.g. here's Thames with a 'primary' row style:

<img width="1063" height="221" alt="image" src="https://github.com/user-attachments/assets/431ad6a0-4e7d-444c-80d1-e5e048e13a34" />

There's likely other SK/FB emphasis style combinations I've not found that have issues - so testing appreciated.