### PR TITLE
dev/wordpress#166 Ensure that admin is redirected back to the contact…

### DIFF
--- a/CRM/Contact/Form/Task/Useradd.php
+++ b/CRM/Contact/Form/Task/Useradd.php
@@ -44,6 +44,8 @@ class CRM_Contact_Form_Task_Useradd extends CRM_Core_Form {
     $this->_displayName = $contact->display_name;
     $this->_email = $contact->email;
     $this->setTitle(ts('Create User Record for %1', [1 => $this->_displayName]));
+    $url = (string) Civi::url('backend://civicrm/contact/view')->addVars(['cid' => $params['id'], 'reset' => 1]);
+    CRM_Core_Session::singleton()->pushUserContext($url);
   }
 
   /**


### PR DESCRIPTION
… summary after user creation

Overview
----------------------------------------
After a CMS user is created on wordpress there is no indication of where to go so your just sent to a page which doesn't show anything sensible

Before
----------------------------------------
No specific redirection on wordpress

After
----------------------------------------
Redirected back to the contact summary screen reliably

@andyburnsco 