### PR TITLE
dev/core#6572 - Pass entity info to hook_civicrm_ importAlterMappedRow

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -1722,12 +1722,12 @@ abstract class CRM_Utils_Hook {
    * @param array $mappedRow (reference) The rows that have been mapped to an array of params.
    * @param array $rowValues The row from the data source (non-associative array)
    * @param int $userJobID id from civicrm_user_job
+   * @param array|null $importEntities
    *
    * @return mixed
    */
-  public static function importAlterMappedRow(string $importType, string $context, array &$mappedRow, array $rowValues, int $userJobID) {
-    $null = NULL;
-    return self::singleton()->invoke(['importType', 'context', 'mappedRow', 'rowValues', 'userJobID', 'fieldMappings'], $context, $importType, $mappedRow, $rowValues, $userJobID, $null,
+  public static function importAlterMappedRow(string $importType, string $context, array &$mappedRow, array $rowValues, int $userJobID, ?array $importEntities = NULL) {
+    return self::singleton()->invoke(['importType', 'context', 'mappedRow', 'rowValues', 'userJobID', 'importEntities'], $context, $importType, $mappedRow, $rowValues, $userJobID, $importEntities,
       'civicrm_importAlterMappedRow'
     );
   }

--- a/ext/civiimport/Civi/Import/ContributionParser.php
+++ b/ext/civiimport/Civi/Import/ContributionParser.php
@@ -313,7 +313,21 @@ class ContributionParser extends ImportParser {
     $rowNumber = (int) ($values[array_key_last($values)]);
     try {
       $params = $this->getMappedRow($values);
-      \CRM_Utils_Hook::importAlterMappedRow('import', 'contribution_import', $params, $values, $this->getUserJobID());
+      $entities = [
+        '' => [
+          'entity' => 'Contribution',
+          'join' => NULL,
+        ],
+        'Contact' => [
+          'entity' => 'Contact',
+          'join' => [],
+        ],
+        'SoftCreditContact' => [
+          'entity' => 'Contact',
+          'join' => [],
+        ],
+      ];
+      \CRM_Utils_Hook::importAlterMappedRow('import', 'contribution_import', $params, $values, $this->getUserJobID(), $entities);
 
       $contributionParams = $params['Contribution'];
       //CRM-10994

--- a/ext/civiimport/Civi/Import/GenericParser.php
+++ b/ext/civiimport/Civi/Import/GenericParser.php
@@ -173,7 +173,17 @@ class GenericParser extends ImportParser {
     try {
       $params = $this->getMappedRow($values);
       $this->removeEmptyValues($params);
-      \CRM_Utils_Hook::importAlterMappedRow('import', $this->getBaseEntity() . '_import', $params, $values, $this->getUserJobID());
+      $entities = [
+        '' => [
+          'entity' => $this->getBaseEntity(),
+          'join' => NULL,
+        ],
+        'Contact' => [
+          'entity' => 'Contact',
+          'join' => [],
+        ],
+      ];
+      \CRM_Utils_Hook::importAlterMappedRow('import', $this->getBaseEntity() . '_import', $params, $values, $this->getUserJobID(), $entities);
 
       $existing = !isset($params[$this->getBaseEntity()]['id']) ? [] : civicrm_api4($this->getBaseEntity(), 'get', [
         'where' => [

--- a/ext/search_kit/CRM/Search/Import/Parser.php
+++ b/ext/search_kit/CRM/Search/Import/Parser.php
@@ -63,7 +63,7 @@ class CRM_Search_Import_Parser extends CRM_Import_Parser {
       return;
     }
     try {
-      \CRM_Utils_Hook::importAlterMappedRow('import', strtolower($this->baseEntity) . '_import_searchkit', $mappedRow, $values, $this->getUserJobID());
+      \CRM_Utils_Hook::importAlterMappedRow('import', strtolower($this->baseEntity) . '_import_searchkit', $mappedRow, $values, $this->getUserJobID(), $this->getImportEntitiesList());
       $this->saveEntities($mappedRow);
       $idField = CoreUtil::getIdFieldName($this->baseEntity);
       $this->setImportStatus($rowNumber, 'IMPORTED', '', $mappedRow[$this->baseEntity][$idField]);
@@ -295,6 +295,58 @@ class CRM_Search_Import_Parser extends CRM_Import_Parser {
       $this->importEntities[$entityName] = $entities[$entityName];
     }
     return $this->importEntities;
+  }
+
+  /**
+   * Get the list of entities processed by this import with aliases, names, and joins.
+   *
+   * @return array
+   */
+  public function getImportEntitiesList(): array {
+    $joins = [];
+    foreach ($this->getJoins() as $join) {
+      $joins[$join['alias']] = $join;
+    }
+
+    $entities = [
+      '' => [
+        'entity' => $this->baseEntity,
+        'join' => NULL,
+      ],
+    ];
+
+    foreach ($this->getJoins() as $join) {
+      $alias = $join['alias'];
+      $path = [];
+      $parentAlias = $this->getJoinParentAlias($join, $joins);
+      while ($parentAlias !== NULL) {
+        array_unshift($path, $parentAlias);
+        $parentAlias = isset($joins[$parentAlias]) ? $this->getJoinParentAlias($joins[$parentAlias], $joins) : NULL;
+      }
+      $entities[$alias] = [
+        'entity' => $join['entity'],
+        'join' => $path,
+      ];
+    }
+
+    return $entities;
+  }
+
+  private function getJoinParentAlias(array $join, array $joins): ?string {
+    foreach ($join['on'] ?? [] as $clause) {
+      $prefix = $join['alias'] . '.';
+      if (
+        count($clause) === 3 && $clause[1] === '=' &&
+        (str_starts_with($clause[0], $prefix) || str_starts_with($clause[2], $prefix))
+      ) {
+        $otherField = str_starts_with($clause[0], $prefix) ? $clause[2] : $clause[0];
+        [$otherJoin] = explode('.', $otherField);
+        if (str_contains($otherField, '.') && isset($joins[$otherJoin])) {
+          return $otherJoin;
+        }
+      }
+    }
+    return NULL;
   }
 
   public function validateRow(?array $values): bool {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchBatch/SearchBatchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchBatch/SearchBatchTest.php
@@ -415,6 +415,15 @@ class SearchBatchTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
               '"in_honor_of"',
             ],
           ],
+          [
+            'Email AS Contribution_Contact_contact_id_01_Email_01',
+            'LEFT',
+            [
+              'Contribution_Contact_contact_id_01.id',
+              '=',
+              'Contribution_Contact_contact_id_01_Email_01.contact_id',
+            ],
+          ],
         ],
         'having' => [],
       ],
@@ -546,7 +555,36 @@ class SearchBatchTest extends \PHPUnit\Framework\TestCase implements HeadlessInt
     ]);
     $this->assertCount(3, $newRows);
 
+    $hookCalled = 0;
+    $hookEntities = [];
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_importAlterMappedRow', function($importType, $context, &$mappedRow, $rowValues, $userJobID, $importEntities = NULL) use (&$hookCalled, &$hookEntities) {
+      if ($context === 'import') {
+        $hookCalled++;
+        $hookEntities = $importEntities;
+      }
+    });
+
     $import = civicrm_api4($apiName, 'import');
+    $this->assertGreaterThan(0, $hookCalled);
+    $expectedEntities = [
+      '' => [
+        'entity' => 'Contribution',
+        'join' => NULL,
+      ],
+      'Contribution_Contact_contact_id_01' => [
+        'entity' => 'Contact',
+        'join' => [],
+      ],
+      'Contribution_ContributionSoft_contribution_id_01' => [
+        'entity' => 'ContributionSoft',
+        'join' => [],
+      ],
+      'Contribution_Contact_contact_id_01_Email_01' => [
+        'entity' => 'Email',
+        'join' => ['Contribution_Contact_contact_id_01'],
+      ],
+    ];
+    $this->assertEquals($expectedEntities, $hookEntities);
     $this->assertCount(3, $import);
     $this->assertEquals('IMPORTED', $import[0]['_status']);
     $this->assertEquals('IMPORTED', $import[1]['_status']);

--- a/tests/phpunit/CRM/Import/ParserTest.php
+++ b/tests/phpunit/CRM/Import/ParserTest.php
@@ -94,4 +94,61 @@ class CRM_Import_ParserTest extends CiviUnitTestCase {
     $this->assertEquals($expectedType, $result);
   }
 
+  /**
+   * Test that importAlterMappedRow hook is called with the correct importEntities.
+   */
+  public function testImportAlterMappedRowEntitiesHook(): void {
+    $mockDataSource = $this->createMock(\CRM_Import_DataSource::class);
+
+    $parser = $this->getMockBuilder(\Civi\Import\GenericParser::class)
+      ->onlyMethods(['getDataSourceObject', 'getUserJob', 'getUserJobID'])
+      ->getMock();
+    $parser->method('getDataSourceObject')->willReturn($mockDataSource);
+    $parser->method('getUserJobID')->willReturn(123);
+    $parser->method('getUserJob')->willReturn([
+      'id' => 123,
+      'job_type' => 'activity_import',
+      'metadata' => [
+        'base_entity' => 'Activity',
+        'import_mappings' => [
+          ['name' => 'Activity.subject'],
+        ],
+        'DataSource' => [
+          'number_of_columns' => 1,
+        ],
+      ],
+    ]);
+
+    $parser->init();
+
+    $hookCalled = 0;
+    $hookEntities = [];
+    \CRM_Utils_Hook::singleton()->setHook('civicrm_importAlterMappedRow', function($importType, $context, &$mappedRow, $rowValues, $userJobID, $importEntities = NULL) use (&$hookCalled, &$hookEntities) {
+      if ($context === 'import') {
+        $hookCalled++;
+        $hookEntities = $importEntities;
+      }
+    });
+
+    try {
+      $parser->import(['Subject of Activity', 1]);
+    }
+    catch (\Exception $e) {
+      // Ignored: we only care about the hook execution before save
+    }
+
+    $this->assertEquals(1, $hookCalled);
+    $expectedEntities = [
+      '' => [
+        'entity' => 'Activity',
+        'join' => NULL,
+      ],
+      'Contact' => [
+        'entity' => 'Contact',
+        'join' => [],
+      ],
+    ];
+    $this->assertEquals($expectedEntities, $hookEntities);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Passes information about every entity in the import to `CRM_Utils_Hook::importAlterMappedRow()` when called with `'import'` as the first parameter. This allows hook listeners to know which entities are being processed by the import.

Fixes [dev/core#6572](https://lab.civicrm.org/dev/core/-/work_items/6572)

Technical Details
----------------------------------------
Hook listeners can inspect a new parameter `$importEntities` containing the structure and join relationships of the imported entities.

For example, a multi-join SearchKit batch import yields the following `$importEntities` structure:
```php
[
  '' => [
    'entity' => 'Contribution',
    'join' => NULL,
  ],
  'Contribution_Contact_contact_id_01' => [
    'entity' => 'Contact',
    'join' => [],
  ],
  'Contribution_ContributionSoft_contribution_id_01' => [
    'entity' => 'ContributionSoft',
    'join' => [],
  ],
  'Contribution_Contact_contact_id_01_Email_01' => [
    'entity' => 'Email',
    'join' => ['Contribution_Contact_contact_id_01'],
  ],
]
```

Note that the primary entity has no alias (so is always at array key `''`) and no join. Secondary entities joined to the first will have an empty join array and their alias as key. Joins of joins will populate their join array with their ancestors.