### PR TITLE
Fix wording in 'Pending from Approval' email notification

### DIFF
--- a/CRM/Event/BAO/Participant.php
+++ b/CRM/Event/BAO/Participant.php
@@ -1437,6 +1437,7 @@ UPDATE  civicrm_participant
     $emailType = NULL;
     $toStatus = $statusTypes[$toStatusId];
     $fromStatus = $statusTypes[$fromStatusId] ?? NULL;
+    $isPendingFromApproval = ($toStatus === 'Pending from approval');
 
     switch ($toStatus) {
       case 'Pending from waitlist':
@@ -1481,7 +1482,8 @@ UPDATE  civicrm_participant
               $participantDetails[$additionalId],
               $eventDetails[$participantDetails[$additionalId]['event_id']],
               NULL,
-              $emailType
+              $emailType,
+              $isPendingFromApproval
             );
 
             //get the mail participant ids
@@ -1500,7 +1502,8 @@ UPDATE  civicrm_participant
           $participantValues,
           $eventDetails[$participantValues['event_id']],
           NULL,
-          $emailType
+          $emailType,
+          $isPendingFromApproval
         );
 
         //get the mail participant ids
@@ -1547,6 +1550,10 @@ UPDATE  civicrm_participant
    *   Required contact details.
    * @param string $mailType
    *   (eg 'approval', 'confirm', 'expired' ).
+   * @param bool $isPendingFromApproval
+   *   True if this 'Confirm' mail is for someone whose new status is
+   *   'Pending from approval' (event approval workflow), as opposed to
+   *   'Pending from waitlist' (event waitlist).
    *
    * @return bool
    */
@@ -1555,7 +1562,8 @@ UPDATE  civicrm_participant
     $participantValues,
     $eventDetails,
     $contactDetails,
-    $mailType
+    $mailType,
+    $isPendingFromApproval = FALSE
   ) {
     //send emails.
     $mailSent = FALSE;
@@ -1610,6 +1618,7 @@ UPDATE  civicrm_participant
             'isAdditional' => $participantValues['registered_by_id'],
             'isExpired' => $mailType === 'Expired',
             'isConfirm' => $mailType === 'Confirm',
+            'isPendingFromApproval' => $isPendingFromApproval,
             'checksumValue' => $checksumValue,
           ],
           'modelProps' => [

--- a/xml/templates/message_templates/participant_confirm_html.tpl
+++ b/xml/templates/message_templates/participant_confirm_html.tpl
@@ -21,7 +21,11 @@
   <tr>
    <td>
     {assign var="greeting" value="{contact.email_greeting_display}"}{if $greeting}<p>{$greeting},</p>{/if}
+    {if $isPendingFromApproval}
+    <p>{ts}This is an invitation to complete your registration which was pending approval.{/ts}</p>
+    {else}
     <p>{ts}This is an invitation to complete your registration that was initially waitlisted.{/ts}</p>
+    {/if}
    </td>
   </tr>
   {if !$isAdditional and {participant.id|boolean}}


### PR DESCRIPTION
## Overview 

As per mentioned : https://lab.civicrm.org/dev/core/-/work_items/6571
If the Event Approval workflow is enabled, when a participant's status is updated to 'Pending from Approval', the confirmation email hardcoded wording saying the registration "was initially waitlisted" — even though the
participant came from the approval workflow, not the waitlist.

## Fix
Added an `isPendingFromApproval` flag to
`CRM_Event_BAO_Participant::sendTransitionParticipantMail()`, based on the participant's new status, and uses it in `participant_confirm_html.tpl` to show approval-specific wording when the new status is 'Pending from Approval'. The waitlist wording is unchanged for 'Pending from waitlist'.

## Note on existing installations

`xml/templates/message_templates/participant_confirm_html.tpl` is the only template file changed. On upgrade, CiviCRM's existing `CRM_Upgrade_Incremental_MessageTemplates::updateReservedAndMaybeDefaultTemplates()`
task automatically refreshes the reserved copy for every site, and refreshes the live/active copy too for any site that hasn't customized this specific template. Sites that have already customized the `participant_confirm`
template body will need to manually reapply the `isPendingFromApproval` conditional after upgrading, since CiviCRM won't overwrite existing customizations.

