### PR TITLE
Set expiration for Complete with Errors imports to one month in the future

### DIFF
--- a/CRM/Core/BAO/UserJob.php
+++ b/CRM/Core/BAO/UserJob.php
@@ -90,11 +90,15 @@ class CRM_Core_BAO_UserJob extends CRM_Core_DAO_UserJob implements HookInterface
       }
     }
     if ($newStatus !== $userJob['status_id:name']) {
+      $expiryByStatus = [
+        'completed' => '+1 week',
+        'complete_with_errors' => '+1 month',
+      ];
       UserJob::update(FALSE)
         ->addWhere('id', '=', $userJobId)
         ->addValue('status_id:name', $newStatus)
         ->addValue('end_date', 'now')
-        ->addValue('expires_date', $newStatus === 'completed' ? '+1 week' : NULL)
+        ->addValue('expires_date', $expiryByStatus[$newStatus] ?? NULL)
         ->execute();
     }
   }


### PR DESCRIPTION
We're found that folks don't tend to delete their imports with errors after they've resolved the problem, so instead let's set them to expire after a month. A month is plenty of time for users to review and correct, but avoids old import entities hanging around forever, with associated performance degradation.