### PR TITLE
dev/core#6721 changeFeeSelections: reverse only what was omitted, and reverse all of it

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -703,10 +703,25 @@ WHERE li.contribution_id = %1";
       unset($updateFinancialItemInfoValues['created_date']);
       $previousLineItem = $previousLineItems[$updateFinancialItemInfoValues['entity_id']];
 
-      // if not submitted and difference is not 0 make it negative
-      if ((empty($lineItemsToUpdate) || (in_array($updateFinancialItemInfoValues['price_field_value_id'], $priceFieldValueIDsToCancel) &&
-          $totalFinancialAmount == $updateFinancialItemInfoValues['amount'])
-        ) && $updateFinancialItemInfoValues['amount'] > 0
+      // Reverse only line items that were actually omitted from the submission.
+      // The former empty($lineItemsToUpdate) shortcut made this condition true for
+      // every positive financial item whenever nothing needed updating, silently
+      // wiping the revenue of submitted, unchanged line items while those line
+      // items stayed active.
+      //
+      // The amount is checked for being non-zero rather than positive: a discount
+      // line carries a legitimate negative amount that has to be reversed as well
+      // once its line item is omitted.
+      //
+      // The amount is no longer compared against the line item total either. That
+      // comparison held only for a line item with exactly one financial item, so a
+      // line carrying sales tax (revenue plus a separate tax item) or a Text field
+      // whose amount had been adjusted before matched on neither of its items and
+      // was left unreversed entirely. Items that were already reversed are filtered
+      // out by getNonCancelledFinancialItems(), which is what keeps this from
+      // reversing the same amount twice.
+      if (in_array($updateFinancialItemInfoValues['price_field_value_id'], $priceFieldValueIDsToCancel)
+        && $updateFinancialItemInfoValues['amount'] != 0
       ) {
 
         // INSERT negative financial_items
@@ -717,8 +732,11 @@ WHERE li.contribution_id = %1";
           $updateFinancialItemInfoValues['tax']['amount'] = -($previousLineItem['tax_amount']);
           $updateFinancialItemInfoValues['tax']['description'] = $this->getSalesTaxTerm();
         }
-        // INSERT negative financial_items for tax amount
-        $financialItemsArray[$updateFinancialItemInfoValues['entity_id']] = $updateFinancialItemInfoValues;
+        // Append rather than key on entity_id: one line item can carry several
+        // financial items (revenue plus sales tax) and each needs its own reversal
+        // on its own financial account. The loop that consumes this array reads
+        // only the values, so the key carries no meaning.
+        $financialItemsArray[] = $updateFinancialItemInfoValues;
       }
       // INSERT a financial item to record surplus/lesser amount when a text price fee is changed
       elseif (

--- a/tests/phpunit/CRM/Price/BAO/ChangeFeeSelectionsFinancialItemTest.php
+++ b/tests/phpunit/CRM/Price/BAO/ChangeFeeSelectionsFinancialItemTest.php
@@ -1,0 +1,484 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Tests financial-item adjustments when fee selections change.
+ *
+ * When no line items need updating, the old shortcut incorrectly reverses
+ * submitted, unchanged line items. These tests verify that an unchanged line
+ * retains its revenue while an omitted line is still zeroed and reversed.
+ *
+ * A separate test covers omitted line items with a negative amount, such as a
+ * discount: those were skipped by the amount > 0 guard and kept their negative
+ * financial item after the line item itself had been zeroed.
+ *
+ * A third covers a line item carrying sales tax, which has a separate financial
+ * item for the tax. Comparing each item against the line item total matched on
+ * neither of them, so such a line was not reversed at all.
+ *
+ * @group headless
+ * @group financial
+ */
+class CRM_Price_BAO_ChangeFeeSelectionsFinancialItemTest extends CiviUnitTestCase {
+
+  /**
+   * IDs created by the current test fixture.
+   *
+   * @var array
+   */
+  private $fixture = [];
+
+  /**
+   * An unchanged submitted line item retains its financial item.
+   */
+  public function testUnchangedLineItemKeepsItsFinancialItem(): void {
+    $this->createPaidOrderWithTwoPriceFields();
+
+    CRM_Price_BAO_LineItem::changeFeeSelections(
+      ['price_' . $this->fixture['kept_field_id'] => $this->fixture['kept_value_id']],
+      $this->fixture['participant_id'],
+      'participant',
+      $this->fixture['contribution_id']
+    );
+
+    $lineItem = $this->getLineItemFinancialSummary($this->fixture['kept_value_id']);
+    $this->assertEquals(1.0, (float) $lineItem->qty);
+    $this->assertEqualsWithDelta(
+      (float) $lineItem->line_total,
+      (float) $lineItem->net_financial_amount,
+      0.001,
+      'The submitted, unchanged line item should retain revenue equal to its line total.'
+    );
+    $this->assertEquals(
+      [35.00],
+      $this->getFinancialItemAmounts($this->fixture['kept_value_id']),
+      'The unchanged line item should still have its single original financial item.'
+    );
+  }
+
+  /**
+   * An omitted line item is still zeroed and financially reversed.
+   */
+  public function testOmittedLineItemIsStillReversed(): void {
+    $this->createPaidOrderWithTwoPriceFields();
+
+    CRM_Price_BAO_LineItem::changeFeeSelections(
+      ['price_' . $this->fixture['kept_field_id'] => $this->fixture['kept_value_id']],
+      $this->fixture['participant_id'],
+      'participant',
+      $this->fixture['contribution_id']
+    );
+
+    $lineItem = $this->getLineItemFinancialSummary($this->fixture['omitted_value_id']);
+    $this->assertEquals(0.0, (float) $lineItem->qty);
+    $this->assertEquals(0.0, (float) $lineItem->line_total);
+    $this->assertEquals(
+      [-10.00, 10.00],
+      $this->getFinancialItemAmounts($this->fixture['omitted_value_id']),
+      'The omitted line item should have its original item and exactly one reversal.'
+    );
+  }
+
+  /**
+   * An omitted line item with a negative amount is reversed as well.
+   *
+   * A discount line carries a negative financial item. Zeroing the line item
+   * without reversing that item leaves the discount on the revenue account
+   * forever, so the accounting side keeps a negative remainder that the
+   * contribution no longer accounts for.
+   */
+  public function testOmittedNegativeLineItemIsAlsoReversed(): void {
+    $this->createPaidOrderWithDiscountLine();
+
+    CRM_Price_BAO_LineItem::changeFeeSelections(
+      ['price_' . $this->fixture['kept_field_id'] => $this->fixture['kept_value_id']],
+      $this->fixture['participant_id'],
+      'participant',
+      $this->fixture['contribution_id']
+    );
+
+    $lineItem = $this->getLineItemFinancialSummary($this->fixture['discount_value_id']);
+    $this->assertEquals(0.0, (float) $lineItem->qty);
+    $this->assertEquals(0.0, (float) $lineItem->line_total);
+    $this->assertEquals(
+      [-5.00, 5.00],
+      $this->getFinancialItemAmounts($this->fixture['discount_value_id']),
+      'The omitted discount line should have its negative item and exactly one reversal.'
+    );
+  }
+
+  /**
+   * A line item carrying sales tax has both of its financial items reversed.
+   *
+   * Revenue and tax are recorded as two financial items on one line item, each on
+   * its own financial account. Both have to be reversed when the line is omitted,
+   * and each on its own account: a single combined reversal would move the tax off
+   * the tax account and onto the revenue account.
+   */
+  public function testOmittedTaxedLineItemReversesBothItems(): void {
+    $this->createPaidOrderWithTaxedLines();
+
+    CRM_Price_BAO_LineItem::changeFeeSelections(
+      ['price_' . $this->fixture['kept_field_id'] => $this->fixture['kept_value_id']],
+      $this->fixture['participant_id'],
+      'participant',
+      $this->fixture['contribution_id']
+    );
+
+    $lineItem = $this->getLineItemFinancialSummary($this->fixture['omitted_value_id']);
+    $this->assertEquals(0.0, (float) $lineItem->qty);
+    $this->assertEquals(0.0, (float) $lineItem->line_total);
+    $this->assertEquals(
+      [-35.00, -3.50, 3.50, 35.00],
+      $this->getFinancialItemAmounts($this->fixture['omitted_value_id']),
+      'Both the revenue and the tax item of the omitted line should be reversed.'
+    );
+
+    // Each reversal belongs on the account of the item it reverses.
+    $perAccount = $this->getFinancialItemTotalsPerAccount($this->fixture['omitted_value_id']);
+    $this->assertCount(2, $perAccount, 'Expected items on a revenue and a tax account.');
+    foreach ($perAccount as $accountID => $total) {
+      $this->assertEqualsWithDelta(
+        0.0,
+        $total,
+        0.001,
+        'Financial account ' . $accountID . ' should net to zero after the reversal.'
+      );
+    }
+  }
+
+  /**
+   * Create and fully pay an order whose lines carry 10% sales tax.
+   */
+  private function createPaidOrderWithTaxedLines(): void {
+    $financialTypeID = $this->getDonationFinancialTypeID();
+    $this->enableTaxAndInvoicing();
+    $this->addTaxAccountToFinancialType($financialTypeID);
+    $this->createEventWithPriceSet($financialTypeID);
+
+    [$omittedFieldID, $omittedValueID] = $this->createPriceFieldAndValue(
+      'thirty_five_euros',
+      'Thirty-five euros',
+      35.00,
+      $financialTypeID
+    );
+    [$keptFieldID, $keptValueID] = $this->createPriceFieldAndValue(
+      'ten_euros',
+      'Ten euros',
+      10.00,
+      $financialTypeID
+    );
+    $this->fixture += [
+      'omitted_field_id' => $omittedFieldID,
+      'omitted_value_id' => $omittedValueID,
+      'kept_field_id' => $keptFieldID,
+      'kept_value_id' => $keptValueID,
+    ];
+
+    $omitted = $this->getOrderLineItem($omittedFieldID, $omittedValueID, 'Thirty-five euros', 35.00, $financialTypeID);
+    $omitted['tax_amount'] = 3.50;
+    $kept = $this->getOrderLineItem($keptFieldID, $keptValueID, 'Ten euros', 10.00, $financialTypeID);
+    $kept['tax_amount'] = 1.00;
+
+    $this->createPaidOrder(49.50, [$omitted, $kept], ['tax_amount' => 4.50]);
+  }
+
+  /**
+   * Create and fully pay an order containing a EUR 10 line and a EUR -5 discount.
+   */
+  private function createPaidOrderWithDiscountLine(): void {
+    $financialTypeID = $this->getDonationFinancialTypeID();
+    $this->createEventWithPriceSet($financialTypeID);
+
+    [$keptFieldID, $keptValueID] = $this->createPriceFieldAndValue(
+      'ten_euros',
+      'Ten euros',
+      10.00,
+      $financialTypeID
+    );
+    [$discountFieldID, $discountValueID] = $this->createPriceFieldAndValue(
+      'discount_five_euros',
+      'Five euro discount',
+      -5.00,
+      $financialTypeID
+    );
+    $this->fixture += [
+      'kept_field_id' => $keptFieldID,
+      'kept_value_id' => $keptValueID,
+      'discount_field_id' => $discountFieldID,
+      'discount_value_id' => $discountValueID,
+    ];
+
+    $this->createPaidOrder(5.00, [
+      $this->getOrderLineItem($keptFieldID, $keptValueID, 'Ten euros', 10.00, $financialTypeID),
+      $this->getOrderLineItem($discountFieldID, $discountValueID, 'Five euro discount', -5.00, $financialTypeID),
+    ]);
+  }
+
+  /**
+   * Create and fully pay an order containing EUR 10 and EUR 35 price lines.
+   */
+  private function createPaidOrderWithTwoPriceFields(): void {
+    $financialTypeID = $this->getDonationFinancialTypeID();
+    $this->createEventWithPriceSet($financialTypeID);
+
+    [$omittedFieldID, $omittedValueID] = $this->createPriceFieldAndValue(
+      'ten_euros',
+      'Ten euros',
+      10.00,
+      $financialTypeID
+    );
+    [$keptFieldID, $keptValueID] = $this->createPriceFieldAndValue(
+      'thirty_five_euros',
+      'Thirty-five euros',
+      35.00,
+      $financialTypeID
+    );
+    $this->fixture += [
+      'omitted_field_id' => $omittedFieldID,
+      'omitted_value_id' => $omittedValueID,
+      'kept_field_id' => $keptFieldID,
+      'kept_value_id' => $keptValueID,
+    ];
+
+    $this->createPaidOrder(45.00, [
+      $this->getOrderLineItem($omittedFieldID, $omittedValueID, 'Ten euros', 10.00, $financialTypeID),
+      $this->getOrderLineItem($keptFieldID, $keptValueID, 'Thirty-five euros', 35.00, $financialTypeID),
+    ]);
+  }
+
+  /**
+   * Get the financial type ID of the default Donation type.
+   */
+  private function getDonationFinancialTypeID(): int {
+    return (int) CRM_Core_PseudoConstant::getKey(
+      'CRM_Contribute_BAO_Contribution',
+      'financial_type_id',
+      'Donation'
+    );
+  }
+
+  /**
+   * Create the contact, the price set, and the monetary event they belong to.
+   */
+  private function createEventWithPriceSet(int $financialTypeID): void {
+    $contact = civicrm_api3('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'first_name' => 'Fee selection',
+      'last_name' => 'Financial item test',
+    ]);
+    $this->fixture['contact_id'] = $contact['id'];
+
+    $priceSet = civicrm_api3('PriceSet', 'create', [
+      'name' => strtolower(__CLASS__) . '_' . uniqid(),
+      'title' => 'Fee selection financial item test',
+      'extends' => 'CiviEvent',
+      'financial_type_id' => $financialTypeID,
+      'is_active' => 1,
+    ]);
+    $this->fixture['price_set_id'] = $priceSet['id'];
+
+    $event = civicrm_api3('Event', 'create', [
+      'title' => 'Fee selection financial item test',
+      'start_date' => date('YmdHis'),
+      'event_type_id' => 1,
+      'is_monetary' => 1,
+      'is_active' => 1,
+    ]);
+    $this->fixture['event_id'] = $event['id'];
+    CRM_Price_BAO_PriceSet::addTo(
+      'civicrm_event',
+      $this->fixture['event_id'],
+      $this->fixture['price_set_id']
+    );
+  }
+
+  /**
+   * Register a participant with the given line items and pay the order in full.
+   *
+   * @param float $totalAmount
+   *   The order total, which is also the amount that gets paid.
+   * @param array $lineItems
+   *   Line-item parameter arrays as built by getOrderLineItem().
+   * @param array $extraOrderParams
+   *   Extra parameters for Order.create, such as tax_amount.
+   */
+  private function createPaidOrder(float $totalAmount, array $lineItems, array $extraOrderParams = []): void {
+    $order = civicrm_api3('Order', 'create', $extraOrderParams + [
+      'contact_id' => $this->fixture['contact_id'],
+      'financial_type_id' => $this->getDonationFinancialTypeID(),
+      'total_amount' => $totalAmount,
+      'is_test' => 1,
+      'line_items' => [
+        [
+          'params' => [
+            'contact_id' => $this->fixture['contact_id'],
+            'event_id' => $this->fixture['event_id'],
+            'status_id' => 'Registered',
+            'role_id' => 'Attendee',
+            'register_date' => date('YmdHis'),
+          ],
+          'line_item' => $lineItems,
+        ],
+      ],
+    ]);
+    $this->fixture['contribution_id'] = $order['id'];
+    $this->fixture['participant_id'] = (int) CRM_Core_DAO::singleValueQuery(
+      "SELECT entity_id
+       FROM civicrm_line_item
+       WHERE contribution_id = %1 AND entity_table = 'civicrm_participant'
+       LIMIT 1",
+      [
+        1 => [$this->fixture['contribution_id'], 'Integer'],
+      ]
+    );
+
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => $this->fixture['contribution_id'],
+      'total_amount' => $totalAmount,
+    ]);
+  }
+
+  /**
+   * Create one radio price field with one value.
+   *
+   * @return int[]
+   *   The price field ID and price field value ID.
+   */
+  private function createPriceFieldAndValue(
+    string $name,
+    string $label,
+    float $amount,
+    int $financialTypeID
+  ): array {
+    $priceField = civicrm_api3('PriceField', 'create', [
+      'price_set_id' => $this->fixture['price_set_id'],
+      'name' => $name,
+      'label' => $label,
+      'html_type' => 'Radio',
+      'is_active' => 1,
+    ]);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'create', [
+      'price_field_id' => $priceField['id'],
+      'name' => $name,
+      'label' => $label,
+      'amount' => $amount,
+      'financial_type_id' => $financialTypeID,
+      'is_active' => 1,
+    ]);
+    return [(int) $priceField['id'], (int) $priceFieldValue['id']];
+  }
+
+  /**
+   * Build one Order.create line-item parameter array.
+   */
+  private function getOrderLineItem(
+    int $fieldID,
+    int $valueID,
+    string $label,
+    float $amount,
+    int $financialTypeID
+  ): array {
+    return [
+      'price_field_id' => $fieldID,
+      'price_field_value_id' => $valueID,
+      'entity_table' => 'civicrm_participant',
+      'label' => $label,
+      'qty' => 1,
+      'unit_price' => $amount,
+      'line_total' => $amount,
+      'financial_type_id' => $financialTypeID,
+    ];
+  }
+
+  /**
+   * Get the individual financial item amounts of one line item, ascending.
+   *
+   * Asserting on the separate amounts rather than only on their sum makes a
+   * missing reversal and a duplicated one distinguishable: both leave a sum that
+   * a laxer assertion would accept.
+   *
+   * @return float[]
+   */
+  private function getFinancialItemAmounts(int $priceFieldValueID): array {
+    $amounts = CRM_Core_DAO::executeQuery(
+      "SELECT fi.amount
+       FROM civicrm_line_item li
+       INNER JOIN civicrm_financial_item fi
+         ON fi.entity_table = 'civicrm_line_item' AND fi.entity_id = li.id
+       WHERE li.contribution_id = %1 AND li.price_field_value_id = %2
+       ORDER BY fi.amount",
+      [
+        1 => [$this->fixture['contribution_id'], 'Integer'],
+        2 => [$priceFieldValueID, 'Integer'],
+      ]
+    )->fetchMap('amount', 'amount');
+    return array_map('floatval', array_values($amounts));
+  }
+
+  /**
+   * Get the net financial item total per financial account for one line item.
+   *
+   * @return array
+   *   Financial account ID => net amount.
+   */
+  private function getFinancialItemTotalsPerAccount(int $priceFieldValueID): array {
+    $totals = [];
+    $dao = CRM_Core_DAO::executeQuery(
+      "SELECT fi.financial_account_id AS account_id, SUM(fi.amount) AS total
+       FROM civicrm_line_item li
+       INNER JOIN civicrm_financial_item fi
+         ON fi.entity_table = 'civicrm_line_item' AND fi.entity_id = li.id
+       WHERE li.contribution_id = %1 AND li.price_field_value_id = %2
+       GROUP BY fi.financial_account_id",
+      [
+        1 => [$this->fixture['contribution_id'], 'Integer'],
+        2 => [$priceFieldValueID, 'Integer'],
+      ]
+    );
+    while ($dao->fetch()) {
+      $totals[(int) $dao->account_id] = (float) $dao->total;
+    }
+    return $totals;
+  }
+
+  /**
+   * Get the line-item state and the net amount of its financial items.
+   */
+  private function getLineItemFinancialSummary(int $priceFieldValueID): CRM_Core_DAO {
+    $dao = CRM_Core_DAO::executeQuery(
+      "SELECT li.qty, li.line_total, COALESCE(SUM(fi.amount), 0) AS net_financial_amount
+       FROM civicrm_line_item li
+       LEFT JOIN civicrm_financial_item fi
+         ON fi.entity_table = 'civicrm_line_item' AND fi.entity_id = li.id
+       WHERE li.contribution_id = %1 AND li.price_field_value_id = %2
+       GROUP BY li.id, li.qty, li.line_total",
+      [
+        1 => [$this->fixture['contribution_id'], 'Integer'],
+        2 => [$priceFieldValueID, 'Integer'],
+      ]
+    );
+    $this->assertTrue($dao->fetch(), 'Expected line item was not found.');
+    return $dao;
+  }
+
+  /**
+   * Clean up the fixture.
+   *
+   * quickCleanUpFinancialEntities() covers everything the fixture creates,
+   * including non-default price sets.
+   */
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    parent::tearDown();
+  }
+
+}


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/6721

