### PR TITLE
Afform - fix `url-arg` on tabsets outside the Angular SPA

### DIFF
--- a/ext/afform/core/ang/af/afTabset.component.js
+++ b/ext/afform/core/ang/af/afTabset.component.js
@@ -16,7 +16,7 @@
       pageNavButtons: '<',
       pageNavSubmitText: '@',
     },
-    controller: function($scope, $element, $timeout) {
+    controller: function($scope, $element, $location, $timeout) {
       const ts = $scope.ts = CRM.ts('org.civicrm.afform');
 
       this.tabs = [];
@@ -25,14 +25,26 @@
         $element.addClass('crm-tabset');
 
         if (this.urlArg) {
-          $scope.$bindToRoute({
-            expr: '$ctrl.selectedTab',
-            param: this.urlArg,
-            format: 'raw'
+          // Afforms are not routed (@see afCore.js), so `$bindToRoute` is unavailable
+          // outside the Angular SPA. Bind to the location's search params directly.
+          this.selectedTab = $location.search()[this.urlArg] || this.selectedTab;
+          $scope.$watch(() => $location.search()[this.urlArg], (tabName) => {
+            if (tabName && tabName !== this.selectedTab) {
+              this.selectTab(tabName);
+            }
+          });
+          $scope.$watch('$ctrl.selectedTab', (tabName) => {
+            if (tabName) {
+              $location.search(this.urlArg, tabName);
+            }
           });
         }
 
         $timeout(() => {
+          // A url or cached selection may name a tab that no longer exists.
+          if (this.selectedTab && this.findTabIndex(this.selectedTab) < 0) {
+            this.selectedTab = null;
+          }
           if (!this.selectedTab && this.rememberSelection) {
             const rememberedName = CRM.cache.get(this.getCacheKey());
             if (rememberedName) {
@@ -59,8 +71,12 @@
       };
 
       this.selectTab = (tabName) => {
-        const currentIndex = this.findTabIndex(this.selectedTab);
         const newIndex = this.findTabIndex(tabName);
+        // Ignore a tab that doesn't exist, e.g. a stale url or remembered selection
+        if (newIndex < 0) {
+          return;
+        }
+        const currentIndex = this.findTabIndex(this.selectedTab);
 
         // validate before moving forward
         if (newIndex > currentIndex) {


### PR DESCRIPTION
Overview
----------------------------------------

`<af-tabset url-arg="...">` throws on any standalone Afform page, and the exception takes the whole tabset down with it — not just the deep-linking.

Before
----------------------------------------

Put a tabset with `url-arg` in an Afform with a `server_route` and load that page:

```
TypeError: $scope.$bindToRoute is not a function
```

The exception aborts `$onInit` before the initial tab is chosen, so the tabset renders with no tab selected and an empty panel.

It works on `civicrm/admin/afform` (the form list), which is why this has gone unnoticed — that page is inside the Angular SPA.

After
----------------------------------------

`url-arg` works on a standalone page: the tab is read from the URL on load, the URL updates as tabs are switched, and browser back/forward moves between tabs. Behaviour inside the SPA is unchanged.

Technical Details
----------------------------------------

`$bindToRoute` comes from `crmRouteBinder`, which neither `af` nor `afCore` requires.

Requiring it is not sufficient on its own: it pulls in `ngRoute`, and `$bindToRoute` dereferences `$route.current`, which is undefined unless a route has been configured. That is exactly why the form list works — `afAdmin.js` declares routes — and a plain Afform page does not.

So this binds to `$location.search()` instead, which is what Afform already does for its other URL params (@see `afCore.js`) and needs no router.

While in here, `selectTab()` now ignores a name that matches no tab, so a stale bookmark or a remembered selection pointing at a since-deleted tab falls back to the first tab rather than leaving the panel empty.

Comments
----------------------------------------

No test — the Afform runtime directives have no karma coverage to extend. Verified by hand on a Standalone site.

@colemanw Extracted from afDashboard work.
