### PR TITLE
CaseType - Fix broken hook_civicrm_post

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -419,7 +419,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
 
     $transaction->commit();
 
-    CRM_Utils_Hook::post($action, 'CaseType', $caseType->id, $case, $params);
+    CRM_Utils_Hook::post($action, 'CaseType', $caseType->id, $caseType, $params);
 
     return $caseType;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes undefined variable causing hook_civicrm_post failure in CaseType create/update.

Technical Details
-------


Looks like `hook_civicrm_post` never worked for the caseType entity, due to a copy-paste error it's been passed an undefined variable since the BAO file was [created 12 years ago](https://github.com/civicrm/civicrm-core/blob/8ffdec1716359d3e71a8c89c5a7142c8422dbefa/CRM/Case/BAO/CaseType.php).