### PR TITLE
dev/core#6736 - APIv4 - Index the temp table behind the "groups" filter so joined searches can probe it

### DIFF
--- a/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
+++ b/Civi/Api4/Service/Spec/Provider/ContactSpecProvider.php
@@ -178,7 +178,10 @@ class ContactSpecProvider extends \Civi\Core\Service\AutoService implements Gene
    */
   public static function getContactGroupSql(array $field, string $fieldAlias, string $operator, $value, Api4SelectQuery $query, int $depth): string {
     $tempTable = \CRM_Utils_SQL_TempTable::build();
-    $tempTable->createWithColumns('contact_id INT');
+    // Index the contact list so the optimizer can probe it from the other side of a join;
+    // without it a joined query is forced to drive from this table and scan every joined
+    // row of every listed contact. CRM_Report_Form::buildGroupTempTable() does the same.
+    $tempTable->createWithColumns('contact_id INT, INDEX (contact_id)');
     $tableName = $tempTable->getName();
     \CRM_Contact_BAO_GroupContactCache::populateTemporaryTableWithContactsInGroups((array) $value, $tableName);
     // SQL optimization - use INNER JOIN if the base table is Contact & this clause is not nested


### PR DESCRIPTION
Overview
----------------------------------------
The APIv4 `groups` / `groups:name` filter on Contact (every SearchKit search and every APIv4 smart group) materialises the contacts in the requested groups into a temp table in `ContactSpecProvider::getContactGroupSql()`. That table is created as `contact_id INT` with no index. When the query also joins another entity, the optimizer has no cheap way to look a contact up in the temp table from the joined side, so it is forced to drive the whole query from the temp table and walk every joined row for every listed contact. 

This PR creates the table with `INDEX (contact_id)`, which is what `CRM_Report_Form::buildGroupTempTable()` has done for CiviReport's group filter since CRM-19170 (2016).

This dramatically sped up some searches for us.

GitLab: https://lab.civicrm.org/dev/core/-/issues/6736
