### PR TITLE
dev/core#6703 Ensure contact imports don't erroneously use a mapping when it's not specified

### DIFF
--- a/CRM/Import/Forms.php
+++ b/CRM/Import/Forms.php
@@ -475,12 +475,16 @@ class CRM_Import_Forms extends CRM_Core_Form {
       CRM_Core_Error::deprecatedWarning('Classes should implement getUserJobType');
       return;
     }
+    $mappingName = $this->getMappingName();
+    if ($mappingName === '') {
+      return;
+    }
     $this->templateID = UserJob::create(FALSE)->setValues([
       'is_template' => 1,
       'created_id' => CRM_Core_Session::getLoggedInContactID(),
       'job_type' => $this->getUserJobType(),
       'status_id:name' => 'draft',
-      'name' => 'import_' . $this->getMappingName(),
+      'name' => 'import_' . $mappingName,
       'metadata' => ['submitted_values' => $this->getSubmittedValues()],
     ])->execute()->first()['id'];
   }
@@ -925,18 +929,29 @@ class CRM_Import_Forms extends CRM_Core_Form {
       $templateID = $this->getUserJob()['metadata']['template_id'] ?? NULL;
     }
 
+    $jobType = $this->getUserJobType();
     if ($templateID) {
       $templateJob = UserJob::get(FALSE)
         ->addWhere('id', '=', $templateID)
         ->addWhere('is_template', '=', TRUE)
+        ->addWhere('job_type', '=', $jobType)
         ->execute()->first();
       $this->templateID = $templateJob['id'] ?? NULL;
     }
     else {
       $mappingName = $this->getMappingName();
+      // A blank mapping name would look up civicrm_user_job.name = 'import_'.
+      // Saving any import template without a name creates that row, and the
+      // name is unique across all job types, so a nameless contribution
+      // template would be applied to every contact/activity/membership
+      // import that did not select a saved mapping.
+      if ($mappingName === '') {
+        return NULL;
+      }
       $templateJob = UserJob::get(FALSE)
         ->addWhere('name', '=', 'import_' . $mappingName)
         ->addWhere('is_template', '=', TRUE)
+        ->addWhere('job_type', '=', $jobType)
         ->execute()->first();
       $this->templateID = $templateJob['id'] ?? NULL;
     }

