### PR TITLE
allow guzzlehttp/psr7 3

### DIFF
--- a/CRM/Core/Payment/AuthorizeNet.php
+++ b/CRM/Core/Payment/AuthorizeNet.php
@@ -173,10 +173,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
 
     $response = (string) $this->getGuzzleClient()->post($this->_paymentProcessor['url_site'], [
       'body' => implode('&', $postFields),
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     $response_fields = $this->explode_csv($response);
@@ -310,10 +307,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
         'Content-Type' => 'text/xml; charset=UTF8',
       ],
       'body' => $arbXML,
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ]);
     $responseFields = $this->_ParseArbReturn((string) $response->getBody());
 
@@ -558,10 +552,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
         'Content-Type' => 'text/xml; charset=UTF8',
       ],
       'body' => $arbXML,
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     $responseFields = $this->_ParseArbReturn($response);
@@ -611,10 +602,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
         'Content-Type' => 'text/xml; charset=UTF8',
       ],
       'body' => $arbXML,
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     // submit to authorize.net
@@ -668,10 +656,7 @@ class CRM_Core_Payment_AuthorizeNet extends CRM_Core_Payment {
         'Content-Type' => 'text/xml; charset=UTF8',
       ],
       'body' => $arbXML,
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     $responseFields = $this->_parseArbReturn($response);

