### PR TITLE
FormBuilder payments - support html in confirmation messages

### DIFF
--- a/ext/civi_contribute/js/landing.js
+++ b/ext/civi_contribute/js/landing.js
@@ -6,7 +6,7 @@
     let recheckCount = 0;
 
     const setMessage = (message, showLoader) => {
-      document.querySelector('#checkoutLanding .crm-checkout-message').innerText = message;
+      document.querySelector('#checkoutLanding .crm-checkout-message').innerHTML = message;
       document.querySelector('#checkoutLanding .crm-loading-spinner').style.display = showLoader ? null : 'none';
     };
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix rendering HTML in confirmation messages when using FormBuilder payments landing page.

Before
----------------------------------------
- Since https://github.com/civicrm/civicrm-core/pull/34498 we have allowed form builders to put html in form confirmation messages.
- This is broken when using FormBuilder payments

After
----------------------------------------
- HTML works in FormBuilder payments confirmation messages too

Technical Details
----------------------------------------
Is it safe? The message content is embedded in the checkout session JWT - so should be tamper-resistant and faithful to the original message HTML.

