### PR TITLE
Fix failure to add num_membership_terms to line item

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -274,20 +274,18 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
         $defaults['member_of_contact_id'], 'display_name'
       );
     }
-    if (!empty($defaults['membership_type_id'])) {
-      $this->_memType = $defaults['membership_type_id'];
-    }
-    if (is_numeric($this->_memType)) {
+    $membershipTypeID = $this->getMembershipValue('membership_type_id');
+    if ($membershipTypeID) {
       $defaults['membership_type_id'] = [];
       $defaults['membership_type_id'][0] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
-        $this->_memType,
+        $membershipTypeID,
         'member_of_contact_id',
         'id'
       );
-      $defaults['membership_type_id'][1] = $this->_memType;
+      $defaults['membership_type_id'][1] = $membershipTypeID;
     }
     else {
-      $defaults['membership_type_id'] = $this->_memType;
+      $defaults['membership_type_id'] = $membershipTypeID;
     }
     return $defaults;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix failure to add num_membership_terms to line item

Before
----------------------------------------
In 6.16 a patch was added here https://github.com/civicrm/civicrm-core/pull/35608/changes#diff-ec3dc801460bc5a7df063522070c8bf774369947b808bea4187259730dbb2abeR622 to set the membership_num_terms on the line item as set on the renewal form.

However, it does not work because `_memType` is overwritten in `setDefaults()` from the integer set in `preProcess()` to a string number which is ignored by this comparison

After
----------------------------------------
`setDefaults()` no longer touches `_memType` which is adequately set already. Internally it uses a local variable which is retreived using the preferred method `$this->getMembershipValue('membership_type_id');`

Technical Details
----------------------------------------
 `$this->getMembershipValue('membership_type_id');` ultimately calls apiv4 and gets the correctly typed values. However, there is no reason for `getDefaultValues()` to be touching `_memType` so we also stop altering it here

Comments
----------------------------------------
@mattwire 

