### PR TITLE
AdminUI - Improve scheduled job log display

### DIFF
--- a/CRM/Core/JobLogger.php
+++ b/CRM/Core/JobLogger.php
@@ -34,7 +34,7 @@ class CRM_Core_JobLogger extends \Psr\Log\AbstractLogger {
       $dao->job_id = $job->id;
       $dao->name = $job->name;
 
-      $dao->command = ts("Entity:") . " " . $job->api_entity . " " . ts("Action:") . " " . $job->api_action;
+      $dao->command = ts('Entity: %1', [1 => $job->api_entity]) . "\n" . ts('Action: %1', [1 => $job->api_action]);
       // This seems weird to me - the output is a little hard to read. More punctuation?
 
       $data = '';

--- a/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Scheduled_Jobs_Log.mgd.php
@@ -78,7 +78,7 @@ return [
               'key' => 'name',
               'label' => 'Job Name and Command',
               'sortable' => TRUE,
-              'rewrite' => '[name]<br><br>[command]',
+              'rewrite' => '{$name|escape}<br><pre>{$command|escape}</pre>',
             ],
             [
               'type' => 'field',
@@ -87,10 +87,11 @@ return [
               'sortable' => TRUE,
             ],
             [
-              'type' => 'field',
+              'type' => 'html',
               'key' => 'data',
               'label' => 'Data',
               'sortable' => TRUE,
+              'rewrite' => '<details><summary class="nowrap">{ts escape="html"}View Details{/ts}</summary><pre>{$data|trim|escape}</pre></details>',
             ],
           ],
           'classes' => [

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -343,10 +343,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
    * @return string
    */
   protected function rewrite(string $rewrite, array $data, string $format = 'view'): string {
+    // Check if the original string contains smarty
+    $hasSmarty = str_contains($rewrite, '{') && str_contains($rewrite, '}');
     $output = $this->replaceTokens($rewrite, $data, $format);
     $output = \Civi\Token\TokenCompatSubscriber::renderConditionalPunctuation($output);
-    // Cheap str_contains to skip Smarty processing if not needed
-    $hasSmarty = str_contains($output, '{');
     if ($hasSmarty) {
       $vars = [];
       $nestedIds = [];


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #36370

Formats everything a bit more nicely and avoids any special characters breaking the display.

Before
----------------------------------------
<img width="3204" height="380" alt="Screenshot 2026-07-29 at 9 49 15 PM" src="https://github.com/user-attachments/assets/9d74c2dd-50e1-465e-83c0-d30d97ceb875" />


After
----------------------------------------
<img width="3208" height="380" alt="Screenshot 2026-07-29 at 9 44 24 PM" src="https://github.com/user-attachments/assets/4a4d5bf7-af34-4f05-8137-9e61d3cecc94" />

Technical Details
---------
The change to [AbstractRunAction.php](https://github.com/civicrm/civicrm-core/compare/master...colemanw:civicrm-core:ScheduledJobLog?expand=1#diff-4ff3093a707d49165ad2e8afd6d08ccc922011ff5f8bc98749365be676184b58) ought to prevent token content accidentally being evaluated as smarty.