### PR TITLE
Tag - Add reverse tag lookup across all taggable entities

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -359,7 +359,7 @@ class CRM_Admin_Page_AJAX {
             'usages' => civicrm_api3('EntityTag', 'getcount', [
               'entity_table' => ['IN' => $usedFor],
               'tag_id' => $dao->id,
-            ]),
+            ]) + array_sum(array_map('count', CRM_Core_BAO_EntityTag::getNonDbTaggedIds($dao->id, $usedFor))),
           ],
         ];
         if ($dao->description || $dao->is_reserved) {

--- a/CRM/Core/BAO/EntityTag.php
+++ b/CRM/Core/BAO/EntityTag.php
@@ -419,6 +419,35 @@ class CRM_Core_BAO_EntityTag extends CRM_Core_DAO_EntityTag implements \Civi\Cor
   }
 
   /**
+   * Get the ids of entities tagged with a given tag, for any entity registered via the
+   * alterNonDbTaggableEntities hook (tag-able but not a physical table, e.g. Afform) - these
+   * have no `EntityTag` rows for a DB-based lookup to find.
+   *
+   * @param int $tagId
+   * @param array|null $onlyEntities
+   *   If given, only invoke the callback for these entity names - lets a caller who already
+   *   knows a tag's `used_for` skip the (often several-query) callback for entities it
+   *   doesn't apply to.
+   * @return array
+   *   Array keyed by entity name, each value an array of that entity's own id/primary-key values.
+   */
+  public static function getNonDbTaggedIds(int $tagId, ?array $onlyEntities = NULL): array {
+    $nonDbEntities = [];
+    CRM_Utils_Hook::alterNonDbTaggableEntities($nonDbEntities);
+    $result = [];
+    foreach ($nonDbEntities as $entityName => $callback) {
+      if ($onlyEntities !== NULL && !in_array($entityName, $onlyEntities, TRUE)) {
+        continue;
+      }
+      $ids = array_column($callback($tagId), 'id');
+      if ($ids) {
+        $result[$entityName] = $ids;
+      }
+    }
+    return $result;
+  }
+
+  /**
    * Pseudoconstant condition_provider for tag_id field.
    * @see \Civi\Schema\EntityMetadataBase::getConditionFromProvider
    */

--- a/CRM/Core/Permission.php
+++ b/CRM/Core/Permission.php
@@ -1146,6 +1146,7 @@ class CRM_Core_Permission {
       'get' => ['access CiviCRM'],
       'create' => ['access CiviCRM'],
       'update' => ['access CiviCRM'],
+      'getTaggedEntities' => ['access CiviCRM'],
     ];
 
     //relationship permissions

--- a/CRM/Core/xml/Menu/Tag.xml
+++ b/CRM/Core/xml/Menu/Tag.xml
@@ -24,6 +24,12 @@
     <access_arguments>administer CiviCRM;manage tags</access_arguments>
   </item>
   <item>
+    <path>civicrm/tag/usage</path>
+    <title>Tag Usage</title>
+    <page_callback>CRM_Tag_Page_Usage</page_callback>
+    <access_arguments>administer CiviCRM;manage tags</access_arguments>
+  </item>
+  <item>
     <path>civicrm/ajax/tagTree</path>
     <page_callback>CRM_Admin_Page_AJAX::getTagTree</page_callback>
     <access_arguments>administer CiviCRM;manage tags</access_arguments>

