### PR TITLE
Inconsistent query-strings (B) - Prohibit nonstandard separator

### DIFF
--- a/CRM/Upgrade/Form.php
+++ b/CRM/Upgrade/Form.php
@@ -409,6 +409,15 @@ SET    version = '$version'
       ]);
     }
 
+    $installRequirements = new \Civi\Install\Requirements();
+    // FIXME: Duplicate checks appear in `Civi\Install\Requirements`. De-duplicate them. For now, we cherry-pick non-duplicates.
+    foreach (['checkArgSeparator'] as $installReq) {
+      $checkResult = $this->convertInstallCheckToError($installRequirements->$installReq());
+      if ($checkResult) {
+        $errors[] = $checkResult;
+      }
+    }
+
     // CIVICRM_CRED_KEYS was introduced in 5.34. We make it required in 6.10+.
     // Some sites may not have it (if installed before 5.34; or if manually disabled).
     if (!defined('CIVICRM_CRED_KEYS') || in_array(trim(CIVICRM_CRED_KEYS), ['', 'plain'])) {
@@ -443,6 +452,18 @@ SET    version = '$version'
     }
 
     return $errors;
+  }
+
+  protected function convertInstallCheckToError(?array $checkResult): ?string {
+    if (empty($checkResult) || !array_key_exists('severity', $checkResult)) {
+      throw new \RuntimeException(ts('Malformed output from installation-requirements check.'));
+    }
+    return match($checkResult['severity']) {
+      \Civi\Install\Requirements::REQUIREMENT_ERROR => sprintf("<strong>%s</strong>: %s", htmlentities($checkResult['title']), htmlentities($checkResult['details'])),
+      // FIXME: Upgrade UI doesn't provide warning support for this kind of thing. Maybe nice to add another code-path through pre-upgrade message?
+      \Civi\Install\Requirements::REQUIREMENT_WARNING => NULL,
+      \Civi\Install\Requirements::REQUIREMENT_OK => NULL,
+    };
   }
 
   /**

--- a/Civi/Install/Requirements.php
+++ b/Civi/Install/Requirements.php
@@ -28,6 +28,7 @@ class Requirements {
    */
   protected $system_checks = [
     'checkMemory',
+    'checkArgSeparator',
   ];
 
   protected $system_checks_web = [
@@ -211,6 +212,23 @@ class Requirements {
       default:
         return round($memString);
     }
+  }
+
+  public function checkArgSeparator() {
+    $separator = ini_get('arg_separator.output');
+    $ok = ($separator === '&');
+
+    return $ok
+      ? [
+        'title' => 'PHP Argument Separator',
+        'severity' => $this::REQUIREMENT_OK,
+        'details' => 'Standard separator is configured.',
+      ]
+      : [
+        'title' => 'PHP Argument Separator',
+        'severity' => $this::REQUIREMENT_ERROR,
+        'details' => 'The INI setting "arg_separator.output" has a non-standard value. CiviCRM requires the standard "&" separator.',
+      ];
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

* The codebase includes some calls to the standard `http_build_query()`, which constructs query-strings. Most calls use default arguments.
* The default calls to `http_build_query()` aren't entirely reliable. They work fine in most normal configurations. However, if your deployment originated a long time ago (eg Drupal 5? Drupal 6?), then the configuration may have some quirky overrides that break.
    * Ex: https://lab.civicrm.org/dev/core/-/work_items/2563 has the issue affecting crypto-tokens. It was only closed b/c the reporter fixed their own configuration. But it has come again. And the odds are the same problem breaks other use-cases -- just in less obvious ways.
* This is one of two possible fixes. An alternate is #36534.

Before
----------------------------------------

* You can install/upgrade an old system (eg Drupal 5=>6=>7) and wind up with quirky data in `settings.php`, like
    ```php
    ini_set('arg_separator.output',     '&amp;');
    ```
* When code in CiviCRM-land uses `http_build_query()`, it becomes flaky.

After
----------------------------------------

* CiviCRM refuses to install or upgrade if you have a quirky value of `arg_separator.output`.
* The INI setting is more reliable, so the default behavior of `http_build_query()` is more predictable.

Comments
----------------------------------------

This would make `http_build_query()` more reliable. Consequently, there's little need for core to define its own `CRM_Utils_System::makeQueryString()`. Another update could look to phase-out that logic.