### PR TITLE
Increase mailing.name to varchar(255)

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -39,6 +39,10 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
       'default' => 0,
     ]);
     $this->addTask(ts('Initialize relationship type weights'), 'initializeRelationshipTypeWeights');
+    $this->addTask('Change column "Mailing.name" to varchar(255)', 'alterSchemaField', 'Mailing', 'name', [
+      'sql_type' => 'varchar(255)',
+      'description' => ts('Mailing Name.'),
+    ]);
   }
 
   /**

--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -146,7 +146,7 @@ return [
     ],
     'name' => [
       'title' => ts('Mailing Name'),
-      'sql_type' => 'varchar(128)',
+      'sql_type' => 'varchar(255)',
       'input_type' => 'Text',
       'description' => ts('Mailing Name.'),
       'unique_name' => 'mailing_name',


### PR DESCRIPTION
You'd think 128 would be enough for anyone, but apparently our team uses some ridiculously long mailing names. Doesn't hurt anything to increase this and we use 255 for many other name fields.