### PR TITLE
add Civi::router facade over CRM_Core_Menu

### DIFF
--- a/CRM/Admin/Form/Setting.php
+++ b/CRM/Admin/Form/Setting.php
@@ -116,7 +116,7 @@ class CRM_Admin_Form_Setting extends CRM_Core_Form {
     $config = CRM_Core_Config::singleton(TRUE, TRUE);
 
     // rebuild menu items
-    CRM_Core_Menu::store();
+    \Civi::router()->rebuild();;
   }
 
 }

--- a/CRM/Core/Invoke.php
+++ b/CRM/Core/Invoke.php
@@ -141,7 +141,7 @@ class CRM_Core_Invoke {
     else {
       $path = $args;
     }
-    $item = CRM_Core_Menu::get($path);
+    $item = \Civi::router()->get($path);
 
     return $item;
   }
@@ -242,7 +242,7 @@ class CRM_Core_Invoke {
       return $result;
     }
 
-    CRM_Core_Menu::store();
+    \Civi::router()->rebuild();;
     CRM_Core_Session::setStatus(ts('Menu has been rebuilt'), ts('Complete'), 'success');
     return CRM_Utils_System::redirect();
   }

--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -332,6 +332,9 @@ class CRM_Core_Menu {
     return FALSE;
   }
 
