### PR TITLE
Tag - Support hierarchical drag-and-drop reordering via a weight column

### DIFF
--- a/CRM/Core/DAO/Tag.php
+++ b/CRM/Core/DAO/Tag.php
@@ -20,6 +20,7 @@
  * @property int|string|null $created_id
  * @property string|null $color
  * @property string|null $created_date
+ * @property int|string $weight
  */
 class CRM_Core_DAO_Tag extends CRM_Core_DAO_Base {
 }

--- a/CRM/Upgrade/Incremental/sql/6.19.alpha1.mysql.tpl
+++ b/CRM/Upgrade/Incremental/sql/6.19.alpha1.mysql.tpl
@@ -1,1 +1,3 @@
 {* file to handle db changes in 6.19.alpha1 during upgrade *}
+
+ALTER TABLE `civicrm_tag` ADD COLUMN `weight` int NOT NULL DEFAULT 0 COMMENT 'Ordering weight among sibling tags.';

--- a/Civi/Api4/Tag.php
+++ b/Civi/Api4/Tag.php
@@ -19,9 +19,13 @@ namespace Civi\Api4;
  * @see https://docs.civicrm.org/user/en/latest/organising-your-data/groups-and-tags/#tags
  * @searchable secondary
  * @since 5.19
+ * @orderBy weight
+ * @groupWeightsBy parent_id
  * @package Civi\Api4
  */
 class Tag extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
+  use Generic\Traits\HierarchicalEntity;
+  use Generic\Traits\SortableEntity;
 
 }

--- a/schema/Core/Tag.entityType.php
+++ b/schema/Core/Tag.entityType.php
@@ -139,6 +139,15 @@ return [
       'add' => '4.7',
       'default' => NULL,
     ],
+    'weight' => [
+      'title' => ts('Order'),
+      'sql_type' => 'int',
+      'input_type' => 'Number',
+      'required' => TRUE,
+      'description' => ts('Ordering weight among sibling tags.'),
+      'add' => '6.19',
+      'default' => 0,
+    ],
     'created_date' => [
       'title' => ts('Tag Created Date'),
       'sql_type' => 'datetime',


### PR DESCRIPTION
## Overview

`Tag` already supports a parent/child hierarchy (`parent_id`) but had no per-parent ordering, so a SearchKit hierarchical/draggable display had nothing to persist a drag-reorder against.

## Before

No `weight` column existed on `civicrm_tag`, and the `Tag` entity had no ordering annotations, so sibling tags had no stable, user-controllable order.

## After

Adds a `weight` column plus the `@orderBy`/`@groupWeightsBy` annotations and the `HierarchicalEntity`/`SortableEntity` traits already used by other self-referencing, orderable entities, scoping weight-based ordering to each tag's own group of siblings (via `parent_id`) rather than globally.

## Technical details

- `schema/Core/Tag.entityType.php`: new `weight` field (`int`, required, default `0`).
- `Civi/Api4/Tag.php`: `@orderBy weight`, `@groupWeightsBy parent_id`, `HierarchicalEntity` + `SortableEntity` traits.
- `CRM/Upgrade/Incremental/sql/6.19.alpha1.mysql.tpl`: `ALTER TABLE civicrm_tag ADD COLUMN weight ...` for existing installs.

## Comments
