### PR TITLE
dev/core#6665 Fix VALUE_SEPARATOR characters in entity tokens

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -102,6 +102,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       // eg. role_id for participant would be an array here.
       $fieldValue = implode(', ', $fieldValue);
     }
+    elseif (is_string($fieldValue) && str_contains($fieldValue, \CRM_Core_DAO::VALUE_SEPARATOR)) {
+      $fieldValue = implode(', ', \CRM_Utils_Array::explodePadded($fieldValue));
+    }
 
     if ($this->isPseudoField($field)) {
       if (!empty($fieldValue)) {

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -2209,4 +2209,28 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     ], 1);
   }
 
+  /**
+   * Test that emailed receipt for quick-config contribution page does not contain ASCII 0x01 (SOH) characters.
+   */
+  public function testQuickConfigEmailedReceiptNoASCII0x01(): void {
+    $this->contributionPageQuickConfigCreate(
+      ['is_email_receipt' => 1],
+      [],
+      FALSE,
+      FALSE,
+      TRUE,
+      FALSE
+    );
+
+    $this->submitOnlineContributionForm([
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+      'price_' . $this->ids['PriceField']['contribution_amount'] => $this->ids['PriceFieldValue']['contribution_amount_15'],
+      'id' => $this->getContributionPageID(),
+      'email-5' => 'donor@example.com',
+    ] + $this->getBillingSubmitValues(), $this->getContributionPageID());
+
+    $this->assertMailSentCount(1);
+    $this->assertMailSentNotContainingString(CRM_Core_DAO::VALUE_SEPARATOR);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6665](https://lab.civicrm.org/dev/core/-/work_items/6665) issue where contribution receipt emails generated for quick-config contribution pages (Fixed Contribution Options) contain ASCII 0x01 (`VALUE_SEPARATOR`) characters before and after the price option label.

Before
----------------------------------------
Invisible control characters are sent in emails from quick-config contribution pages.

After
----------------------------------------
Clean emails.

Technical Details
----------------------------------------
When a donor submits a contribution via a contribution page using fixed contribution options (quick-config pricing), `amount_level` is stored in the database with `CRM_Core_DAO::VALUE_SEPARATOR` (`\x01`) delimiters (e.g. `\x01Fifteen - 1\x01`). When `{contribution.amount_level}` is evaluated in the receipt template, the raw string is output directly, resulting in ASCII 0x01 control characters in the email body.
