### PR TITLE
Riverlea: fixes link alignment in CiviCase dashlet

### DIFF
--- a/ext/riverlea/core/css/dashboard.css
+++ b/ext/riverlea/core/css/dashboard.css
@@ -174,6 +174,14 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
   border: 0 solid transparent;
 }
 
+/* Case dashlet */
+#case_dashboard_dashlet ul {
+  display: flex;
+  gap: var(--crm-flex-gap);
+  margin: 0;
+  padding: var(--crm-heading-padding);
+}
+
 /* Available (inactive) dashlets */
 #civicrm-dashboard .crm-inactive-dashlet-fieldset {
   background-color: var(--crm-dashlet-dashlets-bg-color);
@@ -218,7 +226,6 @@ crm-dashlet[is-fullscreen=true] > .crm-dashlet-content {
 }
 
 /* Searchkit Dashlets */
-
 .crm-dashlet .crm-search-display .form-inline {
   padding: var(--crm-padding-reg);
 }


### PR DESCRIPTION
Overview
----------------------------------------
The CiviCase dashlet uses UL for the links which adds a margin that makes it look odd. This PR removes that margin, changes the layout to flex and the padding to match the header it's floating on top of.

Before
----------------------------------------
<img width="775" height="566" alt="image" src="https://github.com/user-attachments/assets/5af16ce1-0a13-4aad-8c14-dfc66337726c" />

After
----------------------------------------

Each Stream:
<img width="764" height="600" alt="image" src="https://github.com/user-attachments/assets/807c5f98-cd73-4a64-9a6b-9fe73fab1a8b" />

At various widths:
<img width="580" height="204" alt="image" src="https://github.com/user-attachments/assets/e0c4d9a2-6e64-4439-b8f3-84774dbb35b6" />
<img width="661" height="180" alt="image" src="https://github.com/user-attachments/assets/5bed2238-5066-4bc5-a160-ed21d96bf75e" />
<img width="815" height="119" alt="image" src="https://github.com/user-attachments/assets/044787b3-7b10-465e-aabc-00d63311321c" />

Comments
----------------------------------------
This isn't a problem on Thames at present and the change makes Thames look a little less aligned.. but hard to mitigate that in a way that doesn't change all streams - and it def looks broken on the other three so I think worth it on balance.