### PR TITLE
Fix changeFeeSelections reversing financial items from a different contribution

### DIFF
--- a/CRM/Price/BAO/LineItem.php
+++ b/CRM/Price/BAO/LineItem.php
@@ -14,6 +14,7 @@
  * @package CRM
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
+use Civi\Api4\FinancialItem;
 use Civi\Api4\LineItem;
 
 /**
@@ -585,6 +586,9 @@ WHERE li.contribution_id = %1";
     $feeAmount = $order->getTotalAmount();
     $taxAmount = $order->getTotalTaxAmount();
     $submittedLineItems = $order->getLineItems();
+    $previousLineItems = (array) LineItem::get(FALSE)
+      ->addWhere('contribution_id', '=', $contributionId)
+      ->execute()->indexBy('id');
     $entityTable = 'civicrm_' . $entity;
     // initialize empty Lineitem instance to call protected helper functions
     $lineItemObj = new CRM_Price_BAO_LineItem();
@@ -596,9 +600,7 @@ WHERE li.contribution_id = %1";
       // @todo - this IF is to get this through PR merge but I suspect that it should not
       // be necessary & is masking something else.
       $financialItemsArray = $lineItemObj->getAdjustedFinancialItemsToRecord(
-        $entityID,
-        $entityTable,
-        $contributionId,
+        $previousLineItems,
         array_keys($requiredChanges['line_items_to_cancel']),
         $requiredChanges['line_items_to_update']
       );
@@ -661,20 +663,17 @@ WHERE li.contribution_id = %1";
   /**
    * Function to retrieve financial items that need to be recorded as result of changed fee
    *
-   * @param int $entityID
-   * @param string $entityTable
-   * @param int $contributionID
+   * @param array $previousLineItems
+   *   All of the contribution's line items prior to this change, keyed by line item id.
    * @param array $priceFieldValueIDsToCancel
    * @param array $lineItemsToUpdate
    *
    * @return array
    *   List of formatted reverse Financial Items to be recorded
    */
