### PR TITLE
Expose read-only raw queue item data in API/SK

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/QueueItemSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/QueueItemSpecProvider.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Service\Spec\Provider;
 
+use Civi\Api4\Service\Spec\FieldSpec;
 use Civi\Api4\Service\Spec\RequestSpec;
 use Civi\Core\Service\AutoService;
 
@@ -19,6 +20,9 @@ use Civi\Core\Service\AutoService;
  * Set permissions on Queue Items to allow some fields (release_date etc) but NOT the data to be
  * edited for queue items - this allows search kits to be used to manage queue items but not to inject
  * executable code.
+ *
+ * A read-only `data_raw` field exposes the same column as an un-unserialized string so it can be
+ * displayed (e.g. in SearchKit) for debugging.
  *
  * @service
  * @internal
@@ -30,6 +34,17 @@ class QueueItemSpecProvider extends AutoService implements Generic\SpecProviderI
    */
   public function modifySpec(RequestSpec $spec): void {
     $spec->getFieldByName('data')->setPermission([\CRM_Core_Permission::ALWAYS_DENY_PERMISSION]);
+
+    if ($spec->getAction() === 'get') {
+      $field = (new FieldSpec('data_raw', 'QueueItem', 'String'))
+        ->setTitle(ts('Data (raw)'))
+        ->setLabel(ts('Data (raw)'))
+        ->setDescription(ts('Raw serialized data'))
+        ->setColumnName('data')
+        ->setType('Extra')
+        ->setReadonly(TRUE);
+      $spec->addFieldSpec($field);
+    }
   }
 
   /**


### PR DESCRIPTION
Just returns the raw serialized string and only for get, so shouldn't be any security issues. Just for convenience.