### PR TITLE
Financial - Make Payment::create idempotent for a repeated trxn_id

### DIFF
--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -19,11 +19,20 @@ use Civi\Api4\Contribution;
 use Civi\Api4\FinancialItem;
 use Civi\Api4\LineItem;
 use Civi\Api4\EntityFinancialTrxn;
+use Civi\Api4\Payment;
 
 /**
  * This class contains payment related functions.
  */
 class CRM_Financial_BAO_Payment {
+
+  /**
+   * Seconds to wait for the per-contribution lock in create() before giving up.
+   *
+   * Covers the slowest thing that can happen while held - completing an order can send a
+   * receipt email synchronously.
+   */
+  const PAYMENT_CREATE_LOCK_TIMEOUT = 15;
 
   /**
    * Function to process additional payment for partial and refund
@@ -44,6 +53,46 @@ class CRM_Financial_BAO_Payment {
    * @throws \CRM_Core_Exception
    */
   public static function create(array $params, $disableActionsOnCompleteOrder = FALSE): CRM_Financial_DAO_FinancialTrxn {
+    // Serialise payment-recording per contribution, and treat a repeated trxn_id as idempotent,
+    // to guard against a payment processor webhook racing a synchronous confirmation of the
+    // same charge (e.g. via CRM_Contribute_Form_Contribution_Confirm).
+    $lock = \Civi::lockManager()->acquire('data.contribute.paymentCreate.' . $params['contribution_id'], self::PAYMENT_CREATE_LOCK_TIMEOUT);
+    if (!$lock->isAcquired()) {
+      throw new CRM_Core_Exception(ts('Could not acquire a lock to record a payment for contribution %1. Another payment may currently be being recorded for the same contribution.', [
+        1 => $params['contribution_id'],
+      ]), 'payment_create_lock_failed');
+    }
+    try {
+      if (!empty($params['trxn_id'])) {
+        // Match total_amount too - a refund shares the payment's trxn_id but is a negative-amount
+        // payment (not a distinct is_payment=0 row), so trxn_id alone could match either.
+        $existingTrxnID = Payment::get(FALSE)
+          ->addWhere('contribution_id', '=', $params['contribution_id'])
+          ->addWhere('trxn_id', '=', $params['trxn_id'])
+          ->addWhere('total_amount', '=', $params['total_amount'])
+          ->addSelect('id')
+          ->execute()
+          ->first()['id'] ?? NULL;
+        if ($existingTrxnID) {
+          // Already recorded by a concurrent call - return it rather than duplicating it.
+          return CRM_Financial_DAO_FinancialTrxn::findById($existingTrxnID);
+        }
+      }
+      return self::completePayment($params, $disableActionsOnCompleteOrder);
+    }
+    finally {
+      $lock->release();
+    }
+  }
+
+  /**
+   * @param array $params
+   * @param bool $disableActionsOnCompleteOrder
+   *
+   * @return \CRM_Financial_DAO_FinancialTrxn
+   * @throws \CRM_Core_Exception
+   */
+  private static function completePayment(array $params, $disableActionsOnCompleteOrder): CRM_Financial_DAO_FinancialTrxn {
     $contribution = Contribution::get(FALSE)
       ->addWhere('id', '=', $params['contribution_id'])
       ->addSelect('*', 'contribution_status_id:name', 'balance_amount', 'paid_amount')

--- a/CRM/Financial/BAO/Payment.php
+++ b/CRM/Financial/BAO/Payment.php
@@ -19,11 +19,20 @@ use Civi\Api4\Contribution;
 use Civi\Api4\FinancialItem;
 use Civi\Api4\LineItem;
 use Civi\Api4\EntityFinancialTrxn;
+use Civi\Api4\Payment;
 
 /**
  * This class contains payment related functions.
  */
 class CRM_Financial_BAO_Payment {
+
+  /**
+   * Seconds to wait for the per-contribution lock in create() before giving up.
+   *
+   * Needs to comfortably cover the slowest thing that can happen while the lock is held -
+   * completing an order can send a receipt email synchronously.
+   */
+  const PAYMENT_CREATE_LOCK_TIMEOUT = 15;
 
   /**
    * Function to process additional payment for partial and refund
@@ -44,6 +53,48 @@ class CRM_Financial_BAO_Payment {
    * @throws \CRM_Core_Exception
    */
   public static function create(array $params, $disableActionsOnCompleteOrder = FALSE): CRM_Financial_DAO_FinancialTrxn {
+    // Serialise payment-recording per contribution, and treat a second payment carrying the same
+    // trxn_id as idempotent - returning the payment already recorded instead of creating a
+    // duplicate. Without this, a payment processor webhook racing a synchronous front-end/back-office
+    // confirmation of the same charge (e.g. paying an existing pending contribution via
+    // CRM_Contribute_Form_Contribution_Confirm) can both read the contribution as not-yet-completed
+    // and both go on to record a payment for it.
+    $lock = \Civi::lockManager()->acquire('data.contribute.paymentCreate.' . $params['contribution_id'], self::PAYMENT_CREATE_LOCK_TIMEOUT);
+    if (!$lock->isAcquired()) {
+      throw new CRM_Core_Exception(ts('Could not acquire a lock to record a payment for contribution %1. Another payment may currently be being recorded for the same contribution.', [
+        1 => $params['contribution_id'],
+      ]), 'payment_create_lock_failed');
+    }
+    try {
+      if (!empty($params['trxn_id'])) {
+        $existingTrxnID = Payment::get(FALSE)
+          ->addWhere('contribution_id', '=', $params['contribution_id'])
+          ->addWhere('trxn_id', '=', $params['trxn_id'])
+          ->addSelect('id')
+          ->execute()
+          ->first()['id'] ?? NULL;
+        if ($existingTrxnID) {
+          // A concurrent call (e.g. a payment processor webhook for this same charge) already
+          // recorded this exact payment - return it rather than creating a duplicate or erroring.
+          // From the caller's point of view this payment succeeded, so this is the correct result.
+          return CRM_Financial_DAO_FinancialTrxn::findById($existingTrxnID);
+        }
+      }
+      return self::completePayment($params, $disableActionsOnCompleteOrder);
+    }
+    finally {
+      $lock->release();
+    }
+  }
+
+  /**
+   * @param array $params
+   * @param bool $disableActionsOnCompleteOrder
+   *
+   * @return \CRM_Financial_DAO_FinancialTrxn
+   * @throws \CRM_Core_Exception
+   */
+  private static function completePayment(array $params, $disableActionsOnCompleteOrder): CRM_Financial_DAO_FinancialTrxn {
     $contribution = Contribution::get(FALSE)
       ->addWhere('id', '=', $params['contribution_id'])
       ->addSelect('*', 'contribution_status_id:name', 'balance_amount', 'paid_amount')

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -9,8 +9,10 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
 use Civi\Api4\EntityFinancialTrxn;
 use Civi\Api4\Order;
+use Civi\Api4\Payment;
 
 /**
  *  Test APIv3 civicrm_contribute_* functions
@@ -1537,6 +1539,50 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       ->execute();
     $this->assertCount(2, $trxns);
     Civi::settings()->set('always_post_to_accounts_receivable', 0);
+  }
+
+  /**
+   * Test that a second Payment.create carrying a trxn_id already recorded for the contribution is
+   * idempotent - it returns the existing payment rather than creating a duplicate or erroring.
+   *
+   * This covers a payment processor webhook racing a synchronous front-end/back-office
+   * confirmation of the same charge, where both calls can read the contribution as not-yet-completed
+   * and both attempt to record the same payment.
+   */
+  public function testCreatePaymentDuplicateTrxnIDIsIdempotent(): void {
+    $contributionID = $this->contributionCreate([
+      'contact_id' => $this->individualCreate(),
+      'total_amount' => 100,
+      'contribution_status_id' => 'Pending',
+      'fee_amount' => 0,
+    ]);
+
+    $firstPayment = Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->addValue('trxn_id', 'ch_race_condition')
+      ->execute()->single();
+
+    $secondPayment = Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->addValue('trxn_id', 'ch_race_condition')
+      ->execute()->single();
+
+    $this->assertEquals($firstPayment['id'], $secondPayment['id'], 'The second call should return the payment the first call recorded, not create a new one.');
+
+    $paymentCount = Payment::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->selectRowCount()
+      ->execute()
+      ->count();
+    $this->assertEquals(1, $paymentCount, 'Only one payment should have been recorded for the contribution.');
+
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('id', '=', $contributionID)
+      ->addSelect('contribution_status_id:name')
+      ->execute()->single();
+    $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
   }
 
 }

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -9,8 +9,10 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contribution;
 use Civi\Api4\EntityFinancialTrxn;
 use Civi\Api4\Order;
+use Civi\Api4\Payment;
 
 /**
  *  Test APIv3 civicrm_contribute_* functions
@@ -1537,6 +1539,137 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
       ->execute();
     $this->assertCount(2, $trxns);
     Civi::settings()->set('always_post_to_accounts_receivable', 0);
+  }
+
+  /**
+   * A second Payment.create with a trxn_id already recorded for the contribution should be
+   * idempotent - returning the existing payment rather than erroring or duplicating it. Covers
+   * a payment processor webhook racing a synchronous confirmation of the same charge.
+   */
+  public function testCreatePaymentDuplicateTrxnIDIsIdempotent(): void {
+    $contributionID = $this->contributionCreate([
+      'contact_id' => $this->individualCreate(),
+      'total_amount' => 100,
+      'contribution_status_id' => 'Pending',
+      'fee_amount' => 0,
+    ]);
+
+    $firstPayment = Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->addValue('fee_amount', 2.50)
+      ->addValue('trxn_date', date('Y-m-d H:i:s'))
+      ->addValue('trxn_id', 'ch_race_condition')
+      ->execute()->single();
+
+    $secondPayment = Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->addValue('fee_amount', 2.50)
+      ->addValue('trxn_date', date('Y-m-d H:i:s'))
+      ->addValue('trxn_id', 'ch_race_condition')
+      ->execute()->single();
+
+    $this->assertEquals($firstPayment['id'], $secondPayment['id'], 'The second call should return the payment the first call recorded, not create a new one.');
+
+    $paymentCount = Payment::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->selectRowCount()
+      ->execute()
+      ->count();
+    $this->assertEquals(1, $paymentCount, 'Only one payment should have been recorded for the contribution.');
+
+    $totalFeeAmount = array_sum(Payment::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->addSelect('fee_amount')
+      ->execute()
+      ->column('fee_amount'));
+    $this->assertEquals(2.50, $totalFeeAmount, 'The fee should be recorded once, not doubled by the duplicate call.');
+
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('id', '=', $contributionID)
+      ->addSelect('contribution_status_id:name')
+      ->execute()->single();
+    $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
+  }
+
+  /**
+   * A payment and its refund can share a trxn_id (some processors don't mint a distinct one for
+   * a refund). A replayed payment call must still match itself, not the refund.
+   */
+  public function testCreatePaymentDuplicateTrxnIDDoesNotMatchRefundSharingIt(): void {
+    $contributionID = $this->contributionCreate([
+      'contact_id' => $this->individualCreate(),
+      'total_amount' => 100,
+      'contribution_status_id' => 'Pending',
+      'fee_amount' => 0,
+    ]);
+
+    $payment = Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->addValue('trxn_id', 'ch_reused_for_refund')
+      ->execute()->single();
+
+    $refund = $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $contributionID,
+      'total_amount' => -100,
+      'trxn_id' => 'ch_reused_for_refund',
+      'cancelled_payment_id' => $payment['id'],
+    ]);
+
+    // A webhook replay of the *original* payment call - it must find itself, not the refund.
+    $paymentReplay = Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->addValue('trxn_id', 'ch_reused_for_refund')
+      ->execute()->single();
+
+    $this->assertEquals($payment['id'], $paymentReplay['id'], 'A replay of the original payment should match the payment, not the refund sharing its trxn_id.');
+    $this->assertNotEquals($refund['id'], $paymentReplay['id']);
+
+    $paymentCount = Payment::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->selectRowCount()
+      ->execute()
+      ->count();
+    $this->assertEquals(2, $paymentCount, 'The replay must not create a third row.');
+  }
+
+  /**
+   * create() must hold the per-contribution lock while recording the payment and release it
+   * afterwards.
+   *
+   * This asserts the locking is wired up, not the race itself - GET_LOCK() is per-connection, so
+   * a single-connection test can't hold and contend for the lock at once (same limitation as
+   * CRM_Core_MenuTest::testRebuildRunsUnderLock()). The hold is observed via the civicrm_post
+   * hook on FinancialTrxn, which fires mid-completePayment().
+   */
+  public function testCreateRunsUnderLock(): void {
+    $contributionID = $this->contributionCreate([
+      'contact_id' => $this->individualCreate(),
+      'total_amount' => 100,
+      'contribution_status_id' => 'Pending',
+      'fee_amount' => 0,
+    ]);
+    $isFree = fn() => (int) Civi::lockManager()->create('data.contribute.paymentCreate.' . $contributionID)->isFree();
+
+    $this->assertSame(1, $isFree(), 'the payment-create lock should be free before create()');
+
+    $freeDuringCreate = NULL;
+    CRM_Utils_Hook::singleton()->setHook('civicrm_post', function ($op, $objectName, $objectId, &$objectRef) use ($isFree, &$freeDuringCreate) {
+      if ($objectName === 'FinancialTrxn' && $op === 'create' && $freeDuringCreate === NULL) {
+        $freeDuringCreate = $isFree();
+      }
+    });
+
+    Payment::create(FALSE)
+      ->addValue('contribution_id', $contributionID)
+      ->addValue('total_amount', 100)
+      ->execute();
+
+    $this->assertSame(0, $freeDuringCreate, 'create() should hold the lock while recording the payment');
+    $this->assertSame(1, $isFree(), 'create() should release the lock when finished');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
A payment processor webhook racing a synchronous front-end/back-office confirmation of the same charge (e.g. paying an existing pending contribution via CRM_Contribute_Form_Contribution_Confirm) can both read the contribution as not-yet-completed and both go on to record a payment for it. Add a per-contribution lock via Civi::lockManager() around create(), and treat a second payment carrying an already-recorded trxn_id as a no-op success (returning the existing FinancialTrxn) rather than creating a duplicate. Every caller gets this for free with no changes needed at the call site. Includes a regression test using APIv4 Payment::create/get.

Alternative to the reject-with-exception approach in [fix-payment-create-race-lock](https://github.com/civicrm/civicrm-core/pull/36401) - see that branch for comparison.

Before
----------------------------------------
Two payments recorded (or crash for one of them) if user-side and webhook record payment at the same time.

After
----------------------------------------
One payment recorded and both sides think they recorded it - desired outcome.

Technical Details
----------------------------------------
Adds a lock and relies on trxn_id being unique (which is enforced by DB entity).
The downstream code has 15 seconds to complete otherwise it will throw a CRM_Core_Exception. If downstream code completes in time the payment record is returned just the same as for the first caller.

Comments
----------------------------------------
This should be a cleaner solution than #36401 because it doesn't require code changes anywhere else.
