### PR TITLE
Don't overwrite SearchDisplay totals column aggregate selection when loading

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.component.js
@@ -64,7 +64,7 @@
         }
       };
 
-      this.setColumnMode = (value) => {
+      this.setColumnMode = (value, setTallyDefaults) => {
         if (value === 'auto') {
           delete this.display.settings.columns;
         }
@@ -72,7 +72,7 @@
         // and populate or validate this.settings.columns
         else {
           this.parent.initColumns({label: true, sortable: true});
-          if (this.display.settings.tally) {
+          if (setTallyDefaults && this.display.settings.tally) {
             this.setTallyDefaults();
           }
         }

--- a/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/searchAdminDisplayTable.html
@@ -149,7 +149,7 @@
       {{:: ts('Use default columns from search') }}
     </label>
     <label class="radio-inline">
-      <input type="radio" ng-click="$ctrl.setColumnMode('custom')" ng-checked="$ctrl.display.settings.columnMode === 'custom'">
+      <input type="radio" ng-click="$ctrl.setColumnMode('custom', true)" ng-checked="$ctrl.display.settings.columnMode === 'custom'">
       {{:: ts('Use custom columns') }}
     </label>
   </div>


### PR DESCRIPTION
Overview
----------------------------------------
Regression in 6.16 due to #35455

1. Create a SearchDisplay
2. Add footer totals
3. Change to custom columns
4. Change one of the footer aggregate options
5. Save

Before
----------------------------------------
After the save and reload, the footer aggregate option will be reset to the default value and if you save again, this will overwrite your change.

After
----------------------------------------
Selected option preserved.