### PR TITLE
SearchKit - Improve smart group UX

### DIFF
--- a/CRM/Contact/BAO/SavedSearch.php
+++ b/CRM/Contact/BAO/SavedSearch.php
@@ -361,9 +361,9 @@ class CRM_Contact_BAO_SavedSearch extends CRM_Contact_DAO_SavedSearch implements
    */
   public static function getEditSearchUrl($id) {
     $savedSearch = self::retrieve(['id' => $id]);
-    // APIv4 search
+    // APIv4 - Link to SearchKit
     if (!empty($savedSearch->api_entity)) {
-      return CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, "/edit/$id");
+      return CRM_Utils_System::url('civicrm/admin/search', NULL, FALSE, "/edit/$id?tab=group");
     }
     // Classic search builder
     if (!empty($savedSearch->mapping_id)) {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdmin.component.js
@@ -334,7 +334,7 @@
       // Set current tab: Tab is passed through url by toggleEntitySet
       let defaultTab = $location.search().tab;
       if (!defaultTab || !this.mainTabs.some(t => t.key === defaultTab)) {
-        defaultTab = this.mainTabs[0].key;
+        defaultTab = defaultTab === 'group' && this.groupExists ? 'group' : this.mainTabs[0].key;
       }
       $scope.controls = {tab: defaultTab, joinType: 'LEFT'};
 

--- a/ext/search_kit/ang/crmSearchAdmin/tabs.html
+++ b/ext/search_kit/ang/crmSearchAdmin/tabs.html
@@ -37,7 +37,6 @@
         {{:: ts('Smart Group') }}
       </a>
     </li>
-    <li class="dropdown-header">{{:: ts('Display') }}</li>
     <li ng-repeat="type in ::$ctrl.displayTypes">
       <a href ng-click="$ctrl.addDisplay(type.id)" title="{{:: type.description }}">
         <i class="crm-i {{:: type.icon }}" role="img" aria-hidden="true"></i>


### PR DESCRIPTION
Overview
----------------------------------------
Minor tweak to SmartGroup UX in SearchKit.

- Link directly to group tab from "Edit Smart Group Criteria" button
- Remove extra "Display" header under "Add Smart Group"