### PR TITLE
Add computed my_case_role, is_my_case and is_my_managed_case fields to Case API4 entity

### DIFF
--- a/CRM/Case/Tokens.php
+++ b/CRM/Case/Tokens.php
@@ -32,11 +32,21 @@ class CRM_Case_Tokens extends CRM_Core_EntityTokens {
    * @return string[]
    */
   protected function getSkippedFields(): array {
-    // A raw contact ID with no :label variant (it's an FK, not a
-    // pseudoconstant) - not useful as a standalone merge token, same
-    // rationale as why {case.contact_id} is downgraded to sysadmin
-    // audience in the parent class.
-    return array_merge(parent::getSkippedFields(), ['case_manager_id']);
+    return array_merge(parent::getSkippedFields(), [
+      // A raw contact ID with no :label variant (it's an FK, not a
+      // pseudoconstant) - not useful as a standalone merge token, same
+      // rationale as why {case.contact_id} is downgraded to sysadmin
+      // audience in the parent class.
+      'case_manager_id',
+      // These three all resolve relative to whoever is currently
+      // logged in (CRM_Core_Session::getLoggedInContactID()), not a
+      // fixed/portable attribute of the case itself - the value would
+      // depend on who runs the mail merge, not the recipient, so
+      // they're not meaningful as standalone tokens either.
+      'my_case_role',
+      'is_my_case',
+      'is_my_managed_case',
+    ]);
   }
 
 }

--- a/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseRoleSpecProvider.php
+++ b/ext/civi_case/Civi/Api4/Service/Spec/Provider/CaseRoleSpecProvider.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Service\Spec\Provider;
+
+use Civi\Api4\Query\Api4SelectQuery;
+use Civi\Api4\Service\Spec\FieldSpec;
+use Civi\Api4\Service\Spec\RequestSpec;
+
+/**
+ * Adds computed fields describing the logged-in user's relationship to a
+ * Case: `my_case_role` (a role label, mirroring the case_role logic in
+ * CRM_Case_BAO_Case::getCases()), `is_my_case` (a boolean covering any
+ * role - not just the case manager), and `is_my_managed_case` (a boolean
+ * scoped specifically to the case manager role, via CaseManagerSpecProvider's
+ * existing `case_manager_id` logic).
+ *
+ * @service
+ * @internal
+ */
+class CaseRoleSpecProvider extends \Civi\Core\Service\AutoService implements Generic\SpecProviderInterface {
+
+  /**
+   * @inheritDoc
+   */
+  public function modifySpec(RequestSpec $spec) {
+    $role = (new FieldSpec('my_case_role', $spec->getEntity(), 'String'))
+      ->setTitle(ts('My Role'))
+      ->setDescription(ts('The relationship role(s) the logged-in user holds on this case.'))
+      ->setType('Extra')
+      ->setColumnName('id')
+      ->setSqlRenderer([__CLASS__, 'renderMyCaseRoleSql']);
+    $spec->addFieldSpec($role);
+
+    $isMyCase = (new FieldSpec('is_my_case', $spec->getEntity(), 'Boolean'))
+      ->setTitle(ts('Is My Case'))
+      ->setDescription(ts('Whether the logged-in user holds any active relationship role on this case.'))
+      ->setType('Extra')
+      ->setColumnName('id')
+      ->setInputType('Toggle')
+      ->setSqlRenderer([__CLASS__, 'renderIsMyCaseSql']);
+    $spec->addFieldSpec($isMyCase);
+
+    $isMyManagedCase = (new FieldSpec('is_my_managed_case', $spec->getEntity(), 'Boolean'))
+      ->setTitle(ts('I Am Case Manager'))
+      ->setDescription(ts('Whether the logged-in user is the configured case manager for this case.'))
+      ->setType('Extra')
+      ->setColumnName('id')
+      ->setInputType('Toggle')
+      ->setSqlRenderer([__CLASS__, 'renderIsMyManagedCaseSql']);
+    $spec->addFieldSpec($isMyManagedCase);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function applies($entity, $action) {
+    return $entity === 'Case' && $action === 'get';
+  }
+
+  public static function renderMyCaseRoleSql(array $field, Api4SelectQuery $query): string {
+    $alias = self::getAlias($field);
+    $userID = (int) (\CRM_Core_Session::getLoggedInContactID() ?? 0);
+    if (!$userID) {
+      return 'NULL';
+    }
+    return "(SELECT GROUP_CONCAT(DISTINCT IF(r.`contact_id_b` = $userID, rt.`label_a_b`, rt.`label_b_a`) SEPARATOR ', ')
+      FROM `civicrm_relationship` r
+      INNER JOIN `civicrm_relationship_type` rt ON rt.`id` = r.`relationship_type_id`
+      WHERE r.`case_id` = $alias.`id`
+        AND (r.`contact_id_a` = $userID OR r.`contact_id_b` = $userID))";
+  }
+
+  public static function renderIsMyCaseSql(array $field, Api4SelectQuery $query): string {
+    $alias = self::getAlias($field);
+    $userID = (int) (\CRM_Core_Session::getLoggedInContactID() ?? 0);
+    if (!$userID) {
+      return '0';
+    }
+    return "EXISTS (SELECT 1 FROM `civicrm_relationship` r
+      WHERE r.`case_id` = $alias.`id`
+        AND r.`is_active`
+        AND (r.`contact_id_a` = $userID OR r.`contact_id_b` = $userID))";
+  }
+
+  /**
+   * Reuses CaseManagerSpecProvider::renderCaseManagerSql() (the per-case-type
+   * manager-role lookup) rather than duplicating it, wrapping its subquery
+   * in an equality check against the logged-in user. $field/$query are
+   * passed straight through: CaseManagerSpecProvider's alias derivation
+   * only depends on $field['sql_name'], which resolves identically here
+   * (both fields share `columnName('id')` on the same base Case row).
+   */
+  public static function renderIsMyManagedCaseSql(array $field, Api4SelectQuery $query): string {
+    $userID = (int) (\CRM_Core_Session::getLoggedInContactID() ?? 0);
+    if (!$userID) {
+      return '0';
+    }
+    $managerSql = CaseManagerSpecProvider::renderCaseManagerSql($field, $query);
+    return "($managerSql = $userID)";
+  }
+
+  /**
+   * $field['sql_name'] is the alias-qualified `id` column (e.g. `a`.`id`)
+   * in whatever context this field is being selected from (main entity or a join).
+   */
+  private static function getAlias(array $field): string {
+    return substr($field['sql_name'], 0, strrpos($field['sql_name'], '.'));
+  }
+
+}

