### PR TITLE
[dev/joomla#54] Fix class not found errors in Joomla installation/upgrade

### DIFF
--- a/setup/plugins/installFiles/InstallJoomlaSettingsFile.civi-setup.php
+++ b/setup/plugins/installFiles/InstallJoomlaSettingsFile.civi-setup.php
@@ -23,7 +23,12 @@ if (!defined('CIVI_SETUP')) {
 
     \Civi\Setup::log()->info(sprintf('[%s] Handle %s', basename(__FILE__), 'installFiles'));
 
-    $liveSite = substr_replace(JURI::root(), '', -1, 1);
+    if (version_compare(JVERSION, '4.0', 'ge')) {
+      $liveSite = substr_replace(\Joomla\CMS\Uri\Uri::root(), '', -1, 1);
+    }
+    else {
+      $liveSite = substr_replace(JURI::root(), '', -1, 1);
+    }
 
     /**
      * @var \Civi\Setup\Model $m
@@ -47,7 +52,13 @@ if (!defined('CIVI_SETUP')) {
 
     foreach ($files as $fileSpec) {
       $str = \Civi\Setup\SettingsUtil::evaluate($tplPath, $fileSpec['params']);
-      JFile::write($fileSpec['file'], $str);
+
+      if (version_compare(JVERSION, '4.0', 'ge')) {
+        \Joomla\CMS\Filesystem\File::write($fileSpec['file'], $str);
+      }
+      else {
+        JFile::write($fileSpec['file'], $str);
+      }
     }
 
   }, \Civi\Setup::PRIORITY_LATE);


### PR DESCRIPTION
Overview
----------------------------------------
This is another fix as part of [joomla#54](https://lab.civicrm.org/dev/joomla/-/work_items/54), J5 compatibility.

Before
----------------------------------------
Installation / upgrade of CiviCRM fails with `Class 'JURI' not found` or `Class 'JFile' not found` errors, if running on J5 without the backward compatibility plugin enabled.

After
----------------------------------------
Installation / upgrade proceeds as normal.

Technical Details
----------------------------------------
As elsewhere, this solution is to use `version_compare()` to select between the obsolete Joomla! class aliases and the modern namespaced class names.

Comments
----------------------------------------
The `version_compare()` and old code could be removed at some point as part of tidying up and withdrawing J3 support.
