### PR TITLE
Additional fixes for API4 bool format for mailings

### DIFF
--- a/CRM/Mailing/BAO/Mailing.php
+++ b/CRM/Mailing/BAO/Mailing.php
@@ -1061,7 +1061,7 @@ ORDER BY   civicrm_email.is_bulkmail DESC
         // load the default config settings for each
         // eg reply_id, unsubscribe_id need to use
         // correct template IDs here
-        'override_verp' => TRUE,
+        'override_verp' => !Civi::settings()->get('track_civimail_replies'),
         'forward_replies' => FALSE,
         'open_tracking' => Civi::settings()->get('open_tracking_default'),
         'url_tracking' => Civi::settings()->get('url_tracking_default'),

--- a/ext/civi_mail/ang/crmMailing/BlockResponses.html
+++ b/ext/civi_mail/ang/crmMailing/BlockResponses.html
@@ -12,16 +12,16 @@ Required vars: mailing, crmMailingConst
           type="checkbox"
           ng-change="checkVerpChange(mailing)"
           ng-model="mailing.override_verp"
-          ng-true-value="'0'"
-          ng-false-value="'1'"
+          ng-true-value="false"
+          ng-false-value="true"
           />
       </span>
     </div>
-    <div crm-ui-field="{title: ts('Forward Replies'), help: hs('forward_replies')}" crm-layout="checkbox" ng-show="'0' == mailing.override_verp">
-      <input name="forward_replies" type="checkbox" ng-model="mailing.forward_replies" ng-true-value="'1'" ng-false-value="'0'" />
+    <div crm-ui-field="{title: ts('Forward Replies'), help: hs('forward_replies')}" crm-layout="checkbox" ng-show="!mailing.override_verp">
+      <input name="forward_replies" type="checkbox" ng-model="mailing.forward_replies" />
     </div>
-    <div crm-ui-field="{title: ts('Auto-Respond to Replies'), help: hs('auto_responder')}" crm-layout="checkbox" ng-show="'0' == mailing.override_verp">
-      <input name="auto_responder" type="checkbox" ng-model="mailing.auto_responder" ng-true-value="'1'" ng-false-value="'0'" />
+    <div crm-ui-field="{title: ts('Auto-Respond to Replies'), help: hs('auto_responder')}" crm-layout="checkbox" ng-show="!mailing.override_verp">
+      <input name="auto_responder" type="checkbox" ng-model="mailing.auto_responder" />
     </div>
   </div>
 </div>
@@ -30,7 +30,7 @@ Required vars: mailing, crmMailingConst
 
 <div class="crm-block" ng-form="subform" crm-ui-id-scope>
   <div class="crm-group">
-    <div crm-ui-field="{name: 'subform.reply_id', title: ts('Auto-Respond Message')}" ng-show="'0' == mailing.override_verp && '1' == mailing.auto_responder">
+    <div crm-ui-field="{name: 'subform.reply_id', title: ts('Auto-Respond Message')}" ng-show="!mailing.override_verp && mailing.auto_responder">
       <select
         crm-ui-id="subform.reply_id"
         name="reply_id"

--- a/ext/civi_mail/ang/crmMailing/BlockReview.html
+++ b/ext/civi_mail/ang/crmMailing/BlockReview.html
@@ -38,16 +38,16 @@ Required vars: mailing, attachments
         {{crmMailingConst.enabledLanguages[mailing.language]}}
       </div>
       <div crm-ui-field="{title: ts('Tracking')}">
-        <span crm-mailing-review-bool crm-on="mailing.url_tracking=='1'" crm-title="ts('Click-Throughs')"></span>
-        <span crm-mailing-review-bool crm-on="mailing.open_tracking=='1'" crm-title="ts('Opens')"></span>
+        <span crm-mailing-review-bool crm-on="mailing.url_tracking" crm-title="ts('Click-Throughs')"></span>
+        <span crm-mailing-review-bool crm-on="mailing.open_tracking" crm-title="ts('Opens')"></span>
       </div>
       <div crm-ui-field="{title: ts('Responding')}">
         <div>
-          <span crm-mailing-review-bool crm-on="mailing.override_verp=='0'" crm-title="ts('Track Replies')"></span>
-          <span crm-mailing-review-bool crm-on="mailing.override_verp=='0' && mailing.forward_replies=='1'" crm-title="ts('Forward Replies')"></span>
+          <span crm-mailing-review-bool crm-on="!mailing.override_verp" crm-title="ts('Track Replies')"></span>
+          <span crm-mailing-review-bool crm-on="!mailing.override_verp && mailing.forward_replies" crm-title="ts('Forward Replies')"></span>
         </div>
         <div ng-controller="PreviewComponentCtrl">
-          <span ng-show="mailing.override_verp == '0' && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), mailing.reply_id)">{{:: ts('Auto-Respond') }}</a></span>
+          <span ng-show="!mailing.override_verp && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), mailing.reply_id)">{{:: ts('Auto-Respond') }}</a></span>
           <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Opt-out'), mailing.optout_id)">{{:: ts('Opt-out') }}</a></span>
           <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Resubscribe'), mailing.resubscribe_id)">{{:: ts('Resubscribe') }}</a></span>
           <span><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Unsubscribe'), mailing.unsubscribe_id)">{{:: ts('Unsubscribe') }}</a></span>

