### PR TITLE
Replace removed-in-v4 lodash aliases in core js/ang with native JS

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -1088,7 +1088,8 @@ apiCalls.${results} = [${jsCall}];
 
         case 'php_ts':
           // Fields marked 'localizable' in the schema should get wrapped in ts() for the php_ts format
-          let localizable = _.pluck(_.filter(_.findWhere(getEntity().actions, {name: $scope.action}).fields, {localizable: true}), 'name') || [];
+          let action = getEntity().actions.find((a) => a.name === $scope.action);
+          let localizable = action.fields.filter((f) => f.localizable === true).map((f) => f.name) || [];
           // More field names that probably should be translated
           localizable = _.union(localizable, ['label', 'title', 'description', 'text']);
           // SearchKit settings are not needs to be translated at runtime and not once when the managed file is loaded in the database
@@ -1257,7 +1258,7 @@ apiCalls.${results} = [${jsCall}];
       if ($scope.entity && $routeParams.api4action !== newVal && !_.isUndefined(newVal)) {
         $location.url('/explorer/' + $scope.entity + '/' + newVal);
       } else if (newVal) {
-        setHelp($scope.entity + '::' + newVal, _.pick(_.findWhere(getEntity().actions, {name: newVal}), ['description', 'comment', 'see', 'deprecated']));
+        setHelp($scope.entity + '::' + newVal, _.pick(getEntity().actions.find((a) => a.name === newVal), ['description', 'comment', 'see', 'deprecated']));
       }
     });
 
@@ -1580,7 +1581,7 @@ apiCalls.${results} = [${jsCall}];
         }
 
         function setActions() {
-          scope.actions = [''].concat(_.pluck(getEntity(scope.chain[1][0]).actions, 'name'));
+          scope.actions = [''].concat(getEntity(scope.chain[1][0]).actions.map((a) => a.name));
         }
 
         // Set default params when choosing action

