### PR TITLE
Fix Mixin Test failures on Drupal Clean runs because entity might not…

### DIFF
--- a/CRM/Core/Resources.php
+++ b/CRM/Core/Resources.php
@@ -572,7 +572,7 @@ class CRM_Core_Resources implements CRM_Core_Resources_CollectionAdderInterface 
 
     foreach (CRM_Core_DAO_AllCoreTables::daoToClass() as $entity => $daoName) {
       // Skip DAOs of disabled components
-      if (!$daoName::isComponentEnabled()) {
+      if (!class_exists($daoName) || !$daoName::isComponentEnabled()) {
         continue;
       }
       $baoName = str_replace('_DAO_', '_BAO_', $daoName);


### PR DESCRIPTION
… have an Actual DAO class

Overview
----------------------------------------
This aims to fix the mixin test failures shown here https://test.civicrm.org/duderino/batch/CiviCRM-RC-Periodic/20890111 the problem is that there is an error about `Class &quot;CRM_Shimmy_DAO_ShimThing2&quot; not found    </main>` which is causing hte test fail to happen. This is becuase the entity-v2 test mixin has an entity defined https://github.com/civicrm/civicrm-core/blob/master/mixin/entity-types-php%402/example/tests/mixin/EntityTypes2Test.php#L22 but no actual DAO class exists

Before
----------------------------------------
Error because class doesn't exist

After
----------------------------------------
No Error

ping @colemanw @MegaphoneJon @ufundo 