### PR TITLE
Localization settings - allow any language for contact default

### DIFF
--- a/CRM/Admin/Form/Setting/Localization.php
+++ b/CRM/Admin/Form/Setting/Localization.php
@@ -378,12 +378,16 @@ class CRM_Admin_Form_Setting_Localization extends CRM_Admin_Form_Generic {
    * @return array
    */
   public static function getDefaultLanguageOptions() {
-    $availableOptions = [
+    $languages = \Civi\Api4\OptionValue::get(FALSE)
+      ->addWhere('option_group_id.name', '=', 'languages')
+      ->execute()
+      ->indexBy('name')
+      ->column('label');
+
+    return array_merge([
       '*default*' => ts('Use default site language'),
       'current_site_language' => ts('Use language in use at the time'),
-    ];
-    $availableLanguages = array_merge($availableOptions, CRM_Admin_Form_Setting_Localization::getDefaultLocaleOptions());
-    return $availableLanguages;
+    ], $languages);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Before
----------------------------------------
- Default contact language is restricted to couple of automatic options + UI languages
- Once you've created the contact, you can change their Preferred Language to any of the options in `languages` option group

After
----------------------------------------
- Default contact language can be the existing automatic options + any of the options in `languages` option group

Technical Details
----------------------------------------
As far as I can see, all this setting is ever used for is populating the default for `preferred_language` field on Contact. No reason the default shouldn't be any of the valid options for this field.
