### PR TITLE
Add CRM.utils.escapeHtml() and replace all 86 lodash _.escape() calls

### DIFF
--- a/ang/api4Explorer/Explorer.js
+++ b/ang/api4Explorer/Explorer.js
@@ -353,9 +353,9 @@
     };
 
     $scope.formatSelect2Item = function(row) {
-      return _.escape(row.text) +
+      return CRM.utils.escapeHtml(row.text) +
         (row.required ? '<span class="crm-marker"> *</span>' : '') +
-        (row.description ? '<div class="crm-select2-row-description"><p>' + _.escape(row.description) + '</p></div>' : '');
+        (row.description ? '<div class="crm-select2-row-description"><p>' + CRM.utils.escapeHtml(row.description) + '</p></div>' : '');
     };
 
     $scope.clearParam = function(name, idx) {
@@ -952,7 +952,7 @@ apiCalls.${results} = [${jsCall}];
       }
       _.each($scope.code, function(vals) {
         _.each(vals, function(style) {
-          style.code = code[style.name] ? prettyPrintOne(_.escape(code[style.name])) : '';
+          style.code = code[style.name] ? prettyPrintOne(CRM.utils.escapeHtml(code[style.name])) : '';
         });
       });
     }
@@ -1035,7 +1035,7 @@ apiCalls.${results} = [${jsCall}];
           ret += (ret.length ? ', ' : '') + key + ': ' + (Array.isArray(val) ? '[' + val + ']' : val);
         }
       });
-      return prettyPrintOne(_.escape(ret));
+      return prettyPrintOne(CRM.utils.escapeHtml(ret));
     }
 
     $scope.execute = function() {
@@ -1079,11 +1079,11 @@ apiCalls.${results} = [${jsCall}];
       $scope.result = [formatMeta(response.meta)];
       switch (ctrl.resultFormat) {
         case 'json':
-          $scope.result.push(prettyPrintOne((Array.isArray(response.values) ? '(' + response.values.length + ') ' : '') + _.escape(JSON.stringify(response.values, null, 2)), 'js', 1));
+          $scope.result.push(prettyPrintOne((Array.isArray(response.values) ? '(' + response.values.length + ') ' : '') + CRM.utils.escapeHtml(JSON.stringify(response.values, null, 2)), 'js', 1));
           break;
 
         case 'php':
-          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2)) + ';', 'php', 1));
+          $scope.result.push(prettyPrintOne('return ' + CRM.utils.escapeHtml(phpFormat(response.values, 2, 2)) + ';', 'php', 1));
           break;
 
         case 'php_ts':
@@ -1094,13 +1094,13 @@ apiCalls.${results} = [${jsCall}];
           localizable = _.union(localizable, ['label', 'title', 'description', 'text']);
           // SearchKit settings are not needs to be translated at runtime and not once when the managed file is loaded in the database
           const ignoreLocalization = ['settings'];
-          $scope.result.push(prettyPrintOne('return ' + _.escape(phpFormat(response.values, 2, 2, localizable, ignoreLocalization)) + ';', 'php_ts', 1));
+          $scope.result.push(prettyPrintOne('return ' + CRM.utils.escapeHtml(phpFormat(response.values, 2, 2, localizable, ignoreLocalization)) + ';', 'php_ts', 1));
           break;
       }
     };
 
     function debugFormat(data) {
-      const debug = data.debug ? prettyPrintOne(_.escape(JSON.stringify(data.debug, null, 2)).replace(/\\n/g, "\n")) : null;
+      const debug = data.debug ? prettyPrintOne(CRM.utils.escapeHtml(JSON.stringify(data.debug, null, 2)).replace(/\\n/g, "\n")) : null;
       delete data.debug;
       return debug;
     }

--- a/ext/civi_case/ang/civiCaseTasks/civiCaseTaskCaseRole.ctrl.js
+++ b/ext/civi_case/ang/civiCaseTasks/civiCaseTaskCaseRole.ctrl.js
@@ -89,9 +89,9 @@
           }
         });
       });
-      let msg = _.escape(ts('1 case role added.', {plural: '%count case roles added.', count: added}));
+      let msg = CRM.utils.escapeHtml(ts('1 case role added.', {plural: '%count case roles added.', count: added}));
       if (duplicate) {
-        msg += '<br>' + _.escape(ts('1 case role already occupied by the selected contact.', {plural: '%count case roles already occupied by the selected contact.', count: duplicate}));
+        msg += '<br>' + CRM.utils.escapeHtml(ts('1 case role already occupied by the selected contact.', {plural: '%count case roles already occupied by the selected contact.', count: duplicate}));
       }
       CRM.alert(msg, ts('Saved'), 'success');
       this.close(result);

