### PR TITLE
Inconsistent query-strings (A) -- Use `CRM_Utils_System::makeQueryString()`

### DIFF
--- a/CRM/Mailing/Page/Url.php
+++ b/CRM/Mailing/Page/Url.php
@@ -120,7 +120,7 @@ class CRM_Mailing_Page_Url extends CRM_Core_Page {
       unset($query_param['option']);
     }
 
-    $query_string = http_build_query($query_param);
+    $query_string = \CRM_Utils_System::makeQueryString($query_param);
     return $query_string;
   }
 

--- a/CRM/Report/Utils/Report.php
+++ b/CRM/Report/Utils/Report.php
@@ -519,7 +519,7 @@ WHERE  inst.report_id = %1";
             $url_params["{$basename}_value"] = (is_array($string_values[$basename]) ? implode(',', $string_values[$basename]) : $string_values[$basename]);
           }
         }
-        $query_string = http_build_query($url_params);
+        $query_string = \CRM_Utils_System::makeQueryString($url_params);
       }
       else {
         $query_string = '';

--- a/CRM/Utils/Address/USPS.php
+++ b/CRM/Utils/Address/USPS.php
@@ -274,7 +274,7 @@ class CRM_Utils_Address_USPS {
       $addressData = self::formatAddressForAPI($values);
 
       // Make API request
-      $url = self::USPS_API_BASE . self::ADDRESS_VALIDATE_ENDPOINT . '?' . http_build_query($addressData);
+      $url = self::USPS_API_BASE . self::ADDRESS_VALIDATE_ENDPOINT . '?' . \CRM_Utils_System::makeQueryString($addressData);
       $ch = curl_init($url);
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
       curl_setopt($ch, CURLOPT_HTTPHEADER, [

--- a/CRM/Utils/GuzzleMiddleware.php
+++ b/CRM/Utils/GuzzleMiddleware.php
@@ -88,13 +88,13 @@ class CRM_Utils_GuzzleMiddleware {
                   $request->getMethod(),
                   $request->getUri(),
                   $request->getHeaders(),
-                  http_build_query(['_authx' => "Bearer $tok"]) . ($query ? '&' : '') . $query
+                  \CRM_Utils_System::makeQueryString(['_authx' => "Bearer $tok"]) . ($query ? '&' : '') . $query
                 );
               }
               else {
                 $query = $request->getUri()->getQuery();
                 $request = $request->withUri($request->getUri()->withQuery(
-                  http_build_query(['_authx' => "Bearer $tok"]) . ($query ? '&' : '') . $query
+                  \CRM_Utils_System::makeQueryString(['_authx' => "Bearer $tok"]) . ($query ? '&' : '') . $query
                 ));
               }
               break;

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -203,19 +203,24 @@ class CRM_Utils_System {
   /**
    * Generate a query string if input is an array.
    *
-   * @param array|string $query
-   *
+   * @param array|object|string $query
+   *  - Arrays and objects (with public properties) are encoded. Nested values are also encoded.
+   *  - String is assumed to be pre-encoded. No extra encoding performed.
+   * @param int $encoding
+   *   Choose one of:
+   *   - PHP_QUERY_RFC1738 (spaces become "+")
+   *   - PHP_QUERY_RFC3986 (spaces become "%20")
    * @return string|null
    */
-  public static function makeQueryString($query) {
-    if (is_array($query)) {
-      $buf = '';
-      foreach ($query as $key => $value) {
-        $buf .= ($buf ? '&' : '') . urlencode($key ?? '') . '=' . urlencode($value ?? '');
-      }
-      $query = $buf;
+  public static function makeQueryString($query, int $encoding = PHP_QUERY_RFC1738) {
+    if (is_array($query) || is_object($query)) {
+      // Some deployments may coerce 'arg_separator.output=&amp;', which is deeply confusing.
+      // We want reliable separator.
+      return http_build_query($query, '', '&', $encoding);
     }
-    return $query;
+    else {
+      return $query;
+    }
   }
 
   /**

--- a/CRM/Utils/System.php
+++ b/CRM/Utils/System.php
@@ -1048,7 +1048,7 @@ class CRM_Utils_System {
     // make a GET request to $url
     $ch = curl_init($url);
     if ($addCookie) {
-      curl_setopt($ch, CURLOPT_COOKIE, http_build_query($_COOKIE));
+      curl_setopt($ch, CURLOPT_COOKIE, \CRM_Utils_System::makeQueryString($_COOKIE));
     }
     // it's quite alright to use a self-signed cert
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);

--- a/CRM/Utils/Url.php
+++ b/CRM/Utils/Url.php
@@ -142,7 +142,7 @@ class CRM_Utils_Url {
         unset($queryParts[$urlVar]);
       }
       if (!empty($queryParts)) {
-        $result['query'] = http_build_query($queryParts);
+        $result['query'] = \CRM_Utils_System::makeQueryString($queryParts);
       }
     }
 

--- a/CRM/Utils/VersionCheck.php
+++ b/CRM/Utils/VersionCheck.php
@@ -291,7 +291,7 @@ class CRM_Utils_VersionCheck {
       'http' => [
         'method' => 'POST',
         'header' => 'Content-type: application/x-www-form-urlencoded',
-        'content' => http_build_query($this->stats),
+        'content' => \CRM_Utils_System::makeQueryString($this->stats),
       ],
     ];
     $ctx = stream_context_create($params);

--- a/Civi/Crypto/CryptoToken.php
+++ b/Civi/Crypto/CryptoToken.php
@@ -109,7 +109,7 @@ class CryptoToken extends AutoService {
     $cipherSuite = $registry->findSuite($key['suite']);
     $cipherText = $cipherSuite->encrypt($plainText, $key);
 
-    return $this->delim . self::FMT_QUERY . \http_build_query([
+    return $this->delim . self::FMT_QUERY . \CRM_Utils_System::makeQueryString([
       'k' => $key['id'],
       't' => \CRM_Utils_String::base64UrlEncode($cipherText),
     ]);

--- a/api/class.api.php
+++ b/api/class.api.php
@@ -262,7 +262,7 @@ class civicrm_api3 {
    */
   private function remoteCall($entity, $action, $params = []) {
     $query = $this->uri . "?entity=$entity&action=$action";
-    $fields = http_build_query([
+    $fields = \CRM_Utils_System::makeQueryString([
       'key' => $this->key,
       'api_key' => $this->api_key,
       'json' => json_encode($params),

--- a/ext/contributioncancelactions/tests/phpunit/CancelTest.php
+++ b/ext/contributioncancelactions/tests/phpunit/CancelTest.php
@@ -88,7 +88,7 @@ class CancelTest extends TestCase implements HeadlessInterface, HookInterface, T
     $this->assertCount(2, $memberships);
 
     $ipn = new CRM_Core_Payment_PayPalProIPN([
-      'rp_invoice_id' => http_build_query([
+      'rp_invoice_id' => \CRM_Utils_System::makeQueryString([
         'b' => $this->ids['Contribution'][0],
         'm' => 'contribute',
         'i' => 'zyx',

--- a/ext/standaloneusers/CRM/Standaloneusers/Page/TOTPSetup.php
+++ b/ext/standaloneusers/CRM/Standaloneusers/Page/TOTPSetup.php
@@ -51,7 +51,7 @@ class CRM_Standaloneusers_Page_TOTPSetup extends CRM_Core_Page {
     $domain = CRM_Core_BAO_Domain::getDomain()->name;
     $url = 'otpauth://totp/' . rawurlencode(str_replace(':', '', $domain))
       . ':' . rawurlencode(str_replace(':', '', $pending['username']))
-      . '?' . http_build_query([
+      . '?' . \CRM_Utils_System::makeQueryString([
         'secret' => $seed,
         'digits' => 6,
         'period' => 30,

--- a/extern/url.php
+++ b/extern/url.php
@@ -24,7 +24,7 @@ $url = CRM_Mailing_Event_BAO_MailingEventTrackableURLOpen::track($queue_id, $url
 // Looking for additional query variables and append them when redirecting.
 $query_param = $_GET;
 unset($query_param['q'], $query_param['qid'], $query_param['u']);
-$query_string = http_build_query($query_param);
+$query_string = \CRM_Utils_System::makeQueryString($query_param);
 
 if (strlen($query_string) > 0) {
   // Parse the url to preserve the fragment.


### PR DESCRIPTION
Overview
----------------------------------------

* The codebase includes a mix of calls to internal `CRM_Utils_System::makeQueryString` and to the standard `http_build_query()`.
* Calls to `http_build_query()` aren't entirely reliable. They work fine in most normal configurations. However, if your deployment originated a long time ago (eg Drupal 5? Drupal 6?), then the configuration may have some quirky overrides that break.
    * Ex: https://lab.civicrm.org/dev/core/-/work_items/2563 has the issue affecting crypto-tokens, which was closed b/c sysadmin fixed their configuration. But it's come again. And the odds are the same problem breaks other use-cases -- just in less obvious ways.
* This is one of two possible fixes. I'll add another PR with the other variant.

Before
----------------------------------------

* CiviCRM uses mix of `CRM_Utils_System::makeQueryString` and `http_build_query()`
* `CRM_Utils_System::makeQueryString` accepts query-data as `string` or shallow `array`

After
----------------------------------------

* CiviCRM uses `CRM_Utils_System::makeQueryString`
* `CRM_Utils_System::makeQueryString` is more suitable as a drop-in replacement for `http_build_query()`
    * It accepts deeper inputs (eg nested arrays)
    * It accepts objects with public properties (encoded like arrays).
    * It still accepts the same inputs as before

Comments
----------------------------------------

More comments in commit-message.
