### PR TITLE
SearchKit - Only show appropriate entities for "Combine Searches" mode

### DIFF
--- a/Civi/Api4/EntitySet.php
+++ b/Civi/Api4/EntitySet.php
@@ -15,7 +15,7 @@ use Civi\Api4\Generic\BasicGetFieldsAction;
 /**
  * Combine multiple entities with a UNION query.
  *
- * @searchable secondary
+ * @searchable bridge
  * @since 5.64
  * @package Civi\Api4
  */

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -577,9 +577,10 @@
           }
           return '';
         },
-        getPrimaryAndSecondaryEntitySelect: function() {
-          const primaryEntities = CRM.crmSearchAdmin.schema.filter(entity => entity.searchable === 'primary' && entity.fields.length);
-          const secondaryEntities = CRM.crmSearchAdmin.schema.filter(entity => entity.searchable === 'secondary' && entity.fields.length);
+        getPrimaryAndSecondaryEntitySelect: function(filter) {
+          filter = filter || (() => true);
+          const primaryEntities = CRM.crmSearchAdmin.schema.filter(entity => entity.searchable === 'primary' && entity.fields.length).filter(filter);
+          const secondaryEntities = CRM.crmSearchAdmin.schema.filter(entity => entity.searchable === 'secondary' && entity.fields.length).filter(filter);
           const select = formatForSelect2(primaryEntities, 'name', 'title_plural', ['description', 'icon']);
           select.push({
             text: ts('More...'),

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearch-settings.html
@@ -14,7 +14,7 @@
 <div class="form-group">
   <crm-search-admin-tags tag-ids="$ctrl.savedSearch.tag_id" class="btn-group btn-group-sm"></crm-search-admin-tags>
 </div>
-<label>
+<label ng-if=":: $ctrl.canBeEntitySet()">
   {{:: ts('Combine Searches (advanced)') }}
   <a crm-ui-help="hs({id: 'entity_set', title: ts('Combine Searches (advanced)')})"></a>
   <div class="crm-form-toggle-container">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -299,8 +299,13 @@
       return !ctrl.savedSearch.groups.length && !ctrl.savedSearch.is_template;
     };
 
+    this.canBeEntitySet = () => {
+      // Any sql-based entity compatible with UNIONs will support GROUP BY (importantly, this also includes the EntitySet api).
+      return searchMeta.getEntity(this.savedSearch.api_entity).params.includes('groupBy');
+    };
+
     this.isEntitySet = () => {
-      return ctrl.savedSearch.api_entity === 'EntitySet';
+      return this.savedSearch.api_entity === 'EntitySet';
     };
 
     this.toggleEntitySet = () => {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminEntitySetSelect.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminEntitySetSelect.component.js
@@ -15,7 +15,7 @@
 
       $scope.getEntity = searchMeta.getEntity;
       this.setOperations = CRM.crmSearchAdmin.setOperations;
-      $scope.mainEntitySelect = searchMeta.getPrimaryAndSecondaryEntitySelect();
+      this.addEntitySelect = searchMeta.getPrimaryAndSecondaryEntitySelect((entity) => entity.params.includes('groupBy'));
 
       this.hasFunction = (expr) => {
         return expr && this.crmSearchAdmin.hasFunction(expr);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminEntitySetSelect.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminEntitySetSelect.html
@@ -14,7 +14,7 @@
       <th>
         <label for="add-entity-set" class="sr-only">{{:: ts('Add Search') }}</label>
         <input id="add-entity-set" class="form-control crm-auto-width crm-action-menu fa-plus"
-               crm-ui-select="{placeholder: ' ', data: mainEntitySelect}"
+               crm-ui-select="{placeholder: ' ', data: $ctrl.addEntitySelect}"
                on-crm-ui-select="$ctrl.addEntitySet(selection)" >
       </th>
     </tr>


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #36191 to improve the UI & prevent invalid UNION searches from being created.

 - Hide entities that do not support UNIONs from EntitySet selector.
- Hide "Combind Searches" toggle when the main entity doesn't support UNIONs.