### PR TITLE
Fix APIv4 Payment::create() not persisting custom fields on FinancialTrxn

### DIFF
--- a/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
+++ b/ext/civi_contribute/Civi/Api4/Action/Payment/Create.php
@@ -171,6 +171,10 @@ class Create extends \Civi\Api4\Generic\AbstractCreateAction {
       }
     }
     $this->validateValues();
+    // This action bypasses the normal writeObjects()/write() pipeline (it calls the
+    // Payment BAO directly, below), so the custom-field flattening that pipeline
+    // would otherwise apply has to be done explicitly here.
+    $this->formatCustomParams($this->values, NULL);
     $trxn = \CRM_Financial_BAO_Payment::create($this->values, $this->disableActionsOnCompleteOrder);
     $savedRecords = [];
     $savedRecords[] = $this->baoToArray($trxn, $this->values);

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -134,6 +134,76 @@ class api_v3_PaymentTest extends CiviUnitTestCase {
   }
 
   /**
+   * Test that a custom field on FinancialTrxn is persisted when creating a Payment,
+   * via both APIv3 (custom_N) and APIv4 (GroupName.field_name) param styles.
+   *
+   * @dataProvider versionThreeAndFour
+   * @throws \CRM_Core_Exception
+   */
+  public function testCreateWithCustomField($apiVersion): void {
+    $this->_apiversion = $apiVersion;
+    // 'FinancialTrxn' isn't one of the entities core itself registers as a valid
+    // CustomGroup.extends target (mjwshared normally adds this via a managed
+    // OptionValue) - register it here so the group below can be created without
+    // that extension installed.
+    $financialTrxnExtendsOption = \Civi\Api4\OptionValue::get(FALSE)
+      ->addWhere('option_group_id:name', '=', 'cg_extend_objects')
+      ->addWhere('value', '=', 'FinancialTrxn')
+      ->execute()
+      ->first();
+    if (!$financialTrxnExtendsOption) {
+      \Civi\Api4\OptionValue::create(FALSE)
+        ->addValue('option_group_id.name', 'cg_extend_objects')
+        ->addValue('label', 'Financial Transaction (Payment)')
+        ->addValue('value', 'FinancialTrxn')
+        ->addValue('name', 'civicrm_financial_trxn')
+        ->addValue('is_active', TRUE)
+        ->execute();
+    }
+
+    $customGroup = $this->customGroupCreate([
+      'title' => 'Payment Custom Data',
+      'extends' => 'FinancialTrxn',
+    ]);
+    $customField = $this->customFieldCreate([
+      'custom_group_id' => $customGroup['id'],
+      'label' => 'Reference Note',
+    ]);
+    CRM_Core_PseudoConstant::flush();
+    $customFieldName = $customField['values'][$customField['id']]['name'];
+    $customGroupName = $customGroup['values'][$customGroup['id']]['name'];
+
+    $contributionID = $this->contributionCreate([
+      'contact_id' => $this->individualCreate(),
+      'total_amount' => 100,
+      'contribution_status_id' => 'Pending',
+    ]);
+
+    $paymentParams = [
+      'contribution_id' => $contributionID,
+      'total_amount' => 100,
+      'trxn_date' => date('Y-m-d'),
+    ];
+    $customFieldKey = $apiVersion === 3 ? ('custom_' . $customField['id']) : ($customGroupName . '.' . $customFieldName);
+    $paymentParams[$customFieldKey] = 'Some reference text';
+
+    $payment = $this->callAPISuccess('Payment', 'create', $paymentParams);
+
+    $trxn = \Civi\Api4\FinancialTrxn::get(FALSE)
+      ->addSelect('custom.*')
+      ->addWhere('id', '=', $payment['id'])
+      ->execute()
+      ->single();
+    $this->assertEquals('Some reference text', $trxn[$customGroupName . '.' . $customFieldName]);
+
+    // The custom group's table is DDL, not part of the per-test transaction rollback,
+    // so it has to be cleaned up explicitly (it would otherwise collide with the
+    // same-titled group created on the next dataProvider run).
+    $this->customFieldDelete($customField['id']);
+    $this->customGroupDelete($customGroup['id']);
+  }
+
+  /**
    * Retrieve Payment using trxn_id.
    *
    * @throws \CRM_Core_Exception


### PR DESCRIPTION
Overview
----------------------------------------
`Payment::create` in APIv4 silently drops any custom field value passed to it, even though it advertises those fields (`GroupName.field_name`) as settable via `getFields()`. This fixes the underlying cause and adds test coverage across both API versions.

Before
----------------------------------------
```php
Civi\Api4\Payment::create(FALSE)
  ->setValues([
    'contribution_id' => $contributionID,
    'total_amount' => 100,
    'trxn_date' => date('Y-m-d'),
    'Payment_details.available_on' => '2023-06-10 20:05:05',
  ])
  ->execute();
```
`Payment_details.available_on` is accepted without error but never saved against the created `FinancialTrxn` — the custom value is silently lost.

After
----------------------------------------
The same call now persists the custom field correctly, exactly as the equivalent APIv3 call (`custom_N` param) already does.

Technical Details
----------------------------------------
`Civi\Api4\Action\Payment\Create::_run()` bypasses the standard API4 write pipeline — instead of calling `$this->writeObjects()`, it calls `CRM_Financial_BAO_Payment::create()` directly. That standard pipeline is where `DAOActionTrait::formatCustomParams()` normally converts flat `GroupName.field_name` params into the nested `$params['custom']` structure that `CRM_Core_DAO::writeRecord()` (and ultimately `CRM_Core_BAO_CustomValueTable::store()`) expects. Since `Create::_run()` never calls it, `$params['custom']` was always empty by the time it reached the BAO, regardless of what was passed in.

The rest of the chain (`CRM_Financial_BAO_Payment::create()`'s `custom` passthrough, `CRM_Core_BAO_FinancialTrxn::create()`, `CRM_Core_DAO::writeRecord()`, `CustomValueTable::store()`) already works correctly — this is not a wider FinancialTrxn/custom-data bug, and APIv3's `Payment.create` is unaffected since `_civicrm_api3_format_params_for_create()` already performs the equivalent flattening.

The fix is one line: call `$this->formatCustomParams($this->values, NULL)` (the trait method the class already uses) before handing off to the BAO, mirroring what `writeObjects()` does for every other entity.

Comments
----------------------------------------
Found while investigating a false-positive "possible duplicate payment" report on a client site, where a Stripe extension fix needed to record an additional `Payment` (with custom `Payment_details` fields) via API4 and hit this silently-lost-data bug. New test `testCreateWithCustomField` in `tests/phpunit/api/v3/PaymentTest.php` uses `@dataProvider versionThreeAndFour` to assert the same custom field round-trips correctly via both API3 and API4 param styles. Full `PaymentTest.php` suite (38 tests, 1339 assertions) passes with this change.