### PR TITLE
Afform - Ensure anonymous users can save contact images

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/SubmitFile.php
@@ -90,6 +90,7 @@ class SubmitFile extends AbstractProcessor {
     // Handle special case for image URL
     elseif (isset($entityId) && $this->getFieldName() === 'image_URL') {
       civicrm_api4('Contact', 'update', [
+        'checkPermissions' => FALSE,
         'values' => [
           'id' => $entityId,
           'image_URL' => \CRM_Utils_System::url('civicrm/contact/imagefile', 'photo=' . $file['uri'], TRUE, NULL, TRUE, TRUE),


### PR DESCRIPTION


Overview
----------------------------------------
Makes sure anonymous users can save contact images in FormBuilder.

Followup to https://github.com/civicrm/civicrm-core/pull/36326

Technical Details
----------------------------------------

This disables permission checks when internally saving image files in FormBuilder (consistent with other api calls in this class). This is ok because entity permissions are already checked during the Submit action.
