### PR TITLE
Allow EntityReference custom fields to store multiple values

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -961,6 +961,7 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
           // Autocomplete for FK fields
           if ($field->data_type == 'EntityReference') {
             $fieldAttributes['entity'] = $field->fk_entity;
+            $fieldAttributes['select']['multiple'] = $search ? TRUE : !empty($field->serialize);
           }
           // Autocomplete for field with option values
           else {
@@ -1167,18 +1168,26 @@ class CRM_Core_BAO_CustomField extends CRM_Core_DAO_CustomField implements \Civi
         }
         elseif ($field['data_type'] == 'EntityReference' && $value) {
           try {
+            $ids = (array) $value;
             $result = civicrm_api4($field['fk_entity'], 'autocomplete', [
               'checkPermissions' => FALSE,
-              'ids' => [$value],
+              'ids' => $ids,
             ]);
-            $display = $result->single()['label'];
+            $labels = [];
+            foreach ($result as $row) {
+              $labels[$row['id']] = $row['label'];
+            }
+            // Preserve the original order/multiplicity of $ids; drop any that couldn't be resolved.
+            $display = implode(', ', array_filter(array_map(fn($id) => $labels[$id] ?? NULL, $ids)));
           }
           catch (CRM_Core_Exception $e) {
             $display = '';
           }
         }
         elseif (in_array($field['data_type'], ['ContactReference', 'EntityReference'])) {
-          $display = $value;
+          // $value is falsy here (the truthy cases are handled above) - but for a serialized
+          // field that can still be an empty array, which must not be assigned to $display as-is.
+          $display = is_array($value) ? '' : $value;
         }
         elseif (is_array($value)) {
           $v = [];

--- a/Civi/Api4/Action/GetLinks.php
+++ b/Civi/Api4/Action/GetLinks.php
@@ -141,6 +141,11 @@ class GetLinks extends BasicGetAction {
         $tokens = \CRM_Utils_String::getSquareTokens($link['path']);
         foreach ($tokens as $token) {
           $value = $this->getValue($token['content']);
+          // A multi-valued (e.g. serialized) field can't resolve to a single token value.
+          // Unwrap an unambiguous single-item array; otherwise treat it as unresolved, same as a missing value.
+          if (is_array($value)) {
+            $value = count($value) === 1 ? reset($value) : NULL;
+          }
           // A '?' in the token makes it optional
           if (!isset($value) && $token['qualifier'] === '?') {
             $value = '';

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -304,7 +304,7 @@
 
       $("#noteColumns, #noteRows, #noteLength", $form).toggle(dataType === 'Memo');
 
-      $(".crm-custom-field-form-block-serialize", $form).toggle(htmlTypesWithOptionalSerialize.includes(htmlType) && dataType !== 'EntityReference');
+      $(".crm-custom-field-form-block-serialize", $form).toggle(htmlTypesWithOptionalSerialize.includes(htmlType));
 
       makeDefaultValueField(dataType);
     }

--- a/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
+++ b/tests/phpunit/CRM/Core/BAO/CustomFieldTest.php
@@ -1162,4 +1162,95 @@ class CRM_Core_BAO_CustomFieldTest extends CiviUnitTestCase {
     $this->assertEquals(array_keys($colors), $value);
   }
 
+  /**
+   * A serialized EntityReference field should store and retrieve multiple FK ids,
+   * the same way a serialized Select/Autocomplete-Select field already does.
+   */
+  public function testMultiValueEntityReferenceStorage(): void {
+    $customGroupId = $this->customGroupCreate(['extends' => 'Individual'])['id'];
+    $fieldId = CRM_Core_BAO_CustomField::create([
+      'custom_group_id' => $customGroupId,
+      'label' => 'multi_entity_ref',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Activity',
+      'serialize' => 1,
+    ])->id;
+
+    $activity1 = $this->activityCreate(['subject' => 'One']);
+    $activity2 = $this->activityCreate(['subject' => 'Two']);
+
+    $contactId = $this->individualCreate(['custom_' . $fieldId => [$activity1['id'], $activity2['id']]]);
+    $value = $this->callAPISuccessGetValue('Contact', [
+      'id' => $contactId,
+      'return' => 'custom_' . $fieldId,
+    ]);
+    $this->assertEquals([$activity1['id'], $activity2['id']], $value);
+
+    $this->customGroupDelete($customGroupId);
+  }
+
+  /**
+   * The rendered widget for a serialized EntityReference field must actually allow
+   * multiple selections - it's not enough for the value to be storable.
+   */
+  public function testMultiValueEntityReferenceWidgetIsMultiple(): void {
+    $customGroupId = $this->customGroupCreate(['extends' => 'Individual'])['id'];
+    $fieldId = CRM_Core_BAO_CustomField::create([
+      'custom_group_id' => $customGroupId,
+      'label' => 'multi_entity_ref_widget',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Activity',
+      'serialize' => 1,
+    ])->id;
+
+    $form = new CRM_Core_Form();
+    $element = CRM_Core_BAO_CustomField::addQuickFormElement($form, 'custom_' . $fieldId, $fieldId);
+    $this->assertEquals(['multiple' => TRUE], json_decode($element->getAttribute('data-select-params'), TRUE));
+
+    $this->customGroupDelete($customGroupId);
+  }
+
+  /**
+   * CRM_Core_BAO_CustomField::displayValue() for an EntityReference field must resolve
+   * every id when given multiple values, not just the first, and must not error out.
+   */
+  public function testGetDisplayedValuesEntityRef(): void {
+    $customGroupId = $this->customGroupCreate(['extends' => 'Individual'])['id'];
+    $fieldId = CRM_Core_BAO_CustomField::create([
+      'custom_group_id' => $customGroupId,
+      'label' => 'entity_ref_display',
+      'data_type' => 'EntityReference',
+      'html_type' => 'Autocomplete-Select',
+      'fk_entity' => 'Activity',
+      'serialize' => 1,
+    ])->id;
+
+    $activity1 = $this->activityCreate(['subject' => 'First test activity']);
+    $activity2 = $this->activityCreate(['subject' => 'Second test activity']);
+
+    // Fetch the expected labels independently, via the same autocomplete API the display code uses,
+    // rather than hard-coding an assumed label format.
+    $labels = [];
+    foreach (civicrm_api4('Activity', 'autocomplete', ['checkPermissions' => FALSE, 'ids' => [$activity1['id'], $activity2['id']]]) as $row) {
+      $labels[$row['id']] = $row['label'];
+    }
+
+    $this->assertEquals($labels[$activity1['id']], CRM_Core_BAO_CustomField::displayValue($activity1['id'], $fieldId));
+    $this->assertEquals(
+      $labels[$activity1['id']] . ', ' . $labels[$activity2['id']],
+      CRM_Core_BAO_CustomField::displayValue([$activity1['id'], $activity2['id']], $fieldId)
+    );
+    // An id that can no longer be resolved (e.g. deleted) is dropped rather than erroring.
+    $this->assertEquals($labels[$activity1['id']], CRM_Core_BAO_CustomField::displayValue([$activity1['id'], 999999], $fieldId));
+    // A serialized field with no value yet (e.g. viewing a brand new record) unserializes to an
+    // empty array - this must render as an empty string, not the array itself, or the entity's
+    // custom data view template errors trying to cast the array to a string.
+    $this->assertSame('', CRM_Core_BAO_CustomField::displayValue([], $fieldId));
+
+    civicrm_api4('Activity', 'delete', ['checkPermissions' => FALSE, 'where' => [['id', 'IN', [$activity1['id'], $activity2['id']]]]]);
+    $this->customGroupDelete($customGroupId);
+  }
+
 }

--- a/tests/phpunit/api/v4/Action/GetLinksTest.php
+++ b/tests/phpunit/api/v4/Action/GetLinksTest.php
@@ -23,6 +23,7 @@ use api\v4\Api4TestBase;
 use Civi\Api4\Activity;
 use Civi\Api4\Contact;
 use Civi\Api4\ContactType;
+use Civi\Api4\Group;
 use Civi\Api4\Individual;
 use Civi\Api4\RelationshipCache;
 use Civi\Test\TransactionalInterface;
@@ -157,6 +158,36 @@ class GetLinksTest extends Api4TestBase implements TransactionalInterface {
     $this->assertStringContainsString("id={$acts[2]}", $links['delete']['path']);
     $this->assertStringContainsString("caseid=$case1", $links['delete']['path']);
     $this->assertStringNotContainsString("id={$acts[2]}", $links['add']['path']);
+  }
+
+  /**
+   * A serialized/multi-valued field's raw value can end up as the token source for a link
+   * built for a single record (e.g. SearchKit rendering a link per multi-value custom field
+   * item without fully splitting the row first). This must not fatal - a link with an
+   * unresolvable required token should just be dropped, same as if the value were missing.
+   */
+  public function testMultiValueTokenDoesNotFatal(): void {
+    $links = Group::getLinks(FALSE)
+      ->setValues(['id' => [1, 2]])
+      ->execute();
+    foreach ($links as $link) {
+      $this->assertStringNotContainsString('[id]', $link['path']);
+      $this->assertStringNotContainsString('Array', $link['path']);
+    }
+    // Links whose path requires `id` are dropped; links without an `id` token remain.
+    $this->assertNotContains('view', array_column((array) $links, 'ui_action'));
+  }
+
+  /**
+   * A single-item array (e.g. a multi-value field that happens to have exactly one value)
+   * unambiguously resolves to that one value.
+   */
+  public function testSingleItemArrayTokenIsUnwrapped(): void {
+    $group = $this->createTestRecord('Group');
+    $links = Group::getLinks(FALSE)
+      ->setValues(['id' => [$group['id']]])
+      ->execute()->indexBy('ui_action');
+    $this->assertStringContainsString((string) $group['id'], $links['view']['path']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Enable multi-select for EntityReference fields. Just like we can do for Contacts.

Config:

<img width="737" height="347" alt="image" src="https://github.com/user-attachments/assets/9f466ea2-a1f0-4175-8af1-f37f8093217c" />

Single select:

<img width="737" height="347" alt="image" src="https://github.com/user-attachments/assets/826fec82-dd77-426f-b573-5f5fbf7bacad" />

Multi select:

<img width="897" height="398" alt="image" src="https://github.com/user-attachments/assets/72de1665-39ba-4623-9151-f80bf603f40f" />

Before
----------------------------------------
EntityReference custom fields can't be multi-select.


After
----------------------------------------
EntityReference custom fields can be multi-select.


Technical Details
----------------------------------------
The storage layer already fully supported this: fieldToSQLType() returns 'text' for any serialized field regardless of data type, and prepareCreateParams() already skips the FK constraint for a serialized EntityReference field ("Serialized fields store value-separated strings which are incompatible with FK constraints"). It was only ever exposed through the UI/widget for other Autocomplete-Select fields, not this one:

- Field.tpl explicitly hid the "Multi-Select" toggle whenever data_type === 'EntityReference', even though Autocomplete-Select (its only html_type) already supports serialize for every other data type that uses it.
- addQuickFormElement() never passed serialize through to the widget's select.multiple option for the EntityReference branch, so even with serialize saved the rendered field would have stayed single-select.
- formatDisplayValue() called the FK entity's autocomplete API with 'ids' => [$value] and read ->single()['label'], which breaks the moment $value is an array of more than one id. Now resolves every id in one call and joins the labels, silently dropping any id that no longer resolves (matches the ContactReference branch's guard) instead of erroring.

Comments
----------------------------------------
