### PR TITLE
dev/core#6630 - Fix errors in trigger rebuild 

### DIFF
--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -76,11 +76,8 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
     }
 
     $triggers = [];
-    $existingTables = [];
-    foreach (\CRM_Core_DAO::executeQuery('SHOW TABLES')->fetchAll() as $table) {
-      $tableName = reset($table);
-      $existingTables[$tableName] = $tableName;
-    };
+    $query = "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'";
+    $existingTables = \CRM_Core_DAO::executeQuery($query)->fetchMap('table_name', 'table_name');
 
     // now enumerate the tables and the events and collect the same set in a different format
     foreach ($info as $value) {


### PR DESCRIPTION
Overview
----------------------------------------
- Fixes https://lab.civicrm.org/dev/core/-/work_items/6630
- Replaces https://github.com/civicrm/civicrm-core/pull/36188 with more concise code.

Technical Details
----------
As spotted in the wild, there are a few reasons why this new query is preferable to SHOW TABLES:

- SHOW TABLES returns both base tables and views, but views are incompatible with triggers
- Querying `information_schema.tables` directly for table_name is standard database metadata practice and avoids driver/naming quirks.
- When table names fail to match due to SHOW TABLES returning empty or unexpected rows, CiviCRM skips creating triggers, leading to warnings & errors.