### PR TITLE
Drupal - use cache tag to flush Drupal content

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -564,12 +564,9 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function flush() {
-    // CiviCRM and Drupal both provide (different versions of) Symfony (and possibly share other classes too).
-    // If we call drupal_flush_all_caches(), Drupal will attempt to rediscover all of its classes, use Civicrm's
-    // alternatives instead and then die. Instead, we only clear cache bins and no more.
-    foreach (Drupal\Core\Cache\Cache::getBins() as $service_id => $cache_backend) {
-      $cache_backend->deleteAll();
-    }
+    // All Drupal content touched by CiviCRM has a `civicrm` cache tag. When flushing from CiviCRM
+    // we just invalidate this tag
+    \Drupal::service('cache_tags.invalidator')->invalidateTags(['civicrm']);
   }
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
- Drupal flush uses a slightly hacky bin clearing method

After
----------------------------------------
- Drupal flush uses the cache tag invalidator with cache tag added in https://github.com/civicrm/civicrm-drupal-8/pull/113
- this invalidates content CiviCRM has touched, but can leave other content in the Drupal cache alone

Comments
----------------------------------------
I've been running this + https://github.com/civicrm/civicrm-core/pull/33728 on a production site for a year or so. The combo successfully solved https://lab.civicrm.org/dev/core/-/work_items/6137

cc @jackrabbithanna as per your suggestion https://github.com/civicrm/civicrm-drupal-8/pull/113#issuecomment-3373381256