### PR TITLE
oauth-client - Show configured client count on the provider list

### DIFF
--- a/ext/oauth-client/CRM/OAuth/Angular.php
+++ b/ext/oauth-client/CRM/OAuth/Angular.php
@@ -6,9 +6,36 @@ class CRM_OAuth_Angular {
     $s = [];
 
     $s['redirectUrl'] = \CRM_OAuth_BAO_OAuthClient::getRedirectUri();
-    $s['providers'] = civicrm_api4('OAuthProvider', 'get', [])->indexBy('name');
+    $s['providers'] = self::getProvidersWithClientCounts();
 
     return $s;
+  }
+
+  /**
+   * Get the provider list, annotated with the number of clients configured for each.
+   *
+   * @return array
+   *   Providers keyed by name, each with extra keys `client_count` and `active_client_count`.
+   */
+  private static function getProvidersWithClientCounts(): array {
+    $providers = civicrm_api4('OAuthProvider', 'get', [])->indexBy('name')->getArrayCopy();
+
+    $counts = [];
+    // Permission-checked, so this only counts clients whose provider the user may see.
+    $clients = \Civi\Api4\OAuthClient::get()->addSelect('provider', 'is_active')->execute();
+    foreach ($clients as $client) {
+      $counts[$client['provider']]['total'] = ($counts[$client['provider']]['total'] ?? 0) + 1;
+      if ($client['is_active']) {
+        $counts[$client['provider']]['active'] = ($counts[$client['provider']]['active'] ?? 0) + 1;
+      }
+    }
+
+    foreach ($providers as $name => &$provider) {
+      $provider['client_count'] = $counts[$name]['total'] ?? 0;
+      $provider['active_client_count'] = $counts[$name]['active'] ?? 0;
+    }
+
+    return $providers;
   }
 
 }

--- a/ext/oauth-client/ang/oauthProviderList.aff.html
+++ b/ext/oauth-client/ang/oauthProviderList.aff.html
@@ -15,6 +15,7 @@
   <tr>
     <th>{{ts('Name')}}</th>
     <th>{{ts('Title')}}</th>
+    <th>{{ts('Clients')}}</th>
   </tr>
   </thead>
   <tbody>
@@ -24,6 +25,13 @@
     </td>
     <td>
       <a ng-href="#!/?provider={{provider.name}}">{{provider.title}}</a>
+    </td>
+    <td>
+      <span ng-if="!provider.client_count" class="crm-oauth-no-clients">{{ts('None')}}</span>
+      <span ng-if="provider.client_count">{{provider.client_count}}</span>
+      <span ng-if="provider.client_count > provider.active_client_count">
+        ({{ts('%1 disabled', {1: provider.client_count - provider.active_client_count})}})
+      </span>
     </td>
   </tr>
   </tbody>


### PR DESCRIPTION
Overview
----------------------------------------
The OAuth2 Client Administration screen lists the available providers but gives no indication of which ones actually have clients configured. You have to click into every provider in turn to find out where your credentials are.

Before
----------------------------------------
`Administer » System Settings » OAuth` lists each provider with just Name and Title. A site with a Google Mail client configured and nothing else looks identical to a site with nothing configured at all.

| Name | Title |
| --- | --- |
| beeceptor.com | Beeceptor Mock OAuth 2.0 Server |
| gmail | Google Mail |
| ms-exchange | Microsoft Exchange Online |

After
----------------------------------------
A "Clients" column shows how many clients each provider has, and how many of those are disabled.

| Name | Title | Clients |
| --- | --- | --- |
| beeceptor.com | Beeceptor Mock OAuth 2.0 Server | None |
| gmail | Google Mail | 2 (1 disabled) |
| ms-exchange | Microsoft Exchange Online | 1 |

<img width="1512" height="784" alt="screenshot-1788779609197-6" src="https://github.com/user-attachments/assets/e5d20a28-ea02-4176-a756-201a008acace" />

Technical Details
----------------------------------------
The provider list is rendered from `CRM.oauthUtil.providers`, which comes from `CRM_OAuth_Angular::getSettings()` via the `settingsFactory` in `ang/oauthUtil.ang.php` — not from a live API call — so the counts are folded in there rather than fetched separately by the Angular controller.

`OAuthClient::get()` is left permission-checked, so the counts only reflect clients whose provider the user is allowed to see (`CRM_OAuth_BAO_OAuthClient::addSelectWhereClause()` already filters these).

Comments
----------------------------------------
Independent of the other Mail Account / OAuth PRs in this series; can be merged on its own.
