### PR TITLE
Afform - Fix undefined variable when processing a stored submission

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -98,10 +98,7 @@ class Submit extends AbstractProcessor {
       $submissionData = $this->combineValuesAndIds($this->getValues(), $this->_entityIds);
       // Update submission record with entity IDs.
       if (!empty($this->_afform['create_submission'])) {
-        $submissionId = $submission['id'];
-        if (!empty($this->args['sid'])) {
-          $submissionId = $this->args['sid'];
-        }
+        $submissionId = !empty($this->args['sid']) ? $this->args['sid'] : $submission['id'];
 
         AfformSubmission::update(FALSE)
           ->addWhere('id', '=', $submissionId)


### PR DESCRIPTION
Overview
----------------------------------------
Fix an undefined variable read when an Afform submit is given the id of an existing submission.

Before
----------------------------------------
`Submit::processForm()` only assigns `$submission` when it is creating a new submission record, which it skips when `sid` is passed:

```php
// Save submission record
if (!empty($this->_afform['create_submission']) && empty($this->args['sid'])) {
  ...
  $submission = AfformSubmission::save(FALSE)
    ->addRecord($submissionRecord)
    ->execute()->first();
}
```

Further down it reads that variable before overwriting it with the sid on the very next line:

```php
$submissionId = $submission['id'];
if (!empty($this->args['sid'])) {
  $submissionId = $this->args['sid'];
}
```

So whenever `sid` is set — completing a submission that was held back for manual processing — `$submission` is undefined. The resulting value is discarded immediately, so the outcome is correct, but it emits `Undefined variable $submission` plus `Trying to access array offset on value of type null` on every such submit, and is fatal anywhere warnings are converted to exceptions:

```
Undefined variable $submission
.../ext/afform/core/Civi/Api4/Action/Afform/Submit.php:101
```

After
----------------------------------------
Pick the id without reading the unset variable first:

```php
$submissionId = !empty($this->args['sid']) ? $this->args['sid'] : $submission['id'];
```

Behaviour is unchanged; the warning is gone.

Technical Details
----------------------------------------
The two branches are mutually exclusive by construction: `$submission` is assigned exactly when `$this->args['sid']` is empty, which is the only case the ternary's else arm can reach.

Found while writing a PHPUnit test for the manual-processing path — the test errored on this before it could reach what it was actually testing, because PHPUnit runs with `convertWarningsToExceptions="true"`.

Comments
----------------------------------------