### PR TITLE
restrict the membership types by domain

### DIFF
--- a/CRM/Member/Page/MembershipType.php
+++ b/CRM/Member/Page/MembershipType.php
@@ -119,8 +119,7 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
         'weight',
         'auto_renew',
         'is_active',
-      ])->addWhere('domain_id', '=', 'current_domain')
-      ])->execute()->indexBy('id');
+      ])->addWhere('domain_id', '=', 'current_domain')->execute()->indexBy('id');
 
     foreach ($membershipType as $type) {
       $links = $this->links();

--- a/CRM/Member/Page/MembershipType.php
+++ b/CRM/Member/Page/MembershipType.php
@@ -119,6 +119,7 @@ class CRM_Member_Page_MembershipType extends CRM_Core_Page {
         'weight',
         'auto_renew',
         'is_active',
+      ])->addWhere('domain_id', '=', 'current_domain')
       ])->execute()->indexBy('id');
 
     foreach ($membershipType as $type) {


### PR DESCRIPTION
Overview
----------------------------------------
restrict the membership types by domain

Before
----------------------------------------
Domain id is not respected as is done for other entities

After
----------------------------------------
Membership types configured for the domain are shown on _Membership Types_ screen
