### PR TITLE
AdminUI - Only show enabled fields on custom forms

### DIFF
--- a/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
+++ b/ext/afform/core/Civi/Api4/Action/CustomGroup/GetAfforms.php
@@ -55,8 +55,11 @@ class GetAfforms extends \Civi\Api4\Generic\BasicBatchAction {
   protected function doTask($item) {
     $forms = [];
 
-    // get field names once, for use across all the generate actions
+    // Get all enabled fields
     $fields = \CRM_Core_BAO_CustomGroup::getGroup(['id' => $item['id']])['fields'];
+    $fields = array_filter($fields, function ($field) {
+      return $field['is_active'];
+    });
     $item['field_names'] = array_column($fields, 'name');
 
     // Custom group has no enabled fields; nothing to generate.


### PR DESCRIPTION
Overview
----------------------------------------
Excludes disabled custom fields on the custom field view/edit forms generated by AdminUI.