### PR TITLE
Use a pattern-validated expiryDate picker for Afform Payments

### DIFF
--- a/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
+++ b/ext/civi_contribute/Civi/Checkout/CheckoutOptionUtils.php
@@ -129,9 +129,92 @@ class CheckoutOptionUtils {
       if ($field['htmlType'] === 'select') {
         $field['options'] = array_map(fn ($key) => ['id' => $key, 'label' => $field['attributes'][$key]], array_keys($field['attributes']));
       }
+      elseif ($field['htmlType'] === 'date' && $field['name'] === 'credit_card_exp_date') {
+        $field['htmlType'] = 'expiryDate';
+      }
       unset($field['attributes'], $field['extra']);
       return $field;
     }, $allFields);
+  }
+
+  /**
+   * Optional helper function to map Afform's card fields to the equivalent
+   *   params expected by doPayment() and payment processors.
+   *
+   * Currently just handles expiry_month/expiry_year - Afform uses the
+   *   "expiry_" prefix rather than the plain "month"/"year" quickform uses,
+   *   since those would be ambiguous if the form had any other month or year
+   *   fields. Afform also collects the expiry year as 2 digits (matching
+   *   what's printed on a physical card) but doPayment() and payment
+   *   processors expect a 4 digit year, so it is expanded here (assuming the
+   *   current century).
+   *
+   * @param array $paramsToMap
+   *
+   * @return array
+   */
+  public static function mapCardParams(array $paramsToMap): array {
+    if (array_key_exists('expiry_month', $paramsToMap)) {
+      $paramsToMap['month'] = $paramsToMap['expiry_month'];
+    }
+    if (array_key_exists('expiry_year', $paramsToMap)) {
+      $paramsToMap['year'] = self::expandExpiryYear($paramsToMap['expiry_year']);
+    }
+    return $paramsToMap;
+  }
+
+  /**
+   * Optional helper function to validate a card expiry month/year submitted from Afform.
+   *
+   * A html5 pattern attribute can restrict the *format* of the month/year fields
+   *   (eg. 2 digits) but cannot check whether the resulting date is a sane one -
+   *   that requires comparing against today's date, so it's done here instead.
+   *
+   * @param string $month
+   *   2 digit month, eg. "04".
+   * @param string $year
+   *   2 digit year, eg. "27".
+   *
+   * @return bool
+   */
+  public static function validateExpiryDate(string $month, string $year): bool {
+    $fullYear = self::expandExpiryYear($year);
+
+    // Reject anything further out than the site's configured credit card expiry
+    //   offset (eg. current year + 10) - without this a mistyped 2 digit year
+    //   like "94" would otherwise be accepted as the (technically future) year 2094.
+    $maxYear = (int) date('Y') + self::getMaxCreditCardExpiryOffset();
+    if ($fullYear > $maxYear) {
+      return FALSE;
+    }
+
+    return \CRM_Utils_Rule::currentDate(['M' => $month, 'Y' => $fullYear]);
+  }
+
+  /**
+   * @param string $year
+   *   2 digit year, eg. "27".
+   *
+   * @return int
+   *   4 digit year, assuming the current century, eg. 2027.
+   */
+  private static function expandExpiryYear(string $year): int {
+    $currentCentury = ((int) floor(date('Y') / 100)) * 100;
+    return $currentCentury + (int) $year;
+  }
+
+  /**
+   * @return int
+   *   Number of years into the future a credit card is allowed to expire,
+   *   per the site's "creditCard" date preferences (falls back to 10).
+   */
+  private static function getMaxCreditCardExpiryOffset(): int {
+    $dao = new \CRM_Core_DAO_PreferencesDate();
+    $dao->name = 'creditCard';
+    if ($dao->find(TRUE) && $dao->end !== NULL) {
+      return (int) $dao->end;
+    }
+    return 10;
   }
 
   public static function getPaymentProcessorPairs(array $paymentProcessorTypeNames): array {

--- a/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
+++ b/ext/civi_contribute/ang/afCheckout/afCheckoutBlock.component.js
@@ -140,6 +140,12 @@
         })))
         .then((options) => this.stateProvinceOptions[controlValue] = options);
 
