### PR TITLE
CiviCase - Drop support for XML configuration files

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -96,11 +96,6 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
       [$xml] = CRM_Utils_XML::parseString($value);
       $value = $xml ? self::convertXmlToDefinition($xml) : [];
     }
-    elseif (!empty($row['id']) || !empty($row['name'])) {
-      $caseTypeName = $row['name'] ?? CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $row['id']);
-      $xml = CRM_Case_XMLRepository::singleton()->retrieve($caseTypeName);
-      $value = $xml ? self::convertXmlToDefinition($xml) : [];
-    }
   }
 
   /**
@@ -500,13 +495,7 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
    *   TRUE if there are *both* DB and file-based definitions
    */
   public static function isForked($caseTypeId) {
-    $caseTypeName = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'name', 'id', TRUE);
-    if ($caseTypeName) {
-      $dbDefinition = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'definition', 'id', TRUE);
-      $fileDefinition = CRM_Case_XMLRepository::singleton()->retrieveFile($caseTypeName);
-      return $fileDefinition && $dbDefinition;
-    }
-    return NULL;
+    return FALSE;
   }
 
   /**
@@ -519,10 +508,9 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
   public static function isForkable($caseTypeId) {
     $caseTypeName = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseTypeId, 'name', 'id', TRUE);
     if ($caseTypeName) {
-      // if file-based definition explicitly disables "forkable" option, then don't allow changes to definition
-      $fileDefinition = CRM_Case_XMLRepository::singleton()->retrieveFile($caseTypeName);
-      if ($fileDefinition && isset($fileDefinition->forkable)) {
-        return CRM_Utils_String::strtobool((string) $fileDefinition->forkable);
+      $xml = CRM_Case_XMLRepository::singleton()->retrieve($caseTypeName);
+      if ($xml && count($xml->forkable) > 0) {
+        return (bool) (int) $xml->forkable;
       }
     }
     return TRUE;

--- a/CRM/Case/ManagedEntities.php
+++ b/CRM/Case/ManagedEntities.php
@@ -24,14 +24,16 @@ class CRM_Case_ManagedEntities {
     $caseTypes = [];
     CRM_Utils_Hook::caseTypes($caseTypes);
 
-    $proc = new CRM_Case_XMLProcessor();
     foreach ($caseTypes as $name => $caseType) {
-      $xml = $proc->retrieve($name);
-      if (!$xml) {
-        throw new CRM_Core_Exception("Failed to load XML for case type (" . $name . ")");
-      }
-
-      if (isset($caseType['module'], $caseType['name'], $caseType['file'])) {
+      if (isset($caseType['module'], $caseType['name'], $caseType['file']) && file_exists($caseType['file'])) {
+        $dom = new DOMDocument();
+        $dom->loadXML(file_get_contents($caseType['file']));
+        $dom->documentURI = $caseType['file'];
+        $dom->xinclude();
+        $xml = simplexml_import_dom($dom);
+        if (!$xml) {
+          throw new CRM_Core_Exception("Failed to load XML for case type (" . $name . ")");
+        }
         $entities[] = [
           'module' => $caseType['module'],
           'name' => $caseType['name'],
@@ -42,9 +44,10 @@ class CRM_Case_ManagedEntities {
               'name' => $caseType['name'],
               'title' => (string) $xml->name,
               'description' => (string) $xml->description,
+              'definition' => CRM_Case_BAO_CaseType::convertXmlToDefinition($xml),
               'is_reserved' => TRUE,
               'is_active' => TRUE,
-              'weight' => $xml->weight ?: 1,
+              'weight' => (int) ($xml->weight ?? 1),
             ],
             'match' => ['name'],
           ],

--- a/CRM/Case/XMLRepository.php
+++ b/CRM/Case/XMLRepository.php
@@ -76,6 +76,11 @@ class CRM_Case_XMLRepository {
    * @throws \CRM_Core_Exception
    */
   public function retrieve($caseType) {
+    // Used by unit tests
+    if (!empty($this->xml[$caseType])) {
+      return $this->xml[$caseType];
+    }
+
     // check if xml definition is defined in db
     $definition = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseType, 'definition', 'name');
 
@@ -87,131 +92,7 @@ class CRM_Case_XMLRepository {
       return $xml;
     }
 
