### PR TITLE
CRM_Utils_Check_Component_Source - Ensure case-sensitive orphaned file detection on all filesystems

### DIFF
--- a/CRM/Utils/Check/Component/Source.php
+++ b/CRM/Utils/Check/Component/Source.php
@@ -29,15 +29,16 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
    */
   public function findOrphanedFiles() {
     $orphans = [];
+    $root = rtrim(Civi::paths()->getPath('[civicrm.root]/'), '/');
+    $dirCache = [];
     foreach ($this->getRemovedFiles() as $file) {
-      $path = Civi::paths()->getPath("[civicrm.root]/$file");
-      $path = rtrim($path, '/*');
-      // On case-insensitive filesystems we need to do some more work
-      $actualPath = $this->findCorrectCaseForFile($path);
+      $cleanRelPath = rtrim($file, '/*');
+      // On case-insensitive filesystems we need to verify every path segment
+      $actualPath = $this->findCorrectCaseForPath($root, $cleanRelPath, $dirCache);
       if ($actualPath !== NULL) {
         $orphans[] = [
           'name' => $file,
-          'path' => $path,
+          'path' => $actualPath,
         ];
       }
     }
@@ -68,24 +69,37 @@ class CRM_Utils_Check_Component_Source extends CRM_Utils_Check_Component {
   }
 
   /**
-   * Linux is case sensitive, so this will be a no-op.
-   * Windows is case insensitive, Mac is usually insensitive but sometimes
-   * sensitive.
-   * Note that realpath() will return the real casing for a file on windows,
-   * but not on mac, so we need a different method. glob returns the real
-   * casing, but means we need to loop.
+   * Linux is case sensitive, but Windows is case insensitive and Mac is usually
+   * case insensitive.
    *
-   * @param string $path
+   * Note that realpath() will return the real casing for a file on Windows,
+   * but not on Mac. To ensure exact case matching on all filesystems, we
+   * verify each path segment against the directory listing.
+   *
+   * @param string $basePath
+   * @param string $relativePath
+   * @param array $dirCache
    * @return string|null
    */
-  private function findCorrectCaseForFile(string $path): ?string {
-    $fileToFind = basename($path);
-    foreach (glob(dirname($path) . '/*', GLOB_NOSORT) as $theRealFile) {
-      if ($fileToFind === basename($theRealFile)) {
-        return $theRealFile;
+  private function findCorrectCaseForPath(string $basePath, string $relativePath, array &$dirCache = []): ?string {
+    $current = rtrim($basePath, '/');
+    $segments = array_filter(explode('/', $relativePath), 'strlen');
+
+    foreach ($segments as $segment) {
+      if (!is_dir($current)) {
+        return NULL;
       }
+      if (!isset($dirCache[$current])) {
+        $entries = scandir($current);
+        $dirCache[$current] = $entries !== FALSE ? array_flip($entries) : [];
+      }
+      if (!isset($dirCache[$current][$segment])) {
+        return NULL;
+      }
+      $current .= '/' . $segment;
     }
-    return NULL;
+
+    return file_exists($current) ? $current : NULL;
   }
 
 }

--- a/tests/phpunit/CRM/Utils/Check/Component/SourceTest.php
+++ b/tests/phpunit/CRM/Utils/Check/Component/SourceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Class CRM_Utils_Check_Component_SourceTest
+ * @package CiviCRM
+ * @subpackage CRM_Utils_Check
+ * @group headless
+ */
+class CRM_Utils_Check_Component_SourceTest extends CiviUnitTestCase {
+
+  /**
+   * Test that on a clean repository, checkOrphans returns no messages.
+   */
+  public function testCheckOrphansEmptyOnCleanRepo(): void {
+    $check = new CRM_Utils_Check_Component_Source();
+    $messages = $check->checkOrphans();
+    $this->assertEmpty($messages);
+  }
+
+  /**
+   * Test case sensitivity when detecting orphaned files and directories.
+   */
+  public function testFindOrphanedFilesCaseSensitivity(): void {
+    $mockCheck = new class() extends CRM_Utils_Check_Component_Source {
+      public array $mockFiles = [];
+
+      public function getRemovedFiles() {
+        return $this->mockFiles;
+      }
+
+    };
+
+    $root = rtrim(Civi::paths()->getPath('[civicrm.root]/'), '/');
+
+    // 1. A path that differs only by case in a directory segment should NOT match
+    $mockCheck->mockFiles = [
+      'ext/civiimport/Managed/*',
+      'ext/civiimport/Managed/ImportSearches.mgd.php',
+    ];
+    $this->assertEmpty($mockCheck->findOrphanedFiles());
+
+    // 2. An actual file with matching case should be detected
+    $testRelFile = 'CRM/Utils/Check/test_orphan_dummy.php';
+    $testAbsFile = $root . '/' . $testRelFile;
+    file_put_contents($testAbsFile, '<?php // dummy');
+
+    try {
+      $mockCheck->mockFiles = [$testRelFile];
+      $orphans = $mockCheck->findOrphanedFiles();
+      $this->assertCount(1, $orphans);
+      $this->assertEquals($testAbsFile, $orphans[0]['path']);
+      $this->assertEquals($testRelFile, $orphans[0]['name']);
+
+      // But if the casing is different (e.g. CRM/UTILS/...), it should NOT be detected
+      $mockCheck->mockFiles = ['CRM/UTILS/Check/test_orphan_dummy.php'];
+      $this->assertEmpty($mockCheck->findOrphanedFiles());
+    }
+    finally {
+      if (file_exists($testAbsFile)) {
+        unlink($testAbsFile);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Ensure `CRM_Utils_Check_Component_Source::findOrphanedFiles()` correctly verifies case-sensitivity across files and directories on macOS, Windows, and Linux.

Before
----------------------------------------
On case-insensitive filesystems (macOS APFS, Windows NTFS), `findCorrectCaseForFile()` only checked the casing of `basename($path)` using `glob(dirname($path) . '/*')`. Because `glob()` resolved `dirname($path)` case-insensitively, any nested file whose parent directory changed case (e.g., `ext/civiimport/Managed/Foo.php` when `ext/civiimport/managed/Foo.php` exists) was falsely detected as an orphaned file. If upgrade cleanup ran, active files could be inadvertently unlinked.

After
----------------------------------------
`findCorrectCaseForPath()` iterates each path segment starting from `[civicrm.root]` and verifies exact casing against `scandir()` directory listings (cached per run for high performance). This ensures true case-sensitive validation on all operating systems without false positives.

Technical Details
----------------------------------------
- Replaced `findCorrectCaseForFile(string $path)` with `findCorrectCaseForPath(string $basePath, string $relativePath, array &$dirCache = [])`.
- Added unit tests in `CRM_Utils_Check_Component_SourceTest` covering case sensitivity on directories and files, as well as verification on clean repos.
