### PR TITLE
riverlea - fix thames darkmode leaks with user switcher

### DIFF
--- a/ext/riverlea/streams/thames/_dark.css
+++ b/ext/riverlea/streams/thames/_dark.css
@@ -79,90 +79,86 @@
 /* Wizard '--crm-wizard-' */
 /* Alpha filter '--crm-filter-' */
   --crm-filter-bg-color: var(--crm-c-dkblue-02);
-/* Frontend '--crm-f- */
-}
 
-.crm-container div.crm-summary-row div.crm-label {
-  --crm-c-blue-darker: var(--crm-c-blue);
-}
+  /* todo variablize all that follows... */
 
-/* todo variablize this */
-.crm-container .ui-tabs:not(#mainTabContainer) {
-  background: var(--crm-c-dkblue-01);
-  --crm-tabs-border: solid 4px var(--crm-c-dkblue-01);
-}
+  .crm-container div.crm-summary-row div.crm-label {
+    --crm-c-blue-darker: var(--crm-c-blue);
+  }
 
-.crm-container .crm-accordion-bold>summary:is(:hover,
-:focus) {
-  background-color: var(--crm-c-dkblue-01);
-}
+  .crm-container .ui-tabs:not(#mainTabContainer) {
+    background: var(--crm-c-dkblue-01);
+    --crm-tabs-border: solid 4px var(--crm-c-dkblue-01);
+  }
 
-/* Get rid of the ugly black overlay during loading */
-@keyframes aahblockoverlay-dark {
-  0% {
+  .crm-container .crm-accordion-bold>summary:is(:hover,
+  :focus) {
     background-color: var(--crm-c-dkblue-01);
   }
 
-  50% {
-    background-color: var(--crm-c-dkblue-03);
+  /* Get rid of the ugly black overlay during loading */
+  @keyframes aahblockoverlay-dark {
+    0% {
+      background-color: var(--crm-c-dkblue-01);
+    }
+
+    50% {
+      background-color: var(--crm-c-dkblue-03);
+    }
+
+    100% {
+      background-color: var(--crm-c-dkblue-01);
+    }
   }
-
-  100% {
-    background-color: var(--crm-c-dkblue-01);
+  .crm-container .blockUI.blockOverlay {
+    animation: aahblockoverlay-dark 10s infinite;
   }
-}
-
-.crm-container .blockUI.blockOverlay {
-  animation: aahblockoverlay-dark 10s infinite;
-}
-
-.crm-container .crm-dashlet-content {
-  background: var(--crm-c-dkblue-00) !important;
-}
-.crm-container .crm-dashlet-header {
-  background: var(--crm-c-dkblue-01) !important;
-}
-.crm-container summary {
-  /* background: var(--crm-c-dkblue-03); */
-  color: var(--crm-accordion-header-color);
-}
-.crm-container summary:hover,
-.crm-container summary:focus {
-  background: var(--crm-c-blue-overlay4);
-}
-.crm-container details {
-  background-color: var(--crm-c-dkblue-02);
-}
-.standalone-errors {
-  background: #3e0a01;
-}
-/* .crm-container .crm-search-nav-tabs { border-color: var(--crm-c-dkblue-01); } */
-
-/* override standalone.css */
-#login-form {
-  --crm-input-width: 100%;
-}
-/* Override _fixes.scss */
-.crm-container del,
-.crm-container .ui-icons_deleted,
-.crm-container table.caseSelector td.status-urgent,
-.crm-container .font-red,
-.crm-container .status-removed,
-.crm-container .status-overdue,
-.crm-container .status-fatal,
-.crm-container .status-hold,
-.crm-container .status-past,
-.crm-contact-deceased,
-.crm-container .status-warning {
-  --crm-danger-color: var(--crm-c-red);
-}
-#civicrm-footer a,
-nav.breadcrumb a {
-  --crm-link-color: var(--crm-c-dkblue-08);
-  --crm-link-hover-color: var(--crm-c-blue);
-}
-
-/* eg. Frontend theme selection */
-.select2-drop.select2-drop-active.crm-container .select2-results > li {
-  --crm-c-blue-dark: var(--crm-c-blue);
+  .crm-container .crm-dashlet-content {
+    background: var(--crm-c-dkblue-00) !important;
+  }
+  .crm-container .crm-dashlet-header {
+    background: var(--crm-c-dkblue-01) !important;
+  }
+  .crm-container summary {
+    /* background: var(--crm-c-dkblue-03); */
+    color: var(--crm-accordion-header-color);
+  }
+  .crm-container summary:hover,
+  .crm-container summary:focus {
+    background: var(--crm-c-blue-overlay4);
+  }
+  .crm-container details {
+    background-color: var(--crm-c-dkblue-02);
+  }
+  .standalone-errors {
+    background: #3e0a01;
+  }
+  /* .crm-container .crm-search-nav-tabs { border-color: var(--crm-c-dkblue-01); } */
+  /* override standalone.css */
+  #login-form {
+    --crm-input-width: 100%;
+  }
+  /* Override _fixes.scss */
+  .crm-container del,
+  .crm-container .ui-icons_deleted,
+  .crm-container table.caseSelector td.status-urgent,
+  .crm-container .font-red,
+  .crm-container .status-removed,
+  .crm-container .status-overdue,
+  .crm-container .status-fatal,
+  .crm-container .status-hold,
+  .crm-container .status-past,
+  .crm-contact-deceased,
+  .crm-container .status-warning {
+    --crm-danger-color: var(--crm-c-red);
+  }
+  #civicrm-footer a,
+  nav.breadcrumb a {
+    --crm-link-color: var(--crm-c-dkblue-08);
+    --crm-link-hover-color: var(--crm-c-blue);
+  }
+  /* eg. Frontend theme selection */
+  .select2-drop.select2-drop-active.crm-container .select2-results > li {
+    --crm-c-blue-dark: var(--crm-c-blue);
+  }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix regression in Thames from https://github.com/civicrm/civicrm-core/pull/35430

Before
----------------------------------------
- https://github.com/civicrm/civicrm-core/pull/35430 reworked how stream css is compiled for dark mode, to allow user frontend switching
- the rendering reasonably assumes the only rules in the stream's dark mode file use a  `:root` block (its expected they are variable redeclarations)
- there are some other rules in the Thames dark mode file, which now leak and are added if you have dark mode set to auto, and OS is in light mode:

<img width="1229" height="644" alt="image" src="https://github.com/user-attachments/assets/5e88476f-31f3-4a4d-a9b6-4ec464b6f2d4" />


After
----------------------------------------
- all the Thames dark mode file declarations are inside the `:root` block
- they don't leak, works as expected


Comments
----------------------------------------
The need for all the declarations to be in `:root` block isn't specified anywhere, and people making custom streams / adding custom css for dark mode might hit the same problem. Possibly in the long run the rendering could be made more subtle to deal with other blocks. In general the framework as a whole works best if streams are defined as a flat list of variable declarations though (as all the other core streams except Thames are)
