### PR TITLE
Afform - Fix live-update of token-based field defaults

### DIFF
--- a/ext/afform/core/ang/af/afField.component.js
+++ b/ext/afform/core/ang/af/afField.component.js
@@ -116,7 +116,7 @@
 
         // check for tokens in the default value
         const tokens = this.afForm?.identifyTokens(this.defn.afform_default);
-        if (tokens && tokens.length) {
+        if (tokens && tokens.size) {
           const calculateValueWatcher = $scope.$watchCollection(() => Object.values(this.afForm.getTokenValues(tokens)), () => {
             if ($element[0].querySelector('.ng-touched')) {
               // user has touched this input, stop calculating


### PR DESCRIPTION
Overview
----------------------------------------
Fix live-update of token-based `afform_default` field values which regressed in 6.16 via https://github.com/civicrm/civicrm-core/pull/35562.

Fixes [dev/core#6674](https://lab.civicrm.org/dev/core/-/work_items/6674)

Before
----------------------------------------
When a field's default value contains a token referencing another field (e.g. `[Contact.1.first_name]`), the target field should recalculate its value whenever the source field changes. This was silently broken.

After
----------------------------------------
Live-update works as designed.

Technical Details
----------------------------------------
575232ff1c changed `afForm.identifyTokens()` to return a `Set` instead of an array, but the existing code was still checking for `.length`. `Set` objects don't have a `.length` they have a `.size` (thanks javascript) so `tokens.length` was always `undefined` (falsy), so the `$watchCollection` for live-updating was never registered.
