### PR TITLE
Ext - Remove redundant dependencies

### DIFF
--- a/ext/afform/admin/info.xml
+++ b/ext/afform/admin/info.xml
@@ -29,10 +29,6 @@
     <ver>5</ver>
   </smarty_compatibility>
   <comments>FormBuilder provides a UI to administer and edit forms. It is an optional admin tool and not required for the forms to function.</comments>
-  <requires>
-    <ext>org.civicrm.afform</ext>
-    <ext>org.civicrm.search_kit</ext>
-  </requires>
   <civix>
     <namespace>CRM/AfformAdmin</namespace>
     <format>25.10.2</format>

--- a/ext/afform/core/info.xml
+++ b/ext/afform/core/info.xml
@@ -40,9 +40,6 @@
     <psr4 prefix="Civi\" path="Civi"/>
     <psr0 prefix="CRM_" path="."/>
   </classloader>
-  <requires>
-    <ext>authx</ext>
-  </requires>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>
     <mixin>mgd-php@2.0.0</mixin>

--- a/ext/afform/html/info.xml
+++ b/ext/afform/html/info.xml
@@ -28,9 +28,6 @@
   <smarty_compatibility>
     <ver>5</ver>
   </smarty_compatibility>
-  <requires>
-    <ext>org.civicrm.afform</ext>
-  </requires>
   <comments>This extension is experimental and has limited functionality.</comments>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>

--- a/ext/afform/login_token/info.xml
+++ b/ext/afform/login_token/info.xml
@@ -32,10 +32,6 @@
   <smarty_compatibility>
     <ver>5</ver>
   </smarty_compatibility>
-  <requires>
-    <ext>org.civicrm.afform</ext>
-    <ext>authx</ext>
-  </requires>
   <comments/>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/ext/afform/mock/info.xml
+++ b/ext/afform/mock/info.xml
@@ -30,9 +30,6 @@
   <smarty_compatibility>
     <ver>5</ver>
   </smarty_compatibility>
-  <requires>
-    <ext>org.civicrm.afform</ext>
-  </requires>
   <comments>Examples and tests for CiviCRM Afforms.</comments>
   <mixins>
     <mixin>ang-php@1.0.0</mixin>

--- a/ext/chart_kit/info.xml
+++ b/ext/chart_kit/info.xml
@@ -44,7 +44,4 @@
     <mixin>ang-php@1.0.0</mixin>
     <mixin>scan-classes@1.0.0</mixin>
   </mixins>
-  <requires>
-    <ext>org.civicrm.search_kit</ext>
-  </requires>
 </extension>

--- a/ext/civigrant/info.xml
+++ b/ext/civigrant/info.xml
@@ -30,8 +30,6 @@
   </smarty_compatibility>
   <comments>CiviGrant was originally a core component before migrating to an extension</comments>
   <requires>
-    <ext>org.civicrm.afform</ext>
-    <ext>org.civicrm.search_kit</ext>
     <ext>chart_kit</ext>
   </requires>
   <classloader>

--- a/ext/civiimport/info.xml
+++ b/ext/civiimport/info.xml
@@ -34,10 +34,6 @@
     <ver>5</ver>
   </smarty_compatibility>
   <comments>CiviCRM import functionality</comments>
-  <requires>
-    <ext>org.civicrm.afform</ext>
-    <ext>org.civicrm.search_kit</ext>
-  </requires>
   <classloader>
     <psr0 prefix="CRM_" path="."/>
     <psr4 prefix="Civi\" path="Civi"/>

--- a/ext/standaloneusers/info.xml
+++ b/ext/standaloneusers/info.xml
@@ -30,11 +30,6 @@
   <smarty_compatibility>
     <ver>5</ver>
   </smarty_compatibility>
-  <requires>
-    <ext>org.civicrm.search_kit</ext>
-    <ext>authx</ext>
-    <ext>org.civicrm.afform</ext>
-  </requires>
   <comments>Don't enable this on a standard CMS-based install!</comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>


### PR DESCRIPTION
Overview
----------------------------------------
Cleanup redundant dependency info from core extensions.


Technical Details
----------------------------------------
Extensions such as `afform`, `search_kit` and `authx` which are tagged `mgmt:required` will always be available and do not need to be declared as dependencies.