### PR TITLE
Stop assigning receipt_date in MemberRenewal

### DIFF
--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -509,7 +509,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
 
     if ($this->getSubmittedValue('send_receipt')) {
       $this->_params['receipt_date'] = $now;
-      $this->assign('receipt_date', CRM_Utils_Date::mysqlToIso($this->_params['receipt_date']));
     }
     else {
       $this->_params['receipt_date'] = NULL;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1347,6 +1347,7 @@ class CRM_Utils_Token {
           '$contributionStatus' => 'contribution.contribution_status_id:name',
           '$contributionStatusID' => 'contribution.contribution_status_id',
           '$receive_date' => 'contribution.receive_date',
+          '$receipt_date' => 'contribution.receipt_date',
           '$formValues' => 'use relevant token/s',
           '$module' => 'unknown',
           '$currency' => 'contribution.currency',


### PR DESCRIPTION
This really just looks like copy & paste - no evidence of it in the template or related forms or in the template. I added it to the deprecated tokens as a precaution

