### PR TITLE
Full Text Search - Fix warning about activity_type_id

### DIFF
--- a/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
+++ b/ext/legacycustomsearches/CRM/Contact/Form/Search/Custom/FullText.php
@@ -380,11 +380,10 @@ WHERE      t.table_name = 'Activity' AND
     while ($dao->fetch()) {
       $row = [];
       foreach ($this->_tableFields as $name => $dontCare) {
-        if ($name !== 'activity_type_id') {
-          $row[$name] = $dao->$name;
-        }
-        else {
+        $row[$name] = $dao->$name;
+        if ($name === 'activity_type_id') {
           $row['activity_type'] = CRM_Core_PseudoConstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $dao->$name);
+
         }
       }
       if (isset($row['participant_role'])) {


### PR DESCRIPTION
Overview
----------------------------------------

Fix a warning when using the "Full Text Search" from `legacycustomsearches`.

Reproduction
----------------------------------------

My environment:

```
$ cv status
+-------------------------+-----------------------------------------------+
| name                    | value                                         |
+-------------------------+-----------------------------------------------+
| summary                 | 6.19.alpha1 php83m80 standalone darwin        |
| civicrm                 | 6.19.alpha1                                   |
| cv                      | 0.3.72 (phar)                                 |
| cv plugins              | 2x (alias-cmd, basic-alias)                   |
| php                     | 8.3.30 (cli, nix)                             |
| mysql                   | 8.0.42                                        |
| standalone              | Unknown                                       |
| os                      | Darwin 25.6.0 (arm64, nix)                    |
| smarty                  | 5                                             |
```

Steps:

* Enable `legacycustomsearches`
* Open "Search > Custom Searches > Full Text Search"
* Search for "phone" in "Activities"

Before
----------------------------------------

Many warnings, like:

<img width="1230" height="473" alt="Screenshot 2026-09-02 at 1 13 27 PM" src="https://github.com/user-attachments/assets/5c481b17-aaa6-4294-bae3-9f0269224be4" />

All columns are passed from `FullText.php` controller to `FullText.tpl` view, _except_ for `activity_type_id` -- which is rewritten as `activity_type`. Consequently, the view cannot read `activity_type_id`.

After
----------------------------------------

No warnings

All columns are passed from `FullText.php` controller to `FullText.tpl` view. Additionally, `activity_type` is also passed.

