### PR TITLE
dev/core#6701 Ensure that Zero Dates with sql mode NO_ZERO_DATE enabl…

### DIFF
--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -128,6 +128,32 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
   public static function addCurrencyFk($ctx, $entityName, $fieldName): bool {
     $tableName = Civi::entity($entityName)->getMeta('table');
 
+    // dev/core#6701 Ensure that there are no zero date issues when altering table to add FK on currency
+    $sqlModes = CRM_Utils_SQL::getSqlModes();
+    $changedSQLModes = $sqlModes;
+    if (!empty($sqlModes) && in_array('NO_ZERO_DATE', $changedSQLModes)) {
+      if ($key = array_search('NO_ZERO_DATE', $changedSQLModes)) {
+        unset($changedSQLModes[$key]);
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $changedSQLModes) . "'");
+        $fields = Civi::entity($entityName)->getFields();
+        foreach ($fields as $sqlFieldName => $field) {
+          if ($field['sql_type'] === 'datetime') {
+            $check = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM `$tableName` WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
+            if (!empty($check)) {
+              // If the field is required it will be set to NOT NULL so set it to be today otherwise set the value to be NULL
+              if ($field['required']) {
+                CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$sqlFieldName` =  NOW() WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
+              }
+              else {
+                CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$sqlFieldName` =  NULL WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
+              }
+            }
+          }
+        }
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
+      }
+    }
+
     // Safety check, remove any invalid currency
     CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$fieldName` = NULL WHERE `$fieldName` IS NOT NULL AND `$fieldName` NOT IN (SELECT `name` FROM `civicrm_currency`)", i18nRewrite: FALSE);
 
@@ -138,7 +164,6 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
         'on_delete' => 'SET NULL',
       ],
     ]);
-
     return TRUE;
   }
 

--- a/CRM/Upgrade/Incremental/php/SixEighteen.php
+++ b/CRM/Upgrade/Incremental/php/SixEighteen.php
@@ -130,28 +130,24 @@ class CRM_Upgrade_Incremental_php_SixEighteen extends CRM_Upgrade_Incremental_Ba
 
     // dev/core#6701 Ensure that there are no zero date issues when altering table to add FK on currency
     $sqlModes = CRM_Utils_SQL::getSqlModes();
-    $changedSQLModes = $sqlModes;
-    if (!empty($sqlModes) && in_array('NO_ZERO_DATE', $changedSQLModes)) {
-      if ($key = array_search('NO_ZERO_DATE', $changedSQLModes)) {
-        unset($changedSQLModes[$key]);
-        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $changedSQLModes) . "'");
-        $fields = Civi::entity($entityName)->getFields();
-        foreach ($fields as $sqlFieldName => $field) {
-          if ($field['sql_type'] === 'datetime') {
-            $check = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM `$tableName` WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
-            if (!empty($check)) {
-              // If the field is required it will be set to NOT NULL so set it to be today otherwise set the value to be NULL
-              if ($field['required']) {
-                CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$sqlFieldName` =  NOW() WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
-              }
-              else {
-                CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$sqlFieldName` =  NULL WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
-              }
+    if (in_array('NO_ZERO_DATE', $sqlModes)) {
+      CRM_Utils_Sql::setSqlModes(array_diff($sqlModes, ['NO_ZERO_DATE']));
+      $fields = Civi::entity($entityName)->getFields();
+      foreach ($fields as $sqlFieldName => $field) {
+        if ($field['sql_type'] === 'datetime') {
+          $check = CRM_Core_DAO::singleValueQuery("SELECT count(id) FROM `$tableName` WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
+          if (!empty($check)) {
+            // If the field is required it will be set to NOT NULL so set it to be today otherwise set the value to be NULL
+            if ($field['required']) {
+              CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$sqlFieldName` =  NOW() WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
+            }
+            else {
+              CRM_Core_DAO::executeQuery("UPDATE `$tableName` SET `$sqlFieldName` =  NULL WHERE `$sqlFieldName` = '0000-00-00 00:00:00'");
             }
           }
         }
-        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
       }
+      CRM_Utils_Sql::setSqlModes($sqlModes);
     }
 
     // Safety check, remove any invalid currency

--- a/CRM/Utils/SQL.php
+++ b/CRM/Utils/SQL.php
@@ -113,12 +113,20 @@ class CRM_Utils_SQL {
   }
 
   /**
-   * Get current sqlModes of the session
+   * Get current sql_mode of the session
    * @return array
    */
