### PR TITLE
Add Composite Index On Mailing Recipients Table

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixNineteen.php
+++ b/CRM/Upgrade/Incremental/php/SixNineteen.php
@@ -30,6 +30,7 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
   public function upgrade_6_19_alpha1($rev): void {
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Drop OptionValue.domain_id column', 'dropColumn', 'civicrm_option_value', 'domain_id');
+    $this->addTask(ts('Create index %1', [1 => 'civicrm_mailing_recipients.index_mailing_id_contact_id']), 'addIndex', 'civicrm_mailing_recipients', [['mailing_id', 'contact_id']], 'index');
   }
 
 }

--- a/schema/Mailing/MailingRecipients.entityType.php
+++ b/schema/Mailing/MailingRecipients.entityType.php
@@ -9,6 +9,15 @@ return [
     'title_plural' => ts('Mailing Recipients'),
     'description' => ts('Stores information about the recipients of a mailing.'),
   ],
+  'getIndices' => fn() => [
+    'index_mailing_id_contact_id' => [
+      'fields' => [
+        'mailing_id' => TRUE,
+        'contact_id' => TRUE,
+      ],
+      'add' => '6.19',
+    ],
+  ],
   'getFields' => fn() => [
     'id' => [
       'title' => ts('Mailing Recipients ID'),


### PR DESCRIPTION
Overview
----------------------------------------
This PR adds a new composite index on civicrm_mailing_recipients (mailing_id, contact_id) as this can really speed up mailing report queries.