### PR TITLE
dev/core#6692 APIv3 CustomValue - Resolve custom field names in bulk

### DIFF
--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -166,6 +166,25 @@ function civicrm_api3_custom_value_get($params) {
     unset($result['is_error'], $result['entityID']);
     // Convert multi-value strings to arrays
     $sp = CRM_Core_DAO::VALUE_SEPARATOR;
+    // The field-name lookup below is only consumed when the caller asked for
+    // 'format.field_names'. Calling the (deprecated, uncached) getNameFromID()
+    // once per field made this an N+1: an entity with 319 custom fields produced
+    // 688 queries, every one of them discarded unless field names were requested.
+    // Resolve them once, in bulk, and only when needed -- getNameFromID() already
+    // accepts an array of ids.
+    $fieldInfo = [];
+    if (!empty($params['format.field_names'])) {
+      $fieldNumbers = [];
+      foreach (array_keys($result) as $resultKey) {
+        $keyParts = explode('_', $resultKey);
+        if (($keyParts[0] ?? NULL) === 'custom' && isset($keyParts[1])) {
+          $fieldNumbers[$keyParts[1]] = $keyParts[1];
+        }
+      }
+      if ($fieldNumbers) {
+        $fieldInfo = CRM_Core_BAO_CustomField::getNameFromID($fieldNumbers);
+      }
+    }
     foreach ($result as $id => $value) {
       if (str_contains(($value ?? ''), $sp)) {
         $value = explode($sp, trim($value, $sp));
@@ -176,8 +195,8 @@ function civicrm_api3_custom_value_get($params) {
         continue;
       }
       $fieldNumber = $idArray[1];
-      $customFieldInfo = CRM_Core_BAO_CustomField::getNameFromID($fieldNumber);
-      $info = array_pop($customFieldInfo);
+      // Resolved in bulk above, and only when field names are needed.
+      $info = $fieldInfo[$fieldNumber] ?? NULL;
       // id is the index for returned results
 
       if (empty($idArray[2])) {


### PR DESCRIPTION
Overview
----------------------------------------

Issue: https://lab.civicrm.org/dev/core/-/issues/6692

`CustomValue.get` (APIv3) looks up the name of every custom field it returns, one
query per field, even though those names are only used when the caller asks for
them. On an entity with a few hundred custom fields that is hundreds of queries
per call, nearly all of them discarded.

This resolves the names in a single bulk lookup, and only when they are actually
requested.

Before
----------------------------------------

The loop over the returned values calls `getNameFromID()` for each field:

```php
$fieldNumber = $idArray[1];
$customFieldInfo = CRM_Core_BAO_CustomField::getNameFromID($fieldNumber);
$info = array_pop($customFieldInfo);
```

`getNameFromID()` is uncached and marked `@deprecated Old function only used by
APIv3`. `$info` is then read in exactly one place — the `format.field_names`
branch — so without that parameter every one of those queries is thrown away.

The cost scales with the number of custom *fields*, while the value fetch itself
(`CustomValueTable::getValues()`) scales with the number of custom *groups*:

| entity | groups | fields | queries |
|---|---|---|---|
| Contribution | 3 | 27 | 60 |
| Participant | 25 | 109 | 268 |
| Participant | 25 | 319 | 688 |

After
----------------------------------------

Same call, same output:

| entity | groups | fields | queries |
|---|---|---|---|
| Contribution | 3 | 27 | **6** |
| Participant | 25 | 109 | **50** |
| Participant | 25 | 319 | **50** |

The last two rows are the point: cost now depends only on the number of groups,
so 109 and 319 fields cost the same. With `format.field_names` the bulk lookup
adds exactly 2 queries regardless of size.

Wall-clock for the call itself, measured on two Drupal 11 installations against
the same record (127 custom fields, 25 groups), three runs of 80 measurements per
condition each:

| install | queries | median before | median after | wall-clock | CPU |
|---|---|---|---|---|---|
| A | 304 -> 50 | 17.6-21.5 ms | 5.4-6.7 ms | **-69%** | -65% |
| B | 304 -> 50 | 15.8-18.7 ms | 5.3-6.4 ms | **-66%** | -62% |

The query counts came out identical in all six runs; the wall-clock percentages
varied by about one point between runs, so the effect is well outside the noise
(interquartile ranges of the two conditions do not overlap).

Technical Details
----------------------------------------

`getNameFromID()` already accepts an array of ids and builds a single
`WHERE f.id IN (...)` query, so no new API is needed — it was simply being called
one id at a time. The change collects the field numbers from the result keys,
calls it once, and indexes into that result inside the loop.

The lookup is additionally skipped altogether when `format.field_names` is absent,
since `$info` is not read on that path.

`array_pop()` on the previous single-element result is equivalent to indexing that
element, so `$info` is identical in both modes. Verified on the same records
before and after: without `format.field_names` the result `id` remains the field
number (`1948`), with it the field name (`regdate`), and the returned value set is
unchanged (319 fields, no differences).

Measured on two independent Drupal 11 installations, CiviCRM 6.16.2 on PHP 8.4.24
with MariaDB 11.8. Query counts are deterministic and reproduced identically on
every run; wall-clock differences are reported separately below because they are
dominated by machine load, not by this change.

Comments
----------------------------------------

There are no in-core callers of this action — every caller is an extension. That
is likely why the cost has gone unnoticed in core profiling.

It matters most in combination with CiviRules, which calls `CustomValue.get`
without a field filter from `CRM_Civirules_Utils_PreData::pre()`. To be precise
about the scope: `PreData::pre()` does guard itself — it returns early unless
`findRulesByObjectNameAndOp()` finds an active rule for that entity and op. So
this does not hit every write on every install. It hits every write of an entity
that has active rules, which for Contact and Participant is the common case.

A concrete example of the resulting cost, on an install with 25 custom groups on
Participant and active rules on that entity: a single one-field
`Participant.create` went from **449 to 195 queries** (measured on Drupal 11,
three interleaved rounds, identical counts each round).

Worth being precise about what that does and does not buy: on the full write path
the wall-clock gain is only a few percent, because the API call is a small part of
a chain dominated by hooks, rule evaluation and the write itself. The 66-69% above
is the gain on the call that is actually patched. Both numbers are real; they just
measure different scopes.

Other extensions calling it the same way include `de.systopia.xcm`,
`de.systopia.eventmessages`, `action-provider` and `selfupdateparticipant`.

On "why not just use APIv4": `Civi\Api4\CustomValue` provides virtual entities for
multi-record custom groups only, so it is not a replacement for fetching all
custom data of an entity. `Contact::get()->addSelect('custom.*')` does that in 2
queries but keys the result by `GROUP.field` rather than `custom_<id>`, so it is
not a drop-in either. This code path is not going away.

An alternative would be to add a static cache inside `getNameFromID()`. That seemed
the wrong direction for a function core already marks as deprecated — better to
stop calling it in a loop than to make the deprecated path faster.