### PR TITLE
Resolves session conflict when working with multiple browser tabs. See #6625

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -990,7 +990,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     $formValues = $this->_params;
     $formValues = $this->setPriceSetParameters($formValues);
 
-    if ($this->_id) {
+    if ($this->_id && ($this->_action & CRM_Core_Action::UPDATE)) {
       $params['id'] = $this->_id;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Editing and saving memberships across multiple browser tabs concurrently can result in the accidental deletion of an existing membership. See https://lab.civicrm.org/dev/core/-/work_items/6625

Before
----------------------------------------
See https://lab.civicrm.org/dev/core/-/work_items/6625

After
----------------------------------------
Fixes this bug.


