### PR TITLE
CustomField - Fix "View / Edit Multiple Choice Options" link in field edit form

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -252,6 +252,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $this->freeze('data_type');
       if (!empty($this->_values['option_group_id'])) {
         $this->assign('hasOptionGroup', in_array($this->_values['html_type'], self::$htmlTypesWithOptions));
+        $this->assign('optionGroupId', $this->_values['option_group_id']);
         // Before dev/core#155 we didn't set the is_reserved flag properly, which should be handled by the upgrade script...
         //  but it is still possible that existing installs may have optiongroups linked to custom fields that are marked reserved.
         $optionGroupParams['id'] = $this->_values['option_group_id'];

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -394,6 +394,6 @@
 {* Give link to view/edit option group *}
 {if $action eq 2 && !empty($hasOptionGroup)}
   <div class="action-link">
-    {crmButton p="civicrm/admin/custom/group/field/option" q="reset=1&action=browse&fid=`$id`&gid=`$gid`" icon="pencil"}{ts}View / Edit Multiple Choice Options{/ts}{/crmButton}
+    {crmButton p="civicrm/admin/custom/group/field/options" f="?option_group_id=`$optionGroupId`" icon="pencil"}{ts}View / Edit Multiple Choice Options{/ts}{/crmButton}
   </div>
 {/if}


### PR DESCRIPTION
GitLab Issue: https://lab.civicrm.org/dev/core/-/work_items/6659

## Overview
Fixes the **View / Edit Multiple Choice Options** link in the custom field edit form, which opened the Custom Field Groups screen instead of the field's options.

## Before
Editing a custom field that uses a multiple-choice option set (e.g. Data Type = Alphanumeric, Input Field Type = Select) and clicking **View / Edit Multiple Choice Options** in the edit popup opened the **Custom Field Groups** screen.

## After
The same button opens the field's **Multiple Choice Options** screen, matching the **Multiple Choice Options** action already available from the field listing's actions menu.

## Technical Details
The button in `templates/CRM/Custom/Form/Field.tpl` linked to the legacy route `civicrm/admin/custom/group/field/option` (with `fid`/`gid`). That route was removed when the options screen moved to the SearchKit afform `civicrm/admin/custom/group/field/options` (filtered by `option_group_id`). Because the old path no longer resolves, the menu router falls back to the nearest ancestor route, `civicrm/admin/custom/group` (Custom Field Groups).

The link now targets the current route and passes `option_group_id` via the URL fragment, matching the link used by `managed/administer/SavedSearch_Administer_Custom_Fields.mgd.php`. `option_group_id` is assigned to the template in `CRM/Custom/Form/Field.php`.

## Reproduction
Reproducible on current `master` and on the CiviCRM demo site.

## Comments
lab.civicrm.org issue: https://lab.civicrm.org/dev/core/-/issues/6659

🤖 Generated with [Claude Code](https://claude.com/claude-code)
