### PR TITLE
Fix missing 'audience' key on ContributionProduct's bespoke token

### DIFF
--- a/CRM/Contribute/ContributionProductTokens.php
+++ b/CRM/Contribute/ContributionProductTokens.php
@@ -74,6 +74,7 @@ class CRM_Contribute_ContributionProductTokens extends CRM_Core_EntityTokens {
         'type' => 'calculated',
         'options' => NULL,
         'data_type' => 'string',
+        'audience' => 'user',
       ],
     ];
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug where building a token list that includes Contribution Product tokens (`contribution_productId`) throws a PHP warning, because one of that entity's tokens is missing required metadata.

Before
----------------------------------------
Building a `TokenProcessor` with `contribution_productId` in its schema throws:

```
Warning: Undefined array key "audience" in CRM/Core/EntityTokens.php on line 63
```

This surfaces as a visible error banner in any UI that lists tokens for such a schema.

After
----------------------------------------
The same call lists tokens cleanly, with no warning, including `{contribution_product.product_option:label}`.

Technical Details
----------------------------------------


Comments
----------------------------------------

