### PR TITLE
[REF] Migrate getEmailDetails() to use APIv4

### DIFF
--- a/CRM/Contact/BAO/Contact/Location.php
+++ b/CRM/Contact/BAO/Contact/Location.php
@@ -9,6 +9,9 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\Contact;
+use Civi\Api4\Email;
+
 /**
  *
  * @package CRM
@@ -29,34 +32,37 @@ class CRM_Contact_BAO_Contact_Location {
    *   Array of display_name, email, location type and location id if found, or (null,null,null, null)
    */
   public static function getEmailDetails($id, $isPrimary = TRUE, $locationTypeID = NULL) {
-    $params = [
-      'contact_id' => $id,
-      'return' => ['display_name', 'email.email'],
-      'api.Email.get' => [
-        'location_type_id' => $locationTypeID,
-        'sequential' => 0,
-        'return' => ['email', 'location_type_id', 'id'],
-      ],
-    ];
+    if (!$id) {
+      return [NULL, NULL, NULL, NULL];
+    }
+
+    $emailQuery = Email::get(FALSE)
+      ->addSelect('email', 'location_type_id', 'id', 'contact_id.display_name')
+      ->addWhere('contact_id', '=', $id)
+      ->setLimit(1);
+
+    if ($locationTypeID) {
+      $emailQuery->addWhere('location_type_id', '=', $locationTypeID);
+    }
     if ($isPrimary) {
-      $params['api.Email.get']['is_primary'] = 1;
+      $emailQuery->addWhere('is_primary', '=', TRUE);
     }
 
-    $contacts = civicrm_api3('Contact', 'get', $params);
-    if ($contacts['count'] > 0) {
-      $contact = reset($contacts['values']);
-      if ($contact['api.Email.get']['count'] > 0) {
-        $email = reset($contact['api.Email.get']['values']);
-      }
-    }
-    $returnParams = [
-      (isset($contact['display_name'])) ? $contact['display_name'] : NULL,
-      (isset($email['email'])) ? $email['email'] : NULL,
-      (isset($email['location_type_id'])) ? $email['location_type_id'] : NULL,
-      (isset($email['id'])) ? $email['id'] : NULL,
+    $email = $emailQuery->execute()->first();
+
+    // Lookup contact name if not returned by the email query
+    $displayName = $email['contact_id.display_name'] ?? Contact::get(FALSE)
+      ->addSelect('display_name')
+      ->addWhere('id', '=', $id)
+      ->execute()
+      ->first()['display_name'] ?? NULL;
+
+    return [
+      $displayName ?? NULL,
+      $email['email'] ?? NULL,
+      $email['location_type_id'] ?? NULL,
+      $email['id'] ?? NULL,
     ];
-
-    return $returnParams;
   }
 
   /**

--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -1468,7 +1468,9 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     foreach ($this->getCreatedMemberships() as $membership) {
       $endDate = $membership['end_date'] ?? NULL;
     }
-    $statusMsg = ts('Membership for %1 has been updated.', [1 => htmlentities($this->_memberDisplayName)]);
+    $statusMsg = ts('Membership for %1 has been updated.', [
+      1 => htmlentities((string) $this->_memberDisplayName),
+    ]);
     if ($endDate) {
       $endDate = CRM_Utils_Date::customFormat($endDate);
       $statusMsg .= ' ' . ts('The Membership Expiration Date is %1.', [1 => $endDate]);
@@ -1486,7 +1488,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
     foreach ($this->getCreatedMemberships() as $membership) {
       $statusMsg[$membership['membership_type_id']] = ts('%1 membership for %2 has been added.', [
         1 => $this->allMembershipTypeDetails[$membership['membership_type_id']]['name'],
-        2 => htmlentities($this->_memberDisplayName),
+        2 => htmlentities((string) $this->_memberDisplayName),
       ]);
 
       $memEndDate = $membership['end_date'] ?? NULL;
@@ -1853,7 +1855,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
    */
   protected function getContributionSource(): string {
     [$userName] = CRM_Contact_BAO_Contact_Location::getEmailDetails(CRM_Core_Session::getLoggedInContactID());
-    $userName = htmlentities($userName);
+    $userName = htmlentities((string) $userName);
     if ($this->_mode) {
       return ts('%1 Membership Signup: Credit card or direct debit (by %2)',
         [1 => $this->getSelectedMembershipLabels(), 2 => $userName]

--- a/CRM/Member/Form/MembershipRenewal.php
+++ b/CRM/Member/Form/MembershipRenewal.php
@@ -604,7 +604,7 @@ class CRM_Member_Form_MembershipRenewal extends CRM_Member_Form {
       [$userName] = CRM_Contact_BAO_Contact_Location::getEmailDetails(CRM_Core_Session::singleton()->get('userID'));
       $this->membershipTypeName = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType', $membershipParams['membership_type_id'],
         'name');
-      $userName = htmlentities($userName);
+      $userName = htmlentities((string) $userName);
       $this->_params['contribution_source'] = "{$this->membershipTypeName} Membership: Offline membership renewal (by {$userName})";
 
       //create line items

--- a/tests/phpunit/CRM/Contact/BAO/ContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/ContactTest.php
@@ -1546,6 +1546,30 @@ class CRM_Contact_BAO_ContactTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test getEmailDetails with primary email and specific location type.
+   */
+  public function testGetEmailDetails(): void {
+    $contactId = $this->individualCreate();
+    $email = $this->callAPISuccess('Email', 'create', [
+      'contact_id' => $contactId,
+      'email' => 'work@example.com',
+      'location_type_id' => 2,
+      'is_primary' => 0,
+    ]);
+    $emailId = $email['id'];
+    $displayName = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $contactId, 'display_name');
+
+    // Test primary email lookup
+    $resultPrimary = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId, TRUE);
+    $this->assertEquals($displayName, $resultPrimary[0]);
+    $this->assertNotEmpty($resultPrimary[1]);
+
+    // Test specific location type lookup
+    $resultLocation = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactId, FALSE, 2);
+    $this->assertEquals([$displayName, 'work@example.com', 2, $emailId], $resultLocation);
+  }
+
+  /**
    * Test that contact details are still displayed if no email is present.
    *
    * @throws \Exception


### PR DESCRIPTION
Overview
----------------------------------------
Upgrade an api3 call to use api4.

Technical Details
-------
This turned up a real bug - the previous api3 function incorrectly dropped `contact_id => NULL` and returned the first database contact. Now it correctly returns no results when $id = `NULL`.

Code passing the output of this function directly into `htmlentities()` have been updated to cast the value to `(string)` to avoid triggering PHP 8.1+ deprecation errors.