### PR TITLE
dev/core#6708 SearchKit - Prevent load-order issues when saving managed displays

### DIFF
--- a/ext/search_kit/Civi/Api4/Event/Subscriber/BatchDisplaySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/BatchDisplaySubscriber.php
@@ -65,6 +65,11 @@ class BatchDisplaySubscriber extends AutoService implements EventSubscriberInter
       if (empty($column['key']) || in_array($column['key'], $pseudoFields)) {
         continue;
       }
+      // If saving for the first time and `spec` exists, it's probably coming fully-formed from hook_civicrm_managed/.mgd.php
+      // Skip recalculating it in that case to prevent load-order issues. dev/core#6708
+      if (!$event->id && !empty($column['spec'])) {
+        continue;
+      }
       $expr = $this->getSelectExpression($column['key']);
       if ($expr) {
         $column['spec'] = Meta::formatFieldSpec($column, $expr);
@@ -85,7 +90,7 @@ class BatchDisplaySubscriber extends AutoService implements EventSubscriberInter
   }
 
   /**
-   * Check if pre/post hook applies to a SearchDisplay type 'entity'
+   * Check if pre/post hook applies to a SearchDisplay type 'batch'
    *
    * @param \Civi\Core\Event\PreEvent|\Civi\Core\Event\PostEvent $event
    * @return bool

--- a/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
+++ b/ext/search_kit/Civi/Api4/Event/Subscriber/SKEntitySubscriber.php
@@ -116,7 +116,11 @@ class SKEntitySubscriber extends AutoService implements EventSubscriberInterface
       if (!$expr) {
         continue;
       }
-      $column['spec'] = Meta::formatFieldSpec($column, $expr);
+      // If saving for the first time and `spec` exists, it's probably coming fully-formed from hook_civicrm_managed/.mgd.php
+      // Skip recalculating it in that case to prevent load-order issues. dev/core#6708
+      if ($event->id || empty($column['spec'])) {
+        $column['spec'] = Meta::formatFieldSpec($column, $expr);
+      }
       $table['fields'][] = $this->formatSQLSpec($column, $expr);
       if (in_array($column['key'], $primaryKeys)) {
         $newSettings['primaryKey'][] = $column['spec']['name'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes [dev/core#6708](https://lab.civicrm.org/dev/core/-/work_items/6708)

Technical Details
----------------------------------------
Some types of displays perform preprocessing while saving. This can go wrong if the entity types don't all exist, as when installing an extension that packages both search displays and the ECK entities they depend on.
