### PR TITLE
Set trxn date on payment create api call

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -84,6 +84,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           ->addValue('fee_amount', $result['fee_amount'] ?? NULL)
           ->addValue('card_type_id', $paymentParams['card_type_id'])
           ->addValue('pan_truncation', $paymentParams['pan_truncation'])
+          ->addValue('trxn_date', ($result['receive_date'] ?? date('YmdHis')))
           ->execute();
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When attempting to pay an existing **Pay Later** contribution via the Contribution Page using an online payment processor, the system throws the following error:

> **DB Error: unknown error**

I was able to reproduce this issue on the latest `dmaster`. The functionality works correctly in **CiviCRM 6.13.x**, but appears to have regressed in **6.14.x**, likely as a result of this commit:

https://github.com/civicrm/civicrm-core/commit/b308f4e1a1a8c77f155d33aad9a63737850eead3

### Steps to reproduce

1. Create a **Pending (Pay Later)** contribution for a contact.
2. Open the contribution payment page.
3. Attempt to pay the contribution using an online payment processor.



Before
----------------------------------------
The payment fails with a **"DB Error: unknown error"**.
**Error:** ````DB Error: unknown error INSERT INTO `civicrm_financial_item` (`created_date` , `contact_id` , `description` , `amount` , `currency` , `financial_account_id` , `status_id` , `entity_table` , `entity_id` ) VALUES ( 20260708095315 ,  1 , 'Fee' ,  3.45 , 'GBP' ,  5 ,  1 , 'civicrm_financial_trxn' ,  599436 )  [nativecode=1364 ** Field 'transaction_date' doesn't have a default value]````

After
----------------------------------------
The payment is processed successfully and the contribution is marked as completed.
