### PR TITLE
Fixing missing x button for dialogs

### DIFF
--- a/ext/riverlea/core/css/components/_dialogs.css
+++ b/ext/riverlea/core/css/components/_dialogs.css
@@ -48,6 +48,8 @@
   margin: 0;
   right: unset !important /* vs inline - ie CiviCase Actiity View */;
   top: unset;
+  width: var(--crm-dialog-header-size);
+  height: var(--crm-dialog-header-size);
 }
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-state-hover .ui-icon,
 .crm-container.ui-dialog .ui-dialog-titlebar .ui-state-focus .ui-icon,


### PR DESCRIPTION
Overview
----------------------------------------
Specifically, I noticed in WordPress on some installation (like with WPML or other plugins) the X button in the dialog is missing. I think it's because we aren't explicitly defining the width/height.

Before
----------------------------------------
<img width="1252" height="888" alt="Close" src="https://github.com/user-attachments/assets/4eafae07-9098-47bf-bee6-07de4c037710" />


After
----------------------------------------
<img width="897" height="162" alt="image" src="https://github.com/user-attachments/assets/6df1e96b-4e07-4af8-ac73-b7f903c95cb8" />

