### PR TITLE
Allow customizing the placeholder for EntityReference custom fields

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -1028,20 +1028,41 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
    * array.
    *
    * @param string $attrString
-   *   The attributes as a string, e.g. `rows=3 cols=40`.
+   *   The attributes as a string, e.g. `rows=3 cols=40` or `placeholder="Find sites"`.
    *
    * @return array
    *   The attributes as an array, e.g. `['rows' => 3, 'cols' => 40]`.
    */
   public static function attributesFromString($attrString) {
     $attributes = [];
-    foreach (explode(' ', $attrString) as $at) {
-      if (strpos($at, '=')) {
-        [$k, $v] = explode('=', $at);
-        $attributes[$k] = trim($v, ' "');
-      }
+    // Values may be quoted (single or double) to allow spaces, e.g. placeholder="Find sites".
+    preg_match_all('/([\w-]+)=("[^"]*"|\'[^\']*\'|\S*)/', (string) $attrString, $matches, PREG_SET_ORDER);
+    foreach ($matches as [, $key, $value]) {
+      $attributes[$key] = html_entity_decode(trim($value, '"\''));
     }
     return $attributes;
+  }
+
+  /**
+   * Take an associative array of HTML element attributes and turn it into a string.
+   *
+   * Inverse of self::attributesFromString().
+   *
+   * @param array $attributes
+   *   The attributes as an array, e.g. `['rows' => 3, 'placeholder' => 'Find sites']`.
+   *
+   * @return string
+   *   The attributes as a string, e.g. `rows=3 placeholder="Find sites"`.
+   */
+  public static function attributesToString(array $attributes): string {
+    $parts = [];
+    foreach ($attributes as $key => $value) {
+      if ($value === NULL || $value === '') {
+        continue;
+      }
+      $parts[] = $key . '="' . htmlspecialchars((string) $value, ENT_QUOTES) . '"';
+    }
+    return implode(' ', $parts);
   }
 
   /**

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -161,6 +161,10 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
         $defaults['filter_selected'] = $contactRefFilter;
       }
 
+      if ($defaults['data_type'] == 'EntityReference' && !empty($defaults['attributes'])) {
+        $defaults['placeholder'] = CRM_Core_BAO_CustomField::attributesFromString($defaults['attributes'])['placeholder'] ?? NULL;
+      }
+
       $defaults['option_type'] = 2;
     }
 
@@ -246,6 +250,12 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
     ]);
 
     $this->addField('fk_entity_on_delete');
+
+    $this->add('text',
+      'placeholder',
+      ts('Placeholder'),
+      ['class' => 'twenty']
+    );
 
     $isUpdateAction = $this->_action == CRM_Core_Action::UPDATE;
     if ($isUpdateAction) {
@@ -882,6 +892,18 @@ AND    option_group_id = %2";
       }
     }
     $params['filter'] = $filter;
+
+    if ($params['data_type'] === 'EntityReference') {
+      // Merge the placeholder into 'attributes' without disturbing any other attributes already stored there.
+      $attributes = CRM_Core_BAO_CustomField::attributesFromString($this->_values['attributes'] ?? '');
+      if (!empty($params['placeholder'])) {
+        $attributes['placeholder'] = $params['placeholder'];
+      }
+      else {
+        unset($attributes['placeholder']);
+      }
+      $params['attributes'] = CRM_Core_BAO_CustomField::attributesToString($attributes);
+    }
 
     // fix for CRM-316
     $oldWeight = NULL;

--- a/Civi/Schema/EntityMetadataBase.php
+++ b/Civi/Schema/EntityMetadataBase.php
@@ -297,6 +297,14 @@ abstract class EntityMetadataBase implements EntityMetadataInterface {
             'on_delete' => $onDelete,
           ];
         }
+        // A custom placeholder (from `attributes`) reaches the legacy QuickForm widget for free
+        // (parsed generically at the top of addQuickFormElement()) - do the same here for APIv4/Afform.
+        if ($customField['data_type'] === 'EntityReference' && !empty($customField['attributes'])) {
+          $placeholder = \CRM_Core_BAO_CustomField::attributesFromString($customField['attributes'])['placeholder'] ?? NULL;
+          if ($placeholder) {
+            $field['input_attrs']['placeholder'] = $placeholder;
+          }
+        }
         if ($customField['option_group_id']) {
           // Options for Select, Radio, Checkbox
           $field['pseudoconstant'] = [

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -179,7 +179,7 @@ class AfformMetadataInjector {
     if ($inputType === 'Select' || $inputType === 'ChainSelect') {
       $fieldInfo['input_attrs']['placeholder'] = E::ts('Select');
     }
-    elseif ($inputType === 'EntityRef' && !empty($fieldInfo['fk_entity']) && empty($field['input_attrs']['placeholder'])) {
+    elseif ($inputType === 'EntityRef' && !empty($fieldInfo['fk_entity']) && empty($fieldInfo['input_attrs']['placeholder'])) {
       $info = civicrm_api4('Entity', 'get', [
         'where' => [['name', '=', $fieldInfo['fk_entity']]],
         'checkPermissions' => FALSE,

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformMetadataTest.php
@@ -94,4 +94,47 @@ class AfformMetadataTest extends \PHPUnit\Framework\TestCase implements Headless
     $this->assertEquals('Organization 1', $options[1]['label']);
   }
 
+  /**
+   * A placeholder already present on the incoming field metadata (e.g. from a custom field's
+   * "Placeholder" setting) must not be clobbered by the auto-generated "Select X" default.
+   */
+  public function testEntityRefCustomPlaceholderIsPreserved(): void {
+    $doc = \phpQuery::newDocumentHTML('<af-field name="test_field"></af-field>');
+    $afField = $doc->find('af-field')->get(0);
+    $fieldInfo = [
+      'input_type' => 'EntityRef',
+      'fk_entity' => 'Activity',
+      'data_type' => 'Integer',
+      'input_attrs' => [
+        'placeholder' => '- choose an activity -',
+        'multiple' => TRUE,
+      ],
+    ];
+    AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
+    $defn = \CRM_Utils_JS::getRawProps($afField->getAttribute('defn'));
+    $inputAttrs = \CRM_Utils_JS::decode($defn['input_attrs']);
+    $this->assertEquals('- choose an activity -', $inputAttrs['placeholder']);
+  }
+
+  /**
+   * Without a custom placeholder, the auto-generated default still applies - and uses the
+   * plural entity title for multi-value fields.
+   */
+  public function testEntityRefDefaultPlaceholderUsesPluralForMultiple(): void {
+    $doc = \phpQuery::newDocumentHTML('<af-field name="test_field"></af-field>');
+    $afField = $doc->find('af-field')->get(0);
+    $fieldInfo = [
+      'input_type' => 'EntityRef',
+      'fk_entity' => 'Activity',
+      'data_type' => 'Integer',
+      'input_attrs' => [
+        'multiple' => TRUE,
+      ],
+    ];
+    AfformMetadataInjector::setFieldMetadata($afField, $fieldInfo);
+    $defn = \CRM_Utils_JS::getRawProps($afField->getAttribute('defn'));
+    $inputAttrs = \CRM_Utils_JS::decode($defn['input_attrs']);
+    $this->assertEquals('Select Activities', $inputAttrs['placeholder']);
+  }
+
 }

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -37,6 +37,13 @@
       <td class="label">{$form.fk_entity_on_delete.label} <span class="crm-marker">*</span></td>
       <td class="html-adjust">{$form.fk_entity_on_delete.html}</td>
     </tr>