--- a/ext/civi_case/ang/civiCaseTasks/civiCaseTaskOpenCase.ctrl.js
+++ b/ext/civi_case/ang/civiCaseTasks/civiCaseTaskOpenCase.ctrl.js
@@ -28,7 +28,7 @@
         ctrl.ids = ctrl.ids.filter(id => !ctrl.existingCaseContacts.includes(id));
       }
       if (!ctrl.ids.length) {
-        CRM.alert(_.escape(ts('No cases to open.')), _.escape(ts('All contacts skipped')));
+        CRM.alert(CRM.utils.escapeHtml(ts('No cases to open.')), CRM.utils.escapeHtml(ts('All contacts skipped')));
         ctrl.cancel();
       }
       if (ctrl.multipleClients) {
@@ -42,11 +42,11 @@
     };
 
     this.onSuccess = function(result) {
-      let msg = _.escape(ts('Successfully opened 1 case.', {plural: 'Successfully opened %count cases.', count: result.length}));
+      let msg = CRM.utils.escapeHtml(ts('Successfully opened 1 case.', {plural: 'Successfully opened %count cases.', count: result.length}));
       if (result.length === 1) {
         const viewLink = this.getUrl('view', result[0]);
         if (viewLink) {
-          msg += '<br><a href="' + viewLink + '" target="_blank"><i class="crm-i fa-external-link" role="img" aria-hidden="true"></i> ' + _.escape(ts('View case')) + '</a>';
+          msg += '<br><a href="' + viewLink + '" target="_blank"><i class="crm-i fa-external-link" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('View case')) + '</a>';
         }
       }
       CRM.alert(msg, ts('Saved'), 'success');

--- a/ext/civi_mail/ang/crmMailing/Templates.js
+++ b/ext/civi_mail/ang/crmMailing/Templates.js
@@ -21,9 +21,9 @@
             function formatItem(item) {
               if (!item.id) {
                 // return `text` for optgroup
-                return _.escape(item.text);
+                return CRM.utils.escapeHtml(item.text);
               }
-              return '<span class="crmMailing-template">' + _.escape(item.text) + '</span>';
+              return '<span class="crmMailing-template">' + CRM.utils.escapeHtml(item.text) + '</span>';
             }
 
             var rcpAjaxState = {

--- a/ext/civigrant/ang/civiGrantTasks/civiGrantTaskAddGrant.ctrl.js
+++ b/ext/civigrant/ang/civiGrantTasks/civiGrantTaskAddGrant.ctrl.js
@@ -25,7 +25,7 @@
         ctrl.ids = ctrl.ids.filter(id => !ctrl.existingGrantContacts.includes(id));
       }
       if (!ctrl.ids.length) {
-        CRM.alert(_.escape(ts('No grants to add.')), _.escape(ts('All contacts skipped')));
+        CRM.alert(CRM.utils.escapeHtml(ts('No grants to add.')), CRM.utils.escapeHtml(ts('All contacts skipped')));
         ctrl.cancel();
       }
       apiParams.records = [_.zipObject(ctrl.values)];
@@ -33,11 +33,11 @@
     };
 
     this.onSuccess = function(result) {
-      let msg = _.escape(ts('Successfully added 1 grant.', {plural: 'Successfully added %count grants.', count: result.length}));
+      let msg = CRM.utils.escapeHtml(ts('Successfully added 1 grant.', {plural: 'Successfully added %count grants.', count: result.length}));
       if (result.length === 1) {
         const viewLink = this.getUrl('view', result[0]);
         if (viewLink) {
-          msg += '<br><a href="' + viewLink + '" target="_blank"><i class="crm-i fa-external-link" role="img" aria-hidden="true"></i> ' + _.escape(ts('View grant')) + '</a>';
+          msg += '<br><a href="' + viewLink + '" target="_blank"><i class="crm-i fa-external-link" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('View grant')) + '</a>';
         }
       }
       CRM.alert(msg, ts('Saved'), 'success');

--- a/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
+++ b/ext/search_kit/ang/crmSearchAdmin/searchListing/crmSearchAdminSearchListing.component.js
@@ -139,37 +139,37 @@
           revert = !!search['base_module:label'];
         function getMessage() {
           let title = revert ? ts('Revert this search to its packaged settings?') : ts('Permanently delete this saved search?'),
-            msg = '<h4>' + _.escape(title) + '</h4>' +
+            msg = '<h4>' + CRM.utils.escapeHtml(title) + '</h4>' +
             '<ul>';
           if (revert) {
             if (search.display_label && search.display_label.length === 1) {
-              msg += '<li>' + _.escape(ts('Includes 1 display which will also be reverted.')) + '</li>';
+              msg += '<li>' + CRM.utils.escapeHtml(ts('Includes 1 display which will also be reverted.')) + '</li>';
             } else if (search.display_label && search.display_label.length > 1) {
-              msg += '<li>' + _.escape(ts('Includes %1 displays which will also be reverted.', {1: search.display_label.length})) + '</li>';
+              msg += '<li>' + CRM.utils.escapeHtml(ts('Includes %1 displays which will also be reverted.', {1: search.display_label.length})) + '</li>';
             }
             _.each(search.groups, function(smartGroup) {
-              msg += '<li>' + _.escape(ts('Smart group "%1" will be reset to the packaged search criteria.', {1: smartGroup})) + '</li>';
+              msg += '<li>' + CRM.utils.escapeHtml(ts('Smart group "%1" will be reset to the packaged search criteria.', {1: smartGroup})) + '</li>';
             });
             if (row.afform_count) {
               _.each(ctrl.afforms[search.name], function(afform) {
-                msg += '<li><i class="crm-i fa-list-alt" role="img" aria-hidden="true"></i> ' + _.escape(ts('Form "%1" will be affected because it contains an embedded display from this search.', {1: afform.title})) + '</li>';
+                msg += '<li><i class="crm-i fa-list-alt" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('Form "%1" will be affected because it contains an embedded display from this search.', {1: afform.title})) + '</li>';
               });
             }
           } else {
             if (search.display_label && search.display_label.length === 1) {
-              msg += '<li>' + _.escape(ts('Includes 1 display which will also be deleted.')) + '</li>';
+              msg += '<li>' + CRM.utils.escapeHtml(ts('Includes 1 display which will also be deleted.')) + '</li>';
             } else if (search.display_label && search.display_label.length > 1) {
-              msg += '<li>' + _.escape(ts('Includes %1 displays which will also be deleted.', {1: search.display_label.length})) + '</li>';
+              msg += '<li>' + CRM.utils.escapeHtml(ts('Includes %1 displays which will also be deleted.', {1: search.display_label.length})) + '</li>';
             }
             _.each(search.groups, function (smartGroup) {
-              msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle" role="img" aria-hidden="true"></i> ' + _.escape(ts('Smart group "%1" will also be deleted.', {1: smartGroup})) + '</li>';
+              msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('Smart group "%1" will also be deleted.', {1: smartGroup})) + '</li>';
             });
             _.each(search.schedule_title, (communication) => {
-              msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle" role="img" aria-hidden="true"></i> ' + _.escape(ts('Communication "%1" will also be deleted.', {1: communication})) + '</li>';
+              msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('Communication "%1" will also be deleted.', {1: communication})) + '</li>';
             });
             if (row.afform_count) {
               _.each(ctrl.afforms[search.name], function (afform) {
-                msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle" role="img" aria-hidden="true"></i> ' + _.escape(ts('Form "%1" will also be deleted because it contains an embedded display from this search.', {1: afform.title})) + '</li>';
+                msg += '<li class="crm-error"><i class="crm-i fa-exclamation-triangle" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('Form "%1" will also be deleted because it contains an embedded display from this search.', {1: afform.title})) + '</li>';
               });
             }
           }

