### PR TITLE
modernize Drupal CMS cache clear mechanism

### DIFF
--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -564,9 +564,17 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
    * @inheritDoc
    */
   public function flush() {
+    $container = \Drupal::getContainer();
+    if ($container->has('civicrm.cache_invalidator')) {
+      // The Drupal integration knows which caches depend on CiviCRM data.
+      $container->get('civicrm.cache_invalidator')->invalidate();
+      return;
+    }
+
     // CiviCRM and Drupal both provide (different versions of) Symfony (and possibly share other classes too).
     // If we call drupal_flush_all_caches(), Drupal will attempt to rediscover all of its classes, use Civicrm's
-    // alternatives instead and then die. Instead, we only clear cache bins and no more.
+    // alternatives instead and then die. Older versions of the Drupal integration do not provide targeted
+    // invalidation, so retain the previous cache-bin clearing behavior as a compatibility fallback.
     foreach (Drupal\Core\Cache\Cache::getBins() as $service_id => $cache_backend) {
       $cache_backend->deleteAll();
     }

--- a/Civi/Core/Rebuilder.php
+++ b/Civi/Core/Rebuilder.php
@@ -185,6 +185,8 @@ class Rebuilder {
     }
     if (!empty($targets['router'])) {
       CRM_Core_Menu::store();
+      // Rebuild CMS routes only after CiviCRM's menu data has been refreshed.
+      $config->userSystem->invalidateRouteCache();
     }
     if (!empty($targets['navigation'])) {
       Civi::cache('navigation')->flush();
@@ -207,11 +209,6 @@ class Rebuilder {
     }
     if (!empty($targets['triggers'])) {
       Civi::service('sql_triggers')->rebuild();
-      // (1) Rebuild Drupal 8/9/10 route cache only if "triggerRebuild" is set to TRUE as it's
-      // computationally very expensive and only needs to be done when routes change on the Civi-side.
-      // For example - when uninstalling an extension. We already set "triggerRebuild" to true for these operations.
-      // (2) FIXME: That ^^ seems silly now. Shouldn't it go under $targets['menu']?
-      $config->userSystem->invalidateRouteCache();
     }
     if (!empty($targets['entities'])) {
       CRM_Core_ManagedEntities::singleton(TRUE)->reconcile();


### PR DESCRIPTION
Overview
----------------------------------------
Updates stemming from discussion on https://github.com/civicrm/civicrm-core/pull/36544

Before
----------------------------------------
CiviCRM clears all cache bins

After
----------------------------------------
CiviCRM looks for and invokes a Drupal service to pass management of cache clearing to the Drupal module and/or other Drupal modules


