### PR TITLE
SearchKit: add colors column option for table displays

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -328,6 +328,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     if (!empty($column['icons'])) {
       $out['icons'] = $this->getColumnIcons($column, $data, $out);
     }
+    if (!empty($column['colors'])) {
+      $out['colors'] = $this->getColumnColors($column, $data, $out);
+    }
     return $out;
   }
 
@@ -474,6 +477,57 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
   }
 
   /**
+   * Add colors to a column
+   *
+   * Note: Only one color is allowed per value (no left/right distinction as with icons).
+   * If more than one color rule is given, latter rules are treated as fallbacks
+   * and only used if prior ones are missing.
+   *
+   * @param array $column
+   * @param array $data
+   * @param array $out
+   * @return array
+   */
+  protected function getColumnColors(array $column, array $data, array $out): array {
+    // Column is either outputting an array of links, or a plain value
+    // Value could be an array if field is multivalued or aggregated.
+    $value = $out['links'] ?? $out['val'] ?? NULL;
+    // Get 0-indexed keys of the values (pad so we have at least one)
+    $keys = array_pad(array_keys(array_values((array) $value)), 1, 0);
+    $result = [];
+    foreach ($keys as $index) {
+      $result[$index] = $this->getColumnColor($column['colors'], $index, $data, is_array($value));
+    }
+    // Drop if empty
+    return array_filter($result) ? $result : [];
+  }
+
+  private function getColumnColor(array $colors, int $index, array $data, bool $isMulti): ?string {
+    // Latter colors are fallbacks, earlier ones take priority
+    foreach ($colors as $color) {
+      $colorValue = NULL;
+      $color += ['color' => NULL];
+      $colorField = !empty($color['field']) ? $this->renameIfAggregate($color['field']) : NULL;
+      if (!empty($colorField) && !empty($data[$colorField])) {
+        // Color field may be multivalued e.g. tag_id:color, or it may be aggregated
+        // If both base field and color field are multivalued, use corresponding index
+        if ($isMulti && is_array($data[$colorField])) {
+          $colorValue = $data[$colorField][$index] ?? NULL;
+        }
+        // Otherwise get a single value
+        else {
+          $colorValue = \CRM_Utils_Array::first(array_filter((array) $data[$colorField]));
+        }
+      }
+      $colorValue ??= $color['color'];
+      if ($colorValue) {
+        return $colorValue;
+      }
+    }
+    return NULL;
+  }
+
+  /**
    * Returns the condition of a cssRules
    *
    * @param array $clause
@@ -536,6 +590,22 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       if ($fieldKey) {
         // For fields used in group by, add aggregation
         $select[] = $this->renameIfAggregate($fieldKey, TRUE);
+      }
+    }
+    return $select;
+  }
+
+  /**
+   * Return fields needed for calculating a column's colors
+   *
+   * @param array $colors
+   * @return array
+   */
+  protected function getColorsSelect($colors) {
+    $select = [];
+    foreach ($colors as $color) {
+      if (!empty($color['field'])) {
+        $select[] = $this->renameIfAggregate($color['field'], TRUE);
       }
     }
     return $select;
@@ -1548,6 +1618,9 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $this->addSelectExpression($addition);
       }
       foreach ($this->getIconsSelect($column['icons'] ?? []) as $addition) {
+        $this->addSelectExpression($addition);
+      }
+      foreach ($this->getColorsSelect($column['colors'] ?? []) as $addition) {
         $this->addSelectExpression($addition);
       }
     }

--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -441,7 +441,35 @@
         if (defaults.sortable) {
           values.sortable = field.type && field.type !== 'Pseudo';
         }
+        if (values.type === 'field') {
+          const colorField = getColorField(fieldExpr, savedSearch);
+          if (colorField) {
+            values.colors = [{field: colorField}];
+          }
+        }
         return values;