-  public static function getSqlModes() {
-    $sqlModes = explode(',', CRM_Core_DAO::singleValueQuery('SELECT @@sql_mode'));
-    return $sqlModes;
+  public static function getSqlModes(): array {
+    return explode(',', CRM_Core_DAO::singleValueQuery('SELECT @@sql_mode')) ?: [];
+  }
+
+  /**
+   * Set sql_mode for the session.
+   *
+   * @param array $sqlModes
+   */
+  public static function setSqlModes(array $sqlModes): void {
+    CRM_Core_DAO::executeQuery('SET SESSION sql_mode = %1', [1 => [implode(',', $sqlModes), 'String']]);
   }
 
   /**

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/SixEighteenTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/SixEighteenTest.php
@@ -9,19 +9,15 @@ class CRM_Upgrade_Incremental_php_SixEighteenTest extends CiviUnitTestCase {
   public function testContributionPageTableAlter(): void {
     $pageID = $this->contributionPageCreate()['id'];
     $sqlModes = CRM_Utils_SQL::getSqlModes();
-    $changedSQLModes = $sqlModes;
-    if (!empty($sqlModes) && in_array('NO_ZERO_DATE', $changedSQLModes)) {
-      if ($key = array_search('NO_ZERO_DATE', $changedSQLModes)) {
-        unset($changedSQLModes[$key]);
-        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $changedSQLModes) . "'");
-      }
+    if (in_array('NO_ZERO_DATE', $sqlModes)) {
+      CRM_Utils_Sql::setSqlModes(array_diff($sqlModes, ['NO_ZERO_DATE']));
     }
     elseif (!empty($sqlModes)) {
       $sqlModes[] = 'NO_ZERO_DATE';
     }
-    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_contribution_page DROP CONSTRAINT `FK_civicrm_contribution_page_currency`");
+    CRM_Core_BAO_SchemaHandler::safeRemoveFK('civicrm_contribution_page', 'FK_civicrm_contribution_page_currency');
     CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution_page SET created_date = '0000-00-00 00:00:00' WHERE id = %1", [1 => [$pageID, 'Positive']]);
-    CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
+    CRM_Utils_Sql::setSqlModes($sqlModes);
     CRM_Upgrade_Incremental_php_SixEighteen::addCurrencyFk(NULL, 'ContributionPage', 'currency');
   }
 

--- a/tests/phpunit/CRM/Upgrade/Incremental/php/SixEighteenTest.php
+++ b/tests/phpunit/CRM/Upgrade/Incremental/php/SixEighteenTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Class CRM_Upgrade_Incremental_php_SixEighteenTest
+ * @group headless
+ */
+class CRM_Upgrade_Incremental_php_SixEighteenTest extends CiviUnitTestCase {
+
+  public function testContributionPageTableAlter(): void {
+    $pageID = $this->contributionPageCreate()['id'];
+    $sqlModes = CRM_Utils_SQL::getSqlModes();
+    $changedSQLModes = $sqlModes;
+    if (!empty($sqlModes) && in_array('NO_ZERO_DATE', $changedSQLModes)) {
+      if ($key = array_search('NO_ZERO_DATE', $changedSQLModes)) {
+        unset($changedSQLModes[$key]);
+        CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $changedSQLModes) . "'");
+      }
+    }
+    elseif (!empty($sqlModes)) {
+      $sqlModes[] = 'NO_ZERO_DATE';
+    }
+    CRM_Core_DAO::executeQuery("ALTER TABLE civicrm_contribution_page DROP CONSTRAINT `FK_civicrm_contribution_page_currency`");
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_contribution_page SET created_date = '0000-00-00 00:00:00' WHERE id = %1", [1 => [$pageID, 'Positive']]);
+    CRM_Core_DAO::executeQuery("SET SESSION sql_mode = '" . implode(',', $sqlModes) . "'");
+    CRM_Upgrade_Incremental_php_SixEighteen::addCurrencyFk(NULL, 'ContributionPage', 'currency');
+  }
+
+}

--- a/tests/phpunit/CRM/Utils/SQLTest.php
+++ b/tests/phpunit/CRM/Utils/SQLTest.php
@@ -118,4 +118,19 @@ class CRM_Utils_SQLTest extends CiviUnitTestCase {
     $this->assertFalse($tempTable->isMemory());
   }
 
+  /**
+   * Test getSqlModes and setSqlModes.
+   */
+  public function testGetAndSetSqlModes(): void {
+    $originalModes = CRM_Utils_SQL::getSqlModes();
+    try {
+      CRM_Utils_SQL::setSqlModes(['STRICT_TRANS_TABLES', 'ERROR_FOR_DIVISION_BY_ZERO']);
+      $newModes = CRM_Utils_SQL::getSqlModes();
+      $this->assertEquals(['STRICT_TRANS_TABLES', 'ERROR_FOR_DIVISION_BY_ZERO'], $newModes);
+    }
+    finally {
+      CRM_Utils_SQL::setSqlModes($originalModes);
+    }
+  }
+
 }


### PR DESCRIPTION
…ed does not affect FK by fixing data

Overview
----------------------------------------
If there is a date with a value of 0000-00-00 00:00:00 and the NO_ZERO_DATE SQL mode is enabled this can block the adding of the currency FK

Before
----------------------------------------
Possibility for upgrade to error on adding of FK

After
----------------------------------------
No Error

ping @ufundo @colemanw @demeritcowboy 