### PR TITLE
APIv4 - Throw exception on duplicate alias in SELECT clause

### DIFF
--- a/Civi/Api4/Query/Api4Query.php
+++ b/Civi/Api4/Query/Api4Query.php
@@ -649,6 +649,11 @@ abstract class Api4Query {
     if ($checkAlias && $alias != $expr->getExpr() && isset($this->apiFieldSpec[$alias])) {
       throw new \CRM_Core_Exception('Cannot use existing field name as alias');
     }
+    // Two expressions sharing an alias cannot both be returned, and ORDER BY/HAVING
+    // would resolve the alias to only one of them.
+    if (isset($this->selectAliases[$alias]) && $this->selectAliases[$alias] !== $expr->getExpr()) {
+      throw new \CRM_Core_Exception("Duplicate alias '$alias' in SELECT clause");
+    }
     $this->selectAliases[$alias] = $expr->getExpr();
     $this->query->select($expr->render($this, TRUE));
     return TRUE;

--- a/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
+++ b/tests/phpunit/api/v4/Query/Api4SelectQueryTest.php
@@ -157,4 +157,33 @@ class Api4SelectQueryTest extends Api4TestBase {
     }
   }
 
+  public function testDuplicateSelectAlias(): void {
+    // Two different expressions may not share an alias; only one of them could
+    // be returned, and ORDER BY/HAVING would resolve the alias to the other.
+    $api = Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['ROUND(id) AS dupe', 'ROUND(0) AS dupe'],
+    ]);
+    $query = new Api4SelectQuery($api);
+    try {
+      $query->run();
+      $this->fail('An Exception Should have been raised');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertStringContainsString("Duplicate alias 'dupe'", $e->getMessage());
+    }
+
+    // The same expression repeated is harmless
+    $api = Request::create('Contact', 'get', [
+      'version' => 4,
+      'checkPermissions' => FALSE,
+      'select' => ['ROUND(id) AS dupe', 'ROUND(id) AS dupe'],
+      'limit' => 1,
+    ]);
+    $query = new Api4SelectQuery($api);
+    $result = $query->run();
+    $this->assertArrayHasKey('dupe', $result[0]);
+  }
+
 }


### PR DESCRIPTION

## Overview

When two different expressions in an APIv4 select share an alias, the second silently overwrites the first in `selectAliases` — but only in the returned values. `ORDER BY`/`HAVING` resolve the alias against the first expression, so the same alias means two different things in one query.

Follow-up from https://github.com/civicrm/civicrm-core/pull/36391#issuecomment-5177937795 — degenerate aliases like `SUM_` saved by the SearchKit function builder between 6.14.0 and 0e8e1cf99 hit exactly this.

## Before

```php
Contact::get()->setSelect(['ROUND(id) AS dupe', 'ROUND(0) AS dupe'])->addOrderBy('dupe');
```
Returns `dupe = 0` for every row, but sorts by `ROUND(id)` — ascending yields ids 1,2,3; descending 4,3,2; the returned value never changes. No error.

## After

```
Duplicate alias 'dupe' in SELECT clause
```

The same expression repeated under one alias stays valid (it's harmless and `array_unique` already tolerates the string-identical case). Bare field names can't be aliased at all (`SqlField`), so only expression selects are affected.

## Technical Details

The check sits in `Api4Query::addExprToSelectClause()`, next to the existing "Cannot use existing field name as alias" validation, and therefore covers both `Api4SelectQuery` and `Api4EntitySetQuery`.

The silent overwrite dates back to c9e3ae2e6a (2020).

Verified against 6.16.2: full `api/v4` suite (661 tests) and full `search_kit` suite (101 tests) show no new failures with the check applied; the exception never fires in either suite.
