### PR TITLE
 Afform - Fix primary key metadata in AfformBehavior API

### DIFF
--- a/ext/afform/core/Civi/Api4/AfformBehavior.php
+++ b/ext/afform/core/Civi/Api4/AfformBehavior.php
@@ -7,6 +7,7 @@ namespace Civi\Api4;
  * Behaviors provide special functionality for different types of entities.
  * Provided by the Afform: Core Runtime extension.
  *
+ * @primaryKey key
  * @searchable secondary
  * @since 5.56
  * @package Civi\Api4


### PR DESCRIPTION
Overview
----------------------------------------
Fixes minor api metadata issue in Afform

Before
----------------------------------------
SearchKit defaults to a nonexistent column when you search for Afform Behaviors

After
----------------------------------------
Fixed

Technical Details
-------
 Primary key was defaulting to 'id' and that field doesn't exist in this entity.