### PR TITLE
[REF] Migrate getPaymentProcessorID() to use APIv4

### DIFF
--- a/CRM/Contribute/BAO/ContributionRecur.php
+++ b/CRM/Contribute/BAO/ContributionRecur.php
@@ -241,10 +241,11 @@ class CRM_Contribute_BAO_ContributionRecur extends CRM_Contribute_DAO_Contributi
    *   pseudo processor used for pay-later.
    */
   public static function getPaymentProcessorID($recurID) {
-    $recur = civicrm_api3('ContributionRecur', 'getsingle', [
-      'id' => $recurID,
-      'return' => ['payment_processor_id'],
-    ]);
+    $recur = ContributionRecur::get(FALSE)
+      ->addSelect('payment_processor_id')
+      ->addWhere('id', '=', $recurID)
+      ->execute()
+      ->first();
     return (int) ($recur['payment_processor_id'] ?? 0);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Upgrade an api3 call to use api4.

Technical Details
-------
Api3 -> Api4 update, no other functional changes.