### PR TITLE
Increase Tag name and label column lengths to 128

### DIFF
--- a/CRM/Core/DAO.php
+++ b/CRM/Core/DAO.php
@@ -3530,22 +3530,24 @@ SELECT contact_id
     $name = CRM_Utils_String::munge($label, '_', $maxLen - $maxSuffixLen);
 
     // Define an arbitrary limit on how many guesses we will perform before
-    // throwing an exception. This would occur only in some unanticipated use
-    // case.
-    $max_guesses = 36 ^ ($maxSuffixLen - 1);
+    // throwing an exception. Hitting this limit is extremely improbable.
+    $max_guesses = 1000;
 
     $guesses_per_loop = 5;
     $guess_count = 0;
+
+    // Start with the full, unsuffixed name as the first cantidate
+    $start = 1;
+    $candidates = [CRM_Utils_String::munge($label, '_', $maxLen)];
 
     do {
       // Make an initial attempt to guess a unique name by searching for
       // 5 candidates (the original $name plus $name with 4 random suffixes).
       // If all of these happen to exist in the table, we'll keep trying,
       // doubling the number of guesses each time through the loop.
-      for ($i = 0; $i < $guesses_per_loop; $i++, $guess_count++) {
-        $suffix = $guess_count == 0 ? '' :
-          '_' . CRM_Utils_String::createRandom($maxSuffixLen - 1, 'abcdefghijklmnopqrstuvwxyz0123456789');
-        $candidates[$i] = $name . $suffix;
+      for ($i = $start; $i < $guesses_per_loop; $i++, $guess_count++) {
+        $suffix = CRM_Utils_String::createRandom($maxSuffixLen - 1, 'abcdefghijklmnopqrstuvwxyz0123456789');
+        $candidates[$i] = $name . '_' . $suffix;
       }
 
       $sql = new CRM_Utils_SQL_Select($this::getTableName());
@@ -3579,15 +3581,16 @@ SELECT contact_id
           }
         }
       }
-      else {
-        // All candidates were found in the table. Try harder next time.
-        $guesses_per_loop = min(1000, $guesses_per_loop * 2);
+      // All candidates were found in the table. Try harder next time.
+      $guesses_per_loop = min(1000, $guesses_per_loop * 2);
 
-        if ($guess_count > $max_guesses) {
-          throw new CRM_Core_Exception("CRM_Core_DAO::makeNameFromLabel failed to generate a unique name for label $label.");
-        }
-      }
-    } while (1);
+      // No more special treatment of the first cantidate, from now on they'll all be suffixed
+      $start = 0;
+
+    } while ($max_guesses > $guess_count);
+
+    // Something is very wrong if we hit this line - the odds of matching this many random strings is infinitesimal
+    throw new CRM_Core_Exception("CRM_Core_DAO::makeNameFromLabel failed to generate a unique name for label $label.");
   }
 
   /**

--- a/CRM/Upgrade/Incremental/php/SixNineteen.php
+++ b/CRM/Upgrade/Incremental/php/SixNineteen.php
@@ -31,6 +31,22 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
     $this->addTask(ts('Upgrade DB to %1: SQL', [1 => $rev]), 'runSql', $rev);
     $this->addTask('Drop OptionValue.domain_id column', 'dropColumn', 'civicrm_option_value', 'domain_id');
     $this->addTask('Update Localization menu label', 'updateLocalizationMenuLabels');
+    $this->addTask('Increase Tag.name length to 128', 'alterSchemaField', 'Tag', 'name', [
+      'title' => ts('Tag Name'),
+      'sql_type' => 'varchar(128)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('Unique machine name'),
+      'add' => '1.1',
+    ]);
+    $this->addTask('Increase Tag.label length to 128', 'alterSchemaField', 'Tag', 'label', [
+      'title' => ts('Tag Label'),
+      'sql_type' => 'varchar(128)',
+      'input_type' => 'Text',
+      'required' => TRUE,
+      'description' => ts('User-facing tag name'),
+      'add' => '5.68',
+    ]);
     $this->addTask('Update UFGroup.is_cms_user', 'alterSchemaField', 'UFGroup', 'is_cms_user', [
       'title' => ts('User account registration'),
       'sql_type' => 'tinyint',

--- a/schema/Core/Tag.entityType.php
+++ b/schema/Core/Tag.entityType.php
@@ -35,7 +35,7 @@ return [
     ],
     'name' => [
       'title' => ts('Tag Name'),
-      'sql_type' => 'varchar(64)',
+      'sql_type' => 'varchar(128)',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('Unique machine name'),
@@ -43,7 +43,7 @@ return [
     ],
     'label' => [
       'title' => ts('Tag Label'),
-      'sql_type' => 'varchar(64)',
+      'sql_type' => 'varchar(128)',
       'input_type' => 'Text',
       'required' => TRUE,
       'description' => ts('User-facing tag name'),

--- a/tests/phpunit/api/v4/Entity/TagTest.php
+++ b/tests/phpunit/api/v4/Entity/TagTest.php
@@ -131,4 +131,15 @@ class TagTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotContains('tagset', $options);
   }
 
+  public function testTagLongNameAndLabel(): void {
+    $longName = \CRM_Utils_String::createRandom(128, \CRM_Utils_String::ALPHANUMERIC);
+
+    $tag = Tag::create(FALSE)
+      ->addValue('label', $longName)
+      ->execute()->first();
+
+    $this->assertSame($longName, $tag['name']);
+    $this->assertSame($longName, $tag['label']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Increase the length of the `name` and `label` fields in the `civicrm_tag` schema to 128 characters.

Ref: https://dev.nysenate.gov/issues/17442

Before
----------------------------------------
`Tag.name` and `Tag.label` are limited to 64 characters in the schema definition.

After
----------------------------------------
`Tag.name` and `Tag.label` are `varchar(128)`.

Technical Details
----------------------------------------
- Updated `name` and `label` columns in `Tag.entityType.php` to `varchar(128)`.
- Added database upgrade tasks to `SixNineteen.php` using `alterSchemaField`.
- Added unit test verifying tags with 128-character label.
- Fixed some oddities in function `makeNameFromLabel()` when supplied label is near the length limit.