### PR TITLE
Afform - Let Form Builder point a dynamic foreign key at another entity on the form

### DIFF
--- a/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
+++ b/ext/afform/admin/Civi/AfformAdmin/AfformAdminMeta.php
@@ -99,7 +99,7 @@ class AfformAdminMeta {
         ...array_keys(\CRM_Core_SelectValues::optionAttributes()),
       ],
       'action' => 'create',
-      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'suffixes', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'readonly', 'operators'],
+      'select' => ['name', 'label', 'input_type', 'input_attrs', 'required', 'options', 'suffixes', 'help_pre', 'help_post', 'serialize', 'data_type', 'entity', 'fk_entity', 'dfk_entities', 'readonly', 'operators'],
       'where' => [['deprecated', '=', FALSE], ['input_type', 'IS NOT NULL']],
     ];
     if ($entityName === 'Address') {

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.component.js
@@ -84,6 +84,43 @@
 
       $scope.getField = afGui.getField;
 
+      /**
+       * Field metadata for one of the entity's preset values.
+       *
+       * A dynamic foreign key only knows which entity it points to once its controlling
+       * field is set - e.g. ContactRole.entity_id is a Contact, an Event or whatever else
+       * entity_table names. Resolve it from the value alongside it so the input can offer
+       * the matching entities on this form.
+       */
+      // Resolved copies are cached so the object identity only changes when the target
+      // entity does; the input widget is rebuilt whenever it changes.
+      const dfkFields = {};
+
+      $scope.getValueField = function(fieldName) {
+        const field = afGui.getField(ctrl.getEntityType(), $scope.getUnsuffixedName(fieldName));
+        const controlField = field && field.input_attrs && field.input_attrs.control_field;
+        if (!field || !controlField || !field.dfk_entities) {
+          return field;
+        }
+        const fkEntity = field.dfk_entities[ctrl.entity.data[controlField]] || null;
+        if (!dfkFields[fieldName] || dfkFields[fieldName].fk_entity !== fkEntity) {
+          dfkFields[fieldName] = Object.assign({}, field, {fk_entity: fkEntity});
+        }
+        return dfkFields[fieldName];
+      };
+
+      /**
+       * A dynamic foreign key cannot be filled in until its controlling field has a value.
+       */
+      $scope.getUnsetControlField = function(fieldName) {
+        const field = afGui.getField(ctrl.getEntityType(), $scope.getUnsuffixedName(fieldName));
+        const controlField = field && field.input_attrs && field.input_attrs.control_field;
+        if (!controlField || !field.dfk_entities || ctrl.entity.data[controlField]) {
+          return null;
+        }
+        return $scope.getMeta().fields[controlField] ? $scope.getMeta().fields[controlField].label : controlField;
+      };
+
       $scope.valuesFields = () => {
         const fields = Object.values($scope.getMeta().fields).map(field => ({
           id: field.name,

--- a/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
+++ b/ext/afform/admin/ang/afGuiEditor/afGuiEntity.html
@@ -13,11 +13,15 @@
                class="form-control"
                placeholder="{{:: ts('Pick Date') }}"
                ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] === 'Date' && $ctrl.entity.data[fieldName] === 'now'">
+        <input disabled
+               class="form-control"
+               ng-if="getUnsetControlField(fieldName)"
+               placeholder="{{ ts('Set %1 first', {1: getUnsetControlField(fieldName)}) }}" />
         <input required
-               ng-if="getField($ctrl.getEntityType(), fieldName)['input_type'] !== 'Date' || $ctrl.entity.data[fieldName] !== 'now'"
+               ng-if="!getUnsetControlField(fieldName) && (getField($ctrl.getEntityType(), fieldName)['input_type'] !== 'Date' || $ctrl.entity.data[fieldName] !== 'now')"
                id="{{ $ctrl.getFieldId(fieldName) }}"
                class="form-control"
-               af-gui-field-value="getField($ctrl.getEntityType(), getUnsuffixedName(fieldName))"
+               af-gui-field-value="getValueField(fieldName)"
                ng-model-options="{ getterSetter: true }"
                ng-model="entityDataGetterSetter(fieldName)" />
         <a href ng-click="removeValue($ctrl.entity, fieldName)">

--- a/ext/afform/admin/tests/phpunit/CiviAfformAdminAfformAdminMetaTest.php
+++ b/ext/afform/admin/tests/phpunit/CiviAfformAdminAfformAdminMetaTest.php
@@ -53,4 +53,18 @@ class CiviAfformAdminAfformAdminMetaTest extends \PHPUnit\Framework\TestCase imp
     $this->assertSame([], $adminSettings['locales']);
   }
 
+  /**
+   * A dynamic foreign key needs its table-to-entity map and the name of the field
+   * that controls it, so the form builder can resolve which entity it points to.
+   */
+  public function testDynamicForeignKeyMetadata():void {
+    $fields = \Civi\AfformAdmin\AfformAdminMeta::getFields('Note');
+
+    $this->assertEquals('entity_table', $fields['entity_id']['input_attrs']['control_field']);
+    $this->assertEquals('Contact', $fields['entity_id']['dfk_entities']['civicrm_contact']);
+    // A plain foreign key has no map to resolve
+    $this->assertEquals('Contact', $fields['contact_id']['fk_entity']);
+    $this->assertArrayNotHasKey('dfk_entities', array_filter($fields['contact_id']));
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Form Builder can point a foreign key at another entity on the same form — that's how `contact_id: 'Individual1'` is set. It can't do that for a *dynamic* foreign key, so anyone using one has to hand-edit the form markup.

The [Contact Roles](https://lab.civicrm.org/extensions/contact_roles) extension documents this as a required workaround: "you currently have to add the `entity_id` value to your afform html manually".

Before
----------------------------------------
`afGuiFieldValue` already offers the form's own entities as picker options:

```js
if (field.fk_entity) {
  (ctrl.editor ? ctrl.editor.getEntities() : []).forEach((entity) => {
    let filtersMatch = (entity.type === field.fk_entity) || …;
    if (filtersMatch) options.push({id: entity.name, label: entity.label, …});
  });
```

The whole branch is gated on `field.fk_entity`. A dynamic FK has none until its controlling field is known — `ContactRole.entity_id` is a Contact, an Event or whatever else `entity_table` names. `SpecGatherer::setDynamicFk()` resolves it when `getFields` is given a value for the controlling column:

| getFields call | `fk_entity` |
|---|---|
| plain | `null` |
| with `values: {entity_table: 'civicrm_event'}` | `"Event"` |

But the editor fetches field metadata once per entity type with no values, so `fk_entity` is always null there. The input fell through to a plain text box: no autocomplete, no entity options, and no validation of what was typed. The only way to attach a ContactRole to the entity beside it on the form was to edit the markup by hand:

```html
<af-entity type="ContactRole" name="ContactRole1" …
           data="{contact_role_type_id: 1, entity_table: 'civicrm_event', entity_id: 'Event1'}" />
```

After
----------------------------------------
Setting `Entity Table` to Event makes the `Entity ID` input offer the form's Event entity, and the saved markup comes out of the UI:

```html
data="{contact_role_type_id: 1, entity_id: 'Event1', entity_table: 'civicrm_event'}"
```

Before the controlling field has a value there is nothing to point at, so the input is disabled with a "Set Entity Table first" hint rather than accepting a value that cannot resolve.

https://github.com/user-attachments/assets/773b5b8c-1813-4950-ae46-59a9f0b740ec

Technical Details
----------------------------------------
No extra server round-trip. The table-to-entity map is already computed by `setDynamicFk()` and the controlling column is already published as `input_attrs.control_field`; the editor simply wasn't being sent the map. So:

- `AfformAdminMeta::getFields()` — add `dfk_entities` to the `select` list, alongside the `fk_entity` and `input_attrs` it already requested.
- `afGuiEntity` — `getValueField()` returns the field with `fk_entity` resolved from `dfk_entities[data[control_field]]`. Resolved copies are cached so the object identity changes only when the target entity does, otherwise the one-way binding would rebuild the select2 widget on every digest.
- `getUnsetControlField()` drives the disabled state, naming the controlling field in the placeholder.

This applies to every dynamic FK in Form Builder, not just ContactRole — `Note.entity_id` and the other `entity_table`/`entity_id` pairs behave the same way. There is precedent for value-dependent field metadata in this same method, which already passes `country_id`/`state_province_id` when gathering Address fields.

Comments
----------------------------------------
Verified by driving the real Form Builder UI on a form with an `Event1` entity and a ContactRole block: the picker's static options came back as `[{id: "Event1", label: "Event 1", icon: "fa-calendar"}]`, and the saved layout contained `entity_id: 'Event1'`.

phpunit test on Note entity.