### PR TITLE
Afform: use shared crm-entity-tags widget for the Form Builder tag picker

### DIFF
--- a/ang/crmEntityTags.js
+++ b/ang/crmEntityTags.js
@@ -15,7 +15,7 @@
       get: function(entityTable) {
         if (!cache[entityTable]) {
           cache[entityTable] = crmApi4('Tag', 'get', {
-            select: ['id', 'label', 'color', 'is_selectable', 'description'],
+            select: ['id', 'name', 'label', 'color', 'is_selectable', 'description'],
             where: [['used_for', 'CONTAINS', entityTable]]
           });
         }

--- a/ext/afform/admin/ang/afGuiEditor.ang.php
+++ b/ext/afform/admin/ang/afGuiEditor.ang.php
@@ -8,7 +8,7 @@ return [
   ],
   'css' => ['ang/afGuiEditor.css'],
   'partials' => ['ang/afGuiEditor'],
-  'requires' => ['crmUi', 'crmUtil', 'crmDialog', 'api4', 'crmMonaco', 'ui.sortable'],
+  'requires' => ['crmUi', 'crmUtil', 'crmDialog', 'api4', 'crmMonaco', 'ui.sortable', 'crmEntityTags'],
   'settingsFactory' => ['Civi\AfformAdmin\AfformAdminMeta', 'getModuleSettings'],
   'basePages' => [],
   'exports' => [

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEditor.component.js
@@ -18,7 +18,7 @@
       mode: '@'
     },
     controllerAs: 'editor',
-    controller: function($scope, $element, crmApi4, crmUiHelp, afGui, $parse, $timeout, $location, $route, $rootScope, formatForSelect2) {
+    controller: function($scope, $element, crmApi4, crmUiHelp, afGui, $parse, $timeout, $location, $route, $rootScope, crmEntityTagsCache) {
       const ts = $scope.ts = CRM.ts('org.civicrm.afform_admin');
       $scope.hs = crmUiHelp({file: 'CRM/AfformAdmin/afformBuilder'});
 
@@ -33,7 +33,41 @@
       let undoAction = null;
       let lastSaved = {};
       const sortableOptions = {};
-      this.afformTags = formatForSelect2(this.meta.afform_fields.tags.options || [], 'id', 'label', ['description', 'color']);
+      // crm-entity-tags works in terms of real tag ids; Afform.tags is stored as tag names for
+      // portability across sites (see AfformTags::getTagOptions). afformTagsList/afformTagIds
+      // bridge the two - populated once the shared tag list loads, then kept in sync below.
+      // afformTagsList stays the same array crmEntityTagsCache resolved, so a tag the widget
+      // creates inline (which is pushed into that array in place) is visible here too.
+      this.afformTagIds = [];
+      let afformTagsList = [];
+      function syncAfformTagIds() {
+        editor.afformTagIds = afformTagsList
+          .filter((tag) => (editor.afform.tags || []).includes(tag.name))
+          .map((tag) => tag.id);
+      }
+      // Loads (once, cached) the full list of tags used_for Afform, then computes the
+      // initial afformTagIds selection now that afformTagsList is populated.
+      crmEntityTagsCache.get('Afform').then(function(tags) {
+        afformTagsList = tags;
+        syncAfformTagIds();
+      });
+
+      // The widget mutates afformTagIds directly (toggle/create); mirror that back into
+      // editor.afform.tags (by name) so it's what actually gets saved & undo-tracked. The
+      // equality check avoids re-triggering the undo-history watch below when the names
+      // round-trip to the same set they started from.
+      $scope.$watchCollection('editor.afformTagIds', function(newIds, oldIds) {
+        if (newIds === oldIds) {
+          return;
+        }
+        const names = afformTagsList
+          .filter((tag) => newIds.includes(tag.id))
+          .map((tag) => tag.name)
+          .sort();
+        if (!_.isEqual(names, (editor.afform.tags || []).slice().sort())) {
+          editor.afform.tags = names;
+        }
+      });
 
       // ngModelOptions to debounce input
       // Used to prevent cluttering the undo history with every keystroke
@@ -207,6 +241,7 @@
         undoPosition += direction;
         undoAction = 'change';
         editor.afform = _.cloneDeep(undoHistory[undoPosition].afform);
+        syncAfformTagIds();
         setEditorLayout();
         editor.canvasTab = 'layout';
         $scope.selectedEntityName = undoHistory[undoPosition].selectedEntityName;

--- a/ext/afform/admin/ang/afGuiEditor/config-form.html
+++ b/ext/afform/admin/ang/afGuiEditor/config-form.html
@@ -43,11 +43,13 @@
   </div>
 
   <div class="form-group">
-    <label for="afform_tags">
+    <label>
       {{:: editor.meta.afform_fields.tags.title }}
       <a crm-ui-help="hs({id: 'tags', title: editor.meta.afform_fields.tags.title})"></a>
     </label>
-    <input ng-list crm-ui-select="{multiple: true, data: editor.afformTags, placeholder: ts('None')}" class="form-control" id="afform_tags" ng-model="editor.afform.tags">
+    <div>
+      <crm-entity-tags tag-ids="editor.afformTagIds" entity-table="'Afform'" class="btn-group btn-group-sm"></crm-entity-tags>
+    </div>
   </div>
 
   <!-- Placement options do not apply to blocks -->


### PR DESCRIPTION
Overview
----------------------------------------
Switches FormBuilder's own tag picker over to the shared `crm-entity-tags` widget introduced in [#36492](https://github.com/civicrm/civicrm-core/pull/36492), instead of a bespoke multiselect, so it gets the same tag-management UI as SearchKit (colored badges, inline "create tag") for free.

<img width="670" height="418" alt="image" src="https://github.com/user-attachments/assets/3765b437-cd3e-4fcb-86f7-1316e1a2735d" />


Before
----------------------------------------
The FormBuilder editor's Tags field was a plain `<input crm-ui-select>` multiselect: a dropdown of existing tags with no inline creation and no visual tag styling.

After
----------------------------------------
The Tags field is now the shared `crm-entity-tags` widget: a "Tags" toggle button, colored badges for applied tags, and an inline "Create Tag" option in the dropdown — the same widget already used for tagging Saved Searches.

Technical Details
----------------------------------------
`crm-entity-tags` works in terms of real tag IDs, but `Afform.tags` is stored as an array of tag *names* (deliberately, for portability — a form shipped by an extension shouldn't reference a tag ID that may not exist on the installing site). The FormBuilder editor controller (`afGuiEditor.component.js`) bridges the two: it maintains an `afformTagIds` array translated to/from `editor.afform.tags` by name, kept in sync on load, on every toggle, and across undo/redo. Since Afform has no `EntityTag` rows, `entity-id` is deliberately left unset on the widget, which puts it in its existing "local mutation only" mode — it doesn't fire any `EntityTag` API calls itself; the ID→name array is just persisted as part of the normal `Afform.save()`.

Also added `name` to the shared widget's own `Tag.get` select (`ang/crmEntityTags.js`) — needed by the above bridge, harmless for its other consumers which don't use that field.

Comments
----------------------------------------
Manually verified in the browser: toggling an existing tag, inline-creating a new one, undo, redo, save, and a hard page reload all round-trip correctly through `Afform.tags` as an array of names.