### PR TITLE
dev/core#6684 - make utf8conversion work again on mariadb

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -864,6 +864,7 @@ MODIFY      {$columnName} varchar( $length )
         ];
       }
     }
+    $foreign_keys = self::dropNonNumericForeignKeys($databases);
     CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 0', [], TRUE, NULL, FALSE, FALSE);
     foreach ($tables as $table => $param) {
       $query = "ALTER TABLE $table";
@@ -912,6 +913,7 @@ MODIFY      {$columnName} varchar( $length )
       CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, FALSE);
     }
     CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 1', [], TRUE, NULL, FALSE, FALSE);
+    self::restoreNonNumericForeignKeys($foreign_keys);
     // Rebuild triggers and other schema reconciliation if needed.
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
@@ -1039,6 +1041,42 @@ MODIFY      {$columnName} varchar( $length )
       return substr($sqlType, $open + 1, -1);
     }
     return NULL;
+  }
+
+  /**
+   * Currency is odd in that we refer to it via string instead of an id, so
+   * the foreign key is a string. All other foreign keys use ids.
+   * This causes problems with alter table where it might end up with a
+   * mismatch, and in mariadb FOREIGN_KEY_CHECKS doesn't avoid it.
+   * @param array $databases
+   * @return array
+   */
+  private static function dropNonNumericForeignKeys(array $databases): array {
+    $keys = [];
+    foreach ($databases as $database) {
+      // The "AS" in the select is to avoid the situation where it might come back as a lower-case DAO property in php.
+      $dao = CRM_Core_DAO::executeQuery("SELECT CONSTRAINT_NAME AS CONSTRAINT_NAME, TABLE_NAME AS TABLE_NAME FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA=%1 AND REFERENCED_TABLE_NAME='civicrm_currency'", [1 => [$database, 'String']]);
+      while ($dao->fetch()) {
+        $keys[] = [
+          'name' => $dao->CONSTRAINT_NAME,
+          'table' => $dao->TABLE_NAME,
+          'database' => $database,
+        ];
+        CRM_Core_DAO::executeQuery("ALTER TABLE `$database`.`{$dao->TABLE_NAME}` DROP FOREIGN KEY `{$dao->CONSTRAINT_NAME}`");
+      }
+    }
+    return $keys;
+  }
+
+  /**
+   * @param array $keys
+   */
+  private static function restoreNonNumericForeignKeys(array $keys): void {
+    foreach ($keys as $key) {
+      // blech
+      $field = ($key['name'] == 'FK_civicrm_participant_fee_currency') ? 'fee_currency' : 'currency';
+      CRM_Core_DAO::executeQuery("ALTER TABLE `{$key['database']}`.`{$key['table']}` ADD CONSTRAINT `{$key['name']}` FOREIGN KEY (`$field`) REFERENCES `civicrm_currency` (`name`) ON DELETE SET NULL");
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
https://lab.civicrm.org/dev/core/-/work_items/6684
No longer working in 6.18+

Before
----------------------------------------
Crash about foreign key something something.

After
----------------------------------------
Messy, but runs.

Technical Details
----------------------------------------
In mariadb setting foreign_key_checks to 0 doesn't let you get around the temporary existence of inconsistent references, e.g. one using ut8mb3 but the field is utf8mb4. You have to drop the key before altering the charset.

For I assume historical reasons currency is the only one where we don't use an integer id and use a string, so that's why it's coming up now.

Since the tests run on mysql, the tests won't tell much here.

Comments
----------------------------------------
I'm not crazy about this solution. Ideally it would be a generic lookup for any non-numeric keys and use the metadata to recreate them after.