### PR TITLE
Advertise v4 rather than v3 style custom tokens

### DIFF
--- a/CRM/Contact/Tokens.php
+++ b/CRM/Contact/Tokens.php
@@ -480,15 +480,22 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
           $tableAlias = 'openid_primary';
           $joins[$tableAlias] = $fieldSpec['entity'];
         }
-        if ($fieldSpec['type'] === 'Custom') {
+        if ($fieldSpec['type'] === 'Custom' && !str_contains($field, ':')) {
+          // Suffixed tokens (e.g. `Custom_Group.Field:label`) are already resolved to
+          // their display value by the api directly under that key - for unsuffixed fields
+          // add in the v3 version.
           $customFields['custom_' . $fieldSpec['custom_field_id']] = $fieldSpec['name'];
         }
       }
-      $returnProperties[] = $prefix . $this->getMetadataForField($field)['name'];
+      $returnProperties[] = $prefix . $fieldSpec['name'];
     }
 
     if ($getAll) {
-      $returnProperties = array_merge(['*', 'custom.*'], $this->getDeprecatedTokens(), $this->getTokenMappingsForRelatedEntities());
+      // Keep the specific (e.g. suffixed/related) properties already gathered above
+      // as well as the wildcards - the wildcards alone would fetch raw values only,
+      // whereas the api resolves pseudoconstant suffixes (e.g. `:label`) and related
+      // entity tokens (e.g. `.display_name`) only when explicitly selected.
+      $returnProperties = array_unique(array_merge(['*', 'custom.*'], $returnProperties, $this->getDeprecatedTokens(), $this->getTokenMappingsForRelatedEntities()));
     }
 
     $contactApi = Contact::get($this->checkPermissions)
