### PR TITLE
Make Accounts Payable actually get used when configured on a financial type

### DIFF
--- a/CRM/Contribute/BAO/FinancialProcessor.php
+++ b/CRM/Contribute/BAO/FinancialProcessor.php
@@ -111,6 +111,10 @@ class CRM_Contribute_BAO_FinancialProcessor {
     if (!$this->originalContribution) {
       return NULL;
     }
+    $payableAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($this->originalContribution->financial_type_id, 'Accounts Payable Account is');
+    if ($payableAccount) {
+      return $payableAccount;
+    }
     $accountRelationship = $this->updatedContribution->revenue_recognition_date ? 'Deferred Revenue Account is' : 'Income Account is';
     return CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($this->originalContribution->financial_type_id, $accountRelationship);
   }
@@ -129,6 +133,13 @@ class CRM_Contribute_BAO_FinancialProcessor {
    * @throws CRM_Core_Exception
    */
   private function getRevenueAccountForType(int $financialTypeID): int {
+    // Where a financial type has an Accounts Payable account configured, its money is being
+    // held to pay back out rather than kept as income, so it belongs there rather than in the
+    // usual income (or deferred revenue) account.
+    $payableAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($financialTypeID, 'Accounts Payable Account is');
+    if ($payableAccount) {
+      return $payableAccount;
+    }
     $accountRelationship = $this->updatedContribution->revenue_recognition_date ? 'Deferred Revenue Account is' : 'Income Account is';
     $account = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($financialTypeID, $accountRelationship);
     if (!$account) {
@@ -153,6 +164,20 @@ class CRM_Contribute_BAO_FinancialProcessor {
       return $params['financial_account_id'];
     }
 
+    // Where the financial type the item was already recorded under has an Accounts
+    // Payable account configured, its money was never recorded as income, so every
+    // status change - including a refund or cancellation paying it back out - should
+    // stay against Accounts Payable rather than being routed through the
+    // income-reversal accounts below. This has to check the type the item was
+    // already on (prevContribution), not params['financial_type_id'], because when a
+    // financial type change is in progress that field has already been updated to
+    // the new type by the time this reversal runs.
+    $payableAccount = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($params['prevContribution']->financial_type_id, 'Accounts Payable Account is');
+    if ($payableAccount) {
+      return $payableAccount;
+    }
+
+    $financialTypeID = !empty($params['financial_type_id']) ? $params['financial_type_id'] : $params['prevContribution']->financial_type_id;
     $contributionStatus = CRM_Contribute_PseudoConstant::contributionStatus($params['contribution_status_id'], 'name');
     $preferredAccountsRelationships = [
       'Refunded' => 'Credit/Contra Revenue Account is',
@@ -160,11 +185,13 @@ class CRM_Contribute_BAO_FinancialProcessor {
     ];
 
     if (array_key_exists($contributionStatus, $preferredAccountsRelationships)) {
-      $financialTypeID = !empty($params['financial_type_id']) ? $params['financial_type_id'] : $params['prevContribution']->financial_type_id;
-      return CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $account = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
         $financialTypeID,
         $preferredAccountsRelationships[$contributionStatus]
       );
+      if ($account) {
+        return $account;
+      }
     }
     return $default;
   }

--- a/CRM/Financial/BAO/FinancialItem.php
+++ b/CRM/Financial/BAO/FinancialItem.php
@@ -79,6 +79,14 @@ class CRM_Financial_BAO_FinancialItem extends CRM_Financial_DAO_FinancialItem {
       if (property_exists($contribution, 'revenue_recognition_date') && !CRM_Utils_System::isNull($contribution->revenue_recognition_date)) {
         $accountRelName = 'Deferred Revenue Account is';
       }
+      if ($lineItem->financial_type_id
+        && CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship($lineItem->financial_type_id, 'Accounts Payable Account is')
+      ) {
+        // Where a financial type has an Accounts Payable account configured, the money
+        // is being held to pay back out rather than kept as income, so it should never
+        // be recorded as income in the first place.
+        $accountRelName = 'Accounts Payable Account is';
+      }
     }
     if ($lineItem->financial_type_id) {
       $params['financial_account_id'] = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -12,8 +12,10 @@
 use Civi\Api4\Contribution;
 use Civi\Api4\EntityFinancialAccount;
 use Civi\Api4\FinancialAccount;
+use Civi\Api4\FinancialItem;
 use Civi\Api4\FinancialTrxn;
 use Civi\Api4\FinancialType;
+use Civi\Api4\LineItem;
 use Civi\Core\HookInterface;
 
 /**
@@ -489,6 +491,280 @@ class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase implements
       ->addWhere('to_financial_account_id', '=', $financialAccount[0]['id'])
       ->execute();
     $this->assertCount(1, $financialTrxns);
+  }
+
+  /**
+   * Set up a reserved financial type together with a Liability account
+   * configured as its 'Accounts Payable Account is' relationship.
+   *
+   * @return array{financialTypeID: int, incomeAccountID: int, payableAccountID: int, contactID: int}
+   */
+  private function createFinancialTypeWithAccountsPayable(string $name): array {
+    $financialType = FinancialType::create(FALSE)->setValues([
+      'name' => $name,
+      'is_reserved' => 1,
+    ])->execute()->first();
+
+    $incomeAccount = FinancialAccount::get(FALSE)
+      ->addWhere('name', '=', $name)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()->single();
+
+    $contactId = $this->individualCreate();
+    $payableAccount = FinancialAccount::create(FALSE)
+      ->addValue('name', $name . '_payable')
+      ->addValue('label', $name . ' Payable')
+      ->addValue('contact_id', $contactId)
+      ->addValue('financial_account_type_id:name', 'Liability')
+      ->execute()->single();
+
+    EntityFinancialAccount::create(FALSE)
+      ->addValue('entity_id', $financialType['id'])
+      ->addValue('entity_table', 'civicrm_financial_type')
+      ->addValue('financial_account_id', $payableAccount['id'])
+      ->addValue('account_relationship:name', 'Accounts Payable Account is')
+      ->execute();
+
+    return [
+      'financialTypeID' => $financialType['id'],
+      'incomeAccountID' => $incomeAccount['id'],
+      'payableAccountID' => $payableAccount['id'],
+      'contactID' => $contactId,
+    ];
+  }
+
+  /**
+   * Where a financial type has an Accounts Payable account configured, a line
+   * item using it is money being held to pay back out, not income - so it
+   * should be recorded against Accounts Payable from the moment it's created,
+   * not just once a refund is under way.
+   */
+  public function testLineItemUsesAccountsPayableAccountWhenConfigured(): void {
+    $setup = $this->createFinancialTypeWithAccountsPayable('Line Item AP Test');
+
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'total_amount' => 300,
+      'currency' => 'USD',
+      'contact_id' => $setup['contactID'],
+      'financial_type_id' => $setup['financialTypeID'],
+      'contribution_status_id' => 'Completed',
+    ]);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+
+    $this->assertEquals($setup['payableAccountID'], $this->getLatestFinancialItemAccountID($lineItem['id']), 'A line item on a financial type with Accounts Payable configured should never be recorded as income.');
+  }
+
+  /**
+   * Once money held in Accounts Payable is paid back out - a refund, in
+   * CiviCRM's terms - the financial item should stay against Accounts
+   * Payable. There is no income to reverse, so it should not be routed
+   * through the Credit/Contra Revenue account the way a normal refund is.
+   */
+  public function testAccountsPayableLineItemStaysInAccountsPayableWhenRefunded(): void {
+    $setup = $this->createFinancialTypeWithAccountsPayable('Refund AP Test');
+
+    $contributionParams = [
+      'total_amount' => 300,
+      'currency' => 'USD',
+      'contact_id' => $setup['contactID'],
+      'financial_type_id' => $setup['financialTypeID'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 'original_payment_ap_test',
+    ];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+
+    $this->assertEquals($setup['payableAccountID'], $this->getLatestFinancialItemAccountID($lineItem['id']));
+
+    $this->callAPISuccess('Contribution', 'create', array_merge($contributionParams, [
+      'id' => $contribution['id'],
+      'contribution_status_id' => 'Refunded',
+      'cancel_date' => date('Y-m-d'),
+      'refund_trxn_id' => 'the_refund_ap_test',
+    ]));
+
+    $this->assertEquals($setup['payableAccountID'], $this->getLatestFinancialItemAccountID($lineItem['id']), 'A refund on an Accounts Payable line item should stay in Accounts Payable, not move to a revenue account.');
+  }
+
+  /**
+   * CiviCRM's "Record Refund" screen, and most payment-processor refund
+   * webhooks, record a refund via Payment.create rather than by directly
+   * changing the contribution's status. That code path never re-classifies
+   * an existing financial item - it just links the refund transaction to it
+   * - so an Accounts Payable line item should simply stay there.
+   */
+  public function testAccountsPayableLineItemStaysInAccountsPayableWhenRefundedViaPaymentApi(): void {
+    $setup = $this->createFinancialTypeWithAccountsPayable('Payment API Refund AP Test');
+
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'total_amount' => 300,
+      'currency' => 'USD',
+      'contact_id' => $setup['contactID'],
+      'financial_type_id' => $setup['financialTypeID'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 'original_payment_api_ap_test',
+    ]);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+
+    $this->assertEquals($setup['payableAccountID'], $this->getLatestFinancialItemAccountID($lineItem['id']));
+
+    $this->callAPISuccess('Payment', 'create', [
+      'contribution_id' => $contribution['id'],
+      'total_amount' => -300,
+      'trxn_date' => date('YmdHis'),
+    ]);
+
+    $this->assertEquals('Refunded', CRM_Core_PseudoConstant::getName(
+      'CRM_Contribute_BAO_Contribution',
+      'contribution_status_id',
+      $this->callAPISuccessGetValue('Contribution', ['id' => $contribution['id'], 'return' => 'contribution_status_id'])
+    ), 'A full refund via Payment.create should move the contribution to Refunded.');
+    $this->assertEquals($setup['payableAccountID'], $this->getLatestFinancialItemAccountID($lineItem['id']), 'A refund recorded via Payment.create should leave the Accounts Payable line item exactly where it was.');
+  }
+
+  /**
+   * Where a financial type has no Accounts Payable account configured,
+   * contributions using it should behave exactly as before: recorded to the
+   * income account, and moved to the Credit/Contra Revenue account (which
+   * falls back to income when not separately configured) on refund.
+   */
+  public function testNormalLineItemUnaffectedWithoutAccountsPayableConfigured(): void {
+    $financialType = FinancialType::create(FALSE)->setValues([
+      'name' => 'No AP Test',
+      'is_reserved' => 1,
+    ])->execute()->first();
+
+    $incomeAccount = FinancialAccount::get(FALSE)
+      ->addWhere('name', '=', 'No AP Test')
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()->single();
+
+    $contactId = $this->individualCreate();
+    $contributionParams = [
+      'total_amount' => 300,
+      'currency' => 'USD',
+      'contact_id' => $contactId,
+      'financial_type_id' => $financialType['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 'original_payment_no_ap_test',
+    ];
+    $contribution = $this->callAPISuccess('Contribution', 'create', $contributionParams);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+
+    $this->assertEquals($incomeAccount['id'], $this->getLatestFinancialItemAccountID($lineItem['id']), 'Completed contribution should be recorded to the income account.');
+
+    $this->callAPISuccess('Contribution', 'create', array_merge($contributionParams, [
+      'id' => $contribution['id'],
+      'contribution_status_id' => 'Refunded',
+      'cancel_date' => date('Y-m-d'),
+      'refund_trxn_id' => 'the_refund_no_ap_test',
+    ]));
+
+    $this->assertEquals($incomeAccount['id'], $this->getLatestFinancialItemAccountID($lineItem['id']), 'Without an Accounts Payable account configured, a refund should behave as before and stay on the income account.');
+  }
+
+  /**
+   * Changing a paid contribution's financial type to one with Accounts
+   * Payable configured reverses the original (income) item and creates a new
+   * one. The reversal should net out against the account the item was
+   * actually on, and the replacement item should land on Accounts Payable,
+   * not income.
+   */
+  public function testChangeFinancialTypeToAccountsPayableOnPaidContribution(): void {
+    $setup = $this->createFinancialTypeWithAccountsPayable('Change To AP Test');
+    $plainFinancialType = FinancialType::create(FALSE)->setValues([
+      'name' => 'Change From Plain Test',
+      'is_reserved' => 1,
+    ])->execute()->first();
+    $plainIncomeAccount = FinancialAccount::get(FALSE)
+      ->addWhere('name', '=', 'Change From Plain Test')
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()->single();
+
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'total_amount' => 300,
+      'currency' => 'USD',
+      'contact_id' => $setup['contactID'],
+      'financial_type_id' => $plainFinancialType['id'],
+      'contribution_status_id' => 'Completed',
+      'trxn_id' => 'change_type_paid_test',
+    ]);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+
+    $this->callAPISuccess('Contribution', 'create', [
+      'id' => $contribution['id'],
+      'financial_type_id' => $setup['financialTypeID'],
+    ]);
+
+    $items = FinancialItem::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_line_item')
+      ->addWhere('entity_id', '=', $lineItem['id'])
+      ->addOrderBy('id')
+      ->addSelect('amount', 'financial_account_id')
+      ->execute();
+    $this->assertCount(3, $items, 'A financial type change should reverse the original item and create a new one.');
+    $items = $items->getArrayCopy();
+    $this->assertEquals([$plainIncomeAccount['id'], 300.0], [$items[1]['financial_account_id'], -$items[1]['amount']], 'The reversal should net out against the account the item was actually recorded on.');
+    $this->assertEquals($setup['payableAccountID'], $items[2]['financial_account_id'], 'The replacement item should be recorded to Accounts Payable, not income.');
+  }
+
+  /**
+   * The same financial type change, but before any payment has been applied
+   * (the contribution is still Pending). This should not affect the Accounts
+   * Payable classification - it's independent of the receivable/cash-side
+   * handling that differs between paid and unpaid contributions.
+   */
+  public function testChangeFinancialTypeToAccountsPayableOnPendingContribution(): void {
+    $setup = $this->createFinancialTypeWithAccountsPayable('Change To AP Pending Test');
+    $plainFinancialType = FinancialType::create(FALSE)->setValues([
+      'name' => 'Change From Plain Pending Test',
+      'is_reserved' => 1,
+    ])->execute()->first();
+
+    $contribution = $this->callAPISuccess('Contribution', 'create', [
+      'total_amount' => 300,
+      'currency' => 'USD',
+      'contact_id' => $setup['contactID'],
+      'financial_type_id' => $plainFinancialType['id'],
+      'contribution_status_id' => 'Pending',
+      'is_pay_later' => 1,
+    ]);
+    $lineItem = LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contribution['id'])
+      ->execute()->single();
+
+    $this->callAPISuccess('Contribution', 'create', [
+      'id' => $contribution['id'],
+      'financial_type_id' => $setup['financialTypeID'],
+      // is_pay_later has to be repeated on every update to a pending pay-later
+      // contribution, or CiviCRM treats it as an incomplete/pending update and
+      // skips financial recording altogether.
+      'is_pay_later' => 1,
+    ]);
+
+    $this->assertEquals($setup['payableAccountID'], $this->getLatestFinancialItemAccountID($lineItem['id']), 'A financial type change on an unpaid contribution should still land the item on Accounts Payable.');
+  }
+
+  /**
+   * Get the financial_account_id of the most recently created financial item for a line item.
+   */
+  private function getLatestFinancialItemAccountID(int $lineItemID): int {
+    return (int) FinancialItem::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_line_item')
+      ->addWhere('entity_id', '=', $lineItemID)
+      ->addOrderBy('id', 'DESC')
+      ->setLimit(1)
+      ->execute()->single()['financial_account_id'];
   }
 
   public static function preHook(\Civi\Core\Event\PreEvent $event): void {


### PR DESCRIPTION
Overview
----------------------------------------
#34249 added a new "Accounts Payable Account is" option so a financial type can point at a liability account for money that's being held and will get paid back out, rather than kept as income. That PR was merged, but during review it came up that setting up the option didn't actually change anything — every financial item still got recorded against Income. This PR makes that setting take effect wherever a line item's account gets decided: when it's first created, when a refund happens, and when a contribution's financial type is changed after the fact.

Before
----------------------------------------
If you configured an Accounts Payable account for a financial type, it made no difference. A contribution using that financial type still had its line items recorded against Income, exactly as if Accounts Payable had never been set up. Getting the books to reflect reality meant going in after the fact and manually correcting things, and handling any refund by hand as well.

After
----------------------------------------
A line item whose financial type has an Accounts Payable account configured is now recorded against that account from the moment it's created — it's never treated as income. If that contribution is later refunded (either directly or through Payment.create, which is what the "Record Refund" screen actually uses), the amount stays against Accounts Payable rather than being routed through the usual income-reversal account. CiviCRM already reverses a line item and creates a new one when a contribution's financial type is changed after the fact — that part isn't new. What's new is that the replacement item now correctly lands on Accounts Payable when the new financial type has one configured, instead of always defaulting to Income. Financial types without an Accounts Payable account configured are unaffected — everything behaves exactly as it did before.

Technical Details
----------------------------------------
Three places needed to change, all in `CRM_Financial_BAO_FinancialItem` and `CRM_Contribute_BAO_FinancialProcessor`:

  - `FinancialItem::add()` always used the "Income Account is" relationship (or "Deferred Revenue Account is" when revenue recognition applied) when creating a line item's financial item. It now checks for an "Accounts Payable Account is" relationship on the financial type first, and uses that instead of either.
  - `FinancialProcessor::getFinancialAccountForStatusChangeTrxn()` decides which account a financial item moves to when a contribution's status changes (this is what runs on a refund or chargeback done by directly changing status). It now checks for Accounts Payable on the financial type the item was already recorded under, before falling back to its existing Refunded/Chargeback handling.
  - `FinancialProcessor::getRevenueAccountForType()` and `getOriginalFinancialAccount()` decide the account used for the new item when a contribution's financial type itself changes. CiviCRM already reverses the old item and creates a new one in this scenario — that mechanism isn't something this PR adds. What these two functions didn't do before is consider Accounts Payable at all; they only ever chose between Income and Deferred Revenue. They now check Accounts Payable first, so the replacement item lands there when the new type has it configured.

One thing worth calling out: the reversal of the old item (via `getFinancialAccountForStatusChangeTrxn`) was already correctly netting out against whatever account the item was actually on before this PR touched anything — core already falls back to that item's own recorded account for a plain financial-type change, since "Completed" isn't one of the statuses its Refunded/Chargeback handling looks for. My first pass at this fix nearly broke that: I initially had the Accounts Payable check key off `params['financial_type_id']`, which by the time the reversal runs has already been updated to the new type, so it would have pointed the reversal at the new type's Accounts Payable account instead of correctly netting against the old one. I caught this by testing the reversal's actual output, not just the new item, and fixed it by keying the check off `prevContribution`'s financial type instead — the type the item was actually recorded under.

Also confirmed this holds up outside of `Contribution.create` status changes — CiviCRM's actual "Record Refund" screen calls `Payment.create`, which is a separate code path that never re-classifies an existing financial item's account at all. That path stays correct simply because the item was already put in the right place at creation time.

Added six tests to `CRM_Financial_BAO_FinancialAccountTest` covering: a line item recorded to Accounts Payable at creation, a refund via direct status change staying there, a refund via `Payment.create` staying there, a financial type change onto Accounts Payable on a paid contribution (checking the reversal nets against the right account and the new item lands on Accounts Payable), the same on a still-Pending contribution, and a control test confirming financial types without Accounts Payable configured are unaffected.

Ran `FinancialAccountTest`, `FinancialItemTest`, the `ContributionTest` BAO suite, and the full `api/v3/ContributionTest` suite — no regressions (a handful of unrelated, pre-existing mail-assertion failures show up in that last suite regardless of this change).

Comments
----------------------------------------
This is the follow-up @seamuslee001 and I discussed on #34249 — we agreed at the time to merge that PR as-is and handle this separately.
  
  While verifying this end to end I also found a separate, pre-existing issue that isn't fixed here: changing a contribution's financial type after it's been paid, where the old and new types have different tax configurations, doesn't adjust `total_amount` or flag a balance. I tested a plain type with no tax changed to one with a 10% tax rate on an already-Completed $300 contribution — the new tax gets recorded as its own $30 financial item tied to the same $300 transaction, `total_amount` stays at 300, and `balance_amount` stays at 0, so nothing on the contribution flags that the books now show $330 of recognized value against $300 of actual cash received. I confirmed this happens identically with and without this PR's changes, so it's unrelated to Accounts Payable specifically — it's a gap in how a financial-type change recalculates tax against an already-settled payment. Flagging it here since it came up during review, but I'd treat it as a separate issue rather than something to fold into this PR.