--- a/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
+++ b/ext/search_kit/ang/crmSearchDisplayBatch/crmSearchDisplayBatch.component.js
@@ -214,11 +214,11 @@
           let markup = '';
           // Run each item in array through _.escape
           tallyMismatches.forEach((item, index, array) => {
-            markup += '<p><i class="crm-i fa-warning" role="img" aria-hidden="true"></i> ' + _.escape(item) + '</p>';
+            markup += '<p><i class="crm-i fa-warning" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(item) + '</p>';
           });
           CRM.confirm({
             title: ts('Totals Mismatch'),
-            message: markup + '<p>' + _.escape(ts('Run import anyway?')) + '</p>',
+            message: markup + '<p>' + CRM.utils.escapeHtml(ts('Run import anyway?')) + '</p>',
             options: {
               no: ts('Cancel'),
               yes: ts('Run Import'),
@@ -267,15 +267,15 @@
         }
 
         invalidRowNumbers.forEach((rowNum) => {
-          messages.push(_.escape(ts('Row %1: %2', {1: rowNum, 2: invalidRows[rowNum].join(', ')})));
+          messages.push(CRM.utils.escapeHtml(ts('Row %1: %2', {1: rowNum, 2: invalidRows[rowNum].join(', ')})));
         });
         if (more) {
-          messages.push(_.escape(ts('And %1 more', {1: more})));
+          messages.push(CRM.utils.escapeHtml(ts('And %1 more', {1: more})));
         }
 
         errorNotification = CRM.alert(
           '<ul><li>' + messages.join('</li><li>') + '</li></ul>',
-          _.escape(ts('Please complete the following:')),
+          CRM.utils.escapeHtml(ts('Please complete the following:')),
           'error'
         );
       };

--- a/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.js
+++ b/ext/search_kit/ang/crmSearchTasks/crmSearchTaskRelationship.js
@@ -72,9 +72,9 @@
           added++;
         }
       });