+  /**
+   * @internal
+   */
   public static function clear() {
     // Take the rebuild lock: TRUNCATE is a writer too, and clearing the table out from under an
     // in-flight self::store() would leave it holding only the rows that store() inserts after the
@@ -360,6 +363,7 @@ class CRM_Core_Menu {
 
   /**
    * This function recomputes menu from xml and populates civicrm_menu.
+   * @internal
    */
   public static function store() {
     // Take the rebuild lock: without it, concurrent rebuilds collide on the (path, domain_id)
@@ -622,6 +626,7 @@ class CRM_Core_Menu {
   }
 
   /**
+   * @internal
    * @param string $path
    *   Path of menu item to retrieve.
    *

--- a/CRM/Utils/GuzzleMiddleware.php
+++ b/CRM/Utils/GuzzleMiddleware.php
@@ -186,7 +186,7 @@ class CRM_Utils_GuzzleMiddleware {
     }
 
     if ($scheme === 'route') {
-      $menu = CRM_Core_Menu::get($hostPath);
+      $menu = \Civi::router()->get($hostPath);
       $scheme = ($menu && !empty($menu['is_public'])) ? 'frontend' : 'backend';
     }
 

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -707,7 +707,7 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
     $path = CRM_Utils_System::currentPath() ?? '';
 
     // Get the menu for above URL.
-    $item = CRM_Core_Menu::get($path);
+    $item = \Civi::router()->get($path);
     // In case the URL is not a civicrm page (a drupal page) we set the FE theme to TRUE - covering the corner case
     return (empty($item) || !empty($item['is_public']));
   }

--- a/Civi.php
+++ b/Civi.php
@@ -260,6 +260,13 @@ class Civi {
   }
 
   /**
+   * @return Civi\Core\Router
+   */
+  public static function router() {
+    return \Civi::service('civi.router');
+  }
+
+  /**
    * Obtain the contact's personal settings.
    *
    * @param NULL|int $contactID

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -22,7 +22,6 @@ use CRM_Core_Config;
 use CRM_Core_DAO;
 use CRM_Core_DAO_AllCoreTables;
 use CRM_Core_ManagedEntities;
-use CRM_Core_Menu;
 use CRM_Core_OptionGroup;
 use CRM_Core_Resources;
 use CRM_Core_Session;
@@ -184,7 +183,7 @@ class Rebuilder {
       $session->reset(2);
     }
     if (!empty($targets['router'])) {
-      CRM_Core_Menu::store();
+      \Civi::router()->rebuild();;
     }
     if (!empty($targets['navigation'])) {
       Civi::cache('navigation')->flush();

--- a/Civi/Core/Router.php
+++ b/Civi/Core/Router.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Civi\Core;
+
+use Civi\Core\Service\AutoService;
+
+/**
+ * @service civi.router
+ */
+class Router extends AutoService {
+
+  /**
+   * Clear the routing table.
+   *
+   * It will be rebuilt on next access
+   */
+  public function clear(): void {
+    \CRM_Core_Menu::clear();
+  }
+
+  /**
+   * Rebuild the routing table.
+   *
+   * This is costly so please consider using `clear` instead
+   */
+  public function rebuild(): void {
+    \CRM_Core_Menu::store();
+  }
+
+  /**
+   * Get route for a path from the routing table.
+   *
+   * @param string $path e.g. civicrm/mailing/subscribe
+   *
+   * @return array
+   */
+  public function get(string $path): array {
+    return \CRM_Core_Menu::get($path);
+  }
+
+}

--- a/Civi/Core/Router.php
+++ b/Civi/Core/Router.php
@@ -32,9 +32,9 @@ class Router extends AutoService {
    *
    * @param string $path e.g. civicrm/mailing/subscribe
    *
-   * @return array
+   * @return ?array best matching route, or NULL
    */
-  public function get(string $path): array {
+  public function get(string $path): ?array {
     return \CRM_Core_Menu::get($path);
   }
 

--- a/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Revert.php
@@ -37,7 +37,7 @@ class Revert extends \Civi\Api4\Generic\BasicBatchAction {
       \CRM_Core_ManagedEntities::singleton()->reconcile(E::LONG_NAME);
     }
     if ($this->flushMenu) {
-      \CRM_Core_Menu::clear();
+      \Civi::router()->clear();;
     }
   }
 

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -73,7 +73,7 @@ trait AfformSaveTrait {
     }
 
     if (Utils::shouldClearMenuCache($item, $orig ?? [])) {
-      \CRM_Core_Menu::clear();
+      \Civi::router()->clear();;
     }
 
     $item['module_name'] = _afform_angular_module_name($item['name'], 'camel');

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -459,7 +459,7 @@ function afform_civicrm_post($op, $entityName, $id, $object, $params) {
       // Adding a new custom field to an empty field group may auto-generate afforms with menu routes.
       // @see Civi\Api4\Action\CustomGroup\GetAfforms::getCustomGroupAfforms
       if ($op === 'create' && $entityName === 'CustomField') {
-        \CRM_Core_Menu::clear();
+        \Civi::router()->clear();;
       }
     }
   }

--- a/ext/civi_contribute/Civi/Api4/Service/ContributionTasksProvider.php
+++ b/ext/civi_contribute/Civi/Api4/Service/ContributionTasksProvider.php
@@ -34,7 +34,7 @@ class ContributionTasksProvider extends \Civi\Core\Service\AutoSubscriber {
     foreach (\CRM_Contribute_Task::tasks() as $id => $task) {
       if (!empty($task['url'])) {
         $path = explode('?', $task['url'], 2)[0];
-        $menu = \CRM_Core_Menu::get($path);
+        $menu = \Civi::router()->get($path);
         $key = $menu ? \CRM_Core_Key::get($menu['page_callback'], TRUE) : '';
 
         $event->tasks['Contribution']['contribution.' . $id] = [

--- a/ext/civi_member/Civi/Api4/Service/MembershipTasksProvider.php
+++ b/ext/civi_member/Civi/Api4/Service/MembershipTasksProvider.php
@@ -33,7 +33,7 @@ class MembershipTasksProvider extends \Civi\Core\Service\AutoSubscriber {
     foreach (\CRM_Member_Task::tasks() as $id => $task) {
       if (!empty($task['url'])) {
         $path = explode('?', $task['url'], 2)[0];
-        $menu = \CRM_Core_Menu::get($path);
+        $menu = \Civi::router()->get($path);
         $key = $menu ? \CRM_Core_Key::get($menu['page_callback'], TRUE) : '';
 
         $event->tasks['Membership']['membership.' . $id] = [

--- a/ext/oembed/Civi/Oembed/Oembed.php
+++ b/ext/oembed/Civi/Oembed/Oembed.php
@@ -20,7 +20,7 @@ class Oembed extends AutoService {
     $options = $this->normalizeOptions($options);
     $query = $this->findPropagatedParams($query);
 
-    $route = \CRM_Core_Menu::get($path);
+    $route = \Civi::router()->get($path);
     $result = [
       'type' => 'rich',
       'version' => '1.0',

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -780,7 +780,7 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
 
     $result = NULL;
     if ($routeName = parse_url($pathExpr, PHP_URL_PATH)) {
-      if ($routeItem = \CRM_Core_Menu::get($routeName)) {
+      if ($routeItem = \Civi::router()->get($routeName)) {
         if (!empty($routeItem['page_callback'])) {
           $result = \CRM_Core_Key::get($routeItem['page_callback']);
         }

--- a/tests/phpunit/CRM/Core/MenuTest.php
+++ b/tests/phpunit/CRM/Core/MenuTest.php
@@ -70,8 +70,8 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
    * stored and loaded.
    */
   public function testModuleData(): void {
-    CRM_Core_Menu::clear();
-    $item = CRM_Core_Menu::get('civicrm/case');
+    \Civi::router()->clear();
+    $item = \Civi::router()->get('civicrm/case');
     $this->assertFalse(isset($item['ids_arguments']['exceptions']));
     $this->assertFalse(isset($item['whimsy']));
 
@@ -80,8 +80,8 @@ class CRM_Core_MenuTest extends CiviUnitTestCase {
       $items['civicrm/case']['whimsy'] = 'godliness';
     });
 
-    CRM_Core_Menu::clear();
-    $item = CRM_Core_Menu::get('civicrm/case');
+    \Civi::router()->clear();
+    $item = \Civi::router()->get('civicrm/case');
     $this->assertTrue(in_array('foobar', $item['ids_arguments']['exceptions']));
     $this->assertEquals('godliness', $item['whimsy']);
   }


### PR DESCRIPTION
Overview
----------------------------------------
This adds a prettier facade over CRM_Core_Menu. It helps make clear what the expected public methods are, and that we are talking about application routes rather than navigation menu items.

