### PR TITLE
Add "Last 6 months" relative date filter and support any "last N days/weeks/months" range

### DIFF
--- a/CRM/Contact/BAO/Query.php
+++ b/CRM/Contact/BAO/Query.php
@@ -7049,7 +7049,6 @@ AND   displayRelType.is_active = 1
     $fieldName = substr($values[0], 0, strlen($values[0]) - 9);
     $fieldSpec = $this->_fields[$fieldName];
     $tableName = $fieldSpec['table_name'];
-    $filters = CRM_Core_OptionGroup::values('relative_date_filters');
     $grouping = $values[3] ?? NULL;
     // If the table value is already set for a custom field it will be more nuanced than just '1'.
     $this->_tables[$tableName] ??= 1;
@@ -7066,7 +7065,7 @@ AND   displayRelType.is_active = 1
       $secondWhere = str_replace('civicrm_contact.', 'contact_a.', $secondWhere);
     }
 
-    $this->_qill[$grouping][] = $this->getQillForRelativeDateRange($dates[0], $dates[1], $fieldSpec['title'], $filters[$value]);
+    $this->_qill[$grouping][] = $this->getQillForRelativeDateRange($dates[0], $dates[1], $fieldSpec['title'], CRM_Utils_Date::getRelativeDateFilterLabel($value) ?? $value);
     if ($fieldName === 'relation_active_period_date') {
       // Hack this to fix regression https://lab.civicrm.org/dev/core/issues/1592
       // Not sure the  'right' fix.

--- a/CRM/Core/Form/Search.php
+++ b/CRM/Core/Form/Search.php
@@ -324,7 +324,7 @@ class CRM_Core_Form_Search extends CRM_Core_Form {
           }
           else {
             $relative = CRM_Utils_Request::retrieveValue($fieldName . '_relative', 'String', NULL, NULL, 'GET');
-            if (!empty($relative) && isset(CRM_Core_OptionGroup::values('relative_date_filters')[$relative])) {
+            if (!empty($relative) && CRM_Utils_Date::isRelativeDateFilter($relative)) {
               $defaults[$fieldName . '_relative'] = $relative;
             }
           }

--- a/CRM/Upgrade/Incremental/php/SixNineteen.php
+++ b/CRM/Upgrade/Incremental/php/SixNineteen.php
@@ -69,6 +69,7 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
       'add' => '1.1',
     ]);
     $this->addTask('Decode Mailing.template_options HTML entities', 'decodeMailingTemplateOptions');
+    $this->addTask('Add "Last 6 months" relative date filter', 'addLastSixMonthsDateFilter');
   }
 
   /**
@@ -112,6 +113,27 @@ class CRM_Upgrade_Incremental_php_SixNineteen extends CRM_Upgrade_Incremental_Ba
         ]);
       }
     }
+    return TRUE;
+  }
+
+  /**
+   * Add the "Last 6 months including today" relative date filter, directly after "Last 90 days".
+   */
+  public static function addLastSixMonthsDateFilter(CRM_Queue_TaskContext $ctx): bool {
+    $groupId = (int) CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_option_group WHERE name = 'relative_date_filters'");
+    $params = [1 => [$groupId, 'Integer']];
+    if (!$groupId || CRM_Core_DAO::singleValueQuery("SELECT id FROM civicrm_option_value WHERE option_group_id = %1 AND value = 'ending_6.month'", $params)) {
+      return TRUE;
+    }
+    $weight = 1 + (int) CRM_Core_DAO::singleValueQuery("SELECT COALESCE(MAX(CASE WHEN value = 'ending_90.day' THEN weight END), MAX(weight), 0) FROM civicrm_option_value WHERE option_group_id = %1", $params);
+    CRM_Core_DAO::executeQuery('UPDATE civicrm_option_value SET weight = weight + 1 WHERE option_group_id = %1 AND weight >= %2', $params + [2 => [$weight, 'Integer']]);
+    CRM_Core_BAO_OptionValue::ensureOptionValueExists([
+      'option_group_id' => 'relative_date_filters',
+      'name' => 'ending_6.month',
+      'value' => 'ending_6.month',
+      'label' => ts('Last 6 months including today'),
+      'weight' => $weight,
+    ]);
     return TRUE;
   }
 