--- a/tests/phpunit/api/v4/Entity/CaseTest.php
+++ b/tests/phpunit/api/v4/Entity/CaseTest.php
@@ -25,6 +25,7 @@ use Civi\Api4\Activity;
 use Civi\Api4\CaseActivity;
 use Civi\Api4\CiviCase;
 use Civi\Api4\Relationship;
+use Civi\Api4\RelationshipType;
 
 /**
  * @group headless
@@ -146,6 +147,111 @@ class CaseTest extends Api4TestBase {
       ->single();
 
     $this->assertNull($result['case_manager_id']);
+  }
+
+  public function testCaseRoleFieldsForCaseManager(): void {
+    $uid = $this->createLoggedInUser();
+    $contactID = $this->createTestRecord('Contact')['id'];
+
+    // housing_support's "Homeless Services Coordinator" role has both
+    // creator=1 and manager=1, so opening the case as the logged-in user
+    // makes them both the creator and the case manager.
+    $case = $this->createTestRecord('Case', [
+      'creator_id' => 'user_contact_id',
+      'contact_id' => $contactID,
+    ]);
+
+    $expectedRole = $this->getExpectedCaseRole($case['id'], $uid);
+
+    $result = CiviCase::get(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->addSelect('my_case_role', 'is_my_case', 'is_my_managed_case')
+      ->execute()
+      ->single();
+
+    $this->assertEquals($expectedRole, $result['my_case_role']);
+    $this->assertTrue($result['is_my_case']);
+    $this->assertTrue($result['is_my_managed_case']);
+  }
+
+  public function testCaseRoleFieldsForUninvolvedUser(): void {
+    $this->createLoggedInUser();
+    $contactID = $this->createTestRecord('Contact')['id'];
+    $otherContactID = $this->createTestRecord('Contact')['id'];
+
+    // The case is opened by a different contact, so the logged-in user has
+    // no relationship to it at all.
+    $case = $this->createTestRecord('Case', [
+      'creator_id' => $otherContactID,
+      'contact_id' => $contactID,
+    ]);
+
+    $result = CiviCase::get(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->addSelect('my_case_role', 'is_my_case', 'is_my_managed_case')
+      ->execute()
+      ->single();
+
+    $this->assertNull($result['my_case_role']);
+    $this->assertFalse($result['is_my_case']);
+    $this->assertFalse($result['is_my_managed_case']);
+  }
+
+  public function testCaseRoleFieldsForInvolvedNonManager(): void {
+    $this->createLoggedInUser();
+    $contactID = $this->createTestRecord('Contact')['id'];
+
+    $case = $this->createTestRecord('Case', [
+      'creator_id' => 'user_contact_id',
+      'contact_id' => $contactID,
+    ]);
+
+    // Switch the logged-in user to a second contact who holds housing_support's
+    // "Health Services Coordinator" role on the same case - a role that's
+    // neither creator nor manager, so they're involved without managing it.
+    $coordinatorID = $this->createLoggedInUser();
+    $relationshipTypeID = RelationshipType::get(FALSE)
+      ->addWhere('label_b_a', '=', 'Health Services Coordinator')
+      ->addSelect('id')
+      ->execute()->single()['id'];
+    $relationship = $this->createTestRecord('Relationship', [
+      'relationship_type_id' => $relationshipTypeID,
+      'contact_id_a' => $contactID,
+      'contact_id_b' => $coordinatorID,
+      'case_id' => $case['id'],
+      'is_active' => TRUE,
+    ]);
+
+    $expectedRole = $this->getExpectedCaseRole($case['id'], $coordinatorID, $relationship['id']);
+
+    $result = CiviCase::get(FALSE)
+      ->addWhere('id', '=', $case['id'])
+      ->addSelect('my_case_role', 'is_my_case', 'is_my_managed_case')
+      ->execute()
+      ->single();
+
+    $this->assertEquals($expectedRole, $result['my_case_role']);
+    $this->assertTrue($result['is_my_case']);
+    $this->assertFalse($result['is_my_managed_case']);
+  }
+
+  /**
+   * Mirrors CaseRoleSpecProvider::renderMyCaseRoleSql()'s direction logic:
+   * the role label is read from whichever side of the relationship type
+   * the given user occupies, rather than assuming a fixed label column.
+   */
+  private function getExpectedCaseRole(int $caseID, int $userID, ?int $relationshipID = NULL): ?string {
+    $query = Relationship::get(FALSE)
+      ->addWhere('case_id', '=', $caseID)
+      ->addSelect('contact_id_b', 'relationship_type_id.label_a_b', 'relationship_type_id.label_b_a');
+    if ($relationshipID) {
+      $query->addWhere('id', '=', $relationshipID);
+    }
+    $relationship = $query->execute()->single();
+
+    return $relationship['contact_id_b'] == $userID
+      ? $relationship['relationship_type_id.label_a_b']
+      : $relationship['relationship_type_id.label_b_a'];
   }
 
   public function testCaseActivity(): void {


### PR DESCRIPTION
## Overview

This effectively gives us the data we need to build an equivalent of the existing case dashboard as well as other, more targetted/custom dashboards / case displays.

Adds three more computed fields alongside case_manager_id, all derived from the logged-in user's relationships on a case:

- my_case_role (the role label(s) the user holds, mirroring the case_role logic in CRM_Case_BAO_Case::getCases())
- is_my_case (whether the user holds any active relationship role at all, not just case manager)
- is_my_managed_case (whether the user is specifically the case manager, reusing CaseManagerSpecProvider's existing per-case-type manager-role lookup wrapped in an equality check against the logged-in user, rather than duplicating that logic).

Together these give SearchKit (and any other API4 consumer) a real, server-computed "is this my case" filter instead of needing an unreliable client-side comparison against the current user's contact ID.

Also skips all three in CRM_Case_Tokens: CRM_Core_EntityTokens.

Before
----------------------------------------
Cannot reliably get these filters using joins alone.

After
----------------------------------------
Can get this data easily using calculated fields.

Technical Details
----------------------------------------
The problem: SearchKit lets you filter/display data declaratively, but everything it computes has to resolve to server-side SQL over real columns, joins, and aggregates. "Is this my case" and "what's my role on it" aren't attributes of the case row itself — they're relative to whoever is looking, computed by comparing the logged-in user's contact ID against the case's civicrm_relationship rows.

What existing SK/FB tools can't do here:
- Joins can get you the data, but not "as me." You can join Case → Relationship → filter contact_id_b = X, but SearchKit has no built-in "current user" placeholder you can drop into a join condition or filter value in the Search Builder UI/FormBuilder — there's no equivalent of API4's user_contact_id default-value token usable as a join condition operand or arbitrary filter value at display time. You'd need the ID hardcoded or passed as a run-time search parameter, which doesn't work for a dashboard everyone loads with no query params.
- Multiple relationship rows per case, multiple roles. A case can have several relationship rows (creator, manager, other staff). Joining Relationship onto Case in SearchKit either duplicates the case row per relationship (breaks a "one row per case" dashboard/list) or forces a GROUP BY with aggregation SearchKit's UI doesn't expose for arbitrary string concatenation (GROUP_CONCAT with the IF(...) direction logic) or boolean existence checks (EXISTS).
- Role label direction is conditional SQL, not a column. The label shown depends on which side of the relationship (contact_id_a/contact_id_b) the user occupies — that's exactly what CRM_Case_BAO_Case::getCases() computes procedurally for the legacy dashboard. There's no declarative SK/FB primitive for "pick column A or column B based on a runtime comparison."

What the computed fields give you instead: each one is a real, selectable/filterable/sortable API4 field — is_my_case, is_my_managed_case, my_case_role — backed by a correlated SQL subquery (SqlRenderer) that does the "current user" resolution and direction logic once, server-side, per case row. That means:
- SearchKit/FormBuilder can filter on them like any normal field (is_my_case = TRUE toggle, no join fan-out, no duplicate rows).
- They work in the FormBuilder-built dashboard exactly like case_manager_id already does — no custom JS, no client-side "is this contactID === my contactID" comparison (which the commit message calls out as unreliable — e.g. it breaks under caching/multiple relationship rows and doesn't cover the "any role" case at all).

So the short version: these aren't things existing declarative SK/FB tooling is missing by oversight — they're server-relative, session-dependent, multi-row-collapsing computations that only a real SQL-level computed field (like the already-merged case_manager_id) can express as a normal filterable/selectable entity field.

Comments
----------------------------------------
