### PR TITLE
Standalone - Deprecate YAGNI user pass processing

### DIFF
--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -108,6 +108,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
   public function createUser(&$params, $emailParam) {
     try {
       $email = $params[$emailParam];
+      // Profiles pass in this param inconsistently
       $contactId = $params['contactID'] ?? $params['contact_id'] ?? NULL;
       $userParams = [
         'username' => $params['cms_name'],
@@ -115,6 +116,7 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
         'contact_id' => $contactId,
       ];
       if (!empty($params['cms_pass'])) {
+        CRM_Core_Error::deprecatedWarning("Don't supply 'cms_pass' to Standalone::createUser(), instead pass 'notify' => TRUE and users will receive a welcome email to set their own password.");
         $userParams['password'] = $params['cms_pass'];
       }
       $userID = \Civi\Api4\User::create(FALSE)

--- a/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Api4/Action/UserTest.php
@@ -130,14 +130,14 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
         'contact_type' => 'Individual',
         'display_name' => 'Admin McTest',
       ])->execute()->first()['id'];
-    $params = [
-      'cms_name' => 'user_one',
-      'cms_pass' => 'secret1',
-      'notify' => FALSE,
-      'contact_id' => $this->adminContactID,
-      'email' => 'user_one@example.org',
-    ];
-    $this->adminUserID = \CRM_Core_BAO_CMSUser::create($params, 'email');
+    $this->adminUserID = User::create(FALSE)
+      ->setValues([
+        'username' => 'user_one',
+        'password' => 'secret1',
+        'contact_id' => $this->adminContactID,
+        'uf_name' => 'user_one@example.org',
+      ])
+      ->execute()->first()['id'];
     $this->assertGreaterThan(0, $this->adminUserID);
     $user = User::get(FALSE)->addWhere('id', '=', $this->adminUserID)->execute()->single();
     $this->assertEquals('user_one', $user['username']);
@@ -163,8 +163,14 @@ class UserTest extends \PHPUnit\Framework\TestCase implements EndToEndInterface,
         'contact_type' => 'Individual',
         'display_name' => 'Nonadmin McTest',
       ])->execute()->first()['id'];
-    $params = ['cms_name' => 'nonadmin', 'cms_pass' => 'secret2', 'notify' => FALSE, 'contact_id' => $this->nonAdminContactID, 'email' => 'nonadmin@example.org'];
-    $this->nonAdminUserID = \CRM_Core_BAO_CMSUser::create($params, 'email');
+    $this->nonAdminUserID = User::create(FALSE)
+      ->setValues([
+        'username' => 'nonadmin',
+        'password' => 'secret2',
+        'contact_id' => $this->nonAdminContactID,
+        'uf_name' => 'nonadmin@example.org',
+      ])
+      ->execute()->first()['id'];
     $this->assertGreaterThan(0, $this->nonAdminUserID);
     $this->assertGreaterThan(0, $this->adminUserID);
     $roleID = $this->createNonadminRole();

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -136,8 +136,15 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
         'display_name' => 'Admin McDemo',
       ])->execute()->first()['id'];
 
-    $params = ['cms_name' => 'user_one', 'cms_pass' => 'secret1', 'notify' => FALSE, 'contact_id' => $contactID, 'email' => 'user_one@example.org'];
-    $userID = \CRM_Core_BAO_CMSUser::create($params, 'email');
+    $user = User::create(FALSE)
+      ->setValues([
+        'username' => 'user_one',
+        'password' => 'secret1',
+        'contact_id' => $contactID,
+        'uf_name' => 'user_one@example.org',
+      ])
+      ->execute()->first();
+    $userID = $user['id'];
     $this->assertGreaterThan(0, $userID);
     $this->contactID = $contactID;
     $this->userID = $userID;


### PR DESCRIPTION
Overview
----------------------------------------
Followup to #36529 to remove unneeded password processing when creating users via profile.

Comments
----------------------------------------
It was decided that Standalone doesn't support setting passwords via profile so this code isn't used anywhere.
