### PR TITLE
Add unit test coverage for WorkflowMessage::getTemplateFields

### DIFF
--- a/Civi/Api4/Action/WorkflowMessage/GetTemplateFields.php
+++ b/Civi/Api4/Action/WorkflowMessage/GetTemplateFields.php
@@ -17,7 +17,7 @@ class GetTemplateFields extends \Civi\Api4\Generic\BasicGetAction {
    * @var string
    * @required
    */
-  public $workflow;
+  protected $workflow;
 
   /**
    * Controls the return format.

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -193,4 +193,35 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
     $this->assertArrayNotHasKey('text', $result);
   }
 
+  /**
+   * Test WorkflowMessage::getTemplateFields action.
+   */
+  public function testGetTemplateFields(): void {
+    // Default format is metadata
+    $fields = WorkflowMessage::getTemplateFields(FALSE)
+      ->setWorkflow('case_activity')
+      ->execute()
+      ->indexBy('name');
+    $this->assertNotEmpty($fields);
+    $this->assertArrayHasKey('activity', $fields);
+
+    // Format 'example'
+    $example = WorkflowMessage::getTemplateFields(FALSE)
+      ->setWorkflow('case_activity')
+      ->setFormat('example')
+      ->execute()
+      ->single();
+    $this->assertNotEmpty($example);
+    $this->assertArrayHasKey('name', $example);
+
+    // Required workflow parameter validation
+    try {
+      WorkflowMessage::getTemplateFields(FALSE)->execute();
+      $this->fail('Expected CRM_Core_Exception because workflow is required.');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Parameter "workflow" is required.', $e->getMessage());
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add unit test coverage for WorkflowMessage::getTemplateFields APIv4 action.

Before
----------------------------------------
No unit tests covered WorkflowMessage::getTemplateFields.

After
----------------------------------------
Unit test coverage added.

Technical Details
----------------------------------------
getTemplateFields api was added in 8f73531e.