### PR TITLE
Fix Contribution Date Issue

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1825,7 +1825,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
                 'payment_processor_id' => $this->getPaymentProcessorID(),
                 'is_transactional' => FALSE,
                 'fee_amount' => $result['result']['fee_amount'] ?? NULL,
-                'receive_date' => $result['result']['receive_date'] ?? NULL,
+                'receive_date' => $this->getExistingContributionID() ? NULL : ($result['result']['receive_date'] ?? NULL),
                 'card_type_id' => $paymentParams['card_type_id'] ?? NULL,
                 'pan_truncation' => $paymentParams['pan_truncation'] ?? NULL,
               ]);
@@ -2426,7 +2426,7 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
               'payment_processor_id' => $this->getPaymentProcessorID(),
               'is_transactional' => FALSE,
               'fee_amount' => $result['fee_amount'] ?? NULL,
-              'receive_date' => $result['receive_date'] ?? NULL,
+              'receive_date' => $this->getExistingContributionID() ? NULL : ($result['receive_date'] ?? NULL),
               'card_type_id' => $paymentParams['card_type_id'] ?? NULL,
               'pan_truncation' => $paymentParams['pan_truncation'] ?? NULL,
             ]);
@@ -2618,6 +2618,16 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
     }
     // In case of 'Pay now' payment, append the contribution source with new text 'Paid later via page ID: N.'
     else {
+      if (!empty($contributionParams['id'])) {
+        $existingReceiveDate = CRM_Core_DAO::getFieldValue(
+          'CRM_Contribute_DAO_Contribution',
+          $contributionParams['id'],
+          'receive_date'
+        );
+        if (!empty($existingReceiveDate)) {
+          $contributionParams['receive_date'] = $existingReceiveDate;
+        }
+      }
       // contribution.source only allows 255 characters so we are using ellipsify(...) to ensure it.
       $contributionParams['source'] = CRM_Utils_String::ellipsify(
         ts('Paid later via page ID: %1. %2', [

--- a/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php
@@ -134,6 +134,115 @@ class CRM_Contribute_Form_Contribution_ConfirmTest extends CiviUnitTestCase {
     $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
   }
 
+  /**
+   * Test that paying an existing contribution online does not overwrite its
+   * receive_date with today's date.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPayNowPaymentDoesNotOverwriteReceiveDate(): void {
+    $originalReceiveDate = '2020-03-04 05:06:07';
+
+    $individualID = $this->createLoggedInUser();
+    $paymentProcessorID = $this->paymentProcessorCreate(['payment_processor_type_id' => 'Dummy', 'is_test' => FALSE], 'dummy');
+    $this->setDummyProcessorResult([
+      'payment_status_id' => 1,
+      'payment_status' => 'Completed',
+      'receive_date' => date('Y-m-d H:i:s'),
+      'trxn_id' => 'pay-now-preserves-date',
+    ]);
+
+    // The page the original (pending) contribution was created against.
+    $contributionPageID1 = $this->createContributionPage(['payment_processor' => $paymentProcessorID]);
+
+    $contribution = $this->createTestEntity('Contribution', [
+      'contact_id' => $individualID,
+      'financial_type_id:name' => 'Campaign Contribution',
+      'currency' => 'USD',
+      'total_amount' => 100.00,
+      'receive_date' => $originalReceiveDate,
+      'contribution_status_id:name' => 'Pending',
+      'contribution_page_id' => $contributionPageID1,
+      'source' => 'backoffice pending contribution',
+    ]);
+
+    // Sanity check - the date we asked for is the date that got stored.
+    $this->assertEquals($originalReceiveDate, Contribution::get(FALSE)
+      ->addWhere('id', '=', $contribution['id'])
+      ->addSelect('receive_date')
+      ->execute()->single()['receive_date']);
+
+    // A different page, used to take the payment.
+    $contributionPageID2 = $this->createContributionPage(['payment_processor' => $paymentProcessorID]);
+
+    $this->submitOnlineContributionForm([
+      'credit_card_number' => 4111111111111111,
+      'cvv2' => 234,
+      'credit_card_exp_date' => [
+        'M' => 2,
+        'Y' => (int) (CRM_Utils_Time::date('Y')) + 1,
+      ],
+      $this->getPriceFieldLabelForContributionPage($contributionPageID2) => 100,
+      'credit_card_type' => 'Visa',
+      'email-5' => 'test@test.com',
+      'payment_processor_id' => $paymentProcessorID,
+    ], $contributionPageID2, ['ccid' => $contribution['id']]);
+
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('id', '=', $contribution['id'])
+      ->addSelect('receive_date', 'contribution_page_id', 'contribution_status_id:name', 'total_amount')
+      ->execute()->single();
+
+    // The whole point of this test - the historic date survives the payment.
+    $this->assertEquals($originalReceiveDate, $contribution['receive_date']);
+    // And the rest of the CRM-21200 protections still hold.
+    $this->assertEquals($contributionPageID1, $contribution['contribution_page_id']);
+    $this->assertEquals('Completed', $contribution['contribution_status_id:name']);
+    $this->assertEquals(100.00, $contribution['total_amount']);
+
+    // The payment itself is recorded against today, not against the original
+    // receive_date - the money did arrive today.
+    $payment = $this->callAPISuccess('Payment', 'get', [
+      'contribution_id' => $contribution['id'],
+      'sequential' => 1,
+      'version' => 3,
+    ])['values'][0];
+    $this->assertEquals(date('Y-m-d'), substr($payment['trxn_date'], 0, 10));
+  }
+
+  /**
+   * Test that a brand new contribution created through a contribution page
+   * still gets receive_date = now.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testNewOnlineContributionReceiveDateIsToday(): void {
+    $this->createLoggedInUser();
+    $paymentProcessorID = $this->paymentProcessorCreate(['payment_processor_type_id' => 'Dummy', 'is_test' => FALSE], 'dummy');
+    $contributionPageID = $this->createContributionPage(['payment_processor' => $paymentProcessorID]);
+
+    $this->submitOnlineContributionForm([
+      'credit_card_number' => 4111111111111111,
+      'cvv2' => 234,
+      'credit_card_exp_date' => [
+        'M' => 2,
+        'Y' => (int) (CRM_Utils_Time::date('Y')) + 1,
+      ],
+      $this->getPriceFieldLabelForContributionPage($contributionPageID) => 60,
+      'credit_card_type' => 'Visa',
+      'email-5' => 'test@test.com',
+      'payment_processor_id' => $paymentProcessorID,
+    ], $contributionPageID);
+
+    $contribution = Contribution::get(FALSE)
+      ->addWhere('contribution_page_id', '=', $contributionPageID)
+      ->addSelect('receive_date', 'total_amount')
+      ->execute()->single();
+
+    $this->assertEquals(date('Y-m-d'), substr($contribution['receive_date'], 0, 10));
+    $this->assertEquals(60, $contribution['total_amount']);
+  }
+
   public function testOnBehalf(): void {
     $individualID = $this->individualCreate();
     // create a contribution page which is later used to make pay-later contribution


### PR DESCRIPTION
Overview
----------------------------------------

Paying an existing contribution through a contribution page (`/civicrm/contribute/transact?reset=1&id=N&ccid=M`) overwrites that contribution's `receive_date` with today's date.

The contribution being paid usually already exists for a reason — an invoice raised last quarter, a membership renewal recorded in advance, a pending pledge payment. Recording the payment is correct; silently moving the contribution's own received date forward to "today" is not. It quietly shifts historic income into the current period and skews any report, export or reconciliation that groups by `receive_date`.

Before
----------------------------------------

Given a Pending contribution created on 2020-03-04:

| Field | Value |
| --- | --- |
| `receive_date` | `2020-03-04 05:06:07` |
| `contribution_status_id` | Pending |
| `total_amount` | 100.00 |

Visit `civicrm/contribute/transact?reset=1&id=<pageID>&ccid=<contributionID>` and complete the payment. The contribution becomes:

| Field | Value |
| --- | --- |
| `receive_date` | **`2026-08-14 11:42:00`** ← today, the original date is gone |
| `contribution_status_id` | Completed |
| `total_amount` | 100.00 |

`contribution_page_id` and `campaign_id` are correctly left alone (that is what CRM-21200 fixed); `receive_date` is not.

After
----------------------------------------

Same steps, same page:

| Field | Value |
| --- | --- |
| `receive_date` | `2020-03-04 05:06:07` ← preserved |
| `contribution_status_id` | Completed |
| `total_amount` | 100.00 |

The payment itself is still recorded against today via the `FinancialTrxn` / `Payment` record, which is where the "when did the money arrive" information belongs.

Contributions **created** through a contribution page are unaffected and still get `receive_date = now`.

Technical Details
----------------------------------------

`CRM_Contribute_Form_Contribution_Confirm::processConfirm()` sets

```php
$contributionParams = [
  'id' => $paymentParams['contribution_id'] ?? NULL,
  ...
];
```

so for a Pay Now submission the subsequent write is an **update** of the existing contribution rather than an insert. `processFormContribution()` then does

```php
$contributionParams = array_merge($this->getContributionParams(
  $params,
  $recurringContributionID), $contributionParams
);
```

and `getContributionParams()` unconditionally supplies

```php
'receive_date' => !empty($params['receive_date']) ? CRM_Utils_Date::processDate($params['receive_date']) : date('YmdHis'),
```

`$params['receive_date']` was itself defaulted to `date('YmdHis')` a few lines earlier in `processConfirm()` (the CRM-16317 fix), so the update always carries `receive_date = now` and clobbers the stored value.

The existing CRM-21200 guard in `processConfirm()` only protects `contribution_page_id` and `campaign_id`. This PR extends its `else` branch to also carry the stored `receive_date` forward:

```php
if (!empty($contributionParams['id'])) {
  $existingReceiveDate = CRM_Core_DAO::getFieldValue(
    'CRM_Contribute_DAO_Contribution',
    $contributionParams['id'],
    'receive_date'
  );
  if (!empty($existingReceiveDate)) {
    $contributionParams['receive_date'] = $existingReceiveDate;
  }
}
```

Because `$contributionParams` is the *second* argument to the `array_merge()` above, it wins over `getContributionParams()`.

The guard is keyed off `$contributionParams['id']` rather than `$form->_params['contribution_id']` so that it can only ever apply to an update. A brand new contribution has no `id`, takes the `if` branch, and keeps the existing `receive_date = now` behaviour.

Two secondary changes cover the completion step. `CRM_Contribute_BAO_Contribution::completeOrder()` has `receive_date` in its `$inputContributionWhiteList`, and both `contribution.completetransaction` calls in this form pass `'receive_date' => $result['receive_date'] ?? NULL` straight from the payment-processor result. Core processors do not return a `receive_date` from `doPayment()`, but a processor extension is entitled to, and that would re-stamp the contribution and undo the fix above. Both call sites now pass a real `NULL` in the Pay Now case, which `CRM_Core_DAO::copyValues()` skips, leaving the stored value untouched.

`processPaymentOnExistingContribution()` — the newer `Payment::create()`-based path — is already correct and is not touched. Note that it is only reached when `isRecordPaymentOnly()` is true, i.e. a *partial* payment; paying the full outstanding amount still goes through `processConfirm()`, which is why the bug is still reachable on master.

Comments
----------------------------------------

**Files changed**

- `CRM/Contribute/Form/Contribution/Confirm.php` — the fix (3 hunks)
- `tests/phpunit/CRM/Contribute/Form/Contribution/ConfirmTest.php` — 2 new tests

**Test coverage**

`testPayNowPaymentDoesNotOverwriteReceiveDate()` — creates a Pending contribution dated 2020-03-04, pays it through a second contribution page with `ccid`, and asserts the original `receive_date` survives while status, `contribution_page_id` and `total_amount` behave as CRM-21200 already required. The Dummy processor is deliberately configured to return a `receive_date` in its `doPayment()` result so that the `completetransaction` guard is actually exercised rather than being dead code under test. It also asserts the resulting `Payment` record *is* dated today.

`testNewOnlineContributionReceiveDateIsToday()` — the counterpart guard: a normal contribution page submission with no `ccid` still gets `receive_date = today`. This is what would fail if the fix ever leaked into the create path.

Both are modelled on the existing `testPayNowPayment()`, which already proves this harness reaches the branch being changed — its `assertMatchesRegularExpression("/Paid later via page ID: .../")` only passes if execution enters the exact `else` branch this PR edits.

**Reviewer note**

`getContributionParams()` also forces `contribution_status_id` to `Pending` on this same update. It is benign in practice because `completetransaction` immediately moves it to Completed, but it does briefly reset the status of the contribution being paid. I have deliberately left that alone to keep this PR to one behaviour change — happy to address it here or in a follow-up if reviewers prefer.