### PR TITLE
CRM_Utils_System_WordPress::isFrontEndPage - flip is_admin check, pin down test behaviour

### DIFF
--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -46,9 +46,10 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   public function isFrontEndPage() {
-    // check to see if we are on the front end of WP.  Ensure function exists in case we are running cron via cli
-    if (function_exists('is_admin') && !is_admin()) {
-      return TRUE;
+    // check to see if we are definitively on the WP backend
+    // NOTE: function is not always defined on CLI / Civi-only boots
+    if (function_exists('is_admin') && is_admin()) {
+      return FALSE;
     }
 
     $path = CRM_Utils_System::currentPath() ?? '';

--- a/tests/phpunit/E2E/Core/PathUrlTest.php
+++ b/tests/phpunit/E2E/Core/PathUrlTest.php
@@ -147,9 +147,12 @@ class PathUrlTest extends \CiviEndToEndTestCase {
     else {
       $this->assertEquals($front, $back, "On Drupal/Backdrop/Standalone, frontend and backend URLs should look the same.");
     }
-    // For purposes of this test, it doesn't matter if "current" is frontend or backend - as long as it's consistent.
-    // "current" should resolve consistently to whichever flavor matches the actual request context - it doesn't matter which, as long as it's one of the two.
-    $this->assertContains($current, [$front, $back], "Within E2E tests, current routing style should match either frontend or backend.");
+    if (CIVICRM_UF === 'WordPress') {
+      $this->assertEquals($current, $front, "On WordPress, current scheme (unusually) defaults to frontend.");
+    }
+    else {
+      $this->assertEquals($current, $back, "On most systems, current scheme defaults to backend.");
+    }
   }
 
   public function testUrl_DefaultUI(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Follow up to https://github.com/civicrm/civicrm-core/pull/36568

Before
----------------------------------------
- If `is_admin` is false => frontend; otherwise check the path
- Test is a bit open about what the right behaviour is

After
----------------------------------------
- If `is_admin` is true => backend; otherwise check the path
- Test makes clear the current behaviour (with WP being the unusual case)

Technical Details
----------------------------------------
It does seem to odd to me that WP "defaults" to frontend on the E2E test. I feel like ideally it would answer `backend` in that context, but importantly *without* answering backend on a load of other WP pages which dont have CiviCRM paths.

Another school of thought would be: the E2E test context is not a real request => there isn't really a lot of sense in asking what the "current" scheme is => Maybe we could just rip out the $current testing from that test.

Comments
----------------------------------------
@kcristiano 
