### PR TITLE
dev/core#6655 - fix various issues when premiums have no options.

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -736,7 +736,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     if ($this->getSelectedProductID()) {
       $option = $this->getSelectedProductOption();
-      $this->buildPremiumsBlock(FALSE, $option);
+      $this->buildPremiumsBlock(FALSE, $option, 'Confirm');
       $this->set('option', $option);
     }
     else {

--- a/CRM/Contribute/Form/Contribution/ThankYou.php
+++ b/CRM/Contribute/Form/Contribution/ThankYou.php
@@ -102,7 +102,7 @@ class CRM_Contribute_Form_Contribution_ThankYou extends CRM_Contribute_Form_Cont
     $this->assign('receiptFromEmail', $this->_values['receipt_from_email'] ?? NULL);
 
     if ($this->getProductID()) {
-      $this->buildPremiumsBlock(FALSE, $option);
+      $this->buildPremiumsBlock(FALSE, $option, 'ThankYou');
     }
     else {
       $this->assign('products');

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -1061,10 +1061,11 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
    *
    * @param bool $formItems
    * @param string $selectedOption
+   * @param string $context
    *
    * @noinspection PhpUnhandledExceptionInspection
    */
-  protected function buildPremiumsBlock(bool $formItems = FALSE, $selectedOption = NULL): void {
+  protected function buildPremiumsBlock(bool $formItems = FALSE, $selectedOption = NULL, $context = NULL): void {
     $selectedProductID = $this->getProductID();
     $this->add('hidden', 'selectProduct', $selectedProductID, ['id' => 'selectProduct']);
     $premiumProducts = PremiumsProduct::get()
@@ -1081,14 +1082,22 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
     foreach ($premiumProducts as $premiumProduct) {
       $product = CRM_Utils_Array::filterByPrefix($premiumProduct, 'product_id.');
       $premium = CRM_Utils_Array::filterByPrefix($premiumProduct, 'premiums_id.');
-      if ($selectedProductID === $product['id'] && $selectedOption) {
-        // In this case we are on the thank you or confirm page so assign
-        // the selected option to the page for display.
-        $product['options'] = ts('Selected Option') . ': ' . $selectedOption;
-      }
-      elseif ($selectedOption) {
-        // We are on the thank you or confirm page, but this option wasn't selected.
-        continue;
+      if ($context == 'ThankYou' || $context == 'Confirm') {
+        // In this case we are on the thank you or confirm page
+        if ($selectedProductID === $product['id']) {
+          if ($selectedOption) {
+            // Assign the selected option to the page for display.
+            $product['options'] = ts('Selected Option') . ': ' . $selectedOption;
+          }
+          else {
+            // No options, but make it a string to avoid blowing up the template
+            $product['options'] = '';
+          }
+        }
+        else {
+          // We are on the thank you or confirm page, but this product wasn't selected.
+          continue;
+        }
       }
       $options = array_filter((array) $product['options']);
       $productOptions = [];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes issues when premiums have no options.  See https://lab.civicrm.org/dev/core/-/work_items/6655

Before
----------------------------------------
If a premium is created with no options and this is selected on a contribution page, then moving to the Confirm or ThankYou pages fails.

After
----------------------------------------
No failure

Technical Details
----------------------------------------
The previous code checks whether `$selectedOption` is empty to determine whether the context is the main contribution page where products can be selected, or the thankyou/confirm pages where only the previously selected product is displayed.  This works when the product has options, but `$selectedOption` is null both on the main page and when there is no option to select.

Instead of deriving the context from the selected option, this code explicitly passes in the context.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
