### PR TITLE
Fix for #6715 - Proximity search can exclude contacts at the exact coordinates

### DIFF
--- a/CRM/Contact/BAO/ProximityQuery.php
+++ b/CRM/Contact/BAO/ProximityQuery.php
@@ -198,12 +198,18 @@ class CRM_Contact_BAO_ProximityQuery {
     $where = "
 {$geoCodeWhereClause} AND
 ACOS(
-    COS(RADIANS({$tablePrefix}.geo_code_1)) *
-    COS(RADIANS($latitude)) *
-    COS(RADIANS({$tablePrefix}.geo_code_2) - RADIANS($longitude)) +
-    SIN(RADIANS({$tablePrefix}.geo_code_1)) *
-    SIN(RADIANS($latitude))
-  ) * 6378137  <= $distance
+  LEAST(
+    1.0,
+    GREATEST(
+      -1.0,
+      COS(RADIANS({$tablePrefix}.geo_code_1)) *
+      COS(RADIANS($latitude)) *
+      COS(RADIANS({$tablePrefix}.geo_code_2) - RADIANS($longitude)) +
+      SIN(RADIANS({$tablePrefix}.geo_code_1)) *
+      SIN(RADIANS($latitude))
+    )
+  )
+) * 6378137 <= $distance
 ";
     return $where;
   }

--- a/tests/phpunit/api/v4/Entity/AddressTest.php
+++ b/tests/phpunit/api/v4/Entity/AddressTest.php
@@ -76,6 +76,7 @@ class AddressTest extends Api4TestBase implements TransactionalInterface {
       ['geo_code_1' => 21, 'geo_code_2' => 21],
       ['geo_code_1' => 19, 'geo_code_2' => 19],
       ['geo_code_1' => 15, 'geo_code_2' => 15],
+      ['geo_code_1' => 8, 'geo_code_2' => 20],
     ];
     $addreses = $this->saveTestRecords('Address', [
       'records' => $sampleData,
@@ -92,6 +93,14 @@ class AddressTest extends Api4TestBase implements TransactionalInterface {
     $this->assertContains($addreses[1], $result);
     $this->assertContains($addreses[2], $result);
     $this->assertNotContains($addreses[3], $result);
+
+    // Regression test for dev/core#6715: identical coordinates can round above 1 before ACOS().
+    $exactResult = Address::get(FALSE)
+      ->addWhere('contact_id', '=', $cid)
+      ->addWhere('proximity', '<=', ['distance' => 0, 'geo_code_1' => 8, 'geo_code_2' => 20])
+      ->execute()->column('id');
+
+    $this->assertContains($addreses[4], $exactResult);
   }
 
   public function testMasterAddressUpdate(): void {


### PR DESCRIPTION
Overview
-------------------------------------
Fixes #6715.

Proximity searches could exclude contacts whose coordinates exactly matched the search coordinates because floating-point rounding could produce a value slightly outside the valid range for `ACOS()`.

Before
-------------------------------------
Contacts at the exact search coordinates could be excluded from proximity results, even while nearby contacts were returned.

See: https://lab.civicrm.org/dev/core/-/work_items/6715

After
-------------------------------------
The value passed to `ACOS()` is clamped to the valid range of `-1` to `1`, so identical coordinates correctly produce a distance of zero and are included in the results.

Technical Details
-------------------------------------
Updated the existing proximity API test to cover the identical-coordinate case.
