### PR TITLE
MailingTokens - move to deprecate the legacy names, use standard functions

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -347,8 +347,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    */
   protected function getFieldValue(TokenRow $row, string $field) {
     $entityName = $this->getEntityName();
-    if (isset($row->context[$entityName][$field])) {
-      return $row->context[$entityName][$field];
+    $entity = (array) $row->context[$entityName] ?? [];
+    if (isset($entity[$field])) {
+      return $entity[$field];
     }
 
     $entityID = $row->context[$this->getEntityIDField()];
@@ -648,7 +649,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     if (!isset($messageTokens[$this->entity])) {
       return FALSE;
     }
-    return array_intersect($messageTokens[$this->entity], array_keys($this->getTokenMetadata()));
+    return array_intersect($messageTokens[$this->entity], array_keys($this->getTokenMetadata() + $this->getDeprecatedTokens()));
   }
 
   /**

--- a/CRM/Mailing/Tokens.php
+++ b/CRM/Mailing/Tokens.php
@@ -11,6 +11,7 @@
  */
 
 use Civi\Api4\MailingGroup;
+use Civi\Token\TokenRow;
 
 /**
  * Class CRM_Mailing_Tokens
@@ -38,21 +39,26 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
    */
   protected function getBespokeTokens(): array {
     return [
-      'id' => ['title' => ts('Mailing ID'), 'name' => 'id', 'type' => 'calculated', 'audience' => 'user'],
       'key' => ['title' => ts('Mailing Key'), 'name' => 'key', 'type' => 'calculated', 'audience' => 'user'],
-      'name' => ['title' => ts('Mailing Name'), 'name' => 'name', 'type' => 'calculated', 'audience' => 'user'],
       'group' => ['title' => ts('Mailing Group(s)'), 'name' => 'group', 'type' => 'calculated', 'audience' => 'user'],
-      'subject' => ['title' => ts('Mailing Subject'), 'name' => 'subject', 'type' => 'calculated', 'audience' => 'user'],
       'viewUrl' => ['title' => ts('Mailing URL (View)'), 'name' => 'viewUrl', 'type' => 'calculated', 'audience' => 'user'],
       'editUrl' => ['title' => ts('Mailing URL (Edit)'), 'name' => 'editUrl', 'type' => 'calculated', 'audience' => 'user'],
       'scheduleUrl' => ['title' => ts('Mailing URL (Schedule)'), 'name' => 'scheduleUrl', 'type' => 'calculated', 'audience' => 'user'],
       'html' => ['title' => ts('Mailing HTML'), 'name' => 'html', 'type' => 'calculated', 'audience' => 'user'],
-      'approvalStatus' => ['title' => ts('Mailing Approval Status'), 'name' => 'approvalStatus', 'type' => 'calculated', 'audience' => 'user'],
-      'approvalNote' => ['title' => ts('Mailing Approval Note'), 'name' => 'approvalNote', 'type' => 'calculated', 'audience' => 'user'],
       'approveUrl' => ['title' => ts('Mailing Approval URL'), 'name' => 'approveUrl', 'type' => 'calculated', 'audience' => 'user'],
       'creator' => ['title' => ts('Mailing Creator (Name)'), 'name' => 'creator', 'type' => 'calculated', 'audience' => 'user'],
       'creatorEmail' => ['title' => ts('Mailing Creator (Email)'), 'name' => 'creatorEmail', 'type' => 'calculated', 'audience' => 'user'],
     ];
+  }
+
+  /**
+   * These tokens still work but we don't advertise them.
+   *
+   * @return string[]
+   *   Keys are deprecated tokens and values are their replacements.
+   */
+  protected function getDeprecatedTokens(): array {
+    return ['approvalNote' => 'approval_note', 'approvalStatus' => 'approval_status_id:label'];
   }
 
   /**
@@ -77,9 +83,9 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
     $mailing = isset($processor->context['mailing'])
       ? $processor->context['mailing']
       : (isset($processor->context['mailingId']) ? CRM_Mailing_BAO_Mailing::findById($processor->context['mailingId']) : NULL);
-
+    $mailing = (array) $mailing;
     if ($mailing && !isset($processor->context['mailingId'])) {
-      $processor->context['mailingId'] = $mailing->id;
+      $processor->context['mailingId'] = $mailing['id'];
     }
 
     $prefetch = parent::prefetch($e) ?? [];
@@ -91,11 +97,16 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
   /**
    * @inheritDoc
    */
-  public function evaluateToken(\Civi\Token\TokenRow $row, $entity, $field, $prefetch = NULL) {
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
     $bespokeTokens = array_keys($this->getBespokeTokens());
     if (in_array($field, $bespokeTokens, TRUE)) {
       $row->format('text/plain')->tokens($entity, $field,
-        (string) $this->getMailingTokenReplacement($field, $prefetch['mailing']->id ?? NULL, $prefetch['mailing']));
+        (string) $this->getMailingTokenReplacement($field, $this->getFieldValue($row, 'id'), $prefetch['mailing']));
+    }
+    elseif (!empty($this->getDeprecatedTokens()[$field])) {
+      $realField = $this->getDeprecatedTokens()[$field];
+      parent::evaluateToken($row, $entity, $realField, $prefetch);
+      $row->format('text/plain')->tokens($entity, $field, (string) $row->tokens[$entity][$realField]);
     }
     else {
       parent::evaluateToken($row, $entity, $field, $prefetch);
@@ -111,11 +122,6 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
    */
   private function getMailingTokenReplacement($token, ?int $id, $mailing) {
     switch ($token) {
-      // CRM-7663
-
-      case 'id':
-        $value = $id ?: 'undefined';
-        break;
 
       // Key is the ID, or the hash when the hash URLs setting is enabled
       case 'key':
@@ -125,17 +131,9 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
         }
         break;
 
-      case 'name':
-        $value = $mailing ? $mailing->name : 'Mailing Name';
-        break;
-
       case 'group':
         $groups = $id ? ($this->getGroupNames($id) ?? []) : ['Mailing Groups'];
         $value = implode(', ', $groups);
-        break;
-
-      case 'subject':
-        $value = $mailing->subject;
         break;
 
       case 'viewUrl':
@@ -164,14 +162,6 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
         $value = $page->run($id, NULL, FALSE, TRUE);
         break;
 
-      case 'approvalStatus':
-        $value = CRM_Core_PseudoConstant::getLabel('CRM_Mailing_DAO_Mailing', 'approval_status_id', $mailing->approval_status_id);
-        break;
-
-      case 'approvalNote':
-        $value = $mailing->approval_note;
-        break;
-
       case 'approveUrl':
         $value = CRM_Utils_System::url('civicrm/mailing/approve',
           "reset=1&mid={$id}",
@@ -180,15 +170,14 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
         break;
 
       case 'creator':
-        $value = CRM_Contact_BAO_Contact::displayName($mailing->created_id);
+        $value = CRM_Contact_BAO_Contact::displayName($mailing['created_id']);
         break;
 
       case 'creatorEmail':
-        $value = CRM_Contact_BAO_Contact::getPrimaryEmail($mailing->created_id);
+        $value = CRM_Contact_BAO_Contact::getPrimaryEmail($mailing['created_id']);
         break;
 
       default:
-        $value = "{mailing.$token}";
         break;
     }
 

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Civi\Token\TokenProcessor;
+
 /**
  * @group headless
  */
@@ -12,12 +14,17 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
       ['api.mail_settings.create' => ['domain' => 'chaos.org']]);
   }
 
-  public static function getExampleTokens() {
+  public static function getExampleTokens(): array {
     $cases = [];
 
-    $cases[] = ['text/plain', 'The {mailing.id}!', ';The [0-9]+!;'];
-    $cases[] = ['text/plain', 'The {mailing.name}!', ';The Example Name!;'];
-    $cases[] = ['text/plain', 'The {mailing.editUrl}!', ';The http.*civicrm/mailing/send.*!;'];
+    $cases['id'] = ['text/plain', 'The {mailing.id}!', ';The [0-9]+!;'];
+    $cases['name'] = ['text/plain', 'The {mailing.name}!', ';The Example Name!;'];
+    $cases['subject'] = ['text/plain', 'The {mailing.subject}!', ';The Mailing Subject!;'];
+    $cases['approval_note'] = ['text/plain', 'The {mailing.approval_note}!', ';I approve!;'];
+    $cases['approvalNote'] = ['text/plain', 'The {mailing.approvalNote}!', ';I approve!;'];
+    $cases['approvalStatus'] = ['text/plain', 'The {mailing.approvalStatus}!', ';Approved!;'];
+    $cases['approval_status_id:label'] = ['text/plain', 'The {mailing.approval_status_id:label}!', ';Approved!;'];
+    $cases['editUrl'] = ['text/plain', 'The {mailing.editUrl}!', ';The http.*civicrm/mailing/send.*!;'];
     $cases[] = ['text/plain', 'To subscribe: {action.subscribeUrl}!', ';To subscribe: http.*civicrm/mailing/subscribe.*!;'];
     $cases[] = ['text/plain', 'To optout: {action.optOutUrl}!', ';To optout: http.*civicrm/mailing/optout.*!;'];
     $cases[] = ['text/plain', 'To unsubscribe: {action.unsubscribe}!', ';To unsubscribe: u\.123\.456\.abcd1234@chaos.org!;'];
@@ -38,13 +45,17 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
    * @dataProvider getExampleTokens
    */
   public function testTokensWithMailingId($inputTemplateFormat, $inputTemplate, $expectRegex) {
-    $mailing = CRM_Core_DAO::createTestObject('CRM_Mailing_DAO_Mailing', [
+    $this->createLoggedInUser();
+    $mailing = $this->createTestEntity('Mailing', [
       'name' => 'Example Name',
+      'subject' => 'Mailing Subject',
+      'approval_note' => 'I approve',
+      'approval_status_id:label' => 'Approved',
     ]);
     $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
-    $p = new \Civi\Token\TokenProcessor(Civi::dispatcher(), [
-      'mailingId' => $mailing->id,
+    $p = new TokenProcessor(Civi::dispatcher(), [
+      'mailingId' => $mailing['id'],
     ]);
     $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
     $p->addRow()->context([
@@ -65,6 +76,18 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $this->assertEquals(1, $count);
   }
 
+  public function testListTokens() {
+    $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
+      'controller' => __CLASS__,
+      'smarty' => FALSE,
+      'schema' => ['mailingId'],
+    ]);
+    $listedTokens = $tokenProcessor->listTokens();
+    $this->assertEquals('Mailing ID', $listedTokens['{mailing.id}']);
+    $this->assertEquals('Subject', $listedTokens['{mailing.subject}']);
+    $this->assertEquals('Approval Note', $listedTokens['{mailing.approval_note}']);
+  }
+
   /**
    * Check that mailing-tokens are generated (given a mailing DAO as input).
    */
@@ -80,7 +103,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     ]);
     $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
-    $p = new \Civi\Token\TokenProcessor(Civi::dispatcher(), [
+    $p = new TokenProcessor(Civi::dispatcher(), [
       'mailing' => $mailing,
     ]);
     $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
@@ -126,7 +149,7 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     ]);
     $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
-    $p = new \Civi\Token\TokenProcessor(Civi::dispatcher(), [
+    $p = new TokenProcessor(Civi::dispatcher(), [
       'mailing' => $mailing,
     ]);
     $p->addMessage('example', $inputTemplateText, $inputTemplateFormat);


### PR DESCRIPTION
Overview
----------------------------------------
It turns out that calling mailing tokens more than once can be flakey - it the test fail here is when it tries to find a found DAO
https://github.com/civicrm/civicrm-core/pull/36315

However, we don't actually need that DAO with https://github.com/civicrm/civicrm-core/pull/36280 as it just duplicates the loading now done in the parent.

This moves us towards greater standardisation - / more tests

- I mean to fully stop it loading the object but will do the rest as a follow up
