### PR TITLE
PR Commands: Switch from App Token to PR_COMMANDS_PAT

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -36,19 +36,9 @@ jobs:
             exit 1
           fi
 
-      - name: Generate GitHub App Token
-        id: generate-token
-        env:
-          CIVIBOT_APP_ID: ${{ secrets.CIVIBOT_APP_ID }}
-        if: ${{ env.CIVIBOT_APP_ID != '' }}
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.CIVIBOT_APP_ID }}
-          private-key: ${{ secrets.CIVIBOT_PRIVATE_KEY }}
-
       - name: Add Eyes Reaction
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh api \
             --method POST \
@@ -60,7 +50,7 @@ jobs:
       - name: Fetch PR Details
         id: pr_info
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
         run: |
           PR_JSON=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName,headRepository,headRepositoryOwner,baseRefName,state,mergeCommit)
 
@@ -82,12 +72,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Parse and Execute Command
         id: exec
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
         run: |
           # Configure Git
           git config user.name "github-actions[bot]"
@@ -101,7 +91,7 @@ jobs:
             git checkout -b pr-branch FETCH_HEAD
           else
             # Connect remote head_repo
-            git remote add head_repo "https://x-access-token:${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}@github.com/${{ steps.pr_info.outputs.head_owner }}/${{ steps.pr_info.outputs.head_repo }}.git"
+            git remote add head_repo "https://x-access-token:${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}@github.com/${{ steps.pr_info.outputs.head_owner }}/${{ steps.pr_info.outputs.head_repo }}.git"
             git fetch head_repo ${{ steps.pr_info.outputs.head_ref }}
             git checkout -b pr-branch head_repo/${{ steps.pr_info.outputs.head_ref }}
           fi
@@ -250,7 +240,7 @@ jobs:
       - name: Add Success Reaction
         if: success()
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
         run: |
           gh api \
             --method POST \
@@ -262,7 +252,7 @@ jobs:
       - name: Add Failure Reaction and Comment
         if: failure()
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN }}
         run: |
           # 1. Add reaction
           gh api \


### PR DESCRIPTION
Overview
----------------------------------------
To resolve limitations where GitHub Apps cannot push workflow changes to contributor forks because they are not installed on those forks, this PR switches the PR commands workflow to use a Personal Access Token (`PR_COMMANDS_PAT`).

Before
----------------------------------------
Pushes that updated workflow files on contributor forks failed when using a GitHub App token with:
`refusing to allow a GitHub App to create or update workflow .github/workflows/pr-commands.yml without workflows permission`

After
----------------------------------------
If `PR_COMMANDS_PAT` is defined as a secret (belonging to a machine/bot user or a maintainer account with `workflow` and `repo` scopes), it is used to authenticate git and API operations, successfully allowing workflow updates to forks. Otherwise, it falls back to the default `GITHUB_TOKEN`.

Technical Details
----------------------------------------
- Removed the `actions/create-github-app-token` step.
- Replaced token references with `secrets.PR_COMMANDS_PAT || secrets.GITHUB_TOKEN`.

Comments
----------------------------------------
None.
