### PR TITLE
Remove the unreachable CLOSE branch in CRM_Mailing_Form_Action

### DIFF
--- a/CRM/Mailing/Form/Action.php
+++ b/CRM/Mailing/Form/Action.php
@@ -122,10 +122,6 @@ class CRM_Mailing_Form_Action extends CRM_Core_Form {
       CRM_Mailing_BAO_MailingJob::pause($this->_mailingId);
       CRM_Core_Session::setStatus(ts('The mailing has been paused. Active message deliveries may continue for a few minutes, but CiviMail will not begin delivery of any more batches.'), ts('Paused'), 'success');
     }
-    elseif ($this->_action & CRM_Core_Action::CLOSE) {
-      CRM_Mailing_BAO_MailingJob::pause($this->_mailingId);
-      CRM_Core_Session::setStatus(ts('The mailing has been paused. Active message deliveries may continue for a few minutes, but CiviMail will not begin delivery of any more batches.'), ts('Paused'), 'success');
-    }
     if ($this->_action & CRM_Core_Action::REOPEN) {
       CRM_Mailing_BAO_MailingJob::resume($this->_mailingId);
       CRM_Core_Session::setStatus(ts('The mailing has been resumed.'), ts('Resumed'), 'success');


### PR DESCRIPTION
Overview
----------------------------------------
`CRM_Mailing_Form_Action::postProcess` opens with `if ($this->_action & CLOSE)` and follows it with an `elseif` on the very same condition and the same body, so the second one has never run.

Before
----------------------------------------
The two branches are byte for byte identical, pause the job and set the same "Paused" status. PHP takes the first, the `elseif` is unreachable.

After
----------------------------------------
Only the `if` remains. Pausing a mailing does exactly what it does today.

Technical Details
----------------------------------------
There is a second copy of that same branch further down in the method, in the `if (DISABLE) ... elseif (CLOSE) ... elseif (RENEW)` chain, and that one is reachable. With `_action` set to CLOSE alone, the opening `if` pauses the job and sets the status, then `DISABLE` fails and the chain's `elseif (CLOSE)` pauses it and sets the status again, so a plain Pause runs `MailingJob::pause` twice and shows the same green message twice.

I left that one alone. Removing it is not equivalent for an `_action` carrying CLOSE together with RENEW or DELETE, since those would start reaching their own arms, and whether that combination is possible from the UI is your call rather than mine.

Comments
----------------------------------------
Found while reading the file, no issue behind it.
