### PR TITLE
remove outdated check for multilingual logging

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -92,10 +92,6 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Generic {
         $attributes['disabled'] = 'disabled';
         $this->sections['multi']['description'] = ts("In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled.");
       }
-      elseif (Civi::settings()->get('logging')) {
-        $attributes['disabled'] = 'disabled';
-        $this->sections['multi']['description'] = ts("(Multilingual support currently cannot be enabled on installations with enabled logging.)");
-      }
       else {
         $this->sections['multi']['description'] = ts("Check this box and click 'Save' to switch this installation from single- to multi-language, then add further languages.");
       }

--- a/CRM/Core/BAO/Setting.php
+++ b/CRM/Core/BAO/Setting.php
@@ -562,12 +562,8 @@ class CRM_Core_BAO_Setting extends CRM_Core_DAO_Setting {
 
   public static function loggingMetadataCallback(array &$setting): void {
     // Disable field on setting form if system does not meet requirements
-    if (\CRM_Core_I18n::isMultilingual()) {
-      $setting['description'] = ts('Logging is not supported in multilingual environments.');
-      $setting['html_attributes']['disabled'] = 'disabled';
-    }
-    elseif (!\CRM_Core_DAO::checkTriggerViewPermission(FALSE)) {
-      $setting['description'] = ts("In order to use this functionality, the installation's database user must have privileges to create triggers (in MySQL 5.0 – and in MySQL 5.1 if binary logging is enabled – this means the SUPER privilege). This install either does not seem to have the required privilege enabled.");
+    if (!\CRM_Core_DAO::checkTriggerViewPermission(FALSE)) {
+      $setting['description'] = ts("In order to use this functionality, the installation's database user must have privileges to create triggers and views (if binary logging is enabled – this means the SUPER privilege). This install does not have the required privilege(s) enabled.");
       $setting['html_attributes']['disabled'] = 'disabled';
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
In #28338, we support advanced logging on multilingual instances.  However, a shift from generating the *System Settings » Misc* page with metadata meant that the fixes made in `CRM/Admin/Form/Setting/Localization.php` no longer apply, since this form is generating from `CRM/Core/BAO/Setting.php`.  So I'm applying the 

This also caused #16539 to regress, so I fix the wording on the following check to remove references to MySQL 5.0/5.1.

In my grepping, I also realized that the converse issue existed as well - you can't enable multilingual if logging is enabled.  So that's also removed.

Before
----------------------------------------
Multilingual logging can't be enabled; will be disabled when saving the Misc settings. 

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Technically a regression, but an old one (introduced in 6.9).

A bit dangerous - I didn't realize I'd turned off advanced logging by saving a different change on this page.