### PR TITLE
dev/core#6728 changeFeeSelections: remove the reverse-transaction branch that has never run

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -636,29 +636,11 @@ WHERE li.contribution_id = %1";
     }
     // $contributionId must not be NULL
     $trxn = $lineItemObj->_recordAdjustedAmt($updatedAmount, $contributionId, $taxAmount, $updateAmountLevel);
-    $contributionStatus = CRM_Core_PseudoConstant::getName('CRM_Contribute_DAO_Contribution', 'contribution_status_id', CRM_Core_DAO::getFieldValue('CRM_Contribute_DAO_Contribution', $contributionId, 'contribution_status_id'));
 
     if (!empty($financialItemsArray)) {
       foreach ($financialItemsArray as $updateFinancialItemInfoValues) {
         $newFinancialItem = CRM_Financial_BAO_FinancialItem::create($updateFinancialItemInfoValues);
-        // record reverse transaction only if Contribution is Completed because for pending refund or
-        //   partially paid we are already recording the surplus owed or refund amount
-        if (!empty($updateFinancialItemInfoValues['financialTrxn']) && ($contributionStatus == 'Completed')) {
-          $updateFinancialItemInfoValues = array_merge($updateFinancialItemInfoValues['financialTrxn'], [
-            'entity_id' => $newFinancialItem->id,
-            'entity_table' => 'civicrm_financial_item',
-          ]);
-          $reverseTrxn = CRM_Core_BAO_FinancialTrxn::create($updateFinancialItemInfoValues);
-          // record reverse entity financial trxn linked to membership's related contribution
-          civicrm_api3('EntityFinancialTrxn', 'create', [
-            'entity_table' => "civicrm_contribution",
-            'entity_id' => $contributionId,
-            'financial_trxn_id' => $reverseTrxn->id,
-            'amount' => $reverseTrxn->total_amount,
-          ]);
-          unset($updateFinancialItemInfoValues['financialTrxn']);
-        }
-        elseif ($trxn && $newFinancialItem->amount != 0) {
+        if ($trxn && $newFinancialItem->amount != 0) {
           civicrm_api3('EntityFinancialTrxn', 'create', [
             'entity_id' => $newFinancialItem->id,
             'entity_table' => 'civicrm_financial_item',
@@ -697,7 +679,6 @@ WHERE li.contribution_id = %1";
       $updateFinancialItemInfoValues['transaction_date'] = date('YmdHis');
 
       // the below params are not needed as we are creating new financial item
-      $previousFinancialItemID = $updateFinancialItemInfoValues['id'];
       $totalFinancialAmount = $this->checkFinancialItemTotalAmountByLineItemID($updateFinancialItemInfoValues['entity_id']);
       unset($updateFinancialItemInfoValues['id']);
       unset($updateFinancialItemInfoValues['created_date']);
@@ -711,8 +692,6 @@ WHERE li.contribution_id = %1";
 
         // INSERT negative financial_items
         $updateFinancialItemInfoValues['amount'] = -$updateFinancialItemInfoValues['amount'];
-        // reverse the related financial trxn too
-        $updateFinancialItemInfoValues['financialTrxn'] = $this->getRelatedCancelFinancialTrxn($previousFinancialItemID);
         if ($previousLineItems[$updateFinancialItemInfoValues['entity_id']]['tax_amount']) {
           $updateFinancialItemInfoValues['tax']['amount'] = -($previousLineItem['tax_amount']);
           $updateFinancialItemInfoValues['tax']['description'] = $this->getSalesTaxTerm();
@@ -1042,45 +1021,6 @@ WHERE li.contribution_id = %1";
       }
     }
     return ($taxRate / 100) * $params['line_total'];
-  }
-
-  /**
-   * Helper function to retrieve financial trxn parameters to reverse
-   *  for given financial item identified by $financialItemID
-   *
-   * @param int $financialItemID
-   *
-   * @return array $financialTrxn
-   *
-   */
-  protected function _getRelatedCancelFinancialTrxn($financialItemID) {
-    try {
-      $financialTrxn = civicrm_api3('EntityFinancialTrxn', 'getsingle', [
-        'entity_table' => 'civicrm_financial_item',
-        'entity_id' => $financialItemID,
-        'options' => [
-          'sort' => 'id DESC',
-          'limit' => 1,
-        ],
-        'api.FinancialTrxn.getsingle' => [
-          'id' => "\$value.financial_trxn_id",
-        ],
-      ]);
-    }
-    catch (CRM_Core_Exception $e) {
-      return [];
-    }
-
-    $financialTrxn = array_merge($financialTrxn['api.FinancialTrxn.getsingle'], [
-      'trxn_date' => date('YmdHis'),
-      'total_amount' => -$financialTrxn['api.FinancialTrxn.getsingle']['total_amount'],
-      'net_amount' => -$financialTrxn['api.FinancialTrxn.getsingle']['net_amount'],
-      'entity_table' => 'civicrm_financial_item',
-      'entity_id' => $financialItemID,
-    ]);
-    unset($financialTrxn['id']);
-
-    return $financialTrxn;
   }
 
   /**

--- a/tests/phpunit/CRM/Price/BAO/ChangeFeeSelectionsPaymentTest.php
+++ b/tests/phpunit/CRM/Price/BAO/ChangeFeeSelectionsPaymentTest.php
@@ -1,0 +1,222 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC. All rights reserved.                        |
+ |                                                                    |
+ | This work is published under the GNU AGPLv3 license with some      |
+ | permitted exceptions and without any warranty. For full license    |
+ | and copyright information, see https://civicrm.org/licensing       |
+ +--------------------------------------------------------------------+
+ */
+
+/**
+ * Tests that changing a fee selection leaves the recorded payment alone.
+ *
+ * Swapping one price option for another of the same price changes nothing about
+ * what is owed or what was paid, so the payment recorded against the contribution
+ * has to come out of it untouched.
+ *
+ * This pins down behaviour that used to be at risk. The method held a branch that
+ * reversed the financial transaction a financial item was linked to, and that
+ * transaction is the payment itself, not the line's share of it. The branch never
+ * executed because of a mismatch between the name it was called by and the name it
+ * was defined under, so the payment survived by accident rather than by design.
+ * With the branch removed the outcome is the same, and this test keeps it that way.
+ *
+ * @group headless
+ * @group financial
+ */
+class CRM_Price_BAO_ChangeFeeSelectionsPaymentTest extends CiviUnitTestCase {
+
+  /**
+   * IDs created by the fixture.
+   *
+   * @var array
+   */
+  private $fixture = [];
+
+  /**
+   * Swapping a price option for one of the same price leaves the payment intact.
+   */
+  public function testSwappingEqualPricedOptionKeepsThePayment(): void {
+    // validatePayments() does not survive a fee change: the financial items of the
+    // line that comes in stay allocated to the original payment, so the allocated
+    // total ends up above the amount paid. That reproduces on unpatched core and is
+    // unrelated to what this test pins down. ChangeFeeSelectionTest skips the same
+    // check for the same reason, calling it "likely a real bug".
+    $this->isValidateFinancialsOnPostAssert = FALSE;
+    $this->createPaidOrder();
+
+    CRM_Price_BAO_LineItem::changeFeeSelections(
+      [
+        'price_' . $this->fixture['swap_in_field_id'] => $this->fixture['swap_in_value_id'],
+        'price_' . $this->fixture['kept_field_id'] => $this->fixture['kept_value_id'],
+      ],
+      $this->fixture['participant_id'],
+      'participant',
+      $this->fixture['contribution_id']
+    );
+
+    $contribution = civicrm_api3('Contribution', 'getsingle', [
+      'id' => $this->fixture['contribution_id'],
+      'return' => ['total_amount', 'contribution_status_id'],
+    ]);
+    $this->assertEquals(85.00, (float) $contribution['total_amount'], 'The swap should not change what is owed.');
+
+    $payments = $this->getContributionTransactions();
+    $this->assertEquals(
+      [85.00],
+      $payments,
+      'The contribution should still carry exactly its original payment, with no reversal.'
+    );
+  }
+
+  /**
+   * Get the payment transaction amounts recorded against the contribution.
+   *
+   * @return float[]
+   */
+  private function getContributionTransactions(): array {
+    $amounts = [];
+    $dao = CRM_Core_DAO::executeQuery(
+      "SELECT ft.total_amount
+       FROM civicrm_entity_financial_trxn eft
+       INNER JOIN civicrm_financial_trxn ft ON ft.id = eft.financial_trxn_id
+       WHERE eft.entity_table = 'civicrm_contribution'
+         AND eft.entity_id = %1
+         AND ft.is_payment = 1
+       ORDER BY ft.id",
+      [1 => [$this->fixture['contribution_id'], 'Integer']]
+    );
+    while ($dao->fetch()) {
+      $amounts[] = (float) $dao->total_amount;
+    }
+    return $amounts;
+  }
+
+  /**
+   * Register a participant on a EUR 50 and a EUR 35 option and pay in full.
+   *
+   * A third option priced at EUR 50 is created to swap the first one for, so the
+   * order total stays at EUR 85 and the contribution stays Completed.
+   */
+  private function createPaidOrder(): void {
+    $financialTypeID = (int) CRM_Core_PseudoConstant::getKey(
+      'CRM_Contribute_BAO_Contribution',
+      'financial_type_id',
+      'Donation'
+    );
+
+    $this->fixture['contact_id'] = $this->individualCreate();
+    $priceSet = civicrm_api3('PriceSet', 'create', [
+      'name' => strtolower(__CLASS__) . '_' . uniqid(),
+      'title' => 'Fee selection payment test',
+      'extends' => 'CiviEvent',
+      'financial_type_id' => $financialTypeID,
+      'is_active' => 1,
+    ]);
+    $this->fixture['price_set_id'] = $priceSet['id'];
+
+    $event = civicrm_api3('Event', 'create', [
+      'title' => 'Fee selection payment test',
+      'start_date' => date('YmdHis'),
+      'event_type_id' => 1,
+      'is_monetary' => 1,
+      'is_active' => 1,
+    ]);
+    $this->fixture['event_id'] = $event['id'];
+    CRM_Price_BAO_PriceSet::addTo('civicrm_event', $event['id'], $priceSet['id']);
+
+    [$swapOutFieldID, $swapOutValueID] = $this->createPriceFieldAndValue('fifty_euros', 50.00, $financialTypeID);
+    [$keptFieldID, $keptValueID] = $this->createPriceFieldAndValue('thirty_five_euros', 35.00, $financialTypeID);
+    [$swapInFieldID, $swapInValueID] = $this->createPriceFieldAndValue('fifty_euros_again', 50.00, $financialTypeID);
+    $this->fixture += [
+      'kept_field_id' => $keptFieldID,
+      'kept_value_id' => $keptValueID,
+      'swap_in_field_id' => $swapInFieldID,
+      'swap_in_value_id' => $swapInValueID,
+    ];
+
+    $order = civicrm_api3('Order', 'create', [
+      'contact_id' => $this->fixture['contact_id'],
+      'financial_type_id' => $financialTypeID,
+      'total_amount' => 85.00,
+      'line_items' => [
+        [
+          'params' => [
+            'contact_id' => $this->fixture['contact_id'],
+            'event_id' => $this->fixture['event_id'],
+            'status_id' => 'Registered',
+            'role_id' => 'Attendee',
+            'register_date' => date('YmdHis'),
+          ],
+          'line_item' => [
+            $this->getOrderLineItem($swapOutFieldID, $swapOutValueID, 50.00, $financialTypeID),
+            $this->getOrderLineItem($keptFieldID, $keptValueID, 35.00, $financialTypeID),
+          ],
+        ],
+      ],
+    ]);
+    $this->fixture['contribution_id'] = $order['id'];
+    $this->fixture['participant_id'] = (int) CRM_Core_DAO::singleValueQuery(
+      "SELECT entity_id
+       FROM civicrm_line_item
+       WHERE contribution_id = %1 AND entity_table = 'civicrm_participant'
+       LIMIT 1",
+      [1 => [$this->fixture['contribution_id'], 'Integer']]
+    );
+
+    civicrm_api3('Payment', 'create', [
+      'contribution_id' => $this->fixture['contribution_id'],
+      'total_amount' => 85.00,
+    ]);
+  }
+
+  /**
+   * Create one radio price field with one value.
+   *
+   * @return int[]
+   *   The price field ID and price field value ID.
+   */
+  private function createPriceFieldAndValue(string $name, float $amount, int $financialTypeID): array {
+    $priceField = civicrm_api3('PriceField', 'create', [
+      'price_set_id' => $this->fixture['price_set_id'],
+      'name' => $name,
+      'label' => $name,
+      'html_type' => 'Radio',
+      'is_active' => 1,
+    ]);
+    $priceFieldValue = civicrm_api3('PriceFieldValue', 'create', [
+      'price_field_id' => $priceField['id'],
+      'name' => $name,
+      'label' => $name,
+      'amount' => $amount,
+      'financial_type_id' => $financialTypeID,
+      'is_active' => 1,
+    ]);
+    return [(int) $priceField['id'], (int) $priceFieldValue['id']];
+  }
+
+  /**
+   * Build one Order.create line-item parameter array.
+   */
+  private function getOrderLineItem(int $fieldID, int $valueID, float $amount, int $financialTypeID): array {
+    return [
+      'price_field_id' => $fieldID,
+      'price_field_value_id' => $valueID,
+      'entity_table' => 'civicrm_participant',
+      'label' => 'Option ' . $valueID,
+      'qty' => 1,
+      'unit_price' => $amount,
+      'line_total' => $amount,
+      'financial_type_id' => $financialTypeID,
+    ];
+  }
+
+  public function tearDown(): void {
+    $this->quickCleanUpFinancialEntities();
+    $this->fixture = [];
+    parent::tearDown();
+  }
+
+}


### PR DESCRIPTION
Fixes https://lab.civicrm.org/dev/core/-/issues/6728

> **Note on the related PR.** [#36633](https://github.com/civicrm/civicrm-core/pull/36633) fixes three behavioural defects in the condition just above this branch. The two are independent: they merge into each other cleanly in either order, and with both applied the combined result passes both test classes. Kept apart because that one changes behaviour and this one does not, and because the design question below should not hold up those fixes.

## What is dead

`getAdjustedFinancialItemsToRecord()` sets a `financialTrxn` key on the array it
returns, and `changeFeeSelections()` has a branch that turns that into a reverse
`FinancialTrxn` on the contribution. That key is set here:

```php
$updateFinancialItemInfoValues['financialTrxn'] = $this->getRelatedCancelFinancialTrxn($previousFinancialItemID);
```

The method it calls is defined as `_getRelatedCancelFinancialTrxn()`, with a
leading underscore, and that name appears nowhere else in the codebase. So the call
falls through to `DB_DataObject::__call()`, whose `_call()` takes the leading `get`,
looks for a *property* named `RelatedCancelFinancialTrxn`, does not find one, and
leaves its by-reference return at `NULL`. `financialTrxn` is therefore always empty
and the branch that consumes it never executes.

`git blame` dates the mismatch precisely:

| | commit | date | author |
|---|---|---|---|
| the call, without underscore | `f7620bfe39` "NFC code tidy up preparatory to CRM-19273" | 2017-11-13 | eileen |
| the definition, with underscore | `6dde7f043a` CRM-21245 | 2017-10-06 | deb.monish |

Two commits five weeks apart that did not see each other. The branch has been
unreachable ever since — over eight years — and in that time `_recordAdjustedAmt()`
and the `elseif` below it have been carrying the work.

## Why this is worth removing rather than leaving alone

Because the next person to tidy up that name will break accounting, silently.

Measured on a clean master build. An event registration of EUR 85 (a EUR 50 option
and a EUR 35 option), paid in full, then swapping the EUR 50 option for another
priced at EUR 50 — so nothing about what is owed changes and the contribution stays
`Completed`:

```
                        transactions on the contribution
as shipped              +85.00 (the payment)
with the name fixed     +85.00 (the payment), -85.00 (reversal)
```

The contribution still owes EUR 85 and EUR 85 is still in the bank, but the
recorded payment now nets to zero. That happens because
`_getRelatedCancelFinancialTrxn()` reverses the full amount of the transaction the
financial item is linked to, and that transaction is the payment, not the line's
share of it. One omitted line is enough; it does not take two.

So the name cannot be corrected on its own, and that is not obvious from reading
it. Removing the branch takes the trap out.

## What this changes

Nothing at runtime. The branch cannot execute, so deleting it cannot alter
behaviour. It removes:

- the assignment of `financialTrxn` and the `$previousFinancialItemID` variable that
  only fed it;
- the branch in `changeFeeSelections()` that consumed it, leaving its `elseif` as a
  plain `if`;
- the `$contributionStatus` lookup, which only existed for that branch's condition;
- `_getRelatedCancelFinancialTrxn()` itself.

61 lines out, 1 in.

## The alternative: revive it instead

Removing is not the only defensible option, and this may well be a decision for
maintainers rather than for me. The other route is to keep the intent and make it
work:

1. correct the call to `_getRelatedCancelFinancialTrxn()`, and
2. change that helper so it reverses the financial item's own share rather than the
   whole transaction, allocating per item instead of per transaction.

That is a design change to how `changeFeeSelections()` reallocates payments when a
price changes, not a rename. It needs a decision about what *should* happen to a
payment when one line of a paid order is cancelled while the total stays the same —
whether the payment stays allocated to the remaining lines, gets partially
reversed, or becomes an overpayment. It also needs tests, because the current suite
does not cover it: `ParticipantTest` passes identically with the branch dead and
alive, which is exactly how this survived unnoticed.

If that is the direction preferred, I am happy to close this and open an issue for
the design question first. What I would rather not leave standing is the current
state, where the code looks live, is not, and punishes the first person who fixes
the obvious typo.

## Tests

Adds `ChangeFeeSelectionsPaymentTest::testSwappingEqualPricedOptionKeepsThePayment()`,
which registers a participant on two options, pays in full, swaps one option for
another of the same price, and asserts that the contribution still carries exactly
its original payment of 85.00 and still owes 85.00.

It passes both before and after this patch, which is the point: it does not test the
removal, it pins down the behaviour the removal has to preserve. It fails if the
branch is ever revived without reworking the allocation, so the trap described above
becomes a red test rather than a silent accounting error.

Regression: `ParticipantTest` (22 tests, 881 assertions) passes. `civilint` is clean
on both files.

