### PR TITLE
allow overriding scheduled job class

### DIFF
--- a/CRM/Core/JobManager.php
+++ b/CRM/Core/JobManager.php
@@ -108,10 +108,12 @@ class CRM_Core_JobManager {
       ->getArrayCopy();
 
     $jobs = array_merge($successfulJobs, $maybeUnsuccessfulJobs);
+    // Extensions can substitute a CRM_Core_ScheduledJob subclass using hook_civicrm_container (see com.skvare.crontab for an example).
+    $scheduledJobClass = \Civi::container()->getParameter('civicrm.scheduled_job.class') ?: 'CRM_Core_ScheduledJob';
     foreach ($jobs as $job) {
       $temp = ['class' => NULL, 'parameters' => NULL, 'last_run' => NULL];
       $scheduledJobParams = array_merge($temp, $job);
-      $jobDAO = new CRM_Core_ScheduledJob($scheduledJobParams);
+      $jobDAO = new $scheduledJobClass($scheduledJobParams);
 
       if ($jobDAO->needsRunning()) {
         $this->executeJob($jobDAO);

--- a/Civi/Core/Container.php
+++ b/Civi/Core/Container.php
@@ -397,6 +397,7 @@ class Container {
       'object',
       [new Reference('service_container')]
     ))->setFactory([new Reference(self::SELF), 'createEsmLoader'])->setPublic(TRUE);
+    $container->setParameter('civicrm.scheduled_job.class', \CRM_Core_ScheduledJob::class);
 
     \CRM_Utils_Hook::container($container);
 


### PR DESCRIPTION
Overview
----------------------------------------
There is a demand for extensions that override `CRM_Core_ScheduledJob`, but currently that requires a file override, which leads to all the problems of file overrides.  This implements dependency injection to allow extensions to override `CRM_Core_ScheduledJob` without a file override.

Comments
----------------------------------------
I considered creating a new hook like `hook_civicrm_alterMailer` but it seems likely we'll want to do this in the future for other classes and we don't want to create new hooks for each one.
