### PR TITLE
Update Smarty to 5.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
     "pontedilana/php-weasyprint": "^0.13.0 || ^1 || ^2",
     "knplabs/knp-snappy": "^1.4",
     "phpseclib/phpseclib2_compat": "^1.0",
-    "smarty/smarty": "5.7.0"
+    "smarty/smarty": "^5.8.2"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c48eda88818afda46c6f83feb8d55c02",
+    "content-hash": "054576b8cf0602c458c9c0d7f6cc5942",
     "packages": [
         {
             "name": "adrienrn/php-mimetyper",
@@ -4082,16 +4082,16 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v5.7.0",
+            "version": "v5.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "73da7e90f302175a570662fcb0ba41f57b7a92ab"
+                "reference": "94a27cbbc7820198d7adc17a2be8d457fb267753"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/73da7e90f302175a570662fcb0ba41f57b7a92ab",
-                "reference": "73da7e90f302175a570662fcb0ba41f57b7a92ab",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/94a27cbbc7820198d7adc17a2be8d457fb267753",
+                "reference": "94a27cbbc7820198d7adc17a2be8d457fb267753",
                 "shasum": ""
             },
             "require": {
@@ -4146,7 +4146,7 @@
             "support": {
                 "forum": "https://github.com/smarty-php/smarty/discussions",
                 "issues": "https://github.com/smarty-php/smarty/issues",
-                "source": "https://github.com/smarty-php/smarty/tree/v5.7.0"
+                "source": "https://github.com/smarty-php/smarty/tree/v5.8.4"
             },
             "funding": [
                 {
@@ -4154,7 +4154,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-19T21:36:38+00:00"
+            "time": "2026-06-29T10:46:32+00:00"
         },
         {
             "name": "soundasleep/html2text",


### PR DESCRIPTION


Overview
----------------------------------------
Update Smarty to 5.8.2
This is a security hardening update

Before
----------------------------------------
5.7.0

After
----------------------------------------
5.8.4, restriction set to 5.8.2 plus (that version being the earliest one with all security patches)

Technical Details
----------------------------------------
Per policy we apply all security updates to the rc (regardless of whether it is known to have any application) - we do a security update if shown to be relevant to Civi.

Note that I don't think there is a reason not to have a composer requirement that allows updates within the 5.x series - in this case I *think* it's why dependabot didn't kick in

Comments
----------------------------------------
