### PR TITLE
Fix Custom Fields not saved during membership renewal

### DIFF
--- a/CRM/Contribute/Form/Contribution/Confirm.php
+++ b/CRM/Contribute/Form/Contribution/Confirm.php
@@ -1707,6 +1707,11 @@ class CRM_Contribute_Form_Contribution_Confirm extends CRM_Contribute_Form_Contr
         $this->_params['membershipID'] = $membership['id'];
         $lineItems[$index]['entity_id'] = $membership['id'];
       }
+      else {
+        $membership = $this->getExistingMembership($membershipTypeID);
+        CRM_Core_BAO_CustomValueTable::postProcess($this->_params, 'civicrm_membership', $membership['id'], 'Membership');
+        $this->_params['membershipID'] = $membership['id'];
+      }
       // Overwrite the array with our augmented version.
       $this->setLineItems($lineItems);
       $this->lineItems = $lineItems;


### PR DESCRIPTION
Overview
----------------------------------------
Trying to fix https://lab.civicrm.org/dev/core/-/work_items/6717

Since https://github.com/civicrm/civicrm-core/commit/9f0e13bb04fc89dbce9e87c16d077168b3a37a70#diff-fa1d97e1889c16127a161492e1fed358409b2d2b39cc37e799e648ac68b5efd8 aka 6.12, membership Custom Fields are not saved during a membership renewal from à contribution page

Before
----------------------------------------

**The initial membership :**
<img width="829" height="580" alt="image" src="https://github.com/user-attachments/assets/ff892918-dc77-40ef-8fd8-54a5ea38abd0" />

**An error mesage on the contribution page :** 
<img width="936" height="71" alt="image" src="https://github.com/user-attachments/assets/5f101240-b168-4b50-9493-4051ce7f680e" />

**The result of the contribution page :**
<img width="607" height="599" alt="image" src="https://github.com/user-attachments/assets/43c5e879-cafe-4d0e-af9a-d83c57bddab1" />

**the membership not updated :**
<img width="820" height="604" alt="image" src="https://github.com/user-attachments/assets/3c9fe40e-8caa-461b-9fc0-5276d55a5c3d" />

After
----------------------------------------

**The initial membership :**
<img width="820" height="604" alt="image" src="https://github.com/user-attachments/assets/9a9862b8-6a5b-4c6b-ac2c-51b829fab5fc" />

**The result of the contribution page :**
<img width="609" height="608" alt="image" src="https://github.com/user-attachments/assets/8183a5f7-00aa-4c63-a657-f2bc810588a0" />

**the membership updated :**
<img width="810" height="574" alt="image" src="https://github.com/user-attachments/assets/5a73f821-6891-4ef5-95d6-d7a4983803e4" />


Technical Details
----------------------------------------
Just fixing a regression

Comments
----------------------------------------
Tested on 6.12 and on civicrm-6.19.alpha1-drupal-202608281244
