### PR TITLE
dev/core#6647 Standalone - Enable public registration

### DIFF
--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -1415,4 +1415,15 @@ class CRM_Core_SelectValues {
     ];
   }
 
+  /**
+   * Options for UFGroup.is_cms_user
+   */
+  public static function profileUserRegistrationMode(): array {
+    return [
+      0 => ts('Disabled'),
+      1 => ts('Enabled, but not required'),
+      2 => ts('Required'),
+    ];
+  }
+
 }

--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -53,8 +53,12 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
 
     $form->addElement('text', 'notify', ts('Notify when profile form is submitted'));
     $form->addElement('select', 'add_contact_to_group', ts('Add contacts to a group'), $group);
-    $form->addElement('select', 'is_cms_user', ts('User account registration'), [ts('Disabled'), ts('Enabled, but not required'), ts('Required')]);
     $form->addElement('advcheckbox', 'add_captcha', ts('Include reCAPTCHA'));
+
+    // Include user registration option if the CMS supports it
+    if (CRM_Core_Config::singleton()->userSystem->isUserRegistrationPermitted()) {
+      $form->addElement('select', 'is_cms_user', ts('User account registration'), [ts('Disabled'), ts('Enabled, but not required'), ts('Required')]);
+    }
 
     if (function_exists('legacyprofiles_civicrm_config')) {
       // Options for Profile Listings

--- a/CRM/UF/Form/AdvanceSetting.php
+++ b/CRM/UF/Form/AdvanceSetting.php
@@ -57,7 +57,7 @@ class CRM_UF_Form_AdvanceSetting extends CRM_UF_Form_Group {
 
     // Include user registration option if the CMS supports it
     if (CRM_Core_Config::singleton()->userSystem->isUserRegistrationPermitted()) {
-      $form->addElement('select', 'is_cms_user', ts('User account registration'), [ts('Disabled'), ts('Enabled, but not required'), ts('Required')]);
+      $form->addElement('select', 'is_cms_user', ts('User account registration'), CRM_Core_SelectValues::profileUserRegistrationMode());
     }
 
     if (function_exists('legacyprofiles_civicrm_config')) {

--- a/CRM/Upgrade/Incremental/php/SixNineteen.php
+++ b/CRM/Upgrade/Incremental/php/SixNineteen.php
@@ -31,6 +31,18 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Drop OptionValue.domain_id column', 'dropColumn', 'civicrm_option_value', 'domain_id');
     $this->addTask('Update Localization menu label', 'updateLocalizationMenuLabels');
+    $this->addTask('Update UFGroup.is_cms_user', 'alterSchemaField', 'UFGroup', 'is_cms_user', [
+      'title' => ts('User account registration'),
+      'sql_type' => 'tinyint',
+      'input_type' => 'Select',
+      'required' => TRUE,
+      'description' => ts('Should we create a cms user for this profile'),
+      'add' => '1.8',
+      'default' => 0,
+      'pseudoconstant' => [
+        'callback' => ['CRM_Core_SelectValues', 'profileUserRegistrationMode'],
+      ],
+    ]);
   }
 
   /**

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1248,7 +1248,23 @@ abstract class CRM_Utils_System_Base {
    * @return string
    */
   public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
-    return 'email';
+    $emailName = '';
+    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
+    if (array_key_exists("email-{$billingLocationTypeID}", $fields)) {
+      // this is a transaction related page
+      $emailName = 'email-' . $billingLocationTypeID;
+    }
+    else {
+      // find the email field in a profile page
+      foreach ($fields as $name => $dontCare) {
+        if (str_starts_with($name, 'email')) {
+          $emailName = $name;
+          break;
+        }
+      }
+    }
+
+    return $emailName;
   }
 
   /**

--- a/CRM/Utils/System/DrupalBase.php
+++ b/CRM/Utils/System/DrupalBase.php
@@ -783,29 +783,6 @@ abstract class CRM_Utils_System_DrupalBase extends CRM_Utils_System_Base {
   /**
    * @inheritdoc
    */
-  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
-    $emailName = '';
-    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
-    if (array_key_exists("email-{$billingLocationTypeID}", $fields)) {
-      // this is a transaction related page
-      $emailName = 'email-' . $billingLocationTypeID;
-    }
-    else {
-      // find the email field in a profile page
-      foreach ($fields as $name => $dontCare) {
-        if (str_starts_with($name, 'email')) {
-          $emailName = $name;
-          break;
-        }
-      }
-    }
-
-    return $emailName;
-  }
-
-  /**
-   * @inheritdoc
-   */
   public function mailingWorkflowIsEnabled():bool {
     if (!module_exists('rules')) {
       return FALSE;

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -121,29 +121,6 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
   /**
    * @inheritdoc
    */
-  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
-    $emailName = '';
-    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
-    if (array_key_exists("email-{$billingLocationTypeID}", $fields)) {
-      // this is a transaction related page
-      $emailName = 'email-' . $billingLocationTypeID;
-    }
-    else {
-      // find the email field in a profile page
-      foreach ($fields as $name => $dontCare) {
-        if (str_starts_with($name, 'email')) {
-          $emailName = $name;
-          break;
-        }
-      }
-    }
-
-    return $emailName;
-  }
-
-  /**
-   * @inheritdoc
-   */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
     $config = CRM_Core_Config::singleton();
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -502,8 +502,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function isUserRegistrationPermitted() {
-    // We don't support user registration in Standalone.
-    return FALSE;
+    return (bool) Civi::settings()->get('standaloneusers_allow_public_registration');
   }
 
   /**

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -108,13 +108,22 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   public function createUser(&$params, $emailParam) {
     try {
       $email = $params[$emailParam];
+      $contactId = $params['contactID'] ?? $params['contact_id'] ?? NULL;
+      $userParams = [
+        'username' => $params['cms_name'],
+        'uf_name' => $email,
+        'contact_id' => $contactId,
+      ];
+      if (!empty($params['cms_pass'])) {
+        $userParams['password'] = $params['cms_pass'];
+      }
       $userID = \Civi\Api4\User::create(FALSE)
-        ->addValue('username', $params['cms_name'])
-        ->addValue('uf_name', $email)
-        ->addValue('password', $params['cms_pass'])
-        ->addValue('contact_id', $params['contact_id'] ?? NULL)
-        // ->addValue('uf_id', 0) // does not work without this.
+        ->setValues($userParams)
         ->execute()->single()['id'];
+
+      if ($params['notify'] ?? TRUE) {
+        $this->sendUserRegistrationEmail($userID);
+      }
     }
     catch (\Exception $e) {
       \Civi::log()->warning("Failed to create user '$email': " . $e->getMessage());
@@ -122,6 +131,63 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
     }
 
     return (int) $userID;
+  }
+
+  /**
+   * Send a welcome / registration email to a newly created user with a password reset link.
+   *
+   * @param int $userID
+   * @param int $tokenTimeout Token validity in minutes (default 24 hours).
+   * @return bool
+   */
+  public function sendUserRegistrationEmail(int $userID, int $tokenTimeout = 1440): bool {
+    if (!$this->isUserExtensionAvailable()) {
+      return FALSE;
+    }
+
+    $user = \Civi\Api4\User::get(FALSE)
+      ->addWhere('id', '=', $userID)
+      ->addSelect('id', 'username', 'uf_name', 'contact_id')
+      ->execute()->first();
+
+    if (!$user || !filter_var($user['uf_name'] ?? '', \FILTER_VALIDATE_EMAIL)) {
+      \Civi::log()->warning("Cannot send registration email: user not found or invalid email.", ['userId' => $userID]);
+      return FALSE;
+    }
+
+    // Check for message template
+    $tplID = \Civi\Api4\MessageTemplate::get(FALSE)
+      ->setSelect(['id'])
+      ->addWhere('workflow_name', '=', 'user_registration')
+      ->addWhere('is_default', '=', TRUE)
+      ->addWhere('is_reserved', '=', FALSE)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()->first()['id'] ?? NULL;
+
+    if (!$tplID) {
+      \Civi::log()->notice("No active default user_registration message template found for user {username}", ['username' => $user['username']]);
+      return FALSE;
+    }
+
+    $token = \Civi\Api4\Action\User\PasswordReset::updateToken($user['id'], $tokenTimeout);
+
+    [$domainFromName, $domainFromEmail] = \CRM_Core_BAO_Domain::getNameAndEmail(TRUE);
+    try {
+      $workflowMessage = (new \CRM_Standaloneusers_WorkflowMessage_UserRegistration())
+        ->setRequiredParams($user['username'], $user['uf_name'], (int) $user['contact_id'], $token, $tokenTimeout)
+        ->setFrom("\"$domainFromName\" <$domainFromEmail>");
+
+      [$sent] = $workflowMessage->sendTemplate();
+      if ($sent) {
+        \Civi::log()->info("Successfully sent user registration email to user {$user['id']} ({$user['username']}) at {$user['uf_name']}");
+        return TRUE;
+      }
+    }
+    catch (\Exception $e) {
+      \Civi::log()->error("Failed to send user registration email to user {$user['id']}: " . $e->getMessage());
+    }
+
+    return FALSE;
   }
 
   /**
@@ -543,8 +609,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
    * @inheritDoc
    */
   public function isPasswordUserGenerated() {
-    // @todo User management not implemented, but we should do like on WP
-    // and always generate a password for the user, as part of the login process.
+    // We always generate a password for new users and then email them a password reset link.
     return FALSE;
   }
 

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -137,6 +137,40 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   /**
    * @inheritDoc
    */
+  public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
+    if (!$this->isUserExtensionAvailable()) {
+      return;
+    }
+
+    if (!empty($params['name'])) {
+      $user = \Civi\Api4\User::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('username', '=', $params['name'])
+        ->execute()
+        ->first();
+      if ($user) {
+        $errors['cms_name'] = ts('The username %1 is already taken. Please select another username.', [1 => $params['name']]);
+      }
+    }
+
+    if (!empty($params['mail'])) {
+      $user = \Civi\Api4\User::get(FALSE)
+        ->addSelect('id')
+        ->addWhere('uf_name', '=', $params['mail'])
+        ->execute()
+        ->first();
+      if ($user) {
+        $resetUrl = CRM_Utils_System::url('civicrm/login/password', '', TRUE);
+        $errors[$emailName] = ts('The email address %1 already has an account associated with it. <a href="%2">Have you forgotten your password?</a>',
+          [1 => $params['mail'], 2 => $resetUrl]
+        );
+      }
+    }
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function getLoginURL($destination = '') {
     $query = $destination ? ['destination' => $destination] : [];
     return CRM_Utils_System::url('civicrm/login', $query, TRUE);

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1032,29 +1032,6 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   /**
    * @inheritdoc
    */
-  public function getEmailFieldName(CRM_Core_Form $form, array $fields):string {
-    $emailName = '';
-    $billingLocationTypeID = CRM_Core_BAO_LocationType::getBilling();
-    if (array_key_exists("email-{$billingLocationTypeID}", $fields)) {
-      // this is a transaction related page
-      $emailName = 'email-' . $billingLocationTypeID;
-    }
-    else {
-      // find the email field in a profile page
-      foreach ($fields as $name => $dontCare) {
-        if (str_starts_with($name, 'email')) {
-          $emailName = $name;
-          break;
-        }
-      }
-    }
-
-    return $emailName;
-  }
-
-  /**
-   * @inheritdoc
-   */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {
     if (!empty($params['name'])) {
       if (!validate_username($params['name'])) {

--- a/ext/standaloneusers/CRM/Standaloneusers/WorkflowMessage/UserRegistration.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/WorkflowMessage/UserRegistration.php
@@ -1,0 +1,108 @@
+<?php
+use Civi\WorkflowMessage\GenericWorkflowMessage;
+use CRM_Standaloneusers_ExtensionUtil as E;
+
+/**
+ * Workflow message for user account creation / registration.
+ *
+ * @method $this setResetUrlPlaintext(string $s)
+ * @method $this setResetUrlHtml(string $s)
+ * @method $this setUsernamePlaintext(string $s)
+ * @method $this setUsernameHtml(string $s)
+ * @method $this setTokenTimeoutPlaintext(string $s)
+ * @method $this setTokenTimeoutHtml(string $s)
+ *
+ */
+class CRM_Standaloneusers_WorkflowMessage_UserRegistration extends GenericWorkflowMessage {
+
+  public const WORKFLOW = 'user_registration';
+
+  /**
+   * Plaintext full URL to user's password reset.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $resetUrlPlaintext;
+
+  /**
+   * HTML full URL to user's password reset.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $resetUrlHtml;
+
+  /**
+   * Plaintext username.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $usernamePlaintext;
+
+  /**
+   * HTML username.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $usernameHtml;
+
+  /**
+   * Plaintext token timeout.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $tokenTimeoutPlaintext;
+
+  /**
+   * HTML token timeout.
+   *
+   * @var string
+   *
+   * @scope tplParams
+   */
+  public $tokenTimeoutHtml;
+
+  /**
+   * Load the required tplParams
+   */
+  public function setRequiredParams(
+    string $username,
+    string $email,
+    int $contactId,
+    string $token,
+    int $tokenTimeout
+  ) {
+    $resetUrlPlaintext = \CRM_Utils_System::url('civicrm/login/password', ['token' => $token], TRUE, NULL, FALSE);
+
+    if ($tokenTimeout < 120) {
+      $timeout = E::ts("This link expires %1 minutes after the date of this email.", [1 => $tokenTimeout]);
+    }
+    elseif ($tokenTimeout < 60 * 48) {
+      $timeout = E::ts("This link expires %1 hours after the date of this email.", [1 => floor($tokenTimeout / 60)]);
+    }
+    else {
+      $timeout = E::ts("This link expires %1 days after the date of this email.", [1 => floor($tokenTimeout / 60 / 24)]);
+    }
+
+    $this
+      ->setResetUrlPlaintext($resetUrlPlaintext)
+      ->setResetUrlHtml(htmlspecialchars($resetUrlPlaintext))
+      ->setUsernamePlaintext($username)
+      ->setUsernameHtml(htmlspecialchars($username))
+      ->setTokenTimeoutPlaintext($timeout)
+      ->setTokenTimeoutHtml(htmlspecialchars($timeout))
+      ->setTo(['name' => $username, 'email' => $email])
+      ->setContactID($contactId);
+    return $this;
+  }
+
+}

--- a/ext/standaloneusers/managed/MessageTemplate_UserRegistration.mgd.php
+++ b/ext/standaloneusers/managed/MessageTemplate_UserRegistration.mgd.php
@@ -1,0 +1,65 @@
+<?php
+use CRM_Standaloneusers_ExtensionUtil as E;
+
+$userRegistrationSubject = '{ts}Account details for{/ts} {$usernameHtml} {ts}at{/ts} {domain.name}';
+
+$userRegistrationHtml = <<<HTML
+  <p>{ts}An account has been created for you at {domain.name}.{/ts}</p>
+
+  <p>{ts}Your username:{/ts} <strong>{\$usernameHtml}</strong></p>
+
+  <p>{ts}To set your password and log in, click the link below:{/ts}</p>
+
+  <p><a href="{\$resetUrlHtml}">{\$resetUrlHtml}</a></p>
+
+  <p><strong>{\$tokenTimeoutHtml}</strong></p>
+
+  <p>{domain.name}</p>
+HTML;
+
+return [
+  [
+    'name' => 'MessageTemplate_UserRegistrationReserved',
+    'entity' => 'MessageTemplate',
+    'cleanup' => 'unused',
+    'update' => 'always',
+    'params' => [
+      'version' => 4,
+      'match' => [
+        'workflow_name',
+        'is_reserved',
+      ],
+      'values' => [
+        'workflow_name' => 'user_registration',
+        'msg_title' => E::ts('User registration'),
+        'msg_subject' => $userRegistrationSubject,
+        'msg_text' => '',
+        'msg_html' => $userRegistrationHtml,
+        'is_default' => FALSE,
+        'is_reserved' => TRUE,
+      ],
+    ],
+  ],
+  [
+    'name' => 'MessageTemplate_UserRegistrationEditable',
+    'entity' => 'MessageTemplate',
+    'cleanup' => 'unused',
+    'update' => 'never',
+    'params' => [
+      'version' => 4,
+      'match' => [
+        'workflow_name',
+        'is_reserved',
+      ],
+      'values' => [
+        'workflow_name' => 'user_registration',
+        'msg_title' => E::ts('User registration'),
+        'msg_subject' => $userRegistrationSubject,
+        'msg_text' => '',
+        'msg_html' => $userRegistrationHtml,
+        'is_default' => TRUE,
+        'is_reserved' => FALSE,
+      ],
+    ],
+  ],
+];

--- a/ext/standaloneusers/settings/standaloneusers.setting.php
+++ b/ext/standaloneusers/settings/standaloneusers.setting.php
@@ -2,6 +2,17 @@
 use CRM_Standaloneusers_ExtensionUtil as E;
 
 return [
+  'standaloneusers_allow_public_registration' => [
+    'name' => 'standaloneusers_allow_public_registration',
+    'group' => 'standaloneusers',
+    'type' => 'Boolean',
+    'title' => E::ts('Users Can Register'),
+    'description' => E::ts('Allow public user registration.'),
+    'default' => FALSE,
+    'html_type' => 'toggle',
+    'is_domain' => 1,
+    'is_contact' => 0,
+  ],
   'standaloneusers_session_max_lifetime' => [
     'name' => 'standaloneusers_session_max_lifetime',
     'group' => 'standaloneusers',

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -791,4 +791,36 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
     }
   }
 
+  public function testCheckUserNameEmailExists() {
+    $userSystem = \CRM_Core_Config::singleton()->userSystem;
+
+    // Test non-existing username and email
+    $errors = [];
+    $params = [
+      'name' => 'unique_user_' . mt_rand(),
+      'mail' => 'unique_user_' . mt_rand() . '@example.org',
+    ];
+    $userSystem->checkUserNameEmailExists($params, $errors);
+    $this->assertEmpty($errors);
+
+    // Test existing username
+    $errors = [];
+    $params = [
+      'name' => 'nonadmin',
+    ];
+    $userSystem->checkUserNameEmailExists($params, $errors);
+    $this->assertArrayHasKey('cms_name', $errors);
+    $this->assertStringContainsString('nonadmin', $errors['cms_name']);
+
+    // Test existing email
+    $errors = [];
+    $params = [
+      'mail' => 'nonadmin@example.org',
+    ];
+    $userSystem->checkUserNameEmailExists($params, $errors, 'custom_email_field');
+    $this->assertArrayHasKey('custom_email_field', $errors);
+    $this->assertStringContainsString('nonadmin@example.org', $errors['custom_email_field']);
+    $this->assertStringContainsString('civicrm/login/password', $errors['custom_email_field']);
+  }
+
 }

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -823,4 +823,33 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
     $this->assertStringContainsString('civicrm/login/password', $errors['custom_email_field']);
   }
 
+  public function testSendUserRegistrationEmail() {
+    $mut = new \CiviMailUtils($this, TRUE);
+
+    $contact = \Civi\Api4\Contact::create(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('first_name', 'Reg')
+      ->addValue('last_name', 'User')
+      ->execute()->first();
+
+    $params = [
+      'cms_name' => 'reguser_' . mt_rand(),
+      'email' => 'reguser_' . mt_rand() . '@example.org',
+      'contact_id' => $contact['id'],
+      'notify' => TRUE,
+    ];
+
+    $userSystem = \CRM_Core_Config::singleton()->userSystem;
+
+    $userID = $userSystem->createUser($params, 'email');
+    $this->assertNotEmpty($userID);
+
+    $raw = $mut->getMostRecentEmail('raw');
+    $this->assertStringContainsString($params['email'], $raw);
+    $this->assertStringContainsString($params['cms_name'], $raw);
+    $this->assertStringContainsString('civicrm/login/password', $raw);
+    $this->assertStringContainsString('token=', $raw);
+    $mut->stop();
+  }
+
 }

--- a/schema/Core/UFGroup.entityType.php
+++ b/schema/Core/UFGroup.entityType.php
@@ -224,13 +224,16 @@ return [
       ],
     ],
     'is_cms_user' => [
-      'title' => ts('Create CMS User?'),
-      'sql_type' => 'boolean',
-      'input_type' => 'CheckBox',
+      'title' => ts('User account registration'),
+      'sql_type' => 'tinyint',
+      'input_type' => 'Select',
       'required' => TRUE,
       'description' => ts('Should we create a cms user for this profile'),
       'add' => '1.8',
-      'default' => FALSE,
+      'default' => 0,
+      'pseudoconstant' => [
+        'callback' => ['CRM_Core_SelectValues', 'profileUserRegistrationMode'],
+      ],
     ],
     'notify' => [
       'title' => ts('Notify on Profile Submit'),

--- a/templates/CRM/UF/Form/AdvanceSetting.tpl
+++ b/templates/CRM/UF/Form/AdvanceSetting.tpl
@@ -46,10 +46,12 @@
             {include file="CRM/Core/Form/Field.tpl"}
           </tr>
         {/foreach}
-        <tr class="crm-uf-advancesetting-form-block-is_cms_user">
+        {if isset($form.is_cms_user)}
+          <tr class="crm-uf-advancesetting-form-block-is_cms_user">
                 <td class="label">{$form.is_cms_user.label} {help id='is_cms_user'}</td>
                 <td>{$form.is_cms_user.html}</td>
-        </tr>
+          </tr>
+        {/if}
         <tr class="crm-uf-advancesetting-form-block-is_update_dupe">
             <td class="label">{$form.is_update_dupe.label} {help id='is_update_dupe'}</td>
             <td>{$form.is_update_dupe.html}</td>


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new setting which enables CiviCRM Standalone to create users via profile. A configurable welcome email is sent which contains a link to set one's password:

<img width="2108" height="1020" alt="Screenshot 2026-08-21 at 10 35 21 AM" src="https://github.com/user-attachments/assets/2f8ddfb5-0fa6-4052-9e6e-9531b5568575" />


See [dev/core#6647](https://lab.civicrm.org/dev/core/-/work_items/6647)
