### PR TITLE
dev/core#6694 Fix loading of Managed ACLs screen due to smarty error …

### DIFF
--- a/ext/civicrm_admin_ui/managed/SavedSearch_Manage_ACLs.mgd.php
+++ b/ext/civicrm_admin_ui/managed/SavedSearch_Manage_ACLs.mgd.php
@@ -109,7 +109,7 @@ return [
               'key' => 'deny',
               'label' => 'Mode',
               'sortable' => TRUE,
-              'rewrite' => '{if $deny}{ts}Deny{/ts}{else}{ts}Allow{/ts}',
+              'rewrite' => '{if $deny}{ts}Deny{/ts}{else}{ts}Allow{/ts}{/if}',
             ],
             [
               'type' => 'field',


### PR DESCRIPTION
…in rewrite

Overview
----------------------------------------
This fixes the 500 error on the manage ACLs screen because of a smarty error about an unclosed {/if}. This regresssed in https://github.com/civicrm/civicrm-core/commit/950427bae0afdced6a4105bb74a1385d370657c5

Before
----------------------------------------
Manage ACLs doesn't show any ACLs due to smarty error

After
----------------------------------------
ACLs load

ping @colemanw 