### PR TITLE
Deprecate some fairly pointless functions only called from deprecated…

### DIFF
--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1829,10 +1829,12 @@ class CRM_Core_Permission {
    *
    * @return string
    *   a comma separated list of email addresses
+   *
+   * @deprecated since 6.18 will be removed around 6.28
    */
   public static function permissionEmails($permissionName) {
-    $config = CRM_Core_Config::singleton();
-    return $config->userPermissionClass->permissionEmails($permissionName);
+    CRM_Core_Error::deprecatedFunctionWarning('use userPermissionClass');
+    return CRM_Core_Config::singleton()->userPermissionClass->permissionEmails($permissionName);
   }
 
   /**
@@ -1843,10 +1845,12 @@ class CRM_Core_Permission {
    *
    * @return string
    *   a comma separated list of email addresses
+   *
+   * @deprecated since 6.18 will be removed around 6.28
    */
   public static function roleEmails($roleName) {
-    $config = CRM_Core_Config::singleton();
-    return $config->userRoleClass->roleEmails($roleName);
+    CRM_Core_Error::deprecatedFunctionWarning('use userPermissionClass');
+    return CRM_Core_Config::singleton()->userRoleClass->roleEmails($roleName);
   }
 
   /**

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -991,11 +991,11 @@ class CRM_Utils_Token {
 
     switch ($objectName) {
       case 'permission':
-        $value = CRM_Core_Permission::permissionEmails($objectValue);
+        $value = CRM_Core_Config::singleton()->userPermissionClass->permissionEmails($objectValue);
         break;
 
       case 'role':
-        $value = CRM_Core_Permission::roleEmails($objectValue);
+        $value = CRM_Core_Config::singleton()->userRoleClass->roleEmails($objectValue);
         break;
     }
 


### PR DESCRIPTION
… code

Only called from drupal civicrm rules module - the one that ships with core, not the one that people use - am separately
working to remove those calls

