### PR TITLE
SearchKit - Fix missing smart group config

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.html
@@ -106,6 +106,9 @@
         <div ng-repeat="activeTab in $ctrl.mainTabs" class="panel-body" role="tabpanel" ng-if="controls.tab === activeTab.key">
           <div ng-include="activeTab.template" class="crm-search-admin-relative"></div>
         </div>
+        <div class="panel-body" role="tabpanel" ng-if="controls.tab === 'group'">
+          <div ng-include="'~/crmSearchAdmin/crmSearch-group.html'" class="crm-search-admin-relative"></div>
+        </div>
         <div ng-if="$ctrl.selectedDisplay()" class="panel-body" role="tabpanel">
           <div ng-repeat="display in $ctrl.savedSearch.displays" ng-if="controls.tab === ('display_' + $index)">
             <crm-search-admin-display class="crm-search-admin-relative" display="display" saved-search="$ctrl.savedSearch"></crm-search-admin-display>


### PR DESCRIPTION
Overview
----------------------------------------
Fixes unreleased regression caused by f97d028e2024e

Before
----------------------------------------
Missing smart group screen:

<img width="1920" height="814" alt="image" src="https://github.com/user-attachments/assets/7390ae50-2461-4030-a3f0-1c8d4177fe14" />


After
----------------------------------------
Fixed :)