### PR TITLE
PR Commands: Map App ID secret to env for if condition

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Generate GitHub App Token
         id: generate-token
-        if: ${{ secrets.CIVIBOT_APP_ID != '' }}
+        env:
+          CIVIBOT_APP_ID: ${{ secrets.CIVIBOT_APP_ID }}
+        if: ${{ env.CIVIBOT_APP_ID != '' }}
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.CIVIBOT_APP_ID }}


### PR DESCRIPTION
Overview
----------------------------------------
In the previous PR, we added an `if:` condition checking if the secret `CIVIBOT_APP_ID` is set. However, GitHub Actions does not allow direct reference to the `secrets` context inside `if` conditionals, resulting in validation errors.

This PR fixes that error by mapping the secret to an environment variable and checking the environment variable instead.

Before
----------------------------------------
The workflow failed with the error:
`Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.CIVIBOT_APP_ID != ''`

After
----------------------------------------
The workflow correctly evaluates whether the app token should be generated without parser errors.

Technical Details
----------------------------------------
- Added `env.CIVIBOT_APP_ID` to the token generation step.
- Updated `if` condition to check `env.CIVIBOT_APP_ID != ''`.

Comments
----------------------------------------
None.
