### PR TITLE
Consolidate code for entity Task Delete forms

### DIFF
--- a/CRM/Activity/Form/Task/Delete.php
+++ b/CRM/Activity/Form/Task/Delete.php
@@ -10,69 +10,26 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-/**
- * This class provides the functionality to delete a group of
- * Activities. This class provides functionality for the actual
- * deletion.
+ * This class provides the functionality to delete a group of Activities.
  */
 class CRM_Activity_Form_Task_Delete extends CRM_Activity_Form_Task {
 
-  /**
-   * Are we operating in "single mode", i.e. deleting one
-   * specific Activity?
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
+  use CRM_Core_Form_Task_DeleteTrait;
 
   /**
    * @var bool
    */
   public $submitOnce = TRUE;
 
-  /**
-   * Build all the data structures needed to build the form.
-   */
-  public function preProcess() {
-    parent::preProcess();
+  protected function getIDs(): array {
+    return $this->_activityHolderIds ?? [];
   }
 
-  /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    CRM_Utils_System::setTitle(ts('Delete Activities'));
-    $this->addDefaultButtons(ts('Delete Activities'), 'done');
-  }
-
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    $deleted = $failed = 0;
-    foreach ($this->_activityHolderIds as $activityId['id']) {
-      $moveToTrash = CRM_Case_BAO_Case::isCaseActivity($activityId['id']);
-      if (CRM_Activity_BAO_Activity::deleteActivity($activityId, $moveToTrash)) {
-        $deleted++;
-      }
-      else {
-        $failed++;
-      }
-    }
-
-    if ($deleted) {
-      $msg = ts('%count activity deleted.', ['plural' => '%count activities deleted.', 'count' => $deleted]);
-      CRM_Core_Session::setStatus($msg, ts('Removed'), 'success');
-    }
-
-    if ($failed) {
-      CRM_Core_Session::setStatus(ts('1 could not be deleted.', ['plural' => '%count could not be deleted.', 'count' => $failed]), ts('Error'), 'error');
-    }
+  protected function deleteRecord($id): bool {
+    $activityId = is_array($id) ? ($id['id'] ?? reset($id)) : $id;
+    $params = ['id' => $activityId];
+    $moveToTrash = CRM_Case_BAO_Case::isCaseActivity($activityId);
+    return (bool) CRM_Activity_BAO_Activity::deleteActivity($params, $moveToTrash);
   }
 
 }

