### PR TITLE
dev/core#6666 : Garbled date in Event Registration thank you Screen

### DIFF
--- a/CRM/Event/Form/Registration/Confirm.php
+++ b/CRM/Event/Form/Registration/Confirm.php
@@ -652,7 +652,7 @@ class CRM_Event_Form_Registration_Confirm extends CRM_Event_Form_Registration {
         if (!$pending && !empty($participantRecord['is_primary']) &&
           !$this->_allowWaitlist && !$this->_requireApproval
         ) {
-          $this->set('receiveDate', CRM_Utils_Date::mysqlToIso($participantRecord['receive_date'] ?? NULL));
+          $this->set('receiveDate', $participantRecord['receive_date'] ?? NULL);
           $this->set('trxnId', $participantRecord['trxn_id'] ?? NULL);
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
After event registration, on thank you page transaction date seems to be wrong. Check the transaction date in the screenshot below:
<img width="863" height="697" alt="Screenshot 2026-07-30 at 9 57 15 PM" src="https://github.com/user-attachments/assets/55b81494-f151-4458-b377-c7b193d8a256" />


Technical Details
----------------------------------------
The bug starts from : 
1. At L629 [here](https://github.com/civicrm/civicrm-core/blob/master/CRM/Event/Form/Registration/Confirm.php#L629) value comes back in MySQL format 2026-07-25 20:14:33
2. Then at L655, it through CRM_Utils_Date::mysqlToIso(). That function slices by fixed character offsets and expects the compact YmdHis form (20260725201433). Fed the separator form, it produces garbage: 2026--0-7- 25: 2:0:.
3. On ThankYou.tpl the trxn date is displayed as {$receive_date|crmDate}, which re-parses by offset and gets month=0, day=7, hour=25, minute=2 and thus formatted into 7th, 2026 13:02 PM.

Comments
----------------------------------------
ping @colemanw @seamuslee001 