### PR TITLE
Replace removed-in-v4 lodash aliases in civi_mail with native JS

### DIFF
--- a/ext/civi_mail/ang/crmMailing/EditMailingCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/EditMailingCtrl.js
@@ -14,7 +14,7 @@
     const block = $scope.block = crmBlocker();
     let myAutosave = null;
 
-    const templateTypes = _.where(CRM.crmMailing.templateTypes, {name: selectedMail.template_type});
+    const templateTypes = CRM.crmMailing.templateTypes.filter((t) => t.name === selectedMail.template_type);
     if (!templateTypes[0]) throw 'Unrecognized template type: ' + selectedMail.template_type;
     $scope.mailingEditorUrl = templateTypes[0].editorUrl;
 

--- a/ext/civi_mail/ang/crmMailing/PreviewComponentCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/PreviewComponentCtrl.js
@@ -6,7 +6,7 @@
     const ts = $scope.ts = CRM.ts('civi_mail');
 
     $scope.previewComponent = function previewComponent(title, componentId) {
-      var component = _.where(CRM.crmMailing.headerfooterList, {id: "" + componentId});
+      var component = CRM.crmMailing.headerfooterList.filter((c) => c.id === "" + componentId);
       if (!component || !component[0]) {
         CRM.alert(ts('Invalid component ID (%1)', {
           1: componentId

--- a/ext/civi_mail/ang/crmMailing/ViewRecipCtrl.js
+++ b/ext/civi_mail/ang/crmMailing/ViewRecipCtrl.js
@@ -8,7 +8,7 @@
       crmMailingLoader.getGroupNames(mailing);
       crmMailingLoader.getCiviMails(mailing);
       _.each(mailing.recipients.groups.include, function(id) {
-        var group = _.where(CRM.crmMailing.groupNames, {id: parseInt(id)});
+        var group = CRM.crmMailing.groupNames.filter((g) => g.id === parseInt(id));
         if (group.length) {
           if (!first) {
             names = names + ', ';
@@ -18,7 +18,7 @@
         }
       });
       _.each(mailing.recipients.mailings.include, function(id) {
-        var oldMailing = _.where(CRM.crmMailing.civiMails, {id: parseInt(id)});
+        var oldMailing = CRM.crmMailing.civiMails.filter((m) => m.id === parseInt(id));
         if (oldMailing.length) {
           if (!first) {
             names = names + ', ';
@@ -33,7 +33,7 @@
       var first = true;
       var names = '';
       _.each(mailing.recipients.groups.exclude, function(id) {
-        var group = _.where(CRM.crmMailing.groupNames, {id: parseInt(id)});
+        var group = CRM.crmMailing.groupNames.filter((g) => g.id === parseInt(id));
         if (group.length) {
           if (!first) {
             names = names + ', ';
@@ -43,7 +43,7 @@
         }
       });
       _.each(mailing.recipients.mailings.exclude, function(id) {
-        var oldMailing = _.where(CRM.crmMailing.civiMails, {id: parseInt(id)});
+        var oldMailing = CRM.crmMailing.civiMails.filter((m) => m.id === parseInt(id));
         if (oldMailing.length) {
           if (!first) {
             names = names + ', ';

--- a/ext/civi_mail/ang/crmMailing/services.js
+++ b/ext/civi_mail/ang/crmMailing/services.js
@@ -40,13 +40,13 @@
         return result;
       },
       getByEmail: function getByEmail(email) {
-        return first(_.where(addrs, {email: email}));
+        return first(addrs.filter((a) => a.email === email));
       },
       getByLabel: function (label) {
-        return first(_.where(addrs, {label: label}));
+        return first(addrs.filter((a) => a.label === label));
       },
       getDefault: function getDefault() {
-        return first(_.where(addrs, {is_default: "1"}));
+        return first(addrs.filter((a) => a.is_default === "1"));
       }
     };
   });
@@ -96,10 +96,7 @@
   angular.module('crmMailing').factory('crmMailingMgr', function ($q, crmApi, crmApi4, crmFromAddresses, crmQueue) {
     const qApi = crmQueue(crmApi4);
     var pickDefaultMailComponent = function pickDefaultMailComponent(type) {
-      var mcs = _.where(CRM.crmMailing.headerfooterList, {
-        component_type: type,
-        is_default: "1"
-      });
+      var mcs = CRM.crmMailing.headerfooterList.filter((mc) => mc.component_type === type && mc.is_default === "1");
       return (mcs.length >= 1) ? mcs[0].id : null;
     };
 
@@ -196,13 +193,13 @@
         if (!_.isEmpty(mailing[field]) && !CRM.crmMailing.disableMandatoryTokensCheck) {
           var body = '';
           if (mailing.footer_id) {
-            var footer = _.where(CRM.crmMailing.headerfooterList, {id: "" + mailing.footer_id});
+            var footer = CRM.crmMailing.headerfooterList.filter((c) => c.id === "" + mailing.footer_id);
             body = body + footer[0][field];
 
           }
           body = body + mailing[field];
           if (mailing.header_id) {
-            var header = _.where(CRM.crmMailing.headerfooterList, {id: "" + mailing.header_id});
+            var header = CRM.crmMailing.headerfooterList.filter((c) => c.id === "" + mailing.header_id);
             body = body + header[0][field];
           }
 
@@ -479,7 +476,7 @@
           if (!_.isEmpty(gids)) {
             CRM.api3('Group', 'get', {'id': {"IN": gids}}).then(function(result) {
               _.each(result.values, function(grp) {
-                if (_.isEmpty(_.where(groupNames, {id: parseInt(grp.id)}))) {
+                if (_.isEmpty(groupNames.filter((g) => g.id === parseInt(grp.id)))) {
                   groupNames.push({id: parseInt(grp.id), title: grp.title, is_hidden: grp.is_hidden});
                 }
               });
@@ -505,7 +502,7 @@
           if (!_.isEmpty(mids)) {
             CRM.api3('Mailing', 'get', {'id': {"IN": mids}}).then(function(result) {
               _.each(result.values, function(mail) {
-                if (_.isEmpty(_.where(civimails, {id: parseInt(mail.id)}))) {
+                if (_.isEmpty(civimails.filter((m) => m.id === parseInt(mail.id)))) {
                   civimails.push({id: parseInt(mail.id), name: mail.name});
                 }
               });

--- a/ext/civi_mail/ang/crmMailingAB/services.js
+++ b/ext/civi_mail/ang/crmMailingAB/services.js
@@ -2,11 +2,11 @@
 
   function OptionGroup(values) {
     this.get = function get(value) {
-      var r = _.where(values, {value: '' + value});
+      var r = Object.values(values).filter((v) => v.value === '' + value);
       return r.length > 0 ? r[0] : null;
     };
     this.getByName = function get(name) {
-      var r = _.where(values, {name: '' + name});
+      var r = Object.values(values).filter((v) => v.name === '' + name);
       return r.length > 0 ? r[0] : null;
     };
     this.getAll = function getAll() {


### PR DESCRIPTION
Overview
----------------------------------------
Part of a staged effort to remove lodash from civicrm-core's JS: replaces `_.where`, `_.findWhere`, and `_.pluck` with native JS across `civi_mail`. These three are lodash-compat-only aliases — removed in lodash v4, only still callable here because of the bundled compat shim.

Before
----------------------------------------
```js
// EditMailingCtrl.js
const templateTypes = _.where(CRM.crmMailing.templateTypes, {name: selectedMail.template_type});

// PreviewComponentCtrl.js
var component = _.where(CRM.crmMailing.headerfooterList, {id: "" + componentId});

// ViewRecipCtrl.js (x2, include/exclude branches)
var group = _.where(CRM.crmMailing.groupNames, {id: parseInt(id)});
var oldMailing = _.where(CRM.crmMailing.civiMails, {id: parseInt(id)});

// services.js
getByEmail: function getByEmail(email) {
  return first(_.where(addrs, {email: email}));
},
var mcs = _.where(CRM.crmMailing.headerfooterList, {
  component_type: type,
  is_default: "1"
});
if (_.isEmpty(_.where(groupNames, {id: parseInt(grp.id)}))) { ... }

// crmMailingAB/services.js
this.get = function get(value) {
  var r = _.where(values, {value: '' + value});
  return r.length > 0 ? r[0] : null;
};
```

After
----------------------------------------
```js
// EditMailingCtrl.js
const templateTypes = CRM.crmMailing.templateTypes.filter((t) => t.name === selectedMail.template_type);

// PreviewComponentCtrl.js
var component = CRM.crmMailing.headerfooterList.filter((c) => c.id === "" + componentId);

// ViewRecipCtrl.js (x2, include/exclude branches)
var group = CRM.crmMailing.groupNames.filter((g) => g.id === parseInt(id));
var oldMailing = CRM.crmMailing.civiMails.filter((m) => m.id === parseInt(id));

// services.js
getByEmail: function getByEmail(email) {
  return first(addrs.filter((a) => a.email === email));
},
var mcs = CRM.crmMailing.headerfooterList.filter((mc) => mc.component_type === type && mc.is_default === "1");
if (_.isEmpty(groupNames.filter((g) => g.id === parseInt(grp.id)))) { ... }

// crmMailingAB/services.js
this.get = function get(value) {
  var r = Object.values(values).filter((v) => v.value === '' + value);
  return r.length > 0 ? r[0] : null;
};
```

Technical Details
----------------------------------------
- `_.where(collection, {k: v})` → `.filter(item => item.k === v)`; `_.findWhere` → `.find(...)`; `_.pluck(collection, 'k')` → `.map(item => item.k)`.
- One multi-key match (`pickDefaultMailComponent` in `services.js`) needed `&&`-combined conditions rather than a naive single-key comparison.
- `crmMailingAB/services.js`'s `OptionGroup` wraps a plain object (`{'1': {...}, '2': {...}}`), not an array — lodash's collection functions work on both, but native array methods don't, so this one uses `Object.values(values).filter(...)` instead of a direct `.filter()`. That code path isn't currently called from any template in the tree, so it's verified only by static reasoning, not live.
- Verified via civilint/jshint (clean) and live in a sandbox: the "From" address dropdown, header/footer selection and preview, and template-type selection on the New Mailing screen — all working, all lodash-free code paths confirmed hit.
- While testing this, found and separately fixed (PR #36570, not part of this PR) a pre-existing bug in `findMissingTokens` unrelated to this conversion — confirmed present on unmodified master via `git stash` before fixing it.

Comments
----------------------------------------
