### PR TITLE
dev/core#6565 Upgrader - Ensure entity list is up-to-date

### DIFF
--- a/Civi/Core/CiviEventDispatcher.php
+++ b/Civi/Core/CiviEventDispatcher.php
@@ -393,6 +393,8 @@ class CiviEventDispatcher implements CiviEventDispatcherInterface {
       $this->dispatchPolicyRegex = NULL;
     }
 
+    \Civi\Schema\EntityRepository::flush();
+
     return $this;
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
This is an attempt to fix https://lab.civicrm.org/dev/core/-/work_items/6565

Technical Details
------
When the upgrader changes the dispatch policy, the static cache of entities must be refreshed. On standalone upgrades, the stale cache may have prevented the `UserRole` entity from loading.

That's the theory anyway. But I haven't been able to reproduce the bug myself so this needs testing by @eileenmcnaughton 