### PR TITLE
Revert "Always call constructor for ECK entities so we always have valid field definitions and joins work"

### DIFF
--- a/Civi/Schema/LegacySqlEntityMetadata.php
+++ b/Civi/Schema/LegacySqlEntityMetadata.php
@@ -58,16 +58,7 @@ class LegacySqlEntityMetadata extends EntityMetadataBase {
   public function getFields(): array {
     $fields = [];
     $primaryKeys = $this->getProperty('primary_keys');
-    $className = $this->getClassName();
-    if (isset($this->entityName)) {
-      // Make sure we always call the constructor for ECK entities
-      $class = new $className($this->entityName);
-      $daoFields = $class::fields();
-    }
-    else {
-      $daoFields = $className()::fields();
-    }
-    foreach ($daoFields as $uniqueName => $legacyField) {
+    foreach ($this->getClassName()::fields() as $uniqueName => $legacyField) {
       $fieldName = $legacyField['name'];
       $field = [
         'title' => $legacyField['title'] ?? $fieldName,


### PR DESCRIPTION
Reverts civicrm/civicrm-core#33263

Not needed after https://github.com/systopia/de.systopia.eck/pull/218 is merged :)