### PR TITLE
provide functions to add/remove UF Roles

### DIFF
--- a/CRM/Utils/System/Backdrop.php
+++ b/CRM/Utils/System/Backdrop.php
@@ -92,6 +92,37 @@ class CRM_Utils_System_Backdrop extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    $user = user_load($ufID);
+    if (!$user || !array_key_exists($role, user_roles())) {
+      return FALSE;
+    }
+    if (!in_array($role, $user->roles, TRUE)) {
+      $user->roles[] = $role;
+      $user->save();
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    $user = user_load($ufID);
+    if (!$user || !array_key_exists($role, user_roles())) {
+      return FALSE;
+    }
+    $key = array_search($role, $user->roles, TRUE);
+    if ($key !== FALSE) {
+      unset($user->roles[$key]);
+      $user->save();
+    }
+    return TRUE;
+  }
+
+  /**
    * @inheritdoc
    */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {

--- a/CRM/Utils/System/Base.php
+++ b/CRM/Utils/System/Base.php
@@ -1118,6 +1118,42 @@ abstract class CRM_Utils_System_Base {
   }
 
   /**
+   * Add a role to a CMS user.
+   *
+   * @param int $ufID
+   *   User ID in the CMS.
+   * @param string $role
+   *   Name of the role to add. This is a key from the array returned by
+   *   getRoleNames().
+   *
+   * @return bool
+   *   TRUE if the user now has the role (including if it was already
+   *   assigned). FALSE if the action could not be completed, e.g. because
+   *   the user or role does not exist.
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    return FALSE;
+  }
+
+  /**
+   * Remove a role from a CMS user.
+   *
+   * @param int $ufID
+   *   User ID in the CMS.
+   * @param string $role
+   *   Name of the role to remove. This is a key from the array returned by
+   *   getRoleNames().
+   *
+   * @return bool
+   *   TRUE if the user no longer has the role (including if it was never
+   *   assigned). FALSE if the action could not be completed, e.g. because
+   *   the user or role does not exist.
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    return FALSE;
+  }
+
+  /**
    * Determine if the Views module exists.
    *
    * @return bool

--- a/CRM/Utils/System/Drupal.php
+++ b/CRM/Utils/System/Drupal.php
@@ -100,6 +100,44 @@ class CRM_Utils_System_Drupal extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    $user = user_load($ufID);
+    if (!$user) {
+      return FALSE;
+    }
+    $rid = array_search($role, user_roles());
+    if ($rid === FALSE) {
+      return FALSE;
+    }
+    if (!isset($user->roles[$rid])) {
+      user_save($user, ['roles' => $user->roles + [$rid => $role]]);
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    $user = user_load($ufID);
+    if (!$user) {
+      return FALSE;
+    }
+    $rid = array_search($role, user_roles());
+    if ($rid === FALSE) {
+      return FALSE;
+    }
+    if (isset($user->roles[$rid])) {
+      $roles = $user->roles;
+      unset($roles[$rid]);
+      user_save($user, ['roles' => $roles]);
+    }
+    return TRUE;
+  }
+
+  /**
    * @inheritdoc
    */
   public function checkUserNameEmailExists(&$params, &$errors, $emailName = 'email') {

--- a/CRM/Utils/System/Drupal8.php
+++ b/CRM/Utils/System/Drupal8.php
@@ -863,6 +863,41 @@ class CRM_Utils_System_Drupal8 extends CRM_Utils_System_DrupalBase {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    // The anonymous/authenticated roles are implicit and cannot be assigned;
+    // Drupal\user\Entity\User::addRole() throws for them.
+    if (in_array($role, [\Drupal\user\RoleInterface::ANONYMOUS_ID, \Drupal\user\RoleInterface::AUTHENTICATED_ID], TRUE)) {
+      return FALSE;
+    }
+    $user = \Drupal\user\Entity\User::load($ufID);
+    if (!$user || !\Drupal\user\Entity\Role::load($role)) {
+      return FALSE;
+    }
+    if (!$user->hasRole($role)) {
+      $user->addRole($role);
+      $user->save();
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    $user = \Drupal\user\Entity\User::load($ufID);
+    if (!$user || !\Drupal\user\Entity\Role::load($role)) {
+      return FALSE;
+    }
+    if ($user->hasRole($role)) {
+      $user->removeRole($role);
+      $user->save();
+    }
+    return TRUE;
+  }
+
+  /**
    * Determine if the Views module exists.
    *
    * @return bool

--- a/CRM/Utils/System/Joomla.php
+++ b/CRM/Utils/System/Joomla.php
@@ -1235,4 +1235,58 @@ class CRM_Utils_System_Joomla extends CRM_Utils_System_Base {
     return $roles;
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    $groupID = $this->getUfRoleGroupId($role);
+    if (!$groupID || !$this->ufUserExists($ufID)) {
+      return FALSE;
+    }
+    return (bool) \Joomla\CMS\User\UserHelper::addUserToGroup($ufID, $groupID);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    $groupID = $this->getUfRoleGroupId($role);
+    if (!$groupID || !$this->ufUserExists($ufID)) {
+      return FALSE;
+    }
+    return (bool) \Joomla\CMS\User\UserHelper::removeUserFromGroup($ufID, $groupID);
+  }
+
+  /**
+   * Look up a Joomla user group ID by its title.
+   *
+   * @param string $role
+   *
+   * @return int|null
+   */
+  private function getUfRoleGroupId(string $role): ?int {
+    $userGroups = \Joomla\CMS\Helper\UserGroupsHelper::getInstance()->loadAll()->getAll();
+    foreach ($userGroups as $userGroup) {
+      if ($userGroup->title === $role) {
+        return (int) $userGroup->id;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Check that a Joomla user id exists.
+   *
+   * UserHelper::addUserToGroup()/removeUserFromGroup() do not report
+   * failure for an unknown user id, so this must be checked separately.
+   *
+   * @param int $ufID
+   *
+   * @return bool
+   */
+  private function ufUserExists($ufID) {
+    $user = new \Joomla\CMS\User\User((int) $ufID);
+    return (int) $user->id === (int) $ufID;
+  }
+
 }

--- a/CRM/Utils/System/Standalone.php
+++ b/CRM/Utils/System/Standalone.php
@@ -863,4 +863,62 @@ class CRM_Utils_System_Standalone extends CRM_Utils_System_Base {
       ->column('label', 'name');
   }
 
+  /**
+   * @inheritDoc
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    if (!$this->isUserExtensionAvailable() || !$this->getUserById($ufID)) {
+      return FALSE;
+    }
+    $roleID = $this->getUfRoleId($role);
+    if (!$roleID) {
+      return FALSE;
+    }
+    $exists = \Civi\Api4\UserRole::get(FALSE)
+      ->addWhere('user_id', '=', $ufID)
+      ->addWhere('role_id', '=', $roleID)
+      ->selectRowCount()
+      ->execute()->count();
+    if (!$exists) {
+      \Civi\Api4\UserRole::create(FALSE)
+        ->addValue('user_id', $ufID)
+        ->addValue('role_id', $roleID)
+        ->execute();
+    }
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    if (!$this->isUserExtensionAvailable() || !$this->getUserById($ufID)) {
+      return FALSE;
+    }
+    $roleID = $this->getUfRoleId($role);
+    if (!$roleID) {
+      return FALSE;
+    }
+    \Civi\Api4\UserRole::delete(FALSE)
+      ->addWhere('user_id', '=', $ufID)
+      ->addWhere('role_id', '=', $roleID)
+      ->execute();
+    return TRUE;
+  }
+
+  /**
+   * Look up a Standalone role id by its name.
+   *
+   * @param string $role
+   *
+   * @return int|null
+   */
+  private function getUfRoleId($role): ?int {
+    return \Civi\Api4\Role::get(FALSE)
+      ->addSelect('id')
+      ->addWhere('name', '=', $role)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()->first()['id'] ?? NULL;
+  }
+
 }

--- a/CRM/Utils/System/WordPress.php
+++ b/CRM/Utils/System/WordPress.php
@@ -1378,6 +1378,36 @@ class CRM_Utils_System_WordPress extends CRM_Utils_System_Base {
   }
 
   /**
+   * @inheritDoc
+   */
+  public function addUfRole(int $ufID, string $role): bool {
+    if (!wp_roles()->is_role($role)) {
+      return FALSE;
+    }
+    $user = get_userdata($ufID);
+    if (!$user) {
+      return FALSE;
+    }
+    $user->add_role($role);
+    return TRUE;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function removeUfRole(int $ufID, string $role): bool {
+    if (!wp_roles()->is_role($role)) {
+      return FALSE;
+    }
+    $user = get_userdata($ufID);
+    if (!$user) {
+      return FALSE;
+    }
+    $user->remove_role($role);
+    return TRUE;
+  }
+
+  /**
    * Perform any necessary actions prior to redirecting via POST.
    *
    * Redirecting via POST means that cookies need to be sent with SameSite=None.


### PR DESCRIPTION
Overview
----------------------------------------
This adds CMS-specific code for adding/removing roles.

Comments
----------------------------------------
Standalone already has this capability but we don't have it for the CMSes.  I originally put it in an extension, but it seems like people building user application workflows should have the same capability in the CMSes as in Standalone.

I have a CiviRules action that uses this, and will put an action in Action Provider at some point.
