### PR TITLE
Fix hidden CiviCRM menu

### DIFF
--- a/css/menubar-drupal8.css
+++ b/css/menubar-drupal8.css
@@ -37,7 +37,7 @@ nav#civicrm-menu-nav .crm-menubar-toggle-btn span.crm-menu-logo {
 
   body.crm-menubar-below-cms-menu > #civicrm-menu-nav ul#civicrm-menu {
     z-index: 1000;
-    top: 40px;
+    top: var(--drupal-displace-offset-top);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
In Drupal 10/11 it seems that the CiviCRM menu is hidden below the top menu if the menu is setup to appear below (when clicking Manage) the main menu.

Before
----------------------------------------

<img width="1730" height="173" alt="drupaltop" src="https://github.com/user-attachments/assets/4ed4a4ca-44b5-4c76-a430-d536d40ba77b" />


After
----------------------------------------
<img width="1728" height="206" alt="image" src="https://github.com/user-attachments/assets/3025f140-1a12-42b0-a2ee-c6bb586adf8a" />

Comments
----------------------------------------

It's weird @vingle I thought a while back we streamlined this for WP, Joomla, etc but maybe not. Anyway it's clearly not working. The only thing I didn't get working is if they click on `Manage` again then the CiviCRM menu disappears (a hidden class is added). I find it weird but that's another issue.

cc @colemanw @vingle 