### PR TITLE
dev/core#6606 - allow changing default contribution status for new backoffice contributions

### DIFF
--- a/CRM/Contribute/Form/Contribution.php
+++ b/CRM/Contribute/Form/Contribution.php
@@ -511,12 +511,7 @@ class CRM_Contribute_Form_Contribution extends CRM_Contribute_Form_AbstractEditP
     }
 
     if (!$this->_id && empty($defaults['contribution_status_id'])) {
-      // Default to Pending: a newly recorded back-office contribution has not been received yet.
-      $defaults['contribution_status_id'] = CRM_Core_PseudoConstant::getKey(
-        'CRM_Contribute_BAO_Contribution',
-        'contribution_status_id',
-        'Pending'
-      );
+      $defaults['contribution_status_id'] = CRM_Core_OptionGroup::getDefaultValue('contribution_status') ?? CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     }
 
     $this->assign('is_test', !empty($defaults['is_test']));

--- a/CRM/Event/Form/EventFees.php
+++ b/CRM/Event/Form/EventFees.php
@@ -195,12 +195,7 @@ class CRM_Event_Form_EventFees {
       }
     }
     else {
-      // Default to Pending: a newly recorded back-office contribution has not been received yet.
-      $defaults['contribution_status_id'] = CRM_Core_PseudoConstant::getKey(
-        'CRM_Contribute_BAO_Contribution',
-        'contribution_status_id',
-        'Pending'
-      );
+      $defaults['contribution_status_id'] = CRM_Core_OptionGroup::getDefaultValue('contribution_status') ?? CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed');
     }
     return $defaults;
   }

--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -391,7 +391,12 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
       if (empty($defaults['payment_instrument_id'])) {
         $defaults['payment_instrument_id'] = key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
       }
-      return $defaults + CRM_Event_Form_EventFees::setDefaultValues($this);
+      $feeDefaults = CRM_Event_Form_EventFees::setDefaultValues($this);
+      // if the default contribution status is pending, uncheck the record payment box otherwise it doesn't make sense
+      if ($feeDefaults['contribution_status_id'] == CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Pending')) {
+        $defaults['record_contribution'] = 0;
+      }
+      return $defaults + $feeDefaults;
     }
 
     $defaults = [];


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6606

Before
----------------------------------------
* Everyone is forced to switch to having contributions default to pending.
* Backend event form currently has nonsensical defaults.

After
----------------------------------------
* You can set the default to pending by setting is_default to 1 for contribution_status option_value Pending (and clearing cache).

Technical Details
----------------------------------------


Comments
----------------------------------------

