### PR TITLE
dev/core#6731 Ensure userEntered text is available to the template for back-office message

### DIFF
--- a/CRM/Event/Form/ParticipantFeeSelection.php
+++ b/CRM/Event/Form/ParticipantFeeSelection.php
@@ -591,9 +591,6 @@ SELECT  id, html_type
     CRM_Core_DAO::commonRetrieveAll('CRM_Event_DAO_Event', 'id', $params['event_id'], $events, $returnProperties);
     $event = $events[$params['event_id']];
     unset($event['start_date'], $event['end_date']);
-    if ($params['receipt_text']) {
-      $event['confirm_email_text'] = $params['receipt_text'];
-    }
     $this->assign('event', $event);
 
     // Retrieve the name and email of the contact - this will be the TO for receipt email
@@ -613,6 +610,7 @@ SELECT  id, html_type
         'contactId' => $this->getContactID(),
         'eventID' => $params['event_id'],
         'contributionID' => $this->getContributionID(),
+        'userEnteredText' => $this->getSubmittedValue('receipt_text'),
       ],
     ];
 

--- a/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
+++ b/tests/phpunit/CRM/Event/BAO/ChangeFeeSelectionTest.php
@@ -112,7 +112,10 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'contribution_status_id' => 'Pending',
       'receive_date' => date('Y-m-d') . ' 00:00:00',
       'line_items' => [],
-      'api.Payment.create' => ['total_amount' => $actualPaidAmt],
+      'api.Payment.create' => [
+        'total_amount' => $actualPaidAmt,
+        'is_send_contribution_notification' => FALSE,
+      ],
     ];
     foreach ($lineItems as $lineItem) {
       $orderParams['line_items'][] = [
@@ -573,6 +576,31 @@ class CRM_Event_BAO_ChangeFeeSelectionTest extends CiviUnitTestCase {
       'id' => $this->ids['Participant']['order'],
       'action' => CRM_Core_Action::UPDATE,
     ])->processForm();
+  }
+
+  /**
+   * The "Confirmation Message" text entered on the back-office
+   * "Change Registration" screen should be included in the confirmation
+   * email when "Send Confirmation?" is ticked.
+   *
+   * https://lab.civicrm.org/dev/core/-/work_items/6731
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testChangeFeeSelectionEmailIncludesConfirmationMessage(): void {
+    $this->registerParticipantAndPay($this->_expensiveFee);
+    $fromEmailAddress = array_key_first(CRM_Event_BAO_Event::getFromEmailIds($this->getEventID())['from_email_id']);
+    $this->getTestForm('CRM_Event_Form_ParticipantFeeSelection', [
+      $this->getPriceFieldFormLabel('PaidEvent') => $this->getCheapFeeID(),
+      'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Event_BAO_Participant', 'status_id', 'Registered'),
+      'send_receipt' => 1,
+      'from_email_address' => $fromEmailAddress,
+      'receipt_text' => 'This is my distinctive confirmation message',
+    ], [
+      'id' => $this->ids['Participant']['order'],
+      'action' => CRM_Core_Action::UPDATE,
+    ])->processForm();
+    $this->assertMailSentContainingString('This is my distinctive confirmation message');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6731 Ensure userEntered text is available to the template for back-office message

Before
----------------------------------------
email_confirm_text not assigned to the userEnteredText variable in the template

After
----------------------------------------
Now it is

Technical Details
----------------------------------------
Just the fix from https://github.com/civicrm/civicrm-core/pull/36670/commits

Comments
----------------------------------------
