### PR TITLE
Filter GenericEntityTokens to only expose by metadata on entityType

### DIFF
--- a/Civi/Token/GenericEntityTokens.php
+++ b/Civi/Token/GenericEntityTokens.php
@@ -36,4 +36,23 @@ class GenericEntityTokens extends \CRM_Core_EntityTokens {
     return $this->apiEntityName;
   }
 
+  /**
+   * Get entity fields that should be exposed as tokens.
+   *
+   * @return string[]
+   *
+   */
+  protected function getExposedFields(): array {
+    $return = [];
+    foreach ($this->getFieldMetadata() as $field) {
+      if (!in_array($field['name'], $this->getSkippedFields(), TRUE)) {
+        if ($field['type'] !== 'Custom' && !in_array('token', $field['usage'] ?? [], TRUE)) {
+          continue;
+        }
+        $return[] = $field['name'];
+      }
+    }
+    return $return;
+  }
+
 }

--- a/tests/phpunit/Civi/Token/GenericEntityTokensTest.php
+++ b/tests/phpunit/Civi/Token/GenericEntityTokensTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace Civi\Token;
+
+/**
+ * @group headless
+ */
+class GenericEntityTokensTest extends \CiviUnitTestCase {
+
+  /**
+   * Only Custom fields, or fields whose metadata declares `usage: token`,
+   * should be exposed as tokens.
+   */
+  public function testGetExposedFieldsFiltersByUsage(): void {
+    $tokens = new class('Contact') extends GenericEntityTokens {
+
+      protected function getFieldMetadata(): array {
+        return [
+          'exposed_field' => ['name' => 'exposed_field', 'type' => 'String', 'usage' => ['token']],
+          'hidden_field' => ['name' => 'hidden_field', 'type' => 'String', 'usage' => ['export']],
+          'no_usage_field' => ['name' => 'no_usage_field', 'type' => 'String'],
+          'custom_field' => ['name' => 'custom_field', 'type' => 'Custom', 'usage' => ['export']],
+        ];
+      }
+
+      public function getExposedFieldsForTest(): array {
+        return $this->getExposedFields();
+      }
+
+    };
+
+    $this->assertEquals(['exposed_field', 'custom_field'], $tokens->getExposedFieldsForTest());
+  }
+
+}


### PR DESCRIPTION


Overview
----------------------------------------
Filter GenericEntityTokens to only expose by metadata on entityType

This class was recently added in converting Grant over & can reasonably filter on usage as the Grant entity Type class has been updated as if that were happening.

There is no uptake of this class yet in universe although this cleanup / tightening arose from me trying to address the documentation

https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1325

Before
----------------------------------------
Class does not filter based on `usage` although looking at the genesis of it - being written for Grant which was fixed to have usage this was clearly intended

After
----------------------------------------
filters on usage

Technical Details
----------------------------------------

Comments
----------------------------------------