--- a/ext/civiimport/ang/crmCiviimport.js
+++ b/ext/civiimport/ang/crmCiviimport.js
@@ -375,6 +375,11 @@
               'label' : $scope.userJob.label,
             };
             if ($scope.mappingSaving.newFieldMapping) {
+              if (!$scope.mappingSaving.newFieldMappingName) {
+                userJobs.push($scope.userJob);
+                $scope.saveJobs(userJobs);
+                return;
+              }
               templateJob.name = 'import_' + $scope.mappingSaving.newFieldMappingName;
               crmApi4('UserJob', 'get', {where: [['name', '=', templateJob.name]]})
                 .then(function(result) {

--- a/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
+++ b/tests/phpunit/CRM/Contact/Import/Form/DataSourceTest.php
@@ -117,6 +117,61 @@ class CRM_Contact_Import_Form_DataSourceTest extends CiviUnitTestCase {
   }
 
   /**
+   * A contribution template named import_ must not attach to a contact import
+   * that has no saved mapping.
+   *
+   * Saving a contribution import template with a blank mapping name creates
+   * civicrm_user_job.name = 'import_'. Contact import then looked that up
+   * without filtering on job_type, copied the contribution mappings, and
+   * padded extra Match Fields rows until Preview crashed looking up
+   * Contribution.contact_id.
+   */
+  public function testNamelessContributionTemplateIsNotUsedForContactImport(): void {
+    $this->createLoggedInUser();
+    UserJob::create(FALSE)
+      ->setValues([
+        'is_template' => TRUE,
+        'job_type' => 'contribution_import',
+        'status_id:name' => 'draft',
+        'name' => 'import_',
+        'metadata' => [
+          'import_mappings' => [
+            ['name' => 'Contribution.contact_id', 'column_number' => 0],
+            ['name' => 'Contribution.total_amount', 'column_number' => 1],
+            ['name' => 'Contact.first_name', 'column_number' => 2],
+            ['name' => 'Contribution.financial_type_id', 'column_number' => 3],
+          ],
+          'entity_configuration' => [
+            'Contribution' => ['action' => 'create'],
+          ],
+        ],
+      ])
+      ->execute();
+
+    $form = $this->submitDataSourceForm([
+      'dataSource' => 'CRM_Import_DataSource_CSV',
+      'skipColumnHeader' => 1,
+      'contactType' => 'Individual',
+      'uploadFile' => [
+        'name' => __DIR__ . '/data/yogi.csv',
+        'type' => 'text/csv',
+      ],
+    ]);
+    $userJob = UserJob::get(FALSE)
+      ->addWhere('id', '=', $form->getUserJobID())
+      ->addSelect('metadata', 'job_type')
+      ->execute()
+      ->first();
+
+    $this->assertEquals('contact_import', $userJob['job_type']);
+    $this->assertEmpty($userJob['metadata']['import_mappings'] ?? []);
+    $this->assertEmpty($userJob['metadata']['template_id'] ?? NULL);
+    $this->assertEquals(3, $userJob['metadata']['DataSource']['number_of_columns']);
+    $this->assertCount(3, $userJob['metadata']['DataSource']['column_headers']);
+    $this->assertArrayNotHasKey('Contribution', $userJob['metadata']['entity_configuration'] ?? []);
+  }
+
+  /**
    * Submit the dataSoure form with the provided form values.
    *
    * @param array $sqlFormValues


### PR DESCRIPTION
## Overview

Fixes [dev/core#6703](https://lab.civicrm.org/dev/core/-/issues/6703): a contact import with no saved mapping no longer inherits a nameless import template from another job type (typically contribution import).

## Before

If any import (usually Contributions) was saved as a UserJob template with a **blank mapping name**, Civi created `civicrm_user_job.name = 'import_'`. That name is unique across all job types.

After that, **Contacts → Import Contacts** with Saved Field Mapping left as “- select -” silently loaded that contribution template:

- Match Fields showed more mapper rows than columns in the CSV (extra rows with empty column names).
- The new `contact_import` job copied contribution mappings (`Contribution.contact_id`, etc.) and `entity_configuration`.
- Continuing to Preview crashed looking up contribution fields:

```
TypeError: CRM_Import_Parser::getFieldMetadata(): Return value must be of type array, null returned
```

Selecting a named saved mapping worked. The same leak could affect Activity / Membership / Participant import with no saved mapping.

## After

A contact (or other) import with no saved mapping does not attach a template from another `job_type`, and does not look up `civicrm_user_job.name = 'import_'` when the mapping name is empty.

Match Fields has one row per CSV column. Saving a new mapping with a blank name no longer creates a template named `import_`.

## Technical Details

`CRM_Import_Forms::getTemplateJob()` looked up templates by `name = 'import_' . $mappingName` with **no `job_type` filter**. With no saved mapping, `$mappingName` is `''`, so it loaded whichever nameless template owned the unique name `import_`.

This change:

1. Does not resolve a template when the mapping name is empty.
2. Filters template lookups by `job_type`.
3. Does not save a new template named `import_` (PHP `createTemplateJob()` and the Angular save path in `crmCiviimport.js`).

Existing nameless `import_` rows are left in place; they are simply no longer applied to other import types.

Adds `testNamelessContributionTemplateIsNotUsedForContactImport` to cover a contact import against a leftover contribution `import_` template.

## Comments

Reproduced on https://d10-master.demo.civicrm.org/. Related to https://lab.civicrm.org/dev/core/-/work_items/6250.