### PR TITLE
dev/core#6649 - fix blank admin console

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -631,8 +631,8 @@ class CRM_Core_Menu {
   public static function get($path) {
     $path = (string) $path;
 
-    // all civicrm routes begin with civicrm
-    if ($path !== 'civicrm' && !str_starts_with($path, 'civicrm/')) {
+    // all civicrm routes begin with civicrm, except see getAdminLinks()
+    if ($path !== 'admin' && $path !== 'civicrm' && !str_starts_with($path, 'civicrm/')) {
       return NULL;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Admin console is blank after https://github.com/civicrm/civicrm-core/pull/36168

Before
----------------------------------------
blank

After
----------------------------------------
sitemap!

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/36168#discussion_r3617608915

Comments
----------------------------------------

