### PR TITLE
Allow EntityReference custom field "Advanced Filter" to accept a raw where-clause

### DIFF
--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -651,9 +651,16 @@ SELECT count(*)
       }
     }
 
-    if ($dataType === 'EntityReference' && $self->_action == CRM_Core_Action::ADD) {
-      if (empty($fields['fk_entity'])) {
+    if ($dataType === 'EntityReference') {
+      if ($self->_action == CRM_Core_Action::ADD && empty($fields['fk_entity'])) {
         $errors['fk_entity'] = ts('Selecting an entity is required');
+      }
+      $filter = trim($fields['filter'] ?? '');
+      if (str_starts_with($filter, '[')) {
+        json_decode($filter);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+          $errors['filter'] = ts('This does not look like valid JSON: %1', [1 => json_last_error_msg()]);
+        }
       }
     }
 

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -866,17 +866,22 @@ AND    option_group_id = %2";
     }
 
     $filter = 'null';
-    if ($params['data_type'] == 'ContactReference' && !empty($params['filter_selected'])) {
-      if ($params['filter_selected'] == 'Advance' && trim($params['filter'] ?? '')) {
-        $filter = trim($params['filter']);
+    if (in_array($params['data_type'], ['ContactReference', 'EntityReference'])) {
+      $trimmedFilter = trim($params['filter'] ?? '');
+      if ($params['data_type'] === 'ContactReference' && !empty($params['filter_selected'])) {
+        if ($params['filter_selected'] == 'Advance' && $trimmedFilter) {
+          $filter = $trimmedFilter;
+        }
+        elseif ($params['filter_selected'] == 'Group' && !empty($params['group_id'])) {
+          $filter = 'action=lookup&group=' . implode(',', $params['group_id']);
+        }
       }
-      elseif ($params['filter_selected'] == 'Group' && !empty($params['group_id'])) {
-        $filter = 'action=lookup&group=' . implode(',', $params['group_id']);
+      elseif ($params['data_type'] === 'EntityReference') {
+        // EntityReference has no Group/Advance toggle - filter_selected is a ContactReference-only concept.
+        $filter = $trimmedFilter ?: NULL;
       }
     }
-    if ($params['data_type'] !== 'EntityReference') {
-      $params['filter'] = $filter;
-    }
+    $params['filter'] = $filter;
 
     // fix for CRM-316
     $oldWeight = NULL;

--- a/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
+++ b/Civi/Api4/Event/Subscriber/AutocompleteFieldSubscriber.php
@@ -76,6 +76,14 @@ class AutocompleteFieldSubscriber extends AutoService implements EventSubscriber
           $apiRequest->addFilter($key, $value);
         }
 
+        // Auto-add raw where-clauses defined in schema (e.g. a custom field's "Advanced Filter"
+        // pasted in as a where-clause instead of the simpler flat field=value syntax).
+        // `input_attrs.where` is populated by EntityMetadataBase::getCustomFields() from the
+        // raw JSON - it's never literally present in what the user typed.
+        foreach ($fieldSpec['input_attrs']['where'] ?? [] as $clause) {
+          $apiRequest->addWhere($clause);
+        }
+
         // Use FK key from fieldSpec, e.g. custom Autocomplete field keys by 'value' not 'id'
         if (!$apiRequest->getKey() && !empty($fieldSpec['fk_column'])) {
           $apiRequest->setKey($fieldSpec['fk_column']);

--- a/Civi/Api4/Generic/AutocompleteAction.php
+++ b/Civi/Api4/Generic/AutocompleteAction.php
@@ -139,6 +139,17 @@ class AutocompleteAction extends AbstractAction {
    */
   private $trustedFilters = [];
 
+  /**
+   * Raw `where` clauses set programmatically by `civi.api.prepare` listener. Automatically trusted.
+   *
+   * Unlike `$trustedFilters`, these support any where-clause syntax (operators, AND/OR groups, etc)
+   * instead of a flat fieldName => value match.
+   *
+   * Format: [[fieldName, op, value], ...]
+   * @var array
+   */
+  private $trustedWhere = [];
+
   private $trustedSavedSearch;
 
   private $trustedDisplay;
@@ -194,6 +205,9 @@ class AutocompleteAction extends AbstractAction {
       ]));
     }
     $this->loadSavedSearch();
+    if ($this->trustedWhere) {
+      $this->savedSearch['api_params']['where'] = array_merge($this->savedSearch['api_params']['where'], $this->trustedWhere);
+    }
     $this->loadSearchDisplay();
     $this->loadSearchFields();
 
@@ -277,6 +291,22 @@ class AutocompleteAction extends AbstractAction {
   public function addFilter(string $fieldName, $value) {
     $this->filters[$fieldName] = $value;
     $this->trustedFilters[$fieldName] = $value;
+    return $this;
+  }
+
+  /**
+   * Method for `civi.api.prepare` listener to add a trusted, raw where-clause condition.
+   *
+   * Use this instead of `addFilter()` when the condition can't be expressed as a simple
+   * fieldName => value match, e.g. it uses an operator other than IN/=, or combines
+   * multiple fields in an AND/OR group.
+   *
+   * @param array $clause
+   *   A single APIv4 where-clause condition, e.g. `['case_type_id:name', 'IN', ['a', 'b']]`.
+   * @return $this
+   */
+  public function addWhere(array $clause) {
+    $this->trustedWhere[] = $clause;
     return $this;
   }
 

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -264,20 +264,36 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
         }
         // Unserialize filters from url-arg-style string
         if (!empty($customField['filter'])) {
-          $customGroupFilters = explode('&', $customField['filter']);
-          foreach ($customGroupFilters as $filter) {
-            if (str_contains($filter, '=')) {
-              [$filterKey, $filterValue] = explode('=', $filter, 2);
-              // Convert legacy ContactRef filter to EntityRef format
-              if ($customField['data_type'] === 'ContactReference') {
-                $filterKey = $filterKey === 'group' ? 'groups' : $filterKey;
-                if ($filterKey === 'action') {
-                  continue;
-                }
+          $filter = $customField['filter'];
+          // Also accept a raw APIv4 `where` clause (e.g. copy/pasted from the API Explorer)
+          // for filters more complex than a flat list of `field=value` pairs.
+          if (str_starts_with($filter, '[')) {
+            $where = json_decode($filter, TRUE);
+            if (is_array($where)) {
+              // Accept either a full list of clauses (`[["field", "op", "value"], ...]`)
+              // or a single bare clause (`["field", "op", "value"]`) pasted on its own.
+              if (isset($where[0]) && !is_array($where[0])) {
+                $where = [$where];
               }
-              // A comma-separated value means "match any of these" - pass as an array so the
-              // query builder can use IN/CONTAINS instead of a literal (and always-failing) match.
-              $field['input_attrs']['filter'][$filterKey] = str_contains($filterValue, ',') ? explode(',', $filterValue) : $filterValue;
+              $field['input_attrs']['where'] = $where;
+            }
+          }
+          else {
+            $customGroupFilters = explode('&', $filter);
+            foreach ($customGroupFilters as $filterPart) {
+              if (str_contains($filterPart, '=')) {
+                [$filterKey, $filterValue] = explode('=', $filterPart, 2);
+                // Convert legacy ContactRef filter to EntityRef format
+                if ($customField['data_type'] === 'ContactReference') {
+                  $filterKey = $filterKey === 'group' ? 'groups' : $filterKey;
+                  if ($filterKey === 'action') {
+                    continue;
+                  }
+                }
+                // A comma-separated value means "match any of these" - pass as an array so the
+                // query builder can use IN/CONTAINS instead of a literal (and always-failing) match.
+                $field['input_attrs']['filter'][$filterKey] = str_contains($filterValue, ',') ? explode(',', $filterValue) : $filterValue;
+              }
             }
           }
         }

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -275,7 +275,9 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
                   continue;
                 }
               }
-              $field['input_attrs']['filter'][$filterKey] = $filterValue;
+              // A comma-separated value means "match any of these" - pass as an array so the
+              // query builder can use IN/CONTAINS instead of a literal (and always-failing) match.
+              $field['input_attrs']['filter'][$filterKey] = str_contains($filterValue, ',') ? explode(',', $filterValue) : $filterValue;
             }
           }
         }

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -95,7 +95,9 @@
           {ts}Filter search results for this field using API-style parameters{/ts}
           (<code>field=value&another_field=val1,val2</code>).<br>
           {ts}EXAMPLE (Contact entity): To list Students in "Volunteers" or "Supporters" groups:{/ts}
