### PR TITLE
SearchKit - Fix Embedded Subsearch filter loading issue 

### DIFF
--- a/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.html
+++ b/ext/search_kit/ang/crmSearchAdmin/crmSearchAdminSubsearch.html
@@ -7,12 +7,12 @@
 </div>
 <table class="table table-condensed" ng-if="$ctrl.column.subsearch.search">
   <thead>
-  <tr>
-    <th>{{:: ts('Filter Subsearch Display') }}</th>
-    <th>{{:: ts('With Value') }}</th>
-  </tr>
+    <tr>
+      <th>{{:: ts('Filter Subsearch Display') }}</th>
+      <th>{{:: ts('With Value') }}</th>
+    </tr>
   </thead>
-  <tbody>
+  <tbody ng-if="$ctrl.savedSearch">
     <tr ng-repeat="filter in $ctrl.column.subsearch.filters">
       <td>
         <input class="form-control" ng-model="filter.subsearch_field" crm-ui-select="{data: $ctrl.subsearchFields, placeholder: ' '}" ng-change="$ctrl.onChangeFilter($index)">


### PR DESCRIPTION
Overview
----------------------------------------
Resolves a issue with filters not loading when editing an existing Embedded Subsearch within SearchKit.

Before
----------------------------------------
When editing an existing Embedded Subsearch the filters do not fully load:
<img width="783" height="594" alt="image" src="https://github.com/user-attachments/assets/d6685d2c-cd26-42f6-9ab6-ec17711e2b99" />

After
----------------------------------------
When editing an existing Embedded Subsearch the filter does fully load.
<img width="926" height="553" alt="image" src="https://github.com/user-attachments/assets/5b408724-3a03-4ee6-90e2-a831e76b16b5" />