### PR TITLE
Api4 - Fix possible infinite recursion in getFields

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -27,8 +27,6 @@ use Civi\Api4\Utils\CoreUtil;
  * @method $this setLoadOptions(bool|array $value)
  * @method bool|array getLoadOptions()
  * @method $this setAction(string $value)
- * @method $this setValues(array $values)
- * @method array getValues()
  */
 class BasicGetFieldsAction extends BasicGetAction {
 

--- a/Civi/Api4/Generic/Traits/GetSetValueTrait.php
+++ b/Civi/Api4/Generic/Traits/GetSetValueTrait.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Generic\Traits;
 
+use Civi\Api4\Generic\BasicGetFieldsAction;
 use Civi\Api4\Utils\FormattingUtil;
 
 /**
@@ -55,6 +56,10 @@ trait GetSetValueTrait {
   public function getValue(string $fieldExpr) {
     if (array_key_exists($fieldExpr, $this->values)) {
       return $this->values[$fieldExpr];
+    }
+    // Don't call getFields recursively inside getFields
+    if ($this instanceof BasicGetFieldsAction) {
+      return NULL;
     }
     // If exact match not found, try pseudoconstants
     [$fieldName, $suffix] = array_pad(explode(':', $fieldExpr), 2, NULL);


### PR DESCRIPTION
Overview
----------------------------------------
Fix Api4 internals

Before
----------------------------------------
If getFields calls getValue it will call getFields which will call getValue, etc.

After
----------------------------------------
 Guard added to prevent infinite loop. Also validates the suffix now.

Comments
---------
I caught this in a unit test which I'll be pushing up shortly, but wanted to get this fix merged first.