+      }
+      // For a given field, returns the name of a companion field that supplies its color
+      // (either a `:color` suffix on the same pseudoconstant field, or a sibling `color`
+      // field on the same directly-joined entity), or null if no color is available.
+      function getColorField(fieldExpr, savedSearch) {
+        const field = getFieldAndJoin(fieldExpr, savedSearch).field;
+        if (!field) {
+          return null;
+        }
+        const pathPart = fieldExpr.split(':')[0];
+        const lastDot = pathPart.lastIndexOf('.');
+        const prefix = lastDot >= 0 ? pathPart.substring(0, lastDot + 1) : '';
+        const fieldName = lastDot >= 0 ? pathPart.substring(lastDot + 1) : pathPart;
+        if (fieldName === 'color') {
+          // A color field has no color field of its own
+          return null;
+        }
+        if ((field.suffixes || []).includes('color')) {
+          return prefix + fieldName + ':color';
+        }
+        const colorField = getFieldAndJoin(prefix + 'color', savedSearch).field;
+        return colorField ? prefix + 'color' : null;
       }
       return {
         getEntity: getEntity,
@@ -453,6 +481,7 @@
         parseExpr: parseExpr,
         getDefaultLabel: getDefaultLabel,
         fieldToColumn: fieldToColumn,
+        getColorField: getColorField,
         getSearchTasks: function(entityName) {
           if (!(entityName in searchTasks)) {
             searchTasks[entityName] = crmApi4('SearchDisplay', 'getSearchTasks', {

--- a/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/colType/field.html
@@ -94,4 +94,5 @@
   </label>
 </div>
 <search-admin-icons item="col"></search-admin-icons>
+<search-admin-colors item="col"></search-admin-colors>
 <search-admin-css-rules label="{{:: ts('Style') }}" item="col" default="col.key"></search-admin-css-rules>

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminColors.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminColors.component.js
@@ -1,0 +1,36 @@
+(function(angular, $, _) {
+  "use strict";
+
+  angular.module('crmSearchAdmin').component('searchAdminColors', {
+    bindings: {
+      item: '<'
+    },
+    require: {
+      crmSearchAdmin: '^crmSearchAdmin'
+    },
+    templateUrl: '~/crmSearchAdmin/displays/common/searchAdminColors.html',
+    controller: function($scope, searchMeta) {
+      const ts = $scope.ts = CRM.ts('org.civicrm.search_kit');
+
+      this.$onInit = () => {
+        const savedSearch = this.crmSearchAdmin.savedSearch;
+        const field = searchMeta.getField(this.item.key, savedSearch);
+        this.colorField = field ? searchMeta.getColorField(this.item.key, savedSearch) : null;
+        if (this.colorField) {
+          this.colorLabel = ts('Use %1 color', {1: field.label});
+        }
+      };
+
+      this.toggleColor = () => {
+        if (this.item.colors && this.item.colors.length) {
+          delete this.item.colors;
+        }
+        else {
+          this.item.colors = [{field: this.colorField}];
+        }
+      };
+
+    }
+  });
+
+})(angular, CRM.$, CRM._);

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminColors.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminColors.html
@@ -1,0 +1,6 @@
+<div class="form-inline" ng-if="$ctrl.colorField">
+  <label title="{{:: ts('Display this field as a colored badge, using its associated color.') }}">
+    <input type="checkbox" ng-checked="$ctrl.item.colors && $ctrl.item.colors.length" ng-click="$ctrl.toggleColor()">
+    {{:: $ctrl.colorLabel }}
+  </label>
+</div>

--- a/ext/search_kit/ang/crmSearchDisplay/colType/field.html
+++ b/ext/search_kit/ang/crmSearchDisplay/colType/field.html
@@ -1,12 +1,12 @@
 <span ng-if=":: !$ctrl.isArray(colData.val)">
   <i ng-if=":: colData.icons.left[0]" class="crm-i {{:: colData.icons.left[0] }}" role="img" aria-hidden="true"></i>
-  <span class="crm-search-field-value">{{:: colData.val }}</span>
+  <span ng-if=":: !colData.colors[0]" class="crm-search-field-value">{{:: colData.val }}</span>
+  <span ng-if=":: colData.colors[0]" class="crm-search-field-value badge" style="{{:: $ctrl.getColorStyle(colData.colors[0]) }}">{{:: colData.val }}</span>
   <i ng-if=":: colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i>
 </span>
 <span ng-if=":: $ctrl.isArray(colData.val)">
   <span ng-repeat="val in colData.val track by $index">
-    <i ng-if=":: colData.icons.left[$index]" class="crm-i {{:: colData.icons.left[$index] }}" role="img" aria-hidden="true"></i>
-      <span class="crm-search-field-value">{{:: val }}</span><i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i><span ng-if="!$last">,
+    <i ng-if=":: colData.icons.left[$index]" class="crm-i {{:: colData.icons.left[$index] }}" role="img" aria-hidden="true"></i><span ng-if=":: !colData.colors[$index]" class="crm-search-field-value">{{:: val }}</span><span ng-if=":: colData.colors[$index]" class="crm-search-field-value badge" style="{{:: $ctrl.getColorStyle(colData.colors[$index]) }}">{{:: val }}</span><i ng-if="colData.icons.right[$index]" class="crm-i {{:: colData.icons.right[$index] }}" role="img" aria-hidden="true"></i><span ng-if="!$last && !colData.colors[$index]">,
     </span>
   </span>
 </span>

--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -311,6 +311,12 @@
         return (colData.cssClass || '') + ' crm-search-col-type-' + this.columns[colIndex].type + (this.columns[colIndex].break ? '' : ' crm-inline-block');
       },
 
+      // Returns an inline style string for a colored badge, using CRM.utils.colorContrast
+      // to pick readable text color. Used by colType/field.html for the `colors` column option.
+      getColorStyle: function(color) {
+        return color ? 'background-color: ' + color + '; color: ' + CRM.utils.colorContrast(color) + ';' : '';
+      },
+
       getFieldTemplate: function(colIndex, colData) {
         let colType = this.columns[colIndex].type;
         if (colType === 'include') {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3248,6 +3248,89 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('', $row[3][3]['val']);
   }
 
+  /**
+   * Tests the `colors` column option: a companion GROUP_CONCAT'd color
+   * expression should be reflected per-value in `columns[$index]['colors']`,
+   * mirroring how `icons` already works.
+   */
+  public function testRunWithColorsColumn(): void {
+    $contactId = $this->saveTestRecords('Contact', ['records' => 3])->column('id');
+    $tags = $this->saveTestRecords('Tag', [
+      'records' => [
+        ['label' => uniqid('a'), 'color' => '#ff0000'],
+        ['label' => uniqid('b'), 'color' => '#00ff00'],
+      ],
+    ]);
+    $tagId = $tags->column('id');
+    $this->saveTestRecords('EntityTag', [
+      'records' => [
+        ['entity_id' => $contactId[0], 'tag_id' => $tagId[0]],
+        ['entity_id' => $contactId[0], 'tag_id' => $tagId[1]],
+        ['entity_id' => $contactId[1], 'tag_id' => $tagId[0]],
+      ],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'GROUP_CONCAT(DISTINCT Contact_EntityTag_Tag_01.label) AS GROUP_CONCAT_Contact_EntityTag_Tag_01_label',
+            'GROUP_CONCAT(DISTINCT Contact_EntityTag_Tag_01.color) AS GROUP_CONCAT_Contact_EntityTag_Tag_01_color',
+          ],
+          'orderBy' => ['id' => 'ASC'],
+          'where' => [
+            ['id', 'IN', $contactId],
+          ],
+          'groupBy' => ['id'],
+          'join' => [
+            [
+              'Tag AS Contact_EntityTag_Tag_01',
+              'LEFT',
+              'EntityTag',
+              ['id', '=', 'Contact_EntityTag_Tag_01.entity_id'],
+              ['Contact_EntityTag_Tag_01.entity_table', '=', "'civicrm_contact'"],
+            ],
+          ],
+          'having' => [],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'testColorsDisplay',
+        'settings' => [
+          'limit' => 20,
+          'columns' => [
+            ['type' => 'field', 'key' => 'id', 'label' => 'ID'],
+            [
+              'type' => 'field',
+              'key' => 'GROUP_CONCAT_Contact_EntityTag_Tag_01_label',
+              'label' => 'Tags',
+              'colors' => [
+                ['field' => 'GROUP_CONCAT_Contact_EntityTag_Tag_01_color'],
+              ],
+            ],
+          ],
+          'sort' => [['id', 'ASC']],
+        ],
+      ],
+      'afform' => NULL,
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertCount(3, $result);
+
+    // First contact has 2 tags with 2 different colors.
+    $this->assertEqualsCanonicalizing(['#ff0000', '#00ff00'], $result[0]['columns'][1]['colors']);
+    // Second contact has 1 tag with 1 color.
+    $this->assertEquals(['#ff0000'], $result[1]['columns'][1]['colors']);
+    // Third contact has no tags - colors is empty (consistent with how `icons` behaves).
+    $this->assertEmpty($result[2]['columns'][1]['colors']);
+  }
+
   public function testRunWithTagFilter(): void {
     $contactId = $this->saveTestRecords('Contact', ['records' => 6])->column('id');
     $tags = $this->saveTestRecords('Tag', [


### PR DESCRIPTION
Overview
----------------------------------------
Some OptionValues (eg. Activity Status and Case Status) and other elements (eg. Tags) allow you to define a colour. But SearchKit doesn't use that information. This PR allows you to use that information in SearchKit to render values with the defined colours.

Add a `colors` column config for SearchDisplay table columns, mirroring the existing `icons` mechanism: a value renders as a colored badge when viewing. Color values are sourced from a companion `:color`-suffixed field.

Exposed in SearchKit's admin column editor as a single "Use <field> color" checkbox, shown only when the column's field actually has a color available - either as a `:color` suffix on the same field (pseudoconstant/option-list fields like Tags or Activity Type), or as a sibling `color` field on the same directly-joined entity (e.g. a Tag join exposing both `.label` and `.color`).

See https://lab.civicrm.org/extensions/civirules/-/merge_requests/370 for an example of usage.

You can also test by building a searchkit with Contacts+Tags or Activities with activity status (but you need to add some colour values in the DB for that) or Cases with case status (add colour values to DB first).

Before
----------------------------------------
We can't use defined colours in SearchKit.

After
----------------------------------------
We can use defined colours in SearchKit like this:

Contact search with tags:
<img width="908" height="588" alt="image" src="https://github.com/user-attachments/assets/16b39eb3-0472-42d4-866c-88d119235554" />

Activities with status:
<img width="942" height="785" alt="image" src="https://github.com/user-attachments/assets/870a65dc-31fc-44b2-92b6-b4a4ebd71577" />


Technical Details
----------------------------------------


Comments
----------------------------------------
