### PR TITLE
Restricts the Message Token Login to be active for 2 days maximum

### DIFF
--- a/ext/afform/login_token/Civi/AfformLoginToken/Tokens.php
+++ b/ext/afform/login_token/Civi/AfformLoginToken/Tokens.php
@@ -131,7 +131,7 @@ class Tokens extends AutoService implements EventSubscriberInterface {
    */
   public static function createUrl($afform, $contactId): string {
     $expires = \CRM_Utils_Time::time() +
-      (\Civi::settings()->get('checksum_timeout') * 24 * 60 * 60);
+      (2 * 24 * 60 * 60);
 
     /** @var \Civi\Crypto\CryptoJwt $jwt */
     $jwt = \Civi::service('crypto.jwt');

--- a/ext/afform/login_token/Civi/AfformLoginToken/Tokens.php
+++ b/ext/afform/login_token/Civi/AfformLoginToken/Tokens.php
@@ -130,6 +130,9 @@ class Tokens extends AutoService implements EventSubscriberInterface {
    * @throws \Civi\Crypto\Exception\CryptoException
    */
   public static function createUrl($afform, $contactId): string {
+    // We limit this to a 2 day expiry, and not to use checksum_timeout
+    // because some people have large timeouts which could be a security risk
+    // Eventually we could make this configurable for each instance.
     $expires = \CRM_Utils_Time::time() +
       (2 * 24 * 60 * 60);
 


### PR DESCRIPTION
Overview
----------------------------------------

As discussed in [dev/core#6686](https://lab.civicrm.org/dev/core/-/work_items/6686) we should restrict the number of days that a Message Token (Login) link is valid for. The reason being is that this provides a full-access rather than restricted to a specific page like a checksum. So it raises security concerns and clients won't be aware that whatever high number of days they entered in the checksum will also grant that here.

Before
----------------------------------------

Uses the `checksum` duration to generate the actual expiration of the link, which could be any number a client enters. Typically this is around `30-60 days` for people to renew memberships, etc.

After
----------------------------------------

Now it limits it to `2 days`. I figured that this provides an ample amount of time to use the link.

Comments
----------------------------------------
Eventually, we could probably add a custom field attached below the `checksum` to allow people to configure it, but for now concerning security I wanted to change this.

cc @totten @bgm