-  protected function getAdjustedFinancialItemsToRecord($entityID, $entityTable, $contributionID, $priceFieldValueIDsToCancel, $lineItemsToUpdate) {
-    $previousLineItems = CRM_Price_BAO_LineItem::getLineItems($entityID, str_replace('civicrm_', '', $entityTable));
-
+  protected function getAdjustedFinancialItemsToRecord(array $previousLineItems, $priceFieldValueIDsToCancel, $lineItemsToUpdate): array {
     $financialItemsArray = [];
-    $financialItemResult = $this->getNonCancelledFinancialItems($entityID, $entityTable);
+    $financialItemResult = $this->getNonCancelledFinancialItems($previousLineItems);
     foreach ($financialItemResult as $updateFinancialItemInfoValues) {
       $updateFinancialItemInfoValues['transaction_date'] = date('YmdHis');
 
@@ -1114,40 +1113,45 @@ WHERE li.contribution_id = %1";
   /**
    * Get Financial items, culling out any that have already been reversed.
    *
-   * @param int $entityID
-   * @param string $entityTable
+   * Only financial items belonging to one of $previousLineItems are eligible -
+   * matching purely on price_field_value_id would otherwise also catch a
+   * settled financial item on a completely different contribution that
+   * happens to reuse the same price option (eg. a membership renewal reusing
+   * the same price field value each time).
+   *
+   * @param array $previousLineItems
+   *   The contribution's line items, keyed by line item id.
    *
    * @return array
-   *   Array of financial items that have not be reversed.
+   *   Array of financial items that have not been reversed.
    */
-  protected function getNonCancelledFinancialItems($entityID, $entityTable) {
-    // gathering necessary info to record negative (deselected) financial_item
-    $updateFinancialItem = "
-  SELECT fi.*, price_field_value_id, financial_type_id, tax_amount
-    FROM civicrm_financial_item fi LEFT JOIN civicrm_line_item li ON (li.id = fi.entity_id AND fi.entity_table = 'civicrm_line_item')
-  WHERE (li.entity_table = '{$entityTable}' AND li.entity_id = {$entityID})
-  GROUP BY li.entity_table, li.entity_id, price_field_value_id, fi.id
-    ";
-    $updateFinancialItemInfoDAO = CRM_Core_DAO::executeQuery($updateFinancialItem);
+  protected function getNonCancelledFinancialItems(array $previousLineItems) {
+    if (empty($previousLineItems)) {
+      return [];
+    }
+    $financialItemResult = (array) FinancialItem::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_line_item')
+      ->addWhere('entity_id', 'IN', array_keys($previousLineItems))
+      ->execute();
 
-    $financialItemResult = $updateFinancialItemInfoDAO->fetchAll();
+    // price_field_value_id isn't a financial_item field - pull it in from the line item.
+    foreach ($financialItemResult as $index => $financialItem) {
+      $financialItemResult[$index]['price_field_value_id'] = $previousLineItems[$financialItem['entity_id']]['price_field_value_id'];
+    }
+
     $items = [];
     foreach ($financialItemResult as $index => $financialItem) {
       $items[$financialItem['price_field_value_id']][$index] = $financialItem['amount'];
 
-      if (!empty($items[$financialItem['price_field_value_id']])) {
-        foreach ($items[$financialItem['price_field_value_id']] as $existingItemID => $existingAmount) {
-          if ($financialItem['amount'] + $existingAmount == 0) {
-            // Filter both rows as they cancel each other out.
-            unset($financialItemResult[$index]);
-            unset($financialItemResult[$existingItemID]);
-            unset($items['price_field_value_id'][$existingItemID]);
-            unset($items[$financialItem['price_field_value_id']][$index]);
-          }
+      foreach ($items[$financialItem['price_field_value_id']] as $existingItemID => $existingAmount) {
+        if ($financialItem['amount'] + $existingAmount == 0) {
+          // Filter both rows as they cancel each other out.
+          unset($financialItemResult[$index]);
+          unset($financialItemResult[$existingItemID]);
+          unset($items[$financialItem['price_field_value_id']][$existingItemID]);
+          unset($items[$financialItem['price_field_value_id']][$index]);
         }
-
       }
-
     }
     return $financialItemResult;
   }

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -17,6 +17,7 @@
  * @author Walt Haas <walt@dharmatech.org> (801) 534-1262
  */
 
+use Civi\Api4\FinancialItem;
 use Civi\Api4\FinancialType;
 use Civi\Api4\LineItem;
 use Civi\Api4\Membership;
@@ -699,6 +700,142 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0']]);
     $this->assertEquals($this->ids['MembershipType']['lifetime'], $membership['membership_type_id']);
     $this->assertTrue(empty($membership['end_date']), 'Lifetime Membership on the individual has an End date.');
+  }
+
+  /**
+   * A financial item belonging to a DIFFERENT contribution must not be
+   * reversed just because its line item shares a price_field_value_id with
+   * a line being omitted from the contribution actually being edited.
+   *
+   * This is the same signup as testContributionUpdateOnMembershipTypeChange(),
+   * but with a second, independent contribution added against the same
+   * membership before the type change - eg. a separately recorded extra
+   * payment that happens to reuse AnnualFixed's price option. The type
+   * change below edits the LATEST contribution (the second one) and cancels
+   * AnnualFixed's price_field_value_id there, which is correct. Previously,
+   * getAdjustedFinancialItemsToRecord() matched financial items to reverse
+   * purely on price_field_value_id, with no check that the line item it was
+   * about to reverse belonged to the contribution actually being edited - so
+   * the FIRST, untouched contribution's settled financial item was wrongly
+   * reversed too.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function testMembershipTypeChangeDoesNotReverseAnotherContributionsFinancialItem(): void {
+    $this->createLoggedInUser();
+    // Step 1: Create a Membership via backoffice with a 50.00 payment.
+    $this->getTestForm('CRM_Member_Form_Membership', [
+      'cid' => $this->ids['Contact']['individual_0'],
+      'join_date' => date('Y-m-d'),
+      'start_date' => '',
+      'end_date' => '',
+      'membership_type_id' => [$this->ids['Contact']['organization'], $this->ids['MembershipType']['AnnualFixed']],
+      'record_contribution' => 1,
+      'total_amount' => 50,
+      'receive_date' => date('Y-m-d', time()) . ' 20:36:00',
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'contribution_status_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'contribution_status_id', 'Completed'),
+      'financial_type_id' => '2',
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+    ])->processForm();
+
+    $membership = $this->callAPISuccessGetSingle('Membership', ['contact_id' => $this->ids['Contact']['individual_0'], 'version' => 4]);
+    $firstContribution = $this->callAPISuccessGetSingle('Contribution', ['contact_id' => $this->ids['Contact']['individual_0'], 'version' => 4]);
+
+    // The line item the signup recorded for AnnualFixed - reused below for a
+    // second, independent contribution against the same membership.
+    $annualFixedLine = LineItem::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_membership')
+      ->addWhere('entity_id', '=', $membership['id'])
+      ->addWhere('contribution_id', '=', $firstContribution['id'])
+      ->execute()->single();
+
+    // Step 1.5: an independent second contribution against the SAME
+    // membership that happens to reuse AnnualFixed's price_field_value_id -
+    // eg. a second, separately recorded payment. The line item and financial
+    // item are built directly (rather than via Order.create) so the line
+    // item attaches to the EXISTING membership instead of creating a new one.
+    $secondContribution = $this->createTestEntity('Contribution', [
+      'contact_id' => $this->ids['Contact']['individual_0'],
+      'financial_type_id' => $annualFixedLine['financial_type_id'],
+      'total_amount' => 50,
+      'currency' => 'USD',
+      'receive_date' => date('Y-m-d', strtotime('+1 day')) . ' 20:36:00',
+      'contribution_status_id:name' => 'Completed',
+    ], 'second');
+    $secondLineItem = $this->createTestEntity('LineItem', [
+      'entity_table' => 'civicrm_membership',
+      'entity_id' => $membership['id'],
+      'contribution_id' => $secondContribution['id'],
+      'price_field_id' => $annualFixedLine['price_field_id'],
+      'price_field_value_id' => $annualFixedLine['price_field_value_id'],
+      'label' => $annualFixedLine['label'],
+      'qty' => 1,
+      'unit_price' => $annualFixedLine['unit_price'],
+      'line_total' => $annualFixedLine['unit_price'],
+      'financial_type_id' => $annualFixedLine['financial_type_id'],
+    ], 'second');
+    $incomeAccountID = CRM_Financial_BAO_FinancialAccount::getFinancialAccountForFinancialTypeByRelationship(
+      $annualFixedLine['financial_type_id'],
+      'Income Account is'
+    );
+    $this->createTestEntity('FinancialItem', [
+      'transaction_date' => $secondContribution['receive_date'],
+      'contact_id' => $this->ids['Contact']['individual_0'],
+      'amount' => $annualFixedLine['unit_price'],
+      'currency' => 'USD',
+      'entity_table' => 'civicrm_line_item',
+      'entity_id' => $secondLineItem['id'],
+      'description' => $annualFixedLine['label'],
+      'status_id:name' => 'Paid',
+      'financial_account_id' => $incomeAccountID,
+    ], 'second');
+
+    // Step 2: Change the membership type away from AnnualFixed. This edits
+    // the LATEST contribution's line items (the second one), and should only
+    // ever touch that contribution's financial items.
+    $secondMembershipType = $this->createTestEntity('MembershipType', [
+      'domain_id' => 1,
+      'name' => 'Second Test Membership',
+      'member_of_contact_id' => $this->ids['Contact']['organization'],
+      'duration_unit' => 'month',
+      'minimum_fee' => 25,
+      'duration_interval' => 1,
+      'period_type' => 'fixed',
+      'fixed_period_start_day' => '101',
+      'fixed_period_rollover_day' => '1231',
+      'relationship_type_id' => 20,
+      'financial_type_id' => 2,
+    ]);
+    Civi::settings()->set('update_contribution_on_membership_type_change', TRUE);
+
+    $this->getTestForm('CRM_Member_Form_Membership', [
+      'cid' => $this->ids['Contact']['individual_0'],
+      'join_date' => date('Y-m-d'),
+      'start_date' => '',
+      'end_date' => '',
+      'membership_type_id' => [$this->ids['Contact']['organization'], $secondMembershipType['id']],
+      'status_id' => 1,
+      'receive_date' => date('Y-m-d', strtotime('+1 day')) . ' 20:36:00',
+      'payment_instrument_id' => CRM_Core_PseudoConstant::getKey('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', 'Check'),
+      'financial_type_id' => '2',
+      'payment_processor_id' => $this->ids['PaymentProcessor']['dummy'],
+    ], [
+      'id' => $membership['id'],
+      'action' => 2,
+    ])->processForm();
+
+    // The FIRST contribution's AnnualFixed financial item must be untouched -
+    // it belongs to a contribution nobody asked to edit.
+    $firstContributionFinancialItems = FinancialItem::get(FALSE)
+      ->addWhere('entity_table', '=', 'civicrm_line_item')
+      ->addWhere('entity_id', '=', $annualFixedLine['id'])
+      ->execute();
+    $this->assertCount(
+      1,
+      $firstContributionFinancialItems,
+      'The first contribution is untouched by the type change on the second - it should still have exactly its one original financial item, not a spurious reversal.'
+    );
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix changeFeeSelections reversing financial items from a different contribution

Before
----------------------------------------
When changing the membership type there is code to change the associated line items - setting dependent - but it was not restricted to the current contribution - meaning it could change all contributions associated with the membership

After
----------------------------------------
Restricted to the contribution from the form

Technical Details
----------------------------------------

getAdjustedFinancialItemsToRecord() looked up "previous" financial items by entity_id/entity_table alone, then matched them for reversal purely on price_field_value_id. An entity (eg. a renewing membership) with line items on more than one contribution that reuses the same price field value each time could therefore have a settled financial item on an untouched contribution wrongly reversed when a different contribution's fee selection changed. getNonCancelledFinancialItems() is now scoped to the specific line items of the contribution actually being edited, via the API instead of raw SQL.

Comments
----------------------------------------
