### PR TITLE
dev/core#6581 - Fix "Find Memberships" crash when CiviContribute is disabled

### DIFF
--- a/CRM/Member/BAO/Membership.php
+++ b/CRM/Member/BAO/Membership.php
@@ -1497,19 +1497,25 @@ WHERE  civicrm_membership.contact_id = civicrm_contact.id
 
     if (!array_key_exists($cacheKeyString, $supportsCancel)) {
       $supportsCancel[$cacheKeyString] = FALSE;
-      $membership = Membership::get(FALSE)
-        ->addSelect('contribution_recur_id')
-        ->addWhere('id', '=', $mid)
-        ->addWhere('contribution_recur_id.contribution_status_id:name', '!=', 'Cancelled')
-        ->execute()->first();
-      if (isset($membership['contribution_recur_id'])) {
-        try {
-          $paymentObject = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($membership['contribution_recur_id']);
-          $supportsCancel[$cacheKeyString] = $paymentObject->supports('cancelRecurring');
-        }
-        catch (CRM_Core_Exception $e) {
-          // An error could be thrown because the payment processor id on the contribution recur can be NULL.
-          // This happens with CiviSepa.
+      // Always return false if CiviContribute is disabled
+      $isCiviContributeEnabled = CRM_Extension_System::singleton()
+        ->getManager()
+        ->isEnabled('civi_contribute');
+      if ($isCiviContributeEnabled) {
+        $membership = Membership::get(FALSE)
+          ->addSelect('contribution_recur_id')
+          ->addWhere('id', '=', $mid)
+          ->addWhere('contribution_recur_id.contribution_status_id:name', '!=', 'Cancelled')
+          ->execute()->first();
+        if (isset($membership['contribution_recur_id'])) {
+          try {
+            $paymentObject = CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorForRecurringContribution($membership['contribution_recur_id']);
+            $supportsCancel[$cacheKeyString] = $paymentObject->supports('cancelRecurring');
+          }
+          catch (CRM_Core_Exception $e) {
+            // An error could be thrown because the payment processor id on the contribution recur can be NULL.
+            // This happens with CiviSepa.
+          }
         }
       }
     }

--- a/ext/civi_member/Civi/Api4/Service/Links/MembershipLinksProvider.php
+++ b/ext/civi_member/Civi/Api4/Service/Links/MembershipLinksProvider.php
@@ -61,20 +61,26 @@ class MembershipLinksProvider extends \Civi\Core\Service\AutoSubscriber {
         self::unsetLinks($links, ['update', 'delete', 'renew', 'followup', 'cancelrecur', 'changebilling']);
       }
       elseif ($membershipId) {
-        $membership = Membership::get(FALSE)
-          ->addWhere('id', '=', $membershipId)
-          ->addSelect('contribution_recur_id.payment_processor_id')
-          ->addSelect('contribution_recur_id.contribution_status_id:name')
-          ->addSelect('status_id:name')
-          ->execute()->first();
-        $paymentProcessorID = $membership['contribution_recur_id.payment_processor_id'] ?? NULL;
-        if ($paymentProcessorID) {
-          $paymentObject = System::singleton()->getById($paymentProcessorID);
-          if (!$paymentObject->supports('updateSubscriptionBillingInfo')) {
-            self::unsetLinks($links, ['changebilling']);
-          }
-          if ($membership['contribution_recur_id.contribution_status_id:name'] !== 'Cancelled' && !$paymentObject->supports('cancelRecurring')) {
-            self::unsetLinks($links, ['cancelrecur']);
+        // Billing links require CiviContribute
+        if (!\CRM_Extension_System::singleton()->getManager()->isEnabled('civi_contribute')) {
+          self::unsetLinks($links, ['cancelrecur', 'changebilling']);
+        }
+        else {
+          $membership = Membership::get(FALSE)
+            ->addWhere('id', '=', $membershipId)
+            ->addSelect('contribution_recur_id.payment_processor_id')
+            ->addSelect('contribution_recur_id.contribution_status_id:name')
+            ->addSelect('status_id:name')
+            ->execute()->first();
+          $paymentProcessorID = $membership['contribution_recur_id.payment_processor_id'] ?? NULL;
+          if ($paymentProcessorID) {
+            $paymentObject = System::singleton()->getById($paymentProcessorID);
+            if (!$paymentObject->supports('updateSubscriptionBillingInfo')) {
+              self::unsetLinks($links, ['changebilling']);
+            }
+            if ($membership['contribution_recur_id.contribution_status_id:name'] !== 'Cancelled' && !$paymentObject->supports('cancelRecurring')) {
+              self::unsetLinks($links, ['cancelrecur']);
+            }
           }
         }
       }

--- a/tests/phpunit/CRM/Member/Selector/SearchTest.php
+++ b/tests/phpunit/CRM/Member/Selector/SearchTest.php
@@ -57,4 +57,24 @@ class CRM_Member_Selector_SearchTest extends CiviUnitTestCase {
     $this->assertCount(1, $rows);
   }
 
+  /**
+   * Test membership search when CiviContribute component is disabled.
+   * @see https://lab.civicrm.org/dev/core/-/work_items/6581
+   */
+  public function testSearchWithCiviContributeDisabled(): void {
+    CRM_Core_BAO_ConfigSetting::enableComponent('CiviMember');
+    CRM_Core_BAO_ConfigSetting::disableComponent('CiviContribute');
+    $this->quickCleanup(['civicrm_membership']);
+    $contactID = $this->individualCreate();
+    $membershipTypeID = $this->membershipTypeCreate();
+    $this->createTestEntity('Membership', [
+      'contact_id' => $contactID,
+      'membership_type_id' => $membershipTypeID,
+    ]);
+    $params = [];
+    $selector = new CRM_Member_Selector_Search($params);
+    $rows = $selector->getRows(CRM_Core_Permission::VIEW, 0, 25, NULL);
+    $this->assertCount(1, $rows);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6581](https://lab.civicrm.org/dev/core/-/work_items/6581)

Before
----------------------------------------
When CiviContribute is turned off the "Find Memberships" search is broken.

After
----------------------------------------
It works :)