### PR TITLE
Api4 - Ensure fields within functions are formatted correctly

### DIFF
--- a/Civi/Api4/Query/Api4EntitySetQuery.php
+++ b/Civi/Api4/Query/Api4EntitySetQuery.php
@@ -71,7 +71,7 @@ class Api4EntitySetQuery extends Api4Query {
     $results = $this->getResults();
     // Aggregated queries will have to make due with limited field info
     if (!isset($results[0]['_api_set_index'])) {
-      FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, 'get', $this->selectAliases);
+      FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, 'get', $this->selectAliases, $this);
       return $results;
     }
     // Categorize rows by set, so each set can be formatted as a batch
@@ -86,7 +86,7 @@ class Api4EntitySetQuery extends Api4Query {
     foreach ($setResults as $index => &$setResult) {
       $fieldSpec = $this->getSubquery($index)->apiFieldSpec + $this->apiFieldSpec;
       $selectAliases = $this->getSubquery($index)->selectAliases;
-      FormattingUtil::formatOutputValues($setResult, $fieldSpec, 'get', $selectAliases);
+      FormattingUtil::formatOutputValues($setResult, $fieldSpec, 'get', $selectAliases, $this->getSubquery($index));
     }
     return $results;
   }

--- a/Civi/Api4/Query/Api4SelectQuery.php
+++ b/Civi/Api4/Query/Api4SelectQuery.php
@@ -104,7 +104,7 @@ class Api4SelectQuery extends Api4Query {
    */
   public function run(): array {
     $results = $this->getResults();
-    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, 'get', $this->selectAliases);
+    FormattingUtil::formatOutputValues($results, $this->apiFieldSpec, 'get', $this->selectAliases, $this);
     return $results;
   }
 

