### PR TITLE
APIv4 - Prevent object types in parameters

### DIFF
--- a/Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/ValidateFieldsSubscriber.php
@@ -69,12 +69,15 @@ class ValidateFieldsSubscriber extends Generic\AbstractPrepareSubscriber {
     if ($value === NULL) {
       return TRUE;
     }
+    // Api4 only accepts scalar/array params
+    if (is_object($value)) {
+      return FALSE;
+    }
     foreach ($types as $type) {
       switch ($type) {
         case 'array':
         case 'bool':
         case 'string':
-        case 'object':
           $tester = 'is_' . $type;
           if ($tester($value)) {
             return TRUE;

--- a/tests/phpunit/api/v4/Action/RequiredActionParameterTest.php
+++ b/tests/phpunit/api/v4/Action/RequiredActionParameterTest.php
@@ -19,6 +19,7 @@
 namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Event\Subscriber\ValidateFieldsSubscriber;
 use Civi\Api4\Generic\AbstractAction;
 use Civi\Api4\Generic\Result;
 use Civi\Api4\MockBasicEntity;
@@ -120,6 +121,40 @@ class RequiredActionParameterTest extends Api4TestBase {
     $this->expectException(\CRM_Core_Exception::class);
     $this->expectExceptionMessage('Parameter "string" is required.');
     $action->setString('');
+    $action->execute();
+  }
+
+  public function testObjectNotAllowed(): void {
+    $object = new \stdClass();
+
+    static::assertFalse(ValidateFieldsSubscriber::checkType($object, ['mixed']));
+    static::assertFalse(ValidateFieldsSubscriber::checkType($object, ['string']));
+    static::assertFalse(ValidateFieldsSubscriber::checkType($object, ['array']));
+
+    $action = new class(MockBasicEntity::getEntityName(), 'mixed') extends AbstractAction {
+
+      /**
+       * @var mixed
+       */
+      protected $mixed;
+
+      public function setMixed($mixed) {
+        $this->mixed = $mixed;
+        return $this;
+      }
+
+      public function getMixed() {
+        return $this->mixed;
+      }
+
+      public function _run(Result $result) {
+      }
+
+    };
+
+    $action->setMixed($object);
+    $this->expectException(\CRM_Core_Exception::class);
+    $this->expectExceptionMessage('Parameter "mixed" is not of the correct type.');
     $action->execute();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This does the exact opposite of https://github.com/civicrm/civicrm-core/pull/35822

Sorry @eileenmcnaughton 😢