### PR TITLE
Api4: Fix typed properties on actions with no default throw \Error instead of \CRM_Core_Exception

### DIFF
--- a/Civi/Api4/Action/ContributionRecur/UpdateAmountOnRecur.php
+++ b/Civi/Api4/Action/ContributionRecur/UpdateAmountOnRecur.php
@@ -19,7 +19,7 @@ class UpdateAmountOnRecur extends BasicBatchAction {
    * @var float
    * @required
    */
-  protected float $amount;
+  protected ?float $amount = NULL;
 
   /**
    * @inheritDoc

--- a/Civi/Api4/Action/PaymentProcessor/Refund.php
+++ b/Civi/Api4/Action/PaymentProcessor/Refund.php
@@ -23,7 +23,7 @@ class Refund extends \Civi\Api4\Generic\AbstractAction {
    * @var int
    * @required
    */
-  protected int $paymentProcessorID;
+  protected ?int $paymentProcessorID = NULL;
 
   /**
    * The amount to refund
@@ -31,7 +31,7 @@ class Refund extends \Civi\Api4\Generic\AbstractAction {
    * @var float
    * @required
    */
-  protected float $amountToRefund;
+  protected ?float $amountToRefund = NULL;
 
   /**
    * The currency of the amount to refund (Optional)
@@ -47,7 +47,7 @@ class Refund extends \Civi\Api4\Generic\AbstractAction {
    * @var string
    * @required
    */
-  protected string $transactionID;
+  protected ?string $transactionID = NULL;
 
   /**
    * @see \Civi\Api4\Generic\AbstractEntity::permissions()

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -567,7 +567,7 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
   /**
    * @return string
    */
-  public function getName():string {
+  public function getName(): ?string {
     return $this->name;
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -800,7 +800,7 @@ class Submit extends AbstractProcessor {
   /**
    * @return array
    */
-  public function getValues():array {
+  public function getValues(): ?array {
     return $this->values;
   }
 

--- a/tests/phpunit/api/v4/RequiredParamsSafeTest.php
+++ b/tests/phpunit/api/v4/RequiredParamsSafeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC https://civicrm.org/licensing
+ */
+
+namespace api\v4;
+
+use Civi\API\Exception\NotImplementedException;
+use Civi\API\Request;
+use Civi\Api4\Entity;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Scans every registered Api4 entity+action (core and installed
+ * extensions) and checks that every param the action declares as
+ * "required" is safe to read via its getter on a freshly-constructed,
+ * nothing-set instance.
+ *
+ * A required param declared as a typed PHP property with no default value
+ * (e.g. `protected int $foo;`) is uninitialized in that state, and PHP
+ * throws a raw \Error ("must not be accessed before initialization") the
+ * moment anything reads it - which is exactly what
+ * Civi\Api4\Event\Subscriber\ValidateFieldsSubscriber does internally
+ * (call the getter, check for NULL) to produce the API's normal
+ * CRM_Core_Exception("Parameter ... is required."). That crash pre-empts
+ * the friendly exception with a much less helpful internal error.
+ *
+ * @group headless
+ */
+class RequiredParamsSafeTest extends Api4TestBase {
+
+  public function setUp(): void {
+    // Enable all components so component-gated entities/actions
+    // (Event, Campaign, etc) are included in the scan.
+    \CRM_Core_BAO_ConfigSetting::enableAllComponents();
+    parent::setUp();
+  }
+
+  public function testRequiredParamsAreSafeToReadBeforeBeingSet(): void {
+    $failures = [];
+
+    $entityNames = Entity::get(FALSE)->execute()->column('name');
+    foreach ($entityNames as $entityName) {
+      $entityClass = CoreUtil::getApiClass($entityName);
+      if (!$entityClass) {
+        continue;
+      }
+      try {
+        $actionNames = $entityClass::getActions(FALSE)->execute()->column('name');
+      }
+      catch (\Throwable $e) {
+        // Some entities (e.g. dynamic ones needing class_args) can't
+        // enumerate their own actions generically - not what this test
+        // is checking, so skip rather than fail.
+        continue;
+      }
+
+      foreach ($actionNames as $actionName) {
+        try {
+          $action = Request::create($entityName, $actionName, ['version' => 4]);
+        }
+        catch (NotImplementedException $e) {
+          continue;
+        }
+        catch (\Throwable $e) {
+          continue;
+        }
+
+        foreach ($action->getParamInfo() as $param => $info) {
+          if (empty($info['required'])) {
+            continue;
+          }
+          $getter = 'get' . ucfirst($param);
+          try {
+            $action->$getter();
+          }
+          catch (\Error $e) {
+            $failures[] = sprintf(
+              '%s::%s() required param "%s" is not safely readable before being set (%s)',
+              $entityName,
+              $actionName,
+              $param,
+              $e->getMessage()
+            );
+          }
+        }
+      }
+    }
+
+    $this->assertEmpty($failures, "The following required params crash with a raw \\Error instead of the friendly \"Parameter ... is required.\" CRM_Core_Exception - give them a nullable type with an explicit `= NULL` default:\n" . implode("\n", $failures));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
If you define a typed property on an API4 action with no default it crashes with a PHP \Error ("must not be accessed before initialization") instead of the expected API \CRM_Core_Exception.
This comes from ValidateFieldsSubscriber's own getter-based required-field check. Making them nullable with a NULL default keeps them safely readable before being set, without changing the declared API type/required metadata (which comes from the @var/@required docblocks, not the native PHP type).

Before
----------------------------------------
These APIs returning \Error on missing parameters

After
----------------------------------------
These APIs returning \CRM_Core_Exception for consistency with other APIs on missing parameters.

Technical Details
----------------------------------------
This only affects typed properties in API4 action definitions.

Comments
----------------------------------------
@colemanw 
