### PR TITLE
AdminUI - Fix scheduled job log display

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
@@ -81,11 +81,16 @@ return [
               'rewrite' => '[name]<br><br>[command]',
             ],
             [
-              'type' => 'html',
+              'type' => 'field',
               'key' => 'description',
-              'label' => 'Output',
+              'label' => 'Result',
               'sortable' => TRUE,
-              'rewrite' => '<b>{ts}Summary:{/ts}</b> [description]<br><b>{ts}Details:{/ts}</b><pre>[data]</pre>',
+            ],
+            [
+              'type' => 'field',
+              'key' => 'data',
+              'label' => 'Data',
+              'sortable' => TRUE,
             ],
           ],
           'classes' => [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes broken display of scheduled job logs with AdminUI enabled.

See https://lab.civicrm.org/dev/core/-/work_items/3912#note_208255

Technical Details
----------------------------------------
Job data containing curly braces was being incorrectly parsed as smarty.