### PR TITLE
Managed - Remove redundant 'checkPermissions' from .mgd.php files

### DIFF
--- a/ext/eventcart/managed/MessageTemplate.mgd.php
+++ b/ext/eventcart/managed/MessageTemplate.mgd.php
@@ -15,7 +15,6 @@ return [
     'update' => 'never',
     'params' => [
       'version' => 4,
-      'checkPermissions' => FALSE,
       'match' => [
         'workflow_name',
         'is_reserved',
@@ -39,7 +38,6 @@ return [
     'update' => 'never',
     'params' => [
       'version' => 4,
-      'checkPermissions' => FALSE,
       'match' => [
         'workflow_name',
         'is_reserved',

--- a/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
+++ b/ext/standaloneusers/managed/MessageTemplate_PasswordReset.mgd.php
@@ -21,7 +21,6 @@ return [
     'update' => 'always',
     'params' => [
       'version' => 4,
-      'checkPermissions' => FALSE,
       'match' => [
         'workflow_name',
         'is_reserved',
@@ -44,7 +43,6 @@ return [
     'update' => 'never',
     'params' => [
       'version' => 4,
-      'checkPermissions' => FALSE,
       'match' => [
         'workflow_name',
         'is_reserved',


### PR DESCRIPTION
Overview
----------------------------------------
Remove unnecessary 'checkPermissions' from .mgd.php files that would have been ignored.

Technical Details
----------------------------------------
Managed entity inserts/updates always bypass permission checks so these lines were redundant.
