### PR TITLE
dev/core#6669 - SearchKit - Clean up display event handler, visibility poller and debounced searches on $destroy

### DIFF
--- a/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
+++ b/ext/search_kit/ang/crmSearchDisplay/traits/searchDisplayBaseTrait.service.js
@@ -101,11 +101,13 @@
         }
 
         // Popup forms in this display or surrounding Afform trigger a refresh
+        const $closestForm = $element.closest('form');
+        const onFormSuccess = () => {
+          ctrl.rowCount = null;
+          ctrl.getResultsPronto();
+        };
         if (!isSubsearch) {
-          $element.closest('form').on('crmPopupFormSuccess crmFormSuccess', () => {
-            ctrl.rowCount = null;
-            ctrl.getResultsPronto();
-          });
+          $closestForm.on('crmPopupFormSuccess crmFormSuccess', onFormSuccess);
         }
 
         // When filters are changed, trigger callbacks and refresh search (if there's no search button)
@@ -176,12 +178,13 @@
         $element.css('display', 'block');
 
         // If the search display is visible, go ahead & run it
+        let checkVisibility;
         if ($element.is(':visible')) {
           setUpWatches();
         }
         // Wait until display is visible
         else {
-          let checkVisibility = $interval(() => {
+          checkVisibility = $interval(() => {
             if ($element.is(':visible')) {
               $interval.cancel(checkVisibility);
               setUpWatches();
@@ -204,6 +207,19 @@
             });
           }
         }, 900);
+
+        // Clean up the form handler, visibility poller and pending debounced
+        // searches, which are not released by the $scope itself
+        $scope.$on('$destroy', () => {
+          if (!isSubsearch) {
+            $closestForm.off('crmPopupFormSuccess crmFormSuccess', onFormSuccess);
+          }
+          if (checkVisibility) {
+            $interval.cancel(checkVisibility);
+          }
+          ctrl.getResultsPronto.cancel();
+          ctrl.getResultsSoon.cancel();
+        });
       },
 
       hasExtraFirstColumn: function() {


### PR DESCRIPTION
## Overview

`searchDisplayBaseTrait` binds an anonymous handler on the surrounding form and, for hidden displays, starts a 250ms visibility `$interval`; neither is released when the controller's scope is destroyed, and pending debounced searches can still fire afterwards. Repeatedly mounting displays in the same page context (admin preview, Afform re-render) retains controllers and keeps pollers running.

See https://lab.civicrm.org/dev/core/-/issues/6669

## Before

Handler, poller and debounced searches survive scope destruction; easiest to observe by toggling a display's type in the SearchKit admin preview with a profiler open.

## After

A `$destroy` listener unbinds the (now named) form handler, cancels the poller and cancels pending debounced searches. No behavior change for live displays.

## Comments

Affects every display type mixing in the trait; no per-component changes needed. `debounced.cancel()` is provided by the bundled lodash-compat 3.0.1.