### PR TITLE
Endure default type of Field is set for all GetFields results

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -118,6 +118,8 @@ class BasicGetFieldsAction extends BasicGetAction {
   protected function formatResults(&$values, $isInternal) {
     $fieldDefaults = array_column($this->fields(), 'default_value', 'name') +
       array_fill_keys(array_column($this->fields(), 'name'), NULL);
+    // Add the default type if it is missing (e.g. Setting)
+    $fieldDefaults += ['type' => 'Field'];
     // Enforce field permissions
     if ($this->checkPermissions) {
       foreach ($values as $key => $field) {


### PR DESCRIPTION
Api Explorer 4, select Setting, note that the Actions are all undefined.

The problem is that Setting has its own custom getFields. In #36251, the API Explorer adds `select: ['*', 'ui_params']` to the getActions. expandSelectClauseWildcards() only adds fields that have a type, so the custom getFields for Setting that doesn't have a type results in the fields being excluded. Then selectArray() strips out $name because it isn't in the intersection (`$value = array_intersect_key($value, $keys)`). Now name is undefined.

I think this is the better fix than trying to specify the type for Setting specifically, because this ensures the default type is always set to 'Field' as intended.

Unreleased regression.