### PR TITLE
Api3 - Improve fetching field names

### DIFF
--- a/CRM/Core/BAO/CustomField.php
+++ b/CRM/Core/BAO/CustomField.php
@@ -2550,13 +2550,14 @@ AND      default_value IS NOT NULL";
   }
 
   /**
-   * @deprecated Old function only used by APIv3.
+   * @deprecated since 6.19 will be removed around 6.25
    *
    * @param array $ids
    *
    * @return array
    */
   public static function getNameFromID($ids) {
+    CRM_Core_Error::deprecatedFunctionWarning('CRM_Core_BAO_CustomField::getField');
     if (is_array($ids)) {
       $ids = implode(',', $ids);
     }

--- a/api/v3/CustomValue.php
+++ b/api/v3/CustomValue.php
@@ -176,10 +176,7 @@ function civicrm_api3_custom_value_get($params) {
         continue;
       }
       $fieldNumber = $idArray[1];
-      $customFieldInfo = CRM_Core_BAO_CustomField::getNameFromID($fieldNumber);
-      $info = array_pop($customFieldInfo);
       // id is the index for returned results
-
       if (empty($idArray[2])) {
         $n = 0;
         $id = $fieldNumber;
@@ -189,7 +186,7 @@ function civicrm_api3_custom_value_get($params) {
         $id = $fieldNumber . "." . $idArray[2];
       }
       if (!empty($params['format.field_names'])) {
-        $id = $info['field_name'];
+        $id = CRM_Core_BAO_CustomField::getField($fieldNumber)['name'];
       }
       else {
         $id = $fieldNumber;


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a performance bottleneck in Api3 and gets us off another deprecated function.

Fixes https://lab.civicrm.org/dev/core/-/issues/6692

Before
----------------------------------------
Deprecated function run unconditionally to fetch field names even when not needed. This resulted in a lot of unnecessary queries.

After
----------------------------------------
Cached function used, and only when needed.

Technical Details
----------------------------------------
Replaces https://github.com/civicrm/civicrm-core/pull/36491

Also, from what I can tell, `format.field_names` has no unit test coverage and is never used in core. So unconditionally processing that option was very silly.
This keeps it working as before, but now much more efficient.