### PR TITLE
UtilsSql - Optimize inserts with int values

### DIFF
--- a/CRM/Utils/SQL/Insert.php
+++ b/CRM/Utils/SQL/Insert.php
@@ -145,7 +145,7 @@ class CRM_Utils_SQL_Insert {
 
     $escapedRow = [];
     foreach ($this->columns as $column) {
-      if (is_bool($row[$column])) {
+      if (is_bool($row[$column]) || is_int($row[$column])) {
         $escapedRow[$column] = (int) $row[$column];
       }
       else {

--- a/tests/phpunit/CRM/Utils/SQL/InsertTest.php
+++ b/tests/phpunit/CRM/Utils/SQL/InsertTest.php
@@ -13,11 +13,11 @@ class CRM_Utils_SQL_InsertTest extends CiviUnitTestCase {
 
   public function testRow_twice(): void {
     $insert = CRM_Utils_SQL_Insert::into('foo')
-      ->row(['first' => '1', 'second' => '2'])
+      ->row(['first' => '1', 'second' => 2])
       ->row(['second' => '2b', 'first' => '1b']);
     $expected = '
       INSERT INTO foo (`first`,`second`) VALUES
-      ("1","2"),
+      ("1",2),
       ("1b","2b")
     ';
     $this->assertLike($expected, $insert->toSQL());


### PR DESCRIPTION
Overview
----------------------------------------
Slightly speeds up inserts by skipping string escaping when it's redundant.

Technical Details
----------------------------------------
Pure int values do not need to be run through string escaping.
Has test coverage.