### PR TITLE
php warning for payableItemIndex

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -550,6 +550,7 @@ class CRM_Financial_BAO_Payment {
     }
 
     $payableItems = [];
+    $payableItemIndex = NULL;
 
     foreach ($items as $item) {
       $lineItemID = $item['id'];


### PR DESCRIPTION
Overview
----------------------------------------
php warning if it never got set

Before
----------------------------------------
Warning: Undefined variable $payableItemIndex in CRM_Financial_BAO_Payment::getPayableItems() (line 608 of .../CRM/Financial/BAO/Payment.php)

After
----------------------------------------


Technical Details
----------------------------------------
The code for `isset($payableItems[$payableItemIndex]))` was just merged in https://github.com/civicrm/civicrm-core/pull/34624, but in php `isset` doesn't guard against an unset variable used as the array index, e.g.

`php -r '$x = []; echo isset($x[$y]);'`
gives
`PHP Warning:  Undefined variable $y in Command line code on line 1`

Comments
----------------------------------------

