### PR TITLE
PR Commands - Do not skip rebase when changing base branch

### DIFF
--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -163,12 +163,8 @@ jobs:
               UPSTREAM="origin/$base_branch"
             fi
 
-            if [ "$ACTION" = "rebase" ] && git merge-base --is-ancestor origin/$NEW_BASE HEAD; then
-              echo "Branch is already fast-forward mergeable with $NEW_BASE."
-              if [ "$NEW_BASE" != "$base_branch" ]; then
-                echo "Changing PR base branch to $NEW_BASE..."
-                gh pr edit ${{ github.event.issue.number }} --base $NEW_BASE --repo ${{ github.repository }}
-              fi
+            if [ "$ACTION" = "rebase" ] && [ "$NEW_BASE" = "$base_branch" ] && git merge-base --is-ancestor origin/$base_branch HEAD; then
+              echo "Branch is already up to date with $base_branch."
             else
               if ! git rebase --onto origin/$NEW_BASE $UPSTREAM HEAD; then
                 echo "REBASE_FAILED=true" >> $GITHUB_ENV


### PR DESCRIPTION
Overview
----------------------------------------
Fixes a bug in the PR commands workflow where running `/rebase <branch>` (e.g. `/rebase 6.19`) on a PR targeting `master` incorrectly skipped the git rebase step and only edited the PR base branch on GitHub, causing commits on `master` that were not in the target branch to be retained in the PR.

Before
----------------------------------------
When running `/rebase 6.19` on a PR targeting `master`, `git merge-base --is-ancestor origin/$NEW_BASE HEAD` evaluated to true because `origin/6.19` was in the commit history of `master`. The workflow assumed the branch was already fast-forward mergeable with `6.19`, skipped `git rebase --onto`, and simply edited the PR base to `6.19`. As seen in #36672, this caused 11 commits from `master` to appear in the PR instead of just the PR's original commit.

After
----------------------------------------
The rebase is only skipped if `$NEW_BASE` matches the current `$base_branch` and the branch is already up to date with it. When `$NEW_BASE != $base_branch`, `git rebase --onto` is executed so that the PR commits are properly transplanted onto the new base branch without carrying over intermediate commits from the old base.


Comments
----------------------------------------
Discovered when running `/rebase 6.19` on https://github.com/civicrm/civicrm-core/pull/36672.
