### PR TITLE
Fix typo that prevents API rendering message template by ID

### DIFF
--- a/Civi/Api4/Action/WorkflowMessage/Render.php
+++ b/Civi/Api4/Action/WorkflowMessage/Render.php
@@ -78,7 +78,7 @@ class Render extends \Civi\Api4\Generic\AbstractAction {
     $r = \CRM_Core_BAO_MessageTemplate::renderTemplate([
       'model' => $this->_model,
       'messageTemplate' => $this->getMessageTemplate(),
-      'messageTemplateId' => $this->getMessageTemplateId(),
+      'messageTemplateID' => $this->getMessageTemplateId(),
       'language' => $this->getLanguage(),
     ]);
     $result[] = \CRM_Utils_Array::subset($r, ['subject', 'html', 'text']);

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -56,6 +56,28 @@ class CRM_Core_BAO_MessageTemplateTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test rendering a specific message template by its ID.
+   *
+   * The template is loaded purely from its ID, with no workflow. Only
+   * default templates can be loaded this way.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testRenderTemplateByID(): void {
+    $templateID = MessageTemplate::create(FALSE)->setValues([
+      'msg_html' => '<p>Rendered by ID</p>',
+      'workflow_name' => 'test_render_specific_template',
+      'is_active' => TRUE,
+      'is_default' => TRUE,
+    ])->execute()->first()['id'];
+
+    $rendered = CRM_Core_BAO_MessageTemplate::renderTemplate([
+      'messageTemplateID' => $templateID,
+    ]);
+    $this->assertStringContainsString('<p>Rendered by ID</p>', $rendered['html']);
+  }
+
+  /**
    * Data provider for locale configurations to test.
    *
    * @return array

--- a/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
+++ b/tests/phpunit/api/v4/Entity/WorkflowMessageTest.php
@@ -88,6 +88,34 @@ class WorkflowMessageTest extends Api4TestBase implements TransactionalInterface
     $this->assertMatchesRegularExpression('/The role is myrole./', $result['text']);
   }
 
+  /**
+   * Test rendering a specific message template by its ID.
+   *
+   * The template is loaded by its ID rather than the workflow's own default
+   * template. Only default templates can be loaded this way.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testRenderTemplateById(): void {
+    $templateId = $this->createTestRecord('MessageTemplate', [
+      'msg_text' => 'Rendered by ID',
+      'workflow_name' => 'test_render_specific_template',
+      'is_active' => TRUE,
+      'is_default' => TRUE,
+    ])['id'];
+
+    $ex = ExampleData::get(FALSE)
+      ->addWhere('name', '=', 'workflow/case_activity_test/CaseModelExample')
+      ->addSelect('data')
+      ->execute()->single();
+    $result = WorkflowMessage::render(FALSE)
+      ->setWorkflow('case_activity_test')
+      ->setValues($ex['data']['modelProps'])
+      ->setMessageTemplateId($templateId)
+      ->execute()->single();
+    $this->assertMatchesRegularExpression('/Rendered by ID/', $result['text']);
+  }
+
   public function testRenderExamplesBaseline(): void {
     $examples = $this->getRenderExamples();
     $this->assertTrue(isset($examples['workflow/contribution_recurring_edit/AlexCancelled']));


### PR DESCRIPTION
ID versus Id strikes again!
See [@scope envelope as messageTemplateID](https://github.com/civicrm/civicrm-core/blob/f1f92c5f9f68a22e2e37d582975a7ebe8dbbf64a/Civi/WorkflowMessage/Traits/TemplateTrait.php#L47)

Before: You can pass in messageTemplateId, but it will be ignored.
After: messageTemplateId is respected.