### PR TITLE
Strip query strings when comparing parent and child URLs.

### DIFF
--- a/CRM/Utils/Url.php
+++ b/CRM/Utils/Url.php
@@ -171,7 +171,8 @@ class CRM_Utils_Url {
   public static function isChildOf($child, $parent): bool {
     $childRel = static::toRelative((string) $child);
     $parentRel = static::toRelative((string) $parent);
-    return str_starts_with($childRel, $parentRel);
+    $parentPath = strtok($parentRel, '?');
+    return str_starts_with($childRel, $parentPath);
   }
 
 }


### PR DESCRIPTION
When using the iframe extension with WP  we could get session errors as the Query string would not match and trigger a failure.

Overview
----------------------------------------
An error occurred on a site where any submission of an iframe embedded contribution form on Chromium or Safari would get a session error when trying to display the Thank You page.



Before
----------------------------------------
```
2026-09-03 14:25:10-0500  [info] Contribution 315 updated successfully 
2026-09-03 14:25:11-0500  [info] Contribution 315 Receipt sent
2026-09-03 14:25:12-0500  [error]$Fatal Error Details = array:3 [  "message" => "Sorry, your session has expired. Please reload the page or go back and try again."  "code" => null  "exception" => CRM_Core_Exception {#8485    #message: "Sorry, your session has expired. Please reload the page or go back and try again."    #code: 419    #file: "/home/example/public_html/wp-content/plugins/civicrm/civicrm/CRM/Core/Controller.php"
```

Adding debuggin on cosession  based on @ufundo 's input shows

```
2026-09-03 14:25:11-0500  [debug] COSESSION DEBUGArray
(
    [redirectUrl] => https://example.org/civicrm/contribute/transact/?_qf_ThankYou_display=1&qfKey=CRMContributeControllerContributionPp4h0Z1M4zUS89cZ1P0nGBZ0xEO65zXycZ0jnzk719Z2EFCM_6136&_cvwpif=1    
    [embedUrl] => https://example.org/civicrm/?_cvwpif=1    
    [isChildOf] => false)
```



After
----------------------------------------
No Error Thank you page displays on all browsers

```
2026-09-03 14:33:55-0500  [info] Contribution 316 updated successfully
2026-09-03 14:33:56-0500  [info] Contribution 316 Receipt sent
2026-09-03 14:33:56-0500  [debug] COSESSION DEBUG
Array
(
    [redirectUrl] => https://example.org/civicrm/contribute/transact/?_qf_ThankYou_display=1&qfKey=CRMContributeControllerContributionPRKnauSpfsGVRtAlZ2fc9mlCDG9Q7SZ0hIJ77yvkkZ2UJs_8506&_cvwpif=1
    [embedUrl] => https://example.org/civicrm/?_cvwpif=1
    [isChildOf] => true
)
```

Comments
----------------------------------------
Needs Testing and feedback.  I have only encountered this on one site, and am curious why no one else has hit this issue.  We also need to test on Standalone and Drupal.  