### PR TITLE
Afform - support conditions relative to today's date or another date field

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiClause.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiClause.html
@@ -16,7 +16,7 @@
       </div>
       <div ng-if="!$ctrl.conjunctions[clause[0]]" class="api4-input-group">
         <input class="form-control collapsible-optgroups" ng-model="clause[0]" crm-ui-select="{data: $ctrl.fields, allowClear: true, placeholder: 'Field'}" ng-change="$ctrl.changeClauseField(clause, index)" />
-        <af-gui-condition clause="clause" field="$ctrl.getField(clause[0])" offset="1" format="$ctrl.format" class="form-group"></af-gui-condition>
+        <af-gui-condition clause="clause" field="$ctrl.getField(clause[0])" offset="1" format="$ctrl.format" all-fields="$ctrl.fields" field-defns="$ctrl.fieldDefns" class="form-group"></af-gui-condition>
       </div>
       <fieldset class="clearfix" ng-if="$ctrl.conjunctions[clause[0]]">
         <af-gui-clause clauses="clause[1]" fields="$ctrl.fields" field-defns="$ctrl.fieldDefns" op="{{ clause[0] }}" delete-group="$ctrl.deleteRow(index)"></af-gui-clause>

--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.component.js
@@ -7,7 +7,9 @@
       clause: '<',
       format: '<',
       optionKey: '<',
-      offset: '<'
+      offset: '<',
+      allFields: '<',
+      fieldDefns: '<'
     },
     templateUrl: '~/afGuiEditor/afGuiCondition.html',
     controller: function ($scope) {
@@ -78,16 +80,24 @@
         return getValue();
       };
 
+      function getValueAt(index) {
+        const currentVal = getValue();
+        return Array.isArray(currentVal) ? currentVal[index] : undefined;
+      }
+
+      function setValueAt(index, val) {
+        const newVal = Array.isArray(getValue()) ? getValue().slice() : ['', ''];
+        newVal[index] = val;
+        setValue(newVal);
+      }
+
       // Getter/setter for one side of a BETWEEN/NOT BETWEEN range, for use with ng-model
       function getSetValueAt(index) {
         return function(val) {
           if (arguments.length) {
-            const newVal = Array.isArray(getValue()) ? getValue().slice() : ['', ''];
-            newVal[index] = val;
-            setValue(newVal);
+            setValueAt(index, val);
           }
-          const currentVal = getValue();
-          return Array.isArray(currentVal) ? currentVal[index] : undefined;
+          return getValueAt(index);
         };
       }
       this.getSetValueAt0 = getSetValueAt(0);
