### PR TITLE
Wysiwyg - Fix missing function param causing undefined variable error

### DIFF
--- a/js/wysiwyg/crm.wysiwyg.js
+++ b/js/wysiwyg/crm.wysiwyg.js
@@ -62,7 +62,7 @@
         e.preventDefault();
         this.openEditor();
       };
-      this.preview.onkeystroke = () => {
+      this.preview.onkeystroke = (e) => {
         e.preventDefault();
         this.openEditor();
       };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a possible browser error when using wysiwyg inputs.

Technical Details
----------------------------------------
Fixes error introduced in f3fa12917 - the `e` variable called on line 66 was undefined. It should have been passed into the function as it was on line 61.