### PR TITLE
show message status not ok when needed to be alarmed

### DIFF
--- a/CRM/Utils/Check.php
+++ b/CRM/Utils/Check.php
@@ -266,7 +266,7 @@ class CRM_Utils_Check {
    * @return string
    */
   public static function toStatusLabel($level) {
-    if ($level > 1) {
+    if ($level > 2) {
       $options = array_column(self::getSeverityOptions(), 'label', 'id');
       return ts('System Status: %1', [1 => $options[$level]]);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Lower-severity notices should not be displayed in the footer, particularly on development sites or in cases where the message is informational only.

Before
----------------------------------------
Notices are highlighted for system status in footer for all CiviCRM pages causing unnecessary alarm. 

After
----------------------------------------
The footer message should be displayed only for messages with the warning, error, critical, alert, or emergency severity levels.