### PR TITLE
Generic Settings Form: hide contact settings

### DIFF
--- a/CRM/Admin/Form/Generic.php
+++ b/CRM/Admin/Form/Generic.php
@@ -43,8 +43,9 @@ class CRM_Admin_Form_Generic extends CRM_Core_Form {
     $filter = $this->getSettingPageFilter();
     // Start with fully-resolved metadata for all settings; this allows callbacks to add/remove themselves from pages
     $allSettings = \Civi\Core\SettingsMetadata::getMetadata(NULL, NULL, TRUE, FALSE, TRUE);
+    // Filter by page filter, and also hide contact-specific settings
     $this->_settings = array_filter($allSettings, function ($setting) use ($filter) {
-      return !empty($setting['settings_pages'][$filter]);
+      return !empty($setting['settings_pages'][$filter]) && empty($setting['is_contact']);
     });
     // Add CSS for File CRUD form elements
     Civi::resources()->addStyleFile('civicrm', 'css/admin.css');


### PR DESCRIPTION
Overview
----------------------------------------

If an extension declares a setting which has `is_contact => 1` (i.e. it is a setting for contacts, not a global admin setting), the setting is currently displayed when viewing `civicrm/adming/setting/myext`.

The [login security]() extension uses this, for example. Enable the extension, then go to Administer > System Settings > Login Security. A user-specific OTP field is visible at the bottom.

Before
----------------------------------------

User settings field are shown.

After
----------------------------------------

Hidden.

Technical Details
----------------------------------------

This would make it impossible to use `CRM_Admin_Form_Generic` for a contact/user settings form, but I don't think it is possible at all currently. By adding the filter here, it seems like a low-risk fix.
