### PR TITLE
Note - After editing a note, redirect back to parent

### DIFF
--- a/CRM/Core/BAO/Note.php
+++ b/CRM/Core/BAO/Note.php
@@ -477,4 +477,14 @@ WHERE participant.contact_id = %1 AND  note.entity_table = 'civicrm_participant'
     return $clauses;
   }
 
+  public static function getTopParent(int $id): CRM_Core_DAO_Note {
+    do {
+      $note = new CRM_Core_DAO_Note();
+      $note->id = $id;
+      $note->find(TRUE);
+      $id = $note->entity_id;
+    } while ($note->entity_table === 'civicrm_note');
+    return $note;
+  }
+
 }

--- a/CRM/Note/Form/Note.php
+++ b/CRM/Note/Form/Note.php
@@ -175,6 +175,22 @@ class CRM_Note_Form_Note extends CRM_Core_Form {
     $this->setEntityId($note->id);
 
     CRM_Core_Session::setStatus(ts('Your Note has been saved.'), ts('Saved'), 'success');
+
+    // Redirect to viewing the entity to which this note (or note parent) belongs
+    $parent = CRM_Core_BAO_Note::getTopParent($note->id);
+    $entityName = Civi::table($parent->entity_table)->getMeta('name');
+    $link = civicrm_api4($entityName, 'getLinks', [
+      'values' => ['id' => $parent->entity_id],
+      'where' => [['ui_action', '=', 'view']],
+    ])->first();
+    if ($link) {
+      $path = $link['path'];
+      if ($entityName === 'Contact') {
+        $path .= '&selectedChild=note';
+      }
+      $url = (string) Civi::url($path);
+      CRM_Core_Session::singleton()->pushUserContext($url);
+    }
   }
 
   /**

--- a/tests/phpunit/CRM/Core/BAO/NoteTest.php
+++ b/tests/phpunit/CRM/Core/BAO/NoteTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Civi\Api4\Contact;
+use Civi\Api4\Note;
+
+/**
+ * Class CRM_Core_BAO_NoteTest
+ *
+ * @group headless
+ */
+class CRM_Core_BAO_NoteTest extends CiviUnitTestCase {
+
+  public function tearDown(): void {
+    $this->quickCleanup(['civicrm_note', 'civicrm_contact'], TRUE);
+    parent::tearDown();
+  }
+
+  /**
+   * Test getTopParent returns the top-most parent note.
+   */
+  public function testGetTopParent(): void {
+    $contact = Contact::create(FALSE)->setValues([
+      'first_name' => 'Top',
+      'last_name' => 'Parent',
+    ])->execute()->first();
+
+    $parentNote = Note::create(FALSE)->setValues([
+      'entity_table' => 'civicrm_contact',
+      'entity_id' => $contact['id'],
+      'note' => 'Parent note',
+    ])->execute()->first();
+
+    $childNote = Note::create(FALSE)->setValues([
+      'entity_table' => 'civicrm_note',
+      'entity_id' => $parentNote['id'],
+      'note' => 'Child note',
+    ])->execute()->first();
+
+    $grandChildNote = Note::create(FALSE)->setValues([
+      'entity_table' => 'civicrm_note',
+      'entity_id' => $childNote['id'],
+      'note' => 'Grandchild note',
+    ])->execute()->first();
+
+    // Top parent of parentNote is itself
+    $topOfParent = CRM_Core_BAO_Note::getTopParent($parentNote['id']);
+    $this->assertEquals($parentNote['id'], $topOfParent->id);
+    $this->assertEquals('civicrm_contact', $topOfParent->entity_table);
+    $this->assertEquals($contact['id'], $topOfParent->entity_id);
+
+    // Top parent of childNote is parentNote
+    $topOfChild = CRM_Core_BAO_Note::getTopParent($childNote['id']);
+    $this->assertEquals($parentNote['id'], $topOfChild->id);
+
+    // Top parent of grandChildNote is parentNote
+    $topOfGrandChild = CRM_Core_BAO_Note::getTopParent($grandChildNote['id']);
+    $this->assertEquals($parentNote['id'], $topOfGrandChild->id);
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fixes missing redirect on full-page note editing form. A regression although not too recent.

Reported here: https://civicrm.stackexchange.com/questions/51654/odd-behaviour-after-saving-a-note-for-a-contact

Before
----------------------------------------
After creating a note full-screen (not in a popup), the form redirects you to the website homepage.

After
----------------------------------------
Correctly redirects you back to the entity the note belongs to.