### PR TITLE
dev/core#6621 - Lock CRM_Core_Menu::store()/clear() route-table rebuilds

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -345,13 +345,17 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
       'TRUNCATE TABLE civicrm_prevnext_cache',
       'UPDATE civicrm_group SET cache_date = NULL',
       'TRUNCATE TABLE civicrm_group_contact_cache',
-      'TRUNCATE TABLE civicrm_menu',
       'UPDATE civicrm_setting SET value = NULL WHERE name="navigation" AND contact_id IS NOT NULL',
     ];
 
     foreach ($queries as $query) {
       CRM_Core_DAO::executeQuery($query);
     }
+
+    // Clear the route table through CRM_Core_Menu::clear() rather than a bare TRUNCATE, so it
+    // takes the data.core.menu lock and drops the derived route cache. Otherwise this cache clear
+    // can wipe civicrm_menu mid-rebuild. dev/core#6621.
+    CRM_Core_Menu::clear();
 
     // Clear the Redis prev-next cache, if there is one.
     // Since we truncated the civicrm_cache table it is logical to also remove

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -46,6 +46,21 @@ class CRM_Core_Menu {
   const MENU_ITEM = 1;
 
   /**
+   * Lock held around a civicrm_menu rebuild, so concurrent rebuilds cannot corrupt the table.
+   *
+   * @see self::store()
+   */
+  private const REBUILD_LOCK = 'data.core.menu';
+
+  /**
+   * Seconds to wait for REBUILD_LOCK before falling back to an unlocked (best-effort) rebuild.
+   *
+   * Generous because a rebuild pays a DB round trip per route and can run for tens of seconds on
+   * an install with a network-remote database.
+   */
+  private const REBUILD_LOCK_TIMEOUT = 180;
+
+  /**
    * This function fetches the menu items from xml and xmlMenu hooks.
    *
    * @param bool $fetchFromXML
@@ -318,8 +333,28 @@ class CRM_Core_Menu {
   }
 
   public static function clear() {
-    $query = 'TRUNCATE civicrm_menu';
-    CRM_Core_DAO::executeQuery($query);
+    // Take the rebuild lock: TRUNCATE is a writer too, and clearing the table out from under an
+    // in-flight self::store() would leave it holding only the rows that store() inserts after the
+    // truncate. Callers include extensions (e.g. Afform) that clear on save.
+    $lock = Civi::lockManager()->acquire(self::REBUILD_LOCK, self::REBUILD_LOCK_TIMEOUT);
+    if (!$lock->isAcquired()) {
+      Civi::log()->warning('CRM_Core_Menu::clear() is truncating civicrm_menu without the ' . self::REBUILD_LOCK . ' lock after waiting ' . self::REBUILD_LOCK_TIMEOUT . 's; a concurrent rebuild may be in progress.');
+    }
+    try {
+      self::clearMenu();
+    }
+    finally {
+      $lock->release();
+    }
+  }
+
+  /**
+   * TRUNCATE civicrm_menu and drop the derived route cache.
+   *
+   * Unlocked; callers hold REBUILD_LOCK (see self::clear() and self::store()).
+   */
+  private static function clearMenu() {
+    CRM_Core_DAO::executeQuery('TRUNCATE civicrm_menu');
     Civi::cache('long')->delete('PublicRouteIndex');
   }
 
@@ -327,9 +362,30 @@ class CRM_Core_Menu {
    * This function recomputes menu from xml and populates civicrm_menu.
    */
   public static function store() {
-    // first clean up existing records
-    self::clear();
+    // Take the rebuild lock: without it, concurrent rebuilds collide on the (path, domain_id)
+    // unique key and can leave the table partially populated. On lock-wait timeout, rebuild anyway (best
+    // effort) rather than skip: an unlocked rebuild is the historical behaviour, so the worst case
+    // is no worse than before, and skipping would leave the empty-table caller in self::get() with
+    // no route table. release() no-ops if the lock is not held.
+    $lock = Civi::lockManager()->acquire(self::REBUILD_LOCK, self::REBUILD_LOCK_TIMEOUT);
+    if (!$lock->isAcquired()) {
+      Civi::log()->warning('CRM_Core_Menu::store() is rebuilding civicrm_menu without the ' . self::REBUILD_LOCK . ' lock after waiting ' . self::REBUILD_LOCK_TIMEOUT . 's; a concurrent rebuild may be in progress.');
+    }
+    try {
+      self::clearMenu();
+      self::rebuild();
+    }
+    finally {
+      $lock->release();
+    }
+  }
 
+  /**
+   * Repopulate civicrm_menu from the route definitions.
+   *
+   * Unlocked; go through self::store(), which clears the table and holds REBUILD_LOCK around this.
+   */
+  private static function rebuild() {
     $menuArray = self::items(TRUE);
     self::build($menuArray);
 

--- a/tests/phpunit/CRM/Core/MenuTest.php
+++ b/tests/phpunit/CRM/Core/MenuTest.php
@@ -140,4 +140,45 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
     $this->assertEquals(TRUE, \CRM_Core_Menu::isPublicRoute('civicrm/contribute/transact'));
   }
 
+  /**
+   * Regression guard for the fix: both civicrm_menu writers, store() (TRUNCATE +
+   * repopulate) and clear() (TRUNCATE), run under the data.core.menu lock and
+   * release it. That is what stops two concurrent rebuilds from colliding on
+   * the (path, domain_id) unique key or leaving a partial table. dev/core#6621.
+   *
+   * This asserts the locking is wired up, not the race itself: reproducing the
+   * collision needs two rebuilds interleaving on separate DB connections, and
+   * GET_LOCK() is per-connection, so this single-connection test cannot both
+   * hold and contend for the lock. The rebuild's lock hold is observed from the
+   * civicrm_alterMenu hook, which fires after the TRUNCATE and before the table
+   * is repopulated - the exact window the race corrupts - so the probe checks
+   * both that the lock is held and that civicrm_menu is empty at that point
+   * (isFree() reports a lock held by the current connection as in-use).
+   */
+  public function testRebuildRunsUnderLock(): void {
+    $isFree = fn() => (int) Civi::lockManager()->create('data.core.menu')->isFree();
+
+    $this->assertSame(1, $isFree(), 'the rebuild lock should be free before store()');
+
+    $freeDuringRebuild = NULL;
+    $menuRowsDuringRebuild = NULL;
+    CRM_Utils_Hook::singleton()->setHook('civicrm_alterMenu', function (&$items) use ($isFree, &$freeDuringRebuild, &$menuRowsDuringRebuild) {
+      $freeDuringRebuild = $isFree();
+      $menuRowsDuringRebuild = (int) CRM_Core_DAO::singleValueQuery('SELECT COUNT(*) FROM civicrm_menu');
+    });
+
+    CRM_Core_Menu::store();
+
+    $this->assertSame(0, $freeDuringRebuild, 'store() should hold the rebuild lock while repopulating civicrm_menu');
+    $this->assertSame(0, $menuRowsDuringRebuild, 'the lock should be held while civicrm_menu is empty mid-rebuild (the window the race corrupts)');
+    $this->assertSame(1, $isFree(), 'store() should release the rebuild lock when finished');
+
+    // clear() is the other writer; it takes the same lock and must release it too.
+    CRM_Core_Menu::clear();
+    $this->assertSame(1, $isFree(), 'clear() should release the rebuild lock');
+
+    // Leave the route table populated for subsequent tests.
+    CRM_Core_Menu::store();
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Core_Menu::store()` rebuilds the `civicrm_menu` route table (TRUNCATE, then one find/save per route) with no locking, so two concurrent rebuilds collide on the `(path, domain_id)` unique key and can leave the table partially populated. This puts the route-table writers behind a lock. Ref dev/core#6621.

Before
----------------------------------------
The `civicrm_menu` writers run unlocked. Two rebuilds at once (two flushes, or a flush racing the empty-table lazy rebuild in `CRM_Core_Menu::get()`) interleave their inserts; one dies with `DB Error: already exists`, and the route table can be left partial (missing routes 404/500 until the next clean rebuild). Two other writers can TRUNCATE the table out from under an in-flight `store()`: the public `clear()` (called by Afform when a form's route changes) and `CRM_Core_Config::clearDBCache()` (on the `Civi::rebuild(['tables'])` / clear-caches path). Since #36168, a mid-rebuild TRUNCATE leaves a *sticky* partial table, because `get()` only self-heals a fully-empty one.

The window is sub-second on a local DB but spans the whole rebuild (hundreds of round-trips) on installs where the DB is network-remote, which is where we hit it: repeated partial-menu outages.

After
----------------------------------------
The route-table writers acquire a shared `data.core.menu` lock (`Civi::lockManager()`):

- `store()` clears and repopulates under the lock, via private unlocked helpers (`clearMenu()`, `rebuild()`), so there is no nested/re-entrant acquire.
- the public `clear()` takes the same lock.
- `CRM_Core_Config::clearDBCache()` clears the route table through the locked `clear()` instead of a bare TRUNCATE. (Dropping this piece would leave the mid-rebuild-TRUNCATE hole open, which is why it's included here.)

Per the existing `data.*` lock convention this is a per-database-per-domain lock, so only one rebuild at a time runs within a domain (see the multi-domain note under Comments).

Technical Details
----------------------------------------
- Lock-wait timeout (180s): `acquire()` returns an un-acquired lock rather than throwing; in that case `store()`/`clear()` log a warning and proceed anyway, since an unlocked rebuild is the historical behaviour (never worse than today) and skipping would leave `get()`'s empty-table caller with no route table. A consequence: flush paths that used to return instantly can now wait behind an in-flight rebuild.
- The per-row `find(TRUE)` in `rebuild()` looks redundant under the lock, but it is what keeps the timeout-fallback path survivable (a best-effort unlocked rebuild colliding with a locked one updates rows instead of dying on the unique key), so it stays.
- Relation to dev/core#6569 (#36168): narrowing the lazy rebuild in `get()` removed the self-amplifying case (a partial table no longer turns every request into a competing rebuilder), but the writers are still unlocked, so concurrent full rebuilds still race. This complements that change by closing the remaining window.

Comments
----------------------------------------
Includes a headless regression test (`testRebuildRunsUnderLock`) asserting that both writers run under the lock and release it, and that the lock is held at the point `civicrm_menu` is empty mid-rebuild - i.e. it covers the window the race corrupts. The probe uses a `civicrm_alterMenu` hook, which fires after the TRUNCATE and before the repopulate, and `IS_FREE_LOCK` (which reports a lock held by the current connection as in-use). A true write-write collision needs concurrent connections and isn't unit-testable; that was verified manually on 6.16.0 with the equivalent lock (TRUNCATE + 9 concurrent rebuilders: 8 of 9 died on `already exists` unpatched; all 9 clean with the lock).

Known limitations, both pre-existing behaviours this change narrows rather than introduces: queued lazy rebuilds are not deduped (N requests that saw an empty table each rebuild in turn, one after another), and the lock is domain-scoped while TRUNCATE is table-wide, so two *different* domains rebuilding concurrently still race.


