### PR TITLE
Sensible sort order for payments listed on a contribution

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -1059,7 +1059,7 @@ class CRM_Contribute_BAO_Contribution extends CRM_Contribute_DAO_Contribution im
           LEFT JOIN civicrm_financial_account fa ON fa.id = fi.financial_account_id
 
         WHERE con.id = %1 AND ft.is_payment = 1
-        GROUP BY ft.id";
+        GROUP BY ft.id ORDER BY ft.trxn_date";
     $queryParams = [
       1 => [$contributionId, 'Integer'],
       2 => [$feeFinancialAccount, 'Integer'],


### PR DESCRIPTION
Overview
----------------------------------------
You expect them to be ordered by date.

Before
----------------------------------------
Normally, there's either only one payment on a contribution or the order that they happened happens to match the internal id sort order, so you don't notice. But consider a site where most transactions are entered manually by staff.

Here's one scenario:

1. Create a pending contribution, e.g. $100. Date it 3 days ago so this is easier to see. Save.
2. Use the record payment link on it to add a partial payment, e.g. $10. Date it today.
3. Use the record payment link on it to add another partial payment, e.g. $10. Date it 2 days ago.
4. Use the record payment link on it to add another partial payment, e.g. $10. Date it yesterday. (Pretend the scenario is the person is backentering payments and just didn't enter them in date order either by mistake or because the stack of paper they had wasn't in order or whatever.)
5. Note the order of the transactions listed on the contribution. It doesn't make sense.

Another scenario involves recording refunds to correct a mistakenly entered amount because civi doesn't let you edit payment amounts even when they are manual and not tied to a payment processor. If you date the refund the same as the original payment hoping it will line up, it won't display in that sort order.

In all these cases you can always delete the contribution and start again, but suppose you've been entering monthly payments and you've already made 10 entries and now one isn't in order. That would be tedious to recreate the whole sequence.

After
----------------------------------------
Sense.

Technical Details
----------------------------------------


Comments
----------------------------------------

