### PR TITLE
Declare usage of token for entities where exporting id seems pretty deliberate

### DIFF
--- a/schema/Activity/Activity.entityType.php
+++ b/schema/Activity/Activity.entityType.php
@@ -65,6 +65,7 @@ return [
         'import',
         'export',
         'duplicate_matching',
+        'token',
       ],
       'primary_key' => TRUE,
       'auto_increment' => TRUE,

--- a/schema/Case/Case.entityType.php
+++ b/schema/Case/Case.entityType.php
@@ -43,6 +43,7 @@ return [
       'usage' => [
         'import',
         'export',
+        'token',
         'duplicate_matching',
       ],
       'primary_key' => TRUE,

--- a/schema/Contact/Group.entityType.php
+++ b/schema/Contact/Group.entityType.php
@@ -59,6 +59,9 @@ return [
       'add' => '1.1',
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'token',
+      ],
     ],
     'name' => [
       'title' => ts('Group Name'),

--- a/schema/Contribute/Contribution.entityType.php
+++ b/schema/Contribute/Contribution.entityType.php
@@ -91,6 +91,7 @@ return [
         'import',
         'export',
         'duplicate_matching',
+        'token',
       ],
       'primary_key' => TRUE,
       'auto_increment' => TRUE,

--- a/schema/Contribute/ContributionRecur.entityType.php
+++ b/schema/Contribute/ContributionRecur.entityType.php
@@ -51,6 +51,9 @@ return [
       'unique_name' => 'contribution_recur_id',
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'token',
+      ],
     ],
     'contact_id' => [
       'title' => ts('Contact ID'),

--- a/schema/Event/Participant.entityType.php
+++ b/schema/Event/Participant.entityType.php
@@ -47,6 +47,7 @@ return [
         'import',
         'export',
         'duplicate_matching',
+        'token',
       ],
       'primary_key' => TRUE,
       'auto_increment' => TRUE,

--- a/schema/Mailing/Mailing.entityType.php
+++ b/schema/Mailing/Mailing.entityType.php
@@ -36,6 +36,9 @@ return [
       'required' => TRUE,
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'token',
+      ],
     ],
     'domain_id' => [
       'title' => ts('Domain ID'),

--- a/schema/Member/Membership.entityType.php
+++ b/schema/Member/Membership.entityType.php
@@ -40,6 +40,7 @@ return [
         'import',
         'export',
         'duplicate_matching',
+        'token',
       ],
       'primary_key' => TRUE,
       'auto_increment' => TRUE,

--- a/schema/Pledge/Pledge.entityType.php
+++ b/schema/Pledge/Pledge.entityType.php
@@ -40,6 +40,7 @@ return [
         'import',
         'export',
         'duplicate_matching',
+        'token',
       ],
       'primary_key' => TRUE,
       'auto_increment' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
Declare usage of token for entities where exporting id seems pretty deliberate

Before
----------------------------------------
We are not enforcing the `usage` key yet but I'm starting to look to ensure our token fields DO have the `token` usage declared

After
----------------------------------------
declared for `id` fields on a smattering of entities - no practical change

Technical Details
----------------------------------------

Comments
----------------------------------------