@@ -95,6 +105,103 @@
 
       this.isBetween = function() {
         return ['BETWEEN', 'NOT BETWEEN'].includes(getOperator());
+      };
+
+      this.isDateField = function() {
+        return (ctrl.field || {}).data_type === 'Date';
+      };
+
+      // Recognizes the "@now"/"@now±N" (relative to today) and "@field:<path>"/"@field:<path>±N"
+      // (relative to another date field) tokens used in place of a literal date value.
+      const NOW_PATTERN = /^@now([+-]\d+)?$/;
+      // Path may be empty here (unlike the runtime patterns) - the admin may have switched to
+      // "relative to another field" mode but not picked a field yet.
+      const FIELD_PATTERN = /^@field:([^+-]*)([+-]\d+)?$/;
+
+      function parseDateToken(val) {
+        if (typeof val === 'string') {
+          let match = val.match(NOW_PATTERN);
+          if (match) {
+            return {mode: 'now', fieldPath: '', offset: match[1] ? parseInt(match[1], 10) : 0};
+          }
+          match = val.match(FIELD_PATTERN);
+          if (match) {
+            return {mode: 'field', fieldPath: match[1], offset: match[2] ? parseInt(match[2], 10) : 0};
+          }
+        }
+        return {mode: 'literal', fieldPath: '', offset: 0};
+      }
+
+      function formatDateToken(mode, fieldPath, offset) {
+        if (mode === 'now') {
+          return offset ? ('@now' + (offset > 0 ? '+' : '') + offset) : '@now';
+        }
+        if (mode === 'field') {
+          const base = '@field:' + (fieldPath || '');
+          return offset ? (base + (offset > 0 ? '+' : '') + offset) : base;
+        }
+        return '';
+      }
+
+      // Builds getter/setter functions (for use with ng-model) for the "mode"/"offset"/"field"
+      // of a value that can be a literal date, "relative to today", or "relative to another
+      // date field" - given plain get/set functions for that underlying value.
+      function makeDateValueControl(getVal, setVal) {
+        return {
+          getSetMode: function(val) {
+            if (arguments.length) {
+              const current = parseDateToken(getVal());
+              setVal(val === 'literal' ? '' : formatDateToken(val, current.fieldPath, current.offset));
+            }
+            return parseDateToken(getVal()).mode;
+          },
+          getSetOffset: function(val) {
+            const current = parseDateToken(getVal());
+            if (arguments.length) {
+              setVal(formatDateToken(current.mode, current.fieldPath, parseInt(val, 10) || 0));
+            }
+            return current.offset;
+          },
+          getSetFieldPath: function(val) {
+            const current = parseDateToken(getVal());
+            if (arguments.length) {
+              setVal(formatDateToken('field', val, current.offset));
+            }
+            return current.fieldPath;
+          }
+        };
+      }
+
+      const singleValueControl = makeDateValueControl(getValue, setValue);
+      this.getSetMode = singleValueControl.getSetMode;
+      this.getSetOffset = singleValueControl.getSetOffset;
+      this.getSetFieldPath = singleValueControl.getSetFieldPath;
+
+      const value0Control = makeDateValueControl(() => getValueAt(0), (val) => setValueAt(0, val));
+      this.getSetMode0 = value0Control.getSetMode;
+      this.getSetOffset0 = value0Control.getSetOffset;
+      this.getSetFieldPath0 = value0Control.getSetFieldPath;
+
+      const value1Control = makeDateValueControl(() => getValueAt(1), (val) => setValueAt(1, val));
+      this.getSetMode1 = value1Control.getSetMode;
+      this.getSetOffset1 = value1Control.getSetOffset;
+      this.getSetFieldPath1 = value1Control.getSetFieldPath;
+
+      // Date fields available to anchor a "relative to another field" value to (excludes the
+      // field this condition is testing, and non-Date fields).
+      this.getDateFieldOptions = function() {
+        const currentPath = ctrl.clause[0];
+        const defns = ctrl.fieldDefns || {};
+        return (ctrl.allFields || []).reduce((groups, group) => {
+          const children = (group.children || []).filter((item) => {
+            const defn = defns[item.id];
+            return defn && defn.data_type === 'Date' && item.id !== currentPath;
+          });
+          if (children.length) {
+            groups.push({text: group.text, children: children});
+          }
+          return groups;
+        }, []);
       };
 
       // Return a list of operators allowed for the current field

--- a/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiCondition.html
@@ -2,10 +2,46 @@
   <option ng-repeat="(name, label) in $ctrl.getOperators()" value="{{:: name }}">{{:: label }}</option>
 </select>
 <div class="form-group" ng-if="$ctrl.operatorTakesInput() && !$ctrl.isBetween()">
-  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValue" op="$ctrl.clause[$ctrl.offset]" ng-model-options="{getterSetter: true}" class="form-control">
+  <select class="form-control" ng-if="$ctrl.isDateField()" ng-model="$ctrl.getSetMode" ng-model-options="{getterSetter: true}">
+    <option value="literal">{{ ts('Specific date') }}</option>
+    <option value="now">{{ ts('Relative to today') }}</option>
+    <option value="field">{{ ts('Relative to another date field') }}</option>
+  </select>
+  <input af-gui-field-value="$ctrl.field" ng-if="!$ctrl.isDateField() || $ctrl.getSetMode() === 'literal'" ng-model="$ctrl.getSetValue" op="$ctrl.clause[$ctrl.offset]" ng-model-options="{getterSetter: true}" class="form-control">
+  <span ng-if="$ctrl.isDateField() && $ctrl.getSetMode() === 'field'">
+    <input class="form-control" ng-model="$ctrl.getSetFieldPath" ng-model-options="{getterSetter: true}" crm-ui-select="{data: $ctrl.getDateFieldOptions(), allowClear: true, placeholder: ts('Field')}">
+  </span>
+  <span ng-if="$ctrl.isDateField() && $ctrl.getSetMode() !== 'literal'">
+    <input type="number" ng-model="$ctrl.getSetOffset" ng-model-options="{getterSetter: true, updateOn: 'blur'}" class="form-control">
+    {{ ts('days offset') }}
+  </span>
 </div>
 <div class="form-group" ng-if="$ctrl.isBetween()">
