### PR TITLE
Don't use table locking on queue_items

### DIFF
--- a/CRM/Queue/Queue/Sql.php
+++ b/CRM/Queue/Queue/Sql.php
@@ -37,6 +37,18 @@ class CRM_Queue_Queue_Sql extends CRM_Queue_Queue {
   /**
    * Get the next item.
    *
+   * The SELECT then guarded UPDATE prevents two processes from claiming the same
+   * item without requiring table-level locking. The subquery picks the head of
+   * the queue regardless of if it has been claimed; the outer WHERE returns it
+   * only if it's available, so we don't fall through to the next item
+   * (see testBasicLinearPolling).
+   * Retry rather than directly returning NULL so this doesn't falsely indicate
+   * that the queue is empty.
+   *
+   * TODO: On MariaDB 10.6+ / MySQL 8+ we could use SELECT ... FOR UPDATE SKIP LOCKED
+   * instead, so a claimer never picks the same candidate that another just selected
+   * (avoiding the retry).
+   *
    * @param int|null $lease_time
    *   Hold a lease on the claimed item for $X seconds.
    *   If NULL, inherit a queue default (`$queueSpec['lease_time']`) or system default (`DEFAULT_LEASE_TIME`).
@@ -46,41 +58,39 @@ class CRM_Queue_Queue_Sql extends CRM_Queue_Queue {
   public function claimItem($lease_time = NULL) {
     $lease_time = $lease_time ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
 
-    $result = NULL;
-    CRM_Core_DAO::executeQuery('LOCK TABLES civicrm_queue_item WRITE;');
-    $sql = '
-        SELECT first_in_queue.* FROM (
-          SELECT id, queue_name, submit_time, release_time, run_count, data
-          FROM civicrm_queue_item
-          WHERE queue_name = %1
-          ORDER BY weight, id
-          LIMIT 1
-        ) first_in_queue
-        WHERE release_time IS NULL OR UNIX_TIMESTAMP(release_time) < %2
-      ';
-    $params = [
-      1 => [$this->getName(), 'String'],
-      2 => [CRM_Utils_Time::time(), 'Integer'],
-    ];
-    $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, 'CRM_Queue_DAO_QueueItem');
+    $maxAttempts = 5;
+    for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
+      $dao = CRM_Core_DAO::executeQuery('
+          SELECT first_in_queue.* FROM (
+            SELECT id, queue_name, submit_time, release_time, run_count, data
+            FROM civicrm_queue_item
+            WHERE queue_name = %1
+            ORDER BY weight, id
+            LIMIT 1
+          ) first_in_queue
+          WHERE release_time IS NULL OR UNIX_TIMESTAMP(release_time) < %2
+        ', [
+          1 => [$this->getName(), 'String'],
+          2 => [CRM_Utils_Time::time(), 'Integer'],
+        ], TRUE, 'CRM_Queue_DAO_QueueItem');
 
-    if ($dao->fetch()) {
-      $nowEpoch = CRM_Utils_Time::getTimeRaw();
-      $dao->run_count++;
-      $sql = 'UPDATE civicrm_queue_item SET release_time = from_unixtime(unix_timestamp() + %1), run_count = %3 WHERE id = %2';
-      $sqlParams = [
-        '1' => [CRM_Utils_Time::delta() + $lease_time, 'Integer'],
-        '2' => [$dao->id, 'Integer'],
-        '3' => [$dao->run_count, 'Integer'],
-      ];
-      CRM_Core_DAO::executeQuery($sql, $sqlParams);
-      $dao->data = unserialize($dao->data);
-      $result = $dao;
+      if (!$dao->fetch()) {
+        return NULL;
+      }
+
+      if ($this->attemptClaim($dao, $lease_time)) {
+        $dao->run_count++;
+        $dao->data = unserialize($dao->data);
+        return $dao;
+      }
+      // If we can't claim the selected item, retry
     }
 
-    CRM_Core_DAO::executeQuery('UNLOCK TABLES;');
-
-    return $result;
+    \Civi::log('queue')->warning('Failed to claim item from queue "{queue}" after {attempts} attempts due to contention.', [
+      'queue' => $this->getName(),
+      'attempts' => $maxAttempts,
+    ]);
+    return NULL;
   }
 
   /**

--- a/CRM/Queue/Queue/SqlParallel.php
+++ b/CRM/Queue/Queue/SqlParallel.php
@@ -43,51 +43,60 @@ class CRM_Queue_Queue_SqlParallel extends CRM_Queue_Queue implements CRM_Queue_Q
   }
 
   /**
+   * Claim multiple items.
+   *
+   * Claims each row via attemptClaim()'s guarded UPDATE to prevent
+   * duplicate claims.
+   *
+   * A candidate claimed by another process is left out of the result,
+   * but if all candidates are unclaimed, it retries — otherwise it
+   * reports an empty result that looks like the queue is empty.
+   *
    * @inheritDoc
    */
   public function claimItems(int $limit, ?int $lease_time = NULL): array {
     $lease_time = $lease_time ?: $this->getSpec('lease_time') ?: static::DEFAULT_LEASE_TIME;
     $limit = $this->getSpec('batch_limit') ? min($limit, $this->getSpec('batch_limit')) : $limit;
 
-    $dao = CRM_Core_DAO::executeQuery('LOCK TABLES civicrm_queue_item WRITE;');
-    $sql = "SELECT id, queue_name, submit_time, release_time, run_count, data
-        FROM civicrm_queue_item
-        WHERE queue_name = %1
-              AND (release_time IS NULL OR UNIX_TIMESTAMP(release_time) < %2)
-        ORDER BY weight ASC, id ASC
-        LIMIT %3
-      ";
-    $params = [
-      1 => [$this->getName(), 'String'],
-      2 => [CRM_Utils_Time::time(), 'Integer'],
-      3 => [$limit, 'Integer'],
-    ];
-    $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, 'CRM_Queue_DAO_QueueItem');
-    if (is_a($dao, 'DB_Error')) {
-      // FIXME - Adding code to allow tests to pass
-      CRM_Core_Error::fatal();
-    }
-
-    $result = [];
-    while ($dao->fetch()) {
-      $result[] = (object) [
-        'id' => $dao->id,
-        'data' => unserialize($dao->data),
-        'queue_name' => $dao->queue_name,
-        'run_count' => 1 + (int) $dao->run_count,
+    $maxAttempts = 5;
+    for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
+      $sql = "SELECT id, queue_name, submit_time, release_time, run_count, data
+          FROM civicrm_queue_item
+          WHERE queue_name = %1
+                AND (release_time IS NULL OR UNIX_TIMESTAMP(release_time) < %2)
+          ORDER BY weight ASC, id ASC
+          LIMIT %3
+        ";
+      $params = [
+        1 => [$this->getName(), 'String'],
+        2 => [CRM_Utils_Time::time(), 'Integer'],
+        3 => [$limit, 'Integer'],
       ];
-    }
-    if ($result) {
-      $sql = CRM_Utils_SQL::interpolate('UPDATE civicrm_queue_item SET release_time = FROM_UNIXTIME(UNIX_TIMESTAMP() + #release), run_count = 1+run_count WHERE id IN (#ids)', [
-        'release' => CRM_Utils_Time::delta() + $lease_time,
-        'ids' => CRM_Utils_Array::collect('id', $result),
-      ]);
-      CRM_Core_DAO::executeQuery($sql);
+      $dao = CRM_Core_DAO::executeQuery($sql, $params, TRUE, 'CRM_Queue_DAO_QueueItem');
+
+      $result = [];
+      while ($dao->fetch()) {
+        if ($this->attemptClaim($dao, $lease_time)) {
+          $result[] = (object) [
+            'id' => $dao->id,
+            'data' => unserialize($dao->data),
+            'queue_name' => $dao->queue_name,
+            'run_count' => 1 + (int) $dao->run_count,
+          ];
+        }
+      }
+
+      if (!$dao->N || $result) {
+        return $result;
+      }
+      // Every candidate was claimed by another process, retry
     }
 
-    $dao = CRM_Core_DAO::executeQuery('UNLOCK TABLES;');
-
-    return $result;
+    \Civi::log('queue')->warning('Failed to claim any items from queue "{queue}" after {attempts} attempts due to contention.', [
+      'queue' => $this->getName(),
+      'attempts' => $maxAttempts,
+    ]);
+    return [];
   }
 
   /**

--- a/CRM/Queue/Queue/SqlTrait.php
+++ b/CRM/Queue/Queue/SqlTrait.php
@@ -199,6 +199,40 @@ trait CRM_Queue_Queue_SqlTrait {
     $this->releaseItems($items);
   }
 
+  /**
+   * Try to claim a specific candidate row via a guarded UPDATE.
+   *
+   * This allows claiming of items without table-level locking:
+   * the UPDATE only succeeds if the row's run_count still matches what
+   * the caller's SELECT returned and the release_time is still eligible,
+   * so two processes can't both successfully claim the same row if they
+   * select it concurrently.
+   *
+   * @param object $dao
+   *   The candidate row.
+   * @param int $lease_time
+   *
+   * @return bool
+   *   TRUE if claimed; FALSE if another process has claimed the item (run
+   *   count incremented) or release time is now in the future.
+   */
+  protected function attemptClaim($dao, int $lease_time): bool {
+    $result = CRM_Core_DAO::executeQuery('
+        UPDATE civicrm_queue_item
+        SET release_time = from_unixtime(unix_timestamp() + %1), run_count = %2
+        WHERE id = %3
+          AND run_count = %4
+          AND (release_time IS NULL OR UNIX_TIMESTAMP(release_time) < %5)
+      ', [
+        1 => [CRM_Utils_Time::delta() + $lease_time, 'Integer'],
+        2 => [$dao->run_count + 1, 'Integer'],
+        3 => [$dao->id, 'Integer'],
+        4 => [$dao->run_count, 'Integer'],
+        5 => [CRM_Utils_Time::time(), 'Integer'],
+      ]);
+    return (bool) $result->affectedRows();
+  }
+
   protected function freeDAOs($mixed) {
     $mixed = (array) $mixed;
     foreach ($mixed as $item) {

--- a/tests/phpunit/CRM/Queue/Queue/RacesCandidateTrait.php
+++ b/tests/phpunit/CRM/Queue/Queue/RacesCandidateTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Test instrumentation for CRM_Queue_Queue_Sql / CRM_Queue_Queue_SqlParallel.
+ *
+ * Mix into an anonymous subclass of either queue to simulate a candidate
+ * that gets claimed-then-released by another process a number of
+ * times before finally being successfully claimed.
+ */
+trait CRM_Queue_Queue_RacesCandidateTrait {
+
+  /**
+   * @var int
+   */
+  public $racesRemaining = 0;
+
+  /**
+   * @var int
+   */
+  public $attemptCount = 0;
+
+  protected function attemptClaim($dao, int $lease_time): bool {
+    $this->attemptCount++;
+    if ($this->racesRemaining > 0) {
+      $this->racesRemaining--;
+      // run_count advances (so the guarded UPDATE will fail),
+      // but the item is available again on the next SELECT.
+      CRM_Core_DAO::executeQuery('UPDATE civicrm_queue_item SET run_count = run_count + 1 WHERE id = %1', [
+        1 => [$dao->id, 'Integer'],
+      ]);
+    }
+    return parent::attemptClaim($dao, $lease_time);
+  }
+
+}

--- a/tests/phpunit/CRM/Queue/Queue/SqlParallelTest.php
+++ b/tests/phpunit/CRM/Queue/Queue/SqlParallelTest.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * @group headless
+ * @group queue
+ */
+class CRM_Queue_Queue_SqlParallelTest extends CiviUnitTestCase {
+
+  use \Civi\Test\QueueTestTrait;
+
+  public function tearDown(): void {
+    CRM_Utils_Time::resetTime();
+
+    $tablesToTruncate = ['civicrm_queue_item'];
+    $this->quickCleanup($tablesToTruncate);
+    parent::tearDown();
+  }
+
+  /**
+   * claimItems() claims each candidate via attemptClaim()'s guarded UPDATE.
+   * Simulate a race by selecting a batch of 3 then having another process
+   * claim the middle item in between the initial SELECT and attemptClaim()
+   * being called for it.
+   */
+  public function testClaimItemsExcludesCandidateLostToRace() {
+    $setupQueue = new CRM_Queue_Queue_SqlParallel(['type' => 'SqlParallel', 'name' => 'test-queue']);
+    $setupQueue->createItem(['test-key' => 'a']);
+    $setupQueue->createItem(['test-key' => 'b']);
+    $setupQueue->createItem(['test-key' => 'c']);
+
+    $ids = array_column(CRM_Core_DAO::executeQuery('SELECT id FROM civicrm_queue_item WHERE queue_name = %1 ORDER BY weight, id', [
+      1 => ['test-queue', 'String'],
+    ])->fetchAll(), 'id');
+    $this->assertCount(3, $ids);
+
+    $queue = $this->makeQueueThatRacesCandidate($ids[1]);
+
+    $result = $queue->claimItems(3);
+
+    $this->assertEquals([$ids[0], $ids[2]], array_column($result, 'id'), 'The raced item should be excluded; the others should keep their original order.');
+  }
+
+  /**
+   * @param int $raceItemId
+   * @return CRM_Queue_Queue_SqlParallel
+   *   A queue that simulates another process claiming item $raceItemId in
+   *   between claimItems()'s SELECT and attemptClaim() being called for it.
+   */
+  private function makeQueueThatRacesCandidate(int $raceItemId) {
+    $queue = new class(['type' => 'SqlParallel', 'name' => 'test-queue']) extends CRM_Queue_Queue_SqlParallel {
+      public $raceItemId;
+
+      protected function attemptClaim($dao, int $lease_time): bool {
+        if ((int) $dao->id === $this->raceItemId) {
+          CRM_Core_DAO::executeQuery('UPDATE civicrm_queue_item SET release_time = from_unixtime(unix_timestamp() + 60), run_count = run_count + 1 WHERE id = %1', [
+            1 => [$this->raceItemId, 'Integer'],
+          ]);
+        }
+        return parent::attemptClaim($dao, $lease_time);
+      }
+
+    };
+    $queue->raceItemId = $raceItemId;
+    return $queue;
+  }
+
+  /**
+   * If every candidate in a batch loses its race, claimItems() must retry
+   * rather than reporting an empty result.
+   *
+   * Simulate a candidate that gets claimed-then-released by another process
+   * a few times in a row before finally being claimable.
+   */
+  public function testClaimItemsRetriesWhenAllCandidatesLostRace() {
+    $queue = $this->makeQueueThatLosesRaceNTimes(3);
+    $queue->createItem(['test-key' => 'a']);
+    $queue->createItem(['test-key' => 'b']);
+
+    $result = $queue->claimItems(1);
+
+    $this->assertCount(1, $result);
+    $this->assertEquals('a', $result[0]->data['test-key']);
+    $this->assertEquals(4, $queue->attemptCount, 'Should retry until it wins: 3 losses + 1 success.');
+  }
+
+  /**
+   * @param int $racesRemaining
+   * @return CRM_Queue_Queue_SqlParallel
+   *   A queue whose candidate loses its race the first $racesRemaining
+   *   times attemptClaim() is called for it, then succeeds in claiming.
+   */
+  private function makeQueueThatLosesRaceNTimes(int $racesRemaining) {
+    $queue = new class(['type' => 'SqlParallel', 'name' => 'test-queue']) extends CRM_Queue_Queue_SqlParallel {
+      use CRM_Queue_Queue_RacesCandidateTrait;
+    };
+    $queue->racesRemaining = $racesRemaining;
+    return $queue;
+  }
+
+}

--- a/tests/phpunit/CRM/Queue/Queue/SqlTest.php
+++ b/tests/phpunit/CRM/Queue/Queue/SqlTest.php
@@ -138,4 +138,88 @@ class CRM_Queue_Queue_SqlTest extends CiviUnitTestCase {
     $this->assertQueueStats(0, 0, 0, $this->queue);
   }
 
+  /**
+   * claimItem()'s guarded UPDATE (attemptClaim()) is what prevents two
+   * processes from claiming the same item without table-level locking.
+   * Simulate the race by claiming the item once, then try attemptClaim()
+   * again using the state a racer would have read before that claim:
+   * once with a stale run_count and once with a release_time that's since
+   * moved into the future (e.g. releaseItem() set a later retry,
+   * which doesn't touch run_count).
+   */
+  public function testAttemptClaimRejectsStaleClaims() {
+    $queue = $this->makeInstrumentedQueue(['type' => 'Sql', 'name' => 'test-queue', 'retry_interval' => 100]);
+    $queue->createItem(['test-key' => 'a']);
+
+    $id = (int) CRM_Core_DAO::singleValueQuery('SELECT id FROM civicrm_queue_item WHERE queue_name = %1', [
+      1 => ['test-queue', 'String'],
+    ]);
+    $staleDao = (object) ['id' => $id, 'run_count' => 0];
+
+    // Someone else claims it first.
+    $item = $queue->claimItem();
+    $this->assertEquals($id, $item->id);
+    $this->assertEquals(1, $item->run_count);
+
+    // A racer holding the pre-claim run_count must be rejected.
+    $won = $queue->attemptClaim($staleDao, 60);
+    $this->assertFalse($won, 'A claim based on stale run_count should be rejected.');
+    $this->assertEquals(1, CRM_Core_DAO::singleValueQuery('SELECT run_count FROM civicrm_queue_item WHERE id = %1', [
+      1 => [$id, 'Integer'],
+    ]), 'The winning claim should be untouched.');
+
+    // The claimant releases it for a later retry: run_count stays the same,
+    // but release_time moves into the future.
+    $queue->releaseItem($item);
+
+    // A racer whose run_count still matches the current value must still be
+    // rejected, since the item is now on a retry delay.
+    $stillCurrentDao = (object) ['id' => $id, 'run_count' => $item->run_count];
+    $won = $queue->attemptClaim($stillCurrentDao, 60);
+    $this->assertFalse($won, 'A claim must be rejected once release_time has moved into the future, even if run_count still matches.');
+  }
+
+  /**
+   * @param array $queueSpec
+   * @return CRM_Queue_Queue_Sql
+   *   A queue with attemptClaim() made public.
+   */
+  private function makeInstrumentedQueue(array $queueSpec = ['type' => 'Sql', 'name' => 'test-queue']) {
+    return new class($queueSpec) extends CRM_Queue_Queue_Sql {
+
+      public function attemptClaim($dao, int $lease_time): bool {
+        return parent::attemptClaim($dao, $lease_time);
+      }
+
+    };
+  }
+
+  /**
+   * If claimItem() keeps losing the race to another process, it must retry
+   * with a fresh SELECT and eventually succeed.
+   */
+  public function testClaimItemRetriesUntilItWins() {
+    $queue = $this->makeQueueThatLosesRaceNTimes(3);
+    $queue->createItem(['test-key' => 'a']);
+
+    $item = $queue->claimItem();
+
+    $this->assertEquals('a', $item->data['test-key']);
+    $this->assertEquals(4, $queue->attemptCount, 'Should retry until it wins: 3 losses + 1 success.');
+  }
+
+  /**
+   * @param int $racesRemaining
+   * @return CRM_Queue_Queue_Sql
+   *   A queue whose candidate loses its race the first $racesRemaining
+   *   times attemptClaim() is called for it, then wins normally.
+   */
+  private function makeQueueThatLosesRaceNTimes(int $racesRemaining) {
+    $queue = new class(['type' => 'Sql', 'name' => 'test-queue']) extends CRM_Queue_Queue_Sql {
+      use CRM_Queue_Queue_RacesCandidateTrait;
+    };
+    $queue->racesRemaining = $racesRemaining;
+    return $queue;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Locking the whole table when claiming queue items can cause deadlocks when another process attempts to insert a new queue item. See discussion [here](https://github.com/civicrm/civicrm-packages/pull/446#issuecomment-5027539813) and #15421 which added the table locking.

Before
----------------------------------------
The whole table is locked to select and claim queue items.

After
----------------------------------------
First select the relevant row(s) that the process intends to claim. Then attempt to claim them, checking run count and release date, and if unsuccessful because another process got there first, retry up to 5 times. 

Technical Details
----------------------------------------

- As noted, this could be simplified once we require MySQL 8.0.
- claimItems() in SQLParallel now runs one UPDATE per queue item it is trying to claim. I think N+1 queries without locking the table is better than 2 queries on a locked table.
- I also considered doing UPDATE first and then SELECT to see which items were successfully claimed (this would require a new field to allow this function to mark which items it is claiming with a unique ID). That simplifies things a little, but the cost is that we could no longer tell if we claimed 0 items because there were none to claim or if we claimed 0 items because another process grabbed them out from under us, so we wouldn't know whether to try or not.
- 5 is an arbitrary number of retries which should be plenty unless things have gone wrong somehow.

Comments
----------------------------------------

- I've added some tests, but these are necessarily meagre as it isn't really possible to mock this in a test. I've also smoke tested in the debugger by editing the queue rows.
- Also, I learned in this process that deadlocks due to table-level locks are not logged like row-level locking deadlocks are logged in MySQL/MariaDB. In fact they aren't logged at all. That made figuring this one out more difficult, but fortunately the ones I'm proposing to remove here are the only table-level locks in core (except the one in the installer compatibility check). **Maybe [that installer check](checkMysqlLockTables) could go away now?**
- We will test this at WMF to make sure it does indeed reduce the deadlocks
