### PR TITLE
Fix EntityReference custom field "Advanced Filter" to support multiple values

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -866,17 +866,22 @@ AND    option_group_id = %2";
     }
 
     $filter = 'null';
-    if ($params['data_type'] == 'ContactReference' && !empty($params['filter_selected'])) {
-      if ($params['filter_selected'] == 'Advance' && trim($params['filter'] ?? '')) {
-        $filter = trim($params['filter']);
+    if (in_array($params['data_type'], ['ContactReference', 'EntityReference'])) {
+      $trimmedFilter = trim($params['filter'] ?? '');
+      if ($params['data_type'] === 'ContactReference' && !empty($params['filter_selected'])) {
+        if ($params['filter_selected'] == 'Advance' && $trimmedFilter) {
+          $filter = $trimmedFilter;
+        }
+        elseif ($params['filter_selected'] == 'Group' && !empty($params['group_id'])) {
+          $filter = 'action=lookup&group=' . implode(',', $params['group_id']);
+        }
       }
-      elseif ($params['filter_selected'] == 'Group' && !empty($params['group_id'])) {
-        $filter = 'action=lookup&group=' . implode(',', $params['group_id']);
+      elseif ($params['data_type'] === 'EntityReference') {
+        // EntityReference has no Group/Advance toggle - filter_selected is a ContactReference-only concept.
+        $filter = $trimmedFilter ?: NULL;
       }
     }
-    if ($params['data_type'] !== 'EntityReference') {
-      $params['filter'] = $filter;
-    }
+    $params['filter'] = $filter;
 
     // fix for CRM-316
     $oldWeight = NULL;

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -275,7 +275,9 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
                   continue;
                 }
               }
-              $field['input_attrs']['filter'][$filterKey] = $filterValue;
+              // A comma-separated value means "match any of these" - pass as an array so the
+              // query builder can use IN/CONTAINS instead of a literal (and always-failing) match.
+              $field['input_attrs']['filter'][$filterKey] = str_contains($filterValue, ',') ? explode(',', $filterValue) : $filterValue;
             }
           }
         }

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -564,6 +564,43 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     $this->assertEquals($contacts[0]['id'], $result[0]['id']);
   }
 
+  public function testCustomFieldMultiValueAdvancedFilter(): void {
+    $lastName = uniqid(__FUNCTION__);
+    // All Individuals sharing a last name, so the name search matches all three equally -
+    // only the gender filter should decide which ones come back.
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'IncludeMale', 'last_name' => $lastName, 'gender_id:name' => 'Male'],
+        ['first_name' => 'IncludeFemale', 'last_name' => $lastName, 'gender_id:name' => 'Female'],
+        ['first_name' => 'ExcludeOther', 'last_name' => $lastName, 'gender_id:name' => 'Other'],
+      ],
+    ]);
+
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => __FUNCTION__,
+    ]);
+    $customField = $this->createTestRecord('CustomField', [
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'contact_ref',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      // Multi-value "match any of these" filter, per the custom field's "Advanced Filter".
+      'filter' => 'gender_id:name=Male,Female',
+    ]);
+
+    $result = Contact::autocomplete()
+      ->setInput($lastName)
+      ->setFieldName('Activity.' . $customGroup['name'] . '.' . $customField['name'])
+      ->execute();
+
+    $this->assertEqualsCanonicalizing(
+      [$contacts[0]['id'], $contacts[1]['id']],
+      (array) $result->column('id')
+    );
+  }
+
 }
 
 class AutocompleteTestForm extends \CRM_Core_Form {

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -624,4 +624,23 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $this->assertEquals(['contact_type' => 'Household', 'groups' => 2], $getField['input_attrs']['filter']);
   }
 
+  public function testMultiValueEntityRefFiltersAreParsedAsArrays(): void {
+    $grp = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'act_test_grp3',
+    ]);
+    $field = $this->createTestRecord('CustomField', [
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      'custom_group_id' => $grp['id'],
+      // A comma-separated value means "match any of these".
+      'filter' => 'contact_type:name=Individual,Organization',
+    ]);
+    $getField = Activity::getFields(FALSE)
+      ->addWhere('custom_field_id', '=', $field['id'])
+      ->execute()->single();
+    $this->assertEquals(['contact_type:name' => ['Individual', 'Organization']], $getField['input_attrs']['filter']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
When setting up a custom field of type ContactReference or EntityReference you have an "Advanced Filter" field with a helpful description. But it doesn't actually work as described because multiple values don't work.

With this PR this example now works:
<img width="816" height="517" alt="image" src="https://github.com/user-attachments/assets/156d2504-137a-4427-ad57-9a1e61fb2fce" />


Before
----------------------------------------
Multiple values don't work in advance filters

After
----------------------------------------
Multiple values work in advance filters

Technical Details
----------------------------------------
The filter textbox already documents `field=val1,val2` as meaning "match any of these", but the parser stored the value as a plain string, so AutocompleteAction's query builder (which only turns array values into an IN/CONTAINS clause) applied it as a literal equality/LIKE match instead - silently matching nothing whenever more than one value was given.

Also trim the filter on save like the ContactReference filter already does, combined into the same data_type check: previously a stray leading/trailing space in an EntityReference filter was saved as-is and corrupted the parsed field key, silently dropping the filter.

Comments
----------------------------------------
