### PR TITLE
Explicitly declare api version on apiv3 tests

### DIFF
--- a/tests/phpunit/api/v3/ACLCachingTest.php
+++ b/tests/phpunit/api/v3/ACLCachingTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_ACLCachingTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_params;
 
   public function setUp(): void {

--- a/tests/phpunit/api/v3/ACLPermissionTest.php
+++ b/tests/phpunit/api/v3/ACLPermissionTest.php
@@ -24,6 +24,7 @@ use Civi\Api4\Entity;
  * @group headless
  */
 class api_v3_ACLPermissionTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use Civi\Test\ACLPermissionTrait;
 

--- a/tests/phpunit/api/v3/ActionScheduleTest.php
+++ b/tests/phpunit/api/v3/ActionScheduleTest.php
@@ -32,6 +32,7 @@
  * @group headless
  */
 class api_v3_ActionScheduleTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_entity = 'action_schedule';
 

--- a/tests/phpunit/api/v3/ActivityCaseTest.php
+++ b/tests/phpunit/api/v3/ActivityCaseTest.php
@@ -7,6 +7,7 @@
  * @group headless
  */
 class api_v3_ActivityCaseTest extends CiviCaseTestCase {
+  protected $_apiversion = 3;
   /**
    * @var array
    *  APIv3 Result (Case.create)

--- a/tests/phpunit/api/v3/ActivityTest.php
+++ b/tests/phpunit/api/v3/ActivityTest.php
@@ -40,6 +40,7 @@
  * @group headless
  */
 class api_v3_ActivityTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_params;
   protected $_params2;
   protected $_entity = 'activity';

--- a/tests/phpunit/api/v3/AddressTest.php
+++ b/tests/phpunit/api/v3/AddressTest.php
@@ -21,6 +21,7 @@
  * @group headless
  */
 class api_v3_AddressTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_contactID;
   protected $_locationTypeID;
   protected $_params;

--- a/tests/phpunit/api/v3/AttachmentTest.php
+++ b/tests/phpunit/api/v3/AttachmentTest.php
@@ -33,6 +33,7 @@
  * @group headless
  */
 class api_v3_AttachmentTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected static $filePrefix = NULL;
 
   /**

--- a/tests/phpunit/api/v3/BatchTest.php
+++ b/tests/phpunit/api/v3/BatchTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_BatchTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_entity = 'batch';
 

--- a/tests/phpunit/api/v3/CaseContactTest.php
+++ b/tests/phpunit/api/v3/CaseContactTest.php
@@ -6,6 +6,7 @@
  * @group headless
  */
 class api_v3_CaseContactTest extends CiviCaseTestCase {
+  protected $_apiversion = 3;
 
   /**
    * @var array

--- a/tests/phpunit/api/v3/CaseTypeTest.php
+++ b/tests/phpunit/api/v3/CaseTypeTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_CaseTypeTest extends CiviCaseTestCase {
+  protected $_apiversion = 3;
 
   const APPLICATION_WITH_DEFINITION_PARAMS = [
     'title' => 'Application with Definition',

--- a/tests/phpunit/api/v3/ClassAPITest.php
+++ b/tests/phpunit/api/v3/ClassAPITest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class class_api_test extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Test that error doesn't occur for non-existent file.

--- a/tests/phpunit/api/v3/ContactTest.php
+++ b/tests/phpunit/api/v3/ContactTest.php
@@ -40,6 +40,7 @@ use Civi\Api4\File;
  * @group headless
  */
 class api_v3_ContactTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use CRMTraits_Custom_CustomDataTrait;
 

--- a/tests/phpunit/api/v3/ContactTypeTest.php
+++ b/tests/phpunit/api/v3/ContactTypeTest.php
@@ -14,7 +14,7 @@
  * @group headless
  */
 class api_v3_ContactTypeTest extends CiviUnitTestCase {
-  protected $_apiversion;
+  protected $_apiversion = 3;
 
   /**
    * @var string

--- a/tests/phpunit/api/v3/ContributionPageTest.php
+++ b/tests/phpunit/api/v3/ContributionPageTest.php
@@ -22,6 +22,7 @@ use Civi\Test\ContributionPageTestTrait;
  * @group headless
  */
 class api_v3_ContributionPageTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   use CRMTraits_Financial_PriceSetTrait;
   use ContributionPageTestTrait;
 

--- a/tests/phpunit/api/v3/ContributionRecurTest.php
+++ b/tests/phpunit/api/v3/ContributionRecurTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_ContributionRecurTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $params;
   protected $_entity = 'ContributionRecur';
 

--- a/tests/phpunit/api/v3/ContributionTest.php
+++ b/tests/phpunit/api/v3/ContributionTest.php
@@ -28,6 +28,7 @@ use Civi\Test\FormTrait;
  * @group headless
  */
 class api_v3_ContributionTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use CRMTraits_Profile_ProfileTrait;
   use CRMTraits_Custom_CustomDataTrait;

--- a/tests/phpunit/api/v3/CountryTest.php
+++ b/tests/phpunit/api/v3/CountryTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_CountryTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_params;
 
   public function setUp(): void {

--- a/tests/phpunit/api/v3/CustomFieldTest.php
+++ b/tests/phpunit/api/v3/CustomFieldTest.php
@@ -19,6 +19,7 @@ use Civi\Api4\OptionGroup;
  * @group headless
  */
 class api_v3_CustomFieldTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Clean up after test.

--- a/tests/phpunit/api/v3/CustomSearchTest.php
+++ b/tests/phpunit/api/v3/CustomSearchTest.php
@@ -5,7 +5,7 @@
  * @group headless
  */
 class api_v3_CustomSearchTest extends CiviUnitTestCase {
-  protected $_apiversion;
+  protected $_apiversion = 3;
 
   public function setUp(): void {
     $this->_apiversion = 3;

--- a/tests/phpunit/api/v3/CustomValueContactTypeTest.php
+++ b/tests/phpunit/api/v3/CustomValueContactTypeTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_CustomValueContactTypeTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * @var int

--- a/tests/phpunit/api/v3/DomainTest.php
+++ b/tests/phpunit/api/v3/DomainTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_DomainTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $params;
 

--- a/tests/phpunit/api/v3/EmailTest.php
+++ b/tests/phpunit/api/v3/EmailTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_EmailTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_contactID;
   protected $_locationTypeID;
   protected $locationType2ID;

--- a/tests/phpunit/api/v3/EntityBatchTest.php
+++ b/tests/phpunit/api/v3/EntityBatchTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_EntityBatchTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $params;
   protected $id;
   protected $_entity;

--- a/tests/phpunit/api/v3/EntityJoinTest.php
+++ b/tests/phpunit/api/v3/EntityJoinTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_EntityJoinTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v3/EventTest.php
+++ b/tests/phpunit/api/v3/EventTest.php
@@ -15,7 +15,7 @@
  */
 class api_v3_EventTest extends CiviUnitTestCase {
   protected $_params;
-  protected $_apiversion;
+  protected $_apiversion = 3;
   protected $_entity;
 
   /**

--- a/tests/phpunit/api/v3/ExceptionTest.php
+++ b/tests/phpunit/api/v3/ExceptionTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_ExceptionTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Sets up the fixture, for example, opens a network connection.

--- a/tests/phpunit/api/v3/ExtensionTest.php
+++ b/tests/phpunit/api/v3/ExtensionTest.php
@@ -21,6 +21,7 @@
  * @group headless
  */
 class api_v3_ExtensionTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use \Civi\Test\GuzzleTestTrait;
 

--- a/tests/phpunit/api/v3/FinancialTypeACLTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeACLTest.php
@@ -22,7 +22,7 @@ class api_v3_FinancialTypeACLTest extends CiviUnitTestCase {
   protected $_individualId;
   protected $_contribution;
   protected $_financialTypeId = 1;
-  protected $_apiversion;
+  protected $_apiversion = 3;
   protected $_entity = 'Contribution';
   public $debug = 0;
   protected $_params;

--- a/tests/phpunit/api/v3/FinancialTypeTest.php
+++ b/tests/phpunit/api/v3/FinancialTypeTest.php
@@ -14,6 +14,7 @@
  * @package CiviCRM_APIv3
  */
 class api_v3_FinancialTypeTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function tearDown(): void {
     $this->quickCleanUpFinancialEntities();

--- a/tests/phpunit/api/v3/GetfieldsCacheTest.php
+++ b/tests/phpunit/api/v3/GetfieldsCacheTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_GetfieldsCacheTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v3/GroupContactTest.php
+++ b/tests/phpunit/api/v3/GroupContactTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_GroupContactTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * @var int

--- a/tests/phpunit/api/v3/GroupNestingTest.php
+++ b/tests/phpunit/api/v3/GroupNestingTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_GroupNestingTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Sets up the fixture, for example, opens a network connection.

--- a/tests/phpunit/api/v3/GroupOrganizationTest.php
+++ b/tests/phpunit/api/v3/GroupOrganizationTest.php
@@ -16,7 +16,7 @@
  * @group headless
  */
 class api_v3_GroupOrganizationTest extends CiviUnitTestCase {
-  protected $_apiversion;
+  protected $_apiversion = 3;
 
   /**
    * @var int

--- a/tests/phpunit/api/v3/GroupTest.php
+++ b/tests/phpunit/api/v3/GroupTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_GroupTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_groupID;
 

--- a/tests/phpunit/api/v3/ImTest.php
+++ b/tests/phpunit/api/v3/ImTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_ImTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v3/JobProcessMembershipTest.php
+++ b/tests/phpunit/api/v3/JobProcessMembershipTest.php
@@ -26,6 +26,7 @@ use Civi\Api4\Membership;
  * @group headless
  */
 class api_v3_JobProcessMembershipTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Caches some reference dates

--- a/tests/phpunit/api/v3/JobTest.php
+++ b/tests/phpunit/api/v3/JobTest.php
@@ -26,6 +26,7 @@ use Civi\Api4\Contact;
  * @group headless
  */
 class api_v3_JobTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Entities to return to their original values during tearDown.

--- a/tests/phpunit/api/v3/LineItemTest.php
+++ b/tests/phpunit/api/v3/LineItemTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_LineItemTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   use CRM_Financial_Form_SalesTaxTrait;
 
   protected $params;

--- a/tests/phpunit/api/v3/LoggingTest.php
+++ b/tests/phpunit/api/v3/LoggingTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_LoggingTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Sets up the fixture, for example, opens a network connection.

--- a/tests/phpunit/api/v3/MailingContactTest.php
+++ b/tests/phpunit/api/v3/MailingContactTest.php
@@ -24,6 +24,7 @@
  * @group headless
  */
 class api_v3_MailingContactTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function tearDown(): void {
     $this->quickCleanup(['civicrm_contact', 'civicrm_mailing_recipients', 'civicrm_mailing_event_queue', 'civicrm_mailing', 'civicrm_mailing_event_delivered']);

--- a/tests/phpunit/api/v3/MailingGroupTest.php
+++ b/tests/phpunit/api/v3/MailingGroupTest.php
@@ -19,6 +19,7 @@ use Civi\Api4\MailingComponent;
  * @group headless
  */
 class api_v3_MailingGroupTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function setUp(): void {
     parent::setUp();

--- a/tests/phpunit/api/v3/MailingTest.php
+++ b/tests/phpunit/api/v3/MailingTest.php
@@ -31,6 +31,7 @@
  * @group headless
  */
 class api_v3_MailingTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_groupID;
   protected $_email;
   protected $_entity = 'Mailing';

--- a/tests/phpunit/api/v3/MappingTest.php
+++ b/tests/phpunit/api/v3/MappingTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_MappingTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $params;
   protected $id;

--- a/tests/phpunit/api/v3/MembershipTest.php
+++ b/tests/phpunit/api/v3/MembershipTest.php
@@ -25,6 +25,7 @@ use Civi\Api4\RelationshipType;
  * @group headless
  */
 class api_v3_MembershipTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use CRMTraits_Financial_OrderTrait;
 

--- a/tests/phpunit/api/v3/MembershipTypeTest.php
+++ b/tests/phpunit/api/v3/MembershipTypeTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_MembershipTypeTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_contactID;
   protected $_entity = 'MembershipType';
 

--- a/tests/phpunit/api/v3/MessageTemplateTest.php
+++ b/tests/phpunit/api/v3/MessageTemplateTest.php
@@ -17,6 +17,7 @@
  * @group msgtpl
  */
 class api_v3_MessageTemplateTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $entity = 'MessageTemplate';
   protected $params;

--- a/tests/phpunit/api/v3/NoteTest.php
+++ b/tests/phpunit/api/v3/NoteTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_NoteTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_contactID;
   protected $_params;

--- a/tests/phpunit/api/v3/OpenIDTest.php
+++ b/tests/phpunit/api/v3/OpenIDTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_OpenIDTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Should location types be checked to ensure primary addresses are correctly assigned after each test.

--- a/tests/phpunit/api/v3/OrderTest.php
+++ b/tests/phpunit/api/v3/OrderTest.php
@@ -20,6 +20,7 @@ use Civi\Api4\FinancialItem;
  * @group headless
  */
 class api_v3_OrderTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use CRMTraits_Financial_TaxTrait;
 

--- a/tests/phpunit/api/v3/ParticipantPaymentTest.php
+++ b/tests/phpunit/api/v3/ParticipantPaymentTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_ParticipantPaymentTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * @var int

--- a/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
+++ b/tests/phpunit/api/v3/ParticipantStatusTypeTest.php
@@ -14,7 +14,7 @@
  * @group headless
  */
 class api_v3_ParticipantStatusTypeTest extends CiviUnitTestCase {
-  protected $_apiversion;
+  protected $_apiversion = 3;
   protected $params;
   protected $id;
 

--- a/tests/phpunit/api/v3/ParticipantTest.php
+++ b/tests/phpunit/api/v3/ParticipantTest.php
@@ -22,6 +22,7 @@ use Civi\Api4\Participant;
  * @group headless
  */
 class api_v3_ParticipantTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_entity;
   protected $_contactID;

--- a/tests/phpunit/api/v3/PaymentProcessorTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_PaymentProcessorTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_paymentProcessorType;
   protected $_params;
 

--- a/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
+++ b/tests/phpunit/api/v3/PaymentProcessorTypeTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_PaymentProcessorTypeTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_ppTypeID;
 
   public function setUp(): void {

--- a/tests/phpunit/api/v3/PaymentTest.php
+++ b/tests/phpunit/api/v3/PaymentTest.php
@@ -20,6 +20,7 @@ use Civi\Api4\Order;
  * @group headless
  */
 class api_v3_PaymentTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Clean up after each test.

--- a/tests/phpunit/api/v3/PaymentTokenTest.php
+++ b/tests/phpunit/api/v3/PaymentTokenTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_PaymentTokenTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $params;
   protected $id;
 

--- a/tests/phpunit/api/v3/PcpTest.php
+++ b/tests/phpunit/api/v3/PcpTest.php
@@ -29,6 +29,7 @@
  * @group headless
  */
 class api_v3_PcpTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $params;
   protected $entity = 'Pcp';
 

--- a/tests/phpunit/api/v3/PhoneTest.php
+++ b/tests/phpunit/api/v3/PhoneTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_PhoneTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_contactID;
   protected $_locationType;
   protected $_params;

--- a/tests/phpunit/api/v3/PledgePaymentTest.php
+++ b/tests/phpunit/api/v3/PledgePaymentTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_PledgePaymentTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_individualId;
   protected $_pledgeID;

--- a/tests/phpunit/api/v3/PledgeTest.php
+++ b/tests/phpunit/api/v3/PledgeTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_PledgeTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $_individualId;
   protected $_pledge;

--- a/tests/phpunit/api/v3/PriceFieldTest.php
+++ b/tests/phpunit/api/v3/PriceFieldTest.php
@@ -14,6 +14,7 @@
  * @group headless
  */
 class api_v3_PriceFieldTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_params;
   protected $id = 0;
   protected $priceSetID = 0;

--- a/tests/phpunit/api/v3/PriceFieldValueTest.php
+++ b/tests/phpunit/api/v3/PriceFieldValueTest.php
@@ -15,6 +15,7 @@
  * @group headless
  */
 class api_v3_PriceFieldValueTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * @var array

--- a/tests/phpunit/api/v3/ProfileTest.php
+++ b/tests/phpunit/api/v3/ProfileTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_ProfileTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   use CRMTraits_Custom_CustomDataTrait;
 
   protected $_profileID = 0;

--- a/tests/phpunit/api/v3/RelationshipTest.php
+++ b/tests/phpunit/api/v3/RelationshipTest.php
@@ -16,6 +16,7 @@ use Civi\Api4\RelationshipType;
  * @group headless
  */
 class api_v3_RelationshipTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use CRMTraits_Custom_CustomDataTrait;
 

--- a/tests/phpunit/api/v3/ReportTemplateTest.php
+++ b/tests/phpunit/api/v3/ReportTemplateTest.php
@@ -20,6 +20,7 @@ use Civi\Test\ACLPermissionTrait;
  * @group headless
  */
 class api_v3_ReportTemplateTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   use ACLPermissionTrait;
   use CRMTraits_PCP_PCPTestTrait;

--- a/tests/phpunit/api/v3/SavedSearchTest.php
+++ b/tests/phpunit/api/v3/SavedSearchTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_SavedSearchTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $params;
   protected $id;

--- a/tests/phpunit/api/v3/SelectQueryTest.php
+++ b/tests/phpunit/api/v3/SelectQueryTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_SelectQueryTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   private $hookEntity;
   private $hookCondition = [];

--- a/tests/phpunit/api/v3/SettingTest.php
+++ b/tests/phpunit/api/v3/SettingTest.php
@@ -22,6 +22,7 @@
  * @group headless
  */
 class api_v3_SettingTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   protected $currentDomain;
   protected $domainID2;

--- a/tests/phpunit/api/v3/StateProvinceTest.php
+++ b/tests/phpunit/api/v3/StateProvinceTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_StateProvinceTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_params;
 
   public function setUp(): void {

--- a/tests/phpunit/api/v3/StatusPreferenceTest.php
+++ b/tests/phpunit/api/v3/StatusPreferenceTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_StatusPreferenceTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $_contactID;
   protected $_locationType;
   protected $_params;

--- a/tests/phpunit/api/v3/SurveyTest.php
+++ b/tests/phpunit/api/v3/SurveyTest.php
@@ -29,6 +29,7 @@
  * @group headless
  */
 class api_v3_SurveyTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $params;
   protected $entity = 'survey';
 

--- a/tests/phpunit/api/v3/SystemCheckTest.php
+++ b/tests/phpunit/api/v3/SystemCheckTest.php
@@ -22,6 +22,7 @@ use Civi\Api4\StatusPreference;
  * @group headless
  */
 class api_v3_SystemCheckTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * @throws \CRM_Core_Exception

--- a/tests/phpunit/api/v3/SystemTest.php
+++ b/tests/phpunit/api/v3/SystemTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_SystemTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   private const TEST_CACHE_PATH = 'api/v3/system';
 

--- a/tests/phpunit/api/v3/TaxContributionPageTest.php
+++ b/tests/phpunit/api/v3/TaxContributionPageTest.php
@@ -23,6 +23,7 @@ use Civi\Api4\LineItem;
  * @group headless
  */
 class api_v3_TaxContributionPageTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   protected $params;
   protected $financialTypeID;
   protected $financialAccountId;

--- a/tests/phpunit/api/v3/UFFieldTest.php
+++ b/tests/phpunit/api/v3/UFFieldTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_UFFieldTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * Set up for test.

--- a/tests/phpunit/api/v3/UFGroupTest.php
+++ b/tests/phpunit/api/v3/UFGroupTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_UFGroupTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
   /**
    * ids from the uf_group_test.xml fixture
    * @var int

--- a/tests/phpunit/api/v3/UFJoinTest.php
+++ b/tests/phpunit/api/v3/UFJoinTest.php
@@ -17,6 +17,7 @@
  * @group headless
  */
 class api_v3_UFJoinTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function tearDown(): void {
     $this->quickCleanup([

--- a/tests/phpunit/api/v3/UFMatchTest.php
+++ b/tests/phpunit/api/v3/UFMatchTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_UFMatchTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   public function tearDown(): void {
     $this->quickCleanup([

--- a/tests/phpunit/api/v3/ValidateTest.php
+++ b/tests/phpunit/api/v3/ValidateTest.php
@@ -16,6 +16,7 @@
  * @group headless
  */
 class api_v3_ValidateTest extends CiviUnitTestCase {
+  protected $_apiversion = 3;
 
   /**
    * This method is called before a test is executed.


### PR DESCRIPTION
Towards making v4 the default

