### PR TITLE
Fix fatal error when case is create from Anonymous submission

### DIFF
--- a/Civi/CCase/SequenceListener.php
+++ b/Civi/CCase/SequenceListener.php
@@ -123,6 +123,9 @@ class SequenceListener implements CaseChangeListener {
     $case = $analyzer->getCase();
     if (!empty($case['contact_id'])) {
       $params['target_id'] = \CRM_Utils_Array::first($case['contact_id']);
+      if (!\CRM_Core_Session::getLoggedInContactID()) {
+        $params['source_contact_id'] = \CRM_Utils_Array::first($case['contact_id']);
+      }
     }
 
     civicrm_api3('Activity', 'create', $params);


### PR DESCRIPTION
Overview
----------------------------------------
When a form is submitted by an anonymous user (via Webform or FormBuilder) for a Case Type with a sequence configured, a fatal error occurs stating that source_contact_id is not valid.

This happens because source_contact_id defaults to the currently logged-in user. For anonymous submissions, no user is logged in, so the value is left blank, causing the fatal error.

This PR resolves the issue by automatically setting the source_contact_id to the Case Client contact when the submission is made anonymously.

Before
----------------------------------------
Error: CRM_Core_Exception: source_contact_id is not a valid integer in civicrm_api3() (line 150 of /var/www/html/pradeep/drupal10/vendor/civicrm/civicrm-core/api/api.php).

or 

Afform: afformCaasasa: Silently ignoring exception on submit in processGenericEntity call for "Case1". Message: source_contact_id is not a valid integer

After
----------------------------------------
No error