### PR TITLE
Stop overriding the label specified in the price set for the contribution_amount field

### DIFF
--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -544,7 +544,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
           }
         }
         if (!empty($options)) {
-          $label = (!empty($this->_membershipBlock) && $field['name'] === 'contribution_amount') ? ts('Additional Contribution') : $field['label'];
           $extra = [];
           $fieldID = (int) $field['id'];
           if ($fieldID === $this->getPriceFieldOtherID()) {
@@ -575,7 +574,7 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
             $field['id'],
             FALSE,
             $field['is_required'] ?? FALSE,
-            $label,
+            $field['label'],
             $options,
             [],
             $extra


### PR DESCRIPTION
Overview
----------------------------------------
On a Contribution Page using a PriceSet for memberships, the label for the 'contribution_amount' field specified in the PriceSet is ignored and force to 'Additional Contribution'.

Before
----------------------------------------
Always labelled "Additional Contribution"

After
----------------------------------------
Use the label specified in the PriceSet, as happens with all other fields in the PriceSet.

Technical Details
----------------------------------------


Comments
----------------------------------------

