### PR TITLE
[REF] - Remove redundant addDefaultButtons()

### DIFF
--- a/CRM/Activity/Form/Task.php
+++ b/CRM/Activity/Form/Task.php
@@ -103,31 +103,6 @@ WHERE  activity_id IN ( $IDs ) AND
   }
 
   /**
-   * Simple shell that derived classes can call to add buttons to
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   *   Button type for the form after processing.
-   * @param string $backType
-   * @param bool $submitOnce
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
-  /**
    * Get the token processor schema required to list any tokens for this task.
    *
    * @return array

--- a/CRM/Campaign/Form/Task.php
+++ b/CRM/Campaign/Form/Task.php
@@ -63,29 +63,4 @@ class CRM_Campaign_Form_Task extends CRM_Core_Form_Task {
     $this->_contactIds = $this->_voterIds;
   }
 
-  /**
-   * Simple shell that derived classes can call to add buttons to.
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   *   Button type for the form after processing.
-   * @param string $backType
-   * @param bool $submitOnce
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
 }

--- a/CRM/Contribute/Form/Task.php
+++ b/CRM/Contribute/Form/Task.php
@@ -80,31 +80,6 @@ class CRM_Contribute_Form_Task extends CRM_Core_Form_Task {
   }
 
   /**
-   * Simple shell that derived classes can call to add buttons to
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   *   Button type for the form after processing.
-   * @param string $backType
-   * @param bool $submitOnce
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
-  /**
    * Get the token processor schema required to list any tokens for this task.
    *
    * @return array

--- a/CRM/Event/Form/Task.php
+++ b/CRM/Event/Form/Task.php
@@ -126,32 +126,6 @@ class CRM_Event_Form_Task extends CRM_Core_Form_Task {
   }
 
   /**
-   * Simple shell that derived classes can call to add buttons to.
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   * @param string $backType
-   * @param bool $submitOnce
-   *
-   * @return void
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
-  /**
    * Get the rows form the search, keyed to make the token processor happy.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Mailing/Form/Task.php
+++ b/CRM/Mailing/Form/Task.php
@@ -82,28 +82,4 @@ class CRM_Mailing_Form_Task extends CRM_Core_Form_Task {
     $session->replaceUserContext($url);
   }
 
-  /**
-   * Simple shell that derived classes can call to add buttons to
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   * @param string $backType
-   * @param bool $submitOnce
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
 }

--- a/CRM/Pledge/Form/Task.php
+++ b/CRM/Pledge/Form/Task.php
@@ -86,28 +86,4 @@ class CRM_Pledge_Form_Task extends CRM_Core_Form_Task {
     );
   }
 
-  /**
-   * Simple shell that derived classes can call to add buttons to
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   * @param string $backType
-   * @param bool $submitOnce
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-        [
-          'type' => $nextType,
-          'name' => $title,
-          'isDefault' => TRUE,
-        ],
-        [
-          'type' => $backType,
-          'name' => ts('Cancel'),
-        ],
-    ]);
-  }
-
 }

--- a/ext/civigrant/CRM/Grant/Form/Task.php
+++ b/ext/civigrant/CRM/Grant/Form/Task.php
@@ -86,29 +86,4 @@ class CRM_Grant_Form_Task extends CRM_Core_Form_Task {
     );
   }
 
-  /**
-   * Simple shell that derived classes can call to add buttons to.
-   * the form with a customized title for the main Submit
-   *
-   * @param string $title
-   *   Title of the main button.
-   * @param string $nextType
-   * @param string $backType
-   *
-   * @param bool $submitOnce
-   */
-  public function addDefaultButtons($title, $nextType = 'next', $backType = 'back', $submitOnce = FALSE) {
-    $this->addButtons([
-      [
-        'type' => $nextType,
-        'name' => $title,
-        'isDefault' => TRUE,
-      ],
-      [
-        'type' => $backType,
-        'name' => ts('Cancel'),
-      ],
-    ]);
-  }
-
 }


### PR DESCRIPTION
Overview
----------------------------------------
Removes redundant copies of `addDefaultButtons()` in various `Form_Task` classes.


Technical Details
----------------------------------------
- Deleted `addDefaultButtons` from:
  - `CRM/Activity/Form/Task.php`
  - `CRM/Campaign/Form/Task.php`
  - `CRM/Contribute/Form/Task.php`
  - `CRM/Event/Form/Task.php`
  - `CRM/Mailing/Form/Task.php`
  - `CRM/Pledge/Form/Task.php`
  - `ext/civigrant/CRM/Grant/Form/Task.php`

All 100% identical to the implementation in their parent class (`CRM_Core_Form_Task`).