### PR TITLE
Tag - Add a color picker default and show who created a tag

### DIFF
--- a/CRM/Tag/Form/Edit.php
+++ b/CRM/Tag/Form/Edit.php
@@ -122,6 +122,10 @@ class CRM_Tag_Form_Edit extends CRM_Admin_Form {
         $isReserved->freeze();
       }
       $this->assign('adminReservedTags', $adminReservedTags);
+
+      $createdId = $this->_id ? ($this->_values['created_id'] ?? NULL) : NULL;
+      $this->assign('createdDate', $this->_id ? ($this->_values['created_date'] ?? NULL) : NULL);
+      $this->assign('createdByName', $createdId ? CRM_Contact_BAO_Contact::displayName($createdId) : NULL);
     }
     $this->setPageTitle($this->_isTagSet ? ts('Tag Set') : ts('Tag'));
     parent::buildQuickForm();
@@ -145,7 +149,7 @@ class CRM_Tag_Form_Edit extends CRM_Admin_Form {
       $defaults = $this->_values;
     }
     if (empty($defaults['color'])) {
-      $defaults['color'] = '#ffffff';
+      $defaults['color'] = $this->_action == CRM_Core_Action::ADD ? CRM_Utils_Color::getRandomColor() : '#ffffff';
     }
     if (empty($this->_id) && empty($defaults['used_for'])) {
       $defaults['used_for'] = 'civicrm_contact';

--- a/CRM/Utils/Color.php
+++ b/CRM/Utils/Color.php
@@ -138,4 +138,52 @@ class CRM_Utils_Color {
     return FALSE;
   }
 
+  /**
+   * Generate a random but legible color (fixed saturation/lightness, random hue).
+   *
+   * @return string
+   */
+  public static function getRandomColor(): string {
+    return self::rgbToHex(self::hslToRgb(mt_rand(0, 359) / 360, 0.55, 0.5));
+  }
+
+  /**
+   * @param float $h Hue, 0-1
+   * @param float $s Saturation, 0-1
+   * @param float $l Lightness, 0-1
+   * @return int[] [r, g, b], each 0-255
+   */
+  public static function hslToRgb(float $h, float $s, float $l): array {
+    if ($s == 0) {
+      $r = $g = $b = $l;
+    }
+    else {
+      $q = $l < 0.5 ? $l * (1 + $s) : $l + $s - $l * $s;
+      $p = 2 * $l - $q;
+      $r = self::hueToRgb($p, $q, $h + 1 / 3);
+      $g = self::hueToRgb($p, $q, $h);
+      $b = self::hueToRgb($p, $q, $h - 1 / 3);
+    }
+    return [(int) round($r * 255), (int) round($g * 255), (int) round($b * 255)];
+  }
+
+  private static function hueToRgb(float $p, float $q, float $t): float {
+    if ($t < 0) {
+      $t += 1;
+    }
+    if ($t > 1) {
+      $t -= 1;
+    }
+    if ($t < 1 / 6) {
+      return $p + ($q - $p) * 6 * $t;
+    }
+    if ($t < 1 / 2) {
+      return $q;
+    }
+    if ($t < 2 / 3) {
+      return $p + ($q - $p) * (2 / 3 - $t) * 6;
+    }
+    return $p;
+  }
+
 }

