### PR TITLE
Change case start date's datatype to datetime to allow entering a time for open case in formbuilder/api4

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixTwenty.php
+++ b/CRM/Upgrade/Incremental/php/SixTwenty.php
@@ -30,6 +30,55 @@ class CRM_Upgrade_Incremental_php_SixTwenty extends CRM_Upgrade_Incremental_Base
   public function upgrade_6_20_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Install Order Completion Metadata entity', 'createEntityTable', '6.20.alpha1.OrderCompletionMetadata.entityType.php');
+    $this->addTask('Change case start date from date to datetime', 'alterSchemaField', 'Case', 'start_date', [
+      'title' => ts('Case Start Date'),
+      'sql_type' => 'datetime',
+      'input_type' => 'Select Date',
+      'description' => ts('Date on which given case starts.'),
+      'default' => 'CURRENT_TIMESTAMP',
+      'add' => '1.8',
+    ]);
+
+    $this->addTask('Add time to existing cases based on time of open case activity ', 'backFillCaseStartTime');
+  }
+
+  /**
+   * Backfill case start time.
+   *
+   * We are changing the case start_date from a date to a datetime field. This
+   * query uses the time from any open case activities to back fill the time
+   * for previously created cases, but only if the date matches.
+   *
+   */
+  public static function backFillCaseStartTime(CRM_Queue_TaskContext $ctx): bool {
+    $sql = "SELECT ov.value AS value
+      FROM
+        civicrm_option_value ov INNER JOIN civicrm_option_group og ON (ov.option_group_id = og.id AND og.name = 'activity_type')
+      WHERE ov.name = 'Open Case'";
+
+    $dao = \CRM_Core_DAO::executeQuery($sql);
+    $dao->fetch();
+    $activityTypeId = $dao->value;
+    if (!$activityTypeId) {
+      // Maybe cases are not enabled?
+      return TRUE;
+    }
+
+    $sql = "
+      UPDATE civicrm_case c
+        JOIN civicrm_case_activity ca ON c.id = ca.case_id
+        JOIN civicrm_activity a ON ca.activity_id = a.id
+      SET
+        c.start_date = a.activity_date_time
+      WHERE
+        DATE(a.activity_date_time) = DATE(c.start_date) AND
+        a.is_deleted = 0 AND
+        a.activity_type_id = %0
+    ";
+    $params = [0 => [$activityTypeId, "Integer"]];
+    \CRM_Core_DAO::executeQuery($sql, $params);
+
+    return TRUE;
   }
 
 }

