### PR TITLE
APIv4 - quote option-value column names when loading options

### DIFF
--- a/Civi/Api4/Generic/BasicGetFieldsAction.php
+++ b/Civi/Api4/Generic/BasicGetFieldsAction.php
@@ -289,6 +289,9 @@ class BasicGetFieldsAction extends BasicGetAction {
     $optionGroupId = \CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', $optionGroupName, 'id', 'name');
     $select = CoreUtil::getOptionValueFields($optionGroupName);
     unset($select['id'], $select['value']);
+    // Quote the column names: an option group is free to declare a field whose name
+    // is a reserved word, e.g. `grouping`.
+    $select = array_map(fn($column) => "`$column`", $select);
     array_unshift($select, 'value AS id');
     $query = "SELECT " . implode(', ', $select) . " FROM civicrm_option_value WHERE option_group_id = %1 ORDER BY weight";
     return \CRM_Core_DAO::executeQuery($query, [1 => [$optionGroupId, 'Int']])->fetchAll();

--- a/tests/phpunit/api/v4/Action/GetFieldsTest.php
+++ b/tests/phpunit/api/v4/Action/GetFieldsTest.php
@@ -30,6 +30,8 @@ use Civi\Api4\ContributionSoft;
 use Civi\Api4\CustomGroup;
 use Civi\Api4\Email;
 use Civi\Api4\EntityTag;
+use Civi\Api4\Afform;
+use Civi\Api4\OptionGroup;
 use Civi\Api4\OptionValue;
 use Civi\Api4\PCP;
 use Civi\Api4\Tag;
@@ -385,6 +387,34 @@ class GetFieldsTest extends Api4TestBase implements TransactionalInterface {
     CoreUtil::topSortFields($entityFields2);
     $this->assertEquals($orderedFieldNames, array_column($entityFields, 'name'));
     $this->assertEquals($orderedFieldNames, array_column($entityFields2, 'name'));
+  }
+
+  /**
+   * `grouping` is an offered option-value field but is also a reserved word in SQL,
+   * so loading options for a field that uses it must still produce valid sql.
+   */
+  public function testLoadOptionsWithReservedWordFieldName(): void {
+    // `afform_type` is a pseudoconstant on a Basic entity, so its options are read
+    // by BasicGetFieldsAction rather than through the schema.
+    OptionGroup::update(FALSE)
+      ->addWhere('name', '=', 'afform_type')
+      ->addValue('option_value_fields', ['name', 'label', 'icon', 'description', 'grouping'])
+      ->execute();
+    OptionValue::update(FALSE)
+      ->addWhere('option_group_id.name', '=', 'afform_type')
+      ->addWhere('name', '=', 'search')
+      ->addValue('grouping', 'searchlike')
+      ->execute();
+    \Civi::cache('metadata')->clear();
+
+    $field = Afform::getFields(FALSE)
+      ->setLoadOptions(['id', 'name', 'label', 'grouping'])
+      ->addWhere('name', '=', 'type')
+      ->execute()->single();
+
+    $options = array_column($field['options'], 'grouping', 'name');
+    $this->assertArrayHasKey('search', $options);
+    $this->assertEquals('searchlike', $options['search']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

`APIv4 …::getFields(['loadOptions' => …])` fails with a SQL syntax error, instead of returning options, whenever the underlying option group declares `grouping` among its `option_value_fields`.

Before
----------------------------------------

Set an option group to expose `grouping` — which the UI offers, and which several core groups already use — and then ask APIv4 for the options of a field pointing at it:

```php
OptionGroup::update(FALSE)
  ->addWhere('name', '=', 'afform_type')
  ->addValue('option_value_fields', ['name', 'label', 'icon', 'description', 'grouping'])
  ->execute();

Afform::getFields(FALSE)
  ->setLoadOptions(['id', 'name', 'label', 'grouping'])
  ->addWhere('name', '=', 'type')
  ->execute();
```

```
Civi\Core\Exception\DBQueryException: DB Error: syntax error
```

After
----------------------------------------

The options come back, `grouping` included.

Technical Details
----------------------------------------

`BasicGetFieldsAction::fetchOptionValues()` builds its SELECT by interpolating the option group's `option_value_fields` straight into the query. `grouping` is a reserved word in MySQL 8, so the resulting statement is invalid. The column names are now backtick-quoted.

This affects entities whose options are read by `BasicGetFieldsAction` — i.e. `Basic` entities such as `Afform`, rather than those resolved through the schema — so it is easy to miss, but the failure is a hard fatal for any caller that hits it.

Comments
----------------------------------------

Added `GetFieldsTest::testLoadOptionsWithReservedWordFieldName`, which errors on master with the exception above and passes with the fix.

@colemanw Extracted from afdashboard work
