### PR TITLE
dev/core#6662: safe help text with purify not escape

### DIFF
--- a/templates/CRM/Custom/Form/CustomField.hlp
+++ b/templates/CRM/Custom/Form/CustomField.hlp
@@ -10,5 +10,5 @@
 {* Dynamically fetch the help text for a custom field *}
 {htxt id=$id}
   {crmAPI var='result' entity='CustomField' action='getsingle' id=$id}
-  {$result.help_post|escape}
+  {$result.help_post|purify}
 {/htxt}

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -11,7 +11,7 @@
 {if $element.help_pre}
   <tr class="custom_field-help-pre-row {$element.element_name}-row-help-pre">
     <td>&nbsp;</td>
-    <td class="html-adjust description">{$element.help_pre|escape}</td>
+    <td class="html-adjust description">{$element.help_pre|purify}</td>
   </tr>
 {/if}
 {if $element.html_type === 'Hidden'}

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -31,7 +31,7 @@
     {foreach from=$cd_edit.fields item=element key=field_id}
       {if $element.is_view eq 0}{* fix for CRM-2699 *}
         {if !empty($element.help_pre)}
-            <tr><td class="label"></td><td class="description">{$element.help_pre|escape}</td></tr>
+            <tr><td class="label"></td><td class="description">{$element.help_pre|purify}</td></tr>
         {/if}
   {if !empty($element.options_per_line)}
         {assign var="element_name" value=$element.element_name}

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -62,8 +62,8 @@
               <td class="crm-price-option-label crm-editable" data-field="label">{$row.label|escape}</td>
               <td class="crm-price-option-value">{$row.amount|crmMoney}</td>
               <td class="crm-price-option-non-deductible-amount">{$row.non_deductible_amount|crmMoney}</td>
-              <td class="crm-price-option-pre-help">{$row.help_pre|escape}</td>
-              <td class="crm-price-option-post-help">{$row.help_post|escape}</td>
+              <td class="crm-price-option-pre-help">{$row.help_pre|purify}</td>
+              <td class="crm-price-option-post-help">{$row.help_post|purify}</td>
               {if $isEvent}
                 <td class="crm-price-option-count">{$row.count}</td>
                 <td class="crm-price-option-max">{$row.max_value}</td>


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/work_items/6662

The [recent security fix](https://github.com/civicrm/civicrm-core/commit/4b2b4ab0ff246895b50d4f44e993fec729c88e98#diff-ffb97cae15f0e2304f4f7e40c53f9d8931f87821c20d10bd5d4b12267066ef50) is inconsistent in how it treats help text. In some places help text is secured with `purify` and in other places with `escape`. I propose making it consistent on `purify` so that it is backwards compatible where people used links in help text (as we've done with clients who need links to further documentation). That security fix broke that. This PR fixes it.