### PR TITLE
SearchKit - Add a Color field type to the bulk-edit task's input

### DIFF
--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/color.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/color.html
@@ -1,0 +1,4 @@
+<div class="form-group">
+  <input type="color" ng-model="$ctrl.value" style="width: 2.6em; height: 2.1em; padding: 2px; vertical-align: middle;" id="{{:: $ctrl.labelId }}">
+  <input type="text" class="form-control" ng-model="$ctrl.value" style="width: 6.5em; display: inline-block; margin-left: 4px; vertical-align: middle;" placeholder="#rrggbb" ng-pattern="/^#[0-9a-fA-F]{6}$/">
+</div>

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -150,6 +150,10 @@
           return '~/crmSearchTasks/crmSearchInput/boolean.html';
         }
 
+        if (field.input_type === 'Color') {
+          return '~/crmSearchTasks/crmSearchInput/color.html';
+        }
+
         if (!['>', '<', '>=', '<='].includes(ctrl.op)) {
           // Only use option list if the field has a "name" suffix
           if (field.options && (!field.suffixes || field.suffixes.includes('name'))) {


### PR DESCRIPTION
Overview
----------------------------------------
Adds a native color picker for fields declared as `input_type: 'Color'`, everywhere SearchKit renders an editable input for a field value — the generic bulk-edit "Update" task and inline in-place cell editing on a table display alike, since both go through the same shared input component.

https://github.com/user-attachments/assets/03cf3107-f6f7-44a3-84a2-3eaa54ad2a72

<img width="1248" height="903" alt="download" src="https://github.com/user-attachments/assets/5d598e97-27bc-4e67-b581-7767020b5e00" />

<img width="1248" height="903" alt="download" src="https://github.com/user-attachments/assets/00f9c651-1b8f-48bf-9a15-98a476a22e3e" />

Before
----------------------------------------
Both the "Update" bulk task and inline cell editing can already edit any field on any entity, but had no dedicated input for a Color-typed field — it fell through to a plain text box, requiring users to know or type a hex value by hand.

After
----------------------------------------
A Color-typed field now renders a native `<input type="color">` picker paired with a hex textbox (`#rrggbb`), kept in sync with each other, following the same pattern as the existing boolean/select input partials.

Technical Details
----------------------------------------
- `crmSearchInputVal.component.js` routes `input_type === 'Color'` to a new `~/crmSearchTasks/crmSearchInput/color.html` partial, alongside the existing boolean/select routing.
- `color.html` is a plain `ng-model`-bound `<input type="color">` next to a text input constrained with `ng-pattern="/^#[0-9a-fA-F]{6}$/"`.
- This one component is shared by both editing paths: the bulk "Update" task's `crmSearchInput` and inline in-place cell editing's `crmSearchDisplayEditable` both render through `<crm-search-input>` → `<crm-search-input-val>`, so this fix applies to both without any extra wiring.
- No entity currently declares `input_type: 'Color'` ite for a follow-up PR making `Tag.color` use it.

Comments
----------------------------------------
Verified in the browser by temporarily marking `Tag.color` as `input_type: 'Color'`: the picker + hex textbox render and stay in sync both in the "Update" bulk task dialog and in an inline-edit table cell (screenshots attached).