### PR TITLE
Use default value when matching managed entities

### DIFF
--- a/Civi/Api4/Generic/Traits/MatchParamTrait.php
+++ b/Civi/Api4/Generic/Traits/MatchParamTrait.php
@@ -56,6 +56,13 @@ trait MatchParamTrait {
           }
         }
       }
+      // Fields omitted from the record, which are in the match, get their default value.
+      foreach (array_diff($this->match, array_keys($record)) as $key) {
+        $default = $this->entityFields()[$key]['default_value'] ?? NULL;
+        if (isset($default)) {
+          $where[] = [$key, '=', $default];
+        }
+      }
       if (count($where) === count($this->match)) {
         $existing = civicrm_api4($this->getEntityName(), 'get', [
           'select' => [$primaryKey],

--- a/tests/phpunit/api/v4/Action/SaveTest.php
+++ b/tests/phpunit/api/v4/Action/SaveTest.php
@@ -20,6 +20,7 @@ namespace api\v4\Action;
 
 use api\v4\Api4TestBase;
 use Civi\Api4\Contact;
+use Civi\Api4\Navigation;
 use Civi\Test\TransactionalInterface;
 
 /**
@@ -117,6 +118,32 @@ class SaveTest extends Api4TestBase implements TransactionalInterface {
     ];
 
     self::assertEquals($expected, $allCreatedAndSavedContacts->getArrayCopy());
+  }
+
+  /**
+   * A match field omitted from the record should fall back to the field default.
+   *
+   * One common instance is a Navigation that matches on domain_id, but doesn't supply it.
+   */
+  public function testSaveWithMatchOnOmittedFieldWithDefault(): void {
+    $original = Navigation::create(FALSE)
+      ->addValue('name', 'test_match_default')
+      ->addValue('label', 'Original')
+      ->execute()->single();
+    self::assertEquals(\CRM_Core_BAO_Domain::getDomain()->id, $original['domain_id']);
+
+    $saved = Navigation::save(FALSE)
+      ->setMatch(['name', 'domain_id'])
+      ->setRecords([['name' => 'test_match_default', 'label' => 'Updated']])
+      ->execute()->single();
+
+    self::assertEquals($original['id'], $saved['id']);
+    self::assertEquals('Updated', $saved['label']);
+
+    $all = Navigation::get(FALSE)
+      ->addWhere('name', '=', 'test_match_default')
+      ->execute();
+    self::assertCount(1, $all);
   }
 
 }


### PR DESCRIPTION
This applies to Navigation entities where you might not supply domain_id even though it is part of the match. If a Navigation already exists and you add the same as a managed entity without providing domain_id, a duplicate will be created. This can cause problems later if you reference that Navigation by name in another managed entity (e.g. as a parent), giving an error. This is not merely a problem in special cases, it is in fact the default behaviour if you create a Navigation via UI and then export it to a managed entity.

To replicate, create a navigation manually, then civix export it, then Managed.reconcile. You will see two identical entries in the navigation table.

With this PR, the default domain_id is inserted for match purposes, in the same way as it will be for the actual insert.
The only other field I can see that would be affected is MessageTemplate.is_reserved, which seems entirely reasonable as it would be fine to not pass in is_reserved for a MessageTemplate.