### PR TITLE
Prevent draft msg templates from sending when contact's language has no translation

### DIFF
--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -306,6 +306,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookI
       \Civi::$statics[__CLASS__]['site_language_translation'] = [];
       $translations = Translation::get(FALSE)
         ->addWhere('entity_table', '=', CRM_Core_DAO_AllCoreTables::getTableForEntityName($entity))
+        ->addWhere('status_id:name', '=', 'active')
         ->setCheckPermissions(FALSE)
         ->setSelect(['entity_field', 'entity_id', 'string', 'language'])
         ->addWhere('language', '=', \Civi::settings()->get('lcMessages'))

--- a/tests/phpunit/api/v4/Options/TranslationModeTest.php
+++ b/tests/phpunit/api/v4/Options/TranslationModeTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Options;
 use api\v4\Api4TestBase;
 use Civi\Api4\MessageTemplate;
 use Civi\Api4\Translation;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Tests for the option `$apiRequest->setTranslationMode(...)`.
@@ -32,7 +33,7 @@ use Civi\Api4\Translation;
  *
  * @group headless
  */
-class TranslationModeTest extends Api4TestBase {
+class TranslationModeTest extends Api4TestBase implements TransactionalInterface {
 
   public static function getTranslationSettings(): array {
     $es = [];
@@ -82,6 +83,65 @@ class TranslationModeTest extends Api4TestBase {
       ->execute()->indexBy('workflow_name');
 
     $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+  }
+
+  /**
+   * Test that a draft translation is never used in place of the active one.
+   *
+   * @dataProvider getTranslationSettings
+   * @throws \CRM_Core_Exception
+   * @group locale
+   */
+  public function testDraftTranslationsAreNotUsed($translationSettings): void {
+    $cleanup = \CRM_Utils_AutoClean::swapSettings($translationSettings);
+
+    // Case 1: The requested language has no translation and
+    // falls back to the site-default language.
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['status_id:name' => 'active', 'string' => 'Active English Subject'],
+      ['status_id:name' => 'draft', 'string' => 'Draft English Subject'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'entity_field' => 'msg_subject',
+      'language' => 'en_US',
+    ])->execute();
+
+    $fallbackResult = MessageTemplate::get()
+      ->addWhere('id', '=', $messageTemplateID)
+      ->addSelect('id', 'msg_subject')
+      ->setLanguage('fr_CA')
+      ->setTranslationMode('fuzzy')
+      ->execute()->single();
+
+    $this->assertEquals('Active English Subject', $fallbackResult['msg_subject']);
+    $this->assertEquals('en_US', $fallbackResult['actual_language']);
+
+    // Case 2: The requested language itself has a translation.
+    $this->addTranslation();
+    Translation::create()->setValues([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'entity_field' => 'msg_subject',
+      'language' => 'fr_FR',
+      'status_id:name' => 'draft',
+      'string' => 'Bonjour (draft)',
+    ])->execute();
+
+    $frenchResult = MessageTemplate::get()
+      ->addWhere('id', '=', $messageTemplateID)
+      ->addSelect('id', 'msg_subject', 'msg_html')
+      ->setLanguage('fr_FR')
+      ->setTranslationMode('fuzzy')
+      ->execute()->single();
+
+    $this->assertFrenchTranslationRetrieved($frenchResult);
   }
 
   /**


### PR DESCRIPTION
Without filtering on active here, if we fall back to the default language the foreach causes the later, higher id draft to overwrite the lower id active version here.

Put this against 6.17 even though it is a longstanding bug because the impact is potentially significant (e.g. if you have a broken template in drafts) and the change is tiny.