--- a/ext/civi_mail/ang/crmMailing/EditRecipOptionsDialogCtrl.html
+++ b/ext/civi_mail/ang/crmMailing/EditRecipOptionsDialogCtrl.html
@@ -6,8 +6,6 @@
         <input
           type="checkbox"
           ng-model="model.mailing.dedupe_email"
-          ng-true-value="'1'"
-          ng-false-value="'0'"
           >
       </div>
 

--- a/ext/civi_mail/ang/crmMailing/EmailAddrCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EmailAddrCtrl.js
@@ -15,13 +15,13 @@
 
     $scope.crmFromAddresses = crmFromAddresses;
     $scope.checkReplyToChange = function checkReplyToChange(mailing) {
-      if (!_.isEmpty(mailing.replyto_email) && mailing.override_verp == '0') {
-        mailing.override_verp = '1';
+      if (!_.isEmpty(mailing.replyto_email) && !mailing.override_verp) {
+        mailing.override_verp = true;
         changeAlert(ts('Reply-To'), ts('Track Replies'));
       }
     };
     $scope.checkVerpChange = function checkVerpChange(mailing) {
-      if (!_.isEmpty(mailing.replyto_email) && mailing.override_verp == '0') {
+      if (!_.isEmpty(mailing.replyto_email) && !mailing.override_verp) {
         mailing.replyto_email = '';
         changeAlert(ts('Track Replies'), ts('Reply-To'));
       }

--- a/ext/civi_mail/ang/crmMailingAB/EditCtrl/report.html
+++ b/ext/civi_mail/ang/crmMailingAB/EditCtrl/report.html
@@ -155,18 +155,18 @@
     <tr>
       <td>{{:: ts('Tracking') }}</td>
       <td ng-repeat="am in getActiveMailings()">
-        <div crm-mailing-review-bool crm-on="am.mailing.url_tracking=='1'" crm-title="ts('Click-Throughs')"></div>
-        <div crm-mailing-review-bool crm-on="am.mailing.open_tracking=='1'" crm-title="ts('Opens')"></div>
+        <div crm-mailing-review-bool crm-on="am.mailing.url_tracking" crm-title="ts('Click-Throughs')"></div>
+        <div crm-mailing-review-bool crm-on="am.mailing.open_tracking" crm-title="ts('Opens')"></div>
       </td>
       <td ng-show="abtest.ab.status == 'Testing'"></td>
     </tr>
     <tr>
       <td>{{:: ts('Responding') }}</td>
       <td ng-repeat="am in getActiveMailings()">
-        <div crm-mailing-review-bool crm-on="am.mailing.override_verp=='0'" crm-title="ts('Track Replies')"></div>
-        <div crm-mailing-review-bool crm-on="am.mailing.override_verp=='0' && mailing.forward_replies=='1'" crm-title="ts('Forward Replies')"></div>
+        <div crm-mailing-review-bool crm-on="!am.mailing.override_verp" crm-title="ts('Track Replies')"></div>
+        <div crm-mailing-review-bool crm-on="!am.mailing.override_verp && am.mailing.forward_replies" crm-title="ts('Forward Replies')"></div>
         <div ng-controller="PreviewComponentCtrl">
-          <div ng-show="am.mailing.override_verp == '0' && mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), am.mailing.reply_id)">{{:: ts('Auto-Respond') }}</a></div>
+          <div ng-show="!am.mailing.override_verp && am.mailing.auto_responder"><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Auto-Respond'), am.mailing.reply_id)">{{:: ts('Auto-Respond') }}</a></div>
           <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Opt-out'), am.mailing.optout_id)">{{:: ts('Opt-out') }}</a></div>
           <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Resubscribe'), am.mailing.resubscribe_id)">{{:: ts('Resubscribe') }}</a></div>
           <div><a crm-icon="fa-envelope" class="crm-hover-button action-item" ng-click="previewComponent(ts('Unsubscribe'), am.mailing.unsubscribe_id)">{{:: ts('Unsubscribe') }}</a></div>

--- a/ext/civi_mail/ang/crmMailingAB/services.js
+++ b/ext/civi_mail/ang/crmMailingAB/services.js
@@ -85,8 +85,8 @@
           var mailingDefaults = {
             // Most defaults provided by Mailing.create API, but we
             // want to force-enable tracking.
-            open_tracking: "1",
-            url_tracking: "1",
+            open_tracking: true,
+            url_tracking: true,
             mailing_type:"experiment"
           };
           crmMailingAB.mailings.a = crmMailingMgr.create(mailingDefaults);


### PR DESCRIPTION
Follow up on #36545, turns out there were a bunch more of these. Converted everything to use regular bools.

override_verp (Track Replies) had a long pre-existing bug that always disabled it on creating a new mailing, now it will respect the setting instead. Also the Auto-Respond and Forward Replies settings display on the AB Mailing report were incorrect due to the missing `am`.