### PR TITLE
Initiators - Let an initiator describe an existing connection

### DIFF
--- a/CRM/Utils/Hook.php
+++ b/CRM/Utils/Hook.php
@@ -3021,14 +3021,22 @@ abstract class CRM_Utils_Hook {
    *   Descriptor for the context/record wherein we want an API key. Some combination of:
    *   - for: string (REQUIRED), a symbol that identifies the kind of context, e.g.
    *      - "PaymentProcessor" (v6.10+): Add or reset the API key for a PaymentProcessor
+   *      - "MailSettings" (v6.19+): Add or reset the credentials for a Mail Account
    *   - payment_processor_type: string (OPTIONAL), a symbol like "Stripe" which identifies the type of payment-processor
    *   - payment_processor_id: int (OPTIONAL), unique id for the PaymentProcessor record
    *   - is_test: bool (OPTIONAL), whether this payproc is for testing
+   *   - mail_settings_id: int (OPTIONAL), unique id for the MailSettings record
    * @param array $available
    *   List of available actions. Each item has a symbolic-key, and it has the properties:
    *     - title: string
    *     - render: callable, the function which renders the initiator buttons
    *        Signature: function(CRM_Core_Region $region, array $context, array $initiator):
+   *     - is_connected: bool (OPTIONAL), whether this record is currently connected via this initiator
+   *     - status_message: string (OPTIONAL), describes the current connection, e.g. "Connected as foo@example.org"
+   *     - status_severity: string (OPTIONAL), one of 'success', 'warning', 'danger'
+   *     - manage_url: string (OPTIONAL), address of the screen which administers this connection
+   *     - managed_fields: string[] (OPTIONAL), form fields supplied by this connection at runtime.
+   *        The form hides these, and leaves their stored values untouched on save.
    * @param string|null $default
    *
    * @return mixed

--- a/Civi/Connect/Initiators.php
+++ b/Civi/Connect/Initiators.php
@@ -26,9 +26,11 @@ class Initiators {
    *   Some combination of:
    *     - for: string (REQUIRED), a symbol that identifies the kind of context. Possible values:
    *         - "PaymentProcessor" (v6.7+): Add or reset the API key for a PaymentProcessor
+   *         - "MailSettings" (v6.19+): Add or reset the credentials for a Mail Account
    *     - payment_processor_type: string (OPTIONAL), a symbol like "PayPal" or "Stripe" which identifies the type of payment-processor
    *     - payment_processor_id: int (OPTIONAL), unique id for the PaymentProcessor record
    *     - is_test: bool (OPTIONAL), whether this payproc is for testing
+   *     - mail_settings_id: int (OPTIONAL), unique id for the MailSettings record
    * @readonly
    */
   public array $context;
@@ -48,6 +50,12 @@ class Initiators {
    *     - title: string
    *     - render: callback to generate the UI widget
    *        Signature: function(CRM_Core_Region $region, array $context, array $initiator):
+   *     - is_connected: bool (OPTIONAL), whether the subject record is currently connected via this initiator
+   *     - status_message: string (OPTIONAL), describes the current connection, e.g. "Connected as foo@example.org"
+   *     - status_severity: string (OPTIONAL), one of 'success', 'warning', 'danger'
+   *     - manage_url: string (OPTIONAL), address of the screen which administers this connection
+   *     - managed_fields: string[] (OPTIONAL), fields supplied by this connection at runtime, which
+   *        the consuming form should hide and leave untouched on save
    *     - name: string (COMPUTED; same as array-key)
    *     - url: string (COMPUTED; HTTP address for this initiator)
    *     - is_default: bool (COMPUTED)
@@ -79,6 +87,29 @@ class Initiators {
 
   public function get(string $name): ?array {
     return $this->available[$name] ?? NULL;
+  }
+
+  /**
+   * Find the initiator (if any) which reports an active connection for the subject record.
+   *
+   * @return array|null
+   */
+  public function getConnected(): ?array {
+    foreach ($this->available as $initiator) {
+      if (!empty($initiator['is_connected'])) {
+        return $initiator;
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Fields which the active connection supplies at runtime.
+   *
+   * @return string[]
+   */
+  public function getManagedFields(): array {
+    return $this->getConnected()['managed_fields'] ?? [];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
`hook_civicrm_initiators` describes how to *start* a connection to an external service, but carries nothing about whether the record in hand is already connected. This adds optional properties so an implementer can say so directly.

This is groundwork for showing connection status on the Mail Accounts screen (follow-up PRs), but is useful to any consumer.

Before
----------------------------------------
An initiator has only `title` and `render`. The one existing consumer, the Payment Processor form, works out whether a connection exists by looking at whether the credential fields happen to be populated:

```smarty
{elseif empty($form.user_name.value) && empty($form.password.value) }
  ...not fully established...
```

That guess is not reusable. A connector which supplies its credentials at runtime rather than storing them leaves those columns empty by design, so "empty" and "not connected" are not the same thing.

After
----------------------------------------
`$available[<key>]` accepts five further optional properties:

| key | type | meaning |
| --- | --- | --- |
| `is_connected` | bool | this record is currently connected via this initiator |
| `status_message` | string | describes the connection, e.g. "Connected as foo@example.org" |
| `status_severity` | string | `success`, `warning` or `danger` |
| `manage_url` | string | the screen which administers this connection |
| `managed_fields` | string[] | fields this connection supplies at runtime |

And two accessors:

```php
$initiators = \Civi\Connect\Initiators::create(['for' => 'Something', ...]);
$connected = $initiators->getConnected();   // ?array
$managed = $initiators->getManagedFields(); // string[]
```

Technical Details
----------------------------------------
Every new key is optional and nothing reads them unless an implementer sets them, so the existing PaymentProcessor initiator in `oauth-client` and the PaymentProcessor form are unaffected.

`getConnected()` returns the first initiator reporting `is_connected`; `getManagedFields()` is a convenience for the connected one's `managed_fields`.

Also documents `for => "MailSettings"` in the context enum, which the follow-up PR uses.

Comments
----------------------------------------
First of a stack. They should be reviewed and merged in order:

1. **this PR**
2. #36696 — Show connection status on the Mail Account form
3. #36697 — Report and renew the OAuth connection behind a Mail Account
4. #36698 — Show which accounts are OAuth-connected in the listing
