### PR TITLE
Replace removed-in-v4 lodash aliases in afform/chart_kit/civi_case with native JS

### DIFF
--- a/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
@@ -142,7 +142,7 @@
         if (block['af-join']) {
           return !!getElement(ctrl.display.fieldset['#children'], {'af-join': block['af-join']});
         }
-        const fieldsInBlock = _.pluck(afGui.findRecursive(afGui.meta.blocks[block['#tag']].layout, {'#tag': 'af-field'}), 'name');
+        const fieldsInBlock = afGui.findRecursive(afGui.meta.blocks[block['#tag']].layout, {'#tag': 'af-field'}).map((field) => field.name);
         return !!getElement(ctrl.display.fieldset['#children'], function(item) {
           return item['#tag'] === 'af-field' && fieldsInBlock.includes(item.name);
         });

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -152,7 +152,7 @@
           // Calc fields are specific to a search display, not part of the schema
           if (!defn && ctrl.container.getSearchDisplay()) {
             const searchDisplay = ctrl.container.getSearchDisplay();
-            defn = _.findWhere(searchDisplay.calc_fields, {name: fieldName});
+            defn = searchDisplay.calc_fields.find((field) => field.name === fieldName);
           }
         } else if (ctrl.node.defn?.input_type) {
           // Extra (non-entity) field: seed from the inputType's extra_defn

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiGenericElement.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiGenericElement.js
@@ -17,7 +17,7 @@
       let elementType = {};
 
       this.$onInit = function() {
-        elementType = _.findWhere(afGui.meta.elements, {directive: ctrl.node['#tag']});
+        elementType = Object.values(afGui.meta.elements).find((element) => element.directive === ctrl.node['#tag']);
       };
 
       this.getTemplate = function() {

--- a/ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
+++ b/ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
@@ -44,7 +44,7 @@
       this.$onInit = () => {
         this.searchColumns = this.apiParams.select.map((select) => {
           const info = searchMeta.parseExpr(select, {api_entity: this.apiEntity, api_params: this.apiParams});
-          const field = (_.findWhere(info.args, {type: 'field'}) || {}).field || {};
+          const field = (info.args.find((arg) => arg.type === 'field') || {}).field || {};
           let dataType = (info.fn && info.fn.data_type) || field.data_type;
           // hack: search kit reports option group columns as
           // "Integer" data type - but for our purposes they

--- a/ext/civi_case/ang/crmCaseType.js
+++ b/ext/civi_case/ang/crmCaseType.js
@@ -412,7 +412,7 @@
       activitySet.activityTypes = [];
 
       var offset = 1;
-      var names = _.pluck($scope.caseType.definition.activitySets, 'name');
+      var names = $scope.caseType.definition.activitySets.map((activitySet) => activitySet.name);
       while (_.contains(names, workflow + '_' + offset)) offset++;
       activitySet.name = workflow + '_' + offset;
       activitySet.label = (offset == 1  ) ? $scope.workflows[workflow] : ($scope.workflows[workflow] + ' #' + offset);
@@ -477,7 +477,7 @@
 
     /// Add a new top-level activity-type entry
     $scope.addActivityType = function(activityType) {
-      var names = _.pluck($scope.caseType.definition.activityTypes, 'name');
+      var names = $scope.caseType.definition.activityTypes.map((activityType) => activityType.name);
       if (!_.contains(names, activityType)) {
         // Add an activity type that exists
         if ($scope.activityTypes[activityType]) {
@@ -521,7 +521,7 @@
       // roles for the case type. Unfortunately, caseRoles only stores name,
       // which doesn't indicate the id or direction, because the xml spec
       // doesn't support those.
-      var names = _.pluck($scope.caseType.definition.caseRoles, 'name');
+      var names = $scope.caseType.definition.caseRoles.map((caseRole) => caseRole.name);
       if (matchingRole) {
         // If it's not in the table already, add it, otherwise do nothing since
         // don't want to add it twice.
@@ -622,7 +622,7 @@
         case 'timeline':
           return true;
         case 'sequence':
-          return 0 === _.where($scope.caseType.definition.activitySets, {sequence: '1'}).length;
+          return 0 === $scope.caseType.definition.activitySets.filter((activitySet) => activitySet.sequence === '1').length;
         default:
           CRM.console('warn', 'Denied access to unrecognized workflow: (' + workflow + ')');
           return false;


### PR DESCRIPTION
Overview
----------------------------------------
Continues the staged lodash removal effort ([civicrm-core PR #36563](https://github.com/civicrm/civicrm-core/pull/36563)) by converting the `afform`, `chart_kit`, and `civi_case` extensions from the removed-in-v4 lodash aliases `_.where`/`_.findWhere`/`_.pluck` to native `Array.prototype` methods. These aliases only work because civicrm-core bundles the `lodash-compat` shim; lodash v4 itself dropped them entirely.

Before
----------------------------------------
```js
// ext/afform/admin/ang/afGuiEditor/afGuiSearch.component.js
const fieldsInBlock = _.pluck(afGui.findRecursive(afGui.meta.blocks[block['#tag']].layout, {'#tag': 'af-field'}), 'name');

// ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
defn = _.findWhere(searchDisplay.calc_fields, {name: fieldName});

// ext/afform/admin/ang/afGuiEditor/elements/afGuiGenericElement.js
elementType = _.findWhere(afGui.meta.elements, {directive: ctrl.node['#tag']});

// ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
const field = (_.findWhere(info.args, {type: 'field'}

// ext/civi_case/ang/crmCaseType.js
var names = _.pluck($scope.caseType.definition.activitySets, 'name');
var names = _.pluck($scope.caseType.definition.activityTypes, 'name');
var names = _.pluck($scope.caseType.definition.caseRo
return 0 === _.where($scope.caseType.definition.activitySets, {sequence: '1'}).length;
```

After
----------------------------------------
```js
// ext/afform/admin/ang/afGuiEditor/afGuiSearch.compo
const fieldsInBlock = afGui.findRecursive(afGui.meta.blocks[block['#tag']].layout, {'#tag': 'af-field'}).map((field) => field.name);

// ext/afform/admin/ang/afGuiEditor/elements/afGuiFie
defn = searchDisplay.calc_fields.find((field) => field.name === fieldName);

// ext/afform/admin/ang/afGuiEditor/elements/afGuiGenericElement.js
elementType = Object.values(afGui.meta.elements).find((element) => element.directive === ctrl.node['#tag']);

// ext/chart_kit/ang/crmChartKitAdmin/searchAdminDisplayChartKit.component.js
const field = (info.args.find((arg) => arg.type === 'field') || {}).field || {};

// ext/civi_case/ang/crmCaseType.js
var names = $scope.caseType.definition.activitySets.map((activitySet) => activitySet.name);
var names = $scope.caseType.definition.activityTypes.map((activityType) => activityType.name);
var names = $scope.caseType.definition.caseRoles.map((caseRole) => caseRole.name);
return 0 === $scope.caseType.definition.activitySets.itySet.sequence === '1').length;
```

Technical Details
----------------------------------------
`afGui.meta.elements` (in `afGuiGenericElement.js`) is a plain object keyed by element name, not an array — confirmed via its other call sites (`Object.entries`/`Object.values` usage, `.fieldset.element` property access elsewhere in the same directory). A direct `.find()` would silently do nothing there, so it's wrapped in `Object.values(...)` first. All other converted call sites (`calc_fields`, `info.args`, and all three `crmCaseType.js` definition arrays) were confirmed to be plain arrays by checking their construction/`.push()`/`.length` usage elsewhere in the same files before converting.

No behavior change. Verified via `civilint` (clean, no jshint errors) and live in a sandbox site: FormBuilder's search-form editor (field settings panel, calc-fields lookup) and the Case Type editor (adding Timeline/Sequence activity sets, Case Roles, Activity Types) all worked with no console errors.

Comments
----------------------------------------
Part of the staged lodash removal effort tracked alongside #36563, #36570, and #36571.