### PR TITLE
Config - Add noisy deprecation to function that does nothing

### DIFF
--- a/CRM/Core/Config.php
+++ b/CRM/Core/Config.php
@@ -191,9 +191,10 @@ class CRM_Core_Config extends CRM_Core_Config_MagicMerge {
    * Reset the serialized array and recompute.
    * use with care
    *
-   * @deprecated
+   * @deprecated in 4.6 will be removed around 6.31
    */
   public function reset() {
+    CRM_Core_Error::deprecatedWarning('CRM_Core_Config::reset function is deprecated and does nothing.');
     // This is what it used to do. However, it hasn't meant anything since 4.6.
     // $query = "UPDATE civicrm_domain SET config_backend = null";
     // CRM_Core_DAO::executeQuery($query);


### PR DESCRIPTION
Overview
----------------------------------------
Warn developers not to use deprecated function.

Before
----------------------------------------
Function does nothing.

After
----------------------------------------
Function emits deprecation notice, then proceeds to do nothing.