### PR TITLE
oauth-client - Restore the OAuth menu item when the extension is re-enabled

### DIFF
--- a/ext/oauth-client/managed/Navigation_OAuth.mgd.php
+++ b/ext/oauth-client/managed/Navigation_OAuth.mgd.php
@@ -18,6 +18,9 @@ return [
         ],
         'permission_operator' => 'OR',
         'parent_id.name' => 'System Settings',
+        // Must be declared: a managed entity keeps its stored value for any omitted field,
+        // so without this the menu item stays hidden after the extension is disabled and re-enabled.
+        'is_active' => TRUE,
       ],
       // Matching on `url` because `name` may have been null due to a bug in previous versions `CRM_OAuth_Upgrader::install()`
       'match' => ['url', 'domain_id'],


### PR DESCRIPTION
Overview
----------------------------------------
Disabling and then re-enabling the OAuth Client extension permanently removes the "OAuth" item from the navigation menu, leaving the OAuth admin screen reachable only by typing the URL.

Before
----------------------------------------
1. Enable `oauth-client`. "OAuth" appears under *Administer » System Settings*.
2. `cv dis oauth-client`
3. `cv en oauth-client`
4. The menu item is gone, and stays gone through any number of cache flushes.

The record is still there — it is just inactive:

```
civicrm_navigation: name=OAuth, url=civicrm/admin/oauth, is_active=0
civicrm_managed:    module=oauth-client, entity_type=Navigation, name=Navigation_OAuth
```

After
----------------------------------------
The menu item comes back when the extension is re-enabled.

Technical Details
----------------------------------------
Disabling an extension deactivates its managed entities. On re-enable, the managed entity is reconciled against its declaration — but a managed entity retains its stored value for any field the declaration omits, and `managed/Navigation_OAuth.mgd.php` never declared `is_active`. Nothing therefore ever set it back to `1`.

Declaring `is_active => TRUE` explicitly fixes it.

Verified on a standalone build by running the disable/enable cycle both with and without the change: without it `is_active` stays `0`, with it `is_active` is `1`.

Comments
----------------------------------------
Found incidentally while testing that the Mail Accounts screen degrades correctly when `oauth-client` is disabled. Independent of the rest of that series.