--- a/CRM/Tag/Page/Usage.php
+++ b/CRM/Tag/Page/Usage.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Popup listing the entities tagged with a given tag.
+ */
+class CRM_Tag_Page_Usage extends CRM_Core_Page {
+
+  public function run() {
+    $tagId = CRM_Utils_Request::retrieve('tag_id', 'Positive', $this, TRUE);
+    $tag = civicrm_api4('Tag', 'get', [
+      'select' => ['label'],
+      'where' => [['id', '=', $tagId]],
+      'checkPermissions' => FALSE,
+    ])->first();
+    if (!$tag) {
+      CRM_Core_Error::statusBounce(ts('Tag not found.'));
+    }
+
+    CRM_Utils_System::setTitle(ts('Records tagged "%1"', [1 => $tag['label']]));
+    $this->assign('tagLabel', $tag['label']);
+
+    $itemsByType = [];
+    $tagged = civicrm_api4('Tag', 'getTaggedEntities', [
+      'where' => [['tag_id', '=', $tagId]],
+      'select' => ['entity_type', 'label', 'url'],
+      'checkPermissions' => FALSE,
+    ]);
+    foreach ($tagged as $item) {
+      $itemsByType[$item['entity_type']][] = ['label' => $item['label'], 'url' => $item['url']];
+    }
+    $groups = [];
+    foreach ($itemsByType as $entityType => $items) {
+      $groups[] = [
+        'title' => \Civi\Api4\Utils\CoreUtil::getInfoItem($entityType, 'title_plural') ?: $entityType,
+        'items' => $items,
+      ];
+    }
+    $this->assign('groups', $groups);
+
+    parent::run();
+  }
+
+}