+      // Used to validate the credit card expiry month/year fields (2 digits each,
+      // matching what's printed on a physical card). Format-only - whether the
+      // resulting date is actually in the future is checked server-side, since
+      // that can't be expressed with a static pattern.
+      this.expiryMonthPattern = /^(0[1-9]|1[0-2])$/;
+      this.expiryYearPattern = /^[0-9]{2}$/;
 
       this.exportParamValues = () => {
         // this is a quick way to check the data provider is ready

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/date.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/date.html
@@ -1,5 +1,0 @@
-<label>{{:: field.title }}</label>
-<div class="crm-flex-box af-checkout-field-date">
-  <input type="number" name='month' placeholder="MM" ng-model="$ctrl.checkout_params[field.name].M" ng-required="field.is_required">
-  <input type="number" name='year' placeholder="YY" ng-model="$ctrl.checkout_params[field.name].Y" ng-required="field.is_required">
-</div>

--- a/ext/civi_contribute/ang/afCheckout/checkoutFields/expiryDate.html
+++ b/ext/civi_contribute/ang/afCheckout/checkoutFields/expiryDate.html
@@ -1,0 +1,13 @@
+<label>{{:: field.title }}</label>
+<div class="crm-flex-box af-checkout-field-date">
+  <input type="text" name="{{:: field.name }}.month" placeholder="MM"
+         aria-label="{{:: ts('Expiration month') }}"
+         ng-model="$ctrl.checkout_params.expiry_month"
+         ng-pattern="$ctrl.expiryMonthPattern"
+         ng-required="field.is_required">
+  <input type="text" name="{{:: field.name }}.year" placeholder="YY"
+         aria-label="{{:: ts('Expiration year') }}"
+         ng-model="$ctrl.checkout_params.expiry_year"
+         ng-pattern="$ctrl.expiryYearPattern"
+         ng-required="field.is_required">
+</div>

--- a/ext/civi_contribute/tests/phpunit/Civi/Contribute/CheckoutOptionUtilsTest.php
+++ b/ext/civi_contribute/tests/phpunit/Civi/Contribute/CheckoutOptionUtilsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Civi\Contribute;
+
+use Civi\Checkout\CheckoutOptionUtils;
+use Civi\Test;
+use Civi\Test\CiviEnvBuilder;
+use Civi\Test\HeadlessInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group headless
+ */
+class CheckoutOptionUtilsTest extends TestCase implements HeadlessInterface {
+
+  public function setUpHeadless(): CiviEnvBuilder {
+    return Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function testMapCardParamsExpandsYear(): void {
+    $currentYear = (int) date('Y');
+    $shortYear = substr((string) ($currentYear + 1), 2, 2);
+
+    $mapped = CheckoutOptionUtils::mapCardParams([
+      'expiry_month' => '04',
+      'expiry_year' => $shortYear,
+      'amount' => 10,
+    ]);
+
+    $this->assertEquals('04', $mapped['month']);
+    $this->assertEquals($currentYear + 1, $mapped['year']);
+    // Original expiry_ prefixed keys should still be present - this is
+    // an additive mapping, not a rename.
+    $this->assertEquals('04', $mapped['expiry_month']);
+    $this->assertEquals(10, $mapped['amount']);
+  }
+
+  public function testMapCardParamsLeavesUnrelatedParamsUntouched(): void {
+    $mapped = CheckoutOptionUtils::mapCardParams(['amount' => 10]);
+    $this->assertEquals(['amount' => 10], $mapped);
+  }
+
+  public function testValidateExpiryDateAcceptsCurrentMonthAndYear(): void {
+    $now = getdate();
+    $month = str_pad((string) $now['mon'], 2, '0', STR_PAD_LEFT);
+    $year = substr((string) $now['year'], 2, 2);
+    $this->assertTrue(CheckoutOptionUtils::validateExpiryDate($month, $year));
+  }
+
+  public function testValidateExpiryDateRejectsPastYear(): void {
+    $lastYear = substr((string) ((int) date('Y') - 1), 2, 2);
+    $this->assertFalse(CheckoutOptionUtils::validateExpiryDate('01', $lastYear));
+  }
+
+  public function testValidateExpiryDateRejectsPastMonthInCurrentYear(): void {
+    $now = getdate();
+    if ($now['mon'] === 1) {
+      $this->markTestSkipped('Cannot construct a past month in January without crossing years.');
+    }
+    $pastMonth = str_pad((string) ($now['mon'] - 1), 2, '0', STR_PAD_LEFT);
+    $year = substr((string) $now['year'], 2, 2);
+    $this->assertFalse(CheckoutOptionUtils::validateExpiryDate($pastMonth, $year));
+  }
+
+  public function testValidateExpiryDateRejectsMistypedShortYearAsTooFarInFuture(): void {
+    // A mistyped/nonsense year like "94" expands to 2094 under a naive
+    // current-century assumption, which is technically in the future -
+    // the max-offset check is what actually catches this.
+    $this->assertFalse(CheckoutOptionUtils::validateExpiryDate('06', '94'));
+  }
+
+  public function testValidateExpiryDateRejectsInvalidMonth(): void {
+    $year = substr((string) ((int) date('Y') + 1), 2, 2);
+    $this->assertFalse(CheckoutOptionUtils::validateExpiryDate('13', $year));
+    $this->assertFalse(CheckoutOptionUtils::validateExpiryDate('00', $year));
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Extracted from https://github.com/civicrm/civicrm-core/pull/36092

Replaces the two unrestricted number inputs (which allow eg. month=-10, year=94) with two text inputs constrained by an ng-pattern (MM 01-12, YY 2-digit, matching what's printed on a physical card).

Before
----------------------------------------
Unuseable expiry date fields on Formbuilder payments.

After
----------------------------------------
Useable expiry date fields on Formbuilder payments.

Technical Details
----------------------------------------
Adds CheckoutOptionUtils::mapCardParams() and validateExpiryDate() as static, optional helpers (rather than instance methods on CheckoutSession), matching how getBillingAddress()/getBillingEmail() were relocated in #36165 following review feedback that optional/BC helpers shouldn't be forced on every CheckoutOption.
validateExpiryDate() closes a gap where Afform checkout has no equivalent of classic QuickForm's currentDate validation rule, since a static HTML pattern can't check whether a date is actually in the past - it delegates that check to the existing CRM_Utils_Rule::currentDate(), after expanding the submitted 2-digit year to 4 digits and bounding it against the site's configured creditCard expiry offset.

Comments
----------------------------------------
@rbaugh @ufundo 