### PR TITLE
Fix missing contact name in membership related contributions selector

### DIFF
--- a/templates/CRM/Member/Form/MembershipView.tpl
+++ b/templates/CRM/Member/Form/MembershipView.tpl
@@ -70,7 +70,7 @@
         </summary>
         <div class="crm-accordion-body">
           {if $rows.0.contribution_id}
-            {include file="CRM/Contribute/Form/Selector.tpl" context="Search" single=true}
+            {include file="CRM/Contribute/Form/Selector.tpl" context="dashboard" single=false}
           {/if}
           <script type="text/javascript">
             var membershipID = {$id};


### PR DESCRIPTION
Overview
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/36411 was just merged yesterday but it causes the contact name to go missing

Before
----------------------------------------
contact name is missing

After
----------------------------------------


Technical Details
----------------------------------------
this is the same fix done for participant view last year

Comments
----------------------------------------
To see it, make a related paid membership, then view the primary membership. There's a section for related contributions. Note the name column is blank before the PR.