--- a/CRM/Utils/Date.php
+++ b/CRM/Utils/Date.php
@@ -21,6 +21,13 @@
 class CRM_Utils_Date {
 
   /**
+   * Pattern for dynamic "last N units including today" relative date terms, e.g. "ending_45.day".
+   *
+   * @see relativeToAbsolute()
+   */
+  public const DYNAMIC_RELATIVE_DATE_PATTERN = '/^ending_([1-9]\d*)\.(day|week|month|quarter|year)$/';
+
+  /**
    * Date input formats.
    *
    * For example a user selecting `DATE_dd_mm_yyyy` in the context of an import is
@@ -1032,6 +1039,49 @@ class CRM_Utils_Date {
       "yy" => 'Y',
     ];
     return $dateInputFormats;
+  }
+
+  /**
+   * Is the given value a relative date filter term?
+   *
+   * TRUE for values in the `relative_date_filters` option group (e.g. "this.month") and for
+   * dynamic "last N units" terms like "ending_45.day" which relativeToAbsolute() understands
+   * without them being defined as options.
+   *
+   * @param mixed $value
+   *
+   * @return bool
+   */
+  public static function isRelativeDateFilter($value): bool {
+    return is_string($value) && (
+      array_key_exists($value, (array) CRM_Core_OptionGroup::values('relative_date_filters'))
+      || preg_match(self::DYNAMIC_RELATIVE_DATE_PATTERN, $value)
+    );
+  }
+
+  /**
+   * Get a human-readable label for a relative date filter term.
+   *
+   * @param string $value
+   *   E.g. "this.month" or "ending_45.day".
+   *
+   * @return string|null
+   *   The option label, a generated label for dynamic `ending_N.unit` terms, or NULL if not recognised.
+   */
+  public static function getRelativeDateFilterLabel(string $value): ?string {
+    $label = CRM_Core_OptionGroup::values('relative_date_filters')[$value] ?? NULL;
+    if ($label === NULL && preg_match(self::DYNAMIC_RELATIVE_DATE_PATTERN, $value, $m)) {
+      $n = ['count' => (int) $m[1]];
+      $units = [
+        'day' => ts('%count day', $n + ['plural' => '%count days']),
+        'week' => ts('%count week', $n + ['plural' => '%count weeks']),
+        'month' => ts('%count month', $n + ['plural' => '%count months']),
+        'quarter' => ts('%count quarter', $n + ['plural' => '%count quarters']),
+        'year' => ts('%count year', $n + ['plural' => '%count years']),
+      ];
+      $label = ts('Last %1 including today', [1 => $units[$m[2]]]);
+    }
+    return $label;
   }
 
   /**

--- a/Civi/Api4/Utils/FormattingUtil.php
+++ b/Civi/Api4/Utils/FormattingUtil.php
@@ -136,7 +136,7 @@ class FormattingUtil {
         // @see https://lab.civicrm.org/dev/core/-/work_items/6612
         $format = $operator !== NULL ? 'Y-m-d H:i:s' : 'YmdHis';
         // Using `=` with a Y-m-d timestamp means we really want `BETWEEN` midnight and 11:59:59pm.
-        if ($operator && is_string($value) && !array_key_exists($value, \CRM_Core_OptionGroup::values('relative_date_filters'))) {
+        if ($operator && is_string($value) && !\CRM_Utils_Date::isRelativeDateFilter($value)) {
           $isYmd = (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value));
           if ($isYmd && in_array($operator, ['=', '!=', '<>'])) {
             $operator = $operator === '=' ? 'BETWEEN' : 'NOT BETWEEN';
@@ -176,7 +176,7 @@ class FormattingUtil {
    */
   public static function formatDateValue($format, $value, &$operator = NULL, $index = NULL) {
     // Non-relative dates (or if no search operator)
-    if (!$operator || !array_key_exists($value ?? '', (array) \CRM_Core_OptionGroup::values('relative_date_filters'))) {
+    if (!$operator || !\CRM_Utils_Date::isRelativeDateFilter($value)) {
       return date($format, strtotime($value ?? ''));
     }
     if (isset($index) && !strstr($operator, 'BETWEEN')) {

--- a/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
+++ b/ext/afform/admin/ang/afGuiEditor/elements/afGuiField.component.js
@@ -450,6 +450,12 @@
 
       this.allowTokensInDefault = () => this.editor.getFormType() === 'form' && ['Text', 'TextArea', 'Hidden', 'DisplayOnly'].includes(this.fieldDefn.input_type);
 
+      // Dynamic "last N units including today" relative date, e.g. "ending_45.day"
+      // @see CRM_Utils_Date::DYNAMIC_RELATIVE_DATE_PATTERN
+      const endingPattern = /^ending_(\d+)\.(day|week|month|quarter|year)$/;
+
+      this.isDateSelect = () => this.fieldDefn.input_type === 'Select' && _.includes(['Date', 'Timestamp'], $scope.getProp('data_type'));
+
       this.defaultDateType = function(newValue) {
         if (arguments.length) {
           if (newValue === 'relative') {
@@ -471,7 +477,31 @@
             return 'relative';
           }
         }
+        // Dynamic "ending_N.unit" default (values from the option list are handled by the list select)
+        if (this.isDateSelect() && endingPattern.test(getSet('afform_default')) && !_.findWhere(CRM.afGuiEditor.dateRanges, {id: getSet('afform_default')})) {
+          return 'ending';
+        }
         return 'fixed';
+      };
+
+      // Getter/setters for a dynamic "ending_N.unit" default
+      const getEnding = () => endingPattern.exec(getSet('afform_default')) || [null, '14', 'day'];
+      const setEnding = (number, unit) => {
+        getSet('afform_default', 'ending_' + Math.max(1, parseInt(number, 10) || 1) + '.' + unit);
+        ctrl.hasDefaultValue = true;
+      };
+      this.toggleDynamicDateDefault = () => this.defaultDateType() === 'ending' ? $scope.toggleDefaultValue() : setEnding(14, 'day');
+      this.defaultEndingNumber = function(newValue) {
+        if (arguments.length) {
+          setEnding(newValue, getEnding()[2]);
+        }
+        return parseInt(getEnding()[1], 10);
+      };
+      this.defaultEndingUnit = function(newValue) {
+        if (arguments.length) {
+          setEnding(getEnding()[1], newValue);
+        }
+        return getEnding()[2];
       };
 
       this.defaultDateOffset = function(newValue) {

--- a/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
+++ b/ext/afform/admin/ang/afGuiEditor/inputType/Select.html
@@ -15,6 +15,23 @@
               {{ opt.label }}
             </a>
           </li>
+          <li ng-if="$ctrl.isDateSelect()" class="af-gui-field-dynamic-date-default">
+            <form class="form-inline" ng-click="$event.stopPropagation()" title="{{:: ts('Any number of days, weeks, months or years ending today') }}">
+              <a href ng-click="$ctrl.toggleDynamicDateDefault(); $event.stopPropagation(); $event.target.blur();">
+                <i class="crm-i fa-{{ $ctrl.defaultDateType() === 'ending' ? 'check-' : '' }}circle-o" role="img" aria-hidden="true"></i>
+                {{:: ts('Last') }}
+              </a>
+              <input class="form-control input-sm" type="number" min="1" step="1" size="3" ng-model="$ctrl.defaultEndingNumber" ng-model-options="{getterSetter: true}">
+              <select class="form-control input-sm" ng-model="$ctrl.defaultEndingUnit" ng-model-options="{getterSetter: true}">
+                <option value="day">{{ $ctrl.defaultEndingNumber() !== 1 ? ts('Days') : ts('Day') }}</option>
+                <option value="week">{{ $ctrl.defaultEndingNumber() !== 1 ? ts('Weeks') : ts('Week') }}</option>
+                <option value="month">{{ $ctrl.defaultEndingNumber() !== 1 ? ts('Months') : ts('Month') }}</option>
+                <option value="quarter">{{ $ctrl.defaultEndingNumber() !== 1 ? ts('Quarters') : ts('Quarter') }}</option>
+                <option value="year">{{ $ctrl.defaultEndingNumber() !== 1 ? ts('Years') : ts('Year') }}</option>
+              </select>
+              <span>{{:: ts('including today') }}</span>
+            </form>
+          </li>
         </ul>
       </div>
     </div>

--- a/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
+++ b/ext/afform/core/Civi/Afform/AfformMetadataInjector.php
@@ -198,6 +198,14 @@ class AfformMetadataInjector {
         if ($isSearchRange) {
           $dateOptions = array_merge([['id' => '{}', 'label' => E::ts('Choose Date Range')]], $dateOptions);
         }
+        // A dynamic "last N units" default (e.g. "ending_45.day") isn't in the option group, so add it to the list.
+        $default = isset($fieldDefn['afform_default']) ? \CRM_Utils_JS::decode($fieldDefn['afform_default']) : NULL;
+        if (is_string($default) && !in_array($default, array_column($dateOptions, 'id'), TRUE)) {
+          $defaultLabel = \CRM_Utils_Date::getRelativeDateFilterLabel($default);
+          if ($defaultLabel !== NULL) {
+            $dateOptions[] = ['id' => $default, 'label' => $defaultLabel];
+          }
+        }
         $fieldInfo['options'] = $dateOptions;
       }
     }

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/crmSearchInputVal.component.js
@@ -13,7 +13,10 @@
     template: '<div class="form-group" ng-include="$ctrl.getTemplate()"></div>',
     controller: function($scope, formatForSelect2, crmApi4) {
       const ts = $scope.ts = CRM.ts('org.civicrm.search_kit'),
-        ctrl = this;
+        ctrl = this,
+        // Dynamic "last N units including today" relative date, e.g. "ending_45.day"
+        // @see CRM_Utils_Date::DYNAMIC_RELATIVE_DATE_PATTERN
+        endingPattern = /^ending_(\d+)\.(day|week|month|quarter|year)$/;
 
       this.$onInit = function() {
         const field = getField();
@@ -35,6 +38,8 @@
         function setDateType() {
           if (_.findWhere(ctrl.dateRanges, {id: ctrl.value})) {
             ctrl.dateType = 'range';
+          } else if (endingPattern.test(ctrl.value)) {
+            ctrl.dateType = 'ending';
           } else if (ctrl.value === 'now') {
             ctrl.dateType = 'now';
           } else if (_.includes(ctrl.value, 'now -')) {
@@ -86,6 +91,10 @@
             ctrl.value = ctrl.dateRanges[0].id;
             break;
 
+          case 'ending':
+            ctrl.value = 'ending_14.day';
+            break;
+
           case 'now':
             ctrl.value = 'now';
             break;
@@ -93,6 +102,21 @@
           default:
             ctrl.value = ctrl.dateType + ' 1 day';
         }
+      };
+
+      // Getter/setters for a dynamic "ending_N.unit" relative date
+      const getEnding = () => endingPattern.exec(ctrl.value) || [null, '14', 'day'];
+      this.endingNumber = function(setNumber) {
+        if (arguments.length) {
+          ctrl.value = 'ending_' + Math.max(1, parseInt(setNumber, 10) || 1) + '.' + getEnding()[2];
+        }
+        return parseInt(getEnding()[1], 10);
+      };
+      this.endingUnits = function(setUnit) {
+        if (arguments.length) {
+          ctrl.value = 'ending_' + getEnding()[1] + '.' + setUnit;
+        }
+        return getEnding()[2];
       };
 
       this.dateUnits = function(setUnit) {

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchInput/date.html
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchInput/date.html
@@ -2,6 +2,7 @@
   <select id="{{:: $ctrl.labelId }}" class="form-control eight" ng-if="$ctrl.isMulti() === false" ng-model="$ctrl.dateType" ng-change="$ctrl.changeDateType()">
     <option value="fixed">{{:: ts('Pick Date') }}</option>
     <option value="range">{{:: ts('Date Range') }}</option>
+    <option value="ending">{{:: ts('Last N Days/Weeks/Months') }}</option>
     <option value="now">{{:: ts('Now') }}</option>
     <option value="now -">{{:: ts('Before now') }}</option>
     <option value="now +">{{:: ts('After now') }}</option>
@@ -16,6 +17,19 @@
 
     <div class="form-group" ng-switch-when="range">
       <input class="form-control" crm-ui-select="{data: $ctrl.dateRanges}" ng-model="$ctrl.value" >
+    </div>
+
+    <div class="form-group" ng-switch-when="ending">
+      <label>{{:: ts('Last') }}</label>
+      <input class="form-control four" type="number" min="1" step="1" ng-model="$ctrl.endingNumber" ng-model-options="{getterSetter: true}" >
+      <select class="form-control eight" ng-model="$ctrl.endingUnits" ng-model-options="{getterSetter: true}" >
+        <option value="day">{{ $ctrl.endingNumber() === 1 ? ts('Day') : ts('Days') }}</option>
+        <option value="week">{{ $ctrl.endingNumber() === 1 ? ts('Week') : ts('Weeks') }}</option>
+        <option value="month">{{ $ctrl.endingNumber() === 1 ? ts('Month') : ts('Months') }}</option>
+        <option value="quarter">{{ $ctrl.endingNumber() === 1 ? ts('Quarter') : ts('Quarters') }}</option>
+        <option value="year">{{ $ctrl.endingNumber() === 1 ? ts('Year') : ts('Years') }}</option>
+      </select>
+      <label>{{:: ts('including today') }}</label>
     </div>
 
     <div class="form-group" ng-switch-when="now +|now -" ng-switch-when-separator="|">

--- a/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
+++ b/ext/search_kit/tests/phpunit/api/v4/SearchDisplay/SearchAfformTest.php
@@ -541,6 +541,61 @@ class SearchAfformTest extends \PHPUnit\Framework\TestCase implements HeadlessIn
     $this->assertCount(0, $result);
   }
 
+  /**
+   * A dynamic "last N units" default (e.g. "ending_45.day") isn't in the relative_date_filters
+   * option group, so the metadata injector should add it to the date select's option list.
+   */
+  public function testDynamicRelativeDateDefaultIsInjectedAsOption(): void {
+    $this->createTestRecord('SavedSearch', [
+      'name' => 'TestActivityDateSearch',
+      'label' => 'TestActivityDateSearch',
+      'api_entity' => 'Activity',
+      'api_params' => [
+        'version' => 4,
+        'select' => ['id', 'subject', 'activity_date_time'],
+        'where' => [],
+      ],
+    ]);
+
+    $markup = <<<HTML
+      <div af-fieldset="">
+        <af-field name="activity_date_time" defn="{input_type: 'Select', search_range: true, afform_default: 'ending_45.day'}" />
+        <crm-search-display-table search-name="TestActivityDateSearch" display-name=""></crm-search-display-table>
+      </div>
+      HTML;
+
+    Afform::create(FALSE)
+      ->addValue('name', 'TestAfformWithDynamicDate')
+      ->addValue('title', 'TestAfformWithDynamicDate')
+      ->addValue('type', 'search')
+      ->setLayoutFormat('html')
+      ->addValue('layout', $markup)
+      ->execute();
+
+    $moduleName = Afform::get(FALSE)
+      ->addWhere('name', '=', 'TestAfformWithDynamicDate')
+      ->addSelect('module_name')
+      ->execute()->single()['module_name'];
+    \Civi::service('angular')->clear();
+    $partials = \Civi::service('angular')->getPartials($moduleName);
+    $formHtml = NULL;
+    foreach ($partials as $key => $html) {
+      if (str_ends_with($key, '.aff.html')) {
+        $formHtml = $html;
+        break;
+      }
+    }
+    $this->assertNotNull($formHtml);
+    // Standard option-group values are present, including the new "Last 6 months" one
+    $this->assertStringContainsString("'ending_6.month'", $formHtml);
+    $this->assertStringContainsString('Last 6 months including today', $formHtml);
+    // The dynamic default has been added with a generated label
+    $this->assertStringContainsString("'ending_45.day'", $formHtml);
+    $this->assertStringContainsString('Last 45 days including today', $formHtml);
+    // A dynamic term with a different number is not present
+    $this->assertStringNotContainsString("'ending_46.day'", $formHtml);
+  }
+
   public function testRunWithJoinFilters(): void {
     $lastName = uniqid();
 

--- a/sql/civicrm_data/civicrm_option_group/relative_date_filters.sqldata.php
+++ b/sql/civicrm_data/civicrm_option_group/relative_date_filters.sqldata.php
@@ -21,6 +21,7 @@ return CRM_Core_CodeGen_OptionGroup::create('relative_date_filters', 'a/0078')
     [ts('Last 60 days including today'), 'ending_2.month', 'value' => 'ending_60.day'],
     [ts('Last 90 days including today'), 'ending.quarter', 'value' => 'ending_90.day'],
     // Suspicious... name and value disagree... ^^^
+    [ts('Last 6 months including today'), 'ending_6.month'],
     [ts('Last 12 months including today'), 'ending.year'],
     [ts('Last 2 years including today'), 'ending_2.year'],
     [ts('Last 3 years including today'), 'ending_3.year'],

--- a/tests/phpunit/CRM/Utils/DateTest.php
+++ b/tests/phpunit/CRM/Utils/DateTest.php
@@ -183,6 +183,8 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       'ending_18.week' => '- 18 weeks + 1 day',
       'ending_18.month' => '- 18 months + 1 day',
       'ending_18.day' => '- 17 days',
+      'ending_6.month' => '- 6 months + 1 day',
+      'ending_45.day' => '- 44 days',
     ];
 
     foreach ($relativeDateValues as $key => $value) {
@@ -2771,6 +2773,37 @@ class CRM_Utils_DateTest extends CiviUnitTestCase {
       // German format https://civicrm.stackexchange.com/questions/34174/contact-import-german-date-format-support
       '01.10.2022' => ['date' => '01.10.2022', 'format' => CRM_Utils_Date::DATE_dd_mm_yyyy, 'expected' => '20221001000000'],
     ];
+  }
+
+  /**
+   * Test recognition of relative date filter terms, including dynamic "ending_N.unit" terms.
+   */
+  public function testIsRelativeDateFilter(): void {
+    // Terms defined in the option group.
+    $this->assertTrue(CRM_Utils_Date::isRelativeDateFilter('this.month'));
+    $this->assertTrue(CRM_Utils_Date::isRelativeDateFilter('ending_90.day'));
+    $this->assertTrue(CRM_Utils_Date::isRelativeDateFilter('ending_6.month'));
+    // Dynamic "last N units" terms not defined in the option group.
+    $this->assertTrue(CRM_Utils_Date::isRelativeDateFilter('ending_45.day'));
+    $this->assertTrue(CRM_Utils_Date::isRelativeDateFilter('ending_10.year'));
+    // Not relative date terms.
+    $this->assertFalse(CRM_Utils_Date::isRelativeDateFilter('2024-01-01'));
+    $this->assertFalse(CRM_Utils_Date::isRelativeDateFilter('now - 1 day'));
+    $this->assertFalse(CRM_Utils_Date::isRelativeDateFilter('ending_0.day'));
+    $this->assertFalse(CRM_Utils_Date::isRelativeDateFilter('ending_5.fortnight'));
+    $this->assertFalse(CRM_Utils_Date::isRelativeDateFilter('starting_5.day'));
+    $this->assertFalse(CRM_Utils_Date::isRelativeDateFilter(NULL));
+  }
+
+  /**
+   * Test labels for relative date filter terms.
+   */
+  public function testGetRelativeDateFilterLabel(): void {
+    $this->assertEquals('This calendar month', CRM_Utils_Date::getRelativeDateFilterLabel('this.month'));
+    $this->assertEquals('Last 6 months including today', CRM_Utils_Date::getRelativeDateFilterLabel('ending_6.month'));
+    $this->assertEquals('Last 45 days including today', CRM_Utils_Date::getRelativeDateFilterLabel('ending_45.day'));
+    $this->assertEquals('Last 1 week including today', CRM_Utils_Date::getRelativeDateFilterLabel('ending_1.week'));
+    $this->assertNull(CRM_Utils_Date::getRelativeDateFilterLabel('2024-01-01'));
   }
 
 }

--- a/tests/phpunit/api/v4/Action/DateTest.php
+++ b/tests/phpunit/api/v4/Action/DateTest.php
@@ -146,6 +146,45 @@ class DateTest extends Api4TestBase implements TransactionalInterface {
     $this->assertNotContains($act[6], $result);
   }
 
+  /**
+   * Dynamic "last N units including today" terms (e.g. "ending_45.day") should work
+   * as relative date filters even though they're not in the relative_date_filters option group.
+   */
+  public function testDynamicRelativeDateRanges(): void {
+    $c1 = $this->createTestRecord('Contact')['id'];
+
+    $act = Activity::save(FALSE)
+      ->setDefaults(['activity_type_id:name' => 'Meeting', 'source_contact_id' => $c1])
+      ->addRecord(['activity_date_time' => date('Y-m-d H:i:s', strtotime('- 200 days'))])
+      ->addRecord(['activity_date_time' => date('Y-m-d H:i:s', strtotime('- 100 days'))])
+      ->addRecord(['activity_date_time' => date('Y-m-d H:i:s', strtotime('- 40 days'))])
+      ->addRecord(['activity_date_time' => date('Y-m-d H:i:s', strtotime('- 10 days'))])
+      ->addRecord(['activity_date_time' => 'now'])
+      ->addRecord(['activity_date_time' => date('Y-m-d H:i:s', strtotime('+ 10 days'))])
+      ->execute()->column('id');
+
+    // Not in the option group, but a valid dynamic term.
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '=', 'ending_45.day')
+      ->execute()->column('id');
+    $this->assertNotContains($act[0], $result);
+    $this->assertNotContains($act[1], $result);
+    $this->assertContains($act[2], $result);
+    $this->assertContains($act[3], $result);
+    $this->assertContains($act[4], $result);
+    $this->assertNotContains($act[5], $result);
+
+    // Newly-added option group value.
+    $result = Activity::get(FALSE)->addSelect('id')
+      ->addWhere('activity_date_time', '=', 'ending_6.month')
+      ->execute()->column('id');
+    $this->assertNotContains($act[0], $result);
+    $this->assertContains($act[1], $result);
+    $this->assertContains($act[2], $result);
+    $this->assertContains($act[4], $result);
+    $this->assertNotContains($act[5], $result);
+  }
+
   public function testJoinOnRelativeDate(): void {
     $c1 = Contact::create(FALSE)
       ->addValue('first_name', 'Contributor')


### PR DESCRIPTION
Overview
----------------------------------------
Adds a "Last 6 months including today" relative date option, and lets searches and forms use
any "last N days / weeks / months / quarters / years" range instead of only the fixed choices
in the option list.

Before
----------------------------------------
The relative date list jumps from "Last 90 days" to "Last 12 months". Only values defined in the
`relative_date_filters` option group are accepted, so there is no way to search for e.g. the
last 45 days or last 6 months without picking absolute dates.

After
----------------------------------------
- "Last 6 months including today" appears after "Last 90 days" in every relative date select.
- SearchKit date filters have a new "Last N Days/Weeks/Months" choice with a number box and
  unit select, stored as e.g. `ending_45.day`.
- FormBuilder: for a date field shown as a range select, the "Default Value" dropdown gains a
  "Last [N] [unit] including today" row. The end-user form lists that default as an option with
  a generated label such as "Last 45 days including today".
- API4 accepts such terms directly, e.g. `['activity_date_time', '=', 'ending_45.day']`.

Technical Details
----------------------------------------
- `CRM_Utils_Date::relativeToAbsolute()` already handled `ending_N.unit` for every unit; the
  blocker was validation against the option group in API4 `FormattingUtil`, `CRM_Core_Form_Search`
  and the qill label lookup in `CRM_Contact_BAO_Query`. Those now use the new
  `CRM_Utils_Date::isRelativeDateFilter()` / `getRelativeDateFilterLabel()`, which accept option
  group values plus the pattern `ending_N.(day|week|month|quarter|year)` with N >= 1.
- New option value `ending_6.month` is added to the seed data and via a 6.19.alpha1 upgrade task
  that slots it after `ending_90.day` (idempotent).
- `AfformMetadataInjector` appends a dynamic `afform_default` to the injected date options so the
  afform field controller treats it as a valid select value.
- Tests: `CRM_Utils_DateTest`, `api\v4\Action\DateTest`, `SearchAfformTest`.

Comments
----------------------------------------
Classic (QuickForm) search forms still only offer the option-list values in their select.