-          <code>contact_sub_type=Student&groups:name=Volunteers,Supporters</code>
+          <code>contact_sub_type=Student&groups:name=Volunteers,Supporters</code><br>
+          {ts}For filters this simple syntax can't express (multiple fields combined with OR, other operators, etc), paste a JSON-encoded `where` clause built in the API Explorer instead, e.g.{/ts}
+          <code>[["contact_sub_type", "=", "Student"], ["groups:name", "IN", ["Volunteers", "Supporters"]]]</code>
           {docURL page="dev/api"}
         </span>
       </td>

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -601,6 +601,38 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     );
   }
 
+  public function testCustomFieldJsonWhereClauseAdvancedFilter(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'Include', 'last_name' => $lastName, 'is_deceased' => FALSE],
+        ['first_name' => 'Exclude', 'last_name' => $lastName, 'is_deceased' => TRUE],
+      ],
+    ]);
+
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => __FUNCTION__,
+    ]);
+    $customField = $this->createTestRecord('CustomField', [
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'contact_ref',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      // A pasted-in `where` clause, for filters the flat field=value syntax can't express.
+      'filter' => '[["is_deceased", "=", false]]',
+    ]);
+
+    $result = Contact::autocomplete()
+      ->setInput($lastName)
+      ->setFieldName('Activity.' . $customGroup['name'] . '.' . $customField['name'])
+      ->execute();
+
+    $this->assertCount(1, $result);
+    $this->assertEquals($contacts[0]['id'], $result[0]['id']);
+  }
+
 }
 
 class AutocompleteTestForm extends \CRM_Core_Form {

--- a/tests/phpunit/api/v4/Action/AutocompleteTest.php
+++ b/tests/phpunit/api/v4/Action/AutocompleteTest.php
@@ -564,6 +564,43 @@ class AutocompleteTest extends Api4TestBase implements HookInterface, Transactio
     $this->assertEquals($contacts[0]['id'], $result[0]['id']);
   }
 
