### PR TITLE
Double length of CustomGroup.title schema field

### DIFF
--- a/CRM/Core/BAO/CustomGroup.php
+++ b/CRM/Core/BAO/CustomGroup.php
@@ -343,13 +343,9 @@ class CRM_Core_BAO_CustomGroup extends CRM_Core_DAO_CustomGroup implements Event
     }
     else {
       if (!empty($params['name'])) {
-        $params['name'] = CRM_Utils_String::munge($params['name']);
+        $params['name'] = CRM_Utils_String::munge($params['name'], '_', 64);
+        self::validateCustomGroupName($params);
       }
-      else {
-        $params['name'] = CRM_Utils_String::munge($params['title']);
-      }
-
-      self::validateCustomGroupName($params);
 
       if (isset($params['table_name'])) {
         $tableName = $params['table_name'];

--- a/CRM/Upgrade/Incremental/php/SixNineteen.php
+++ b/CRM/Upgrade/Incremental/php/SixNineteen.php
@@ -43,6 +43,15 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
         'callback' => ['CRM_Core_SelectValues', 'profileUserRegistrationMode'],
       ],
     ]);
+    $this->addTask('Increase CustomGroup.title length to 128', 'alterSchemaField', 'CustomGroup', 'title', [
+      'title' => ts('Custom Group Title'),
+      'sql_type' => 'varchar(128)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'localizable' => TRUE,
+      'description' => ts('Friendly Name.'),
+      'add' => '1.1',
+    ]);
     $this->addTask('Decode Mailing.template_options HTML entities', 'decodeMailingTemplateOptions');
   }
 

--- a/schema/Core/CustomGroup.entityType.php
+++ b/schema/Core/CustomGroup.entityType.php
@@ -57,7 +57,7 @@ return [
     ],
     'title' => [
       'title' => ts('Custom Group Title'),
-      'sql_type' => 'varchar(64)',
+      'sql_type' => 'varchar(128)',
       'input_type' => 'Text',
       'required' => TRUE,
       'localizable' => TRUE,

--- a/tests/phpunit/api/v4/Custom/CustomGroupTest.php
+++ b/tests/phpunit/api/v4/Custom/CustomGroupTest.php
@@ -210,4 +210,33 @@ class CustomGroupTest extends Api4TestBase {
     $this->assertFalse($customGroup['is_active']);
   }
 
+  public function testCreateCustomGroupLongTitleAutoName(): void {
+    // Create 2 groups with very long titles that are identical except for the last letter
+    $prefix = \CRM_Utils_String::createRandom(127, \CRM_Utils_String::ALPHANUMERIC);
+    $title1 = $prefix . 'a';
+    $title2 = $prefix . 'b';
+
+    $group1 = CustomGroup::create(FALSE)
+      ->addValue('title', $title1)
+      ->execute()->first();
+
+    $group2 = CustomGroup::create(FALSE)
+      ->addValue('title', $title2)
+      ->execute()->first();
+
+    $this->assertSame($title1, $group1['title']);
+    $this->assertSame($title2, $group2['title']);
+    $this->assertNotEquals($group1['name'], $group2['name']);
+    $this->assertLessThanOrEqual(64, strlen($group1['name']));
+    $this->assertLessThanOrEqual(64, strlen($group2['name']));
+
+    // Explicit 64-char name should be preserved and not truncated to 63
+    $explicitName = \CRM_Utils_String::createRandom(64, \CRM_Utils_String::ALPHANUMERIC);
+    $group3 = CustomGroup::create(FALSE)
+      ->addValue('title', 'Group with 64-char name')
+      ->addValue('name', $explicitName)
+      ->execute()->first();
+    $this->assertSame($explicitName, $group3['name']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Double the maximum length of the `CustomGroup.title` field from 64 to 128 characters.

Ref: https://dev.nysenate.gov/issues/17442

Before
----------------------------------------
`CustomGroup.title` was limited to `varchar(64)`.

After
----------------------------------------
`CustomGroup.title` is `varchar(128)`.

Technical Details
----------------------------------------
- Updated `schema/Core/CustomGroup.entityType.php` to define `title` with `'sql_type' => 'varchar(128)'`.
- Added upgrade step in `CRM_Upgrade_Incremental_php_SixNineteen` using the `alterSchemaField` callback.
- Updated `CRM_Core_BAO_CustomGroup::create` to allow `CRM_Core_DAO::makeNameFromLabel` to handle unique truncated `name` auto-generation when `name` is omitted.
- Added unit test in `tests/phpunit/api/v4/Custom/CustomGroupTest.php` covering creation of custom groups with 128-character titles and truncated unique names.

