### PR TITLE
Fix GroupContact bulk add misreading a truncated GROUP_CONCAT

### DIFF
--- a/CRM/Contact/BAO/GroupContact.php
+++ b/CRM/Contact/BAO/GroupContact.php
@@ -698,7 +698,7 @@ VALUES
 
       // lets check their current status
       $sql = "
-SELECT GROUP_CONCAT(contact_id) as contactStr
+SELECT contact_id
 FROM   civicrm_group_contact
 WHERE  group_id = %1
 AND    status = %2
@@ -711,9 +711,8 @@ AND    contact_id IN ( $contactStr )
 
       $presentIDs = [];
       $dao = CRM_Core_DAO::executeQuery($sql, $params);
-      if ($dao->fetch()) {
-        $presentIDs = explode(',', ($dao->contactStr ?? ''));
-        $presentIDs = array_flip($presentIDs);
+      while ($dao->fetch()) {
+        $presentIDs[$dao->contact_id] = TRUE;
       }
 
       $gcValues = $shValues = [];

--- a/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
+++ b/tests/phpunit/CRM/Contact/BAO/GroupContactTest.php
@@ -264,4 +264,53 @@ class CRM_Contact_BAO_GroupContactTest extends CiviUnitTestCase {
     }
   }
 
+  /**
+   * Contacts already in a group must not be added again when the presence check
+   * cannot fit its result into group_concat_max_len.
+   *
+   * The check reads a GROUP_CONCAT of the batch it is about to write. MySQL
+   * truncates that at group_concat_max_len and only warns, so on a large enough
+   * site the ids past the cut look absent and get re-written on every call.
+   */
+  public function testBulkAddIsIdempotentWhenPresenceCheckTruncates(): void {
+    $groupID = (int) $this->callAPISuccess('Group', 'create', [
+      'title' => 'Presence check truncation',
+      'is_active' => 1,
+    ])['id'];
+
+    $contactIDs = [];
+    for ($i = 0; $i < 20; $i++) {
+      $contactIDs[] = (int) $this->individualCreate(['first_name' => 'Trunc' . $i]);
+    }
+
+    CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIDs, $groupID);
+    $this->assertEquals(count($contactIDs), $this->getSubscriptionHistoryCount($groupID));
+
+    // Low enough that the presence string cannot hold the batch, whatever the ids are.
+    $originalMaxLen = (int) CRM_Core_DAO::singleValueQuery('SELECT @@session.group_concat_max_len');
+    CRM_Core_DAO::executeQuery('SET SESSION group_concat_max_len = 4');
+    try {
+      [, $added, $notAdded] = CRM_Contact_BAO_GroupContact::addContactsToGroup($contactIDs, $groupID);
+    }
+    finally {
+      CRM_Core_DAO::executeQuery('SET SESSION group_concat_max_len = ' . $originalMaxLen);
+    }
+
+    $this->assertEquals(0, $added, 'Contacts already in the group were added again.');
+    $this->assertEquals(count($contactIDs), $notAdded);
+    $this->assertEquals(count($contactIDs), $this->getSubscriptionHistoryCount($groupID),
+      'A truncated presence check appended duplicate subscription history.');
+  }
+
+  /**
+   * @param int $groupID
+   * @return int
+   */
+  private function getSubscriptionHistoryCount(int $groupID): int {
+    return (int) CRM_Core_DAO::singleValueQuery(
+      'SELECT COUNT(*) FROM civicrm_subscription_history WHERE group_id = %1',
+      [1 => [$groupID, 'Integer']]
+    );
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------

`CRM_Contact_BAO_GroupContact::bulkAddContactsToGroup` decides which contacts are already in a group by reading a `GROUP_CONCAT(contact_id)` and exploding it. MySQL truncates that string at `group_concat_max_len` and raises only a warning, which CiviCRM never reads, so on a large enough site the check silently returns the wrong answer.

The batch is 200 ids (`CRM_Core_DAO::BULK_INSERT_HIGH_COUNT`), so the string stops fitting MySQL's 1024-byte default once contact ids reach five digits, i.e. any MySQL-backed site past ~10k contacts. MariaDB defaults to 1M and is unaffected.

Before
----------------------------------------

Two things go wrong once the string truncates.

**Contacts past the cut are re-written every run.** They read as absent, so each call issues a `REPLACE INTO civicrm_group_contact`, appends a `civicrm_subscription_history` row, and fires the audit-log triggers, for memberships that already exist.

**A contact at the cut can be skipped entirely.** `array_flip` turns a numeric string into an integer key, and truncation leaves a partial trailing token, so a contact whose id equals that prefix reads as *present* and is never added:

```php
$k = array_flip(explode(',', '12345,123'));  // truncated result
isset($k[123]);                              // TRUE, for a contact that is absent
```

That one is silent data loss rather than redundant writes, and it is most likely exactly when ids are transitioning from four to five digits.

Both are invisible: `GROUP_CONCAT` truncation raises a warning, not an error, and nothing reads it. The `[total, added, notAdded]` return is also wrong, so callers that assert idempotence on it are misled.

After
----------------------------------------

The presence check fetches rows instead of building a delimited string, which removes both failures: no length ceiling, so nobody past the cut is re-written; nothing to parse, so no partial token can mask a real add. The result no longer depends on `group_concat_max_len`.

```php
$sql = "
SELECT contact_id
FROM   civicrm_group_contact
WHERE  group_id = %1
AND    status = %2
AND    contact_id IN ( $contactStr )
";
...
$presentIDs = [];
$dao = CRM_Core_DAO::executeQuery($sql, $params);
while ($dao->fetch()) {
  $presentIDs[$dao->contact_id] = TRUE;
}
```

Technical Details
----------------------------------------

`$presentIDs` is only ever consumed by `isset($presentIDs[$cid])` further down the same loop. PHP coerces numeric-string array keys to integers, which is what `array_flip` was relying on, so the map this builds is identical to the untruncated case and the change is behaviour-preserving wherever the old code was already correct.

The `GROUP_CONCAT` was never needed: it built a string that the next line exploded straight back into an array. Removing it also removes a dependency on a server variable that core does not set, does not document, and does not check in `Civi\Install\Requirements` alongside `thread_stack`, InnoDB, temp tables, triggers, utf8mb4 and `auto_increment_increment`.

Comments
----------------------------------------

The included test reproduces it by lowering the cap rather than by creating 10k contacts, which isolates it to the one variable.

Also verified against a running 6.18.0 install, by patching the method in place and re-running the same experiment on the same contacts, stock versus fixed. The spurious re-add count tracks the cap exactly on stock (each id costs its digits plus a comma) and is 0 everywhere once the rows are fetched:

```
20 two-digit ids, so a complete presence string is 59 bytes

cap        stock    fixed
1048576        0        0
     39        7        0
     30       10        0
     20       13        0
     10       17        0
      4       19        0
```

Found on a site about 25 bytes of headroom away from tripping it.