--- a/schema/Core/Tag.entityType.php
+++ b/schema/Core/Tag.entityType.php
@@ -134,7 +134,7 @@ return [
     'color' => [
       'title' => ts('Color'),
       'sql_type' => 'varchar(255)',
-      'input_type' => 'Text',
+      'input_type' => 'Color',
       'description' => ts('Hex color value e.g. #ffffff'),
       'add' => '4.7',
       'default' => NULL,

--- a/templates/CRM/Tag/Form/Edit.tpl
+++ b/templates/CRM/Tag/Form/Edit.tpl
@@ -38,7 +38,9 @@
       {if !empty($form.color.html)}
         <tr class="crm-tag-form-block-color">
           <td class="label">{$form.color.label}</td>
-          <td>{$form.color.html}</td>
+          <td>{$form.color.html}
+            <input type="text" id="color_hex" class="crm-form-text" placeholder="#rrggbb" pattern="^#[0-9a-fA-F]{ldelim}6{rdelim}$" style="width: 6.5em; display: inline-block; margin-left: 4px;" />
+          </td>
         </tr>
       {/if}
         <tr class="crm-tag-form-block-is_reserved">
@@ -51,6 +53,12 @@
              <td class="label">{$form.is_selectable.label}</td>
              <td>{$form.is_selectable.html}<br /><span class="description">{ts}Defines if you can select this tag.{/ts}
              </td>
+          </tr>
+        {/if}
+        {if $createdDate}
+          <tr class="crm-tag-form-block-created">
+             <td class="label">{ts}Created{/ts}</td>
+             <td>{$createdDate|crmDate}{if $createdByName} {ts 1=$createdByName}by %1{/ts}{/if}</td>
           </tr>
         {/if}
     </table>
@@ -71,6 +79,20 @@
       }
     }
     $('input[name=parent_id]', $form).change(toggleUsedFor).each(toggleUsedFor);
+
+    // Keep the native color picker and its hex text mirror in sync, matching the
+    // picker+hex combo SearchKit's bulk-edit/inline-edit inputs already use for Color fields.
+    var $colorPicker = $('input#color', $form),
+      $colorHex = $('#color_hex', $form);
+    $colorHex.val($colorPicker.val());
+    $colorPicker.on('input change', function() {
+      $colorHex.val(this.value);
+    });
+    $colorHex.on('input change', function() {
+      if (/^#[0-9a-fA-F]{6}$/.test(this.value)) {
+        $colorPicker.val(this.value);
+      }
+    });
   });
 </script>
 {/literal}


### PR DESCRIPTION
Overview
----------------------------------------
Gives new tags a random, legible default color instead of plain white, shows who created an existing tag and when, and switches `Tag.color`'s schema `input_type` to `Color` so SearchKit renders it with a proper picker. Built on #36513 (merged), which teaches SearchKit's editable inputs to render a color picker for `input_type: 'Color'`.

<img width="1735" height="725" alt="image" src="https://github.com/user-attachments/assets/8cc6b212-5dd4-4c3b-8388-e1275b31b1b4" />


Before
----------------------------------------
A newly-created tag always defaulted its color to `#ffffff`, so every uncustomized tag looked identical until someone manually picked a color. The edit popup also had no record of when or by whom an existing tag was created, even though `created_date`/`created_id` were already being collected.

After
----------------------------------------
A new tag now defaults to a random but legible color (fixed saturation/lightness, random hue) instead of white. Editing an existing tag shows a read-only "Created" row with the date and, if known, who created it. `Tag.color`'s schema `input_type` changes from `Text` to `Color`, so SearchKit's inline-editable grid columns and bulk-edit "Update" task render it with a color picker rather than a plain text box (per #36513).

Technical Details
----------------------------------------
- `CRM_Tag_Form_Edit::setDefaultValues()` calls a new `getRandomColor()` only when adding (`CRM_Core_Action::ADD`) and no color is already set; editing an existing tag with no color still falls back to white rather than picking a fresh random one on every edit.
- `getRandomColor()`/`hslToRgb()`/`hueToRgb()` generate the color via HSL with fixed saturation (0.55) and lightness (0.5) and a random hue, converted to hex — avoids the muddy or unreadable colors a fully random RGB pick could produce.
- `buildQuickForm()` assigns `createdDate`/`createdByName` (via `CRM_Contact_BAO_Contact::displayName()`) only when editing an existing tag (`$this->_id`); `Edit.tpl` renders them as a read-only "Created" row, following the same conditional-row pattern as the existing reserved-tag notice above it.
- `schema/Core/Tag.entityType.php`: `color`'s `input_type` changes from `Text` to `Color`.

Comments
----------------------------------------
Builds on #36513 (merged) for the input_type change to have visible effect.