### PR TITLE
Stop assigning BillingName to membership_offline_receipt

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1344,7 +1344,6 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
         // templates.
         $formValues['receipt_text_signup'] = $this->getSubmittedValue('receipt_text');
         // send email receipt
-        $this->assignBillingName();
         $this->emailMembershipReceipt($formValues);
         $this->addStatusMessage(ts('A membership confirmation and receipt has been sent to %1.', [1 => $this->_contributorEmail]));
       }

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -466,7 +466,6 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
   public function postProcess(): void {
     // get the submitted form values.
     $this->_params = $this->controller->exportValues($this->_name);
-    $this->assignBillingName();
 
     try {
       $this->submit();


### PR DESCRIPTION
This has been subject to warnings in status checks for some time

