### PR TITLE
CustomField - Fix redirect after creating new group

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -311,14 +311,12 @@ class CRM_Custom_Form_Group extends CRM_Admin_Form {
       CRM_Core_Session::setStatus(ts('Your custom field set \'%1 \' has been saved.', [1 => $group['title']]), ts('Saved'), 'success');
     }
     else {
-      // Jump directly to adding a field if popups are disabled
-      $action = CRM_Core_Resources::singleton()->ajaxPopupsEnabled ? '' : '/add';
-      $url = CRM_Utils_System::url("civicrm/admin/custom/group/field$action", 'reset=1&new=1&gid=' . $group['id']);
+      // Redirect to search display of fields
+      $url = Civi::url('civicrm/admin/custom/group/fields#/?gid=' . $group['id']);
       CRM_Core_Session::setStatus(ts("Your custom field set '%1' has been added. You can add custom fields now.",
         [1 => $group['title']]
       ), ts('Saved'), 'success');
-      $session = CRM_Core_Session::singleton();
-      $session->replaceUserContext($url);
+      CRM_Core_Session::singleton()->replaceUserContext((string) $url);
     }
 
     // prompt Drupal Views users to update $db_prefix in settings.php, if necessary


### PR DESCRIPTION
Overview
----------------------------------------
Fixes redirect after creating a new custom group.

Before
----------------------------------------
Takes you back to the list of custom groups.

After
----------------------------------------
After creating a new custom group, this redirects you to create a new field.

Technical Details
----------------------------------------
Regressed with e72b05ba54f1fe4 when the url changed but this line was missed.