### PR TITLE
Use source_record_id for Contact::getMergedTo when merged contact has been deleted

### DIFF
--- a/Civi/Api4/Action/Contact/GetMergedTo.php
+++ b/Civi/Api4/Action/Contact/GetMergedTo.php
@@ -61,8 +61,23 @@ class GetMergedTo extends \Civi\Api4\Generic\AbstractAction {
         ->addWhere('activity_id', '=', $deleteActivity['activity_id.parent_id'])
         ->addWhere('record_type_id:name', '=', 'Activity Targets')
         ->execute()
-        ->first()['contact_id'];
+        ->first()['contact_id'] ?? NULL;
     }
+    // If the original contact was deleted from trash, then the above ActivityContact
+    // will be gone, but we can get the new contact ID from the source_record_id on
+    // the Contact Merged activity that targets the new contact.
+    if (empty($returnId)) {
+      $returnId = \Civi\Api4\Activity::get($this->checkPermissions)
+        ->addSelect('target_contact_id')
+        ->addWhere('activity_type_id:name', '=', 'Contact Merged')
+        ->addWhere('source_record_id', '=', $this->contactId)
+        ->addWhere('is_deleted', '=', FALSE)
+        ->addWhere('is_test', '=', $this->isTest)
+        ->addOrderBy('activity_date_time', 'DESC')
+        ->setLimit(1)
+        ->execute()->first()['target_contact_id'][0] ?? NULL;
+    }
+
     $result[] = (empty($returnId) ? $returnId : ['id' => $returnId]);
   }
 

--- a/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
+++ b/tests/phpunit/api/v4/Action/ContactDuplicatesTest.php
@@ -229,6 +229,20 @@ class ContactDuplicatesTest extends Api4TestBase {
       ->execute()
       ->first()['id'];
     $this->assertEquals($testContacts[0], $mergedFromID);
+
+    // Hard-delete the merged-away contact so the "Contact Deleted
+    // by Merge" activity is gone, forcing getMergedTo to fall back to the
+    // source_record_id on the "Contact Merged" activity.
+    Contact::delete(FALSE)
+      ->setUseTrash(FALSE)
+      ->addWhere('id', '=', $testContacts[0])
+      ->execute();
+
+    $mergedToID = Contact::getMergedTo(FALSE)
+      ->setContactId($testContacts[0])
+      ->execute()
+      ->first()['id'];
+    $this->assertEquals($testContacts[1], $mergedToID);
   }
 
   public function testPhoneNumeric(): void {


### PR DESCRIPTION
If you merge two contacts and then delete from trash the contact which was deleted by merge, you'll lose the Contact Deleted by Merge activity that allows you to getMergedTo for that deleted contact id. But now that we are storing the deleted contact id in source_record_id (#35999), we can use that as a fallback in case the original contact has been deleted.