### PR TITLE
Fix for Search Chart Display with parameter

### DIFF
--- a/CRM/Core/BAO/Translation.php
+++ b/CRM/Core/BAO/Translation.php
@@ -306,6 +306,7 @@ class CRM_Core_BAO_Translation extends CRM_Core_DAO_Translation implements HookI
       \Civi::$statics[__CLASS__]['site_language_translation'] = [];
       $translations = Translation::get(FALSE)
         ->addWhere('entity_table', '=', CRM_Core_DAO_AllCoreTables::getTableForEntityName($entity))
+        ->addWhere('status_id:name', '=', 'active')
         ->setCheckPermissions(FALSE)
         ->setSelect(['entity_field', 'entity_id', 'string', 'language'])
         ->addWhere('language', '=', \Civi::settings()->get('lcMessages'))

--- a/CRM/Custom/Form/Field.php
+++ b/CRM/Custom/Form/Field.php
@@ -252,6 +252,7 @@ class CRM_Custom_Form_Field extends CRM_Core_Form {
       $this->freeze('data_type');
       if (!empty($this->_values['option_group_id'])) {
         $this->assign('hasOptionGroup', in_array($this->_values['html_type'], self::$htmlTypesWithOptions));
+        $this->assign('optionGroupId', $this->_values['option_group_id']);
         // Before dev/core#155 we didn't set the is_reserved flag properly, which should be handled by the upgrade script...
         //  but it is still possible that existing installs may have optiongroups linked to custom fields that are marked reserved.
         $optionGroupParams['id'] = $this->_values['option_group_id'];

--- a/ext/chart_kit/js/components/civi-search-display.js
+++ b/ext/chart_kit/js/components/civi-search-display.js
@@ -175,15 +175,6 @@
         });
       }
 
-      if (this.afFieldset) {
-        // Add filter title to Afform
-        this.onPostRun.push((apiResults) => {
-          if (apiResults.run.labels && apiResults.run.labels.length && $scope.$parent.addTitle) {
-            console.log("$scope.$parent.addTitle(apiResults.run.labels.join(' '));");
-          }
-        });
-      }
-
       // Trigger an event when the searchDisplay has completely (re-)loaded
       this.onPostRun.push(() => this.dispatchEvent(new Event('load')));
 

--- a/templates/CRM/Custom/Form/CustomField.hlp
+++ b/templates/CRM/Custom/Form/CustomField.hlp
@@ -10,5 +10,5 @@
 {* Dynamically fetch the help text for a custom field *}
 {htxt id=$id}
   {crmAPI var='result' entity='CustomField' action='getsingle' id=$id}
-  {$result.help_post|escape}
+  {$result.help_post|purify}
 {/htxt}

--- a/templates/CRM/Custom/Form/Edit/CustomField.tpl
+++ b/templates/CRM/Custom/Form/Edit/CustomField.tpl
@@ -11,7 +11,7 @@
 {if $element.help_pre}
   <tr class="custom_field-help-pre-row {$element.element_name}-row-help-pre">
     <td>&nbsp;</td>
-    <td class="html-adjust description">{$element.help_pre|escape}</td>
+    <td class="html-adjust description">{$element.help_pre|purify}</td>
   </tr>
 {/if}
 {if $element.html_type === 'Hidden'}

--- a/templates/CRM/Custom/Form/Field.tpl
+++ b/templates/CRM/Custom/Form/Field.tpl
@@ -394,6 +394,6 @@
 {* Give link to view/edit option group *}
 {if $action eq 2 && !empty($hasOptionGroup)}
   <div class="action-link">
-    {crmButton p="civicrm/admin/custom/group/field/option" q="reset=1&action=browse&fid=`$id`&gid=`$gid`" icon="pencil"}{ts}View / Edit Multiple Choice Options{/ts}{/crmButton}
+    {crmButton p="civicrm/admin/custom/group/field/options" f="?option_group_id=`$optionGroupId`" icon="pencil"}{ts}View / Edit Multiple Choice Options{/ts}{/crmButton}
   </div>
 {/if}

--- a/templates/CRM/Custom/Form/Preview.tpl
+++ b/templates/CRM/Custom/Form/Preview.tpl
@@ -31,7 +31,7 @@
     {foreach from=$cd_edit.fields item=element key=field_id}
       {if $element.is_view eq 0}{* fix for CRM-2699 *}
         {if !empty($element.help_pre)}
-            <tr><td class="label"></td><td class="description">{$element.help_pre|escape}</td></tr>
+            <tr><td class="label"></td><td class="description">{$element.help_pre|purify}</td></tr>
         {/if}
   {if !empty($element.options_per_line)}
         {assign var="element_name" value=$element.element_name}

--- a/templates/CRM/Price/Page/Option.tpl
+++ b/templates/CRM/Price/Page/Option.tpl
@@ -62,8 +62,8 @@
               <td class="crm-price-option-label crm-editable" data-field="label">{$row.label|escape}</td>
               <td class="crm-price-option-value">{$row.amount|crmMoney}</td>
               <td class="crm-price-option-non-deductible-amount">{$row.non_deductible_amount|crmMoney}</td>
-              <td class="crm-price-option-pre-help">{$row.help_pre|escape}</td>
-              <td class="crm-price-option-post-help">{$row.help_post|escape}</td>
+              <td class="crm-price-option-pre-help">{$row.help_pre|purify}</td>
+              <td class="crm-price-option-post-help">{$row.help_post|purify}</td>
               {if $isEvent}
                 <td class="crm-price-option-count">{$row.count}</td>
                 <td class="crm-price-option-max">{$row.max_value}</td>

