### PR TITLE
CiviCase - Prevent CaseType.definition xml from being escaped

### DIFF
--- a/CRM/Utils/API/HTMLInputCoder.php
+++ b/CRM/Utils/API/HTMLInputCoder.php
@@ -135,6 +135,8 @@ class CRM_Utils_API_HTMLInputCoder extends CRM_Utils_API_AbstractFieldCoder {
         'password',
         'hashed_password',
         'password_reset_token',
+        // CaseType.definition
+        'definition',
       ];
       $custom = CRM_Core_DAO::executeQuery('
         SELECT cf.id, cf.name AS field_name, cg.name AS group_name

--- a/tests/phpunit/api/v3/CaseTypeTest.php
+++ b/tests/phpunit/api/v3/CaseTypeTest.php
@@ -148,6 +148,11 @@ class api_v3_CaseTypeTest extends CiviCaseTestCase {
 
     $caseXml = CRM_Case_XMLRepository::singleton()->retrieve('Application_with_Definition');
     $this->assertTrue($caseXml instanceof SimpleXMLElement);
+
+    $dbDefinition = CRM_Core_DAO::singleValueQuery('SELECT definition FROM civicrm_case_type WHERE id = ' . $id);
+    $this->assertStringContainsString('<CaseType>', $dbDefinition);
+    $this->assertStringNotContainsString('&lt;', $dbDefinition);
+    $this->assertStringNotContainsString('&gt;', $dbDefinition);
   }
 
   /**

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -23,7 +23,6 @@ use api\v4\Api4TestBase;
 use Civi\API\Exception\UnauthorizedException;
 use Civi\Api4\Activity;
 use Civi\Api4\CaseActivity;
-use Civi\Api4\CaseType;
 use Civi\Api4\CiviCase;
 use Civi\Api4\Relationship;
 
@@ -147,59 +146,6 @@ class CaseTest extends Api4TestBase {
       ->single();
 
     $this->assertNull($result['case_manager_id']);
-  }
-
-  public function testCgExtendsObjects(): void {
-    $this->createTestRecord('CaseType', [
-      'title' => 'Test Case Type',
-      'name' => 'test_case_type1',
-    ]);
-
-    $field = \Civi\Api4\CustomGroup::getFields(FALSE)
-      ->setLoadOptions(TRUE)
-      ->addValue('extends', 'Case')
-      ->addWhere('name', '=', 'extends_entity_column_value')
-      ->execute()
-      ->first();
-
-    $this->assertContains('Test Case Type', $field['options']);
-  }
-
-  public function testGetStatusIdPerCaseType(): void {
-    $this->createTestRecord('OptionValue', [
-      'option_group_id:name' => 'case_status',
-      'label' => 'Testing',
-      'name' => 'Testing',
-      'grouping' => 'Opened',
-    ]);
-
-    $caseType = $this->createTestRecord('CaseType', [
-      'title' => 'Test Case Type',
-      'name' => 'test_case_type2',
-      'definition' => [
-        'statuses' => ['Testing', 'Closed'],
-      ],
-    ]);
-
-    $field = CiviCase::getFields(FALSE)
-      ->setLoadOptions(['id', 'label', 'name'])
-      ->addValue('case_type_id:name', 'test_case_type2')
-      ->addWhere('name', '=', 'status_id')
-      ->execute()
-      ->first();
-    $options = array_column($field['options'], 'name');
-
-    $this->assertEquals(['Closed', 'Testing'], $options);
-  }
-
-  public function testCaseTypeDefinition(): void {
-    $caseTypeToTest = CaseType::get(FALSE)
-      ->addSelect('definition')
-      ->addWhere('name', '=', 'housing_support')
-      ->execute()
-      ->first();
-    $this->assertArrayHasKey('definition', $caseTypeToTest);
-    $this->assertNotNull($caseTypeToTest['definition']);
   }
 
   public function testCaseActivity(): void {

--- a/tests/phpunit/api/v4/Entity/CaseTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTypeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace api\v4\Entity;
+
+use api\v4\Api4TestBase;
+use Civi\Api4\CaseType;
+use Civi\Api4\CiviCase;
+
+/**
+ * @group headless
+ */
+class CaseTypeTest extends Api4TestBase {
+
+  public function setUp(): void {
+    parent::setUp();
+    \CRM_Core_Dao::executeQuery('DELETE FROM civicrm_case_type WHERE id > 2');
+    \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
+  }
+
+  public function testCaseTypeDefinition(): void {
+    $caseType = CaseType::get(FALSE)
+      ->addSelect('definition')
+      ->addWhere('name', '=', 'housing_support')
+      ->execute()->single();
+
+    $this->assertEquals('Open Case', $caseType['definition']['activityTypes'][0]['name']);
+  }
+
+  public function testGetStatusIdPerCaseType(): void {
+    $this->createTestRecord('OptionValue', [
+      'option_group_id:name' => 'case_status',
+      'label' => 'Testing',
+      'name' => 'Testing',
+      'grouping' => 'Opened',
+    ]);
+
+    $caseType = $this->createTestRecord('CaseType', [
+      'title' => 'Test Case Type',
+      'name' => 'test_case_type2',
+      'definition' => [
+        'statuses' => ['Testing', 'Closed'],
+      ],
+    ]);
+
+    // Ensure saved xml is well-formed
+    $dbDefinition = \CRM_Core_DAO::singleValueQuery('SELECT definition FROM civicrm_case_type WHERE id = ' . $caseType['id']);
+    $this->assertStringContainsString('<CaseType>', $dbDefinition);
+    $this->assertStringNotContainsString('&lt;', $dbDefinition);
+    $this->assertStringNotContainsString('&gt;', $dbDefinition);
+
+    $field = CiviCase::getFields(FALSE)
+      ->setLoadOptions(['id', 'label', 'name'])
+      ->addValue('case_type_id:name', 'test_case_type2')
+      ->addWhere('name', '=', 'status_id')
+      ->execute()
+      ->first();
+    $options = array_column($field['options'], 'name');
+
+    $this->assertEquals(['Closed', 'Testing'], $options);
+  }
+
+  public function testCgExtendsObjects(): void {
+    $this->createTestRecord('CaseType', [
+      'title' => 'Test Case Type',
+      'name' => 'test_case_type1',
+    ]);
+
+    $field = \Civi\Api4\CustomGroup::getFields(FALSE)
+      ->setLoadOptions(TRUE)
+      ->addValue('extends', 'Case')
+      ->addWhere('name', '=', 'extends_entity_column_value')
+      ->execute()
+      ->first();
+
+    $this->assertContains('Test Case Type', $field['options']);
+  }
+
+  public function testCreateWithXmlString(): void {
+    $xmlString = '<CaseType><name>TestXmlString</name><ActivityTypes><ActivityType><name>Open Case</name></ActivityType></ActivityTypes></CaseType>';
+
+    $id = civicrm_api4('CaseType', 'create', [
+      'checkPermissions' => FALSE,
+      'values' => [
+        'name' => 'TestXmlString',
+        'title' => 'Test XML String',
+        'definition' => $xmlString,
+      ],
+    ])->single()['id'];
+
+    $dbDefinition = \CRM_Core_DAO::singleValueQuery('SELECT definition FROM civicrm_case_type WHERE id = ' . $id);
+    $this->assertStringContainsString('<CaseType>', $dbDefinition);
+    $this->assertStringNotContainsString('&lt;', $dbDefinition);
+    $this->assertStringNotContainsString('&gt;', $dbDefinition);
+
+    $caseType = CaseType::get(FALSE)
+      ->addSelect('definition')
+      ->addWhere('id', '=', $id)
+      ->execute()->single();
+
+    $this->assertEquals('Open Case', $caseType['definition']['activityTypes'][0]['name']);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
The Api correctly reads/writes CaseType as an array, but feeding it a canonical xml string would cause the asinine `HTMLInputCoder` to escape all the angle brackets, resulting in a fatal runtime error whenever using CiviCase.

Before
----------------------------------------
Utterly asinine.

After
----------------------------------------
Less asinine.

Technical Details
-------
I moved some CaseType tests into their own class and added more assertions to ensure escaping never happens.