### PR TITLE
dev/core#6704 Use correct type when comparing max_additional_participants

### DIFF
--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -369,7 +369,7 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
         // Label is value + 1, since the code sees this is ADDITIONAL participants (in addition to "self")
         $additionalOptions = [];
         $additionalOptions[''] = 1;
-        for ($i = 1; $i <= $this->_values['event']['max_additional_participants']; $i++) {
+        for ($i = 1; $i <= $this->getEventValue('max_additional_participants'); $i++) {
           $additionalOptions[$i] = $i + 1;
         }
         $this->add('select', 'additional_participants',


### PR DESCRIPTION
Overview
----------------------------------------
dev/core#6704 Use correct type when comparing max_additional_participants

Before
----------------------------------------
numeric function on string

After
----------------------------------------
Value comes from apiv4 so it is an integer

Technical Details
----------------------------------------

Comments
----------------------------------------
I didn't replicate the problem with or without this but it is more correct