### PR TITLE
Afform - export missing `af` module symbols so they auto-require the module

### DIFF
--- a/ext/afform/core/ang/af.ang.php
+++ b/ext/afform/core/ang/af.ang.php
@@ -18,5 +18,10 @@ return [
     'af-repeat' => 'A',
     'af-repeat-item' => 'A',
     'af-field' => 'E',
+    'af-if' => 'A',
+    'af-search-param-sets' => 'E',
+    'af-tab' => 'E',
+    'af-tabset' => 'E',
+    'af-title' => 'A',
   ],
 ];


### PR DESCRIPTION
Afform - export missing `af` module symbols so they auto-require the module

Overview
----------------------------------------

Five directives defined by the `af` Angular module are missing from that module's `exports`, so a layout using only those directives never loads the module and they silently do nothing.

Before
----------------------------------------

`AngularDependencyMapper::autoReq()` loads a module only when the layout uses a symbol listed in its `exports`. `af.ang.php` lists `af-entity`, `af-fieldset`, `af-form`, `af-join`, `af-repeat`, `af-repeat-item` and `af-field`, but not `af-if`, `af-search-param-sets`, `af-tab`, `af-tabset` or `af-title`.

A layout whose root is a bare `<af-tabset>` therefore never requires `af`: the directive is never registered, the element renders as inert markup, and nothing is logged.

In practice this is masked because almost every Afform also contains `af-fieldset` or `af-field`, which do pull the module in.

After
----------------------------------------

The five symbols are exported, so any layout using them loads `af`.

Technical Details
----------------------------------------

Five lines in `ext/afform/core/ang/af.ang.php`. `af-if` and `af-title` are attributes (`'A'`), the rest elements (`'E'`), matching how each is declared.

Comments
----------------------------------------
@colemanw Extracted from afDashboard work