### PR TITLE
closes core/6628 - fix contact references in FormBuilder

### DIFF
--- a/CRM/Contact/BAO/GroupContactCache.php
+++ b/CRM/Contact/BAO/GroupContactCache.php
@@ -645,13 +645,12 @@ ORDER BY   gc.contact_id, g.children
    */
   public static function populateTemporaryTableWithContactsInGroups(array $groupIDs, string $temporaryTable): void {
     $childAndParentGroupIDs = array_merge($groupIDs, CRM_Contact_BAO_GroupNesting::getDescendentGroupIds($groupIDs));
-    $groups = civicrm_api3('Group', 'get', [
-      'is_active' => 1,
-      'id' => ['IN' => $childAndParentGroupIDs],
-      'saved_search_id' => ['>' => 0],
-      'return' => 'id',
-    ]);
-    $smartGroups = array_keys($groups['values']);
+    $smartGroups = \Civi\Api4\Group::get(TRUE)
+      ->addSelect('id')
+      ->addWhere('is_active', '=', TRUE)
+      ->addWhere('saved_search_id', 'IS NOT EMPTY')
+      ->addWhere('id', 'IN', $childAndParentGroupIDs)
+      ->execute()->column('id');
 
     $query = '
        SELECT DISTINCT group_contact.contact_id as contact_id


### PR DESCRIPTION
Overview
----------------------------------------
See https://lab.civicrm.org/dev/core/-/work_items/6628.

Before
----------------------------------------
"Loading failed" when using a contact reference filtered by multiple groups.

After
----------------------------------------
Returns autocomplete list.

Comments
----------------------------------------
I started to implement the fix @VangelisP recommended, then realized that this was just working around an API3 quirk, so I converted it to API4, which handles the scenario correctly.
