### PR TITLE
Case API: Add case_manager_id calculated field

### DIFF
--- a/CRM/Case/Tokens.php
+++ b/CRM/Case/Tokens.php
@@ -26,4 +26,17 @@ class CRM_Case_Tokens extends CRM_Core_EntityTokens {
     return 'Case';
   }
 
+  /**
+   * Get entity fields that should not be exposed as tokens.
+   *
+   * @return string[]
+   */
+  protected function getSkippedFields(): array {
+    // A raw contact ID with no :label variant (it's an FK, not a
+    // pseudoconstant) - not useful as a standalone merge token, same
+    // rationale as why {case.contact_id} is downgraded to sysadmin
+    // audience in the parent class.
+    return array_merge(parent::getSkippedFields(), ['case_manager_id']);
+  }
+
 }

--- a/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseManagerSpecProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseManagerSpecProvider.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Query\Api4SelectQuery;
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * Adds a computed `case_manager_id` field to the Case entity.
+ *
+ * There's no fixed relationship type for "case manager" - each CaseType's
+ * XML definition (<CaseRoles>) declares which relationship type/direction
+ * plays that role, so it can't be expressed as a plain DB join. This
+ * provider resolves the per-case-type role via
+ * CRM_Case_XMLProcessor_Process::getCaseManagerRoleId() once per query and
+ * bakes the result into a CASE-driven correlated subquery.
+ *
+ * @service
+ * @internal
+ */
+class CaseManagerSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $field = (new FieldSpec('case_manager_id', $spec->getEntity(), 'Integer'))
+      ->setTitle(ts('Case Manager'))
+      ->setDescription(ts('Contact currently holding the case-type\'s manager role for this case.'))
+      ->setType('Extra')
+      ->setColumnName('id')
+      ->setFkEntity('Contact')
+      ->setInputType('EntityRef')
+      ->setOperators(['=', '!=', 'IN', 'NOT IN', 'IS EMPTY', 'IS NOT EMPTY', 'IS NULL', 'IS NOT NULL'])
+      ->setSqlRenderer([__CLASS__, 'renderCaseManagerSql']);
+    $spec->addFieldSpec($field);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'Case' && $action === 'get';
+  }
+
+  /**
+   * Builds a `CASE case_type_id WHEN ... THEN (correlated subquery) END`
+   * expression that picks the active (or, failing that, most-recently
+   * expired) contact in the case-type's configured manager role.
+   *
+   * Mirrors the selection logic in CRM_Case_BAO_Case::getCaseManagerContact().
+   */
+  public static function renderCaseManagerSql(array $field, Api4SelectQuery $query): string {
+    // $field['sql_name'] is the alias-qualified `id` column (e.g. `a`.`id`)
+    // in whatever context this field is being selected from (main entity or a join).
+    $alias = substr($field['sql_name'], 0, strrpos($field['sql_name'], '.'));
+
+    $xmlProcessor = new \CRM_Case_XMLProcessor_Process();
+    $caseTypeNames = \CRM_Case_PseudoConstant::caseType('name');
+
+    $whenClauses = [];
+    foreach ($caseTypeNames as $caseTypeId => $caseTypeName) {
+      $managerRoleId = $xmlProcessor->getCaseManagerRoleId($caseTypeName);
+      if (empty($managerRoleId)) {
+        continue;
+      }
+      $relationshipTypeId = (int) substr($managerRoleId, 0, -4);
+      $contactColumn = substr($managerRoleId, -4) === '_a_b' ? 'contact_id_b' : 'contact_id_a';
+      $caseTypeId = (int) $caseTypeId;
+
+      $whenClauses[] = "WHEN $alias.`case_type_id` = $caseTypeId THEN (
+        SELECT r.`$contactColumn`
+        FROM `civicrm_relationship` r
+        WHERE r.`case_id` = $alias.`id`
+          AND r.`relationship_type_id` = $relationshipTypeId
+        ORDER BY r.`is_active` DESC, r.`end_date` DESC
+        LIMIT 1
+      )";
+    }
+
+    if (!$whenClauses) {
+      return 'NULL';
+    }
+
+    return '(CASE ' . implode(' ', $whenClauses) . ' END)';
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -72,6 +72,83 @@ class CaseTest extends Api4TestBase {
     $this->assertEquals($contactID, $relationships[0]['contact_id_a']);
   }
 
