### PR TITLE
dev/core#6668 Fix reversed CiviCase activity sort labels

### DIFF
--- a/CRM/Case/Info.php
+++ b/CRM/Case/Info.php
@@ -298,8 +298,8 @@ class CRM_Case_Info extends CRM_Core_Component_Info {
   public static function getSortOptions() {
     return [
       'default' => ts('Default'),
-      '0' => ts('Definition order'),
-      '1' => ts('Alphabetical order'),
+      '0' => ts('Alphabetical order'),
+      '1' => ts('Definition order'),
     ];
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

This PR fixes the reversed labels in the CiviCase **Activity Type Sorting** setting.

The existing sorting behavior is correct, but the labels shown to administrators do not match that behavior.

Related issue: [dev/core#6668](https://lab.civicrm.org/dev/core/-/work_items/6668)

Before
----------------------------------------

`CRM_Case_Info::getSortOptions()` currently defines:

```php
'0' => ts('Definition order'),
'1' => ts('Alphabetical order'),
```

However, the Manage Case screen applies alphabetical sorting when the setting value is `0`.

As a result:

- **Definition order** produces alphabetical order.
- **Alphabetical order** preserves the order configured in the Case Type.

After
----------------------------------------

The labels are swapped so they match the existing behavior:

```php
'0' => ts('Alphabetical order'),
'1' => ts('Definition order'),
```

The setting will now accurately show:

- **Alphabetical order** when activity types are sorted alphabetically.
- **Definition order** when activity types follow the order configured in the Case Type.

Technical Details
----------------------------------------

This PR changes only the labels returned by `CRM_Case_Info::getSortOptions()`.

It does not change:

- Stored setting values.
- Existing sorting logic.
- Database data.
- Existing activity ordering after an upgrade.

Changing the sorting condition instead would alter the current display order on existing CiviCase-enabled sites.