### PR TITLE
SearchKit - Add "No Results" toolbar button condition

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -840,11 +840,14 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    *
    * @param array $link
    * @param array $data
+   * @param int|null $rowCount
+   *   Total matched rows, if known (only applicable to toolbar buttons, which
+   *   aren't tied to a specific row - used to evaluate the "no results" condition).
    * @return bool
    */
-  protected function checkLinkConditions(array $link, array $data): bool {
+  protected function checkLinkConditions(array $link, array $data, ?int $rowCount = NULL): bool {
     foreach ($link['conditions'] ?? [] as $condition) {
-      if (!$this->checkLinkCondition($condition, $data)) {
+      if (!$this->checkLinkCondition($condition, $data, $rowCount)) {
         return FALSE;
       }
     }
@@ -856,9 +859,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    *
    * @param array $condition
    * @param array $data
+   * @param int|null $rowCount
    * @return bool
    */
-  protected function checkLinkCondition(array $condition, array $data): bool {
+  protected function checkLinkCondition(array $condition, array $data, ?int $rowCount = NULL): bool {
     if (empty($condition[0]) || empty($condition[1])) {
       return TRUE;
     }
@@ -874,6 +878,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $permissions = [$permissions];
       }
       return \CRM_Core_Permission::check($permissions) == ($op !== '!=');
+    }
+    if ($condition[0] === 'no results') {
+      // Only applicable to toolbar buttons
+      return $rowCount === 0;
     }
     $field = $this->getField($condition[0]);
     // Handle date/time-based conditionals

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/Run.php
@@ -133,7 +133,7 @@ class Run extends AbstractRunAction {
         $apiResult = array_slice((array) $apiResult, 0, $apiParams['limit'] - 1);
       }
       else {
-        $result->toolbar = $this->formatToolbar();
+        $result->toolbar = $this->formatToolbar($result->rowCount);
       }
       $result->exchangeArray($this->formatResult($apiResult));
       $result->labels = $this->filterLabels;
@@ -231,7 +231,7 @@ class Run extends AbstractRunAction {
     }
   }
 
-  private function formatToolbar(): array {
+  private function formatToolbar(?int $rowCount): array {
     $toolbar = [];
     $settings = $this->display['settings'];
     // If no toolbar, early return
@@ -245,7 +245,7 @@ class Run extends AbstractRunAction {
       $settings['toolbar'][] = $settings['addButton'] + ['style' => 'primary', 'target' => 'crm-popup'];
     }
     foreach ($settings['toolbar'] ?? [] as $button) {
-      if (!$this->checkLinkConditions($button, $data)) {
+      if (!$this->checkLinkConditions($button, $data, $rowCount)) {
         continue;
       }
       $button = $this->formatLink($button, $data, TRUE);

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -6,7 +6,8 @@
       group: '<',
       apiEntity: '<',
       apiParams: '<',
-      links: '<'
+      links: '<',
+      isToolbar: '<'
     },
     templateUrl: '~/crmSearchAdmin/crmSearchAdminLinkGroup.html',
     controller: function ($scope, $element, $timeout, searchMeta) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.html
@@ -36,7 +36,7 @@
         <crm-search-admin-token-select model="item" field="text" suffix=":label"></crm-search-admin-token-select>
       </td>
       <td>
-        <crm-search-conditions item="item"></crm-search-conditions>
+        <crm-search-conditions item="item" is-toolbar="$ctrl.isToolbar"></crm-search-conditions>
       </td>
       <td>
         <div class="btn-group">

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.component.js
@@ -4,6 +4,7 @@
   angular.module('crmSearchAdmin').component('crmSearchConditions', {
     bindings: {
       item: '<',
+      isToolbar: '<',
     },
     require: {
       crmSearchAdmin: '^crmSearchAdmin'
@@ -26,12 +27,19 @@
         let selectFields = this.crmSearchAdmin.getSelectFields(this.crmSearchAdmin.savedSearch);
         // Use machine names not labels for option matching
         selectFields.forEach((field) => field.id = field.id.replace(':label', ':name'));
-        let permissionField = [{
+        let extraConditions = [{
           text: ts('Current User Permission'),
           id: 'check user permission',
           description: ts('Check permission of logged-in user')
         }];
-        return {results: permissionField.concat(selectFields)};
+        if (this.isToolbar) {
+          extraConditions.push({
+            text: ts('No Results'),
+            id: 'no results',
+            description: ts('Only show this button when the search has no results')
+          });
+        }
+        return {results: extraConditions.concat(selectFields)};
       };
 
       this.addCondition = (selection) => {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchConditions.html
@@ -5,7 +5,7 @@
     <input class="form-control" crm-ui-select="{data: $ctrl.permissions, multiple: true}" ng-model="condition[2]" ng-list>
   </div>
   <crm-search-condition class="form-group"
-    ng-if="condition[0] && condition[0] !== 'check user permission'"
+    ng-if="condition[0] && condition[0] !== 'check user permission' && condition[0] !== 'no results'"
     clause="condition"
     field="$ctrl.getField(condition[0])"
     offset="1"

--- a/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminToolbarConfig.html
+++ b/ext/search_kit/ang/crmSearchAdmin/displays/common/searchAdminToolbarConfig.html
@@ -7,5 +7,5 @@
       </label>
     </div>
   </div>
-  <crm-search-admin-link-group ng-if="$ctrl.display.settings.toolbar" links="$ctrl.links" group="$ctrl.display.settings.toolbar" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams"></crm-search-admin-link-group>
+  <crm-search-admin-link-group ng-if="$ctrl.display.settings.toolbar" links="$ctrl.links" group="$ctrl.display.settings.toolbar" api-entity="$ctrl.apiEntity" api-params="$ctrl.apiParams" is-toolbar="true"></crm-search-admin-link-group>
 </fieldset>

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -2882,6 +2882,70 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
   }
 
   /**
+   * A toolbar link flagged with a "no results" condition should only appear in the
+   * (single) `toolbar` array when the search has zero matching rows, and be excluded
+   * from it otherwise - same array as every other toolbar button, just conditional.
+   */
+  public function testToolbarNoResultsCondition(): void {
+    Contact::create(FALSE)
+      ->addValue('first_name', 'ToolbarNoResultsTest')
+      ->addValue('contact_type', 'Individual')
+      ->execute();
+
+    $params = [
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['first_name'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => 'testNoResultsToolbar',
+        'settings' => [
+          'pager' => [],
+          'toolbar' => [
+            [
+              'path' => 'civicrm/test/always',
+              'text' => 'Always',
+            ],
+            [
+              'path' => 'civicrm/test/no-results-only',
+              'text' => 'Add New',
+              'conditions' => [['no results', '=']],
+            ],
+          ],
+          'columns' => [
+            [
+              'key' => 'first_name',
+              'label' => 'First',
+              'type' => 'field',
+            ],
+          ],
+          'sort' => [],
+        ],
+      ],
+      'filters' => ['first_name' => 'NameThatDoesNotExistAnywhere123'],
+    ];
+
+    // No matching contacts: both buttons appear in the same toolbar array.
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertEquals(0, $result->rowCount);
+    $this->assertCount(2, $result->toolbar);
+    $this->assertEquals('Always', $result->toolbar[0]['text']);
+    $this->assertEquals('Add New', $result->toolbar[1]['text']);
+
+    // With matching contacts: the "no results" button is excluded from the toolbar.
+    $params['filters'] = ['first_name' => 'ToolbarNoResultsTest'];
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $this->assertGreaterThan(0, $result->rowCount);
+    $this->assertCount(1, $result->toolbar);
+    $this->assertEquals('Always', $result->toolbar[0]['text']);
+  }
+
+  /**
    * Ensure a multivalued field like contact_sub_type can still be used as a token
    * even though the filter operator will be CONTAINS.
    */


### PR DESCRIPTION
Overview
----------------------------------------
Adds a "No Results condition" for SearchKit toolbar buttons so it only appears in the toolbar when the search has zero matching rows - e.g. an "Add New" button shown only when nothing was found.

Works for any searchdisplay that implements the "toolbar".

Before
----------------------------------------
Can only show plain text "no results text".

After
----------------------------------------
Can configure and show specific toolbar buttons when there are no results.

<img width="1081" height="240" alt="image" src="https://github.com/user-attachments/assets/c15b6d49-6cc7-4b02-bf5c-5c461415cc9b" />

<img width="1131" height="145" alt="image" src="https://github.com/user-attachments/assets/0d8cb339-d64e-4ae9-8677-8db4a8cd958b" />


Technical Details
----------------------------------------
Adds a new conditional in a similar way to "check user permission". The conditional is only visible on toolbar buttons.

Passes through "rowCount" from results into the link checking functions so that we can check the conditional. We might want to pass more through in future if we add more conditions that rely on data from the results. But the function is private so we could change the signature again in future if we needed to.

Comments
----------------------------------------
