### PR TITLE
Port: "SearchKit - Safely fallback to empty array if baseEntity joins are undefined" to 6.16

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin.module.js
+++ b/ext/search_kit/ang/crmSearchAdmin.module.js
@@ -195,7 +195,7 @@
         let result;
         while (path.length) {
           /* jshint -W083 */
-          join = CRM.crmSearchAdmin.joins[baseEntity].find(join =>
+          join = (CRM.crmSearchAdmin.joins[baseEntity] || []).find(join =>
             new RegExp('^' + join.alias + '_\\d\\d').test(path)
           );
           if (!join) {


### PR DESCRIPTION
Port of #36325 to 6.16.