### PR TITLE
Fix default status on Find Participant form

### DIFF
--- a/CRM/Event/Form/Search.php
+++ b/CRM/Event/Form/Search.php
@@ -413,19 +413,25 @@ class CRM_Event_Form_Search extends CRM_Core_Form_Search {
 
     $status = CRM_Utils_Request::retrieve('status', 'String');
     if (isset($status)) {
+      $statusTypes = [];
       if ($status === 'true') {
-        $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1");
+        $statusTypes = array_keys(CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1"));
       }
       elseif ($status === 'false') {
-        $statusTypes = CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 0");
+        $statusTypes = array_keys(CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 0"));
       }
       elseif (is_numeric($status)) {
-        $statusTypes = (int) $status;
+        $statusTypes = [(int) $status];
+      }
+      elseif (is_string($status) && str_contains($status, ',')) {
+        $statusTypes = array_map('intval', explode(',', $status));
       }
       elseif (is_array($status) && !array_key_exists('IN', $status)) {
         $statusTypes = array_keys($status);
       }
-      $this->_defaults['participant_status_id'] = is_array($statusTypes) ? array_keys($statusTypes) : $statusTypes;
+      if (!empty($statusTypes)) {
+        $this->_defaults['participant_status_id'] = $statusTypes;
+      }
     }
     return $this->_defaults;
   }

--- a/tests/phpunit/CRM/Event/Form/SearchTest.php
+++ b/tests/phpunit/CRM/Event/Form/SearchTest.php
@@ -65,4 +65,36 @@ class CRM_Event_Form_SearchTest extends CiviUnitTestCase {
     $this->assertCount(1, $rows, 'Exactly one row should be returned for given price field value.');
   }
 
+  /**
+   * Test setDefaultValues with various status parameter formats.
+   *
+   * @dataProvider statusDefaultProvider
+   */
+  public function testSetDefaultValuesStatus($statusParam, $expectedDefaults): void {
+    if ($expectedDefaults === 'counted') {
+      $expectedDefaults = array_keys(CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 1"));
+    }
+    elseif ($expectedDefaults === 'non-counted') {
+      $expectedDefaults = array_keys(CRM_Event_PseudoConstant::participantStatus(NULL, "is_counted = 0"));
+    }
+
+    $formWrapper = $this->getTestForm('CRM_Event_Form_Search', [], ['status' => $statusParam]);
+    $formWrapper->processForm(\Civi\Test\FormWrapper::BUILT);
+
+    $form = \Civi\Test\Invasive::get([$formWrapper, 'form']);
+
+    $this->assertEquals($expectedDefaults, $form->_defaults['participant_status_id'] ?? NULL);
+  }
+
+  public function statusDefaultProvider(): array {
+    return [
+      ['true', 'counted'],
+      ['false', 'non-counted'],
+      ['1', [1]],
+      ['1,2', [1, 2]],
+      [[1 => 1, 2 => 1], [1, 2]],
+      ['bogus', NULL],
+    ];
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix setting default status from the URL on *Find Participants*

Replaces https://github.com/civicrm/civicrm-core/pull/31391

Correctly handles all the permutations of the 'status' url param and adds a test.