### PR TITLE
Afform - don't recurse forever when embedded forms form a loop

### DIFF
--- a/ext/afform/core/Civi/Afform/FormDataModel.php
+++ b/ext/afform/core/Civi/Afform/FormDataModel.php
@@ -44,6 +44,12 @@ class FormDataModel {
    */
   protected $secureApi4s = [];
 
+  /**
+   * @var string[]
+   *   Directive names of the embedded afforms currently being parsed, innermost last.
+   */
+  private $embedStack = [];
+
   public function __construct($layout) {
     $root = AHQ::makeRoot($layout);
     $this->entities = array_column(AHQ::getTags($root, 'af-entity'), NULL, 'name');
@@ -214,13 +220,16 @@ class FormDataModel {
       elseif (!empty($node['#children'])) {
         $this->parseFields($node['#children'], $entity, $join, $searchDisplay, $nodeAfIfConditions);
       }
-      // Recurse into embedded blocks
-      if (isset($this->blocks[$node['#tag']])) {
+      // Recurse into embedded blocks, unless doing so would revisit a form that is
+      // already being parsed further up the stack, which would never terminate.
+      if (isset($this->blocks[$node['#tag']]) && !in_array($node['#tag'], $this->embedStack, TRUE)) {
         if (!isset($this->blocks[$node['#tag']]['layout'])) {
           $this->blocks[$node['#tag']] = Afform::get(FALSE)->setSelect(['name', 'layout'])->addWhere('name', '=', $this->blocks[$node['#tag']]['name'])->execute()->first();
         }
         if (!empty($this->blocks[$node['#tag']]['layout'])) {
+          $this->embedStack[] = $node['#tag'];
           $this->parseFields($this->blocks[$node['#tag']]['layout'], $entity, $join, $searchDisplay, $nodeAfIfConditions);
+          array_pop($this->embedStack);
         }
       }
     }

--- a/ext/afform/core/Civi/Afform/Utils.php
+++ b/ext/afform/core/Civi/Afform/Utils.php
@@ -240,6 +240,67 @@ class Utils {
     }
   }
 
+  /**
+   * Names of the afforms embedded in a layout, resolved from their directive tags.
+   *
+   * @param string $html
+   * @param array $directiveNames
+   *   Map of directive name => afform name.
+   * @return string[]
+   */
+  public static function findEmbeddedAfforms(string $html, array $directiveNames): array {
+    $elements = array_keys(\Civi\Afform\Symbols::scan($html)->elements);
+    return array_values(array_intersect_key($directiveNames, array_flip($elements)));
+  }
+
+  /**
+   * Find a chain of embedded afforms leading from $name back to itself.
+   *
+   * An afform which embeds itself, directly or via other afforms, recurses forever
+   * when Angular compiles it and locks up the browser, so this has to be caught
+   * before the layout is written.
+   *
+   * @param string $name
+   *   The afform being saved.
+   * @param string $html
+   *   Its new layout.
+   * @return string[]
+   *   The cycle, starting and ending at $name; empty if there is none.
+   */
+  public static function findEmbedCycle(string $name, string $html): array {
+    /** @var \CRM_Afform_AfformScanner $scanner */
+    $scanner = \Civi::service('afform_scanner');
+    $directiveNames = [];
+    foreach (array_keys($scanner->findFilePaths()) as $afformName) {
+      $directiveNames[_afform_angular_module_name($afformName, 'dash')] = $afformName;
+    }
+    // Breadth-first, tracking the path taken so the error can name the chain.
+    $queue = [];
+    foreach (self::findEmbeddedAfforms($html, $directiveNames) as $embedded) {
+      $queue[] = [$name, $embedded];
+    }
+    $visited = [];
+    while ($queue) {
+      $path = array_shift($queue);
+      $current = end($path);
+      if ($current === $name) {
+        return $path;
+      }
+      if (isset($visited[$current])) {
+        continue;
+      }
+      $visited[$current] = TRUE;
+      $layoutPath = $scanner->findFilePath($current, \CRM_Afform_AfformScanner::LAYOUT_FILE);
+      if (!$layoutPath) {
+        continue;
+      }
+      foreach (self::findEmbeddedAfforms(file_get_contents($layoutPath), $directiveNames) as $embedded) {
+        $queue[] = array_merge($path, [$embedded]);
+      }
+    }
+    return [];
+  }
+
   public static function getSearchDisplayTags(): array {
     $displayTags = array_column(Display::getDisplayTypes(['name'], TRUE), 'name');
     $displayTags[] = 'crm-search-display';

--- a/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
+++ b/ext/afform/core/Civi/Api4/Utils/AfformSaveTrait.php
@@ -43,6 +43,13 @@ trait AfformSaveTrait {
       \CRM_Utils_File::createDir(dirname($layoutPath));
       $html = $this->convertInputToHtml($item['layout']);
 
+      $cycle = Utils::findEmbedCycle($item['name'], $html);
+      if ($cycle) {
+        throw new \CRM_Core_Exception(ts('A form cannot embed itself. This layout would form the loop: %1', [
+          1 => implode(' → ', $cycle),
+        ]));
+      }
+
       // Are we multilingual.
       if (\CRM_Core_I18n::isMultiLingual()) {
         self::saveTranslations($item, $html);

--- a/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformTest.php
+++ b/ext/afform/mock/tests/phpunit/api/v4/Afform/AfformTest.php
@@ -348,4 +348,45 @@ class AfformTest extends AfformTestCase implements TransactionalInterface {
     Afform::revert()->addWhere('name', '=', $formName)->execute();
   }
 
+  public function testEmbedCycleIsRejected(): void {
+    $setLayout = fn(string $name, string $layout) => Afform::update()
+      ->addWhere('name', '=', $name)
+      ->setLayoutFormat('html')
+      ->setValues(['layout' => $layout])
+      ->execute();
+
+    try {
+      // mockPage embeds mock-bare-file and mock-foo by default; embedding an
+      // unrelated form is fine.
+      $setLayout('mockPage', '<div><mock-foo/></div>');
+
+      try {
+        $setLayout('mockPage', '<div><mock-page/></div>');
+        $this->fail('Expected a form embedding itself to be rejected');
+      }
+      catch (\CRM_Core_Exception $e) {
+        $this->assertStringContainsString('mockPage', $e->getMessage());
+      }
+
+      // Indirect: mockPage embeds mock-foo, so mockFoo may not embed mock-page.
+      try {
+        $setLayout('mockFoo', '<div><mock-page/></div>');
+        $this->fail('Expected an indirect embed cycle to be rejected');
+      }
+      catch (\CRM_Core_Exception $e) {
+        $this->assertStringContainsString('mockFoo', $e->getMessage());
+        $this->assertStringContainsString('mockPage', $e->getMessage());
+      }
+
+      // The rejected saves must not have been written.
+      $layout = Afform::get()->addWhere('name', '=', 'mockPage')->addSelect('layout')
+        ->setLayoutFormat('html')->execute()->single()['layout'];
+      $this->assertStringContainsString('<mock-foo', $layout);
+      $this->assertStringNotContainsString('<mock-page', $layout);
+    }
+    finally {
+      Afform::revert()->addWhere('name', 'IN', ['mockPage', 'mockFoo'])->execute();
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

Two Afforms which embed each other — or an Afform which embeds itself — recurse without limit. The server aborts on stack depth and the browser locks up, and neither failure says anything about what is wrong. This makes the loop survivable, and stops a new one being saved.

Before
----------------------------------------

Give form A a layout containing `<afform-b/>` and form B a layout containing `<afform-a/>` (hand-written markup; Form Builder cannot currently produce this). Then load either form, or anything that reads its data model:

- **Server:** `FormDataModel::parseFields()` follows the embed on every pass and never terminates; the request dies on maximum stack depth.
- **Browser:** Angular keeps compiling the nested directive; the tab has to be killed.

There is no error naming the forms involved, and the site cannot be recovered through the UI — the offending layout has to be edited on disk.

After
----------------------------------------

- Loading such a form no longer hangs. The embed is followed once and not re-entered, so a site that already holds a loop stays usable and can be repaired through the UI.
- Saving a layout that would close a loop is rejected, naming the chain:

  ```
  A form cannot embed itself. This layout would form the loop: afformA → afformB → afformA
  ```

Technical Details
----------------------------------------

`FormDataModel` keeps an `$embedStack` of the embeds it is currently inside and declines to re-enter one. It is a **path**, not a set of everything seen, because a form may legitimately embed the same block more than once in different places — a set would silently drop the second occurrence's fields.

`Utils::findEmbedCycle()` walks the saved layouts breadth-first from the form being saved, resolving directive tags back to Afform names via the scanner, and returns the path taken so the message can name the chain. `AfformSaveTrait` calls it after the layout is converted to HTML and before it is written.

Comments
----------------------------------------

Reachable on released CiviCRM today via hand-written markup. It becomes much easier to hit once Form Builder can embed arbitrary forms, which is what I ran into it doing — but the fix stands on its own and I would rather it landed separately.

`ext/afform/mock` `AfformTest` covers a self-embed, a two-form loop, and the legitimate repeated-block case. Full suite green (177 tests).

@colemanw Extracted from afDashboard work