### PR TITLE
Fix type mismatch in findMissingTokens header/footer lookup

### DIFF
--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -193,13 +193,13 @@
         if (!_.isEmpty(mailing[field]) && !CRM.crmMailing.disableMandatoryTokensCheck) {
           var body = '';
           if (mailing.footer_id) {
-            var footer = _.where(CRM.crmMailing.headerfooterList, {id: mailing.footer_id});
+            var footer = _.where(CRM.crmMailing.headerfooterList, {id: "" + mailing.footer_id});
             body = body + footer[0][field];
 
           }
           body = body + mailing[field];
           if (mailing.header_id) {
-            var header = _.where(CRM.crmMailing.headerfooterList, {id: mailing.header_id});
+            var header = _.where(CRM.crmMailing.headerfooterList, {id: "" + mailing.header_id});
             body = body + header[0][field];
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
`findMissingTokens` (used to check for required tokens across a mailing's body, header, and footer) throws a `TypeError` whenever a mailing has a header or footer actually set — which is the normal case for most mailings, not an edge case. Root cause is an API type mismatch: `Mailing.get` (APIv4, typed) returns `header_id`/`footer_id` as integers, but `MailingComponent.get` (APIv3, untyped) returns component `id` as a string, so the strict-equality lookup between them never matches.

Before
----------------------------------------
```js
if (mailing.footer_id) {
  var footer = _.where(CRM.crmMailing.headerfooterList, {id: mailing.footer_id});
  body = body + footer[0][field];
}
```
`mailing.footer_id` is `2` (number, from APIv4). `CRM.crmMailing.headerfooterList` entries have `id: "2"` (string, from APIv3). `2 === "2"` is `false`, so `footer` is always `[]`, and `footer[0][field]` throws `TypeError: Cannot read properties of undefined (reading 'body_html')` — reproducible on every digest cycle that runs this check, on unmodified master.

After
----------------------------------------
```js
if (mailing.footer_id) {
  var footer = _.where(CRM.crmMailing.headerfooterList, {id: "" + mailing.footer_id});
  body = body + footer[0][field];
}
```
Same fix applied to the header lookup just below it.

Technical Details
----------------------------------------
- `PreviewComponentCtrl.js`, in the same directory, already works around this exact API mismatch with the same `"" + componentId` coercion — this brings `findMissingTokens` in line with that existing idiom rather than inventing a new pattern.
- Verified via a sandbox site: reproduced the exact `TypeError` on unpatched code by setting a mailing's header, confirmed it disappears
with this fix, and confirmed (via `git stash`) that t unmodified master and not something introducedelsewhere.
- Only touches the two comparisons; `_.where` itself is untouched here (that's separate lodash-removal work).

Comments
----------------------------------------
Found while doing unrelated lodash-removal cleanup in this file. Independent, standalone fix — no dependency on that work.