### PR TITLE
dev/core#6670 Always use function that ensures count is set for option value calculations

### DIFF
--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -682,21 +682,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
    * @internal function has had several recent signature changes & is expected to be eventually removed.
    */
   private function initEventFee(): void {
-    //get the price set fields participant count.
-    //get option count info.
-    if ($this->getOrder()->isUseParticipantCount()) {
-      $optionsCountDetails = [];
-      if (!empty($this->_priceSet['fields'])) {
-        foreach ($this->_priceSet['fields'] as $field) {
-          foreach ($field['options'] as $option) {
-            $count = $option['count'] ?? 0;
-            $optionsCountDetails['fields'][$field['id']]['options'][$option['id']] = $count;
-          }
-        }
-      }
-      $this->_priceSet['optionsCountDetails'] = $optionsCountDetails;
-    }
-
     //get option max value info.
     $optionsMaxValueTotal = 0;
     $optionsMaxValueDetails = [];
@@ -916,6 +901,31 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
   }
 
   /**
+   * Get the price set fields that participant count applies to.
+   *
+   * If no fields in the price set have a count added to them then then all count as 1 and count
+   * is ignored. But if it is set for any then we need to consider the count for all. If it is
+   * unset it counts as zero.
+   *
+   * @return array
+   * @throws \CRM_Core_Exception
+   */
+  public function getPriceSetFieldsSubjectToParticipantCount(): array {
+    //get the price set fields participant count.
+    //get option count info.
+    $optionsCountDetails = [];
+    if ($this->getOrder()->isUseParticipantCount()) {
+      foreach ($this->getOrder()->getPriceFieldsMetadata() as $field) {
+        foreach ($field['options'] as $option) {
+          $count = $option['count'] ?? 0;
+          $optionsCountDetails[$field['id']]['options'][$option['id']] = $count;
+        }
+      }
+    }
+    return $optionsCountDetails;
+  }
+
+  /**
    * Get the array of price field value IDs on the form that 'count' as
    * full, which will be frozen.
    *
@@ -1015,10 +1025,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
     $priceSetFields = [];
     $hasPriceFieldsCount = FALSE;
     if ($priceSetId) {
-      $priceSetDetails = $form->get('priceSet');
-      if ($form->getOrder()->isUseParticipantCount()) {
+      if ($this->getOrder()->isUseParticipantCount()) {
         $hasPriceFieldsCount = TRUE;
-        $priceSetFields = $priceSetDetails['optionsCountDetails']['fields'];
+        $priceSetFields = $this->getPriceSetFieldsSubjectToParticipantCount();
       }
     }
 
@@ -1166,11 +1175,9 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       return $optionsCount;
     }
 
-    $priceSetFields = $priceMaxFieldDetails = [];
-    if ($form->getOrder()->isUseParticipantCount()) {
-      $priceSetFields = $priceSet['optionsCountDetails']['fields'];
-    }
+    $priceSetFields = $this->getPriceSetFieldsSubjectToParticipantCount();
 
+    $priceMaxFieldDetails = [];
     if ($this->isMaxValueValidationRequired()) {
       $priceMaxFieldDetails = $priceSet['optionsMaxValueDetails']['fields'];
     }
@@ -1416,7 +1423,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       return $errors;
     }
 
-    $optionsCountDetails = $optionsMaxValueDetails = [];
+    $optionsMaxValueDetails = [];
     if (
       $this->isMaxValueValidationRequired()
     ) {
@@ -1424,10 +1431,7 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $optionsMaxValueDetails = $priceSetDetails['optionsMaxValueDetails']['fields'];
     }
 
-    if ($this->getOrder()->isUseParticipantCount()) {
-      $hasOptCount = TRUE;
-      $optionsCountDetails = $priceSetDetails['optionsCountDetails']['fields'];
-    }
+    $optionsCountDetails = $this->getPriceSetFieldsSubjectToParticipantCount();
 
     $optionMaxValues = $optionWithoutCurrentValues = $fieldSelected = [];
     $currentParticipantNo = (int) substr($this->_name, 12);

--- a/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/ConfirmTest.php
@@ -289,6 +289,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
     $participantCount = [
       'standard' => 1,
       'student' => 4,
+      'free' => NULL,
       'student_plus' => 2,
     ];
     foreach ($participantCount as $key => $count) {
@@ -300,7 +301,7 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
       'first_name' => 'Participant1',
       'last_name' => 'LastName',
       'email-Primary' => 'participant1@example.com',
-      'additional_participants' => 2,
+      'additional_participants' => 3,
       'priceSetId' => $this->getPriceSetID('PaidEvent'),
       'payment_processor_id' => 0,
       'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_standard'],
@@ -312,6 +313,14 @@ class CRM_Event_Form_Registration_ConfirmTest extends CiviUnitTestCase {
         'email-Primary' => 'participant2@example.com',
         'priceSetId' => $this->getPriceSetID('PaidEvent'),
         'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_student'],
+      ])
+      ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
+        'first_name' => 'Participant-free',
+        'last_name' => 'Free Loader',
+        'job_title' => 'hobo',
+        'email-Primary' => 'participant-free@example.com',
+        'priceSetId' => $this->getPriceSetID('PaidEvent'),
+        'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_free'],
       ])
       ->addSubsequentForm('CRM_Event_Form_Registration_AdditionalParticipant', [
         'first_name' => 'Participant3',

--- a/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
+++ b/tests/phpunit/CRM/Event/Form/Registration/RegisterTest.php
@@ -9,6 +9,7 @@
  +--------------------------------------------------------------------+
  */
 
