### PR TITLE
dev/core#6656 - crash on contribution confirmation page if paying an existing contribution, and amount is formatted, e.g. bigger than 999.99

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -43,6 +43,8 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
 
   public $submitOnce = TRUE;
 
+  protected $submittableMoneyFields = ['total_amount'];
+
   private array $lineItems;
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6656

If paying an outstanding invoice using the online contribution page, and the amount is bigger than 999.99, it will crash. E.g. the Pay Now link you get from the user dashboard if they have a pending contribution.

Before
----------------------------------------
show me the money

After
----------------------------------------
here is the money

Technical Details
----------------------------------------
There was a change to fix a problem with it taking the value from the line items, but it introduced formatting into the value which then gives an error later. Declaring it as a money field tells it to unformat it.

Comments
----------------------------------------

