### PR TITLE
afTabset - fix url param

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset-menu.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset-menu.html
@@ -1,5 +1,5 @@
 <li>
-  <a href ng-click="$ctrl.addTab()"><i class="crm-i fa-plus-square" role="img" aria-hidden="true"></i> {{:: ts('Add Tab') }}</a>
+  <a href ng-click="$ctrl.addTab()"><i class="crm-i fa-plus-square" role="img" aria-hidden="true"></i> {{:: $ctrl.isPages() ? ts('Add Page') : ts('Add Tab') }}</a>
 </li>
 <li role="separator" class="divider"></li>
-<li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash" role="img" aria-hidden="true"></i> {{:: ts('Delete Tabset') }}</span></a></li>
+<li><a href ng-click="$ctrl.deleteThis()"><span class="text-danger"><i class="crm-i fa-trash" role="img" aria-hidden="true"></i> {{:: $ctrl.isPages() ? ts('Delete Pages') : ts('Delete Tabset') }}</span></a></li>

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.component.js
@@ -46,10 +46,10 @@
         }
       };
 
-      this.addTab = function() {
+      this.addTab = () => {
         this.node['#children'].push({
           '#tag': 'af-tab',
-          'title': ts('New Tab'),
+          'title': this.isPages() ? ts('New Page') : ts('New Tab'),
           '#children': [],
         });
         this.selectTab(this.node['#children'].length - 1);
@@ -104,7 +104,7 @@
         return _.wrap(tabIndex, getSetCount);
       };
 
-      this.hasPageNavButtons = () => this.node['page-nav-buttons'];
+      this.isPages = () => this.node['page-nav-buttons'];
 
     }
   });

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.html
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiTabset.html
@@ -1,6 +1,6 @@
 <div class="af-gui-bar">
   <div class="form-inline">
-    <span>{{:: $ctrl.node['page-nav-buttons'] ? ts('Pages') : ts('Tab Set') }}</span>
+    <span>{{:: $ctrl.isPages() ? ts('Pages') : ts('Tab Set') }}</span>
     <div class="btn-group pull-right" af-gui-menu>
       <button type="button" class="btn btn-default btn-xs dropdown-toggle af-gui-add-element-button" data-toggle="dropdown" title="{{:: ts('Configure') }}">
         <span><i class="crm-i fa-gear" role="img" aria-hidden="true"></i></span>
@@ -26,7 +26,7 @@
 <div ng-repeat="(tabIndex, item) in $ctrl.node['#children']" ng-if="tabIndex === $ctrl.selectedTab">
   <af-gui-container node="item" entity-name="$ctrl.entityName" data-entity="{{ $ctrl.getDataEntity() }}" ></af-gui-container>
 </div>
-<div class="crm-buttons" ng-if="$ctrl.node['page-nav-buttons']">
+<div class="crm-buttons" ng-if="$ctrl.isPages()">
   <button class="crm-button crm-button-back" type="button" ng-if="$ctrl.selectedTab > 0" ng-click="$ctrl.selectTab($ctrl.selectedTab - 1)">
     <i class="crm-i fa-angle-left" role="img" aria-hidden="true"></i>
     {{:: ts('Back') }}

--- a/ext/afform/core/ang/af/afTabset.component.js
+++ b/ext/afform/core/ang/af/afTabset.component.js
@@ -14,7 +14,7 @@
       selectedTab: '=?',
       rememberSelection: '<',
       pageNavButtons: '<',
