### PR TITLE
remove dupes from prevnext cache

### DIFF
--- a/CRM/Core/PrevNextCache/Sql.php
+++ b/CRM/Core/PrevNextCache/Sql.php
@@ -253,7 +253,7 @@ ORDER BY id
     $cids = [];
     $dao = CRM_Utils_SQL_Select::from('civicrm_prevnext_cache pnc')
       ->where('pnc.cachekey = @cacheKey', ['cacheKey' => $cacheKey])
-      ->select('pnc.entity_id1 as cid')
+      ->select('DISTINCT pnc.entity_id1 as cid')
       ->orderBy('pnc.id')
       ->limit($rowCount, $offset)
       ->execute();


### PR DESCRIPTION
Overview
----------------------------------------
See details here: https://lab.civicrm.org/dev/core/-/work_items/6638

Before
----------------------------------------
Changing the sort order of research results sometimes changed the number of results.


After
----------------------------------------
The number of results stays the same

Comments
----------------------------------------
Is there any reason we would ever want dupes in the prev next cache?
