### PR TITLE
Replace removed-in-v4 lodash aliases in search_kit with native JS

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminDisplay.component.js
@@ -152,7 +152,7 @@
       this.getDataType = function(key) {
         const expr = ctrl.getExprFromSelect(key);
         const info = searchMeta.parseExpr(expr, ctrl.savedSearch);
-        const field = (_.findWhere(info.args, {type: 'field'}) || {}).field || {};
+        const field = (info.args.find((arg) => arg.type === 'field') || {}).field || {};
         return (info.fn && info.fn.data_type) || field.data_type;
       };
 
@@ -273,7 +273,7 @@
         }
         const expr = ctrl.getExprFromSelect(col.key),
           info = searchMeta.parseExpr(expr, ctrl.savedSearch),
-          arg = (info && info.args && _.findWhere(info.args, {type: 'field'})) || {};
+          arg = (info && info.args && info.args.find((arg) => arg.type === 'field')) || {};
         return arg.field && arg.field.type !== 'Pseudo';
       };
 
@@ -299,7 +299,7 @@
 
       this.onChangeLink = function(column, afterLink) {
         column.link = column.link || {};
-        const beforeLink = column.link.action && _.findWhere(ctrl.getLinks(column.key), {action: column.link.action});
+        const beforeLink = column.link.action && ctrl.getLinks(column.key).find((link) => link.action === column.link.action);
         if (!afterLink.action && !afterLink.path && !afterLink.task) {
           if (beforeLink && beforeLink.text === column.title) {
             delete column.title;

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminImport.component.js
@@ -62,7 +62,7 @@
                     const info = results.Entity[entity],
                       count = getCalls[entity][2].where[0][2].length,
                       existing = results[entity].count,
-                      saveCall = _.findWhere(apiCalls, {0: entity});
+                      saveCall = apiCalls.find((call) => call[0] === entity);
                     // Unless it's an afform, the api save params must include `match` or an update is not possible
                     if (existing && entity !== 'Afform' && (!saveCall[2].match || !saveCall[2].match.length)) {
                       ctrl.error += ' ' + ts('Cannot create %1 %2 because an existing one with the same name already exists.', {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminLinkGroup.component.js
@@ -18,7 +18,7 @@
       this.styles = CRM.crmSearchAdmin.styles;
 
       this.getStyle = function(item) {
-        return _.findWhere(this.styles, {key: item.style});
+        return this.styles.find((style) => style.key === item.style);
       };
 
       this.sortableOptions = {

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchClause.component.js
@@ -42,7 +42,7 @@
       function getFirstArgFromExpr(expr) {
         if (!(expr in meta)) {
           const args = searchMeta.parseExpr(expr, ctrl.savedSearch).args;
-          meta[expr] = _.findWhere(args, {type: 'field'});
+          meta[expr] = args.find((arg) => arg.type === 'field');
         }
         return meta[expr] || {};
       }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchCondition.component.js
@@ -108,7 +108,7 @@
 
       // Ensures clause is using an operator that is allowed for the field
       function updateOperators() {
-        if ((!getOperator() || !_.includes(_.pluck(ctrl.getOperators(), 'key'), getOperator()))) {
+        if ((!getOperator() || !ctrl.getOperators().map((operator) => operator.key).includes(getOperator()))) {
           setOperator(ctrl.getOperators()[0].key);
         }
       }

--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchFunction.component.js
@@ -142,7 +142,7 @@
             (ctrl.savedSearch.api_params.groupBy || []).forEach(function(fieldStr) {
               if (fieldStr.includes(ctrl.fieldArg.field.name) && fieldStr.includes('(')) {
                 let fieldExpr = searchMeta.parseExpr(fieldStr, ctrl.savedSearch);
-                let field = _.findWhere(fieldExpr.args, {type: 'field'});
+                let field = fieldExpr.args.find((arg) => arg.type === 'field');
                 if (fieldExpr.fn && fieldExpr.fn.name !== 'e' && field && field.field.name === ctrl.fieldArg.field.name) {
                   functions.push({
                     text: allTypes[fieldExpr.fn.category],

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmMultiSelectDate.directive.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmMultiSelectDate.directive.js
@@ -42,7 +42,7 @@
                 $input
                   .datepicker({
                     beforeShow: function() {
-                      const existingSelections = _.pluck($el.select2('data') || [], 'id');
+                      const existingSelections = ($el.select2('data') || []).map((selection) => selection.id);
                       return {
                         changeMonth: true,
                         changeYear: true,

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -33,7 +33,7 @@
         });
 
         function setDateType() {
-          if (_.findWhere(ctrl.dateRanges, {id: ctrl.value})) {
+          if (ctrl.dateRanges.find((dateRange) => dateRange.id === ctrl.value)) {
             ctrl.dateType = 'range';
           } else if (ctrl.value === 'now') {
             ctrl.dateType = 'now';

--- a/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
+++ b/ext/search_kit/ang/crmSearchTasks/traits/searchDisplayTasksTrait.service.js
@@ -39,7 +39,7 @@
         return !displayCtrl.loading && displayCtrl.results && displayCtrl.results.length;
       };
       this.getTaskInfo = function(taskName) {
-        return _.findWhere(mngr.tasks, {name: taskName});
+        return mngr.tasks.find((task) => task.name === taskName);
       };
 
       this.doTask = function(task, ids, isLink) {
@@ -119,7 +119,7 @@
       // Select all rows on the current page
       selectPage: function() {
         this.allRowsSelected = (this.rowCount <= this.results.length);
-        this.selectedRows = _.uniq(_.pluck(this.results, 'key'));
+        this.selectedRows = _.uniq(this.results.map((result) => result.key));
       },
 
       // Clear selection
@@ -169,7 +169,7 @@
         if (index < 0) {
           // Shift-click - select range between clicked checkbox and the nearest selected row
           if (event.shiftKey && ctrl.selectedRows.length) {
-            const allRows = _.pluck(ctrl.results, 'key'),
+            const allRows = ctrl.results.map((result) => result.key),
               checkboxPosition = allRows.indexOf(row.key);
 
             const nearestBefore = checkRange(allRows, checkboxPosition, -1),
@@ -233,7 +233,7 @@
         if (editedRow && status === 'success' && this.selectedRows) {
           // If edited row disappears (because edits cause it to not meet search criteria), deselect it
           const index = this.selectedRows.indexOf(editedRow.key);
-          if (index > -1 && !_.findWhere(apiResults.run, {key: editedRow.key})) {
+          if (index > -1 && !apiResults.run.find((row) => row.key === editedRow.key)) {
             this.selectedRows.splice(index, 1);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Completes the `_.where`/`_.findWhere`/`_.pluck` portion of the staged lodash removal effort ([civicrm-core PR #36563](https://github.com/civicrm/civicrm-core/pull/36563), [#36576](https://github.com/civicrm/civicrm-core/pull/36576)) by converting `search_kit` — the largest and most actively developed extension using these aliases — to native `Array.prototype` methods. These aliases only work because civicrm-core bundles the `lodash-compat` shim; lodash v4 itself dropped them entirely.

Before
----------------------------------------
```js
// crmSearchAdminDisplay.component.js (x3)
const field = (_.findWhere(info.args, {type: 'field'}) || {}).field || {};
arg = (info && info.args && _.findWhere(info.args, {type: 'field'})) || {};
const beforeLink = column.link.action && _.findWhere(ctrl.getLinks(column.key), {action: column.link.action});

// crmSearchAdminImport.component.js
saveCall = _.findWhere(apiCalls, {0: entity});

// crmSearchAdminLinkGroup.component.js
return _.findWhere(this.styles, {key: item.style});

// crmSearchClause.component.js
meta[expr] = _.findWhere(args, {type: 'field'});

// crmSearchCondition.component.js
if ((!getOperator() || !_.includes(_.pluck(ctrl.getOperators(), 'key'), getOperator()))) {

// crmSearchFunction.component.js
let field = _.findWhere(fieldExpr.args, {type: 'field'});

// crmMultiSelectDate.directive.js
const existingSelections = _.pluck($el.select2('data') || [], 'id');

// crmSearchInputVal.component.js
if (_.findWhere(ctrl.dateRanges, {id: ctrl.value})) {

// searchDisplayTasksTrait.service.js (x4)
return _.findWhere(mngr.tasks, {name: taskName});
this.selectedRows = _.uniq(_.pluck(this.results, 'key'));
const allRows = _.pluck(ctrl.results, 'key'),
if (index > -1 && !_.findWhere(apiResults.run, {key: editedRow.key})) {
```

After
----------------------------------------
```js
// crmSearchAdminDisplay.component.js (x3)
const field = (info.args.find((arg) => arg.type === 'field') || {}).field || {};
arg = (info && info.args && info.args.find((arg) => arg.type === 'field')) || {};
const beforeLink = column.link.action && ctrl.getLinks(column.key).find((link) => link.action === column.link.action);

// crmSearchAdminImport.component.js
saveCall = apiCalls.find((call) => call[0] === entity);

// crmSearchAdminLinkGroup.component.js
return this.styles.find((style) => style.key === item.style);

// crmSearchClause.component.js
meta[expr] = args.find((arg) => arg.type === 'field');

// crmSearchCondition.component.js
if ((!getOperator() || !ctrl.getOperators().map((operator) => operator.key).includes(getOperator()))) {

// crmSearchFunction.component.js
let field = fieldExpr.args.find((arg) => arg.type === 'field');

// crmMultiSelectDate.directive.js
const existingSelections = ($el.select2('data') || []).map((selection) => selection.id);

// crmSearchInputVal.component.js
if (ctrl.dateRanges.find((dateRange) => dateRange.id === ctrl.value)) {

// searchDisplayTasksTrait.service.js (x4)
return mngr.tasks.find((task) => task.name === taskName);
this.selectedRows = _.uniq(this.results.map((result) => result.key));
const allRows = ctrl.results.map((result) => result.key),
if (index > -1 && !apiResults.run.find((row) => row.key === editedRow.key)) {
```

Technical Details
----------------------------------------
`apiCalls` in `crmSearchAdminImport.component.js` is an array of APIv4 call tuples (`[entity, action, params]`), so `_.findWhere(apiCalls, {0: entity})` (matching on the numeric index `0`) becomes `apiCalls.find((call) => call[0] === entity)`. All other converted values were confirmed to be plain arrays (not lodash-transparent plain objects) by checking their construction elsewhere in the same files — `CRM_Utils_Array::makeNonAssociative()` on the PHP side for `styles`/`dateRanges`, `.push()`/`.length`/`[0]`-indexing for the rest — before converting. `_.uniq()` calls are left untouched; they're out of scope for this stage.

No behavior change. Verified via `civilint` (clean, no jshint errors) and live in a sandbox site: the search builder's filter/clause UI, a display's column editor (sortable headers, auto-populating a default link via "Add Links"), the results preview's row-selection (select-all, shift-click range select), and the row-actions task menu all worked with no console errors.

Comments
----------------------------------------
Part of the staged lodash removal effort tracked alongside #36563, #36570, #36571, and #36576.