### PR TITLE
Switch test api version from 3 to 4 for Financial_BAO tests

### DIFF
--- a/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
+++ b/tests/phpunit/CRM/Activity/Import/Parser/ActivityTest.php
@@ -39,7 +39,7 @@ class CRM_Activity_Import_Parser_ActivityTest extends CiviUnitTestCase {
   public function setUp():void {
     parent::setUp();
     $this->createLoggedInUser();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    $this->callApiV3Success('Extension', 'install', ['keys' => 'civiimport']);
   }
 
   /**

--- a/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
+++ b/tests/phpunit/CRM/Contribute/BAO/ContributionRecurTest.php
@@ -662,6 +662,7 @@ class CRM_Contribute_BAO_ContributionRecurTest extends CiviUnitTestCase {
   public function validateAllCounts(int $membershipId, int $count): void {
     $memPayParams = [
       'membership_id' => $membershipId,
+      'version' => 3,
     ];
     $lineItemParams = [
       'entity_id' => $membershipId,

--- a/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Form/ContributionTest.php
@@ -57,7 +57,7 @@ class CRM_Contribute_Form_ContributionTest extends CiviUnitTestCase {
   public function setUp(): void {
     parent::setUp();
     $this->createLoggedInUser();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    $this->callApiV3Success('Extension', 'install', ['keys' => 'civiimport']);
     $this->individualCreate([], 0);
     $this->_params = [
       'contact_id' => $this->ids['Contact'][0],

--- a/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
+++ b/tests/phpunit/CRM/Contribute/Import/Parser/ContributionTest.php
@@ -61,7 +61,7 @@ class CRM_Contribute_Import_Parser_ContributionTest extends CiviUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    $this->callApiV3Success('Extension', 'install', ['keys' => 'civiimport']);
     $this->enableBackgroundQueueOriginalValue = Civi::settings()->get('enableBackgroundQueue');
   }
 

--- a/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
+++ b/tests/phpunit/CRM/Dedupe/DedupeFinderTest.php
@@ -14,7 +14,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
 
   public function setUp(): void {
     parent::setUp();
-    $this->callAPISuccess('Extension', 'disable', ['keys' => 'legacydedupefinder']);
+    $this->callApiV3Success('Extension', 'disable', ['keys' => 'legacydedupefinder']);
   }
 
   /**
@@ -348,7 +348,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
    */
   public function testCustomRule(): void {
     $this->setupForGroupDedupe();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'legacydedupefinder']);
+    $this->callApiV3Success('Extension', 'install', ['keys' => 'legacydedupefinder']);
 
     $ruleGroup = $this->createRuleGroup();
     foreach (['birth_date', 'first_name', 'last_name'] as $field) {
@@ -364,7 +364,7 @@ class CRM_Dedupe_DedupeFinderTest extends CiviUnitTestCase {
     CRM_Dedupe_Finder::dupes($ruleGroup['id']);
 
     // Make sure it is the same with the extension disabled.
-    $this->callAPISuccess('Extension', 'disable', ['keys' => 'legacydedupefinder']);
+    $this->callApiV3Success('Extension', 'disable', ['keys' => 'legacydedupefinder']);
     $foundDupes = CRM_Dedupe_Finder::dupesInGroup($ruleGroup['id'], $this->ids['Group']['default']);
     $this->assertCount(4, $foundDupes);
     CRM_Dedupe_Finder::dupes($ruleGroup['id']);

--- a/tests/phpunit/CRM/Dedupe/MergerTest.php
+++ b/tests/phpunit/CRM/Dedupe/MergerTest.php
@@ -2030,7 +2030,7 @@ WHERE
       'contact_id'        => $payerId,
       'financial_type_id' => 'Member Dues',
     ]);
