### PR TITLE
chart_kit admin - fix broken markup, add missing (px) units

### DIFF
--- a/ext/chart_kit/ang/crmChartKitAdmin/chartKitAdminColumns.html
+++ b/ext/chart_kit/ang/crmChartKitAdmin/chartKitAdminColumns.html
@@ -33,7 +33,6 @@
         <input type="color" class="form-control" ng-if="axis.colorType === 'one-per-column'"
           ng-model="$ctrl.display.settings.columns[col.index].color" />
       </div>
-      </details>
       <details class="crm-accordion">
         <summary>{{:: ts('Data handling') }}</summary>
 

--- a/ext/chart_kit/ang/crmChartKitAdmin/typeBackends/chartKitCompositeAdmin.html
+++ b/ext/chart_kit/ang/crmChartKitAdmin/typeBackends/chartKitCompositeAdmin.html
@@ -11,13 +11,13 @@
       <div ng-if="$ctrl.chartType.isGroupedBar($ctrl)" class="form-inline">
         <div class="form-inline">
           <label>
-            {{:: ts('Bar Width') }}
+            {{:: ts('Bar Width (px)') }}
           </label>
           <input type="number" class="form-control" ng-model="$ctrl.display.settings.barWidth" />
         </div>
         <div class="form-inline">
           <label>
-            {{:: ts('Bar Gap') }}
+            {{:: ts('Bar Gap (px)') }}
           </label>
           <input type="number" class="form-control" ng-model="$ctrl.display.settings.barGap" />
         </div>

--- a/ext/chart_kit/ang/crmChartKitAdmin/typeBackends/chartKitHeatMapAdmin.html
+++ b/ext/chart_kit/ang/crmChartKitAdmin/typeBackends/chartKitHeatMapAdmin.html
@@ -19,4 +19,6 @@
 
     </fieldset>
 
+  </div>
+
 </div>


### PR DESCRIPTION
Overview
----------------------------------------
Small cleanup of the chart_kit admin config templates: two invalid-markup fixes and a missing unit label.

Before
----------------------------------------
`chartKitAdminColumns.html` (shared by every chart type) had a stray `</details>` closing tag with no matching opening tag, and `chartKitHeatMapAdmin.html` was missing a closing `</div>` for its presentation wrapper - both harmless to rendering (browsers silently recover from unbalanced tags) but invalid markup. Composite's "Bar Width"/"Bar Gap" fields also had no unit shown, unlike other pixel-valued fields elsewhere in the admin UI.

After
----------------------------------------
Both markup issues are fixed, and "Bar Width (px)"/"Bar Gap (px)" now match the labelling convention used elsewhere.

Technical Details
----------------------------------------
No behaviour change - pure markup/label fixes.

Comments
----------------------------------------