### PR TITLE
Fix four small JavaScript defects (listeners, wysiwyg keydown, ChartKit column fallback)

### DIFF
--- a/contributor-key.yml
+++ b/contributor-key.yml
@@ -855,6 +855,10 @@
 - github      : jeromelebleu
   name        : Jérôme Lebleu
 
+- github      : jfilter
+  name        : Johannes Filter
+  organization: civico GmbH
+
 - github      : JGaunt
   name        : Jade Gaunt
   organization: GMCVO Databases

--- a/ext/afform/core/ang/af/afToken.element.js
+++ b/ext/afform/core/ang/af/afToken.element.js
@@ -3,6 +3,13 @@
 
   class AfToken extends HTMLElement {
 
+    constructor() {
+      super();
+      // Bound once: the listener runs on afForm, so a bare
+      // render loses `this`, and .bind() breaks removal.
+      this.onFormChange = () => this.render();
+    }
+
     connectedCallback() {
       this.afForm = this.closest('af-form');
       if (!this.afForm) {
@@ -22,11 +29,11 @@
     }
 
     registerListener() {
-      this.afForm?.addEventListener('change', () => this.render());
+      this.afForm?.addEventListener('change', this.onFormChange);
     }
 
     removeListener() {
-      this.afForm?.removeEventListener('change', () => this.render());
+      this.afForm?.removeEventListener('change', this.onFormChange);
     }
 
     get expression() {

--- a/ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
@@ -232,7 +232,7 @@
       this.getColumnSearchColumnOptions = (col) => {
         const allowedTypes = this.getColumnSourceDataTypes(col);
 
-        if (!allowedTypes && allowedTypes != []) {
+        if (!allowedTypes || !allowedTypes.length) {
           // all keys
           return this.searchColumns.map((searchCol) => searchCol.key);
         }

--- a/ext/chart_kit/js/components/civi-search-display.js
+++ b/ext/chart_kit/js/components/civi-search-display.js
@@ -18,6 +18,9 @@
       this.onPreRun = [];
       this.onPostRun = [];
       this._runCount = 0;
+      // Bound once: the listener runs on afFieldset, so a bare
+      // _onChangeFilters loses `this`, and .bind() breaks removal.
+      this._onChangeFiltersListener = () => this._onChangeFilters();
     }
 
     connectedCallback() {
@@ -25,9 +28,9 @@
     }
 
     disconnectedCallback() {
-      // this removes listeners added in initializeDisplay
-      if (this.formContainer) {
-        this.formContainer.removeEventListener('crmFormChangeFilters', () => this._onChangeFilters());
+      // Must match the element, handler and capture flag used in initializeDisplay.
+      if (this.afFieldset) {
+        this.afFieldset.removeEventListener('crmFormChangeFilters', this._onChangeFiltersListener, true);
       }
     }
 
@@ -183,7 +186,7 @@
 
       // When filters are changed, trigger callbacks and refresh search (if there's no search button)
       if (this.afFieldset) {
-        this.afFieldset.addEventListener('crmFormChangeFilters', () => this._onChangeFilters(), true);
+        this.afFieldset.addEventListener('crmFormChangeFilters', this._onChangeFiltersListener, true);
       }
 
       // TODO: implement pager reload? this could be moved to a trait - not relevant for some displays

--- a/js/wysiwyg/crm.wysiwyg.js
+++ b/js/wysiwyg/crm.wysiwyg.js
@@ -62,7 +62,7 @@
         e.preventDefault();
         this.openEditor();
       };
-      this.preview.onkeystroke = (e) => {
+      this.preview.onkeydown = (e) => {
         e.preventDefault();
         this.openEditor();
       };


### PR DESCRIPTION
## Overview

Split out of #36391 — the four uncontroversial defects, one commit each. The SearchKit
alias question stays in #36391 so the discussion there stays attached to the change it
is about. Any of these can be dropped without affecting the others.

## The defects

**1. Wysiwyg preview ignores keyboard input.** `this.preview.onkeystroke = …` is not a
DOM property, so the handler never runs — the comment above it reads "open the editor
when click/type on preview". Now `onkeydown`. It was the only occurrence in the tree.

**2/3. Two event listeners are never released.** `af-token` passes a fresh arrow
function to both `addEventListener` and `removeEventListener`, so the removal matches
nothing. `civi-search-display` additionally registers on `afFieldset` with capture and
removes from `formContainer` without it. Both now use a stable handler reference, with
add and remove agreeing on element and capture flag.

Same defect class as #36390, different files.

**4. ChartKit — column options never fall back to all keys.** `allowedTypes != []`
compares against a fresh array literal and is always true, so this is effectively
`!allowedTypes`:

```js
if (!allowedTypes && allowedTypes != []) {
  // all keys
```

Now `!allowedTypes || !allowedTypes.length`. This changes the empty-array case:
previously no columns, now all. The "all keys" comment supports that reading, but I am
inferring it — happy to restrict this to `!allowedTypes` if an empty array is meant as
"nothing allowed".

Plus a `contributor-key.yml` entry for myself.

## Technical Details

`jshint` with core's `.jshintrc` passes on all four changed files.

Reviewed in #36391 by @ufundo ("changes 2-5 look good to me") and @colemanw ("the latter
4 are uncontroversial").