+use Civi\Api4\PriceFieldValue;
 use Civi\Test\FormTrait;
 use Civi\Test\FormWrapper;
 
@@ -18,6 +19,11 @@ use Civi\Test\FormWrapper;
  */
 class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
   use FormTrait;
+
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
 
   /**
    * CRM-19626 - Test minimum value configured for price set.
@@ -51,6 +57,31 @@ class CRM_Event_Form_Registration_RegisterTest extends CiviUnitTestCase {
     $form->processForm(FormWrapper::VALIDATED);
     $expectedResult = [
       'additional_participants' => 'There is only enough space left on this event for 2 participant(s).',
+    ];
+    $this->assertValidationError($expectedResult);
+  }
+
+  /**
+   * dev/core#6670 A price option configured with a 'count' should count as
+   * that many participants towards the event's max_participants cap.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testValidateEventWithAvailableSpaceUsesPriceOptionCount(): void {
+    $this->eventCreatePaid(['max_participants' => 1]);
+    PriceFieldValue::update(FALSE)
+      ->addWhere('id', '=', $this->ids['PriceFieldValue']['PaidEvent_student'])
+      ->setValues(['count' => 2])
+      ->execute();
+    $form = $this->getTestForm('CRM_Event_Form_Registration_Register', [
+      'email-Primary' => 'someone@example.com',
+      'priceSetId' => $this->ids['PriceSet']['PaidEvent'],
+      'price_' . $this->ids['PriceField']['PaidEvent'] => $this->ids['PriceFieldValue']['PaidEvent_student'],
+      'payment_processor_id' => 0,
+    ], ['id' => $this->getEventID()]);
+    $form->processForm(FormWrapper::VALIDATED);
+    $expectedResult = [
+      '_qf_default' => 'Only 1 Registrations available.',
     ];
     $this->assertValidationError($expectedResult);
   }


### PR DESCRIPTION

Overview
----------------------------------------
dev/core#6670 Always use function that ensures count is set for option value calculations

Before
----------------------------------------

We have a report of $currentCount = $priceSetFields[$priceFieldId]['options'][$optId] being NULL rather than 0, resulting in a type error on multiplication.

It's hard to trace the sequence of events with the value being taken from the property

After
----------------------------------------
This fixes it to always get it from the same function with no other interference - which should make it reliable

Technical Details
----------------------------------------


Comments
----------------------------------------

