### PR TITLE
Prevent intermittent ACL failures

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -46,8 +46,19 @@ class CRM_ACL_BAO_Cache extends CRM_ACL_DAO_ACLCache {
       return self::$_cache[$id];
     }
 
+    // Use a lock to prevent users from reading this data while the table is being filled
+    // See https://lab.civicrm.org/dev/core/-/work_items/2641
+    $lock = Civi::lockManager()->acquire("data.core.acl.$id");
+
+    self::$_cache[$id] = self::retrieve($id);
+    if (self::$_cache[$id]) {
+      $lock->release();
+      return self::$_cache[$id];
+    }
+
     self::$_cache[$id] = CRM_ACL_BAO_ACL::getAllByContact((int) $id);
     self::store($id, self::$_cache[$id]);
+    $lock->release();
     return self::$_cache[$id];
   }
 

--- a/tests/phpunit/api/v4/Action/ContactAclTest.php
+++ b/tests/phpunit/api/v4/Action/ContactAclTest.php
@@ -190,4 +190,47 @@ class ContactAclTest extends Api4TestBase implements TransactionalInterface, Hoo
     $this->assertEquals(1, substr_count($locationTypeGet->debug['sql'][0], 'civicrm_acl_contact_cache'));
   }
 
+  public function testAclCacheBuildDoubleChecksRetrieveUnderLock(): void {
+    $userID = $this->createLoggedInUser();
+
+    // 1. Setup mock Lock
+    $mockLock = $this->createMock(\Civi\Core\Lock\LockInterface::class);
+    $mockLock->expects($this->once())
+      ->method('release');
+
+    // Mock LockManager to return our custom mock Lock and populate DB when acquire is called
+    $mockLockManager = $this->createMock(\Civi\Core\Lock\LockManager::class);
+    $mockLockManager->expects($this->once())
+      ->method('acquire')
+      ->with("data.core.acl.{$userID}")
+      ->willReturnCallback(function () use ($userID, $mockLock) {
+        // Manually insert a mock ACL ID (999) to simulate a concurrent thread rebuilding the cache while we waited for the lock
+        \CRM_Core_DAO::executeQuery("INSERT INTO civicrm_acl_cache (acl_id, contact_id) VALUES (999, %1)", [
+          1 => [$userID, 'Integer'],
+        ]);
+        return $mockLock;
+      });
+
+    // Swap lockManager in Civi::$statics
+    $originalLockManager = \Civi::$statics['Civi\Core\Container']['boot']['lockManager'];
+    \Civi::$statics['Civi\Core\Container']['boot']['lockManager'] = $mockLockManager;
+
+    try {
+      // Clear caches
+      \CRM_ACL_BAO_Cache::resetCache();
+      \CRM_ACL_BAO_Cache::$_cache = NULL;
+
+      // Call build()
+      $acls = \CRM_ACL_BAO_Cache::build($userID);
+
+      // Verify that build() returned the double-checked database state [999 => 1]
+      // instead of rebuilding it (which would have returned the actual user's ACLs)
+      $this->assertEquals([999 => 1], $acls);
+    }
+    finally {
+      // Restore lockManager
+      \Civi::$statics['Civi\Core\Container']['boot']['lockManager'] = $originalLockManager;
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
This prevents intermittent problems where users lose access to contacts they should be able to see.

- Fixes [dev/core#2641 Users affected by ACLs intermittently lose access to contacts
](https://lab.civicrm.org/dev/core/-/work_items/2641)
- Replaces #33287

Technical Details
-------
This adds a lock to prevent users from reading from the ACL cache while it's in the process of being filled. 

This is the same technique used by other Civi cache/acl tables, e.g. 
https://github.com/civicrm/civicrm-core/blob/d2f350655f5fd44b1fa4e4bea73f6f890324ea90/CRM/Contact/BAO/Contact/Permission.php#L247-L248