### PR TITLE
CiviReport - Support multiple recipients

### DIFF
--- a/CRM/Utils/Mail.php
+++ b/CRM/Utils/Mail.php
@@ -562,8 +562,29 @@ class CRM_Utils_Mail {
    * @return null|string
    */
   public static function formatRFC822Email($name, $email, $useQuote = FALSE) {
-    $result = NULL;
+    if (empty($email)) {
+      return NULL;
+    }
 
+    // Already formatted
+    if (str_contains($email, '<')) {
+      return $email;
+    }
+
+    // Split multiple emails
+    if (str_contains($email, ',') || str_contains($email, ';')) {
+      $emails = preg_split('/[,;]+/', $email);
+      $formatted = [];
+      foreach ($emails as $singleEmail) {
+        $singleEmail = trim($singleEmail);
+        if ($singleEmail !== '') {
+          $formatted[] = self::formatRFC822Email($name, $singleEmail, $useQuote);
+        }
+      }
+      return implode(', ', $formatted);
+    }
+
+    $email = trim($email);
     $name = trim($name ?? '');
 
     // strip out double quotes if present at the beginning AND end
@@ -587,11 +608,10 @@ class CRM_Utils_Mail {
         $name = '"' . $name . '"';
       }
 
-      $result = "$name ";
+      return "$name <{$email}>";
     }
 
-    $result .= "<{$email}>";
-    return $result;
+    return "<{$email}>";
   }
 
   /**

--- a/tests/phpunit/CRM/Utils/MailTest.php
+++ b/tests/phpunit/CRM/Utils/MailTest.php
@@ -50,14 +50,50 @@ class CRM_Utils_MailTest extends CiviUnitTestCase {
         'result' => '"User, Test" <foo@bar.com>',
         'useQuote' => TRUE,
       ],
+      [
+        'name' => '',
+        'email' => 'foo@bar.com',
+        'result' => '<foo@bar.com>',
+      ],
+      [
+        'name' => NULL,
+        'email' => 'foo@bar.com',
+        'result' => '<foo@bar.com>',
+      ],
+      [
+        'name' => '',
+        'email' => 'foo@bar.com, baz@bar.com',
+        'result' => '<foo@bar.com>, <baz@bar.com>',
+      ],
+      [
+        'name' => NULL,
+        'email' => 'foo@bar.com, baz@bar.com',
+        'result' => '<foo@bar.com>, <baz@bar.com>',
+      ],
+      [
+        'name' => '',
+        'email' => 'foo@bar.com; baz@bar.com',
+        'result' => '<foo@bar.com>, <baz@bar.com>',
+      ],
     ];
     foreach ($values as $value) {
       $result = CRM_Utils_Mail::formatRFC822Email($value['name'],
         $value['email'],
         $value['useQuote'] ?? FALSE
       );
-      $this->assertEquals($result, $value['result'], 'Expected encoding does not match');
+      $this->assertEquals($value['result'], $result, 'Expected encoding does not match');
     }
+  }
+
+  public function testSetEmailHeadersMultipleRecipients(): void {
+    $params = [
+      'toEmail' => 'foo@bar.com, baz@bar.com',
+      'from' => 'admin@example.com',
+      'subject' => 'Test',
+      'text' => 'Hello',
+    ];
+    [$headers, $message] = CRM_Utils_Mail::setEmailHeaders($params);
+    $this->assertEquals('<foo@bar.com>, <baz@bar.com>', $headers['To']);
   }
 
   /**

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -2472,6 +2472,39 @@ ENDSQLUPDATE;
   }
 
   /**
+   * Test that the mail_report job sends an email when multiple recipients are specified in email_to.
+   */
+  public function testMailReportMultipleRecipients(): void {
+    $mut = new CiviMailUtils($this, TRUE);
+    $reportInstance = $this->createReportInstance();
+    $this->callAPISuccess('ReportInstance', 'create', [
+      'id' => $reportInstance['id'],
+      'email_to' => 'person1@example.com, person2@example.com',
+    ]);
+
+    if (empty($_SERVER['QUERY_STRING'])) {
+      $_SERVER['QUERY_STRING'] = 'reset=1';
+    }
+
+    ob_start();
+    $this->callApiV3Success('Job', 'mail_report', [
+      'instanceId' => $reportInstance['id'],
+      'format' => 'pdf',
+    ]);
+    ob_end_clean();
+
+    $message = $mut->getMostRecentEmail('ezc');
+
+    $this->assertEquals('This is the email subject', $message->subject);
+    $this->assertCount(2, $message->to);
+    $this->assertEquals('person1@example.com', $message->to[0]->email);
+    $this->assertEquals('person2@example.com', $message->to[1]->email);
+
+    $mut->clearMessages();
+    $mut->stop();
+  }
+
+  /**
    * Helper to create a report instance of the contact summary report.
    *
    * @return array


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#3705](https://lab.civicrm.org/dev/core/-/work_items/3705)

Before
----------------------------------------
Specifying multiple email recipients would fail.

After
----------------------------------------
Works.