### PR TITLE
Afform - implement BETWEEN/NOT BETWEEN operators for conditional rules

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -27,6 +27,8 @@
         'NOT CONTAINS': ts("Doesn't Contain"),
         'IN': ts('Is One Of'),
         'NOT IN': ts('Not One Of'),
+        'BETWEEN': ts('Is Between'),
+        'NOT BETWEEN': ts('Not Between'),
         'LIKE': ts('Is Like'),
         'NOT LIKE': ts('Not Like'),
         'IS EMPTY': ts('Is Empty'),
@@ -74,6 +76,25 @@
           setValue(val);
         }
         return getValue();
+      };
+
+      // Getter/setter for one side of a BETWEEN/NOT BETWEEN range, for use with ng-model
+      function getSetValueAt(index) {
+        return function(val) {
+          if (arguments.length) {
+            const newVal = Array.isArray(getValue()) ? getValue().slice() : ['', ''];
+            newVal[index] = val;
+            setValue(newVal);
+          }
+          const currentVal = getValue();
+          return Array.isArray(currentVal) ? currentVal[index] : undefined;
+        };
+      }
+      this.getSetValueAt0 = getSetValueAt(0);
+      this.getSetValueAt1 = getSetValueAt(1);
+
+      this.isBetween = function() {
+        return ['BETWEEN', 'NOT BETWEEN'].includes(getOperator());
       };
 
       // Return a list of operators allowed for the current field
@@ -129,11 +150,15 @@
             ctrl.clause.push('');
           }
           // Change multi/single value to/from an array
-          const shouldBeArray = ['IN', 'NOT IN'].includes(getOperator());
+          const shouldBeArray = ['IN', 'NOT IN', 'BETWEEN', 'NOT BETWEEN'].includes(getOperator());
           if (!Array.isArray(getValue()) && shouldBeArray) {
             setValue([]);
           } else if (Array.isArray(getValue()) && !shouldBeArray) {
             setValue('');
+          }
+          // BETWEEN/NOT BETWEEN always take exactly 2 values
+          if (ctrl.isBetween() && getValue().length !== 2) {
+            setValue([getValue()[0] || '', getValue()[1] || '']);
           }
         }
       };

--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
@@ -1,6 +1,11 @@
 <select class="form-control api4-operator" ng-model="$ctrl.clause[$ctrl.offset]" ng-change="$ctrl.changeClauseOperator()" >
   <option ng-repeat="(name, label) in $ctrl.getOperators()" value="{{:: name }}">{{:: label }}</option>
 </select>
-<div class="form-group" ng-if="$ctrl.operatorTakesInput()">
+<div class="form-group" ng-if="$ctrl.operatorTakesInput() && !$ctrl.isBetween()">
   <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValue" op="$ctrl.clause[$ctrl.offset]" ng-model-options="{getterSetter: true}" class="form-control">
+</div>
+<div class="form-group" ng-if="$ctrl.isBetween()">
+  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValueAt0" op="'&gt;'" ng-model-options="{getterSetter: true}" class="form-control">
+  -
+  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValueAt1" op="'&lt;'" ng-model-options="{getterSetter: true}" class="form-control">
 </div>

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -315,6 +315,13 @@
             }
             return angular.equals(val1, val2) === yes;
 
+          case 'BETWEEN':
+          case 'NOT BETWEEN':
+            if (Array.isArray(val2) && val2.length === 2) {
+              return (val1 >= val2[0] && val1 <= val2[1]) === yes;
+            }
+            return false;
+
           case 'LIKE':
           case 'NOT LIKE':
             if (typeof val1 === 'string' && typeof val2 === 'string') {

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -189,6 +189,55 @@ EOHTML;
   }
 
   /**
+   * Required field based on a Date field falling within a BETWEEN range
+   */
+  public function testConditionalRequiredFieldBetweenDates(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="birth_date" />
+    <af-field name="last_name" af-required="([[&amp;quot;Individual1[0][fields][birth_date]&amp;quot;,&amp;quot;BETWEEN&amp;quot;,&amp;quot;[\&amp;quot;2026-01-01\&amp;quot;,\&amp;quot;2026-12-31\&amp;quot;]&amp;quot;]])" defn="{required: false, input_attrs: {}}" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Dynamic rule is that last_name is required if birth_date is between 2026-01-01 and 2026-12-31
+
+    // birth_date within range, last_name empty -> should fail
+    $submission = [
+      ['fields' => ['first_name' => 'A', 'birth_date' => '2026-06-15', 'last_name' => '']],
+    ];
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+      $this->fail('Expected validation error for missing last_name under BETWEEN condition.');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
+    }
+
+    // birth_date outside range, last_name empty -> should pass
+    $submission = [
+      ['fields' => ['first_name' => 'B', 'birth_date' => '2027-06-15', 'last_name' => '']],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $this->assertGreaterThan(0, $result[0]['Individual1'][0]['id']);
+  }
+
+  /**
    * Disabled field based on af-disabled attribute directly on the field
    */
   public function testConditionalDisabledField(): void {


### PR DESCRIPTION
Overview
----------------------------------------
FormBuilder's conditional-visibility rules (visibility/required/disabled) already advertised `BETWEEN` and `NOT BETWEEN` as valid operators for Date/Float/Boolean fields, but they didn't actually work: the operator never appeared in the condition editor's dropdown, and even a hand-crafted condition using it would silently evaluate to false at runtime. This PR wires the feature up end-to-end so a condition like "show this field if Event Date is between 2026-01-01 and 2026-12-31" works.

Before
----------------------------------------
Opening the conditional-rules dialog for a Date/Float/Boolean field only offered `=`, `≠`, `<`, `>`, `≤`, `≥`, "Is One Of", "Not One Of", "Is Empty", "Not Empty" — no way to enter a range. If a condition using BETWEEN was injected directly into a form's markup, the client-side evaluator (`checkConditions` in afForm.component.js) had no case for it and always returned false.

After
----------------------------------------
"Is Between" / "Not Between" appear in the operator dropdown for Date/Float/Boolean fields. Selecting either renders two value inputs (matching the existing BETWEEN UI already used in SearchKit's condition editor) instead of one, and the field/element correctly shows, requires, or disables based on whether the value falls in the entered range.

Technical Details
----------------------------------------
- `ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js` / `.html`: added the missing operator labels, a paired getter/setter for editing the two range values, and template logic to render two inputs for these operators.
- `ext/afform/core/ang/af/afForm.component.js`: added the `BETWEEN`/`NOT BETWEEN` case to `compareConditions()`.
- The server-side evaluator (`Civi/Api4/Action/AfformionTrait::compareValues()`) already handled BETWEENcorrectly — this PR only closes the client + admin-GUI gap. Added `AfformConditionalUsageTest::testConditionalRequiredFieldBetweenDates()` to lock in that an `af-required` condition using BETWEEN on a Date field is enforced correctly via `Afform::submit()`.

Comments
----------------------------------------
Purely additive — no existing operator behavior changed. Verified manually in the FormBuilder GUI (built a form, set a Last Name field's visibility to "Birth Date is Between 2026-01-01 and 2s/reloads correctly and toggles visibility as the datechanges) in addition to the automated test.