### PR TITLE
Afform - avoid per-record getFields in contact summary blocks

### DIFF
--- a/ext/afform/core/Civi/Afform/Placement/ContactSummaryBlockPlacement.php
+++ b/ext/afform/core/Civi/Afform/Placement/ContactSummaryBlockPlacement.php
@@ -68,30 +68,41 @@ class ContactSummaryBlockPlacement extends AutoSubscriber {
    */
   public static function onGetBlocks(GenericHookEvent $e) {
     $afforms = \Civi\Api4\Afform::get()
-      ->setSelect(['name', 'title', 'directive_name', 'module_name', 'type', 'type:icon', 'type:label', 'placement_filters'])
+      ->setSelect(['name', 'title', 'directive_name', 'module_name', 'type', 'placement_filters'])
       ->addWhere('placement', 'CONTAINS', 'contact_summary_block')
       ->addOrderBy('title')
       ->execute();
+    // Resolve the afform type option list once, rather than selecting the
+    // `type:icon` & `type:label` pseudoconstant fields, which BasicGetAction
+    // resolves with a separate `Afform.getFields` api call per afform record.
+    $typeField = \Civi\Api4\Afform::getFields(FALSE)
+      ->setLoadOptions(['id', 'label', 'icon'])
+      ->addWhere('name', '=', 'type')
+      ->execute()->first();
+    $typeOptions = array_column($typeField['options'] ?? [], NULL, 'id');
     foreach ($afforms as $index => $afform) {
+      // Default to 'form' (the field's default value) if type is missing or unknown
+      $typeName = isset($typeOptions[$afform['type'] ?? '']) ? $afform['type'] : 'form';
+      $type = $typeOptions[$typeName] ?? [];
       // Create a group per afform type
       $e->blocks += [
-        "afform_{$afform['type']}" => [
-          'title' => $afform['type:label'],
-          'icon' => $afform['type:icon'],
+        "afform_{$typeName}" => [
+          'title' => $type['label'] ?? NULL,
+          'icon' => $type['icon'] ?? NULL,
           'blocks' => [],
         ],
       ];
       // If the form specifies contact types, resolve them to just the parent types (Individual, Organization, Household)
       // because ContactLayout doesn't care about sub-types
       $contactType = PlacementUtils::filterContactTypes($afform['placement_filters']['contact_type'] ?? []);
-      $e->blocks["afform_{$afform['type']}"]['blocks'][$afform['name']] = [
+      $e->blocks["afform_{$typeName}"]['blocks'][$afform['name']] = [
         'title' => $afform['title'],
         'contact_type' => $contactType ?: NULL,
         'tpl_file' => 'afform/InlineAfform.tpl',
         'module' => $afform['module_name'],
         'directive' => $afform['directive_name'],
         'sample' => [
-          $afform['type:label'],
+          $type['label'] ?? NULL,
         ],
         'edit' => 'civicrm/admin/afform#/edit/' . $afform['name'],
         'system_default' => [0, $index % 2],

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformPlacementTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformPlacementTest.php
@@ -177,6 +177,15 @@ class AfformPlacementTest extends TestCase implements HeadlessInterface {
     $this->assertGreaterThan($order[$this->formNames[2]], $order[$this->formNames[1]]);
     // Unless explicit weight is given
     $this->assertGreaterThan($order[$this->formNames[3]], $order[$this->formNames[2]]);
+    // Each block group is labelled & iconed from the afform type option list
+    // (values defined in managed/AfformType.mgd.php)
+    $this->assertEquals('Search Form', $blocks['afform_search']['title']);
+    $this->assertEquals('fa-search', $blocks['afform_search']['icon']);
+    $this->assertEquals('Submission Form', $blocks['afform_form']['title']);
+    $this->assertEquals('fa-list-alt', $blocks['afform_form']['icon']);
+    // The sample text for a block is its type label
+    $this->assertEquals(['Search Form'], $blocks['afform_search']['blocks'][$this->formNames[0]]['sample']);
+    $this->assertEquals(['Submission Form'], $blocks['afform_form']['blocks'][$this->formNames[1]]['sample']);
   }
 
   public function testAfformCaseSummaryBlock(): void {


### PR DESCRIPTION
This is extracted from a patch I made (along with #36247) while investigating performance improvements on an installation. Fair warning, this is AI-assisted and I don't have full context on the code it touches. Happy to take on further testing/verification of this if someone familiar with this part of the codebase has some pointers 🙂 

### Overview

`ContactSummaryBlockPlacement::onGetBlocks()` (the `hook_civicrm_contactSummaryBlocks` implementation) resolves the Afform type option list once, instead of selecting the `type:icon` / `type:label` pseudoconstant fields on `Afform.get`. This removes a per-record `Afform.getFields` API call that dominated the hook's runtime, with identical output.

### Before

Afform is an API-only entity (no `Civi::entity` schema), so `BasicGetAction` resolves the `type:icon`/`type:label` suffixes via `FormattingUtil::getPseudoconstantList()`'s API fallback — a full `Afform.getFields` call **per suffixed field, per record**. Because `BasicGetAction::_run()` formats **all** records before applying the where clause, every Afform on the system (one per custom group/ECK entity type) is formatted, not just the handful placed on the contact summary.

On a site with ~330 Afforms that was ~660 nested `Afform.getFields` calls (~1.6s in production traces) on every contact-summary / ContactLayout-editor page load. Production OTel/APM traces recorded `Afform.getFields` firing 10,952 times in a 31-minute steady-state window.

### After

Fetch the (4-entry, static) `afform_type` option list once and map label/icon in the loop — a single `Afform.getFields` call, identical output. After deploying this on production, `Afform.getFields` dropped to **zero** in the equivalent steady-state window.

### Technical Details

- A missing/unknown `type` falls back to `'form'` (the field's default value per the `Afform.getFields` spec), so the block key and label/icon stay well-defined for any data.
- Extends `AfformPlacementTest::testAfformContactSummaryBlock()` to assert the block-group `title`/`icon` and block `sample` (previously uncovered) locking in the identical output.

### Comments

Complementary to a companion change (#36247) that memoizes the `FormattingUtil` pseudoconstant fallback itself: this PR removes the pathological caller, that one bounds the cost for all API-only entities. They're independent, not alternatives.