--- a/tests/phpunit/api/v4/Options/TranslationModeTest.php
+++ b/tests/phpunit/api/v4/Options/TranslationModeTest.php
@@ -21,6 +21,7 @@ namespace api\v4\Options;
 use api\v4\Api4TestBase;
 use Civi\Api4\MessageTemplate;
 use Civi\Api4\Translation;
+use Civi\Test\TransactionalInterface;
 
 /**
  * Tests for the option `$apiRequest->setTranslationMode(...)`.
@@ -32,7 +33,7 @@ use Civi\Api4\Translation;
  *
  * @group headless
  */
-class TranslationModeTest extends Api4TestBase {
+class TranslationModeTest extends Api4TestBase implements TransactionalInterface {
 
   public static function getTranslationSettings(): array {
     $es = [];
@@ -82,6 +83,65 @@ class TranslationModeTest extends Api4TestBase {
       ->execute()->indexBy('workflow_name');
 
     $this->assertFrenchTranslationRetrieved($messageTemplate['contribution_online_receipt']);
+  }
+
+  /**
+   * Test that a draft translation is never used in place of the active one.
+   *
+   * @dataProvider getTranslationSettings
+   * @throws \CRM_Core_Exception
+   * @group locale
+   */
+  public function testDraftTranslationsAreNotUsed($translationSettings): void {
+    $cleanup = \CRM_Utils_AutoClean::swapSettings($translationSettings);
+
+    // Case 1: The requested language has no translation and
+    // falls back to the site-default language.
+    $messageTemplateID = MessageTemplate::get()
+      ->addWhere('is_default', '=', 1)
+      ->addWhere('workflow_name', '=', 'contribution_online_receipt')
+      ->addSelect('id')
+      ->execute()->first()['id'];
+
+    Translation::save()->setRecords([
+      ['status_id:name' => 'active', 'string' => 'Active English Subject'],
+      ['status_id:name' => 'draft', 'string' => 'Draft English Subject'],
+    ])->setDefaults([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'entity_field' => 'msg_subject',
+      'language' => 'en_US',
+    ])->execute();
+
+    $fallbackResult = MessageTemplate::get()
+      ->addWhere('id', '=', $messageTemplateID)
+      ->addSelect('id', 'msg_subject')
+      ->setLanguage('fr_CA')
+      ->setTranslationMode('fuzzy')
+      ->execute()->single();
+
+    $this->assertEquals('Active English Subject', $fallbackResult['msg_subject']);
+    $this->assertEquals('en_US', $fallbackResult['actual_language']);
+
+    // Case 2: The requested language itself has a translation.
+    $this->addTranslation();
+    Translation::create()->setValues([
+      'entity_table' => 'civicrm_msg_template',
+      'entity_id' => $messageTemplateID,
+      'entity_field' => 'msg_subject',
+      'language' => 'fr_FR',
+      'status_id:name' => 'draft',
+      'string' => 'Bonjour (draft)',
+    ])->execute();
+
+    $frenchResult = MessageTemplate::get()
+      ->addWhere('id', '=', $messageTemplateID)
+      ->addSelect('id', 'msg_subject', 'msg_html')
+      ->setLanguage('fr_FR')
+      ->setTranslationMode('fuzzy')
+      ->execute()->single();
+
+    $this->assertFrenchTranslationRetrieved($frenchResult);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
A search kit chart display can be filtered with a parameter like this:

<img width="756" height="331" alt="image" src="https://github.com/user-attachments/assets/7e67883d-80f6-44ba-b4fd-6813268e13e2" />

Currently this does not work. This PR is a fix for this.

Before
----------------------------------------
To reproduce, add searchkit that is attached to this issue [chartest.json](https://github.com/user-attachments/files/30547142/chartest.json) with the import function of searchkit. And enable the 'Chart Kit' extension.

Go to the following URL: https://patch.ddev.site/civicrm/chartest (use your own test instance). Now it should show a chart. This proves that the Searchkit is imported correctly. 

Now use https://patch.ddev.site/civicrm/chartest#/gender_id=1 . The chart is not shown (use a new tab; otherwise, you see the old chart).

In the JavaScript console, you see the following error:

```` 
Uncaught (in promise) ReferenceError: $scope is not defined
    initializeDisplay civi-search-display.js:181
    runSearch civi-search-display.js:318
    runSearch civi-search-display.js:318
    promise callback*runSearch civi-search-display.js:296
    nextRun civi-search-display.js:107
    setTimeout handler*getResultsSoon civi-search-display.js:107
    filterChangeTimeout civi-search-display.js:246
    setTimeout handler*_onChangeFilters civi-search-display.js:241
    attributeChangedCallback civi-search-display.js:48
    attributeChangedCallback civi-search-display-chart-kit.js:45
    jQuery 3
    Angular 20
    jQuery 2
    <anonymous> Angular
    jQuery 7
    <anonymous> Common.js:1783
    jQuery 8
````


After
----------------------------------------
After installing the PR (after the installation, do a `composer civicrm:publish`)the chart is displayed, the filter works, and no error is shown in the JavaScript console.

Technical Details
----------------------------------------
The only thing the PR does is remove the code that causes the error. But the only thing the code does is show some logging. So maybe it is obsolete and a trace of a debugging process, and it can be safely removed.

