### PR TITLE
Fix corruption of Riverlea stream file paths when editing

### DIFF
--- a/ext/riverlea/js/stream-list.js
+++ b/ext/riverlea/js/stream-list.js
@@ -310,9 +310,6 @@
 
     setData(data) {
       this.data = data;
-      // flatten file path info
-      this.data.css_file = '[' + this.data.extension + ']/' + this.data.file_prefix + this.data.css_file;
-      this.data.css_file_dark = '[' + this.data.extension + ']/' + this.data.file_prefix + this.data.css_file_dark;
     }
 
     get streamName() {
@@ -373,16 +370,24 @@
 
 
       detailsFields.forEach((field) => {
-        const value = this.data[field.key] ?? null;
+        let value = this.data[field.key] ?? null;
 
         if (value) {
 
-          const renderedValue = (typeof value === 'string') ? value : JSON.stringify(value);
+          // render non-strings as JSON
+          if (typeof value !== 'string') {
+            value = JSON.stringify(value);
+          }
+
+          // render the effective pseudo file path for files
+          if (['css_file', 'css_file_dark'].includes(field.key)) {
+            value = '[' + this.data.extension + ']/' + (this.data.file_prefix ? this.data.file_prefix : '') + value;
+          }
 
           const detailItem = document.createElement('div');
           detailItem.innerHTML = `
             <label>${field.label}</label>
-            <code>${renderedValue}</code>
+            <code>${value}</code>
           `;
           container.append(detailItem);
         }


### PR DESCRIPTION
Overview
----------------------------------------
6.17 regression means the file properties of custom streams get corrupted when resaving in the UI editor.
 
Before
----------------------------------------
- css_file and css_file_dark properties get set to "pseudopaths" which are only meant for rendering to screen, if you save the stream, then these pseudovalues are saved as the actual values

After
----------------------------------------
- css_file and css_file_dark "pseudopaths" are only rendered to screen, not broken

Technical Details
----------------------------------------
The original change in `setData` was foolish :facepalm:  mea culpa mea culpa