### PR TITLE
Fix Membership Form Tests to work with full form flow

### DIFF
--- a/CRM/Member/Form.php
+++ b/CRM/Member/Form.php
@@ -216,7 +216,7 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
     parent::preProcess();
     $params = [];
     $params['context'] = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this, FALSE, 'membership');
-    $params['id'] = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $params['id'] = $this->getMembershipID();
     $params['mode'] = CRM_Utils_Request::retrieve('mode', 'Alphanumeric', $this);
 
     $this->setContextVariables($params);
@@ -244,8 +244,8 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    */
   public function setDefaultValues() {
     $defaults = [];
-    if (isset($this->_id)) {
-      $params = ['id' => $this->_id];
+    if ($this->getMembershipID()) {
+      $params = ['id' => $this->getMembershipID()];
       CRM_Member_BAO_Membership::retrieve($params, $defaults);
       if (isset($defaults['minimum_fee'])) {
         $defaults['minimum_fee'] = CRM_Utils_Money::formatLocaleNumericRoundedForDefaultCurrency($defaults['minimum_fee']);
@@ -445,7 +445,10 @@ class CRM_Member_Form extends CRM_Contribute_Form_AbstractEditPayment {
    * is only given where there is specific test cover.
    */
   public function getMembershipID(): ?int {
-    return $this->_id;
+    if (!isset($this->_id)) {
+      $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    }
+    return $this->_id ?: NULL;
   }
 
   /**

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1004,8 +1004,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     // In form mode these are set in preProcess.
     //TODO: set memberships, fixme
     $this->setContextVariables($formValues);
+    $originalMembershipType = $this->getMembershipValue('membership_type_id');
 
-    $this->_memTypeSelected = self::getSelectedMemberships(
+    $selectedMemberships = $this->_memTypeSelected = self::getSelectedMemberships(
       $this->_priceSet,
       $formValues
     );
@@ -1201,7 +1202,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         $params['status_id'] = $pendingMembershipStatusId;
         $params['skipStatusCal'] = TRUE;
         // as membership is pending set dates to null.
-        foreach ($this->_memTypeSelected as $memType) {
+        foreach ($selectedMemberships as $memType) {
           $membershipTypeValues[$memType]['joinDate'] = NULL;
           $membershipTypeValues[$memType]['startDate'] = NULL;
           $membershipTypeValues[$memType]['endDate'] = NULL;
@@ -1228,7 +1229,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       $params['action'] = $this->_action;
 
       // create membership record
-      foreach ($this->_memTypeSelected as $memType) {
+      foreach ($selectedMemberships as $memType) {
         $membershipParams = array_merge($membershipTypeValues[$memType], $params);
         if (isset($result['fee_amount'])) {
           $membershipParams['fee_amount'] = $result['fee_amount'];
@@ -1306,7 +1307,10 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
       }
     }
 
-    $this->updateContributionOnMembershipTypeChange($params);
+    // if selected membership doesn't match with earlier membership
+    if ($originalMembershipType && !in_array($originalMembershipType, $selectedMemberships)) {
+      $this->updateContributionOnMembershipTypeChange($params);
+    }
 
     if (($this->_action & CRM_Core_Action::UPDATE)) {
       $this->addStatusMessage($this->getStatusMessageForUpdate());
@@ -1370,14 +1374,12 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    *
    * @throws \CRM_Core_Exception
    */
-  protected function updateContributionOnMembershipTypeChange($inputParams) {
+  protected function updateContributionOnMembershipTypeChange(array $inputParams): void {
     if (Civi::settings()->get('update_contribution_on_membership_type_change') &&
-    // on update
-      ($this->_action & CRM_Core_Action::UPDATE) &&
-    // if ID is present
-      $this->_id &&
-    // if selected membership doesn't match with earlier membership
-      !in_array($this->_memType, $this->_memTypeSelected)
+      // Note these next 2 tests are pretty much redundant as we only reach this clause it there
+      // was a pre-existing membership that has had a type status change.
+      ($this->getAction() & CRM_Core_Action::UPDATE) &&
+      $this->getMembershipID()
     ) {
       if ($this->isCreateRecurringContribution()) {
         CRM_Core_Session::setStatus(ts('Associated recurring contribution cannot be updated on membership type change.'), ts('Error'), 'error');
@@ -1895,6 +1897,10 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    * Get the created or edited membership ID.
    *
    * @return int|null
+   *
+   * @api This function will not change in a minor release and is supported for
+   * use outside of core. This annotation / external support for properties
+   * is only given where there is specific test cover.
    */
   public function getMembershipID(): ?int {
     return parent::getMembershipID() ?: ($this->_membershipIDs[0] ?? NULL);

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1897,7 +1897,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    * @return int|null
    */
   public function getMembershipID(): ?int {
-    return $this->_membershipIDs[0] ?? NULL;
+    return parent::getMembershipID() ?: ($this->_membershipIDs[0] ?? NULL);
   }
 
   /**

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -453,7 +453,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
    * @dataProvider getThousandSeparators
    */
   public function testSubmit(string $thousandSeparator): void {
-    $_REQUEST['mode'] = 'test';
+
     $this->setCurrencySeparators($thousandSeparator);
     $this->createLoggedInUser();
     $params = [
@@ -490,13 +490,14 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'send_receipt' => TRUE,
       'receipt_text' => 'Receipt text',
     ];
-    $form = $this->getForm($params);
-    $mailUtil = new CiviMailUtils($this, TRUE);
-    $form->buildForm();
-    $form->postProcess();
+
+    $form = $this->getTestForm('CRM_Member_Form_Membership', $params, [
+      'mode' => 'test',
+    ])->processForm();
+
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0']]);
     $this->assertEquals($form->getMembershipID(), $membership['id']);
-    $membershipEndYear = date('Y') + 1;
+    $membershipEndYear = ((int) date('Y')) + 1;
     if (date('m-d') === '12-31') {
       // If you join on Dec 31, then the first term would end right away, so
       // add a year.
@@ -535,7 +536,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
         'return' => 'payment_instrument_id',
       ]),
     ], 'online');
-    $mailUtil->checkMailLog([
+    $this->assertMailSentContainingStrings([
       Civi::format()->money('1234.56'),
       'Receipt text',
     ]);
@@ -614,15 +615,15 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
   /**
    * Test the submit function of the membership form on membership type change.
+   *
    *  Check if the related contribution is also updated if the minimum_fee didn't match
    *
    * @throws \CRM_Core_Exception
    */
   public function testContributionUpdateOnMembershipTypeChange(): void {
-    // @todo figure out why financial validation fails with this test.
-    $this->isValidateFinancialsOnPostAssert = FALSE;
+    $this->createLoggedInUser();
     // Step 1: Create a Membership via backoffice whose with 50.00 payment
-    $form = $this->getForm([
+    $this->getTestForm('CRM_Member_Form_Membership', [
       'cid' => $this->ids['Contact']['individual_0'],
       'join_date' => date('Y-m-d'),
       'start_date' => '',
@@ -636,10 +637,8 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
       'financial_type_id' => '2',
       'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
-    ]);
-    $mailUtil = new CiviMailUtils($this, TRUE);
-    $this->createLoggedInUser();
-    $form->postProcess();
+    ])->processForm();
+
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0']]);
     // check the membership status after partial payment, if its Pending
     $this->assertEquals('New', CRM_Core_PseudoConstant::getName('CRM_Member_BAO_Membership', 'status_id', $membership['status_id']));
@@ -651,7 +650,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals(50.00, $contribution['net_amount']);
 
     // Step 2: Change the membership type whose minimum free is less than earlier membership
-    $secondMembershipType = $this->callAPISuccess('membership_type', 'create', [
+    $secondMembershipType = $this->createTestEntity('MembershipType', [
       'domain_id' => 1,
       'name' => 'Second Test Membership',
       'member_of_contact_id' => $this->ids['Contact']['organization'],
@@ -665,7 +664,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'financial_type_id' => 2,
     ]);
     Civi::settings()->set('update_contribution_on_membership_type_change', TRUE);
-    $_REQUEST['id'] = $membership['id'];
+
     $params = [
       'cid' => $this->ids['Contact']['individual_0'],
       'join_date' => date('Y-m-d'),
@@ -680,12 +679,11 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
       'financial_type_id' => '2',
       'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
     ];
-    $form = $this->getForm($params);
-    $form->preProcess();
-    $form->buildQuickForm();
-    $form->_action = CRM_Core_Action::UPDATE;
-    $form->_contactID = $this->ids['Contact']['individual_0'];
-    $form->postProcess();
+
+    $this->getTestForm('CRM_Member_Form_Membership', $params, [
+      'id' => $membership['id'],
+      'action' => 2,
+    ])->processForm();
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0']]);
     // check the membership status after partial payment, if its Pending
     $contribution = $this->callAPISuccessGetSingle('Contribution', [
@@ -701,10 +699,11 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
 
     //Update to lifetime membership.
     $params['membership_type_id'] = [$this->ids['Contact']['organization'], $this->ids['MembershipType']['lifetime']];
-    $form = $this->getForm($params);
-    $form->preProcess();
-    $form->buildQuickForm();
-    $form->postProcess();
+    $this->getTestForm('CRM_Member_Form_Membership', $params, [
+      'id' => $membership['id'],
+      'action' => 2,
+    ])->processForm();
+
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0']]);
     $this->assertEquals($this->ids['MembershipType']['lifetime'], $membership['membership_type_id']);
     $this->assertTrue(empty($membership['end_date']), 'Lifetime Membership on the individual has an End date.');


### PR DESCRIPTION


Overview
----------------------------------------
Fix testContributionUpdateOnMembershipTypeChange to work with full form flow

Before
----------------------------------------
- test used old flow
- `getMembershipID()` was inconsistent

After
----------------------------------------
- full form flow
- more use of local variables
- `getMembershipID()` used more & more reliable

Technical Details
----------------------------------------

Comments
----------------------------------------
