### PR TITLE
Remove call to deprecated price set functions from event cart

### DIFF
--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/ParticipantsAndPrices.php
@@ -195,19 +195,8 @@ class CRM_Event_Cart_Form_Checkout_ParticipantsAndPrices extends CRM_Event_Cart_
    * don't specifically need it & find a better way where we do.
    */
   private function processCartAmount($fields, &$params, &$lineItem = [], $priceSetID = NULL) {
-    // using price set
-    foreach ($fields as $id => $field) {
-      if (empty($params["price_{$id}"]) ||
-        (empty($params["price_{$id}"]) && $params["price_{$id}"] == NULL)
-      ) {
-        // skip if nothing was submitted for this field
-        continue;
-      }
-
-      [$params, $lineItem] = CRM_Price_BAO_PriceSet::getLine($params, $lineItem, $priceSetID, $field, $id);
-    }
     $order = new CRM_Financial_BAO_Order();
-    $order->setLineItems((array) $lineItem);
+    $order->setPriceSelectionFromUnfilteredInput($params);
     $params['amount_level'] = $order->getAmountLevel();
     $params['amount'] = $order->getTotalAmount();
     $params['tax_amount'] = $order->getTotalTaxAmount();

--- a/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
+++ b/ext/eventcart/CRM/Event/Cart/Form/Checkout/Payment.php
@@ -230,10 +230,13 @@ class CRM_Event_Cart_Form_Checkout_Payment extends CRM_Event_Cart_Form_Cart {
           $event_price_values[$matches[1]] = $value;
         }
       }
-      $price_sets = CRM_Price_BAO_PriceSet::getSetDetail($price_set_id, TRUE);
-      $price_set = $price_sets[$price_set_id];
-      $price_set_amount = [];
-      CRM_Price_BAO_PriceSet::processAmount($price_set['fields'], $event_price_values, $price_set_amount);
+      $order = new CRM_Financial_BAO_Order();
+      $order->setPriceSetID($price_set_id);
+      $order->setPriceSelectionFromUnfilteredInput($event_price_values);
+      $price_set_amount = $order->getLineItems();
+      $event_price_values['amount_level'] = $order->getAmountLevel();
+      $event_price_values['amount'] = $order->getTotalAmount();
+      $event_price_values['tax_amount'] = $order->getTotalTaxAmount();
       if (!empty($this->_price_values['discountcode'])) {
         $ret = $this->apply_discount($this->_price_values['discountcode'], $price_set_amount, $cost, $event_in_cart->event_id);
         if ($ret == FALSE) {


### PR DESCRIPTION
Overview
----------------------------------------
Remove call to deprecated price set functions from event cart

Before
----------------------------------------
Event cart still calls functions we have deprecated in favour of the BAO_Order object 

After
----------------------------------------
Updated call 

Technical Details
----------------------------------------

Comments
----------------------------------------

