### PR TITLE
SearchKit - Always allow filtering on the search display row key

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1465,7 +1465,17 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
     // Allow all filters that are included in SELECT clause or are fields on the Afform.
     $fieldFilters = $this->getAfformFilterFields();
     $directiveFilters = $this->getAfformDirectiveFilters();
-    $allowedFilters = array_merge($this->getSelectAliases(), array_keys($fieldFilters), $directiveFilters);
+    // The row key is always an allowed filter, even when it's only used for groupBy and not
+    // independently selected, because it's what selection-based tasks (e.g. download/email
+    // selected rows) filter by to restrict the query to the rows the user picked.
+    $rowKeyName = $this->getRowKeyName();
+    // Matches the row key formatResult() sends the client (not getRowKeyName()'s raw
+    // 'id'); don't fold this into getRowKeyName() itself, since InlineEdit relies on
+    // that method still returning 'id' for its own (different) write-path use.
+    if ($this->savedSearch['api_entity'] === 'RelationshipCache') {
+      $rowKeyName = 'relationship_id';
+    }
+    $allowedFilters = array_merge($this->getSelectAliases(), array_keys($fieldFilters), $directiveFilters, [$rowKeyName]);
 
     // Ignore empty strings
     $filters = array_filter($this->filters, [$this, 'hasValue']);

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchDownloadTest.php
@@ -174,6 +174,70 @@ class SearchDownloadTest extends \PHPUnit\Framework\TestCase implements Headless
   }
 
   /**
+   * A grouped/aggregate search (e.g. a report using GROUP_CONCAT) commonly
+   * groups by the entity's id without selecting it directly. "Download
+   * selected rows" filters by that id (the row key) to restrict the
+   * download to just the checked rows. Before the fix, applyFilters()
+   * only allowed filtering on fields present in the SELECT clause, so this
+   * id filter was silently dropped and the download fell back to
+   * exporting the entire unfiltered result set.
+   */
+  public function testDownloadSelectedRowsWhenRowKeyNotSelected(): void {
+    $lastName = uniqid(__FUNCTION__);
+    $sampleData = [
+      ['first_name' => 'One', 'last_name' => $lastName],
+      ['first_name' => 'Two', 'last_name' => $lastName],
+      ['first_name' => 'Three', 'last_name' => $lastName],
+      ['first_name' => 'Four', 'last_name' => $lastName],
+    ];
+    $contacts = Contact::save(FALSE)->setRecords($sampleData)->execute();
+    $selectedIds = [$contacts[0]['id'], $contacts[1]['id']];
+
+    $params = [
+      'checkPermissions' => FALSE,
+      'format' => 'array',
+      'savedSearch' => [
+        'api_entity' => 'Contact',
+        'api_params' => [
+          'version' => 4,
+          // Note: `id` is used for groupBy only, not selected directly.
+          'select' => ['first_name'],
+          'where' => [['last_name', '=', $lastName]],
+          'groupBy' => ['id'],
+        ],
+      ],
+      'display' => [
+        'type' => 'table',
+        'label' => '',
+        'settings' => [
+          'actions' => TRUE,
+          'pager' => [],
+          'columns' => [
+            [
+              'key' => 'first_name',
+              'label' => 'First Name',
+              'type' => 'field',
+            ],
+          ],
+          'sort' => [
+            ['id', 'ASC'],
+          ],
+        ],
+      ],
+      // Simulates the "download selected rows" task, which filters by the row key.
+      'filters' => ['id' => $selectedIds],
+      'afform' => NULL,
+    ];
+
+    $result = (array) civicrm_api4('SearchDisplay', 'download', $params);
+    // Header + only the 2 selected rows, not all 4.
+    $this->assertCount(3, $result);
+    $this->assertEquals(['First Name'], $result[0]);
+    $this->assertEquals(['One'], $result[1]);
+    $this->assertEquals(['Two'], $result[2]);
+  }
+
+  /**
    * Test downloading xlsx format.
    */
   public function testDownloadXlsxContact(): void {


### PR DESCRIPTION
Overview
----------------------------------------
`SearchDisplay`'s selection-based tasks (e.g. "download selected rows", "email selected rows") work by filtering the query to the row key values the user checked. `AbstractRunAction::applyFilters()` only allows a filter through if its field is present in the search's `SELECT` clause (or is an Afform filter/directive field). A grouped or aggregate SearchKit display — for example a report built with `GROUP_CONCAT()` columns — commonly groups by the entity's `id` without independently selecting it. In that case the row-key filter is silently dropped, and the task falls back to processing the *entire* unfiltered result set instead of just the rows the user selected.

In one real case this caused a PHP fatal "Allowed memory size exhausted" error: a user selected 2 rows out of a large `Contribution` report and clicked "download", but because `id` was only used in `groupBy` (not `select`), the id filter was ignored and the download tried to export and aggregate the org's entire contribution history instead of the 2 selected rows.

Before
----------------------------------------
Given a saved search that groups by `id` but selects other fields only, filtering "download selected rows" by `id` is silently ignored:

```php
'select' => ['first_name'],
'groupBy' => ['id'],
...
'filters' => ['id' => [122816, 122817]],
```

Result: the download exports **every** row in the search, not just the 2 selected — potentially exhausting PHP's memory limit on any sizeable dataset.

After
----------------------------------------
The row key (`AbstractRunAction::getRowKeyName()`) is always included in the set of allowed filters, regardless of whether it's independently selected. The same `filters => ['id' => [...]]` now correctly restricts the query to just the selected rows.

Technical Details
----------------------------------------
- `getRowKeyName()` already identifies the field selection-based UI actions use to key each row (it's also relied on directly, bypa`applyFilters()`, by `InlineEdit::updateExistingRow()plyFilters()`'s allow-list just never consulted it.
- Preserved the existing `RelationshipCache` → `relationship_id` special case (mirrors the same hack already present in `formatResult()`), with a comment explaining why it can't be hoisted into `getRowKeyName()` itself: that method's plain return valualso used by `InlineEdit` for a different purpose (thd name when writing values), which for`RelationshipCache` must stay `id` — folding the two together would break inline-edit's write path for relationships.
- Added `SearchDownloadTest::testDownloadSelectedRowsWhenRowKeyNotSelected()`, which reproduces the bug with a `Contact` search grouped by `id` but not selecting it, and confirms only the filtered/selected rows are downloaded (verified the test fails without the fix 4 rows returned instead of the 2 selected — and passe
- Ran the full `SearchDisplay/SearchDownloadTest.php` (9 tests) and `SearchDisplay/SearchRunTest.php` (56 tests, including several `groupBy`/aggregate-filter cases) — no regressions.

Comments
----------------------------------------
No behavior changes for the common case (fields not used as the row key are unaffected); this only widens the filter allow-list to include the one field every selection-based task already relies on.