### PR TITLE
dev/core#6677 - Remove deleted-files-list entries for shipped files

### DIFF
--- a/deleted-files-list.json
+++ b/deleted-files-list.json
@@ -1483,7 +1483,6 @@
     "packages/recaptcha/*",
     "packages/smarty3/*",
     "packages/smarty4/*",
-    "packages/smarty5/*",
     "packages/snappy/*",
     "packages/tcpdf/*",
     "packages/tinymce/*",


### PR DESCRIPTION
Overview
----------------------------------------
`deleted-files-list.json`lists six paths that the 6.17 release installs, so CRM_Upgrade_Form::doFileCleanup() either deletes them or warns about them during an upgrade.

The most critical path is packages/smarty5. In 6.17, there is no alternative Smarty installation, as CRM/Core/SmartyCompatibility.php unconditionally requires [civicrm.packages]/smarty5/Smarty.php.

This commit, [219fecea07d0d5122e25ead20668a71cc973468d](https://github.com/civicrm/civicrm-core/pull/36140/changes#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34), changes the deployment to install Smarty via Composer instead of the vendor directory. However, that change is included in 6.18 and later.

Until that patch is backported to the 6.17.x branch, this patch hide the vendor/smarty5 directory under old file.


ping @seamuslee001 @totten @ufundo 
