### PR TITLE
SearchKit - offer joins for entities which share a DAO class (eg. ECK)

### DIFF
--- a/ext/search_kit/Civi/Search/Admin.php
+++ b/ext/search_kit/Civi/Search/Admin.php
@@ -157,7 +157,7 @@ class Admin {
   public static function getSchema(): array {
     $schema = [];
     $entities = Entity::get()
-      ->addSelect('name', 'title', 'title_plural', 'bridge_title', 'type', 'primary_key', 'description', 'label_field', 'parent_field', 'search_fields', 'icon', 'dao', 'bridge', 'ui_join_filters', 'searchable', 'order_by')
+      ->addSelect('name', 'title', 'title_plural', 'bridge_title', 'type', 'primary_key', 'description', 'label_field', 'parent_field', 'search_fields', 'icon', 'dao', 'table_name', 'bridge', 'ui_join_filters', 'searchable', 'order_by')
       ->addWhere('searchable', '!=', 'none')
       ->addOrderBy('title_plural')
       ->setChain([
@@ -174,7 +174,7 @@ class Admin {
         }
         try {
           $getFields = civicrm_api4($entity['name'], 'getFields', [
-            'select' => ['name', 'title', 'label', 'description', 'type', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'entity', 'fk_entity', 'readonly', 'operators', 'suffixes', 'nullable'],
+            'select' => ['name', 'title', 'label', 'description', 'type', 'options', 'input_type', 'input_attrs', 'data_type', 'serialize', 'entity', 'fk_entity', 'fk_column', 'readonly', 'operators', 'suffixes', 'nullable'],
             'where' => [['deprecated', '=', FALSE], ['name', 'NOT IN', ['api_key', 'hash']]],
             'orderBy' => ['label' => 'ASC'],
           ])->indexBy('name');
@@ -335,10 +335,8 @@ class Admin {
       // So this entire block could, in theory, be removed in favor of the foreach loop below.
       // Just need a solid before/after comparison to ensure the output stays stable.
       if (!empty($entity['dao']) && !$isVirtualEntity) {
-        /** @var \CRM_Core_DAO $daoClass */
-        $daoClass = $entity['dao'];
-        $references = $daoClass::getReferenceColumns();
         $fields = array_column($entity['fields'], NULL, 'name');
+        $references = self::getEntityReferences($entity, $fields);
         $bridge = in_array('EntityBridge', $entity['type']) ? $entity['name'] : NULL;
 
         // Non-bridge joins directly between 2 entities
@@ -351,7 +349,7 @@ class Admin {
               // Exclude any joins that are better represented by pseudoconstants
               is_a($reference, 'CRM_Core_Reference_OptionValue') ||
               // Sanity check - table should match
-              $daoClass::getTableName() !== $reference->getReferenceTable()
+              $entity['table_name'] !== $reference->getReferenceTable()
             ) {
               continue;
             }
@@ -475,6 +473,38 @@ class Admin {
       $joins[$contactType] = array_merge($joins[$contactType], $joins['Contact']);
     }
     return $joins;
+  }
+
+  /**
+   * Get the foreign-key references declared by a DAO entity.
+   *
+   * A DAO class shared by more than one entity (e.g. the ECK extension's entities) cannot
+   * declare reference columns of its own, so back-fill them from the field metadata.
+   *
+   * @param array $entity
+   * @param array $fields
+   *   Fields of $entity, keyed by name.
+   * @return \CRM_Core_Reference_Basic[]
+   */
+  private static function getEntityReferences(array $entity, array $fields): array {
+    /** @var \CRM_Core_DAO $daoClass */
+    $daoClass = $entity['dao'];
+    $references = $daoClass::getReferenceColumns();
+    $declared = array_map(fn($reference) => $reference->getReferenceKey(), $references);
+    foreach ($fields as $field) {
+      $targetTable = empty($field['fk_entity']) ? NULL : CoreUtil::getTableName($field['fk_entity']);
+      if (
+        // Custom fields are handled separately, and pseudo-fields have no column to join on
+        $field['type'] !== 'Field' || !$targetTable ||
+        in_array($field['name'], $declared, TRUE) ||
+        // Serialized fields hold a list of values so can't be joined with `=`
+        !empty($field['serialize'])
+      ) {
+        continue;
+      }
+      $references[] = new \CRM_Core_Reference_Basic($entity['table_name'], $field['name'], $targetTable, $field['fk_column'] ?? 'id');
+    }
+    return $references;
   }
 
   /**

--- a/ext/search_kit/tests/phpunit/Civi/Search/SharedDaoJoinsTest.php
+++ b/ext/search_kit/tests/phpunit/Civi/Search/SharedDaoJoinsTest.php
@@ -1,0 +1,223 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+namespace Civi\Search {
+
+  use api\v4\Api4TestBase;
+  use Civi\Api4\Contact;
+  use Civi\Core\Event\GenericHookEvent;
+  use Civi\Core\HookInterface;
+  use Civi\Schema\EntityRepository;
+  use Civi\Test\CiviEnvBuilder;
+
+  require_once __DIR__ . '/../../../../../../tests/phpunit/api/v4/Api4TestBase.php';
+
+  /**
+   * Ensure SearchKit offers joins for entities whose DAO class is shared with other
+   * entities (as with the entities supplied by the ECK extension) and therefore
+   * declares its foreign keys as field metadata rather than as reference columns.
+   *
+   * @group headless
+   */
+  class SharedDaoJoinsTest extends Api4TestBase implements HookInterface {
+
+    public function setUpHeadless(): CiviEnvBuilder {
+      return \Civi\Test::headless()->installMe(__DIR__)->apply();
+    }
+
+    public function setUp(): void {
+      $entities = [];
+      self::hook_entityTypes($entities);
+      $createTableSql = \Civi::schemaHelper()->arrayToSql($entities['MockSharedDaoEntity']);
+      \CRM_Core_DAO::executeQuery($createTableSql, [], TRUE, NULL, FALSE, FALSE);
+
+      // hook_civicrm_entityTypes has special significance in system boot. This seems to be more reliable way to register it.
+      \CRM_Utils_Hook::singleton()->setHook('civicrm_entityTypes', [$this, 'hook_entityTypes']);
+      EntityRepository::flush();
+      \Civi::cache('metadata')->flush();
+      parent::setUp();
+    }
+
+    public function tearDown(): void {
+      \CRM_Utils_Hook::singleton()->reset();
+      EntityRepository::flush();
+      \CRM_Core_DAO::executeQuery('DROP TABLE IF EXISTS `civicrm_mock_shared_dao_entity`', [], TRUE, NULL, FALSE, FALSE);
+      parent::tearDown();
+    }
+
+    public static function tearDownAfterClass(): void {
+      // The api4 entity list is persistently cached, and this hook is still registered during
+      // tearDown(), so the mock entity has to be flushed once it has been deregistered.
+      EntityRepository::flush();
+      \Civi::cache('metadata')->flush();
+      parent::tearDownAfterClass();
+    }
+
+    public function testSharedDaoEntityGetJoins(): void {
+      $allowedEntities = Admin::getSchema();
+      $this->assertArrayHasKey('MockSharedDaoEntity', $allowedEntities);
+      $joins = Admin::getJoins($allowedEntities);
+      $this->assertArrayHasKey('MockSharedDaoEntity', $joins);
+
+      $forwardJoins = \CRM_Utils_Array::filter($joins['MockSharedDaoEntity'], [
+        'entity' => 'Contact',
+        'alias' => 'MockSharedDaoEntity_Contact_created_id',
+        'multi' => FALSE,
+      ]);
+      $this->assertCount(1, $forwardJoins);
+      $forwardJoin = reset($forwardJoins);
+      $this->assertEquals(
+        [['created_id', '=', 'MockSharedDaoEntity_Contact_created_id.id']],
+        $forwardJoin['conditions']
+      );
+
+      $reverseJoins = \CRM_Utils_Array::filter($joins['Contact'], [
+        'entity' => 'MockSharedDaoEntity',
+        'alias' => 'Contact_MockSharedDaoEntity_created_id',
+        'multi' => TRUE,
+      ]);
+      $this->assertCount(1, $reverseJoins);
+      $reverseJoin = reset($reverseJoins);
+      $this->assertEquals(
+        [['id', '=', 'Contact_MockSharedDaoEntity_created_id.created_id']],
+        $reverseJoin['conditions']
+      );
+
+      // Serialized fields hold a list of values so are not joinable
+      $this->assertCount(0, \CRM_Utils_Array::filter($joins['MockSharedDaoEntity'], ['entity' => 'Tag']));
+      $this->assertCount(0, \CRM_Utils_Array::filter($joins['Tag'], ['entity' => 'MockSharedDaoEntity']));
+    }
+
+    /**
+     * The join conditions SearchKit generates must be runnable.
+     */
+    public function testSharedDaoEntityJoinRuns(): void {
+      $contact = $this->createTestRecord('Contact');
+      // Inserted directly because the mock DAO class can't write (see MockSharedDao)
+      \CRM_Core_DAO::executeQuery(
+        'INSERT INTO `civicrm_mock_shared_dao_entity` (`title`, `created_id`) VALUES (%1, %2)',
+        [1 => ['Mock thing', 'String'], 2 => [$contact['id'], 'Integer']]
+      );
+
+      $result = Contact::get(FALSE)
+        ->addSelect('id', 'Contact_MockSharedDaoEntity_created_id.title')
+        ->addJoin('MockSharedDaoEntity AS Contact_MockSharedDaoEntity_created_id', 'INNER',
+          ['id', '=', 'Contact_MockSharedDaoEntity_created_id.created_id'])
+        ->execute();
+      $this->assertCount(1, $result);
+      $this->assertEquals($contact['id'], $result[0]['id']);
+      $this->assertEquals('Mock thing', $result[0]['Contact_MockSharedDaoEntity_created_id.title']);
+    }
+
+    /**
+     * @implements CRM_Utils_Hook::entityTypes()
+     */
+    public function hook_entityTypes(array &$entityTypes): void {
+      $entityTypes['MockSharedDaoEntity'] = [
+        'name' => 'MockSharedDaoEntity',
+        'table' => 'civicrm_mock_shared_dao_entity',
+        'class' => 'Civi\DAO\MockSharedDao',
+        'getInfo' => fn() => [
+          'title' => 'Mock Shared Dao Entity',
+          'title_plural' => 'Mock Shared Dao Entities',
+          'description' => 'Mock entity whose DAO class is shared with other entities',
+          'label_field' => 'title',
+          'searchable' => 'secondary',
+          'log' => FALSE,
+        ],
+        'getFields' => fn() => [
+          'id' => [
+            'title' => 'ID',
+            'sql_type' => 'int unsigned',
+            'input_type' => 'Number',
+            'required' => TRUE,
+            'primary_key' => TRUE,
+            'auto_increment' => TRUE,
+          ],
+          'title' => [
+            'title' => 'Title',
+            'sql_type' => 'varchar(255)',
+            'input_type' => 'Text',
+          ],
+          'created_id' => [
+            'title' => 'Created By Contact ID',
+            'sql_type' => 'int unsigned',
+            'input_type' => 'EntityRef',
+            'entity_reference' => [
+              'entity' => 'Contact',
+              'key' => 'id',
+            ],
+          ],
+          'tag_list' => [
+            'title' => 'Tags',
+            'sql_type' => 'varchar(255)',
+            'input_type' => 'EntityRef',
+            'serialize' => \CRM_Core_DAO::SERIALIZE_COMMA,
+            'entity_reference' => [
+              'entity' => 'Tag',
+              'key' => 'id',
+              // A list of ids in a text column, so not a real constraint
+              'fk' => FALSE,
+            ],
+          ],
+        ],
+      ];
+    }
+
+    /**
+     * Listens for civi.api4.entityTypes event to manually add this nonstandard entity
+     */
+    public function on_civi_api4_entityTypes(GenericHookEvent $e): void {
+      $e->entities['MockSharedDaoEntity'] = [
+        'name' => 'MockSharedDaoEntity',
+        'title' => 'Mock Shared Dao Entity',
+        'title_plural' => 'Mock Shared Dao Entities',
+        'table_name' => 'civicrm_mock_shared_dao_entity',
+        'type' => ['DAOEntity'],
+        'paths' => [],
+        'class' => 'Civi\Api4\MockSharedDaoEntity',
+        'dao' => 'Civi\DAO\MockSharedDao',
+        'primary_key' => ['id'],
+        'searchable' => 'secondary',
+      ];
+    }
+
+  }
+
+}
+
+namespace Civi\Api4 {
+
+  class MockSharedDaoEntity extends Generic\DAOEntity {
+  }
+
+}
+
+namespace Civi\DAO {
+
+  /**
+   * Emulates a DAO class shared by several entities, e.g. `CRM_Eck_DAO_Entity`, which
+   * serves every ECK entity type and so can declare neither reference columns nor a
+   * table name of its own.
+   */
+  class MockSharedDao extends \CRM_Core_DAO_Base {
+
+    public static function getReferenceColumns() {
+      return [];
+    }
+
+    public static function getTableName() {
+      return NULL;
+    }
+
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
SearchKit offers no joins whatsoever for entities supplied by the [ECK extension](https://github.com/systopia/de.systopia.eck). The "+ Entity" dropdown on an ECK search is empty, so you can't reach the contact in an ECK entity's `created_id`/`modified_id`, and a Contact search can't reach a contact's ECK entities either. The joins work perfectly well at the APIv4 level — only SearchKit's list of offered joins is missing them.

Before
----------------------------------------
Searching for an ECK entity type, no joins are offered.

```php
Civi\Search\Admin::getJoins(Civi\Search\Admin::getSchema())['Eck_Test'];  // undefined key
```

After
----------------------------------------
The contact references are offered in both directions — "Test Created By" / "Test Modified By" on the ECK entity, and "Contact Test" (described as "Created By" / "Modified By") on Contact:

<img width="1568" height="736" alt="download" src="https://github.com/user-attachments/assets/3d4517f2-3dfd-4b78-a133-c7eb6ab2461a" />

Technical Details
----------------------------------------
- `Admin::getJoins()` derives joins for DAO entities exclusively from `$daoClass::getReferenceColumns()`, which builds its list from `static::fields()` cached against `static::class`. A DAO class serving more than one entity therefore can't populate it: every ECK entity type shares `CRM_Eck_DAO_Entity`, whose `fields()` returns `[]` and whose `getTableName()` returns `NULL` unless an instance has first been constructed for a specific ECK type — which is not the case here.
- The field-metadata loop further down only runs for custom fields and virtual entities, so the `entity_reference` metadata such entities *do* declare (ECK declares it for both `created_id` and `modified_id`) was never consulted.
- A new `getEntityReferences()` starts from the DAO's reference columns and back-fills a `CRM_Core_Reference_Basic` for any remaining field with an `fk_entity`. Everything downstream — labels, bridges, self-reference handling, join defaults — is then unchanged, so these entities get the same joins as any other DAO entity.
- Skipped when back-filling: fields that aren't of type `Field` (custom fields are handled separately, pseudo-fields have no column to join on) and serialized fields (`Group.parents`/`children` hold a comma-separated list of ids, which can't be joined with `=`).
- The "table should match" sanity check now compares against the entity's own `table_name` instead of `$daoClass::getTableName()` — that call is what made ECK's references unusable even once they existed. `table_name` and `fk_column` are added to the metadata `getSchema()` collects.
- Before/after comparison of every join on a site with ~40 extensions installed: 652 join definitions identical, 10 ECK joins added, nothing else changed.

Comments
----------------------------------------
- This addresses part of the `FIXME` at the top of that block, but doesn't remove it — the DAO block is still there, it just no longer relies on the DAO class for the entity's table name.
- The reverse joins are labelled "Contact Test" rather than "Contact Tests" because ECK sets `title_plural` to the same string as `title`; they are distinguishable in the dropdown by their descriptions ("Created By" / "Modified By"). That's an ECK-side matter.
- The new test registers a mock entity whose DAO returns no reference columns and no table name. Note that the api4 entity list is persistently cached and the test's hooks are still registered during `tearDown()`, so the flush has to happen in `tearDownAfterClass()` or the mock entity leaks into subsequent tests.