-  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValueAt0" op="'&gt;'" ng-model-options="{getterSetter: true}" class="form-control">
+  <select class="form-control" ng-if="$ctrl.isDateField()" ng-model="$ctrl.getSetMode0" ng-model-options="{getterSetter: true}">
+    <option value="literal">{{ ts('Specific date') }}</option>
+    <option value="now">{{ ts('Relative to today') }}</option>
+    <option value="field">{{ ts('Relative to another date field') }}</option>
+  </select>
+  <input af-gui-field-value="$ctrl.field" ng-if="!$ctrl.isDateField() || $ctrl.getSetMode0() === 'literal'" ng-model="$ctrl.getSetValueAt0" op="'&gt;'" ng-model-options="{getterSetter: true}" class="form-control">
+  <span ng-if="$ctrl.isDateField() && $ctrl.getSetMode0() === 'field'">
+    <input class="form-control" ng-model="$ctrl.getSetFieldPath0" ng-model-options="{getterSetter: true}" crm-ui-select="{data: $ctrl.getDateFieldOptions(), allowClear: true, placeholder: ts('Field')}">
+  </span>
+  <span ng-if="$ctrl.isDateField() && $ctrl.getSetMode0() !== 'literal'">
+    <input type="number" ng-model="$ctrl.getSetOffset0" ng-model-options="{getterSetter: true, updateOn: 'blur'}" class="form-control">
+    {{ ts('days offset') }}
+  </span>
   -
-  <input af-gui-field-value="$ctrl.field" ng-model="$ctrl.getSetValueAt1" op="'&lt;'" ng-model-options="{getterSetter: true}" class="form-control">
+  <select class="form-control" ng-if="$ctrl.isDateField()" ng-model="$ctrl.getSetMode1" ng-model-options="{getterSetter: true}">
+    <option value="literal">{{ ts('Specific date') }}</option>
+    <option value="now">{{ ts('Relative to today') }}</option>
+    <option value="field">{{ ts('Relative to another date field') }}</option>
+  </select>
+  <input af-gui-field-value="$ctrl.field" ng-if="!$ctrl.isDateField() || $ctrl.getSetMode1() === 'literal'" ng-model="$ctrl.getSetValueAt1" op="'&lt;'" ng-model-options="{getterSetter: true}" class="form-control">
+  <span ng-if="$ctrl.isDateField() && $ctrl.getSetMode1() === 'field'">
+    <input class="form-control" ng-model="$ctrl.getSetFieldPath1" ng-model-options="{getterSetter: true}" crm-ui-select="{data: $ctrl.getDateFieldOptions(), allowClear: true, placeholder: ts('Field')}">
+  </span>
+  <span ng-if="$ctrl.isDateField() && $ctrl.getSetMode1() !== 'literal'">
+    <input type="number" ng-model="$ctrl.getSetOffset1" ng-model-options="{getterSetter: true, updateOn: 'blur'}" class="form-control">
+    {{ ts('days offset') }}
+  </span>
 </div>

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -193,8 +193,43 @@ class Submit extends AbstractProcessor {
       // `==` is deprecated in favor of `=`
       $op = $clause[1] === '==' ? '=' : $clause[1];
       $expected = isset($clause[2]) ? \CRM_Utils_JS::decode($clause[2]) : NULL;
-      return self::compareValues($submittedValue, $op, $expected);
+      return self::compareValues($submittedValue, $op, self::resolveRelativeDate($expected, $allEntityValues));
     }
