### PR TITLE
(NFC) release-notes/6.17.1.md - Tweak credits

### DIFF
--- a/release-notes/6.17.1.md
+++ b/release-notes/6.17.1.md
@@ -27,7 +27,9 @@ Released Tue Aug 04 2026 21:00:00 GMT-0700 (GMT-07:00)
 
 This release was developed by the following authors and reviewers:
 
-CiviCRM Core Team - Coleman Watts; John Kingsnorth;
+Wikimedia Foundation - Eileen McNaughton; Tadpole Collective - Kevin Cristiano; John Kingsnorth; JMA
+Consulting - Seamus Lee; Fuzion - Luke Stewart; Coop SymbioTIC - Mathieu Lutfy; CiviCRM - Coleman
+Watts, Tim Otten; AGH Strategies - Chris Garaffa
 
 ## <a name="feedback"></a>Feedback
 


### PR DESCRIPTION
There were actually a bunch of other reviewers involved on this patch-release, but they don't show up in the normal places. (The workflow was special for this one.)

Note: We don't need to re-roll just for this NFC tweak. But merging will mean that it shows up in web UI.
