### PR TITLE
Setup - Report a malformed database connection string clearly

### DIFF
--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -8,9 +8,16 @@ class DbUtil {
   /**
    * @param string $dsn
    * @return array
+   * @throws \InvalidArgumentException
+   *   If the DSN is not a well-formed URL.
    */
   public static function parseDsn($dsn) {
-    $parsed = array_map('urldecode', parse_url($dsn));
+    $urlParts = parse_url($dsn);
+    // Deliberately omit the DSN itself from the message - it contains the password.
+    if ($urlParts === FALSE || !isset($urlParts['host'])) {
+      throw new \InvalidArgumentException('Failed to parse database connection string. It should look like "mysql://user:password@host:port/database", and any special characters in the user, password or database name must be percent-encoded (for example, "#" as "%23").');
+    }
+    $parsed = array_map('urldecode', $urlParts);
     // parse_url parses 'mysql://admin:secret@unix(/var/lib/mysql/mysql.sock)/otherdb' like:
     // [
     //   'host'   => 'unix(',

--- a/tests/phpunit/Civi/Setup/DbUtilTest.php
+++ b/tests/phpunit/Civi/Setup/DbUtilTest.php
@@ -19,6 +19,84 @@ class DbUtilTest extends \CiviUnitTestCase {
   }
 
   /**
+   * A DSN which is not a well-formed URL should be reported as such.
+   *
+   * @dataProvider malformedDsnProvider
+   * @param string $dsn
+   */
+  public function testParseDsnRejectsMalformed(string $dsn) {
+    $this->expectException(\InvalidArgumentException::class);
+    \Civi\Setup\DbUtil::parseDsn($dsn);
+  }
+
+  /**
+   * Data provider for testParseDsnRejectsMalformed
+   * @return array
+   */
+  public static function malformedDsnProvider():array {
+    return [
+      // Unencoded reserved characters in the password.
+      'unencoded hash' => ['mysql://user:pa#ss@host:3306/db'],
+      'unencoded slash' => ['mysql://user:pa/ss@host:3306/db'],
+      'unencoded question mark' => ['mysql://user:pa?ss@host:3306/db'],
+      // Empty host, eg. from an unset environment variable.
+      'no host' => ['mysql://user:pass@:3306/db'],
+      'no components at all' => ['mysql://:@:/'],
+      'no scheme' => ['user:pass@host/db'],
+    ];
+  }
+
+  /**
+   * A well-formed DSN should survive parsing, including the socket notation.
+   *
+   * @dataProvider wellFormedDsnProvider
+   * @param string $dsn
+   * @param array $expected
+   */
+  public function testParseDsn(string $dsn, array $expected) {
+    $this->assertSame($expected, \Civi\Setup\DbUtil::parseDsn($dsn));
+  }
+
+  /**
+   * Data provider for testParseDsn
+   * @return array
+   */
+  public static function wellFormedDsnProvider():array {
+    return [
+      'simple' => [
+        'mysql://user:pass@host:3306/db',
+        [
+          'server' => 'host:3306',
+          'username' => 'user',
+          'password' => 'pass',
+          'database' => 'db',
+          'ssl_params' => [],
+        ],
+      ],
+      'encoded password' => [
+        'mysql://user:pa%23ss@host:3306/db',
+        [
+          'server' => 'host:3306',
+          'username' => 'user',
+          'password' => 'pa#ss',
+          'database' => 'db',
+          'ssl_params' => [],
+        ],
+      ],
+      'unix socket' => [
+        'mysql://user:pass@unix(/var/lib/mysql/mysql.sock)/db',
+        [
+          'server' => 'unix(/var/lib/mysql/mysql.sock)',
+          'username' => 'user',
+          'password' => 'pass',
+          'database' => 'db',
+          'ssl_params' => [],
+        ],
+      ],
+    ];
+  }
+
+  /**
    * Data provider for testParseSSL
    * @return array
    */


### PR DESCRIPTION
Overview
----------------------------------------

`Civi\Setup\DbUtil::parseDsn()` aborts with a PHP `TypeError` instead of a usable message when the database connection string cannot be parsed. This replaces it with an explanation of what is wrong.

Before
----------------------------------------

Installing with a database password that contains a `#`:

$ cv core:install --db='mysql://civicrm:pa#ss@db:3306/civicrm' --url=...
Found code for civicrm-core in /var/www/html/core
Found code for civicrm-setup in /var/www/html/core/setup

In DbUtil.php line 13:

  array_map(): Argument #2 ($array) must be of type array, false given

Nothing indicates that the password needs percent-encoding, or even that the DSN is the problem.

After
----------------------------------------

Failed to parse database connection string. It should look like
"mysql://user:password@host:port/database", and any special characters in the
user, password or database name must be percent-encoded (for example, "#" as "%23").

Technical Details
----------------------------------------

`parseDsn()` passed the result of `parse_url()` straight into `array_map()`. `parse_url()` returns `FALSE` — not an array — when it cannot parse the string, which happens whenever the password contains an unencoded reserved character (`#`, `/`, `?`), and also when the host is empty. The latter is easy to hit from a script that builds the DSN by string concatenation, because an unset environment variable yields `mysql://user:pass@:3306/db`.

The guard also covers a parse that succeeds but yields no `host` key (for example a string with no scheme). That previously produced an "Undefined array key" warning followed by wrong behaviour rather than an error.

The message deliberately does not quote the DSN back to the user, because it contains the password.

Adds `DbUtilTest::testParseDsnRejectsMalformed` covering six malformed shapes, and `testParseDsn` asserting that well-formed strings — including the `unix(/path/to/socket)` notation — are unaffected.

Comments
----------------------------------------

Encountered while installing via a Docker image whose entrypoint builds the DSN from environment variables.

There is a second, quieter bug in the same area — the encode and decode conventions for DSN credentials disagree — which I have put in a separate PR.