### PR TITLE
(dev/core#2641) ACL Cache - Warn if lock anomalies arise

### DIFF
--- a/CRM/ACL/BAO/Cache.php
+++ b/CRM/ACL/BAO/Cache.php
@@ -49,6 +49,11 @@ class CRM_ACL_BAO_Cache extends CRM_ACL_DAO_ACLCache {
     // Use a lock to prevent users from reading this data while the table is being filled
     // See https://lab.civicrm.org/dev/core/-/work_items/2641
     $lock = Civi::lockManager()->acquire("data.core.acl.$id");
+    if (!$lock->isAcquired()) {
+      \Civi::log()->debug("Failed to acquire lock data.core.acl.$id. Lock will be ignored. ACL may have inconsistencies.");
+      // If you're hitting this frequently, then the question is... Why? Maybe you just need to extend the
+      // timeout? Or maybe there's a structural reason?
+    }
 
     self::$_cache[$id] = self::retrieve($id);
     if (self::$_cache[$id]) {


### PR DESCRIPTION
Overview
----------------------------------------

This is a follow-up to a recent PR (#36228; @colemanw ) which defined a new lock.

In general, lock-handling code shouldn't assume successful acquisition -- it should be intentional. But I can't really say the best way to respond if this lock fails. The least we can do is... make anomalous lock issues transparent.

Before
----------------------------------------

Try to claim a lock. If you fail, then just pretend like you got the lock anyway.

After
----------------------------------------

Try to claim a lock. If you fail, then just pretend like you got the lock anyway. _But also... record a warning._

Comments
----------------------------------------

~~At the moment of submission, I haven't `r-run` yet. I'll update/delete this comment when I have.~~