### PR TITLE
Stop assigning some unused online receipt template variables

### DIFF
--- a/CRM/Contribute/BAO/Contribution.php
+++ b/CRM/Contribute/BAO/Contribution.php
@@ -2416,7 +2416,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
     }
 
     $template->assign('trxn_id', $this->trxn_id);
-    $values['receipt_date'] = (empty($this->receipt_date) ? NULL : $this->receipt_date);
     $template->assign('action', $this->is_test ? 1024 : 1);
     $template->assign('receipt_text', $values['receipt_text'] ?? NULL);
     $template->assign('is_monetary', 1);
@@ -3194,7 +3193,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'is_partial_payment',
       'is_recur_installments',
       'is_recur_interval',
-      'is_share',
       'max_amount',
       'min_amount',
       'min_initial_amount',
@@ -3202,7 +3200,6 @@ INNER JOIN civicrm_activity ON civicrm_activity_contact.activity_id = civicrm_ac
       'start_date',
       'thankyou_footer',
       'thankyou_text',
-      'thankyou_title',
 
     ];
     foreach ($valuesToCopy as $valueToCopy) {

--- a/CRM/Contribute/BAO/ContributionPage.php
+++ b/CRM/Contribute/BAO/ContributionPage.php
@@ -173,18 +173,9 @@ class CRM_Contribute_BAO_ContributionPage extends CRM_Contribute_DAO_Contributio
       // All of these will be assigned to the template, replacing any that might be assigned elsewhere.
       $tplParams = [
         'email' => $email,
-        'receiptFromEmail' => $values['receipt_from_email'] ?? NULL,
-        'contactID' => $contactID,
-        'displayName' => $displayName,
-        'contributionID' => $values['contribution_id'] ?? NULL,
         'contributionOtherID' => $values['contribution_other_id'] ?? NULL,
         'title' => $title,
-        'isShare' => $values['is_share'] ?? NULL,
-        'thankyou_title' => $values['thankyou_title'] ?? NULL,
-        'is_pay_later' => $values['is_pay_later'] ?? FALSE,
-        'receipt_date' => empty($values['receipt_date']) ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
         'pay_later_receipt' => $values['pay_later_receipt'] ?? NULL,
-        'contributionStatus' => $values['contribution_status'] ?? NULL,
       ];
       // CRM-6976
       $originalCCReceipt = $values['cc_receipt'] ?? NULL;

--- a/CRM/Utils/Token.php
+++ b/CRM/Utils/Token.php
@@ -1279,6 +1279,12 @@ class CRM_Utils_Token {
           '$email' => 'contact.email_primary.email',
           '$address' => 'contribution.address_id.display',
           '$amount' => ts('see default template for how to show this'),
+          '$is_share' => 'event.is_share|bool',
+          '$thankyou_title' => 'event.thankyou_title',
+          '$contributionStatus' => 'contribution.contribution_status_id:label',
+          '$receipt_date' => 'contribution.receipt_date',
+          '$receiptFromEmail' => 'no longer used',
+          '$is_pay_later' => 'contribution.is_pay_later|bool',
         ],
         'membership_offline_receipt' => [
           // receipt_text_renewal appears to be long gone.

--- a/tests/templates/message_templates/contribution_online_receipt_html.tpl
+++ b/tests/templates/message_templates/contribution_online_receipt_html.tpl
@@ -3,8 +3,8 @@
 <head>
 </head>
 <body>
-  receive_date:::{$receive_date}
-  receipt_date:::{$receipt_date}
+  receive_date:::{contribution.receive_date|crmDate:"%Y%m%d"}
+  receipt_date:::{contribution.receipt_date|crmDate:"%Y%m%d"}
   {if !empty($receipt_text)}
   receipt_text:::{$receipt_text}
   {/if}
@@ -38,9 +38,6 @@
   {/if}
   {if !empty($is_monetary)}
   is_monetary:::{$is_monetary}
-  {/if}
-  {if !empty($isShare)}
-  isShare:::{$isShare}
   {/if}
   honor_block_is_active:::{$honor_block_is_active}
   {if $honor_block_is_active}
@@ -97,7 +94,7 @@
   {if !empty($customPost_grouptitle)}
   customPost_grouptitle:::{$customPost_grouptitle}
   {/if}
-  contributionStatus:::{$contributionStatus}
+  contributionStatus:::{contribution.contribution_status_id:label}
  {if !empty($lineItem)}
  {foreach from=$lineItem item=value key=priceset}
   {foreach from=$value item=line}


### PR DESCRIPTION


Overview
----------------------------------------
Stop assigning some unused online receipt template variables

These are ones that are not in the shipped receipt and have not been for a long time, if ever. There will be status checks if sites ARE using them

Before
----------------------------------------
Variables unnecessarily assigned (with all the generation & passing around that entails)

After
----------------------------------------

Variables assigned that are already assigned via the WorkflowMessage:
- contactID
- contributionID

Variables already subject to status checks
- displayName

Variables added to status checks
-  'receiptFromEmail' => $values['receipt_from_email'] ?? NULL,- 
- 'isShare' => $values['is_share'] ?? NULL,
-   'thankyou_title' => $values['thankyou_title'] ?? NULL,
- 'is_pay_later' => $values['is_pay_later'] ?? FALSE,
-  'receipt_date' => empty($values['receipt_date']) ? NULL : date('YmdHis', strtotime($values['receipt_date'])),
-  'contributionStatus' => $values['contribution_status'] ?? NULL,


Technical Details
----------------------------------------


Comments
----------------------------------------