@@ -529,7 +536,7 @@ class CRM_Contact_Tokens extends CRM_Core_EntityTokens {
 
     //update value of custom field token
     foreach ($customFields as $apiv3Name => $fieldName) {
-      $value = $contact[$fieldName];
+      $value = $contact[$fieldName] ?? '';
       if ($this->getMetadataForField($apiv3Name)['data_type'] === 'Boolean') {
         $value = (int) $value;
       }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -116,17 +116,6 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       $split = explode(':', $field);
       $baseField = $split[0];
       $pseudoKey = $split[1];
-      $baseFieldMetadata = $this->getMetadataForField($baseField);
-      // Custom fields with options need special label resolution via displayValue.
-      if (($baseFieldMetadata['type'] ?? NULL) === 'Custom' && !empty($baseFieldMetadata['custom_field_id'])) {
-        $rawValue = $this->getFieldValue($row, $baseField);
-        if ($pseudoKey === 'label') {
-          $labelValue = $rawValue !== '' ? CRM_Core_BAO_CustomField::displayValue($rawValue, $baseFieldMetadata['custom_field_id']) : '';
-          return $row->format('text/plain')->tokens($entity, $field, (string) $labelValue);
-        }
-        // For :name just return the raw stored value.
-        return $row->format('text/plain')->tokens($entity, $field, (string) $rawValue);
-      }
       return $row->tokens($entity, $field, $this->getPseudoValue($baseField, $pseudoKey, $this->getFieldValue($row, $baseField)));
     }
     if ($this->isCustomField($field)) {
@@ -322,6 +311,18 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
    * @internal function will likely be protected soon.
    */
   protected function getPseudoValue(string $realField, string $pseudoKey, $fieldValue): string {
+    $fieldMetadata = $this->getMetadataForField($realField);
+    // Custom field names are like 'Group.Field' - not an 'entity.field' reference to
+    // a joined entity like the fields handled below - so resolve any pseudoconstant
+    // value using the api's own option list handling, rather than assuming a
+    // DAO/BAO exists for the (non-existent) 'Group' entity.
+    if (($fieldMetadata['type'] ?? NULL) === 'Custom' && !empty($fieldMetadata['custom_field_id'])) {
+      if ($fieldValue === '' || $fieldValue === NULL) {
+        return '';
+      }
+      $options = \Civi\Api4\Utils\FormattingUtil::getPseudoconstantList($fieldMetadata, $realField . ':' . $pseudoKey);
+      return implode(', ', (array) \Civi\Api4\Utils\FormattingUtil::replacePseudoconstant($options, $fieldValue));
+    }
     // If the field name is in the format 'entity.field' then we need to just get 'field'
     $explode = explode('.', $realField);
     $realField = end($explode);
@@ -548,12 +549,9 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       }
       elseif (str_contains($token, ':')) {
         $baseToken = explode(':', $token)[0];
-        $baseMetadata = $this->getMetadataForField($baseToken);
-        // Suffix tokens for custom fields need the raw base field prefetched for displayValue resolution.
-        if (($baseMetadata['type'] ?? NULL) === 'Custom') {
-          $requiredFields[] = $baseToken;
-        }
-        elseif (in_array($token, $allTokens, TRUE)) {
+        // The api resolves pseudoconstant suffixes (including for custom fields)
+        // directly, so the suffixed token itself can be requested.
+        if (in_array($token, $allTokens, TRUE)) {
           $requiredFields[] = $token;
         }
         elseif (in_array($baseToken, $allTokens, TRUE)) {
@@ -728,8 +726,8 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
       $parts = explode(': ', $field['label'], 2);
       $field['title'] = isset($parts[1]) ? "{$parts[1]} :: {$parts[0]}" : $field['label'];
       $tokensMetadata[$legacyTokenName] = $field;
-      // For now, keep api4-style tokens unannounced
-      $field['audience'] = 'sysadmin';
+      // Keep v3 style working, but only advertise v4 style.
+      $tokensMetadata[$legacyTokenName]['audience'] = 'sysadmin';
       $tokensMetadata[$tokenName] = $field;
 
       $fkEntity = $field['fk_entity'] ?? ($field['data_type'] === 'ContactReference' ? 'Contact' : NULL);
@@ -738,6 +736,19 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         foreach ($relatedTokens as $relTokenName => $relTokenSpec) {
           $relTokenSpec['audience'] = 'sysadmin';
           $tokensMetadata[$relTokenName] = $relTokenSpec;
+        }
+        // Fields like this have no pseudoconstant options, so unlike other
+        // custom fields (which get an explicit `:label` token) there's no
+        // other way to expose a human-readable value - promote the related
+        // token for the fk entity's own label field (e.g. `display_name` for
+        // Contact) to be the user-facing, api4-style token, and demote the
+        // bare token (raw fk id) to sysadmin.
+        $labelField = \Civi\Api4\Utils\CoreUtil::getInfoItem($fkEntity, 'label_field');
+        $labelTokenName = $tokenName . '.' . $labelField;
+        if ($labelField && isset($tokensMetadata[$labelTokenName])) {
+          $tokensMetadata[$labelTokenName]['title'] = $field['title'];
+          $tokensMetadata[$labelTokenName]['audience'] = 'user';
+          $field['audience'] = 'sysadmin';
         }
       }
     }

--- a/CRM/Core/EntityTokens.php
+++ b/CRM/Core/EntityTokens.php
@@ -743,7 +743,7 @@ class CRM_Core_EntityTokens extends AbstractTokenSubscriber {
         // token for the fk entity's own label field (e.g. `display_name` for
         // Contact) to be the user-facing, api4-style token, and demote the
         // bare token (raw fk id) to sysadmin.
-        $labelField = \Civi\Api4\Utils\CoreUtil::getInfoItem($fkEntity, 'label_field');
+        $labelField = \Civi\Api4\Utils\CoreUtil::getInfoItem($fkEntity, 'label_field') ?? '';
         $labelTokenName = $tokenName . '.' . $labelField;
         if ($labelField && isset($tokensMetadata[$labelTokenName])) {
           $tokensMetadata[$labelTokenName]['title'] = $field['title'];

--- a/CRM/Core/SelectValues.php
+++ b/CRM/Core/SelectValues.php
@@ -683,29 +683,28 @@ class CRM_Core_SelectValues {
   /**
    * @param int $caseTypeId
    * @return array
+   *
+   * @deprecated use the token processor
    */
-  public static function caseTokens($caseTypeId = NULL) {
-    $tokens = [
-      '{case.id}' => ts('Case ID'),
-      '{case.case_type_id:label}' => ts('Case Type'),
-      '{case.subject}' => ts('Case Subject'),
-      '{case.start_date}' => ts('Case Start Date'),
-      '{case.end_date}' => ts('Case End Date'),
-      '{case.details}' => ts('Details'),
-      '{case.status_id:label}' => ts('Case Status'),
-      '{case.is_deleted:label}' => ts('Case is in the Trash'),
-      '{case.created_date}' => ts('Created Date'),
-      '{case.modified_date}' => ts('Modified Date'),
-    ];
-
-    $customFilters = ['extends' => 'Case', 'is_active' => TRUE];
-    if ($caseTypeId) {
-      $customFilters['extends_entity_column_value'] = [$caseTypeId, NULL];
+  public static function caseTokens($caseTypeId = NULL): array {
+    $tokenProcessor = new TokenProcessor(Civi::dispatcher(), ['schema' => ['caseId']]);
+    $tokens = $tokenProcessor->listTokens();
+    foreach (array_keys($tokens) as $token) {
+      if (str_starts_with($token, '{domain.') || str_starts_with($token, '{site.')) {
+        unset($tokens[$token]);
+      }
     }
-    $customGroups = CRM_Core_BAO_CustomGroup::getAll($customFilters);
-    foreach ($customGroups as $customGroup) {
-      foreach ($customGroup['fields'] as $id => $field) {
-        $tokens["{case.custom_$id}"] = "{$field['label']} :: {$customGroup['title']}";
+
+    if ($caseTypeId) {
+      // @todo - pass extends context to tokenProcessor, handle there.
+      $customGroups = CRM_Core_BAO_CustomGroup::getAll();
+      foreach ($customGroups as $customGroup) {
+        if ($customGroup['extends_entity_column_value'] && $customGroup['extends_entity_column_value'] != $caseTypeId) {
+          foreach ($customGroup['fields'] as $id => $field) {
+            $api4Name = 'case.' . $customGroup['name'] . '.' . $field['name'];
+            unset($tokens["{case.custom_$id}"], $tokens[$api4Name], $tokens[$api4Name . ':label']);
+          }
+        }
       }
     }
     return $tokens;

--- a/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
+++ b/tests/phpunit/CRM/Core/BAO/MessageTemplateTest.php
@@ -834,18 +834,10 @@ emo
     $this->setupContactFromTokeData($tokenData);
 
     $context = ['contactId' => $tokenData['contact_id']];
-    $render = static function (string $templateText) use ($context, $tokenData) {
-      try {
-        return CRM_Core_TokenSmarty::render(['text' => $templateText], $context)['text'];
-      }
-      catch (\Throwable $t) {
-        return 'EXCEPTION:' . $t->getMessage();
-      }
-    };
 
     // Build $tokenLines, a list of expressions like 'contact.display_name:{contact.display_name}'
     $tokenLines = [];
-    $tokenNames = array_keys($this->getAdvertisedTokens());
+    $tokenNames = array_keys(array_merge($this->getAdvertisedTokens(), $tokenData));
     foreach ($tokenNames as $tokenName) {
       $tokenLines[] = trim($tokenName, '{}') . ':' . $tokenName;
     }
@@ -856,16 +848,20 @@ emo
     sort($tokenLines);
 
     // Evaluate all these token lines
-    $oneByOne = array_map($render, $tokenLines);
-    $allAtOnce = $render(implode("\n", $tokenLines));
+    $oneByOne = [];
+    foreach ($tokenLines as $tokenLine) {
+      $oneByOne[] = CRM_Core_TokenSmarty::render(['text' => $tokenLine], $context)['text'];
+    }
+    $allAtOnce = CRM_Core_TokenSmarty::render(['text' => implode("\n", $tokenLines)], $context)['text'];
     $this->assertEquals($allAtOnce, implode("\n", $oneByOne));
 
     $emptyLines = preg_grep('/:$/', $oneByOne);
     $this->assertEquals([
+      'contact.Custom_Group.My_file:',
+      'contact.Custom_Group.Number_select:label:',
       'contact.address_primary.county_id:label:',
       'contact.contact_is_deleted:',
       'contact.county:',
-      'contact.custom_15:',
       'contact.custom_6:',
       'contact.deceased_date:',
       'contact.do_not_phone:',
@@ -1074,26 +1070,26 @@ emo
       '{contact.im_primary.name}' => 'IM Screen Name',
       '{contact.address_primary.country_id.region_id:name}' => 'World Region',
       '{contact.website_first.url}' => 'Website',
-      '{contact.custom_9}' => 'Contact reference field :: Custom Group',
-      '{contact.custom_7}' => 'Country :: Custom Group',
-      '{contact.custom_8}' => 'Country-multi :: Custom Group',
-      '{contact.custom_4}' => 'Enter integer here :: Custom Group',
-      '{contact.custom_1}' => 'Enter text here :: Custom Group',
-      '{contact.custom_6}' => 'My file :: Custom Group',
-      '{contact.custom_2}' => 'Pick Color :: Custom Group',
-      '{contact.custom_13}' => 'Pick Shade :: Custom Group',
-      '{contact.custom_10}' => 'State :: Custom Group',
-      '{contact.custom_11}' => 'State-multi :: Custom Group',
-      '{contact.custom_5}' => 'test_link :: Custom Group',
-      '{contact.custom_12}' => 'Yes No :: Custom Group',
-      '{contact.custom_3}' => 'Test Date :: Custom Group',
+      '{contact.Custom_Group.Contact_reference_field.display_name}' => 'Contact reference field :: Custom Group',
+      '{contact.Custom_Group.Country:label}' => 'Custom Group: Country',
+      '{contact.Custom_Group.Country_multi:label}' => 'Custom Group: Country-multi',
+      '{contact.Custom_Group.Enter_integer_here}' => 'Enter integer here :: Custom Group',
+      '{contact.Custom_Group.Enter_text_here}' => 'Enter text here :: Custom Group',
+      '{contact.Custom_Group.My_file}' => 'My file :: Custom Group',
+      '{contact.Custom_Group.Pick_Color:label}' => 'Custom Group: Pick Color',
+      '{contact.Custom_Group.Pick_Shade:label}' => 'Custom Group: Pick Shade',
+      '{contact.Custom_Group.State:label}' => 'Custom Group: State',
+      '{contact.Custom_Group.State_multi:label}' => 'Custom Group: State-multi',
+      '{contact.Custom_Group.test_link}' => 'test_link :: Custom Group',
+      '{contact.Custom_Group.Yes_No:label}' => 'Yes No :: Custom Group',
+      '{contact.Custom_Group.test_date}' => 'Test Date :: Custom Group',
+      '{contact.Custom_Group.Integer_radio:label}' => 'Custom Group: Integer radio',
+      '{contact.Custom_Group.Number_select:label}' => 'Custom Group: Number select',
       '{contact.checksum}' => 'Checksum (with cs=)',
       '{contact.checksum_value}' => 'Checksum value',
       '{contact.id}' => 'Contact ID',
       '{important_stuff.favourite_emoticon}' => 'Best coolest emoticon',
       '{site.message_header}' => 'Message Header',
-      '{contact.custom_14}' => 'Integer radio :: Custom Group',
-      '{contact.custom_15}' => 'Number select :: Custom Group',
     ];
   }
 
@@ -1456,26 +1452,26 @@ im_primary.provider_id:label |Yahoo
 im_primary.name |IM Screen Name
 address_primary.country_id.region_id:name |America South, Central, North and Caribbean
 website_first.url |https://civicrm.org
-custom_9 |Mr. Spider Man II
-custom_7 |New Zealand
-custom_8 |France, Canada
-custom_4 |999
-custom_1 |Bobsled
-custom_6 |
-custom_2 |Red
-custom_13 |Purple
-custom_10 |Queensland
-custom_11 |Victoria, New South Wales
-custom_5 |<a href="https://civicrm.org" target="_blank">https://civicrm.org</a>
-custom_12 |Yes
-custom_3 |01/20/2021 12:00AM
+Custom_Group.Contact_reference_field.display_name |Mr. Spider Man II
+Custom_Group.Country:label |New Zealand
+Custom_Group.Country_multi:label |France, Canada
+Custom_Group.Enter_integer_here |999
+Custom_Group.Enter_text_here |Bobsled
+Custom_Group.My_file |
+Custom_Group.Pick_Color:label |Red
+Custom_Group.Pick_Shade:label |Purple
+Custom_Group.State:label |Queensland
+Custom_Group.State_multi:label |Victoria, New South Wales
+Custom_Group.test_link |https://civicrm.org
+Custom_Group.Yes_No:label |Yes
+Custom_Group.test_date |January 20th, 2021
+Custom_Group.Integer_radio:label |100
+Custom_Group.Number_select:label |
 checksum |cs=' . $checksum . '
 checksum_value |' . $checksum . '
 id |' . $tokenData['contact_id'] . '
 t_stuff.favourite_emoticon |
 sage_header |<div><!-- This content comes from the site message header token--></div>
-custom_14 |100
-custom_15 |
 ';
   }
 

--- a/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
+++ b/tests/phpunit/CRM/Utils/TokenConsistencyTest.php
@@ -101,7 +101,7 @@ case.status_id:label :Ongoing
 case.is_deleted:label :No
 case.created_date :' . CRM_Utils_Date::customFormat($this->case['created_date']) . '
 case.modified_date :' . CRM_Utils_Date::customFormat($this->case['modified_date']) . '
-case.custom_1 :' . '
+case.Custom_Group.Life_Cycle_Status :' . '
 ';
   }
 
@@ -145,7 +145,7 @@ case.custom_1 :' . '
       '{case.is_deleted:label}' => 'Case is in the Trash',
       '{case.created_date}' => 'Created Date',
       '{case.modified_date}' => 'Modified Date',
-      '{case.custom_1}' => 'Life Cycle: Status :: Group with field text',
+      '{case.Custom_Group.Life_Cycle_Status}' => 'Life Cycle: Status :: Group with field text',
     ];
   }
 
@@ -630,7 +630,7 @@ contribution_recur.payment_instrument_id:name :Check
     $tokenString = $newStyleTokens . implode("\n", array_keys($this->getMembershipTokens()));
 
     // Custom fields work in the processor so test it....
-    $tokenString .= "\n{membership." . $this->getCustomFieldName('text') . '}';
+    $tokenString .= "\n{membership." . $this->getCustomFieldName('text', 4) . '}';
     // Now compare with scheduled reminder
     $mut = new CiviMailUtils($this);
     $this->callAPISuccess('ActionSchedule', 'create', [
@@ -646,8 +646,6 @@ contribution_recur.payment_instrument_id:name :Check
     ]);
     $this->callAPISuccess('Job', 'send_reminder', []);
     $expected = $this->getExpectedMembershipTokenOutput();
-    // Unlike the legacy method custom fields are resolved by the processor.
-    $expected .= "\nmy field";
     $mut->checkMailLog([$expected]);
 
     $tokenProcessor = new TokenProcessor(\Civi::dispatcher(), [
@@ -666,6 +664,28 @@ contribution_recur.payment_instrument_id:name :Check
     $tokenProcessor->evaluate();
     $this->assertEquals($expected, $tokenProcessor->getRow(0)->render('html'));
 
+  }
+
+  /**
+   * Test that a pseudoconstant (option-based) custom field on a non-contact
+   * entity resolves its `:label` token to the option label, not the raw
+   * stored value.
+   *
+   * Contact has separate, bespoke handling for custom field tokens - this
+   * covers the shared `CRM_Core_EntityTokens` prefetch/evaluate path used by
+   * every other token-supporting entity (membership, event, participant,
+   * case, pledge, contribution_recur ...).
+   */
+  public function testMembershipCustomOptionFieldToken(): void {
+    $this->createLoggedInUser();
+    $this->restoreMembershipTypes();
+    $this->createCustomGroupWithFieldOfType(['extends' => 'Membership'], 'radio');
+    $membershipID = $this->contactMembershipCreate([
+      'contact_id' => $this->getContactID(),
+      $this->getCustomFieldName('radio', 4) => 4,
+    ]);
+    $text = $this->renderText(['membershipId' => $membershipID], '{membership.' . $this->getCustomFieldName('radio', 4) . ':label}');
+    $this->assertEquals('100', $text);
   }
 
   public function testPledgeTokens(): void {
@@ -706,7 +726,7 @@ contribution_recur.payment_instrument_id:name :Check
    */
   public function getTokensAdvertisedByTokenProcessorButNotLegacy(): array {
     return [
-      '{membership.custom_1}' => 'Enter text here :: Group with field text',
+      '{membership.Custom_Group.Enter_text_here}' => 'Enter text here :: Group with field text',
       '{membership.source}' => 'Membership Source',
       '{membership.status_override_end_date}' => 'Status Override End Date',
     ];
@@ -797,7 +817,7 @@ United States<br />
 event.info_url :' . CRM_Utils_System::url('civicrm/event/info', NULL, TRUE) . '&reset=1&id=1
 event.registration_url :' . CRM_Utils_System::url('civicrm/event/register', NULL, TRUE) . '&reset=1&id=1
 event.pay_later_receipt :Please transfer funds to our bank account.
-event.custom_1 :my field
+event.Custom_Group.Enter_text_here :my field
 event.confirm_email_text :
 event.fee_label :Event fees
 ';
@@ -820,7 +840,8 @@ January 21st, 2007
 December 21st, 2007
 $100.00
 $100.00
-1';
+1
+my field';
   }
 
   /**
@@ -1097,7 +1118,7 @@ United States', $tokenProcessor->getRow(0)->render('message'));
       '{event.info_url}' => 'Event Info URL',
       '{event.registration_url}' => 'Event Registration URL',
       '{event.pay_later_receipt}' => 'Pay Later Receipt Text',
-      '{event.' . $this->getCustomFieldName('text') . '}' => 'Enter text here :: Group with field text',
+      '{event.' . $this->getCustomFieldName('text', 4) . '}' => 'Enter text here :: Group with field text',
       '{event.confirm_email_text}' => 'Confirmation Email Text',
       '{event.fee_label}' => 'Fee Label',
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Follow on to https://github.com/civicrm/civicrm-core/pull/36285 - expose the apiv4 style tokens

Before
----------------------------------------
Both apiv4 & v3 style custom tokens work but v3 are available to select in token picker

After
----------------------------------------
Both still work but v4 is in token picker

Technical Details
----------------------------------------
@colemanw 

Comments
----------------------------------------
