### PR TITLE
Standalone - Remove redundant "Home" breadcrumb

### DIFF
--- a/templates/CRM/common/standalone.tpl
+++ b/templates/CRM/common/standalone.tpl
@@ -17,7 +17,6 @@
   <div id="crm-container" class="crm-container standalone-page-padding {if !empty($urlIsPublic)}crm-public{/if}" lang="{$config->lcMessages|substr:0:2}" xml:lang="{$config->lcMessages|substr:0:2}">
     {if $breadcrumb}
       <nav aria-label="{ts escape='htmlattribute'}Breadcrumb{/ts}" class="breadcrumb"><ol>
-        <li><a href="/civicrm/dashboard?reset=1" >{ts}Home{/ts}</a></li>
         {foreach from=$breadcrumb item=crumb key=key}
           <li><a href="{$crumb.url}">{$crumb.title}</a></li>
         {/foreach}


### PR DESCRIPTION
Overview
----------------------------------------
On standalone, "Home" is the same as "CiviCRM" so we don't need both.

Before
----------------------------------------
<img width="1184" height="116" alt="Screenshot 2026-07-20 at 10 56 49 PM" src="https://github.com/user-attachments/assets/1a35f12b-042e-4ab0-8849-0b3f3b4f174d" />

After
----------------------------------------
<img width="1184" height="116" alt="Screenshot 2026-07-20 at 10 56 31 PM" src="https://github.com/user-attachments/assets/d7003756-9ad7-4e0f-9bb1-5a28a1569f55" />
