### PR TITLE
Afform process submission as submitter

### DIFF
--- a/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
+++ b/ext/afform/core/Civi/Afform/Behavior/ContactAutofill.php
@@ -115,7 +115,7 @@ class ContactAutofill extends AbstractBehavior implements EventSubscriberInterfa
       $relatedContact = $entity['autofill-relationship'] ?? NULL;
       // Autofill with current user, but only if this is an "entire form" prefill
       if (!$id && $autoFillMode === 'user' && $apiRequest->getFillMode() === 'form') {
-        $id = \CRM_Core_Session::getLoggedInContactID();
+        $id = $apiRequest->getSubmitterContactID();
         if ($id) {
           $apiRequest->loadEntity($entity, [['id' => $id]]);
         }

--- a/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
+++ b/ext/afform/core/Civi/Afform/Behavior/GroupSubscription.php
@@ -80,7 +80,7 @@ class GroupSubscription extends AbstractBehavior implements EventSubscriberInter
     }
     $contact = $subscriptionEntity['data']['contact_id'];
     if ($contact === 'user_contact_id') {
-      $cid = \CRM_Core_Session::getLoggedInContactID();
+      $cid = $event->getApiRequest()->getSubmitterContactID();
     }
     elseif ($contact && \CRM_Utils_Rule::positiveInteger($contact)) {
       $cid = $contact;

--- a/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/AbstractProcessor.php
@@ -7,6 +7,7 @@ use Civi\Afform\Event\AfformPrefillEvent;
 use Civi\Afform\Event\AfformSubmitEvent;
 use Civi\Afform\FormDataModel;
 use Civi\API\Exception\UnauthorizedException;
+use Civi\Api4\AfformSubmission;
 use Civi\Api4\File;
 use Civi\Api4\Generic\Result;
 use Civi\Api4\Utils\CoreUtil;
@@ -48,6 +49,13 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
    * @var array
    */
   protected $_afform;
+
+  /**
+   * Contact id resolved by getSubmitterContactID(), or FALSE before it has been resolved.
+   *
+   * @var int|null|false
+   */
+  private $_submitterContactId = FALSE;
 
   /**
    * @var \Civi\Afform\FormDataModel
@@ -140,6 +148,53 @@ abstract class AbstractProcessor extends \Civi\Api4\Generic\AbstractAction {
     $this->loadEntities();
     // TODO: use _response more consistently
     $result->exchangeArray($this->processForm());
+  }
+
+  /**
+   * Id of the stored submission being completed, if this is not a fresh submission.
+   *
+   * @return int|null
+   */
+  protected function getSubmissionId() {
+    return $this->args['sid'] ?? NULL;
+  }
+
+  /**
+   * Contact id that this form is being filled in on behalf of.
+   *
+   * Normally the logged-in user, but a stored submission is completed by someone else -
+   * an admin processing a form held back for manual processing, or the anonymous request
+   * behind an email-verification link. The values in it belong to the contact who
+   * submitted it, so resolving to whoever is processing it writes their answers onto the
+   * wrong contact.
+   *
+   * The lookup inherits this action's permission setting, so an untrusted request cannot
+   * act as another contact by passing their submission id.
+   *
+   * @return int|null
+   */
+  public function getSubmitterContactID(): ?int {
+    if ($this->_submitterContactId === FALSE) {
+      $submissionId = $this->getSubmissionId();
+      if (!$submissionId) {
+        $this->_submitterContactId = \CRM_Core_Session::getLoggedInContactID() ?: NULL;
+      }
+      else {
+        $submission = AfformSubmission::get($this->getCheckPermissions())
+          ->addSelect('contact_id')
+          ->addWhere('id', '=', $submissionId)
+          ->addWhere('afform_name', '=', $this->name)
+          ->execute()->first();
+        // Falling back to the current user here would write the submitted values onto
+        // whoever is processing the form, so refuse rather than act as the wrong contact
+        if (!$submission) {
+          throw new UnauthorizedException(E::ts('Submission %1 is not available to process.', [1 => $submissionId]));
+        }
+        // An anonymous submission has no contact, so nothing is autofilled
+        $this->_submitterContactId = $submission['contact_id'] ?: NULL;
+      }
+    }
+    return $this->_submitterContactId;
   }
 
   /**

--- a/ext/afform/core/Civi/Api4/Action/Afform/Process.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Process.php
@@ -17,6 +17,10 @@ class Process extends AbstractProcessor {
    */
   protected $submissionId;
 
+  protected function getSubmissionId() {
+    return $this->submissionId;
+  }
+
   protected function processForm() {
     // get the submitted data
     $afformSubmissionData = AfformSubmission::get(FALSE)

--- a/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
+++ b/ext/afform/core/Civi/Api4/Action/Afform/Submit.php
@@ -98,10 +98,7 @@ class Submit extends AbstractProcessor {
       $submissionData = $this->combineValuesAndIds($this->getValues(), $this->_entityIds);
       // Update submission record with entity IDs.
       if (!empty($this->_afform['create_submission'])) {
-        $submissionId = $submission['id'];
-        if (!empty($this->args['sid'])) {
-          $submissionId = $this->args['sid'];
-        }
+        $submissionId = !empty($this->args['sid']) ? $this->args['sid'] : $submission['id'];
 
         AfformSubmission::update(FALSE)
           ->addWhere('id', '=', $submissionId)

--- a/ext/afform/core/tests/phpunit/Civi/Afform/AfformProcessSubmissionTest.php
+++ b/ext/afform/core/tests/phpunit/Civi/Afform/AfformProcessSubmissionTest.php
@@ -1,0 +1,187 @@
+<?php
+namespace Civi\Afform;
+
+use Civi\Api4\Afform;
+use Civi\Api4\AfformSubmission;
+use Civi\Api4\Contact;
+use Civi\Test\Api4TestTrait;
+use Civi\Test\HeadlessInterface;
+
+/**
+ * Completing a stored submission on behalf of the contact who submitted it.
+ *
+ * @group headless
+ */
+class AfformProcessSubmissionTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
+
+  use Api4TestTrait;
+
+  private $formName;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install(['org.civicrm.search_kit', 'org.civicrm.afform'])
+      ->apply();
+  }
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->formName = 'mock_manual_form_' . rand(0, 100000);
+    $this->setPermissions(['access CiviCRM', 'view all contacts', 'edit all contacts', 'administer afform', 'manage own afform']);
+
+    $layout = <<<EOHTML
+<af-form ctrl="afform">
+  <af-entity type="Individual" name="Individual1" label="Individual 1" actions="{create: false, update: true}" security="FBAC" autofill="user" />
+  <fieldset af-fieldset="Individual1" class="af-container">
+    <af-field name="job_title" />
+  </fieldset>
+  <button class="af-button btn btn-primary" ng-click="afform.submit()">Submit</button>
+</af-form>
+EOHTML;
+    Afform::create(FALSE)
+      ->setLayoutFormat('html')
+      ->setValues([
+        'title' => 'Manual Processing Test Form',
+        'name' => $this->formName,
+        'layout' => $layout,
+        'permission' => \CRM_Core_Permission::ALWAYS_ALLOW_PERMISSION,
+        'create_submission' => TRUE,
+        'manual_processing' => TRUE,
+      ])
+      ->execute();
+  }
+
+  public function tearDown(): void {
+    $this->setPermissions(NULL);
+    Afform::revert(FALSE)->addWhere('name', '=', $this->formName)->execute();
+    \CRM_Core_Session::singleton()->set('userID', NULL);
+    parent::tearDown();
+  }
+
+  /**
+   * An admin processing someone else's stored submission must write the submitted
+   * values to the submitter's contact, not to their own.
+   */
+  public function testProcessingActsAsTheSubmitter(): void {
+    $submitter = $this->createTestRecord('Individual')['id'];
+    $admin = $this->createTestRecord('Individual')['id'];
+
+    $submissionId = $this->submitAs($submitter, 'Proposer');
+    // manual_processing defers the writes
+    $this->assertNull($this->getJobTitle($submitter));
+
+    $this->login($admin);
+    Afform::process()->setName($this->formName)->setSubmissionId($submissionId)->execute();
+
+    $this->assertEquals('Proposer', $this->getJobTitle($submitter));
+    $this->assertNull($this->getJobTitle($admin), 'The processing user must not be written to');
+  }
+
+  /**
+   * The same applies to Submit when it is given a submission id.
+   */
+  public function testSubmittingWithSidActsAsTheSubmitter(): void {
+    $submitter = $this->createTestRecord('Individual')['id'];
+    $admin = $this->createTestRecord('Individual')['id'];
+
+    $submissionId = $this->submitAs($submitter, 'Proposer');
+
+    $this->login($admin);
+    Afform::submit()->setName($this->formName)
+      ->setArgs(['sid' => $submissionId])
+      ->setValues(['Individual1' => [['fields' => ['job_title' => 'Proposer']]]])
+      ->execute();
+
+    $this->assertEquals('Proposer', $this->getJobTitle($submitter));
+    $this->assertNull($this->getJobTitle($admin), 'The processing user must not be written to');
+  }
+
+  /**
+   * The email-verification link is an anonymous request, so the lookup must still
+   * resolve the submitter when the caller is trusted.
+   */
+  public function testAnonymousVerificationActsAsTheSubmitter(): void {
+    $submitter = $this->createTestRecord('Individual')['id'];
+    $submissionId = $this->submitAs($submitter, 'Proposer');
+
+    // As CRM_Afform_Page_Verify does after decoding the emailed token
+    $this->login(NULL);
+    $this->setPermissions([]);
+    Afform::process(FALSE)->setName($this->formName)->setSubmissionId($submissionId)->execute();
+
+    $this->assertEquals('Proposer', $this->getJobTitle($submitter));
+  }
+
+  /**
+   * A submission made by an anonymous user has no contact, so processing it must not
+   * fall back to autofilling the contact of whoever processes it.
+   */
+  public function testProcessingAnonymousSubmissionDoesNotAutofill(): void {
+    $admin = $this->createTestRecord('Individual')['id'];
+
+    $submissionId = $this->submitAs(NULL, 'Anon');
+    $this->assertNull(
+      AfformSubmission::get(FALSE)->addWhere('id', '=', $submissionId)->execute()->single()['contact_id']
+    );
+
+    $this->login($admin);
+    Afform::process()->setName($this->formName)->setSubmissionId($submissionId)->execute();
+
+    $this->assertNull($this->getJobTitle($admin), 'The processing user must not be written to');
+  }
+
+  /**
+   * The lookup is permission-checked, so passing someone else's submission id must not
+   * let an untrusted request act as that contact.
+   */
+  public function testCannotActAsAnotherContactWithoutPermission(): void {
+    $submitter = $this->createTestRecord('Individual')['id'];
+    $attacker = $this->createTestRecord('Individual')['id'];
+
+    $submissionId = $this->submitAs($submitter, 'Proposer');
+
+    // Cannot see the submitter, so cannot read their submission
+    $this->login($attacker);
+    $this->setPermissions(['access CiviCRM', 'manage own afform']);
+    try {
+      Afform::process()->setName($this->formName)->setSubmissionId($submissionId)->execute();
+      $this->fail('Expected UnauthorizedException');
+    }
+    catch (\Civi\API\Exception\UnauthorizedException $e) {
+    }
+
+    $this->setPermissions(['access CiviCRM', 'view all contacts', 'edit all contacts', 'administer afform', 'manage own afform']);
+    $this->assertNull($this->getJobTitle($submitter), 'The submitter must not be written to');
+    $this->assertNull($this->getJobTitle($attacker), 'The caller must not be written to either');
+  }
+
+  /**
+   * Submit as the given contact, returning the id of the stored submission.
+   */
+  private function submitAs($contactId, string $jobTitle) {
+    $this->login($contactId);
+    Afform::submit(FALSE)->setName($this->formName)
+      ->setValues(['Individual1' => [['fields' => ['job_title' => $jobTitle]]]])
+      ->execute();
+    return AfformSubmission::get(FALSE)
+      ->addWhere('afform_name', '=', $this->formName)
+      ->execute()->single()['id'];
+  }
+
+  private function login($contactId): void {
+    \CRM_Core_Session::singleton()->set('userID', $contactId);
+  }
+
+  /**
+   * Replace the permission set. CRM_Core_Permission_UnitTests grants everything while
+   * its $permissions array is unset, so it has to be assigned, not supplemented.
+   */
+  private function setPermissions(?array $permissions): void {
+    \CRM_Core_Config::singleton()->userPermissionClass->permissions = $permissions;
+  }
+
+  private function getJobTitle($contactId) {
+    return Contact::get(FALSE)->addSelect('job_title')->addWhere('id', '=', $contactId)->execute()->single()['job_title'];
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
When a stored Afform submission is completed by someone other than the person who submitted it, the submitted values are written onto the wrong contact.

This affects both ways a stored submission gets completed: an admin working through the manual-processing queue, and the anonymous request behind an email-verification link.

Before
----------------------------------------
Completing a stored submission runs `Afform.process` (or `Afform.submit` with a `sid`) in the session of whoever is processing it. Current-user resolution reads that session directly — `ContactAutofill`, for `autofill="user"`:

```php
if (!$id && $autoFillMode === 'user' && $apiRequest->getFillMode() === 'form') {
  $id = \CRM_Core_Session::getLoggedInContactID();
```

and `GroupSubscription`, for `data="{contact_id: 'user_contact_id'}"`:

```php
if ($contact === 'user_contact_id') {
  $cid = \CRM_Core_Session::getLoggedInContactID();
```

So on a form with `manual_processing` enabled and an `autofill="user"` contact block:

1. A user submits. Nothing is written yet; the values are stored on the `AfformSubmission` record.
2. An admin clicks Process.
3. The form resolves to the **admin's** contact, and the submitter's answers are written onto the admin's own record. The submitter's record is left untouched.

The same applies to the email-verification link, where the request is anonymous.

After
----------------------------------------
The contact is resolved from the submission being completed, so the values reach the contact who submitted them and the processing user's record is untouched.

Technical Details
----------------------------------------
`AbstractProcessor::getSubmitterContactID()` resolves the contact, and the two behaviours call it instead of reading the session. The submission id comes from an overridable `getSubmissionId()`, because the two entry points carry it differently: `Submit` reads `$this->args['sid']`, while `Process` — used by both the SearchKit "Process Submissions" task and `CRM_Afform_Page_Verify` — has its own `$submissionId` property.`$submissionId` property.

The lookup inherits the action's own permission setting:

```php
$submission = AfformSubmission::get($this->getCheckPermissions())
```

so trust follows the caller. The verification page calls `Afform::process(FALSE)` from an anonymous request, having already authorized it by decoding a signed 10-minute JWT, and still resolves the submitter; an AJAX submit is permission-checked as usual and cannot act as another contact by passing their submission id.

When a submission id is supplied but cannot be read, this throws rather than falling back to the current user. That fallback is precisely what wrote to the wrong contact, so silently keeping it would leave the bug reachable via an unauthorized `sid`. Note that reading `AfformSubmission` under permissions is also subject to the standard contact ACL on its `contact_id`, so a processing user needs to be able to see the submitter.

An anonymous submission has no contact, so nothing is autofilled — rather than falling back to whoever is processing it.

`Prefill` is unaffected: given a `sid` it calls `populateSubmissionData()` and returns without `parent::loadEntities()`, so the autofill events never fire there.

Tests: `AfformProcessSubmissionTest` covers processing via `Afform.process`, via `Afform.submit` with a `sid`, the anonymous verification path, an anonymous submission, and the permission check. The full `ext/afform/core` suite passes (66 tests, 211 assertions).

Comments
----------------------------------------
Stacked on https://github.com/civicrm/civicrm-core/pull/36581, which fixes an undefined variable in the same code path — that warning is fatal under PHPUnit's `convertWarningsToExceptions`, so the tests here need it. Please merge that one first, or review the second commit only.

Worth noting for anyone hitting this: on an affected form, the damage is silent, and a form field bound to the autofilled contact will have overwritten data on staff contacts.