> **Note on the related PR.** [#36646](https://github.com/civicrm/civicrm-core/pull/36646) touches the same method, removing a branch that has been unreachable since 2017. The two are independent: they merge into each other cleanly in either order, and with both applied the combined result passes both test classes. Kept apart because this one changes behaviour and that one does not, and because the removal carries an open design question that should not hold up these three fixes.

## Problem

Changing a price selection on a paid contribution can remove the recorded revenue
of line items that were submitted and did not change. The line item stays active
with its full amount, `total_amount` still matches, the payment is still there —
only the `civicrm_financial_item` rows are reversed. Nothing in the UI shows it.

In `getAdjustedFinancialItemsToRecord()`:

```php
// if not submitted and difference is not 0 make it negative
if ((empty($lineItemsToUpdate) || (in_array($updateFinancialItemInfoValues['price_field_value_id'], $priceFieldValueIDsToCancel) &&
    $totalFinancialAmount == $updateFinancialItemInfoValues['amount'])
  ) && $updateFinancialItemInfoValues['amount'] > 0
) {
```

The comment says "if not submitted" and the `in_array(...)` check does exactly
that. The `empty($lineItemsToUpdate) ||` in front short-circuits it, so whenever
there is nothing to update, every positive financial item on the contribution gets
reversed — including submitted, unchanged ones.

Replacing one option with another counts as cancel + add rather than an update, so
`$lineItemsToUpdate` is empty precisely in that case.

## Why this matters in practice

We are a small charity running summer camps for children, and this is how it bit
us. Participants register and pay in December. In June some of them decide they
want to rent a bike after all. The bike is a second price field on the same
registration, so adding it is just a price selection change.

For a participant who had originally selected "I'll bring my own bike", adding the
rental removed the revenue of their camp fee — a line that had nothing to do with
the bike. The registration still looked correct to our office staff: the amount was
right, the payment was right, the participant owed nothing. But the money was no
longer on a revenue account.

We only found it because our Contribution Summary and Bookkeeping Transactions
reports disagreed. Checking further, it turned out to go back years, on a long tail
of registrations where someone changed their mind about the bike.

The intermittent nature made it hard to spot: if the participant had made no
earlier choice on that field, there is nothing to cancel and
`changeFeeSelections()` skips `getAdjustedFinancialItemsToRecord()` entirely, so
the very same action is harmless. Same office task, same button, different outcome
depending on what the participant picked six months earlier.

## Second problem in the same condition: omitted discount lines

The trailing `$amount > 0` guard means a **negative** financial item is never
reversed. A discount is a price field value with a negative amount, so it carries a
negative financial item. When such a line is omitted from the submission, its line
item is correctly zeroed but its financial item stays, leaving a negative remainder
on the revenue account that the contribution no longer accounts for.

Concretely, with a EUR 10 line and a EUR -5 discount line, both paid, then
submitting only the EUR 10 line:

```
line item                    qty   line_total   net financial items
Ten euros (submitted)          1        10.00                10.00
Five euro discount (omitted)   0         0.00                -5.00   <-- should be 0
```

We have this in our own data too, on registrations where a family discount was
removed: seven cases spread over several years. It is smaller in money than the
first problem, but it is the same condition and the same kind of silent divergence,
so it seemed better to fix both at once than to leave half of it.

## Third problem in the same condition: lines with more than one financial item

`$totalFinancialAmount` is the sum over *all* financial items of the line item,
compared against the amount of the *individual* item being examined. For a line
item with exactly one financial item those are the same number. For anything else
they never are, so the condition matches on none of its items and the line is not
reversed at all.

Two ordinary situations produce more than one financial item on one line item:

- **Sales tax.** Revenue and tax are recorded as two items, on two different
  financial accounts.
- **A Text price field whose amount was adjusted before.** The `elseif` branch
  below records the difference as an additional item, so the line then carries two.

Measured on a clean master build, with 10% tax on a EUR 35 line, paid in full, then
submitting only the other line:

```
                     line item              financial items
before             qty 1, total 35.00       35.00 (revenue), 3.50 (tax)
after (unpatched)  qty 0, total  0.00       35.00 (revenue), 3.50 (tax)   <-- untouched
after (patched)    qty 0, total  0.00       35.00, 3.50, -35.00, -3.50
```

Both reversals land on the account of the item they reverse, so revenue and tax
each net to zero. A single combined reversal of -38.50 would have moved the tax off
the tax account onto the revenue account, which is why each item needs its own.

## Proposed change

Three changes, all in the one condition:

- Drop the `empty($lineItemsToUpdate) ||` shortcut, so the condition does what its
  comment already described: reverse only what is in `$priceFieldValueIDsToCancel`.
- Compare the amount against zero rather than requiring it to be positive, so an
  omitted discount line is reversed too.
- Stop comparing the amount against the line item total, and append to
  `$financialItemsArray` instead of keying it on `entity_id`, so every financial
  item of an omitted line gets its own reversal on its own account.

On the last point: keying on `entity_id` meant a second financial item silently
overwrote the first, which is why lifting the total comparison alone would not have
been enough. The loop that consumes the array reads only the values, so the key
carried no meaning.

What keeps this from reversing the same amount twice is
`getNonCancelledFinancialItems()`, which filters out items that already have a
matching reversal. Verified against a line item taken through two omit/restore
cycles: the items stay at 50.00, -50.00, 50.00, -50.00 and net to zero, with one
reversal per omission and no duplicates.

```diff
-      // if not submitted and difference is not 0 make it negative
-      if ((empty($lineItemsToUpdate) || (in_array($updateFinancialItemInfoValues['price_field_value_id'], $priceFieldValueIDsToCancel) &&
-          $totalFinancialAmount == $updateFinancialItemInfoValues['amount'])
-        ) && $updateFinancialItemInfoValues['amount'] > 0
+      if (in_array($updateFinancialItemInfoValues['price_field_value_id'], $priceFieldValueIDsToCancel)
+        && $updateFinancialItemInfoValues['amount'] != 0
       ) {
...
-        $financialItemsArray[$updateFinancialItemInfoValues['entity_id']] = $updateFinancialItemInfoValues;
+        $financialItemsArray[] = $updateFinancialItemInfoValues;
```

## Measured before and after (6.17.3)

Order with field A at EUR 10 and the free option of field B, paid in full, then
switching field B to the paid option (EUR 35) with the complete selection
submitted:

| | line items (qty > 0) | net financial items | reversals |
|---|---|---|---|
| before patch | 45.00 | 35.00 | 2 |
| after patch | 45.00 | 45.00 | 1 |

The one remaining reversal is the omitted free option, which is correct and
unchanged by this patch.

## Tests

`ChangeFeeSelectionsFinancialItemTest.php` covers all four sides:

- `testUnchangedLineItemKeepsItsFinancialItem()` — a submitted, unchanged line keeps
  its revenue.
- `testOmittedLineItemIsStillReversed()` — the intended reversal keeps working, so
  the fix does not trade one bug for another.
- `testOmittedNegativeLineItemIsAlsoReversed()` — the discount case.
- `testOmittedTaxedLineItemReversesBothItems()` — the multi-item case, asserting per
  financial account that revenue and tax each net to zero.

The assertions check the individual financial item amounts rather than only their
sum, so a missing reversal and a duplicated one are distinguishable.

Run against a clean `standalone-clean` master build:

- unpatched core: `Tests: 4, Assertions: 45, Failures: 3` — the three tests that pin
  down the defects fail, the guard test passes.
- with the patch: `OK (4 tests, 61 assertions)`.
- regression: `CRM/Event/Form/ParticipantTest.php` (22 tests, 881 assertions) and
  `api/v3/OrderTest.php` plus `api/v3/PaymentTest.php` (30 tests, 720 assertions)
  pass. Those are the only core test files that exercise `changeFeeSelections()` or
  `getAdjustedFinancialItemsToRecord()`.
- `civilint` is clean on both changed files.

The first of the three changes has been running on our production install since
30-08-2026, the second since 01-09-2026, and our own extension suite (79 tests,
including the payment and refund paths) passes with them.

## Adjacent problems this patch deliberately does not touch

Reviewing this condition turned up four further issues in the same code path. None
of them get worse by this patch, and the first one carries a warning worth reading
before anyone touches it.

**1. The reverse-transaction branch is dead code, and reviving it needs care.**
Line 730 calls `$this->getRelatedCancelFinancialTrxn(...)`, but the method is named
`_getRelatedCancelFinancialTrxn()` — with a leading underscore, and that name
appears nowhere else in the codebase. The call therefore falls through to
`DB_DataObject::__call()`, whose `_call()` takes the leading `get`, looks for a
*property* named `RelatedCancelFinancialTrxn`, does not find one, and returns
`NULL`. So `$updateFinancialItemInfoValues['financialTrxn']` is always empty and the
reverse `FinancialTrxn` branch in `changeFeeSelections()` never executes.

Please do not fix the name on its own. That helper reverses the *full transaction
amount* rather than the amount of the item it is called for
(`-$financialTrxn['api.FinancialTrxn.getsingle']['total_amount']`). With two
financial items on one payment — the ordinary sales-tax case — reviving it as-is
would create two reversals of the whole payment. Whoever revives it should allocate
per financial item at the same time.

**2. A wrong array key in `getNonCancelledFinancialItems()`.** Line 1195 reads
`unset($items['price_field_value_id'][$existingItemID]);` while the line directly
below it correctly uses `$financialItem['price_field_value_id']` as the key. As
written it clears an entry in an array that is never read.

**3. A wrong array key in the tax branch.** Line 745 indexes `$lineItemsToUpdate`
with `$updateFinancialItemInfoValues['entity_id']`, the line item ID, but that array
is populated with `price_field_value_id` as its key and read that way everywhere
else in the same condition.

**4. `validatePayments()` fails on a swap involving tax.** Replacing one taxed line
with another of the same price leaves the new line's financial items allocated to
the original payment, so the allocated total exceeds the payment. This reproduces on
unpatched core as well, so it is not caused by anything here.

The `tax` key this condition sets is also worth noting: `FinancialItem::create()`
runs its parameters through `copyValues()` and `civicrm_financial_item` has no `tax`
column, so that array is dropped. With each financial item now reversed
individually, the tax item is reversed on its own account anyway, which is what that
code was presumably reaching for.

## Note on the existing @todo

`changeFeeSelections()` already carries this note near the call:

```php
// @todo - this IF is to get this through PR merge but I suspect that it should not
// be necessary & is masking something else.
```

That is about the guard around the call rather than this condition, but it is the
same code path. It may well be describing this.

I am not a core developer, so if there is a reason this shortcut needs to stay —
some case where reversing everything is intended — I would rather hear it than have
the patch merged and break something else. Happy to adjust the approach.

