### PR TITLE
Afform - Save contact image

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -87,6 +87,16 @@ class SubmitFile extends AbstractProcessor {
     if ($this->isDraft()) {
       return $this->updateDraft($draft, $file['id']);
     }
+    // Handle special case for image URL
+    elseif (isset($entityId) && $this->getFieldName() === 'image_URL') {
+      civicrm_api4('Contact', 'update', [
+        'values' => [
+          'id' => $entityId,
+          'image_URL' => \CRM_Utils_System::url('civicrm/contact/imagefile', 'photo=' . $file['uri'], TRUE, NULL, TRUE, TRUE),
+        ],
+      ]);
+      return [];
+    }
     else {
       return $this->updateEntity($entityId, $file['id']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Adds basic support for saving contact image in FormBuilder

Reroll of #32780

Technical Details
------
Don't get me started on how bad the current contact image handling is in core, but at least FormBuilder can save them now.