### PR TITLE
APIv4 - cache API-only pseudoconstant fallback in FormattingUtil

### DIFF
--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -353,15 +353,16 @@ class FormattingUtil {
     // so cache it; otherwise formatting a large result set for an api-only
     // entity repeats the `getFields` api call once per record. The key mirrors
     // the option-cache convention in BasicGetFieldsAction (domain + locale, with
-    // munged identifiers) so translated labels don't bleed across languages or
-    // domains. Invalidation rides on the metadata cache being cleared whenever
-    // option-affecting metadata changes (e.g. CRM_Core_BAO_OptionValue::add).
+    // the field name munged since it may contain dots) so translated labels
+    // don't bleed across languages or domains. Invalidation rides on the
+    // metadata cache being cleared whenever option-affecting metadata changes
+    // (e.g. CRM_Core_BAO_OptionValue::add).
     if (!isset($options)) {
       $cacheKey = implode('_', [
         \CRM_Core_Config::domainID(),
         \CRM_Core_I18n::getLocale(),
         'api4options',
-        \CRM_Utils_String::munge($field['entity'], '_', 0),
+        $field['entity'],
         \CRM_Utils_String::munge($field['name'], '_', 0),
         $valueType,
         $action,

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -350,15 +350,36 @@ class FormattingUtil {
     }
     // Fallback for option lists that only exist in the api but not in core.
     // Unlike `getFieldOptions()`, this lookup does not depend on $entityValues,
-    // so cache it per-field; otherwise formatting a large result set for an
-    // api-only entity repeats the `getFields` api call once per record.
+    // so cache it; otherwise formatting a large result set for an api-only
+    // entity repeats the `getFields` api call once per record. The key mirrors
+    // the option-cache convention in BasicGetFieldsAction (domain + locale, with
+    // munged identifiers) so translated labels don't bleed across languages or
+    // domains. Invalidation rides on the metadata cache being cleared whenever
+    // option-affecting metadata changes (e.g. CRM_Core_BAO_OptionValue::add).
     if (!isset($options)) {
-      $cacheKey = "api4.options.{$field['entity']}.{$field['name']}.{$valueType}.{$action}";
-      // FALSE = cached "no options found" (a cache miss returns NULL)
+      $cacheKey = implode('_', [
+        \CRM_Core_Config::domainID(),
+        \CRM_Core_I18n::getLocale(),
+        'api4options',
+        \CRM_Utils_String::munge($field['entity'], '_', 0),
+        \CRM_Utils_String::munge($field['name'], '_', 0),
+        $valueType,
+        $action,
+      ]);
+      // A cache miss returns NULL. Only a found option list (an array, possibly
+      // empty) is cached; a field with no options is not cached as a negative,
+      // so a transient empty result can't stick until the next cache flush.
       $options = \Civi::cache('metadata')->get($cacheKey);
-      if (!isset($options)) {
-        $options = civicrm_api4($field['entity'], 'getFields', ['checkPermissions' => FALSE, 'action' => $action, 'loadOptions' => ['id', $valueType], 'where' => [['name', '=', $field['name']]]])[0]['options'] ?? FALSE;
-        \Civi::cache('metadata')->set($cacheKey, $options);
+      if (!is_array($options)) {
+        $options = civicrm_api4($field['entity'], 'getFields', [
+          'checkPermissions' => FALSE,
+          'action' => $action,
+          'loadOptions' => ['id', $valueType],
+          'where' => [['name', '=', $field['name']]],
+        ])[0]['options'] ?? NULL;
+        if (is_array($options)) {
+          \Civi::cache('metadata')->set($cacheKey, $options);
+        }
       }
     }
 

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -349,14 +349,7 @@ class FormattingUtil {
       // Entity not in Civi (api-only) will use fallback below
     }
     // Fallback for option lists that only exist in the api but not in core.
-    // Unlike `getFieldOptions()`, this lookup does not depend on $entityValues,
-    // so cache it; otherwise formatting a large result set for an api-only
-    // entity repeats the `getFields` api call once per record. The key mirrors
-    // the option-cache convention in BasicGetFieldsAction (domain + locale, with
-    // the field name munged since it may contain dots) so translated labels
-    // don't bleed across languages or domains. Invalidation rides on the
-    // metadata cache being cleared whenever option-affecting metadata changes
-    // (e.g. CRM_Core_BAO_OptionValue::add).
+    // Cached per domain/locale to avoid repeating getFields for every record.
     if (!isset($options)) {
       $cacheKey = implode('_', [
         \CRM_Core_Config::domainID(),
@@ -367,9 +360,8 @@ class FormattingUtil {
         $valueType,
         $action,
       ]);
-      // A cache miss returns NULL. Only a found option list (an array, possibly
-      // empty) is cached; a field with no options is not cached as a negative,
-      // so a transient empty result can't stick until the next cache flush.
+
+      // Only a found option list is cached; "no options" is not cached as a negative.
       $options = \Civi::cache('metadata')->get($cacheKey);
       if (!is_array($options)) {
         $options = civicrm_api4($field['entity'], 'getFields', [

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -348,8 +348,19 @@ class FormattingUtil {
     catch (\CRM_Core_Exception $e) {
       // Entity not in Civi (api-only) will use fallback below
     }
-    // Fallback for option lists that only exist in the api but not in core
-    $options ??= civicrm_api4($field['entity'], 'getFields', ['checkPermissions' => FALSE, 'action' => $action, 'loadOptions' => ['id', $valueType], 'where' => [['name', '=', $field['name']]]])[0]['options'] ?? NULL;
+    // Fallback for option lists that only exist in the api but not in core.
+    // Unlike `getFieldOptions()`, this lookup does not depend on $entityValues,
+    // so cache it per-field; otherwise formatting a large result set for an
+    // api-only entity repeats the `getFields` api call once per record.
+    if (!isset($options)) {
+      $cacheKey = "api4.options.{$field['entity']}.{$field['name']}.{$valueType}.{$action}";
+      // FALSE = cached "no options found" (a cache miss returns NULL)
+      $options = \Civi::cache('metadata')->get($cacheKey);
+      if (!isset($options)) {
+        $options = civicrm_api4($field['entity'], 'getFields', ['checkPermissions' => FALSE, 'action' => $action, 'loadOptions' => ['id', $valueType], 'where' => [['name', '=', $field['name']]]])[0]['options'] ?? FALSE;
+        \Civi::cache('metadata')->set($cacheKey, $options);
+      }
+    }
 
     $options = $options ? array_column($options, $valueType, 'id') : $options;
     if (is_array($options)) {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -20,8 +20,10 @@
 namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
+use Civi\API\Event\PrepareEvent;
 use Civi\Api4\MockBasicEntity;
 use Civi\Api4\Utils\CoreUtil;
+use Civi\Api4\Utils\FormattingUtil;
 use Civi\Core\Event\GenericHookEvent;
 use Civi\Test\CiviEnvBuilder;
 use Civi\Core\HookInterface;
@@ -34,12 +36,31 @@ use Civi\Test\TransactionalInterface;
 class BasicActionsTest extends Api4TestBase implements HookInterface, TransactionalInterface {
 
   /**
+   * Number of times MockBasicEntity::getFields has run during a test.
+   *
+   * @var int
+   */
+  private $getFieldsCallCount = 0;
+
+  /**
    * Listens for civi.api4.entityTypes event to manually add this nonstandard entity
    *
    * @param \Civi\Core\Event\GenericHookEvent $e
    */
   public function on_civi_api4_entityTypes(GenericHookEvent $e): void {
     $e->entities['MockBasicEntity'] = MockBasicEntity::getInfo();
+  }
+
+  /**
+   * Counts nested MockBasicEntity::getFields calls so tests can assert memoization.
+   *
+   * @param \Civi\API\Event\PrepareEvent $event
+   */
+  public function on_civi_api_prepare(PrepareEvent $event): void {
+    $request = $event->getApiRequest();
+    if (is_object($request) && $request->getEntityName() === 'MockBasicEntity' && $request->getActionName() === 'getFields') {
+      $this->getFieldsCallCount++;
+    }
   }
 
   public function setUpHeadless(): CiviEnvBuilder {
@@ -254,6 +275,54 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
     // Complex options should give all requested properties
     $this->assertEquals('Banana', $getFields['fruit']['options'][2]['label']);
     $this->assertEquals('yellow', $getFields['fruit']['options'][2]['color']);
+  }
+
+  /**
+   * MockBasicEntity has no Civi::entity schema, so resolving a pseudoconstant
+   * suffix falls back to a getFields api call. That fallback is memoized in
+   * Civi::cache('metadata') so formatting a large result set runs it once rather
+   * than once per record.
+   */
+  public function testPseudoconstantFallbackIsCached(): void {
+    $field = ['name' => 'group', 'entity' => 'MockBasicEntity'];
+    \Civi::cache('metadata')->clear();
+    $this->getFieldsCallCount = 0;
+
+    // Resolve the same api-only option list several times, as formatting a
+    // multi-record result set would.
+    $expected = ['one' => 'First', 'two' => 'Second'];
+    for ($i = 0; $i < 3; $i++) {
+      $options = FormattingUtil::getPseudoconstantList($field, 'group:label');
+      $this->assertEquals($expected, $options);
+    }
+
+    // The getFields fallback was memoized, so it ran once regardless of how many
+    // times the option list was resolved.
+    $this->assertEquals(1, $this->getFieldsCallCount);
+  }
+
+  /**
+   * A fallback that finds no options is cached as FALSE (distinct from a NULL
+   * cache miss) so repeat lookups don't re-run getFields, while still raising the
+   * same "No option list found" exception.
+   */
+  public function testPseudoconstantFallbackCachesEmptyResult(): void {
+    // 'color' is a MockBasicEntity field with no option list.
+    $field = ['name' => 'color', 'entity' => 'MockBasicEntity'];
+    \Civi::cache('metadata')->clear();
+    $this->getFieldsCallCount = 0;
+
+    for ($i = 0; $i < 2; $i++) {
+      try {
+        FormattingUtil::getPseudoconstantList($field, 'color:label');
+        $this->fail('Expected a CRM_Core_Exception for a field with no option list');
+      }
+      catch (\CRM_Core_Exception $e) {
+        $this->assertStringContainsString('No option list found', $e->getMessage());
+      }
+    }
+
+    $this->assertEquals(1, $this->getFieldsCallCount);
   }
 
   public function testItemsToGet(): void {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -69,6 +69,13 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
     return parent::setUpHeadless();
   }
 
+  public function tearDown(): void {
+    // Some tests cache MockBasicEntity option lists in the persistent metadata
+    // cache; clear it so leftover entries don't couple later tests.
+    \Civi::cache('metadata')->clear();
+    parent::tearDown();
+  }
+
   private function replaceRecords(&$records) {
     MockBasicEntity::delete()->addWhere('identifier', '>', 0)->execute();
     foreach ($records as &$record) {
@@ -302,11 +309,12 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
   }
 
   /**
-   * A fallback that finds no options is cached as FALSE (distinct from a NULL
-   * cache miss) so repeat lookups don't re-run getFields, while still raising the
-   * same "No option list found" exception.
+   * A fallback that finds no options is not cached, so each lookup re-runs
+   * getFields rather than persisting a negative result that could stick until the
+   * next cache flush, while still raising the same "No option list found"
+   * exception.
    */
-  public function testPseudoconstantFallbackCachesEmptyResult(): void {
+  public function testPseudoconstantFallbackDoesNotCacheMissingOptions(): void {
     // 'color' is a MockBasicEntity field with no option list.
     $field = ['name' => 'color', 'entity' => 'MockBasicEntity'];
     \Civi::cache('metadata')->clear();
@@ -322,7 +330,36 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
       }
     }
 
-    $this->assertEquals(1, $this->getFieldsCallCount);
+    // The "no options" result is not cached, so getFields ran once per lookup.
+    // This keeps a transient empty result from sticking until a cache flush.
+    $this->assertEquals(2, $this->getFieldsCallCount);
+  }
+
+  /**
+   * Cached option lists are scoped per locale, so resolving the same field under
+   * a different locale re-runs getFields rather than serving another locale's
+   * (potentially translated) labels from the first locale's cache entry.
+   */
+  public function testPseudoconstantFallbackIsLocaleScoped(): void {
+    global $tsLocale;
+    $field = ['name' => 'group', 'entity' => 'MockBasicEntity'];
+    \Civi::cache('metadata')->clear();
+    $this->getFieldsCallCount = 0;
+    $originalLocale = $tsLocale;
+
+    try {
+      $tsLocale = 'en_US';
+      FormattingUtil::getPseudoconstantList($field, 'group:label');
+      $this->assertEquals(1, $this->getFieldsCallCount);
+
+      // A different locale must not read the first locale's cache entry.
+      $tsLocale = 'fr_FR';
+      FormattingUtil::getPseudoconstantList($field, 'group:label');
+      $this->assertEquals(2, $this->getFieldsCallCount);
+    }
+    finally {
+      $tsLocale = $originalLocale;
+    }
   }
 
   public function testItemsToGet(): void {

--- a/tests/phpunit/api/v4/Action/BasicActionsTest.php
+++ b/tests/phpunit/api/v4/Action/BasicActionsTest.php
@@ -36,8 +36,6 @@ use Civi\Test\TransactionalInterface;
 class BasicActionsTest extends Api4TestBase implements HookInterface, TransactionalInterface {
 
   /**
-   * Number of times MockBasicEntity::getFields has run during a test.
-   *
    * @var int
    */
   private $getFieldsCallCount = 0;
@@ -52,7 +50,7 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
   }
 
   /**
-   * Counts nested MockBasicEntity::getFields calls so tests can assert memoization.
+   * Counts MockBasicEntity::getFields calls so tests can assert caching.
    *
    * @param \Civi\API\Event\PrepareEvent $event
    */
@@ -70,8 +68,7 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
   }
 
   public function tearDown(): void {
-    // Some tests cache MockBasicEntity option lists in the persistent metadata
-    // cache; clear it so leftover entries don't couple later tests.
+    // Clear cached MockBasicEntity option lists
     \Civi::cache('metadata')->clear();
     parent::tearDown();
   }
@@ -284,38 +281,22 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
     $this->assertEquals('yellow', $getFields['fruit']['options'][2]['color']);
   }
 
-  /**
-   * MockBasicEntity has no Civi::entity schema, so resolving a pseudoconstant
-   * suffix falls back to a getFields api call. That fallback is memoized in
-   * Civi::cache('metadata') so formatting a large result set runs it once rather
-   * than once per record.
-   */
   public function testPseudoconstantFallbackIsCached(): void {
     $field = ['name' => 'group', 'entity' => 'MockBasicEntity'];
     \Civi::cache('metadata')->clear();
     $this->getFieldsCallCount = 0;
 
-    // Resolve the same api-only option list several times, as formatting a
-    // multi-record result set would.
     $expected = ['one' => 'First', 'two' => 'Second'];
     for ($i = 0; $i < 3; $i++) {
       $options = FormattingUtil::getPseudoconstantList($field, 'group:label');
       $this->assertEquals($expected, $options);
     }
 
-    // The getFields fallback was memoized, so it ran once regardless of how many
-    // times the option list was resolved.
     $this->assertEquals(1, $this->getFieldsCallCount);
   }
 
-  /**
-   * A fallback that finds no options is not cached, so each lookup re-runs
-   * getFields rather than persisting a negative result that could stick until the
-   * next cache flush, while still raising the same "No option list found"
-   * exception.
-   */
   public function testPseudoconstantFallbackDoesNotCacheMissingOptions(): void {
-    // 'color' is a MockBasicEntity field with no option list.
+    // The 'color' field has no option list.
     $field = ['name' => 'color', 'entity' => 'MockBasicEntity'];
     \Civi::cache('metadata')->clear();
     $this->getFieldsCallCount = 0;
@@ -330,16 +311,9 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
       }
     }
 
-    // The "no options" result is not cached, so getFields ran once per lookup.
-    // This keeps a transient empty result from sticking until a cache flush.
     $this->assertEquals(2, $this->getFieldsCallCount);
   }
 
-  /**
-   * Cached option lists are scoped per locale, so resolving the same field under
-   * a different locale re-runs getFields rather than serving another locale's
-   * (potentially translated) labels from the first locale's cache entry.
-   */
   public function testPseudoconstantFallbackIsLocaleScoped(): void {
     global $tsLocale;
     $field = ['name' => 'group', 'entity' => 'MockBasicEntity'];
@@ -352,7 +326,6 @@ class BasicActionsTest extends Api4TestBase implements HookInterface, Transactio
       FormattingUtil::getPseudoconstantList($field, 'group:label');
       $this->assertEquals(1, $this->getFieldsCallCount);
 
-      // A different locale must not read the first locale's cache entry.
       $tsLocale = 'fr_FR';
       FormattingUtil::getPseudoconstantList($field, 'group:label');
       $this->assertEquals(2, $this->getFieldsCallCount);


### PR DESCRIPTION
This is extracted from a patch I made while investigating performance improvements on an installation.

## Overview

Caches the `getFields` fallback in `FormattingUtil::getPseudoconstantList()`, which resolves option lists for api-only entities (e.g. Afform).

## Before

The fallback runs once per record per suffixed field, so formatting a large result set repeats the identical nested `getFields` call for every row. 

In a production trace, a SearchKit display request averaged 2.05s, ~83% of it nested `getFields`.

## After

The fallback result is cached in `Civi::cache('metadata')`, keyed by domain/locale/entity/field/suffix/action, so `getFields` runs once. 

The same production request dropped to ~0.3s.

## Technical Details

- Invalidation rides on the existing metadata-cache flush, matching `BasicGetFieldsAction`'s option cache.
- A "no options" result is not cached; exception behaviour is unchanged.
- Tests cover caching, locale scoping, and the no-options case.