### PR TITLE
SearchKit: Allow joining entity displays on (some) aggregated IDs

### DIFF
--- a/Civi/Api4/Query/SqlFunction.php
+++ b/Civi/Api4/Query/SqlFunction.php
@@ -43,6 +43,18 @@ abstract class SqlFunction extends SqlExpression {
    */
   protected static $category;
 
+  /**
+   * Set to TRUE by aggregate functions (e.g. GROUP_FIRST, MIN, MAX) which are
+   * guaranteed to output one of the actual values of the field they wrap,
+   * as opposed to a computed value that doesn't correspond to any real row
+   * (e.g. SUM, AVG, COUNT). This allows the wrapped field's entity_reference
+   * (FK) to be preserved on the aggregated output, so it can still be used
+   * as a join key even though it's aggregated.
+   *
+   * @var bool
+   */
+  public $preservesEntityReference = FALSE;
+
   const CATEGORY_AGGREGATE = 'aggregate',
     CATEGORY_COMPARISON = 'comparison',
     CATEGORY_DATE = 'date',

--- a/Civi/Api4/Query/SqlFunctionGROUP_FIRST.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_FIRST.php
@@ -19,6 +19,8 @@ class SqlFunctionGROUP_FIRST extends SqlFunction {
 
   public $supportsExpansion = TRUE;
 
+  public $preservesEntityReference = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static function params(): array {

--- a/Civi/Api4/Query/SqlFunctionGROUP_NTH.php
+++ b/Civi/Api4/Query/SqlFunctionGROUP_NTH.php
@@ -21,6 +21,8 @@ class SqlFunctionGROUP_NTH extends SqlFunction {
 
   public $supportsExpansion = TRUE;
 
+  public $preservesEntityReference = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static function params(): array {

--- a/Civi/Api4/Query/SqlFunctionMAX.php
+++ b/Civi/Api4/Query/SqlFunctionMAX.php
@@ -18,6 +18,8 @@ class SqlFunctionMAX extends SqlFunction {
 
   public $supportsExpansion = TRUE;
 
+  public $preservesEntityReference = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static function params(): array {

--- a/Civi/Api4/Query/SqlFunctionMIN.php
+++ b/Civi/Api4/Query/SqlFunctionMIN.php
@@ -18,6 +18,8 @@ class SqlFunctionMIN extends SqlFunction {
 
   public $supportsExpansion = TRUE;
 
+  public $preservesEntityReference = TRUE;
+
   protected static $category = self::CATEGORY_AGGREGATE;
 
   protected static function params(): array {

--- a/ext/search_kit/Civi/Search/Meta.php
+++ b/ext/search_kit/Civi/Search/Meta.php
@@ -188,6 +188,13 @@ class Meta {
         $spec['options'] = TRUE;
         $spec['suffixes'] = $field['suffixes'];
       }
+      // Aggregate functions like GROUP_FIRST/GROUP_NTH/MIN/MAX are guaranteed to
+      // output one of the wrapped field's actual values, so if that field is a FK,
+      // the aggregated result can still be treated (and joined on) as one.
+      elseif (!empty($field) && $expr['expr']->preservesEntityReference) {
+        $spec['entity_reference'] = self::getFieldEntityReference($field);
+        $spec['input_type'] = $spec['entity_reference'] ? 'EntityRef' : self::getInputTypeFromDataType($spec['data_type']);
+      }
       else {
         $spec['input_type'] = self::getInputTypeFromDataType($spec['data_type']);
       }
@@ -199,6 +206,31 @@ class Meta {
       }
     }
     return $spec;
+  }
+
+  /**
+   * Determine whether a field (as resolved via SavedSearchInspectorTrait::getField())
+   * refers to another entity, either because it *is* that entity's id field or
+   * because it has an explicit FK.
+   *
+   * @param array $field
+   * @return array|null
+   */
+  private static function getFieldEntityReference(array $field): ?array {
+    // An entity id counts as a FK
+    if (empty($field['fk_entity']) && $field['name'] === CoreUtil::getIdFieldName($field['entity'])) {
+      return ['entity' => $field['entity']];
+    }
+    $originalEntity = CoreUtil::isContact($field['entity']) ? 'Contact' : $field['entity'];
+    // API-only pseudo-fields (e.g. Activity.target_contact_id) don't exist
+    // in the schema definition, so fall back to the APIv4 field spec which
+    // is already resolved in $field via getSelectClause().
+    $originalField = \Civi::entity($originalEntity)->getField($field['name']) ?? $field;
+    return $originalField['entity_reference']
+      ?? (!empty($originalField['fk_entity']) ? array_filter([
+        'entity' => $originalField['fk_entity'],
+        'key' => $originalField['fk_column'] ?? NULL,
+      ]) : NULL);
   }
 
   private static function getInputTypeFromDataType(string $dataType): ?string {

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/EntityDisplayTest.php
@@ -328,6 +328,97 @@ class EntityDisplayTest extends Api4TestBase {
   }
 
   /**
+   * Aggregate functions that are guaranteed to output one of the wrapped field's
+   * actual values (GROUP_FIRST/GROUP_NTH/MIN/MAX) should preserve that field's
+   * entity_reference, so a "First Event" (etc.) column can still be joined on.
+   * Aggregates that don't preserve identity (e.g. COUNT) should not.
+   *
+   * @dataProvider getDataModes
+   */
+  public function testEntityDisplayWithAggregateJoin(string $dataMode): void {
+    $lastName = uniqid(__FUNCTION__);
+    $contacts = (array) $this->saveTestRecords('Individual', [
+      'records' => [
+        ['last_name' => $lastName, 'first_name' => 'a'],
+        ['last_name' => $lastName, 'first_name' => 'b'],
+      ],
+    ]);
+    $event1 = $this->createTestRecord('Event', ['title' => __FUNCTION__ . '1']);
+    $event2 = $this->createTestRecord('Event', ['title' => __FUNCTION__ . '2']);
+    $this->saveTestRecords('Participant', [
+      'records' => [
+        ['contact_id' => $contacts[0]['id'], 'event_id' => $event1['id']],
+        ['contact_id' => $contacts[0]['id'], 'event_id' => $event2['id']],
+      ],
+    ]);
+
+    $savedSearch = $this->createTestRecord('SavedSearch', [
+      'label' => __FUNCTION__,
+      'api_entity' => 'Contact',
+      'api_params' => [
+        'version' => 4,
+        'select' => [
+          'id',
+          'sort_name',
+          'GROUP_FIRST(Contact_Participant_contact_id_01.event_id ORDER BY Contact_Participant_contact_id_01.event_id ASC) AS GROUP_FIRST_event_id',
+          'COUNT(Contact_Participant_contact_id_01.id) AS COUNT_participant_id',
+        ],
+        'where' => [['last_name', '=', $lastName]],
+        'groupBy' => ['id'],
+        'join' => [
+          ['Participant AS Contact_Participant_contact_id_01', 'LEFT', ['id', '=', 'Contact_Participant_contact_id_01.contact_id']],
+        ],
+      ],
+    ]);
+
+    SearchDisplay::create(FALSE)
+      ->addValue('saved_search_id', $savedSearch['id'])
+      ->addValue('type', 'entity')
+      ->addValue('label', 'MyAggregateJoinEntity')
+      ->addValue('name', 'MyAggregateJoinEntity')
+      ->addValue('settings', [
+        'data_mode' => $dataMode,
+        'columns' => [
+          ['key' => 'id', 'label' => 'Contact ID', 'type' => 'field'],
+          ['key' => 'sort_name', 'label' => 'Sort Name', 'type' => 'field'],
+          ['key' => 'GROUP_FIRST_event_id', 'label' => 'First Event ID', 'type' => 'field'],
+          ['key' => 'COUNT_participant_id', 'label' => 'Participant Count', 'type' => 'field'],
+        ],
+        'sort' => [['id', 'ASC']],
+      ])
+      ->execute();
+
+    $fields = civicrm_api4('SK_MyAggregateJoinEntity', 'getFields', [], 'name');
+    $this->assertCount(4, $fields);
+
+    // GROUP_FIRST is identity-preserving, so it should carry a FK just like a plain field would
+    $this->assertSame('Integer', $fields['GROUP_FIRST_event_id']['data_type']);
+    $this->assertSame('EntityRef', $fields['GROUP_FIRST_event_id']['input_type']);
+    $this->assertSame('Event', $fields['GROUP_FIRST_event_id']['fk_entity']);
+
+    // COUNT doesn't correspond to any real row, so it must NOT be treated as a FK
+    $this->assertSame('Integer', $fields['COUNT_participant_id']['data_type']);
+    $this->assertSame('Number', $fields['COUNT_participant_id']['input_type']);
+    $this->assertNull($fields['COUNT_participant_id']['fk_entity']);
+
+    civicrm_api4('SK_MyAggregateJoinEntity', 'refresh');
+    $rows = (array) civicrm_api4('SK_MyAggregateJoinEntity', 'get', [
+      'select' => ['*', 'GROUP_FIRST_event_id.title'],
+      'orderBy' => ['id' => 'ASC'],
+    ]);
+    $this->assertCount(2, $rows);
+    $this->assertEquals($event1['id'], $rows[0]['GROUP_FIRST_event_id']);
+    $this->assertEquals(__FUNCTION__ . '1', $rows[0]['GROUP_FIRST_event_id.title']);
+    $this->assertNull($rows[1]['GROUP_FIRST_event_id']);
+
+    // The aggregated FK column should now be joinable in the SearchKit builder
+    $allowedEntities = Admin::getSchema();
+    $joins = Admin::getJoins($allowedEntities);
+    $joinsFromEntity = $joins['SK_MyAggregateJoinEntity'];
+    $this->assertContains('SK_MyAggregateJoinEntity_Event_GROUP_FIRST_event_id', array_column($joinsFromEntity, 'alias'));
+  }
+
+  /**
    * @dataProvider getDataModes
    */
   public function testEntityWithSqlFunctions(string $dataMode): void {


### PR DESCRIPTION
Overview
----------------------------------------
If you create an Entity display from a SearchKit query, you can join that entity to any other entity that you've provided a foreign key for.  So if you join Contacts to Participants to Events, you can join the resulting entity to any of those entities.

However - if you aggregate by any of those foreign keys, it becomes the *only* key you can use for joins.  Which makes sense in most cases - you don't want to join `COUNT(event_id)` to events.  However, some aggregations will return a single value that represents an actual row - `FIRST`, `NTH`, `MIN` and `MAX`.  So you should still be able to use those foreign keys for joins.

Before
----------------------------------------
Can't use aggregated foreign keys for joins.

After
----------------------------------------
Can use aggregated foreign keys for joins, provided they only return a single value that corresponds to an actual row in the foreign table.
