### PR TITLE
Add initial Unsubscribe test

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -846,8 +846,8 @@ ORDER BY   civicrm_email.is_bulkmail DESC
   /**
    * Get verp, urls and headers
    *
-   * @param int $job_id
-   *   ID of the Job associated with this message.
+   * @param int|null $job_id
+   *   (deprecated) ID of the Job associated with this message.
    * @param int $event_queue_id
    *   ID of the EventQueue.
    * @param string $hash

--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -283,12 +283,12 @@ WHERE  email = %2
    *   List of group IDs.
    * @param bool $is_domain
    *   Is this domain-level?.
-   * @param int $job
-   *   The job ID.
+   * @param int|null $job
+   *   The job ID (deprecated), ignored when processing incoming verp addresses.
    *
    * @throws \CRM_Core_Exception
    */
-  public static function send_unsub_response($queue_id, $groups, $is_domain, $job) {
+  public static function send_unsub_response($queue_id, $groups, $is_domain, $job = NULL) {
     $domain = CRM_Core_BAO_Domain::getDomain();
 
     //get the default domain email address.

--- a/api/v3/MailingEventResubscribe.php
+++ b/api/v3/MailingEventResubscribe.php
@@ -24,10 +24,10 @@
  * @return array
  *   api result array
  */
-function civicrm_api3_mailing_event_resubscribe_create($params) {
+function civicrm_api3_mailing_event_resubscribe_create(array $params): array {
 
   $groups = CRM_Mailing_Event_BAO_MailingEventResubscribe::resub_to_mailing(
-    $params['job_id'],
+    $params['job_id'] ?? NULL,
     $params['event_queue_id'],
     $params['hash']
   );
@@ -51,15 +51,10 @@ function civicrm_api3_mailing_event_resubscribe_create($params) {
  * @param array $params
  *   Array of parameters determined by getfields.
  */
-function _civicrm_api3_mailing_event_resubscribe_create_spec(&$params) {
+function _civicrm_api3_mailing_event_resubscribe_create_spec(array &$params): void {
   $params['event_queue_id'] = [
     'api.required' => 1,
     'title' => 'Event Queue ID',
-    'type' => CRM_Utils_Type::T_INT,
-  ];
-  $params['job_id'] = [
-    'api.required' => 1,
-    'title' => 'Job ID',
     'type' => CRM_Utils_Type::T_INT,
   ];
   $params['hash'] = [

--- a/api/v3/MailingEventUnsubscribe.php
+++ b/api/v3/MailingEventUnsubscribe.php
@@ -38,7 +38,7 @@ function civicrm_api3_mailing_event_unsubscribe_get($params) {
  */
 function civicrm_api3_mailing_event_unsubscribe_create($params) {
 
-  $job = $params['job_id'];
+  $job = $params['job_id'] ?? NULL;
   $queue = $params['event_queue_id'];
   $hash = $params['hash'];
   if (empty($params['org_unsubscribe'])) {
@@ -69,12 +69,7 @@ function civicrm_api3_mailing_event_unsubscribe_create($params) {
  * @param array $params
  *   Array of parameters determined by getfields.
  */
-function _civicrm_api3_mailing_event_unsubscribe_create_spec(&$params) {
-  $params['job_id'] = [
-    'api.required' => 1,
-    'title' => 'Mailing Job ID',
-    'type' => CRM_Utils_Type::T_INT,
-  ];
+function _civicrm_api3_mailing_event_unsubscribe_create_spec(array &$params): void {
   $params['hash'] = [
     'api.required' => 1,
     'title' => 'Mailing Hash',

--- a/tests/phpunit/api/v3/MailingGroupTest.php
+++ b/tests/phpunit/api/v3/MailingGroupTest.php
@@ -9,6 +9,8 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Email;
+
 /**
  *  Test APIv3 civicrm_mailing_group_* functions
  *
@@ -49,15 +51,26 @@ class api_v3_MailingGroupTest extends CiviUnitTestCase {
   }
 
   /**
-   * Test civicrm_mailing_group_event_unsubscribe with wrong params.
+   * Test civicrm_mailing_event_unsubscribe.
    */
-  public function testMailerGroupUnsubscribeWrongParams(): void {
-    $this->callAPIFailure('MailingEventUnsubscribe', 'create', [
-      'job_id' => 'Wrong ID',
-      'event_queue_id' => 'Wrong ID',
-      'hash' => 'Wrong Hash',
-      'time_stamp' => '20101212121212',
+  public function testMailerGroupUnsubscribe(): void {
+    $mail = new CiviMailUtils($this);
+    $this->createTestEntity('Mailing', ['name' => 'mail']);
+    $this->createTestEntity('Group', ['name' => 'group', 'frontend_title' => 'group']);
+    $this->createTestEntity('MailingGroup', ['mailing_id' => $this->ids['Mailing']['default'], 'group_type' => 'Include', 'entity_table' => 'civicrm_group', 'entity_id' => $this->ids['Group']['default']]);
+    $this->createTestEntity('MailingEventQueue', [
+      'contact_id' => $this->individualCreate(),
+      'hash' => 'brown',
+      'email_id' => Email::get(FALSE)->addWhere('contact_id', '=', $this->ids['Contact']['individual_0'])->setLimit(1)->execute()->single(),
+      'mailing_id' => $this->ids['Mailing']['default'],
     ]);
+    $params = [
+      'event_queue_id' => $this->ids['MailingEventQueue']['default'],
+      'hash' => 'brown',
+      'time_stamp' => '20101212121212',
+    ];
+    $this->callAPISuccess('MailingEventUnsubscribe', 'create', $params);
+    $mail->checkMailLog(['You have been un-subscribed from the following groups']);
   }
 
   /**


### PR DESCRIPTION
This deliberately replaces the useless 'failure' test (which just tests the api wrapper) with a success test. Changes are made to make job_id optional as it is no longer required when retrieving mailings or processing incoming verp (this was done to allow job_it to be intermittantly purged without losing any functionality)

