### PR TITLE
FileGetSpecProvider: Fix fetching uri

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/FileGetSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/FileGetSpecProvider.php
@@ -98,7 +98,7 @@ class FileGetSpecProvider extends \Civi\Core\Service\AutoService implements Gene
   public static function formatFileContent(&$content, $file) {
     // Virtual field fetches the id and expects it to be transformed into file contents by this function
     $fileId = $content;
-    $uri = $file['uri'] ?? ($fileId ? \CRM_Core_DAO_File::getDbVal('is_public', $fileId) : NULL);
+    $uri = $file['uri'] ?? ($fileId ? \CRM_Core_DAO_File::getDbVal('uri', $fileId) : NULL);
     if ($uri && is_string($uri)) {
       $isPublic = $file['is_public'] ?? \CRM_Core_DAO_File::getDbVal('is_public', $fileId);
       $settingName = $isPublic ? 'imageUploadDir' : 'customFileUploadDir';

--- a/tests/phpunit/api/v4/Entity/FileTest.php
+++ b/tests/phpunit/api/v4/Entity/FileTest.php
@@ -117,6 +117,13 @@ class FileTest extends Api4TestBase {
     // Assert the url contains the file name (it's public)
     $this->assertStringContainsString($getResult['uri'], $getResult['url']);
 
+    // Assert we can get content without selecting uri
+    $getResult = \Civi\Api4\File::get(FALSE)
+      ->addSelect('content')
+      ->addWhere('id', '=', $create['id'])
+      ->execute()->single();
+    $this->assertEquals($fileContent, $getResult['content']);
+
     // Update file to is_public = FALSE
     \Civi\Api4\File::update(FALSE)
       ->addValue('is_public', FALSE)


### PR DESCRIPTION
Overview
----------------------------------------
In `\Civi\Api4\Service\Spec\Provider\FileGetSpecProvider::formatFileContent()` `is_public` was fetched from the DB instead of `uri`.