### PR TITLE
Fix searchkit drag-and-drop reordering bugs

### DIFF
--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -146,20 +146,21 @@ class CRM_Utils_Weight {
       $newWeight = 1;
     }
 
-    // if they're the same, nothing to do
-    if ($oldWeight == $newWeight) {
+    // Check for an existing record with this weight
+    $existing = self::query('SELECT', $daoName, $fieldValues, "id", "$weightField = $newWeight");
+
+    // Nothing to do only if no other row shares this weight (a real tie falls through below)
+    if ($oldWeight == $newWeight && $existing->N <= 1) {
       return $newWeight;
     }
 
-    // Check for an existing record with this weight
-    $existing = self::query('SELECT', $daoName, $fieldValues, "id", "$weightField = $newWeight");
     // Nothing to do if no existing record has this weight
     if (empty($existing->N)) {
       return $newWeight;
     }
 
-    // if oldWeight not present, indicates new weight is to be added. So create a gap for a new row to be inserted.
-    if (!isset($oldWeight)) {
+    // No old weight, or tied with it: treat as a fresh insertion, making a gap.
+    if (!isset($oldWeight) || $oldWeight == $newWeight) {
       $additionalWhere = "$weightField >= $newWeight";
       $update = "$weightField = ($weightField + 1)";
       CRM_Utils_Weight::query('UPDATE', $daoName, $fieldValues, $update, $additionalWhere);

--- a/CRM/Utils/Weight.php
+++ b/CRM/Utils/Weight.php
@@ -143,7 +143,8 @@ class CRM_Utils_Weight {
       }
     }
     elseif ($newWeight < 1) {
-      $newWeight = 1;
+      // Floor to the group's own minimum, not a hardcoded 1, in case rows already sit below 1.
+      $newWeight = min(1, self::getMin($daoName, $fieldValues, $weightField) ?? 1);
     }
 
     // Check for an existing record with this weight
@@ -247,6 +248,27 @@ class CRM_Utils_Weight {
       return $weightDAO->max_weight;
     }
     return 0;
+  }
+
+  /**
+   * Returns the lowest weight currently in use.
+   *
+   * @param string $daoName
+   *   Full name of the DAO.
+   * @param array $fieldValues
+   *   Field => value to be used in the WHERE.
+   * @param string $weightField
+   *   Field which contains the weight value.
+   *   defaults to 'weight'
+   *
+   * @return int|null
+   *   Null if no records currently exist.
+   */
+  public static function getMin($daoName, $fieldValues = NULL, $weightField = 'weight') {
+    $selectField = "MIN(ROUND($weightField)) AS min_weight";
+    $weightDAO = CRM_Utils_Weight::query('SELECT', $daoName, $fieldValues, $selectField);
+    $weightDAO->fetch();
+    return isset($weightDAO->min_weight) ? (int) $weightDAO->min_weight : NULL;
   }
 
   /**

--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php
@@ -236,6 +236,9 @@ class InlineEdit extends Run {
       throw new \CRM_Core_Exception('Cannot update draggable weight: no value provided.');
     }
     $entityName = $this->savedSearch['api_entity'];
+    if (!CoreUtil::isType($entityName, 'SortableEntity')) {
+      throw new \CRM_Core_Exception("Cannot drag-sort '$entityName': entity must declare itself a SortableEntity (see Civi\\Api4\\Generic\\Traits\\SortableEntity) for weights to be reordered correctly.");
+    }
     $keyName = CoreUtil::getIdFieldName($entityName);
     // For security, do not accept arbitrary values; only update weight.
     $values = [

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
@@ -651,6 +651,148 @@ class EditableSearchTest extends Api4TestBase {
     $this->assertSame([1, 2, 3, 4, 5], $weights);
   }
 
+  /**
+   * Drag-sorting a non-SortableEntity must fail loudly, not silently tie weights.
+   */
+  public function testDraggableSearchDisplayRequiresSortableEntity(): void {
+    $product = $this->createTestRecord('PremiumsProduct', ['weight' => 1]);
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'savedSearch' => [
+        'api_entity' => 'PremiumsProduct',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['weight'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'settings' => [
+          'draggable' => 'weight',
+          'columns' => [
+            [
+              'key' => 'weight',
+              'label' => 'Weight',
+              'type' => 'field',
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $this->expectException(\CRM_Core_Exception::class);
+    $this->expectExceptionMessage('PremiumsProduct');
+    SearchDisplay::inlineEdit()
+      ->setSavedSearch($params['savedSearch'])
+      ->setDisplay($params['display'])
+      ->setReturn('draggableWeight')
+      ->setRowKey($product['id'])
+      ->setValues(['weight' => 1])
+      ->execute();
+  }
+
+  /**
+   * Reproduces two symptoms reported against the drag-and-drop weight logic:
+   * dragging among tied weights (e.g. a freshly added weight column
+   * defaulting to the same value for every row) must still produce distinct
+   * weights, and that must hold up over repeated drags and survive a reload.
+   */
+  public function testDraggableSearchDisplayResolvesTiedWeights(): void {
+    $name = __FUNCTION__;
+    $this->createTestRecord('OptionGroup', [
+      'title' => $name,
+    ]);
+    $optionIds = $this->saveTestRecords('OptionValue', [
+      'defaults' => ['option_group_id.name' => $name],
+      'records' => [
+        ['value' => 'A'],
+        ['value' => 'B'],
+        ['value' => 'C'],
+        ['value' => 'D'],
+      ],
+    ])->column('id');
+    // Force all weights to the same value, simulating a weight column that
+    // was just added to the schema with a blanket default for every existing
+    // row (bypassing the API so SortableEntity doesn't prevent the tie).
+    // Note: 1, not 0 - CRM_Utils_Weight::updateOtherWeights() treats weights
+    // as 1-indexed and clamps anything below 1 up to 1, which is a separate,
+    // pre-existing quirk unrelated to the bug under test here.
+    \CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET weight = 1 WHERE id IN (' . implode(',', $optionIds) . ')');
+    $params = [
+      'checkPermissions' => FALSE,
+      'return' => 'page:1',
+      'savedSearch' => [
+        'api_entity' => 'OptionValue',
+        'api_params' => [
+          'version' => 4,
+          'select' => ['value', 'weight'],
+          'where' => [['option_group_id.name', '=', $name]],
+          'orderBy' => ['weight' => 'ASC', 'id' => 'ASC'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'settings' => [
+          'draggable' => 'weight',
+          'columns' => [
+            [
+              'key' => 'value',
+              'label' => 'Value',
+              'type' => 'field',
+            ],
+            [
+              'key' => 'weight',
+              'label' => 'Weight',
+              'type' => 'field',
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    // All 4 rows start tied on the same weight (1)
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $weights = array_column($result->column('data'), 'weight');
+    $this->assertSame([1, 1, 1, 1], $weights);
+
+    // Drag D (last) to A's position (first) - the client sends the displaced
+    // row's (tied) weight, 1, as the target weight.
+    SearchDisplay::inlineEdit()
+      ->setSavedSearch($params['savedSearch'])
+      ->setDisplay($params['display'])
+      ->setReturn('draggableWeight')
+      ->setRowKey($optionIds[3])
+      ->setValues(['weight' => 1])
+      ->execute();
+
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $weights = array_column($result->column('data'), 'weight');
+    // D's weight must now be strictly lower than the still-tied A/B/C, not left tied with them.
+    $this->assertSame([1, 2, 2, 2], $weights);
+    $this->assertSame([$optionIds[3], $optionIds[0], $optionIds[1], $optionIds[2]], $result->column('key'));
+
+    // Drag C to second position - repeating the drag must not recreate a tie.
+    $secondWeight = $result->column('data')[1]['weight'];
+    SearchDisplay::inlineEdit()
+      ->setSavedSearch($params['savedSearch'])
+      ->setDisplay($params['display'])
+      ->setReturn('draggableWeight')
+      ->setRowKey($optionIds[2])
+      ->setValues(['weight' => $secondWeight])
+      ->execute();
+
+    // Re-run as a fresh query (not just the inlineEdit return value) to
+    // confirm the new order actually persisted and isn't undone by a
+    // secondary sort key silently reverting on reload.
+    $result = civicrm_api4('SearchDisplay', 'run', $params);
+    $weights = array_column($result->column('data'), 'weight');
+    // C is now separated from the remaining tied A/B pair, and D's earlier
+    // separation from the pack survived the second drag and the reload.
+    $this->assertSame([1, 2, 3, 3], $weights);
+    $this->assertSame([$optionIds[3], $optionIds[2], $optionIds[0], $optionIds[1]], $result->column('key'));
+  }
+
   public function testEditWithGroupBy(): void {
     $lastName = uniqid();
     $cid = $this->saveTestRecords('Contact', [

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php
@@ -693,10 +693,8 @@ class EditableSearchTest extends Api4TestBase {
   }
 
   /**
-   * Reproduces two symptoms reported against the drag-and-drop weight logic:
-   * dragging among tied weights (e.g. a freshly added weight column
-   * defaulting to the same value for every row) must still produce distinct
-   * weights, and that must hold up over repeated drags and survive a reload.
+   * Dragging among tied (including below-1) weights must break the tie, hold up over
+   * repeated drags, and survive a reload.
    */
   public function testDraggableSearchDisplayResolvesTiedWeights(): void {
     $name = __FUNCTION__;
@@ -712,13 +710,8 @@ class EditableSearchTest extends Api4TestBase {
         ['value' => 'D'],
       ],
     ])->column('id');
-    // Force all weights to the same value, simulating a weight column that
-    // was just added to the schema with a blanket default for every existing
-    // row (bypassing the API so SortableEntity doesn't prevent the tie).
-    // Note: 1, not 0 - CRM_Utils_Weight::updateOtherWeights() treats weights
-    // as 1-indexed and clamps anything below 1 up to 1, which is a separate,
-    // pre-existing quirk unrelated to the bug under test here.
-    \CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET weight = 1 WHERE id IN (' . implode(',', $optionIds) . ')');
+    // Force a tie at 0, bypassing the API (as a retrofitted weight column default would).
+    \CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET weight = 0 WHERE id IN (' . implode(',', $optionIds) . ')');
     $params = [
       'checkPermissions' => FALSE,
       'return' => 'page:1',
@@ -751,28 +744,26 @@ class EditableSearchTest extends Api4TestBase {
       ],
     ];
 
-    // All 4 rows start tied on the same weight (1)
+    // All 4 rows start tied on the same weight (0)
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $weights = array_column($result->column('data'), 'weight');
-    $this->assertSame([1, 1, 1, 1], $weights);
+    $this->assertSame([0, 0, 0, 0], $weights);
 
-    // Drag D (last) to A's position (first) - the client sends the displaced
-    // row's (tied) weight, 1, as the target weight.
+    // Drag D (last) onto A (first) - client sends the displaced row's tied weight, 0.
     SearchDisplay::inlineEdit()
       ->setSavedSearch($params['savedSearch'])
       ->setDisplay($params['display'])
       ->setReturn('draggableWeight')
       ->setRowKey($optionIds[3])
-      ->setValues(['weight' => 1])
+      ->setValues(['weight' => 0])
       ->execute();
 
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $weights = array_column($result->column('data'), 'weight');
-    // D's weight must now be strictly lower than the still-tied A/B/C, not left tied with them.
-    $this->assertSame([1, 2, 2, 2], $weights);
+    $this->assertSame([0, 1, 1, 1], $weights);
     $this->assertSame([$optionIds[3], $optionIds[0], $optionIds[1], $optionIds[2]], $result->column('key'));
 
-    // Drag C to second position - repeating the drag must not recreate a tie.
+    // Drag C to second position - must not recreate a tie.
     $secondWeight = $result->column('data')[1]['weight'];
     SearchDisplay::inlineEdit()
       ->setSavedSearch($params['savedSearch'])
@@ -782,14 +773,10 @@ class EditableSearchTest extends Api4TestBase {
       ->setValues(['weight' => $secondWeight])
       ->execute();
 
-    // Re-run as a fresh query (not just the inlineEdit return value) to
-    // confirm the new order actually persisted and isn't undone by a
-    // secondary sort key silently reverting on reload.
+    // Fresh query, not the inlineEdit return value, to confirm it persisted.
     $result = civicrm_api4('SearchDisplay', 'run', $params);
     $weights = array_column($result->column('data'), 'weight');
-    // C is now separated from the remaining tied A/B pair, and D's earlier
-    // separation from the pack survived the second drag and the reload.
-    $this->assertSame([1, 2, 3, 3], $weights);
+    $this->assertSame([0, 1, 2, 2], $weights);
     $this->assertSame([$optionIds[3], $optionIds[2], $optionIds[0], $optionIds[1]], $result->column('key'));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------

Fixes SearchKit's drag-and-drop reordering (SearchDisplay.settings.draggable) leaving rows with duplicate weights instead of actually reordering them — worst when a weight column starts every row tied on the same default value, where dragging didn't change order at all.

Before
----------------------------------------

Dragging a row in a draggable SearchKit display sent the displaced row's current weight as the target weight, and InlineEdit/CRM_Utils_Weight wrote it through more or less verbatim:
- If the target entity wasn't a SortableEntity, the row silently ended up tied with its neighbor — no error, no reorder.
- Even on a SortableEntity, if the dragged row's own current weight already equalled the requested value (e.g. every row starts tied at the same default), the update was treated as a no-op and nothing moved.
- If a weight column had pre-existing values below 1 (e.g. defaulting to 0), the weight-clamping logic pushed the dragged row up to 1, which could put it after untouched siblings still at 0 — inverting the drag.

After
----------------------------------------

- Drag-sorting a non-SortableEntity entity now throws a clear CRM_Core_Exception naming the entity, instead of silently corrupting weights.
- Dragging into a genuinely tied weight now breaks the tie and reorders correctly, including when every row starts out tied.
- A below-1 starting weight is respected instead of being clamped above it, so the drag lands in the correct position.

Technical Details
----------------------------------------

- ext/search_kit/Civi/Api4/Action/SearchDisplay/InlineEdit.php: updateDraggableWeight() now requires the target entity to be a SortableEntity (@orderBy + use Generic\Traits\SortableEntity), the existing core contract that wires up automatic weight-tie resolution via Civi\Api4\Generic\Traits\DAOActionTrait::updateWeight(). Every core screen currently using draggable already targets a SortableEntity (OptionValue, CustomGroup, PriceField, PriceFieldValue, Navigation, RelationshipType, MembershipStatus, MembershipType, UFField), so this tightens an already-universal assumption rather than changing behavior for any shipped screen.
- CRM/Utils/Weight.php, updateOtherWeights():
  - No longer short-circuits as a no-op when the row's own current weight equals the requested weight if another row also holds that weight — falls through to the same "create a gap" logic used for new/regrouped rows, so a genuine tie is actually broken.
  - Adds getMin() (mirrors getMax()) and clamps a sub-1 request to min(1, group's actual minimum) instead of a hardcoded 1, so it never clamps above rows that are already below 1.

Comments
----------------------------------------

Two commits, each independently passing the test suite. Added regression tests to ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EditableSearchTest.php:
- One drag-sorts a non-SortableEntity entity (PremiumsProduct, unmodified core, has a weight field) and asserts it throws.
- One reproduces the original bug end-to-end against OptionValue: all rows tied at 0, drag, assert order/weights, drag again, assert it holds up, then re-query fresh to confirm it persisted.

Ran NavigationTest, OptionValueTest, and CustomGroupTest as smoke checks against other SortableEntity consumers — no regressions.