### PR TITLE
show primary members only as default filter

### DIFF
--- a/CRM/Report/Form/Member/Detail.php
+++ b/CRM/Report/Form/Member/Detail.php
@@ -413,9 +413,9 @@ HERESQL;
     //re-name IS NULL/IS NOT NULL for clarity
     if ($fieldName === 'owner_membership_id') {
       $result = [];
-      $result[''] = ts('Any');
       $result['nll'] = ts('Primary members only');
       $result['nnll'] = ts('Non-primary members only');
+      $result[''] = ts('Any');
     }
     else {
       $result = parent::getOperationPair($type, $fieldName);


### PR DESCRIPTION
Overview
----------------------------------------
We should show primary members only as default filter as is consistent with other membership reports.

Before
----------------------------------------
By default, the report template will show all memberships

After
----------------------------------------
Keep this consistent with other membership reports and show primary memberships as default.