### PR TITLE
Fix for 36195 Check correct array for receive_date

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -84,7 +84,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
           ->addValue('fee_amount', $result['fee_amount'] ?? NULL)
           ->addValue('card_type_id', $paymentParams['card_type_id'])
           ->addValue('pan_truncation', $paymentParams['pan_truncation'])
-          ->addValue('trxn_date', ($result['receive_date'] ?? date('YmdHis')))
+          ->addValue('trxn_date', ($paymentParams['receive_date'] ?? date('YmdHis')))
           ->execute();
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix for #36195 

Before
----------------------------------------
Checking wrong array - $result is not expected to contain receive_date

After
----------------------------------------
Checking right array

Technical Details
----------------------------------------
doPayment has a minimal defined set of return values. Everything else should come from the params before doPayment().

Comments
----------------------------------------
@colemanw @pradpnayak 