### PR TITLE
Afform - Broadcast afFormPreSubmit event before building the submit request

### DIFF
--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -458,6 +458,9 @@
           }
           return;
         }
+        // Give elements (e.g. captcha widgets) a chance to write their
+        // current value into `data` before it's read for the API call.
+        $scope.$parent.$broadcast('afFormPreSubmit', data);
         $element.block();
         if (cancelDraftWatcher) {
           cancelDraftWatcher();


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new `afFormPreSubmit` event, broadcast by `afForm.component.js` immediately before it builds the `Afform.submit` API call. This lets independent Angular components (for example a third-party form element like a CAPTCHA widget) write a last-moment value into the form's data before it's read for submission, without needing to monkey-patch `ctrl.submit` itself.

This follows the same broadcast/listen pattern Afform already uses for `afFormReset` and `afIfDestroy` — a component broadcasts a lifecycle moment and unrelated field/element components can listen and react, with no direct coupling between them.

Before
----------------------------------------
There's no hook point between form validation passing and the `Afform.submit` API call being built from `data`. Extensions that need to write a fresh value at that exact moment (e.g. the `formprotection` extension's Cloudflare Turnstile / reCAPTCHA v2 widgets, which need to make sure their captcha token hasn't gone stale before it's read) have to work around this by monkey-patching `ctrl.afForm.submit` directly:

```js
var originalSubmit = ctrl.afForm.submit.bind(ctrl.afForm);
ctrl.afForm.submit = function() {
  syncTokenToExtra();
  return originalSubmit();
};
```

Without a real hook, e.g. Turnstile tokens can expire silently while a user is still filling out a long form, and the stale/empty token gets submitted.

After
----------------------------------------

afForm.component.js's submit() now does:
```js
$scope.$parent.$broadcast('afFormPreSubmit', data);
```

right after required-field validation passes and before $element.block() / the API call is built. Any component nested in the form can react without touching submit itself:

```js
$scope.$on('afFormPreSubmit', function() {
  var extra = ctrl.afForm.getData('extra');
  extra.recaptcha = currentTokenValue();
});
```

See this commit in the formprotection extension for a real usage example, switching its Turnstile and reCAPTCHA v2 widgets over to this event (keeping the old monkey-patch only as a fallback for cores without it yet).

Technical Details
----------------------------------------

- Broadcasts from $scope.$parent, matching the existing afFormReset broadcast in the same file — afForm has no template of its own, so $scope.$parent (not $scope) is the actual scope ancestor of the form's field/element components.
- Only fires from this.submit, not submitDraft — a captcha token generally shouldn't be required for a draft save.
- The event payload is the form's internal data object (the same object returned by getData()), so listeners can mutate it directly instead of needing to look anything up.
- Purely additive — no behavior changes for forms with nothing listening for it.

Comments
----------------------------------------

Prompted by work item #6, where a "pre-submit" hook was identified as needed for reCAPTCHA v3 support in FormBuilder. This also lets the existing Turnstile / reCAPTCHA v2 workaround in formprotection [!39](https://lab.civicrm.org/extensions/formprotection/-/merge_requests/39) drop its ctrl.afForm.submit monkey-patch in favour of listening for this event.