+    <tr class="crm-custom-field-form-block-placeholder">
+      <td class="label">{$form.placeholder.label}</td>
+      <td class="html-adjust">
+        {$form.placeholder.html}
+        <span class="description">{ts}Leave blank to use the default placeholder.{/ts}</span>
+      </td>
+    </tr>
     <tr class="crm-custom-field-form-block-serialize">
       <td class="label">{$form.serialize.label}</td>
       <td class="html-adjust">{$form.serialize.html}</td>
@@ -196,6 +203,7 @@
       // Show/hide entityReference selector
       $('.crm-custom-field-form-block-fk_entity').toggle(dataType === 'EntityReference');
       $('.crm-custom-field-form-block-fk_entity_on_delete').toggle(dataType === 'EntityReference');
+      $('.crm-custom-field-form-block-placeholder').toggle(dataType === 'EntityReference');
 
       // Toggle file access
       $('tr.crm-custom-field-form-block-file_is_public').toggle(dataType === 'File');

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -1162,4 +1162,47 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $this->assertEquals(array_keys($colors), $value);
   }
 
+  /**
+   * @dataProvider attributesStringDataProvider
+   */
+  public function testAttributesFromStringRoundTrip(string $attrString, array $expected): void {
+    $parsed = CRM_Core_BAO_CustomField::attributesFromString($attrString);
+    $this->assertEquals($expected, $parsed);
+    // Re-encoding then re-parsing should be lossless, even for values containing spaces/quotes.
+    $reparsed = CRM_Core_BAO_CustomField::attributesFromString(CRM_Core_BAO_CustomField::attributesToString($parsed));
+    $this->assertEquals($parsed, $reparsed);
+  }
+
+  public static function attributesStringDataProvider(): array {
+    return [
+      'unquoted, single word' => ['rows=3 cols=40', ['rows' => '3', 'cols' => '40']],
+      'unquoted, no spaces needed' => ['placeholder=Select', ['placeholder' => 'Select']],
+      'double-quoted value with a space' => ['placeholder="Find sites"', ['placeholder' => 'Find sites']],
+      'single-quoted value with a space' => ["placeholder='Find sites'", ['placeholder' => 'Find sites']],
+      'mixed quoted and unquoted' => ['a=1 b="two words" c=3', ['a' => '1', 'b' => 'two words', 'c' => '3']],
+      'empty string' => ['', []],
+    ];
+  }
+
+  /**
+   * A placeholder set via `attributes` (e.g. `placeholder="Find sites"`) should reach the
+   * rendered form element for an EntityReference field exactly as entered, overriding the
+   * auto-generated "- select X -" default.
+   */
+  public function testEntityReferencePlaceholderFromAttributes(): void {
+    $customGroupId = $this->customGroupCreate(['extends' => 'Individual'])['id'];
+    $field = CustomField::create(FALSE)
+      ->addValue('custom_group_id', $customGroupId)
+      ->addValue('label', 'entity_ref_placeholder')
+      ->addValue('data_type', 'EntityReference')
+      ->addValue('html_type', 'Autocomplete-Select')
+      ->addValue('fk_entity', 'Activity')
+      ->addValue('attributes', 'placeholder="Find sites"')
+      ->execute()->single();
+
+    $form = new CRM_Core_Form();
+    $element = CRM_Core_BAO_CustomField::addQuickFormElement($form, 'custom_' . $field['id'], $field['id']);
+    $this->assertEquals('Find sites', $element->getAttribute('placeholder'));
+  }
+
 }

