### PR TITLE
Extend guard around CIVICRM_IFRAME constant to theme check

### DIFF
--- a/ext/iframe/Civi/Iframe/Cosession.php
+++ b/ext/iframe/Civi/Iframe/Cosession.php
@@ -114,7 +114,7 @@ class Cosession extends AutoService implements EventSubscriberInterface {
    * @see \CRM_Utils_Hook::activeTheme()
    */
   public function pickTheme(&$themeKey, $context): void {
-    if (!defined('CIVICRM_IFRAME')) {
+    if (!(defined('CIVICRM_IFRAME') && CIVICRM_IFRAME)) {
       return;
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
As proposed here https://github.com/civicrm/civicrm-wordpress/pull/341#issuecomment-2644186966 a guard was added to one instance of the CIVICRM_IFRAME constant check by https://github.com/civicrm/civicrm-core/pull/31997. 

However, it was not extended to the other instance in the theme check function which can result in the iframe theme being applied in contexts outside the iframe.

Before
----------------------------------------
In Wordpress if the iframe_theme setting is defined the theme will be applied to the backend of CiviCRM in addition to elements inside the iframe.

After
----------------------------------------
The theme is only applied where CIVICRM_IFRAME is defined and set to true.

Technical Details
----------------------------------------
Extends the guard added by https://github.com/civicrm/civicrm-core/pull/31997 to the pickTheme function.

Comments
----------------------------------------
