### PR TITLE
Tag - Use HierarchicalEntity for parent/child grouping in SearchKit displays

### DIFF
--- a/Civi/Api4/Tag.php
+++ b/Civi/Api4/Tag.php
@@ -23,5 +23,6 @@ namespace Civi\Api4;
  */
 class Tag extends Generic\DAOEntity {
   use Generic\Traits\ManagedEntity;
+  use Generic\Traits\HierarchicalEntity;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adds parent/child grouping for `Tag` in SearchKit hierarchical displays.

Before
----------------------------------------
`Tag` supports a `parent_id` hierarchy, but had no way for a SearchKit `hierarchical` display to compute nesting depth, so it couldn't render Tag rows nested like `Group` already does.

After
----------------------------------------
`Tag` now uses the `HierarchicalEntity` trait, so a `hierarchical: true` display can render Tag's parent/child rows nested with expand/collapse.

Technical Details
----------------------------------------
- `Civi\Api4\Tag` adds `use Generic\Traits\HierarchicalEntity;` alongside its existing `ManagedEntity` trait.

Comments
----------------------------------------
