### PR TITLE
fix importing campaign/event ID on a contribution starting with a number

### DIFF
--- a/CRM/Import/Parser.php
+++ b/CRM/Import/Parser.php
@@ -883,14 +883,22 @@ abstract class CRM_Import_Parser implements UserJobInterface {
     // getOptions does not retrieve these fields with high potential results
     if ($fieldMetadata['name'] === 'event_id' && $fieldMetadata['fk_entity'] === 'Event') {
       if (!isset(Civi::$statics[__CLASS__][$fieldName][$importedValue])) {
-        $event = Event::get()->addClause('OR', ['title', '=', $importedValue], ['id', '=', $importedValue])->addSelect('id')->execute()->first();
+        $searchClause = [['title', '=', $importedValue]];
+        if (is_numeric($importedValue)) {
+          $searchClause[] = ['id', '=', $importedValue];
+        }
+        $event = Event::get()->addClause('OR', $searchClause)->addSelect('id')->execute()->first();
         Civi::$statics[__CLASS__][$fieldName][$importedValue] = $event['id'] ?? FALSE;
       }
       return Civi::$statics[__CLASS__][$fieldName][$importedValue] ?? 'invalid_import_value';
     }
     if ($fieldMetadata['name'] === 'campaign_id') {
       if (!isset(Civi::$statics[__CLASS__][$fieldName][$importedValue])) {
-        $campaign = Campaign::get()->addClause('OR', ['title', '=', $importedValue], ['name', '=', $importedValue], ['id', '=', $importedValue])->addSelect('id')->execute()->first();
+        $searchClause = [['title', '=', $importedValue], ['name', '=', $importedValue]];
+        if (is_numeric($importedValue)) {
+          $searchClause[] = ['id', '=', $importedValue];
+        }
+        $campaign = Campaign::get()->addClause('OR', $searchClause)->addSelect('id')->execute()->first();
         Civi::$statics[__CLASS__][$fieldName][$importedValue] = $campaign['id'] ?? FALSE;
       }
       return Civi::$statics[__CLASS__][$fieldName][$importedValue] ?: 'invalid_import_value';


### PR DESCRIPTION
Overview
----------------------------------------
If you have a campaign or event whose title starts with a number e.g. "26FY donations", and you import a contribution using that title, it will be treated as a campaign ID (in this case, 26) if that campaign ID is found first.

It appears that events have the same issue.

You can replicate this by creating a new campaign starting with 1, e.g. "1 test".  Import a contribution with the Campaign column set to `1 test`.

Before
----------------------------------------
Campaign titles imported as if they're IDs.

After
----------------------------------------
Only numeric values are searched by ID.


Technical Details
----------------------------------------
This has to do with how MySQL casts the value, but we should fix this at the import layer, not the API/db layer.