### PR TITLE
table_name needs to be table_name

### DIFF
--- a/Civi/Core/SqlTriggers.php
+++ b/Civi/Core/SqlTriggers.php
@@ -76,7 +76,8 @@ class SqlTriggers extends \Civi\Core\Service\AutoService {
     }
 
     $triggers = [];
-    $query = "SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'";
+    // without the "AS" sometimes the DAO field is TABLE_NAME, and then fetchmap fails because $dao->table_name doesn't exist because php is case-sensitive
+    $query = "SELECT table_name AS table_name FROM information_schema.tables WHERE table_schema = DATABASE() AND table_type = 'BASE TABLE'";
     $existingTables = \CRM_Core_DAO::executeQuery($query)->fetchMap('table_name', 'table_name');
 
     // now enumerate the tables and the events and collect the same set in a different format


### PR DESCRIPTION
Overview
----------------------------------------
table_name, sometimes TABLE_NAME

This isn't a windows thing.

The important part is the "AS table_name" because otherwise $dao->table_name doesn't exist sometimes. The LOWER is mostly to match the code in mixin.