### PR TITLE
Use token processor within (deprecated) `CRM_Utils_Token::replaceMailingTokens`

### DIFF
--- a/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
+++ b/CRM/Mailing/Event/BAO/MailingEventUnsubscribe.php
@@ -295,7 +295,7 @@ WHERE  email = %2
     [$domainEmailName, $domainEmailAddress] = CRM_Core_BAO_Domain::getNameAndEmail();
 
     $dao = CRM_Core_DAO::executeQuery("
-      SELECT * FROM civicrm_mailing m
+      SELECT m.id as id, optout_id, unsubscribe_id FROM civicrm_mailing m
       INNER JOIN civicrm_mailing_event_queue queue ON
         queue.mailing_id = m.id
       WHERE queue.id = $queue_id");

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -172,19 +172,17 @@ class CRM_Utils_Token {
     $knownTokens = NULL,
     $escapeSmarty = FALSE
   ) {
-    $key = 'mailing';
-    if (!$knownTokens || !isset($knownTokens[$key])) {
-      return $str;
-    }
+    $mailingContext = $mailing->id ? ['mailingId' => (int) $mailing->id] : [];
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), $mailingContext + [
+      'controller' => __CLASS__,
+      'smarty' => FALSE,
+    ]);
 
-    $str = preg_replace_callback(
-      self::tokenRegex($key),
-      function ($matches) use (&$mailing, $escapeSmarty) {
-        return CRM_Utils_Token::getMailingTokenReplacement($matches[1], $mailing, $escapeSmarty);
-      },
-      $str
-    );
-    return $str;
+    $tokenProcessor->addMessage('string', $str, 'text/html');
+    $tokenProcessor->addRow();
+    $tokenProcessor->evaluate();
+    $string = $tokenProcessor->getRow(0)->render('string');
+    return $string;
   }
 
   /**
@@ -193,8 +191,11 @@ class CRM_Utils_Token {
    * @param bool $escapeSmarty
    *
    * @return string
+   *
+   * @deprecated since 6.18 will be removed around 6.24
    */
   public static function getMailingTokenReplacement($token, &$mailing, $escapeSmarty = FALSE) {
+    CRM_Core_Error::deprecatedFunctionWarning('token processor');
     $value = '';
     switch ($token) {
       // CRM-7663

--- a/tests/phpunit/api/v3/MailingGroupTest.php
+++ b/tests/phpunit/api/v3/MailingGroupTest.php
@@ -10,6 +10,7 @@
  */
 
 use Civi\Api4\Email;
+use Civi\Api4\MailingComponent;
 
 /**
  *  Test APIv3 civicrm_mailing_group_* functions
@@ -52,10 +53,18 @@ class api_v3_MailingGroupTest extends CiviUnitTestCase {
 
   /**
    * Test civicrm_mailing_event_unsubscribe.
+   *
+   * @throws \CRM_Core_Exception
    */
   public function testMailerGroupUnsubscribe(): void {
+    MailingComponent::update(FALSE)
+      ->addWhere('name', '=', 'Unsubscribe Message')
+      ->setValues([
+        'body_html' => '{mailing.approvalNote} - You have been un-subscribed from the following groups: {unsubscribe.group}. You can re-subscribe by mailing {action.resubscribe} or clicking <a href="{action.resubscribeUrl}">here</a>.',
+        'body_text' => '{mailing.approvalNote} - You have been un-subscribed from the following groups: {unsubscribe.group}. You can re-subscribe by mailing {action.resubscribe} or clicking {action.resubscribeUrl}',
+      ])->execute();
     $mail = new CiviMailUtils($this);
-    $this->createTestEntity('Mailing', ['name' => 'mail']);
+    $this->createTestEntity('Mailing', ['name' => 'mail', 'approval_note' => 'I approve']);
     $this->createTestEntity('Group', ['name' => 'group', 'frontend_title' => 'group']);
     $this->createTestEntity('MailingGroup', ['mailing_id' => $this->ids['Mailing']['default'], 'group_type' => 'Include', 'entity_table' => 'civicrm_group', 'entity_id' => $this->ids['Group']['default']]);
     $this->createTestEntity('MailingEventQueue', [
@@ -70,7 +79,12 @@ class api_v3_MailingGroupTest extends CiviUnitTestCase {
       'time_stamp' => '20101212121212',
     ];
     $this->callAPISuccess('MailingEventUnsubscribe', 'create', $params);
-    $mail->checkMailLog(['You have been un-subscribed from the following groups']);
+    $mail->checkMailLog([
+      'mailto:e..1.brown@EXAMPLE.ORG',
+      'You have been un-subscribed from the following groups',
+      'I approve',
+      'civicrm/mailing/resubscribe',
+    ]);
   }
 
   /**


### PR DESCRIPTION
I want to remove calls to this function & add noisy deprecation but figured that if I internally switch I can use the test to prove it & then copy the new internals back to the remaining callers
