### PR TITLE
add APIv3 getfields cache

### DIFF
--- a/Civi/Core/MetadataFlush.php
+++ b/Civi/Core/MetadataFlush.php
@@ -31,6 +31,11 @@ class MetadataFlush extends Service\AutoSubscriber {
    * as it's being deleted.
    */
   public static function onClearMetadata(): void {
+    // APIv3 getfields metadata is cached for the lifetime of the request.
+    // Keep it in sync with other metadata caches regardless of how the clear
+    // was initiated (APIv3, APIv4, BAO hooks, or direct cache access).
+    \Civi::$statics['civicrm_api3_generic_getfields'] = [];
+
     // This seems to cause problems during unit test setup
     if (CIVICRM_UF === 'UnitTests') {
       return;

--- a/api/v3/Generic.php
+++ b/api/v3/Generic.php
@@ -39,7 +39,8 @@
  *   API success object
  */
 function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
-  static $results = [];
+  Civi::$statics[__FUNCTION__] ??= [];
+  $results = &Civi::$statics[__FUNCTION__];
   if (!empty($apiRequest['params']['cache_clear'])) {
     $results = [];
     // we will also clear pseudoconstants here - should potentially be moved to relevant BAO classes
@@ -61,7 +62,6 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
   }
   $entity = $apiRequest['entity'];
   $lowercase_entity = _civicrm_api_get_entity_name_from_camel($entity);
-  $subentity = $apiRequest['params']['contact_type'] ?? NULL;
   $action = $apiRequest['params']['action'] ?? NULL;
   $sequential = empty($apiRequest['params']['sequential']) ? 0 : 1;
   $apiRequest['params']['options'] ??= [];
@@ -70,10 +70,25 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
   if (!$action || $action == 'getvalue' || $action == 'getcount') {
     $action = 'get';
   }
-  // If no options, return results from cache
-  if (!$apiRequest['params']['options'] && isset($results[$entity . $subentity], $action, $results[$entity . $subentity], $action, $results[$entity . $subentity][$sequential])) {
-    return $results[$entity . $subentity][$action][$sequential];
+
+  // Requests which resolve options are context-sensitive and are not cached.
+  $cacheKey = NULL;
+  if (!$apiRequest['params']['options']) {
+    $cacheParams = $apiRequest['params'];
+    unset($cacheParams['cache_clear']);
+    $effectiveUnique = in_array($action, ['create', 'update', 'replace'], TRUE) ? FALSE : $unique;
+    $cacheKey = hash('sha256', serialize([
+      'entity' => $entity,
+      'action' => $action,
+      'sequential' => $sequential,
+      'unique' => $effectiveUnique,
+      'params' => $cacheParams,
+    ]));
+    if (isset($results[$cacheKey])) {
+      return $results[$cacheKey];
+    }
   }
+
   // defaults based on data model and API policy
   switch ($action) {
     case 'getfields':
@@ -191,8 +206,11 @@ function civicrm_api3_generic_getfields($apiRequest, $unique = TRUE) {
     }
   }
 
-  $results[$entity][$action][$sequential] = civicrm_api3_create_success($metadata, $apiRequest['params'], $entity, 'getfields');
-  return $results[$entity][$action][$sequential];
+  $result = civicrm_api3_create_success($metadata, $apiRequest['params'], $entity, 'getfields');
+  if ($cacheKey !== NULL) {
+    $results[$cacheKey] = $result;
+  }
+  return $result;
 }
 
 /**

--- a/tests/phpunit/api/v3/GetfieldsCacheTest.php
+++ b/tests/phpunit/api/v3/GetfieldsCacheTest.php
@@ -1,0 +1,146 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test the APIv3 getfields request cache.
+ *
+ * @group headless
+ */
+class api_v3_GetfieldsCacheTest extends CiviUnitTestCase {
+
+  protected function setUp(): void {
+    parent::setUp();
+    Civi::$statics['civicrm_api3_generic_getfields'] = [];
+    Civi::$statics['api_v3_getfields_cache_test'] = ['spec_calls' => 0];
+  }
+
+  protected function tearDown(): void {
+    unset(Civi::$statics['civicrm_api3_generic_getfields']);
+    unset(Civi::$statics['api_v3_getfields_cache_test']);
+    parent::tearDown();
+  }
+
+  public function testIdenticalRequestsAndCacheClear(): void {
+    $first = $this->getFields([
+      'cache_clear' => 1,
+      'variant' => 'first',
+    ]);
+    $second = $this->getFields(['variant' => 'first']);
+
+    $this->assertSame('first', $first['values']['cache_probe']['title']);
+    $this->assertSame($first, $second);
+    $this->assertSame(1, $this->getSpecCallCount());
+
+    $rebuilt = $this->getFields([
+      'cache_clear' => 1,
+      'variant' => 'first',
+    ]);
+    $afterRebuild = $this->getFields(['variant' => 'first']);
+
+    $this->assertSame($rebuilt, $afterRebuild);
+    $this->assertSame(2, $this->getSpecCallCount());
+  }
+
+  public function testParametersUseSeparateEntries(): void {
+    $first = $this->getFields([
+      'cache_clear' => 1,
+      'variant' => 'first',
+    ]);
+    $second = $this->getFields(['variant' => 'second']);
+    $firstAgain = $this->getFields(['variant' => 'first']);
+
+    $this->assertSame('first', $first['values']['cache_probe']['title']);
+    $this->assertSame('second', $second['values']['cache_probe']['title']);
+    $this->assertSame($first, $firstAgain);
+    $this->assertSame(2, $this->getSpecCallCount());
+  }
+
+  public function testUniqueModesUseSeparateEntries(): void {
+    $this->getFields(['cache_clear' => 1], TRUE);
+    $this->getFields([], FALSE);
+    $this->getFields([], FALSE);
+
+    $this->assertSame(2, $this->getSpecCallCount());
+  }
+
+  public function testSequentialModesUseSeparateEntries(): void {
+    $this->getFields(['cache_clear' => 1]);
+    $this->getFields(['sequential' => 1]);
+    $this->getFields(['sequential' => 1]);
+
+    $this->assertSame(2, $this->getSpecCallCount());
+  }
+
+  public function testOptionRequestsBypassCache(): void {
+    $params = [
+      'options' => ['get_options' => []],
+    ];
+    $this->getFields(['cache_clear' => 1] + $params);
+    $this->getFields($params);
+
+    $this->assertSame(2, $this->getSpecCallCount());
+  }
+
+  public function testMetadataClearInvalidatesCache(): void {
+    $first = $this->getFields([
+      'cache_clear' => 1,
+      'variant' => 'first',
+    ]);
+    $cached = $this->getFields(['variant' => 'first']);
+
+    $this->assertSame($first, $cached);
+    $this->assertSame(1, $this->getSpecCallCount());
+
+    Civi::cache('metadata')->clear();
+    $rebuilt = $this->getFields(['variant' => 'first']);
+
+    $this->assertSame($first, $rebuilt);
+    $this->assertSame(2, $this->getSpecCallCount());
+  }
+
+  /**
+   * Invoke the generic getfields implementation for the test action.
+   */
+  private function getFields(array $params = [], bool $unique = TRUE): array {
+    $params += ['action' => 'cacheprobe'];
+    return civicrm_api3_generic_getfields([
+      'entity' => 'Contact',
+      'version' => 3,
+      'params' => $params,
+    ], $unique);
+  }
+
+  /**
+   * Get the number of times the test action's spec callback has run.
+   */
+  private function getSpecCallCount(): int {
+    return Civi::$statics['api_v3_getfields_cache_test']['spec_calls'];
+  }
+
+}
+
+/**
+ * Test-only API action used to make its getfields spec observable.
+ */
+function civicrm_api3_contact_cacheprobe($params) {
+  return civicrm_api3_create_success([], $params, 'Contact', 'cacheprobe');
+}
+
+/**
+ * Add an observable, parameter-dependent field to the test action's spec.
+ */
+function _civicrm_api3_contact_cacheprobe_spec(&$fields, $apiRequest): void {
+  Civi::$statics['api_v3_getfields_cache_test']['spec_calls']++;
+  $fields['cache_probe'] = [
+    'title' => $apiRequest['params']['variant'] ?? 'default',
+    'type' => CRM_Utils_Type::T_STRING,
+  ];
+}


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM Entity is a heavy use of APIv3 'getfields' API calls. If these could be cached it would be a performance boost. 

Looking for second opinions. What do you think @eileenmcnaughton @colemanw  ?