--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -956,6 +956,26 @@ abstract class CRM_Utils_Hook {
   }
 
   /**
+   * This hook lets extensions declare entities that can be tagged (their `tag_used_for`
+   * option value has `filter = 1`) but aren't rows in a physical table, so `EntityTag`
+   * can't reference them and a reverse "what's tagged X" lookup has nowhere to join.
+   *
+   * @param array $entities
+   *   Array keyed by the `tag_used_for` option value name (e.g. 'Afform'). Each entry is
+   *   a callable `function(int $tagId): array` returning the matching records - each an
+   *   array with at minimum an `id` key uniquely identifying that record within its entity.
+   *
+   * @return mixed
+   */
+  public static function alterNonDbTaggableEntities(&$entities) {
+    $null = NULL;
+    return self::singleton()->invoke(['entities'], $entities,
+      $null, $null, $null, $null, $null,
+      'civicrm_alterNonDbTaggableEntities'
+    );
+  }
+
+  /**
    * This hook is called when sending an email / printing labels to get the values for all the
    * tokens returned by the 'tokens' hook
    *

--- a/Civi/Api4/Action/Tag/GetTaggedEntities.php
+++ b/Civi/Api4/Action/Tag/GetTaggedEntities.php
@@ -1,0 +1,158 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Api4\Action\Tag;
+
+use Civi\Api4\EntityTag;
+use Civi\Api4\Tag;
+use Civi\Api4\Utils\CoreUtil;
+
+/**
+ * Find every record tagged with one or more tags, across both `EntityTag`-backed
+ * entities (real DB tables) and any entity registered via the
+ * `alterNonDbTaggableEntities` hook (tag-able but not a physical table, e.g. Afform).
+ *
+ * Filter by `tag_id` in the `where` clause (`=`/`IN`) to scope which tags are looked
+ * up; omitting it looks up every tag, which is expensive and rarely what you want.
+ * Every row always has `tag_id`/`entity_table`/`entity_type`/`entity_id`. Including
+ * `label` and/or `url` in `select` additionally resolves a display label and (where
+ * the entity declares one) a link, ready for a UI to render directly -- each costs
+ * one extra `get` call per distinct entity type found, so only ask for them when you
+ * need them.
+ */
+class GetTaggedEntities extends \Civi\Api4\Generic\BasicGetAction {
+
+  protected function getRecords() {
+    $tagIds = $this->_itemsToGet('tag_id');
+    // No tag_id restriction given - look up every tag. Expensive, but the caller asked for it.
+    if ($tagIds === NULL) {
+      $tagIds = Tag::get($this->getCheckPermissions())->addSelect('id')->execute()->column('id');
+    }
+    // Nonexistent tag ids have no tagged entities - that's a legitimate empty
+    // result, not an error, so drop them before invoking any hook callback.
+    $tagIds = Tag::get($this->getCheckPermissions())->addSelect('id')->addWhere('id', 'IN', $tagIds)->execute()->column('id');
+
+    $resolveDisplayInfo = $this->_isFieldSelected('label', 'url');
+
+    $rows = [];
+    foreach ($tagIds as $tagId) {
+      $idsByEntity = [];
+      foreach (EntityTag::get($this->getCheckPermissions())
+        ->addWhere('tag_id', '=', $tagId)
+        ->addSelect('entity_table', 'entity_id')
+        ->execute() as $entityTag) {
+        $entityName = \CRM_Core_DAO_AllCoreTables::getEntityNameForTable($entityTag['entity_table']);
+        if ($entityName) {
+          $idsByEntity[$entityName][] = (int) $entityTag['entity_id'];
+        }
+      }
+      foreach (\CRM_Core_BAO_EntityTag::getNonDbTaggedIds($tagId) as $entityName => $ids) {
+        $idsByEntity[$entityName] = array_merge($idsByEntity[$entityName] ?? [], $ids);
+      }
+
+      foreach ($idsByEntity as $entityName => $ids) {
+        $displayInfo = $resolveDisplayInfo ? $this->getDisplayInfo($entityName, $ids) : [];
+        foreach ($ids as $entityId) {
+          $row = [
+            'tag_id' => $tagId,
+            // Non-DB-backed entities (e.g. Afform) have no real table -- fall back to the
+            // entity name itself, matching what getNonDbTaggedIds() already keys its result by.
+            'entity_table' => CoreUtil::getTableName($entityName) ?: $entityName,
+            'entity_type' => $entityName,
+            'entity_id' => $entityId,
+          ];
+          if ($resolveDisplayInfo) {
+            $row += $displayInfo[$entityId] ?? ['label' => '#' . $entityId, 'url' => NULL];
+          }
+          $rows[] = $row;
+        }
+      }
+    }
+    return $rows;
+  }
+
+  /**
+   * Resolve a display label + url for each id of a given entity type.
+   *
+   * @param string $entityName
+   * @param int[] $ids
+   * @return array<int, array{label: string, url: string|null}>
+   */
+  private function getDisplayInfo(string $entityName, array $ids): array {
+    $idField = CoreUtil::getIdFieldName($entityName);
+    $labelField = CoreUtil::getInfoItem($entityName, 'label_field') ?: $idField;
+    $paths = CoreUtil::getInfoItem($entityName, 'paths') ?? [];
+    $path = $paths['view'] ?? $paths['update'] ?? NULL;
+    try {
+      $records = civicrm_api4($entityName, 'get', [
+        'select' => array_unique([$idField, $labelField]),
+        'where' => [[$idField, 'IN', $ids]],
+        'checkPermissions' => FALSE,
+      ]);
+    }
+    catch (\CRM_Core_Exception $e) {
+      return [];
+    }
+    $info = [];
+    foreach ($records as $record) {
+      $info[$record[$idField]] = [
+        'label' => $record[$labelField] ?? ('#' . $record[$idField]),
+        'url' => $path ? \CRM_Utils_System::url(str_replace('[id]', $record[$idField], $path)) : NULL,
+      ];
+    }
+    return $info;
+  }
+
+  public static function fields() {
+    return [
+      [
+        'name' => 'tag_id',
+        'title' => 'Tag ID',
+        'description' => 'The tag this row is tagged with',
+        'data_type' => 'Integer',
+        'fk_entity' => 'Tag',
+      ],
+      [
+        'name' => 'entity_table',
+        'title' => 'Entity Table',
+        'description' => 'Table name, or the entity name itself for non-DB-backed entities',
+        'data_type' => 'String',
+      ],
+      [
+        'name' => 'entity_type',
+        'title' => 'Entity Type',
+        'description' => 'Api entity name of the tagged record',
+        'data_type' => 'String',
+      ],
+      [
+        'name' => 'entity_id',
+        'title' => 'Entity ID',
+        // Not always Integer - non-DB-backed entities can have a non-numeric primary key
+        // (e.g. Afform's is `name`), so this can't be declared as a fixed data_type without
+        // the output formatter coercing those values down to 0.
+        'description' => 'Id (or other unique identifier) of the tagged record',
+      ],
+      [
+        'name' => 'label',
+        'title' => 'Label',
+        'description' => 'Display label of the tagged record. Only resolved when selected.',
+        'data_type' => 'String',
+      ],
+      [
+        'name' => 'url',
+        'title' => 'URL',
+        'description' => 'Link to view/edit the tagged record, if the entity declares one. Only resolved when selected.',
+        'data_type' => 'String',
+      ],
+    ];
+  }
+
+}

