### PR TITLE
SearchKit - Autofix user-error in path args

### DIFF
--- a/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
+++ b/ext/search_kit/Civi/Api4/Action/SearchDisplay/AbstractRunAction.php
@@ -1027,6 +1027,10 @@ abstract class AbstractRunAction extends \Civi\Api4\Generic\AbstractAction {
       'conditions' => [],
     ];
     $entity = $link['entity'];
+    // Fix user error - if path has args but omits the question mark, change the first `&` to a `?`
+    if ($link['path'] && str_contains($link['path'], '&') && !str_contains($link['path'], '?')) {
+      $link['path'] = preg_replace('/&/', '?', $link['path'], 1);
+    }
     if ($entity && CoreUtil::entityExists($entity)) {
       $idKey = $this->getIdKeyName($entity);
       // Hack to support links to relationships

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchRunTest.php
@@ -402,7 +402,8 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
                   'target' => 'crm-popup',
                 ],
                 [
-                  'path' => 'civicrm/test',
+                  // Intentional user-error (omitting the `?`) AbstractRunAction::preprocessLink should automatically fix this
+                  'path' => 'civicrm/test&foo=1&bar=2',
                   'text' => 'Test Link',
                   'title' => 'View [contact_id.display_name]',
                   'icon' => 'fa-test',
@@ -438,6 +439,8 @@ class SearchRunTest extends Api4TestBase implements TransactionalInterface {
     $this->assertEquals('Test Link', $result[0]['columns'][1]['links'][3]['text']);
     $this->assertEquals('View ' . $result[0]['data']['contact_id.display_name'], $result[0]['columns'][1]['links'][3]['title']);
     $this->assertEquals('fa-test', $result[0]['columns'][1]['links'][3]['icon']);
+    // The user-error malformed path should have been fixed
+    $this->assertStringContainsString('?q=civicrm/test&foo=1&bar=2', $result[0]['columns'][1]['links'][3]['url']);
   }
 
   public function testContactMapLink(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Now SearchKit autocorrects the common user-error where the path accidentally omits the `?` before the first arg (this happens a lot with copy-paste).

`civicrm/test&foo=1&bar=2` will be corrected to `civicrm/test?foo=1&bar=2` (adding a question mark in place of the first ampersand).

Fixes [dev/core#6714](https://lab.civicrm.org/dev/core/-/work_items/6714)