### PR TITLE
Make notes importable

### DIFF
--- a/schema/Core/Note.entityType.php
+++ b/schema/Core/Note.entityType.php
@@ -37,6 +37,9 @@ return [
       'add' => '1.1',
       'primary_key' => TRUE,
       'auto_increment' => TRUE,
+      'usage' => [
+        'import',
+      ],
     ],
     'entity_table' => [
       'title' => ts('Note Entity'),
@@ -50,6 +53,9 @@ return [
       ],
       'pseudoconstant' => [
         'option_group_name' => 'note_used_for',
+      ],
+      'usage' => [
+        'import',
       ],
     ],
     'entity_id' => [
@@ -65,6 +71,9 @@ return [
       'entity_reference' => [
         'dynamic_entity' => 'entity_table',
         'key' => 'id',
+      ],
+      'usage' => [
+        'import',
       ],
     ],
     'note' => [
@@ -109,6 +118,9 @@ return [
       'input_attrs' => [
         'format_type' => 'activityDateTime',
       ],
+      'usage' => [
+        'import',
+      ],
     ],
     'created_date' => [
       'title' => ts('Created Date'),
@@ -146,6 +158,9 @@ return [
       'input_attrs' => [
         'size' => '60',
       ],
+      'usage' => [
+        'import',
+      ],
     ],
     'privacy' => [
       'title' => ts('Privacy'),
@@ -157,6 +172,9 @@ return [
       'default' => '0',
       'pseudoconstant' => [
         'option_group_name' => 'note_privacy',
+      ],
+      'usage' => [
+        'import',
       ],
     ],
   ],


### PR DESCRIPTION
Overview
----------------------------------------
Make notes importable

Before
----------------------------------------
Going to https://dmaster.localhost:32353/civicrm/import/note does not offer enough fields to be able to import notes

After
----------------------------------------
It offers the main fields

Technical Details
----------------------------------------
In response to https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/issues/64

Comments
----------------------------------------
