### PR TITLE
Riverlea: fixes undeclared/misnamed variable

### DIFF
--- a/ext/riverlea/core/css/components/_icons.css
+++ b/ext/riverlea/core/css/components/_icons.css
@@ -258,7 +258,7 @@ div.civicrm-community-messages a.civicrm-community-message-dismiss::before,
 .crm-container .jstree-default .jstree-icon {
   background-image: inherit;
   font-size: var(--crm-l-reg-1);
-  margin-right: var(--btn-icon-spacing);
+  margin-right: var(--crm-btn-icon-spacing);
 }
 .crm-container .jstree-default .jstree-checkbox::before {
   content: '\f096';


### PR DESCRIPTION
Overview
----------------------------------------
Like #36335 fixes a variable naming regression [dating back to 6.10](https://lab.civicrm.org/extensions/riverlea/-/blob/main/CHANGELOG.md), this time restoring a missing `crm-` to a variable name to ensure it actually works.

Before
----------------------------------------
jstree icons are spaced with `var(--btn-icon-spacing)` which isn't defined anywhere so will be zero.

After
----------------------------------------
jstree icons are spaced with `var(--crm-btn-icon-spacing)` which is defined, and defaults to `var(--crm-l-small)`, which is 0.25rem or 4px.