### PR TITLE
Preserves inherited CMS language across AJAX requests and links

### DIFF
--- a/CRM/Admin/Page/AJAX.php
+++ b/CRM/Admin/Page/AJAX.php
@@ -27,6 +27,19 @@ class CRM_Admin_Page_AJAX {
     CRM_Core_Page_AJAX::validateAjaxRequestMethod();
     if (CRM_Core_Session::getLoggedInContactID()) {
 
+      // This endpoint is fetched via a bare, CMS-language-prefix-free URL
+      // (see crm.menubar.js), so CMS-based locale negotiation (as used by
+      // "Inherit CMS Language") can't reliably detect which language the
+      // requesting page is actually in - it may resolve to the CMS's
+      // default language instead. The client already knows its own locale
+      // and passes it here explicitly; honour it so the menu labels match
+      // the page that asked for them.
+      $requestedLocale = CRM_Utils_Request::retrieve('locale', 'String');
+      if ($requestedLocale && in_array($requestedLocale, CRM_Core_I18n::uiLanguages(TRUE))) {
+        global $tsLocale;
+        $tsLocale = $requestedLocale;
+      }
+
       $menu = CRM_Core_BAO_Navigation::buildNavigationTree();
       CRM_Core_BAO_Navigation::buildHomeMenu($menu);
       CRM_Utils_Hook::navigationMenu($menu);

--- a/CRM/Core/BAO/ConfigSetting.php
+++ b/CRM/Core/BAO/ConfigSetting.php
@@ -197,12 +197,19 @@ class CRM_Core_BAO_ConfigSetting {
         // Retrieve locale as reported by CMS.
         $cmsLocale = CRM_Utils_System::getUFLocale();
         if (in_array($cmsLocale, $permittedLanguages)) {
-          $chosenLocale = $cmsLocale;
+          $chosenLocale = $inheritedLocale = $cmsLocale;
+          // Also remember the CMS's own language id (e.g. "es", "pt-br"),
+          // as opposed to the CiviCRM locale it maps to, so CMS-facing code
+          // (e.g. Drupal URL generation) can recover it on later requests
+          // that can't re-negotiate it themselves - such as an unprefixed
+          // AJAX call.
+          $inheritedLanguage = CRM_Utils_System::getCurrentLanguage();
         }
 
         // Clear chosen locale if not activated in multi-language CiviCRM.
         if ($multiLangLocales && !in_array($chosenLocale, $multiLangLocales)) {
-          $chosenLocale = NULL;
+          $chosenLocale = $inheritedLocale = NULL;
+          $inheritedLanguage = NULL;
         }
       }
 
@@ -217,11 +224,17 @@ class CRM_Core_BAO_ConfigSetting {
       $chosenLocale = $defaultLocale;
     }
 
-    if ($chosenLocale && ($requestLocale ?? NULL) === $chosenLocale) {
+    if ($chosenLocale && (($requestLocale ?? NULL) === $chosenLocale || ($inheritedLocale ?? NULL) === $chosenLocale)) {
       // If the locale is passed in via lcMessages key on GET or POST data,
-      // and it's valid against our configured locales, we require the session
+      // or was successfully inherited from the CMS, we require the session
       // to store this, even if that means starting an anonymous session.
+      // Storing the inherited locale gives us a fallback for requests where
+      // the CMS momentarily fails to report the language (e.g. an
+      // unprefixed AJAX call), instead of dropping back to the site default.
       $session->set('lcMessages', $chosenLocale);
+      if (($inheritedLocale ?? NULL) === $chosenLocale) {
+        $session->set('uiLanguage', $inheritedLanguage ?? NULL);
+      }
     }
 
     /*

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -302,13 +302,47 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
 
     $url = $this->parseURL("{$path}?{$query}");
 
+    // CiviCRM's own links are built via Url::fromUri() below (a "base:/..."
+    // URI, not a Drupal route). UnroutedUrlAssembler only runs outbound path
+    // processing - the step that actually adds the language prefix - when
+    // 'path_processing' is truthy, which CiviCRM never set; without it,
+    // these links never carried the CMS's language prefix, in any locale.
+    // And without an explicit 'language' option, that processing falls back
+    // to whatever language Drupal negotiated from the *current request's
+    // own URL*, which diverges from CiviCRM's resolved locale on requests
+    // that don't carry the CMS's language prefix (e.g. the un-prefixed
+    // civicrm/ajax/navmenu call under "Inherit CMS Language") - silently
+    // generating links that drop the user back into the wrong language.
+    // Enable path processing and pin it to the CMS language CiviCRM last
+    // resolved, so generated links stay consistent with it. We prefer the
+    // session-remembered language (set by CRM_Core_BAO_ConfigSetting::
+    // applyLocale() when "Inherit CMS Language" last succeeded) over asking
+    // Drupal to negotiate it fresh: some CiviCRM entry points (e.g. the
+    // unprefixed civicrm/ajax/navmenu call) don't carry the CMS's language
+    // prefix, so a fresh negotiation would silently fall back to Drupal's
+    // default language instead of the one the user is actually in.
+    // Reconstructing a Drupal langcode from the CiviCRM locale (e.g.
+    // truncating to its first two characters) is not safe either: CiviCRM's
+    // locale mapping isn't guaranteed reversible, and Drupal langcodes can
+    // carry region/script info (e.g. "pt-br", "zh-hant") that truncation
+    // would destroy.
+    $options = [
+      'query' => $url['query'],
+      'fragment' => $fragment,
+      'absolute' => $absolute,
+      'path_processing' => TRUE,
+    ];
+    $langcode = CRM_Core_Session::singleton()->get('uiLanguage') ?: $this->getCurrentLanguage();
+    if ($langcode) {
+      $languages = \Drupal::languageManager()->getLanguages();
+      if (isset($languages[$langcode])) {
+        $options['language'] = $languages[$langcode];
+      }
+    }
+
     // Not all links that CiviCRM generates are Drupal routes, so we use the weaker ::fromUri method.
     try {
-      $url = \Drupal\Core\Url::fromUri("{$base}{$url['path']}", [
-        'query' => $url['query'],
-        'fragment' => $fragment,
-        'absolute' => $absolute,
-      ])->toString();
+      $url = \Drupal\Core\Url::fromUri("{$base}{$url['path']}", $options)->toString();
       // Decode %% for better readability, e.g., %%cid%%.
       $url = str_replace('%25%25', '%%', $url);
     }


### PR DESCRIPTION
## Summary

When CiviCRM is set to use "Inherit CMS Language" on Drupal, the language most of the times reverts to the site's default language after the page loads, even though the page itself is in the correct language.

This shows up in two places:

1. The CiviCRM menu bar (top navigation) can render in the wrong language, even when the rest of the page is correct.
2. Links generated by CiviCRM (e.g. buttons, menu items) sometimes drop the language prefix from the URL (e.g. linking to `/civicrm/contact/search` instead of `/es/civicrm/contact/search`), which then bounces the visitor back to the default language when clicked.

## Steps to reproduce

1. Set up a Drupal site with two or more languages, using URL-based language switching (e.g. `/es/` for Spanish).
2. In CiviCRM, go to **Administer → Localization → Languages** ,enable **Inherit CMS Language** and add the same languages on the list of available languages.
3. Visit CiviCRM through a language-prefixed URL, e.g. `/es/civicrm`.
4. Look at the CiviCRM menu bar, and hover/click links generated by CiviCRM.

## Expected

Everything should stay in Spanish: the page, the menu bar, and any links CiviCRM generates.

## Actual

- The menu bar most of the times shows the wrong (default) language, because it's loaded via a separate background request that doesn't carry the `/es/` part of the URL, so the language gets re-detected incorrectly for that request.
- Links generated by CiviCRM can be missing the `/es/` prefix entirely, because CiviCRM isn't asking Drupal to apply its normal language-aware link formatting.

## Why this happens 

CiviCRM correctly figures out the language when you first load a page like `/es/civicrm`, because the URL itself tells Drupal (and CiviCRM) which language to use.

The problem is that this "which language are we in" check doesn't happen only once, it happens again, separately, in a couple of other places, and those places don't have the same clue to go on:

- **The menu bar** loads its contents through a separate background request, to a URL like `/civicrm/ajax/navmenu`, notice it has no `/es/` in it. That request already carries the correct language along with it (the menu bar code sends it), but the server-side code that builds the menu currently ignores that and just tries to detect the language again from the URL and since the URL has no `/es/`, it detects the wrong (default) language instead.

- **Generated links** run into a similar issue in a different way: CiviCRM builds its own links through a shortcut method that skips Drupal's normal "format this link for the current language" step entirely. So even on a page that's correctly in Spanish, the links CiviCRM creates come out plain, with no `/es/` added because the step that would normally add it never runs.

In both cases, the language is known and correct at first, it's just not being carried through consistently to every part of the page, so anything that has to re-derive it from a bare/background URL gets it wrong.

## Suggested fix

- Have the menu bar's background request pass along the language it already knows (it already sends this information, it's just not being used).
- Have CiviCRM ask Drupal to apply its normal language-aware URL formatting when generating links, using the language CiviCRM already resolved, instead of leaving Drupal to guess again from scratch.

## Environment

- Drupal 8/9/10
- CiviCRM 6.17.2 with "Inherit CMS Language" enabled (not multilingual)
- Drupal configured with URL-prefix based language negotiation (e.g. `/es/`, `/fr/`)