--- a/Civi/Api4/Query/SqlEquation.php
+++ b/Civi/Api4/Query/SqlEquation.php
@@ -136,8 +136,10 @@ class SqlEquation extends SqlExpression {
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
    * @param string|null $dataType
    * @param array $values
+   * @param string $key
+   * @param Api4Query|null $query
    */
-  public function formatOutputValue(?string &$dataType, array &$values) {
+  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL) {
     foreach (self::$comparisonOperators as $op) {
       if (strpos($this->expr, " $op ")) {
         $dataType = 'Boolean';

--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -119,19 +119,19 @@ abstract class SqlFunction extends SqlExpression {
    * @param string|null $dataType
    * @param array $values
    * @param string $key
+   * @param \Civi\Api4\Query\Api4Query|null $query
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
    */
-  public function formatOutputValue(?string &$dataType, array &$values, string $key): void {
-    if (static::$dataType) {
-      $dataType = static::$dataType;
-    }
-    elseif (static::$category === self::CATEGORY_AGGREGATE) {
+  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL): void {
+    $dataType = $this->getRenderedDataType($query) ?? $dataType;
+    if (static::$category === self::CATEGORY_AGGREGATE) {
       $exprArgs = $this->getArgs();
       // If the first expression is a SqlFunction/SqlEquation, allow it to control the aggregate dataType
       if (method_exists($exprArgs[0]['expr'][0], 'formatOutputValue')) {
-        $exprArgs[0]['expr'][0]->formatOutputValue($dataType, $values, $key);
+        $exprArgs[0]['expr'][0]->formatOutputValue($dataType, $values, $key, $query);
       }
     }
+
     if (isset($values[$key]) && $this->suffix && $this->suffix !== 'id') {
       $dataType = 'String';
       $value =& $values[$key];

--- a/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_CONCAT.php
@@ -57,9 +57,10 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
    * @param string|null $dataType
    * @param array $values
    * @param string $key
+   * @param Api4Query|null $query
    * @see \Civi\Api4\Utils\FormattingUtil::formatOutputValues
    */
-  public function formatOutputValue(?string &$dataType, array &$values, string $key): void {
+  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL): void {
     $exprArgs = $this->getArgs();
     // By default, values are split into an array and formatted according to the field's dataType
     if ($this->getSerialize()) {
@@ -67,9 +68,10 @@ class SqlFunctionGROUP_CONCAT extends SqlFunction {
       // If the first expression is a SqlFunction/SqlEquation, allow it to control the dataType
       if (method_exists($exprArgs[0]['expr'][0], 'formatOutputValue')) {
         foreach (array_keys($values[$key]) as $index) {
-          $exprArgs[0]['expr'][0]->formatOutputValue($dataType, $values[$key], $index);
+          $exprArgs[0]['expr'][0]->formatOutputValue($dataType, $values[$key], $index, $query);
         }
       }
+
       // Perform deduping by unique id
       if ($this->args[0]['prefix'] === ['UNIQUE'] && isset($values["_$key"])) {
         $ids = \CRM_Utils_Array::explodePadded($values["_$key"]);

--- a/Civi/Api4/Query/SqlFunctionIF.php
+++ b/Civi/Api4/Query/SqlFunctionIF.php
@@ -16,6 +16,8 @@ namespace Civi\Api4\Query;
  */
 class SqlFunctionIF extends SqlFunction {
 
+  public $supportsExpansion = TRUE;
+
   protected static $category = self::CATEGORY_COMPARISON;
 
   protected static function params(): array {
@@ -52,6 +54,32 @@ class SqlFunctionIF extends SqlFunction {
    */
   public static function getDescription(): string {
     return ts('If the field is boolean TRUE, or any number except 0, or a string starting with the digits 1-9, the first value; otherwise the second.');
+  }
+
+  public function getFields(): array {
+    $fields = [];
+    foreach ([$this->args[1] ?? NULL, $this->args[2] ?? NULL, $this->args[0] ?? NULL] as $arg) {
+      if (!empty($arg['expr'])) {
+        foreach ($arg['expr'] as $expr) {
+          $fields = array_merge($fields, $expr->getFields());
+        }
+      }
+    }
+    return array_unique($fields);
+  }
+
+  public function getRenderedDataType(?Api4Query $query): ?string {
+
+    foreach ([$this->args[1] ?? NULL, $this->args[2] ?? NULL] as $arg) {
+      if (!empty($arg['expr'][0])) {
+        $expr = $arg['expr'][0];
+        $type = $expr->getRenderedDataType($query);
+        if ($type) {
+          return $type;
+        }
+      }
+    }
+    return static::$dataType;
   }
 
 }

--- a/Civi/Api4/Query/SqlFunctionSUM.php
+++ b/Civi/Api4/Query/SqlFunctionSUM.php
@@ -49,7 +49,7 @@ class SqlFunctionSUM extends SqlFunction {
    * As far as I can tell none of the suffix logic in parent will apply to SUM values
    * so is not needed here
    */
-  public function formatOutputValue(?string &$dataType, array &$values, string $key): void {
+  public function formatOutputValue(?string &$dataType, array &$values, string $key, ?Api4Query $query = NULL): void {
     if ($dataType === 'Boolean') {
       $dataType = 'Integer';
     }

--- a/Civi/Api4/Query/SqlNumber.php
+++ b/Civi/Api4/Query/SqlNumber.php
@@ -22,6 +22,10 @@ class SqlNumber extends SqlExpression {
     \CRM_Utils_Type::validate($this->expr, 'Float');
   }
 
+  public function getRenderedDataType(?Api4Query $query): ?string {
+    return is_numeric($this->expr) && !str_contains((string) $this->expr, '.') ? 'Integer' : 'Float';
+  }
+
   public static function getTitle(): string {
     return ts('Number');
   }

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Utils;
 
+use Civi\Api4\Query\Api4Query;
 use Civi\Api4\Query\SqlExpression;
 
 require_once 'api/v3/utils.php';
@@ -230,9 +231,10 @@ class FormattingUtil {
    * @param array $fields
    * @param string $action
    * @param array $selectAliases
+   * @param \Civi\Api4\Query\Api4Query|null $query
    * @throws \CRM_Core_Exception
    */
-  public static function formatOutputValues(&$records, $fields, $action = 'get', $selectAliases = []) {
+  public static function formatOutputValues(&$records, $fields, $action = 'get', $selectAliases = [], ?Api4Query $query = NULL) {
     $fieldExprs = [];
     foreach ($records as &$result) {
       $contactTypePaths = [];
@@ -260,9 +262,10 @@ class FormattingUtil {
         $dataType = $field['data_type'] ?? ($fieldName == 'id' ? 'Integer' : NULL);
         // Allow Sql Functions to alter the value and/or $dataType
         if (method_exists($fieldExpr, 'formatOutputValue') && is_string($value)) {
-          $fieldExpr->formatOutputValue($dataType, $result, $key);
+          $fieldExpr->formatOutputValue($dataType, $result, $key, $query);
           $value = $result[$key];
         }
+        // Output postprocessing - @see FieldSpec::addOutputFormatter
         if (!empty($field['output_formatters'])) {
           self::applyFormatters($result, $fieldExpr, $field, $value);
           $dataType = NULL;

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -23,6 +23,8 @@ use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\API\Event\PrepareEvent;
 use Civi\Api4\Contact;
+use Civi\Api4\Group;
+use Civi\Api4\Mailing;
 use Civi\Api4\MockBasicEntity;
 use Civi\Api4\EntitySet;
 use Civi\Api4\SavedSearch;
@@ -59,6 +61,7 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
   }
 
   public function setUp(): void {
+    \CRM_Core_BAO_ConfigSetting::enableAllComponents();
     $this->hookCallback = NULL;
     $this->autocompleteRunCount = 0;
     // Ensure MockBasicEntity gets added via above listener
@@ -371,6 +374,41 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
       ->execute();
     $this->assertCount(1, $result);
     $this->assertEquals('Donors contributed > $100', $result[0]['label']);
+  }
+
+  public function testMailingRecipientsAutocomplete(): void {
+    Group::delete()->addWhere('id', '>', 0)->execute();
+    Mailing::delete()->addWhere('id', '>', 0)->execute();
+    $group = $this->createTestRecord('Group', [
+      'title' => 'Test Recipient Group',
+      'group_type:name' => 'Mailing List',
+    ]);
+    $mailing = $this->createTestRecord('Mailing', [
+      'name' => 'Test Newsletter',
+      'subject' => 'July Newsletter Subject',
+      'is_completed' => TRUE,
+    ]);
+
+    $result = EntitySet::autocomplete()
+      ->setInput('Test')
+      ->setFieldName('Mailing.recipients_include')
+      ->setFormName('crmMailing.0')
+      ->execute();
+
+    $this->assertCount(2, $result);
+
+    $rows = array_column((array) $result, NULL, 'id');
+
+    $groupRow = $rows['groups_' . $group['id']] ?? NULL;
+    $this->assertNotNull($groupRow);
+    $this->assertSame('Test Recipient Group', $groupRow['label']);
+    $this->assertSame('fa-group', $groupRow['icon']);
+
+    $mailingRow = $rows['mailings_' . $mailing['id']] ?? NULL;
+    $this->assertNotNull($mailingRow);
+    $this->assertSame('Test Newsletter', $mailingRow['label']);
+    $this->assertSame('fa-envelope', $mailingRow['icon']);
+    $this->assertStringContainsString('Sent Mailing', $mailingRow['description'][0]);
   }
 
   /**

--- a/tests/phpunit/api/v4/Action/SqlFunctionTest.php
+++ b/tests/phpunit/api/v4/Action/SqlFunctionTest.php
@@ -23,6 +23,7 @@ use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\Contribution;
+use Civi\Api4\CustomGroup;
 use Civi\Api4\Utils\CoreUtil;
 use Civi\Test\TransactionalInterface;
 
@@ -612,6 +613,7 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
   }
 
   public function testJsonExtract(): void {
+    CustomGroup::delete(FALSE)->addWhere('id', '>', 0)->execute();
     \Civi\Api4\CustomGroup::create(FALSE)
       ->addValue('name', 'json_test')
       ->addValue('title', 'Json test')
@@ -674,6 +676,40 @@ class SqlFunctionTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals(4, $result[1]['first_element']);
     $this->assertEquals(15, $result[1]['second_element']);
     $this->assertEquals(9, $result[1]['third_element']);
+  }
+
+  /**
+   * Ensures field data is formatted correctly within the IF() function.
+   */
+  public function testSqlFunctionIfDataType(): void {
+    $cid = Contact::create(FALSE)
+      ->addValue('first_name', 'hello')
+      ->addValue('birth_date', '2020-05-05')
+      ->addValue('is_opt_out', TRUE)
+      ->addValue('preferred_communication_method:name', ['Phone', 'Email'])
+      ->execute()->first()['id'];
+
+    $result = Contact::get(FALSE)
+      ->addWhere('id', '=', $cid)
+      ->addSelect('IF(is_deleted, "Yes", "No") AS string_lit')
+      ->addSelect('IF(is_deleted, "Yes", first_name) AS string_field')
+      ->addSelect('IF(is_deleted, 10, 20) AS int_val')
+      ->addSelect('IF(is_deleted, 0, id) AS int_field')
+      ->addSelect('IF(is_deleted, 1.5, 2.5) AS float_val')
+      ->addSelect('IF(is_deleted, created_date, birth_date) AS date_val')
+      ->addSelect('IF(is_deleted, is_deleted, is_opt_out) AS bool_val')
+      ->addSelect('IF(is_deleted, NULL, preferred_communication_method:name) AS array_val')
+      ->execute()->first();
+
+    $this->assertSame('No', $result['string_lit']);
+    $this->assertSame('hello', $result['string_field']);
+    $this->assertSame(20, $result['int_val']);
+    $this->assertSame((int) $cid, $result['int_field']);
+    $this->assertSame(2.5, $result['float_val']);
+    $this->assertSame('2020-05-05 00:00:00', $result['date_val']);
+
+    $this->assertSame(TRUE, $result['bool_val']);
+    $this->assertSame(['Phone', 'Email'], $result['array_val']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
This fixes a regression from 7ceb8a72 causing the CiviMail autocomplete of Groups+Mailings to fail to show group names correctly.

In addition to fixing the bug, this makes the output of sql functions much cleaner: fields are correctly type cast according to their data_type, even when being returned from a sql function.

Before
----------------------------
<img width="1636" height="848" alt="Screenshot 2026-07-21 at 11 26 17 AM" src="https://github.com/user-attachments/assets/aebb6a63-a778-4bfd-8209-900a273ed1f9" />



After
----------------------------------------
<img width="1626" height="738" alt="Screenshot 2026-07-21 at 11 25 59 AM" src="https://github.com/user-attachments/assets/623897da-7c03-4c79-924e-03a05722d0a4" />
