### PR TITLE
Declare token_class in entityType for all core tokens

### DIFF
--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -351,47 +351,8 @@ class Container {
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 
-    foreach (['Activity', 'Contact', 'Contribute', 'Event', 'Mailing', 'Member', 'Case', 'Pledge'] as $component) {
-      $container->setDefinition('crm_' . strtolower($component) . '_tokens', new Definition(
-        "CRM_{$component}_Tokens",
-        []
-      ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    }
-    $container->setDefinition("crm_financial_trxn_tokens", new Definition(
-      'CRM_Financial_FinancialTrxnTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-
     $container->setDefinition('civi_token_impliedcontext', new Definition(
       'Civi\Token\ImpliedContextSubscriber',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_participant_tokens', new Definition(
-      'CRM_Event_ParticipantTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_contribution_recur_tokens', new Definition(
-      'CRM_Contribute_RecurTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_contribution_recur_tokens', new Definition(
-      'CRM_Contribute_RecurTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_contribution_product_tokens', new Definition(
-      'CRM_Contribute_ContributionProductTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_survey_tokens', new Definition(
-      'CRM_Campaign_SurveyTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_group_tokens', new Definition(
-      'CRM_Core_GroupTokens',
-      []
-    ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
-    $container->setDefinition('crm_domain_tokens', new Definition(
-      'CRM_Core_DomainTokens',
       []
     ))->addTag('kernel.event_subscriber')->setPublic(TRUE);
 

--- a/schema/Activity/Activity.entityType.php
+++ b/schema/Activity/Activity.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Activity',
   'table' => 'civicrm_activity',
   'class' => 'CRM_Activity_DAO_Activity',
+  'token_class' => 'CRM_Activity_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Activity'),
     'title_plural' => ts('Activities'),

--- a/schema/Campaign/Survey.entityType.php
+++ b/schema/Campaign/Survey.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Survey',
   'table' => 'civicrm_survey',
   'class' => 'CRM_Campaign_DAO_Survey',
+  'token_class' => 'CRM_Campaign_SurveyTokens',
   'getInfo' => fn() => [
     'title' => ts('Survey'),
     'title_plural' => ts('Surveys'),

--- a/schema/Case/Case.entityType.php
+++ b/schema/Case/Case.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Case',
   'table' => 'civicrm_case',
   'class' => 'CRM_Case_DAO_Case',
+  'token_class' => 'CRM_Case_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Case'),
     'title_plural' => ts('Cases'),

--- a/schema/Contact/Contact.entityType.php
+++ b/schema/Contact/Contact.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Contact',
   'table' => 'civicrm_contact',
   'class' => 'CRM_Contact_DAO_Contact',
+  'token_class' => 'CRM_Contact_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Contact'),
     'title_plural' => ts('Contacts'),

--- a/schema/Contact/Group.entityType.php
+++ b/schema/Contact/Group.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Group',
   'table' => 'civicrm_group',
   'class' => 'CRM_Contact_DAO_Group',
+  'token_class' => 'CRM_Core_GroupTokens',
   'getInfo' => fn() => [
     'title' => ts('Group'),
     'title_plural' => ts('Groups'),

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Contribution',
   'table' => 'civicrm_contribution',
   'class' => 'CRM_Contribute_DAO_Contribution',
+  'token_class' => 'CRM_Contribute_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Contribution'),
     'title_plural' => ts('Contributions'),

--- a/schema/Contribute/ContributionProduct.entityType.php
+++ b/schema/Contribute/ContributionProduct.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'ContributionProduct',
   'table' => 'civicrm_contribution_product',
   'class' => 'CRM_Contribute_DAO_ContributionProduct',
+  'token_class' => 'CRM_Contribute_ContributionProductTokens',
   'getInfo' => fn() => [
     'title' => ts('Contribution Product'),
     'title_plural' => ts('Contribution Products'),

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'ContributionRecur',
   'table' => 'civicrm_contribution_recur',
   'class' => 'CRM_Contribute_DAO_ContributionRecur',
+  'token_class' => 'CRM_Contribute_RecurTokens',
   'getInfo' => fn() => [
     'title' => ts('Recurring Contribution'),
     'title_plural' => ts('Recurring Contributions'),

--- a/schema/Core/Domain.entityType.php
+++ b/schema/Core/Domain.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Domain',
   'table' => 'civicrm_domain',
   'class' => 'CRM_Core_DAO_Domain',
+  'token_class' => 'CRM_Core_DomainTokens',
   'getInfo' => fn() => [
     'title' => ts('Domain'),
     'title_plural' => ts('Domains'),

--- a/schema/Event/Event.entityType.php
+++ b/schema/Event/Event.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Event',
   'table' => 'civicrm_event',
   'class' => 'CRM_Event_DAO_Event',
+  'token_class' => 'CRM_Event_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Event'),
     'title_plural' => ts('Events'),

--- a/schema/Event/Participant.entityType.php
+++ b/schema/Event/Participant.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Participant',
   'table' => 'civicrm_participant',
   'class' => 'CRM_Event_DAO_Participant',
+  'token_class' => 'CRM_Event_ParticipantTokens',
   'getInfo' => fn() => [
     'title' => ts('Participant'),
     'title_plural' => ts('Participants'),

--- a/schema/Financial/FinancialTrxn.entityType.php
+++ b/schema/Financial/FinancialTrxn.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'FinancialTrxn',
   'table' => 'civicrm_financial_trxn',
   'class' => 'CRM_Financial_DAO_FinancialTrxn',
+  'token_class' => 'CRM_Financial_FinancialTrxnTokens',
   'getInfo' => fn() => [
     'title' => ts('Financial Trxn'),
     'title_plural' => ts('Financial Trxns'),

--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Mailing',
   'table' => 'civicrm_mailing',
   'class' => 'CRM_Mailing_DAO_Mailing',
+  'token_class' => 'CRM_Mailing_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Mailing'),
     'title_plural' => ts('Mailings'),

--- a/schema/Member/Membership.entityType.php
+++ b/schema/Member/Membership.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Membership',
   'table' => 'civicrm_membership',
   'class' => 'CRM_Member_DAO_Membership',
+  'token_class' => 'CRM_Member_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Membership'),
     'title_plural' => ts('Memberships'),

--- a/schema/Pledge/Pledge.entityType.php
+++ b/schema/Pledge/Pledge.entityType.php
@@ -4,6 +4,7 @@ return [
   'name' => 'Pledge',
   'table' => 'civicrm_pledge',
   'class' => 'CRM_Pledge_DAO_Pledge',
+  'token_class' => 'CRM_Pledge_Tokens',
   'getInfo' => fn() => [
     'title' => ts('Pledge'),
     'title_plural' => ts('Pledges'),


### PR DESCRIPTION


Overview
----------------------------------------
Declare token_class in entityType for all core tokens

I realised with https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1323

That we are still copying & pasting the old way...

Before
----------------------------------------
Token classes hand entered into `Container`

After
----------------------------------------
Use the mechanism we added at the beach

Technical Details
----------------------------------------
Heavily tested

Comments
----------------------------------------
