### PR TITLE
RiverLea: replaces undeclared variable with the colour value it once had

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -81,7 +81,7 @@ details.af-container.af-layout-inline > *:not(summary) {
   padding-top: 50px !important; /* vs next line */
 }
 #bootstrap-theme .af-container-style-pane > .af-title {
-  background-color: var(--crm-form-block-header-color, #70716b);
+  background-color: var(--crm-inverse-bg-color, #70716b);
   color: var(--crm-text-light-color, white);
   border-radius: var(--crm-form-block-border-radius, 4px) var(--crm-form-block-border-radius, 4px) 0 0;
   position: absolute;


### PR DESCRIPTION
Overview
----------------------------------------
`--crm-form-block-header-color` is used in afcore.css but isn't declared anywhere, this PR changes the css to point to one that is, with the same colour value and purpose it used to have, back before 6.10 when this likely broke.

Before
----------------------------------------
Title bg is `--crm-form-block-header-color` which isn't defined anywhere, so switches to the fallback of #70716b.
 
After
----------------------------------------
Title bg is `--crm-inverse-bg-color` which defaults to `--crm-c-gray-700` which defaults to `#696969`.

Technical Details
----------------------------------------
This likely happened at 6.10 during [a large variable rename](https://lab.civicrm.org/extensions/riverlea/-/blob/main/CHANGELOG.md) process and hasn't been spotted because there's a fallback. Back then the variable for the background of this af-title [was](https://lab.civicrm.org/extensions/riverlea/-/blob/main/core/org.civicrm.afform-ang/afCore.css?ref_type=heads#L84) `--crm-c-background5` which defaulted to `--crm-c-gray-700`.

Comments
----------------------------------------
FTR, `--crm-c-background5`was dropped in 6.10 (along with bg3 and bg4) - the replacement style for 'dark region with white text on top that survives dark-mode' is `--crm-inverse-bg-color`.

There shouldn't be any visible change with this PR (or rather a tiny change of the bg colour from `#70716b` to `#696969`).