### PR TITLE
[dev/core#6317] Also update unedited default template if text field empty

### DIFF
--- a/CRM/Upgrade/Incremental/MessageTemplates.php
+++ b/CRM/Upgrade/Incremental/MessageTemplates.php
@@ -304,23 +304,26 @@ class CRM_Upgrade_Incremental_MessageTemplates {
       $fileExists = [];
       foreach (['html', 'text', 'subject'] as $type) {
         $filePath = \Civi::paths()->getPath('[civicrm.root]/xml/templates/message_templates/' . $dao->workflow_name . '_' . $type . '.tpl');
-        if (!file_exists($filePath)) {
+        $fileExists[$type] = file_exists($filePath);
+        $content = FALSE;
+
+        if (!$fileExists[$type]) {
           // We could be here for two reasons:
           // 1. This may be a core template where the text field is no longer used and so we want to blank out the text field
           //    to make sure to remove old text versions. We make the reasonable assumption this is the situation if there is
           //    no text file but there is an html file.
           // 2. The query may have picked up some non-core templates that will not have files to find, and so we simply skip.
           if (($type == 'text') && (!empty($fileExists['html']))) {
-            CRM_Core_DAO::executeQuery(
-              "UPDATE civicrm_msg_template SET msg_{$type} = '' WHERE id = %1", [
-                1 => [$dao->id, 'Integer'],
-              ]
-            );
+            $content = '';
           }
-          continue;
+          else {
+            continue;
+          }
         }
-        $fileExists[$type] = TRUE;
-        $content = file_get_contents($filePath);
+        else {
+          $content = file_get_contents($filePath);
+        }
+
         if ($content !== FALSE) {
           CRM_Core_DAO::executeQuery(
             "UPDATE civicrm_msg_template SET msg_{$type} = %1 WHERE id = %2", [


### PR DESCRIPTION
Overview
----------------------------------------
This is a follow-up to #36622 which also now empties out the text field of unedited default templates (as well as reserved workflow templates) if the text template has been intentionally deleted.

Before
----------------------------------------
Only `is_reserved` template updated.

After
----------------------------------------
Both `is_reserved` and `is_default` template updated if default has not been edited.

Technical Details
----------------------------------------
In the initial ticket, it was noticed that messages with differing reserved vs default text fields are not counted as 'edited', so this may unintentionally clear out edited templates as well. NEEDS TESTING!

Comments
----------------------------------------
Untested - just a proposal if needed.
