### PR TITLE
Fix Register Participant from the Advanced Search

### DIFF
--- a/CRM/Event/Form/Task/Register.php
+++ b/CRM/Event/Form/Task/Register.php
@@ -76,7 +76,7 @@ class CRM_Event_Form_Task_Register extends CRM_Event_Form_Participant {
     $key = CRM_Core_Key::get('CRM_Event_Form_Participant', TRUE);
     $this->assign('participantQfKey', $key);
     $this->assign('participantAction', CRM_Core_Action::ADD);
-    $this->assign('urlPathVar', "_qf_Participant_display=true&context=search");
+    $this->assign('urlPathVar', "_qf_Participant_display=true&context=search&action=add");
   }
 
   /**

--- a/tests/phpunit/CRM/Event/Page/TabTest.php
+++ b/tests/phpunit/CRM/Event/Page/TabTest.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Test CRM_Event_Page_Tab.
+ *
+ * @package CiviCRM
+ * @group headless
+ */
+class CRM_Event_Page_TabTest extends CiviUnitTestCase {
+
+  /**
+   * Request parameters as they were before the test started.
+   *
+   * @var array
+   */
+  private array $originalRequest;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->useTransaction();
+    $this->originalRequest = [$_REQUEST, $_GET];
+  }
+
+  public function tearDown(): void {
+    [$_REQUEST, $_GET] = $this->originalRequest;
+    CRM_Core_Session::singleton()->resetScope('CRM_Event_Page_Tab');
+    parent::tearDown();
+  }
+
+  /**
+   * Test the action the participant route resolves to for various url parameters.
+   *
+   * @dataProvider urlParameterProvider
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testPreProcessResolvesAction(array $urlParameters, int $expectedAction): void {
+    $urlParameters['cid'] = $this->individualCreate();
+    $_REQUEST = $_GET = $urlParameters + ['q' => 'civicrm/contact/view/participant'];
+    // retrieve() writes the action into the session & reads it back before
+    // falling back to the default, so a leftover value would mask the url.
+    CRM_Core_Session::singleton()->resetScope('CRM_Event_Page_Tab');
+
+    $page = new CRM_Event_Page_Tab();
+    $page->preProcess();
+    $this->assertEquals($expectedAction, $page->getTemplateVars('action'));
+  }
+
+  public static function urlParameterProvider(): array {
+    return [
+      // Fee block ajax on the 'Register participants' search task.
+      'search_task_fee_block' => [
+        'url_parameters' => ['context' => 'search', 'action' => 'add', 'snippet' => 4],
+        'expected_action' => CRM_Core_Action::ADD,
+      ],
+      // Pager on the participant listing - dev/core#5758. This must not flip to
+      // 'add' or the listing is replaced by an empty registration form.
+      'search_listing' => [
+        'url_parameters' => ['context' => 'search'],
+        'expected_action' => CRM_Core_Action::BROWSE,
+      ],
+      'search_edit' => [
+        'url_parameters' => ['context' => 'search', 'action' => 'update'],
+        'expected_action' => CRM_Core_Action::UPDATE,
+      ],
+      'search_view' => [
+        'url_parameters' => ['context' => 'search', 'action' => 'view'],
+        'expected_action' => CRM_Core_Action::VIEW,
+      ],
+      'standalone_add' => [
+        'url_parameters' => ['context' => 'standalone', 'action' => 'add'],
+        'expected_action' => CRM_Core_Action::ADD,
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

Using the Advanced Search > Action > Register participants to event, it was not possible to register a participant to a paid event, after a regression caused by b9d3da6eb0 in #32239.

To reproduce:

- Advanced Search, select 1-2 contacts
- Actions : register event participant
- Select any event

The priceset is not visible, nor is the option to send a receipt.

When looking at the ajax requests, it fails on getFieldValue. In `CRM/Event/Page/Tab.php`, the `action` defaults to `browse`, sending the requests in the wrong direction.

<img width="2310" height="1448" alt="image" src="https://github.com/user-attachments/assets/e2765d54-a4f3-44b8-8d21-cccc42121762" />


The big mystery: I ran into this issue on a site that had been using this workflow for a long time, and we have not done any updates recently, besides upgrading WordPress. I thought maybe WordPress was causing issues, but I can reproduce the problem on Standalone (smaster).

Before
----------------------------------------

broken

After
----------------------------------------

Fixed
