### PR TITLE
Add CRM.utils.cloneDeep() and convert core-file lodash cloneDeep calls

### DIFF
--- a/ang/crmRouteBinder.js
+++ b/ang/crmRouteBinder.js
@@ -66,7 +66,7 @@
           value = fmt.decode($route.current.params[options.param]);
         }
         else {
-          value = _.cloneDeep(options.default);
+          value = structuredClone(options.default);
           ignorable[options.param] = fmt.encode(options.default);
         }
         $parse(options.expr).assign(_scope, value);

--- a/ang/crmUi.js
+++ b/ang/crmUi.js
@@ -632,7 +632,7 @@
               $timeout(function () {
                 // ex: msg_template_id adds new item then selects it; use $timeout to ensure that
                 // new item is added before selection is made
-                let newVal = _.cloneDeep(ngModel.$modelValue);
+                let newVal = structuredClone(ngModel.$modelValue);
                 // Fix possible data-type mismatch
                 if (typeof newVal === 'string' && element.select2('container').hasClass('select2-container-multi')) {
                   newVal = newVal.length ? newVal.split(scope.crmUiSelect.separator || ',') : [];
@@ -715,7 +715,7 @@
             $timeout(function () {
               // ex: msg_template_id adds new item then selects it; use $timeout to ensure that
               // new item is added before selection is made
-              let newVal = _.cloneDeep(ngModel.$modelValue);
+              let newVal = structuredClone(ngModel.$modelValue);
               // Fix possible data-type mismatch
               if (typeof newVal === 'string' && element.select2('container').hasClass('select2-container-multi')) {
                 newVal = newVal.length ? newVal.split(',') : [];

--- a/js/Common.js
+++ b/js/Common.js
@@ -307,6 +307,39 @@ if (!CRM.vars) CRM.vars = {};
   };
 
   /**
+   * Deep-clones a value that structuredClone() can't handle - typically because it contains
+   * functions, which structuredClone() throws on. Anything it doesn't recognise (functions,
+   * DOM nodes, class instances) is passed through by reference rather than cloned.
+   * Prefer structuredClone() directly for values known to hold only data.
+   * @param {*} value
+   * @return {*}
+   */
+  CRM.utils.cloneDeep = function(value) {
+    if (Array.isArray(value)) {
+      return value.map(CRM.utils.cloneDeep);
+    }
+    if (value instanceof Date) {
+      return new Date(value.getTime());
+    }
+    if (value instanceof RegExp) {
+      return new RegExp(value.source, value.flags);
+    }
+    if (value !== null && typeof value === 'object') {
+      const proto = Object.getPrototypeOf(value);
+      if (proto === null || proto === Object.prototype) {
+        const result = {};
+        for (const key in value) {
+          if (Object.prototype.hasOwnProperty.call(value, key)) {
+            result[key] = CRM.utils.cloneDeep(value[key]);
+          }
+        }
+        return result;
+      }
+    }
+    return value;
+  };
+
+  /**
    * Render an option list
    * @param options {array}
    * @param val {string} default value
@@ -982,8 +1015,8 @@ if (!CRM.vars) CRM.vars = {};
   function getEntityRefApiParams($el) {
     var
       params = $.extend({params: {}}, $el.data('api-params') || {}),
-      // Prevent original data from being modified - $.extend and _.clone don't cut it, they pass nested objects by reference!
-      combined = _.cloneDeep(params),
+      // Deep clone: a shallow copy would leave nested objects shared with the original
+      combined = structuredClone(params),
       filter = $.extend({}, $el.data('user-filter') || {});
     if (filter.key && filter.value) {
       // Fieldname may be prefixed with joins
@@ -1116,7 +1149,7 @@ if (!CRM.vars) CRM.vars = {};
     var markup = '';
     if (filterSpec) {
       var attrs = '',
-        attributes = _.cloneDeep(filterSpec.attributes);
+        attributes = structuredClone(filterSpec.attributes);
       if (filterSpec.type !== 'select') {
         attributes.type = filterSpec.type;
         attributes.value = typeof filter.value !== 'undefined' ? filter.value : '';
@@ -1182,7 +1215,7 @@ if (!CRM.vars) CRM.vars = {};
   }
 
   function getEntityRefFilterOptions(fieldName, $el, filterSpec) {
-    var values = _.cloneDeep(filterSpec.options),
+    var values = structuredClone(filterSpec.options),
       params = $.extend({params: {}}, $el.data('api-params') || {}).params;
     if (fieldName === 'contact_type' && params.contact_type) {
       values = _.remove(values, function(option) {
@@ -1424,7 +1457,7 @@ if (!CRM.vars) CRM.vars = {};
       }
       helpDisplay.close();
     }
-    helpPrevious = _.cloneDeep(params);
+    helpPrevious = structuredClone(params);
     helpDisplay = CRM.alert(ajax ? '...' : params, title, 'crm-help ' + (ajax ? 'crm-msg-loading' : 'info'), {expires: 0});
     if (ajax) {
       if (!url) {

--- a/js/crm.datepicker.js
+++ b/js/crm.datepicker.js
@@ -20,7 +20,8 @@
       }
       var
         $dataField = $(this).wrap('<span class="crm-form-date-wrapper" />'),
-        settings = _.cloneDeep(options || {}),
+        // Not structuredClone(): jQuery UI datepicker options may include callbacks, which it can't clone
+        settings = CRM.utils.cloneDeep(options || {}),
         $dateField = $(),
         $timeField = $(),
         $clearLink = $(),

--- a/js/crm.menubar.js
+++ b/js/crm.menubar.js
@@ -584,7 +584,7 @@
   }
 
   function attr(el, item) {
-    var ret = [], attr = _.cloneDeep(item.attr || {}), a = ['rel', 'accesskey', 'target'];
+    var ret = [], attr = structuredClone(item.attr || {}), a = ['rel', 'accesskey', 'target'];
     if (el === 'a') {
       attr = _.pick(attr, a);
       attr.href = item.url || "#";

--- a/templates/CRM/common/TabHeader.js
+++ b/templates/CRM/common/TabHeader.js
@@ -7,7 +7,7 @@
    */
   $(function($) {
     // CRM.tabSettings.active is the name of the tab which should open on page load
-    var tabSettings = CRM.tabSettings ? _.cloneDeep(CRM.tabSettings) : {};
+    var tabSettings = CRM.tabSettings ? structuredClone(CRM.tabSettings) : {};
     tabSettings.active = tabSettings.active ? $('#tab_' + tabSettings.active).prevAll().length : 0;
     $("#mainTabContainer")
       .on('tabsbeforeactivate', function(e, ui) {


### PR DESCRIPTION
Overview
----------------------------------------

Replaces the ten `_.cloneDeep()` calls in core JavaScript, as part of the ongoing removal of lodash. Nine use the browser-native `structuredClone()`; the tenth uses a new `CRM.utils.cloneDeep()` helper because native cloning can't handle what it's given.

Before
----------------------------------------

Ten call sites across `js/Common.js`, `ang/crmUi.js`, `ang/crmRouteBinder.js`, `js/crm.menubar.js`, `js/crm.datepicker.js` and `templates/CRM/common/TabHeader.js` deep-clone through lodash:

```js
var tabSettings = CRM.tabSettings ? _.cloneDeep(CRM.tabSettings) : {};
```

After
----------------------------------------

Nine of them call the native function directly:

```js
var tabSettings = CRM.tabSettings ? structuredClone(CRM.tabSettings) : {};
```

`js/crm.datepicker.js` uses the new helper instead, with a comment recording why:

```js
// Not structuredClone(): jQuery UI datepicker options may include callbacks, which it can't clone
settings = CRM.utils.cloneDeep(options || {}),
```

No user-visible change.

Technical Details
----------------------------------------

`structuredClone()` is not a drop-in replacement for `_.cloneDeep()`. Lodash passes functions held as object properties through by reference; `structuredClone()` throws `DataCloneError` if a function appears anywhere in the graph. So each site was checked against where its value actually comes from:

| Site | Why it is plain data |
| --- | --- |
| `Common.js` — entityRef api-params | PHP writes it as `json_encode($props['api'])` into a `data-` attribute (`CRM/Core/Form.php:2214,2282`) |
| `Common.js` — `filterSpec.attributes` | HTML attributes, rendered into markup |
| `Common.js` — `filterSpec.options` | a `CRM.api3 getoptions` response |
| `Common.js` — `CRM.help` params | embedded via `JSON.stringify(options)` in an onclick (`crm.helptext.js:35`), so they must be JSON-serializable |
| `crmRouteBinder.js` — `options.default` | `fmt.encode()`d into the URL on the following line |
| `crmUi.js` ×2 — `ngModel.$modelValue` | passed straight to `element.select2('val', …)` |
| `crm.menubar.js` — `item.attr` | HTML attributes from `CRM_Core_BAO_Navigation` |
| `TabHeader.js` — `CRM.tabSettings` | `Civi::resources()->addSetting(['tabSettings' => …])`, nine PHP call sites |

`crm.datepicker.js` is the exception: it clones caller-supplied jQuery UI datepicker options, whose documented surface includes callbacks such as `beforeShowDay` and `onClose`, and the file assigns `settings.onSelect` immediately after the clone. Every in-core caller happens to pass plain data today, but this is a public jQuery plugin (`$el.crmDatepicker({…})`), so an extension passing a callback would go from working to a hard crash.

`CRM.utils.cloneDeep()` therefore tries `structuredClone()` first and falls back to a manual recursive clone only for values it rejects — the common case still takes the native path.

The helper has one consumer in this PR, but it is also needed by the `search_kit` conversions still to come: roughly two thirds of those clone display trait objects full of methods, via the `angular.extend(this, _.cloneDeep(searchDisplayBaseTrait), …)` mixin pattern, which `structuredClone()` cannot do at all.

`.jshintrc` gains `structuredClone` in `predef`, since that file uses an explicit global allowlist rather than `browser: true`.

Comments
----------------------------------------

Tested manually against a Standalone build, with no console errors at any point:

- **Contact Summary** — tabs render and switching to Relationships loads via ajax (`TabHeader.js`).
- **Menu bar** — the Contacts menu and its submenus render with their attributes (`crm.menubar.js`).
- **Add Relationship** — choosing "Employee of" re-renders the contact field as organisation-only, exercising the api-params clone.
- **entityRef "Refine search"** — the *City* filter renders a text input (the `attributes` clone) and *Group* renders a populated select (the `options` clone).
- **Datepicker** — picking a date writes `2026-09-09` to the underlying field while displaying `09/09/2026`, so the `onSelect` assigned after the clone survives (the helper path).
- **`CRM.help`** — the Access Keys icon toggles open → closed → open. This is the sharpest test of that site: the close branch only fires when `_.isEqual(helpPrevious, params)` matches, which requires the clone to be faithful.
- **SearchKit** — built a Contact search with an Email join and ran it, 204 results (`crmRouteBinder` defaults plus `crmUi`'s `$render`).

All six changed files are `civilint` clean.

Also rewrote one comment in `Common.js` that referred to `_.clone`, which would have been stale the moment this merged.