-    $this->callAPISuccess('MembershipPayment', 'create', [
+    $this->callApiV3Success('MembershipPayment', 'create', [
       'contribution_id' => $contributionId,
       'membership_id'   => $membershipId,
     ]);

--- a/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
+++ b/tests/phpunit/CRM/Event/Import/Parser/ParticipantTest.php
@@ -27,7 +27,7 @@ class CRM_Event_Import_Parser_ParticipantTest extends CiviUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    $this->callApiV3Success('Extension', 'install', ['keys' => 'civiimport']);
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialAccountTest.php
@@ -21,6 +21,7 @@ use Civi\Core\HookInterface;
  * @group headless
  */
 class CRM_Financial_BAO_FinancialAccountTest extends CiviUnitTestCase implements HookInterface {
+  protected $_apiversion = 4;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialItemTest.php
@@ -17,6 +17,7 @@ use Civi\Api4\FinancialItem;
  * @group headless
  */
 class CRM_Financial_BAO_FinancialItemTest extends CiviUnitTestCase {
+  protected $_apiversion = 4;
 
   /**
    * Should financials be checked after the test but before tear down.

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeAccountTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class CRM_Financial_BAO_FinancialTypeAccountTest extends CiviUnitTestCase {
+  protected $_apiversion = 4;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -17,7 +17,7 @@ use Civi\Api4\MembershipType;
  * @group headless
  */
 class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
-
+  protected $_apiversion = 4;
   public function tearDown(): void {
     global $dbLocale;
     if ($dbLocale) {
@@ -63,7 +63,7 @@ class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
    * Set ACLs for Financial Types()
    */
   public function setACL(): void {
-    $this->callAPISuccess('extension', 'install', ['key' => 'financialacls', 'sequential' => 1])['values'];
+    $this->callAPISuccess('extension', 'install', ['version' => 3, 'key' => 'financialacls', 'sequential' => 1])['values'];
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/FinancialTypeTest.php
@@ -18,6 +18,7 @@ use Civi\Api4\MembershipType;
  */
 class CRM_Financial_BAO_FinancialTypeTest extends CiviUnitTestCase {
   protected $_apiversion = 4;
+
   public function tearDown(): void {
     global $dbLocale;
     if ($dbLocale) {

--- a/tests/phpunit/CRM/Financial/BAO/OrderTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/OrderTest.php
@@ -25,6 +25,8 @@ use Civi\Test\EventTestTrait;
 class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
   use EventTestTrait;
 
+  protected $_apiversion = 4;
+
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     parent::tearDown();
@@ -107,7 +109,7 @@ class CRM_Financial_BAO_OrderTest extends CiviUnitTestCase {
       ->execute()->single();
     $this->assertEquals('2006-12-21', $membership['end_date']);
     // A membership payment should have been created for legacy compatibility.
-    $this->callAPISuccessGetSingle('MembershipPayment', ['membership_id' => $lineItem['entity_id'], 'contribution_id' => $contribution['id']]);
+    $this->callAPISuccessGetSingle('MembershipPayment', ['version' => 3, 'membership_id' => $lineItem['entity_id'], 'contribution_id' => $contribution['id']]);
   }
 
   /**

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTest.php
@@ -16,6 +16,7 @@ use Civi\Api4\PaymentProcessor;
  * @group headless
  */
 class CRM_Financial_BAO_PaymentProcessorTest extends CiviUnitTestCase {
+  protected $_apiversion = 4;
 
   /**
    * Check method create()

--- a/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTypeTest.php
+++ b/tests/phpunit/CRM/Financial/BAO/PaymentProcessorTypeTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class CRM_Financial_BAO_PaymentProcessorTypeTest extends CiviUnitTestCase {
+  protected $_apiversion = 4;
 
   /**
    * Check method create()

--- a/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentEditTest.php
@@ -14,6 +14,7 @@
  */
 class CRM_Financial_Form_PaymentEditTest extends CiviUnitTestCase {
 
+  protected $_apiversion = 4;
   protected $_individualID;
 
   /**

--- a/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
+++ b/tests/phpunit/CRM/Financial/Form/PaymentFormsTest.php
@@ -31,16 +31,18 @@ use Civi\Api4\Participant;
  */
 class CRM_Financial_Form_PaymentFormsTest extends CiviUnitTestCase {
 
+  protected $_apiversion = 4;
+
   use CRM_Core_Payment_AuthorizeNetTrait;
 
   public function setUp(): void {
     parent::setUp();
-    $this->callAPISuccess('Extension', 'enable', ['keys' => ['eventcart']]);
+    $this->callApiV3Success('Extension', 'enable', ['keys' => ['eventcart']]);
   }
 
   public function tearDown(): void {
-    $this->callAPISuccess('Extension', 'disable', ['keys' => ['eventcart']]);
-    $this->callAPISuccess('Extension', 'uninstall', ['keys' => ['eventcart']]);
+    $this->callApiV3Success('Extension', 'disable', ['keys' => ['eventcart']]);
+    $this->callApiV3Success('Extension', 'uninstall', ['keys' => ['eventcart']]);
     parent::tearDown();
   }
 
@@ -50,7 +52,7 @@ class CRM_Financial_Form_PaymentFormsTest extends CiviUnitTestCase {
    * @throws \CRM_Core_Exception
    */
   public function testEventPaymentForms(): void {
-    $this->callAPISuccess('Extension', 'install', ['keys' => ['eventcart']]);
+    $this->callApiV3Success('Extension', 'install', ['keys' => ['eventcart']]);
     $this->createAuthorizeNetProcessor();
     $processors = [$this->ids['PaymentProcessor']['anet']];
     $eventID = $this->eventCreatePaid([

--- a/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxBatchSummaryTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class CRM_Financial_Page_AjaxBatchSummaryTest extends CiviUnitTestCase {
+  protected $_apiversion = 4;
 
   /**
    * Test the makeBatchSummary function.

--- a/tests/phpunit/CRM/Financial/Page/AjaxTest.php
+++ b/tests/phpunit/CRM/Financial/Page/AjaxTest.php
@@ -15,6 +15,8 @@
  */
 class CRM_Financial_Page_AjaxTest extends CiviUnitTestCase {
 
+  protected $_apiversion = 4;
+
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();
     $this->quickCleanUp([

--- a/tests/phpunit/CRM/Import/DataSource/FormsTest.php
+++ b/tests/phpunit/CRM/Import/DataSource/FormsTest.php
@@ -22,7 +22,7 @@ class CRM_Import_FormsTest extends CiviUnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+    $this->callApiV3Success('Extension', 'install', ['keys' => 'civiimport']);
   }
 
   public function tearDown(): void {

--- a/tests/phpunit/CRM/Import/ParserTest.php
+++ b/tests/phpunit/CRM/Import/ParserTest.php
@@ -36,7 +36,7 @@ class CRM_Import_ParserTest extends CiviUnitTestCase {
       ->addWhere('key', '=', 'civiimport')
       ->execute()->first();
     if (empty($extension['status']) || $extension['status'] !== 'installed') {
-      $this->callAPISuccess('Extension', 'install', ['keys' => 'civiimport']);
+      $this->callApiV3Success('Extension', 'install', ['keys' => 'civiimport']);
     }
   }
 

--- a/tests/phpunit/CRM/Member/Form/MembershipTest.php
+++ b/tests/phpunit/CRM/Member/Form/MembershipTest.php
@@ -809,6 +809,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->callAPISuccessGetCount('MembershipPayment', [
       'membership_id' => $membership['id'],
       'contribution_id' => $contribution['id'],
+      'version' => 3,
     ], 1);
 
     // CRM-16992.
@@ -854,7 +855,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $memberships = $this->callAPISuccess('Membership', 'get')['values'];
     $this->assertCount(2, $memberships);
     $this->callAPISuccessGetSingle('Contribution', ['financial_type_id' => 1]);
-    $this->callAPISuccessGetCount('MembershipPayment', [], 2);
+    $this->callAPISuccessGetCount('MembershipPayment', ['version' => 3], 2);
     $lines = $this->callAPISuccess('LineItem', 'get', ['sequential' => 1])['values'];
     $this->assertCount(2, $lines);
     $this->assertEquals('civicrm_membership', $lines[0]['entity_table']);
@@ -1093,6 +1094,7 @@ class CRM_Member_Form_MembershipTest extends CiviUnitTestCase {
     $this->assertEquals($membership['status_id'], array_search('Pending', $memStatus));
     $contribution = $this->callAPISuccessGetSingle('MembershipPayment', [
       'membership_id' => $membership['id'],
+      'version' => 3,
     ]);
     $prevContribution = $this->callAPISuccessGetSingle('Contribution', ['id' => $contribution['id']]);
     $this->callAPISuccess('Payment', 'create', [

--- a/tests/phpunit/CiviTest/CiviUnitTestCase.php
+++ b/tests/phpunit/CiviTest/CiviUnitTestCase.php
@@ -2566,6 +2566,7 @@ class CiviUnitTestCaseCommon extends PHPUnit\Framework\TestCase {
    */
   protected function createPartiallyPaidParticipantOrder(): array {
     $orderParams = $this->getParticipantOrderParams(3);
+    $orderParams['version'] = 3;
     $orderParams['api.Payment.create'] = ['total_amount' => 150];
     return $this->callAPISuccess('Order', 'create', $orderParams);
   }

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -2480,7 +2480,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $lineItem = $this->callAPISuccessGetSingle('LineItem', ['contribution_id' => $contribution['id']]);
     $this->assertEquals('civicrm_membership', $lineItem['entity_table']);
-    $this->callAPISuccessGetCount('MembershipPayment', ['membership_id' => $membership['id']]);
+    $this->callAPISuccessGetCount('MembershipPayment', ['membership_id' => $membership['id'], 'version' => 3]);
   }
 
   /**
@@ -2568,7 +2568,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
 
     $lineItem = $this->callAPISuccessGetSingle('LineItem', ['contribution_id' => $contribution['id']]);
     $this->assertEquals('civicrm_membership', $lineItem['entity_table']);
-    $this->callAPISuccessGetCount('MembershipPayment', ['membership_id' => $membership['id']]);
+    $this->callAPISuccessGetCount('MembershipPayment', ['membership_id' => $membership['id'], 'version' => 3]);
   }
 
   /**
@@ -3660,7 +3660,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ], $contributionParams));
 
     $this->ids['Contribution'][$key] = $contribution['id'];
-    $this->_ids['membership'] = $this->callAPISuccessGetValue('MembershipPayment', ['return' => 'membership_id', 'contribution_id' => $contribution['id']]);
+    $this->_ids['membership'] = $this->callAPISuccessGetValue('MembershipPayment', ['return' => 'membership_id', 'contribution_id' => $contribution['id'], 'version' => 3]);
   }
 
   /**
@@ -4330,7 +4330,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     $this->assertEquals('civicrm_membership', $lineItem['entity_table']);
     $membership = $this->callAPISuccess('Membership', 'getsingle', ['id' => $lineItem['entity_id']]);
     $this->callAPISuccess('LineItem', 'getsingle', []);
-    $this->callAPISuccessGetCount('MembershipPayment', ['membership_id' => $membership['id']], 1);
+    $this->callAPISuccessGetCount('MembershipPayment', ['membership_id' => $membership['id'], 'version' => 3], 1);
 
     return [$originalContribution, $membership];
   }
@@ -4451,7 +4451,7 @@ class api_v3_ContributionTest extends CiviUnitTestCase {
     ]);
 
     // Let's see if the membership payments got created while we're at it.
-    $membershipPayments = $this->callAPISuccess('MembershipPayment', 'get', [
+    $membershipPayments = $this->callApiV3Success('MembershipPayment', 'get', [
       'membership_id' => $membership['id'],
     ]);
     $this->assertEquals(2, $membershipPayments['count']);

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -126,7 +126,7 @@ class api_v3_MembershipTest extends CiviUnitTestCase {
       'total_amount' => 100,
       'contact_id' => $this->_params['contact_id'],
     ]);
-    $this->callAPISuccess('MembershipPayment', 'create', [
+    $this->callApiV3Success('MembershipPayment', 'create', [
       'sequential' => 1,
       'contribution_id' => $ContributionCreate['values'][0]['id'],
       'membership_id' => $membershipID,

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -233,7 +233,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
       ],
     ];
     $this->checkPaymentResult($order, $expectedResult);
-    $membershipPayment = $this->callAPISuccessGetSingle('MembershipPayment', $params);
+    $membershipPayment = $this->callAPISuccessGetSingle('MembershipPayment', $params + ['version' => 3]);
 
     $this->callAPISuccessGetSingle('Membership', ['id' => $membershipPayment['id']]);
     $this->callAPISuccess('Contribution', 'Delete', ['id' => $order['id']]);
@@ -264,7 +264,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     ];
     $order = $this->callAPISuccess('Order', 'get', $paymentMembership);
     $this->checkPaymentResult($order, $expectedResult);
-    $this->callAPISuccessGetCount('MembershipPayment', $paymentMembership, 2);
+    $this->callAPISuccessGetCount('MembershipPayment', $paymentMembership + ['version' => 3], 2);
     $this->callAPISuccess('Payment', 'create', [
       'contribution_id' => $order['id'],
       'payment_instrument_id' => 'Check',
@@ -380,7 +380,7 @@ class api_v3_OrderTest extends CiviUnitTestCase {
     }
 
     // Check membership details
-    $membershipPayment = $this->callAPISuccessGetSingle('MembershipPayment', ['contribution_id' => $order['id']]);
+    $membershipPayment = $this->callAPISuccessGetSingle('MembershipPayment', ['contribution_id' => $order['id'], 'version' => 3]);
     $membership = $this->callAPISuccessGetSingle('Membership', ['id' => $membershipPayment['id']]);
 
     if (isset($expectations['status_id'])) {


### PR DESCRIPTION
We want to move the default to 4 & only use 3 when required or when testing v3

