### PR TITLE
Small fixes for membership admin

### DIFF
--- a/CRM/Member/Form/Membership.php
+++ b/CRM/Member/Form/Membership.php
@@ -185,7 +185,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
             }
             $mem['membership_type'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipType',
               $mem['membership_type_id'],
-              'name', 'id'
+              'title', 'id'
             );
             $mem['membership_status'] = CRM_Core_DAO::getFieldValue('CRM_Member_DAO_MembershipStatus',
               $mem['status_id'],
@@ -1487,7 +1487,7 @@ class CRM_Member_Form_Membership extends CRM_Member_Form {
   protected function getStatusMessageForCreate(): string {
     foreach ($this->getCreatedMemberships() as $membership) {
       $statusMsg[$membership['membership_type_id']] = ts('%1 membership for %2 has been added.', [
-        1 => $this->allMembershipTypeDetails[$membership['membership_type_id']]['name'],
+        1 => $this->allMembershipTypeDetails[$membership['membership_type_id']]['title'],
         2 => htmlentities((string) $this->_memberDisplayName),
       ]);
 

--- a/CRM/Member/Form/MembershipType.php
+++ b/CRM/Member/Form/MembershipType.php
@@ -435,7 +435,7 @@ class CRM_Member_Form_MembershipType extends CRM_Member_Form_MembershipConfig {
       }
 
       $membershipTypeResult = CRM_Member_BAO_MembershipType::add($params);
-      $membershipTypeName = $membershipTypeResult->name;
+      $membershipTypeName = $membershipTypeResult->title;
 
       CRM_Core_Session::setStatus(ts("The membership type '%1' has been saved.",
         [1 => $membershipTypeName]

--- a/templates/CRM/Member/Form/Membership.tpl
+++ b/templates/CRM/Member/Form/Membership.tpl
@@ -668,7 +668,7 @@
               }
               else {
                 relatable = '{/literal}{ts escape='js' 1='%1'}%1 contacts are currently eligible to inherit this relationship.{/ts}{literal}';
-                relatable = ts(relatable, {1: result});
+                relatable = ts(relatable, {1: result.result});
               }
               cj('#eligibleRelated').text(relatable);
             }


### PR DESCRIPTION
Overview
----------------------------------------
This provides a couple of small fixes in the interface relating to membership admin:
- use `title` instead of internal `name` in the interface
- show correctly the count of contacts eligible for membership

If you create a membership type like 'A&B',  `title` is 'A&B' but `name` is 'A_B'. 

Before
----------------------------------------
A few places use `name` which is confusing to the user.

When adding an inheritable membership, the page shows `%1 contacts are currently eligible to inherit this relationship.`  '%1' is not substituted.

After
----------------------------------------
Use `title` instead.

'%1' is replaced by the count of contacts correctly.
