### PR TITLE
Remove trivial _.template() calls with no interpolation

### DIFF
--- a/ext/ckeditor4/js/admin.ckeditor-configurator.js
+++ b/ext/ckeditor4/js/admin.ckeditor-configurator.js
@@ -4,8 +4,7 @@
   'use strict';
   /* jshint validthis: true */
 
-  var configRowTpl = _.template($('#config-row-tpl').html()),
-    options;
+  var options;
 
   // Weird conflict with drupal styles
   $('body').removeClass('toolbar');
@@ -70,7 +69,7 @@
   }
 
   function addOption() {
-    $('#crm-custom-config-options').append($(configRowTpl({})));
+    $('#crm-custom-config-options').append($($('#config-row-tpl').html()));
     $('.crm-config-option-row:last input.crm-config-option-name', '#crm-custom-config-options').crmSelect2({
       data: getOptionList,
       formatSelection: function(field) {

--- a/js/view/crm.designer.js
+++ b/js/view/crm.designer.js
@@ -521,7 +521,7 @@
     },
     render: function() {
       var ufFieldCanvasView = this;
-      this.$el.html(_.template($('#field_canvas_view_template').html()));
+      this.$el.html($('#field_canvas_view_template').html());
 
       // BOTTOM: Setup field-level editing
       var $fields = this.$('.crm-designer-fields');


### PR DESCRIPTION
Overview
----------------------------------------
Part of a staged effort to remove lodash from civicrm-core's JS. Of the 13 remaining `_.template()` calls, 2 compile templates that contain no `<% %>` interpolation at all — the lodash templating engine buys nothing there, so this drops `_.template()` from those two call sites and uses the raw template markup directly.

Before
----------------------------------------
`ext/ckeditor4/js/admin.ckeditor-configurator.js`:

```js
var configRowTpl = _.template($('#config-row-tpl').html()),
  options;
...
$('#crm-custom-config-options').append($(configRowTpl({})));
```

`js/view/crm.designer.js`:

```js
this.$el.html(_.template($('#field_canvas_view_template').html()));
```

Both `#config-row-tpl` and `#field_canvas_view_template` are static markup with no template placeholders, so `_.template(...)(data)` always just returns the markup unchanged regardless of `data`.

After
----------------------------------------
`ext/ckeditor4/js/admin.ckeditor-configurator.js`:

```js
var options;
...
$('#crm-custom-config-options').append($($('#config-row-tpl').html()));
```

`js/view/crm.designer.js`:

```js
this.$el.html($('#field_canvas_view_template').html());
```

No output change — same markup is inserted either way.

Technical Details
----------------------------------------
`crm.designer.js`'s previous code was calling the compiled template function via jQuery's `.html(fn)` signature, which invokes `fn(index, oldHtml)` rather than `fn(data)`. This happened to work only because the template has no interpolation to break; removing `_.template` avoids relying on that incidental behavior.

Comments
----------------------------------------
Live-verified `admin.ckeditor-configurator.js` in a local sandbox: `civicrm/admin/ckeditor` → "Show empty toolbar groups" renders the config-row select2 widget correctly, no console errors. `crm.designer.js`'s field-canvas template has no reachable UI route on this build (`CRM_UF_Page_ProfileEditor` only exposes an AJAX schema endpoint) — verified by static analysis (no interpolation) and civilint instead.