### PR TITLE
Formbuilder Add markup edit toggle

### DIFF
--- a/ext/afform/admin/afform_admin.php
+++ b/ext/afform/admin/afform_admin.php
@@ -29,3 +29,16 @@ function afform_admin_civicrm_install() {
 function afform_admin_civicrm_enable() {
   _afform_admin_civix_civicrm_enable();
 }
+
+/**
+ * Implements hook_civicrm_permission().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/security/permissions/
+ */
+function afform_admin_civicrm_permission(&$permissions) {
+  $permissions['edit afform html'] = [
+    'label' => E::ts('FormBuilder: edit raw HTML markup'),
+    'description' => E::ts('Allows editing the raw HTML markup of a form directly in the FormBuilder'),
+    'implied_by' => ['administer CiviCRM'],
+  ];
+}

--- a/ext/afform/admin/ang/afAdmin.ang.php
+++ b/ext/afform/admin/ang/afAdmin.ang.php
@@ -15,6 +15,7 @@ return [
   'permissions' => [
     'administer afform',
     'manage own afform',
+    'edit afform html',
     // Used to check permissions by afGuiSearchDisplay component
     'all CiviCRM permissions and ACLs',
     'administer search_kit',

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -110,8 +110,10 @@
         if (!editor.afform.placement_filters || Array.isArray(editor.afform.placement_filters)) {
           editor.afform.placement_filters = {};
         }
-        $scope.canvasTab = 'layout';
-        $scope.layoutHtml = '';
+        editor.canvasTab = 'layout';
+        editor.layoutHtml = '';
+        editor.markupEditMode = false;
+        editor.markupEditBaseline = '';
         $scope.entities = {};
         setEditorLayout();
         setLastSaved();
@@ -206,7 +208,7 @@
         undoAction = 'change';
         editor.afform = _.cloneDeep(undoHistory[undoPosition].afform);
         setEditorLayout();
-        $scope.canvasTab = 'layout';
+        editor.canvasTab = 'layout';
         $scope.selectedEntityName = undoHistory[undoPosition].selectedEntityName;
       }
 
@@ -227,15 +229,115 @@
         return options.find(option => option.id === editor.afform.type).label;
       };
 
+      this.checkPerm = function(permissionName) {
+        return CRM.checkPerm(permissionName);
+      };
+
       $scope.updateLayoutHtml = function() {
-        $scope.layoutHtml = '...Loading...';
+        editor.layoutHtml = '...Loading...';
         crmApi4('Afform', 'convert', {layout: editor.afform.layout, from: 'deep', to: 'html', formatWhitespace: true})
           .then((r) => {
-            $scope.layoutHtml = r[0].layout || '(Error)';
+            editor.layoutHtml = r[0].layout || '(Error)';
           })
           .catch((r) => {
-            $scope.layoutHtml = '(Error)';
+            editor.layoutHtml = '(Error)';
           });
+      };
+
+      // Minimal sanity check - not full schema validation, just guards against the markup
+      // editor producing something obviously broken (e.g. a lost <af-form> wrapper).
+      function isValidLayout(layout) {
+        if (!Array.isArray(layout) || !layout.length) {
+          return false;
+        }
+        if (editor.getFormType() === 'form') {
+          return afGui.findRecursive(layout, {'#tag': 'af-form'}).length === 1;
+        }
+        return true;
+      }
+
+      // Converts the edited markup back into the layout tree and applies it to the working form.
+      // Returns a promise resolving true on success, false if the markup couldn't be applied.
+      function applyMarkupToLayout() {
+        return crmApi4('Afform', 'convert', {layout: editor.layoutHtml, from: 'html', to: 'deep', formatWhitespace: true})
+          .then((r) => {
+            const newLayout = r[0].layout;
+            if (!isValidLayout(newLayout)) {
+              CRM.alert(ts('The markup could not be applied because it produced an invalid layout structure.'), ts('Invalid markup'), 'error');
+              return false;
+            }
+            editor.afform.layout = newLayout;
+            setEditorLayout();
+            if (editor.getFormType() === 'form') {
+              $scope.entities = _.mapValues(afGui.findRecursive(editor.layout['#children'], {'#tag': 'af-entity'}, 'name'), backfillEntityDefaults);
+            }
+            else if (editor.getFormType() === 'search') {
+              editor.searchDisplays = getSearchDisplaysOnForm();
+            }
+            editor.markupEditMode = false;
+            return true;
+          })
+          .catch((error) => {
+            const message = error?.error_message ? error.error_message : ts('Unknown error');
+            CRM.alert(message, ts('Could not apply markup'), 'error');
+            return false;
+          });
+      }
+
+      $scope.hasUnappliedMarkupEdits = function() {
+        return editor.markupEditMode && editor.layoutHtml !== editor.markupEditBaseline;
+      };
+
+      // Prompts to apply or discard pending markup edits (e.g. before leaving edit mode
+      // or switching to the Layout tab). Does nothing if the user cancels.
+      function resolvePendingMarkupEdits(onDiscard, onApply) {
+        CRM.confirm({
+          title: ts('Unsaved markup changes'),
+          message: ts('You have made changes to the markup. Apply them to the layout, or discard them, before continuing.'),
+          options: {
+            cancel: ts('Cancel'),
+            discard: ts('Discard changes'),
+            apply: ts('Apply changes'),
+          },
+        })
+          .on('crmConfirm:discard', function() {
+            $scope.$apply(function() {
+              editor.layoutHtml = editor.markupEditBaseline;
+              editor.markupEditMode = false;
+              onDiscard();
+            });
+          })
+          .on('crmConfirm:apply', function() {
+            applyMarkupToLayout().then((applied) => {
+              if (applied) {
+                onApply();
+              }
+              // else: stay put, still in edit mode, so the user can fix their HTML
+            });
+          });
+      }
+
+      $scope.toggleMarkupEdit = function() {
+        if (!editor.markupEditMode) {
+          editor.markupEditBaseline = editor.layoutHtml;
+          editor.markupEditMode = true;
+          return;
+        }
+        if (!$scope.hasUnappliedMarkupEdits()) {
+          editor.markupEditMode = false;
+          return;
+        }
+        resolvePendingMarkupEdits(angular.noop, angular.noop);
+      };
+
+      $scope.switchToLayoutTab = function() {
+        if (!$scope.hasUnappliedMarkupEdits()) {
+          editor.markupEditMode = false;
+          editor.canvasTab = 'layout';
+          return;
+        }
+        const goToLayout = () => { editor.canvasTab = 'layout'; };
+        resolvePendingMarkupEdits(goToLayout, goToLayout);
       };
 
       this.addEntity = function(type, selectTab) {
@@ -716,6 +818,18 @@
       };
 
       $scope.save = function() {
+        if ($scope.hasUnappliedMarkupEdits()) {
+          applyMarkupToLayout().then((applied) => {
+            if (applied) {
+              doSave();
+            }
+          });
+          return;
+        }
+        doSave();
+      };
+
+      function doSave() {
         // save and close any open rich text elements
         $element[0].querySelectorAll('civi-rich-text-input[editing]').forEach((el) => el.saveAndCloseEditor());
 
@@ -755,7 +869,7 @@
             CRM.alert(message, ts('Save failed'), 'error');
             $scope.saving = false;
           });
