### PR TITLE
dev/core#6645 - CRM_Utils_Check - refresh the cached max-severity when a full status sweep runs

### DIFF
--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -128,15 +128,28 @@ class CRM_Utils_Check {
   public static function getMaxSeverity(bool $force = FALSE): int {
     $maxSeverity = Civi::cache('checks')->get('systemStatusCheckResult');
     if ($maxSeverity === NULL || $force) {
-      $maxSeverity = 1;
-      foreach (self::checkAll() as $message) {
-        if ($message->isVisible()) {
-          $maxSeverity = max($maxSeverity, $message->getLevel());
-        }
-      }
-      Civi::cache('checks')->set('systemStatusCheckResult', $maxSeverity, self::CHECK_TIMER);
+      $maxSeverity = self::publishMaxSeverity(self::checkAll());
     }
     return $maxSeverity ?? 0;
+  }
+
+  /**
+   * Publish the summary severity of a complete set of status messages to the cache.
+   *
+   * @param \CRM_Utils_Check_Message[] $messages
+   *   A full, unfiltered sweep, as returned by checkAll().
+   *
+   * @return int
+   */
+  private static function publishMaxSeverity(array $messages): int {
+    $maxSeverity = 1;
+    foreach ($messages as $message) {
+      if ($message->isVisible()) {
+        $maxSeverity = max($maxSeverity, $message->getLevel());
+      }
+    }
+    Civi::cache('checks')->set('systemStatusCheckResult', $maxSeverity, self::CHECK_TIMER);
+    return $maxSeverity;
   }
 
   /**
@@ -236,6 +249,14 @@ class CRM_Utils_Check {
     }
 
     CRM_Utils_Hook::check($messages, $statusNames, $includeDisabled);
+
+    // Publish the summary of a completed, unfiltered sweep, so a live status view
+    // refreshes the cached footer severity instead of it outlasting a cleared warning.
+    // Only a full, enabled-only run: a name-filtered sweep summarises a subset, and an
+    // includeDisabled sweep counts disabled checks.
+    if (!$statusNames && !$includeDisabled) {
+      self::publishMaxSeverity($messages);
+    }
 
     return $messages;
   }

--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -1508,6 +1508,9 @@
   name        : Robert Gilman
   organization: Context Institute
 
+- github      : RisingOrange
+  name        : Jakub Fidler
+
 - github      : robbrandt
   name        : Rob Brandt
   organization: Botanical Society of America

--- a/tests/phpunit/CRM/Utils/CheckTest.php
+++ b/tests/phpunit/CRM/Utils/CheckTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @package CiviCRM
+ * @group headless
+ */
+class CRM_Utils_CheckTest extends CiviUnitTestCase {
+
+  /**
+   * When TRUE, the check hook injects one WARNING-level message.
+   *
+   * @var bool
+   */
+  private $injectWarning = FALSE;
+
+  protected function tearDown(): void {
+    $this->injectWarning = FALSE;
+    Civi::cache('checks')->delete('systemStatusCheckResult');
+    unset(Civi::$statics['CRM_Utils_Check']);
+    parent::tearDown();
+  }
+
+  /**
+   * hook_civicrm_check: add a WARNING-level message when $injectWarning is set.
+   */
+  public function hook_civicrm_check(&$messages, $statusNames = [], $includeDisabled = FALSE): void {
+    if ($this->injectWarning && (!$statusNames || in_array('checkTestInjected', $statusNames, TRUE))) {
+      $messages[] = new CRM_Utils_Check_Message(
+        'checkTestInjected',
+        'injected by CRM_Utils_CheckTest',
+        'Injected',
+        \Psr\Log\LogLevel::WARNING,
+        'fa-bug'
+      );
+    }
+  }
+
+  /**
+   * A completed, unfiltered sweep publishes its max visible severity to the cache.
+   */
+  public function testFullSweepPublishesMaxSeverity(): void {
+    $this->hookClass->setHook('civicrm_check', [$this, 'hook_civicrm_check']);
+    $this->injectWarning = TRUE;
+
+    // A stale sentinel a full sweep must overwrite. 7 (EMERGENCY) is above any real check, so a
+    // pass cannot be vacuous: the published value must differ from it.
+    Civi::cache('checks')->set('systemStatusCheckResult', 7, CRM_Utils_Check::CHECK_TIMER);
+    unset(Civi::$statics['CRM_Utils_Check']);
+
+    $messages = CRM_Utils_Check::checkStatus();
+    $expected = 1;
+    foreach ($messages as $message) {
+      if ($message->isVisible()) {
+        $expected = max($expected, $message->getLevel());
+      }
+    }
+
+    // The injected warning guarantees the live max is at least WARNING (3), and below the sentinel.
+    $this->assertGreaterThanOrEqual(3, $expected);
+    $this->assertLessThan(7, $expected);
+    $this->assertEquals($expected, Civi::cache('checks')->get('systemStatusCheckResult'));
+  }
+
+  /**
+   * A name-filtered sweep must not publish (it only summarises a subset).
+   */
+  public function testFilteredSweepDoesNotPublish(): void {
+    Civi::cache('checks')->set('systemStatusCheckResult', 7, CRM_Utils_Check::CHECK_TIMER);
+    unset(Civi::$statics['CRM_Utils_Check']);
+
+    CRM_Utils_Check::checkStatus(['checkDefaultMailbox']);
+
+    $this->assertEquals(7, Civi::cache('checks')->get('systemStatusCheckResult'));
+  }
+
+  /**
+   * An includeDisabled sweep must not publish (it counts checks the site switched off).
+   */
+  public function testIncludeDisabledSweepDoesNotPublish(): void {
+    Civi::cache('checks')->set('systemStatusCheckResult', 7, CRM_Utils_Check::CHECK_TIMER);
+    unset(Civi::$statics['CRM_Utils_Check']);
+
+    CRM_Utils_Check::checkStatus([], TRUE);
+
+    $this->assertEquals(7, Civi::cache('checks')->get('systemStatusCheckResult'));
+  }
+
+  /**
+   * getMaxSeverity() returns the cached value on a hit and recomputes with $force.
+   */
+  public function testGetMaxSeverityCaching(): void {
+    // 7 (EMERGENCY) is above any real check, so a recompute must return something different: an
+    // ignored $force would leave 7 in place and fail these assertions instead of passing vacuously.
+    Civi::cache('checks')->set('systemStatusCheckResult', 7, CRM_Utils_Check::CHECK_TIMER);
+    unset(Civi::$statics['CRM_Utils_Check']);
+
+    // Cache hit: returned as-is, no recompute.
+    $this->assertEquals(7, CRM_Utils_Check::getMaxSeverity());
+
+    // Force: recomputes to the real (lower) value and re-caches it.
+    $forced = CRM_Utils_Check::getMaxSeverity(TRUE);
+    $this->assertLessThan(7, $forced);
+    $this->assertEquals($forced, Civi::cache('checks')->get('systemStatusCheckResult'));
+  }
+
+}

--- a/tests/phpunit/CRM/Utils/CheckTest.php
+++ b/tests/phpunit/CRM/Utils/CheckTest.php
@@ -62,26 +62,20 @@ class CRM_Utils_CheckTest extends CiviUnitTestCase {
   }
 
   /**
-   * A name-filtered sweep must not publish (it only summarises a subset).
+   * A partial sweep must not publish: a name-filtered run summarises a subset, and an
+   * includeDisabled run counts checks the site has switched off.
    */
-  public function testFilteredSweepDoesNotPublish(): void {
+  public function testPartialSweepsDoNotPublish(): void {
+    // Name-filtered.
     Civi::cache('checks')->set('systemStatusCheckResult', 7, CRM_Utils_Check::CHECK_TIMER);
     unset(Civi::$statics['CRM_Utils_Check']);
-
     CRM_Utils_Check::checkStatus(['checkDefaultMailbox']);
-
     $this->assertEquals(7, Civi::cache('checks')->get('systemStatusCheckResult'));
-  }
 
-  /**
-   * An includeDisabled sweep must not publish (it counts checks the site switched off).
-   */
-  public function testIncludeDisabledSweepDoesNotPublish(): void {
+    // includeDisabled.
     Civi::cache('checks')->set('systemStatusCheckResult', 7, CRM_Utils_Check::CHECK_TIMER);
     unset(Civi::$statics['CRM_Utils_Check']);
-
     CRM_Utils_Check::checkStatus([], TRUE);
-
     $this->assertEquals(7, Civi::cache('checks')->get('systemStatusCheckResult'));
   }
 


### PR DESCRIPTION
### What's happening

The System Status severity in the admin footer is cached (24h) and isn't refreshed when the checks change, so it can be stale in either direction: it can keep showing an old warning/error after it's resolved, or keep showing a clean status while a newly-appeared problem is live. Either way it disagrees with the System Status page, which is always computed fresh. It probably goes unnoticed on most installs because a `cv flush` clears the cached value on the default SQL cache; it only really persists on memory-backed caches (Redis/Memcache), where the flush doesn't reach it.

### What this fixes

A completed status-check run now publishes its result, so any live run (viewing the System Status page, `System.check`, etc.) refreshes the footer instead of waiting out the 24h cache.

Fixes dev/core#6645

### Implementation notes

- `getMaxSeverity()`'s max-severity loop moves into a `publishMaxSeverity()` helper it still calls (behaviour unchanged).
- Publish is in `checkStatus()`, not `checkAll()`, because API4 `System.check` calls it directly and bypasses `checkAll()`'s memoization; guarded to `!$statusNames && !$includeDisabled` so filtered / includeDisabled runs don't under- or over-report.
- On a cold `checkAll()` the value can be written twice (idempotent).
- Consistent with [dev/core#174](https://lab.civicrm.org/dev/core/-/issues/174) / [civicrm-core#12336](https://github.com/civicrm/civicrm-core/pull/12336), which first moved this value into the `checks` cache, calling it "an ephemeral value ... apt to being recalculated at arbitrary times".
- Test included.
