### PR TITLE
Add unique index on name for MembershipStatus and ParticipantStatusType

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -50,6 +50,8 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
       'sql_type' => 'varchar(255)',
       'description' => ts('Mailing Name.'),
     ]);
+    $this->addTask(ts('Create index %1', [1 => 'civicrm_membership_status.UI_name']), 'addIndex', 'civicrm_membership_status', 'name', 'UI');
+    $this->addTask(ts('Create index %1', [1 => 'civicrm_participant_status_type.UI_name']), 'addIndex', 'civicrm_participant_status_type', 'name', 'UI');
   }
 
   /**

--- a/CRM/Upgrade/Incremental/sql/6.18.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.18.alpha1.mysql.tpl
@@ -25,3 +25,12 @@ INSERT IGNORE INTO civicrm_state_province (country_id, abbreviation, name) VALUE
 (@country_id, 'F', 'Bolívar'),
 (@country_id, 'R', 'Sucre'),
 (@country_id, 'Z', 'Amazonas');
+
+UPDATE civicrm_membership_status s1, civicrm_membership_status s2
+  SET s2.name = CONCAT(s2.name, '_', s2.id)
+  WHERE s2.name = s1.name AND s2.id > s1.id;
+
+UPDATE civicrm_participant_status_type s1, civicrm_participant_status_type s2
+  SET s2.name = CONCAT(s2.name, '_', s2.id)
+  WHERE s2.name = s1.name AND s2.id > s1.id;
+

--- a/schema/Event/ParticipantStatusType.entityType.php
+++ b/schema/Event/ParticipantStatusType.entityType.php
@@ -17,6 +17,15 @@ return [
     'update' => 'civicrm/admin/participant_status?action=update&id=[id]&reset=1',
     'delete' => 'civicrm/admin/participant_status?action=delete&id=[id]&reset=1',
   ],
+  'getIndices' => fn() => [
+    'UI_name' => [
+      'fields' => [
+        'name' => TRUE,
+      ],
+      'unique' => TRUE,
+      'add' => '6.18',
+    ],
+  ],
   'getFields' => fn() => [
     'id' => [
       'title' => ts('Participant Status Type ID'),

--- a/schema/Member/MembershipStatus.entityType.php
+++ b/schema/Member/MembershipStatus.entityType.php
@@ -18,6 +18,15 @@ return [
     'update' => 'civicrm/admin/member/membershipStatus/add?action=update&id=[id]&reset=1',
     'delete' => 'civicrm/admin/member/membershipStatus/add?action=delete&id=[id]&reset=1',
   ],
+  'getIndices' => fn() => [
+    'UI_name' => [
+      'fields' => [
+        'name' => TRUE,
+      ],
+      'unique' => TRUE,
+      'add' => '6.18',
+    ],
+  ],
   'getFields' => fn() => [
     'id' => [
       'title' => ts('Membership Status ID'),

--- a/tests/phpunit/CRM/Event/BAO/ParticipantStatusTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ParticipantStatusTest.php
@@ -98,10 +98,13 @@ class CRM_Event_BAO_ParticipantStatusTest extends CiviUnitTestCase {
       'visibility_id' => 1,
     ];
 
-    $statusType = CRM_Event_BAO_ParticipantStatusType::writeRecord($params);
+    $statusType = civicrm_api4('ParticipantStatusType', 'save', [
+      'records' => [$params],
+      'match' => ['name'],
+    ])->single();
 
     // retrieve status type
-    $retrieveParams = ['id' => $statusType->id];
+    $retrieveParams = ['id' => $statusType['id']];
     $default = [];
     $retrieveStatusType = CRM_Event_BAO_ParticipantStatusType::retrieve($retrieveParams, $default);
 

--- a/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
+++ b/tests/phpunit/CRM/Member/BAO/MembershipStatusTest.php
@@ -90,7 +90,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
 
   public function testGetMembershipStatusByDate(): void {
     $params = [
-      'name' => 'Current',
+      'name' => uniqid('Current'),
       'is_active' => 1,
       'start_event' => 'start_date',
       'end_event' => 'end_date',
@@ -100,7 +100,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
     $toDate = date('Ymd');
 
     $result = CRM_Member_BAO_MembershipStatus::getMembershipStatusByDate($toDate, $toDate, $toDate, 'now', TRUE, NULL, $params);
-    $this->assertEquals($result['name'], 'Current', 'Verify membership status record.');
+    $this->assertEquals($params['name'], $result['name'], 'Verify membership status record.');
 
     $this->callAPISuccess('MembershipStatus', 'Delete', ['id' => $membershipStatus->id]);
   }
@@ -343,7 +343,7 @@ class CRM_Member_BAO_MembershipStatusTest extends CiviUnitTestCase {
 
   public function testgetMembershipStatusCurrent(): void {
     $params = [
-      'name' => 'Current',
+      'name' => uniqid('Current'),
       'is_active' => 1,
       'is_current_member' => 1,
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Add a unique index on the `name` column for `MembershipStatus` and `ParticipantStatusType` entities.

Technical Details
----------------------------------------
A machine name doesn't make much sense if it isn't unique...

- Added `getIndices` with `UI_name` unique index (`'unique' => TRUE`, `'add' => '6.18'`) to `MembershipStatus.entityType.php` and `ParticipantStatusType.entityType.php`.
- Added defensive `UPDATE` statements to `6.18.alpha1.mysql.tpl` appending `_[id]` to duplicate names to ensure smooth database upgrades without unique key conflicts.
- Added `addIndex` tasks in `CRM_Upgrade_Incremental_php_SixEighteen::upgrade_6_18_alpha1()`.
