### PR TITLE
dev/core#6684 - Fix Utf8Mb4 conversion on MariaDB

### DIFF
--- a/CRM/Core/BAO/SchemaHandler.php
+++ b/CRM/Core/BAO/SchemaHandler.php
@@ -864,6 +864,18 @@ MODIFY      {$columnName} varchar( $length )
         ];
       }
     }
+
+    $schemaHelper = \Civi::schemaHelper();
+
+    // Drop non-numeric foreign keys. See dev/core#6684
+    // In MariaDB, ALTER TABLE statements that change charset/collation on a column used
+    // in a foreign key constraint fail if the referenced table/column is still on the old
+    // collation, even when FOREIGN_KEY_CHECKS = 0.
+    $nonNumericForeignKeys = self::getNonNumericForeignKeys();
+    foreach ($nonNumericForeignKeys as $key) {
+      $schemaHelper->dropForeignKey($key['table'], $key['name']);
+    }
+
     CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 0', [], TRUE, NULL, FALSE, FALSE);
     foreach ($tables as $table => $param) {
       $query = "ALTER TABLE $table";
@@ -912,6 +924,12 @@ MODIFY      {$columnName} varchar( $length )
       CRM_Core_DAO::executeQuery($query, $params, TRUE, NULL, FALSE, FALSE);
     }
     CRM_Core_DAO::executeQuery('SET FOREIGN_KEY_CHECKS = 1', [], TRUE, NULL, FALSE, FALSE);
+
+    // Restore non-numeric foreign keys
+    foreach ($nonNumericForeignKeys as $key) {
+      $schemaHelper->createForeignKey($key['table'], $key['field'], $key['spec']);
+    }
+
     // Rebuild triggers and other schema reconciliation if needed.
     $logging = new CRM_Logging_Schema();
     $logging->fixSchemaDifferences();
@@ -1039,6 +1057,39 @@ MODIFY      {$columnName} varchar( $length )
       return substr($sqlType, $open + 1, -1);
     }
     return NULL;
+  }
+
+  /**
+   * Get metadata for all non-numeric foreign keys across core and active extensions.
+   *
+   * @return array
+   */
+  public static function getNonNumericForeignKeys(): array {
+    $keys = [];
+    foreach (\Civi\Schema\EntityRepository::getEntities() as $entityName => $entity) {
+      if (empty($entity['table'])) {
+        continue;
+      }
+      foreach (\Civi::entity($entityName)->getFields() as $fieldName => $fieldSpec) {
+        $ref = $fieldSpec['entity_reference'] ?? NULL;
+        if (empty($ref['entity']) || empty($ref['key']) || ($ref['fk'] ?? TRUE) === FALSE) {
+          continue;
+        }
+        $refFieldSpec = \Civi::entity($ref['entity'])->getField($ref['key']);
+        if (!$refFieldSpec || in_array(CRM_Utils_Schema::getDataType($refFieldSpec), ['Integer', 'Float', 'Money'])) {
+          continue;
+        }
+
+        $tableName = $entity['table'];
+        $keys[] = [
+          'table' => $tableName,
+          'field' => $fieldName,
+          'name' => 'FK_' . self::getIndexName($tableName, $fieldName),
+          'spec' => $fieldSpec,
+        ];
+      }
+    }
+    return $keys;
   }
 
 }

--- a/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
+++ b/tests/phpunit/CRM/Core/BAO/SchemaHandlerTest.php
@@ -411,4 +411,29 @@ class CRM_Core_BAO_SchemaHandlerTest extends CiviUnitTestCase {
     $this->assertEquals('ALTER TABLE civicrm_contact DROP COLUMN `big_bob`', trim($sql));
   }
 
+  /**
+   * Tests lookup of non-numeric foreign keys.
+   */
+  public function testGetNonNumericForeignKeys(): void {
+    $keys = CRM_Core_BAO_SchemaHandler::getNonNumericForeignKeys();
+    $keysByName = array_column($keys, NULL, 'name');
+
+    $this->assertArrayHasKey('FK_civicrm_contribution_currency', $keysByName);
+    $this->assertEquals('civicrm_contribution', $keysByName['FK_civicrm_contribution_currency']['table']);
+    $this->assertEquals('currency', $keysByName['FK_civicrm_contribution_currency']['field']);
+    $this->assertEquals('Currency', $keysByName['FK_civicrm_contribution_currency']['spec']['entity_reference']['entity']);
+    $this->assertEquals('name', $keysByName['FK_civicrm_contribution_currency']['spec']['entity_reference']['key']);
+    $this->assertEquals('SET NULL', $keysByName['FK_civicrm_contribution_currency']['spec']['entity_reference']['on_delete']);
+
+    $this->assertArrayHasKey('FK_civicrm_participant_fee_currency', $keysByName);
+    $this->assertEquals('civicrm_participant', $keysByName['FK_civicrm_participant_fee_currency']['table']);
+    $this->assertEquals('fee_currency', $keysByName['FK_civicrm_participant_fee_currency']['field']);
+    $this->assertEquals('Currency', $keysByName['FK_civicrm_participant_fee_currency']['spec']['entity_reference']['entity']);
+    $this->assertEquals('name', $keysByName['FK_civicrm_participant_fee_currency']['spec']['entity_reference']['key']);
+    $this->assertEquals('SET NULL', $keysByName['FK_civicrm_participant_fee_currency']['spec']['entity_reference']['on_delete']);
+
+    // Numeric foreign keys should not be included.
+    $this->assertArrayNotHasKey('FK_civicrm_contribution_contact_id', $keysByName);
+  }
+
 }

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -87,16 +87,18 @@ class api_v3_SystemTest extends CiviUnitTestCase {
    */
   public function testSystemUTFMB8Conversion(): void {
     if (version_compare(CRM_Utils_SQL::getDatabaseVersion(), '5.7', '>=')) {
-      $this->callAPISuccess('System', 'utf8conversion', []);
-      $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');
-      $table->fetch();
-      $this->assertStringEndsWith('DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', $table->Create_Table);
-
+      // 1. Revert schema to Utf8mb3
       $this->callAPISuccess('System', 'utf8conversion', ['is_revert' => 1]);
       $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');
       $table->fetch();
       // "utf8" are "utf8mb3" synonymous, but the canonical form gets flipfloppy depending on the specific versions of MySQL/MariaDB.
       $this->assertMatchesRegularExpression(';DEFAULT CHARSET=utf8(mb3)? COLLATE=utf8(mb3)?_unicode_ci ROW_FORMAT=DYNAMIC;', $table->Create_Table);
+
+      // 2. Upgrade schema to Utf8mb4
+      $this->callAPISuccess('System', 'utf8conversion', []);
+      $table = CRM_Core_DAO::executeQuery('SHOW CREATE TABLE civicrm_contact');
+      $table->fetch();
+      $this->assertStringEndsWith('DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC', $table->Create_Table);
     }
     else {
       $this->markTestSkipped('MySQL Version does not support ut8mb4 testing');


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6684](https://lab.civicrm.org/dev/core/-/work_items/6684)

This replaces PR #36509

Technical Details
----------------------------------------
In MariaDB, `ALTER TABLE` statements that change charset/collation on a column used in a foreign key constraint fail if the referenced table/column is still on the old collation, even when `FOREIGN_KEY_CHECKS = 0`.

See https://mariadb.com/docs/server/reference/error-codes/mariadb-error-codes-1800-to-1899/e1832

While I was testing this I also flipped around `testSystemUTFMB8Conversion()` to reflect the current status-quo - now the starting and ending point of the test are both MB4 rather than MB3.