### PR TITLE
Setting input-large class to use 95% of allowed space

### DIFF
--- a/ext/riverlea/core/css/_variables.css
+++ b/ext/riverlea/core/css/_variables.css
@@ -248,7 +248,7 @@
   --crm-input-large-padding: var(--crm-l-small) var(--crm-l-medium-1);
   --crm-input-height: var(--crm-l-large);
   --crm-input-width: 15em;
-  --crm-input-large-width: 25em;
+  --crm-input-large-width: 95%;
   --crm-input-font-size: var(--crm-l-medium-3);
   --crm-input-label-weight: bold;
   --crm-input-label-font: var(--crm-font);


### PR DESCRIPTION
Overview
----------------------------------------
Currently, textarea and large fields are dictated by the `--crm-input-large-width` variable, which on most screens is about 25% of the allowed space (at 25em). It's not that bad and when most people I work with see the fields they think there is a bug in core. I'm just attempting (at least) with some of these things to fix little things that make it look consistent.

WYSIWYG sets the textarea (replicated) to 95% so I figured that might be a good start.

Before
----------------------------------------
<img width="1671" height="1182" alt="image" src="https://github.com/user-attachments/assets/a3ce8c55-73f0-41a5-825b-a74603cd660e" />


After
----------------------------------------
<img width="1671" height="297" alt="image" src="https://github.com/user-attachments/assets/2cd8267e-5e1d-41b9-907a-8f4a2da012a2" />

Comments
----------------------------------------
I was also thinking that it might be better to at least increase `crm-input-width` to something more than `15em` also. It's about 15% which is super tiny too for most fields. Sure it works for some names, but not addresses and other things. I was thinking more like `25em`?

_Also I know the text area isn't really used but it's a good example_

cc @vingle @colemanw 