+  public function testCustomFieldMultiValueAdvancedFilter(): void {
+    $lastName = uniqid(__FUNCTION__);
+    // All Individuals sharing a last name, so the name search matches all three equally -
+    // only the gender filter should decide which ones come back.
+    $contacts = $this->saveTestRecords('Contact', [
+      'records' => [
+        ['first_name' => 'IncludeMale', 'last_name' => $lastName, 'gender_id:name' => 'Male'],
+        ['first_name' => 'IncludeFemale', 'last_name' => $lastName, 'gender_id:name' => 'Female'],
+        ['first_name' => 'ExcludeOther', 'last_name' => $lastName, 'gender_id:name' => 'Other'],
+      ],
+    ]);
+
+    $customGroup = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => __FUNCTION__,
+    ]);
+    $customField = $this->createTestRecord('CustomField', [
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'contact_ref',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      // Multi-value "match any of these" filter, per the custom field's "Advanced Filter".
+      'filter' => 'gender_id:name=Male,Female',
+    ]);
+
+    $result = Contact::autocomplete()
+      ->setInput($lastName)
+      ->setFieldName('Activity.' . $customGroup['name'] . '.' . $customField['name'])
+      ->execute();
+
+    $this->assertEqualsCanonicalizing(
+      [$contacts[0]['id'], $contacts[1]['id']],
+      (array) $result->column('id')
+    );
+  }
+
 }
 
 class AutocompleteTestForm extends \CRM_Core_Form {

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -624,4 +624,23 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $this->assertEquals(['contact_type' => 'Household', 'groups' => 2], $getField['input_attrs']['filter']);
   }
 
+  public function testMultiValueEntityRefFiltersAreParsedAsArrays(): void {
+    $grp = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'act_test_grp3',
+    ]);
+    $field = $this->createTestRecord('CustomField', [
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      'custom_group_id' => $grp['id'],
+      // A comma-separated value means "match any of these".
+      'filter' => 'contact_type:name=Individual,Organization',
+    ]);
+    $getField = Activity::getFields(FALSE)
+      ->addWhere('custom_field_id', '=', $field['id'])
+      ->execute()->single();
+    $this->assertEquals(['contact_type:name' => ['Individual', 'Organization']], $getField['input_attrs']['filter']);
+  }
+
 }

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -690,4 +690,41 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $this->assertSame('Find sites', $getField['input_attrs']['placeholder']);
   }
 
+  public function testEntityRefFilterAcceptsJsonWhereClause(): void {
+    $grp = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'act_test_grp4',
+    ]);
+    // A full list of where-clauses...
+    $fieldWithList = $this->createTestRecord('CustomField', [
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      'custom_group_id' => $grp['id'],
+      'filter' => '[["contact_type", "=", "Individual"], ["is_deceased", "=", false]]',
+    ]);
+    // ...or a single bare clause pasted on its own should both be accepted.
+    $fieldWithBareClause = $this->createTestRecord('CustomField', [
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      'custom_group_id' => $grp['id'],
+      'filter' => '["contact_type", "=", "Individual"]',
+    ]);
+    $fields = Activity::getFields(FALSE)
+      ->addWhere('custom_field_id', 'IN', [$fieldWithList['id'], $fieldWithBareClause['id']])
+      ->execute()->indexBy('custom_field_id');
+
+    $this->assertEquals(
+      [['contact_type', '=', 'Individual'], ['is_deceased', '=', FALSE]],
+      $fields[$fieldWithList['id']]['input_attrs']['where']
+    );
+    $this->assertArrayNotHasKey('filter', $fields[$fieldWithList['id']]['input_attrs']);
+
+    $this->assertEquals(
+      [['contact_type', '=', 'Individual']],
+      $fields[$fieldWithBareClause['id']]['input_attrs']['where']
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Builds on https://github.com/civicrm/civicrm-core/pull/36344

Allows you to use a JSON formatted where-clause filter in the "Advanced Filter" for custom fields. The allows for a lot more flexibility and possibilities for those fields.

<img width="1140" height="405" alt="image" src="https://github.com/user-attachments/assets/4e0275d0-a9c6-409c-bfb1-f44a7b6022d1" />


Before
----------------------------------------
Only very simple filters supported

After
----------------------------------------
Can filter by anything supported in a "where" clause.

Technical Details
----------------------------------------
The flat `field=value&field2=val1,val2` syntax can't express conditions that combine multiple fields with OR, use operators other than =/IN, or nest AND/OR groups. Let the filter box alternatively accept a JSON-encoded APIv4 where-clause (a single clause, or a list of clauses) pasted in directly, e.g. from the API Explorer's generated code.

Comments
----------------------------------------

