### PR TITLE
dev/core#6657 - SqlGroup: skip the cache write instead of aborting when the lock is unavailable

### DIFF
--- a/CRM/Utils/Cache/SqlGroup.php
+++ b/CRM/Utils/Cache/SqlGroup.php
@@ -103,7 +103,6 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
    * @return bool
    *
    * @throws \CRM_Core_Exception
-   * @throws \CRM_Utils_Cache_CacheException
    * @throws \CRM_Utils_Cache_InvalidArgumentException
    */
   public function set($key, $value, $ttl = NULL) {
@@ -111,7 +110,10 @@ class CRM_Utils_Cache_SqlGroup implements CRM_Utils_Cache_Interface {
 
     $lock = Civi::lockManager()->acquire("cache.{$this->group}_{$key}._null");
     if (!$lock->isAcquired()) {
-      throw new \CRM_Utils_Cache_CacheException("SqlGroup: Failed to acquire lock on cache key.");
+      // Contention is transient and the caller already has the value, so skip
+      // the write rather than abort the request (cf. FileCache::set()).
+      Civi::log()->warning('SqlGroup: skipped cache write, lock unavailable', ['group' => $this->group]);
+      return FALSE;
     }
 
     if (is_int($ttl) && $ttl <= 0) {

--- a/tests/phpunit/E2E/Cache/SqlGroupLockTest.php
+++ b/tests/phpunit/E2E/Cache/SqlGroupLockTest.php
@@ -1,0 +1,115 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * When the cache-key lock is held by another connection, SqlGroup::set()
+ * should skip the write and report FALSE -- not abort the caller.
+ *
+ * A cache-write is an optimization: the caller has already computed the value
+ * and returns it either way. Lock contention is transient, so throwing here
+ * turns a self-healing condition into a hard failure on an unrelated request.
+ *
+ * @group e2e
+ */
+class E2E_Cache_SqlGroupLockTest extends \CiviEndToEndTestCase {
+
+  const GROUP = 'e2eSqlGroupLockTest';
+  const KEY = 'contendedKey';
+
+  /**
+   * Second connection used to hold the lock that SqlGroup wants.
+   *
+   * @var \mysqli|null
+   */
+  private $blocker;
+
+  public function tearDown(): void {
+    if ($this->blocker) {
+      $this->blocker->close();
+      $this->blocker = NULL;
+    }
+    CRM_Core_DAO::executeQuery('DELETE FROM civicrm_cache WHERE group_name = %1', [
+      1 => [self::GROUP, 'String'],
+    ]);
+    parent::tearDown();
+  }
+
+  public function testSetSkipsWriteWhenLockUnavailable(): void {
+    $cache = new CRM_Utils_Cache_SqlGroup(['group' => self::GROUP, 'prefetch' => FALSE]);
+
+    $this->holdLock();
+    // CRM_Core_Lock::TIMEOUT applies here, so this call blocks briefly.
+    $result = $cache->set(self::KEY, 'value-that-should-not-be-stored');
+
+    $this->assertFalse($result, 'set() should report failure rather than throw.');
+    $this->assertEquals(0, $this->countRows(), 'No row should be written while the lock is held.');
+  }
+
+  public function testSetSucceedsOnceLockIsReleased(): void {
+    $cache = new CRM_Utils_Cache_SqlGroup(['group' => self::GROUP, 'prefetch' => FALSE]);
+
+    $this->holdLock();
+    $cache->set(self::KEY, 'first');
+    $this->releaseLock();
+
+    $this->assertTrue($cache->set(self::KEY, 'second'));
+    $this->assertEquals(1, $this->countRows());
+    $this->assertEquals('second', $cache->get(self::KEY));
+  }
+
+  /**
+   * Grab the same named lock SqlGroup::set() will ask for, on a separate
+   * connection (MySQL user-locks are re-entrant within one connection, so the
+   * test's own connection cannot block itself).
+   */
+  private function holdLock(): void {
+    $dsn = DB::parseDSN(CIVICRM_DSN);
+    $this->blocker = new mysqli(
+      $dsn['hostspec'],
+      $dsn['username'],
+      $dsn['password'],
+      $dsn['database'],
+      $dsn['port'] ?: NULL
+    );
+    $this->assertNull($this->blocker->connect_error, 'Could not open a second connection.');
+
+    $stmt = $this->blocker->prepare('SELECT GET_LOCK(?, 0)');
+    $lockId = $this->lockId();
+    $stmt->bind_param('s', $lockId);
+    $stmt->execute();
+    $this->assertSame(1, (int) $stmt->get_result()->fetch_row()[0], 'Could not acquire the blocking lock.');
+  }
+
+  private function releaseLock(): void {
+    $stmt = $this->blocker->prepare('SELECT RELEASE_LOCK(?)');
+    $lockId = $this->lockId();
+    $stmt->bind_param('s', $lockId);
+    $stmt->execute();
+    $stmt->get_result();
+  }
+
+  /**
+   * Mirror the name/hash scheme of CRM_Core_Lock::__construct().
+   */
+  private function lockId(): string {
+    $dsn = DB::parseDSN(CIVICRM_DSN);
+    $name = 'cache.' . self::GROUP . '_' . self::KEY . '._null';
+    return sha1($dsn['database'] . '.' . CRM_Core_Config::domainID() . '.' . $name);
+  }
+
+  private function countRows(): int {
+    return (int) CRM_Core_DAO::singleValueQuery(
+      'SELECT COUNT(*) FROM civicrm_cache WHERE group_name = %1 AND path = %2',
+      [1 => [self::GROUP, 'String'], 2 => [self::KEY, 'String']]
+    );
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
When `CRM_Utils_Cache_SqlGroup` cannot acquire the lock for a cache key, it throws, and the exception aborts the whole request with an HTTP 500. A failed cache *write* is not a failed operation, so it should be reported and skipped instead.

See https://lab.civicrm.org/dev/core/-/issues/6657 for the production impact (5-6 user-visible 500s per day on a small, low-traffic install).

Before
----------------------------------------
```php
$lock = Civi::lockManager()->acquire("cache.{$this->group}_{$key}._null");
if (!$lock->isAcquired()) {
  throw new \CRM_Utils_Cache_CacheException("SqlGroup: Failed to acquire lock on cache key.");
}
```

`CRM_Core_Lock` uses `GET_LOCK(..., 3)` with no retry and no backoff, so three seconds of contention on a single cache key fails an unrelated request. The typical trace is `CRM_Core_OptionGroup::values()` while APIv4 builds a field spec during the permission check — i.e. on essentially every request:

```
CRM/Utils/Cache/SqlGroup.php:114   CRM_Utils_Cache_SqlGroup->set($key, $value, $ttl)
CRM/Utils/Cache/CacheWrapper.php:55
CRM/Core/OptionGroup.php:173
Civi/Api4/Service/Spec/Provider/EntityTagFilterSpecProvider.php:57
Civi/Api4/Service/Spec/SpecGatherer.php:142
Civi/Api4/Generic/DAOGetFieldsAction.php:42
Civi/Api4/Query/Api4SelectQuery.php:75
Civi/Api4/Generic/DAOGetAction.php:106
...
CRM/Core/Permission.php:146
ext/authx/Civi/Authx/Authenticator.php:267
CRM/Core/Invoke.php:80
```

After
----------------------------------------
```php
$lock = Civi::lockManager()->acquire("cache.{$this->group}_{$key}._null");
if (!$lock->isAcquired()) {
  // Contention is transient and the caller already has the value, so skip
  // the write rather than abort the request (cf. FileCache::set()).
  Civi::log()->warning('SqlGroup: skipped cache write, lock unavailable', ['group' => $this->group]);
  return FALSE;
}
```

The value is still returned to the caller; only the cache write is skipped.

Technical Details
----------------------------------------
- The lock is retained. It still guards the non-atomic `SELECT COUNT` + `INSERT|UPDATE` against the `UI_group_name_path` unique index. Only the unavailable-lock branch changes.
- `CRM_Utils_Cache_Interface::set()` is declared to return `bool`, so `FALSE` is within the contract. The now-unreachable `@throws CRM_Utils_Cache_CacheException` is dropped from the docblock.
- This aligns `SqlGroup` with `CRM_Utils_Cache_FileCache::set()`, which already returns `FALSE` when its write fails — today the same logical condition yields `FALSE` on one backend and an HTTP 500 on another.
- Adds `tests/phpunit/E2E/Cache/SqlGroupLockTest.php`. It holds the same named lock on a second connection (MySQL user locks are re-entrant within a single connection, so a second connection is required), then asserts that `set()` returns `FALSE`, writes no row, and does not throw — plus that it succeeds again once the lock is released.
- Verified both ways against a CiviCRM 6.16.1 Standalone install. Against unpatched core both tests error with `CRM_Utils_Cache_CacheException: SqlGroup: Failed to acquire lock on cache key.` at `CRM/Utils/Cache/SqlGroup.php:114`, i.e. the test reproduces the reported failure. With the patch applied: `OK (2 tests, 9 assertions)`.

Comments
----------------------------------------
Deliberately narrow. `CRM_Utils_Cache_CacheWrapper` is untouched, so callers that write and then immediately read the same key (e.g. `CRM/Core/DomainTokens.php:157-159`) are unaffected beyond a cache miss, which they already handle by recomputing.
