### PR TITLE
Encode DSN credentials per RFC 3986, so spaces survive 

### DIFF
--- a/Civi/Core/SettingsBag.php
+++ b/Civi/Core/SettingsBag.php
@@ -621,7 +621,9 @@ class SettingsBag {
         // (but could be one of the other components has been explicitly nulled))
         return [];
       }
-      $componentValues[$componentKey] = urlencode($value);
+      // rawurlencode() rather than urlencode(): this DSN is read back with
+      // DB::parseDSN(), which takes a '+' literally instead of as a space.
+      $componentValues[$componentKey] = rawurlencode($value);
     }
 
     $dsn = "mysql://{$componentValues['user']}:{$componentValues['password']}@{$componentValues['host']}:{$componentValues['port']}/{$componentValues['name']}?new_link=true";

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -17,7 +17,7 @@ class DbUtil {
     if ($urlParts === FALSE || !isset($urlParts['host'])) {
       throw new \InvalidArgumentException('Failed to parse database connection string. It should look like "mysql://user:password@host:port/database", and any special characters in the user, password or database name must be percent-encoded (for example, "#" as "%23").');
     }
-    $parsed = array_map('urldecode', $urlParts);
+    $parsed = array_map('rawurldecode', $urlParts);
     // parse_url parses 'mysql://admin:secret@unix(/var/lib/mysql/mysql.sock)/otherdb' like:
     // [
     //   'host'   => 'unix(',
@@ -52,12 +52,12 @@ class DbUtil {
    * @return string
    */
   public static function encodeDsn($db) {
-    $escapedHostPort = implode(':', array_map('urlencode', explode(':', $db['server'])));
+    $escapedHostPort = implode(':', array_map('rawurlencode', explode(':', $db['server'])));
     return sprintf('mysql://%s:%s@%s/%s',
-      urlencode($db['username']),
-      urlencode($db['password']),
+      rawurlencode($db['username']),
+      rawurlencode($db['password']),
       $escapedHostPort,
-      urlencode($db['database'])
+      rawurlencode($db['database'])
     );
   }
 

--- a/setup/src/Setup/DbUtil.php
+++ b/setup/src/Setup/DbUtil.php
@@ -8,9 +8,16 @@ class DbUtil {
   /**
    * @param string $dsn
    * @return array
+   * @throws \InvalidArgumentException
+   *   If the DSN is not a well-formed URL.
    */
   public static function parseDsn($dsn) {
-    $parsed = array_map('urldecode', parse_url($dsn));
+    $urlParts = parse_url($dsn);
+    // Deliberately omit the DSN itself from the message - it contains the password.
+    if ($urlParts === FALSE || !isset($urlParts['host'])) {
+      throw new \InvalidArgumentException('Failed to parse database connection string. It should look like "mysql://user:password@host:port/database", and any special characters in the user, password or database name must be percent-encoded (for example, "#" as "%23").');
+    }
+    $parsed = array_map('urldecode', $urlParts);
     // parse_url parses 'mysql://admin:secret@unix(/var/lib/mysql/mysql.sock)/otherdb' like:
     // [
     //   'host'   => 'unix(',

--- a/setup/src/Setup/SettingsUtil.php
+++ b/setup/src/Setup/SettingsUtil.php
@@ -14,10 +14,12 @@ class SettingsUtil {
     // ??why is frontEnd=0??
     $params['frontEnd'] = 0;
     $params['baseURL'] = addslashes(rtrim($m->cmsBaseUrl, '/'));
-    $params['dbUser'] = addslashes(urlencode($m->db['username']));
-    $params['dbPass'] = addslashes(urlencode($m->db['password'] ?? ''));
-    $params['dbHost'] = addslashes(implode(':', array_map('urlencode', explode(':', $m->db['server']))));
-    $params['dbName'] = addslashes(urlencode($m->db['database']));
+    // rawurlencode() rather than urlencode(): PEAR::DB reads these back with
+    // rawurldecode(), which takes a '+' literally instead of as a space.
+    $params['dbUser'] = addslashes(rawurlencode($m->db['username']));
+    $params['dbPass'] = addslashes(rawurlencode($m->db['password'] ?? ''));
+    $params['dbHost'] = addslashes(implode(':', array_map('rawurlencode', explode(':', $m->db['server']))));
+    $params['dbName'] = addslashes(rawurlencode($m->db['database']));
     // The '&' prefix is awkward, but we don't know what's already in the file.
     // At the time of writing, it has ?new_link=true. If that is removed,
     // then need to update this.
@@ -26,10 +28,10 @@ class SettingsUtil {
     // need to use %20 for spaces.
     $params['dbSSL'] = empty($m->db['ssl_params']) ? '' : addslashes('&' . http_build_query($m->db['ssl_params'], '', '&', PHP_QUERY_RFC3986));
     $params['cms'] = addslashes($m->cms);
-    $params['CMSdbUser'] = addslashes(urlencode($m->cmsDb['username']));
-    $params['CMSdbPass'] = addslashes(urlencode($m->cmsDb['password']));
-    $params['CMSdbHost'] = addslashes(implode(':', array_map('urlencode', explode(':', $m->cmsDb['server']))));
-    $params['CMSdbName'] = addslashes(urlencode($m->cmsDb['database']));
+    $params['CMSdbUser'] = addslashes(rawurlencode($m->cmsDb['username']));
+    $params['CMSdbPass'] = addslashes(rawurlencode($m->cmsDb['password']));
+    $params['CMSdbHost'] = addslashes(implode(':', array_map('rawurlencode', explode(':', $m->cmsDb['server']))));
+    $params['CMSdbName'] = addslashes(rawurlencode($m->cmsDb['database']));
     // The '&' prefix is awkward, but we don't know what's already in the file.
     // At the time of writing, it has ?new_link=true. If that is removed,
     // then need to update this.

--- a/tests/phpunit/Civi/Core/SettingsBagTest.php
+++ b/tests/phpunit/Civi/Core/SettingsBagTest.php
@@ -78,4 +78,49 @@ class SettingsBagTest extends \CiviUnitTestCase {
     $this->assertSame($defaultValue, $bagGetRedux, "Check value consistency. Report: $report");
   }
 
+  /**
+   * A DSN composed from the CIVICRM_DB_* environment variables must survive
+   * being read back by DB::parseDSN(), which decodes with rawurldecode().
+   *
+   * @dataProvider dsnComponentProvider
+   * @param string $username
+   * @param string $password
+   * @param string $database
+   */
+  public function testInterpolateDsnRoundTrip(string $username, string $password, string $database): void {
+    $bag = new SettingsBag(0, NULL);
+    $bag->loadDefaults([
+      'civicrm_db_host' => 'db.example.org',
+      'civicrm_db_port' => 3306,
+      'civicrm_db_name' => $database,
+      'civicrm_db_user' => $username,
+      'civicrm_db_password' => $password,
+    ]);
+    $bag->loadMandatory([]);
+
+    $parsed = \DB::parseDSN($bag->get('civicrm_db_dsn'));
+
+    $this->assertSame($username, $parsed['username']);
+    $this->assertSame($password, $parsed['password']);
+    $this->assertSame($database, $parsed['database']);
+    $this->assertSame('db.example.org', $parsed['hostspec']);
+  }
+
+  /**
+   * Data provider for testInterpolateDsnRoundTrip.
+   * @return array
+   */
+  public static function dsnComponentProvider(): array {
+    return [
+      'plain' => ['civicrm', 'secret', 'civicrm'],
+      'hash' => ['civicrm', 'pa#ss', 'civicrm'],
+      'slash' => ['civicrm', 'pa/ss', 'civicrm'],
+      'at sign' => ['civicrm', 'pa@ss', 'civicrm'],
+      'percent' => ['civicrm', 'pa%ss', 'civicrm'],
+      'space' => ['civicrm', 'pa ss', 'civicrm'],
+      'plus' => ['civicrm', 'pa+ss', 'civicrm'],
+      'special database' => ['civicrm', 'secret', 'db name'],
+    ];
+  }
+
 }

--- a/tests/phpunit/Civi/Setup/DbUtilTest.php
+++ b/tests/phpunit/Civi/Setup/DbUtilTest.php
@@ -47,6 +47,51 @@ class DbUtilTest extends \CiviUnitTestCase {
   }
 
   /**
+   * encodeDsn() and parseDsn() must be inverses of each other, and the string
+   * they agree on must also be readable by PEAR::DB at runtime.
+   *
+   * @dataProvider credentialProvider
+   * @param string $username
+   * @param string $password
+   * @param string $database
+   */
+  public function testEncodeDsnRoundTrip(string $username, string $password, string $database) {
+    $db = [
+      'server' => 'db.example.org:3306',
+      'username' => $username,
+      'password' => $password,
+      'database' => $database,
+      'ssl_params' => [],
+    ];
+    $dsn = \Civi\Setup\DbUtil::encodeDsn($db);
+    $this->assertSame($db, \Civi\Setup\DbUtil::parseDsn($dsn));
+
+    $pear = \DB::parseDSN($dsn);
+    $this->assertSame($username, $pear['username']);
+    $this->assertSame($password, $pear['password']);
+    $this->assertSame($database, $pear['database']);
+  }
+
+  /**
+   * Data provider for testEncodeDsnRoundTrip
+   * @return array
+   */
+  public static function credentialProvider():array {
+    return [
+      'plain' => ['civicrm', 'secret', 'civicrm'],
+      'hash' => ['civicrm', 'pa#ss', 'civicrm'],
+      'slash' => ['civicrm', 'pa/ss', 'civicrm'],
+      'question mark' => ['civicrm', 'pa?ss', 'civicrm'],
+      'at sign' => ['civicrm', 'pa@ss', 'civicrm'],
+      'colon' => ['civicrm', 'pa:ss', 'civicrm'],
+      'percent' => ['civicrm', 'pa%ss', 'civicrm'],
+      'space' => ['civicrm', 'pa ss', 'civicrm'],
+      'plus' => ['civicrm', 'pa+ss', 'civicrm'],
+      'special database' => ['civicrm', 'secret', 'db name'],
+    ];
+  }
+
+  /**
    * A well-formed DSN should survive parsing, including the socket notation.
    *
    * @dataProvider wellFormedDsnProvider

--- a/tests/phpunit/Civi/Setup/DbUtilTest.php
+++ b/tests/phpunit/Civi/Setup/DbUtilTest.php
@@ -19,6 +19,84 @@ class DbUtilTest extends \CiviUnitTestCase {
   }
 
   /**
+   * A DSN which is not a well-formed URL should be reported as such.
+   *
+   * @dataProvider malformedDsnProvider
+   * @param string $dsn
+   */
+  public function testParseDsnRejectsMalformed(string $dsn) {
+    $this->expectException(\InvalidArgumentException::class);
+    \Civi\Setup\DbUtil::parseDsn($dsn);
+  }
+
+  /**
+   * Data provider for testParseDsnRejectsMalformed
+   * @return array
+   */
+  public static function malformedDsnProvider():array {
+    return [
+      // Unencoded reserved characters in the password.
+      'unencoded hash' => ['mysql://user:pa#ss@host:3306/db'],
+      'unencoded slash' => ['mysql://user:pa/ss@host:3306/db'],
+      'unencoded question mark' => ['mysql://user:pa?ss@host:3306/db'],
+      // Empty host, eg. from an unset environment variable.
+      'no host' => ['mysql://user:pass@:3306/db'],
+      'no components at all' => ['mysql://:@:/'],
+      'no scheme' => ['user:pass@host/db'],
+    ];
+  }
+
+  /**
+   * A well-formed DSN should survive parsing, including the socket notation.
+   *
+   * @dataProvider wellFormedDsnProvider
+   * @param string $dsn
+   * @param array $expected
+   */
+  public function testParseDsn(string $dsn, array $expected) {
+    $this->assertSame($expected, \Civi\Setup\DbUtil::parseDsn($dsn));
+  }
+
+  /**
+   * Data provider for testParseDsn
+   * @return array
+   */
+  public static function wellFormedDsnProvider():array {
+    return [
+      'simple' => [
+        'mysql://user:pass@host:3306/db',
+        [
+          'server' => 'host:3306',
+          'username' => 'user',
+          'password' => 'pass',
+          'database' => 'db',
+          'ssl_params' => [],
+        ],
+      ],
+      'encoded password' => [
+        'mysql://user:pa%23ss@host:3306/db',
+        [
+          'server' => 'host:3306',
+          'username' => 'user',
+          'password' => 'pa#ss',
+          'database' => 'db',
+          'ssl_params' => [],
+        ],
+      ],
+      'unix socket' => [
+        'mysql://user:pass@unix(/var/lib/mysql/mysql.sock)/db',
+        [
+          'server' => 'unix(/var/lib/mysql/mysql.sock)',
+          'username' => 'user',
+          'password' => 'pass',
+          'database' => 'db',
+          'ssl_params' => [],
+        ],
+      ],
+    ];
+  }
+
+  /**
    * Data provider for testParseSSL
    * @return array
    */

--- a/tests/phpunit/Civi/Setup/SettingsUtilTest.php
+++ b/tests/phpunit/Civi/Setup/SettingsUtilTest.php
@@ -1,0 +1,116 @@
+<?php
+namespace Civi\Setup;
+
+/**
+ * Class SettingsUtilTest
+ * @package Civi\Setup
+ * @group headless
+ */
+class SettingsUtilTest extends \CiviUnitTestCase {
+
+  /**
+   * Credentials must survive the trip through civicrm.settings.php.
+   *
+   * SettingsUtil writes them percent-encoded into the CIVICRM_DSN literal, and
+   * PEAR::DB reads them back with rawurldecode(), so whatever went in has to
+   * come back out unchanged.
+   *
+   * @dataProvider credentialProvider
+   * @param string $username
+   * @param string $password
+   * @param string $database
+   */
+  public function testCredentialsSurviveSettingsFile(string $username, string $password, string $database) {
+    $model = $this->makeModel($username, $password, $database);
+    $params = SettingsUtil::createParams($model);
+    $settings = SettingsUtil::evaluate($this->getTemplatePath(), $params);
+
+    // Anchored to the start of a line so this does not match the example DSN
+    // in the template's own doc-comment.
+    $this->assertSame(1, preg_match("/^\s*define\('CIVICRM_DSN', '(.*)'\);/m", $settings, $matches),
+      'Could not find the CIVICRM_DSN definition in the generated settings file.');
+    $parsed = \DB::parseDSN(stripslashes($matches[1]));
+
+    $this->assertSame($username, $parsed['username']);
+    $this->assertSame($password, $parsed['password']);
+    $this->assertSame($database, $parsed['database']);
+    $this->assertSame('db.example.org', $parsed['hostspec']);
+    $this->assertSame('3306', $parsed['port']);
+  }
+
+  /**
+   * Data provider for testCredentialsSurviveSettingsFile.
+   *
+   * Excludes quotes and backslashes, which are the separate concern of the
+   * addslashes() applied on top.
+   *
+   * @return array
+   */
+  public static function credentialProvider():array {
+    return [
+      'plain' => ['civicrm', 'secret', 'civicrm'],
+      'hash' => ['civicrm', 'pa#ss', 'civicrm'],
+      'slash' => ['civicrm', 'pa/ss', 'civicrm'],
+      'question mark' => ['civicrm', 'pa?ss', 'civicrm'],
+      'at sign' => ['civicrm', 'pa@ss', 'civicrm'],
+      'colon' => ['civicrm', 'pa:ss', 'civicrm'],
+      'percent' => ['civicrm', 'pa%ss', 'civicrm'],
+      'ampersand' => ['civicrm', 'pa&ss', 'civicrm'],
+      'space' => ['civicrm', 'pa ss', 'civicrm'],
+      'plus' => ['civicrm', 'pa+ss', 'civicrm'],
+      'space and plus' => ['civicrm', 'pa +ss', 'civicrm'],
+      'special username' => ['user name', 'secret', 'civicrm'],
+      'special database' => ['civicrm', 'secret', 'db name'],
+      'empty password' => ['civicrm', '', 'civicrm'],
+    ];
+  }
+
+  /**
+   * A space must be written as %20, never as '+'.
+   *
+   * PEAR::DB reads the DSN with rawurldecode(), which would take a '+'
+   * literally.
+   */
+  public function testSpaceIsEncodedAsPercent20() {
+    $params = SettingsUtil::createParams($this->makeModel('civicrm', 'pa ss', 'civicrm'));
+    $this->assertSame('pa%20ss', $params['dbPass']);
+  }
+
+  /**
+   * @return string
+   */
+  private function getTemplatePath(): string {
+    return dirname(__DIR__, 4) . '/templates/CRM/common/civicrm.settings.php.template';
+  }
+
+  /**
+   * @param string $username
+   * @param string $password
+   * @param string $database
+   * @return \Civi\Setup\Model
+   */
+  private function makeModel(string $username, string $password, string $database): Model {
+    $db = [
+      'server' => 'db.example.org:3306',
+      'username' => $username,
+      'password' => $password,
+      'database' => $database,
+      'ssl_params' => [],
+    ];
+    $model = new Model();
+    $model->srcPath = dirname(__DIR__, 4);
+    $model->templateCompilePath = '/tmp/templates_c';
+    $model->cmsBaseUrl = 'http://example.org/';
+    $model->cms = 'Standalone';
+    $model->db = $db;
+    $model->cmsDb = $db;
+    $model->siteKey = 'abcd1234ABCD9876';
+    $model->credKeys = ['::abcd1234ABCD9876'];
+    $model->signKeys = ['jwt-hs256::abcd1234ABCD9876'];
+    $model->deployID = '1234ABCD9876';
+    $model->paths = [];
+    $model->mandatorySettings = [];
+    return $model;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------

CiviCRM percent-**encodes** the credentials it writes into a DSN with `urlencode()`, but **decodes** them with `rawurldecode()`. Those two disagree on exactly one character, so a database password containing a space is silently corrupted. This aligns every hop on RFC 3986.

Stacked on https://github.com/civicrm/civicrm-core/pull/36685 - it contains that commit as well. Please merge that one first.

Before
----------------------------------------

Install with a database password of `pa ss`. The installer reports success — its own connection test passes, because at that point it still holds the plaintext password. Every page load afterwards then fails to connect:

```php
// civicrm.settings.php, as written by the installer
define('CIVICRM_DSN', 'mysql://civicrm:pa+ss@localhost:3306/civicrm?new_link=true');
```

`DB::parseDSN()` reads that back as the password `pa+ss`, not `pa ss`.

A space in the database *name* fails worse. PEAR treats a `+` before the `/` as its legacy `protocol+hostspec` separator, so the DSN disintegrates and `DB::parseDSN()` returns no database at all.

After
----------------------------------------

```php
define('CIVICRM_DSN', 'mysql://civicrm:pa%20ss@localhost:3306/civicrm?new_link=true');
```

Verified end-to-end against a real MySQL server, with a user whose password is literally `pa ss`, going through the real settings template and PEAR/mysqli:

```
BEFORE (urlencode)     -> CONNECT FAILED: DB Error: connect failed
AFTER  (rawurlencode)  -> CONNECTED, DATABASE()='civi_sp_test'
```

Technical Details
----------------------------------------

`urlencode()` emits a space as `+`; `rawurldecode()` reads a `+` as a literal `+`. Four places used the non-raw variants:

- `Civi\Setup\SettingsUtil::createParams()` — writes the `CIVICRM_DSN` and `CIVICRM_UF_DSN` literals into `civicrm.settings.php` (eight fields, civi + CMS).
- `Civi\Setup\DbUtil::parseDsn()` — `urldecode` to `rawurldecode`, so install-time parsing agrees with runtime parsing.
- `Civi\Setup\DbUtil::encodeDsn()` — for symmetry with `parseDsn()`.
- `Civi\Core\SettingsBag::interpolateDsnSettings()` — composes a DSN from the `CIVICRM_DB_*` environment variables. This is the runtime path rather than the installer, and affects anyone configuring a container purely from the environment.

The SSL parameters were already correct: the two `http_build_query()` calls in `SettingsUtil` already pass `PHP_QUERY_RFC3986`, and the comment above them describes exactly this hazard ("PEAR::DB will interpret plus signs as a reference to its old DSN format ... so we need to use %20 for spaces"). This applies the same convention to the credentials sitting beside them.

The `host` field keeps its existing `explode(':')` / `implode(':')` shape, which leaves the `host:port` separator unencoded. `DB::parseDSN()` decodes the host *before* splitting on `:`, so an encoded `%3A` there would become a port separator.

**No behaviour that works today changes.** I checked every ASCII punctuation character through both the old and the new chain: a space is the only value whose round trip is currently wrong, and no character that round-trips correctly today stops doing so.

Tests: this was a total coverage gap — `grep -r parseDSN tests/` previously matched nothing, so no test anywhere exercised DSN credential encoding. Adds a new `SettingsUtilTest` that round-trips plaintext through `createParams()`, the real `civicrm.settings.php.template` via `evaluate()`, and `DB::parseDSN()`; `DbUtilTest::testEncodeDsnRoundTrip`; and `SettingsBagTest::testInterpolateDsnRoundTrip`. Each was confirmed to fail before the fix.

Comments
----------------------------------------

`dd589f5333` (dev/core#2663, 2021) established the current scheme and fixed `#` and `&`, but chose `urlencode` over `rawurlencode` and so left the space case behind.

Not addressed here, as it is independent of the encoding choice: an IPv6 hostspec such as `[1234:abcd]:123` cannot survive `DB::parseDSN()`, because the encoded brackets are decoded before the `:` split.