### PR TITLE
Fix Activity Attachment

### DIFF
--- a/CRM/Case/XMLProcessor/Process.php
+++ b/CRM/Case/XMLProcessor/Process.php
@@ -549,6 +549,8 @@ AND        a.is_deleted = 0
     if (!$activity) {
       throw new CRM_Core_Exception('Unable to create Activity');
     }
+    CRM_Core_BAO_File::processAttachment($activityParams, 'civicrm_activity', $activity->id);
+
     return TRUE;
   }
 

--- a/CRM/Contribute/Form/Task/Invoice.php
+++ b/CRM/Contribute/Form/Task/Invoice.php
@@ -646,7 +646,9 @@ class CRM_Contribute_Form_Task_Invoice extends CRM_Contribute_Form_Task {
     if ($contributionId) {
       $activityParams['source_record_id'] = $contributionId;
     }
-    civicrm_api3('Activity', 'create', $activityParams);
+    $activity = civicrm_api3('Activity', 'create', $activityParams);
+
+    CRM_Core_BAO_File::processAttachment($activityParams, 'civicrm_activity', $activity['id']);
   }
 
   /**


### PR DESCRIPTION
## Overview

Fixes invoice PDF attachments no longer appearing on "Emailed Invoice" / "Downloaded Invoice" / "Open Case" activities created by CiviCRM core's flows, after a recent security patch removed attachment processing from the Activity API/BAO.

## Before

- Sending an invoice by email via core's invoice task (contribute and event components) creates the "Emailed Invoice" activity, but the invoice PDF is missing from the activity's attachments.
- Downloading/printing an invoice PDF has the same problem on the "Downloaded Invoice" activity.
- Open case activity has the same problem.

## After

- The invoice PDF is correctly attached to the "Emailed Invoice" / "Downloaded Invoice" / "Open Case"  activity in all three flows, as it was before the security patch.

## Technical Details

A recent CiviCRM security patch deliberately removed attachment processing (`attachFile_N` params) from the `Activity.create` API3 and the Activity BAO, to prevent API callers from manipulating the filesystem. Attachment processing was moved to the form layer — patched core forms now call `CRM_Core_BAO_File::processAttachment()` explicitly after creating the activity (see `CRM_Contact_Form_Task_EmailTrait::createEmailActivity()`).

Some functions were missed by that patch and still relied on the old behaviour, passing `attachFile_1` into `civicrm_api3('Activity', 'create', ...)`, so the attachment param was silently ignored.

The API result is now captured to obtain the activity ID, and the attachment is processed explicitly — the same pattern used by the other core forms updated by the security patch.