--- a/CRM/Case/Form/Task/Delete.php
+++ b/CRM/Case/Form/Task/Delete.php
@@ -10,23 +10,11 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-/**
  * This class provides the functionality to delete a group of case records.
  */
 class CRM_Case_Form_Task_Delete extends CRM_Case_Form_Task {
 
-  /**
-   * Are we operating in "single mode", i.e. deleting one
-   * specific case?
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
+  use CRM_Core_Form_Task_DeleteTrait;
 
   /**
    * Are we moving case to Trash.
@@ -35,52 +23,23 @@ class CRM_Case_Form_Task_Delete extends CRM_Case_Form_Task {
    */
   public $_moveToTrash = TRUE;
 
-  /**
-   * Build all the data structures needed to build the form.
-   *
-   * @throws \CRM_Core_Exception
-   */
-  public function preProcess() {
-    if (!CRM_Core_Permission::checkActionPermission('CiviCase', CRM_Core_Action::DELETE)) {
-      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-    }
-    parent::preProcess();
+  protected function getPermissionModule(): string {
+    return 'CiviCase';
   }
 
-  /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    $this->addDefaultButtons(ts('Delete cases'), 'done');
+  protected function getSuccessMessage(int $deleted): string {
+    if ($this->_moveToTrash) {
+      return ts('%count case moved to trash.', ['plural' => '%count cases moved to trash.', 'count' => $deleted]);
+    }
+    return ts('%count case permanently deleted.', ['plural' => '%count cases permanently deleted.', 'count' => $deleted]);
   }
 
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    $deleted = $failed = 0;
-    foreach ($this->_entityIds as $caseId) {
-      if (CRM_Case_BAO_Case::deleteCase($caseId, $this->_moveToTrash)) {
-        $deleted++;
-      }
-      else {
-        $failed++;
-      }
-    }
+  protected function getIDs(): array {
+    return $this->_entityIds ?? [];
+  }
 
-    if ($deleted) {
-      if ($this->_moveToTrash) {
-        $msg = ts('%count case moved to trash.', ['plural' => '%count cases moved to trash.', 'count' => $deleted]);
-      }
-      else {
-        $msg = ts('%count case permanently deleted.', ['plural' => '%count cases permanently deleted.', 'count' => $deleted]);
-      }
-      CRM_Core_Session::setStatus($msg, ts('Removed'), 'success');
-    }
-
-    if ($failed) {
-      CRM_Core_Session::setStatus(ts('1 could not be deleted.', ['plural' => '%count could not be deleted.', 'count' => $failed]), ts('Error'), 'error');
-    }
+  protected function deleteRecord($id): bool {
+    return (bool) CRM_Case_BAO_Case::deleteCase($id, $this->_moveToTrash);
   }
 
 }

--- a/CRM/Core/Form/Task/DeleteTrait.php
+++ b/CRM/Core/Form/Task/DeleteTrait.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Common functionality for deleting entities in task forms.
+ */
+trait CRM_Core_Form_Task_DeleteTrait {
+
+  /**
+   * Are we operating in "single mode", i.e. deleting one specific entity?
+   *
+   * @var bool
+   */
+  protected $_single = FALSE;
+
+  /**
+   * Build all the data structures needed to build the form.
+   */
+  public function preProcess(): void {
+    $permissionModule = $this->getPermissionModule();
+    if ($permissionModule && !CRM_Core_Permission::checkActionPermission($permissionModule, CRM_Core_Action::DELETE)) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    }
+    parent::preProcess();
+  }
+
+  /**
+   * Build the form object.
+   */
+  public function buildQuickForm(): void {
+    $title = $this->getDeleteTitle();
+    CRM_Utils_System::setTitle($title);
+    $this->addDefaultButtons($title, 'done');
+  }
+
+  /**
+   * Process the form after the input has been submitted and validated.
+   */
+  public function postProcess(): void {
+    $deleted = $failed = 0;
+    foreach ($this->getIDs() as $id) {
+      if ($this->deleteRecord($id)) {
+        $deleted++;
+      }
+      else {
+        $failed++;
+      }
+    }
+
+    if ($deleted) {
+      CRM_Core_Session::setStatus($this->getSuccessMessage($deleted), ts('Removed'), 'success');
+    }
+
+    if ($failed) {
+      CRM_Core_Session::setStatus(ts('1 could not be deleted.', ['plural' => '%count could not be deleted.', 'count' => $failed]), ts('Error'), 'error');
+    }
+  }
+
+  /**
+   * Get permission module name (e.g. 'CiviMember', 'CiviPledge', 'CiviCase').
+   * Return NULL if no permission check is required in preProcess.
+   */
+  protected function getPermissionModule(): ?string {
+    return NULL;
+  }
+
+  /**
+   * Get the title for the delete form / button.
+   */
+  protected function getDeleteTitle(): string {
+    $titlePlural = Civi::entity($this->getDefaultEntity())->getMeta('title_plural');
+    return ts('Delete %1', [1 => $titlePlural]);
+  }
+
+  /**
+   * Get success status message.
+   */
+  protected function getSuccessMessage(int $deleted): string {
+    $entity = Civi::entity($this->getDefaultEntity());
+    $title = strtolower($entity->getMeta('title'));
+    $titlePlural = strtolower($entity->getMeta('title_plural'));
+    return ts('%count %1 deleted.', [
+      'count' => $deleted,
+      'plural' => '%count %2 deleted.',
+      1 => $title,
+      2 => $titlePlural,
+    ]);
+  }
+
+  /**
+   * Get default entity name for the form.
+   * @return string
+   */
+  abstract public function getDefaultEntity();
+
+  /**
+   * Delete a single record by ID.
+   *
+   * @param int|array $id
+   * @return bool
+   */
+  abstract protected function deleteRecord($id): bool;
+
+  /**
+   * Get IDs of records to delete.
+   *
+   * @return array
+   */
+  abstract protected function getIDs(): array;
+
+}

