### PR TITLE
dev/core#6672 fix checkout landing page translations

### DIFF
--- a/ext/civi_contribute/js/landing.js
+++ b/ext/civi_contribute/js/landing.js
@@ -1,4 +1,5 @@
 (function (api4) {
+  const ts = CRM.ts('civi_contribute');
 
   document.addEventListener('DOMContentLoaded', () => {
     // note: token may be updated on subsequent requests


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the translation of Checkout landing page status messages.

Fixes dev/core#6672.

Before
----------------------------------------
Some Checkout status messages were displayed in English in a translated CiviCRM installation.

After
----------------------------------------
The messages use the active CiviCRM language.

Technical Details
----------------------------------------
Uses the existing civi_contribute JavaScript translation domain.

Comments
----------------------------------------
No payment-flow behaviour is changed.