### PR TITLE
resolve user_contact_id in searchkit conditions

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -968,6 +968,22 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
         $condition[2] = \CRM_Core_Config::domainID();
       }
     }
+    // Convert the conditional value of 'user_contact_id' into an actual value that filterCompare can work with
+    if (
+      is_string($field['fk_entity'] ?? NULL)
+      && CoreUtil::isContact($field['fk_entity'])
+    ) {
+      if (($condition[2] ?? NULL) === 'user_contact_id') {
+        // value is a scalar, e.g. `=`, `!=`, `<`, `>`, etc.
+        $condition[2] = FormattingUtil::resolveContactID($field['name'], $condition[2]);
+      }
+      elseif (is_array($condition[2] ?? NULL)) {
+        // value is an array of values, e.g. `IN`, `NOT IN`, `CONTAINS`
+        $condition[2] = array_map(function($value) use ($field) {
+          return $value === 'user_contact_id' ? FormattingUtil::resolveContactID($field['name'], $value) : $value;
+        }, $condition[2]);
+      }
+    }
     return self::filterCompare($data, $condition);
   }
 

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -3152,6 +3152,62 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertCount((int) $shouldBeVisible, $result->toolbar);
   }
 
+  /**
+   * Test link condition with 'user_contact_id' substitution for scalar and array-valued operators.
+   */
+  public function testLinkConditionsUserContactId(): void {
+    $myContactId = $this->createLoggedInUser();
+    $otherContactId = $this->createTestRecord('Individual')['id'];
+
+    $activities = $this->saveTestRecords('Activity', [
+      'records' => [
+        ['subject' => 'My Activity', 'source_contact_id' => $myContactId],
+        ['subject' => 'Other Activity', 'source_contact_id' => $otherContactId],
+      ],
+      'defaults' => ['activity_type_id:name' => 'Meeting'],
+    ]);
+
+    foreach ([['=', 'user_contact_id'], ['IN', ['user_contact_id']]] as [$operator, $value]) {
+      $params = [
+        'return' => 'page:1',
+        'checkPermissions' => FALSE,
+        'savedSearch' => [
+          'api_entity' => 'Activity',
+          'api_params' => [
+            'version' => 4,
+            'select' => ['id', 'subject', 'source_contact_id'],
+            'orderBy' => ['id' => 'ASC'],
+            'where' => [['id', 'IN', $activities->column('id')]],
+          ],
+        ],
+        'display' => [
+          'type' => 'table',
+          'label' => 'testUserContactId',
+          'settings' => [
+            'pager' => [],
+            'sort' => [],
+            'columns' => [
+              ['type' => 'field', 'key' => 'subject', 'label' => 'Subject'],
+              [
+                'type' => 'links',
+                'links' => [
+                  [
+                    'text' => 'My Activity Only',
+                    'path' => 'civicrm/test',
+                    'condition' => ['source_contact_id', $operator, $value],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ];
+      $result = civicrm_api4('SearchDisplay', 'run', $params);
+      $this->assertCount(1, $result[0]['columns'][1]['links'], "operator $operator: my activity should show the link");
+      $this->assertCount(0, $result[1]['columns'][1]['links'], "operator $operator: other activity should not show the link");
+    }
+  }
+
   public function testRunWithEntityFile(): void {
     $cid = $this->createTestRecord('Contact')['id'];
     $notes = $this->saveTestRecords('Note', [


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit allows conditional display of buttons based on record values. For use cases such as preventing self-approval or showing actions only for records belonging to the current user, a Contact ID field (e.g. `Participant.contact_id` or `Participant.created_id`) needs to be compared with `user_contact_id`.

Currently, `user_contact_id` is beeing offered in searchkit conditions to be selected but does not get resolved to the logged-in user's Contact ID when evaluating these conditions.


Before
----------------------------------------
The `user_contact_id` remains a literal string when the condition is evaluated. For a logged-in user with Contact ID 14, comparisons are therefore evaluated like this:
- `13 == 'user_contact_id'` and will return `FALSE`. (this is not me, correct)
- `14 == 'user_contact_id'` and will return `FALSE`. (this is me, **incorrect**)
- `15 == 'user_contact_id'` and will return `FALSE`. (this is not me, correct)


After
----------------------------------------
The `user_contact_id` is resolved to the logged-in user's Contact ID before the condition is evaluated. For a logged-in user with Contact ID 14, the same comparisons are evaluated like this:
- `13 == 14` and will return `FALSE`. (this is not me, correct)
- `14 == 14` and will return `TRUE`. (this is me, **correct**)
- `15 == 14` and will return `FALSE`. (this is not me, correct)


Technical Details
----------------------------------------
Implementation was done in the same way like resolving the `current_domain`.