-      pageNavSubmitText: '<',
+      pageNavSubmitText: '@',
     },
     controller: function($scope, $element, $timeout) {
       const ts = $scope.ts = CRM.ts('org.civicrm.afform');
@@ -34,20 +34,19 @@
 
         $timeout(() => {
           if (!this.selectedTab && this.rememberSelection) {
-            const cachedName = CRM.cache.get(this.getCacheKey());
-            const cachedIndex = this.tabs.findIndex((tab) => tab.name === selectedName);
-            if (cachedIndex !== -1) {
-              this.selectedTab = cachedIndex;
+            const rememberedName = CRM.cache.get(this.getCacheKey());
+            if (rememberedName) {
+              this.selectTab(rememberedName);
             }
           }
           if (!this.selectedTab && this.tabs.length) {
-            this.selectedTab = 0;
+            this.selectTab(this.tabs[0].name);
           }
         });
 
         if (this.rememberSelection) {
           // Watch for tab changes and remember the selection name
-          $scope.$watch('$ctrl.getSelectedName', (newTab) => {
+          $scope.$watch('$ctrl.selectedTab', (newTab) => {
             if (newTab) {
               CRM.cache.set(this.getCacheKey(), newTab);
             }
@@ -59,18 +58,47 @@
         this.tabs.push(tab);
       };
 
-      this.selectTab = (tabIndex) => {
+      this.selectTab = (tabName) => {
+        const currentIndex = this.findTabIndex(this.selectedTab);
+        const newIndex = this.findTabIndex(tabName);
+
         // validate before moving forward
-        if (tabIndex > this.selectedTab) {
-          const currentInvalid = this.tabs[this.selectedTab]?.findInvalid();
-          if (currentInvalid.length) {
+        if (newIndex > currentIndex) {
+          const currentInvalid = this.tabs[currentIndex]?.findInvalid();
+          if (currentInvalid && currentInvalid.length) {
             return;
           }
         }
-        this.selectedTab = tabIndex;
+        this.selectedTab = tabName;
       };
 
-      this.getSelectedName = () => this.tabs[this.selectedTab]?.name;
+      this.findTabIndex = (tabName) => this.tabs.findIndex((tab) => tab.name === tabName);
+
+      this.hasPrevious = () => {
+        const currentIndex = this.findTabIndex(this.selectedTab);
+        return 0 < currentIndex;
+      };
+
+      this.hasNext = () => {
+        const currentIndex = this.findTabIndex(this.selectedTab);
+        return currentIndex < this.tabs.length - 1;
+      };
+
+      this.goToNext = () => {
+        const currentIndex = this.findTabIndex(this.selectedTab);
+        const nextTab = this.tabs[currentIndex + 1];
+        if (nextTab) {
+          this.selectTab(nextTab.name);
+        }
+      };
+
+      this.goToPrevious = () => {
+        const currentIndex = this.findTabIndex(this.selectedTab);
+        const previousTab = this.tabs[currentIndex - 1];
+        if (previousTab) {
+          this.selectTab(previousTab.name);
+        }
+      };
 
       this.getFormName = () => this.afFormCtrl?.getFormMeta().name ?? $scope.$parent.meta.name;
 
@@ -91,7 +119,7 @@
       // Transclude allows the tab scope to be accessed from the inner html as $parent
       transclude: true,
       // ngShow will toggle the class `ng-hide`; also adding it to the markup avoids initial flash
-      template: '<div ng-transclude role="tabpanel" ng-show="afTabsetCtrl.getSelectedName() === name" class="ng-hide"></div>',
+      template: '<div ng-transclude role="tabpanel" ng-show="afTabsetCtrl.selectedTab === name" class="ng-hide"></div>',
       link: function (scope, element, attrs, afTabsetCtrl) {
         scope.name = scope.name || 'tab' + tabNumber++;
         scope.afTabsetCtrl = afTabsetCtrl;

--- a/ext/afform/core/ang/af/afTabset.html
+++ b/ext/afform/core/ang/af/afTabset.html
@@ -1,6 +1,6 @@
 <ul role="tablist" class="nav nav-tabs crm-tab-list">
-  <li ng-repeat="(tabIndex, tab) in $ctrl.tabs" role="tab" class="crm-tab-button" data-name="{{:: tab.name }}" ng-class="{active: tabIndex === $ctrl.selectedTab}">
-    <a href ng-click="$ctrl.selectTab(tabIndex)">
+  <li ng-repeat="tab in $ctrl.tabs" role="tab" class="crm-tab-button" data-name="{{:: tab.name }}" ng-class="{active: tab.name === $ctrl.selectedTab}">
+    <a href ng-click="$ctrl.selectTab(tab.name)">
       <i ng-if="tab.icon" class="crm-i {{ tab.icon }}" role="img" aria-hidden="true"></i>
       {{ tab.title }}
       <span class="badge">{{ tab.count }}</span>
@@ -9,15 +9,15 @@
 </ul>
 <div class="crm-tab-panel" ng-transclude></div>
 <div class="crm-buttons" ng-if="$ctrl.pageNavButtons">
-  <button class="crm-button crm-button-back" type="button" ng-if="$ctrl.selectedTab > 0" ng-click="$ctrl.selectTab($ctrl.selectedTab - 1)">
+  <button class="crm-button crm-button-back" type="button" ng-if="$ctrl.hasPrevious()" ng-click="$ctrl.goToPrevious()">
     <i class="crm-i fa-angle-left" role="img" aria-hidden="true"></i>
     {{:: ts('Back') }}
   </button>
-  <button class="crm-button crm-button-next" ng-if="$ctrl.selectedTab + 1 < $ctrl.tabs.length" ng-click="$ctrl.selectTab($ctrl.selectedTab + 1)">
+  <button class="crm-button crm-button-next" ng-if="$ctrl.hasNext()" ng-click="$ctrl.goToNext()">
     <i class="crm-i fa-angle-right" role="img" aria-hidden="true"></i>
     {{:: ts('Next') }}
   </button>
-  <button class="crm-button crm-button-submit" ng-if="$ctrl.afFormCtrl.showSubmitButton && ($ctrl.selectedTab + 1 == $ctrl.tabs.length)" ng-click="$ctrl.afForm.submit()">
+  <button class="crm-button crm-button-submit" ng-if="$ctrl.afFormCtrl.showSubmitButton && !$ctrl.hasNext()" ng-click="$ctrl.afFormCtrl.submit()">
     {{ $ctrl.pageNavSubmitText }}
   </button>
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Fix url param tracking for tabsets

Before
----------------------------------------
- https://github.com/civicrm/civicrm-core/pull/34495 switched the tracking of the active tab from using tab name to using tab index
- this was easier for doing forward / back buttons etc
- but it broke url param tracking

After
----------------------------------------
- revert to using name to track the active tab
- do the hard work for moving forward / back
- also use "Pages" rather than "Tabs" more consistently in the editor when in Pages mode

