### PR TITLE
Allow direct link to the contributions recurring subtab on the contact summary

### DIFF
--- a/CRM/Contact/Page/View/Summary.php
+++ b/CRM/Contact/Page/View/Summary.php
@@ -373,6 +373,14 @@ class CRM_Contact_Page_View_Summary extends CRM_Contact_Page_View {
         if (CRM_Utils_Request::retrieve('isTest', 'Positive', $this)) {
           $q .= "&isTest=1";
         }
+
+        // The Contributions tab has two possible subtabs
+        if ($i === 'contribute') {
+          $subChild = CRM_Utils_Request::retrieve('subChild', 'String', $this);
+          if ($subChild) {
+            $q .= "&subChild=" . urlencode($subChild);
+          }
+        }
         $allTabs[] = [
           'id' => $i,
           'url' => CRM_Utils_System::url("civicrm/contact/view/$u", $q),

--- a/CRM/Contribute/Page/Tab.php
+++ b/CRM/Contribute/Page/Tab.php
@@ -211,6 +211,9 @@ class CRM_Contribute_Page_Tab extends CRM_Core_Page {
     [$annual['count'], $annual['amount'], $annual['avg']] = CRM_Contribute_BAO_Contribution::annual($this->_contactId);
     $this->assign('annual', $annual);
 
+    // Select "Contributions" / "Recurring Contributions" sub-tab on load
+    $this->assign('subChild', CRM_Utils_Request::retrieve('subChild', 'String', $this));
+
     $controller = new CRM_Core_Controller_Simple(
       'CRM_Contribute_Form_Search',
       ts('Contributions'),

--- a/templates/CRM/common/TabSelected.tpl
+++ b/templates/CRM/common/TabSelected.tpl
@@ -3,7 +3,7 @@
   var selectedTab = '{$defaultTab}';
   var tabContainer = '#mainTabContainer';
   {if $tabContainer}tabContainer = '{$tabContainer}';{/if}
-  {if $selectedChild}selectedTab = '{$selectedChild}';{/if}
+  {if $subChild}selectedTab = '{$subChild}';{/if}
   {literal}
   CRM.$(function($) {
     var tabIndex = $('#tab_' + selectedTab).prevAll().length;


### PR DESCRIPTION
E.g. `civicrm/contact/view?reset=1&cid=103&selectedChild=contribute&subChild=recurring`
Default of the Contributions subtab is unchanged.