### PR TITLE
Finish aligning MailingTokens with other tokens 

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -732,11 +732,12 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @param string $joinField
    * @param array $tokenList
    * @param array $hiddenTokens
+   * @param string $titlePrefix
    *
    * @return array
    * @throws \CRM_Core_Exception
    */
-  protected function getRelatedTokensForEntity(string $entity, string $joinField, array $tokenList, $hiddenTokens = []): array {
+  protected function getRelatedTokensForEntity(string $entity, string $joinField, array $tokenList, $hiddenTokens = [], string $titlePrefix = ''): array {
     if (!array_key_exists($entity, \Civi::service('action_object_provider')->getEntities())) {
       return [];
     }
@@ -748,7 +749,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     $tokens = [];
     foreach ($relatedTokens as $relatedToken) {
       $tokens[$joinField . '.' . $relatedToken['name']] = [
-        'title' => $relatedToken['title'],
+        'title' => $titlePrefix . $relatedToken['title'],
         'name' => $joinField . '.' . $relatedToken['name'],
         'type' => 'mapped',
         'data_type' => $relatedToken['data_type'],

--- a/CRM/Mailing/Tokens.php
+++ b/CRM/Mailing/Tokens.php
@@ -11,6 +11,7 @@
  */
 
 use Civi\Api4\MailingGroup;
+use Civi\Token\Event\TokenValueEvent;
 use Civi\Token\TokenRow;
 
 /**
@@ -46,8 +47,8 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
       'scheduleUrl' => ['title' => ts('Mailing URL (Schedule)'), 'name' => 'scheduleUrl', 'type' => 'calculated', 'audience' => 'user'],
       'html' => ['title' => ts('Mailing HTML'), 'name' => 'html', 'type' => 'calculated', 'audience' => 'user'],
       'approveUrl' => ['title' => ts('Mailing Approval URL'), 'name' => 'approveUrl', 'type' => 'calculated', 'audience' => 'user'],
-      'creator' => ['title' => ts('Mailing Creator (Name)'), 'name' => 'creator', 'type' => 'calculated', 'audience' => 'user'],
-      'creatorEmail' => ['title' => ts('Mailing Creator (Email)'), 'name' => 'creatorEmail', 'type' => 'calculated', 'audience' => 'user'],
+      'creator' => ['title' => ts('Mailing Creator (Name)'), 'name' => 'creator', 'type' => 'calculated', 'audience' => 'hidden'],
+      'creatorEmail' => ['title' => ts('Mailing Creator (Email)'), 'name' => 'creatorEmail', 'type' => 'calculated', 'audience' => 'hidden'],
     ];
   }
 
@@ -58,7 +59,21 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
    *   Keys are deprecated tokens and values are their replacements.
    */
   protected function getDeprecatedTokens(): array {
-    return ['approvalNote' => 'approval_note', 'approvalStatus' => 'approval_status_id:label'];
+    return [
+      'approvalNote' => 'approval_note',
+      'approvalStatus' => 'approval_status_id:label',
+      'creator' => 'created_id.display_name',
+      'creatorEmail' => 'created_id.email_primary.email',
+    ];
+  }
+
+  /**
+   * Get fields which need to be returned to render another token.
+   *
+   * @return array
+   */
+  protected function getDependencies(): array {
+    return $this->getDeprecatedTokens();
   }
 
   /**
@@ -77,36 +92,38 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
    * @return array|null
    * @throws \Exception
    */
-  public function prefetch(\Civi\Token\Event\TokenValueEvent $e): ?array {
+  public function prefetch(TokenValueEvent $e): ?array {
     $processor = $e->getTokenProcessor();
-
-    $mailing = isset($processor->context['mailing'])
-      ? $processor->context['mailing']
-      : (isset($processor->context['mailingId']) ? CRM_Mailing_BAO_Mailing::findById($processor->context['mailingId']) : NULL);
-    $mailing = (array) $mailing;
-    if ($mailing && !isset($processor->context['mailingId'])) {
+    if (!isset($processor->context['mailingId']) && isset($processor->context['mailing'])) {
+      $mailing = (array) $processor->context['mailing'];
       $processor->context['mailingId'] = $mailing['id'];
     }
-
     $prefetch = parent::prefetch($e) ?? [];
-    $prefetch['mailing'] = $mailing;
-
     return $prefetch;
+  }
+
+  /**
+   * Get related tokens related to membership e.g. recurring contribution tokens
+   */
+  protected function getRelatedTokens(): array {
+    $tokens = [];
+    $tokens += $this->getRelatedTokensForEntity('Contact', 'created_id', ['display_name', 'email_primary.email'], [], ts('Creator') . ' : ');
+    return $tokens;
   }
 
   /**
    * @inheritDoc
    */
-  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL) {
+  public function evaluateToken(TokenRow $row, $entity, $field, $prefetch = NULL): void {
     $bespokeTokens = array_keys($this->getBespokeTokens());
-    if (in_array($field, $bespokeTokens, TRUE)) {
-      $row->format('text/plain')->tokens($entity, $field,
-        (string) $this->getMailingTokenReplacement($field, $this->getFieldValue($row, 'id'), $prefetch['mailing']));
-    }
-    elseif (!empty($this->getDeprecatedTokens()[$field])) {
+    if (!empty($this->getDeprecatedTokens()[$field])) {
       $realField = $this->getDeprecatedTokens()[$field];
       parent::evaluateToken($row, $entity, $realField, $prefetch);
       $row->format('text/plain')->tokens($entity, $field, (string) $row->tokens[$entity][$realField]);
+    }
+    elseif (in_array($field, $bespokeTokens, TRUE)) {
+      $row->format('text/plain')->tokens($entity, $field,
+        (string) $this->getMailingTokenReplacement($field, $this->getFieldValue($row, 'id')));
     }
     else {
       parent::evaluateToken($row, $entity, $field, $prefetch);
@@ -116,11 +133,10 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
   /**
    * @param string $token
    * @param int|null $id
-   * @param \CRM_Mailing_BAO_Mailing $mailing
    *
    * @return string
    */
-  private function getMailingTokenReplacement($token, ?int $id, $mailing) {
+  private function getMailingTokenReplacement($token, ?int $id) {
     switch ($token) {
 
       // Key is the ID, or the hash when the hash URLs setting is enabled
@@ -167,14 +183,6 @@ class CRM_Mailing_Tokens extends CRM_Core_EntityTokens {
           "reset=1&mid={$id}",
           TRUE, NULL, FALSE, TRUE
         );
-        break;
-
-      case 'creator':
-        $value = CRM_Contact_BAO_Contact::displayName($mailing['created_id']);
-        break;
-
-      case 'creatorEmail':
-        $value = CRM_Contact_BAO_Contact::getPrimaryEmail($mailing['created_id']);
         break;
 
       default:

--- a/Civi/Test/Api4TestTrait.php
+++ b/Civi/Test/Api4TestTrait.php
@@ -454,8 +454,8 @@ trait Api4TestTrait {
    *   Contact ID of the created user.
    * @throws \CRM_Core_Exception
    */
-  public function createLoggedInUser(): int {
-    $contactID = $this->createTestRecord('Individual', [
+  public function createLoggedInUser(array $params = []): int {
+    $contactID = $this->createTestRecord('Individual', $params + [
       'first_name' => 'Logged In',
       'last_name' => 'User ' . mt_rand(),
     ])['id'];

--- a/Civi/Test/ContactTestTrait.php
+++ b/Civi/Test/ContactTestTrait.php
@@ -37,8 +37,8 @@ trait ContactTestTrait {
    * @return int
    *   Contact ID of the created user.
    */
-  public function createLoggedInUser(): int {
-    $params = [
+  public function createLoggedInUser(array $params = []): int {
+    $params += [
       'first_name' => 'Logged In',
       'last_name' => 'User ' . mt_rand(),
       'contact_type' => 'Individual',

--- a/tests/phpunit/CRM/Mailing/TokensTest.php
+++ b/tests/phpunit/CRM/Mailing/TokensTest.php
@@ -24,6 +24,10 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
     $cases['approvalNote'] = ['text/plain', 'The {mailing.approvalNote}!', ';I approve!;'];
     $cases['approvalStatus'] = ['text/plain', 'The {mailing.approvalStatus}!', ';Approved!;'];
     $cases['approval_status_id:label'] = ['text/plain', 'The {mailing.approval_status_id:label}!', ';Approved!;'];
+    $cases['created_id.display_name'] = ['text/plain', 'The {mailing.created_id.display_name}!', ';Mr. Logged In User II!;'];
+    $cases['creator'] = ['text/plain', 'The {mailing.creator}!', ';Mr. Logged In User II!;'];
+    $cases['created_id.email_primary.email'] = ['text/plain', 'The {mailing.created_id.email_primary.email}!', ';user@example.org!;'];
+    $cases['creatorEmail'] = ['text/plain', 'The {mailing.creatorEmail}!', ';user@example.org!;'];
     $cases['editUrl'] = ['text/plain', 'The {mailing.editUrl}!', ';The http.*civicrm/mailing/send.*!;'];
     $cases[] = ['text/plain', 'To subscribe: {action.subscribeUrl}!', ';To subscribe: http.*civicrm/mailing/subscribe.*!;'];
     $cases[] = ['text/plain', 'To optout: {action.optOutUrl}!', ';To optout: http.*civicrm/mailing/optout.*!;'];
@@ -42,24 +46,24 @@ class CRM_Mailing_TokensTest extends \CiviUnitTestCase {
    * @param string $inputTemplate
    *   Ex: 'Hello, {contact.first_name}'.
    * @param string $expectRegex
+   *
    * @dataProvider getExampleTokens
    */
-  public function testTokensWithMailingId($inputTemplateFormat, $inputTemplate, $expectRegex) {
-    $this->createLoggedInUser();
+  public function testTokensWithMailingId(string $inputTemplateFormat, string $inputTemplate, string $expectRegex): void {
+    $this->createLoggedInUser(['last_name' => 'User', 'email_primary.email' => 'user@example.org']);
     $mailing = $this->createTestEntity('Mailing', [
       'name' => 'Example Name',
       'subject' => 'Mailing Subject',
       'approval_note' => 'I approve',
       'approval_status_id:label' => 'Approved',
     ]);
-    $contact = CRM_Core_DAO::createTestObject('CRM_Contact_DAO_Contact');
 
     $p = new TokenProcessor(Civi::dispatcher(), [
       'mailingId' => $mailing['id'],
     ]);
     $p->addMessage('example', $inputTemplate, $inputTemplateFormat);
     $p->addRow()->context([
-      'contactId' => $contact->id,
+      'contactId' => $this->individualCreate(),
       'mailingJobId' => 123,
       'mailingActionTarget' => [
         'id' => 456,


### PR DESCRIPTION
Overview
----------------------------------------
Finish aligning MailingTokens with other tokens

Before
----------------------------------------
the MailingTokens class had been partially aligned with other entity Tokens. But it was still loading values using a $dao lookup that turned out to cause crashes if the dao lookup had already been called - per https://github.com/civicrm/civicrm-core/pull/36315 - note I hit that issue when the test ran in a suite but not in isolation - however it pointed to an underlying flakiness in the code that was not aligned with all the other entity Token classes.

After
----------------------------------------
Uses same mechanisms as other classes.
Note that previous tokens still works but where there is a more standard name the more standard name is promoted instead - ie

`approvalNote` -> `approval_note`
'approvalStatus`-> `approval_status_id:label`
'creator` -> `created_id.display_name`
`creatorEmail` -> `created_id.email_primary.email

Technical Details
----------------------------------------

Comments
----------------------------------------
@colemanw 