--- a/schema/Case/Case.entityType.php
+++ b/schema/Case/Case.entityType.php
@@ -88,7 +88,7 @@ return [
     ],
     'start_date' => [
       'title' => ts('Case Start Date'),
-      'sql_type' => 'date',
+      'sql_type' => 'datetime',
       'input_type' => 'Select Date',
       'description' => ts('Date on which given case starts.'),
       'add' => '1.8',
@@ -99,8 +99,9 @@ return [
         'duplicate_matching',
       ],
       'input_attrs' => [
-        'format_type' => 'activityDate',
+        'format_type' => 'activityDateTime',
       ],
+      'default' => 'CURRENT_TIMESTAMP',
     ],
     'end_date' => [
       'title' => ts('Case End Date'),

--- a/templates/CRM/Case/Audit/Report.tpl
+++ b/templates/CRM/Case/Audit/Report.tpl
@@ -33,7 +33,7 @@
       <td class="crm-case-report-clientName">{$case.clientName}</td>
       <td class="crm-case-report-caseType">{$case.caseType}</td>
       <td class="crm-case-report-status">{$case.status}</td>
-      <td class="crm-case-report-start_date">{$case.start_date}</td>
+      <td class="crm-case-report-start_date">{$case.start_date|crmDate:"Full"}</td>
       <td class="crm-case-report-{$caseId}">{$caseId}</td>
     </tr>
   </table>

--- a/templates/CRM/Case/Form/CaseView.tpl
+++ b/templates/CRM/Case/Form/CaseView.tpl
@@ -76,7 +76,7 @@
         <span class="crm-case-summary-label">{ts}Status{/ts}:</span>&nbsp;{$caseDetails.case_status}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactID`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStatusId`"}" title="{ts escape='htmlattribute'}Change case status (creates activity record){/ts}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i></a>
       </td>
       <td class="crm-case-caseview-case_start_date label">
-        <span class="crm-case-summary-label">{ts}Open Date{/ts}:</span>&nbsp;{$caseDetails.case_start_date|crmDate}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactID`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStartDateId`"}" title="{ts escape='htmlattribute'}Change case start date (creates activity record){/ts}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i></a>
+        <span class="crm-case-summary-label">{ts}Open Date{/ts}:</span>&nbsp;{$caseDetails.case_start_date|crmDate:"Full"}&nbsp;<a class="crm-hover-button crm-popup"  href="{crmURL p='civicrm/case/activity' q="action=add&reset=1&cid=`$contactID`&caseid=`$caseId`&selectedChild=activity&atype=`$changeCaseStartDateId`"}" title="{ts escape='htmlattribute'}Change case start date (creates activity record){/ts}"><i class="crm-i fa-pencil" role="img" aria-hidden="true"></i></a>
       </td>
       <td class="crm-case-caseview-{$caseID} label">
         <span class="crm-case-summary-label">{ts}ID{/ts}:</span>&nbsp;{$caseID}

--- a/tests/phpunit/CRM/Case/Form/ChangeStartDateTest.php
+++ b/tests/phpunit/CRM/Case/Form/ChangeStartDateTest.php
@@ -23,7 +23,7 @@ class CRM_Case_Form_ChangeStartDateTest extends CiviCaseTestCase {
     $_GET['action'] = $_REQUEST['action'] = 'add';
 
     // set new start date to 2 days ago
-    $new_start_date = date('Y-m-d', strtotime('2 days ago'));
+    $new_start_date = date('Y-m-d H:i:s', strtotime('2 days ago'));
 
     $form = $this->getFormObject('CRM_Case_Form_Activity', [
       'activity_type_id' => $activity_type_id,
@@ -64,7 +64,7 @@ class CRM_Case_Form_ChangeStartDateTest extends CiviCaseTestCase {
       'activity_type_id' => 'Open Case',
       'return' => ['activity_date_time'],
     ]);
-    $this->assertEquals($new_start_date . ' 00:00:00', $result['activity_date_time']);
+    $this->assertEquals($new_start_date, $result['activity_date_time']);
   }
 
 }

--- a/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
+++ b/tests/phpunit/CRM/Case/XMLProcessor/ReportTest.php
@@ -146,7 +146,7 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
           'case' => [
             'clientName' => 'Casey Reportee',
             'subject' => 'Case Subject',
-            'start_date' => '2019-11-14',
+            'start_date' => '2019-11-14 00:00:00',
             'end_date' => NULL,
             'caseType' => 'Housing Support',
             'caseTypeName' => 'housing_support',
@@ -307,7 +307,7 @@ class CRM_Case_XMLProcessor_ReportTest extends CiviCaseTestCase {
           'case' => [
             'clientName' => 'Casey Reportee',
             'subject' => 'Case Subject',
-            'start_date' => '2019-11-14',
+            'start_date' => '2019-11-14 00:00:00',
             'end_date' => NULL,
             'caseType' => 'Housing Support',
             'caseTypeName' => 'housing_support',

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -94,7 +94,7 @@ class CRM_Utils_TokenConsistencyTest extends CiviUnitTestCase {
     return 'case.id :1
 case.case_type_id:label :Housing Support
 case.subject :Case Subject
-case.start_date :July 23rd, 2021
+case.start_date :' . CRM_Utils_Date::customFormat($this->case['start_date']) . '
 case.end_date :July 26th, 2021
 case.details :case details
 case.status_id:label :Ongoing


### PR DESCRIPTION
Overview
----------------------------------------
When creating a case via the New Case form, the start date has both a date and a time element, which defaults to the current date and time. This allows you to specify a time which will be reflected in the activities in the default time line.

However, when creating a case from Apiv4 or from Form Builder, the case start date only offers the date field, not the time field. As a result, the activities that are created as part of the time line, all have 12:00 am as the time.

This patch automatically sets the time to the current time if no time is provided.

Before
----------------------------------------

When creating a case from form builder, we get the time set to 12:00 am:

<img width="845" height="307" alt="image" src="https://github.com/user-attachments/assets/2af19324-5d3c-47b7-b303-d525435e3b25" />

After
----------------------------------------

We get the time that the case was created:

<img width="801" height="274" alt="image" src="https://github.com/user-attachments/assets/80114012-8d37-4719-b51a-c9345c49dfa2" />


Comments
----------------------------------------
Would it be better to change the case start date to a date time field instead?
