### PR TITLE
ManagedEntities - Remove deprecated code that probably never worked

### DIFF
--- a/CRM/Core/ManagedEntities.php
+++ b/CRM/Core/ManagedEntities.php
@@ -628,17 +628,6 @@ class CRM_Core_ManagedEntities {
 
   protected function preprocessDeclarations(array $declarations): array {
     $this->validate($declarations);
-    // FIXME: Some well-meaning developer added this a long time ago to support associative arrays
-    // that use the array index as the declaration name. But it probably never worked, because by the time it gets to this point,
-    // lots of implementations of `hook_civicrm_managed()` would have run `$declarations = array_merge($declarations, [...])`
-    // which would have reset the indexes.
-    // Adding a noisy deprecation notice for now, then we should remove this block:
-    foreach ($declarations as $index => $declaration) {
-      if (empty($declaration['name'])) {
-        CRM_Core_Error::deprecatedWarning(sprintf('Managed entity "%s" declared by extension "%s" without a name.', $index, $declaration['module']));
-        $declarations[$index] += ['name' => $index];
-      }
-    }
     foreach ($declarations as $index => $declaration) {
       $declarations[$index]['checksum'] = $this->computeChecksum($declaration);
     }


### PR DESCRIPTION
Overview
----------------------------------------
Removes noisily deprecated code that probably never worked anyway.


Technical Details
----------------------------------------
Some well-meaning developer added this a long time ago to support associative arrays that use the array index as the declaration name. But it probably never worked, because by the time it gets to this point, lots of implementations of `hook_civicrm_managed()` would have run `$declarations = array_merge($declarations, [...])` which would have reset the indexes.