### PR TITLE
dev/core#6731 Ensure userEntered text is available to the template for back-office message

### DIFF
--- a/CRM/Event/Form/Participant.php
+++ b/CRM/Event/Form/Participant.php
@@ -1407,17 +1407,6 @@ class CRM_Event_Form_Participant extends CRM_Contribute_Form_AbstractEditPayment
   }
 
   /**
-   * @param $eventID
-   * @param $participantRoles
-   * @param $receiptText
-   *
-   * @throws \CRM_Core_Exception
-   */
-  protected function assignEventDetailsToTpl($eventID, $participantRoles, $receiptText): void {
-    $this->assign('event', ['confirm_email_text' => $receiptText]);
-  }
-
-  /**
    * Get the currency for the event.
    *
    * @return string
@@ -1768,7 +1757,6 @@ INNER JOIN civicrm_price_field_value value ON ( value.id = lineItem.price_field_
   protected function sendReceipts($params, array $participants): array {
     $sent = [];
     $notSent = [];
-    $this->assignEventDetailsToTpl($params['event_id'], $params['role_id'] ?? NULL, $params['receipt_text'] ?? NULL);
 
     if ($this->_mode) {
       $valuesForForm = CRM_Contribute_Form_AbstractEditPayment::formatCreditCardDetails($params);

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -583,15 +583,6 @@ SELECT  id, html_type
     if (array_key_exists($params['from_email_address'], $this->_fromEmails['from_email_id'])) {
       $receiptFrom = $params['from_email_address'];
     }
-    //use of the message template below requires variables in different format
-    $events = [];
-    $returnProperties = ['fee_label', 'start_date', 'end_date', 'is_show_location', 'title'];
-
-    //get all event details.
-    CRM_Core_DAO::commonRetrieveAll('CRM_Event_DAO_Event', 'id', $params['event_id'], $events, $returnProperties);
-    $event = $events[$params['event_id']];
-    unset($event['start_date'], $event['end_date']);
-    $this->assign('event', $event);
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email
     [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -591,9 +591,6 @@ SELECT  id, html_type
     CRM_Core_DAO::commonRetrieveAll('CRM_Event_DAO_Event', 'id', $params['event_id'], $events, $returnProperties);
     $event = $events[$params['event_id']];
     unset($event['start_date'], $event['end_date']);
-    if ($params['receipt_text']) {
-      $event['confirm_email_text'] = $params['receipt_text'];
-    }
     $this->assign('event', $event);
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email
@@ -613,6 +610,7 @@ SELECT  id, html_type
         'contactId' => $this->getContactID(),
         'eventID' => $params['event_id'],
         'contributionID' => $this->getContributionID(),
+        'userEnteredText' => $this->getSubmittedValue('receipt_text'),
       ],
     ];
 

--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -551,7 +551,9 @@ SELECT  id, html_type
       $fetchParticipantVals = ['id' => $this->getParticipantID()];
       CRM_Event_BAO_Participant::getValues($fetchParticipantVals, $participantDetails);
       $participantParams = array_merge($params, $participantDetails[$this->getParticipantID()]);
-      $this->emailReceipt($participantParams);
+      if (array_key_exists($this->getSubmittedValue('from_email_address'), $this->_fromEmails['from_email_id'])) {
+        $this->emailReceipt($participantParams);
+      }
     }
 
     // update participant
@@ -580,12 +582,8 @@ SELECT  id, html_type
    * @param array $params
    */
   private function emailReceipt(array $params): void {
-    if (array_key_exists($params['from_email_address'], $this->_fromEmails['from_email_id'])) {
-      $receiptFrom = $params['from_email_address'];
-    }
-
     // Retrieve the name and email of the contact - this will be the TO for receipt email
-    [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->_contactId);
+    [$this->_contributorDisplayName, $this->_contributorEmail, $this->_toDoNotEmail] = CRM_Contact_BAO_Contact::getContactDetails($this->getContactID());
 
     $this->_contributorDisplayName = ($this->_contributorDisplayName == ' ') ? $this->_contributorEmail : $this->_contributorDisplayName;
 
@@ -599,7 +597,7 @@ SELECT  id, html_type
       'modelProps' => [
         'participantID' => $this->getParticipantID(),
         'contactId' => $this->getContactID(),
-        'eventID' => $params['event_id'],
+        'eventID' => $this->getEventID(),
         'contributionID' => $this->getContributionID(),
         'userEnteredText' => $this->getSubmittedValue('receipt_text'),
       ],
@@ -608,7 +606,7 @@ SELECT  id, html_type
     // try to send emails only if email id is present
     // and the do-not-email option is not checked for that contact
     if ($this->_contributorEmail && !$this->_toDoNotEmail) {
-      $sendTemplateParams['from'] = $receiptFrom;
+      $sendTemplateParams['from'] = $this->getSubmittedValue('from_email_address');
       $sendTemplateParams['toName'] = $this->_contributorDisplayName;
       $sendTemplateParams['toEmail'] = $this->_contributorEmail;
       $sendTemplateParams['cc'] = $this->_fromEmails['cc'] ?? NULL;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1365,6 +1365,7 @@ class CRM_Utils_Token {
           '$totalAmount' => 'contribution.total_amount',
           '$location' => 'event.location',
           '$isShowLocation' => 'event.is_show_location|boolean',
+          '$event.event_confirm_text' => 'UserEnteredText',
           '$event.participant_role' => 'participant.role_id:label',
           '$amount_level' => ts('see default template for how to show this'),
           'balanceAmount' => 'contribution.balance_amount',

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -112,7 +112,10 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'contribution_status_id' => 'Pending',
       'receive_date' => date('Y-m-d') . ' 00:00:00',
       'line_items' => [],
-      'api.Payment.create' => ['total_amount' => $actualPaidAmt],
+      'api.Payment.create' => [
+        'total_amount' => $actualPaidAmt,
+        'is_send_contribution_notification' => FALSE,
+      ],
     ];
     foreach ($lineItems as $lineItem) {
       $orderParams['line_items'][] = [
@@ -573,6 +576,31 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'id' => $this->ids['Participant']['order'],
       'action' => CRM_Core_Action::UPDATE,
     ])->processForm();
+  }
+
+  /**
+   * The "Confirmation Message" text entered on the back-office
+   * "Change Registration" screen should be included in the confirmation
+   * email when "Send Confirmation?" is ticked.
+   *
+   * https://lab.civicrm.org/dev/core/-/work_items/6731
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testChangeFeeSelectionEmailIncludesConfirmationMessage(): void {
+    $this->registerParticipantAndPay($this->_expensiveFee);
+    $fromEmailAddress = array_key_first(CRM_Event_BAO_Event::getFromEmailIds($this->getEventID())['from_email_id']);
+    $this->getTestForm('CRM_Event_Form_ParticipantFeeSelection', [
+      $this->getPriceFieldFormLabel('PaidEvent') => $this->getCheapFeeID(),
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Registered'),
+      'send_receipt' => 1,
+      'from_email_address' => $fromEmailAddress,
+      'receipt_text' => 'This is my distinctive confirmation message',
+    ], [
+      'id' => $this->ids['Participant']['order'],
+      'action' => CRM_Core_Action::UPDATE,
+    ])->processForm();
+    $this->assertMailSentContainingString('This is my distinctive confirmation message');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6731 Ensure userEntered text is available to the template for back-office message

Before
----------------------------------------
email_confirm_text not assigned to the userEnteredText variable in the template

After
----------------------------------------
Now it is

Technical Details
----------------------------------------

Comments
----------------------------------------
