### PR TITLE
Fix core/dev#6711: OpenStreetMaps tiles watermarked with "API KEY REQUIRED"

### DIFF
--- a/settings/Map.setting.php
+++ b/settings/Map.setting.php
@@ -74,7 +74,7 @@ return [
       'maxlength' => '64',
     ],
     'default' => NULL,
-    'title' => ts('Map Provider Key'),
+    'title' => ts('Mapping Provider Key'),
     'help_text' => ts('Enter your API Key or Application ID for the selected mapping provider. For Google Maps, refer to developers.google.com for the latest information. For OpenStreetMaps, a CARTO api key may be required.'),
     'help_doc_url' => [
       'page' => 'user/initial-set-up/mapping/',

--- a/settings/Map.setting.php
+++ b/settings/Map.setting.php
@@ -31,7 +31,7 @@ return [
       'maxlength' => '64',
     ],
     'default' => NULL,
-    'title' => ts('Geo Provider Key'),
+    'title' => ts('Geocoding Provider Key'),
     'help_text' => ts('Enter the API key or Application ID associated with your geocoding provider.'),
     'settings_pages' => ['mapping' => ['weight' => 30]],
   ],

--- a/settings/Map.setting.php
+++ b/settings/Map.setting.php
@@ -75,7 +75,10 @@ return [
     ],
     'default' => NULL,
     'title' => ts('Map Provider Key'),
-    'help_text' => ts('Enter your API Key or Application ID. An API Key is required for the Google Maps API. Refer to developers.google.com for the latest information.'),
+    'help_text' => ts('Enter your API Key or Application ID for the selected mapping provider. For Google Maps, refer to developers.google.com for the latest information. For OpenStreetMaps, a CARTO api key may be required.'),
+    'help_doc_url' => [
+      'page' => 'user/initial-set-up/mapping/',
+    ],
     'settings_pages' => ['mapping' => ['weight' => 10]],
   ],
   'mapProvider' => [

--- a/templates/CRM/Admin/Form/Setting/Mapping.tpl
+++ b/templates/CRM/Admin/Form/Setting/Mapping.tpl
@@ -12,19 +12,3 @@
   {docURL page='user/initial-set-up/mapping/'}
 </div>
 {include file='CRM/Admin/Form/Generic.tpl'}
-{literal}
-<script type="text/javascript">
-CRM.$(function($) {
-  var $form = $('form.{/literal}{$form.formClass}{literal}');
-  function showHideMapAPIkey() {
-    var mapProvider = $(this).val();
-    if ( !mapProvider || ( mapProvider === 'OpenStreetMaps' ) ) {
-      $('tr.crm-setting-form-block-mapAPIKey', $form).hide( );
-    } else {
-      $('tr.crm-setting-form-block-mapAPIKey', $form).show( );
-    }
-  }
-  $('#mapProvider').each(showHideMapAPIkey).change(showHideMapAPIkey);
-});
-</script>
-{/literal}

--- a/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
+++ b/templates/CRM/Contact/Form/Task/Map/OpenStreetMaps.tpl
@@ -53,11 +53,13 @@
 
     function initMap() {
         var map = new OpenLayers.Map("osm_map");
+        var mapKeyQuery;
+        {/literal}{if $mapKey}mapKeyQuery="key={$mapKey}";{/if}{literal}
         map.addLayer(new OpenLayers.Layer.OSM("CARTO OSM", [
-          "https://cartodb-basemaps-1.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png",
-          "https://cartodb-basemaps-2.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png",
-          "https://cartodb-basemaps-3.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png",
-          "https://cartodb-basemaps-4.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png",
+          "https://cartodb-basemaps-1.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png?" + mapKeyQuery,
+          "https://cartodb-basemaps-2.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png?" + mapKeyQuery,
+          "https://cartodb-basemaps-3.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png?" + mapKeyQuery,
+          "https://cartodb-basemaps-4.global.ssl.fastly.net/light_all/${z}/${x}/${y}.png?" + mapKeyQuery,
         ], {
             attribution: 'Data &copy; <a href="http://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a>. Map tiles &copy; <a href="https://carto.com/attribution" target="_blank">CARTO</a>.'
         }));


### PR DESCRIPTION
Support api key for OpenStreetMaps provider.

Overview
----------------------------------------
As described in original ticket [dev/core#6711](https://lab.civicrm.org/dev/core/-/work_items/6711), CARTO now requires an api key for tile retrieval; without this, all tiles will be watermarked "api key required" on openStreetMaps maps.

Before
----------------------------------------
All openstreetmaps map tiles have a watermark, "api key required".

After
----------------------------------------
No more watermark (assuming you enter a valid api key in the "Map Provider Key" setting at Administer > System Settings > Mapping and Geocoding).

Technical Details
----------------------------------------
- Stop hiding the  "Map Provider Key" setting for OpenStreetMaps mapping provder, since it's now relevant.
- Modify the help text for this setting to point users in the right direction.
- Use this api key when retrieving tiles for openstreetmaps maps.

Comments
----------------------------------------
This PR adds a 'read more' link in the help text for the Map Provider Key setting, pointing to https://docs.civicrm.org/user/en/latest/initial-set-up/mapping/ -- that docs page could do with a note about CARTO api keys.