-      let msg = _.escape(ts('1 relationship added.', {plural: '%count relationships added.', count: added}));
+      let msg = CRM.utils.escapeHtml(ts('1 relationship added.', {plural: '%count relationships added.', count: added}));
       if (duplicate) {
-        msg += '<br>' + _.escape(ts('1 relationship already exists.', {plural: '%count relationships already exist.', count: duplicate}));
+        msg += '<br>' + CRM.utils.escapeHtml(ts('1 relationship already exists.', {plural: '%count relationships already exist.', count: duplicate}));
       }
       CRM.alert(msg, ts('Saved'), 'success');
       this.close(result);

--- a/js/Common.js
+++ b/js/Common.js
@@ -295,6 +295,18 @@ if (!CRM.vars) CRM.vars = {};
   };
 
   /**
+   * Escapes &, <, >, ", ' for use in HTML markup
+   * @param {*} value
+   * @return {string}
+   */
+  CRM.utils.escapeHtml = function(value) {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value).replace(/[&<>"']/g, (chr) => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[chr]);
+  };
+
+  /**
    * Render an option list
    * @param options {array}
    * @param val {string} default value
@@ -303,7 +315,7 @@ if (!CRM.vars) CRM.vars = {};
    */
   CRM.utils.renderOptions = function(options, val, escapeHtml) {
     var rendered = '',
-      esc = escapeHtml === false ? _.identity : _.escape;
+      esc = escapeHtml === false ? (v) => v : CRM.utils.escapeHtml;
     if (!$.isArray(val)) {
       val = [val];
     }
@@ -411,7 +423,7 @@ if (!CRM.vars) CRM.vars = {};
     if (color) {
       ret += '<span class="crm-select-item-color" style="background-color: ' + color + '"></span> ';
     }
-    return ret + _.escape(row.text) + (description ? '<div class="crm-select2-row-description"><p>' + _.escape(description) + '</p></div>' : '');
+    return ret + CRM.utils.escapeHtml(row.text) + (description ? '<div class="crm-select2-row-description"><p>' + CRM.utils.escapeHtml(description) + '</p></div>' : '');
   }
 
   /**
@@ -436,7 +448,7 @@ if (!CRM.vars) CRM.vars = {};
     var title = '';
     var sr = '';
     if (text) {
-      text = _.escape(text);
+      text = CRM.utils.escapeHtml(text);
       title = ' title="' + text + '"';
       sr = '<span class="sr-only">' + text + '</span>';
     }
@@ -493,7 +505,7 @@ if (!CRM.vars) CRM.vars = {};
       // Placeholder icon - total hack hikacking the escapeMarkup function but select2 3.5 dosn't have any other callbacks for this :(
       if ($el.is('[class*=fa-]')) {
         settings.escapeMarkup = function (m) {
-          var out = _.escape(m),
+          var out = CRM.utils.escapeHtml(m),
             placeholder = settings.placeholder || $el.data('placeholder') || $el.attr('placeholder') || $('option[value=""]', $el).text();
           if (m.length && placeholder === m) {
             iconClass = $el.attr('class').match(/(fa-\S*)/)[1];
@@ -570,9 +582,9 @@ if (!CRM.vars) CRM.vars = {};
     }
     let markup = '<div class="crm-entityref-links crm-entityref-quick-add">';
     quickAddLinks.forEach((link) => {
-      markup += ' <a class="crm-hover-button" href="' + _.escape(CRM.url(link.path)) + '">' +
-        '<i class="crm-i ' + _.escape(link.icon) + '" role="img" aria-hidden="true"></i> ' +
-        _.escape(link.title) + '</a>';
+      markup += ' <a class="crm-hover-button" href="' + CRM.utils.escapeHtml(CRM.url(link.path)) + '">' +
+        '<i class="crm-i ' + CRM.utils.escapeHtml(link.icon) + '" role="img" aria-hidden="true"></i> ' +
+        CRM.utils.escapeHtml(link.title) + '</a>';
     });
     markup += '</div>';
     return markup;
@@ -584,9 +596,9 @@ if (!CRM.vars) CRM.vars = {};
     }
     var markup = '<div class="crm-entityref-links crm-entityref-links-static">';
     _.each(staticItems, function(link) {
-      markup += ' <a class="crm-hover-button" href="#' + _.escape(link.id) + '">' +
-        '<i class="crm-i ' + _.escape(link.icon) + '" role="img" aria-hidden="true"></i> ' +
-        _.escape(link.label) + '</a>';
+      markup += ' <a class="crm-hover-button" href="#' + CRM.utils.escapeHtml(link.id) + '">' +
+        '<i class="crm-i ' + CRM.utils.escapeHtml(link.icon) + '" role="img" aria-hidden="true"></i> ' +
+        CRM.utils.escapeHtml(link.label) + '</a>';
     });
     markup += '</div>';
     return markup;
@@ -721,14 +733,14 @@ if (!CRM.vars) CRM.vars = {};
           }
         },
         formatInputTooShort: function() {
-          let html = _.escape($.fn.select2.defaults.formatInputTooShort.call(this));
+          let html = CRM.utils.escapeHtml($.fn.select2.defaults.formatInputTooShort.call(this));
           html += renderStaticOptionMarkup(staticItems);
           html += renderQuickAddMarkup  (getQuickEditLinks($el));
           html += renderQuickAddMarkup(quickAddLinks);
           return html;
         },
         formatNoMatches: function() {
-          let html = _.escape($.fn.select2.defaults.formatNoMatches);
+          let html = CRM.utils.escapeHtml($.fn.select2.defaults.formatNoMatches);
           html += renderQuickAddMarkup(getQuickEditLinks($el));
           html += renderQuickAddMarkup(quickAddLinks);
           return html;
@@ -900,12 +912,12 @@ if (!CRM.vars) CRM.vars = {};
       }
       else {
         selectParams.formatInputTooShort = function() {
-          var txt = _.escape($el.data('select-params').formatInputTooShort || $.fn.select2.defaults.formatInputTooShort.call(this));
+          var txt = CRM.utils.escapeHtml($el.data('select-params').formatInputTooShort || $.fn.select2.defaults.formatInputTooShort.call(this));
           txt += entityRefFiltersMarkup($el) + renderEntityRefCreateLinks($el);
           return txt;
         };
         selectParams.formatNoMatches = function() {
-          var txt = _.escape($el.data('select-params').formatNoMatches || $.fn.select2.defaults.formatNoMatches);
+          var txt = CRM.utils.escapeHtml($el.data('select-params').formatNoMatches || $.fn.select2.defaults.formatNoMatches);
           txt += entityRefFiltersMarkup($el) + renderEntityRefCreateLinks($el);
           return txt;
         };
@@ -999,27 +1011,27 @@ if (!CRM.vars) CRM.vars = {};
   CRM.utils.formatSelect2Result = function (row) {
     var markup = '<div class="crm-select2-row">';
     if (row.image !== undefined) {
-      markup += '<div class="crm-select2-image"><img src="' + _.escape(row.image) + '"/></div>';
+      markup += '<div class="crm-select2-image"><img src="' + CRM.utils.escapeHtml(row.image) + '"/></div>';
     }
     else if (row.icon_class) {
-      markup += '<div class="crm-select2-icon"><div class="crm-icon ' + _.escape(row.icon_class) + '-icon"></div></div>';
+      markup += '<div class="crm-select2-icon"><div class="crm-icon ' + CRM.utils.escapeHtml(row.icon_class) + '-icon"></div></div>';
     }
-    markup += '<div><div class="crm-select2-row-label ' + _.escape(row.label_class || '') + '">' +
-      (row.color ? '<span class="crm-select-item-color" style="background-color: ' + _.escape(row.color) + '"></span> ' : '') +
-      (row.icon ? '<i class="crm-i ' + _.escape(row.icon) + '" role="img" aria-hidden="true"></i> ' : '') +
-      _.escape((row.prefix !== undefined ? row.prefix + ' ' : '') + row.label + (row.suffix !== undefined ? ' ' + row.suffix : '')) +
+    markup += '<div><div class="crm-select2-row-label ' + CRM.utils.escapeHtml(row.label_class || '') + '">' +
+      (row.color ? '<span class="crm-select-item-color" style="background-color: ' + CRM.utils.escapeHtml(row.color) + '"></span> ' : '') +
+      (row.icon ? '<i class="crm-i ' + CRM.utils.escapeHtml(row.icon) + '" role="img" aria-hidden="true"></i> ' : '') +
+      CRM.utils.escapeHtml((row.prefix !== undefined ? row.prefix + ' ' : '') + row.label + (row.suffix !== undefined ? ' ' + row.suffix : '')) +
       '</div>' +
       '<div class="crm-select2-row-description">';
     $.each(row.description || [], function(k, text) {
-      markup += '<p>' + _.escape(text) + '</p> ';
+      markup += '<p>' + CRM.utils.escapeHtml(text) + '</p> ';
     });
     markup += '</div></div></div>';
     return markup;
   };
 
   function formatEntityRefSelection(row) {
-    return (row.color ? '<span class="crm-select-item-color" style="background-color: ' + _.escape(row.color) + '"></span> ' : '') +
-      _.escape((row.prefix !== undefined ? row.prefix + ' ' : '') + row.label + (row.suffix !== undefined ? ' ' + row.suffix : ''));
+    return (row.color ? '<span class="crm-select-item-color" style="background-color: ' + CRM.utils.escapeHtml(row.color) + '"></span> ' : '') +
+      CRM.utils.escapeHtml((row.prefix !== undefined ? row.prefix + ' ' : '') + row.label + (row.suffix !== undefined ? ' ' + row.suffix : ''));
   }
 
   function renderEntityRefCreateLinks($el) {
@@ -1048,9 +1060,9 @@ if (!CRM.vars) CRM.vars = {};
       }
     }
     _.each(createLinks, function(link) {
-      markup += ' <a class="crm-add-entity crm-hover-button" href="' + _.escape(link.url) + '">' +
-        '<i class="crm-i ' + _.escape(link.icon || 'fa-plus-circle') + '" role="img" aria-hidden="true"></i> ' +
-        _.escape(link.label) + '</a>';
+      markup += ' <a class="crm-add-entity crm-hover-button" href="' + CRM.utils.escapeHtml(link.url) + '">' +
+        '<i class="crm-i ' + CRM.utils.escapeHtml(link.icon || 'fa-plus-circle') + '" role="img" aria-hidden="true"></i> ' +
+        CRM.utils.escapeHtml(link.label) + '</a>';
     });
     markup += '</div>';
     return markup;
@@ -1091,7 +1103,7 @@ if (!CRM.vars) CRM.vars = {};
     }
     var markup = '<div class="crm-entityref-filters">' +
       '<select class="crm-entityref-filter-key' + (filter.key ? ' active' : '') + '">' +
-      '<option value="">' + _.escape(ts('Refine search...')) + '</option>' +
+      '<option value="">' + CRM.utils.escapeHtml(ts('Refine search...')) + '</option>' +
       CRM.utils.renderOptions(filters, filter.key) +
       '</select>' + entityRefFilterValueMarkup($el, filter, filterSpec) + '</div>';
     return markup;
@@ -1323,7 +1335,7 @@ if (!CRM.vars) CRM.vars = {};
       $el.parent().find('.ui-dialog-titlebar .ui-icon-closethick').removeClass('ui-icon-closethick').addClass('fa-times');
       // Add resize button
       if ($el.parent().hasClass('crm-container') && $el.dialog('option', 'resizable')) {
-        $el.parent().find('.ui-dialog-titlebar').append($('<button class="crm-dialog-titlebar-resize ui-dialog-titlebar-close" title="'+ _.escape(ts('Toggle fullscreen'))+'" style="right:2em;"/>').button({icons: {primary: 'fa-expand'}, text: false}));
+        $el.parent().find('.ui-dialog-titlebar').append($('<button class="crm-dialog-titlebar-resize ui-dialog-titlebar-close" title="'+ CRM.utils.escapeHtml(ts('Toggle fullscreen'))+'" style="right:2em;"/>').button({icons: {primary: 'fa-expand'}, text: false}));
         $('.crm-dialog-titlebar-resize', $el.parent()).click(function(e) {
           if ($el.data('origSize')) {
             $el.dialog('option', $el.data('origSize'));
@@ -1450,7 +1462,7 @@ if (!CRM.vars) CRM.vars = {};
         CRM.alert(msg || ts('Sorry an error occurred and your information was not saved'), ts('Error'), 'error');
       }
     }, options || {});
-    var $msg = $('<div class="crm-status-box-outer status-start"><div class="crm-status-box-inner"><div class="crm-status-box-msg">' + _.escape(opts.start) + '</div></div></div>')
+    var $msg = $('<div class="crm-status-box-outer status-start"><div class="crm-status-box-inner"><div class="crm-status-box-msg">' + CRM.utils.escapeHtml(opts.start) + '</div></div></div>')
       .appendTo('body');
     $msg.css('min-width', $msg.width());
     function handle(status, data) {

--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -29,7 +29,7 @@
         type = hasDatepicker ? 'text' : 'number';
 
       if (settings.allowClear !== undefined ? settings.allowClear : !$dataField.is('.required, [required]')) {
-        $clearLink = $('<a class="crm-hover-button crm-clear-link" title="'+ _.escape(ts('Clear')) +'"><i class="crm-i fa-times" role="img" aria-hidden="true"></i></a>')
+        $clearLink = $('<a class="crm-hover-button crm-clear-link" title="'+ CRM.utils.escapeHtml(ts('Clear')) +'"><i class="crm-i fa-times" role="img" aria-hidden="true"></i></a>')
           .insertAfter($dataField);
       }
       if (settings.time !== false) {

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -120,7 +120,7 @@
         .removeClass('crm-menubar-visible');
       document.documentElement.style.setProperty('--crm-menubar-bottom', '0px');
       if (showMessage === true && $('#crm-notification-container').length && initialized) {
-        var alert = CRM.alert('<a href="#" id="crm-restore-menu" >' + _.escape(ts('Restore CiviCRM Menu')) + '</a>', ts('Menu hidden'), 'none', {expires: 10000});
+        var alert = CRM.alert('<a href="#" id="crm-restore-menu" >' + CRM.utils.escapeHtml(ts('Restore CiviCRM Menu')) + '</a>', ts('Menu hidden'), 'none', {expires: 10000});
         $('#crm-restore-menu')
           .click(function(e) {
             e.preventDefault();
@@ -496,7 +496,7 @@
       '</li>',
     drillTpl:
       '<li class="crm-menu-border-bottom" data-name="MenubarDrillDown">' +
-        '<a href="#"><input type="text" id="crm-menubar-drilldown" placeholder="' + _.escape(ts('Find menu item...')) + '" aria-label="' + _.escape(ts('Find menu item...')) + '"><span class="sr-only">' + _.escape(ts('Find menu item...')) + '></span></a>' +
+        '<a href="#"><input type="text" id="crm-menubar-drilldown" placeholder="' + CRM.utils.escapeHtml(ts('Find menu item...')) + '" aria-label="' + CRM.utils.escapeHtml(ts('Find menu item...')) + '"><span class="sr-only">' + CRM.utils.escapeHtml(ts('Find menu item...')) + '></span></a>' +
         '<ul></ul>' +
       '</li>',
     branchTpl:

--- a/js/jquery/jquery.crmEditable.js
+++ b/js/jquery/jquery.crmEditable.js
@@ -72,7 +72,7 @@
             if ($i.data('refresh')) {
               CRM.refreshParent($i);
             } else {
-              value = value === '' ? settings.placeholder : _.escape(value);
+              value = value === '' ? settings.placeholder : CRM.utils.escapeHtml(value);
               $i.html(value);
             }
           }

--- a/templates/CRM/Admin/Page/APIExplorer.js
+++ b/templates/CRM/Admin/Page/APIExplorer.js
@@ -155,13 +155,13 @@
       data: selectFields,
       allowClear: false,
       formatSelection: function(field) {
-        return _.escape(field.text) +
+        return CRM.utils.escapeHtml(field.text) +
           (field.required ? ' <span class="crm-marker">*</span>' : '');
       },
       formatResult: function(field) {
-        return _.escape(field.text) +
+        return CRM.utils.escapeHtml(field.text) +
           (field.required ? ' <span class="crm-marker">*</span>' : '') +
-          '<div class="api-field-desc">' + _.escape(field.description) + '</div>';
+          '<div class="api-field-desc">' + CRM.utils.escapeHtml(field.description) + '</div>';
       }
     }).change();
   }
@@ -201,9 +201,9 @@
     $('.api-chain-entity', $row).crmSelect2({
       formatSelection: function(item) {
         return '<i class="crm-i fa-link" role="img" aria-hidden="true"></i> API ' +
-          ($(item.element).hasClass('strikethrough') ? '<span class="strikethrough">' + _.escape(item.text) + '</span>' : _.escape(item.text));
+          ($(item.element).hasClass('strikethrough') ? '<span class="strikethrough">' + CRM.utils.escapeHtml(item.text) + '</span>' : CRM.utils.escapeHtml(item.text));
       },
-      placeholder: '<i class="crm-i fa-link" role="img" aria-hidden="true"></i> ' + _.escape(ts('Entity')),
+      placeholder: '<i class="crm-i fa-link" role="img" aria-hidden="true"></i> ' + CRM.utils.escapeHtml(ts('Entity')),
       allowClear: false,
       escapeMarkup: function(m) {return m;}
     })
@@ -336,7 +336,7 @@
         multiple: true,
         placeholder: ts('Leave blank for default'),
         formatResult: function(field) {
-          return _.escape(field.text) + '<div class="api-field-desc">' + _.escape(field.description) + '</div>';
+          return CRM.utils.escapeHtml(field.text) + '<div class="api-field-desc">' + CRM.utils.escapeHtml(field.description) + '</div>';
         }
       };
     if (action == 'getstat') {
@@ -371,7 +371,7 @@
    * @returns {string}
    */
   function renderAction(option) {
-    return isActionDeprecated(option.id) ? '<span class="strikethrough">' + _.escape(option.text) + '</span>' : _.escape(option.text);
+    return isActionDeprecated(option.id) ? '<span class="strikethrough">' + CRM.utils.escapeHtml(option.text) + '</span>' : CRM.utils.escapeHtml(option.text);
   }
 
   /**
@@ -946,7 +946,7 @@
     $('#api-entity, #doc-entity').crmSelect2({
       // Add strikethough class to selection to indicate deprecated apis
       formatSelection: function(option) {
-        return $(option.element).hasClass('strikethrough') ? '<span class="strikethrough">' + _.escape(option.text) + '</span>' : _.escape(option.text);
+        return $(option.element).hasClass('strikethrough') ? '<span class="strikethrough">' + CRM.utils.escapeHtml(option.text) + '</span>' : CRM.utils.escapeHtml(option.text);
       }
     });
     $('form#api-explorer')

--- a/templates/CRM/Core/BillingBlock.js
+++ b/templates/CRM/Core/BillingBlock.js
@@ -3,7 +3,7 @@
 
   $(function() {
     $.each(CRM.config.creditCardTypes, function(key, val) {
-      var html = '<a href="#" title="' + _.escape(val.label) + '" class="crm-credit_card_type-icon-' + val.css_key + '"><span>' + _.escape(val.label) + '</span></a>';
+      var html = '<a href="#" title="' + CRM.utils.escapeHtml(val.label) + '" class="crm-credit_card_type-icon-' + val.css_key + '"><span>' + CRM.utils.escapeHtml(val.label) + '</span></a>';
       $('.crm-credit_card_type-icons').append(html);
 
       $('.crm-credit_card_type-icon-' + val.css_key).click(function() {


### PR DESCRIPTION
Overview
----------------------------------------
Part of a staged effort to remove lodash from civicrm-core's JS (see internal tracking; this is Stage 1 of that plan — Stage 2, replacing `_.where`/`_.findWhere`/`_.pluck`, already landed in #36563/#36570/#36571/#36576/#36577).

This PR replaces every remaining `_.escape()` call (86 call sites across 14 files) with a new native `CRM.utils.escapeHtml()` helper, removing one more usage of the lodash-compat shim.

Before
----------------------------------------
HTML-escaping in JS relied on lodash's `_.escape(string)`, e.g. in `js/Common.js`:

```js
esc = escapeHtml === false ? _.identity : _.escape;
...
return ret + _.escape(row.text) + ...
```

After
----------------------------------------
A native helper with identical behavior (escapes `&`, `<`, `>`, `"`, `'`; converts `null`/`undefined` to `''`) is added to `js/Common.js`:

```js
CRM.utils.escapeHtml = function(value) {
  if (value === null || value === undefined) {
    return '';
  }
  return String(value).replace(/[&<>"']/g, (chr) => ({'&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'})[chr]);
};
```

Every `_.escape(...)` call site is replaced with `CRM.utils.escapeHtml(...)`, e.g.:

```js
return ret + CRM.utils.escapeHtml(row.text) + ...
```

`renderOptions()`'s `escapeHtml === false` passthrough now uses an inline `(v) => v` instead of `_.identity`.

No user-visible behavior changes — output is byte-for-byte identical to the g.

Technical Details
----------------------------------------
Files touched: `js/Common.js` (28 sites, plus the new helper), `ang/api4Explorer/Explorer.js` (8), `templates/CRM/Admin/Page/APIExplorer.js` (8), `ext/search_kit/.../crmSearchAdminSearchListing.component.js` (10), `crmSearchDisplayBatch.component.js` (5), and smaller counts in `ext/civi_case`, `ext/civi_mail`, `ext/civigrant`, `ext/search_kit/.../crmSearchTaskRelationship.js`, `js/crm.menubar.js`, `js/crm.datepicker.js`, `js/jquery/jquery.crmEditable.js`, `templates/CRM/Core/BillingBlock.js`.

Every remaining call site was checked to confirm it only ever receives a str)`, or entity label/name fields) — none needed special handling for arrays ornon-string values.

`CRM.utils` is initialized in `js/Common.js`, which loads on every page, so where `_.escape` previously was.

Comments
----------------------------------------
Live-verified in a local sandbox: APIv4 Explorer (entity/action select2 dropdowns, and JSON/PHP pretty-printed result escaping) and the Contact Add form's "Current Employer" quick-add-organization link — no console errors in either case. All 14 files pass civilint.