### PR TITLE
chart_kit - Allow clearing the Canvas Background/Text color to follow the site theme

### DIFF
--- a/ext/chart_kit/ang/crmChartKitAdmin/chartKitAdminCanvas.html
+++ b/ext/chart_kit/ang/crmChartKitAdmin/chartKitAdminCanvas.html
@@ -9,11 +9,31 @@
   </div>
   <div class="form-inline">
     <label>{{:: ts('Background color') }}</label>
-    <input type="color" class="form-control" ng-model="$ctrl.display.settings.format.backgroundColor">
+    <input type="color" class="form-control" ng-if="$ctrl.display.settings.format.backgroundColor !== null"
+      ng-model="$ctrl.display.settings.format.backgroundColor">
+    <a href class="crm-hover-button" title="{{:: ts('Use theme default') }}"
+      ng-if="$ctrl.display.settings.format.backgroundColor !== null"
+      ng-click="$ctrl.display.settings.format.backgroundColor = null">
+      <i class="crm-i fa-times" aria-hidden="true"></i>
+    </a>
+    <a href ng-if="$ctrl.display.settings.format.backgroundColor === null"
+      ng-click="$ctrl.display.settings.format.backgroundColor = '#f2f2ed'">
+      {{:: ts('Set custom color') }}
+    </a>
   </div>
   <div class="form-inline">
     <label>{{:: ts('Text color') }}</label>
-    <input type="color" class="form-control" ng-model="$ctrl.display.settings.format.labelColor">
+    <input type="color" class="form-control" ng-if="$ctrl.display.settings.format.labelColor !== null"
+      ng-model="$ctrl.display.settings.format.labelColor">
+    <a href class="crm-hover-button" title="{{:: ts('Use theme default') }}"
+      ng-if="$ctrl.display.settings.format.labelColor !== null"
+      ng-click="$ctrl.display.settings.format.labelColor = null">
+      <i class="crm-i fa-times" aria-hidden="true"></i>
+    </a>
+    <a href ng-if="$ctrl.display.settings.format.labelColor === null"
+      ng-click="$ctrl.display.settings.format.labelColor = '#000000'">
+      {{:: ts('Set custom color') }}
+    </a>
   </div>
   <div class="form-inline">
     <label>{{:: ts('Width') }}</label>


### PR DESCRIPTION
Overview
----------------------------------------
Every chart_kit display has a "Canvas" Background color and Text color setting, always populated with an explicit `#f2f2ed`/`#000000` default. Because they're plain `<input type="color">` fields, there was no way to unset them, so a chart's colors always stayed pinned to that light appearance no matter what CiviCRM theme (e.g. Riverlea's dark mode) it was actually viewed in.

Before
----------------------------------------
The Canvas tab always shows a color swatch for Background color / Text color with no way to clear it - only a different color can be picked, never "none". A chart therefore always renders black-on-cream, even on a dark-themed site.

After
----------------------------------------
An "×" control next to each of Background color and Text color clears that setting back to unset/null, at which point the chart falls back to following the page's own theme colors. A "Set custom color" link takes its place to bring the picker back if a fixed color is wanted again.

Same chart, colors cleared, viewed under a light theme and a dark theme:

<img width="1568" height="770" alt="download" src="https://github.com/user-attachments/assets/7df5309e-3035-4742-90d8-56a9f44b1165" />

<img width="1568" height="770" alt="download" src="https://github.com/user-attachments/assets/bc8f8a14-79e3-4aae-8a05-773c4d8f56c4" />

Technical Details
----------------------------------------
This only touches the shared `searchAdminDisplayChartKit`/`chartKitAdminCanvas.html` template used by every chart type - no changes to the renderer. `civi-search-display-chart-kit.js` already handled a `null` value correctly on both settings (the `labelColor` write is already guarded by a truthy check, and assigning `null` to a `CSSStyleDeclaration` property is spec'd to clear it), so the only gap was that the UI could never produce that value. Existing displays are unaffected, since they already have explicit hex values saved from `getInitialDisplaySettings()` - this is purely opt-in for anyone who wants a chart to blend into the page theme instead.

Comments
----------------------------------------
Branch: `chart-kit-clear-format-colors`, single commit.