--- a/CRM/Core/Payment/PayPalImpl.php
+++ b/CRM/Core/Payment/PayPalImpl.php
@@ -1265,10 +1265,7 @@ class CRM_Core_Payment_PayPalImpl extends CRM_Core_Payment {
 
     $response = (string) $this->getGuzzleClient()->post($url, [
       'body' => $nvpreq,
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     $result = self::deformat($response);

--- a/CRM/Utils/GuzzleMiddleware.php
+++ b/CRM/Utils/GuzzleMiddleware.php
@@ -224,28 +224,62 @@ class CRM_Utils_GuzzleMiddleware {
    * This logs the list of outgoing requests in curl format.
    */
   public static function curlLog(\Psr\Log\LoggerInterface $logger) {
-
-    $curlFmt = new class() extends \GuzzleHttp\MessageFormatter {
-
-      public function format(RequestInterface $request, ?ResponseInterface $response = NULL, ?\Throwable $error = NULL): string {
-        $cmd = '$ curl';
-        if ($request->getMethod() !== 'GET') {
-          $cmd .= ' -X ' . escapeshellarg($request->getMethod());
-        }
-        foreach ($request->getHeaders() as $header => $lines) {
-          foreach ($lines as $line) {
-            $cmd .= ' -H ' . escapeshellarg("$header: $line");
-          }
-        }
-        $body = (string) $request->getBody();
-        if ($body !== '') {
-          $cmd .= ' -d ' . escapeshellarg($body);
-        }
-        $cmd .= ' ' . escapeshellarg((string) $request->getUri());
-        return $cmd;
+    $formatCurl = function(RequestInterface $request) {
+      $cmd = '$ curl';
+      if ($request->getMethod() !== 'GET') {
+        $cmd .= ' -X ' . escapeshellarg($request->getMethod());
       }
-
+      foreach ($request->getHeaders() as $header => $lines) {
+        foreach ($lines as $line) {
+          $cmd .= ' -H ' . escapeshellarg("$header: $line");
+        }
+      }
+      $body = (string) $request->getBody();
+      if ($body !== '') {
+        $cmd .= ' -d ' . escapeshellarg($body);
+      }
+      $cmd .= ' ' . escapeshellarg((string) $request->getUri());
+      return $cmd;
     };
+
+    if (interface_exists(\GuzzleHttp\MessageFormatterInterface::class)) {
+      $curlFmt = new class($formatCurl) implements \GuzzleHttp\MessageFormatterInterface {
+
+        /**
+         * @var callable
+         */
+        private $formatCurl;
+
+        public function __construct(callable $formatCurl) {
+          $this->formatCurl = $formatCurl;
+        }
+
+        public function format(RequestInterface $request, ?ResponseInterface $response = NULL, ?\Throwable $error = NULL): string {
+          return ($this->formatCurl)($request);
+        }
+
+      };
+    }
+    else {
+      // Guzzle 6 does not provide MessageFormatterInterface, and Middleware::log()
+      // requires an instance of the concrete MessageFormatter class.
+      $curlFmt = new class($formatCurl) extends \GuzzleHttp\MessageFormatter {
+
+        /**
+         * @var callable
+         */
+        private $formatCurl;
+
+        public function __construct(callable $formatCurl) {
+          $this->formatCurl = $formatCurl;
+        }
+
+        public function format(RequestInterface $request, ResponseInterface $response = NULL, \Exception $error = NULL) {
+          return ($this->formatCurl)($request);
+        }
+
+      };
+    }
 
     return \GuzzleHttp\Middleware::log($logger, $curlFmt);
   }

--- a/CRM/Utils/GuzzleMiddleware.php
+++ b/CRM/Utils/GuzzleMiddleware.php
@@ -274,7 +274,7 @@ class CRM_Utils_GuzzleMiddleware {
           $this->formatCurl = $formatCurl;
         }
 
-        public function format(RequestInterface $request, ResponseInterface $response = NULL, \Exception $error = NULL) {
+        public function format(RequestInterface $request, ?ResponseInterface $response = NULL, ?\Exception $error = NULL) {
           return ($this->formatCurl)($request);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,7 @@
     "pear/net_smtp": "1.12.*",
     "pear/net_socket": "1.2.1",
     "pear/mail": "^2.0",
-    "guzzlehttp/guzzle": "^6.3 || ^7.3",
+    "guzzlehttp/guzzle": "^6.3 || ^7.3 || ^8",
     "guzzlehttp/psr7": "^1.9 || ^2.0 || ^3",
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "pear/net_socket": "1.2.1",
     "pear/mail": "^2.0",
     "guzzlehttp/guzzle": "^6.3 || ^7.3",
-    "guzzlehttp/psr7": "^1.9 || ^2.0",
+    "guzzlehttp/psr7": "^1.9 || ^2.0 || ^3",
     "psr/simple-cache": "~1.0.1",
     "cweagans/composer-patches": "~1.0",
     "pear/log": "1.14.5",

--- a/ext/elavon/CRM/Core/Payment/Elavon.php
+++ b/ext/elavon/CRM/Core/Payment/Elavon.php
@@ -165,20 +165,13 @@ class CRM_Core_Payment_Elavon extends CRM_Core_Payment {
     // Convert to XML using function below
     $xml = $this->buildXML($requestFields);
 
-    // Send to the payment processor using cURL
+    // Send to the payment processor.
 
     $chHost = $host . '?xmldata=' . $xml;
-    $curlParams = [
-      CURLOPT_RETURNTRANSFER => TRUE,
-      CURLOPT_TIMEOUT => 36000,
-      CURLOPT_SSL_VERIFYHOST => Civi::settings()->get('verifySSL') ? 2 : 0,
-      CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-    ];
-    if (ini_get('open_basedir') == '') {
-      $curlParams[CURLOPT_FOLLOWLOCATION] = 1;
-    }
     $responseData = $this->getGuzzleClient()->post($chHost, [
-      'curl' => $curlParams,
+      'allow_redirects' => TRUE,
+      'timeout' => 36000,
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     // If gateway returned no data - tell 'em and bail out

--- a/ext/ewaysingle/CRM/Core/Payment/eWAY.php
+++ b/ext/ewaysingle/CRM/Core/Payment/eWAY.php
@@ -290,10 +290,7 @@ class CRM_Core_Payment_eWAY extends CRM_Core_Payment {
 
     $responseData = (string) $this->getGuzzleClient()->post($this->_paymentProcessor['url_site'], [
       'body' => $requestxml,
-      'curl' => [
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-      ],
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ])->getBody();
 
     //----------------------------------------------------------------------------------------------------

--- a/ext/payflowpro/CRM/Core/Payment/PayflowPro.php
+++ b/ext/payflowpro/CRM/Core/Payment/PayflowPro.php
@@ -418,9 +418,9 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
   }
 
   /**
-   * Submit transaction using cURL
+   * Submit a transaction using Guzzle.
    *
-   * @param string $submiturl Url to direct HTTPS GET to
+   * @param string $submiturl URL to submit an HTTPS POST to
    * @param string $payflow_query value string to be posted
    *
    * @return mixed|object
@@ -430,23 +430,24 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     // get data ready for API
     $user_agent = $_SERVER['HTTP_USER_AGENT'] ?? 'Guzzle';
     // Here's your custom headers; adjust appropriately for your setup:
-    $headers[] = "Content-Type: text/namevalue";
+    $headers['Content-Type'] = 'text/namevalue';
     //or text/xml if using XMLPay.
-    $headers[] = "Content-Length : " . strlen($payflow_query);
+    $headers['Content-Length'] = (string) strlen($payflow_query);
     // Length of data to be passed
     // Here the server timeout value is set to 45, but notice
-    // below in the cURL section, the timeout
-    // for cURL is 90 seconds.  You want to make sure the server
+    // below in the HTTP client options, the timeout
+    // for the client is 90 seconds.  You want to make sure the server
     // timeout is less, then the connection.
-    $headers[] = "X-VPS-Timeout: 45";
+    $headers['X-VPS-Timeout'] = '45';
     //random unique number  - the transaction is retried using this transaction ID
     // in this function but if that doesn't work and it is re- submitted
     // it is treated as a new attempt. Payflow Pro doesn't allow
     // you to change details (e.g. card no) when you re-submit
     // you can only try the same details
-    $headers[] = "X-VPS-Request-ID: " . rand(1, 1000000000);
+    $headers['X-VPS-Request-ID'] = (string) rand(1, 1000000000);
     // optional header field
-    $headers[] = "X-VPS-VIT-Integration-Product: CiviCRM";
+    $headers['X-VPS-VIT-Integration-Product'] = 'CiviCRM';
+    $headers['User-Agent'] = $user_agent;
     // other Optional Headers.  If used adjust as necessary.
     // Name of your OS
     //$headers[] = "X-VPS-VIT-OS-Name: Linux";
@@ -463,14 +464,8 @@ class CRM_Core_Payment_PayflowPro extends CRM_Core_Payment {
     $response = $this->getGuzzleClient()->post($submiturl, [
       'body' => $payflow_query,
       'headers' => $headers,
-      'curl' => [
-        CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-        CURLOPT_USERAGENT => $user_agent,
-        CURLOPT_RETURNTRANSFER => TRUE,
-        CURLOPT_TIMEOUT => 90,
-        CURLOPT_SSL_VERIFYHOST => Civi::settings()->get('verifySSL') ? 2 : 0,
-        CURLOPT_POST => TRUE,
-      ],
+      'timeout' => 90,
+      'verify' => (bool) Civi::settings()->get('verifySSL'),
     ]);
 
     // Try to submit the transaction up to 3 times with 5 second delay.  This can be used

--- a/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
+++ b/tests/phpunit/CRM/Core/Payment/AuthorizeNetTest.php
@@ -156,7 +156,7 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
     Civi::settings()->set('verifySSL', '0');
     $this->processor->doPayment($params);
     // turn verifySSL on
-    Civi::settings()->set('verifySSL', '0');
+    Civi::settings()->set('verifySSL', '1');
 
     // if subscription was successful, processor_id / subscription-id must not be null
     $this->assertDBNotNull('CRM_Contribute_DAO_ContributionRecur', $recur['id'], 'processor_id',
@@ -169,10 +169,8 @@ class CRM_Core_Payment_AuthorizeNetTest extends CiviUnitTestCase {
     $this->assertEquals(['apitest.authorize.net'], $header['Host']);
     $this->assertEquals(['text/xml; charset=UTF8'], $header['Content-Type']);
 
-    $this->assertEquals([
-      CURLOPT_RETURNTRANSFER => TRUE,
-      CURLOPT_SSL_VERIFYPEER => Civi::settings()->get('verifySSL'),
-    ], $this->container[0]['options']['curl']);
+    $this->assertFalse($this->container[0]['options']['verify']);
+    $this->assertArrayNotHasKey('curl', $this->container[0]['options']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Drupal 12 now requires guzzlehttp/psr7 ^3
guzzlehttp/guzzle ^ 8

CiviCRM Core only supports 1 and 2, and 7

These necessitate an update to an upcoming league/oauth2-client release (Pending)

Update composer.json to for these versions

  No CiviCRM OAuth runtime changes are needed: the installed OAuth client master differs from 2.9.0 primarily by adding Guzzle 8/PSR-7 3 constraints,
  and Core’s existing ^2.8 requirement remains suitable. Upstream has merged the compatibility work but has not published a newer tag (PR #1112
  (https://github.com/thephpleague/oauth2-client/pull/1112), releases (https://github.com/thephpleague/oauth2-client/releases)).

  ## Implementation Changes

  - Fix CRM_Utils_GuzzleMiddleware::curlLog():
      - On Guzzle 7/8, use an adapter implementing MessageFormatterInterface.
      - On Guzzle 6, retain an adapter extending MessageFormatter.
      - Share the curl-command formatting logic between both adapters.
      - This avoids extending Guzzle 8’s final MessageFormatter without dropping older-version support.

  - Replace unsupported raw CURLOPT_* request options in Authorize.Net, PayPal, eWAY, Elavon, and Payflow Pro:
      - Use verify, timeout, allow_redirects, and associative headers options.
      - Omit CURLOPT_RETURNTRANSFER and CURLOPT_POST, which Guzzle handles internally.
      - Preserve existing timeout, SSL-verification, redirect, and User-Agent behavior.

  - Convert Payflow Pro’s numeric list of raw header strings to valid associative PSR-7 headers, with scalar values converted to strings.
  - Do not change public CiviCRM APIs, the Core league/oauth2-client constraint, or unrelated HTTP behavior.

  ## Validation

  - Refresh only the lock-file content hash, then reinstall the locked civicrm/civicrm-core package so Composer applies the patch; verify no
    dependency versions drift.

  - Exercise curlLog() on successful and rejected requests, confirming it logs correctly and no longer triggers the final-class fatal.
  - Exercise all five affected payment request builders with a Guzzle history/mock handler, asserting:
      - No unsupported raw cURL options remain.
      - SSL, timeout, redirect, method, body, and header semantics are preserved.
      - Payflow Pro headers satisfy PSR-7 3 validation.

  - Run a real CurlHandler request against a controlled local endpoint to confirm Guzzle 8 no longer raises option-validation exceptions.
  - Repeat the middleware/request-option smoke checks in disposable Guzzle 6/PSR-7 1, Guzzle 7/PSR-7 2, and Guzzle 8/PSR-7 3 environments.
  - Re-run the OAuth provider smoke test and finish with composer validate, composer install --dry-run, and an intended-files-only diff review.
