### PR TITLE
Reduce confusion about how up-to-date the open/clicks info is on the mailing report

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1510,6 +1510,28 @@ ORDER BY   civicrm_email.is_bulkmail DESC
       $report['event_totals']['clickthrough_rate'] = 0;
     }
 
+    $runQueue_date = NULL;
+    $runQueue_job_id = \Civi\Api4\Job::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('api_entity', '=', 'Mailing')
+      ->addWhere('api_action', '=', 'runQueue')
+      ->addWhere('is_active', '=', TRUE)
+      ->setLimit(1)
+      ->execute()
+      ->first()['id'] ?? NULL;
+    if ($runQueue_job_id) {
+      $runQueue_date = \Civi\Api4\JobLog::get(FALSE)
+        ->addSelect('run_time')
+        ->addWhere('job_id', '=', $runQueue_job_id)
+        ->addOrderBy('run_time', 'DESC')
+        ->setLimit(1)
+        ->execute()
+        ->first()['run_time'] ?? NULL;
+    }
+    $report['event_totals']['runQueue_date'] = $runQueue_date;
+    // so that we can give a link to it in the template
+    $report['event_totals']['runQueue_jobId'] = $runQueue_job_id;
+
     // Get the click-through totals, grouped by URL
     $mailing->query("
             SELECT      {$t['url']}.url,

--- a/CRM/Mailing/Page/Report.php
+++ b/CRM/Mailing/Page/Report.php
@@ -129,6 +129,7 @@ class CRM_Mailing_Page_Report extends CRM_Core_Page_Basic {
     $this->assign('report', $report);
     CRM_Utils_System::setTitle(ts('CiviMail Report: %1', [1 => $report['mailing']['name']]));
     $this->assign('public_url', CRM_Mailing_BAO_Mailing::getPublicViewUrl($this->_mailing_id));
+    $this->assign('canRefreshRunQueueDate', CRM_Core_Permission::check('administer civicrm system'));
 
     return CRM_Core_Page::run();
   }

--- a/templates/CRM/Mailing/Page/Report.tpl
+++ b/templates/CRM/Mailing/Page/Report.tpl
@@ -28,7 +28,7 @@
       <td>{$report.event_totals.actionlinks.delivered}</td></tr>
 {if $report.mailing.open_tracking}
   <tr><td class="label"><a href="{$report.event_totals.links.opened}&distinct=1">{ts}Unique Opens{/ts}</a></td>
-      <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%)</td>
+      <td>{$report.event_totals.opened} ({$report.event_totals.opened_rate|string_format:"%0.2f"}%){if $report.event_totals.runQueue_date} {ts escape="html" 1=$report.event_totals.runQueue_date|crmDate}(as of %1){/ts}{if $canRefreshRunQueueDate && $report.event_totals.runQueue_jobId} <a class="crm-hover-button" id="refresh_opens" title="{ts escape="html"}Run refresh job now{/ts}" target="_blank" href="{crmURL p='civicrm/admin/joblog' q="reset=1&jid=`$report.event_totals.runQueue_jobId`"}"><i class="crm-i fa-refresh"></i></a>{/if}{/if}</td>
       <td>{$report.event_totals.actionlinks.opened_unique}</td></tr>
   <tr><td class="label"><a href="{$report.event_totals.links.opened}">{ts}Total Opens{/ts}</a></td>
       <td>{$report.event_totals.total_opened}</td>


### PR DESCRIPTION
Overview
----------------------------------------
(Resubmission of https://github.com/civicrm/civicrm-core/pull/36289 with a slightly different UX.)

Since the scheduled job was introduced, it's now always out of date.

Before
----------------------------------------
About once a month I get a support request that "mailings aren't working" since the number of opens is 0, or "too low". Since I keep forgetting that it's updated by a scheduled job now, I always waste time looking into whether mails are actually going, and then eventually hit on the reason.

<img width="170" height="74" alt="untitled3" src="https://github.com/user-attachments/assets/2bc075c4-2104-439a-9efb-df926e3e5977" />


After
----------------------------------------
Gives the date of the last Mailing.runQueue job run. If you have "administer civicrm system" permission then it gives a refresh icon which takes you to the joblog page for the job which has an Execute Now button there. This makes it clear how fresh those numbers are but also prevents non-sysadmins from messing with the purpose of having it be a scheduled job, and for sysadmins also makes it clear what updates those numbers.

<img width="320" height="65" alt="untitled4" src="https://github.com/user-attachments/assets/db0c8d89-c9c3-44f3-842f-3b543143a137" />


Technical Details
----------------------------------------


Comments
----------------------------------------
