### PR TITLE
Use getMergedTo in civiimport when the contact has been deleted from trash

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -132,19 +132,34 @@ abstract class CRM_Import_Parser implements UserJobInterface {
    * @throws \CRM_Core_Exception
    */
   public function getExistingContactValue(int $contactID, string $value): mixed {
+    if (!$this->defineExistingContact($contactID)) {
+      throw new CRM_Core_Exception('No contact found for this contact ID:' . $contactID, CRM_Import_Parser::NO_MATCH);
+    }
+    return $this->lookup('Contact' . $contactID, $value);
+  }
+
+  /**
+   * Load the contact into the lookup cache, returning whether it exists.
+   *
+   * Deleted contacts are not filtered out, since import is used to undelete.
+   *
+   * @param int $contactID
+   * @return bool
+   * @throws \CRM_Core_Exception
+   */
+  private function defineExistingContact(int $contactID): bool {
     $identifier = 'Contact' . $contactID;
     if (!$this->isDefined($identifier)) {
       $existingContact = Contact::get(FALSE)
         ->addWhere('id', '=', $contactID)
-        // Don't auto-filter deleted - people use import to undelete.
         ->addWhere('is_deleted', 'IN', [0, 1])
         ->execute()->first();
       if (empty($existingContact['id'])) {
-        throw new CRM_Core_Exception('No contact found for this contact ID:' . $contactID, CRM_Import_Parser::NO_MATCH);
+        return FALSE;
       }
       $this->define('Contact', $identifier, $existingContact);
     }
-    return $this->lookup($identifier, $value);
+    return TRUE;
   }
 
   /**
@@ -1492,25 +1507,30 @@ abstract class CRM_Import_Parser implements UserJobInterface {
   /**
    * Check if the contact ID has been deleted and merged to another contact.
    *
-   * Return the ID of the merged to contact or the original ID if not.
+   * If the contact has not been deleted, return the original contact ID.
+   * Otherwise return the merged to contact ID or throw an exception if none found.
    *
    * @param int $contactID
    * @return int
    * @throws \CRM_Core_Exception
    */
   protected function getMergedToContactIfDeleted($contactID): int {
-    if ($this->getExistingContactValue($contactID, 'is_deleted')) {
-      $result = Contact::getMergedTo(FALSE)
-        ->setContactId($contactID)
-        ->execute()->first();
-      if ($result) {
-        $contactID = $result['id'];
-      }
-      else {
-        throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact %1', [1 => $contactID]));
-      }
+    $contactExists = $this->defineExistingContact($contactID);
+    if ($contactExists && !$this->getExistingContactValue($contactID, 'is_deleted')) {
+      return $contactID;
     }
-    return $contactID;
+    $mergedToID = Contact::getMergedTo(FALSE)
+      ->setContactId($contactID)
+      ->execute()->first()['id'] ?? NULL;
+    if ($mergedToID) {
+      return $mergedToID;
+    }
+    elseif ($contactExists) {
+      throw new \CRM_Core_Exception(ts('Cannot import to a deleted contact %1', [1 => $contactID]));
+    }
+    else {
+      throw new \CRM_Core_Exception('No contact found for this contact ID:' . $contactID, self::NO_MATCH);
+    }
   }
 
 }

--- a/ext/civiimport/Civi/Import/ImportParser.php
+++ b/ext/civiimport/Civi/Import/ImportParser.php
@@ -561,6 +561,13 @@ abstract class ImportParser extends \CRM_Import_Parser {
    * @throws \CRM_Core_Exception
    */
   protected function getContactID(array $contactParams, ?int $contactID, string $entity, ?array $dedupeRules = NULL): ?int {
+    if ($contactID && !isset($contactParams['is_deleted'])) {
+      // The contact may have been merged since the contact ID was determined (common in cases where
+      // a list of contacts is exported and then some time later imported with augmented data.
+      // As long as is_deleted is not set (ie the importer is not trying to undelete the contact) we can
+      // use the merged to contact instead, if it exists.
+      $contactID = $this->getMergedToContactIfDeleted($contactID);
+    }
     $contactType = $contactParams['contact_type'] ?? NULL;
     if ($contactID) {
       $this->validateContactID($contactID, $contactType);
@@ -584,13 +591,6 @@ abstract class ImportParser extends \CRM_Import_Parser {
       elseif (!in_array($action, ['create', 'ignore', 'save'], TRUE)) {
         throw new \CRM_Core_Exception(ts('No matching %1 found', [1 => $entity]));
       }
-    }
-    if ($contactID && !isset($contactParams['is_deleted'])) {
-      // The contact may have been merged since the contact ID was determined (common in cases where
-      // a list of contacts is exported and then some time later imported with augmented data.
-      // As long as is_deleted is not set (ie the importer is not trying to undelete the contact) we can
-      // use the merged to contact instead, if it exists.
-      $contactID = $this->getMergedToContactIfDeleted($contactID);
     }
     return $contactID;
   }

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -282,6 +282,17 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
       ->addWhere('contact_id', '=', $contactID2)
       ->execute();
     $this->assertCount(1, $contribution);
+
+    // Fully delete the trashed contact, the new contact should still be found.
+    Contact::delete(FALSE)
+      ->setUseTrash(FALSE)
+      ->addWhere('id', '=', $contactID)
+      ->execute();
+    $this->runImport($values, 'create');
+    $contribution = Contribution::get()
+      ->addWhere('contact_id', '=', $contactID2)
+      ->execute();
+    $this->assertCount(2, $contribution);
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
If you import with civiimport to a contact id that was merged away and then deleted from trash, you'll get an import error.

After
----------------------------------------
Import will be to the merged to contact for the deleted contact, assuming the merge happened after #36290.

Technical Details
----------------------------------------
No change to importing contacts.

In order to make this work, I re-ordered operations so that we check for a merged to contact before validating the contact type, which makes more sense since we care about the contact type of the contact we are actually importing to not the original contact id (though it would be rare that they differed).
This re-ordering also fixes the rare case where you were importing with both contact id and external id and your external id had been moved to a new contact by merging (previously you got an error, now it imports to the new contact as expected).

I maintained the two different exceptions for slightly different cases: 1) you're trying to import to a contact id that's in the trash and wasn't merged to another contact and 2) you're trying to import to a contact id that doesn't exist at all and wasn't merged to another contact. Not sure if we need two, but this maintains existing behaviour.