+  }
+
+  /**
+   * Resolves the "@now"/"@now±N" (relative to today) and "@field:<path>"/"@field:<path>±N"
+   * (relative to another date field) tokens into an absolute yyyy-mm-dd string. Other values
+   * pass through.
+   *
+   * @param mixed $value
+   * @param array $allEntityValues
+   * @return mixed
+   */
+  private static function resolveRelativeDate($value, array $allEntityValues) {
+    if (is_array($value)) {
+      return array_map(function($item) use ($allEntityValues) {
+        return self::resolveRelativeDate($item, $allEntityValues);
+      }, $value);
+    }
+    if (!is_string($value)) {
+      return $value;
+    }
+    if (preg_match('/^@now([+-]\d+)?$/', $value, $matches)) {
+      $offset = (int) ($matches[1] ?? 0);
+      $timestamp = \CRM_Utils_Time::strtotime(($offset >= 0 ? '+' : '') . $offset . ' days');
+      return \CRM_Utils_Time::date('Y-m-d', $timestamp);
+    }
+    if (preg_match('/^@field:([^+-]+)([+-]\d+)?$/', $value, $matches)) {
+      $fieldValue = self::getValueFromEntity($matches[1], $allEntityValues);
+      if (empty($fieldValue)) {
+        return NULL;
+      }
+      $offset = (int) ($matches[2] ?? 0);
+      $timestamp = strtotime(($offset >= 0 ? '+' : '') . $offset . ' days', strtotime($fieldValue));
+      return date('Y-m-d', $timestamp);
+    }
+    return $value;
   }
 
   /**

--- a/ext/afform/core/ang/af/afForm.component.js
+++ b/ext/afform/core/ang/af/afForm.component.js
@@ -255,7 +255,7 @@
             }
             let parser1 = $parse(clause[0]);
             let parser2 = $parse(clause[2]);
-            let result = compareConditions(parser1(data), clause[1], parser2(data));
+            let result = compareConditions(parser1(data), clause[1], resolveRelativeDate(parser2(data)));
             if (result === flip) {
               ret = flip;
             }
@@ -263,6 +263,49 @@
         });
         return op === 'NOT' ? !ret : ret;
       };
+
+      // Resolves the "@now"/"@now±N" (relative to today) and "@field:<path>"/"@field:<path>±N"
+      // (relative to another date field) tokens into an absolute yyyy-mm-dd string. Other
+      // values pass through.
+      function resolveRelativeDate(val) {
+        if (Array.isArray(val)) {
+          return val.map(resolveRelativeDate);
+        }
+        if (typeof val !== 'string') {
+          return val;
+        }
+        let baseDate, offsetStr;
+        const nowMatch = val.match(/^@now([+-]\d+)?$/);
+        if (nowMatch) {
+          baseDate = new Date();
+          offsetStr = nowMatch[1];
+        } else {
+          const fieldMatch = val.match(/^@field:([^+-]+)([+-]\d+)?$/);
+          if (!fieldMatch) {
+            return val;
+          }
+          let path = fieldMatch[1];
+          if (path.charAt(0) !== '"') {
+            path = path.replace(/\[([^'"])/g, "['$1").replace(/([^'"])]/g, "$1']");
+          }
+          baseDate = parseDateOnly($parse(path)(data));
+          offsetStr = fieldMatch[2];
+          if (!baseDate) {
+            return null;
+          }
+        }
+        const offset = offsetStr ? parseInt(offsetStr, 10) : 0;
+        baseDate.setDate(baseDate.getDate() + offset);
+        const pad = (n) => (n < 10 ? '0' : '') + n;
+        return baseDate.getFullYear() + '-' + pad(baseDate.getMonth() + 1) + '-' + pad(baseDate.getDate());
+      }
+
+      // Parses a yyyy-mm-dd string as a local-time Date, avoiding new Date(str)'s UTC parsing
+      // (which can shift the date by a day depending on the browser's timezone).
+      function parseDateOnly(val) {
+        const match = typeof val === 'string' && val.match(/^(\d{4})-(\d{2})-(\d{2})/);
+        return match ? new Date(parseInt(match[1], 10), parseInt(match[2], 10) - 1, parseInt(match[3], 10)) : null;
+      }
 
       function compareConditions(val1, op, val2) {
         const yes = (op !== '!=' && !op.includes('NOT '));

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformConditionalUsageTest.php
@@ -238,6 +238,166 @@ EOHTML;
   }
 
   /**
+   * Required field based on a Date field falling before/after "today"
+   */
+  public function testConditionalRequiredFieldRelativeToToday(): void {
+    \CRM_Utils_Time::setTime('2026-06-15 12:00:00');
+    try {
+      $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="birth_date" />
+    <af-field name="last_name" af-required="([[&amp;quot;Individual1[0][fields][birth_date]&amp;quot;,&amp;quot;&gt;&amp;quot;,&amp;quot;\&amp;quot;@now\&amp;quot;&amp;quot;]])" defn="{required: false, input_attrs: {}}" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+      $this->useValues([
+        'layout' => $layout,
+        'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      ]);
+
+      // Dynamic rule is that last_name is required if birth_date is after "today" (frozen at 2026-06-15)
+
+      // birth_date after today, last_name empty -> should fail
+      $submission = [
+        ['fields' => ['first_name' => 'A', 'birth_date' => '2026-06-20', 'last_name' => '']],
+      ];
+      try {
+        Afform::submit()
+          ->setName($this->formName)
+          ->setValues(['Individual1' => $submission])
+          ->execute();
+        $this->fail('Expected validation error for missing last_name under relative-date condition.');
+      }
+      catch (\CRM_Core_Exception $e) {
+        $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
+      }
+
+      // birth_date before today, last_name empty -> should pass
+      $submission = [
+        ['fields' => ['first_name' => 'B', 'birth_date' => '2026-06-10', 'last_name' => '']],
+      ];
+      $result = Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+
+      $this->assertGreaterThan(0, $result[0]['Individual1'][0]['id']);
+    }
+    finally {
+      \CRM_Utils_Time::resetTime();
+    }
+  }
+
+  /**
+   * Required field based on a Date field falling within a range of offsets from "today"
+   */
+  public function testConditionalRequiredFieldBetweenRelativeDates(): void {
+    \CRM_Utils_Time::setTime('2026-06-15 12:00:00');
+    try {
+      $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="birth_date" />
+    <af-field name="last_name" af-required="([[&amp;quot;Individual1[0][fields][birth_date]&amp;quot;,&amp;quot;BETWEEN&amp;quot;,&amp;quot;[\&amp;quot;@now-7\&amp;quot;,\&amp;quot;@now+7\&amp;quot;]&amp;quot;]])" defn="{required: false, input_attrs: {}}" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+      $this->useValues([
+        'layout' => $layout,
+        'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+      ]);
+
+      // Dynamic rule is that last_name is required if birth_date is within 7 days of "today" (frozen at 2026-06-15)
+
+      // birth_date within the relative range, last_name empty -> should fail
+      $submission = [
+        ['fields' => ['first_name' => 'A', 'birth_date' => '2026-06-18', 'last_name' => '']],
+      ];
+      try {
+        Afform::submit()
+          ->setName($this->formName)
+          ->setValues(['Individual1' => $submission])
+          ->execute();
+        $this->fail('Expected validation error for missing last_name under relative BETWEEN condition.');
+      }
+      catch (\CRM_Core_Exception $e) {
+        $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
+      }
+
+      // birth_date outside the relative range, last_name empty -> should pass
+      $submission = [
+        ['fields' => ['first_name' => 'B', 'birth_date' => '2026-07-01', 'last_name' => '']],
+      ];
+      $result = Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+
+      $this->assertGreaterThan(0, $result[0]['Individual1'][0]['id']);
+    }
+    finally {
+      \CRM_Utils_Time::resetTime();
+    }
+  }
+
+  /**
+   * Required field based on a Date field falling within a range of offsets from another field
+   */
+  public function testConditionalRequiredFieldRelativeToAnotherField(): void {
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity data="{source: 'TestConditionals'}" type="Individual" name="Individual1" label="Individual 1" actions="{create: true, update: true}" security="RBAC" />
+  <fieldset af-fieldset="Individual1" class="af-container" af-title="Individual 1">
+    <af-field name="first_name" />
+    <af-field name="deceased_date" />
+    <af-field name="birth_date" />
+    <af-field name="last_name" af-required="([[&amp;quot;Individual1[0][fields][birth_date]&amp;quot;,&amp;quot;BETWEEN&amp;quot;,&amp;quot;[\&amp;quot;@field:Individual1[0][fields][deceased_date]-30\&amp;quot;,\&amp;quot;@field:Individual1[0][fields][deceased_date]+30\&amp;quot;]&amp;quot;]])" defn="{required: false, input_attrs: {}}" />
+  </fieldset>
+  <button class="af-button btn btn-primary" crm-icon="fa-check" ng-click="afform.submit()" ng-if="afform.showSubmitButton">Submit</button>
+</af-form>
+EOHTML;
+    $this->useValues([
+      'layout' => $layout,
+      'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+    ]);
+
+    // Dynamic rule is that last_name is required if birth_date is within 30 days of deceased_date
+
+    // birth_date within range of deceased_date, last_name empty -> should fail
+    $submission = [
+      ['fields' => ['first_name' => 'A', 'deceased_date' => '2026-08-01', 'birth_date' => '2026-08-05', 'last_name' => '']],
+    ];
+    try {
+      Afform::submit()
+        ->setName($this->formName)
+        ->setValues(['Individual1' => $submission])
+        ->execute();
+      $this->fail('Expected validation error for missing last_name under field-relative condition.');
+    }
+    catch (\CRM_Core_Exception $e) {
+      $this->assertStringContainsString('Last Name is a required field.', $e->getMessage());
+    }
+
+    // birth_date outside range of deceased_date, last_name empty -> should pass
+    $submission = [
+      ['fields' => ['first_name' => 'B', 'deceased_date' => '2026-08-01', 'birth_date' => '2026-12-25', 'last_name' => '']],
+    ];
+    $result = Afform::submit()
+      ->setName($this->formName)
+      ->setValues(['Individual1' => $submission])
+      ->execute();
+
+    $this->assertGreaterThan(0, $result[0]['Individual1'][0]['id']);
+  }
+
+  /**
    * Disabled field based on af-disabled attribute directly on the field
    */
   public function testConditionalDisabledField(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Building on #36518 (which added `BETWEEN`/`NOT BETWEEN` support for Afform conditional rules), this extends conditions on Date fields so the comparison value doesn't have to be a fixed, hard-coded date. A Date-field condition (used for `af-if` visibility, `af-required`, or `af-disabled`) can now be set relative to **today**, or relative to **another Date field on the same form** — each with an optional day offset. This works for both single-value comparisons (`=`, `>`, `<`, etc.) and for `BETWEEN`/`NOT BETWEEN` ranges.

Typical use case: show a "next of kin" field only once someone's age is over 18 (Birth Date more than 18 years ago), or flag a field as required only within a 30-day window either side of another date field on the form.

Before
----------------------------------------
The FormBuilder conditional-rules editor only let you pick a literal, fixed date as the comparison value for a Date field condition. There was no way to express "relative to today" or "relative to another field" — every form using date-based visibility rules had to be edited manually whenever the reference date changed, and comparisons against a moving target (like another field's value, or the current date) weren't possible at all.

After
----------------------------------------
The value editor for a Date field condition now offers three modes: **Specific date**, **Relative to today**, and **Relative to another date field**, each with a day offset. This applies to both single-value operators and to each side of a `BETWEEN`/`NOT BETWEEN` range.

<img width="1568" height="770" alt="download" src="https://github.com/user-attachments/assets/3ac25ad5-bd54-4993-bb46-0a7409d315e6" />

On the live form, the condition re-evaluates as the referenced field changes, exactly like an existing literal-date condition would.

Technical Details
----------------------------------------
- Values are stored as compact string tokens that reuse the existing literal-value storage/round-trip mechanism                           (`JSON.stringify`/`$parse`) rather than introducing a
  - `@now`, `@now+N`, `@now-N` — relative to today.
  - `@field:<path>`, `@field:<path>+N`, `@field:<path>-N` — relative to another field, where `<path>` uses the same bracketed entity/field addressing as the field being tested (e.g. `Individual1[0][fields][deceased_date]`).
- Resolution happens in both places a condition is evaluated, so the two stay in sync:                                                      - Client-side, in `afForm.component.js`'s `checkConeRelativeDate()` helper (recurses into arrays for`BETWEEN` ranges).
  - Server-side, in `Civi/Api4/Action/Afform/Submit.php`'s `checkAfformConditionalClause()`, via a matching `resolveRelativeDate()`. This is the security-relevant path — it's what actually enbled` on submit, so a client-side-only implementationwould have been bypassable.
- `@now` resolves via `CRM_Utils_Time::strtotime()`/`::date()` server-side (so it respects the same mockable "now" used elsewhere in core's test suite) and `new Date()` client-side.
- The admin GUI's field-picker for "relative to another date field" mode reuses the existing field-selector tree already built for the
condition's own field-under-test, filtered to Date-tyield being tested.
- Two bugs found and fixed while building this:
  - The offset `<input type="number">` was bound with`ng-model-options`, so typing a negative number gotreformatted back into the field mid-keystroke (e.g. "-30" collapsing to "030"). Fixed by adding `updateOn: 'blur'`.
  - The admin-side regex for parsing the `@field:<path>` token required a non-empty path, so switching to "relative to another date field" mode before actually picking a field caused the UI to silently snap back to "Specific date". Fixed by loosening only the
admin-side pattern (the client/server runtime patternsince a saved condition should always have one).

Comments
----------------------------------------
Covered by new tests in `AfformConditionalUsageTest.pive-to-another-field, and BETWEEN with tworelative-date bounds. Each new test was verified to fail without its corresponding fix before being confirmed to pass.

Builds on #36518 (already merged) — this branch has been rebased onto current master so it applies cleanly on its own.