### PR TITLE
Fix notices, errant icon in membership view

### DIFF
--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -70,7 +70,7 @@
         </summary>
         <div class="crm-accordion-body">
           {if $rows.0.contribution_id}
-            {include file="CRM/Contribute/Form/Selector.tpl" context="Search"}
+            {include file="CRM/Contribute/Form/Selector.tpl" context="Search" single=true}
           {/if}
           <script type="text/javascript">
             var membershipID = {$id};


### PR DESCRIPTION
Overview
----------------------------------------
Fix notices, errant icon in membership view

Before
----------------------------------------
<img width="1121" height="416" alt="image" src="https://github.com/user-attachments/assets/0e7d00e0-e6d2-4b4c-9293-540017066fce" />

- also the little household icon is not supposed to show on individual memberships

<img width="1030" height="261" alt="image" src="https://github.com/user-attachments/assets/f47dff82-8d5f-4a06-a615-339bb70939bd" />


After
----------------------------------------
<img width="1085" height="778" alt="image" src="https://github.com/user-attachments/assets/17df3fcb-c0b0-4148-835b-41e61c543599" />

Technical Details
----------------------------------------

Comments
----------------------------------------
_Anything else you would like the reviewer to note_