### PR TITLE
fix weight notices

### DIFF
--- a/CRM/Core/Action.php
+++ b/CRM/Core/Action.php
@@ -315,7 +315,7 @@ class CRM_Core_Action {
     $url = [];
 
     usort($seqLinks, static function ($a, $b) {
-      return (int) ((int) ($a['weight']) > (int) ($b['weight']));
+      return (int) ((int) ($a['weight'] ?? 0) > (int) ($b['weight'] ?? 0));
     });
 
     foreach ($seqLinks as $i => $link) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices about missing weight wherever possible

Before
----------------------------------------
Some actions may not have been assigned weight, causing notices

After
----------------------------------------
No smarty notices