-    // TODO In 4.6 or 5.0, remove support for weird machine-names
-    //if (!CRM_Case_BAO_CaseType::isValidName($caseType)) {
-    //  // perhaps caller provider a the label instead of the name?
-    //  throw new CRM_Core_Exception("Cannot load caseType with malformed name [$caseType]");
-    //}
-
-    if (empty($this->xml[$caseType])) {
-      $fileXml = $this->retrieveFile($caseType);
-      if ($fileXml) {
-        $this->xml[$caseType] = $fileXml;
-      }
-      else {
-        return FALSE;
-      }
-    }
-    return $this->xml[$caseType];
-  }
-
-  /**
-   * Retrieve file.
-   *
-   * @param string $caseType
-   * @return SimpleXMLElement|FALSE
-   */
-  public function retrieveFile($caseType) {
-    $fileName = NULL;
-    $fileXml = NULL;
-
-    if (CRM_Case_BAO_CaseType::isValidName($caseType)) {
-      // Search for a file based directly on the $caseType name
-      $fileName = $this->findXmlFile($caseType);
-    }
-
-    // For backward compatibility, also search for double-munged file names
-    // TODO In 4.6 or 5.0, remove support for loading double-munged file names
-    if (!$fileName || !file_exists($fileName)) {
-      $fileName = $this->findXmlFile(CRM_Case_XMLProcessor::mungeCaseType($caseType));
-    }
-
-    if ($fileName && file_exists($fileName)) {
-      // read xml file
-      $dom = new DomDocument();
-      $xmlString = file_get_contents($fileName);
-      $dom->loadXML($xmlString);
-      $dom->documentURI = $fileName;
-      $dom->xinclude();
-      $fileXml = simplexml_import_dom($dom);
-    }
-
-    return $fileXml;
-  }
-
-  /**
-   * Find xml file.
-   *
-   * @param string $caseType
-   * @return null|string
-   *   file path
-   */
-  public function findXmlFile($caseType) {
-    // first check custom templates directory
-    $fileName = '';
-
-    if (!$fileName || !file_exists($fileName)) {
-      $caseTypesViaHook = $this->getCaseTypesViaHook();
-      if (isset($caseTypesViaHook[$caseType], $caseTypesViaHook[$caseType]['file'])) {
-        $fileName = $caseTypesViaHook[$caseType]['file'];
-      }
-    }
-
-    if (!$fileName || !file_exists($fileName)) {
-      $config = CRM_Core_Config::singleton();
-      if (isset($config->customTemplateDir) && $config->customTemplateDir) {
-        // check if the file exists in the custom templates directory
-        $fileName = implode(DIRECTORY_SEPARATOR,
-          [
-            $config->customTemplateDir,
-            'CRM',
-            'Case',
-            'xml',
-            'configuration',
-            "$caseType.xml",
-          ]
-        );
-      }
-    }
-
-    if (!$fileName || !file_exists($fileName)) {
-      if (!file_exists($fileName)) {
-        // check if file exists locally
-        $fileName = implode(DIRECTORY_SEPARATOR,
-          [
-            dirname(__FILE__),
-            'xml',
-            'configuration',
-            "$caseType.xml",
-          ]
-        );
-      }
-
-      if (!file_exists($fileName)) {
-        // check if file exists locally
-        $fileName = implode(DIRECTORY_SEPARATOR,
-          [
-            dirname(__FILE__),
-            'xml',
-            'configuration.sample',
-            "$caseType.xml",
-          ]
-        );
-      }
-    }
-    return file_exists($fileName) ? $fileName : NULL;
-  }
-
-  /**
-   * @return array
-   * @see CRM_Utils_Hook::caseTypes
-   */
-  public function getCaseTypesViaHook() {
-    if ($this->hookCache === NULL) {
-      $this->hookCache = [];
-      CRM_Utils_Hook::caseTypes($this->hookCache);
-    }
-    return $this->hookCache;
+    return FALSE;
   }
 
   /**
@@ -231,7 +112,9 @@ class CRM_Case_XMLRepository {
     $p = new CRM_Case_XMLProcessor_Process();
     foreach ($this->getAllCaseTypes() as $caseTypeName) {
       $caseTypeXML = $this->retrieve($caseTypeName);
-      $result = array_merge($result, $p->getDeclaredActivityTypes($caseTypeXML));
+      if ($caseTypeXML) {
+        $result = array_merge($result, $p->getDeclaredActivityTypes($caseTypeXML));
+      }
     }
 
     $result = array_unique($result);
@@ -250,7 +133,9 @@ class CRM_Case_XMLRepository {
     $p = new CRM_Case_XMLProcessor_Process();
     foreach ($this->getAllCaseTypes() as $caseTypeName) {
       $caseTypeXML = $this->retrieve($caseTypeName);
-      $result = array_merge($result, $p->getDeclaredRelationshipTypes($caseTypeXML));
+      if ($caseTypeXML) {
+        $result = array_merge($result, $p->getDeclaredRelationshipTypes($caseTypeXML));
+      }
     }
 
     $result = array_unique($result);
@@ -271,7 +156,7 @@ class CRM_Case_XMLRepository {
     $count = 0;
     foreach ($this->getAllCaseTypes() as $caseTypeName) {
       $caseTypeXML = $this->retrieve($caseTypeName);
-      if (in_array($activityType, $p->getDeclaredActivityTypes($caseTypeXML))) {
+      if ($caseTypeXML && in_array($activityType, $p->getDeclaredActivityTypes($caseTypeXML))) {
         $count++;
       }
     }
@@ -291,7 +176,7 @@ class CRM_Case_XMLRepository {
     $count = 0;
     foreach ($this->getAllCaseTypes() as $caseTypeName) {
       $caseTypeXML = $this->retrieve($caseTypeName);
-      if (in_array($relationshipTypeName, $p->getDeclaredRelationshipTypes($caseTypeXML))) {
+      if ($caseTypeXML && in_array($relationshipTypeName, $p->getDeclaredRelationshipTypes($caseTypeXML))) {
         $count++;
       }
     }

--- a/CRM/Case/xml/configuration.sample/case_sample.mysql.tpl
+++ b/CRM/Case/xml/configuration.sample/case_sample.mysql.tpl
@@ -14,9 +14,199 @@ SELECT @caseCompId := id FROM `civicrm_component` where `name` like 'CiviCase';
 -- *******************************************************/
 SELECT @max_wt  :=  COALESCE( max(weight), 0 ) from civicrm_case_type;
 
