### PR TITLE
Afform: Only show PriceFieldValues that are active

### DIFF
--- a/ext/civi_contribute/Civi/Contribute/Utils/PriceFieldUtils.php
+++ b/ext/civi_contribute/Civi/Contribute/Utils/PriceFieldUtils.php
@@ -61,12 +61,14 @@ class PriceFieldUtils {
       // we also using price set name and label to create full names / labels for each field
       // if we flatten then we should enforce unique names on PriceField
       // and make sure labels are clear
+      // only show active values
       ->addSelect('price_set_id.extends', 'price_set_id.name', 'price_set_id.title')
       ->execute()
       ->indexBy('id');
 
     $fieldValues = (array) \Civi\Api4\PriceFieldValue::get(FALSE)
       ->addSelect('id', 'price_field_id', 'label', 'amount')
+      ->addWhere('is_active', '=', TRUE)
       ->execute();
 
     // Add amount to each PriceFieldValue option label


### PR DESCRIPTION
Overview
----------------------------------------
_Only show PriceFieldValue items that are set as public and are active. Allows for the use of the `visibility_id` field to control what values are presented on the form._

Before
----------------------------------------
_All PriceFieldValue records for a PriceField are shown._

After
----------------------------------------
_Only PriceFIeldValue items with `visibility_id:name = 'public'` and `is_active = TRUE` are shown on a form._


