### PR TITLE
github actions checkout v4 is deprecated

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -69,7 +69,7 @@ jobs:
           echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
 
       - name: Checkout upstream
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Overview
----------------------------------------
There's a note in the action log. Have been using v6 elsewhere for a few months without problems, although not using the `with` clauses, but the release notes don't show any changes needed.