### PR TITLE
dev/core#6649 - admin console is blank again (sometimes)

### DIFF
--- a/CRM/Core/Menu.php
+++ b/CRM/Core/Menu.php
@@ -491,7 +491,13 @@ class CRM_Core_Menu {
    * @return array|null
    */
   public static function getAdminLinks() {
-    return \Civi::cache('long')->get('AdminSiteMapLinks');
+    $links = \Civi::cache('long')->get('AdminSiteMapLinks');
+    if (!$links) {
+      // cache may have expired
+      self::store();
+      $links = \Civi::cache('long')->get('AdminSiteMapLinks');
+    }
+    return $links;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
'cuz caching

Before
----------------------------------------
If the cache has expired, then visiting the admin console gives a blank screen. You can reproduce this by just updating the db expire date manually like `update civicrm_cache set expired_date='2026-08-26' where path='AdminSiteMapLinks';` and then visit `/civicrm/admin?reset=1`

After
----------------------------------------
Rebuild it if blank.

Technical Details
----------------------------------------
I can't just call buildAdminLinks, since it needs the $menu, but we can rebuild it by calling store(), which rebuilds other things too that isn't strictly necessary but this only happens if it's expired.

Comments
----------------------------------------
In https://github.com/civicrm/civicrm-core/pull/36396 we changed it to use cache. FYI @ufundo 