--- a/ang/crmEntityTags.js
+++ b/ang/crmEntityTags.js
@@ -60,7 +60,7 @@
       };
 
       this.getTag = function(id) {
-        return _.findWhere(ctrl.allTags, {id: id});
+        return ctrl.allTags.find((tag) => tag.id === id);
       };
 
       this.hasTag = function(tag) {

--- a/js/Common.js
+++ b/js/Common.js
@@ -704,7 +704,7 @@ if (!CRM.vars) CRM.vars = {};
           if (val === '') {
             return;
           }
-          var idsNeeded = _.difference(val.split(','), _.pluck(staticItems, 'id')),
+          var idsNeeded = _.difference(val.split(','), staticItems.map((item) => item.id)),
             existing = _.filter(staticItems, function(item) {
               return _.includes(val.split(','), item.id);
             });
@@ -742,11 +742,11 @@ if (!CRM.vars) CRM.vars = {};
           // Add static item to selection when clicking static links
           .on('click.crmEntity', '.crm-entityref-links-static a', function() {
             let id = $(this).attr('href').substring(1),
-              item = _.findWhere(staticItems, {id: id});
+              item = staticItems.find((item) => item.id === id);
             $el.select2('close');
             if (multiple) {
               var selection = $el.select2('data');
-              if (!_.findWhere(selection, {id: id})) {
+              if (!selection.find((item) => item.id === id)) {
                 selection.push(item);
                 $el.select2('data', selection, true);
               }
@@ -850,7 +850,7 @@ if (!CRM.vars) CRM.vars = {};
           if (val === '') {
             return;
           }
-          var idsNeeded = _.difference(val.split(','), _.pluck(stored, 'id'));
+          var idsNeeded = _.difference(val.split(','), stored.map((item) => item.id));
           var existing = _.remove(stored, function(item) {
             return _.includes(val.split(','), item.id);
           });
@@ -1036,13 +1036,13 @@ if (!CRM.vars) CRM.vars = {};
         createLinks = CRM.config.entityRef.links[entity];
       }
       else if (typeof params.contact_type === 'string') {
-        createLinks = _.where(CRM.config.entityRef.links[entity], {type: params.contact_type});
+        createLinks = CRM.config.entityRef.links[entity].filter((link) => link.type === params.contact_type);
       } else {
         // lets assume it's an array with filters such as IN etc
         createLinks = [];
         _.each(params.contact_type, function(types) {
           _.each(types, function(type) {
-            createLinks.push(_.findWhere(CRM.config.entityRef.links[entity], {type: type}));
+            createLinks.push(CRM.config.entityRef.links[entity].find((link) => link.type === type));
           });
         });
       }

--- a/js/model/crm.uf.js
+++ b/js/model/crm.uf.js
@@ -245,7 +245,7 @@
       }
     },
     isInSelectorAllowed: function() {
-      var visibility = _.first(_.where(VISIBILITY, {val: this.get('visibility')}));
+      var visibility = VISIBILITY.find((v) => v.val === this.get('visibility'));
       if (visibility) {
         return visibility.isInSelectorAllowed;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Part of a staged effort to remove lodash from civicrm-core's JS: replaces `_.where`, `_.findWhere`, and `_.pluck` with native JS in core `js/`/`ang/` files. These three are lodash-compat-only aliases — removed in lodash v4, only still callable here because of the bundled compat shim — so converting them is pure mechanical cleanup with no behavior change, and a safe first slice to split out on its own.

Before
----------------------------------------
```js
// js/Common.js
var idsNeeded = _.difference(val.split(','), _.pluck(staticItems, 'id'));
item = _.findWhere(staticItems, {id: id});

// js/Common.js (entity-ref quick-add links)
createLinks = _.where(CRM.config.entityRef.links[entity], {type: params.contact_type});

// js/model/crm.uf.js
var visibility = _.first(_.where(VISIBILITY, {val: this.get('visibility')}));

// ang/api4Explorer/Explorer.js
let localizable = _.pluck(_.filter(_.findWhere(getEntity().actions, {name: $scope.action}).fields, {localizable: true}), 'name') || [];

// ang/crmEntityTags.js
return _.findWhere(ctrl.allTags, {id: id});
```

After
----------------------------------------
```js
// js/Common.js
var idsNeeded = _.difference(val.split(','), staticItems.map((item) => item.id));
item = staticItems.find((item) => item.id === id);

// js/Common.js (entity-ref quick-add links)
createLinks = CRM.config.entityRef.links[entity].filter((link) => link.type === params.contact_type);

// js/model/crm.uf.js
var visibility = VISIBILITY.find((v) => v.val === this.get('visibility'));

// ang/api4Explorer/Explorer.js
let action = getEntity().actions.find((a) => a.name === $scope.action);
let localizable = action.fields.filter((f) => f.localizable === true).map((f) => f.name) || [];

// ang/crmEntityTags.js
return ctrl.allTags.find((tag) => tag.id === id);
```

Technical Details
----------------------------------------
- `_.where(collection, {k: v})` → `collection.filter(item => item.k === v)`; `_.findWhere` → `.find(...)` with the same predicate; `_.pluck(collection, 'k')` → `collection.map(item => item.k)`. All call sites here only matched on a single key with no dotted-path arguments, so the direct translation is exact.
- `js/model/crm.uf.js`'s `_.first(_.where(...))` coll`, since that combination is exactly what `_.findWhere` does.
- No behavior change; verified via civilint/jshint (cox: API4 Explorer (including the `php_ts` resultformat, which exercises the `Explorer.js` change), the Contact "Current Employer" quick-add link, and SearchKit's saved-search tags widget. Couldn't find a live UI route to exercise `crm.uf.js`'s `isInSelectorAllowed` (its only wired route in `Misc.xml` is an AJAX schema endpoint) — relied on static equivalence for that one.

Comments
----------------------------------------