--- a/CRM/Member/Form/Task.php
+++ b/CRM/Member/Form/Task.php
@@ -30,6 +30,10 @@ class CRM_Member_Form_Task extends CRM_Core_Form_Task {
    */
   protected $_memberIds;
 
+  public function getDefaultEntity(): string {
+    return 'Membership';
+  }
+
   /**
    * Build all the data structures needed to build the form.
    *

--- a/CRM/Member/Form/Task/Delete.php
+++ b/CRM/Member/Form/Task/Delete.php
@@ -10,74 +10,22 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-/**
- * This class provides the functionality to delete a group of
- * members. This class provides functionality for the actual
- * deletion.
+ * This class provides the functionality to delete a group of members.
  */
 class CRM_Member_Form_Task_Delete extends CRM_Member_Form_Task {
 
-  /**
-   * Are we operating in "single mode", i.e. deleting one
-   * specific membership?
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
+  use CRM_Core_Form_Task_DeleteTrait;
 
-  /**
-   * Build all the data structures needed to build the form.
-   *
-   * @return void
-   */
-  public function preProcess() {
-    //check for delete
-    if (!CRM_Core_Permission::checkActionPermission('CiviMember', CRM_Core_Action::DELETE)) {
-      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-    }
-    parent::preProcess();
+  protected function getPermissionModule(): string {
+    return 'CiviMember';
   }
 
-  /**
-   * Build the form object.
-   *
-   *
-   * @return void
-   */
-  public function buildQuickForm() {
-    $this->addDefaultButtons(ts('Delete Memberships'), 'done');
+  protected function getIDs(): array {
+    return $this->_memberIds ?? [];
   }
 
-  /**
-   * Process the form after the input has been submitted and validated.
-   *
-   *
-   * @return void
-   */
-  public function postProcess() {
-    $deleted = $failed = 0;
-    foreach ($this->_memberIds as $memberId) {
-      if (CRM_Member_BAO_Membership::del($memberId)) {
-        $deleted++;
-      }
-      else {
-        $failed++;
-      }
-    }
-
-    if ($deleted) {
-      $msg = ts('%count membership deleted.', ['plural' => '%count memberships deleted.', 'count' => $deleted]);
-      CRM_Core_Session::setStatus($msg, ts('Removed'), 'success');
-    }
-
-    if ($failed) {
-      CRM_Core_Session::setStatus(ts('1 could not be deleted.', ['plural' => '%count could not be deleted.', 'count' => $failed]), ts('Error'), 'error');
-    }
+  protected function deleteRecord($id): bool {
+    return (bool) CRM_Member_BAO_Membership::del($id);
   }
 
 }

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -28,6 +28,10 @@ class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
    */
   protected $_pledgeIds;
 
+  public function getDefaultEntity(): string {
+    return 'Pledge';
+  }
+
   /**
    * Build all the data structures needed to build the form.
    */

--- a/CRM/Pledge/Form/Task/Delete.php
+++ b/CRM/Pledge/Form/Task/Delete.php
@@ -10,66 +10,22 @@
  */
 
 /**
- *
- * @package CRM
- * @copyright CiviCRM LLC https://civicrm.org/licensing
- */
-
-/**
- * This class provides the functionality to delete a group of
- * participations. This class provides functionality for the actual
- * deletion.
+ * This class provides the functionality to delete a group of pledges.
  */
 class CRM_Pledge_Form_Task_Delete extends CRM_Pledge_Form_Task {
 
-  /**
-   * Are we operating in "single mode", i.e. deleting one
-   * specific pledge?
-   *
-   * @var bool
-   */
-  protected $_single = FALSE;
+  use CRM_Core_Form_Task_DeleteTrait;
 
-  /**
-   * Build all the data structures needed to build the form.
-   */
-  public function preProcess() {
-    //check for delete
-    if (!CRM_Core_Permission::checkActionPermission('CiviPledge', CRM_Core_Action::DELETE)) {
-      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
-    }
-    parent::preProcess();
+  protected function getPermissionModule(): string {
+    return 'CiviPledge';
   }
 
-  /**
-   * Build the form object.
-   */
-  public function buildQuickForm() {
-    $this->addDefaultButtons(ts('Delete Pledges'), 'done');
+  protected function getIDs(): array {
+    return $this->_pledgeIds ?? [];
   }
 
-  /**
-   * Process the form after the input has been submitted and validated.
-   */
-  public function postProcess() {
-    $deleted = $failed = 0;
-    foreach ($this->_pledgeIds as $pledgeId) {
-      if (CRM_Pledge_BAO_Pledge::deletePledge($pledgeId)) {
-        $deleted++;
-      }
-      else {
-        $failed++;
-      }
-    }
-
-    if ($deleted) {
-      $msg = ts('%count pledge deleted.', ['plural' => '%count pledges deleted.', 'count' => $deleted]);
-      CRM_Core_Session::setStatus($msg, ts('Removed'), 'success');
-    }
-
-    if ($failed) {
-      CRM_Core_Session::setStatus(ts('1 could not be deleted.', ['plural' => '%count could not be deleted.', 'count' => $failed]), ts('Error'), 'error');
-    }
+  protected function deleteRecord($id): bool {
+    return (bool) CRM_Pledge_BAO_Pledge::deletePledge($id);
   }
 
 }

--- a/tests/phpunit/CRM/Core/Form/Task/DeleteTraitTest.php
+++ b/tests/phpunit/CRM/Core/Form/Task/DeleteTraitTest.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+use Civi\Test\Api4TestTrait;
+
+require_once 'CiviTest/CiviCaseTestCase.php';
+
+/**
+ * Test class for CRM_Core_Form_Task_DeleteTrait.
+ *
+ * @group headless
+ */
+class CRM_Core_Form_Task_DeleteTraitTest extends CiviCaseTestCase {
+
+  use Api4TestTrait;
+
+  public function setUp(): void {
+    \CRM_Core_BAO_ConfigSetting::enableAllComponents();
+    parent::setUp();
+  }
+
+  /**
+   * Data provider for task delete forms using DeleteTrait.
+   *
+   * @return array
+   */
+  public static function deleteTaskFormDataProvider(): array {
+    return [
+      'Membership' => [
+        'formClass' => 'CRM_Member_Form_Task_Delete',
+        'entityName' => 'Membership',
+        'property' => '_memberIds',
+      ],
+      'Pledge' => [
+        'formClass' => 'CRM_Pledge_Form_Task_Delete',
+        'entityName' => 'Pledge',
+        'property' => '_pledgeIds',
+      ],
+      'Activity' => [
+        'formClass' => 'CRM_Activity_Form_Task_Delete',
+        'entityName' => 'Activity',
+        'property' => '_activityHolderIds',
+      ],
+      'Case' => [
+        'formClass' => 'CRM_Case_Form_Task_Delete',
+        'entityName' => 'Case',
+        'property' => '_entityIds',
+      ],
+    ];
+  }
+
+  /**
+   * Test delete task form functionality across entity forms using DeleteTrait.
+   *
+   * @dataProvider deleteTaskFormDataProvider
+   */
+  public function testDeleteTaskForm(string $formClass, string $entityName, string $property, array $createValues = []): void {
+    $record = $this->createTestRecord($entityName, $createValues);
+    $recordId = $record['id'];
+
+    /** @var CRM_Core_Form $form */
+    $form = $this->getFormObject($formClass);
+    if (property_exists($form, '_moveToTrash')) {
+      $form->_moveToTrash = FALSE;
+    }
+    \Civi\Test\Invasive::set([$form, $property], [$recordId]);
+    $form->postProcess();
+
+    $check = civicrm_api4($entityName, 'get', ['where' => [['id', '=', $recordId]]]);
+    $this->assertCount(0, $check);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Extract `CRM_Core_Form_Task_DeleteTrait` to eliminate duplicated code across "Delete" task forms.

Before
----------------------------------------
Copy-pasted code across entity delete tasks.

After
----------------------------------------
Technical Details
----------------------------------------

- Extracted `CRM_Core_Form_Task_DeleteTrait` (`CRM/Core/Form/Task/DeleteTrait.php`), consolidating standard permission checking, title setting, confirmation button rendering, and item deletion iteration across task forms.
- Refactored `CRM_Member_Form_Task_Delete`, `CRM_Pledge_Form_Task_Delete`, `CRM_Activity_Form_Task_Delete`, and `CRM_Case_Form_Task_Delete` to use `CRM_Core_Form_Task_DeleteTrait`.
- Added unit tests in `CRM_Core_Form_Task_DeleteTraitTest` covering trait deletion functionality.
