### PR TITLE
SearchKit - When filtering a hierarchical entity, don't exclude children

### DIFF
--- a/Civi/Api4/Event/Subscriber/HierarchicalEntitySubscriber.php
+++ b/Civi/Api4/Event/Subscriber/HierarchicalEntitySubscriber.php
@@ -107,8 +107,10 @@ class HierarchicalEntitySubscriber extends AutoService implements EventSubscribe
       // Filter out children, maintaining sorted order
       $children = [];
       if (!$needsExtraDfkQuery) {
-        $records = array_filter($records, function($record) use ($parentName, $dfkControlName, $dfkValue, &$children) {
-          $isChild = !empty($record[$parentName]);
+        $allRecordIds = array_column($records, $idName);
+        $records = array_filter($records, function($record) use ($parentName, $dfkControlName, $dfkValue, $allRecordIds, &$children) {
+          // To avoid orphans disappearing, only designate child if parent can be found
+          $isChild = !empty($record[$parentName]) && array_intersect((array) $record[$parentName], $allRecordIds);
           if ($dfkValue) {
             $isChild = $record[$dfkControlName] == $dfkValue;
           }

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -4104,4 +4104,47 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotContains($contacts[0]['id'], $returnedContactIds, 'Alpha (February 2023) should be excluded');
   }
 
+  /**
+   * Test filtering a hierarchical group SearchDisplay by title.
+   *
+   * Replicates issue where filtering by group title only returns matching top-level groups,
+   * while matching child groups are dropped because their parent groups are excluded by the filter.
+   */
+  public function testHierarchicalGroupFilterByTitle(): void {
+    $parentGroup = $this->createTestRecord('Group', [
+      'title' => 'Parent Group ' . uniqid(),
+    ]);
+    $childGroup = $this->createTestRecord('Group', [
+      'title' => 'Child Group ' . uniqid(),
+      'parents' => [$parentGroup['id']],
+    ]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'savedSearch' => [
+        'api_entity' => 'Group',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['id', 'title', 'parents'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'settings' => [
+          'hierarchical' => TRUE,
+          'columns' => [
+            ['type' => 'field', 'key' => 'title', 'sortable' => TRUE],
+          ],
+        ],
+      ],
+      'filters' => [
+        'title' => $childGroup['title'],
+      ],
+    ];
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $returnedIds = array_column(array_column($result->getArrayCopy(), 'data'), 'id');
+    $this->assertContains($childGroup['id'], $returnedIds, 'Matching child group should be returned when filtering by title');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes an issue with e.g. the "Manage Groups" display where a search filter will only return parent groups

Before
----------------------------------------
Searching the "Manage Groups" screen only returns parents.

After
----------------------------------------
Search matches parents as well as children :)