### PR TITLE
Show tracking settings correctly in traditional mailing

### DIFF
--- a/ext/civi_mail/ang/crmMailing/BlockTracking.html
+++ b/ext/civi_mail/ang/crmMailing/BlockTracking.html
@@ -5,10 +5,10 @@ Required vars: mailing
 <div class="crm-block" ng-form="subform" crm-ui-id-scope>
   <div class="crm-group">
     <div crm-ui-field="{name: 'subform.url_tracking', title: ts('Track Click-Throughs'), help: hs('url_tracking')}" crm-layout="checkbox">
-      <input crm-ui-id="subform.url_tracking" name="url_tracking" type="checkbox" ng-model="mailing.url_tracking" ng-true-value="'1'" ng-false-value="'0'" />
+      <input crm-ui-id="subform.url_tracking" name="url_tracking" type="checkbox" ng-model="mailing.url_tracking" />
     </div>
     <div crm-ui-field="{name: 'subform.open_tracking', title: ts('Track Opens'), help: hs('open_tracking')}" crm-layout="checkbox">
-      <input crm-ui-id="subform.open_tracking" name="open_tracking" type="checkbox" ng-model="mailing.open_tracking" ng-true-value="'1'" ng-false-value="'0'" />
+      <input crm-ui-id="subform.open_tracking" name="open_tracking" type="checkbox" ng-model="mailing.open_tracking" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
These changed to api4, so we no longer need ng-true-value & ng-false-value.

These incorrectly showed unchecked in the mailing if you had tracking enabled in CiviMail settings, but then showed as enabled on the review screen.