### PR TITLE
Deprecate expecting tokens to appear without setting them in usage

### DIFF
--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -452,6 +452,12 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
     $return = [];
     foreach ($this->getFieldMetadata() as $field) {
       if (!in_array($field['name'], $this->getSkippedFields(), TRUE)) {
+        if ($field['type'] !== 'Custom' && !in_array('token', $field['usage'] ?? [], TRUE)) {
+          CRM_Core_Error::deprecatedWarning(
+            "Field '{$field['name']}' on entity '{$this->getApiEntityName()}' is exposed as a token "
+            . "without declaring 'token' in its usage. Add 'usage' => ['token'] to the field definition."
+          );
+        }
         $return[] = $field['name'];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Deprecate expecting tokens to appear without setting them in usage

We intended the `usage` key to drive token exposure  but didn't implement it - so we risk it getting harder & harder to add

This will cause core test fails - I will do the schema changes separately though

Before
----------------------------------------
All fields exposed regardless of `usage`

After
----------------------------------------
All fields exposed regardless of `usage` - but deprecation notices where `usage` not set

Technical Details
----------------------------------------

Comments
----------------------------------------