### PR TITLE
API3 - Handle slashed json parameter in REST API

### DIFF
--- a/CRM/Utils/REST.php
+++ b/CRM/Utils/REST.php
@@ -313,13 +313,16 @@ class CRM_Utils_REST {
       'action' => 1,
     ];
 
-    if (array_key_exists('json', $requestParams) && $requestParams['json'][0] == "{") {
+    if (array_key_exists('json', $requestParams) && is_string($requestParams['json']) && $requestParams['json'][0] === '{') {
       $params = json_decode($requestParams['json'], TRUE);
+      if ($params === NULL) {
+        $params = json_decode(stripslashes($requestParams['json']), TRUE);
+      }
       if ($params === NULL) {
         CRM_Utils_JSON::output([
           'is_error' => 1,
           0 => 'error_message',
-          1 => 'Unable to decode supplied JSON.',
+          1 => 'Unable to decode supplied JSON: ' . json_last_error_msg(),
         ]);
       }
     }
@@ -444,6 +447,9 @@ class CRM_Utils_REST {
     }
     if (!empty($requestParams['json'])) {
       $params = json_decode($requestParams['json'], TRUE);
+      if ($params === NULL && is_string($requestParams['json'])) {
+        $params = json_decode(stripslashes($requestParams['json']), TRUE);
+      }
     }
     $entity = CRM_Utils_String::munge($requestParams['entity'] ?? '');
     $action = CRM_Utils_String::munge($requestParams['action'] ?? '');

--- a/tests/phpunit/CRM/Utils/RestTest.php
+++ b/tests/phpunit/CRM/Utils/RestTest.php
@@ -130,4 +130,29 @@ class CRM_Utils_RestTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Test buildParamList when JSON parameter has backslashes added (e.g. by WordPress wp_magic_quotes).
+   */
+  public function testBuildParamListWithSlashedJson(): void {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['CONTENT_TYPE'] = 'text/html';
+    $_GET['json'] = addslashes('{"sequential":1,"first_name":"Test"}');
+    $params = CRM_Utils_REST::buildParamList();
+    $this->assertEquals(1, $params['sequential']);
+    $this->assertEquals('Test', $params['first_name']);
+    unset($_GET['json']);
+  }
+
+  /**
+   * Test buildParamList when JSON parameter contains escaped double quotes inside string values.
+   */
+  public function testBuildParamListWithEscapedQuotesInJson(): void {
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+    $_SERVER['CONTENT_TYPE'] = 'text/html';
+    $_GET['json'] = '{"note":"He said \"hello\""}';
+    $params = CRM_Utils_REST::buildParamList();
+    $this->assertEquals('He said "hello"', $params['note']);
+    unset($_GET['json']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes APIv3 REST requests getting messed up by Wordpress magic quotes.

This PR supersedes https://github.com/civicrm/civicrm-core/pull/33819 by fixing that scenario without breaking others.

Technical Details
----------------------------------------
In WordPress environments, `wp-load.php` executes `wp_magic_quotes()`, which runs `addslashes()` on `$_GET`, `$_POST`, and `$_REQUEST`.
A REST request with `json={"sequential":1}` is mutated into `json={\"sequential\":1}`.
When `CRM_Utils_REST::buildParamList()` calls `json_decode()`, it fails with a JSON syntax error because backslashes before property quotes are invalid JSON syntax.

PR #33819 proposed using `str_replace('\\"', '"', $requestParams['json'])`. However, that approach is flawed: if valid JSON contains escaped double quotes inside a string property (e.g. `{"note": "He said \"hello\""}`), `str_replace` strips the backslash, turning it into `{"note": "He said "hello""}`, which causes `json_decode()` to fail with a syntax error.