--- a/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomFieldGetFieldsTest.php
@@ -643,4 +643,26 @@ class CustomFieldGetFieldsTest extends Api4TestBase {
     $this->assertEquals(['contact_type:name' => ['Individual', 'Organization']], $getField['input_attrs']['filter']);
   }
 
+  /**
+   * The custom placeholder must reach APIv4 getFields()'s input_attrs, not just the legacy
+   * QuickForm widget - this is what Afform (and anything else API4-driven) actually reads.
+   */
+  public function testCustomPlaceholderIsReturnedForEntityRefFields(): void {
+    $grp = $this->createTestRecord('CustomGroup', [
+      'extends' => 'Activity',
+      'title' => 'act_test_grp5',
+    ]);
+    $field = $this->createTestRecord('CustomField', [
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Contact',
+      'custom_group_id' => $grp['id'],
+      'attributes' => 'placeholder="Find sites"',
+    ]);
+    $getField = Activity::getFields(FALSE)
+      ->addWhere('custom_field_id', '=', $field['id'])
+      ->execute()->single();
+    $this->assertSame('Find sites', $getField['input_attrs']['placeholder']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
EntityReference custom fields always got an auto-generated "- select {fk_entity title} -" placeholder, with no way to override it.

Imagine a site with multiple case types, some of which are related and some are not. Eg.

Case Types: "CiviCRM Site", "WordPress Site" are all "Sites" to the user. We can now add an entityReference field which says "- select Sites -" instead of "- select Cases -".
Case Types: "Onboarding", "Leaving" are "Cases" to the user.

New configuration for ContactReference/EntityReference fields:

<img width="1140" height="405" alt="image" src="https://github.com/user-attachments/assets/d613b3c3-eddd-4627-b4ca-48cd93f62c11" />

Placeholder set:

<img width="737" height="347" alt="image" src="https://github.com/user-attachments/assets/914c473b-f0f0-4530-b8b1-a86621f5c652" />

No placeholder set:

<img width="737" height="347" alt="image" src="https://github.com/user-attachments/assets/e412e982-ecc6-4414-aa4a-b26335ad740b" />

Before
----------------------------------------
Cannot change placeholder on autocomplete for EntityReference.

After
----------------------------------------
Can change placeholder on autocomplete for EntityReference.


Technical Details
----------------------------------------
Reuse the existing `civicrm_custom_field.attributes` column rather than adding a new one: a `placeholder=...` key stored there already reaches the rendered form element, since the EntityReference branch of addQuickFormElement() never overwrites it. Add a "Placeholder" input to the Custom Field admin form (visible only for EntityReference) that reads/writes just that one key, leaving any other attributes untouched.

Fix CustomField::attributesFromString() - it split the whole string on every space with no quote-awareness, so a value with a space (`placeholder="Find sites"`) silently lost everything after the first word. Also add the missing inverse, attributesToString(), needed to write the placeholder back without disturbing other attributes.

Comments
----------------------------------------