-      };
+      }
 
       $scope.$watch('editor.afform.title', function(newTitle, oldTitle) {
         if (typeof oldTitle === 'string') {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditorCanvas.html
@@ -18,24 +18,24 @@
         </a>
       </div>
       <div class="btn-group btn-group-md">
-        <button type="submit" class="btn" ng-class="{'btn-primary': !editor.isSaved() && !saving, 'btn-warning': saving, 'btn-success': editor.isSaved()}" ng-disabled="editor.isSaved() || saving || !editor.afform.title" ng-click="save()">
+        <button type="submit" class="btn" ng-class="{'btn-primary': !(editor.isSaved() && !hasUnappliedMarkupEdits()) && !saving, 'btn-warning': saving, 'btn-success': editor.isSaved() && !hasUnappliedMarkupEdits()}" ng-disabled="(editor.isSaved() && !hasUnappliedMarkupEdits()) || saving || !editor.afform.title" ng-click="save()">
           <i class="crm-i" ng-class="{'fa-check': !saving, 'fa-spin fa-spinner': saving}" role="img" aria-hidden="true"></i>
-          <span ng-if="editor.isSaved() && !saving">{{:: ts('Saved') }}</span>
-          <span ng-if="!editor.isSaved() && !saving">{{:: ts('Save') }}</span>
+          <span ng-if="editor.isSaved() && !hasUnappliedMarkupEdits() && !saving">{{:: ts('Saved') }}</span>
+          <span ng-if="!(editor.isSaved() && !hasUnappliedMarkupEdits()) && !saving">{{:: ts('Save') }}</span>
           <span ng-if="saving">{{:: ts('Saving...') }}</span>
         </button>
       </div>
     </div>
 
     <ul role="tablist" class="nav nav-tabs">
-      <li role="tab" ng-class="{active: canvasTab === 'layout'}">
-        <a href ng-click="canvasTab = 'layout'">
+      <li role="tab" ng-class="{active: editor.canvasTab === 'layout'}">
+        <a href ng-click="switchToLayoutTab()">
           <i class="crm-i fa-list-alt" role="img" aria-hidden="true"></i>
           <span>{{:: ts('Layout') }}</span>
         </a>
       </li>
-      <li role="tab" ng-class="{active: canvasTab === 'markup'}">
-        <a href ng-click="canvasTab = 'markup'; updateLayoutHtml()">
+      <li role="tab" ng-class="{active: editor.canvasTab === 'markup'}">
+        <a href ng-click="editor.canvasTab = 'markup'; !editor.markupEditMode && updateLayoutHtml()">
           <i class="crm-i fa-code" role="img" aria-hidden="true"></i>
           <span>{{:: ts('Markup') }}</span>
         </a>
@@ -43,13 +43,25 @@
     </ul>
 
   </div>
-  <div id="afGuiEditor-canvas-body" role="tabpanel" class="panel-body" ng-if="canvasTab === 'layout'">
+  <div id="afGuiEditor-canvas-body" role="tabpanel" class="panel-body" ng-if="editor.canvasTab === 'layout'">
     <af-gui-container ng-if="editor.layout" node="editor.layout" entity-name="editor.blockEntity" data-entity="{{ editor.blockEntity }}" ></af-gui-container>
   </div>
-  <div class="panel-body" role="tabpanel" ng-if="canvasTab === 'markup'">
-    <p class="help-block">{{:: ts('This is a read-only preview of the auto-generated markup.') }}</p>
-    <!-- Wiring up edit mode wouldn't be super-hard in itself, but it's not worthwhile until we have validation to ensure that GUI+raw content are exchangeable  -->
-    <div crm-monaco="{readOnly: true}" ng-model="layoutHtml"></div>
+  <div class="panel-body" role="tabpanel" ng-if="editor.canvasTab === 'markup'">
+    <div class="af-gui-markup-controls">
+      <!-- Edit mode is gated behind the 'edit afform html' permission, since raw-HTML edits are only
+           structurally (not fully) validated before being applied to the layout. -->
+      <div class="crm-form-toggle-container pull-right"
+           ng-if="editor.checkPerm('edit afform html')">
+        <input type="checkbox" class="crm-form-toggle" title="{{:: ts('Edit raw markup') }}" ng-checked="editor.markupEditMode" ng-click="toggleMarkupEdit()">
+        <span class="crm-form-toggle-text crm-form-toggle-text-off">{{:: ts('View') }}</span>
+        <span class="crm-form-toggle-text crm-form-toggle-text-on">{{:: ts('Edit') }}</span>
+      </div>
+      <p class="help-block">
+        <span ng-if="!editor.markupEditMode">{{:: ts('This is a read-only preview of the auto-generated markup.') }}</span>
+        <span ng-if="editor.markupEditMode">{{:: ts('Editing raw markup. Click Save to apply your changes, or turn off editing to discard them.') }}</span>
+      </p>
+    </div>
+    <div crm-monaco="{readOnly: true}" ng-model="editor.layoutHtml" ng-disabled="!editor.markupEditMode"></div>
   </div>
 
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Back in the dawn of time someone wrote "afform_html" which lets you edit Afform markup. But it hasn't been updated for many decades.

It's definitely an advanced/developer feature but even (especially?) developers like things made easy for them. So let's include the editor directly in the main formbuilder editor!

This PR adds a "View/Edit" toggle if the user has `administer CiviCRM` or `edit afform html` permission.

Here is a screencast of it in action:

https://github.com/user-attachments/assets/dd02175c-b901-4e7b-bc29-b98c82363673

Before
----------------------------------------
Editor hard to find. You have to take the name of the form, then go to a link without a navigation menu entry, then search for the form. Then there is no validation when you edit/save.

After
----------------------------------------
Editor easy to find (if you have the right permissions). You can edit directly in the FormBuilder editor and see changes validated and applied immediately.

Technical Details
----------------------------------------


Comments
----------------------------------------