--- a/Civi/Api4/Tag.php
+++ b/Civi/Api4/Tag.php
@@ -25,4 +25,13 @@ class Tag extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
   use Generic\Traits\HierarchicalEntity;
 
+  /**
+   * @param bool $checkPermissions
+   * @return Action\Tag\GetTaggedEntities
+   */
+  public static function getTaggedEntities($checkPermissions = TRUE) {
+    return (new Action\Tag\GetTaggedEntities(self::getEntityName(), __FUNCTION__))
+      ->setCheckPermissions($checkPermissions);
+  }
+
 }

--- a/ext/afform/core/Civi/Api4/Afform.php
+++ b/ext/afform/core/Civi/Api4/Afform.php
@@ -460,6 +460,8 @@ class Afform extends Generic\AbstractEntity {
   public static function getInfo() {
     $info = parent::getInfo();
     $info['primary_key'] = ['name'];
+    $info['label_field'] = 'title';
+    $info['paths'] = ['update' => 'civicrm/admin/afform#/edit/[id]'];
     return $info;
   }
 

--- a/ext/afform/core/afform.php
+++ b/ext/afform/core/afform.php
@@ -291,6 +291,31 @@ function afform_civicrm_alterMenu(&$items) {
 }
 
 /**
+ * Implements hook_civicrm_alterNonDbTaggableEntities().
+ *
+ * Afform's `tags` field stores tag names, not tag IDs, so this callback has to
+ * resolve the tag ID it's given back to a name before it can match against it.
+ */
+function afform_civicrm_alterNonDbTaggableEntities(&$entities) {
+  $entities['Afform'] = function($tagId) {
+    $tagName = \Civi\Api4\Tag::get(FALSE)
+      ->addWhere('id', '=', $tagId)
+      ->addSelect('name')
+      ->execute()->first()['name'] ?? NULL;
+    if (!$tagName) {
+      return [];
+    }
+    $afforms = (array) \Civi\Api4\Afform::get(FALSE)
+      ->addWhere('tags', 'CONTAINS', $tagName)
+      ->addSelect('name')
+      ->execute();
+    // Afform's primary key column is called `name`, not `id` - normalize to the
+    // generic `id` key the getTaggedEntities contract expects from every callback.
+    return array_map(fn($afform) => ['id' => $afform['name']], $afforms);
+  };
+}
+
+/**
  * Implements hook_civicrm_permission().
  *
  * Define Afform permissions.

--- a/templates/CRM/Tag/Page/Tag.tpl
+++ b/templates/CRM/Tag/Page/Tag.tpl
@@ -515,7 +515,11 @@
         {/literal}
       </div>
     <% {rdelim} %>
-    <div><span class="tdl">{ts}Usage Count:{/ts}</span> <%= data.usages %></div>
+    <div><span class="tdl">{ts}Usage Count:{/ts}</span>
+      {literal}<% if (data.usages) { %>{/literal}
+        <a href="{crmURL p="civicrm/tag/usage" q="tag_id="}<%= id %>" class="crm-popup" title="{ts escape='htmlattribute'}View tagged records{/ts}"><%= data.usages %></a>
+      {literal}<% } else { %><%= data.usages %><% } %>{/literal}
+    </div>
     <a class="clear-tag-selection" href="#" title="{ts escape='htmlattribute'}Clear selection{/ts}"><i class="crm-i fa-ban" role="img" aria-hidden="true"></i></a>
   </div>
   <div class="crm-submit-buttons">

--- a/templates/CRM/Tag/Page/Usage.tpl
+++ b/templates/CRM/Tag/Page/Usage.tpl
@@ -1,0 +1,18 @@
+{if empty($groups)}
+  <p>{ts 1=$tagLabel}No records are currently tagged "%1".{/ts}</p>
+{else}
+  {foreach from=$groups item=group}
+    <h3>{$group.title}</h3>
+    <ul class="crm-tag-usage-list">
+      {foreach from=$group.items item=item}
+        <li>
+          {if $item.url}
+            <a href="{$item.url}">{$item.label}</a>
+          {else}
+            {$item.label}
+          {/if}
+        </li>
+      {/foreach}
+    </ul>
+  {/foreach}
+{/if}

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -18,6 +18,7 @@
 
 namespace api\v4\Entity;
 
+use Civi\Api4\Afform;
 use Civi\Api4\Contact;
 use api\v4\Api4TestBase;
 use Civi\Api4\EntityTag;
@@ -29,6 +30,99 @@ use Civi\Test\TransactionalInterface;
  * @group headless
  */
 class TagTest extends Api4TestBase implements TransactionalInterface {
+
+  private $afformName = 'apiv4TagTestForm';
+
+  public function tearDown(): void {
+    Afform::revert(FALSE)->addWhere('name', '=', $this->afformName)->execute();
+    parent::tearDown();
+  }
+
+  public function testGetTaggedEntities(): void {
+    // Scoped to both a real DB-table entity (Contact, via EntityTag) and Afform,
+    // which has no EntityTag rows and is only reachable via the alterNonDbTaggableEntities
+    // hook - this exercises both code paths through a single tag.
+    $tag = Tag::create(FALSE)
+      ->addValue('name', uniqid('mixed'))
+      ->addValue('used_for', ['civicrm_contact', 'Afform'])
+      ->execute()->single();
+
+    $contact = Contact::create(FALSE)->execute()->single();
+    EntityTag::create(FALSE)
+      ->addValue('entity_id', $contact['id'])
+      ->addValue('entity_table', 'civicrm_contact')
+      ->addValue('tag_id', $tag['id'])
+      ->execute();
+
+    Afform::create(FALSE)
+      ->addValue('name', $this->afformName)
+      ->addValue('title', 'Tag Test Form')
+      ->addValue('tags', [$tag['name']])
+      ->execute();
+
+    $tagged = Tag::getTaggedEntities(FALSE)->addWhere('tag_id', '=', $tag['id'])->execute();
+    $this->assertCount(2, $tagged);
+    $byTable = $tagged->indexBy('entity_table');
+    $this->assertEquals($contact['id'], $byTable['civicrm_contact']['entity_id']);
+    $this->assertEquals($this->afformName, $byTable['Afform']['entity_id']);
+
+    // A tag scoped to Afform but with nothing actually tagged should come back empty,
+    // not error, and shouldn't pick up the other tag's Afform above.
+    $unusedTag = Tag::create(FALSE)
+      ->addValue('name', uniqid('unused'))
+      ->addValue('used_for', 'Afform')
+      ->execute()->single();
+    $this->assertCount(0, Tag::getTaggedEntities(FALSE)->addWhere('tag_id', '=', $unusedTag['id'])->execute());
+
+    // A nonexistent tag ID is an empty result, not an error.
+    $this->assertCount(0, Tag::getTaggedEntities(FALSE)->addWhere('tag_id', '=', $unusedTag['id'] + 999999)->execute());
+
+    // WHERE supports fetching more than one tag at once via IN, and applies additional
+    // filters (here entity_type) on top of the hook/EntityTag-sourced rows.
+    $multiTag = Tag::getTaggedEntities(FALSE)
+      ->addWhere('tag_id', 'IN', [$tag['id'], $unusedTag['id']])
+      ->addWhere('entity_type', '=', 'Afform')
+      ->execute();
+    $this->assertCount(1, $multiTag);
+    $this->assertEquals($this->afformName, $multiTag->first()['entity_id']);
+  }
+
+  public function testGetTaggedEntitiesResolvesLabelAndUrl(): void {
+    // Same mixed scenario as testGetTaggedEntities, but this checks the display-ready
+    // fields (resolved label/url per row) that only get computed when asked for via
+    // `select` -- the plain `entity_table`/`entity_id` shape doesn't pay for them.
+    $tag = Tag::create(FALSE)
+      ->addValue('name', uniqid('summary'))
+      ->addValue('used_for', ['civicrm_contact', 'Afform'])
+      ->execute()->single();
+
+    $contact = Individual::create(FALSE)
+      ->addValue('first_name', 'Rev')
+      ->addValue('last_name', 'Lookup')
+      ->execute()->single();
+    EntityTag::create(FALSE)
+      ->addValue('entity_id', $contact['id'])
+      ->addValue('entity_table', 'civicrm_contact')
+      ->addValue('tag_id', $tag['id'])
+      ->execute();
+
+    Afform::create(FALSE)
+      ->addValue('name', $this->afformName)
+      ->addValue('title', 'Tag Test Form')
+      ->addValue('tags', [$tag['name']])
+      ->execute();
+
+    $tagged = Tag::getTaggedEntities(FALSE)->addWhere('tag_id', '=', $tag['id'])->setSelect(['entity_type', 'label', 'url'])->execute();
+    $this->assertCount(2, $tagged);
+    $byType = $tagged->indexBy('entity_type');
+    $this->assertStringContainsString('Lookup', $byType['Contact']['label']);
+    $this->assertStringContainsString('cid=' . $contact['id'], $byType['Contact']['url']);
+    $this->assertEquals('Tag Test Form', $byType['Afform']['label']);
+    $this->assertStringContainsString('afform#/edit/' . $this->afformName, $byType['Afform']['url']);
+
+    // A nonexistent tag ID is an empty result, not an error.
+    $this->assertCount(0, Tag::getTaggedEntities(FALSE)->addWhere('tag_id', '=', $tag['id'] + 999999)->setSelect(['label', 'url'])->execute());
+  }
 
   public function testTagFilter(): void {
     // Ensure bypassing permissions works correctly by giving none to the logged-in user


### PR DESCRIPTION
Overview
----------------------------------------
Adds a way to answer "what is tagged with X?" across *all* taggable entities, including ones like Afform that aren't backed by a database table and so can't have `EntityTag` rows — and rebuilds the classic "Manage Tags" usage popup on top of it as a SearchKit-backed screen, replacing the old bespoke PHP+Smarty page.

<img width="1172" height="505" alt="image" src="https://github.com/user-attachments/assets/ddffd5cd-0e0b-468d-b671-8b3b99e12228" />

Before
----------------------------------------
`EntityTag` requires a real `entity_id` pointing at a table row. Afform is taggable (`Tag.used_for` includes `Afform`) but stores its tags as a plain array field inside each form's own file, not as `EntityTag` rows — deliberately, per the `filter=1` opt-out in `AfformTags.mgd.php`. That meant there was no way to go from a tag to "which forms have this tag" the way you could go from a tag to "which contacts have this tag" — and on `civicrm/tag`, a tag's "Usage Count" undercounted (or showed 0) if it was only applied to Afforms. The usage popup itself was a bespoke `CRM_Tag_Page_Usage` PHP page and Smarty template, hand-rolling the entity-type grouping.

After
----------------------------------------
A new `TaggedEntity` API4 entity (`@searchable primary`) returns every record tagged with a given tag (or tags): real `EntityTag` rows for table-backed entities, plus — via a new `alterNonDbTaggableEntities` hook — any file/non-table-backed entity that registers a callback for itself. Afform registers for this hook, so forms tagged in FormBuilder now show up in a reverse tag lookup alongside everything else. Because `TaggedEntity` is a normal, primary, `@searchable` entity, it's usable directly in SearchKit like any other entity — no special-casing needed.

That in turn let the classic `civicrm/tag/usage` popup be rebuilt as a small Afform embedding a SearchKit `list` display against a `TaggedEntity` SavedSearch, grouped into sections by `entity_type` via the `section_group_by` setting added in #36560 — reproducing the original grouped-by-type layout declaratively instead of in bespoke PHP. `CRM_Tag_Page_Usage` and its template are removed entirely. The tag tree's "Usage Count" on `civicrm/tag` now also includes non-DB entities in its count, and stays a clickable link to the same popup.

Technical Details
----------------------------------------
- `alterNonDbTaggableEntities(&$entities)` (new hook in `CRM_Utils_Hook`) lets an extension declare, for its own `filter=1` entity, a callback that fetches its tagged records given a tag ID.
- `CRM_Core_BAO_EntityTag::getNonDbTaggedIds($tagId, $onlyEntities = NULL)` invokes that hook directly, optionally scoped to a caller-supplied list of entity names — lets a caller who already knows a tag's `used_for` skip the (often several-query) callback for entities it doesn't apply to. This is the single shared implementation; nothing else re-invokes the hook independently.
- `Civi\Api4\TaggedEntity::get()` (`Civi\Api4\Action\TaggedEntity\Get`, extending `BasicGetAction`) combines real `EntityTag` rows with `getNonDbTaggedIds()`'s results into a flat list of `tag_id`/`entity_table`/`entity_type`/`entity_id` rows, filterable by `tag_id` (including `IN` for multiple tags at once) like any other `get` action's `where`. Selecting `label`/`url` additionally resolves a display label and (where the entity declares one) a link, generically via `CoreUtil::getInfoItem($entity, 'label_field'|'paths')` and `CoreUtil::getIdFieldName()` — the same pattern `CRM_Utils_Recent` uses, and one that works whether an entity's primary key is called `id` or something else (Afform's is `name`). Resolving those costs one extra `get` call per distinct entity type found, so it's only done when selected. A nonexistent `tag_id` is an empty result, not an error.
- Afform's implementation (`afform_civicrm_alterNonDbTaggableEntities` in `ext/afform/core/afform.php`) resolves the tag ID to its name (Afform stores tags by name, not ID — see `AfformTags::getTagOptions()`), then queries `Afform::get()->addWhere('tags', 'CONTAINS', $tagName)`. Afform's `getInfo()` now also declares `label_field`/`paths` so it resolves to a real title and edit link.
- `Civi\Api4\TaggedEntity` was originally two separate actions (`Tag.getTaggedEntities` and `Tag.getUsageSummary`) and a bespoke PHP consumer; per review feedback it's now a single, first-class `@searchable primary` entity so SearchKit can query it directly with the usual `select`/`where`/`orderBy`/`limit`, with no bespoke consumer code needed.
- New managed `SavedSearch`/`SearchDisplay` (`managed/tag/SavedSearch_Tagged_Entities.mgd.php`) targets `TaggedEntity`, filtered by `tag_id` from the route, with a `list` display grouped by `entity_type`. New `afsearchTagUsage.aff.*` Afform embeds that display at the same `civicrm/tag/usage` route and permission (`administer CiviCRM`/`manage tags`) the old page used.
- `CRM_Admin_Page_AJAX::getTagTree()`'s per-tag usage count adds `getNonDbTaggedIds()`'s counts (filtered to that tag's own `used_for`) to the existing `EntityTag.getcount` call.
- Depends on #36560 (merged) for the `section_group_by` display setting the new popup's grouping relies on.
- The SavedSearch's `select` includes `tag_id` even though no column renders it - `AbstractRunAction::applyFilters()` only allows a filter for a field that's in `select` (or an Afform-declared filter field), so without it the Afform's `filters="{tag_id: routeParams.tag_id}"` binding was silently dropped and the popup showed every tagged record in the system instead of just the requested tag's.
- Test coverage (`TagTest::testTaggedEntityGet`/`testTaggedEntityGetResolvesLabelAndUrl`): a tag scoped to both a real DB-table entity and Afform (exercising both the `EntityTag` path and the hook path through one call), an Afform-scoped tag with nothing tagged, a nonexistent tag ID, fetching multiple tags at once via `tag_id IN (...)` combined with an additional `entity_type` filter, and resolved labels/URLs for both a Contact and an Afform.

Comments
----------------------------------------
Manually verified in the browser: tagging both a Contact and an Afform with the same tag and opening `civicrm/tag/usage#?tag_id=N` returns exactly those two records via `TaggedEntity::get`, correctly resolved to their labels/URLs, and the popup itself renders only those two rows (this caught the `select`/`tag_id` filter bug above - before the fix it listed every tagged record in the database).

Not verified locally in this branch: the section headers themselves. This branch predates #36560 and hasn't been rebased onto current master, so soc3's checkout lacks the `section_group_by` support the "Grouped" display's settings rely on - the popup renders as a flat, ungrouped list here for that reason alone. Grouping is expected to work once this merges to master, where #36560 already lives; flagging in case a reviewer tests this branch as-is rather than after a rebase.
