### PR TITLE
DRAFT: Redirect URLs from WP mailings

### DIFF
--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -106,14 +106,14 @@ class WebEntrypoint {
    * @return void
    */
   public static function wpredirect($path, $params) {
-    if (preg_match('/^\/wp-content\/uploads\/civicrm\/persist\/contribute\/images\/(.*)/', $path, $matches)) {
+    if (preg_match('@^/wp-content/uploads/civicrm/persist/contribute/images/(.*)@', $path, $matches)) {
       \CRM_Utils_System::redirect('/public/media/images/' . $matches[1]);
     }
-    if (preg_match('/^\/wp-content\/uploads\/civicrm\/(mosaico_tpl\/.*)/', $path, $matches)) {
+    if (preg_match('@^/wp-content/uploads/civicrm/(mosaico_tpl/.*)@', $path, $matches)) {
       \CRM_Utils_System::redirect('/public/' . $matches[1]);
     }
     if ($path === '/civicrm/' && $params &&
-      preg_match('/^civiwp=CiviCRM\&q=civicrm\/mailing\/url\&(u=\d+\&qid=\d+)/', $params, $matches)) {
+      preg_match('@^civiwp=CiviCRM\&q=civicrm/mailing/url\&(u=\d+\&qid=\d+)@', $params, $matches)) {
       \CRM_Utils_System::redirect('/civicrm/mailing/url?' . $matches[1]);
     }
   }

--- a/Civi/Standalone/WebEntrypoint.php
+++ b/Civi/Standalone/WebEntrypoint.php
@@ -53,6 +53,9 @@ class WebEntrypoint {
     // Remove empty path segments, a//b becomes equivalent to a/b
     $args = array_values(array_filter($args));
 
+    // Redirect urls from WP mailings
+    self::wpredirect($parts[0] ?? '', $parts[1] ?? '');
+
     // if request is for any path that doesn't start civicrm,
     // throw 404 before we waste any effort doing anything else
     // (may well be spam)
@@ -93,6 +96,26 @@ class WebEntrypoint {
 
     // Render the page
     print \CRM_Core_Invoke::invoke($args);
+  }
+
+  /**
+   * Redirect URLs from old mailings sent before migration from WordPress
+   *
+   * @param string $path
+   * @param string $params
+   * @return void
+   */
+  public static function wpredirect($path, $params) {
+    if (preg_match('/^\/wp-content\/uploads\/civicrm\/persist\/contribute\/images\/(.*)/', $path, $matches)) {
+      \CRM_Utils_System::redirect('/public/media/images/' . $matches[1]);
+    }
+    if (preg_match('/^\/wp-content\/uploads\/civicrm\/(mosaico_tpl\/.*)/', $path, $matches)) {
+      \CRM_Utils_System::redirect('/public/' . $matches[1]);
+    }
+    if ($path === '/civicrm/' && $params &&
+      preg_match('/^civiwp=CiviCRM\&q=civicrm\/mailing\/url\&(u=\d+\&qid=\d+)/', $params, $matches)) {
+      \CRM_Utils_System::redirect('/civicrm/mailing/url?' . $matches[1]);
+    }
   }
 
   public static function installer(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Provide URL redirection so that mails sent from Civi on WP continue to work after migration to Standalone.

This reduces one of the points of friction when migrating to Standalone.

Background: https://chat.civicrm.org/civicrm/pl/ojd5d8kisjrd8nmr13qw97take

Before
----------------------------------------
1.  Send a mail from Civi on WordPress
2.  Migrate from WP to Standalone
3.  All your client's historic mails in end-user mailboxes are broken.

After
----------------------------------------
Historic mails continue to work.

Technical Details
----------------------------------------
The first 2 of the redirections could be done at the webserver level - if your hosting provides capability to do that.
The mailing url ones need to look at the parameters.

These URL's are intentionally specific to those found in Mosaico mails, not a general redirection from WP.

The call to `self::wpredirect()` could be gated behind a setting.

This should be fairly safe from weirdly crafted URLs since it just does redirects.

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
