### PR TITLE
WIP: allow edits of afform submissions

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -119,6 +119,14 @@ class Submit extends AbstractProcessor {
     // todo - add only if needed?
     $this->setResponseItem('token', $this->generatePostSubmitToken());
 
+    // Override default afform confirmation settings when we are editing a
+    // record from the submission page. We don't want to redirect, just provide
+    // a simple confirmation.
+    if (preg_match('^/civicrm/admin/afform/submissions/', \CRM_Utils_System::currentPath())) {
+      $this->_response['redirect'] = FALSE;
+      $this->_response['message'] = E::ts('Saved');
+    }
+
     if (isset($this->_response['redirect']) || isset($this->_response['message'])) {
       // redirect / message is already set, ignore defaults
     }

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -59,25 +59,31 @@ class Submit extends AbstractProcessor {
     }
 
     // Save submission record
-    if (!empty($this->_afform['create_submission']) && empty($this->args['sid'])) {
+    if (!empty($this->_afform['create_submission'])) {
       $userId = \CRM_Core_Session::getLoggedInContactID();
-
       $submissionRecord = [
         'contact_id' => $userId,
         'afform_name' => $this->name,
         'data' => $this->getValues(),
         'status_id:name' => 'Pending',
       ];
-      // Update draft if it exists
-      if ($userId) {
-        $draft = AfformSubmission::get(FALSE)
-          ->addWhere('contact_id', '=', $userId)
-          ->addWhere('status_id:name', '=', 'Draft')
-          ->addWhere('afform_name', '=', $this->name)
-          ->addSelect('id')
-          ->execute()->first();
-        if ($draft) {
-          $submissionRecord['id'] = $draft['id'];
+
+      // If we are saving an existing submission, capture the id.
+      if (!empty($this->args['sid'])) {
+        $submissionRecord['id'] = $this->args['sid'];
+      }
+      else {
+        // If it's a new submission, update draft if it exists
+        if ($userId) {
+          $draft = AfformSubmission::get(FALSE)
+            ->addWhere('contact_id', '=', $userId)
+            ->addWhere('status_id:name', '=', 'Draft')
+            ->addWhere('afform_name', '=', $this->name)
+            ->addSelect('id')
+            ->execute()->first();
+          if ($draft) {
+            $submissionRecord['id'] = $draft['id'];
+          }
         }
       }
 
@@ -87,9 +93,12 @@ class Submit extends AbstractProcessor {
     }
 
     // let's not save the data in other CiviCRM table if manual verification is needed.
-    if (!empty($this->_afform['manual_processing']) && empty($this->args['sid'])) {
+    if (!empty($this->_afform['manual_processing'])) {
       // check for verification email
-      $this->processVerificationEmail($submission['id']);
+      $submissionId = $submission['id'] ?? NULL;
+      if ($submissionId) {
+        $this->processVerificationEmail($submissionId);
+      }
     }
     else {
       // process and save various entities
@@ -122,7 +131,7 @@ class Submit extends AbstractProcessor {
     // Override default afform confirmation settings when we are editing a
     // record from the submission page. We don't want to redirect, just provide
     // a simple confirmation.
-    if (preg_match('^/civicrm/admin/afform/submissions/', \CRM_Utils_System::currentPath())) {
+    if (preg_match('^/civicrm/admin/afform/submissions/', \CRM_Utils_System::currentPath() ?? '')) {
       $this->_response['redirect'] = FALSE;
       $this->_response['message'] = E::ts('Saved');
     }

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -43,7 +43,9 @@
           ctrl.loadData()
             .then(setupDraftWatcher);
 
-          ctrl.showSubmitButton = displaySubmitButton(args);
+          displaySubmitButton(args).then((shouldShow) => {
+            ctrl.showSubmitButton = shouldShow;
+          });
         });
       };
 
@@ -103,7 +105,9 @@
             }
           });
           params.args = args;
-          ctrl.showSubmitButton = displaySubmitButton(args);
+          displaySubmitButton(args).then((shouldShow) => {
+            ctrl.showSubmitButton = shouldShow;
+          });
         }
         if (toLoad) {
           if (params.fillMode === 'form') {
@@ -140,10 +144,23 @@
       };
 
       function displaySubmitButton(args) {
-        if (args.sid && args.sid.length > 0) {
-          return false;
+        // If it has not been saved (no sid), show the submit button.
+        if (!args || !args.sid || args.sid.length === 0) {
+          return Promise.resolve(true);
         }
-        return true;
+
+        // If saved, show submit button if the status is pending or draft
+        return crmApi4('AfformSubmission', 'get', {
+          select: ["status_id:name"],
+          where: [["id", "=", args.sid]]
+        }).then((afformSubmission) => {
+          const allowedStatuses = ['Pending', 'Draft'];
+          const statusName = afformSubmission[0] ? afformSubmission[0]['status_id:name'] : null;
+          return allowedStatuses.includes(statusName);
+        }).catch((failure) => {
+          handleError(failure);
+          return false;
+        });
       }
 
       // Used when submitting file fields


### PR DESCRIPTION
Overview
----------------------------------------
If an afform is configured with "verify submissions before processing" it is useful to have an opportunity to make changes before processing them. 

This PR adds that ability.

Before
----------------------------------------
When viewing an afform submission, no "Submit" button is visible.

After
----------------------------------------
When viewing an afform submission, a "Submit" button is visible.

Technical Details
----------------------------------------
This PR additional modifies the submit behavior, overriding a form setting that might cause the page to redirect.