### PR TITLE
Api4SelectQuery - Guard against NULL base table in autoJoinFK

### DIFF
--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -822,8 +822,19 @@ class Api4SelectQuery extends Api4Query {
     $joinTreeNode =& $this->joinTree[$baseTableAlias];
 
     $useBridgeTable = FALSE;
+    $baseTable = $explicitJoin['table'] ?? $this->getFrom();
+    // The base table may not resolve to a string - e.g. getFrom() returns
+    // NULL when the entity's table mapping is not available yet.
+    // Joiner::getPath() is typed `string $baseTable`, so passing NULL would
+    // throw an uncaught \TypeError rather than the \CRM_Core_Exception handled
+    // below. Since the select clause silently ignores unknown fields (see the
+    // fallback in the catch block), this function should not throw - bail out
+    // gracefully instead of fataling.
+    if (!is_string($baseTable)) {
+      return;
+    }
     try {
-      $joinPath = $joiner->getPath($explicitJoin['table'] ?? $this->getFrom(), $pathArray);
+      $joinPath = $joiner->getPath($baseTable, $pathArray);
     }
     catch (\CRM_Core_Exception $e) {
       if (!empty($explicitJoin['bridge'])) {

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -72,6 +72,57 @@ class Api4SelectQueryTest extends Api4TestBase {
   }
 
   /**
+   * Ensures autoJoinFK() does not fatal on an unresolvable base table.
+   *
+   * When the base table cannot be resolved to a string (e.g. getFrom()
+   * returns NULL because the entity's table mapping is unavailable),
+   * autoJoinFK() must bail out gracefully rather than pass NULL to the
+   * strictly-typed Joiner::getPath() and trigger an uncaught \TypeError. The
+   * select clause silently ignores unknown fields, so this path never throws.
+   */
+  public function testAutoJoinWithUnresolvedBaseTableDoesNotThrow(): void {
+    $api = Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['id'],
+    ]);
+    // A query whose base table cannot be resolved to a string. The constructor
+    // still resolves the (real) Contact table, so construction succeeds; only
+    // the later getFrom() lookup inside autoJoinFK() returns NULL.
+    $query = new class($api) extends Api4SelectQuery {
+
+      /**
+       * {@inheritdoc}
+       */
+      public function getFrom() {
+        return NULL;
+      }
+
+      /**
+       * Exposes the protected autoJoinFK() so the test can invoke it directly.
+       *
+       * @param string $key
+       *   The field path to auto-join.
+       */
+      public function callAutoJoin($key) {
+        $this->autoJoinFK($key);
+      }
+
+    };
+
+    $fieldSpecBefore = $query->apiFieldSpec;
+
+    // Before the fix this threw a \TypeError (Argument #1 ($baseTable) must
+    // be of type string, null given) that escaped the \CRM_Core_Exception
+    // handling below.
+    $query->callAutoJoin('some_fk_field.some_column');
+
+    // The unresolvable join is silently skipped, leaving the field spec
+    // untouched - not fatalled partway through.
+    $this->assertEquals($fieldSpecBefore, $query->apiFieldSpec);
+  }
+
+  /**
    * @throws \Civi\API\Exception\NotImplementedException
    */
   public function testInvalidSort(): void {


### PR DESCRIPTION
## Overview

APIv4 select queries can abort a request with an uncaught `TypeError` — instead of failing gracefully — when a field's base table can't be resolved to a string. This guards the single spot where a non-string base table reaches the strictly-typed `Joiner::getPath()`, so an unresolvable implicit join is skipped (exactly as it already is for other unresolvable joins) rather than fataling the whole request.

## Before

`autoJoinFK()` resolves the base table as `$explicitJoin['table'] ?? $this->getFrom()` and passes it straight to `Joiner::getPath(string $baseTable, …)`. `getFrom()` (via `CoreUtil::getTableName()`) is `?string` and can return `NULL` when the entity's table mapping isn't resolvable yet. Passing `NULL` to the strictly-typed parameter throws a `\TypeError` — which is **not** a `\CRM_Core_Exception`, so it bypasses this method's own `catch` block and its documented contract that "this function shouldn't throw exceptions." The `TypeError` propagates uncaught and aborts the request/process.

This is reachable whenever APIv4 is invoked very early in bootstrap, before CiviCRM's entity/table registry has been fully built. We hit it in production during a multi-version site upgrade, where a CMS bootstrap hook reaches into APIv4 ahead of CiviCRM's own schema/registry rebuild. The real call chain was:

```
cv upgrade:db
  -> (CMS) full bootstrap
    -> hook_init()                       // fires on every enabled module
      -> rules_init()                    // a reaction rule on the "init" event
        -> entity_get_property_info()
          -> hook_entity_property_info_alter()   // civicrm_entity integration
            -> \Civi\Api4\EntityFinancialAccount::get()   // live APIv4 call
              -> new Api4SelectQuery()
                -> autoJoinFK()
                  -> Joiner::getPath($this->getFrom(), …)   // getFrom() === NULL here
                     => TypeError: Argument #1 ($baseTable) must be of type string, null given
```

This early in a fresh bootstrap the entity registry isn't built, so `getFrom()` returns `NULL` for an otherwise-valid entity, and any implicit FK-join in the select fatals — aborting the entire upgrade. The Rules / civicrm_entity chain above is just one way to reach APIv4 this early; the vulnerable code is the shared choke point, not any single caller.

## After

`autoJoinFK()` checks that the base table resolved to a string before calling `Joiner::getPath()`. If it didn't, the method returns early — skipping the unresolvable join, exactly as the existing `catch (\CRM_Core_Exception)` fallback does for joins that can't be resolved. No behaviour change on the normal (string base table) path; the select clause continues to silently ignore fields it can't join.

## Technical Details

`Civi/Api4/Query/Api4SelectQuery.php`, `autoJoinFK()`:

```php
$baseTable = $explicitJoin['table'] ?? $this->getFrom();
// The base table may not resolve to a string - e.g. getFrom() returns NULL
// when the entity has no table mapping available at this point. Joiner::getPath()
// is typed `string $baseTable`, so passing NULL would throw an uncaught \TypeError
// rather than the \CRM_Core_Exception handled below. Since the select clause
// silently ignores unknown fields (see the fallback in the catch block), this
// function should not throw - bail out gracefully instead of fataling.
if (!is_string($baseTable)) {
  return;
}
try {
  $joinPath = $joiner->getPath($baseTable, $pathArray);
}
```

Both sources of the base table are `?string` (`getFrom()` → `CoreUtil::getTableName()`, and `$explicitJoin['table']`), so a non-string here is always the unresolvable case — never a valid table that would otherwise have produced a join. This deliberately mirrors the existing "swallow and ignore" contract of the `\CRM_Core_Exception` fallback immediately below, extending it to the type-level failure that was escaping it.

For awareness (out of scope here): the bridge-join fallback a few lines down has the same `CoreUtil::getTableName()` → `getPath()` shape and the same latent `NULL` exposure, but it requires a bridge join to reach and isn't triggered by the path fixed here.

### Core overrides

N/A — this is a fix to core, not an override of it.

## Comments

**Validation:** verified end-to-end on a real database — a site that reproducibly aborted a multi-version upgrade completed the upgrade successfully with this guard in place, with no other change.

**On the test:** the failing state (`getFrom()` returning `NULL`) is a bootstrap-timing artifact — it only occurs while the entity registry is partially built — so it can't be reproduced through a normal `civicrm_api4()` call in a healthy test database, where the registry is always fully built. The regression test therefore forces the state directly: a small anonymous `Api4SelectQuery` subclass overrides `getFrom()` to return `NULL`, then invokes `autoJoinFK()` and asserts it no longer fatals and leaves the field spec untouched. Before the guard this test errors with the `TypeError` above; after it, the join is silently skipped.
