### PR TITLE
SendPasswordResetEmail: Log more verbose error

### DIFF
--- a/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordResetEmail.php
+++ b/ext/standaloneusers/Civi/Api4/Action/User/SendPasswordResetEmail.php
@@ -51,7 +51,7 @@ class SendPasswordResetEmail extends BasicBatchAction {
         Civi::log()->info("Successfully sent password reset to user {$user['id']} ({$user['username']}) to {$user['uf_name']}");
       }
       catch (\Exception $e) {
-        Civi::log()->error("Failed to send password reset to user {$user['id']} ({$user['username']}) to {$user['uf_name']}");
+        Civi::log()->error("Failed to send password reset to user {$user['id']} ({$user['username']}) to {$user['uf_name']}", ['exception' => $e]);
         return [
           'is_error' => TRUE,
         ];


### PR DESCRIPTION
Overview
----------------------------------------

Logs a more detailed error if the password reset email failed.

Before
----------------------------------------

`[error] Failed to send password reset to user 1 (me) to me@example.org`

After
----------------------------------------

`Failed to send password reset to user 1 (me) to me@civicrm.org: Civi\Crypto\Exception\CryptoException: Failed to find key by ID or tag (AbCdEfG)`

Comments
----------------------------------------

While migrating to Standalone, there can be a few hiccups along the way. This helps find the cause of the problem.

Note that errors are never displayed on screen. It's my understanding that api4 batch requests never let errors surface. This is rather annoying for this specific case I ran into, but maybe it's an odd edge case not worth worrying about.

Alternatively, maybe it's not worth catching the error, but api4 batch will catch it, and log, 

`Failed to run User::sendPasswordResetEmail for item: 1. Error: Failed to find key by ID or tag (AbCdEfG)`

which is still obscure, but we could tweak the crypto exception error.

Note that in this case, the error was because the SMTP password was encrypted, but the `CIVICRM_CRED_KEY` had been rotated during the migration.

cc @ufundo @artfulrobot 