### PR TITLE
Afform - Use portable option format by default

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -99,7 +99,7 @@ class AfformAdminMeta {
         ...array_keys(\CRM_Core_SelectValues::optionAttributes()),
       ],
       'action' => 'create',
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'suffixes', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
       'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],
     ];
     if ($entityName === 'Address') {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -136,9 +136,14 @@
         }
 
         function fieldDefaults(field) {
+          let name = field.name;
+          // Use :name suffix if available (improves form portability)
+          if (field.options && Array.isArray(field.suffixes) && field.suffixes.includes('name')) {
+            name += ':name';
+          }
           const tag = {
             "#tag": "af-field",
-            name: field.name
+            name: name
           };
           return tag;
         }

--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -50,9 +50,14 @@
       };
 
       function fieldDefaults(field, prefix) {
+        let name = prefix + field.name;
+        // Use :name suffix if available (improves form portability)
+        if (field.options && Array.isArray(field.suffixes) && field.suffixes.includes('name')) {
+          name += ':name';
+        }
         const tag = {
           "#tag": "af-field",
-          name: prefix + field.name
+          name: name
         };
         if (field.input_type === 'Select' || field.input_type === 'ChainSelect') {
           tag.defn = {input_attrs: {multiple: true}};


### PR DESCRIPTION
Overview
----------------------------------------
Followup to [6fd192d0](https://github.com/civicrm/civicrm-core/pull/35915) to use the :name suffix by default in FormBuilder fields.

See [dev/core#6188](https://lab.civicrm.org/dev/core/-/work_items/6188)