+  public function testCaseManagerId(): void {
+    $uid = $this->createLoggedInUser();
+    $contactID = $this->createTestRecord('Contact')['id'];
+
+    // housing_support's "Homeless Services Coordinator" role has both
+    // creator=1 and manager=1, so opening the case as the logged-in user
+    // makes them both the creator and the case manager.
+    $case = $this->createTestRecord('Case', [
+      'creator_id' => 'user_contact_id',
+      'contact_id' => $contactID,
+    ]);
+
+    $result = CiviCase::get(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->addSelect('case_manager_id')
+      ->execute()
+      ->single();
+
+    $this->assertEquals($uid, $result['case_manager_id']);
+  }
+
+  public function testCaseManagerIdNullWhenCaseTypeHasNoManagerRole(): void {
+    $uid = $this->createLoggedInUser();
+    $contactID = $this->createTestRecord('Contact')['id'];
+
+    // Same shape as the default test CaseType definition, except the
+    // "Parent of" role is only flagged as creator, not manager - so no
+    // relationship type/direction is configured as the case manager role
+    // for this case type at all.
+    $caseType = $this->createTestRecord('CaseType', [
+      'title' => 'Test Case Type No Manager',
+      'name' => 'test_case_type_no_manager',
+      'definition' => [
+        'activityTypes' => [
+          ['name' => 'Open Case', 'max_instances' => 1],
+          ['name' => 'Follow up'],
+        ],
+        'activitySets' => [
+          [
+            'name' => 'standard_timeline',
+            'label' => 'Standard Timeline',
+            'timeline' => 1,
+            'activityTypes' => [
+              ['name' => 'Open Case', 'status' => 'Completed'],
+            ],
+          ],
+        ],
+        'caseRoles' => [
+          ['name' => 'Parent of', 'creator' => 1],
+        ],
+      ],
+    ]);
+
+    $case = $this->createTestRecord('Case', [
+      'case_type_id' => $caseType['id'],
+      'creator_id' => 'user_contact_id',
+      'contact_id' => $contactID,
+    ]);
+
+    // The creator relationship still exists (Parent of, creator=1)...
+    $relationships = Relationship::get(FALSE)
+      ->addWhere('case_id', '=', $case['id'])
+      ->execute();
+    $this->assertCount(1, $relationships);
+    $this->assertEquals($uid, $relationships[0]['contact_id_b']);
+
+    // ...but since no role on this case type is flagged as manager,
+    // case_manager_id has nothing to resolve to.
+    $result = CiviCase::get(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->addSelect('case_manager_id')
+      ->execute()
+      ->single();
+
+    $this->assertNull($result['case_manager_id']);
+  }
+
   public function testCgExtendsObjects(): void {
     $this->createTestRecord('CaseType', [
       'title' => 'Test Case Type',


### PR DESCRIPTION
Overview
----------------------------------------
The case manager isn't a fixed relationship type - each CaseType's XML definition declares which relationship type/direction plays that role, so it can't be expressed as a plain join.
This adds a SpecProvider that resolves the per-case-type manager role once per query (mirroring CRM_Case_BAO_Case::getCaseManagerContact()) and renders it as a CASE-driven correlated subquery, making it a first-class selectable/joinable field for SearchKit and other API4 consumers.

Includes tests covering both branches of the renderer: resolving to the contact holding the case type's configured manager relationship, and falling back to NULL when the case type has no role flagged as manager at all.

_Pre-requisite to replacing case dashboard with SK/FB._

Before
----------------------------------------
No easy way to get case manager in API4

After
----------------------------------------
Easy way to get case manager in API4

Technical Details
----------------------------------------


Comments
----------------------------------------
Working towards a near like-for-like SK/FB replacement for case dashboard:
<img width="1399" height="868" alt="screenshot-1785840843079-0" src="https://github.com/user-attachments/assets/02d97902-ae43-4e2e-8662-51178a27ad85" />


