### PR TITLE
Remove unused code from token replacement

### DIFF
--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -646,36 +646,17 @@ class CRM_Utils_Token {
    *   The domain BAO.
    * @param array $groups
    *   The groups (if any) being unsubscribed.
-   * @param bool $html
-   *   Replace tokens with html or plain text.
-   * @param int $contact_id
-   *   The contact ID.
-   * @param string $hash The security hash of the unsub event
    *
    * @return string
    *   The processed string
    */
-  public static function &replaceUnsubscribeTokens(
+  public static function replaceUnsubscribeTokens(
     $str,
-    &$domain,
-    &$groups,
-    $html,
-    $contact_id,
-    $hash
+    $domain,
+    $groups
   ) {
     if (self::token_match('unsubscribe', 'group', $str)) {
       if (!empty($groups)) {
-        $config = CRM_Core_Config::singleton();
-        $base = CRM_Utils_System::baseURL();
-
-        // FIXME: an ugly hack for CRM-2035, to be dropped once CRM-1799 is implemented
-        $dao = new CRM_Contact_DAO_Group();
-        $dao->find();
-        while ($dao->fetch()) {
-          if (substr($dao->visibility, 0, 6) == 'Public') {
-            $visibleGroups[] = $dao->id;
-          }
-        }
         $value = implode(', ', $groups);
         self::token_replace('unsubscribe', 'group', $value, $str);
       }


### PR DESCRIPTION
Overview
----------------------------------------
Remove unused code from token replacement

Before
----------------------------------------
<img width="1032" height="556" alt="image" src="https://github.com/user-attachments/assets/5c6ff43e-1614-41cd-8eb9-8d4aa94e8bc4" />


After
----------------------------------------
gone

Technical Details
----------------------------------------
it's got good intentions but does nothing

Comments
----------------------------------------
