### PR TITLE
authx - fix garbled settingsBackup in tests

### DIFF
--- a/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
+++ b/ext/authx/tests/phpunit/Civi/Authx/AbstractFlowsTest.php
@@ -42,7 +42,7 @@ class AbstractFlowsTest extends \PHPUnit\Framework\TestCase implements EndToEndI
 
     parent::setUp();
     $this->settingsBackup = [];
-    foreach (\Civi\Authx\Meta::getFlowTypes() as $flowType) {
+    foreach (\Civi\Authx\Meta::getFlowTypes() as $flowType => $label) {
       foreach (["authx_{$flowType}_cred", "authx_{$flowType}_user", "authx_guards"] as $setting) {
         $this->settingsBackup[$setting] = \Civi::settings()->get($setting);
       }


### PR DESCRIPTION
Before
----------------------------------------
Tries to backup settings using setting labels.

After
----------------------------------------
Correctly backs up settings using setting keys.

Comments
---------------------------------------
It's slightly worrying that using totally garbled settings keys throws no sort of warning... see https://github.com/civicrm/civicrm-core/pull/32802