### PR TITLE
FTS - prefer contact_names to contact_name, include middle_name

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -104,6 +104,8 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
       'add' => '6.18',
       'default' => NULL,
     ], 'AFTER in_selector');
+
+    $this->addTask(ts('Recreate Mysql Full Text Search indices if necessary'), 'recreateFtsIndexIfNeeded');
   }
 
   /**
@@ -136,6 +138,15 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
         'on_delete' => 'SET NULL',
       ],
     ]);
+
+    return TRUE;
+  }
+
+  public static function recreateFtsIndexIfNeeded(CRM_Queue_TaskContext $ctx): bool {
+    // drop `contact_name` index if added with old def in 6.17
+    CRM_Core_BAO_SchemaHandler::dropIndexIfExists('civicrm_contact', 'contact_name');
+    // ensure `contact_names` index is added (no op if FTS is disable)
+    self::createMissingFtsIndices();
 
     return TRUE;
   }

--- a/Civi/Schema/FullTextSearch.php
+++ b/Civi/Schema/FullTextSearch.php
@@ -55,7 +55,7 @@ class FullTextSearch extends AutoService implements EventSubscriberInterface {
   public function setDefaultIndices(GenericHookEvent $e): void {
     $e->indices = [
       'Contact' => [
-        'contact_name' => ['first_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name'],
+        'contact_names' => ['first_name', 'middle_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name'],
       ],
     ];
   }

--- a/tests/phpunit/Civi/Schema/FullTextSearchTest.php
+++ b/tests/phpunit/Civi/Schema/FullTextSearchTest.php
@@ -40,12 +40,12 @@ class FullTextSearchTest extends TestCase implements HeadlessInterface {
     $settings->set('search_mysql_fts', FALSE);
     $settings->set('search_mysql_fts', TRUE);
 
-    // check contact_name is available
+    // check contact_names is available
     $contactIndexes = $service->getIndexNamesForEntity('Contact');
-    $this->assertTrue(in_array('contact_name', $contactIndexes), 'contact_name in available indexes');
+    $this->assertTrue(in_array('contact_names', $contactIndexes), 'contact_names in available indexes');
 
     $this->tryQueryUsingContactName();
-    $this->assertTrue(TRUE, 'Query using contact_name index didn\'t crash');
+    $this->assertTrue(TRUE, 'Query using contact_names index didn\'t crash');
   }
 
   public function testTurnOff(): void {
@@ -58,17 +58,17 @@ class FullTextSearchTest extends TestCase implements HeadlessInterface {
     // check we can no longer use it
     try {
       $this->tryQueryUsingContactName();
-      $this->fail('Query using contact_name should have failed as we removed it');
+      $this->fail('Query using contact_names should have failed as we removed it');
     }
     catch (\Throwable $e) {
-      $this->assertTrue(TRUE, 'Query using contact_name index failed, as expected');
+      $this->assertTrue(TRUE, 'Query using contact_names index failed, as expected');
     }
   }
 
   protected function tryQueryUsingContactName(): void {
     // columns must match definition from Civi\Schema\FullTextSearch::setDefaultIndices
-    $match = \implode(',', ['first_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name']);
-    // check we can contact_name index defined in ContactType.entityType.php
+    $match = \implode(',', ['first_name', 'middle_name', 'last_name', 'nick_name', 'organization_name', 'household_name', 'legal_name']);
+    // check we can contact_names index defined in ContactType.entityType.php
     \CRM_Core_DAO::executeQuery("SELECT id FROM civicrm_contact WHERE MATCH({$match}) AGAINST ('joe')");
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Pull out small change to the default definition for contact names index from https://github.com/civicrm/civicrm-core/pull/35867 - get this merged asap as it affects upgrader step.

Before
----------------------------------------
- index is called `contact_name` though the whole point is it searches across all the contacts different name*s*
- index does not include middle_name

After
----------------------------------------
- index is called `contact_names` 
- index includes middle_name


Technical Details
----------------------------------------
If people have already upgraded to 6.17.0/1/2 they are going to have the earlier version, so we will want some kind of upgrader. But this MR at least ensures upgrades to 6.17.3/6.18 etc are in the right place.
