### PR TITLE
SearchKit - Fix ReferenceError and overlong aliases in the function builder

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -221,24 +221,15 @@
         ctrl.writeExpr();
       };
 
-      function safeStringAlias(value) {
-        const MAX_LEN = 20;
-        const cleaned = value
-          .toLowerCase()
-          .replace(/['"]/g, '')        // remove quotes
-          .replace(/[^a-z0-9]+/g, '_') // replace unsafe chars
-          .replace(/^_+|_+$/g, '');    // trim underscores
-
-        const short = cleaned.slice(0, MAX_LEN);
-        return `${short}_${hash}`;
-      }
-
-      // Make a sql-friendly alias for this expression
+      // Make a sql-friendly alias for this expression, using the same
+      // truncate-and-hash formula as the SQL column names it may become.
       function makeAlias() {
         const args = ctrl.args
           .filter(arg => arg.value && (arg.type === 'field' || arg.type === 'number' || arg.type === 'string'))
-          .map(arg => arg.type === 'string' ? safeStringAlias(arg.value) : arg.value);
-        return (ctrl.fnName + '_' + args.join('_')).replace(/[.:]/g, '_');
+          .map(arg => String(arg.value));
+        // Replace the pseudoconstant separator, which createSqlName would strip
+        const alias = (ctrl.fnName + '_' + args.join('_')).replace(/:/g, '_');
+        return searchMeta.createSqlName(alias);
       }
 
       this.writeExpr = function() {


### PR DESCRIPTION
## Overview

**SearchKit — ReferenceError on string function arguments.** `safeStringAlias()` appends
`hash`, which is declared nowhere:

```js
return `${short}_${hash}`;
```

Any SearchKit function given a string argument throws. Now a short digest of the full
value, so two strings that truncate to the same 20-character prefix stay distinct — e.g.
`$.billing_address_line_1` and `$.billing_address_line_2`, which both clean to
`billing_address_line` under `MAX_LEN = 20`. That is what the code was meant to do, see
@braders on https://github.com/civicrm/civicrm-core/pull/35020#discussion_r3695658879.

## Open question

Whether the JS alias needs to match a PHP-generated one, and the 64-character limit
raised in the review of #35020. My reading is in the comments below — happy to drop the
digest and return just the truncated prefix, or to follow up separately with truncating
the whole alias in `makeAlias()`, which would cover every function rather than only
string arguments.

## Technical Details

`jshint` with core's `.jshintrc` passes on the changed file.

This PR originally carried four further, unrelated JavaScript fixes. Those are
uncontroversial and were moved to #36402, so that this PR keeps only the change the
discussion below is about.
