### PR TITLE
SearchKit - Safely fallback to empty array if baseEntity joins are undefined

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -198,7 +198,7 @@
         let result;
         while (path.length) {
           /* jshint -W083 */
-          join = CRM.crmSearchAdmin.joins[baseEntity].find(join =>
+          join = (CRM.crmSearchAdmin.joins[baseEntity] || []).find(join =>
             new RegExp('^' + join.alias + '_\\d\\d').test(path)
           );
           if (!join) {


### PR DESCRIPTION
Overview
----------------------------------------
Ports [a fix already in master](https://github.com/civicrm/civicrm-core/commit/1b9eb40f24d93f9cc2d3c79d93052ae2c1982425) back to 6.17.