### PR TITLE
CiviCase - Improve CaseType.definition lookup

### DIFF
--- a/CRM/Case/BAO/CaseType.php
+++ b/CRM/Case/BAO/CaseType.php
@@ -91,14 +91,15 @@ class CRM_Case_BAO_CaseType extends CRM_Case_DAO_CaseType implements \Civi\Core\
     }
   }
 
-  public static function formatOutputDefinition(&$value, $row) {
-    if ($value) {
+  public static function formatOutputDefinition(&$value) {
+    // `definition` contains the xml string if stored in the database
+    if ($value && str_contains($value, '<CaseType>')) {
       [$xml] = CRM_Utils_XML::parseString($value);
       $value = $xml ? self::convertXmlToDefinition($xml) : [];
     }
-    elseif (!empty($row['id']) || !empty($row['name'])) {
-      $caseTypeName = $row['name'] ?? CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $row['id']);
-      $xml = CRM_Case_XMLRepository::singleton()->retrieve($caseTypeName);
+    // Fallback: when `definition` is null, $value contains CaseType name; lookup the file-based xml
+    elseif ($value) {
+      $xml = CRM_Case_XMLRepository::singleton()->retrieve($value);
       $value = $xml ? self::convertXmlToDefinition($xml) : [];
     }
   }

--- a/Civi/Api4/Service/Spec/FieldSpec.php
+++ b/Civi/Api4/Service/Spec/FieldSpec.php
@@ -223,6 +223,7 @@ class FieldSpec {
   }
 
   /**
+   * @see \Civi\Api4\Utils\FormattingUtil::applyFormatter
    * @param callable $outputFormatter
    * @return $this
    */

--- a/api/v3/CaseType.php
+++ b/api/v3/CaseType.php
@@ -61,9 +61,13 @@ function civicrm_api3_case_type_get($params) {
  */
 function _civicrm_api3_case_type_get_formatResult(&$result, $options = []) {
   foreach ($result['values'] as $key => &$caseType) {
-    if (!empty($caseType['definition']) || empty($options['return']) || !empty($options['return']['definition'])) {
-      $caseType += ['definition' => NULL];
-      CRM_Case_BAO_CaseType::formatOutputDefinition($caseType['definition'], $caseType);
+    if (!empty($caseType['definition']) && str_contains($caseType['definition'], '<CaseType>')) {
+      CRM_Case_BAO_CaseType::formatOutputDefinition($caseType['definition']);
+    }
+    // Fallback: if `definition` is null, pass the caseType.name instead - formatOutputDefinition will do file-based lookup
+    elseif ((empty($options['return']) || !empty($options['return']['definition'])) && (!empty($caseType['id']) || !empty($caseType['name']))) {
+      $caseType['definition'] = $caseType['name'] ?? CRM_Core_DAO::getFieldValue('CRM_Case_DAO_CaseType', $caseType['id']);
+      CRM_Case_BAO_CaseType::formatOutputDefinition($caseType['definition']);
     }
     $caseType['is_forkable'] = CRM_Case_BAO_CaseType::isForkable($caseType['id']);
     $caseType['is_forked'] = CRM_Case_BAO_CaseType::isForked($caseType['id']);

--- a/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseTypeGetSpecProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseTypeGetSpecProvider.php
@@ -12,6 +12,7 @@
 
 namespace Civi\Api4\Service\Spec\Provider;
 
+use Civi\Api4\Query\Api4SelectQuery;
 use Civi\Api4\Service\Spec\RequestSpec;
 
 /**
@@ -24,7 +25,9 @@ class CaseTypeGetSpecProvider extends \Civi\Core\Service\AutoService implements 
    * @param \Civi\Api4\Service\Spec\RequestSpec $spec
    */
   public function modifySpec(RequestSpec $spec) {
-    $spec->getFieldByName('definition')->addOutputFormatter('CRM_Case_BAO_CaseType::formatOutputDefinition');
+    $spec->getFieldByName('definition')
+      ->setSqlRenderer([__CLASS__, 'renderSqlForDefinition'])
+      ->addOutputFormatter(['CRM_Case_BAO_CaseType', 'formatOutputDefinition']);
   }
 
   /**
@@ -35,6 +38,16 @@ class CaseTypeGetSpecProvider extends \Civi\Core\Service\AutoService implements 
    */
   public function applies($entity, $action) {
     return $entity === 'CaseType' && $action === 'get';
+  }
+
+  /**
+   * Fallback when definition is NULL.
+   *
+   * If the definition isn't stored in the database, provide the CaseType.name for file-based lookup
+   * @see \CRM_Case_BAO_CaseType::formatOutputDefinition
+   */
+  public static function renderSqlForDefinition(array $field, Api4SelectQuery $query): string {
+    return "IFNULL({$field['sql_name']}, `name`)";
   }
 
 }

--- a/tests/phpunit/api/v4/Entity/CaseTypeTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTypeTest.php
@@ -3,6 +3,7 @@
 namespace api\v4\Entity;
 
 use api\v4\Api4TestBase;
+use Civi\Api4\Activity;
 use Civi\Api4\CaseType;
 use Civi\Api4\CiviCase;
 
@@ -17,13 +18,31 @@ class CaseTypeTest extends Api4TestBase {
     \CRM_Core_BAO_ConfigSetting::enableComponent('CiviCase');
   }
 
-  public function testCaseTypeDefinition(): void {
+  public function testGetCaseTypeDefinition(): void {
     $caseType = CaseType::get(FALSE)
       ->addSelect('definition')
       ->addWhere('name', '=', 'housing_support')
       ->execute()->single();
 
     $this->assertEquals('Open Case', $caseType['definition']['activityTypes'][0]['name']);
+  }
+
+  public function testGetCaseTypeDefinitionViaJoin(): void {
+    $case = $this->createTestRecord('Case', [
+      'case_type_id:name' => 'housing_support',
+    ]);
+    $activity = $this->createTestRecord('Activity', [
+      'case_id' => $case['id'],
+    ]);
+    $get = Activity::get(FALSE)
+      ->addJoin('Case AS case', 'INNER', 'CaseActivity', ['id', '=', 'case.activity_id'])
+      // Only select caseType.definition, no other caseType fields to test the fallback in CaseTypeGetSpecProvider
+      ->addSelect('case.case_type_id.definition')
+      ->addWhere('id', '=', $activity['id'])
+      ->execute()->first();
+
+    $definition = $get['case.case_type_id.definition'];
+    $this->assertEquals('Open Case', $definition['activityTypes'][0]['name']);
   }
 
   public function testGetStatusIdPerCaseType(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Improves Api handling of the special CaseType.definition field

Before
----------------------------------------
Api would fail to return caseType.definition if it was stored in a file and the api query didn't include caseType.name or caseType.id.

After
----------------------------------------
Always returned when requested.