### PR TITLE
Fix for dropdown menu link color illegibility in Joomla

### DIFF
--- a/ext/riverlea/core/css/joomla.css
+++ b/ext/riverlea/core/css/joomla.css
@@ -70,7 +70,8 @@ body.com_civicm.layout-default .table tbody a:not(.badge):not(.btn):not(.dropdow
   text-decoration: var(--crm-link-decoration);
 }
 .table tbody a:not(.badge):not(.btn):not(.dropdown-item) {
-  text-decoration: none; /* Reset theme */
+  text-decoration: none;
+  color: var(--crm-dropdown-color);
 }
 body.com_civicm #bootstrap-theme .bg-secondary {
   background-color: var(--crm-secondary-color) !important; /* vs !important bg colour in Atum theme */


### PR DESCRIPTION
Last month's illegibility fixes around the menu dropdown missed the Joomla issue that was bugging me so much to start with - rendering links in dropdowns in a dark blue. This is just on Joomla, hence why it didn't come up on the Drupal/standalone tests around https://github.com/civicrm/civicrm-core/pull/36189

# Before

<img width="188" height="230" alt="image" src="https://github.com/user-attachments/assets/1dada6a9-3d2b-46e2-b547-9b4ef1875c75" /> 
<img width="198" height="244" alt="image" src="https://github.com/user-attachments/assets/f2e368af-3d7d-4232-99a4-80537c26d353" />

# After

<img width="187" height="242" alt="image" src="https://github.com/user-attachments/assets/8ce8b18d-ae41-4016-abc4-6f7310e4cdc3" />
<img width="188" height="231" alt="image" src="https://github.com/user-attachments/assets/46540881-f505-4bc8-8dfb-4297bfd4988f" />

# Notes

- This change only impacts Joomla so the automated tests won't have any impact
- Be good to get this into 6.18 with the other dropdown hover fixes. 
- The convoluted selector (`.table tbody a:not(.badge):not(.btn):not(.dropdown-item)`) is initially declared in Atum admin theme's template.css and normally looks like this:

```
    color: rgb(var(--link-color-rgb, var(--table-link-color)));
    text-decoration: underline;
```