-INSERT IGNORE INTO `civicrm_case_type` (  {localize field='title'}`title`{/localize}, `name`, {localize field='description'}`description`{/localize}, `weight`, `is_reserved`, `is_active`) VALUES
-  ({localize}'{ts escape="sql"}Housing Support{/ts}'{/localize}, 'housing_support', {localize}'{ts escape="sql"}Help homeless individuals obtain temporary and long-term housing{/ts}'{/localize}, @max_wt + 1, 0, 1),
-  ({localize}'{ts escape="sql"}Adult Day Care Referral{/ts}'{/localize}, 'adult_day_care_referral', {localize}'{ts escape="sql"}Arranging adult day care for senior individuals{/ts}'{/localize}, @max_wt + 2, 0, 1);
+INSERT IGNORE INTO `civicrm_case_type` (  {localize field='title'}`title`{/localize}, `name`, {localize field='description'}`description`{/localize}, `definition`, `weight`, `is_reserved`, `is_active`) VALUES
+  ({localize}'{ts escape="sql"}Housing Support{/ts}'{/localize}, 'housing_support', {localize}'{ts escape="sql"}Help homeless individuals obtain temporary and long-term housing{/ts}'{/localize}, '<?xml version="1.0" encoding="iso-8859-1" ?>
+<CaseType>
+  <name>housing_support</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>Open Case</name>
+      <max_instances>1</max_instances>
+    </ActivityType>
+    <ActivityType>
+      <name>Medical evaluation</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Mental health evaluation</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Secure temporary housing</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Income and benefits stabilization</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Long-term housing plan</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Follow up</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Change Case Type</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Change Case Status</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Change Case Start Date</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Link Cases</name>
+    </ActivityType>
+  </ActivityTypes>
+  <ActivitySets>
+    <ActivitySet>
+      <name>standard_timeline</name>
+      <label>Standard Timeline</label>
+      <timeline>true</timeline>
+      <ActivityTypes>
+        <ActivityType>
+          <name>Open Case</name>
+          <status>Completed</status>
+        </ActivityType>
+        <ActivityType>
+          <name>Medical evaluation</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>1</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Mental health evaluation</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>1</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Secure temporary housing</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>2</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Follow up</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>3</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Income and benefits stabilization</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>7</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Long-term housing plan</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>14</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Follow up</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>21</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+      </ActivityTypes>
+    </ActivitySet>
+  </ActivitySets>
+  <CaseRoles>
+    <RelationshipType>
+        <name>Homeless Services Coordinator</name>
+        <creator>1</creator>
+        <manager>1</manager>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Health Services Coordinator</name>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Benefits Specialist</name>
+    </RelationshipType>
+ </CaseRoles>
+</CaseType>', @max_wt + 1, 0, 1),
+  ({localize}'{ts escape="sql"}Adult Day Care Referral{/ts}'{/localize}, 'adult_day_care_referral', {localize}'{ts escape="sql"}Arranging adult day care for senior individuals{/ts}'{/localize}, '<?xml version="1.0" encoding="iso-8859-1" ?>
+<CaseType>
+  <name>adult_day_care_referral</name>
+  <ActivityTypes>
+    <ActivityType>
+      <name>Open Case</name>
+      <max_instances>1</max_instances>
+    </ActivityType>
+    <ActivityType>
+      <name>Medical evaluation</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Mental health evaluation</name>
+    </ActivityType>
+    <ActivityType>
+      <name>ADC referral</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Follow up</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Change Case Type</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Change Case Status</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Change Case Start Date</name>
+    </ActivityType>
+    <ActivityType>
+      <name>Link Cases</name>
+    </ActivityType>
+  </ActivityTypes>
+  <ActivitySets>
+    <ActivitySet>
+      <name>standard_timeline</name>
+      <label>Standard Timeline</label>
+      <timeline>true</timeline>
+      <ActivityTypes>
+        <ActivityType>
+          <name>Open Case</name>
+          <status>Completed</status>
+        </ActivityType>
+        <ActivityType>
+          <name>Medical evaluation</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>3</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Mental health evaluation</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>7</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>ADC referral</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>10</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+        <ActivityType>
+          <name>Follow up</name>
+          <reference_activity>Open Case</reference_activity>
+          <reference_offset>14</reference_offset>
+          <reference_select>newest</reference_select>
+        </ActivityType>
+      </ActivityTypes>
+    </ActivitySet>
+  </ActivitySets>
+  <CaseRoles>
+    <RelationshipType>
+        <name>Senior Services Coordinator</name>
+        <creator>1</creator>
+        <manager>1</manager>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Health Services Coordinator</name>
+    </RelationshipType>
+    <RelationshipType>
+        <name>Benefits Specialist</name>
+    </RelationshipType>
+ </CaseRoles>
+</CaseType>', @max_wt + 2, 0, 1);
 
 -- CRM-15343 set the auto increment civicrm_case_type.id start point to max id to avoid conflict in future insertion
 SELECT @max_case_type_id := max(id) from civicrm_case_type;

--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -43,10 +43,25 @@ class CRM_Core_ManagedEntities {
   }
 
   /**
+   * @var bool
+   */
+  private bool $isReconciling = FALSE;
+
+  /**
+   * Check if reconciliation is currently in progress.
+   */
+  public function isReconciling(): bool {
+    return $this->isReconciling;
+  }
+
+  /**
    * Perform an asynchronous reconciliation when the transaction ends.
    * @param array|null $modules
    */
   public static function scheduleReconciliation(?array $modules = NULL) {
+    if (CRM_Core_ManagedEntities::singleton()->isReconciling()) {
+      return;
+    }
     CRM_Core_Transaction::addCallback(
       CRM_Core_Transaction::PHASE_POST_COMMIT,
       function ($modules) {
@@ -74,12 +89,21 @@ class CRM_Core_ManagedEntities {
    * @throws \CRM_Core_Exception
    */
   public function reconcile($modules = NULL) {
-    $modules = $modules ? (array) $modules : NULL;
-    $declarations = $this->getDeclarations($modules);
-    $scope = $modules ? [['module', 'IN', $modules]] : NULL;
-    $plan = $this->createPlan($declarations, $scope);
-    $plan = $this->optimizePlan($plan);
-    $this->reconcileEntities($plan);
+    if ($this->isReconciling) {
+      return;
+    }
+    $this->isReconciling = TRUE;
+    try {
+      $modules = $modules ? (array) $modules : NULL;
+      $declarations = $this->getDeclarations($modules);
+      $scope = $modules ? [['module', 'IN', $modules]] : NULL;
+      $plan = $this->createPlan($declarations, $scope);
+      $plan = $this->optimizePlan($plan);
+      $this->reconcileEntities($plan);
+    }
+    finally {
+      $this->isReconciling = FALSE;
+    }
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixNineteen.php
+++ b/CRM/Upgrade/Incremental/php/SixNineteen.php
@@ -21,6 +21,18 @@
  */
 class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Base {
 
+  public function setPreUpgradeMessage(&$preUpgradeMessage, $rev, $currentVer = NULL): void {
+    parent::setPreUpgradeMessage($preUpgradeMessage, $rev, $currentVer);
+    if ($rev === '6.19.alpha1') {
+      $nullCount = (int) CRM_Core_DAO::singleValueQuery("SELECT count(*) FROM civicrm_case_type WHERE definition IS NULL OR definition = ''");
+      if ($nullCount > 0) {
+        $preUpgradeMessage .= '<p>' .
+          ts('Case type configuration XML files will be copied into the database and no longer read from disk.') .
+          '</p>';
+      }
+    }
+  }
+
   /**
    * Upgrade step; adds tasks including 'runSql'.
    *
@@ -30,6 +42,72 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
   public function upgrade_6_19_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Drop OptionValue.domain_id column', 'dropColumn', 'civicrm_option_value', 'domain_id');
+    $this->addTask(ts('Copy CaseType XML configuration files into database'), 'copyCaseTypeXmlToDatabase');
+  }
+
+  /**
+   * Copy XML configuration files for case types into database definition column if NULL or empty.
+   *
+   * @param CRM_Queue_TaskContext $ctx
+   *
+   * @return bool
+   */
+  public static function copyCaseTypeXmlToDatabase(CRM_Queue_TaskContext $ctx): bool {
+    $dao = CRM_Core_DAO::executeQuery("SELECT id, name FROM civicrm_case_type WHERE definition IS NULL OR definition = ''");
+    $caseTypesViaHook = [];
+    CRM_Utils_Hook::caseTypes($caseTypesViaHook);
+    $config = CRM_Core_Config::singleton();
+
+    while ($dao->fetch()) {
+      $candidates = [$dao->name];
+      $munged = CRM_Case_XMLProcessor::mungeCaseType($dao->name);
+      if ($munged !== $dao->name) {
+        $candidates[] = $munged;
+      }
+
+      $fileName = NULL;
+      foreach ($candidates as $name) {
+        if (isset($caseTypesViaHook[$name]['file']) && file_exists($caseTypesViaHook[$name]['file'])) {
+          $fileName = $caseTypesViaHook[$name]['file'];
+          break;
+        }
+        if (!empty($config->customTemplateDir)) {
+          $customFile = implode(DIRECTORY_SEPARATOR, [$config->customTemplateDir, 'CRM', 'Case', 'xml', 'configuration', "$name.xml"]);
+          if (file_exists($customFile)) {
+            $fileName = $customFile;
+            break;
+          }
+        }
+        $coreFile = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'Case', 'xml', 'configuration', "$name.xml"]);
+        if (file_exists($coreFile)) {
+          $fileName = $coreFile;
+          break;
+        }
+        $sampleFile = implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'Case', 'xml', 'configuration.sample', "$name.xml"]);
+        if (file_exists($sampleFile)) {
+          $fileName = $sampleFile;
+          break;
+        }
+      }
+
+      if ($fileName && file_exists($fileName)) {
+        $dom = new DOMDocument();
+        $xmlString = file_get_contents($fileName);
+        $dom->loadXML($xmlString);
+        $dom->documentURI = $fileName;
+        $dom->xinclude();
+        $fileXml = simplexml_import_dom($dom);
+        if ($fileXml) {
+          $xmlOutput = $fileXml->asXML();
+          CRM_Core_DAO::executeQuery("UPDATE civicrm_case_type SET definition = %1 WHERE id = %2", [
+            1 => [$xmlOutput, 'String'],
+            2 => [$dao->id, 'Integer'],
+          ]);
+        }
+      }
+    }
+
+    return TRUE;
   }
 
 }

--- a/CRM/Utils/Check/Component/Case.php
+++ b/CRM/Utils/Check/Component/Case.php
@@ -19,11 +19,6 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
   const DOCTOR_WHEN = 'https://github.com/civicrm/org.civicrm.doctorwhen';
 
   /**
-   * @var CRM_Case_XMLRepository
-   */
-  protected $xmlRepo;
-
-  /**
    * @var string[]
    */
   protected $caseTypeNames;
@@ -33,7 +28,6 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
    */
   public function __construct() {
     $this->caseTypeNames = CRM_Case_PseudoConstant::caseType('name');
-    $this->xmlRepo = CRM_Case_XMLRepository::singleton();
   }
 
   /**
@@ -41,65 +35,6 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
    */
   public function isEnabled() {
     return CRM_Core_Component::isEnabled('CiviCase');
-  }
-
-  /**
-   * Check that the case-type names don't rely on double-munging.
-   *
-   * @return CRM_Utils_Check_Message[]
-   *   An empty array, or a list of warnings
-   */
-  public function checkCaseTypeNameConsistency() {
-    $messages = [];
-
-    foreach ($this->caseTypeNames as $caseTypeName) {
-      $normalFile = $this->xmlRepo->findXmlFile($caseTypeName);
-      $mungedFile = $this->xmlRepo->findXmlFile(CRM_Case_XMLProcessor::mungeCaseType($caseTypeName));
-
-      if ($normalFile && $mungedFile && $normalFile == $mungedFile) {
-        // ok
-      }
-      elseif ($normalFile && $mungedFile) {
-        $messages[] = new CRM_Utils_Check_Message(
-          __FUNCTION__ . $caseTypeName,
-          ts('Case type "%1" has duplicate XML files ("%2" and "%3")', [
-            1 => $caseTypeName,
-            2 => $normalFile,
-            3 => $mungedFile,
-          ]) .
-          '<br /><a href="' . CRM_Utils_System::getWikiBaseURL() . __FUNCTION__ . '">' .
-          ts('Read more about this warning') .
-          '</a>',
-          ts('CiviCase'),
-          \Psr\Log\LogLevel::WARNING,
-          'fa-puzzle-piece'
-        );
-      }
-      elseif ($normalFile && !$mungedFile) {
-        // ok
-      }
-      elseif (!$normalFile && $mungedFile) {
-        $messages[] = new CRM_Utils_Check_Message(
-          __FUNCTION__ . $caseTypeName,
-          ts('Case type "%1" corresponds to XML file ("%2") The XML file should be named "%3".', [
-            1 => $caseTypeName,
-            2 => $mungedFile,
-            3 => "{$caseTypeName}.xml",
-          ]) .
-          '<br /><a href="' . CRM_Utils_System::getWikiBaseURL() . __FUNCTION__ . '">' .
-          ts('Read more about this warning') .
-          '</a>',
-          ts('CiviCase'),
-          \Psr\Log\LogLevel::WARNING,
-          'fa-puzzle-piece'
-        );
-      }
-      elseif (!$normalFile && !$mungedFile) {
-        // ok -- probably a new or DB-based CaseType
-      }
-    }
-
-    return $messages;
   }
 
   /**
@@ -376,116 +311,6 @@ class CRM_Utils_Check_Component_Case extends CRM_Utils_Check_Component {
       );
     }
 
-    return $messages;
-  }
-
-  /**
-   * Check any xml definitions stored as external files to see if they
-   * have label as the role and where the label is different from the name.
-   * We don't have to think about edge cases because there are already
-   * status checks above for those.
-   *
-   * @return CRM_Utils_Check_Message[]
-   *   An empty array, or a list of warnings
-   */
-  public function checkExternalXmlFileRoleNames() {
-    $messages = [];
-
-    // Get config for relationship types
-    $relationship_types = civicrm_api3('RelationshipType', 'get', [
-      'options' => ['limit' => 0],
-    ])['values'];
-    // keyed on name, with id as the value, e.g. 'Case Coordinator is' => 10
-    $names_a_b = array_column($relationship_types, 'id', 'name_a_b');
-    $names_b_a = array_column($relationship_types, 'id', 'name_b_a');
-    $labels_a_b = array_column($relationship_types, 'id', 'label_a_b');
-    $labels_b_a = array_column($relationship_types, 'id', 'label_b_a');
-
-    $dao = CRM_Core_DAO::executeQuery("SELECT id FROM civicrm_case_type WHERE definition IS NULL OR definition=''");
-    while ($dao->fetch()) {
-      $case_type = civicrm_api3('CaseType', 'get', [
-        'id' => $dao->id,
-      ])['values'][$dao->id];
-      if (empty($case_type['definition'])) {
-        $messages[] = new CRM_Utils_Check_Message(
-          __FUNCTION__ . "missingcasetypedefinition",
-          '<p>' . ts('Unable to locate xml file for Case Type "<em>%1</em>".',
-          [
-            1 => htmlspecialchars(empty($case_type['title']) ? $dao->id : $case_type['title']),
-          ]) . '</p>',
-          ts('Missing Case Type Definition'),
-          \Psr\Log\LogLevel::ERROR,
-          'fa-exclamation'
-        );
-        continue;
-      }
-
-      if (empty($case_type['definition']['caseRoles'])) {
-        $messages[] = new CRM_Utils_Check_Message(
-          __FUNCTION__ . "missingcaseroles",
-          '<p>' . ts('CaseRoles seems to be missing in the xml file for Case Type "<em>%1</em>".',
-          [
-            1 => htmlspecialchars(empty($case_type['title']) ? $dao->id : $case_type['title']),
-          ]) . '</p>',
-          ts('Missing Case Roles'),
-          \Psr\Log\LogLevel::ERROR,
-          'fa-exclamation'
-        );
-        continue;
-      }
-
-      // Loop thru each role in the xml.
-      foreach ($case_type['definition']['caseRoles'] as $role) {
-        $name_to_suggest = NULL;
-        $xml_name = $role['name'];
-        if (isset($names_a_b[$xml_name]) || isset($names_b_a[$xml_name])) {
-          // It matches a name, so either name and label are the same or it's
-          // an edge case already dealt with by core status checks, so do
-          // nothing.
-          continue;
-        }
-        elseif (isset($labels_b_a[$xml_name])) {
-          // $labels_b_a[$xml_name] gives us the id, so then look up name_b_a
-          // from the original relationship_types array which is keyed on id.
-          // We do b_a first because it's the more standard one, although it
-          // will only make a difference in edge cases which we leave to the
-          // other checks.
-          $name_to_suggest = $relationship_types[$labels_b_a[$xml_name]]['name_b_a'];
-        }
-        elseif (isset($labels_a_b[$xml_name])) {
-          $name_to_suggest = $relationship_types[$labels_a_b[$xml_name]]['name_a_b'];
-        }
-
-        // If it didn't match any name or label then that's weird.
-        if (empty($name_to_suggest)) {
-          $messages[] = new CRM_Utils_Check_Message(
-            __FUNCTION__ . "invalidcaserole",
-            '<p>' . ts('CaseRole "<em>%1</em>" in the xml file for Case Type "<em>%2</em>" doesn\'t seem to match any existing relationship type.',
-            [
-              1 => htmlspecialchars($xml_name),
-              2 => htmlspecialchars(empty($case_type['title']) ? $dao->id : $case_type['title']),
-            ]) . '</p>',
-            ts('Invalid Case Role'),
-            \Psr\Log\LogLevel::ERROR,
-            'fa-exclamation'
-          );
-        }
-        else {
-          $messages[] = new CRM_Utils_Check_Message(
-            __FUNCTION__ . "suggestedchange",
-            '<p>' . ts('Please edit the XML file for case type "<em>%2</em>" so that the case role label "<em>%1</em>" is changed to its corresponding name "<em>%3</em>". Using label is deprecated as of version 5.20.',
-            [
-              1 => htmlspecialchars($xml_name),
-              2 => htmlspecialchars(empty($case_type['title']) ? $dao->id : $case_type['title']),
-              3 => htmlspecialchars($name_to_suggest),
-            ]) . '</p>',
-            ts('Case Role using display label instead of internal machine name'),
-            \Psr\Log\LogLevel::WARNING,
-            'fa-code'
-          );
-        }
-      }
-    }
     return $messages;
   }
 

--- a/api/v3/CaseType.php
+++ b/api/v3/CaseType.php
@@ -26,6 +26,9 @@
  *   API result array
  */
 function civicrm_api3_case_type_create($params) {
+  if (empty($params['id']) && !empty($params['name']) && !CRM_Case_BAO_CaseType::isValidName($params['name'])) {
+    throw new CRM_Core_Exception("Cannot create new case-type with malformed name [{$params['name']}]");
+  }
   civicrm_api3_verify_mandatory($params, _civicrm_api3_get_DAO(__FUNCTION__));
 
   $result = _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'CaseType');

--- a/tests/phpunit/CRM/Case/BAO/CaseTypeForkTest.php
+++ b/tests/phpunit/CRM/Case/BAO/CaseTypeForkTest.php
@@ -25,7 +25,7 @@ class CRM_Case_BAO_CaseTypeForkTest extends CiviCaseTestCase {
    * Test Manager contact is correctly assigned via case type def.
    */
   public function testManagerContact(): void {
-    $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', 'ForkableCaseType', 'id', 'name');
+    $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', 'ForkableCaseType', 'id', 'name', TRUE);
     $this->assertTrue(is_numeric($caseTypeId) && $caseTypeId > 0);
 
     $this->callAPISuccess('CaseType', 'create', [
@@ -50,10 +50,10 @@ class CRM_Case_BAO_CaseTypeForkTest extends CiviCaseTestCase {
    * Edit the definition of ForkableCaseType.
    */
   public function testForkable(): void {
-    $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', 'ForkableCaseType', 'id', 'name');
+    $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', 'ForkableCaseType', 'id', 'name', TRUE);
     $this->assertTrue(is_numeric($caseTypeId) && $caseTypeId > 0);
 
-    $this->assertDBNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should not have DB-based definition");
+    $this->assertDBNotNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should have DB-based definition");
     $this->assertTrue(CRM_Case_BAO_CaseType::isForkable($caseTypeId));
     $this->assertFalse(CRM_Case_BAO_CaseType::isForked($caseTypeId));
 
@@ -68,43 +68,20 @@ class CRM_Case_BAO_CaseTypeForkTest extends CiviCaseTestCase {
     ]);
 
     $this->assertTrue(CRM_Case_BAO_CaseType::isForkable($caseTypeId));
-    $this->assertTrue(CRM_Case_BAO_CaseType::isForked($caseTypeId));
-    $this->assertDBNotNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should not have DB-based definition");
-
-    $this->callAPISuccess('CaseType', 'create', [
-      'id' => $caseTypeId,
-      'definition' => 'null',
-    ]);
-
-    $this->assertDBNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should not have DB-based definition");
-    $this->assertTrue(CRM_Case_BAO_CaseType::isForkable($caseTypeId));
     $this->assertFalse(CRM_Case_BAO_CaseType::isForked($caseTypeId));
+    $this->assertDBNotNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should have DB-based definition");
   }
 
   /**
-   * Attempt to edit the definition of UnforkableCaseType. This fails.
+   * Attempt to edit the definition of UnforkableCaseType.
    */
   public function testUnforkable(): void {
-    $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', 'UnforkableCaseType', 'id', 'name');
+    $caseTypeId = CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', 'UnforkableCaseType', 'id', 'name', TRUE);
     $this->assertTrue(is_numeric($caseTypeId) && $caseTypeId > 0);
-    $this->assertDBNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should not have DB-based definition");
+    $this->assertDBNotNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should have DB-based definition");
 
     $this->assertFalse(CRM_Case_BAO_CaseType::isForkable($caseTypeId));
     $this->assertFalse(CRM_Case_BAO_CaseType::isForked($caseTypeId));
-
-    $this->callAPISuccess('CaseType', 'create', [
-      'id' => $caseTypeId,
-      'definition' => [
-        'activityTypes' => [
-          ['name' => 'First act'],
-          ['name' => 'Second act'],
-        ],
-      ],
-    ]);
-
-    $this->assertFalse(CRM_Case_BAO_CaseType::isForkable($caseTypeId));
-    $this->assertFalse(CRM_Case_BAO_CaseType::isForked($caseTypeId));
-    $this->assertDBNull('CRM_Case_BAO_CaseType', $caseTypeId, 'definition', 'id', "Should not have DB-based definition");
   }
 
   /**

--- a/tests/phpunit/CiviTest/CiviCaseTestCase.php
+++ b/tests/phpunit/CiviTest/CiviCaseTestCase.php
@@ -62,6 +62,9 @@ class CiviCaseTestCase extends CiviUnitTestCase {
     /** @var \CRM_Utils_Hook_UnitTests $hooks  */
     $hooks = \CRM_Utils_Hook::singleton();
     $hooks->setHook('civicrm_caseTypes', [$this, 'hook_caseTypes']);
+    CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();
+    CRM_Case_PseudoConstant::flush();
+    CRM_Core_PseudoConstant::flush();
     \CRM_Case_XMLRepository::singleton(TRUE);
     \CRM_Case_XMLProcessor::flushStaticCaches();
 


### PR DESCRIPTION
Overview
----------------------------------------

This drops support for reading CaseType config from xml files. Any remaining file-based config is moved to the database.


Technical Details
----------------------------------------

Historically, CaseType config files were stored in xml. In 4.5 this was switched to use a database column, but the files were still supported for backward compatibility.