### PR TITLE
recur self-cancel form ignores membership ID

### DIFF
--- a/CRM/Contribute/Form/ContributionRecur.php
+++ b/CRM/Contribute/Form/ContributionRecur.php
@@ -252,6 +252,9 @@ class CRM_Contribute_Form_ContributionRecur extends CRM_Core_Form {
           $this->_mid = $membership['id'];
         }
       }
+      else {
+        $this->_mid = $this->lookup('Membership', 'id');
+      }
     }
     return $this->_mid;
   }


### PR DESCRIPTION
Overview
----------------------------------------
This is a regression, but it's 2 years old, so basing this against master.

When you load the membership self-recur page - e.g. `http://wordpress.example.com/civicrm/?civiwp=CiviCRM&q=civicrm%2Fcontribute%2Funsubscribe&reset=1&mid=<membership id>&cs=<checksum>` - the template is rendered as if no membership ID exists.

Before
----------------------------------------
<img width="1002" height="510" alt="Selection_071" src="https://github.com/user-attachments/assets/9a783887-4cc5-4d52-a1af-5cf51409d5e3" />


After
----------------------------------------
<img width="1039" height="505" alt="Selection_070" src="https://github.com/user-attachments/assets/8b10f93c-e8d6-4977-b93e-a3c62146c617" />


Technical Details
----------------------------------------
This issue occurs because during `CRM_Contribute_Form_ContributionRecur::preProcess()`, the following happens:
* `$this->getMembershipID()` is called, but returns early because the contribution recur ID isn't set (see line 236).
* `$this->getContributionRecurID()` is called, calling `$this->getMembershipValue()` (in `MembershipFormTrait`).  This calls `$this->getMembershipID()`, which still returns early - so `getMembershipValue()` calls `$this->define()`, but without setting `$this->_mid`.
* So next time `$this->getMembershipID()` is called, line 239 (is `_mid` not set) is `TRUE` but line 241 (is membership not defined) returns `FALSE`.  So all calls to `getMembershipId()` after this point will return `NULL`.
