### PR TITLE
restrict mailings by domain

### DIFF
--- a/CRM/Mailing/Selector/Browse.php
+++ b/CRM/Mailing/Selector/Browse.php
@@ -633,6 +633,9 @@ LEFT JOIN  civicrm_contact scheduledContact ON ( $mailing.scheduled_id = schedul
       $params[6] = [$language, 'String'];
     }
 
+    $params[7] = [CRM_Core_Config::domainID(), 'Integer'];
+    $clauses[] = " ( domain_id = %7 ) ";
+
     if (empty($clauses)) {
       return 1;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Mailing listings should respect domain.

Before
----------------------------------------
All mailings irrespective of the domain are shown mailing listings.

After
----------------------------------------
Respect domain and only show relevant mailings.