### PR TITLE
Enforce inactive user checks for Standalone AuthX

### DIFF
--- a/ext/standaloneusers/Civi/Authx/Standalone.php
+++ b/ext/standaloneusers/Civi/Authx/Standalone.php
@@ -97,8 +97,15 @@ class Standalone implements AuthxInterface {
    * @inheritDoc
    */
   public function getUserIsBlocked($userId) {
-    // ToDo
-    return FALSE;
+    $user = \Civi\Api4\User::get(FALSE)
+      ->addSelect('is_active')
+      ->addWhere('id', '=', $userId)
+      ->execute()
+      ->first();
+
+    // An unknown user is handled by the normal invalid-principal checks, while
+    // an inactive Standalone user is blocked.
+    return $user !== NULL && !$user['is_active'];
   }
 
 }

--- a/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
+++ b/ext/standaloneusers/tests/phpunit/Civi/Standalone/SecurityTest.php
@@ -80,6 +80,28 @@ class SecurityTest extends \PHPUnit\Framework\TestCase implements EndToEndInterf
     $this->assertFalse($security->checkPassword(['password' => 'some other password'], $user));
   }
 
+  public function testAuthxRecognizesInactiveUsers(): void {
+    [, $userID] = $this->createFixtureContactAndUser();
+    $authx = new \Civi\Authx\Standalone();
+
+    $this->assertFalse($authx->getUserIsBlocked($userID));
+
+    User::update(FALSE)
+      ->addValue('is_active', FALSE)
+      ->addWhere('id', '=', $userID)
+      ->execute();
+
+    $this->assertTrue($authx->getUserIsBlocked($userID));
+    $this->assertFalse($authx->getUserIsBlocked(999999999));
+
+    $this->expectException(\Civi\Authx\AuthxException::class);
+    $this->expectExceptionMessage('Cannot login. User is blocked.');
+    authx_login([
+      'useSession' => TRUE,
+      'principal' => ['userId' => $userID],
+    ]);
+  }
+
   public function testPerms() {
     [$contactID, $userID, $security] = $this->createFixtureContactAndUser();
     $ufID = \CRM_Core_BAO_UFMatch::getUFId($contactID);


### PR DESCRIPTION
## Overview

Implement the Standalone AuthX blocked-user check using the local User.is_active value.

The AuthX login flow already calls getUserIsBlocked() before opening a session, but the Standalone adapter previously returned false unconditionally. This allowed a trusted AuthX caller to open a new session for a locally inactive Standalone user.

Unknown user IDs continue through the existing invalid-principal handling.

This change prevents new AuthX logins for inactive Standalone users. It does not revoke sessions that are already active.

## Testing

- Added coverage for active, inactive, and unknown Standalone user IDs
- Added an integration assertion that authx_login() with useSession enabled rejects an inactive user with Cannot login. User is blocked.
- Focused Standalone tests: 2 tests, 9 assertions
- PHP syntax and git diff checks
- Drupal PHP_CodeSniffer standard on both changed files